### PR TITLE
[fix](planner) vdatetime_value.cpp:1585 Array access may overflow.

### DIFF
--- a/be/src/vec/runtime/vdatetime_value.cpp
+++ b/be/src/vec/runtime/vdatetime_value.cpp
@@ -1583,8 +1583,10 @@ bool VecDateTimeValue::date_add_interval(const TimeInterval& interval) {
         if (_year < MIN_YEAR || _year > MAX_YEAR) {
             return false;
         }
-        // interval.month may be >= 12
-        _month = ((_month + 11 + sign * (interval.month % 12) + 12) % 12) + 1;
+        if (months < 0) {
+            return false;
+        }
+        _month = (months % 12) + 1;
         if (_day > s_days_in_month[_month]) {
             _day = s_days_in_month[_month];
             if (_month == 2 && doris::is_leap(_year)) {

--- a/be/src/vec/runtime/vdatetime_value.cpp
+++ b/be/src/vec/runtime/vdatetime_value.cpp
@@ -1580,9 +1580,6 @@ bool VecDateTimeValue::date_add_interval(const TimeInterval& interval) {
         // This will change month and year information, maybe date.
         int64_t months = _year * 12 + _month - 1 + sign * (12 * interval.year + interval.month);
         _year = months / 12;
-        if (_year > 9999) {
-            return false;
-        }
         if (_year < MIN_YEAR || _year > MAX_YEAR) {
             return false;
         }

--- a/be/src/vec/runtime/vdatetime_value.cpp
+++ b/be/src/vec/runtime/vdatetime_value.cpp
@@ -1583,7 +1583,8 @@ bool VecDateTimeValue::date_add_interval(const TimeInterval& interval) {
         if (_year < MIN_YEAR || _year > MAX_YEAR) {
             return false;
         }
-        _month = ((_month + 11 + sign * interval.month + 12) % 12) + 1;
+        // interval.month may be >= 12
+        _month = ((_month + 11 + sign * (interval.month % 12)  + 12) % 12) + 1;
         if (_day > s_days_in_month[_month]) {
             _day = s_days_in_month[_month];
             if (_month == 2 && doris::is_leap(_year)) {

--- a/be/src/vec/runtime/vdatetime_value.cpp
+++ b/be/src/vec/runtime/vdatetime_value.cpp
@@ -1580,7 +1580,7 @@ bool VecDateTimeValue::date_add_interval(const TimeInterval& interval) {
         // This will change month and year information, maybe date.
         int64_t months = _year * 12 + _month - 1 + sign * (12 * interval.year + interval.month);
         _year = months / 12;
-        DCHECK(months>=0)<<"months should be a non-negative number.";
+        DCHECK(months >= 0) << "months should be a non-negative number.";
         if (_year < MIN_YEAR || _year > MAX_YEAR) {
             return false;
         }

--- a/be/src/vec/runtime/vdatetime_value.cpp
+++ b/be/src/vec/runtime/vdatetime_value.cpp
@@ -1580,11 +1580,10 @@ bool VecDateTimeValue::date_add_interval(const TimeInterval& interval) {
         // This will change month and year information, maybe date.
         int64_t months = _year * 12 + _month - 1 + sign * (12 * interval.year + interval.month);
         _year = months / 12;
-        DCHECK(months >= 0) << "months should be a non-negative number.";
-        if (_year < MIN_YEAR || _year > MAX_YEAR) {
+        if (months < 0) {
             return false;
         }
-        if (months < 0) {
+        if (_year > MAX_YEAR) {
             return false;
         }
         _month = (months % 12) + 1;
@@ -2629,7 +2628,10 @@ bool DateV2Value<T>::date_add_interval(const TimeInterval& interval, DateV2Value
         int64_t months = date_v2_value_.year_ * 12 + date_v2_value_.month_ - 1 +
                          12 * interval.year + interval.month;
         to_value.template set_time_unit<TimeUnit::YEAR>(months / 12);
-        if (to_value.year() > 9999) {
+        if (months < 0) {
+            return false;
+        }
+        if (to_value.year() > MAX_YEAR) {
             return false;
         }
         to_value.template set_time_unit<TimeUnit::MONTH>((months % 12) + 1);
@@ -2698,7 +2700,10 @@ bool DateV2Value<T>::date_add_interval(const TimeInterval& interval) {
         int64_t months = date_v2_value_.year_ * 12 + date_v2_value_.month_ - 1 +
                          12 * interval.year + interval.month;
         this->template set_time_unit<TimeUnit::YEAR>(months / 12);
-        if (this->year() > 9999) {
+        if (months < 0) {
+            return false;
+        }
+        if (this->year() > MAX_YEAR) {
             return false;
         }
         this->template set_time_unit<TimeUnit::MONTH>((months % 12) + 1);

--- a/be/src/vec/runtime/vdatetime_value.cpp
+++ b/be/src/vec/runtime/vdatetime_value.cpp
@@ -1584,7 +1584,7 @@ bool VecDateTimeValue::date_add_interval(const TimeInterval& interval) {
             return false;
         }
         // interval.month may be >= 12
-        _month = ((_month + 11 + sign * (interval.month % 12)  + 12) % 12) + 1;
+        _month = ((_month + 11 + sign * (interval.month % 12) + 12) % 12) + 1;
         if (_day > s_days_in_month[_month]) {
             _day = s_days_in_month[_month];
             if (_month == 2 && doris::is_leap(_year)) {

--- a/be/src/vec/runtime/vdatetime_value.cpp
+++ b/be/src/vec/runtime/vdatetime_value.cpp
@@ -1580,6 +1580,7 @@ bool VecDateTimeValue::date_add_interval(const TimeInterval& interval) {
         // This will change month and year information, maybe date.
         int64_t months = _year * 12 + _month - 1 + sign * (12 * interval.year + interval.month);
         _year = months / 12;
+        DCHECK(months>=0)<<"months should be a non-negative number.";
         if (_year < MIN_YEAR || _year > MAX_YEAR) {
             return false;
         }

--- a/be/src/vec/runtime/vdatetime_value.cpp
+++ b/be/src/vec/runtime/vdatetime_value.cpp
@@ -1583,7 +1583,10 @@ bool VecDateTimeValue::date_add_interval(const TimeInterval& interval) {
         if (_year > 9999) {
             return false;
         }
-        _month = (months % 12) + 1;
+        if (_year < MIN_YEAR || _year > MAX_YEAR) {
+            return false;
+        }
+        _month = ((_month + 11 + sign * interval.month + 12) % 12) + 1;
         if (_day > s_days_in_month[_month]) {
             _day = s_days_in_month[_month];
             if (_month == 2 && doris::is_leap(_year)) {


### PR DESCRIPTION
# Proposed changes

``` cpp
    int64_t months = _year * 12 + _month - 1 + sign * (12 * interval.year + interval.month);
    _year = months / 12;
    if (_year > 9999) {
        return false;
    }
    _month = (months % 12) + 1;
    if (_day > s_days_in_month[_month]) {
        _day = s_days_in_month[_month];
        if (_month == 2 && doris::is_leap(_year)) {
            _day++;
        }
    }
```
The variable "months" may be negative. Taking modulus with it (_month) may also result in a negative value, which can cause an array access overflow.
## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

