### PR TITLE
[refactor](exprcontext) remove useless close method from conext and expr

### DIFF
--- a/be/src/exec/base_scanner.cpp
+++ b/be/src/exec/base_scanner.cpp
@@ -363,11 +363,7 @@ Status BaseScanner::_fill_dest_block(vectorized::Block* dest_block, bool* eof) {
     return Status::OK();
 }
 
-void BaseScanner::close() {
-    if (_vpre_filter_ctx_ptr) {
-        (*_vpre_filter_ctx_ptr)->close(_state);
-    }
-}
+void BaseScanner::close() {}
 
 void BaseScanner::_fill_columns_from_path() {
     const TBrokerRangeDesc& range = _ranges.at(_next_range - 1);

--- a/be/src/exec/base_scanner.h
+++ b/be/src/exec/base_scanner.h
@@ -64,7 +64,7 @@ public:
                 const std::vector<TNetworkAddress>& broker_addresses,
                 const std::vector<TExpr>& pre_filter_texprs, ScannerCounter* counter);
 
-    virtual ~BaseScanner() { vectorized::VExpr::close(_dest_vexpr_ctx, _state); }
+    virtual ~BaseScanner() {}
 
     virtual Status init_expr_ctxes();
     // Open this scanner, will initialize information need to

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -178,11 +178,6 @@ void ExecNode::release_resource(doris::RuntimeState* state) {
             COUNTER_SET(_rows_returned_counter, _num_rows_returned);
         }
 
-        if (_vconjunct_ctx_ptr) {
-            (*_vconjunct_ctx_ptr)->close(state);
-        }
-        vectorized::VExpr::close(_projections, state);
-
         runtime_profile()->add_to_span();
         _is_resource_released = true;
     }

