### PR TITLE
[fix](external table) Use FederationBackendPolicy in Coordinator for ExternalScanNode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/FederationBackendPolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/FederationBackendPolicy.java
@@ -81,4 +81,8 @@ public class FederationBackendPolicy {
     public int numBackends() {
         return backends.size();
     }
+
+    public List<Backend> getBackends() {
+        return backends;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -62,6 +62,7 @@ import org.apache.doris.planner.ScanNode;
 import org.apache.doris.planner.SetOperationNode;
 import org.apache.doris.planner.UnionNode;
 import org.apache.doris.planner.external.ExternalScanNode;
+import org.apache.doris.planner.external.FederationBackendPolicy;
 import org.apache.doris.proto.InternalService;
 import org.apache.doris.proto.InternalService.PExecPlanFragmentResult;
 import org.apache.doris.proto.InternalService.PExecPlanFragmentStartRequest;
@@ -2035,8 +2036,9 @@ public class Coordinator {
             FragmentScanRangeAssignment assignment,
             Map<TNetworkAddress, Long> assignedBytesPerHost,
             Map<TNetworkAddress, Long> replicaNumPerHost) throws Exception {
-        Collection<Backend> aliveBEs = idToBackend.values().stream().filter(SimpleScheduler::isAvailable)
-                .collect(Collectors.toList());
+        FederationBackendPolicy federationBackendPolicy = new FederationBackendPolicy();
+        federationBackendPolicy.init();
+        Collection<Backend> aliveBEs = federationBackendPolicy.getBackends();
         if (aliveBEs.isEmpty()) {
             throw new UserException("No available backends");
         }


### PR DESCRIPTION
Use FederationBackendPolicy in Coordinator for ExternalScanNode so that we can take the user resource tag into consideration.
This pr could support external table resource isolation.

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

