### PR TITLE
[fix](routine-load)Fix crashed when transactionState is null in RoutineLoadJob getTasksShowInfo

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -1332,10 +1332,14 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
         List<List<String>> rows = Lists.newArrayList();
         routineLoadTaskInfoList.forEach(entity -> {
             try {
-                entity.setTxnStatus(Env.getCurrentEnv().getGlobalTransactionMgr().getDatabaseTransactionMgr(dbId)
-                        .getTransactionState(entity.getTxnId()).getTransactionStatus());
+                TransactionState transactionState = Env.getCurrentEnv().getGlobalTransactionMgr()
+                        .getDatabaseTransactionMgr(dbId).getTransactionState(entity.getTxnId());
+                if (transactionState == null) {
+                    throw new UserException("transaction [" + entity.getTxnId() + "] not found");
+                }
+                entity.setTxnStatus(transactionState.getTransactionStatus());
                 rows.add(entity.getTaskShowInfo());
-            } catch (AnalysisException e) {
+            } catch (UserException e) {
                 LOG.warn("failed to setTxnStatus db: {}, txnId: {}, err: {}", dbId, entity.getTxnId(), e.getMessage());
             }
         });

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
@@ -394,7 +394,7 @@ public class OlapTableSink extends DataSink {
             DatabaseTransactionMgr mgr = Env.getCurrentGlobalTransactionMgr().getDatabaseTransactionMgr(dbId);
             mgr.registerTxnReplicas(txnId, replicaNum);
         } catch (Exception e) {
-            LOG.error("register txn replica failed, txnId={}, dbId={}", txnId, dbId);
+            LOG.error("register txn replica failed, txnId={}, dbId={}, err={}", txnId, dbId, e.getMessage());
         }
         return Arrays.asList(locationParam, slaveLocationParam);
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
when org.apache.doris.load.routineload.RoutineLoadTaskInfo#beginTxn fail, the txnId of RoutineLoadTaskInfo will still be -1, and in this case show routine load task will throw an NPE and crash, it will be better to check  if transactionState is null or not, like what org.apache.doris.service.FrontendServiceImpl#loadTxn2PCImpl did.

        DatabaseTransactionMgr dbTransactionMgr = Env.getCurrentGlobalTransactionMgr()
                .getDatabaseTransactionMgr(database.getId());
        TransactionState transactionState = dbTransactionMgr.getTransactionState(request.getTxnId());
        if (transactionState == null) {
            throw new UserException("transaction [" + request.getTxnId() + "] not found");
        }

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

