### PR TITLE
[fix](planner) Failed to create table with CTAS when multiple varchar type filed as key

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -43,6 +43,7 @@ import org.apache.doris.analysis.DropDbStmt;
 import org.apache.doris.analysis.DropPartitionClause;
 import org.apache.doris.analysis.DropTableStmt;
 import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.FunctionCallExpr;
 import org.apache.doris.analysis.HashDistributionDesc;
 import org.apache.doris.analysis.KeysDesc;
 import org.apache.doris.analysis.LinkDbStmt;
@@ -1221,6 +1222,7 @@ public class InternalCatalog implements CatalogIf<Database> {
             List<String> columnNames = stmt.getColumnNames();
             CreateTableStmt createTableStmt = stmt.getCreateTableStmt();
             QueryStmt queryStmt = stmt.getQueryStmt();
+            KeysDesc keysDesc = createTableStmt.getKeysDesc();
             ArrayList<Expr> resultExprs = queryStmt.getResultExprs();
             ArrayList<String> colLabels = queryStmt.getColLabels();
             int size = resultExprs.size();
@@ -1242,7 +1244,11 @@ public class InternalCatalog implements CatalogIf<Database> {
                 TypeDef typeDef;
                 Expr resultExpr = resultExprs.get(i);
                 Type resultType = resultExpr.getType();
-                if (resultType.isStringType()) {
+                if (resultExpr instanceof FunctionCallExpr
+                        && resultExpr.getType().getPrimitiveType().equals(PrimitiveType.VARCHAR)) {
+                    resultType = ScalarType.createVarchar(65533);
+                }
+                if (resultType.isStringType() && (keysDesc == null || !keysDesc.containsCol(name))) {
                     // Use String for varchar/char/string type,
                     // to avoid char-length-vs-byte-length issue.
                     typeDef = new TypeDef(ScalarType.createStringType());

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableAsSelectStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableAsSelectStmtTest.java
@@ -473,7 +473,7 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
         ShowResultSet showResultSet = showCreateTableByName("test_use_key_type");
         Assertions.assertEquals(
                 "CREATE TABLE `test_use_key_type` (\n"
-                        + "  `userId` varchar(65533) NOT NULL,\n"
+                        + "  `userId` varchar(255) NOT NULL,\n"
                         + "  `username` text NOT NULL\n"
                         + ") ENGINE=OLAP\n"
                         + "UNIQUE KEY(`userId`)\n"

--- a/regression-test/suites/ddl_p0/test_ctas.groovy
+++ b/regression-test/suites/ddl_p0/test_ctas.groovy
@@ -107,6 +107,51 @@ suite("test_ctas") {
             rowNum 6
         }
 
+        sql """
+            create table if not exists test_tbl_81748325
+            (
+                `col1`        varchar(66) not null ,
+                `col2`      bigint      not null ,
+                `col3`  varchar(66) not null ,
+                `col4`  varchar(42) not null ,
+                `col5` bigint      not null ,
+                `col6`         bigint      not null ,
+                `col7`        datetime    not null ,
+                `col8`            varchar(66) not null, 
+                `col9`            varchar(66)          ,
+                `col10`            varchar(66)          ,
+                `col11`            varchar(66)          ,
+                `col12`              text                 
+            )
+            UNIQUE KEY (`col1`,`col2`,`col3`,`col4`,`col5`,`col6`)
+            DISTRIBUTED BY HASH(`col4`) BUCKETS 1
+            PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1"
+            );
+        """
+
+        sql """
+            create table `test_tbl_3156019`
+            UNIQUE KEY (col4,col3,from_address,to_address)
+            DISTRIBUTED BY HASH (col4) BUCKETS 1
+            PROPERTIES (
+                  "replication_allocation" = "tag.location.default: 1"
+            )
+           as 
+            select
+                col4                                as col4,
+                col3                                as col3,
+                concat('0x', substring(col9, 27))             as from_address,
+                concat('0x', substring(col10, 27))             as to_address,
+                col7                                      as date_time,
+                now()                                           as update_time,
+                '20230318'                                      as pt,
+                col8                                            as amount
+            from test_tbl_81748325
+            where col4 = '43815251'
+              and substring(col8, 1, 10) = '1451601';
+        """
+
     } finally {
         sql """ DROP TABLE IF EXISTS test_ctas """
 
@@ -119,6 +164,10 @@ suite("test_ctas") {
         sql """ DROP TABLE IF EXISTS test_ctas_json_object1 """
 
         sql """drop table if exists a"""
+
+        sql """DROP TABLE IF EXISTS test_tbl_81748325"""
+
+        sql """DROP TABLE IF EXISTS test_tbl_3156019"""
     }
 
 }


### PR DESCRIPTION
# Proposed changes

Add restricton for converting varchar/char to string type, only fields that is string type and not in key desc could be convert to string type now.

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

