### PR TITLE
[refactor](exceptionsafe) disallow call new method explicitly

### DIFF
--- a/be/src/common/factory_creator.h
+++ b/be/src/common/factory_creator.h
@@ -34,21 +34,21 @@
 // Not use template like cowhelper to implements this feature because it has problem
 // during inherits
 // TODO try to allow make_unique
-#define ENABLE_FACTORY_CREATOR(TypeName)                                                           \
-private:                                                                                           \
-    void* operator new(std::size_t size) { return ::operator new(size); }                          \
-    void* operator new[](std::size_t size) { return ::operator new[](size); }                      \
-                                                                                                   \
-public:                                                                                            \
-    void* operator new(std::size_t count, void* ptr) { return ::operator new(count, ptr); }        \
-    void operator delete(void* ptr, std::size_t size) { return ::operator delete(ptr, size); }     \
-    void operator delete[](void* ptr, std::size_t size) { return ::operator delete[](ptr, size); } \
-    void operator delete(void* ptr, void* place) { return ::operator delete(ptr, place); }         \
-    template <typename... Args>                                                                    \
-    static std::shared_ptr<TypeName> create_shared(Args&&... args) {                               \
-        return std::make_shared<TypeName>(std::forward<Args>(args)...);                            \
-    }                                                                                              \
-    template <typename... Args>                                                                    \
-    static std::unique_ptr<TypeName> create_unique(Args&&... args) {                               \
-        return std::unique_ptr<TypeName>(new TypeName(std::forward<Args>(args)...));               \
+#define ENABLE_FACTORY_CREATOR(TypeName)                                                    \
+private:                                                                                    \
+    void* operator new(std::size_t size) { return ::operator new(size); }                   \
+    void* operator new[](std::size_t size) { return ::operator new[](size); }               \
+                                                                                            \
+public:                                                                                     \
+    void* operator new(std::size_t count, void* ptr) { return ::operator new(count, ptr); } \
+    void operator delete(void* ptr, std::size_t size) { ::operator delete(ptr, size); }     \
+    void operator delete[](void* ptr, std::size_t size) { ::operator delete[](ptr, size); } \
+    void operator delete(void* ptr, void* place) { ::operator delete(ptr, place); }         \
+    template <typename... Args>                                                             \
+    static std::shared_ptr<TypeName> create_shared(Args&&... args) {                        \
+        return std::make_shared<TypeName>(std::forward<Args>(args)...);                     \
+    }                                                                                       \
+    template <typename... Args>                                                             \
+    static std::unique_ptr<TypeName> create_unique(Args&&... args) {                        \
+        return std::unique_ptr<TypeName>(new TypeName(std::forward<Args>(args)...));        \
     }\

--- a/be/src/common/factory_creator.h
+++ b/be/src/common/factory_creator.h
@@ -52,4 +52,4 @@ public:                                                                         
     template <typename... Args>                                                              \
     static std::unique_ptr<TypeName> create_unique(Args&&... args) {                         \
         return std::unique_ptr<TypeName>(new TypeName(std::forward<Args>(args)...));         \
-    }\
+    }

--- a/be/src/common/factory_creator.h
+++ b/be/src/common/factory_creator.h
@@ -34,21 +34,21 @@
 // Not use template like cowhelper to implements this feature because it has problem
 // during inherits
 // TODO try to allow make_unique
