### PR TITLE
[feature](graph)Support querying data from the Nebula graph database

### DIFF
--- a/be/src/vec/exec/vjdbc_connector.cpp
+++ b/be/src/vec/exec/vjdbc_connector.cpp
@@ -202,7 +202,9 @@ Status JdbcConnector::query() {
     }
 
     LOG(INFO) << "JdbcConnector::query has exec success: " << _sql_str;
-    RETURN_IF_ERROR(_check_column_type());
+    if (_conn_param.table_type != TOdbcTableType::NEBULA) {
+        RETURN_IF_ERROR(_check_column_type());
+    }
     return Status::OK();
 }
 

--- a/docs/en/docs/lakehouse/external-table/jdbc.md
+++ b/docs/en/docs/lakehouse/external-table/jdbc.md
@@ -233,7 +233,6 @@ PROPERTIES (
     "table_type"="trino"
 );
 ```
-
 #### 8.OceanBase Test
 
 | OceanBase Version | OceanBase JDBC Driver Version |
@@ -259,6 +258,97 @@ PROPERTIES (
     "table" = "test.test",
     "table_type"="oceanbase"
 );
+```
+### 9.NebulaGraphTest (only supports queries)
+| Nebula version | Nebula JDBC Driver Version |
+|------------|-------------------|
+| 3.0.0       | nebula-jdbc-3.0.0-jar-with-dependencies.jar         |
+
+
+
+```
+#step1.crate test data in nebula
+#1.1 create tag
+(root@nebula) [basketballplayer]> CREATE TAG test(t_str string, 
+    t_int int, 
+    t_date date,
+    t_datetime datetime,
+    t_bool bool,
+    t_timestamp timestamp,
+    t_float float,
+    t_double double
+);
+#1.2 insert test data
+(root@nebula) [basketballplayer]> INSERT VERTEX test_type(t_str,t_int,t_date,t_datetime,t_bool,t_timestamp,t_float,t_double) values "zhangshan":("zhangshan",1000,date("2023-01-01"),datetime("2023-01-23 15:23:32"),true,1234242423,1.2,1.35);
+#1.3 check the data
+(root@nebula) [basketballplayer]> match (v:test_type) where id(v)=="zhangshan" return v.test_type.t_str,v.test_type.t_int,v.test_type.t_date,v.test_type.t_datetime,v.test_type.t_bool,v.test_type.t_timestamp,v.test_type.t_float,v.test_type.t_double,v limit 30;
++-------------------+-------------------+--------------------+----------------------------+--------------------+-------------------------+---------------------+----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| v.test_type.t_str | v.test_type.t_int | v.test_type.t_date | v.test_type.t_datetime     | v.test_type.t_bool | v.test_type.t_timestamp | v.test_type.t_float | v.test_type.t_double | v                                                                                                                                                                                                         |
++-------------------+-------------------+--------------------+----------------------------+--------------------+-------------------------+---------------------+----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| "zhangshan"       | 1000              | 2023-01-01         | 2023-01-23T15:23:32.000000 | true               | 1234242423              | 1.2000000476837158  | 1.35                 | ("zhangshan" :test_type{t_bool: true, t_date: 2023-01-01, t_datetime: 2023-01-23T15:23:32.000000, t_double: 1.35, t_float: 1.2000000476837158, t_int: 1000, t_str: "zhangshan", t_timestamp: 1234242423}) |
++-------------------+-------------------+--------------------+----------------------------+--------------------+-------------------------+---------------------+----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+Got 1 rows (time spent 1616/2048 us)
+Mon, 17 Apr 2023 17:23:14 CST
+#step2. create table in doris
+#2.1 create a resource
+MySQL [test_db]> CREATE EXTERNAL RESOURCE gg_jdbc_resource 
+properties (
+   "type"="jdbc",
+   "user"="root",
+   "password"="123",
+   "jdbc_url"="jdbc:nebula://127.0.0.1:9669/basketballplayer",
+   "driver_url"="file:///home/clz/baidu/bdg/doris/be/lib/nebula-jdbc-3.0.0-jar-with-dependencies.jar",  --Need to be placed in the be/lib directory--
+   "driver_class"="com.vesoft.nebula.jdbc.NebulaDriver"
+);
+#2.2 Create a facade that mainly tells Doris how to parse the data returned by Nebulagraph
+MySQL [test_db]> CREATE TABLE `test_type` ( 
+ `t_str` varchar(64),
+ `t_int` bigint,
+ `t_date` date,
+ `t_datetime` datetime,
+ `t_bool` boolean,
+ `t_timestamp` bigint,
+ `t_float` double,
+ `t_double` double,
+ `t_vertx`  varchar(128) --vertex map type varchar in doris---
+) ENGINE=JDBC
+PROPERTIES (
+"resource" = "gg_jdbc_resource",
+"table" = "xx",  --please fill in any value here, we do not use it --
+"table_type"="nebula"
+);
+#2.3 Query the graph surface and use the g() function to transparently pass the nGQL of the graph to Nebula
+MySQL [test_db]> select * from test_type where g('match (v:test_type) where id(v)=="zhangshan" return v.test_type.t_str,v.test_type.t_int,v.test_type.t_date,v.test_type.t_datetime,v.test_type.t_bool,v.test_type.t_timestamp,v.test_type.t_float,v.test_type.t_double,v')\G;
+*************************** 1. row ***************************
+      t_str: zhangshan
+      t_int: 1000
+     t_date: 2023-01-01
+ t_datetime: 2023-01-23 15:23:32
+     t_bool: 1
+t_timestamp: 1234242423
+    t_float: 1.2000000476837158
+   t_double: 1.35
+    t_vertx: ("zhangshan" :test_type {t_datetime: utc datetime: 2023-01-23T15:23:32.000000, timezoneOffset: 0, t_timestamp: 1234242423, t_date: 2023-01-01, t_double: 1.35, t_str: "zhangshan", t_int: 1000, t_bool: true, t_float: 1.2000000476837158})
+1 row in set (0.024 sec)
+#2.3 Associate queries with other tables in Doris
+#Assuming there is a user table
+MySQL [test_db]> select * from t_user;
++-----------+------+---------------------------------+
+| username  | age  | addr                            |
++-----------+------+---------------------------------+
+| zhangshan |   26 | 北京市西二旗街道1008号          |
++-----------+------+---------------------------------+
+| lisi |   29 | 北京市西二旗街道1007号          |
++-----------+------+---------------------------------+
+1 row in set (0.013 sec)
+#Associate with this table to query user related information
+MySQL [test_db]> select u.* from (select t_str username  from test_type where g('match (v:test_type) where id(v)=="zhangshan" return v.test_type.t_str limit 1')) g left join t_user u on g.username=u.username;
++-----------+------+---------------------------------+
+| username  | age  | addr                            |
++-----------+------+---------------------------------+
+| zhangshan |   26 | 北京市西二旗街道1008号          |
++-----------+------+---------------------------------+
+1 row in set (0.029 sec)
 ```
 
 ## Type Mapping
