### PR TITLE
[Fix](inverted index) fix memory leak when create bkd reader

### DIFF
--- a/be/src/olap/rowset/segment_v2/inverted_index_compound_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_compound_reader.cpp
@@ -244,6 +244,17 @@ int64_t DorisCompoundReader::fileLength(const char* name) const {
     return e->length;
 }
 
+bool DorisCompoundReader::openInput(const char* name,
+                                    std::unique_ptr<lucene::store::IndexInput>& ret,
+                                    CLuceneError& error, int32_t bufferSize) {
+    lucene::store::IndexInput* tmp;
+    bool success = openInput(name, tmp, error, bufferSize);
+    if (success) {
+        ret.reset(tmp);
+    }
+    return success;
+}
+
 bool DorisCompoundReader::openInput(const char* name, lucene::store::IndexInput*& ret,
                                     CLuceneError& error, int32_t bufferSize) {
     if (stream == nullptr) {

--- a/be/src/olap/rowset/segment_v2/inverted_index_compound_reader.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_compound_reader.h
@@ -27,6 +27,7 @@
 #include <stdint.h>
 
 #include <map>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -82,6 +83,8 @@ public:
     int64_t fileLength(const char* name) const override;
     bool openInput(const char* name, lucene::store::IndexInput*& ret, CLuceneError& err,
                    int32_t bufferSize = -1) override;
+    bool openInput(const char* name, std::unique_ptr<lucene::store::IndexInput>& ret,
+                   CLuceneError& err, int32_t bufferSize = -1);
     void renameFile(const char* from, const char* to) override;
     void touchFile(const char* name) override;
     lucene::store::IndexOutput* createOutput(const char* name) override;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

The function compoundReader->openInput is called three times, and if any of these calls fail, an error is logged, and the function returns early. If one or two of the calls succeed, but the others fail, there might be a situation where the allocated memory for the IndexInput objects is not freed.

To fix this, you could use std::unique_ptr to manage the memory for IndexInput objects. This would automatically clean up the memory when the function goes out of scope.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