-#define ENABLE_FACTORY_CREATOR(TypeName)                                                       \
-private:                                                                                       \
-    void* operator new(std::size_t size) { return ::operator new(size); }                      \
-    void* operator new[](std::size_t size) { return ::operator new(size); }                    \
-                                                                                               \
-public:                                                                                        \
-    void* operator new(std::size_t count, void* ptr) { return ::operator new(count, ptr); }    \
-    void operator delete(void* ptr, std::size_t size) { return ::operator delete(ptr, size); } \
-    void operator delete[](void* ptr, std::size_t sz) { return ::operator delete(ptr, size); } \
-    void operator delete(void* ptr, void* place) { return ::operator delete(ptr, place) }      \
-    template <typename... Args>                                                                \
-    static std::shared_ptr<TypeName> create_shared(Args&&... args) {                           \
-        return std::make_shared<TypeName>(std::forward<Args>(args)...);                        \
-    }                                                                                          \
-    template <typename... Args>                                                                \
-    static std::unique_ptr<TypeName> create_unique(Args&&... args) {                           \
-        return std::unique_ptr<TypeName>(new TypeName(std::forward<Args>(args)...));           \
+#define ENABLE_FACTORY_CREATOR(TypeName)                                                         \
+private:                                                                                         \
+    void* operator new(std::size_t size) { return ::operator new(size); }                        \
+    void* operator new[](std::size_t size) { return ::operator new(size); }                      \
+                                                                                                 \
+public:                                                                                          \
+    void* operator new(std::size_t count, void* ptr) { return ::operator new(count, ptr); }      \
+    void operator delete(void* ptr, std::size_t size) { return ::operator delete(ptr, size); }   \
+    void operator delete[](void* ptr, std::size_t size) { return ::operator delete(ptr, size); } \
+    void operator delete(void* ptr, void* place) { return ::operator delete(ptr, place) }        \
+    template <typename... Args>                                                                  \
+    static std::shared_ptr<TypeName> create_shared(Args&&... args) {                             \
+        return std::make_shared<TypeName>(std::forward<Args>(args)...);                          \
+    }                                                                                            \
+    template <typename... Args>                                                                  \
+    static std::unique_ptr<TypeName> create_unique(Args&&... args) {                             \
+        return std::unique_ptr<TypeName>(new TypeName(std::forward<Args>(args)...));             \
     }\

--- a/be/src/common/factory_creator.h
+++ b/be/src/common/factory_creator.h
@@ -34,18 +34,21 @@
 // Not use template like cowhelper to implements this feature because it has problem
 // during inherits
 // TODO try to allow make_unique
-#define ENABLE_FACTORY_CREATOR(TypeName)                                                    \
-private:                                                                                    \
-    void* operator new(std::size_t size) { return ::operator new(size); }                   \
-    void* operator new[](std::size_t size) { return ::operator new(size); }                 \
-                                                                                            \
-public:                                                                                     \
-    void* operator new(std::size_t count, void* ptr) { return ::operator new(count, ptr); } \
-    template <typename... Args>                                                             \
-    static std::shared_ptr<TypeName> create_shared(Args&&... args) {                        \
-        return std::make_shared<TypeName>(std::forward<Args>(args)...);                     \
-    }                                                                                       \
-    template <typename... Args>                                                             \
-    static std::unique_ptr<TypeName> create_unique(Args&&... args) {                        \
-        return std::unique_ptr<TypeName>(new TypeName(std::forward<Args>(args)...));        \
-    }
+#define ENABLE_FACTORY_CREATOR(TypeName)                                                       \
+private:                                                                                       \
+    void* operator new(std::size_t size) { return ::operator new(size); }                      \
+    void* operator new[](std::size_t size) { return ::operator new(size); }                    \
+                                                                                               \
+public:                                                                                        \
+    void* operator new(std::size_t count, void* ptr) { return ::operator new(count, ptr); }    \
+    void operator delete(void* ptr, std::size_t size) { return ::operator delete(ptr, size); } \
+    void operator delete[](void* ptr, std::size_t sz) { return ::operator delete(ptr, size); } \
+    void operator delete(void* ptr, void* place) { return ::operator delete(ptr, place) }      \
+    template <typename... Args>                                                                \
+    static std::shared_ptr<TypeName> create_shared(Args&&... args) {                           \
+        return std::make_shared<TypeName>(std::forward<Args>(args)...);                        \
+    }                                                                                          \
+    template <typename... Args>                                                                \
+    static std::unique_ptr<TypeName> create_unique(Args&&... args) {                           \
+        return std::unique_ptr<TypeName>(new TypeName(std::forward<Args>(args)...));           \
+    }\

--- a/be/src/common/factory_creator.h
+++ b/be/src/common/factory_creator.h
@@ -34,6 +34,7 @@
 // Not use template like cowhelper to implements this feature because it has problem
 // during inherits
 // TODO try to allow make_unique
+//
 #define ENABLE_FACTORY_CREATOR(TypeName)                                                    \
 private:                                                                                    \
     void* operator new(std::size_t size) { return ::operator new(size); }                   \
@@ -41,8 +42,8 @@ private:                                                                        
                                                                                             \
 public:                                                                                     \
     void* operator new(std::size_t count, void* ptr) { return ::operator new(count, ptr); } \
-    void operator delete(void* ptr, std::size_t size) { ::operator delete(ptr, size); }     \
-    void operator delete[](void* ptr, std::size_t size) { ::operator delete[](ptr, size); } \
+    void operator delete(void* ptr) { ::operator delete(ptr); }                             \
+    void operator delete[](void* ptr) { ::operator delete[](ptr); }                         \
     void operator delete(void* ptr, void* place) { ::operator delete(ptr, place); }         \
     template <typename... Args>                                                             \
     static std::shared_ptr<TypeName> create_shared(Args&&... args) {                        \

--- a/be/src/common/factory_creator.h
+++ b/be/src/common/factory_creator.h
@@ -48,6 +48,4 @@ public:                                                                         
     template <typename... Args>                                                             \
     static std::unique_ptr<TypeName> create_unique(Args&&... args) {                        \
         return std::unique_ptr<TypeName>(new TypeName(std::forward<Args>(args)...));        \
-    }                                                                                       \
-    template <class T, class... Args>                                                       \
-    friend std::unique_ptr<T> std::make_unique(Args&&... args);\
+    }

--- a/be/src/common/factory_creator.h
+++ b/be/src/common/factory_creator.h
@@ -34,7 +34,7 @@
 // Not use template like cowhelper to implements this feature because it has problem
 // during inherits
 // TODO try to allow make_unique
-#define DISALLOW_EXPILICT_NEW(TypeName)                                                     \
+#define ENABLE_FACTORY_CREATOR(TypeName)                                                    \
 private:                                                                                    \
     void* operator new(std::size_t size) { return ::operator new(size); }                   \
     void* operator new[](std::size_t size) { return ::operator new(size); }                 \
@@ -48,4 +48,6 @@ public:                                                                         
     template <typename... Args>                                                             \
     static std::unique_ptr<TypeName> create_unique(Args&&... args) {                        \
         return std::unique_ptr<TypeName>(new TypeName(std::forward<Args>(args)...));        \
-    }
+    }                                                                                       \
+    template <class T, class... Args>                                                       \
+    friend std::unique_ptr<T> std::make_unique(Args&&... args);\

