### PR TITLE
[opt](nereids)runtime filter resize

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterTranslator.java
@@ -34,7 +34,6 @@ import org.apache.doris.planner.HashJoinNode;
 import org.apache.doris.planner.HashJoinNode.DistributionMode;
 import org.apache.doris.planner.JoinNodeBase;
 import org.apache.doris.planner.RuntimeFilter.RuntimeFilterTarget;
-import org.apache.doris.planner.RuntimeFilterGenerator.FilterSizeLimits;
 import org.apache.doris.planner.ScanNode;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.thrift.TRuntimeFilterType;
@@ -126,12 +125,11 @@ public class RuntimeFilterTranslator {
         if (!src.getType().equals(target.getType()) && filter.getType() != TRuntimeFilterType.BITMAP) {
             targetExpr = new CastExpr(src.getType(), targetExpr);
         }
-        FilterSizeLimits filterSizeLimits = context.getLimits();
         org.apache.doris.planner.RuntimeFilter origFilter
                 = org.apache.doris.planner.RuntimeFilter.fromNereidsRuntimeFilter(
                 filter.getId(), node, src, filter.getExprOrder(), targetExpr,
                 ImmutableMap.of(targetTupleId, ImmutableList.of(targetSlotId)),
-                filter.getType(), filterSizeLimits);
+                filter.getType(), context.getLimits(), filter.getBuildSideNdv());
         if (node instanceof HashJoinNode) {
             origFilter.setIsBroadcast(((HashJoinNode) node).getDistributionMode() == DistributionMode.BROADCAST);
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -174,6 +174,13 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
         */
         if (originStats == null || originStats.getRowCount() > stats.getRowCount()) {
             groupExpression.getOwnerGroup().setStatistics(stats);
+        } else {
+            if (originStats.getRowCount() > stats.getRowCount()) {
+                stats.updateNdv(originStats);
+                groupExpression.getOwnerGroup().setStatistics(stats);
+            } else {
+                originStats.updateNdv(stats);
+            }
         }
         groupExpression.setEstOutputRowCount(stats.getRowCount());
         groupExpression.setStatDerived(true);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsMathUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsMathUtil.java
@@ -58,5 +58,4 @@ public class StatsMathUtil {
         }
         return a / nonZeroDivisor(b);
     }