--- a/be/src/exec/scan_node.cpp
+++ b/be/src/exec/scan_node.cpp
@@ -71,7 +71,6 @@ void ScanNode::_peel_pushed_vconjunct(RuntimeState* state,
         vectorized::VExpr* new_conjunct_expr_root = vectorized::VectorizedUtils::dfs_peel_conjunct(
                 state, *_vconjunct_ctx_ptr, conjunct_expr_root, leaf_index, checker);
         if (new_conjunct_expr_root == nullptr) {
-            (*_vconjunct_ctx_ptr)->close(state);
             _vconjunct_ctx_ptr.reset(nullptr);
         } else {
             (*_vconjunct_ctx_ptr)->set_root(new_conjunct_expr_root);

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -261,7 +261,6 @@ Status BlockChanger::change_block(vectorized::Block* ref_block,
     if (_where_expr != nullptr) {
         vectorized::VExprContext* ctx = nullptr;
         RETURN_IF_ERROR(vectorized::VExpr::create_expr_tree(&pool, *_where_expr, &ctx));
-        Defer defer {[&]() { ctx->close(state); }};
         RETURN_IF_ERROR(ctx->prepare(state, row_desc));
         RETURN_IF_ERROR(ctx->open(state));
 
@@ -294,7 +293,6 @@ Status BlockChanger::change_block(vectorized::Block* ref_block,
             vectorized::VExprContext* ctx = nullptr;
             RETURN_IF_ERROR(
                     vectorized::VExpr::create_expr_tree(&pool, *_schema_mapping[idx].expr, &ctx));
-            Defer defer {[&]() { ctx->close(state); }};
             RETURN_IF_ERROR(ctx->prepare(state, row_desc));
             RETURN_IF_ERROR(ctx->open(state));
 

--- a/be/src/runtime/fold_constant_executor.cpp
+++ b/be/src/runtime/fold_constant_executor.cpp
@@ -83,9 +83,6 @@ Status FoldConstantExecutor::fold_constant_vexpr(const TFoldConstantParams& para
             const TExpr& texpr = n.second;
             // create expr tree from TExpr
             RETURN_IF_ERROR(vectorized::VExpr::create_expr_tree(&_pool, texpr, &ctx));
-
-            // close context expr
-            Defer defer {[&]() { ctx->close(_runtime_state.get()); }};
             // prepare and open context
             RETURN_IF_ERROR(_prepare_and_open(ctx));
 

--- a/be/src/service/point_query_executor.cpp
+++ b/be/src/service/point_query_executor.cpp
@@ -41,11 +41,7 @@
 
 namespace doris {
 
-Reusable::~Reusable() {
-    for (vectorized::VExprContext* ctx : _output_exprs_ctxs) {
-        ctx->close(_runtime_state.get());
-    }
-}
+Reusable::~Reusable() {}
 
 Status Reusable::init(const TDescriptorTable& t_desc_tbl, const std::vector<TExpr>& output_exprs,
                       size_t block_size) {

--- a/be/src/vec/common/sort/vsort_exec_exprs.cpp
+++ b/be/src/vec/common/sort/vsort_exec_exprs.cpp
@@ -87,12 +87,6 @@ Status VSortExecExprs::open(RuntimeState* state) {
     return Status::OK();
 }
 
-void VSortExecExprs::close(RuntimeState* state) {
-    if (_materialize_tuple) {
-        VExpr::close(_sort_tuple_slot_expr_ctxs, state);
-    }
-    VExpr::close(_lhs_ordering_expr_ctxs, state);
-    VExpr::close(_rhs_ordering_expr_ctxs, state);
-}
+void VSortExecExprs::close(RuntimeState* state) {}
 
 } // namespace doris::vectorized

--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
@@ -97,11 +97,6 @@ RowGroupReader::RowGroupReader(io::FileReaderSPtr file_reader,
 
 RowGroupReader::~RowGroupReader() {
     _column_readers.clear();
-    for (auto* ctx : _dict_filter_conjuncts) {
-        if (ctx) {
-            ctx->close(_state);
-        }
-    }
     _obj_pool->clear();
 }
 

--- a/be/src/vec/exec/join/vhash_join_node.cpp
+++ b/be/src/vec/exec/join/vhash_join_node.cpp
@@ -755,12 +755,6 @@ Status HashJoinNode::alloc_resource(doris::RuntimeState* state) {
 
 void HashJoinNode::release_resource(RuntimeState* state) {
     START_AND_SCOPE_SPAN(state->get_tracer(), span, "HashJoinNode::release_resources");
-    VExpr::close(_build_expr_ctxs, state);
-    VExpr::close(_probe_expr_ctxs, state);
-
-    if (_vother_join_conjunct_ptr) {
-        (*_vother_join_conjunct_ptr)->close(state);
-    }
     _release_mem();
     VJoinNodeBase::release_resource(state);
 }

--- a/be/src/vec/exec/join/vjoin_node_base.cpp
+++ b/be/src/vec/exec/join/vjoin_node_base.cpp
@@ -110,7 +110,6 @@ Status VJoinNodeBase::close(RuntimeState* state) {
 
 void VJoinNodeBase::release_resource(RuntimeState* state) {
     START_AND_SCOPE_SPAN(state->get_tracer(), span, "VJoinNodeBase::release_resource");
-    VExpr::close(_output_expr_ctxs, state);
     _join_block.clear();
     ExecNode::release_resource(state);
 }

--- a/be/src/vec/exec/join/vnested_loop_join_node.cpp
+++ b/be/src/vec/exec/join/vnested_loop_join_node.cpp
@@ -736,8 +736,6 @@ bool VNestedLoopJoinNode::need_more_input_data() const {
 
 void VNestedLoopJoinNode::release_resource(doris::RuntimeState* state) {
     VJoinNodeBase::release_resource(state);
-    VExpr::close(_filter_src_expr_ctxs, state);
-    if (_vjoin_conjunct_ptr) (*_vjoin_conjunct_ptr)->close(state);
 }
 
 } // namespace doris::vectorized

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -836,40 +836,6 @@ Status VFileScanner::close(RuntimeState* state) {
         return Status::OK();
     }
 
-    for (auto ctx : _dest_vexpr_ctx) {
-        if (ctx != nullptr) {
-            ctx->close(state);
-        }
-    }
-
-    for (auto it : _col_default_value_ctx) {
-        if (it.second != nullptr) {
-            it.second->close(state);
-        }
-    }
-
-    if (_pre_conjunct_ctx_ptr) {
-        (*_pre_conjunct_ctx_ptr)->close(state);
-    }
-
-    if (_push_down_expr) {
-        _push_down_expr->close(state);
-    }
-
-    for (auto& [k, v] : _slot_id_to_filter_conjuncts) {
-        for (auto& ctx : v) {
-            if (ctx != nullptr) {
-                ctx->close(state);
-            }
-        }
-    }
-
-    for (auto* ctx : _not_single_slot_filter_conjuncts) {
-        if (ctx != nullptr) {
-            ctx->close(state);
-        }
-    }
-
     if (config::enable_file_cache && _state->query_options().enable_file_cache) {
         io::FileCacheProfileReporter cache_profile(_profile);
         cache_profile.update(_file_cache_statistics.get());

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -458,13 +458,6 @@ void VScanNode::release_resource(RuntimeState* state) {
         IRuntimeFilter* runtime_filter = ctx.runtime_filter;
         runtime_filter->consumer_close();
     }
-
-    for (auto& ctx : _stale_vexpr_ctxs) {
-        (*ctx)->close(state);
-    }
-    if (_common_vexpr_ctxs_pushdown) {
-        (*_common_vexpr_ctxs_pushdown)->close(state);
-    }
     _scanner_pool.clear();
 
     ExecNode::release_resource(state);
@@ -667,20 +660,8 @@ Status VScanNode::_normalize_predicate(VExpr* conjunct_expr_root, VExpr** output
                 *output_expr = conjunct_expr_root;
                 return Status::OK();
             } else {
-                if (left_child == nullptr) {
-                    conjunct_expr_root->children()[0]->close(
-                            _state, *_vconjunct_ctx_ptr,
-                            (*_vconjunct_ctx_ptr)->get_function_state_scope());
-                }
-                if (right_child == nullptr) {
-                    conjunct_expr_root->children()[1]->close(
-                            _state, *_vconjunct_ctx_ptr,
-                            (*_vconjunct_ctx_ptr)->get_function_state_scope());
-                }
                 // here only close the and expr self, do not close the child
                 conjunct_expr_root->set_children({});
-                conjunct_expr_root->close(_state, *_vconjunct_ctx_ptr,
-                                          (*_vconjunct_ctx_ptr)->get_function_state_scope());
             }
 
             // here do not close VExpr* now

--- a/be/src/vec/exec/scan/vscanner.cpp
+++ b/be/src/vec/exec/scan/vscanner.cpp
@@ -142,15 +142,6 @@ Status VScanner::close(RuntimeState* state) {
     if (_is_closed) {
         return Status::OK();
     }
-    for (auto& ctx : _stale_vexpr_ctxs) {
-        ctx->close(state);
-    }
-    if (_vconjunct_ctx) {
-        _vconjunct_ctx->close(state);
-    }
-    if (_common_vexpr_ctxs_pushdown) {
-        _common_vexpr_ctxs_pushdown->close(state);
-    }
 
     COUNTER_UPDATE(_parent->_scanner_wait_worker_timer, _scanner_wait_worker_timer);
     _is_closed = true;

--- a/be/src/vec/exec/vaggregation_node.cpp
+++ b/be/src/vec/exec/vaggregation_node.cpp
@@ -608,7 +608,6 @@ Status AggregationNode::sink(doris::RuntimeState* state, vectorized::Block* in_b
 
 void AggregationNode::release_resource(RuntimeState* state) {
     for (auto* aggregate_evaluator : _aggregate_evaluators) aggregate_evaluator->close(state);
-    VExpr::close(_probe_expr_ctxs, state);
     if (_executor.close) _executor.close();
 
     /// _hash_table_size_counter may be null if prepare failed.

--- a/be/src/vec/exec/vanalytic_eval_node.cpp
+++ b/be/src/vec/exec/vanalytic_eval_node.cpp
@@ -298,11 +298,6 @@ void VAnalyticEvalNode::release_resource(RuntimeState* state) {
     }
     START_AND_SCOPE_SPAN(state->get_tracer(), span, "VAnalyticEvalNode::close");
 
-    VExpr::close(_partition_by_eq_expr_ctxs, state);
-    VExpr::close(_order_by_eq_expr_ctxs, state);
-    for (size_t i = 0; i < _agg_functions_size; ++i) {
-        VExpr::close(_agg_expr_ctxs[i], state);
-    }
     for (auto* agg_function : _agg_functions) {
         agg_function->close(state);
     }

--- a/be/src/vec/exec/vrepeat_node.cpp
+++ b/be/src/vec/exec/vrepeat_node.cpp
@@ -285,7 +285,6 @@ Status VRepeatNode::close(RuntimeState* state) {
 
 void VRepeatNode::release_resource(RuntimeState* state) {
     START_AND_SCOPE_SPAN(state->get_tracer(), span, "VSortNode::close");
-    VExpr::close(_expr_ctxs, state);
     ExecNode::release_resource(state);
 }
 

--- a/be/src/vec/exec/vset_operation_node.cpp
+++ b/be/src/vec/exec/vset_operation_node.cpp
@@ -170,9 +170,6 @@ VSetOperationNode<is_intersect>::VSetOperationNode(ObjectPool* pool, const TPlan
 
 template <bool is_intersect>
 void VSetOperationNode<is_intersect>::release_resource(RuntimeState* state) {
-    for (auto& exprs : _child_expr_lists) {
-        VExpr::close(exprs, state);
-    }
     release_mem();
     ExecNode::release_resource(state);
 }

--- a/be/src/vec/exec/vtable_function_node.h
+++ b/be/src/vec/exec/vtable_function_node.h
@@ -63,8 +63,6 @@ public:
     bool need_more_input_data() const { return !_child_block.rows() && !_child_eos; }
 
     void release_resource(doris::RuntimeState* state) override {
-        VExpr::close(_vfn_ctxs, state);
-
         if (_num_rows_filtered_counter != nullptr) {
             COUNTER_SET(_num_rows_filtered_counter, static_cast<int64_t>(_num_rows_filtered));
         }

--- a/be/src/vec/exec/vunion_node.cpp
+++ b/be/src/vec/exec/vunion_node.cpp
@@ -320,12 +320,6 @@ void VUnionNode::release_resource(RuntimeState* state) {
         return;
     }
     START_AND_SCOPE_SPAN(state->get_tracer(), span, "VUnionNode::close");
-    for (auto& exprs : _const_expr_lists) {
-        VExpr::close(exprs, state);
-    }
-    for (auto& exprs : _child_expr_lists) {
-        VExpr::close(exprs, state);
-    }
     return ExecNode::release_resource(state);
 }
 

--- a/be/src/vec/exprs/vbitmap_predicate.cpp
+++ b/be/src/vec/exprs/vbitmap_predicate.cpp
@@ -117,12 +117,6 @@ doris::Status vectorized::VBitmapPredicate::execute(vectorized::VExprContext* co
     return Status::OK();
 }
 
-void vectorized::VBitmapPredicate::close(doris::RuntimeState* state,
-                                         vectorized::VExprContext* context,
-                                         FunctionContext::FunctionStateScope scope) {
-    VExpr::close(state, context, scope);
-}
-
 const std::string& vectorized::VBitmapPredicate::expr_name() const {
     return _expr_name;
 }

--- a/be/src/vec/exprs/vbitmap_predicate.h
+++ b/be/src/vec/exprs/vbitmap_predicate.h
@@ -56,9 +56,6 @@ public:
     doris::Status open(doris::RuntimeState* state, VExprContext* context,
                        FunctionContext::FunctionStateScope scope) override;
 
-    void close(doris::RuntimeState* state, VExprContext* context,
-               FunctionContext::FunctionStateScope scope) override;
-
     VExpr* clone(doris::ObjectPool* pool) const override {
         return pool->add(new VBitmapPredicate(*this));
     }

--- a/be/src/vec/exprs/vbloom_predicate.cpp
+++ b/be/src/vec/exprs/vbloom_predicate.cpp
@@ -69,11 +69,6 @@ Status VBloomPredicate::open(RuntimeState* state, VExprContext* context,
     return Status::OK();
 }
 
-void VBloomPredicate::close(RuntimeState* state, VExprContext* context,
-                            FunctionContext::FunctionStateScope scope) {
-    VExpr::close(state, context, scope);
-}
-
 Status VBloomPredicate::execute(VExprContext* context, Block* block, int* result_column_id) {
     doris::vectorized::ColumnNumbers arguments(_children.size());
     for (int i = 0; i < _children.size(); ++i) {

--- a/be/src/vec/exprs/vbloom_predicate.h
+++ b/be/src/vec/exprs/vbloom_predicate.h
@@ -47,8 +47,6 @@ public:
                           VExprContext* context) override;
     doris::Status open(doris::RuntimeState* state, VExprContext* context,
                        FunctionContext::FunctionStateScope scope) override;
-    void close(doris::RuntimeState* state, VExprContext* context,
-               FunctionContext::FunctionStateScope scope) override;
     VExpr* clone(doris::ObjectPool* pool) const override {
         return pool->add(new VBloomPredicate(*this));
     }

--- a/be/src/vec/exprs/vcase_expr.cpp
+++ b/be/src/vec/exprs/vcase_expr.cpp
@@ -84,12 +84,6 @@ Status VCaseExpr::open(RuntimeState* state, VExprContext* context,
     return Status::OK();
 }
 
-void VCaseExpr::close(RuntimeState* state, VExprContext* context,
-                      FunctionContext::FunctionStateScope scope) {
-    VExpr::close_function_context(context, scope, _function);
-    VExpr::close(state, context, scope);
-}
-
 Status VCaseExpr::execute(VExprContext* context, Block* block, int* result_column_id) {
     ColumnNumbers arguments(_children.size());
 

--- a/be/src/vec/exprs/vcase_expr.h
+++ b/be/src/vec/exprs/vcase_expr.h
@@ -48,8 +48,6 @@ public:
                            VExprContext* context) override;
     virtual Status open(RuntimeState* state, VExprContext* context,
                         FunctionContext::FunctionStateScope scope) override;
-    virtual void close(RuntimeState* state, VExprContext* context,
-                       FunctionContext::FunctionStateScope scope) override;
     virtual VExpr* clone(ObjectPool* pool) const override {
         return pool->add(new VCaseExpr(*this));
     }

--- a/be/src/vec/exprs/vcast_expr.cpp
+++ b/be/src/vec/exprs/vcast_expr.cpp
@@ -83,12 +83,6 @@ doris::Status VCastExpr::open(doris::RuntimeState* state, VExprContext* context,
     return Status::OK();
 }
 
-void VCastExpr::close(doris::RuntimeState* state, VExprContext* context,
-                      FunctionContext::FunctionStateScope scope) {
-    VExpr::close_function_context(context, scope, _function);
-    VExpr::close(state, context, scope);
-}
-
 doris::Status VCastExpr::execute(VExprContext* context, doris::vectorized::Block* block,
                                  int* result_column_id) {
     // for each child call execute

--- a/be/src/vec/exprs/vcast_expr.h
+++ b/be/src/vec/exprs/vcast_expr.h
@@ -47,8 +47,6 @@ public:
                                   VExprContext* context) override;
     virtual doris::Status open(doris::RuntimeState* state, VExprContext* context,
                                FunctionContext::FunctionStateScope scope) override;
-    virtual void close(doris::RuntimeState* state, VExprContext* context,
-                       FunctionContext::FunctionStateScope scope) override;
     virtual VExpr* clone(doris::ObjectPool* pool) const override {
         return pool->add(new VCastExpr(*this));
     }

--- a/be/src/vec/exprs/vectorized_agg_fn.cpp
+++ b/be/src/vec/exprs/vectorized_agg_fn.cpp
@@ -163,9 +163,7 @@ Status AggFnEvaluator::open(RuntimeState* state) {
     return VExpr::open(_input_exprs_ctxs, state);
 }
 
-void AggFnEvaluator::close(RuntimeState* state) {
-    VExpr::close(_input_exprs_ctxs, state);
-}
+void AggFnEvaluator::close(RuntimeState* state) {}
 void AggFnEvaluator::create(AggregateDataPtr place) {
     _function->create(place);
 }

--- a/be/src/vec/exprs/vectorized_fn_call.cpp
+++ b/be/src/vec/exprs/vectorized_fn_call.cpp
@@ -101,12 +101,6 @@ doris::Status VectorizedFnCall::open(doris::RuntimeState* state, VExprContext* c
     return Status::OK();
 }
 
-void VectorizedFnCall::close(doris::RuntimeState* state, VExprContext* context,
-                             FunctionContext::FunctionStateScope scope) {
-    VExpr::close_function_context(context, scope, _function);
-    VExpr::close(state, context, scope);
-}
-
 doris::Status VectorizedFnCall::execute(VExprContext* context, doris::vectorized::Block* block,
                                         int* result_column_id) {
     // TODO: not execute const expr again, but use the const column in function context

--- a/be/src/vec/exprs/vectorized_fn_call.h
+++ b/be/src/vec/exprs/vectorized_fn_call.h
@@ -47,8 +47,6 @@ public:
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;
-    void close(RuntimeState* state, VExprContext* context,
-               FunctionContext::FunctionStateScope scope) override;
     VExpr* clone(ObjectPool* pool) const override { return pool->add(new VectorizedFnCall(*this)); }
     const std::string& expr_name() const override;
     std::string debug_string() const override;

--- a/be/src/vec/exprs/vexpr.cpp
+++ b/be/src/vec/exprs/vexpr.cpp
@@ -124,13 +124,6 @@ Status VExpr::open(RuntimeState* state, VExprContext* context,
     return Status::OK();
 }
 
-void VExpr::close(doris::RuntimeState* state, VExprContext* context,
-                  FunctionContext::FunctionStateScope scope) {
-    for (int i = 0; i < _children.size(); ++i) {
-        _children[i]->close(state, context, scope);
-    }
-}
-
 Status VExpr::create_expr(doris::ObjectPool* pool, const doris::TExprNode& texpr_node,
                           VExpr** expr) {
     try {
@@ -316,12 +309,6 @@ Status VExpr::prepare(const std::vector<VExprContext*>& ctxs, RuntimeState* stat
     return Status::OK();
 }
 
-void VExpr::close(const std::vector<VExprContext*>& ctxs, RuntimeState* state) {
-    for (auto ctx : ctxs) {
-        ctx->close(state);
-    }
-}
-
 Status VExpr::open(const std::vector<VExprContext*>& ctxs, RuntimeState* state) {
     for (int i = 0; i < ctxs.size(); ++i) {
         RETURN_IF_ERROR(ctxs[i]->open(state));
@@ -443,17 +430,6 @@ Status VExpr::init_function_context(VExprContext* context,
     }
     RETURN_IF_ERROR(function->open(fn_ctx, FunctionContext::THREAD_LOCAL));
     return Status::OK();
-}
-
-void VExpr::close_function_context(VExprContext* context, FunctionContext::FunctionStateScope scope,
-                                   const FunctionBasePtr& function) const {
-    if (_fn_context_index != -1) {
-        FunctionContext* fn_ctx = context->fn_context(_fn_context_index);
-        function->close(fn_ctx, FunctionContext::THREAD_LOCAL);
-        if (scope == FunctionContext::FRAGMENT_LOCAL) {
-            function->close(fn_ctx, FunctionContext::FRAGMENT_LOCAL);
-        }
-    }
 }
 
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/vexpr.h
+++ b/be/src/vec/exprs/vexpr.h
@@ -102,14 +102,6 @@ public:
     virtual Status execute(VExprContext* context, vectorized::Block* block,
                            int* result_column_id) = 0;
 
-    /// Subclasses overriding this function should call VExpr::Close().
-    //
-    /// If scope if FRAGMENT_LOCAL, both fragment- and thread-local state should be torn
-    /// down. Otherwise, if scope is THREAD_LOCAL, only thread-local state should be torn
-    /// down.
-    virtual void close(RuntimeState* state, VExprContext* context,
-                       FunctionContext::FunctionStateScope scope);
-
     DataTypePtr& data_type() { return _data_type; }
 
     TypeDescriptor type() { return _type; }
@@ -136,8 +128,6 @@ public:
 
     static Status clone_if_not_exists(const std::vector<VExprContext*>& ctxs, RuntimeState* state,
                                       std::vector<VExprContext*>* new_ctxs);
-
-    static void close(const std::vector<VExprContext*>& ctxs, RuntimeState* state);
 
     bool is_nullable() const { return _data_type->is_nullable(); }
 
@@ -217,11 +207,6 @@ protected:
     /// thread-local according the input `FunctionStateScope` argument.
     Status init_function_context(VExprContext* context, FunctionContext::FunctionStateScope scope,
                                  const FunctionBasePtr& function) const;
-
-    /// Helper function to close function context, fragment-local or thread-local according
-    /// the input `FunctionStateScope` argument. Called in `close` phase of VExpr.
-    void close_function_context(VExprContext* context, FunctionContext::FunctionStateScope scope,
-                                const FunctionBasePtr& function) const;
 
     TExprNodeType::type _node_type;
     // Used to check what opcode

--- a/be/src/vec/exprs/vexpr_context.cpp
+++ b/be/src/vec/exprs/vexpr_context.cpp
@@ -42,14 +42,9 @@ VExprContext::VExprContext(VExpr* expr)
           _is_clone(false),
           _prepared(false),
           _opened(false),
-          _closed(false),
           _last_result_column_id(-1) {}
 
-VExprContext::~VExprContext() {
-    // Do not delete this code, this code here is used to check if forget to close the opened context
-    // Or there will be memory leak
-    DCHECK(!_prepared || _closed) << get_stack_trace();
-}
+VExprContext::~VExprContext() {}
 
 doris::Status VExprContext::execute(doris::vectorized::Block* block, int* result_column_id) {
     Status st;
@@ -77,14 +72,6 @@ doris::Status VExprContext::open(doris::RuntimeState* state) {
     FunctionContext::FunctionStateScope scope =
             _is_clone ? FunctionContext::THREAD_LOCAL : FunctionContext::FRAGMENT_LOCAL;
     return _root->open(state, this, scope);
-}
-
-void VExprContext::close(doris::RuntimeState* state) {
-    DCHECK(!_closed);
-    FunctionContext::FunctionStateScope scope =
-            _is_clone ? FunctionContext::THREAD_LOCAL : FunctionContext::FRAGMENT_LOCAL;
-    _root->close(state, this, scope);
-    _closed = true;
 }
 
 doris::Status VExprContext::clone(RuntimeState* state, VExprContext** new_ctx) {

--- a/be/src/vec/exprs/vexpr_context.h
+++ b/be/src/vec/exprs/vexpr_context.h
@@ -41,7 +41,6 @@ public:
     ~VExprContext();
     [[nodiscard]] Status prepare(RuntimeState* state, const RowDescriptor& row_desc);
     [[nodiscard]] Status open(RuntimeState* state);
-    void close(RuntimeState* state);
     [[nodiscard]] Status clone(RuntimeState* state, VExprContext** new_ctx);
     [[nodiscard]] Status execute(Block* block, int* result_column_id);
 
@@ -94,7 +93,6 @@ private:
     /// Variables keeping track of current state.
     bool _prepared;
     bool _opened;
-    bool _closed;
 
     /// FunctionContexts for each registered expression. The FunctionContexts are created
     /// and owned by this VExprContext.

--- a/be/src/vec/exprs/vin_predicate.cpp
+++ b/be/src/vec/exprs/vin_predicate.cpp
@@ -83,12 +83,6 @@ Status VInPredicate::open(RuntimeState* state, VExprContext* context,
     return Status::OK();
 }
 
-void VInPredicate::close(RuntimeState* state, VExprContext* context,
-                         FunctionContext::FunctionStateScope scope) {
-    VExpr::close_function_context(context, scope, _function);
-    VExpr::close(state, context, scope);
-}
-
 Status VInPredicate::execute(VExprContext* context, Block* block, int* result_column_id) {
     // TODO: not execute const expr again, but use the const column in function context
     doris::vectorized::ColumnNumbers arguments(_children.size());

--- a/be/src/vec/exprs/vin_predicate.h
+++ b/be/src/vec/exprs/vin_predicate.h
@@ -46,8 +46,6 @@ public:
                           VExprContext* context) override;
     doris::Status open(doris::RuntimeState* state, VExprContext* context,
                        FunctionContext::FunctionStateScope scope) override;
-    void close(doris::RuntimeState* state, VExprContext* context,
-               FunctionContext::FunctionStateScope scope) override;
     VExpr* clone(doris::ObjectPool* pool) const override {
         return pool->add(new VInPredicate(*this));
     }

--- a/be/src/vec/exprs/vruntimefilter_wrapper.cpp
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.cpp
@@ -66,11 +66,6 @@ Status VRuntimeFilterWrapper::open(RuntimeState* state, VExprContext* context,
     return _impl->open(state, context, scope);
 }
 
-void VRuntimeFilterWrapper::close(RuntimeState* state, VExprContext* context,
-                                  FunctionContext::FunctionStateScope scope) {
-    _impl->close(state, context, scope);
-}
-
 bool VRuntimeFilterWrapper::is_constant() const {
     return _impl->is_constant();
 }

--- a/be/src/vec/exprs/vruntimefilter_wrapper.h
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.h
@@ -53,8 +53,6 @@ public:
                        FunctionContext::FunctionStateScope scope) override;
     std::string debug_string() const override { return _impl->debug_string(); }
     bool is_constant() const override;
-    void close(doris::RuntimeState* state, VExprContext* context,
-               FunctionContext::FunctionStateScope scope) override;
     VExpr* clone(doris::ObjectPool* pool) const override {
         return pool->add(new VRuntimeFilterWrapper(*this));
     }

--- a/be/src/vec/exprs/vschema_change_expr.cpp
+++ b/be/src/vec/exprs/vschema_change_expr.cpp
@@ -73,11 +73,6 @@ Status VSchemaChangeExpr::open(doris::RuntimeState* state, VExprContext* context
     return Status::OK();
 }
 
-void VSchemaChangeExpr::close(doris::RuntimeState* state, VExprContext* context,
-                              FunctionContext::FunctionStateScope scope) {
-    VExpr::close(state, context, scope);
-}
-
 Status VSchemaChangeExpr::execute(VExprContext* context, doris::vectorized::Block* block,
                                   int* result_column_id) {
     // Send schema change RPC

--- a/be/src/vec/exprs/vschema_change_expr.h
+++ b/be/src/vec/exprs/vschema_change_expr.h
@@ -52,8 +52,6 @@ public:
                    VExprContext* context) override;
     Status open(doris::RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;
-    void close(doris::RuntimeState* state, VExprContext* context,
-               FunctionContext::FunctionStateScope scope) override;
     VExpr* clone(doris::ObjectPool* pool) const override {
         return pool->add(new VSchemaChangeExpr(*this));
     }

--- a/be/src/vec/functions/function.h
+++ b/be/src/vec/functions/function.h
@@ -171,12 +171,6 @@ public:
                 ->execute(context, block, arguments, result, input_rows_count, dry_run);
     }
 
-    /// Do cleaning work when function is finished, i.e., release state variables in the
-    /// `FunctionContext` which are registered in `prepare` phase.
-    virtual Status close(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
-        return Status::OK();
-    }
-
     virtual bool is_stateful() const { return false; }
 
     virtual bool can_fast_execute() const { return false; }
@@ -527,10 +521,6 @@ public:
 
     Status open(FunctionContext* context, FunctionContext::FunctionStateScope scope) override {
         return function->open(context, scope);
-    }
-
-    Status close(FunctionContext* context, FunctionContext::FunctionStateScope scope) override {
-        return function->close(context, scope);
     }
 
     bool is_suitable_for_constant_folding() const override {

--- a/be/src/vec/functions/function_convert_tz.h
+++ b/be/src/vec/functions/function_convert_tz.h
@@ -210,10 +210,6 @@ public:
         return Status::OK();
     }
 
-    Status close(FunctionContext* context, FunctionContext::FunctionStateScope scope) override {
-        return Status::OK();
-    }
-
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         size_t result, size_t input_rows_count) override {
         auto result_null_map_column = ColumnUInt8::create(input_rows_count, 0);

--- a/be/src/vec/functions/function_java_udf.cpp
+++ b/be/src/vec/functions/function_java_udf.cpp
@@ -304,17 +304,5 @@ Status JavaFunctionCall::execute(FunctionContext* context, Block& block,
     }
     return JniUtil::GetJniExceptionMsg(env);
 }
-/*
-Status JavaFunctionCall::close(FunctionContext* context,
-                               FunctionContext::FunctionStateScope scope) {
-    JniContext* jni_ctx = reinterpret_cast<JniContext*>(
-            context->get_function_state(FunctionContext::THREAD_LOCAL));
-    // JNIContext own some resource and its release method depend on JavaFunctionCall
-    // has to release the resource before JavaFunctionCall is deconstructed.
-    if (jni_ctx) {
-        jni_ctx->close();
-    }
-    return Status::OK();
-}
-*/
+
 } // namespace doris::vectorized

--- a/be/src/vec/functions/function_java_udf.cpp
+++ b/be/src/vec/functions/function_java_udf.cpp
@@ -304,7 +304,7 @@ Status JavaFunctionCall::execute(FunctionContext* context, Block& block,
     }
     return JniUtil::GetJniExceptionMsg(env);
 }
-
+/*
 Status JavaFunctionCall::close(FunctionContext* context,
                                FunctionContext::FunctionStateScope scope) {
     JniContext* jni_ctx = reinterpret_cast<JniContext*>(
@@ -316,4 +316,5 @@ Status JavaFunctionCall::close(FunctionContext* context,
     }
     return Status::OK();
 }
+*/
 } // namespace doris::vectorized

--- a/be/src/vec/functions/function_java_udf.h
+++ b/be/src/vec/functions/function_java_udf.h
@@ -70,8 +70,6 @@ public:
     Status execute(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                    size_t result, size_t input_rows_count, bool dry_run = false) override;
 
-    Status close(FunctionContext* context, FunctionContext::FunctionStateScope scope) override;
-
     bool is_deterministic() const override { return false; }
 
     bool is_deterministic_in_scope_of_query() const override { return false; }

--- a/be/src/vec/functions/function_java_udf.h
+++ b/be/src/vec/functions/function_java_udf.h
@@ -132,10 +132,7 @@ private:
                   batch_size_ptr(new int32_t()),
                   output_intermediate_state_ptr(new IntermediateState()) {}
 
-        void close() {
-            if (is_closed) {
-                return;
-            }
+        ~JniContext() {
             VLOG_DEBUG << "Free resources for JniContext";
             JNIEnv* env;
             Status status = JniUtil::GetJNIEnv(&env);
@@ -148,7 +145,6 @@ private:
             Status s = JniUtil::GetJniExceptionMsg(env);
             if (!s.ok()) LOG(WARNING) << s;
             env->DeleteGlobalRef(executor);
-            is_closed = true;
         }
 
         /// These functions are cross-compiled to IR and used by codegen.

--- a/be/src/vec/functions/function_regexp.cpp
+++ b/be/src/vec/functions/function_regexp.cpp
@@ -474,10 +474,6 @@ public:
                 ColumnNullable::create(std::move(result_data_column), std::move(result_null_map));
         return Status::OK();
     }
-
-    Status close(FunctionContext* context, FunctionContext::FunctionStateScope scope) override {
-        return Status::OK();
-    }
 };
 
 void register_function_regexp_extract(SimpleFunctionFactory& factory) {

--- a/be/src/vec/functions/functions_geo.cpp
+++ b/be/src/vec/functions/functions_geo.cpp
@@ -450,10 +450,6 @@ struct StCircle {
     static Status open(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
         return Status::OK();
     }
-
-    static Status close(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
-        return Status::OK();
-    }
 };
 
 struct StContains {
@@ -495,10 +491,6 @@ struct StContains {
     }
 
     static Status open(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
-        return Status::OK();
-    }
-
-    static Status close(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
         return Status::OK();
     }
 }; // namespace doris::vectorized
@@ -573,10 +565,6 @@ struct StGeoFromText {
     static Status open(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
         return Status::OK();
     }
-
-    static Status close(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
-        return Status::OK();
-    }
 };
 
 struct StGeometryFromWKB {
@@ -623,10 +611,6 @@ struct StGeoFromWkb {
     static Status open(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
         return Status::OK();
     }
-
-    static Status close(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
-        return Status::OK();
-    }
 };
 
 struct StAsBinary {
@@ -665,10 +649,6 @@ struct StAsBinary {
     }
 
     static Status open(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
-        return Status::OK();
-    }
-
-    static Status close(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
         return Status::OK();
     }
 };

--- a/be/src/vec/functions/functions_geo.h
+++ b/be/src/vec/functions/functions_geo.h
@@ -87,14 +87,6 @@ public:
             return Status::OK();
         }
     }
-
-    Status close(FunctionContext* context, FunctionContext::FunctionStateScope scope) override {
-        if constexpr (Impl::NEED_CONTEXT) {
-            return Impl::close(context, scope);
-        } else {
-            return Status::OK();
-        }
-    }
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/functions/in.h
+++ b/be/src/vec/functions/in.h
@@ -214,10 +214,6 @@ public:
         return Status::OK();
     }
 
-    Status close(FunctionContext* context, FunctionContext::FunctionStateScope scope) override {
-        return Status::OK();
-    }
-
 private:
     template <typename T>
     static void search_hash_set_check_null(InState* in_state, size_t input_rows_count,

--- a/be/src/vec/functions/like.cpp
+++ b/be/src/vec/functions/like.cpp
@@ -479,11 +479,6 @@ Status FunctionLikeBase::execute_impl(FunctionContext* context, Block& block,
     return Status::OK();
 }
 
-Status FunctionLikeBase::close(FunctionContext* context,
-                               FunctionContext::FunctionStateScope scope) {
-    return Status::OK();
-}
-
 Status FunctionLikeBase::execute_substring(const ColumnString::Chars& values,
                                            const ColumnString::Offsets& value_offsets,
                                            ColumnUInt8::Container& result,

--- a/be/src/vec/functions/like.h
+++ b/be/src/vec/functions/like.h
@@ -143,8 +143,6 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         size_t result, size_t /*input_rows_count*/) override;
 
-    Status close(FunctionContext* context, FunctionContext::FunctionStateScope scope) override;
-
 protected:
     Status vector_const(const ColumnString& values, const StringRef* pattern_val,
                         ColumnUInt8::Container& result, const LikeFn& function,

--- a/be/src/vec/functions/random.cpp
+++ b/be/src/vec/functions/random.cpp
@@ -100,10 +100,6 @@ public:
         block.replace_by_position(result, std::move(res_column));
         return Status::OK();
     }
-
-    Status close(FunctionContext* context, FunctionContext::FunctionStateScope scope) override {
-        return Status::OK();
-    }
 };
 
 void register_function_random(SimpleFunctionFactory& factory) {

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -650,7 +650,6 @@ Status VDataStreamSender::close(RuntimeState* state, Status exec_status) {
             final_st = st;
         }
     }
-    VExpr::close(_partition_expr_ctxs, state);
     DataSink::close(state, exec_status);
     return final_st;
 }

--- a/be/src/vec/sink/vmemory_scratch_sink.cpp
+++ b/be/src/vec/sink/vmemory_scratch_sink.cpp
@@ -99,7 +99,6 @@ Status MemoryScratchSink::close(RuntimeState* state, Status exec_status) {
     if (_queue != nullptr) {
         _queue->blocking_put(nullptr);
     }
-    VExpr::close(_output_vexpr_ctxs, state);
     return DataSink::close(state, exec_status);
 }
 

--- a/be/src/vec/sink/vresult_file_sink.cpp
+++ b/be/src/vec/sink/vresult_file_sink.cpp
@@ -187,8 +187,6 @@ Status VResultFileSink::close(RuntimeState* state, Status exec_status) {
         _output_block->clear();
     }
 
-    VExpr::close(_output_vexpr_ctxs, state);
-
     _closed = true;
     return Status::OK();
 }

--- a/be/src/vec/sink/vresult_sink.cpp
+++ b/be/src/vec/sink/vresult_sink.cpp
@@ -132,7 +132,6 @@ Status VResultSink::close(RuntimeState* state, Status exec_status) {
             time(nullptr) + config::result_buffer_cancelled_interval_time,
             state->fragment_instance_id());
 
-    VExpr::close(_output_vexpr_ctxs, state);
     return DataSink::close(state, exec_status);
 }
 

--- a/be/src/vec/sink/vtable_sink.cpp
+++ b/be/src/vec/sink/vtable_sink.cpp
@@ -71,7 +71,6 @@ Status VTableSink::close(RuntimeState* state, Status exec_status) {
     if (_closed) {
         return Status::OK();
     }
-    VExpr::close(_output_vexpr_ctxs, state);
     return Status::OK();
 }
 } // namespace vectorized

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -89,11 +89,7 @@ class TExpr;
 
 namespace stream_load {
 
-IndexChannel::~IndexChannel() {
-    if (_where_clause != nullptr) {
-        _where_clause->close(_parent->_state);
-    }
-}
+IndexChannel::~IndexChannel() {}
 
 Status IndexChannel::init(RuntimeState* state, const std::vector<TTabletWithPartition>& tablets) {
     SCOPED_CONSUME_MEM_TRACKER(_index_channel_tracker.get());
@@ -1266,7 +1262,6 @@ Status VOlapTableSink::close(RuntimeState* state, Status exec_status) {
         return _close_status;
     }
     START_AND_SCOPE_SPAN(state->get_tracer(), span, "VOlapTableSink::close");
-    vectorized::VExpr::close(_output_vexpr_ctxs, state);
     Status status = exec_status;
     if (status.ok()) {
         // only if status is ok can we call this _profile->total_time_counter().

--- a/be/src/vec/utils/util.hpp
+++ b/be/src/vec/utils/util.hpp
@@ -98,7 +98,6 @@ public:
 
         if (is_leaf(expr)) {
             if (checker(leaf_index++)) {
-                expr->close(state, context, context->get_function_state_scope());
                 return nullptr;
             }
             return expr;
@@ -114,7 +113,6 @@ public:
             } else {
                 // here only close the and expr self, do not close the child
                 expr->set_children({});
-                expr->close(state, context, context->get_function_state_scope());
             }
 
             return left_child != nullptr ? left_child : right_child;

--- a/be/test/vec/exprs/vexpr_test.cpp
+++ b/be/test/vec/exprs/vexpr_test.cpp
@@ -61,7 +61,6 @@ TEST(TEST_VEXPR, ABSTEST) {
     ASSERT_TRUE(state.ok());
     state = context->open(&runtime_stat);
     ASSERT_TRUE(state.ok());
-    context->close(&runtime_stat);
 }
 
 // Only the unit test depend on this, but it is wrong, should not use TTupleDesc to create tuple desc, not
@@ -157,7 +156,6 @@ TEST(TEST_VEXPR, ABSTEST2) {
     ASSERT_TRUE(state.ok());
     state = context->open(&runtime_stat);
     ASSERT_TRUE(state.ok());
-    context->close(&runtime_stat);
 }
 
 namespace doris {

--- a/be/test/vec/function/function_test_util.h
+++ b/be/test/vec/function/function_test_util.h
@@ -266,9 +266,6 @@ Status check_function(const std::string& func_name, const InputTypeSet& input_ty
         EXPECT_EQ(Status::OK(), st);
     }
 
-    func->close(fn_ctx, FunctionContext::THREAD_LOCAL);
-    func->close(fn_ctx, FunctionContext::FRAGMENT_LOCAL);
-
     // 3. check the result of function
     ColumnPtr column = block.get_columns()[result];
     EXPECT_TRUE(column != nullptr);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

