### PR TITLE
[chore](regression) Add 'sync' after stream_load in some cases

### DIFF
--- a/regression-test/suites/correctness_p0/test_current_timestamp.groovy
+++ b/regression-test/suites/correctness_p0/test_current_timestamp.groovy
@@ -78,6 +78,9 @@ suite("test_current_timestamp") {
 
         time 10000 // limit inflight 10s
     }
+
+    sql "sync"
+
     qt_stream_load_csv1 """ select count(*) from ${tableName} where id > 4 and to_date(dt_0) = to_date(dt_1); """
     qt_stream_load_csv2 """ select count(*) from ${tableName} where id > 4 and to_date(dt_2) = to_date(dt_3); """
     qt_stream_load_csv3 """ select count(*) from ${tableName} where id > 4 and to_date(dt_4) = to_date(dt_5); """
@@ -98,6 +101,9 @@ suite("test_current_timestamp") {
 
         time 10000 // limit inflight 10s
     }
+
+    sql "sync"
+
     qt_stream_load_json1 """ select count(*) from ${tableName} where id > 8 and to_date(dt_0) = to_date(dt_1); """
     qt_stream_load_json2 """ select count(*) from ${tableName} where id > 8 and to_date(dt_2) = to_date(dt_3); """
     qt_stream_load_json3 """ select count(*) from ${tableName} where id > 8 and to_date(dt_4) = to_date(dt_5); """
@@ -117,6 +123,9 @@ suite("test_current_timestamp") {
         file 'test_current_timestamp_streamload.json'
         time 10000 // limit inflight 10s
     }
+
+    sql "sync"
+
     qt_stream_load_json5 """ select id, name, dt_1  from ${tableName2} order by id; """
     qt_stream_load_json6 """ select count(*) from ${tableName2} where dt_2 is not NULL; """
  }

--- a/regression-test/suites/query_p0/sql_functions/aggregate_functions/test_aggregate_all_functions.groovy
+++ b/regression-test/suites/query_p0/sql_functions/aggregate_functions/test_aggregate_all_functions.groovy
@@ -530,6 +530,8 @@ suite("test_aggregate_all_functions") {
         inputIterator rows.iterator()
     }
 
+    sql "sync"
+
     qt_select48 """select dt, id, quantile_percent(quantile_union(price), 0) from ${tableName_21} group by dt, id order by dt, id"""
 
     qt_select49 """select dt, id, quantile_percent(quantile_union(price), 0.5) from ${tableName_21} group by dt, id order by dt, id"""


### PR DESCRIPTION
# Proposed changes

When running regression testing in a multi-fe environment, sometimes test cases fail due to no rows selected.

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