@@ -414,6 +504,17 @@ The followings list how data types in different databases are mapped in Doris.
 |    DATETIME     | DATETIME |
 |     DOUBLE      |  DOUBLE  |
 |     DECIMAL     | DECIMAL  |
+
+### Nebula-graph
+|   nebula   |        Doris        |
+|:------------:|:-------------------:|
+|   tinyint/samllint/int/int64    |       bigint       |
+|   double/float    |       double       |
+|   date   |      date       |
+|   timestamp   |         bigint         |
+|    datetime    |       datetime        |
+| bool |  boolean  |
+|   vertex/edge/path/list/set/time etc    |  varchar  |
 
 ## Q&A
 

--- a/docs/zh-CN/docs/lakehouse/external-table/jdbc.md
+++ b/docs/zh-CN/docs/lakehouse/external-table/jdbc.md
@@ -227,7 +227,6 @@ PROPERTIES (
     "table_type"="trino"
 );
 ```
-
 #### 8.OceanBase测试
 
 | OceanBase 版本 | OceanBase JDBC驱动版本 |
@@ -253,6 +252,97 @@ PROPERTIES (
     "table" = "test.test",
     "table_type"="oceanbase"
 );
+
+### 9.Nebula-graph测试 （仅支持查询）
+| nebula版本 | JDBC驱动版本 |
+|------------|-------------------|
+| 3.0.0       | nebula-jdbc-3.0.0-jar-with-dependencies.jar         |
+
+
+
+```
+#step1.在nebula创建测试数据
+#1.1 创建结点
+(root@nebula) [basketballplayer]> CREATE TAG test(t_str string, 
+    t_int int, 
+    t_date date,
+    t_datetime datetime,
+    t_bool bool,
+    t_timestamp timestamp,
+    t_float float,
+    t_double double
+);
+#1.2 插入数据
+(root@nebula) [basketballplayer]> INSERT VERTEX test_type(t_str,t_int,t_date,t_datetime,t_bool,t_timestamp,t_float,t_double) values "zhangshan":("zhangshan",1000,date("2023-01-01"),datetime("2023-01-23 15:23:32"),true,1234242423,1.2,1.35);
+#1.3 查询数据
+(root@nebula) [basketballplayer]> match (v:test_type) where id(v)=="zhangshan" return v.test_type.t_str,v.test_type.t_int,v.test_type.t_date,v.test_type.t_datetime,v.test_type.t_bool,v.test_type.t_timestamp,v.test_type.t_float,v.test_type.t_double,v limit 30;
++-------------------+-------------------+--------------------+----------------------------+--------------------+-------------------------+---------------------+----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| v.test_type.t_str | v.test_type.t_int | v.test_type.t_date | v.test_type.t_datetime     | v.test_type.t_bool | v.test_type.t_timestamp | v.test_type.t_float | v.test_type.t_double | v                                                                                                                                                                                                         |
++-------------------+-------------------+--------------------+----------------------------+--------------------+-------------------------+---------------------+----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| "zhangshan"       | 1000              | 2023-01-01         | 2023-01-23T15:23:32.000000 | true               | 1234242423              | 1.2000000476837158  | 1.35                 | ("zhangshan" :test_type{t_bool: true, t_date: 2023-01-01, t_datetime: 2023-01-23T15:23:32.000000, t_double: 1.35, t_float: 1.2000000476837158, t_int: 1000, t_str: "zhangshan", t_timestamp: 1234242423}) |
++-------------------+-------------------+--------------------+----------------------------+--------------------+-------------------------+---------------------+----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+Got 1 rows (time spent 1616/2048 us)
+Mon, 17 Apr 2023 17:23:14 CST
+#step2.在doris中创建外表
+#2.1 创建一个resource
+MySQL [test_db]> CREATE EXTERNAL RESOURCE gg_jdbc_resource 
+properties (
+   "type"="jdbc",
+   "user"="root",
+   "password"="123",
+   "jdbc_url"="jdbc:nebula://127.0.0.1:9669/basketballplayer",
+   "driver_url"="file:///home/clz/baidu/bdg/doris/be/lib/nebula-jdbc-3.0.0-jar-with-dependencies.jar",  --仅支持本地路径，需放到be/lib目录下--
+   "driver_class"="com.vesoft.nebula.jdbc.NebulaDriver"
+);
+#2.2 创建一个外表，这个主要是告诉doris如何解析nebulagraph返回的数据
+MySQL [test_db]> CREATE TABLE `test_type` ( 
+ `t_str` varchar(64),
+ `t_int` bigint,
+ `t_date` date,
+ `t_datetime` datetime,
+ `t_bool` boolean,
+ `t_timestamp` bigint,
+ `t_float` double,
+ `t_double` double,
+ `t_vertx`  varchar(128) --vertex对应doris类型是varchar---
+) ENGINE=JDBC
+PROPERTIES (
+"resource" = "gg_jdbc_resource",
+"table" = "xx",  --因为graph没有表的概念，这里随便填一个值--
+"table_type"="nebula"
+);
+#2.3 查询graph外表,用g()函数把图的nGQL透传给nebula
+MySQL [test_db]> select * from test_type where g('match (v:test_type) where id(v)=="zhangshan" return v.test_type.t_str,v.test_type.t_int,v.test_type.t_date,v.test_type.t_datetime,v.test_type.t_bool,v.test_type.t_timestamp,v.test_type.t_float,v.test_type.t_double,v')\G;
+*************************** 1. row ***************************
+      t_str: zhangshan
+      t_int: 1000
+     t_date: 2023-01-01
+ t_datetime: 2023-01-23 15:23:32
+     t_bool: 1
+t_timestamp: 1234242423
+    t_float: 1.2000000476837158
+   t_double: 1.35
+    t_vertx: ("zhangshan" :test_type {t_datetime: utc datetime: 2023-01-23T15:23:32.000000, timezoneOffset: 0, t_timestamp: 1234242423, t_date: 2023-01-01, t_double: 1.35, t_str: "zhangshan", t_int: 1000, t_bool: true, t_float: 1.2000000476837158})
+1 row in set (0.024 sec)
+#2.3 与doris的其他表进行关联查询
+#假设有张用户表
+MySQL [test_db]> select * from t_user;
++-----------+------+---------------------------------+
+| username  | age  | addr                            |
++-----------+------+---------------------------------+
+| zhangshan |   26 | 北京市西二旗街道1008号          |
++-----------+------+---------------------------------+
+| lisi |   29 | 北京市西二旗街道1007号          |
++-----------+------+---------------------------------+
+1 row in set (0.013 sec)
+#与这张用表关联查询用户相关的信息
+MySQL [test_db]> select u.* from (select t_str username  from test_type where g('match (v:test_type) where id(v)=="zhangshan" return v.test_type.t_str limit 1')) g left join t_user u on g.username=u.username;
++-----------+------+---------------------------------+
+| username  | age  | addr                            |
++-----------+------+---------------------------------+
+| zhangshan |   26 | 北京市西二旗街道1008号          |
++-----------+------+---------------------------------+
+1 row in set (0.029 sec)
 ```
 
 ## 类型匹配
@@ -408,6 +498,16 @@ PROPERTIES (
 |     DOUBLE      |  DOUBLE  |
 |     DECIMAL     | DECIMAL  |
 
+### Nebula-graph
+|   nebula   |        Doris        |
+|:------------:|:-------------------:|
+|   tinyint/samllint/int/int64    |       bigint       |
+|   double/float    |       double       |
+|   date   |      date       |
+|   timestamp   |         bigint         |
+|    datetime    |       datetime        |
+| bool |  boolean  |
+|   vertex/edge/path/list/set/time等    |  varchar  |
 
 ## Q&A
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcResource.java
@@ -69,6 +69,7 @@ public class JdbcResource extends Resource {
     public static final String JDBC_CLICKHOUSE = "jdbc:clickhouse";
     public static final String JDBC_SAP_HANA = "jdbc:sap";
     public static final String JDBC_TRINO = "jdbc:trino";
+    public static final String JDBC_NEBULA = "jdbc:nebula";
 
     public static final String MYSQL = "MYSQL";
     public static final String POSTGRESQL = "POSTGRESQL";
@@ -77,6 +78,7 @@ public class JdbcResource extends Resource {
     public static final String CLICKHOUSE = "CLICKHOUSE";
     public static final String SAP_HANA = "SAP_HANA";
     public static final String TRINO = "TRINO";
+    public static final String NEBULA = "NEBULA";
 
     public static final String JDBC_PROPERTIES_PREFIX = "jdbc.";
     public static final String JDBC_URL = "jdbc_url";
@@ -270,6 +272,8 @@ public class JdbcResource extends Resource {
             return SAP_HANA;
         } else if (url.startsWith(JDBC_TRINO)) {
             return TRINO;
+        } else if (url.startsWith(JDBC_NEBULA)) {
+            return NEBULA;
         }
         throw new DdlException("Unsupported jdbc database type, please check jdbcUrl: " + url);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcTable.java
@@ -76,6 +76,7 @@ public class JdbcTable extends Table {
         tempMap.put("clickhouse", TOdbcTableType.CLICKHOUSE);
         tempMap.put("sap_hana", TOdbcTableType.SAP_HANA);
         tempMap.put("trino", TOdbcTableType.TRINO);
+        tempMap.put("nebula", TOdbcTableType.NEBULA);
         TABLE_TYPE_MAP = Collections.unmodifiableMap(tempMap);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/JdbcScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/JdbcScanNode.java
@@ -20,6 +20,7 @@ package org.apache.doris.planner;
 import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.ExprSubstitutionMap;
+import org.apache.doris.analysis.FunctionCallExpr;
 import org.apache.doris.analysis.SlotDescriptor;
 import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.analysis.TupleDescriptor;
@@ -53,6 +54,7 @@ public class JdbcScanNode extends ScanNode {
     private final List<String> filters = new ArrayList<String>();
     private String tableName;
     private TOdbcTableType jdbcType;
+    private String graphQueryString = "";
 
     public JdbcScanNode(PlanNodeId id, TupleDescriptor desc, boolean isJdbcExternalTable) {
         super(id, desc, "JdbcScanNode", StatisticalType.JDBC_SCAN_NODE);
@@ -71,6 +73,26 @@ public class JdbcScanNode extends ScanNode {
     public void init(Analyzer analyzer) throws UserException {
         super.init(analyzer);
         computeStats(analyzer);
+        getGraphQueryString();
+    }
+
+    private boolean isGraph() {
+        return jdbcType == TOdbcTableType.NEBULA;
+    }
+
+    private void getGraphQueryString() {
+        if (!isGraph()) {
+            return;
+        }
+        for (Expr expr : conjuncts) {
+            FunctionCallExpr functionCallExpr = (FunctionCallExpr) expr;
+            if ("g".equals(functionCallExpr.getFnName().getFunction())) {
+                graphQueryString = functionCallExpr.getChild(0).getStringValue();
+                break;
+            }
+        }
+        //clean conjusts cause graph sannnode no need conjuncts
+        conjuncts = Lists.newArrayList();
     }
 
     /**
@@ -130,6 +152,9 @@ public class JdbcScanNode extends ScanNode {
     }
 
     private String getJdbcQueryStr() {
+        if (isGraph()) {
+            return graphQueryString;
+        }
         StringBuilder sql = new StringBuilder("SELECT ");
 
         // Oracle use the where clause to do top n

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/JdbcScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/JdbcScanNode.java
@@ -76,12 +76,12 @@ public class JdbcScanNode extends ScanNode {
         getGraphQueryString();
     }
 
-    private boolean isGraph() {
+    private boolean isNebula() {
         return jdbcType == TOdbcTableType.NEBULA;
     }
 
     private void getGraphQueryString() {
-        if (!isGraph()) {
+        if (!isNebula()) {
             return;
         }
         for (Expr expr : conjuncts) {
@@ -152,7 +152,7 @@ public class JdbcScanNode extends ScanNode {
     }
 
     private String getJdbcQueryStr() {
-        if (isGraph()) {
+        if (isNebula()) {
             return graphQueryString;
         }
         StringBuilder sql = new StringBuilder("SELECT ");

--- a/fe/java-udf/pom.xml
+++ b/fe/java-udf/pom.xml
@@ -36,6 +36,11 @@ under the License.
     </properties>
     <dependencies>
         <dependency>
+            <groupId>com.vesoft</groupId>
+            <artifactId>client</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>fe-common</artifactId>
             <version>${project.version}</version>

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
@@ -860,13 +860,9 @@ public class JdbcExecutor {
             return;
         }
         if (column[firstNotNullIndex] instanceof BigDecimal) {
-            System.out.println("fuck1");
             bigDecimalPutToDouble(column, isNullable, numRows, nullMapAddr, columnAddr, firstNotNullIndex);
         } else if (column[firstNotNullIndex] instanceof Double) {
-            System.out.println("fuck2");
             doublePutToDouble(column, isNullable, numRows, nullMapAddr, columnAddr, firstNotNullIndex);
-        }else{
-            System.out.println("fuck3");
         }
     }
 

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
@@ -213,7 +213,7 @@ public class JdbcExecutor {
             do {
                 for (int i = 0; i < columnCount; ++i) {
                     if (isGraph()) {
-                        block.get(i)[curBlockRows] = tranferToDorisObject((ValueWrapper) resultSet.getObject(i + 1));
+                        block.get(i)[curBlockRows] = transferToObject((ValueWrapper) resultSet.getObject(i + 1));
                     } else {
                         block.get(i)[curBlockRows] = resultSet.getObject(i + 1);
                     }
@@ -1544,7 +1544,8 @@ public class JdbcExecutor {
     }
 
     // only used by nebula-graph
-    public static Object tranferToDorisObject(ValueWrapper value) {
+    // transfer to an object that can copy to the block
+    public static Object tranferToObject(ValueWrapper value) {
         try {
             if (value.isLong()) {
                 return value.asLong();

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
@@ -29,8 +29,6 @@ import com.clickhouse.data.value.UnsignedInteger;
 import com.clickhouse.data.value.UnsignedLong;
 import com.clickhouse.data.value.UnsignedShort;
 import com.google.common.base.Preconditions;
-import com.vesoft.nebula.client.graph.data.DateTimeWrapper;
-import com.vesoft.nebula.client.graph.data.DateWrapper;
 import com.vesoft.nebula.client.graph.data.ValueWrapper;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TDeserializer;
@@ -104,7 +102,7 @@ public class JdbcExecutor {
                 request.jdbc_url, request.jdbc_user, request.jdbc_password, request.op, request.table_type);
     }
 
-    public boolean isGraph() {
+    public boolean isNebula() {
         return tableType == TOdbcTableType.NEBULA;
     }
 
@@ -137,7 +135,7 @@ public class JdbcExecutor {
             resultColumnTypeNames = new ArrayList<>(columnCount);
             block = new ArrayList<>(columnCount);
             for (int i = 0; i < columnCount; ++i) {
-                if (!isGraph()) {
+                if (!isNebula()) {
                     resultColumnTypeNames.add(resultSetMetaData.getColumnClassName(i + 1));
                 }
                 block.add((Object[]) Array.newInstance(Object.class, batchSizeNum));
@@ -212,8 +210,8 @@ public class JdbcExecutor {
             curBlockRows = 0;
             do {
                 for (int i = 0; i < columnCount; ++i) {
-                    if (isGraph()) {
-                        block.get(i)[curBlockRows] = transferToObject((ValueWrapper) resultSet.getObject(i + 1));
+                    if (isNebula()) {
+                        block.get(i)[curBlockRows] = UdfUtils.convertObject((ValueWrapper) resultSet.getObject(i + 1));
                     } else {
                         block.get(i)[curBlockRows] = resultSet.getObject(i + 1);
                     }
@@ -271,6 +269,7 @@ public class JdbcExecutor {
             String jdbcPassword, TJdbcOperation op, TOdbcTableType tableType) throws UdfRuntimeException {
         try {
 <<<<<<< HEAD
+<<<<<<< HEAD
             ClassLoader parent = getClass().getClassLoader();
             ClassLoader classLoader = UdfUtils.getClassLoader(driverUrl, parent);
             druidDataSource = JdbcDataSource.getDataSource().getSource(jdbcUrl + jdbcUser + jdbcPassword);
@@ -310,6 +309,9 @@ public class JdbcExecutor {
 =======
             if (isGraph()) {
 >>>>>>> d038b048dc ([feature](graph)Support querying data from the Nebula graph database)
+=======
+            if (isNebula()) {
+>>>>>>> 3303ea56a5 ([feature](graph)Support querying data from the Nebula graph database)
                 batchSizeNum = batchSize;
                 Class.forName(driverClass);
                 conn = DriverManager.getConnection(jdbcUrl, jdbcUser, jdbcPassword);
@@ -1541,58 +1543,5 @@ public class JdbcExecutor {
             }
         }
         return i;
-    }
-
-    // only used by nebula-graph
-    // transfer to an object that can copy to the block
-    public static Object tranferToObject(ValueWrapper value) {
-        try {
-            if (value.isLong()) {
-                return value.asLong();
-            }
-            if (value.isBoolean()) {
-                return value.asBoolean();
-            }
-            if (value.isDouble()) {
-                return value.asDouble();
-            }
-            if (value.isString()) {
-                return value.asString();
-            }
-            if (value.isTime()) {
-                return value.asTime().toString();
-            }
-            if (value.isDate()) {
-                DateWrapper date = value.asDate();
-                return LocalDate.of(date.getYear(), date.getMonth(), date.getDay());
-            }
-            if (value.isDateTime()) {
-                DateTimeWrapper dateTime = value.asDateTime();
-                return LocalDateTime.of(dateTime.getYear(), dateTime.getMonth(), dateTime.getDay(),
-                        dateTime.getHour(), dateTime.getMinute(), dateTime.getSecond(), dateTime.getMicrosec() * 1000);
-            }
-
-            if (value.isVertex()) {
-                return value.asNode().toString();
-            }
-            if (value.isEdge()) {
-                return value.asRelationship().toString();
-            }
-            if (value.isPath()) {
-                return value.asPath().toString();
-            }
-            if (value.isList()) {
-                return value.asList().toString();
-            }
-            if (value.isSet()) {
-                return value.asSet().toString();
-            }
-            if (value.isMap()) {
-                return value.asMap().toString();
-            }
-            return null;
-        } catch (Exception e) {
-            return null;
-        }
     }
 }

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
@@ -92,8 +92,8 @@ public class JdbcExecutor {
         minPoolSize = Integer.valueOf(System.getProperty("JDBC_MIN_POOL", "1"));
         maxPoolSize = Integer.valueOf(System.getProperty("JDBC_MAX_POOL", "100"));
         maxIdelTime = Integer.valueOf(System.getProperty("JDBC_MAX_IDEL_TIME", "300000"));
-        tableType = request.table_type;
         minIdleSize = minPoolSize > 0 ? 1 : 0;
+        tableType = request.table_type;
         LOG.info("JdbcExecutor set minPoolSize = " + minPoolSize
                 + ", maxPoolSize = " + maxPoolSize
                 + ", maxIdelTime = " + maxIdelTime
@@ -268,55 +268,12 @@ public class JdbcExecutor {
     private void init(String driverUrl, String sql, int batchSize, String driverClass, String jdbcUrl, String jdbcUser,
             String jdbcPassword, TJdbcOperation op, TOdbcTableType tableType) throws UdfRuntimeException {
         try {
-<<<<<<< HEAD
-<<<<<<< HEAD
-            ClassLoader parent = getClass().getClassLoader();
-            ClassLoader classLoader = UdfUtils.getClassLoader(driverUrl, parent);
-            druidDataSource = JdbcDataSource.getDataSource().getSource(jdbcUrl + jdbcUser + jdbcPassword);
-            if (druidDataSource == null) {
-                DruidDataSource ds = new DruidDataSource();
-                ds.setDriverClassLoader(classLoader);
-                ds.setDriverClassName(driverClass);
-                ds.setUrl(jdbcUrl);
-                ds.setUsername(jdbcUser);
-                ds.setPassword(jdbcPassword);
-                ds.setMinIdle(minIdleSize);
-                ds.setInitialSize(minPoolSize);
-                ds.setMaxActive(maxPoolSize);
-                ds.setMaxWait(5000);
-                ds.setTestWhileIdle(true);
-                ds.setTestOnBorrow(false);
-                setValidationQuery(ds, tableType);
-                ds.setTimeBetweenEvictionRunsMillis(maxIdelTime / 5);
-                ds.setMinEvictableIdleTimeMillis(maxIdelTime);
-                druidDataSource = ds;
-                // here is a cache of datasource, which using the string(jdbcUrl + jdbcUser +
-                // jdbcPassword) as key.
-                // and the default datasource init = 1, min = 1, max = 100, if one of connection idle
-                // time greater than 10 minutes. then connection will be retrieved.
-                JdbcDataSource.getDataSource().putSource(jdbcUrl + jdbcUser + jdbcPassword, ds);
-            }
-            conn = druidDataSource.getConnection();
-            if (op == TJdbcOperation.READ) {
-                conn.setAutoCommit(false);
-                Preconditions.checkArgument(sql != null);
-                stmt = conn.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
-                if (tableType == TOdbcTableType.MYSQL) {
-                    stmt.setFetchSize(Integer.MIN_VALUE);
-                } else {
-                    stmt.setFetchSize(batchSize);
-                }
-=======
-            if (isGraph()) {
->>>>>>> d038b048dc ([feature](graph)Support querying data from the Nebula graph database)
-=======
             if (isNebula()) {
->>>>>>> 3303ea56a5 ([feature](graph)Support querying data from the Nebula graph database)
                 batchSizeNum = batchSize;
                 Class.forName(driverClass);
                 conn = DriverManager.getConnection(jdbcUrl, jdbcUser, jdbcPassword);
                 stmt = conn.prepareStatement(sql);
-            } else {
+            } else { 
                 ClassLoader parent = getClass().getClassLoader();
                 ClassLoader classLoader = UdfUtils.getClassLoader(driverUrl, parent);
                 druidDataSource = JdbcDataSource.getDataSource().getSource(jdbcUrl + jdbcUser + jdbcPassword);

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/UdfUtils.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/UdfUtils.java
@@ -29,6 +29,9 @@ import org.apache.doris.thrift.TTypeNode;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
+import com.vesoft.nebula.client.graph.data.DateTimeWrapper;
+import com.vesoft.nebula.client.graph.data.DateWrapper;
+import com.vesoft.nebula.client.graph.data.ValueWrapper;
 import org.apache.log4j.Logger;
 import sun.misc.Unsafe;
 
@@ -583,5 +586,57 @@ public class UdfUtils {
             bytes[length - 1 - i] = temp;
         }
         return bytes;
+    }
+
+    // only used by nebula-graph
+    // transfer to an object that can copy to the block
+    public static Object convertObject(ValueWrapper value) {
+        try {
+            if (value.isLong()) {
+                return value.asLong();
+            }
+            if (value.isBoolean()) {
+                return value.asBoolean();
+            }
+            if (value.isDouble()) {
+                return value.asDouble();
+            }
+            if (value.isString()) {
+                return value.asString();
+            }
+            if (value.isTime()) {
+                return value.asTime().toString();
+            }
+            if (value.isDate()) {
+                DateWrapper date = value.asDate();
+                return LocalDate.of(date.getYear(), date.getMonth(), date.getDay());
+            }
+            if (value.isDateTime()) {
+                DateTimeWrapper dateTime = value.asDateTime();
+                return LocalDateTime.of(dateTime.getYear(), dateTime.getMonth(), dateTime.getDay(),
+                        dateTime.getHour(), dateTime.getMinute(), dateTime.getSecond(), dateTime.getMicrosec() * 1000);
+            }
+            if (value.isVertex()) {
+                return value.asNode().toString();
+            }
+            if (value.isEdge()) {
+                return value.asRelationship().toString();
+            }
+            if (value.isPath()) {
+                return value.asPath().toString();
+            }
+            if (value.isList()) {
+                return value.asList().toString();
+            }
+            if (value.isSet()) {
+                return value.asSet().toString();
+            }
+            if (value.isMap()) {
+                return value.asMap().toString();
+            }
+            return null;
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/gensrc/script/doris_builtins_functions.py
+++ b/gensrc/script/doris_builtins_functions.py
@@ -1445,6 +1445,9 @@ visible_functions = [
     [['esquery'], 'BOOLEAN', ['STRING', 'VARCHAR'], ''],
     [['esquery'], 'BOOLEAN', ['VARIANT', 'VARCHAR'], ''],
 
+    # used for accept graph sql
+    [['g'], 'BOOLEAN', ['VARCHAR'], ''],
+
     # String builtin functions
     [['substr', 'substring'], 'VARCHAR', ['VARCHAR', 'INT'], 'ALWAYS_NULLABLE'],
     [['substr', 'substring'], 'VARCHAR', ['VARCHAR', 'INT', 'INT'], 'ALWAYS_NULLABLE'],

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -384,7 +384,8 @@ enum TOdbcTableType {
     MONGODB,
     CLICKHOUSE,
     SAP_HANA,
-    TRINO
+    TRINO,
+    NEBULA
 }
 
 struct TJdbcExecutorCtorParams {


### PR DESCRIPTION
# Proposed changes

## Problem summary
Support querying data from the Nebula graph database 
This feature comes from the needs of commercial customers who have used Doris and Nebula, hoping to connect these two databases

changes mainly include:
- add  New Graph Database JDBC Type 
- Adapt the type and map the graph to the Doris type

# How to use ?

### Nebula-graph type map
|   nebula   |        Doris        |
|:------------:|:-------------------:|
|   tinyint/samllint/int/int64    |       bigint       |
|   double/float    |       double       |
|   date   |      date       |
|   timestamp   |         bigint         |
|    datetime    |       datetime        |
| bool |  boolean  |
|   vertex/edge/path/list/set/time等    |  varchar  |


### NebulaGraphTest （仅支持查询）
| nebula版本 | JDBC驱动版本 |
|------------|-------------------|
| 3.0.0       | nebula-jdbc-3.0.0-jar-with-dependencies.jar         |



```
#step1.在nebula创建测试数据
#1.1 创建结点
(root@nebula) [basketballplayer]> CREATE TAG test(t_str string, 
    t_int int, 
    t_date date,
    t_datetime datetime,
    t_bool bool,
    t_timestamp timestamp,
    t_float float,
    t_double double
);

