### PR TITLE
[fix](jdbc catalog) Use default value if the user does not set the pool parameter in be.conf

### DIFF
--- a/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
@@ -73,10 +73,10 @@ public class JdbcExecutor {
     private int curBlockRows = 0;
     private static final byte[] emptyBytes = new byte[0];
     private DruidDataSource druidDataSource = null;
-    private int minPoolSize = 1;
-    private int maxPoolSize = 100;
-    private int minIdleSize = 1;
-    private int maxIdelTime = 600000;
+    private int minPoolSize;
+    private int maxPoolSize;
+    private int minIdleSize;
+    private int maxIdelTime;
 
     public JdbcExecutor(byte[] thriftParams) throws Exception {
         TJdbcExecutorCtorParams request = new TJdbcExecutorCtorParams();
@@ -86,10 +86,14 @@ public class JdbcExecutor {
         } catch (TException e) {
             throw new InternalException(e.getMessage());
         }
-        minPoolSize = Integer.valueOf(System.getProperty("JDBC_MIN_POOL"));
-        maxPoolSize = Integer.valueOf(System.getProperty("JDBC_MAX_POOL"));
-        maxIdelTime = Integer.valueOf(System.getProperty("JDBC_MAX_IDEL_TIME"));
+        minPoolSize = Integer.valueOf(System.getProperty("JDBC_MIN_POOL", "1"));
+        maxPoolSize = Integer.valueOf(System.getProperty("JDBC_MAX_POOL", "100"));
+        maxIdelTime = Integer.valueOf(System.getProperty("JDBC_MAX_IDEL_TIME", "600000"));
         minIdleSize = minPoolSize > 0 ? 1 : 0;
+        LOG.info("JdbcExecutor set minPoolSize = " + minPoolSize
+                + ", maxPoolSize = " + maxPoolSize
+                + ", maxIdelTime = " + maxIdelTime
+                + ", minIdleSize = " + minIdleSize);
         init(request.driver_path, request.statement, request.batch_size, request.jdbc_driver_class,
                 request.jdbc_url, request.jdbc_user, request.jdbc_password, request.op, request.table_type);
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

