### PR TITLE
[improvement](planner) remove virtual function call in vbloom_predicate

### DIFF
--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -136,11 +136,6 @@ public:
         return StringRef(&chars[offset_at(n)], size_at(n));
     }
 
-    StringRef get_string_data_at(size_t n) const {
-        assert(n < size());
-        return StringRef(&chars[offset_at(n)], size_at(n));
-    }
-
 /// Suppress gcc 7.3.1 warning: '*((void*)&<anonymous> +8)' may be used uninitialized in this function
 #if !__clang__
 #pragma GCC diagnostic push

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -136,6 +136,11 @@ public:
         return StringRef(&chars[offset_at(n)], size_at(n));
     }
 
+    StringRef get_string_data_at(size_t n) const {
+        assert(n < size());
+        return StringRef(&chars[offset_at(n)], size_at(n));
+    }
+
 /// Suppress gcc 7.3.1 warning: '*((void*)&<anonymous> +8)' may be used uninitialized in this function
 #if !__clang__
 #pragma GCC diagnostic push

--- a/be/src/vec/exprs/vbloom_predicate.cpp
+++ b/be/src/vec/exprs/vbloom_predicate.cpp
@@ -105,8 +105,8 @@ Status VBloomPredicate::execute(VExprContext* context, Block* block, int* result
                     StringRef v((const char*)nullptr, 0);
                     ptr[i] = _filter->find_crc32_hash(reinterpret_cast<const void*>(&v));
                 } else {
-                    auto ele = assert_cast<const ColumnString*>(column_nested.get())
-                                       ->get_data_at(i);
+                    auto ele =
+                            assert_cast<const ColumnString*>(column_nested.get())->get_data_at(i);
                     const StringRef v(ele.data, ele.size);
                     ptr[i] = _filter->find_crc32_hash(reinterpret_cast<const void*>(&v));
                 }
@@ -117,8 +117,8 @@ Status VBloomPredicate::execute(VExprContext* context, Block* block, int* result
                     StringRef v((const char*)nullptr, 0);
                     ptr[i] = _filter->find(reinterpret_cast<const void*>(&v));
                 } else {
-                    auto ele = assert_cast<const ColumnString*>(column_nested.get())
-                                       ->get_data_at(i);
+                    auto ele =
+                            assert_cast<const ColumnString*>(column_nested.get())->get_data_at(i);
                     const StringRef v(ele.data, ele.size);
                     ptr[i] = _filter->find(reinterpret_cast<const void*>(&v));
                 }

