### PR TITLE
[bugfix](MOW) fix core in set_txn_related_delete_bitmap

### DIFF
--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -176,6 +176,11 @@ void TxnManager::set_txn_related_delete_bitmap(
         txn_tablet_map_t& txn_tablet_map = _get_txn_tablet_map(transaction_id);
         auto it = txn_tablet_map.find(key);
         DCHECK(it != txn_tablet_map.end());
+        if (it == txn_tablet_map.end()) {
+            LOG(WARNING) << "transaction_id: " << transaction_id
+                         << " partition_id: " << partition_id << " may be cleared";
+            return;
+        }
         auto load_itr = it->second.find(tablet_info);
         DCHECK(load_itr != it->second.end());
         TabletTxnInfo& load_info = load_itr->second;


### PR DESCRIPTION
Fe will clear transaction info when transaction timeout, but calc delete bitmap related logic in DeltaWriter::close_wait will continue to run. In set_txn_related_delete_bitmap, we return directly when _get_txn_tablet_map return null

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

