### PR TITLE
[refactor](multi catalog)Refactor FileQueryScanNode init and finalize mothods.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/FileLoadScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/FileLoadScanNode.java
@@ -47,7 +47,6 @@ import org.apache.doris.planner.external.LoadScanProvider;
 import org.apache.doris.rewrite.ExprRewriter;
 import org.apache.doris.statistics.StatisticalType;
 import org.apache.doris.thrift.TBrokerFileStatus;
-import org.apache.doris.thrift.TExpr;
 import org.apache.doris.thrift.TFileScanRangeParams;
 import org.apache.doris.thrift.TFileType;
 import org.apache.doris.thrift.TUniqueId;
@@ -69,26 +68,14 @@ public class FileLoadScanNode extends FileScanNode {
 
     public static class ParamCreateContext {
         public BrokerFileGroup fileGroup;
-        public List<Expr> conjuncts;
-
         public TupleDescriptor destTupleDescriptor;
-        public Map<String, SlotDescriptor> destSlotDescByName;
         // === Set when init ===
         public TupleDescriptor srcTupleDescriptor;
         public Map<String, SlotDescriptor> srcSlotDescByName;
         public Map<String, Expr> exprMap;
         public String timezone;
         // === Set when init ===
-
         public TFileScanRangeParams params;
-
-        public void createDestSlotMap() {
-            Preconditions.checkNotNull(destTupleDescriptor);
-            destSlotDescByName = Maps.newHashMap();
-            for (SlotDescriptor slot : destTupleDescriptor.getSlots()) {
-                destSlotDescByName.put(slot.getColumn().getName(), slot);
-            }
-        }
     }
 
     // Save all info about load attributes and files.
@@ -131,14 +118,11 @@ public class FileLoadScanNode extends FileScanNode {
     @Override
     public void init(Analyzer analyzer) throws UserException {
         super.init(analyzer);
-
         for (FileGroupInfo fileGroupInfo : fileGroupInfos) {
             this.scanProviders.add(new LoadScanProvider(fileGroupInfo, desc));
         }
-
         backendPolicy.init();
         numNodes = backendPolicy.numBackends();
-
         initParamCreateContexts(analyzer);
     }
 
@@ -146,12 +130,11 @@ public class FileLoadScanNode extends FileScanNode {
     private void initParamCreateContexts(Analyzer analyzer) throws UserException {
         for (FileScanProviderIf scanProvider : scanProviders) {
             ParamCreateContext context = scanProvider.createContext(analyzer);
-            context.createDestSlotMap();
             // set where and preceding filter.
             // FIXME(cmy): we should support set different expr for different file group.
             initAndSetPrecedingFilter(context.fileGroup.getPrecedingFilterExpr(), context.srcTupleDescriptor, analyzer);
             initAndSetWhereExpr(context.fileGroup.getWhereExpr(), context.destTupleDescriptor, analyzer);
-            context.conjuncts = conjuncts;
+            setDefaultValueExprs(scanProvider, context.srcSlotDescByName, context.params, true);
             this.contexts.add(context);
         }
     }
@@ -214,51 +197,10 @@ public class FileLoadScanNode extends FileScanNode {
         for (int i = 0; i < contexts.size(); ++i) {
             FileLoadScanNode.ParamCreateContext context = contexts.get(i);
             FileScanProviderIf scanProvider = scanProviders.get(i);
-            setDefaultValueExprs(scanProvider, context);
             finalizeParamsForLoad(context, analyzer);
             createScanRangeLocations(context, scanProvider);
             this.inputSplitsNum += scanProvider.getInputSplitNum();
             this.totalFileSize += scanProvider.getInputFileSize();
-        }
-    }
-
-    protected void setDefaultValueExprs(FileScanProviderIf scanProvider, ParamCreateContext context)
-            throws UserException {
-        TableIf tbl = scanProvider.getTargetTable();
-        Preconditions.checkNotNull(tbl);
-        TExpr tExpr = new TExpr();
-        tExpr.setNodes(Lists.newArrayList());
-
-        for (Column column : tbl.getBaseSchema()) {
-            Expr expr;
-            if (column.getDefaultValue() != null) {
-                if (column.getDefaultValueExprDef() != null) {
-                    expr = column.getDefaultValueExpr();
-                } else {
-                    expr = new StringLiteral(column.getDefaultValue());
-                }
-            } else {
-                if (column.isAllowNull()) {
-                    // In load process, the source type is string.
-                    expr = NullLiteral.create(org.apache.doris.catalog.Type.VARCHAR);
-                } else {
-                    expr = null;
-                }
-            }
-            SlotDescriptor slotDesc = context.srcSlotDescByName.get(column.getName());
-            // if slot desc is null, which mean it is an unrelated slot, just skip.
-            // eg:
-            // (a, b, c) set (x=a, y=b, z=c)
-            // c does not exist in file, the z will be filled with null, even if z has default value.
-            // and if z is not nullable, the load will fail.
-            if (slotDesc != null) {
-                if (expr != null) {
-                    expr = castToSlot(slotDesc, expr);
-                    context.params.putToDefaultValueOfSrcSlot(slotDesc.getId().asInt(), expr.treeToThrift());
-                } else {
-                    context.params.putToDefaultValueOfSrcSlot(slotDesc.getId().asInt(), tExpr);
-                }
-            }
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileScanNode.java
@@ -18,12 +18,18 @@
 package org.apache.doris.planner.external;
 
 import org.apache.doris.analysis.Expr;
+import org.apache.doris.analysis.NullLiteral;
+import org.apache.doris.analysis.SlotDescriptor;
+import org.apache.doris.analysis.StringLiteral;
 import org.apache.doris.analysis.TupleDescriptor;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.UserException;
 import org.apache.doris.planner.FileLoadScanNode;
 import org.apache.doris.planner.PlanNodeId;
 import org.apache.doris.statistics.StatisticalType;
 import org.apache.doris.thrift.TExplainLevel;
+import org.apache.doris.thrift.TExpr;
 import org.apache.doris.thrift.TFileRangeDesc;
 import org.apache.doris.thrift.TFileScanNode;
 import org.apache.doris.thrift.TFileScanRangeParams;
@@ -31,6 +37,7 @@ import org.apache.doris.thrift.TPlanNode;
 import org.apache.doris.thrift.TPlanNodeType;
 import org.apache.doris.thrift.TScanRangeLocations;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
@@ -40,6 +47,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Base class for External File Scan, including external query and load.
@@ -155,5 +163,51 @@ public class FileScanNode extends ExternalScanNode {
                                             FileScanProviderIf scanProvider)
             throws UserException {
         scanProvider.createScanRangeLocations(conjuncts, params, backendPolicy, scanRangeLocations);
+    }
+
+    protected void setDefaultValueExprs(FileScanProviderIf scanProvider,
+                                        Map<String, SlotDescriptor> slotDescByName,
+                                        TFileScanRangeParams params,
+                                        boolean useVarcharAsNull) throws UserException {
+        TableIf tbl = scanProvider.getTargetTable();
+        Preconditions.checkNotNull(tbl);
+        TExpr tExpr = new TExpr();
+        tExpr.setNodes(Lists.newArrayList());
+
+        for (Column column : tbl.getBaseSchema()) {
+            Expr expr;
+            if (column.getDefaultValue() != null) {
+                if (column.getDefaultValueExprDef() != null) {
+                    expr = column.getDefaultValueExpr();
+                } else {
+                    expr = new StringLiteral(column.getDefaultValue());
+                }
+            } else {
+                if (column.isAllowNull()) {
+                    // For load, use Varchar as Null, for query, use column type.
+                    if (useVarcharAsNull) {
+                        expr = NullLiteral.create(org.apache.doris.catalog.Type.VARCHAR);
+                    } else {
+                        expr = NullLiteral.create(column.getType());
+                    }
+                } else {
+                    expr = null;
+                }
+            }
+            SlotDescriptor slotDesc = slotDescByName.get(column.getName());
+            // if slot desc is null, which mean it is an unrelated slot, just skip.
+            // eg:
+            // (a, b, c) set (x=a, y=b, z=c)
+            // c does not exist in file, the z will be filled with null, even if z has default value.
+            // and if z is not nullable, the load will fail.
+            if (slotDesc != null) {
+                if (expr != null) {
+                    expr = castToSlot(slotDesc, expr);
+                    params.putToDefaultValueOfSrcSlot(slotDesc.getId().asInt(), expr.treeToThrift());
+                } else {
+                    params.putToDefaultValueOfSrcSlot(slotDesc.getId().asInt(), tExpr);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Refactor FileQueryScanNode init and finalize methods.
Handle schema related initialization in init method, handle scan range generation in finalize method.

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