#1.2 插入数据
(root@nebula) [basketballplayer]> INSERT VERTEX test_type(t_str,t_int,t_date,t_datetime,t_bool,t_timestamp,t_float,t_double) values "zhangshan":("zhangshan",1000,date("2023-01-01"),datetime("2023-01-23 15:23:32"),true,1234242423,1.2,1.35);

#1.3 查询数据
(root@nebula) [basketballplayer]> match (v:test_type) where id(v)=="zhangshan" return v.test_type.t_str,v.test_type.t_int,v.test_type.t_date,v.test_type.t_datetime,v.test_type.t_bool,v.test_type.t_timestamp,v.test_type.t_float,v.test_type.t_double,v limit 30;
+-------------------+-------------------+--------------------+----------------------------+--------------------+-------------------------+---------------------+----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| v.test_type.t_str | v.test_type.t_int | v.test_type.t_date | v.test_type.t_datetime     | v.test_type.t_bool | v.test_type.t_timestamp | v.test_type.t_float | v.test_type.t_double | v                                                                                                                                                                                                         |
+-------------------+-------------------+--------------------+----------------------------+--------------------+-------------------------+---------------------+----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| "zhangshan"       | 1000              | 2023-01-01         | 2023-01-23T15:23:32.000000 | true               | 1234242423              | 1.2000000476837158  | 1.35                 | ("zhangshan" :test_type{t_bool: true, t_date: 2023-01-01, t_datetime: 2023-01-23T15:23:32.000000, t_double: 1.35, t_float: 1.2000000476837158, t_int: 1000, t_str: "zhangshan", t_timestamp: 1234242423}) |
+-------------------+-------------------+--------------------+----------------------------+--------------------+-------------------------+---------------------+----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
Got 1 rows (time spent 1616/2048 us)

