### PR TITLE
[enhance](Nereids): When requiredSlots is empty, prune child previously in ColumnPruning

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -1854,14 +1854,14 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         return leftFragment;
     }
 
-    private PlanFragment constructBucketShuffleJoin(AbstractPhysicalJoin<PhysicalPlan, PhysicalPlan> physicalHashJoin,
+    private PlanFragment constructBucketShuffleJoin(PhysicalHashJoin<PhysicalPlan, PhysicalPlan> physicalHashJoin,
             HashJoinNode hashJoinNode, PlanFragment leftFragment,
             PlanFragment rightFragment, PlanTranslatorContext context) {
         // according to left partition to generate right partition expr list
         DistributionSpecHash leftDistributionSpec
                 = (DistributionSpecHash) physicalHashJoin.left().getPhysicalProperties().getDistributionSpec();
 
-        Pair<List<ExprId>, List<ExprId>> onClauseUsedSlots = JoinUtils.getOnClauseUsedSlots(physicalHashJoin);
+        Pair<List<ExprId>, List<ExprId>> onClauseUsedSlots = physicalHashJoin.getHashConjunctsExprIds();
         List<ExprId> rightPartitionExprIds = Lists.newArrayList(leftDistributionSpec.getOrderedShuffledColumns());
         for (int i = 0; i < leftDistributionSpec.getOrderedShuffledColumns().size(); i++) {
             int idx = leftDistributionSpec.getExprIdToEquivalenceSet()

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
@@ -144,7 +144,7 @@ public class RequestPropertyDeriver extends PlanVisitor<Void, PlanContext> {
     }
 
     private void addShuffleJoinRequestProperty(PhysicalHashJoin<? extends Plan, ? extends Plan> hashJoin) {
-        Pair<List<ExprId>, List<ExprId>> onClauseUsedSlots = JoinUtils.getOnClauseUsedSlots(hashJoin);
+        Pair<List<ExprId>, List<ExprId>> onClauseUsedSlots = hashJoin.getHashConjunctsExprIds();
         // shuffle join
         addRequestPropertyToChildren(
                 PhysicalProperties.createHash(

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/BuildAggForUnion.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/BuildAggForUnion.java
@@ -24,6 +24,8 @@ import org.apache.doris.nereids.trees.plans.algebra.SetOperation.Qualifier;
 import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
 import org.apache.doris.nereids.trees.plans.logical.LogicalUnion;
 
+import com.google.common.collect.ImmutableList;
+
 import java.util.Optional;
 
 /**
@@ -34,7 +36,7 @@ public class BuildAggForUnion extends OneRewriteRuleFactory {
     public Rule build() {
         return logicalUnion().whenNot(LogicalUnion::hasBuildAgg).then(union -> {
             if (union.getQualifier() == Qualifier.DISTINCT) {
-                return new LogicalAggregate(union.getOutputs(), union.getOutputs(),
+                return new LogicalAggregate<>(ImmutableList.copyOf(union.getOutputs()), union.getOutputs(),
                         true, Optional.empty(), union.withHasBuildAgg());
             }
             return union;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/JoinUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/JoinUtils.java
@@ -44,7 +44,6 @@ import com.google.common.collect.Lists;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -171,47 +170,6 @@ public class JoinUtils {
         return result;
     }
 
-    /**
-     * Get all used slots from onClause of join.
-     * Return pair of left used slots and right used slots.
-     */
-    public static Pair<List<ExprId>, List<ExprId>> getOnClauseUsedSlots(
-            AbstractPhysicalJoin<? extends Plan, ? extends Plan> join) {
-
-        List<ExprId> exprIds1 = Lists.newArrayListWithCapacity(join.getHashJoinConjuncts().size());
-        List<ExprId> exprIds2 = Lists.newArrayListWithCapacity(join.getHashJoinConjuncts().size());
-
-        JoinSlotCoverageChecker checker = new JoinSlotCoverageChecker(
-                join.left().getOutputExprIdSet(),
-                join.right().getOutputExprIdSet());
-
-        for (Expression expr : join.getHashJoinConjuncts()) {
-            EqualTo equalTo = (EqualTo) expr;
-            // TODO: we could meet a = cast(b as xxx) here, need fix normalize join hash equals future
-            Optional<Slot> leftSlot = ExpressionUtils.extractSlotOrCastOnSlot(equalTo.left());
-            Optional<Slot> rightSlot = ExpressionUtils.extractSlotOrCastOnSlot(equalTo.right());
-            if (!leftSlot.isPresent() || !rightSlot.isPresent()) {
-                continue;
-            }
-
-            ExprId leftExprId = leftSlot.get().getExprId();
-            ExprId rightExprId = rightSlot.get().getExprId();
-
-            if (checker.isCoveredByLeftSlots(leftExprId)
-                    && checker.isCoveredByRightSlots(rightExprId)) {
-                exprIds1.add(leftExprId);
-                exprIds2.add(rightExprId);
-            } else if (checker.isCoveredByLeftSlots(rightExprId)
-                    && checker.isCoveredByRightSlots(leftExprId)) {
-                exprIds1.add(rightExprId);
-                exprIds2.add(leftExprId);
-            } else {
-                throw new RuntimeException("Could not generate valid equal on clause slot pairs for join: " + join);
-            }
-        }
-        return Pair.of(exprIds1, exprIds2);
-    }
-
     public static boolean shouldNestedLoopJoin(Join join) {
         return join.getHashJoinConjuncts().isEmpty();
     }
@@ -221,7 +179,7 @@ public class JoinUtils {
     }
 
     /**
-     * The left and right child of origin predicates need to be swap sometimes.
+     * The left and right child of origin predicates need to swap sometimes.
      * Case A:
      * select * from t1 join t2 on t2.id=t1.id
      * The left plan node is t1 and the right plan node is t2.

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/Utils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/Utils.java
@@ -30,7 +30,6 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -123,16 +122,6 @@ public class Utils {
     }
 
     /**
-     * equals for List but ignore order.
-     */
-    public static <E> boolean equalsIgnoreOrder(List<E> one, List<E> other) {
-        if (one.size() != other.size()) {
-            return false;
-        }
-        return new HashSet<>(one).containsAll(other) && new HashSet<>(other).containsAll(one);
-    }
-
-    /**
      * Get sql string for plan.
      *
      * @param planName name of plan, like LogicalJoin.
@@ -156,24 +145,6 @@ public class Utils {
         }
 
         return stringBuilder.append(" )").toString();
-    }
-
-    /**
-     * See if there are correlated columns in a subquery expression.
-     */
-    public static boolean containCorrelatedSlot(List<Expression> correlatedSlots, Expression expr) {
-        if (correlatedSlots.isEmpty() || expr == null) {
-            return false;
-        }
-        if (expr instanceof SlotReference) {
-            return correlatedSlots.contains(expr);
-        }
-        for (Expression child : expr.children()) {
-            if (containCorrelatedSlot(correlatedSlots, child)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/Utils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/Utils.java
@@ -257,6 +257,21 @@ public class Utils {
         Preconditions.checkState(false, "item not found in list");
     }
 
+    /**
+     * Judge if two lists are equal without equals method.
+     */
+    public static <T> boolean identityEquals(List<T> lhs, List<T> rhs) {
+        if (lhs.size() != rhs.size()) {
+            return false;
+        }
+        for (int i = 0; i < lhs.size(); ++i) {
+            if (lhs.get(i) != rhs.get(i)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     /** allCombinations */
     public static <T> List<List<T>> allCombinations(List<List<T>> lists) {
         int size = lists.size();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

When requiredSlots is empty, prune child previously in ColumnPruning.

A example:

```
Agg count(*)
- Filter age > 3
-- Scan id, age
```

We should get 

```
Agg count(*)
- Project age
-- Filter age > 3
--- Scan id, age
```

instead of

```
Agg count(*)
- Project age, id
-- Filter age > 3
--- Scan id, age
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

