### PR TITLE
[fix](schema_change) remove shadow prefix of schema for tablesink

### DIFF
--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -1718,9 +1718,10 @@ Status SchemaChangeHandler::_parse_request(const SchemaChangeParams& sc_params,
             continue;
         }
 
-        if (column_name.find_first_of("__doris_shadow_") == 0) {
+        if (column_name.find("__doris_shadow_") == 0) {
             // Should delete in the future, just a protection for bug.
-            return Status::InternalError("failed due to operate on shadow");
+            LOG(INFO) << "a shadow column is encountered " << column_name;
+            return Status::InternalError("failed due to operate on shadow column");
         }
         // Newly added column go here
         column_mapping->ref_column = -1;

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -1712,7 +1712,7 @@ Status SchemaChangeHandler::_parse_request(const SchemaChangeParams& sc_params,
             }
         }
 
-        int32_t column_index = base_tablet_schema->field_index( std::string_view(column_name));
+        int32_t column_index = base_tablet_schema->field_index(std::string_view(column_name));
         if (column_index >= 0) {
             column_mapping->ref_column = column_index;
             continue;
@@ -1724,7 +1724,6 @@ Status SchemaChangeHandler::_parse_request(const SchemaChangeParams& sc_params,
         }
         // Newly added column go here
         column_mapping->ref_column = -1;
-
 
         if (i < base_tablet_schema->num_short_key_columns()) {
             *sc_directly = true;

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -1693,7 +1693,7 @@ Status SchemaChangeHandler::_parse_request(const SchemaChangeParams& sc_params,
     for (int i = 0, new_schema_size = new_tablet->tablet_schema()->num_columns();
          i < new_schema_size; ++i) {
         const TabletColumn& new_column = new_tablet->tablet_schema()->column(i);
-        const string& column_name = new_column.name();
+        const std::string& column_name = new_column.name();
         ColumnMapping* column_mapping = changer->get_mutable_column_mapping(i);
         column_mapping->new_column = &new_column;
 
@@ -1712,13 +1712,13 @@ Status SchemaChangeHandler::_parse_request(const SchemaChangeParams& sc_params,
             }
         }
 
-        int32_t column_index = base_tablet_schema->field_index(std::string_view(column_name));
+        int32_t column_index = base_tablet_schema->field_index(column_name);
         if (column_index >= 0) {
             column_mapping->ref_column = column_index;
             continue;
         }
 
-        if (column_name.starts_with("__doris_shadow_")) {
+        if (column_name.find_first_of("__doris_shadow_") == 0) {
             // Should delete in the future, just a protection for bug.
             return Status::InternalError("failed due to operate on shadow");
         }

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -456,6 +456,8 @@ public:
         return config::max_tablet_io_errors > 0 && _io_error_times >= config::max_tablet_io_errors;
     }
 
+    int64_t get_table_id() { return _tablet_meta->table_id(); }
+
 private:
     Status _init_once_action();
     void _print_missed_versions(const std::vector<Version>& missed_versions) const;

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -698,6 +698,7 @@ public class SchemaChangeHandler extends AlterHandler {
              */
             modColumn.setName(SHADOW_NAME_PREFIX + modColumn.getName());
         }
+        LOG.info("modify column {} ", modColumn);
         return lightSchemaChange;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Column.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Column.java
@@ -270,6 +270,10 @@ public class Column implements Writable, GsonPostProcessable {
         return this.name;
     }
 
+    public String getNonShadowName() {
+        return removeNamePrefix(name);
+    }
+
     public String getNameWithoutMvPrefix() {
         return CreateMaterializedViewStmt.mvColumnBreaker(name);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
@@ -212,7 +212,7 @@ public class OlapTableSink extends DataSink {
             List<String> columns = Lists.newArrayList();
             List<TColumn> columnsDesc = Lists.newArrayList();
             List<TOlapTableIndex> indexDesc = Lists.newArrayList();
-            columns.addAll(indexMeta.getSchema().stream().map(Column::getName).collect(Collectors.toList()));
+            columns.addAll(indexMeta.getSchema().stream().map(Column::getNonShadowName).collect(Collectors.toList()));
             for (Column column : indexMeta.getSchema()) {
                 TColumn tColumn = column.toThrift();
                 column.setIndexFlag(tColumn, table);

--- a/regression-test/suites/schema_change_p0/decimalv3/test_agg_keys_schema_change_decimalv3.groovy
+++ b/regression-test/suites/schema_change_p0/decimalv3/test_agg_keys_schema_change_decimalv3.groovy
@@ -21,6 +21,7 @@ suite("test_agg_keys_schema_change_decimalv3") {
     def tbName = "test_agg_keys_schema_change_decimalv3"
     def getJobState = { tableName ->
          def jobStateResult = sql """  SHOW ALTER TABLE COLUMN WHERE IndexName='${tableName}' ORDER BY createtime DESC LIMIT 1 """
+         logger.info(jobStateResult.toString());
          return jobStateResult[0][9]
     }
 


### PR DESCRIPTION
LSC updates tablet's schema in writing. Be optimized adding columns via linked schema change and it distinguishes adding by comparing column name. e.g. if new column's name is not found in old schema, then it is a newly-add column.

When a table is under schema-changing, it adds __doris_shadow_ prefix in name of columns in shadow index. Then  writes during schema-changing would bring schema with __doris_shadow_ to be. If schema change request arrives at be after writes, then be do it as a add-column schema change due to __doris_shadow_ is not in base tablet.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