Mon, 17 Apr 2023 17:23:14 CST


#step2.在doris中创建外表
#2.1 创建一个resource
MySQL [test_db]> CREATE EXTERNAL RESOURCE gg_jdbc_resource 
properties (
   "type"="jdbc",
   "user"="root",
   "password"="123",
   "jdbc_url"="jdbc:nebula://127.0.0.1:9669/basketballplayer",
   "driver_url"="file:///home/clz/baidu/bdg/doris/be/lib/nebula-jdbc-3.0.0-jar-with-dependencies.jar",  --仅支持本地路径，需放到be/lib目录下--
   "driver_class"="com.vesoft.nebula.jdbc.NebulaDriver"
);

#2.2 创建一个外表，这个主要是告诉doris如何解析nebulagraph返回的数据
MySQL [test_db]> CREATE TABLE `test_type` ( 
 `t_str` varchar(64),
 `t_int` bigint,
 `t_date` date,
 `t_datetime` datetime,
 `t_bool` boolean,
 `t_timestamp` bigint,
 `t_float` double,
 `t_double` double,
 `t_vertx`  varchar(128) --vertex对应doris类型是varchar---
) ENGINE=JDBC
PROPERTIES (
"resource" = "gg_jdbc_resource",
"table" = "xx",  --因为graph没有表的概念，这里随便填一个值--
"table_type"="nebula"
);

