### PR TITLE
[bug](map-type)fix some bugs in map and map element function

### DIFF
--- a/be/src/vec/functions/array/function_array_element.h
+++ b/be/src/vec/functions/array/function_array_element.h
@@ -107,7 +107,8 @@ public:
             args = {col_left, block.get_by_position(arguments[1])};
         }
         ColumnPtr res_column = nullptr;
-        if (args[0].column->is_column_map() || check_column_const<ColumnMap>(args[0].column.get())) {
+        if (args[0].column->is_column_map() ||
+            check_column_const<ColumnMap>(args[0].column.get())) {
             res_column = _execute_map(args, input_rows_count, src_null_map, dst_null_map);
         } else {
             res_column = _execute_nullable(args, input_rows_count, src_null_map, dst_null_map);

--- a/be/src/vec/functions/array/function_array_element.h
+++ b/be/src/vec/functions/array/function_array_element.h
@@ -107,7 +107,7 @@ public:
             args = {col_left, block.get_by_position(arguments[1])};
         }
         ColumnPtr res_column = nullptr;
-        if (args[0].column->is_column_map()) {
+        if (args[0].column->is_column_map() || check_column_const<ColumnMap>(args[0].column.get())) {
             res_column = _execute_map(args, input_rows_count, src_null_map, dst_null_map);
         } else {
             res_column = _execute_nullable(args, input_rows_count, src_null_map, dst_null_map);

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -746,7 +746,7 @@ nonterminal LiteralExpr literal;
 nonterminal CaseExpr case_expr;
 nonterminal ArrayList<CaseWhenClause> case_when_clause_list;
 nonterminal FunctionParams function_params;
-nonterminal Expr function_call_expr, array_expr;
+nonterminal Expr function_call_expr, array_expr, map_expr;
 nonterminal ArrayLiteral array_literal;
 nonterminal MapLiteral map_literal;
 nonterminal StructField struct_field;
@@ -6271,6 +6271,17 @@ map_literal ::=
   :}
   ;
 
+map_expr ::=
+  KW_MAP LPAREN function_params:params RPAREN
+  {:
+    RESULT = new FunctionCallExpr("map", params);
+  :}
+  | KW_MAP LPAREN RPAREN
+  {:
+    RESULT = new MapLiteral();
+  :}
+  ;
+
 struct_field ::=
   ident:name COLON type:type
   {: RESULT = new StructField(name, type); :}
@@ -6316,6 +6327,8 @@ non_pred_expr ::=
   | array_expr:a
   {: RESULT = a; :}
   | array_literal:a
+  {: RESULT = a; :}
+  | map_expr:a
   {: RESULT = a; :}
   | map_literal:a
   {: RESULT = a; :}

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -1461,6 +1461,13 @@ public class FunctionCallExpr extends Expr {
             fn.getReturnType().getPrimitiveType().setTimeType();
         }
 
+        if (fnName.getFunction().equalsIgnoreCase("map")) {
+            if ((children.size() & 1) == 1) {
+                throw new AnalysisException("map can't be odd parameters, need even parameters: "
+                        + this.toSql());
+            }
+        }
+
         if (fnName.getFunction().equalsIgnoreCase("named_struct")) {
             if ((children.size() & 1) == 1) {
                 throw new AnalysisException("named_struct can't be odd parameters, need even parameters: "

--- a/regression-test/conf/regression-conf.groovy
+++ b/regression-test/conf/regression-conf.groovy
@@ -24,11 +24,11 @@ defaultDb = "regression_test"
 // init cmd like: select @@session.tx_read_only
 // at each time we connect.
 // add allowLoadLocalInfile so that the jdbc can execute mysql load data from client.
-jdbcUrl = "jdbc:mysql://127.0.0.1:9030/?useLocalSessionState=true&allowLoadLocalInfile=true"
+jdbcUrl = "jdbc:mysql://127.0.0.1:9032/?useLocalSessionState=true&allowLoadLocalInfile=true"
 jdbcUser = "root"
 jdbcPassword = ""
 
-feHttpAddress = "127.0.0.1:8030"
+feHttpAddress = "127.0.0.1:8032"
 feHttpUser = "root"
 feHttpPassword = ""
 

--- a/regression-test/conf/regression-conf.groovy
+++ b/regression-test/conf/regression-conf.groovy
@@ -24,11 +24,11 @@ defaultDb = "regression_test"
 // init cmd like: select @@session.tx_read_only
 // at each time we connect.
 // add allowLoadLocalInfile so that the jdbc can execute mysql load data from client.
-jdbcUrl = "jdbc:mysql://127.0.0.1:9032/?useLocalSessionState=true&allowLoadLocalInfile=true"
+jdbcUrl = "jdbc:mysql://127.0.0.1:9030/?useLocalSessionState=true&allowLoadLocalInfile=true"
 jdbcUser = "root"
 jdbcPassword = ""
 
-feHttpAddress = "127.0.0.1:8032"
+feHttpAddress = "127.0.0.1:8030"
 feHttpUser = "root"
 feHttpPassword = ""
 

--- a/regression-test/data/load_p0/stream_load/test_map_load_and_function.out
+++ b/regression-test/data/load_p0/stream_load/test_map_load_and_function.out
@@ -60,6 +60,9 @@
 -- !select_map2 --
 {1000:"k11", 2000:"k22"}
 
+-- !select_map3 --
+MAP{}
+
 -- !select_element1 --
 1000
 
@@ -82,6 +85,30 @@ k22
 \N
 
 -- !select_element8 --
+\N
+
+-- !select_element9 --
+1000
+
+-- !select_element10 --
+2000
+
+-- !select_element11 --
+\N
+
+-- !select_element12 --
+\N
+
+-- !select_element13 --
+k11
+
+-- !select_element14 --
+k22
+
+-- !select_element15 --
+\N
+
+-- !select_element16 --
 \N
 
 -- !select_element101 --

--- a/regression-test/suites/load_p0/stream_load/test_map_load_and_function.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_map_load_and_function.groovy
@@ -78,6 +78,7 @@ suite("test_map_load_and_function", "p0") {
     // map construct
     qt_select_map1 "SELECT map('k11', 1000, 'k22', 2000)"
     qt_select_map2 "SELECT map(1000, 'k11', 2000, 'k22')"
+    qt_select_map3 "SELECT map()"
 
     // map element_at
     qt_select_element1 "SELECT map('k11', 1000, 'k22', 2000)['k11']"
@@ -88,6 +89,14 @@ suite("test_map_load_and_function", "p0") {
     qt_select_element6 "SELECT map(1000, 'k11', 2000, 'k22')[2000]"
     qt_select_element7 "SELECT map(1000, 'k11', 2000, 'k22')[3000]"
     qt_select_element8 "SELECT map('k11', 1000, 'k22', 2000)[NULL]"
+    qt_select_element9 "SELECT {'k11':1000, 'k22':2000}['k11']"
+    qt_select_element10 "SELECT {'k11':1000, 'k22':2000}['k22']"
+    qt_select_element11 "SELECT {'k11':1000, 'k22':2000}['nokey']"
+    qt_select_element12 "SELECT {'k11':1000, 'k22':2000}[NULL]"
+    qt_select_element13 "SELECT {1000:'k11', 2000:'k22'}[1000]"
+    qt_select_element14 "SELECT {1000:'k11', 2000:'k22'}[2000]"
+    qt_select_element15 "SELECT {1000:'k11', 2000:'k22'}[3000]"
+    qt_select_element16 "SELECT {1000:'k11', 2000:'k22'}[NULL]"
     qt_select_element101 "SELECT id, m, m['k1'] FROM ${testTable} ORDER BY id"
     qt_select_element102 "SELECT id, m, m['k2'] FROM ${testTable} ORDER BY id"
     qt_select_element103 "SELECT id, m, m['  11amory  '] FROM ${testTable} ORDER BY id"


### PR DESCRIPTION
# Proposed changes

fix some bugs in map and map element function:

1、error occur when map constructor's parameter is empty:

Before:

```
mysql> select map();
ERROR 1105 (HY000): errCode = 2, detailMessage = Unexpected exception: 0
```

After:

```
mysql> SELECT map();
+-------+
| MAP{} |
+-------+
| MAP{} |
+-------+
1 row in set (0.01 sec)
```

2、be core in map constructor when the parameter number is odd:

Before

```
mysql> select map(1,'a',3,'c',5);
ERROR 1105 (HY000): RpcException, msg: io.grpc.StatusRuntimeException: UNAVAILABLE: Network closed for unknown reason
```

After

```
mysql> select map(1,'a',3,'c',5);
ERROR 1105 (HY000): errCode = 2, detailMessage = map can't be odd parameters, need even parameters: map(1, 2, 3, 4, 5)
```

3、be core in map element function

Before

```
mysql> select {1:"a", 3:"b", 5:"c"}[1];
ERROR 1105 (HY000): RpcException, msg: org.apache.doris.rpc.RpcException: io.grpc.StatusRuntimeException: UNAVAILABLE: Network closed for unknown reason
```

After

```
mysql> select {1:"a", 3:"b", 5:"c"}[1];
+------------------------------------------------+
| %element_extract%(MAP{1:'a', 3:'b', 5:'c'}, 1) |
+------------------------------------------------+
| a                                              |
+------------------------------------------------+
1 row in set (0.02 sec)
```

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