--- a/be/src/common/factory_creator.h
+++ b/be/src/common/factory_creator.h
@@ -34,21 +34,21 @@
 // Not use template like cowhelper to implements this feature because it has problem
 // during inherits
 // TODO try to allow make_unique
-#define ENABLE_FACTORY_CREATOR(TypeName)                                                         \
-private:                                                                                         \
-    void* operator new(std::size_t size) { return ::operator new(size); }                        \
-    void* operator new[](std::size_t size) { return ::operator new(size); }                      \
-                                                                                                 \
-public:                                                                                          \
-    void* operator new(std::size_t count, void* ptr) { return ::operator new(count, ptr); }      \
-    void operator delete(void* ptr, std::size_t size) { return ::operator delete(ptr, size); }   \
-    void operator delete[](void* ptr, std::size_t size) { return ::operator delete(ptr, size); } \
-    void operator delete(void* ptr, void* place) { return ::operator delete(ptr, place); }       \
-    template <typename... Args>                                                                  \
-    static std::shared_ptr<TypeName> create_shared(Args&&... args) {                             \
-        return std::make_shared<TypeName>(std::forward<Args>(args)...);                          \
-    }                                                                                            \
-    template <typename... Args>                                                                  \
-    static std::unique_ptr<TypeName> create_unique(Args&&... args) {                             \
-        return std::unique_ptr<TypeName>(new TypeName(std::forward<Args>(args)...));             \
+#define ENABLE_FACTORY_CREATOR(TypeName)                                                           \
+private:                                                                                           \
+    void* operator new(std::size_t size) { return ::operator new(size); }                          \
+    void* operator new[](std::size_t size) { return ::operator new[](size); }                      \
+                                                                                                   \
+public:                                                                                            \
+    void* operator new(std::size_t count, void* ptr) { return ::operator new(count, ptr); }        \
+    void operator delete(void* ptr, std::size_t size) { return ::operator delete(ptr, size); }     \
+    void operator delete[](void* ptr, std::size_t size) { return ::operator delete[](ptr, size); } \
+    void operator delete(void* ptr, void* place) { return ::operator delete(ptr, place); }         \
+    template <typename... Args>                                                                    \
+    static std::shared_ptr<TypeName> create_shared(Args&&... args) {                               \
+        return std::make_shared<TypeName>(std::forward<Args>(args)...);                            \
+    }                                                                                              \
+    template <typename... Args>                                                                    \
+    static std::unique_ptr<TypeName> create_unique(Args&&... args) {                               \
+        return std::unique_ptr<TypeName>(new TypeName(std::forward<Args>(args)...));               \
     }\

--- a/be/src/common/factory_creator.h
+++ b/be/src/common/factory_creator.h
@@ -35,21 +35,21 @@
 // during inherits
 // TODO try to allow make_unique
 //
-#define ENABLE_FACTORY_CREATOR(TypeName)                                                    \
-private:                                                                                    \
-    void* operator new(std::size_t size) { return ::operator new(size); }                   \
-    void* operator new[](std::size_t size) { return ::operator new[](size); }               \
-                                                                                            \
-public:                                                                                     \
-    void* operator new(std::size_t count, void* ptr) { return ::operator new(count, ptr); } \
-    void operator delete(void* ptr) { ::operator delete(ptr); }                             \
-    void operator delete[](void* ptr) { ::operator delete[](ptr); }                         \
-    void operator delete(void* ptr, void* place) { ::operator delete(ptr, place); }         \
-    template <typename... Args>                                                             \
-    static std::shared_ptr<TypeName> create_shared(Args&&... args) {                        \
-        return std::make_shared<TypeName>(std::forward<Args>(args)...);                     \
-    }                                                                                       \
-    template <typename... Args>                                                             \
-    static std::unique_ptr<TypeName> create_unique(Args&&... args) {                        \
-        return std::unique_ptr<TypeName>(new TypeName(std::forward<Args>(args)...));        \
+#define ENABLE_FACTORY_CREATOR(TypeName)                                                     \
+private:                                                                                     \
+    void* operator new(std::size_t size) { return ::operator new(size); }                    \
+    void* operator new[](std::size_t size) { return ::operator new[](size); }                \
+                                                                                             \
+public:                                                                                      \
+    void* operator new(std::size_t count, void* ptr) { return ::operator new(count, ptr); }  \
+    void operator delete(void* ptr) noexcept { ::operator delete(ptr); }                     \
+    void operator delete[](void* ptr) noexcept { ::operator delete[](ptr); }                 \
+    void operator delete(void* ptr, void* place) noexcept { ::operator delete(ptr, place); } \
+    template <typename... Args>                                                              \
+    static std::shared_ptr<TypeName> create_shared(Args&&... args) {                         \
+        return std::make_shared<TypeName>(std::forward<Args>(args)...);                      \
+    }                                                                                        \
+    template <typename... Args>                                                              \
+    static std::unique_ptr<TypeName> create_unique(Args&&... args) {                         \
+        return std::unique_ptr<TypeName>(new TypeName(std::forward<Args>(args)...));         \
     }\

--- a/be/src/common/factory_creator.h
+++ b/be/src/common/factory_creator.h
@@ -43,7 +43,7 @@ public:                                                                         
     void* operator new(std::size_t count, void* ptr) { return ::operator new(count, ptr); }      \
     void operator delete(void* ptr, std::size_t size) { return ::operator delete(ptr, size); }   \
     void operator delete[](void* ptr, std::size_t size) { return ::operator delete(ptr, size); } \
-    void operator delete(void* ptr, void* place) { return ::operator delete(ptr, place) }        \
+    void operator delete(void* ptr, void* place) { return ::operator delete(ptr, place); }       \
     template <typename... Args>                                                                  \
     static std::shared_ptr<TypeName> create_shared(Args&&... args) {                             \
         return std::make_shared<TypeName>(std::forward<Args>(args)...);                          \

--- a/be/src/common/smart_ptr_helper.h
+++ b/be/src/common/smart_ptr_helper.h
@@ -1,0 +1,51 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+#include <memory>
+
+// All object should inherit from this class, like
+// class A  {
+// DISALLOW_EXPILICT_NEW(A);
+// };
+//
+// Then the caller could not call new A() any more, has to call A::create_shared(...)
+// or A::create_unique(...), then we could make sure all object in our project is shared
+// pointer.
+// But could call A a(...);
+
+// A macro to disallow the copy constructor and operator= functions
+// This should be used in the private: declarations for a class
+//
+// Not use template like cowhelper to implements this feature because it has problem
+// during inherits
+// TODO try to allow make_unique
+#define DISALLOW_EXPILICT_NEW(TypeName)                                                     \
+private:                                                                                    \
+    void* operator new(std::size_t size) { return ::operator new(size); }                   \
+    void* operator new[](std::size_t size) { return ::operator new(size); }                 \
+                                                                                            \
+public:                                                                                     \
+    void* operator new(std::size_t count, void* ptr) { return ::operator new(count, ptr); } \
+    template <typename... Args>                                                             \
+    static std::shared_ptr<TypeName> create_shared(Args&&... args) {                        \
+        return std::make_shared<TypeName>(std::forward<Args>(args)...);                     \
+    }                                                                                       \
+    template <typename... Args>                                                             \
+    static std::unique_ptr<TypeName> create_unique(Args&&... args) {                        \
+        return std::unique_ptr<TypeName>(new TypeName(std::forward<Args>(args)...));        \
+    }

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -459,8 +459,8 @@ Status VSchemaChangeDirectly::_inner_process(RowsetReaderSharedPtr rowset_reader
                                              TabletSchemaSPtr base_tablet_schema) {
     do {
         auto new_block =
-                std::make_unique<vectorized::Block>(new_tablet->tablet_schema()->create_block());
-        auto ref_block = std::make_unique<vectorized::Block>(base_tablet_schema->create_block());
+                vectorized::Block::create_unique(new_tablet->tablet_schema()->create_block());
+        auto ref_block = vectorized::Block::create_unique(base_tablet_schema->create_block());
 
         rowset_reader->next_block(ref_block.get());
         if (ref_block->rows() == 0) {
@@ -531,11 +531,10 @@ Status VSchemaChangeWithSorting::_inner_process(RowsetReaderSharedPtr rowset_rea
         return Status::OK();
     };
 
-    auto new_block =
-            std::make_unique<vectorized::Block>(new_tablet->tablet_schema()->create_block());
+    auto new_block = vectorized::Block::create_unique(new_tablet->tablet_schema()->create_block());
 
     do {
-        auto ref_block = std::make_unique<vectorized::Block>(base_tablet_schema->create_block());
+        auto ref_block = vectorized::Block::create_unique(base_tablet_schema->create_block());
         rowset_reader->next_block(ref_block.get());
         if (ref_block->rows() == 0) {
             break;
@@ -557,7 +556,7 @@ Status VSchemaChangeWithSorting::_inner_process(RowsetReaderSharedPtr rowset_rea
 
         // move unique ptr
         blocks.push_back(
-                std::make_unique<vectorized::Block>(new_tablet->tablet_schema()->create_block()));
+                vectorized::Block::create_unique(new_tablet->tablet_schema()->create_block()));
         swap(blocks.back(), new_block);
     } while (true);
 

--- a/be/src/pipeline/exec/data_queue.cpp
+++ b/be/src/pipeline/exec/data_queue.cpp
@@ -60,7 +60,7 @@ std::unique_ptr<vectorized::Block> DataQueue::get_free_block(int child_idx) {
         }
     }
 
-    return std::make_unique<vectorized::Block>();
+    return vectorized::Block::create_unique();
 }
 
 void DataQueue::push_free_block(std::unique_ptr<vectorized::Block> block, int child_idx) {

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -436,7 +436,7 @@ public:
 
     StatefulOperator(OperatorBuilderBase* builder, ExecNode* node)
             : StreamingOperator<OperatorBuilderType>(builder, node),
-              _child_block(new vectorized::Block),
+              _child_block(vectorized::Block::create_unique()),
               _child_source_state(SourceState::DEPEND_ON_SOURCE) {}
 
     virtual ~StatefulOperator() = default;

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -98,7 +98,7 @@ Status PipelineTask::prepare(RuntimeState* state) {
     fmt::format_to(operator_ids_str, "]");
     _task_profile->add_info_string("OperatorIds(source2root)", fmt::to_string(operator_ids_str));
 
-    _block.reset(new doris::vectorized::Block());
+    _block = doris::vectorized::Block::create_unique();
 
     // We should make sure initial state for task are runnable so that we can do some preparation jobs (e.g. initialize runtime filters).
     set_state(PipelineTaskState::RUNNABLE);

--- a/be/src/service/point_query_executor.cpp
+++ b/be/src/service/point_query_executor.cpp
@@ -54,7 +54,7 @@ Status Reusable::init(const TDescriptorTable& t_desc_tbl, const std::vector<TExp
     _runtime_state->set_desc_tbl(_desc_tbl);
     _block_pool.resize(block_size);
     for (int i = 0; i < _block_pool.size(); ++i) {
-        _block_pool[i] = std::make_unique<vectorized::Block>(tuple_desc()->slots(), 10);
+        _block_pool[i] = vectorized::Block::create_unique(tuple_desc()->slots(), 10);
     }
 
     RETURN_IF_ERROR(vectorized::VExpr::create_expr_trees(_runtime_state->obj_pool(), output_exprs,
@@ -69,7 +69,7 @@ Status Reusable::init(const TDescriptorTable& t_desc_tbl, const std::vector<TExp
 std::unique_ptr<vectorized::Block> Reusable::get_block() {
     std::lock_guard lock(_block_mutex);
     if (_block_pool.empty()) {
-        return std::make_unique<vectorized::Block>(tuple_desc()->slots(), 4);
+        return vectorized::Block::create_unique(tuple_desc()->slots(), 4);
     }
     auto block = std::move(_block_pool.back());
     CHECK(block != nullptr);

--- a/be/src/vec/common/sort/sorter.h
+++ b/be/src/vec/common/sort/sorter.h
@@ -52,7 +52,7 @@ public:
             // create_empty_block should ignore invalid slots, unsorted_block
             // should be same structure with arrival block from child node
             // since block from child node may ignored these slots
-            : unsorted_block_(new Block(
+            : unsorted_block_(Block::create_unique(
                       VectorizedUtils::create_empty_block(row_desc, true /*ignore invalid slot*/))),
               offset_(offset),
               limit_(limit),

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -988,7 +988,7 @@ std::string MutableBlock::dump_data(size_t row_limit) const {
 }
 
 std::unique_ptr<Block> Block::create_same_struct_block(size_t size) const {
-    auto temp_block = std::make_unique<Block>();
+    auto temp_block = Block::create_unique();
     for (const auto& d : data) {
         auto column = d.type->create_column();
         column->resize(size);

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -34,6 +34,7 @@
 #include <utility>
 #include <vector>
 
+#include "common/factory_creator.h"
 #include "common/status.h"
 #include "vec/columns/column.h"
 #include "vec/columns/column_nullable.h"
@@ -67,7 +68,7 @@ namespace vectorized {
 class MutableBlock;
 
 class Block {
-    DISALLOW_EXPILICT_NEW(Block);
+    ENABLE_FACTORY_CREATOR(Block);
 
 private:
     using Container = ColumnsWithTypeAndName;
@@ -398,7 +399,7 @@ using BlocksPtr = std::shared_ptr<Blocks>;
 using BlocksPtrs = std::shared_ptr<std::vector<BlocksPtr>>;
 
 class MutableBlock {
-    DISALLOW_EXPILICT_NEW(MutableBlock);
+    ENABLE_FACTORY_CREATOR(MutableBlock);
 
 private:
     MutableColumns _columns;

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -67,10 +67,11 @@ namespace vectorized {
 class MutableBlock;
 
 class Block {
+    DISALLOW_EXPILICT_NEW(Block);
+
 private:
     using Container = ColumnsWithTypeAndName;
     using IndexByName = phmap::flat_hash_map<String, size_t>;
-
     Container data;
     IndexByName index_by_name;
     std::vector<bool> row_same_bit;
@@ -397,6 +398,8 @@ using BlocksPtr = std::shared_ptr<Blocks>;
 using BlocksPtrs = std::shared_ptr<std::vector<BlocksPtr>>;
 
 class MutableBlock {
+    DISALLOW_EXPILICT_NEW(MutableBlock);
+
 private:
     MutableColumns _columns;
     DataTypes _data_types;

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -68,7 +68,7 @@ namespace vectorized {
 class MutableBlock;
 
 class Block {
-    ENABLE_FACTORY_CREATOR(Block)
+    ENABLE_FACTORY_CREATOR(Block);
 
 private:
     using Container = ColumnsWithTypeAndName;
@@ -399,7 +399,7 @@ using BlocksPtr = std::shared_ptr<Blocks>;
 using BlocksPtrs = std::shared_ptr<std::vector<BlocksPtr>>;
 
 class MutableBlock {
-    ENABLE_FACTORY_CREATOR(MutableBlock)
+    ENABLE_FACTORY_CREATOR(MutableBlock);
 
 private:
     MutableColumns _columns;

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -68,7 +68,7 @@ namespace vectorized {
 class MutableBlock;
 
 class Block {
-    ENABLE_FACTORY_CREATOR(Block);
+    ENABLE_FACTORY_CREATOR(Block)
 
 private:
     using Container = ColumnsWithTypeAndName;
@@ -399,7 +399,7 @@ using BlocksPtr = std::shared_ptr<Blocks>;
 using BlocksPtrs = std::shared_ptr<std::vector<BlocksPtr>>;
 
 class MutableBlock {
-    ENABLE_FACTORY_CREATOR(MutableBlock);
+    ENABLE_FACTORY_CREATOR(MutableBlock)
 
 private:
     MutableColumns _columns;

--- a/be/src/vec/core/block_spill_reader.cpp
+++ b/be/src/vec/core/block_spill_reader.cpp
@@ -134,7 +134,7 @@ Status BlockSpillReader::read(Block* block, bool* eos) {
             if (!pb_block.ParseFromArray(result.data, result.size)) {
                 return Status::InternalError("Failed to read spilled block");
             }
-            new_block.reset(new Block(pb_block));
+            new_block = Block::create_unique(pb_block);
         }
         block->swap(*new_block);
     } else {

--- a/be/src/vec/exec/scan/pip_scanner_context.h
+++ b/be/src/vec/exec/scan/pip_scanner_context.h
@@ -137,11 +137,12 @@ public:
                     limit == -1 ? _batch_size : std::min(static_cast<int64_t>(_batch_size), limit);
             int64_t free_blocks_memory_usage = 0;
             for (int i = 0; i < _max_queue_size; ++i) {
-                auto block = std::make_unique<vectorized::Block>(_output_tuple_desc->slots(),
-                                                                 real_block_size,
-                                                                 true /*ignore invalid slots*/);
+                auto block = vectorized::Block::create_unique(_output_tuple_desc->slots(),
+                                                              real_block_size,
+                                                              true /*ignore invalid slots*/);
                 free_blocks_memory_usage += block->allocated_bytes();
-                _colocate_mutable_blocks.emplace_back(new vectorized::MutableBlock(block.get()));
+                _colocate_mutable_blocks.emplace_back(
+                        vectorized::MutableBlock::create_unique(block.get()));
                 _colocate_blocks.emplace_back(std::move(block));
                 _colocate_block_mutexs.emplace_back(new std::mutex);
             }

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -103,8 +103,8 @@ Status ScannerContext::init() {
     // So use _output_tuple_desc;
     int64_t free_blocks_memory_usage = 0;
     for (int i = 0; i < pre_alloc_block_count; ++i) {
-        auto block = std::make_unique<vectorized::Block>(
-                _output_tuple_desc->slots(), real_block_size, true /*ignore invalid slots*/);
+        auto block = vectorized::Block::create_unique(_output_tuple_desc->slots(), real_block_size,
+                                                      true /*ignore invalid slots*/);
         free_blocks_memory_usage += block->allocated_bytes();
         _free_blocks.emplace_back(std::move(block));
     }
@@ -145,8 +145,8 @@ vectorized::BlockUPtr ScannerContext::get_free_block(bool* has_free_block,
     *has_free_block = false;
 
     COUNTER_UPDATE(_newly_create_free_blocks_num, 1);
-    return std::make_unique<vectorized::Block>(_real_tuple_desc->slots(), _batch_size,
-                                               true /*ignore invalid slots*/);
+    return vectorized::Block::create_unique(_real_tuple_desc->slots(), _batch_size,
+                                            true /*ignore invalid slots*/);
 }
 
 void ScannerContext::return_free_block(std::unique_ptr<vectorized::Block> block) {

--- a/be/src/vec/exec/vrepeat_node.cpp
+++ b/be/src/vec/exec/vrepeat_node.cpp
@@ -224,7 +224,7 @@ Status VRepeatNode::push(RuntimeState* state, vectorized::Block* input_block, bo
     DCHECK(!_expr_ctxs.empty());
 
     if (input_block->rows() > 0) {
-        _intermediate_block.reset(new Block());
+        _intermediate_block = Block::create_unique();
 
         for (auto expr : _expr_ctxs) {
             int result_column_id = -1;

--- a/be/src/vec/exec/vsort_node.cpp
+++ b/be/src/vec/exec/vsort_node.cpp
@@ -168,7 +168,7 @@ Status VSortNode::open(RuntimeState* state) {
     // The child has been opened and the sorter created. Sort the input.
     // The final merge is done on-demand as rows are requested in get_next().
     bool eos = false;
-    std::unique_ptr<Block> upstream_block(new Block());
+    std::unique_ptr<Block> upstream_block = Block::create_unique();
     do {
         RETURN_IF_ERROR_AND_CHECK_SPAN(
                 child(0)->get_next_after_projects(

--- a/be/src/vec/runtime/vdata_stream_recvr.cpp
+++ b/be/src/vec/runtime/vdata_stream_recvr.cpp
@@ -147,7 +147,7 @@ void VDataStreamRecvr::SenderQueue::add_block(const PBlock& pblock, int be_numbe
     int64_t deserialize_time = 0;
     {
         SCOPED_RAW_TIMER(&deserialize_time);
-        block.reset(new Block(pblock));
+        block = Block::create_unique(pblock);
     }
 
     auto block_byte_size = block->allocated_bytes();
@@ -186,7 +186,7 @@ void VDataStreamRecvr::SenderQueue::add_block(Block* block, bool use_move) {
 
     auto block_bytes_received = block->bytes();
     // Has to use unique ptr here, because clone column may failed if allocate memory failed.
-    BlockUPtr nblock = std::make_unique<Block>(block->get_columns_with_type_and_name());
+    BlockUPtr nblock = Block::create_unique(block->get_columns_with_type_and_name());
 
     // local exchange should copy the block contented if use move == false
     if (use_move) {

--- a/be/src/vec/runtime/vdata_stream_recvr.h
+++ b/be/src/vec/runtime/vdata_stream_recvr.h
@@ -237,7 +237,7 @@ public:
         if (_is_cancelled || !block->rows()) {
             return;
         }
-        BlockUPtr nblock = std::make_unique<Block>(block->get_columns_with_type_and_name());
+        BlockUPtr nblock = Block::create_unique(block->get_columns_with_type_and_name());
 
         // local exchange should copy the block contented if use move == false
         if (use_move) {

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -202,7 +202,7 @@ Status Channel::add_rows(Block* block, const std::vector<int>& rows) {
 
     if (_mutable_block == nullptr) {
         SCOPED_CONSUME_MEM_TRACKER(_parent->_mem_tracker.get());
-        _mutable_block.reset(new MutableBlock(block->clone_empty()));
+        _mutable_block = MutableBlock::create_unique(block->clone_empty());
     }
 
     int row_wait_add = rows.size();

--- a/be/src/vec/sink/vresult_file_sink.cpp
+++ b/be/src/vec/sink/vresult_file_sink.cpp
@@ -127,7 +127,8 @@ Status VResultFileSink::prepare(RuntimeState* state) {
                 _output_row_descriptor));
     } else {
         // init channel
-        _output_block.reset(new Block(_output_row_descriptor.tuple_descriptors()[0]->slots(), 1));
+        _output_block =
+                Block::create_unique(_output_row_descriptor.tuple_descriptors()[0]->slots(), 1);
         _writer.reset(new (std::nothrow) VFileResultWriter(
                 _file_opts.get(), _storage_type, state->fragment_instance_id(), _output_vexpr_ctxs,
                 _profile, nullptr, _output_block.get(), state->return_object_data_as_binary(),

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -486,7 +486,7 @@ Status VNodeChannel::add_block(vectorized::Block* block, const Payload* payload,
     }
 
     if (UNLIKELY(!_cur_mutable_block)) {
-        _cur_mutable_block.reset(new vectorized::MutableBlock(block->clone_empty()));
+        _cur_mutable_block = vectorized::MutableBlock::create_unique(block->clone_empty());
     }
 
     std::unique_ptr<Payload> temp_payload = nullptr;
@@ -570,7 +570,7 @@ Status VNodeChannel::add_block(vectorized::Block* block, const Payload* payload,
                        << " jobid:" << std::to_string(_state->load_job_id())
                        << " loadinfo:" << _load_info;
         }
-        _cur_mutable_block.reset(new vectorized::MutableBlock(block->clone_empty()));
+        _cur_mutable_block = vectorized::MutableBlock::create_unique(block->clone_empty());
         _cur_add_block_request.clear_tablet_ids();
     }
 
@@ -858,7 +858,7 @@ void VNodeChannel::mark_close() {
         std::lock_guard<std::mutex> l(_pending_batches_lock);
         if (!_cur_mutable_block) {
             // add a dummy block
-            _cur_mutable_block.reset(new vectorized::MutableBlock());
+            _cur_mutable_block = vectorized::MutableBlock::create_unique();
         }
         _pending_blocks.emplace(std::move(_cur_mutable_block), _cur_add_block_request);
         _pending_batches_num++;

--- a/be/test/vec/exec/parquet/parquet_reader_test.cpp
+++ b/be/test/vec/exec/parquet/parquet_reader_test.cpp
@@ -124,7 +124,7 @@ TEST_F(ParquetReaderTest, normal) {
             partition_columns;
     std::unordered_map<std::string, VExprContext*> missing_columns;
     p_reader->set_fill_columns(partition_columns, missing_columns);
-    Block* block = new Block();
+    BlockUPtr block = Block::create_unique();
     for (const auto& slot_desc : tuple_desc->slots()) {
         auto data_type =
                 vectorized::DataTypeFactory::instance().create_data_type(slot_desc->type(), true);
@@ -134,12 +134,11 @@ TEST_F(ParquetReaderTest, normal) {
     }
     bool eof = false;
     size_t read_row = 0;
-    p_reader->get_next_block(block, &read_row, &eof);
+    p_reader->get_next_block(block.get(), &read_row, &eof);
     for (auto& col : block->get_columns_with_type_and_name()) {
         ASSERT_EQ(col.column->size(), 10);
     }
     EXPECT_TRUE(eof);
-    delete block;
     delete p_reader;
 }
 

--- a/be/test/vec/exec/parquet/parquet_thrift_test.cpp
+++ b/be/test/vec/exec/parquet/parquet_thrift_test.cpp
@@ -325,7 +325,7 @@ static void create_block(std::unique_ptr<vectorized::Block>& block) {
     ObjectPool object_pool;
     doris::TupleDescriptor* tuple_desc = create_tuple_desc(&object_pool, column_descs);
     auto tuple_slots = tuple_desc->slots();
-    block.reset(new vectorized::Block());
+    block = vectorized::Block::create_unique();
     for (const auto& slot_desc : tuple_slots) {
         auto data_type = slot_desc->get_data_type_ptr();
         MutableColumnPtr data_column = data_type->create_column();

--- a/be/test/vec/function/function_test_util.cpp
+++ b/be/test/vec/function/function_test_util.cpp
@@ -290,7 +290,7 @@ Block* create_block_from_inputset(const InputTypeSet& input_types, const InputDa
 
     // 1.1 insert data and create block
     auto row_size = input_set.size();
-    std::unique_ptr<Block> block(new Block());
+    std::unique_ptr<Block> block = Block::create_unique();
     for (size_t i = 0; i < descs.size(); ++i) {
         auto& desc = descs[i];
         auto column = desc.data_type->create_column();
@@ -357,7 +357,7 @@ Block* process_table_function(TableFunction* fn, Block* input_block,
         } while (!fn->eos());
     }
 
-    std::unique_ptr<Block> output_block(new Block());
+    std::unique_ptr<Block> output_block = Block::create_unique();
     output_block->insert({std::move(column), descs[0].data_type, descs[0].col_name});
     return output_block.release();
 }


### PR DESCRIPTION
# Proposed changes

1. disallow call new method explicitly
2. force to use create_shared or create_unique to use shared ptr
3. placement new is allowed

reference  https://abseil.io/tips/42 to add factory method to all class.
I think we should follow this guide because if throw exception in new method, the program will terminate.

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

