### PR TITLE
[fix](fixed_hashtable) The incorrect implementation of assignment operator

### DIFF
--- a/be/src/vec/common/hash_table/fixed_hash_table.h
+++ b/be/src/vec/common/hash_table/fixed_hash_table.h
@@ -200,8 +200,9 @@ public:
         destroy_elements();
         free();
 
+        const auto new_size = rhs.size();
         std::swap(buf, rhs.buf);
-        this->set_size(rhs.size());
+        this->set_size(new_size);
 
         Allocator::operator=(std::move(rhs));
         Cell::State::operator=(std::move(rhs));


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

```bash
0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris_master/doris/be/src/common/signal_handler.h:412
 1# 0x00007F39CD020BF9 in /usr/lib/jvm/java-1.11.0-openjdk-amd64/lib/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-1.11.0-openjdk-amd64/lib/server/libjvm.so
 3# 0x00007F39CD01993C in /usr/lib/jvm/java-1.11.0-openjdk-amd64/lib/server/libjvm.so
 4# 0x00007F39D4F280C0 in /lib/x86_64-linux-gnu/libc.so.6
 5# FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>::is_zero(HashTableNoState const&) const at /root/doris_master/doris/be/src/vec/common/hash_table/fixed_hash_map.h:88
 6# FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >::get_size(FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> const*, HashTableNoState const&, unsigned long) const at /root/doris_master/doris/be/src/vec/common/hash_table/fixed_hash_table.h:78
 7# FixedHashTable<unsigned char, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> >::size() const at /root/doris_master/doris/be/src/vec/common/hash_table/fixed_hash_table.h:355
 8# FixedHashTable<unsigned char, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> >::operator=(FixedHashTable<unsigned char, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> >&&) at /root/doris_master/doris/be/src/vec/common/hash_table/fixed_hash_table.h:204
 9# FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> >::operator=(FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> >&&) at /root/doris_master/doris/be/src/vec/common/hash_table/fixed_hash_map.h:119
10# doris::vectorized::AggregationDataWithNullKey<FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> > >::operator=(doris::vectorized::AggregationDataWithNullKey<FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> > >&&) at /root/doris_master/doris/be/src/vec/exec/vaggregation_node.h:285
11# auto doris::vectorized::AggregationNode::_reset_hash_table()::$_4::operator()<doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned char, doris::vectorized::AggregationDataWithNullKey<FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> > >, false> >&>(doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned char, doris::vectorized::AggregationDataWithNullKey<FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> > >, false> >&) const at /root/doris_master/doris/be/src/vec/exec/vaggregation_node.cpp:927
12# doris::Status std::__invoke_impl<doris::Status, doris::vectorized::AggregationNode::_reset_hash_table()::$_4, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned char, doris::vectorized::AggregationDataWithNullKey<FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> > >, false> >&>(std::__invoke_other, doris::vectorized::AggregationNode::_reset_hash_table()::$_4&&, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned char, doris::vectorized::AggregationDataWithNullKey<FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> > >, false> >&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
13# std::__invoke_result<doris::vectorized::AggregationNode::_reset_hash_table()::$_4, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned char, doris::vectorized::AggregationDataWithNullKey<FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> > >, false> >&>::type std::__invoke<doris::vectorized::AggregationNode::_reset_hash_table()::$_4, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned char, doris::vectorized::AggregationDataWithNullKey<FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> > >, false> >&>(doris::vectorized::AggregationNode::_reset_hash_table()::$_4&&, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned char, doris::vectorized::AggregationDataWithNullKey<FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> > >, false> >&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
14# _ZNSt8__detail9__variant17__gen_vtable_implINS0_12_Multi_arrayIPFNS0_21__deduce_visit_resultIN5doris6StatusEEEOZNS4_10vectorized15AggregationNode17_reset_hash_tableEvE3$_4RSt7variantIJNS7_27AggregationMethodSerializedI9PHHashMapINS4_9StringRefEPc11DefaultHashISE_vELb0EEEENS7_26AggregationMethodOneNumberIh12FixedHashMapIhSF_28FixedHashMapImplicitZeroCellIhSF_16HashTableNoStateE28FixedHashTableCalculatedSizeISO_E9AllocatorILb1ELb1EEELb0EEENSK_ItSL_ItSF_SM_ItSF_SN_E24FixedHashTableStoredSizeISV_ESS_ELb0EEENSK_IjSD_IjSF_9HashCRC32IjELb0EELb0EEENSK_ImSD_ImSF_S10_ImELb0EELb0EEENS7_30AggregationMethodStringNoCacheI13StringHashMapISF_SS_EEENSK_INS7_7UInt128ESD_IS1B_SF_S10_IS1B_ELb0EELb0EEENSK_IjSD_IjSF_14HashMixWrapperIjS11_ELb0EELb0EEENSK_ImSD_ImSF_S1F_ImS14_ELb0EELb0EEENSK_IS1B_SD_IS1B_SF_S1F_IS1B_S1C_ELb0EELb0EEENS7_37AggregationMethodSingleNullableColumnINSK_IhNS7_26AggregationDataWithNullKeyIST_EELb0EEEEENS1P_INSK_ItNS1Q_ISY_EELb0EEEEENS1P_INSK_IjNS1Q_IS12_EELb0EEEEENS1P_INSK_ImNS1Q_IS15_EELb0EEEEENS1P_INSK_IjNS1Q_IS1H_EELb0EEEEENS1P_INSK_ImNS1Q_IS1K_EELb0EEEEENS1P_INSK_IS1B_NS1Q_IS1D_EELb0EEEEENS1P_INSK_IS1B_NS1Q_IS1N_EELb0EEEEENS1P_INS17_INS1Q_IS19_EEEEEENS7_26AggregationMethodKeysFixedIS15_Lb0EEENS2I_IS15_Lb1EEENS2I_IS1D_Lb0EEENS2I_IS1D_Lb1EEENS2I_ISD_INS7_7UInt256ESF_S10_IS2N_ELb0EELb0EEENS2I_IS2P_Lb1EEENS2I_IS1K_Lb0EEENS2I_IS1K_Lb1EEENS2I_IS1N_Lb0EEENS2I_IS1N_Lb1EEENS2I_ISD_IS2N_SF_S1F_IS2N_S2O_ELb0EELb0EEENS2I_IS2X_Lb1EEEEEEJEEESt16integer_sequenceImJLm10EEEE14__visit_invokeESA_S31_ at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1013
15# _ZSt10__do_visitINSt8__detail9__variant21__deduce_visit_resultIN5doris6StatusEEEZNS3_10vectorized15AggregationNode17_reset_hash_tableEvE3$_4JRSt7variantIJNS6_27AggregationMethodSerializedI9PHHashMapINS3_9StringRefEPc11DefaultHashISC_vELb0EEEENS6_26AggregationMethodOneNumberIh12FixedHashMapIhSD_28FixedHashMapImplicitZeroCellIhSD_16HashTableNoStateE28FixedHashTableCalculatedSizeISM_E9AllocatorILb1ELb1EEELb0EEENSI_ItSJ_ItSD_SK_ItSD_SL_E24FixedHashTableStoredSizeIST_ESQ_ELb0EEENSI_IjSB_IjSD_9HashCRC32IjELb0EELb0EEENSI_ImSB_ImSD_SY_ImELb0EELb0EEENS6_30AggregationMethodStringNoCacheI13StringHashMapISD_SQ_EEENSI_INS6_7UInt128ESB_IS19_SD_SY_IS19_ELb0EELb0EEENSI_IjSB_IjSD_14HashMixWrapperIjSZ_ELb0EELb0EEENSI_ImSB_ImSD_S1D_ImS12_ELb0EELb0EEENSI_IS19_SB_IS19_SD_S1D_IS19_S1A_ELb0EELb0EEENS6_37AggregationMethodSingleNullableColumnINSI_IhNS6_26AggregationDataWithNullKeyISR_EELb0EEEEENS1N_INSI_ItNS1O_ISW_EELb0EEEEENS1N_INSI_IjNS1O_IS10_EELb0EEEEENS1N_INSI_ImNS1O_IS13_EELb0EEEEENS1N_INSI_IjNS1O_IS1F_EELb0EEEEENS1N_INSI_ImNS1O_IS1I_EELb0EEEEENS1N_INSI_IS19_NS1O_IS1B_EELb0EEEEENS1N_INSI_IS19_NS1O_IS1L_EELb0EEEEENS1N_INS15_INS1O_IS17_EEEEEENS6_26AggregationMethodKeysFixedIS13_Lb0EEENS2G_IS13_Lb1EEENS2G_IS1B_Lb0EEENS2G_IS1B_Lb1EEENS2G_ISB_INS6_7UInt256ESD_SY_IS2L_ELb0EELb0EEENS2G_IS2N_Lb1EEENS2G_IS1I_Lb0EEENS2G_IS1I_Lb1EEENS2G_IS1L_Lb0EEENS2G_IS1L_Lb1EEENS2G_ISB_IS2L_SD_S1D_IS2L_S2M_ELb0EELb0EEENS2G_IS2V_Lb1EEEEEEEDcOT0_DpOT1_ at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1714
16# _ZSt5visitIZN5doris10vectorized15AggregationNode17_reset_hash_tableEvE3$_4JRSt7variantIJNS1_27AggregationMethodSerializedI9PHHashMapINS0_9StringRefEPc11DefaultHashIS7_vELb0EEEENS1_26AggregationMethodOneNumberIh12FixedHashMapIhS8_28FixedHashMapImplicitZeroCellIhS8_16HashTableNoStateE28FixedHashTableCalculatedSizeISH_E9AllocatorILb1ELb1EEELb0EEENSD_ItSE_ItS8_SF_ItS8_SG_E24FixedHashTableStoredSizeISO_ESL_ELb0EEENSD_IjS6_IjS8_9HashCRC32IjELb0EELb0EEENSD_ImS6_ImS8_ST_ImELb0EELb0EEENS1_30AggregationMethodStringNoCacheI13StringHashMapIS8_SL_EEENSD_INS1_7UInt128ES6_IS14_S8_ST_IS14_ELb0EELb0EEENSD_IjS6_IjS8_14HashMixWrapperIjSU_ELb0EELb0EEENSD_ImS6_ImS8_S18_ImSX_ELb0EELb0EEENSD_IS14_S6_IS14_S8_S18_IS14_S15_ELb0EELb0EEENS1_37AggregationMethodSingleNullableColumnINSD_IhNS1_26AggregationDataWithNullKeyISM_EELb0EEEEENS1I_INSD_ItNS1J_ISR_EELb0EEEEENS1I_INSD_IjNS1J_ISV_EELb0EEEEENS1I_INSD_ImNS1J_ISY_EELb0EEEEENS1I_INSD_IjNS1J_IS1A_EELb0EEEEENS1I_INSD_ImNS1J_IS1D_EELb0EEEEENS1I_INSD_IS14_NS1J_IS16_EELb0EEEEENS1I_INSD_IS14_NS1J_IS1G_EELb0EEEEENS1I_INS10_INS1J_IS12_EEEEEENS1_26AggregationMethodKeysFixedISY_Lb0EEENS2B_ISY_Lb1EEENS2B_IS16_Lb0EEENS2B_IS16_Lb1EEENS2B_IS6_INS1_7UInt256ES8_ST_IS2G_ELb0EELb0EEENS2B_IS2I_Lb1EEENS2B_IS1D_Lb0EEENS2B_IS1D_Lb1EEENS2B_IS1G_Lb0EEENS2B_IS1G_Lb1EEENS2B_IS6_IS2G_S8_S18_IS2G_S2H_ELb0EELb0EEENS2B_IS2Q_Lb1EEEEEEEDcOT_DpOT0_ at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1764
17# doris::vectorized::AggregationNode::_reset_hash_table() at /root/doris_master/doris/be/src/vec/exec/vaggregation_node.cpp:903
18# doris::Status doris::vectorized::AggregationNode::_try_spill_disk(bool)::$_9::operator()<doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned char, doris::vectorized::AggregationDataWithNullKey<FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> > >, false> >&>(doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned char, doris::vectorized::AggregationDataWithNullKey<FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> > >, false> >&) const at /root/doris_master/doris/be/src/vec/exec/vaggregation_node.cpp:1414
19# doris::Status std::__invoke_impl<doris::Status, doris::vectorized::AggregationNode::_try_spill_disk(bool)::$_9, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned char, doris::vectorized::AggregationDataWithNullKey<FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> > >, false> >&>(std::__invoke_other, doris::vectorized::AggregationNode::_try_spill_disk(bool)::$_9&&, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned char, doris::vectorized::AggregationDataWithNullKey<FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> > >, false> >&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
20# std::__invoke_result<doris::vectorized::AggregationNode::_try_spill_disk(bool)::$_9, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned char, doris::vectorized::AggregationDataWithNullKey<FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> > >, false> >&>::type std::__invoke<doris::vectorized::AggregationNode::_try_spill_disk(bool)::$_9, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned char, doris::vectorized::AggregationDataWithNullKey<FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> > >, false> >&>(doris::vectorized::AggregationNode::_try_spill_disk(bool)::$_9&&, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned char, doris::vectorized::AggregationDataWithNullKey<FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> > >, false> >&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
21# _ZNSt8__detail9__variant17__gen_vtable_implINS0_12_Multi_arrayIPFNS0_21__deduce_visit_resultIN5doris6StatusEEEOZNS4_10vectorized15AggregationNode15_try_spill_diskEbE3$_9RSt7variantIJNS7_27AggregationMethodSerializedI9PHHashMapINS4_9StringRefEPc11DefaultHashISE_vELb0EEEENS7_26AggregationMethodOneNumberIh12FixedHashMapIhSF_28FixedHashMapImplicitZeroCellIhSF_16HashTableNoStateE28FixedHashTableCalculatedSizeISO_E9AllocatorILb1ELb1EEELb0EEENSK_ItSL_ItSF_SM_ItSF_SN_E24FixedHashTableStoredSizeISV_ESS_ELb0EEENSK_IjSD_IjSF_9HashCRC32IjELb0EELb0EEENSK_ImSD_ImSF_S10_ImELb0EELb0EEENS7_30AggregationMethodStringNoCacheI13StringHashMapISF_SS_EEENSK_INS7_7UInt128ESD_IS1B_SF_S10_IS1B_ELb0EELb0EEENSK_IjSD_IjSF_14HashMixWrapperIjS11_ELb0EELb0EEENSK_ImSD_ImSF_S1F_ImS14_ELb0EELb0EEENSK_IS1B_SD_IS1B_SF_S1F_IS1B_S1C_ELb0EELb0EEENS7_37AggregationMethodSingleNullableColumnINSK_IhNS7_26AggregationDataWithNullKeyIST_EELb0EEEEENS1P_INSK_ItNS1Q_ISY_EELb0EEEEENS1P_INSK_IjNS1Q_IS12_EELb0EEEEENS1P_INSK_ImNS1Q_IS15_EELb0EEEEENS1P_INSK_IjNS1Q_IS1H_EELb0EEEEENS1P_INSK_ImNS1Q_IS1K_EELb0EEEEENS1P_INSK_IS1B_NS1Q_IS1D_EELb0EEEEENS1P_INSK_IS1B_NS1Q_IS1N_EELb0EEEEENS1P_INS17_INS1Q_IS19_EEEEEENS7_26AggregationMethodKeysFixedIS15_Lb0EEENS2I_IS15_Lb1EEENS2I_IS1D_Lb0EEENS2I_IS1D_Lb1EEENS2I_ISD_INS7_7UInt256ESF_S10_IS2N_ELb0EELb0EEENS2I_IS2P_Lb1EEENS2I_IS1K_Lb0EEENS2I_IS1K_Lb1EEENS2I_IS1N_Lb0EEENS2I_IS1N_Lb1EEENS2I_ISD_IS2N_SF_S1F_IS2N_S2O_ELb0EELb0EEENS2I_IS2X_Lb1EEEEEEJEEESt16integer_sequenceImJLm10EEEE14__visit_invokeESA_S31_ at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1013
22# _ZSt10__do_visitINSt8__detail9__variant21__deduce_visit_resultIN5doris6StatusEEEZNS3_10vectorized15AggregationNode15_try_spill_diskEbE3$_9JRSt7variantIJNS6_27AggregationMethodSerializedI9PHHashMapINS3_9StringRefEPc11DefaultHashISC_vELb0EEEENS6_26AggregationMethodOneNumberIh12FixedHashMapIhSD_28FixedHashMapImplicitZeroCellIhSD_16HashTableNoStateE28FixedHashTableCalculatedSizeISM_E9AllocatorILb1ELb1EEELb0EEENSI_ItSJ_ItSD_SK_ItSD_SL_E24FixedHashTableStoredSizeIST_ESQ_ELb0EEENSI_IjSB_IjSD_9HashCRC32IjELb0EELb0EEENSI_ImSB_ImSD_SY_ImELb0EELb0EEENS6_30AggregationMethodStringNoCacheI13StringHashMapISD_SQ_EEENSI_INS6_7UInt128ESB_IS19_SD_SY_IS19_ELb0EELb0EEENSI_IjSB_IjSD_14HashMixWrapperIjSZ_ELb0EELb0EEENSI_ImSB_ImSD_S1D_ImS12_ELb0EELb0EEENSI_IS19_SB_IS19_SD_S1D_IS19_S1A_ELb0EELb0EEENS6_37AggregationMethodSingleNullableColumnINSI_IhNS6_26AggregationDataWithNullKeyISR_EELb0EEEEENS1N_INSI_ItNS1O_ISW_EELb0EEEEENS1N_INSI_IjNS1O_IS10_EELb0EEEEENS1N_INSI_ImNS1O_IS13_EELb0EEEEENS1N_INSI_IjNS1O_IS1F_EELb0EEEEENS1N_INSI_ImNS1O_IS1I_EELb0EEEEENS1N_INSI_IS19_NS1O_IS1B_EELb0EEEEENS1N_INSI_IS19_NS1O_IS1L_EELb0EEEEENS1N_INS15_INS1O_IS17_EEEEEENS6_26AggregationMethodKeysFixedIS13_Lb0EEENS2G_IS13_Lb1EEENS2G_IS1B_Lb0EEENS2G_IS1B_Lb1EEENS2G_ISB_INS6_7UInt256ESD_SY_IS2L_ELb0EELb0EEENS2G_IS2N_Lb1EEENS2G_IS1I_Lb0EEENS2G_IS1I_Lb1EEENS2G_IS1L_Lb0EEENS2G_IS1L_Lb1EEENS2G_ISB_IS2L_SD_S1D_IS2L_S2M_ELb0EELb0EEENS2G_IS2V_Lb1EEEEEEEDcOT0_DpOT1_ at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1714
23# _ZSt5visitIZN5doris10vectorized15AggregationNode15_try_spill_diskEbE3$_9JRSt7variantIJNS1_27AggregationMethodSerializedI9PHHashMapINS0_9StringRefEPc11DefaultHashIS7_vELb0EEEENS1_26AggregationMethodOneNumberIh12FixedHashMapIhS8_28FixedHashMapImplicitZeroCellIhS8_16HashTableNoStateE28FixedHashTableCalculatedSizeISH_E9AllocatorILb1ELb1EEELb0EEENSD_ItSE_ItS8_SF_ItS8_SG_E24FixedHashTableStoredSizeISO_ESL_ELb0EEENSD_IjS6_IjS8_9HashCRC32IjELb0EELb0EEENSD_ImS6_ImS8_ST_ImELb0EELb0EEENS1_30AggregationMethodStringNoCacheI13StringHashMapIS8_SL_EEENSD_INS1_7UInt128ES6_IS14_S8_ST_IS14_ELb0EELb0EEENSD_IjS6_IjS8_14HashMixWrapperIjSU_ELb0EELb0EEENSD_ImS6_ImS8_S18_ImSX_ELb0EELb0EEENSD_IS14_S6_IS14_S8_S18_IS14_S15_ELb0EELb0EEENS1_37AggregationMethodSingleNullableColumnINSD_IhNS1_26AggregationDataWithNullKeyISM_EELb0EEEEENS1I_INSD_ItNS1J_ISR_EELb0EEEEENS1I_INSD_IjNS1J_ISV_EELb0EEEEENS1I_INSD_ImNS1J_ISY_EELb0EEEEENS1I_INSD_IjNS1J_IS1A_EELb0EEEEENS1I_INSD_ImNS1J_IS1D_EELb0EEEEENS1I_INSD_IS14_NS1J_IS16_EELb0EEEEENS1I_INSD_IS14_NS1J_IS1G_EELb0EEEEENS1I_INS10_INS1J_IS12_EEEEEENS1_26AggregationMethodKeysFixedISY_Lb0EEENS2B_ISY_Lb1EEENS2B_IS16_Lb0EEENS2B_IS16_Lb1EEENS2B_IS6_INS1_7UInt256ES8_ST_IS2G_ELb0EELb0EEENS2B_IS2I_Lb1EEENS2B_IS1D_Lb0EEENS2B_IS1D_Lb1EEENS2B_IS1G_Lb0EEENS2B_IS1G_Lb1EEENS2B_IS6_IS2G_S8_S18_IS2G_S2H_ELb0EELb0EEENS2B_IS2Q_Lb1EEEEEEEDcOT_DpOT0_ at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1764
24# doris::vectorized::AggregationNode::_try_spill_disk(bool) at /root/doris_master/doris/be/src/vec/exec/vaggregation_node.cpp:1402
25# doris::vectorized::AggregationNode::sink(doris::RuntimeState*, doris::vectorized::Block*, bool) at /root/doris_master/doris/be/src/vec/exec/vaggregation_node.cpp:596
26# doris::vectorized::AggregationNode::open(doris::RuntimeState*) at /root/doris_master/doris/be/src/vec/exec/vaggregation_node.cpp:533
27# doris::PlanFragmentExecutor::open_vectorized_internal() at /root/doris_master/doris/be/src/runtime/plan_fragment_executor.cpp:301
28# doris::PlanFragmentExecutor::open() at /root/doris_master/doris/be/src/runtime/plan_fragment_executor.cpp:263
29# doris::FragmentExecState::execute() at /root/doris_master/doris/be/src/runtime/fragment_mgr.cpp:262
30# doris::FragmentMgr::_exec_actual(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::RuntimeState*, doris::Status*)> const&) at /root/doris_master/doris/be/src/runtime/fragment_mgr.cpp:527
31# doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_3::operator()() const at /root/doris_master/doris/be/src/runtime/fragment_mgr.cpp:765
32# void std::__invoke_impl<void, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_3&>(std::__invoke_other, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_3&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
33# std::enable_if<is_invocable_r_v<void, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_3&>, void>::type std::__invoke_r<void, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_3&>(doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_3&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
34# std::_Function_handler<void (), doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_3>::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
35# std::function<void ()>::operator()() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
36# doris::FunctionRunnable::run() at /root/doris_master/doris/be/src/util/threadpool.cpp:48
37# doris::ThreadPool::dispatch_thread() at /root/doris_master/doris/be/src/util/threadpool.cpp:531
38# void std::__invoke_impl<void, void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
39# std::__invoke_result<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>::type std::__invoke<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
40# void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420
41# void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::operator()<, void>() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503
42# void std::__invoke_impl<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
43# std::enable_if<is_invocable_r_v<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
44# std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
45# std::function<void ()>::operator()() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
46# doris::Thread::supervise_thread(void*) at /root/doris_master/doris/be/src/util/thread.cpp:465
47# start_thread at /build/glibc-sMfBJT/glibc-2.31/nptl/pthread_create.c:478
48# __clone in /lib/x86_64-linux-gnu/libc.so.6
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