-
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/RuntimeFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/RuntimeFilter.java
@@ -32,27 +32,29 @@ public class RuntimeFilter {
     private final Expression srcSlot;
     //bitmap filter support target expression like  k1+1, abs(k1)
     //targetExpression is an expression on targetSlot, in which there is only one non-const slot
-    private Expression targetExpression;
-    private Slot targetSlot;
+    private final Expression targetExpression;
+    private final Slot targetSlot;
     private final int exprOrder;
-    private AbstractPhysicalJoin builderNode;
+    private final AbstractPhysicalJoin builderNode;
 
-    private boolean bitmapFilterNotIn;
+    private final boolean bitmapFilterNotIn;
+
+    private final long buildSideNdv;
 
     /**
      * constructor
      */
     public RuntimeFilter(RuntimeFilterId id, Expression src, Slot target, TRuntimeFilterType type,
-            int exprOrder, AbstractPhysicalJoin builderNode) {
-        this(id, src, target, target, type, exprOrder, builderNode, false);
+            int exprOrder, AbstractPhysicalJoin builderNode, long buildSideNdv) {
+        this(id, src, target, target, type, exprOrder, builderNode, false, buildSideNdv);
     }
 
     /**
      * constructor
      */
     public RuntimeFilter(RuntimeFilterId id, Expression src, Slot target, Expression targetExpression,
-            TRuntimeFilterType type,
-            int exprOrder, AbstractPhysicalJoin builderNode, boolean bitmapFilterNotIn) {
+            TRuntimeFilterType type, int exprOrder, AbstractPhysicalJoin builderNode, boolean bitmapFilterNotIn,
+            long buildSideNdv) {
         this.id = id;
         this.srcSlot = src;
         this.targetSlot = target;
@@ -61,6 +63,7 @@ public class RuntimeFilter {
         this.exprOrder = exprOrder;
         this.builderNode = builderNode;
         this.bitmapFilterNotIn = bitmapFilterNotIn;
+        this.buildSideNdv = buildSideNdv <= 0 ? -1L : buildSideNdv;
     }
 
     public Expression getSrcExpr() {
@@ -95,4 +98,7 @@ public class RuntimeFilter {
         return targetExpression;
     }
 
+    public long getBuildSideNdv() {
+        return buildSideNdv;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
@@ -317,6 +317,14 @@ public abstract class PlanNode extends TreeNode<PlanNode> implements PlanStats {
         return cardinality;
     }
 
+    public long getCardinalityAfterFilter() {
+        if (cardinalityAfterFilter < 0) {
+            return cardinality;
+        } else {
+            return cardinalityAfterFilter;
+        }
+    }
+
     public int getNumNodes() {
         return numNodes;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -146,6 +146,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String RUNTIME_BLOOM_FILTER_MIN_SIZE = "runtime_bloom_filter_min_size";
     // Maximum runtime bloom filter size, in bytes
     public static final String RUNTIME_BLOOM_FILTER_MAX_SIZE = "runtime_bloom_filter_max_size";
+    public static final String USE_RF_DEFAULT = "use_rf_default";
     // Time in ms to wait until runtime filters are delivered.
     public static final String RUNTIME_FILTER_WAIT_TIME_MS = "runtime_filter_wait_time_ms";
     // Maximum number of bloom runtime filters allowed per query

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
@@ -211,4 +211,20 @@ public class Statistics {
         return colStats.isUnKnown;
     }
 
+    /**
+     * merge this and other colStats.ndv, choose min
+     * @param other
+     */
+    public void updateNdv(Statistics other) {
+        for (Expression expr : expressionToColumnStats.keySet()) {
+            ColumnStatistic otherColStats = other.findColumnStatistics(expr);
+            if (otherColStats != null) {
+                ColumnStatistic thisColStats = expressionToColumnStats.get(expr);
+                if (thisColStats.ndv > otherColStats.ndv) {
+                    expressionToColumnStats.put(expr,
+                            new ColumnStatisticBuilder(thisColStats).setNdv(otherColStats.ndv).build());
+                }
+            }
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/JoinEstimateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/JoinEstimateTest.java
@@ -1,0 +1,94 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.stats;
+
+import org.apache.doris.common.IdGenerator;
+import org.apache.doris.nereids.memo.Group;
+import org.apache.doris.nereids.memo.GroupId;
+import org.apache.doris.nereids.properties.LogicalProperties;
+import org.apache.doris.nereids.trees.expressions.EqualTo;
+import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.plans.GroupPlan;
+import org.apache.doris.nereids.trees.plans.JoinType;
+import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
+import org.apache.doris.nereids.types.IntegerType;
+import org.apache.doris.statistics.ColumnStatistic;
+import org.apache.doris.statistics.ColumnStatisticBuilder;
+import org.apache.doris.statistics.Statistics;
+import org.apache.doris.statistics.StatisticsBuilder;
+
+import com.google.common.base.Supplier;
+import com.google.common.collect.Lists;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class JoinEstimateTest {
+
+    /*
+    L join R on a=b
+    after join
+    a.ndv = b.ndv
+     */
+    @Test
+    public void testInnerJoinStats() {
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
+        EqualTo eq = new EqualTo(a, b);
+        Statistics leftStats = new StatisticsBuilder().setRowCount(100).build();
+        leftStats.addColumnStats(a,
+                new ColumnStatisticBuilder()
+                        .setCount(100)
+                        .setNdv(10)
+                        .build()
+        );
+        Statistics rightStats = new StatisticsBuilder().setRowCount(80).build();
+        rightStats.addColumnStats(b,
+                new ColumnStatisticBuilder()
+                        .setCount(80)
+                        .setNdv(5)
+                        .build()
+        );
+        IdGenerator<GroupId> idGenerator = GroupId.createGenerator();
+        GroupPlan left = new GroupPlan(new Group(idGenerator.getNextId(), new LogicalProperties(
+                new Supplier<List<Slot>>() {
+                    @Override
+                    public List<Slot> get() {
+                        return Lists.newArrayList(a);
+                    }
+                })));
+        GroupPlan right = new GroupPlan(new Group(idGenerator.getNextId(), new LogicalProperties(
+                new Supplier<List<Slot>>() {
+                    @Override
+                    public List<Slot> get() {
+                        return Lists.newArrayList(b);
+                    }
+                })));
+        LogicalJoin join = new LogicalJoin(JoinType.INNER_JOIN, Lists.newArrayList(eq),
+                left, right);
+        Statistics outputStats = JoinEstimation.estimate(leftStats, rightStats, join);
+        ColumnStatistic outAStats = outputStats.findColumnStatistics(a);
+        Assertions.assertNotNull(outAStats);
+        Assertions.assertEquals(5, outAStats.ndv);
+        ColumnStatistic outBStats = outputStats.findColumnStatistics(b);
+        Assertions.assertNotNull(outAStats);
+        Assertions.assertEquals(5, outBStats.ndv);
+    }
+}


### PR DESCRIPTION
compute filter size by build side ndv.
test result
for tpch 1T, improved by about 40 sec
cold run: 383sec to 349 sec
hot run: 306sec to 268 sec

for tpch 500, no improvement.
cold run: 163 sec to 164 sec
hot run: 120 sec to 121 sec

![image](https://github.com/apache/doris/assets/1747806/a78fa56f-d049-4807-aaad-95846ef0d2c0)



Issue Number: close #xxx1

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