--- a/be/src/vec/exprs/vbloom_predicate.cpp
+++ b/be/src/vec/exprs/vbloom_predicate.cpp
@@ -99,26 +99,26 @@ Status VBloomPredicate::execute(VExprContext* context, Block* block, int* result
                                      ->get_nested_column_ptr();
         auto column_nullmap = reinterpret_cast<const ColumnNullable*>(argument_column.get())
                                       ->get_null_map_column_ptr();
+        auto column_str = assert_cast<const ColumnString*>(column_nested.get());
+        auto& column_uint8 = assert_cast<const ColumnUInt8&>(*column_nullmap);
         if (_be_exec_version >= 2) {
             for (size_t i = 0; i < sz; i++) {
-                if (assert_cast<const ColumnUInt8&>(*column_nullmap).get_data()[i] != 0) {
+                if (column_uint8.get_data()[i] != 0) {
                     StringRef v((const char*)nullptr, 0);
                     ptr[i] = _filter->find_crc32_hash(reinterpret_cast<const void*>(&v));
                 } else {
-                    auto ele =
-                            assert_cast<const ColumnString*>(column_nested.get())->get_data_at(i);
+                    auto ele = column_str->get_data_at(i);
                     const StringRef v(ele.data, ele.size);
                     ptr[i] = _filter->find_crc32_hash(reinterpret_cast<const void*>(&v));
                 }
             }
         } else {
             for (size_t i = 0; i < sz; i++) {
-                if (assert_cast<const ColumnUInt8&>(*column_nullmap).get_data()[i] != 0) {
+                if (column_uint8.get_data()[i] != 0) {
                     StringRef v((const char*)nullptr, 0);
                     ptr[i] = _filter->find(reinterpret_cast<const void*>(&v));
                 } else {
-                    auto ele =
-                            assert_cast<const ColumnString*>(column_nested.get())->get_data_at(i);
+                    auto ele = column_str->get_data_at(i);
                     const StringRef v(ele.data, ele.size);
                     ptr[i] = _filter->find(reinterpret_cast<const void*>(&v));
                 }

--- a/be/src/vec/exprs/vbloom_predicate.cpp
+++ b/be/src/vec/exprs/vbloom_predicate.cpp
@@ -29,6 +29,7 @@
 #include "vec/columns/column.h"
 #include "vec/columns/column_nullable.h"
 #include "vec/columns/column_vector.h"
+#include "vec/common/assert_cast.h"
 #include "vec/common/string_ref.h"
 #include "vec/core/block.h"
 #include "vec/core/column_numbers.h"
@@ -84,7 +85,6 @@ Status VBloomPredicate::execute(VExprContext* context, Block* block, int* result
     // call function
     size_t num_columns_without_result = block->columns();
     auto res_data_column = ColumnVector<UInt8>::create(block->rows());
-
     ColumnPtr argument_column =
             block->get_by_position(arguments[0]).column->convert_to_full_column_if_const();
     size_t sz = argument_column->size();

--- a/be/src/vec/exprs/vbloom_predicate.cpp
+++ b/be/src/vec/exprs/vbloom_predicate.cpp
@@ -94,18 +94,34 @@ Status VBloomPredicate::execute(VExprContext* context, Block* block, int* result
     if (type.is_string_or_fixed_string()) {
         // When _be_exec_version is equal to or greater than 2, we use the new hash method.
         // This is only to be used if the be_exec_version may be less than 2. If updated, please delete it.
+        // remove virtual function call in get_data_at to improve performance (argument_column->get_data_at(i)).
+        auto column_nested = reinterpret_cast<const ColumnNullable*>(argument_column.get())
+                                     ->get_nested_column_ptr();
+        auto column_nullmap = reinterpret_cast<const ColumnNullable*>(argument_column.get())
+                                      ->get_null_map_column_ptr();
         if (_be_exec_version >= 2) {
             for (size_t i = 0; i < sz; i++) {
-                /// TODO: remove virtual function call in get_data_at to improve performance
-                auto ele = argument_column->get_data_at(i);
-                const StringRef v(ele.data, ele.size);
-                ptr[i] = _filter->find_crc32_hash(reinterpret_cast<const void*>(&v));
+                if (assert_cast<const ColumnUInt8&>(*column_nullmap).get_data()[i] != 0) {
+                    StringRef v((const char*)nullptr, 0);
+                    ptr[i] = _filter->find_crc32_hash(reinterpret_cast<const void*>(&v));
+                } else {
+                    auto ele = assert_cast<const ColumnString*>(column_nested.get())
+                                       ->get_string_data_at(i);
+                    const StringRef v(ele.data, ele.size);
+                    ptr[i] = _filter->find_crc32_hash(reinterpret_cast<const void*>(&v));
+                }
             }
         } else {
             for (size_t i = 0; i < sz; i++) {
-                auto ele = argument_column->get_data_at(i);
-                const StringRef v(ele.data, ele.size);
-                ptr[i] = _filter->find(reinterpret_cast<const void*>(&v));
+                if (assert_cast<const ColumnUInt8&>(*column_nullmap).get_data()[i] != 0) {
+                    StringRef v((const char*)nullptr, 0);
+                    ptr[i] = _filter->find(reinterpret_cast<const void*>(&v));
+                } else {
+                    auto ele = assert_cast<const ColumnString*>(column_nested.get())
+                                       ->get_string_data_at(i);
+                    const StringRef v(ele.data, ele.size);
+                    ptr[i] = _filter->find(reinterpret_cast<const void*>(&v));
+                }
             }
         }
     } else if (_be_exec_version > 0 && (type.is_int_or_uint() || type.is_float())) {

--- a/be/src/vec/exprs/vbloom_predicate.cpp
+++ b/be/src/vec/exprs/vbloom_predicate.cpp
@@ -106,7 +106,7 @@ Status VBloomPredicate::execute(VExprContext* context, Block* block, int* result
                     ptr[i] = _filter->find_crc32_hash(reinterpret_cast<const void*>(&v));
                 } else {
                     auto ele = assert_cast<const ColumnString*>(column_nested.get())
-                                       ->get_string_data_at(i);
+                                       ->get_data_at(i);
                     const StringRef v(ele.data, ele.size);
                     ptr[i] = _filter->find_crc32_hash(reinterpret_cast<const void*>(&v));
                 }
@@ -118,7 +118,7 @@ Status VBloomPredicate::execute(VExprContext* context, Block* block, int* result
                     ptr[i] = _filter->find(reinterpret_cast<const void*>(&v));
                 } else {
                     auto ele = assert_cast<const ColumnString*>(column_nested.get())
-                                       ->get_string_data_at(i);
+                                       ->get_data_at(i);
                     const StringRef v(ele.data, ele.size);
                     ptr[i] = _filter->find(reinterpret_cast<const void*>(&v));
                 }


### PR DESCRIPTION
# Proposed changes

In the past code, we could determine the type at compile time by "type.is_string_or_fixed_string()".
https://quuxplusone.github.io/blog/2021/02/15/devirtualization/
## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

