### PR TITLE
[fix](mtmv) fix mtmv thread interruption issue

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVJobManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVJobManager.java
@@ -306,7 +306,10 @@ public class MTMVJobManager {
             LOG.warn("fail to obtain scheduled info for job [{}]", job.getName());
             return true;
         }
-        boolean isCancel = future.cancel(true);
+        // MUST not set true for "mayInterruptIfRunning".
+        // Because this thread may doing bdbje write operation, it is interrupted,
+        // FE may exit due to bdbje write failure.
+        boolean isCancel = future.cancel(false);
         if (!isCancel) {
             LOG.warn("fail to cancel scheduler for job [{}]", job.getName());
         }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

When dropping mtmv, it will try to stop schedule job related to this mtmv.
And this may interrupt the schedule thread. But the schedule thread may doing bdbje write operation,
cause edit log write failure, and FE will exit.

```
2023-04-20 19:17:26,577 ERROR (pool-13-thread-1|643) [BDBJEJournal.write():164] catch an exception when writing to database. sleep and retry. journal id 22129
com.sleepycat.je.ThreadInterruptedException: (JE 18.3.12) 172.21.16.6_9013_1681987307162(2):/mnt/hdd01/dorisTestEnv/VEC_ASAN/fe/doris-meta/bdb java.lang.Inter
ruptedException THREAD_INTERRUPTED: InterruptedException may cause incorrect internal state, unable to continue. Environment is invalid and must be closed.
        at com.sleepycat.je.rep.txn.MasterTxn.postLogCommitHook(MasterTxn.java:230) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.txn.Txn.commit(Txn.java:778) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.txn.Txn.commit(Txn.java:631) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.txn.Txn.operationEnd(Txn.java:1773) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.Database.put(Database.java:1638) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.Database.put(Database.java:1688) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at org.apache.doris.journal.bdbje.BDBJEJournal.write(BDBJEJournal.java:155) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.persist.EditLog.logEdit(EditLog.java:1084) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.persist.EditLog.logCreateMTMVTask(EditLog.java:1695) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.mtmv.MTMVTaskManager.submitTask(MTMVTaskManager.java:130) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.mtmv.MTMVJobManager.submitJobTask(MTMVJobManager.java:343) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.mtmv.MTMVJobManager.submitJobTask(MTMVJobManager.java:335) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.mtmv.MTMVJobManager.lambda$createJob$2(MTMVJobManager.java:255) ~[doris-fe.jar:1.2-SNAPSHOT]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_312]
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) ~[?:1.8.0_312]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) ~[?:1.8.0_312]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) ~[?:1.8.0_312]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_312]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_312]
        at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_312]
Caused by: java.lang.InterruptedException
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireSharedNanos(AbstractQueuedSynchronizer.java:1039) ~[?:1.8.0_312]
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.tryAcquireSharedNanos(AbstractQueuedSynchronizer.java:1328) ~[?:1.8.0_312]
        at java.util.concurrent.CountDownLatch.await(CountDownLatch.java:277) ~[?:1.8.0_312]
        at com.sleepycat.je.rep.stream.FeederTxns$TxnInfo.await(FeederTxns.java:223) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.rep.stream.FeederTxns$TxnInfo.access$100(FeederTxns.java:197) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.rep.stream.FeederTxns.awaitReplicaAcks(FeederTxns.java:184) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.rep.impl.RepImpl.postLogCommitHookInternal(RepImpl.java:1444) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.rep.impl.RepImpl.postLogCommitHook(RepImpl.java:1403) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.rep.txn.MasterTxn.postLogCommitHook(MasterTxn.java:228) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        ... 19 more
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