#2.3 查询graph外表,用g()函数把图的nGQL透传给nebula
MySQL [test_db]> select * from test_type where g('match (v:test_type) where id(v)=="zhangshan" return v.test_type.t_str,v.test_type.t_int,v.test_type.t_date,v.test_type.t_datetime,v.test_type.t_bool,v.test_type.t_timestamp,v.test_type.t_float,v.test_type.t_double,v')\G;
*************************** 1. row ***************************
      t_str: zhangshan
      t_int: 1000
     t_date: 2023-01-01
 t_datetime: 2023-01-23 15:23:32
     t_bool: 1
t_timestamp: 1234242423
    t_float: 1.2000000476837158
   t_double: 1.35
    t_vertx: ("zhangshan" :test_type {t_datetime: utc datetime: 2023-01-23T15:23:32.000000, timezoneOffset: 0, t_timestamp: 1234242423, t_date: 2023-01-01, t_double: 1.35, t_str: "zhangshan", t_int: 1000, t_bool: true, t_float: 1.2000000476837158})
1 row in set (0.024 sec)

#2.3 与doris的其他表进行关联查询
#假设有张用户表
MySQL [test_db]> select * from t_user;
+-----------+------+---------------------------------+
| username  | age  | addr                            |
+-----------+------+---------------------------------+
| zhangshan |   26 | 北京市西二旗街道1008号          |
+-----------+------+---------------------------------+
| lisi |   29 | 北京市西二旗街道1007号          |
+-----------+------+---------------------------------+
1 row in set (0.013 sec)

#与这张用表关联查询用户相关的信息
MySQL [test_db]> select u.* from (select t_str username  from test_type where g('match (v:test_type) where id(v)=="zhangshan" return v.test_type.t_str limit 1')) g left join t_user u on g.username=u.username;
+-----------+------+---------------------------------+
| username  | age  | addr                            |
+-----------+------+---------------------------------+
| zhangshan |   26 | 北京市西二旗街道1008号          |
+-----------+------+---------------------------------+
1 row in set (0.029 sec)

```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

