### PR TITLE
[refactor](vectorized) fix some undefined behaviors in BE under ubsan

### DIFF
--- a/be/src/olap/block_column_predicate.cpp
+++ b/be/src/olap/block_column_predicate.cpp
@@ -79,6 +79,9 @@ uint16_t OrBlockColumnPredicate::evaluate(vectorized::MutableColumns& block, uin
     if (num_of_column_predicate() == 1) {
         return _block_column_predicate_vec[0]->evaluate(block, sel, selected_size);
     } else {
+        if (UNLIKELY(selected_size == 0)) {
+            return 0;
+        }
         bool ret_flags[selected_size];
         memset(ret_flags, false, selected_size);
         for (int i = 0; i < num_of_column_predicate(); ++i) {

--- a/be/src/olap/types.h
+++ b/be/src/olap/types.h
@@ -905,7 +905,15 @@ struct FieldTypeTraits<FieldType::OLAP_FIELD_TYPE_LARGEINT>
             uint128_t abs_value = value;
             if (value < 0) {
                 *(current++) = '-';
-                abs_value = -value;
+                if (value == std::numeric_limits<int128_t>::min()) {
+                    //runtime error: negation of 0x 80000000 00000000 00000000 00000000 cannot be represented in type '__int128';
+                    //cast to an unsigned type to negate this value to itself
+                    //so if value is the minimum of negative, Unable to directly convert to positive numbers
+                    abs_value = std::numeric_limits<int128_t>::max();
+                    abs_value = abs_value + 1;
+                } else {
+                    abs_value = -value;
+                }
             }
 
             // the max value of uint64_t is 18446744073709551615UL,

--- a/be/src/vec/aggregate_functions/aggregate_function_collect.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_collect.h
@@ -208,9 +208,7 @@ struct AggregateFunctionCollectListData {
     void write(BufferWritable& buf) const {
         write_var_uint(size(), buf);
         buf.write(data.raw_data(), size() * sizeof(ElementType));
-        if constexpr (HasLimit::value) {
-            write_var_int(max_size, buf);
-        }
+        write_var_int(max_size, buf);
     }
 
     void read(BufferReadable& buf) {
@@ -218,9 +216,7 @@ struct AggregateFunctionCollectListData {
         read_var_uint(rows, buf);
         data.resize(rows);
         buf.read(reinterpret_cast<char*>(data.data()), rows * sizeof(ElementType));
-        if constexpr (HasLimit::value) {
-            read_var_int(max_size, buf);
-        }
+        read_var_int(max_size, buf);
     }
 
     void reset() { data.clear(); }
@@ -266,9 +262,7 @@ struct AggregateFunctionCollectListData<StringRef, HasLimit> {
 
         write_var_uint(col.get_chars().size(), buf);
         buf.write(col.get_chars().raw_data(), col.get_chars().size());
-        if constexpr (HasLimit::value) {
-            write_var_int(max_size, buf);
-        }
+        write_var_int(max_size, buf);
     }
 
     void read(BufferReadable& buf) {
@@ -283,9 +277,7 @@ struct AggregateFunctionCollectListData<StringRef, HasLimit> {
         read_var_uint(chars_size, buf);
         col.get_chars().resize(chars_size);
         buf.read(reinterpret_cast<char*>(col.get_chars().data()), chars_size);
-        if constexpr (HasLimit::value) {
-            read_var_int(max_size, buf);
-        }
+        read_var_int(max_size, buf);
     }
 
     void reset() { data->clear(); }

--- a/be/src/vec/aggregate_functions/aggregate_function_collect.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_collect.h
@@ -208,7 +208,9 @@ struct AggregateFunctionCollectListData {
     void write(BufferWritable& buf) const {
         write_var_uint(size(), buf);
         buf.write(data.raw_data(), size() * sizeof(ElementType));
-        write_var_int(max_size, buf);
+        if constexpr (HasLimit::value) {
+            write_var_int(max_size, buf);
+        }
     }
 
     void read(BufferReadable& buf) {
@@ -216,7 +218,9 @@ struct AggregateFunctionCollectListData {
         read_var_uint(rows, buf);
         data.resize(rows);
         buf.read(reinterpret_cast<char*>(data.data()), rows * sizeof(ElementType));
-        read_var_int(max_size, buf);
+        if constexpr (HasLimit::value) {
+            read_var_int(max_size, buf);
+        }
     }
 
     void reset() { data.clear(); }
@@ -262,7 +266,9 @@ struct AggregateFunctionCollectListData<StringRef, HasLimit> {
 
         write_var_uint(col.get_chars().size(), buf);
         buf.write(col.get_chars().raw_data(), col.get_chars().size());
-        write_var_int(max_size, buf);
+        if constexpr (HasLimit::value) {
+            write_var_int(max_size, buf);
+        }
     }
 
     void read(BufferReadable& buf) {
@@ -277,7 +283,9 @@ struct AggregateFunctionCollectListData<StringRef, HasLimit> {
         read_var_uint(chars_size, buf);
         col.get_chars().resize(chars_size);
         buf.read(reinterpret_cast<char*>(col.get_chars().data()), chars_size);
-        read_var_int(max_size, buf);
+        if constexpr (HasLimit::value) {
+            read_var_int(max_size, buf);
+        }
     }
 
     void reset() { data->clear(); }

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -385,7 +385,7 @@ private:
     WrappedPtr null_map;
 
     bool _need_update_has_null = true;
-    bool _has_null = true;
+    bool _has_null = false;
 
     void _update_has_null();
     template <bool negative>

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -385,7 +385,7 @@ private:
     WrappedPtr null_map;
 
     bool _need_update_has_null = true;
-    bool _has_null;
+    bool _has_null = true;
 
     void _update_has_null();
     template <bool negative>


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
**under ubsan mode, the BE report some runtime errors:**
```
1.doris/be/src/util/string_parser.hpp:244:58: runtime error: signed integer overflow: 9223372036854775807 + 1 cannot be represented in type 'long int'2. 

2.doris/be/src/vec/columns/column_nullable.cpp:280:15: runtime error: load of value 201, which is not a valid value for type 'bool'

3.doris/be/src/olap/types.h:889:29: runtime error: negation of 0x80000000000000000000000000000000 cannot be represented in type '__int128'; cast to an unsigned type to negate this value to itself

4.doris/be/src/vec/exprs/vectorized_agg_fn.cpp:229:44: runtime error: variable length array bound evaluates to non-positive value 0

5.doris/be/src/vec/io/var_int.h:43:43: runtime error: left shift of negative value -1

6.doris/be/src/exec/schema_scanner/schema_columns_scanner.cpp:450:79: runtime error: signed integer overflow: 2147483643 * 4 cannot be represented in type 'int'

7.doris/be/src/olap/block_column_predicate.cpp:74:37: runtime error: variable length array bound evaluates to non-positive value 0
```

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

