### PR TITLE
[enhencement](http) Fe config action supports specified item

### DIFF
--- a/docs/en/docs/admin-manual/http-actions/fe/config-action.md
+++ b/docs/en/docs/admin-manual/http-actions/fe/config-action.md
@@ -42,7 +42,9 @@ None
 
 ## Query parameters
 
-None
+* `conf_item`
+
+    Optional parameters. Return specified item in FE configuration.
 
 ## Request body
 

--- a/docs/zh-CN/docs/admin-manual/http-actions/fe/config-action.md
+++ b/docs/zh-CN/docs/admin-manual/http-actions/fe/config-action.md
@@ -42,7 +42,9 @@ Config Action 用于获取当前 FE 的配置信息
 
 ## Query parameters
 
-无
+* `conf_item`
+
+    可选参数。返回 FE 的配置信息中的指定项。
 
 ## Request body
 

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/ConfigController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/ConfigController.java
@@ -20,6 +20,7 @@ package org.apache.doris.httpv2.controller;
 import org.apache.doris.common.Config;
 import org.apache.doris.httpv2.entity.ResponseEntityBuilder;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.logging.log4j.LogManager;
@@ -31,32 +32,42 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 @RestController
 @RequestMapping("/rest/v1")
 public class ConfigController {
     private static final Logger LOG = LogManager.getLogger(ConfigController.class);
     private static final List<String> CONFIG_TABLE_HEADER = Lists.newArrayList("Name", "Value");
+    private static final String CONF_ITEM = "conf_item";
 
     @RequestMapping(path = "/config/fe", method = RequestMethod.GET)
-    public Object variable() {
+    public Object variable(HttpServletRequest request, HttpServletResponse response) {
         Map<String, Object> result = Maps.newHashMap();
-        appendConfigureInfo(result);
+        String confItem = request.getParameter(CONF_ITEM);
+        appendConfigureInfo(result, confItem);
         return ResponseEntityBuilder.ok(result);
     }
 
-    private void appendConfigureInfo(Map<String, Object> result) {
-
+    private void appendConfigureInfo(Map<String, Object> result, String confItem) {
         result.put("column_names", CONFIG_TABLE_HEADER);
         List<Map<String, String>> list = Lists.newArrayList();
         result.put("rows", list);
         try {
             Map<String, String> confmap = Config.dump();
-            for (String key : confmap.keySet()) {
+            if (!Strings.isNullOrEmpty(confItem)) {
                 Map<String, String> info = new HashMap<>();
-                info.put("Name", key);
-                info.put("Value", confmap.get(key));
+                info.put("Name", confItem);
+                info.put("Value", confmap.get(confItem));
                 list.add(info);
+            } else {
+                for (String key : confmap.keySet()) {
+                    Map<String, String> info = new HashMap<>();
+                    info.put("Name", key);
+                    info.put("Value", confmap.get(key));
+                    list.add(info);
+                }
             }
         } catch (Exception e) {
             LOG.warn("", e);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Fe config action supports specified item.
Support “GET /rest/v1/config/fe/” and “GET /rest/v1/config/fe?conf_item=xxx”.

## Checklist(Required)

* [x] Does it affect the original behavior
* [ ] Has unit tests been added
* [x] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

