### PR TITLE
[chore](build) Use include-what-you-use to optimize includes (PART III)

### DIFF
--- a/be/src/gutil/atomicops-internals-x86.cc
+++ b/be/src/gutil/atomicops-internals-x86.cc
@@ -24,11 +24,6 @@
 
 #include "gutil/atomicops-internals-x86.h"
 
-#include <common/logging.h>
-#include <string.h>
-
-#include "gutil/integral_types.h"
-
 // This file only makes sense with atomicops-internals-x86.h -- it
 // depends on structs that are defined in that file.  If atomicops.h
 // doesn't sub-include that file, then we aren't needed, and shouldn't

--- a/be/src/gutil/atomicops-internals-x86.h
+++ b/be/src/gutil/atomicops-internals-x86.h
@@ -26,8 +26,9 @@
 
 #pragma once
 
-#include <common/logging.h>
+#include "common/logging.h"
 #include <stdint.h>
+#include <ostream>
 
 #define BASE_HAS_ATOMIC64 1 // Use only in tests and base/atomic*
 

--- a/be/src/gutil/bits.h
+++ b/be/src/gutil/bits.h
@@ -4,11 +4,10 @@
 
 #pragma once
 
-#include <common/logging.h>
 
-#include "gutil/basictypes.h"
 #include "gutil/integral_types.h"
-#include "gutil/macros.h"
+// IWYU pragma: no_include <butil/macros.h>
+#include "gutil/macros.h" // IWYU pragma: keep
 
 class Bits {
 public:

--- a/be/src/gutil/casts.h
+++ b/be/src/gutil/casts.h
@@ -9,8 +9,8 @@
 
 #pragma once
 
+#include "common/logging.h"
 #include <assert.h> // for use with down_cast<>
-#include <common/logging.h>
 #include <limits.h> // for enumeration casts and tests
 #include <string.h> // for memcpy
 

--- a/be/src/gutil/cpu.cc
+++ b/be/src/gutil/cpu.cc
@@ -6,12 +6,11 @@
 
 #include <stdlib.h>
 #include <string.h>
-
-#include <algorithm>
+#include <stdint.h>
 #include <fstream>
 #include <sstream>
-#include <streambuf>
 #include <string>
+#include <utility>
 
 #if defined(__x86_64__)
 #if defined(_MSC_VER)

--- a/be/src/gutil/hash/city.cc
+++ b/be/src/gutil/hash/city.cc
@@ -16,9 +16,12 @@
 
 #include "gutil/hash/city.h"
 
-#include <sys/types.h>
+// IWYU pragma: no_include <pstl/glue_algorithm_defs.h>
 
+#include <sys/types.h>
 #include <algorithm>
+#include <iterator>
+
 using std::copy;
 using std::max;
 using std::min;
@@ -26,15 +29,17 @@ using std::reverse;
 using std::sort;
 using std::swap;
 #include <utility>
+
 using std::make_pair;
 using std::pair;
 
-#include <common/logging.h>
+#include "common/logging.h"
 
 #include "gutil/endian.h"
 #include "gutil/hash/hash128to64.h"
 #include "gutil/int128.h"
 #include "gutil/integral_types.h"
+#include "gutil/port.h"
 
 namespace util_hash {
 

--- a/be/src/gutil/hash/hash.cc
+++ b/be/src/gutil/hash/hash.cc
@@ -9,12 +9,11 @@
 
 #include "gutil/hash/hash.h"
 
-#include <common/logging.h>
+#include "common/logging.h"
 
 #include "gutil/hash/jenkins.h"
 #include "gutil/hash/jenkins_lookup2.h"
 #include "gutil/integral_types.h"
-#include "gutil/logging-inl.h"
 
 // For components that ship code externally (notably the Google Search
 // Appliance) we want to change the fingerprint function so that

--- a/be/src/gutil/hash/hash.h
+++ b/be/src/gutil/hash/hash.h
@@ -73,15 +73,13 @@
 #pragma once
 
 #include <stddef.h>
-#include <stdint.h> // for uintptr_t
 #include <string.h>
-
-#include <algorithm>
 #include <string>
-#include <utility>
+#include <cstddef>
+#include <functional>
+#include <iterator>
+#include <string_view>
 
-#include "gutil/casts.h"
-#include "gutil/hash/city.h"
 #include "gutil/hash/hash128to64.h"
 #include "gutil/hash/jenkins.h"
 #include "gutil/hash/jenkins_lookup2.h"
@@ -89,8 +87,7 @@
 #include "gutil/hash/string_hash.h"
 #include "gutil/int128.h"
 #include "gutil/integral_types.h"
-#include "gutil/macros.h"
-#include "gutil/port.h"
+#include "gutil/hash/builtin_type_hash.h"
 
 // ----------------------------------------------------------------------
 // Fingerprint()

--- a/be/src/gutil/hash/jenkins.cc
+++ b/be/src/gutil/hash/jenkins.cc
@@ -18,7 +18,7 @@
 
 #include "gutil/hash/jenkins.h"
 
-#include <common/logging.h>
+#include "common/logging.h"
 
 #include "gutil/hash/jenkins_lookup2.h"
 #include "gutil/integral_types.h"

--- a/be/src/gutil/ref_counted.cc
+++ b/be/src/gutil/ref_counted.cc
@@ -4,8 +4,6 @@
 
 #include "gutil/ref_counted.h"
 
-#include <common/logging.h>
-
 #include "gutil/atomic_refcount.h"
 
 namespace doris {

--- a/be/src/gutil/ref_counted.h
+++ b/be/src/gutil/ref_counted.h
@@ -9,7 +9,8 @@
 #include <utility> // IWYU pragma: keep
 
 #include "gutil/atomicops.h"
-#include "gutil/macros.h"
+// IWYU pragma: no_include <butil/macros.h>
+#include "gutil/macros.h" // IWYU pragma: keep
 #include "gutil/threading/thread_collision_warner.h"
 
 namespace doris {

--- a/be/src/gutil/spinlock_internal.h
+++ b/be/src/gutil/spinlock_internal.h
@@ -36,7 +36,7 @@
 #pragma once
 
 #include "gutil/atomicops.h"
-#include "gutil/basictypes.h"
+#include "gutil/integral_types.h"
 
 namespace base {
 namespace internal {

--- a/be/src/gutil/stringprintf.cc
+++ b/be/src/gutil/stringprintf.cc
@@ -2,15 +2,16 @@
 
 #include "gutil/stringprintf.h"
 
-#include <errno.h>
 #include <stdarg.h> // For va_list and related operations
 #include <stdio.h>  // MSVC requires this for _vsnprintf
-
 #include <vector>
-using std::vector;
-#include <common/logging.h>
+#include <ostream>
 
-#include "gutil/macros.h"
+using std::vector;
+#include "common/logging.h"
+
+// IWYU pragma: no_include <butil/macros.h>
+#include "gutil/macros.h" // IWYU pragma: keep
 
 #ifdef _MSC_VER
 enum { IS__MSC_VER = 1 };

--- a/be/src/gutil/strings/escaping.cc
+++ b/be/src/gutil/strings/escaping.cc
@@ -6,10 +6,13 @@
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
-
+#include <glog/logging.h>
 #include <limits>
+#include <ostream>
+
 using std::numeric_limits;
 #include <vector>
+
 using std::vector;
 
 #include "gutil/charmap.h"
@@ -17,8 +20,8 @@ using std::vector;
 #include "gutil/integral_types.h"
 #include "gutil/port.h"
 #include "gutil/stl_util.h"
-#include "gutil/strings/join.h"
 #include "gutil/utf/utf.h" // for runetochar
+#include "gutil/strings/strcat.h"
 
 namespace strings {
 

--- a/be/src/gutil/strings/escaping.h
+++ b/be/src/gutil/strings/escaping.h
@@ -27,7 +27,7 @@ using std::string;
 #include <vector>
 using std::vector;
 
-#include <common/logging.h>
+#include "common/logging.h"
 
 #include "gutil/strings/ascii_ctype.h"
 #include "gutil/strings/charset.h"

--- a/be/src/gutil/strings/join.cc
+++ b/be/src/gutil/strings/join.cc
@@ -2,7 +2,10 @@
 
 #include "gutil/strings/join.h"
 
-#include <common/logging.h>
+#include "common/logging.h"
+#include <string.h>
+#include <algorithm>
+#include <ostream>
 
 #include "gutil/gscoped_ptr.h"
 #include "gutil/strings/ascii_ctype.h"

--- a/be/src/gutil/strings/join.h
+++ b/be/src/gutil/strings/join.h
@@ -6,33 +6,33 @@
 //
 #pragma once
 
-#include <stdio.h>
-#include <string.h>
-
 #include <iterator>
+// IWYU pragma: no_include <ext/type_traits>
+#include <type_traits> // IWYU pragma: keep
+
 using std::back_insert_iterator;
 using std::iterator_traits;
 #include <map>
+
 using std::map;
 using std::multimap;
 #include <set>
+
 using std::multiset;
 using std::set;
 #include <string>
+
 using std::string;
 #include <utility>
+
 using std::make_pair;
 using std::pair;
 #include <vector>
+
 using std::vector;
 
-#include "gutil/hash/hash.h"
-#include "gutil/integral_types.h"
-#include "gutil/macros.h"
-#include "gutil/strings/numbers.h"
 #include "gutil/strings/strcat.h" // For backward compatibility.
 #include "gutil/strings/stringpiece.h"
-#include "gutil/template_util.h"
 
 // ----------------------------------------------------------------------
 // JoinUsing()

--- a/be/src/gutil/strings/numbers.cc
+++ b/be/src/gutil/strings/numbers.cc
@@ -14,13 +14,17 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
+#include <inttypes.h>
+#include <sys/types.h>
 #include <limits>
+#include <ostream>
+
 using std::numeric_limits;
 #include <string>
+
 using std::string;
 
-#include <common/logging.h>
+#include "common/logging.h"
 #include <fmt/format.h>
 
 #include "gutil/gscoped_ptr.h"

--- a/be/src/gutil/strings/numbers.h
+++ b/be/src/gutil/strings/numbers.h
@@ -6,22 +6,25 @@
 #pragma once
 
 #include <stddef.h>
-#include <stdlib.h>
-#include <string.h>
 #include <time.h>
-
+#include <stdint.h>
 #include <functional>
+
 using std::less;
 #include <limits>
+
 using std::numeric_limits;
 #include <string>
+
 using std::string;
 #include <vector>
+
 using std::vector;
 
 #include "gutil/int128.h"
 #include "gutil/integral_types.h"
-#include "gutil/macros.h"
+// IWYU pragma: no_include <butil/macros.h>
+#include "gutil/macros.h" // IWYU pragma: keep
 #include "gutil/port.h"
 #include "gutil/stringprintf.h"
 

--- a/be/src/gutil/strings/split.cc
+++ b/be/src/gutil/strings/split.cc
@@ -7,22 +7,23 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
-
 #include <iterator>
+#include <ostream>
+
 using std::back_insert_iterator;
 using std::iterator_traits;
 #include <limits>
+
 using std::numeric_limits;
 
 using std::unordered_map;
 using std::unordered_set;
 
-#include <common/logging.h>
+#include "common/logging.h"
 
-#include "gutil/hash/hash.h"
 #include "gutil/integral_types.h"
-#include "gutil/logging-inl.h"
-#include "gutil/macros.h"
+// IWYU pragma: no_include <butil/macros.h>
+#include "gutil/macros.h" // IWYU pragma: keep
 #include "gutil/strings/ascii_ctype.h"
 #include "gutil/strings/util.h"
 #include "gutil/strtoint.h"

--- a/be/src/gutil/strings/split.h
+++ b/be/src/gutil/strings/split.h
@@ -19,8 +19,9 @@
 //
 #pragma once
 
-#include <stddef.h>
+// IWYU pragma: no_include <pstl/glue_algorithm_defs.h>
 
+#include <stddef.h>
 #include <algorithm>
 
 using std::copy;
@@ -30,32 +31,36 @@ using std::reverse;
 using std::sort;
 using std::swap;
 #include <iterator>
+
 using std::back_insert_iterator;
 using std::iterator_traits;
 #include <map>
+
 using std::map;
 using std::multimap;
 #include <set>
+
 using std::multiset;
 using std::set;
 #include <string>
+
 using std::string;
 #include <utility>
+
 using std::make_pair;
 using std::pair;
 #include <vector>
-using std::vector;
-#include <common/logging.h>
 
+using std::vector;
+#include "common/logging.h"
 #include <unordered_map>
 #include <unordered_set>
 
 #include "gutil/integral_types.h"
-#include "gutil/logging-inl.h"
 #include "gutil/strings/charset.h"
-#include "gutil/strings/split_internal.h"
 #include "gutil/strings/stringpiece.h"
 #include "gutil/strings/strip.h"
+#include "gutil/strings/split_internal.h" // IWYU pragma: keep
 
 namespace strings {
 

--- a/be/src/gutil/strings/split_internal.h
+++ b/be/src/gutil/strings/split_internal.h
@@ -27,6 +27,7 @@ using std::vector;
 
 #include "gutil/port.h" // for LANG_CXX11
 #include "gutil/strings/stringpiece.h"
+#include "gutil/template_util.h" // IWYU pragma: keep
 
 #ifdef LANG_CXX11
 // This must be included after "base/port.h", which defines LANG_CXX11.

--- a/be/src/gutil/strings/strcat.cc
+++ b/be/src/gutil/strings/strcat.cc
@@ -2,15 +2,12 @@
 
 #include "gutil/strings/strcat.h"
 
-#include <common/logging.h>
+#include "common/logging.h"
 #include <stdarg.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
 
-#include "gutil/gscoped_ptr.h"
 #include "gutil/stl_util.h"
-#include "gutil/strings/ascii_ctype.h"
 #include "gutil/strings/escaping.h"
 
 AlphaNum gEmptyAlphaNum("");

--- a/be/src/gutil/strings/strcat.h
+++ b/be/src/gutil/strings/strcat.h
@@ -6,12 +6,16 @@
 //
 #pragma once
 
+#include <string.h>
 #include <string>
+#include <utility>
+
 using std::string;
 
 #include "gutil/integral_types.h"
 #include "gutil/strings/numbers.h"
 #include "gutil/strings/stringpiece.h"
+#include "gutil/stringprintf.h"
 
 // The AlphaNum type was designed to be used as the parameter type for StrCat().
 // I suppose that any routine accepting either a string or a number could accept

--- a/be/src/gutil/strings/stringpiece.cc
+++ b/be/src/gutil/strings/stringpiece.cc
@@ -4,16 +4,19 @@
 
 #include "gutil/strings/stringpiece.h"
 
-#include <common/logging.h>
-#include <string.h>
+// IWYU pragma: no_include <pstl/glue_algorithm_defs.h>
 
+#include "common/logging.h"
+#include <string.h>
 #include <algorithm>
 #include <climits>
 #include <string>
+#include <deque>
+#include <ostream>
 
-#include "gutil/hash/hash.h"
 #include "gutil/stl_util.h"
 #include "gutil/strings/memutil.h"
+#include "gutil/hash/legacy_hash.h"
 
 using std::copy;
 using std::max;

--- a/be/src/gutil/strings/stringpiece.h
+++ b/be/src/gutil/strings/stringpiece.h
@@ -114,16 +114,16 @@
 #include <assert.h>
 #include <stddef.h>
 #include <string.h>
-
-#include <functional>
 #include <iosfwd>
-#include <limits>
 #include <string>
+#include <cstddef>
+#include <iterator>
+#include <string_view>
+#include <limits> // IWYU pragma: keep
 
-#include "gutil/hash/hash.h"
-#include "gutil/integral_types.h"
-#include "gutil/port.h"
 #include "gutil/strings/fastmem.h"
+#include "gutil/hash/string_hash.h"
+#include "gutil/int128.h"
 
 class StringPiece {
 private:
@@ -320,7 +320,6 @@ inline bool operator<=(StringPiece x, StringPiece y) {
 inline bool operator>=(StringPiece x, StringPiece y) {
     return !(x < y);
 }
-class StringPiece;
 template <class X>
 struct GoodFastHash;
 

--- a/be/src/gutil/strings/strip.cc
+++ b/be/src/gutil/strings/strip.cc
@@ -6,10 +6,14 @@
 
 #include "gutil/strings/strip.h"
 
+// IWYU pragma: no_include <pstl/glue_algorithm_defs.h>
+
 #include <assert.h>
 #include <string.h>
-
 #include <algorithm>
+#include <iterator>
+#include <mutex>
+
 using std::copy;
 using std::max;
 using std::min;
@@ -17,6 +21,7 @@ using std::reverse;
 using std::sort;
 using std::swap;
 #include <string>
+
 using std::string;
 
 #include "gutil/strings/ascii_ctype.h"

--- a/be/src/gutil/strings/substitute.cc
+++ b/be/src/gutil/strings/substitute.cc
@@ -2,9 +2,12 @@
 
 #include "gutil/strings/substitute.h"
 
-#include <common/logging.h>
+#include "common/logging.h"
+#include <stdint.h>
+#include <ostream>
 
-#include "gutil/macros.h"
+// IWYU pragma: no_include <butil/macros.h>
+#include "gutil/macros.h" // IWYU pragma: keep
 #include "gutil/stl_util.h"
 #include "gutil/strings/ascii_ctype.h"
 #include "gutil/strings/escaping.h"

--- a/be/src/gutil/strings/substitute.h
+++ b/be/src/gutil/strings/substitute.h
@@ -3,13 +3,13 @@
 #pragma once
 
 #include <string.h>
-
 #include <string>
+
 using std::string;
 
-#include "gutil/basictypes.h"
 #include "gutil/strings/numbers.h"
 #include "gutil/strings/stringpiece.h"
+#include "gutil/stringprintf.h"
 
 namespace strings {
 

--- a/be/src/gutil/strings/util.cc
+++ b/be/src/gutil/strings/util.cc
@@ -7,13 +7,18 @@
 
 #include "gutil/strings/util.h"
 
+// IWYU pragma: no_include <pstl/glue_algorithm_defs.h>
+
 #include <assert.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
 #include <time.h> // for FastTimeToBuffer()
-
 #include <algorithm>
+#include <iterator>
+#include <mutex>
+#include <ostream>
+
 using std::copy;
 using std::max;
 using std::min;
@@ -21,17 +26,20 @@ using std::reverse;
 using std::sort;
 using std::swap;
 #include <string>
+
 using std::string;
 #include <vector>
+
 using std::vector;
 
-#include <common/logging.h>
+#include "common/logging.h"
 
 #include "gutil/stl_util.h" // for string_as_array, STLAppendToString
 #include "gutil/strings/ascii_ctype.h"
 #include "gutil/strings/numbers.h"
 #include "gutil/strings/stringpiece.h"
 #include "gutil/utf/utf.h"
+#include "gutil/stringprintf.h"
 
 #ifdef OS_WINDOWS
 #ifdef min // windows.h defines this to something silly

--- a/be/src/gutil/strings/util.h
+++ b/be/src/gutil/strings/util.h
@@ -27,17 +27,19 @@
 
 #include <stddef.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #ifndef _MSC_VER
 #include <strings.h> // for strcasecmp, but msvc does not have this header
 #endif
 
 #include <functional>
+
 using std::less;
 #include <string>
+
 using std::string;
 #include <vector>
+
 using std::vector;
 
 #include "gutil/integral_types.h"

--- a/be/src/gutil/strtoint.cc
+++ b/be/src/gutil/strtoint.cc
@@ -7,7 +7,7 @@
 #include "gutil/strtoint.h"
 
 #include <errno.h>
-
+#include <limits.h>
 #include <limits>
 
 // Replacement strto[u]l functions that have identical overflow and underflow

--- a/be/src/gutil/strtoint.h
+++ b/be/src/gutil/strtoint.h
@@ -34,7 +34,8 @@
 
 using std::string;
 #include "gutil/integral_types.h"
-#include "gutil/macros.h"
+// IWYU pragma: no_include <butil/macros.h>
+#include "gutil/macros.h" // IWYU pragma: keep
 
 // Adapter functions for handling overflow and errno.
 int32 strto32_adapter(const char* nptr, char** endptr, int base);

--- a/be/src/gutil/threading/thread_collision_warner.h
+++ b/be/src/gutil/threading/thread_collision_warner.h
@@ -7,7 +7,8 @@
 #include <cstdint>
 
 #include "gutil/atomicops.h"
-#include "gutil/macros.h"
+// IWYU pragma: no_include <butil/macros.h>
+#include "gutil/macros.h" // IWYU pragma: keep
 
 #ifndef BASE_EXPORT
 #define BASE_EXPORT

--- a/be/src/gutil/utf/rune.c
+++ b/be/src/gutil/utf/rune.c
@@ -11,8 +11,6 @@
  * REPRESENTATION OR WARRANTY OF ANY KIND CONCERNING THE MERCHANTABILITY
  * OF THIS SOFTWARE OR ITS FITNESS FOR ANY PARTICULAR PURPOSE.
  */
-#include <stdarg.h>
-#include <string.h>
 #include "gutil/utf/utf.h"
 #include "gutil/utf/utfdef.h"
 

--- a/be/src/util/hash_util.hpp
+++ b/be/src/util/hash_util.hpp
@@ -28,6 +28,7 @@
 
 // IWYU pragma: no_include <opentelemetry/common/threadlocal.h>
 #include "common/compiler_util.h" // IWYU pragma: keep
+#include "gutil/hash/hash.h"      // IWYU pragma: keep
 #include "runtime/define_primitive_type.h"
 #include "util/cpu_info.h"
 #include "util/murmur_hash3.h"

--- a/be/src/util/rle_encoding.h
+++ b/be/src/util/rle_encoding.h
@@ -18,6 +18,8 @@
 
 #include <glog/logging.h>
 
+#include <limits> // IWYU pragma: keep
+
 #include "gutil/port.h"
 #include "util/bit_stream_utils.inline.h"
 #include "util/bit_util.h"

--- a/be/src/vec/data_types/serde/data_type_array_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_array_serde.cpp
@@ -17,9 +17,14 @@
 
 #include "data_type_array_serde.h"
 
+#include "util/jsonb_document.h"
+#include "vec/columns/column.h"
+#include "vec/common/string_ref.h"
+
 namespace doris {
 
 namespace vectorized {
+class Arena;
 
 void DataTypeArraySerDe::write_one_cell_to_jsonb(const IColumn& column, JsonbWriter& result,
                                                  Arena* mem_pool, int32_t col_id,

--- a/be/src/vec/data_types/serde/data_type_array_serde.h
+++ b/be/src/vec/data_types/serde/data_type_array_serde.h
@@ -18,17 +18,21 @@
 #pragma once
 
 #include <glog/logging.h>
+#include <stdint.h>
 
 #include <ostream>
 
 #include "common/status.h"
 #include "data_type_serde.h"
+#include "util/jsonb_writer.h"
 
 namespace doris {
 class PValues;
+class JsonbValue;
 
 namespace vectorized {
 class IColumn;
+class Arena;
 
 class DataTypeArraySerDe : public DataTypeSerDe {
 public:

--- a/be/src/vec/data_types/serde/data_type_bitmap_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_bitmap_serde.cpp
@@ -17,9 +17,15 @@
 
 #include "data_type_bitmap_serde.h"
 
+#include <gen_cpp/types.pb.h>
+
+#include <string>
+
+#include "util/bitmap_value.h"
+#include "util/jsonb_document.h"
 #include "vec/columns/column_complex.h"
 #include "vec/common/arena.h"
-#include "vec/data_types/data_type.h"
+#include "vec/common/assert_cast.h"
 
 namespace doris {
 

--- a/be/src/vec/data_types/serde/data_type_bitmap_serde.h
+++ b/be/src/vec/data_types/serde/data_type_bitmap_serde.h
@@ -17,14 +17,19 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include "common/status.h"
 #include "data_type_serde.h"
+#include "util/jsonb_writer.h"
 
 namespace doris {
 class PValues;
+class JsonbValue;
 
 namespace vectorized {
 class IColumn;
+class Arena;
 
 class DataTypeBitMapSerDe : public DataTypeSerDe {
 public:

--- a/be/src/vec/data_types/serde/data_type_decimal_serde.h
+++ b/be/src/vec/data_types/serde/data_type_decimal_serde.h
@@ -18,11 +18,18 @@
 #pragma once
 
 #include <gen_cpp/types.pb.h>
+#include <glog/logging.h>
 #include <stddef.h>
+#include <stdint.h>
+
+#include <ostream>
+#include <string>
 
 #include "common/status.h"
 #include "data_type_serde.h"
 #include "olap/olap_common.h"
+#include "util/jsonb_document.h"
+#include "util/jsonb_writer.h"
 #include "vec/columns/column.h"
 #include "vec/common/string_ref.h"
 #include "vec/core/types.h"
@@ -32,6 +39,7 @@ namespace doris {
 namespace vectorized {
 template <typename T>
 class ColumnDecimal;
+class Arena;
 
 template <typename T>
 class DataTypeDecimalSerDe : public DataTypeSerDe {

--- a/be/src/vec/data_types/serde/data_type_fixedlengthobject_serde.h
+++ b/be/src/vec/data_types/serde/data_type_fixedlengthobject_serde.h
@@ -18,17 +18,21 @@
 #pragma once
 
 #include <glog/logging.h>
+#include <stdint.h>
 
 #include <ostream>
 
 #include "common/status.h"
 #include "data_type_serde.h"
+#include "util/jsonb_writer.h"
 
 namespace doris {
 class PValues;
+class JsonbValue;
 
 namespace vectorized {
 class IColumn;
+class Arena;
 
 class DataTypeFixedLengthObjectSerDe : public DataTypeSerDe {
 public:

--- a/be/src/vec/data_types/serde/data_type_hll_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_hll_serde.cpp
@@ -24,6 +24,7 @@
 #include <string>
 
 #include "olap/hll.h"
+#include "util/jsonb_document.h"
 #include "util/slice.h"
 #include "vec/columns/column_complex.h"
 #include "vec/common/arena.h"

--- a/be/src/vec/data_types/serde/data_type_hll_serde.h
+++ b/be/src/vec/data_types/serde/data_type_hll_serde.h
@@ -17,14 +17,19 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include "common/status.h"
 #include "data_type_serde.h"
+#include "util/jsonb_writer.h"
 
 namespace doris {
 class PValues;
+class JsonbValue;
 
 namespace vectorized {
 class IColumn;
+class Arena;
 
 class DataTypeHLLSerDe : public DataTypeSerDe {
 public:

--- a/be/src/vec/data_types/serde/data_type_map_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_map_serde.cpp
@@ -17,8 +17,14 @@
 
 #include "data_type_map_serde.h"
 
+#include "util/jsonb_document.h"
+#include "vec/columns/column.h"
+#include "vec/common/string_ref.h"
+
 namespace doris {
 namespace vectorized {
+class Arena;
+
 void DataTypeMapSerDe::read_one_cell_from_jsonb(IColumn& column, const JsonbValue* arg) const {
     auto blob = static_cast<const JsonbBlobVal*>(arg);
     column.deserialize_and_insert_from_arena(blob->getBlob());

--- a/be/src/vec/data_types/serde/data_type_map_serde.h
+++ b/be/src/vec/data_types/serde/data_type_map_serde.h
@@ -18,17 +18,21 @@
 #pragma once
 
 #include <glog/logging.h>
+#include <stdint.h>
 
 #include <ostream>
 
 #include "common/status.h"
 #include "data_type_serde.h"
+#include "util/jsonb_writer.h"
 
 namespace doris {
 class PValues;
+class JsonbValue;
 
 namespace vectorized {
 class IColumn;
+class Arena;
 
 class DataTypeMapSerDe : public DataTypeSerDe {
 public:

--- a/be/src/vec/data_types/serde/data_type_nullable_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_nullable_serde.cpp
@@ -23,6 +23,7 @@
 #include <boost/iterator/iterator_facade.hpp>
 #include <memory>
 
+#include "util/jsonb_document.h"
 #include "vec/columns/column.h"
 #include "vec/columns/column_nullable.h"
 #include "vec/columns/column_vector.h"
@@ -33,6 +34,7 @@
 namespace doris {
 
 namespace vectorized {
+class Arena;
 
 Status DataTypeNullableSerDe::write_column_to_pb(const IColumn& column, PValues& result, int start,
                                                  int end) const {

--- a/be/src/vec/data_types/serde/data_type_nullable_serde.h
+++ b/be/src/vec/data_types/serde/data_type_nullable_serde.h
@@ -17,14 +17,19 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include "common/status.h"
 #include "data_type_serde.h"
+#include "util/jsonb_writer.h"
 
 namespace doris {
 class PValues;
+class JsonbValue;
 
 namespace vectorized {
 class IColumn;
+class Arena;
 
 class DataTypeNullableSerDe : public DataTypeSerDe {
 public:

--- a/be/src/vec/data_types/serde/data_type_number_serde.h
+++ b/be/src/vec/data_types/serde/data_type_number_serde.h
@@ -18,19 +18,28 @@
 #pragma once
 
 #include <gen_cpp/types.pb.h>
+#include <glog/logging.h>
 #include <stddef.h>
+#include <stdint.h>
+
+#include <ostream>
+#include <string>
 
 #include "common/status.h"
 #include "data_type_serde.h"
 #include "olap/olap_common.h"
+#include "util/jsonb_document.h"
+#include "util/jsonb_writer.h"
 #include "vec/columns/column.h"
 #include "vec/columns/column_vector.h"
 #include "vec/common/string_ref.h"
 #include "vec/core/types.h"
 
 namespace doris {
+class JsonbOutStream;
 
 namespace vectorized {
+class Arena;
 
 template <typename T>
 class DataTypeNumberSerDe : public DataTypeSerDe {

--- a/be/src/vec/data_types/serde/data_type_object_serde.h
+++ b/be/src/vec/data_types/serde/data_type_object_serde.h
@@ -18,17 +18,21 @@
 #pragma once
 
 #include <glog/logging.h>
+#include <stdint.h>
 
 #include <ostream>
 
 #include "common/status.h"
 #include "data_type_serde.h"
+#include "util/jsonb_writer.h"
 
 namespace doris {
 class PValues;
+class JsonbValue;
 
 namespace vectorized {
 class IColumn;
+class Arena;
 
 class DataTypeObjectSerDe : public DataTypeSerDe {
 public:

--- a/be/src/vec/data_types/serde/data_type_quantilestate_serde.h
+++ b/be/src/vec/data_types/serde/data_type_quantilestate_serde.h
@@ -17,9 +17,20 @@
 
 #pragma once
 
+#include <gen_cpp/types.pb.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "common/status.h"
 #include "data_type_serde.h"
+#include "util/jsonb_document.h"
+#include "util/jsonb_writer.h"
+#include "util/quantile_state.h"
+#include "util/slice.h"
+#include "vec/columns/column.h"
 #include "vec/columns/column_complex.h"
 #include "vec/common/arena.h"
+#include "vec/common/string_ref.h"
 
 namespace doris {
 

--- a/be/src/vec/data_types/serde/data_type_serde.h
+++ b/be/src/vec/data_types/serde/data_type_serde.h
@@ -17,18 +17,21 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include <memory>
 #include <vector>
 
 #include "common/status.h"
 #include "util/jsonb_writer.h"
-#include "vec/columns/column.h"
 
 namespace doris {
 class PValues;
+class JsonbValue;
 
 namespace vectorized {
 class IColumn;
+class Arena;
 // Deserialize means read from different file format or memory format,
 // for example read from arrow, read from parquet.
 // Serialize means write the column cell or the total column into another

--- a/be/src/vec/data_types/serde/data_type_string_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_string_serde.cpp
@@ -17,15 +17,18 @@
 
 #include "data_type_string_serde.h"
 
+#include <assert.h>
 #include <gen_cpp/types.pb.h>
 #include <stddef.h>
 
+#include "util/jsonb_document.h"
 #include "vec/columns/column.h"
 #include "vec/columns/column_string.h"
 #include "vec/common/string_ref.h"
 
 namespace doris {
 namespace vectorized {
+class Arena;
 
 Status DataTypeStringSerDe::write_column_to_pb(const IColumn& column, PValues& result, int start,
                                                int end) const {

--- a/be/src/vec/data_types/serde/data_type_string_serde.h
+++ b/be/src/vec/data_types/serde/data_type_string_serde.h
@@ -17,14 +17,19 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include "common/status.h"
 #include "data_type_serde.h"
+#include "util/jsonb_writer.h"
 
 namespace doris {
 class PValues;
+class JsonbValue;
 
 namespace vectorized {
 class IColumn;
+class Arena;
 
 class DataTypeStringSerDe : public DataTypeSerDe {
 public:

--- a/be/src/vec/data_types/serde/data_type_struct_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_struct_serde.cpp
@@ -16,9 +16,16 @@
 // under the License.
 
 #include "data_type_struct_serde.h"
+
+#include "util/jsonb_document.h"
+#include "vec/columns/column.h"
+#include "vec/common/string_ref.h"
+
 namespace doris {
 
 namespace vectorized {
+class Arena;
+
 void DataTypeStructSerDe::write_one_cell_to_jsonb(const IColumn& column, JsonbWriter& result,
                                                   Arena* mem_pool, int32_t col_id,
                                                   int row_num) const {

--- a/be/src/vec/data_types/serde/data_type_struct_serde.h
+++ b/be/src/vec/data_types/serde/data_type_struct_serde.h
@@ -18,17 +18,21 @@
 #pragma once
 
 #include <glog/logging.h>
+#include <stdint.h>
 
 #include <ostream>
 
 #include "common/status.h"
 #include "data_type_serde.h"
+#include "util/jsonb_writer.h"
 
 namespace doris {
 class PValues;
+class JsonbValue;
 
 namespace vectorized {
 class IColumn;
+class Arena;
 
 class DataTypeStructSerDe : public DataTypeSerDe {
 public:

--- a/be/src/vec/functions/uuid.cpp
+++ b/be/src/vec/functions/uuid.cpp
@@ -18,8 +18,8 @@
 #include <glog/logging.h>
 #include <stddef.h>
 
-#include <boost/uuid/random_generator.hpp>
-#include <boost/uuid/uuid_io.hpp>
+// IWYU pragma: no_include <boost/uuid/random_generator.hpp>
+// IWYU pragma: no_include <boost/uuid/uuid_io.hpp>
 #include <memory>
 #include <string>
 #include <utility>

--- a/be/src/vec/jsonb/serialize.cpp
+++ b/be/src/vec/jsonb/serialize.cpp
@@ -18,34 +18,23 @@
 #include "vec/jsonb/serialize.h"
 
 #include <assert.h>
-#include <glog/logging.h>
-#include <stdint.h>
 
 #include <algorithm>
-#include <ostream>
+#include <memory>
 #include <vector>
 
-#include "olap/hll.h"
-#include "olap/olap_common.h"
 #include "olap/tablet_schema.h"
-#include "runtime/define_primitive_type.h"
 #include "runtime/descriptors.h"
-#include "runtime/primitive_type.h"
-#include "runtime/types.h"
-#include "util/bitmap_value.h"
 #include "util/jsonb_document.h"
 #include "util/jsonb_stream.h"
 #include "util/jsonb_writer.h"
-#include "util/slice.h"
 #include "vec/columns/column.h"
 #include "vec/columns/column_string.h"
 #include "vec/common/arena.h"
 #include "vec/common/string_ref.h"
 #include "vec/core/column_with_type_and_name.h"
-#include "vec/core/field.h"
-#include "vec/core/types.h"
 #include "vec/data_types/data_type.h"
-#include "vec/runtime/vdatetime_value.h"
+#include "vec/data_types/serde/data_type_serde.h"
 
 namespace doris::vectorized {
 

--- a/be/src/vec/jsonb/serialize.h
+++ b/be/src/vec/jsonb/serialize.h
@@ -18,7 +18,6 @@
 #pragma once
 #include <stddef.h>
 
-#include "runtime/descriptors.h"
 #include "vec/core/block.h"
 
 namespace doris {

--- a/be/test/agent/utils_test.cpp
+++ b/be/test/agent/utils_test.cpp
@@ -17,10 +17,14 @@
 
 #include "agent/utils.h"
 
+#include <gmock/gmock-actions.h>
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+
 #include <algorithm>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
+#include "gtest/gtest_pred_impl.h"
 #include "service/backend_options.h"
 
 using ::testing::_;

--- a/be/test/common/config_test.cpp
+++ b/be/test/common/config_test.cpp
@@ -16,10 +16,18 @@
 // under the License.
 
 #define __IN_CONFIGBASE_CPP__
-#include "common/configbase.h"
-#undef __IN_CONFIGBASE_CPP__
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include <gtest/gtest.h>
+#include <map>
+#include <ostream>
+#include <string>
+#include <utility>
+
+#include "common/configbase.h"
+#include "gtest/gtest_pred_impl.h"
+
+#undef __IN_CONFIGBASE_CPP__
 
 #include "common/status.h"
 

--- a/be/test/common/exception_test.cpp
+++ b/be/test/common/exception_test.cpp
@@ -17,10 +17,12 @@
 
 #include "common/exception.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include <iostream>
 #include <string>
+
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/common/resource_tls_test.cpp
+++ b/be/test/common/resource_tls_test.cpp
@@ -17,10 +17,13 @@
 
 #include "common/resource_tls.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include "common/configbase.h"
+#include <memory>
+
 #include "gen_cpp/Types_types.h"
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/common/status_test.cpp
+++ b/be/test/common/status_test.cpp
@@ -17,9 +17,10 @@
 
 #include "common/status.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include "gen_cpp/Types_types.h"
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/exprs/bloom_filter_predicate_test.cpp
+++ b/be/test/exprs/bloom_filter_predicate_test.cpp
@@ -15,10 +15,19 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <string.h>
+
+#include <memory>
 #include <string>
 
+#include "common/object_pool.h"
+#include "common/status.h"
+#include "exprs/bloom_filter_func.h"
 #include "exprs/create_predicate_function.h"
-#include "gtest/gtest.h"
+#include "gtest/gtest_pred_impl.h"
+#include "runtime/define_primitive_type.h"
 #include "vec/common/string_ref.h"
 
 namespace doris {

--- a/be/test/exprs/json_function_test.cpp
+++ b/be/test/exprs/json_function_test.cpp
@@ -15,20 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 #include <rapidjson/document.h>
+#include <rapidjson/encodings.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
-#include <re2/re2.h>
 
-#include <boost/algorithm/string.hpp>
-#include <boost/tokenizer.hpp>
 #include <string>
 
-#include "common/object_pool.h"
 #include "exprs/json_functions.h"
-#include "runtime/runtime_state.h"
-#include "util/stopwatch.hpp"
+#include "gtest/gtest_pred_impl.h"
+
 namespace doris {
 
 // mock

--- a/be/test/geo/geo_types_test.cpp
+++ b/be/test/geo/geo_types_test.cpp
@@ -17,11 +17,14 @@
 
 #include "geo/geo_types.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <string.h>
+
+#include <ostream>
 
 #include "common/logging.h"
-#include "geo/geo_types.h"
-#include "geo/wkt_parse.h"
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/geo/wkt_parse_test.cpp
+++ b/be/test/geo/wkt_parse_test.cpp
@@ -17,11 +17,16 @@
 
 #include "geo/wkt_parse.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <string.h>
+
+#include <ostream>
+#include <string>
 
 #include "common/logging.h"
 #include "geo/geo_types.h"
-#include "geo/wkt_parse_ctx.h"
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/gutil/strings/numbers_test.cpp
+++ b/be/test/gutil/strings/numbers_test.cpp
@@ -17,10 +17,12 @@
 
 #include "gutil/strings/numbers.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
 #include <limits>
 
+#include "gtest/gtest_pred_impl.h"
 #include "util/mysql_global.h"
 
 namespace doris {

--- a/be/test/http/http_client_test.cpp
+++ b/be/test/http/http_client_test.cpp
@@ -17,10 +17,13 @@
 
 #include "http/http_client.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <unistd.h>
 
-#include "boost/algorithm/string.hpp"
-#include "common/logging.h"
+#include <boost/algorithm/string/predicate.hpp>
+
+#include "gtest/gtest_pred_impl.h"
 #include "http/ev_http_server.h"
 #include "http/http_channel.h"
 #include "http/http_handler.h"

--- a/be/test/http/http_utils_test.cpp
+++ b/be/test/http/http_utils_test.cpp
@@ -15,13 +15,20 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <event2/http.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include "common/logging.h"
+#include <string>
+
+#include "gtest/gtest_pred_impl.h"
 #include "http/http_headers.h"
 #include "http/http_request.h"
 #include "http/utils.h"
+#include "util/string_util.h"
 #include "util/url_coding.h"
+
+struct evhttp_request;
 
 namespace doris {
 

--- a/be/test/http/message_body_sink_test.cpp
+++ b/be/test/http/message_body_sink_test.cpp
@@ -18,10 +18,12 @@
 #include "runtime/message_body_sink.h"
 
 #include <fcntl.h>
-#include <gtest/gtest.h>
-#include <stdio.h>
-#include <sys/stat.h>
-#include <sys/types.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/io/cache/file_block_cache_test.cpp
+++ b/be/test/io/cache/file_block_cache_test.cpp
@@ -18,16 +18,30 @@
 // https://github.com/ClickHouse/ClickHouse/blob/master/src/Interpreters/tests/gtest_lru_file_cache.cpp
 // and modified by Doris
 
-#include <gtest/gtest.h>
+#include <gen_cpp/Types_types.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stddef.h>
 
+// IWYU pragma: no_include <bits/chrono.h>
+#include <chrono> // IWYU pragma: keep
+#include <condition_variable>
 #include <filesystem>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
 #include <thread>
+#include <vector>
 
 #include "common/config.h"
+#include "gtest/gtest_pred_impl.h"
 #include "io/cache/block/block_file_cache.h"
 #include "io/cache/block/block_file_cache_settings.h"
 #include "io/cache/block/block_file_segment.h"
 #include "io/cache/block/block_lru_file_cache.h"
+#include "io/fs/path.h"
 #include "olap/options.h"
 #include "util/slice.h"
 

--- a/be/test/io/cache/remote_file_cache_test.cpp
+++ b/be/test/io/cache/remote_file_cache_test.cpp
@@ -15,36 +15,41 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <aws/core/auth/AWSCredentials.h>
-#include <aws/s3/S3Client.h>
-#include <aws/s3/model/GetObjectRequest.h>
+#include <fmt/format.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stddef.h>
+#include <stdint.h>
 
+#include <functional>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
+#include "common/config.h"
+#include "common/status.h"
 #include "gen_cpp/olap_file.pb.h"
-#include "gtest/gtest.h"
+#include "gtest/gtest_pred_impl.h"
+#include "io/fs/file_reader_options.h"
+#include "io/fs/file_reader_writer_fwd.h"
 #include "io/fs/file_writer.h"
 #include "io/fs/local_file_system.h"
-#include "io/fs/s3_common.h"
 #include "io/fs/s3_file_system.h"
-#include "olap/comparison_predicate.h"
 #include "olap/data_dir.h"
+#include "olap/olap_common.h"
 #include "olap/options.h"
 #include "olap/row_cursor.h"
-#include "olap/rowset/beta_rowset_reader.h"
-#include "olap/rowset/rowset_factory.h"
-#include "olap/rowset/rowset_reader_context.h"
-#include "olap/rowset/rowset_writer.h"
-#include "olap/rowset/rowset_writer_context.h"
+#include "olap/row_cursor_cell.h"
+#include "olap/rowset/beta_rowset.h"
+#include "olap/rowset/rowset_meta.h"
+#include "olap/rowset/segment_v2/segment.h"
 #include "olap/rowset/segment_v2/segment_writer.h"
 #include "olap/storage_engine.h"
 #include "olap/tablet_schema.h"
 #include "olap/tablet_schema_helper.h"
-#include "olap/utils.h"
 #include "runtime/exec_env.h"
-#include "runtime/memory/mem_tracker.h"
+#include "util/s3_util.h"
 #include "util/slice.h"
 
 namespace doris {

--- a/be/test/io/fs/buffered_reader_test.cpp
+++ b/be/test/io/fs/buffered_reader_test.cpp
@@ -17,15 +17,20 @@
 
 #include "io/fs/buffered_reader.h"
 
-#include <gtest/gtest.h>
+#include <glog/logging.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <limits.h>
 
 #include <memory>
+#include <ostream>
 
+#include "gtest/gtest_pred_impl.h"
 #include "io/fs/file_reader_writer_fwd.h"
-#include "io/fs/local_file_reader.h"
 #include "io/fs/local_file_system.h"
 #include "runtime/exec_env.h"
 #include "util/stopwatch.hpp"
+#include "util/threadpool.h"
 
 namespace doris {
 using io::FileReader;

--- a/be/test/io/fs/local_file_system_test.cpp
+++ b/be/test/io/fs/local_file_system_test.cpp
@@ -17,17 +17,20 @@
 
 #include "io/fs/local_file_system.h"
 
-#include <algorithm>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
 #include <filesystem>
-#include <fstream>
-#include <set>
 #include <vector>
 
 #include "common/status.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
+#include "gtest/gtest_pred_impl.h"
 #include "io/fs/file_reader.h"
 #include "io/fs/file_writer.h"
+#include "util/slice.h"
 
 namespace doris {
 

--- a/be/test/io/fs/remote_file_system_test.cpp
+++ b/be/test/io/fs/remote_file_system_test.cpp
@@ -15,18 +15,36 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <fmt/format.h>
+#include <gen_cpp/PlanNodes_types.h>
+#include <gen_cpp/Types_types.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stddef.h>
+#include <stdint.h>
 
+#include <iostream>
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "common/status.h"
+#include "gtest/gtest_pred_impl.h"
 #include "io/fs/broker_file_system.h"
 #include "io/fs/file_reader.h"
+#include "io/fs/file_reader_writer_fwd.h"
+#include "io/fs/file_system.h"
 #include "io/fs/file_writer.h"
 #include "io/fs/hdfs_file_system.h"
 #include "io/fs/local_file_system.h"
+#include "io/fs/path.h"
 #include "io/fs/s3_file_system.h"
 #include "io/hdfs_builder.h"
 #include "runtime/exec_env.h"
 #include "util/s3_uri.h"
-#include "util/threadpool.h"
+#include "util/s3_util.h"
 
 namespace doris {
 

--- a/be/test/olap/block_column_predicate_test.cpp
+++ b/be/test/olap/block_column_predicate_test.cpp
@@ -17,15 +17,19 @@
 
 #include "olap/block_column_predicate.h"
 
-#include <google/protobuf/stubs/common.h>
-#include <gtest/gtest.h>
+#include <gen_cpp/olap_file.pb.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
+#include <boost/iterator/iterator_facade.hpp>
+#include <memory>
+
+#include "gtest/gtest_pred_impl.h"
 #include "olap/column_predicate.h"
 #include "olap/comparison_predicate.h"
-#include "olap/field.h"
-#include "olap/wrapper_field.h"
+#include "olap/tablet_schema.h"
+#include "runtime/define_primitive_type.h"
 #include "vec/columns/predicate_column.h"
-#include "vec/common/string_ref.h"
 
 namespace doris {
 

--- a/be/test/olap/bloom_filter_test.cpp
+++ b/be/test/olap/bloom_filter_test.cpp
@@ -17,11 +17,13 @@
 
 #include "olap/bloom_filter.hpp"
 
-#include <gtest/gtest.h>
+#include <glog/logging.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
 #include <string>
 
-#include "common/configbase.h"
+#include "gtest/gtest_pred_impl.h"
 
 using std::string;
 

--- a/be/test/olap/common_test.cpp
+++ b/be/test/olap/common_test.cpp
@@ -15,8 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
+#include <algorithm>
+#include <vector>
+
+#include "gtest/gtest_pred_impl.h"
 #include "olap/olap_common.h"
 
 namespace doris {

--- a/be/test/olap/cumulative_compaction_policy_test.cpp
+++ b/be/test/olap/cumulative_compaction_policy_test.cpp
@@ -17,13 +17,18 @@
 
 #include "olap/cumulative_compaction_policy.h"
 
-#include <gtest/gtest.h>
+#include <gen_cpp/AgentService_types.h>
+#include <gen_cpp/olap_file.pb.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include <sstream>
-
+#include "gtest/gtest_pred_impl.h"
 #include "olap/cumulative_compaction.h"
+#include "olap/olap_common.h"
 #include "olap/rowset/rowset_meta.h"
+#include "olap/tablet.h"
 #include "olap/tablet_meta.h"
+#include "util/uid_util.h"
 
 namespace doris {
 

--- a/be/test/olap/decimal12_test.cpp
+++ b/be/test/olap/decimal12_test.cpp
@@ -17,7 +17,10 @@
 
 #include "olap/decimal12.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/olap/delete_handler_test.cpp
+++ b/be/test/olap/delete_handler_test.cpp
@@ -17,26 +17,35 @@
 
 #include "olap/delete_handler.h"
 
+#include <gen_cpp/AgentService_types.h>
 #include <gen_cpp/Descriptors_types.h>
-#include <gtest/gtest.h>
+#include <gen_cpp/PaloInternalService_types.h>
+#include <gen_cpp/Status_types.h>
+#include <gen_cpp/Types_types.h>
+#include <gen_cpp/olap_file.pb.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 #include <unistd.h>
 
-#include <algorithm>
-#include <boost/assign.hpp>
+#include <cstdlib>
 #include <iostream>
-#include <regex>
 #include <string>
 #include <vector>
 
+#include "common/config.h"
+#include "gtest/gtest_pred_impl.h"
+#include "gutil/strings/numbers.h"
 #include "io/fs/local_file_system.h"
+#include "olap/olap_common.h"
 #include "olap/olap_define.h"
+#include "olap/olap_tuple.h"
 #include "olap/options.h"
-#include "olap/push_handler.h"
 #include "olap/row_cursor.h"
 #include "olap/rowset/beta_rowset.h"
+#include "olap/rowset/rowset.h"
 #include "olap/storage_engine.h"
+#include "olap/tablet.h"
 #include "olap/tablet_manager.h"
-#include "olap/utils.h"
 #include "util/cpu_info.h"
 
 using namespace std;

--- a/be/test/olap/delta_writer_test.cpp
+++ b/be/test/olap/delta_writer_test.cpp
@@ -17,31 +17,48 @@
 
 #include "olap/delta_writer.h"
 
-#include <gtest/gtest.h>
-#include <sys/file.h>
+#include <gen_cpp/AgentService_types.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stdlib.h>
+#include <unistd.h>
 
+#include <iostream>
+#include <map>
 #include <string>
+#include <utility>
 
+#include "common/config.h"
+#include "common/object_pool.h"
 #include "exec/tablet_info.h"
 #include "gen_cpp/Descriptors_types.h"
-#include "gen_cpp/PaloInternalService_types.h"
 #include "gen_cpp/Types_types.h"
 #include "gen_cpp/internal_service.pb.h"
+#include "gtest/gtest_pred_impl.h"
 #include "io/fs/local_file_system.h"
-#include "olap/field.h"
+#include "olap/data_dir.h"
+#include "olap/iterators.h"
+#include "olap/olap_define.h"
 #include "olap/options.h"
 #include "olap/rowset/beta_rowset.h"
+#include "olap/rowset/segment_v2/segment.h"
+#include "olap/schema.h"
 #include "olap/storage_engine.h"
 #include "olap/tablet.h"
 #include "olap/tablet_manager.h"
-#include "olap/tablet_meta_manager.h"
 #include "olap/txn_manager.h"
-#include "olap/utils.h"
+#include "runtime/decimalv2_value.h"
+#include "runtime/define_primitive_type.h"
 #include "runtime/descriptor_helper.h"
 #include "runtime/descriptors.h"
 #include "runtime/exec_env.h"
+#include "vec/columns/column.h"
+#include "vec/core/block.h"
+#include "vec/core/column_with_type_and_name.h"
+#include "vec/runtime/vdatetime_value.h"
 
 namespace doris {
+class OlapMeta;
 
 // This is DeltaWriter unit test which used by streaming load.
 // And also it should take schema change into account after streaming load.

--- a/be/test/olap/engine_storage_migration_task_test.cpp
+++ b/be/test/olap/engine_storage_migration_task_test.cpp
@@ -17,29 +17,43 @@
 
 #include "olap/task/engine_storage_migration_task.h"
 
-#include <gtest/gtest.h>
-#include <sys/file.h>
+#include <gen_cpp/AgentService_types.h>
+#include <gen_cpp/types.pb.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stdlib.h>
+#include <unistd.h>
 
+#include <algorithm>
+#include <map>
+#include <memory>
 #include <string>
+#include <utility>
 
+#include "common/config.h"
+#include "common/object_pool.h"
 #include "exec/tablet_info.h"
 #include "gen_cpp/Descriptors_types.h"
-#include "gen_cpp/PaloInternalService_types.h"
 #include "gen_cpp/Types_types.h"
 #include "gen_cpp/internal_service.pb.h"
+#include "gtest/gtest_pred_impl.h"
 #include "io/fs/local_file_system.h"
+#include "olap/data_dir.h"
 #include "olap/delta_writer.h"
-#include "olap/field.h"
+#include "olap/olap_common.h"
+#include "olap/olap_define.h"
 #include "olap/options.h"
 #include "olap/storage_engine.h"
 #include "olap/tablet.h"
-#include "olap/tablet_meta_manager.h"
-#include "olap/utils.h"
+#include "olap/tablet_manager.h"
+#include "olap/txn_manager.h"
+#include "runtime/define_primitive_type.h"
 #include "runtime/descriptor_helper.h"
 #include "runtime/descriptors.h"
 #include "runtime/exec_env.h"
 
 namespace doris {
+class OlapMeta;
 
 static const uint32_t MAX_PATH_LEN = 1024;
 

--- a/be/test/olap/file_header_test.cpp
+++ b/be/test/olap/file_header_test.cpp
@@ -17,13 +17,15 @@
 
 #include "olap/file_header.h"
 
-#include <algorithm>
+#include <gmock/gmock-actions.h>
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+
 #include <filesystem>
-#include <fstream>
 
 #include "common/status.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
+#include "gtest/gtest_pred_impl.h"
 #include "testutil/test_util.h"
 
 using ::testing::_;

--- a/be/test/olap/hll_test.cpp
+++ b/be/test/olap/hll_test.cpp
@@ -17,8 +17,10 @@
 
 #include "olap/hll.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
+#include "gtest/gtest_pred_impl.h"
 #include "util/hash_util.hpp"
 #include "util/slice.h"
 

--- a/be/test/olap/itoken_extractor_test.cpp
+++ b/be/test/olap/itoken_extractor_test.cpp
@@ -17,11 +17,14 @@
 
 #include "olap/itoken_extractor.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
+#include <algorithm>
 #include <string>
+#include <vector>
 
-#include "common/logging.h"
+#include "gtest/gtest_pred_impl.h"
 #include "util/utf8_check.h"
 
 namespace doris {

--- a/be/test/olap/key_coder_test.cpp
+++ b/be/test/olap/key_coder_test.cpp
@@ -17,11 +17,15 @@
 
 #include "olap/key_coder.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include <limits>
 
+#include "gtest/gtest_pred_impl.h"
+#include "olap/uint24.h"
 #include "util/debug_util.h"
 
 namespace doris {

--- a/be/test/olap/lru_cache_test.cpp
+++ b/be/test/olap/lru_cache_test.cpp
@@ -17,10 +17,14 @@
 
 #include "olap/lru_cache.h"
 
-#include <gtest/gtest.h>
+#include <gen_cpp/Metrics_types.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
+#include <iosfwd>
 #include <vector>
 
+#include "gtest/gtest_pred_impl.h"
 #include "runtime/memory/mem_tracker_limiter.h"
 #include "testutil/test_util.h"
 

--- a/be/test/olap/olap_meta_test.cpp
+++ b/be/test/olap/olap_meta_test.cpp
@@ -17,12 +17,16 @@
 
 #include "olap/olap_meta.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stddef.h>
 
 #include <filesystem>
+#include <memory>
 #include <sstream>
 #include <string>
 
+#include "gtest/gtest_pred_impl.h"
 #include "io/fs/local_file_system.h"
 #include "olap/olap_define.h"
 

--- a/be/test/olap/options_test.cpp
+++ b/be/test/olap/options_test.cpp
@@ -17,10 +17,15 @@
 
 #include "olap/options.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stdlib.h>
 
 #include <filesystem>
 #include <string>
+
+#include "gtest/gtest_pred_impl.h"
+#include "olap/olap_define.h"
 
 namespace doris {
 

--- a/be/test/olap/ordered_data_compaction_test.cpp
+++ b/be/test/olap/ordered_data_compaction_test.cpp
@@ -16,25 +16,56 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <gen_cpp/AgentService_types.h>
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/PaloInternalService_types.h>
+#include <gen_cpp/Types_types.h>
+#include <gen_cpp/olap_common.pb.h>
+#include <gen_cpp/olap_file.pb.h>
+#include <glog/logging.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stdint.h>
+#include <unistd.h>
 
+#include <memory>
+#include <ostream>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
+#include "common/config.h"
+#include "common/status.h"
+#include "gtest/gtest_pred_impl.h"
+#include "gutil/stringprintf.h"
+#include "io/fs/local_file_system.h"
 #include "olap/cumulative_compaction.h"
-#include "olap/merger.h"
+#include "olap/data_dir.h"
+#include "olap/delete_handler.h"
+#include "olap/field.h"
+#include "olap/olap_common.h"
+#include "olap/options.h"
 #include "olap/rowset/beta_rowset.h"
 #include "olap/rowset/rowset.h"
 #include "olap/rowset/rowset_factory.h"
+#include "olap/rowset/rowset_meta.h"
 #include "olap/rowset/rowset_reader.h"
 #include "olap/rowset/rowset_reader_context.h"
 #include "olap/rowset/rowset_writer.h"
 #include "olap/rowset/rowset_writer_context.h"
 #include "olap/schema.h"
 #include "olap/storage_engine.h"
+#include "olap/tablet.h"
+#include "olap/tablet_meta.h"
 #include "olap/tablet_schema.h"
-#include "olap/tablet_schema_helper.h"
-#include "vec/olap/vertical_block_reader.h"
-#include "vec/olap/vertical_merge_iterator.h"
+#include "olap/utils.h"
+#include "util/uid_util.h"
+#include "vec/columns/column.h"
+#include "vec/core/block.h"
+#include "vec/core/column_with_type_and_name.h"
+#include "vec/data_types/data_type.h"
 
 namespace doris {
 using namespace ErrorCode;

--- a/be/test/olap/page_cache_test.cpp
+++ b/be/test/olap/page_cache_test.cpp
@@ -17,7 +17,10 @@
 
 #include "olap/page_cache.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/olap/primary_key_index_test.cpp
+++ b/be/test/olap/primary_key_index_test.cpp
@@ -17,11 +17,23 @@
 
 #include "olap/primary_key_index.h"
 
-#include <gtest/gtest.h>
+#include <gen_cpp/segment_v2.pb.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest_pred_impl.h"
+#include "gutil/stringprintf.h"
 #include "io/fs/file_writer.h"
 #include "io/fs/fs_utils.h"
 #include "io/fs/local_file_system.h"
+#include "olap/types.h"
+#include "vec/columns/column.h"
+#include "vec/common/string_ref.h"
+#include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_factory.hpp"
 
 namespace doris {

--- a/be/test/olap/remote_rowset_gc_test.cpp
+++ b/be/test/olap/remote_rowset_gc_test.cpp
@@ -15,27 +15,51 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <gen_cpp/AgentService_types.h>
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/Types_types.h>
+#include <gen_cpp/types.pb.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stdint.h>
+#include <unistd.h>
 
+#include <map>
 #include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "common/config.h"
+#include "common/object_pool.h"
 #include "common/status.h"
 #include "exec/tablet_info.h"
 #include "gen_cpp/internal_service.pb.h"
+#include "gtest/gtest_pred_impl.h"
+#include "io/fs/local_file_system.h"
+#include "io/fs/remote_file_system.h"
 #include "io/fs/s3_file_system.h"
+#include "olap/data_dir.h"
 #include "olap/delta_writer.h"
+#include "olap/olap_common.h"
+#include "olap/options.h"
 #include "olap/rowset/beta_rowset.h"
+#include "olap/rowset/rowset.h"
 #include "olap/storage_engine.h"
 #include "olap/storage_policy.h"
 #include "olap/tablet.h"
 #include "olap/tablet_manager.h"
+#include "olap/tablet_meta.h"
 #include "olap/txn_manager.h"
+#include "runtime/define_primitive_type.h"
 #include "runtime/descriptor_helper.h"
 #include "runtime/descriptors.h"
+#include "util/doris_metrics.h"
 #include "util/s3_util.h"
 
 namespace doris {
+class DISABLED_RemoteRowsetGcTest;
+class OlapMeta;
 
 static StorageEngine* k_engine = nullptr;
 

--- a/be/test/olap/rowid_conversion_test.cpp
+++ b/be/test/olap/rowid_conversion_test.cpp
@@ -17,21 +17,47 @@
 
 #include "olap/rowid_conversion.h"
 
-#include <gtest/gtest.h>
+#include <gen_cpp/AgentService_types.h>
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/PaloInternalService_types.h>
+#include <gen_cpp/Types_types.h>
+#include <gen_cpp/olap_common.pb.h>
+#include <gen_cpp/olap_file.pb.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-param-test.h>
+#include <gtest/gtest-test-part.h>
+#include <stdint.h>
+#include <unistd.h>
 
+#include <memory>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+
+#include "common/status.h"
+#include "gtest/gtest_pred_impl.h"
+#include "gutil/strings/numbers.h"
 #include "io/fs/local_file_system.h"
-#include "olap/data_dir.h"
+#include "io/io_common.h"
 #include "olap/delete_handler.h"
 #include "olap/merger.h"
+#include "olap/options.h"
 #include "olap/rowset/beta_rowset.h"
 #include "olap/rowset/rowset.h"
 #include "olap/rowset/rowset_factory.h"
+#include "olap/rowset/rowset_meta.h"
 #include "olap/rowset/rowset_reader.h"
 #include "olap/rowset/rowset_reader_context.h"
 #include "olap/rowset/rowset_writer.h"
 #include "olap/rowset/rowset_writer_context.h"
 #include "olap/storage_engine.h"
+#include "olap/tablet.h"
+#include "olap/tablet_meta.h"
 #include "olap/tablet_schema.h"
+#include "util/uid_util.h"
+#include "vec/columns/column.h"
+#include "vec/core/block.h"
+#include "vec/core/column_with_type_and_name.h"
 
 namespace doris {
 using namespace ErrorCode;

--- a/be/test/olap/rowset/rowset_meta_manager_test.cpp
+++ b/be/test/olap/rowset/rowset_meta_manager_test.cpp
@@ -17,16 +17,26 @@
 
 #include "olap/rowset/rowset_meta_manager.h"
 
-#include <boost/algorithm/string.hpp>
+#include <gen_cpp/olap_file.pb.h>
+#include <glog/logging.h>
+#include <gmock/gmock-actions.h>
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+
+#include <boost/algorithm/string/replace.hpp>
 #include <filesystem>
 #include <fstream>
-#include <sstream>
+#include <new>
 #include <string>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
+#include "common/config.h"
+#include "gtest/gtest_pred_impl.h"
+#include "olap/olap_define.h"
 #include "olap/olap_meta.h"
+#include "olap/options.h"
 #include "olap/storage_engine.h"
+#include "util/uid_util.h"
 
 using ::testing::_;
 using ::testing::Return;

--- a/be/test/olap/rowset/rowset_meta_test.cpp
+++ b/be/test/olap/rowset/rowset_meta_test.cpp
@@ -17,13 +17,18 @@
 
 #include "olap/rowset/rowset_meta.h"
 
+#include <gmock/gmock-actions.h>
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+
 #include <filesystem>
 #include <fstream>
-#include <sstream>
+#include <new>
 #include <string>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
+#include "common/status.h"
+#include "gtest/gtest_pred_impl.h"
 #include "olap/olap_meta.h"
 
 using ::testing::_;

--- a/be/test/olap/rowset/rowset_tree_test.cpp
+++ b/be/test/olap/rowset/rowset_tree_test.cpp
@@ -21,13 +21,15 @@
 
 #include "olap/rowset/rowset_tree.h"
 
+#include <gen_cpp/olap_file.pb.h>
 #include <glog/logging.h>
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-param-test.h>
+#include <gtest/gtest-test-part.h>
 
-#include <boost/optional/optional.hpp>
+#include <algorithm>
 #include <cstdlib>
 #include <cstring>
-#include <functional>
 #include <memory>
 #include <string>
 #include <tuple>
@@ -35,10 +37,12 @@
 #include <utility>
 #include <vector>
 
+#include "gtest/gtest_pred_impl.h"
 #include "gutil/map-util.h"
 #include "gutil/stringprintf.h"
 #include "gutil/strings/substitute.h"
 #include "olap/rowset/rowset.h"
+#include "olap/rowset/rowset_meta.h"
 #include "olap/rowset/unique_rowset_id_generator.h"
 #include "olap/tablet_schema.h"
 #include "testutil/mock_rowset.h"

--- a/be/test/olap/rowset/segment_v2/bitmap_index_test.cpp
+++ b/be/test/olap/rowset/segment_v2/bitmap_index_test.cpp
@@ -15,17 +15,23 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <gen_cpp/segment_v2.pb.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stdint.h>
+#include <stdlib.h>
 
 #include <memory>
+#include <roaring/roaring.hh>
 #include <string>
+#include <utility>
 
-#include "common/logging.h"
-#include "io/fs/file_reader.h"
+#include "common/status.h"
+#include "gtest/gtest_pred_impl.h"
+#include "io/fs/file_reader_writer_fwd.h"
 #include "io/fs/file_system.h"
 #include "io/fs/file_writer.h"
 #include "io/fs/local_file_system.h"
-#include "olap/key_coder.h"
 #include "olap/olap_common.h"
 #include "olap/rowset/segment_v2/bitmap_index_reader.h"
 #include "olap/rowset/segment_v2/bitmap_index_writer.h"

--- a/be/test/olap/rowset/segment_v2/block_bloom_filter_test.cpp
+++ b/be/test/olap/rowset/segment_v2/block_bloom_filter_test.cpp
@@ -15,10 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <gen_cpp/segment_v2.pb.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stdint.h>
+#include <stdlib.h>
 
 #include <memory>
+#include <string>
+#include <vector>
 
+#include "common/status.h"
+#include "gtest/gtest_pred_impl.h"
 #include "olap/rowset/segment_v2/bloom_filter.h"
 #include "util/slice.h"
 

--- a/be/test/olap/rowset/segment_v2/bloom_filter_index_reader_writer_test.cpp
+++ b/be/test/olap/rowset/segment_v2/bloom_filter_index_reader_writer_test.cpp
@@ -15,18 +15,30 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <gen_cpp/segment_v2.pb.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stddef.h>
+#include <stdint.h>
 
-#include "common/logging.h"
-#include "io/fs/file_system.h"
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "common/status.h"
+#include "gtest/gtest_pred_impl.h"
+#include "io/fs/file_reader_writer_fwd.h"
 #include "io/fs/file_writer.h"
 #include "io/fs/local_file_system.h"
-#include "olap/key_coder.h"
+#include "olap/decimal12.h"
 #include "olap/olap_common.h"
 #include "olap/rowset/segment_v2/bloom_filter.h"
 #include "olap/rowset/segment_v2/bloom_filter_index_reader.h"
 #include "olap/rowset/segment_v2/bloom_filter_index_writer.h"
 #include "olap/types.h"
+#include "olap/uint24.h"
+#include "util/slice.h"
 
 namespace doris {
 namespace segment_v2 {

--- a/be/test/olap/rowset/segment_v2/encoding_info_test.cpp
+++ b/be/test/olap/rowset/segment_v2/encoding_info_test.cpp
@@ -18,11 +18,10 @@
 #include "olap/rowset/segment_v2/encoding_info.h"
 
 #include <gen_cpp/segment_v2.pb.h>
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include <iostream>
-
-#include "common/logging.h"
+#include "gtest/gtest_pred_impl.h"
 #include "olap/olap_common.h"
 #include "olap/types.h"
 

--- a/be/test/olap/rowset/segment_v2/inverted_index_searcher_cache_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index_searcher_cache_test.cpp
@@ -15,9 +15,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
+#include <atomic>
+// IWYU pragma: no_include <bits/chrono.h>
+#include <chrono> // IWYU pragma: keep
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "common/status.h"
+#include "gtest/gtest_pred_impl.h"
 #include "io/fs/local_file_system.h"
+#include "olap/lru_cache.h"
+#include "olap/olap_common.h"
 #include "olap/rowset/segment_v2/inverted_index_cache.h"
 #include "util/time.h"
 

--- a/be/test/olap/rowset/segment_v2/ordinal_page_index_test.cpp
+++ b/be/test/olap/rowset/segment_v2/ordinal_page_index_test.cpp
@@ -17,18 +17,17 @@
 
 #include "olap/rowset/segment_v2/ordinal_page_index.h"
 
-#include <gtest/gtest.h>
+#include <gen_cpp/segment_v2.pb.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
 #include <iostream>
 #include <memory>
 #include <string>
 
-#include "common/logging.h"
-#include "io/fs/file_reader.h"
-#include "io/fs/file_system.h"
+#include "gtest/gtest_pred_impl.h"
 #include "io/fs/file_writer.h"
 #include "io/fs/local_file_system.h"
-#include "olap/page_cache.h"
 
 namespace doris {
 namespace segment_v2 {

--- a/be/test/olap/rowset/segment_v2/row_ranges_test.cpp
+++ b/be/test/olap/rowset/segment_v2/row_ranges_test.cpp
@@ -17,9 +17,10 @@
 
 #include "olap/rowset/segment_v2/row_ranges.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include <memory>
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 namespace segment_v2 {

--- a/be/test/olap/rowset/segment_v2/zone_map_index_test.cpp
+++ b/be/test/olap/rowset/segment_v2/zone_map_index_test.cpp
@@ -17,17 +17,20 @@
 
 #include "olap/rowset/segment_v2/zone_map_index.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <string.h>
 
+#include <algorithm>
 #include <memory>
 #include <string>
 
-#include "common/config.h"
-#include "io/fs/file_system.h"
+#include "gtest/gtest_pred_impl.h"
 #include "io/fs/file_writer.h"
 #include "io/fs/local_file_system.h"
-#include "olap/page_cache.h"
+#include "olap/tablet_schema.h"
 #include "olap/tablet_schema_helper.h"
+#include "util/slice.h"
 
 namespace doris {
 namespace segment_v2 {

--- a/be/test/olap/rowset/unique_rowset_id_generator_test.cpp
+++ b/be/test/olap/rowset/unique_rowset_id_generator_test.cpp
@@ -17,12 +17,15 @@
 
 #include "olap/rowset/unique_rowset_id_generator.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include <iostream>
+#include <memory>
+#include <string>
 
+#include "common/status.h"
+#include "gtest/gtest_pred_impl.h"
 #include "testutil/test_util.h"
-#include "util/pretty_printer.h"
 #include "util/runtime_profile.h"
 #include "util/threadpool.h"
 

--- a/be/test/olap/selection_vector_test.cpp
+++ b/be/test/olap/selection_vector_test.cpp
@@ -17,7 +17,10 @@
 
 #include "olap/selection_vector.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/olap/short_key_index_test.cpp
+++ b/be/test/olap/short_key_index_test.cpp
@@ -17,7 +17,12 @@
 
 #include "olap/short_key_index.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+
+#include <string>
+
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/olap/skiplist_test.cpp
+++ b/be/test/olap/skiplist_test.cpp
@@ -17,12 +17,20 @@
 
 #include "olap/skiplist.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stdint.h>
+#include <stdio.h>
 
+#include <condition_variable>
+#include <functional>
+#include <iterator>
+#include <memory>
+#include <mutex>
 #include <set>
-#include <thread>
+#include <utility>
 
-#include "olap/schema.h"
+#include "gtest/gtest_pred_impl.h"
 #include "testutil/test_util.h"
 #include "util/hash_util.hpp"
 #include "util/priority_thread_pool.hpp"

--- a/be/test/olap/storage_types_test.cpp
+++ b/be/test/olap/storage_types_test.cpp
@@ -15,11 +15,23 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stdint.h>
 
+#include <memory>
+
+#include "gtest/gtest_pred_impl.h"
+#include "gutil/integral_types.h"
+#include "olap/decimal12.h"
 #include "olap/field.h"
+#include "olap/olap_common.h"
+#include "olap/tablet_schema.h"
 #include "olap/types.h"
+#include "olap/uint24.h"
+#include "runtime/collection_value.h"
 #include "util/slice.h"
+#include "vec/common/arena.h"
 
 namespace doris {
 

--- a/be/test/olap/tablet_cooldown_test.cpp
+++ b/be/test/olap/tablet_cooldown_test.cpp
@@ -15,31 +15,60 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <fmt/format.h>
+#include <gen_cpp/AgentService_types.h>
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/Types_types.h>
+#include <gen_cpp/types.pb.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stdint.h>
+#include <unistd.h>
 
+#include <iostream>
+#include <map>
 #include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "common/config.h"
+#include "common/object_pool.h"
 #include "common/status.h"
 #include "exec/tablet_info.h"
 #include "gen_cpp/internal_service.pb.h"
+#include "gtest/gtest_pred_impl.h"
+#include "io/fs/file_reader_options.h"
+#include "io/fs/file_reader_writer_fwd.h"
+#include "io/fs/file_system.h"
 #include "io/fs/file_writer.h"
 #include "io/fs/local_file_system.h"
-#include "io/fs/local_file_writer.h"
+#include "io/fs/path.h"
 #include "io/fs/remote_file_system.h"
-#include "io/fs/s3_file_system.h"
+#include "olap/data_dir.h"
 #include "olap/delta_writer.h"
+#include "olap/olap_common.h"
+#include "olap/options.h"
 #include "olap/rowset/beta_rowset.h"
+#include "olap/rowset/rowset.h"
+#include "olap/rowset/segment_v2/segment.h"
 #include "olap/storage_engine.h"
 #include "olap/storage_policy.h"
 #include "olap/tablet.h"
 #include "olap/tablet_manager.h"
+#include "olap/tablet_meta.h"
 #include "olap/txn_manager.h"
+#include "runtime/define_primitive_type.h"
 #include "runtime/descriptor_helper.h"
 #include "runtime/descriptors.h"
-#include "util/s3_util.h"
+#include "vec/columns/column.h"
+#include "vec/core/block.h"
+#include "vec/core/column_with_type_and_name.h"
+#include "vec/runtime/vdatetime_value.h"
 
 namespace doris {
+class OlapMeta;
+struct Slice;
 
 static StorageEngine* k_engine = nullptr;
 

--- a/be/test/olap/tablet_meta_manager_test.cpp
+++ b/be/test/olap/tablet_meta_manager_test.cpp
@@ -17,14 +17,18 @@
 
 #include "olap/tablet_meta_manager.h"
 
-#include <gtest/gtest.h>
+#include <gen_cpp/olap_file.pb.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 #include <json2pb/json_to_pb.h>
 
 #include <filesystem>
 #include <fstream>
-#include <sstream>
+#include <memory>
+#include <new>
 #include <string>
 
+#include "gtest/gtest_pred_impl.h"
 #include "olap/data_dir.h"
 
 using std::string;

--- a/be/test/olap/tablet_meta_test.cpp
+++ b/be/test/olap/tablet_meta_test.cpp
@@ -17,11 +17,15 @@
 
 #include "olap/tablet_meta.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
 #include <memory>
 #include <string>
+#include <utility>
 
+#include "gtest/gtest_pred_impl.h"
+#include "olap/rowset/rowset.h"
 #include "olap/tablet_schema.h"
 #include "testutil/mock_rowset.h"
 

--- a/be/test/olap/tablet_mgr_test.cpp
+++ b/be/test/olap/tablet_mgr_test.cpp
@@ -15,18 +15,33 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <filesystem>
-#include <fstream>
-#include <sstream>
-#include <string>
+#include <gen_cpp/AgentService_types.h>
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/Types_types.h>
+#include <gmock/gmock-actions.h>
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common/config.h"
+#include "common/status.h"
+#include "gtest/gtest_pred_impl.h"
 #include "io/fs/local_file_system.h"
+#include "olap/data_dir.h"
+#include "olap/olap_common.h"
+#include "olap/olap_define.h"
+#include "olap/options.h"
 #include "olap/storage_engine.h"
+#include "olap/tablet.h"
 #include "olap/tablet_manager.h"
+#include "olap/tablet_meta.h"
 #include "olap/tablet_meta_manager.h"
-#include "olap/txn_manager.h"
+#include "util/uid_util.h"
 
 using ::testing::_;
 using ::testing::Return;

--- a/be/test/olap/tablet_schema_helper.cpp
+++ b/be/test/olap/tablet_schema_helper.cpp
@@ -17,6 +17,9 @@
 
 #include "olap/tablet_schema_helper.h"
 
+#include <string.h>
+
+#include "util/slice.h"
 #include "vec/common/arena.h"
 
 namespace doris {

--- a/be/test/olap/tablet_schema_helper.h
+++ b/be/test/olap/tablet_schema_helper.h
@@ -17,11 +17,18 @@
 
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include <string>
 
+#include "olap/olap_common.h"
 #include "olap/tablet_schema.h"
 
 namespace doris {
+namespace vectorized {
+class Arena;
+} // namespace vectorized
 
 TabletColumn create_int_key(int32_t id, bool is_nullable = true, bool is_bf_column = false,
                             bool has_bitmap_index = false);

--- a/be/test/olap/tablet_test.cpp
+++ b/be/test/olap/tablet_test.cpp
@@ -17,20 +17,26 @@
 
 #include "olap/tablet.h"
 
-#include <gtest/gtest.h>
+#include <gen_cpp/AgentService_types.h>
+#include <gen_cpp/Types_types.h>
+#include <gen_cpp/olap_file.pb.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <unistd.h>
 
-#include <sstream>
-
+#include "gtest/gtest_pred_impl.h"
+#include "gutil/strings/numbers.h"
 #include "http/action/pad_rowset_action.h"
 #include "io/fs/local_file_system.h"
-#include "olap/olap_define.h"
+#include "olap/options.h"
 #include "olap/rowset/beta_rowset.h"
 #include "olap/storage_engine.h"
 #include "olap/storage_policy.h"
 #include "olap/tablet_meta.h"
-#include "olap/tablet_schema_cache.h"
+#include "olap/utils.h"
 #include "testutil/mock_rowset.h"
 #include "util/time.h"
+#include "util/uid_util.h"
 
 using namespace std;
 

--- a/be/test/olap/timestamped_version_tracker_test.cpp
+++ b/be/test/olap/timestamped_version_tracker_test.cpp
@@ -16,15 +16,28 @@
 // under the License.
 
 #include <cctz/time_zone.h>
-#include <gtest/gtest.h>
+#include <fmt/format.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <rapidjson/document.h>
+#include <rapidjson/encodings.h>
 #include <rapidjson/prettywriter.h>
 #include <rapidjson/stringbuffer.h>
+#include <stdint.h>
 
-#include <filesystem>
-#include <fstream>
-#include <sstream>
+// IWYU pragma: no_include <bits/chrono.h>
+#include <chrono> // IWYU pragma: keep
+#include <list>
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
+#include "gtest/gtest_pred_impl.h"
 #include "gutil/strings/substitute.h"
+#include "olap/olap_common.h"
 #include "olap/rowset/rowset_meta.h"
 #include "olap/version_graph.h"
 

--- a/be/test/olap/txn_manager_test.cpp
+++ b/be/test/olap/txn_manager_test.cpp
@@ -17,18 +17,30 @@
 
 #include "olap/txn_manager.h"
 
+#include <gen_cpp/olap_common.pb.h>
+#include <gen_cpp/olap_file.pb.h>
+#include <gmock/gmock-actions.h>
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+
 #include <filesystem>
 #include <fstream>
-#include <sstream>
+#include <memory>
+#include <new>
 #include <string>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
+#include "common/config.h"
+#include "gtest/gtest_pred_impl.h"
 #include "olap/olap_meta.h"
+#include "olap/options.h"
 #include "olap/rowset/rowset.h"
 #include "olap/rowset/rowset_factory.h"
+#include "olap/rowset/rowset_meta.h"
 #include "olap/rowset/rowset_meta_manager.h"
 #include "olap/storage_engine.h"
+#include "olap/tablet_schema.h"
+#include "util/uid_util.h"
 
 using ::testing::_;
 using ::testing::Return;

--- a/be/test/runtime/arena_test.cpp
+++ b/be/test/runtime/arena_test.cpp
@@ -17,10 +17,13 @@
 
 #include "vec/common/arena.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stdint.h>
 
-#include <string>
+#include <iostream>
 
+#include "gtest/gtest_pred_impl.h"
 #include "util/bit_util.h"
 
 namespace doris {

--- a/be/test/runtime/cache/partition_cache_test.cpp
+++ b/be/test/runtime/cache/partition_cache_test.cpp
@@ -15,14 +15,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <gen_cpp/types.pb.h>
+#include <glog/logging.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include "gen_cpp/PaloInternalService_types.h"
+#include <memory>
+#include <ostream>
+
+#include "common/config.h"
 #include "gen_cpp/internal_service.pb.h"
-#include "runtime/buffer_control_block.h"
+#include "gtest/gtest_pred_impl.h"
+#include "gutil/integral_types.h"
+#include "olap/olap_define.h"
 #include "runtime/cache/result_cache.h"
 #include "testutil/test_util.h"
-#include "util/cpu_info.h"
 
 namespace doris {
 

--- a/be/test/runtime/decimalv2_value_test.cpp
+++ b/be/test/runtime/decimalv2_value_test.cpp
@@ -17,10 +17,12 @@
 
 #include "runtime/decimalv2_value.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include <iostream>
 #include <string>
+
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/runtime/external_scan_context_mgr_test.cpp
+++ b/be/test/runtime/external_scan_context_mgr_test.cpp
@@ -17,12 +17,13 @@
 
 #include "runtime/external_scan_context_mgr.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
 #include <memory>
 
-#include "common/config.h"
 #include "common/status.h"
+#include "gtest/gtest_pred_impl.h"
 #include "runtime/exec_env.h"
 #include "runtime/fragment_mgr.h"
 #include "runtime/result_queue_mgr.h"

--- a/be/test/runtime/fragment_mgr_test.cpp
+++ b/be/test/runtime/fragment_mgr_test.cpp
@@ -17,12 +17,20 @@
 
 #include "runtime/fragment_mgr.h"
 
-#include <gtest/gtest.h>
+#include <gen_cpp/PaloInternalService_types.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+
+// IWYU pragma: no_include <bits/chrono.h>
+#include <chrono> // IWYU pragma: keep
+#include <thread>
 
 #include "common/config.h"
 #include "exec/data_sink.h"
+#include "gtest/gtest_pred_impl.h"
 #include "runtime/exec_env.h"
 #include "runtime/plan_fragment_executor.h"
+#include "runtime/runtime_state.h"
 
 namespace doris {
 

--- a/be/test/runtime/heartbeat_flags_test.cpp
+++ b/be/test/runtime/heartbeat_flags_test.cpp
@@ -17,7 +17,12 @@
 
 #include "runtime/heartbeat_flags.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+
+#include <memory>
+
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/runtime/large_int_value_test.cpp
+++ b/be/test/runtime/large_int_value_test.cpp
@@ -17,15 +17,14 @@
 
 #include "runtime/large_int_value.h"
 
-#include <fmt/format.h>
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
 #include <iostream>
-#include <sstream>
+#include <limits>
 #include <string>
 
-#include "common/configbase.h"
-#include "common/logging.h"
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/runtime/mem_limit_test.cpp
+++ b/be/test/runtime/mem_limit_test.cpp
@@ -15,11 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include "runtime/memory/mem_tracker.h"
+#include <memory>
+
+#include "gtest/gtest_pred_impl.h"
 #include "runtime/memory/mem_tracker_limiter.h"
-#include "util/metrics.h"
 
 namespace doris {
 

--- a/be/test/runtime/memory/system_allocator_test.cpp
+++ b/be/test/runtime/memory/system_allocator_test.cpp
@@ -17,9 +17,12 @@
 
 #include "runtime/memory/system_allocator.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include "common/config.h"
+#include <memory>
+
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/runtime/result_queue_mgr_test.cpp
+++ b/be/test/runtime/result_queue_mgr_test.cpp
@@ -17,18 +17,26 @@
 
 #include "runtime/result_queue_mgr.h"
 
-#include <arrow/array.h>
-#include <arrow/builder.h>
+#include <arrow/array/builder_primitive.h>
 #include <arrow/record_batch.h>
+#include <arrow/status.h>
 #include <arrow/type.h>
-#include <gtest/gtest.h>
+#include <gen_cpp/Types_types.h>
+#include <glog/logging.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
 #include <memory>
+#include <ostream>
+#include <utility>
+#include <vector>
 
-#include "gen_cpp/DorisExternalService_types.h"
+#include "gtest/gtest_pred_impl.h"
 #include "runtime/record_batch_queue.h"
-#include "testutil/test_util.h"
-#include "util/blocking_queue.hpp"
+
+namespace arrow {
+class Array;
+} // namespace arrow
 
 namespace doris {
 

--- a/be/test/runtime/routine_load_task_executor_test.cpp
+++ b/be/test/runtime/routine_load_task_executor_test.cpp
@@ -17,16 +17,23 @@
 
 #include "runtime/routine_load/routine_load_task_executor.h"
 
-#include <gtest/gtest.h>
+#include <gen_cpp/Types_types.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 #include <librdkafka/rdkafkacpp.h>
+#include <unistd.h>
 
+#include <map>
+
+#include "common/config.h"
+#include "common/status.h"
 #include "gen_cpp/BackendService_types.h"
 #include "gen_cpp/FrontendService_types.h"
 #include "gen_cpp/HeartbeatService_types.h"
+#include "gtest/gtest_pred_impl.h"
 #include "runtime/exec_env.h"
 #include "runtime/stream_load/new_load_stream_mgr.h"
 #include "runtime/stream_load/stream_load_executor.h"
-#include "util/cpu_info.h"
 
 namespace doris {
 

--- a/be/test/runtime/small_file_mgr_test.cpp
+++ b/be/test/runtime/small_file_mgr_test.cpp
@@ -16,16 +16,3 @@
 // under the License.
 
 #include "runtime/small_file_mgr.h"
-
-#include <gtest/gtest.h>
-
-#include <cstdio>
-#include <cstdlib>
-
-#include "common/logging.h"
-#include "gen_cpp/HeartbeatService_types.h"
-#include "http/ev_http_server.h"
-#include "http/http_channel.h"
-#include "http/http_handler.h"
-#include "http/http_request.h"
-#include "runtime/exec_env.h"

--- a/be/test/runtime/snapshot_loader_test.cpp
+++ b/be/test/runtime/snapshot_loader_test.cpp
@@ -17,11 +17,12 @@
 
 #include "runtime/snapshot_loader.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
 #include <filesystem>
 
-#include "runtime/exec_env.h"
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/runtime/string_value_test.cpp
+++ b/be/test/runtime/string_value_test.cpp
@@ -15,11 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
 #include <string>
 
-#include "util/cpu_info.h"
+#include "gtest/gtest_pred_impl.h"
 #include "vec/common/string_ref.h"
 
 using std::string;

--- a/be/test/runtime/test_env.cc
+++ b/be/test/runtime/test_env.cc
@@ -17,14 +17,25 @@
 
 #include "runtime/test_env.h"
 
-#include <gtest/gtest.h>
-#include <sys/stat.h>
+#include <gen_cpp/PaloInternalService_types.h>
+#include <gen_cpp/Types_types.h>
+#include <glog/logging.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
 #include <memory>
+#include <ostream>
 
+#include "common/config.h"
+#include "common/status.h"
+#include "gtest/gtest_pred_impl.h"
+#include "olap/olap_define.h"
+#include "olap/options.h"
 #include "olap/storage_engine.h"
+#include "runtime/exec_env.h"
 #include "runtime/result_queue_mgr.h"
-#include "util/disk_info.h"
+#include "runtime/runtime_state.h"
+#include "util/uid_util.h"
 
 namespace doris {
 

--- a/be/test/runtime/test_env.h
+++ b/be/test/runtime/test_env.h
@@ -18,10 +18,16 @@
 #ifndef DORIS_BE_TEST_QUERY_RUNTIME_TEST_ENV_H
 #define DORIS_BE_TEST_QUERY_RUNTIME_TEST_ENV_H
 
-#include "runtime/exec_env.h"
-#include "runtime/runtime_state.h"
+#include <stdint.h>
+
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace doris {
+class ExecEnv;
+class RuntimeState;
+class StorageEngine;
 
 /// Helper testing class that creates an environment with runtime memory management
 /// similar to the one used by the Doris runtime. Only one TestEnv can be active at a

--- a/be/test/runtime/user_function_cache_test.cpp
+++ b/be/test/runtime/user_function_cache_test.cpp
@@ -16,15 +16,3 @@
 // under the License.
 
 #include "runtime/user_function_cache.h"
-
-#include <gtest/gtest.h>
-
-#include <cstdio>
-#include <cstdlib>
-
-#include "common/logging.h"
-#include "http/ev_http_server.h"
-#include "http/http_channel.h"
-#include "http/http_handler.h"
-#include "http/http_request.h"
-#include "util/md5.h"

--- a/be/test/testutil/desc_tbl_builder.cc
+++ b/be/test/testutil/desc_tbl_builder.cc
@@ -17,11 +17,16 @@
 
 #include "testutil/desc_tbl_builder.h"
 
-#include <gtest/gtest.h>
+#include <glog/logging.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
 #include <vector>
 
 #include "common/object_pool.h"
+#include "common/status.h"
+#include "gtest/gtest_pred_impl.h"
+#include "runtime/define_primitive_type.h"
 #include "runtime/descriptors.h"
 #include "util/bit_util.h"
 

--- a/be/test/testutil/desc_tbl_builder.h
+++ b/be/test/testutil/desc_tbl_builder.h
@@ -18,13 +18,17 @@
 #ifndef DORIS_BE_SRC_TESTUTIL_DESC_TBL_BUILDER_H
 #define DORIS_BE_SRC_TESTUTIL_DESC_TBL_BUILDER_H
 
-#include "runtime/runtime_state.h"
+#include <gen_cpp/Descriptors_types.h>
+
+#include <vector>
+
 #include "runtime/types.h"
 
 namespace doris {
 
 class ObjectPool;
 class TupleDescBuilder;
+class DescriptorTbl;
 
 // Aids in the construction of a DescriptorTbl by declaring tuples and slots
 // associated with those tuples.

--- a/be/test/testutil/function_utils.cpp
+++ b/be/test/testutil/function_utils.cpp
@@ -17,6 +17,8 @@
 
 #include "testutil/function_utils.h"
 
+#include <gen_cpp/PaloInternalService_types.h>
+
 #include <vector>
 
 #include "runtime/runtime_state.h"

--- a/be/test/testutil/function_utils.h
+++ b/be/test/testutil/function_utils.h
@@ -18,11 +18,12 @@
 #include <memory>
 #include <vector>
 
-#include "udf/udf.h"
+#include "runtime/types.h"
 
 namespace doris {
 
 class RuntimeState;
+class FunctionContext;
 
 class FunctionUtils {
 public:

--- a/be/test/testutil/run_all_tests.cpp
+++ b/be/test/testutil/run_all_tests.cpp
@@ -15,15 +15,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <memory>
+#include <string>
 
 #include "common/config.h"
+#include "common/logging.h"
+#include "gtest/gtest_pred_impl.h"
 #include "olap/page_cache.h"
-#include "olap/rowset/segment_v2/inverted_index_cache.h"
 #include "olap/segment_loader.h"
 #include "olap/tablet_schema_cache.h"
 #include "runtime/exec_env.h"
-#include "runtime/memory/mem_tracker_limiter.h"
+#include "runtime/memory/thread_mem_tracker_mgr.h"
+#include "runtime/thread_context.h"
 #include "service/backend_options.h"
 #include "util/cpu_info.h"
 #include "util/disk_info.h"

--- a/be/test/testutil/test_util.cpp
+++ b/be/test/testutil/test_util.cpp
@@ -18,18 +18,28 @@
 #include "testutil/test_util.h"
 
 #ifndef __APPLE__
-#include <linux/limits.h>
 #else
 #include <mach-o/dyld.h>
 #endif
 
 #include <common/configbase.h>
+#include <ctype.h>
+#include <glog/logging.h>
 #include <libgen.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
 #include <strings.h>
-#include <sys/types.h>
 #include <unistd.h>
 
+#include <algorithm>
+// IWYU pragma: no_include <bits/chrono.h>
+#include <chrono> // IWYU pragma: keep
+#include <random>
+
+#include "gutil/strings/numbers.h"
 #include "gutil/strings/substitute.h"
+#include "olap/olap_common.h"
 
 using strings::Substitute;
 

--- a/be/test/testutil/test_util.h
+++ b/be/test/testutil/test_util.h
@@ -17,14 +17,11 @@
 
 #pragma once
 
-#include <chrono>
 #include <cstdlib>
-#include <random>
 #include <string>
 
-#include "olap/tablet_schema.h"
-
 namespace doris {
+enum class FieldType;
 
 #define LOOP_LESS_OR_MORE(less, more) (AllowSlowTests() ? more : less)
 

--- a/be/test/util/bit_stream_utils_test.cpp
+++ b/be/test/util/bit_stream_utils_test.cpp
@@ -15,25 +15,19 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <algorithm>
+#include "util/bit_stream_utils.h"
+
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+
+#include <boost/utility/binary.hpp>
 #include <cstdint>
-#include <cstdlib>
-#include <cstring>
-#include <limits>
-#include <ostream>
 #include <string>
 #include <vector>
 
-// Must come before gtest.h.
-#include <glog/logging.h>
-#include <gtest/gtest.h>
-
-#include <boost/utility/binary.hpp>
-
-#include "util/bit_stream_utils.h"
+#include "gtest/gtest_pred_impl.h"
 #include "util/bit_stream_utils.inline.h"
 #include "util/bit_util.h"
-#include "util/debug_util.h"
 #include "util/faststring.h"
 
 using std::string;

--- a/be/test/util/bit_util_test.cpp
+++ b/be/test/util/bit_util_test.cpp
@@ -17,15 +17,13 @@
 
 #include "util/bit_util.h"
 
-#include <gtest/gtest.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include <boost/utility.hpp>
-#include <iostream>
+#include <boost/utility/binary.hpp>
+#include <memory>
 
-#include "common/config.h"
-#include "util/cpu_info.h"
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/util/bitmap_test.cpp
+++ b/be/test/util/bitmap_test.cpp
@@ -17,11 +17,10 @@
 
 #include "util/bitmap.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include <iostream>
-
-#include "common/logging.h"
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/util/bitmap_value_test.cpp
+++ b/be/test/util/bitmap_value_test.cpp
@@ -17,11 +17,13 @@
 
 #include "util/bitmap_value.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
 #include <cstdint>
 #include <string>
 
+#include "gtest/gtest_pred_impl.h"
 #include "util/coding.h"
 
 namespace doris {

--- a/be/test/util/block_compression_test.cpp
+++ b/be/test/util/block_compression_test.cpp
@@ -18,10 +18,13 @@
 #include "util/block_compression.h"
 
 #include <gen_cpp/segment_v2.pb.h>
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stdlib.h>
 
-#include <iostream>
+#include <string>
 
+#include "gtest/gtest_pred_impl.h"
 #include "util/faststring.h"
 
 namespace doris {

--- a/be/test/util/brpc_client_cache_test.cpp
+++ b/be/test/util/brpc_client_cache_test.cpp
@@ -17,9 +17,11 @@
 
 #include "util/brpc_client_cache.h"
 
-#include <gen_cpp/function_service.pb.h>
 #include <gen_cpp/internal_service.pb.h>
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/util/byte_buffer2_test.cpp
+++ b/be/test/util/byte_buffer2_test.cpp
@@ -15,9 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include "common/logging.h"
+#include <memory>
+
+#include "gtest/gtest_pred_impl.h"
 #include "util/byte_buffer.h"
 
 namespace doris {

--- a/be/test/util/cgroup_util_test.cpp
+++ b/be/test/util/cgroup_util_test.cpp
@@ -17,9 +17,13 @@
 
 #include "util/cgroup_util.h"
 
-#include <gtest/gtest.h>
+#include <glog/logging.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
 #include <fstream>
+
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/util/cidr_test.cpp
+++ b/be/test/util/cidr_test.cpp
@@ -17,14 +17,10 @@
 
 #include "util/cidr.h"
 
-#include <gtest/gtest.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include <iostream>
-
-#include "common/configbase.h"
-#include "util/cpu_info.h"
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/util/coding_test.cpp
+++ b/be/test/util/coding_test.cpp
@@ -17,9 +17,12 @@
 
 #include "util/coding.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include <iostream>
+#include <string>
+
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/util/core_local_test.cpp
+++ b/be/test/util/core_local_test.cpp
@@ -17,14 +17,17 @@
 
 #include "util/core_local.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stdint.h>
+#include <unistd.h>
 
-#include <atomic>
+#include <ostream>
 #include <thread>
 
 #include "common/logging.h"
+#include "gtest/gtest_pred_impl.h"
 #include "testutil/test_util.h"
-#include "time.h"
 #include "util/stopwatch.hpp"
 
 namespace doris {

--- a/be/test/util/countdown_latch_test.cpp
+++ b/be/test/util/countdown_latch_test.cpp
@@ -17,11 +17,15 @@
 
 #include "util/countdown_latch.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
 #include <functional>
+#include <memory>
 #include <thread>
 
+#include "common/status.h"
+#include "gtest/gtest_pred_impl.h"
 #include "gutil/ref_counted.h"
 #include "util/thread.h"
 #include "util/threadpool.h"

--- a/be/test/util/counts_test.cpp
+++ b/be/test/util/counts_test.cpp
@@ -17,9 +17,10 @@
 
 #include "util/counts.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include "testutil/test_util.h"
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/util/crc32c_test.cpp
+++ b/be/test/util/crc32c_test.cpp
@@ -20,10 +20,13 @@
 
 #include "util/crc32c.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <string.h>
 
 #include <vector>
 
+#include "gtest/gtest_pred_impl.h"
 #include "util/slice.h"
 
 namespace doris {

--- a/be/test/util/date_func_test.cpp
+++ b/be/test/util/date_func_test.cpp
@@ -17,10 +17,10 @@
 
 #include "util/date_func.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include <iostream>
-
+#include "gtest/gtest_pred_impl.h"
 #include "olap/uint24.h"
 
 namespace doris {

--- a/be/test/util/doris_metrics_test.cpp
+++ b/be/test/util/doris_metrics_test.cpp
@@ -17,9 +17,10 @@
 
 #include "util/doris_metrics.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include "common/config.h"
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/util/easy_json-test.cpp
+++ b/be/test/util/easy_json-test.cpp
@@ -17,13 +17,15 @@
 
 #include "util/easy_json.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <rapidjson/allocators.h>
 #include <rapidjson/document.h>
 #include <rapidjson/rapidjson.h>
 
 #include <string>
 
-#include "gutil/integral_types.h"
+#include "gtest/gtest_pred_impl.h"
 
 using rapidjson::SizeType;
 using rapidjson::Value;

--- a/be/test/util/encryption_util_test.cpp
+++ b/be/test/util/encryption_util_test.cpp
@@ -17,11 +17,13 @@
 
 #include "util/encryption_util.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
 #include <memory>
 #include <string>
 
+#include "gtest/gtest_pred_impl.h"
 #include "util/url_coding.h"
 
 namespace doris {

--- a/be/test/util/faststring_test.cpp
+++ b/be/test/util/faststring_test.cpp
@@ -17,13 +17,15 @@
 
 #include "util/faststring.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 #include <time.h>
 
 #include <algorithm>
 #include <cstring>
 #include <memory>
 
+#include "gtest/gtest_pred_impl.h"
 #include "util/random.h"
 
 namespace doris {

--- a/be/test/util/frame_of_reference_coding_test.cpp
+++ b/be/test/util/frame_of_reference_coding_test.cpp
@@ -17,7 +17,10 @@
 
 #include "util/frame_of_reference_coding.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 class TestForCoding : public testing::Test {

--- a/be/test/util/histogram_test.cpp
+++ b/be/test/util/histogram_test.cpp
@@ -17,9 +17,12 @@
 
 #include "util/histogram.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
 #include <cmath>
+
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/util/http_channel_test.cpp
+++ b/be/test/util/http_channel_test.cpp
@@ -17,8 +17,14 @@
 
 #include "http/http_channel.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
+#include <iosfwd>
+
+#include "common/status.h"
+#include "gtest/gtest_pred_impl.h"
+#include "util/slice.h"
 #include "util/zlib.h"
 
 namespace doris {

--- a/be/test/util/interval_tree_test.cpp
+++ b/be/test/util/interval_tree_test.cpp
@@ -22,17 +22,20 @@
 #include "util/interval_tree.h"
 
 #include <glog/logging.h>
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
 #include <algorithm>
 #include <map>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <string>
 #include <tuple> // IWYU pragma: keep
 #include <utility>
 #include <vector>
 
+#include "gtest/gtest_pred_impl.h"
 #include "gutil/stringprintf.h"
 #include "gutil/strings/substitute.h"
 #include "testutil/test_util.h"

--- a/be/test/util/key_util_test.cpp
+++ b/be/test/util/key_util_test.cpp
@@ -17,9 +17,17 @@
 
 #include "util/key_util.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+#include "gtest/gtest_pred_impl.h"
 #include "olap/row_cursor.h"
+#include "olap/row_cursor_cell.h"
+#include "olap/tablet_schema.h"
 #include "olap/tablet_schema_helper.h"
 #include "util/debug_util.h"
 

--- a/be/test/util/lru_cache_util_test.cpp
+++ b/be/test/util/lru_cache_util_test.cpp
@@ -15,11 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
 #include <memory>
 
-#include "common/config.h"
+#include "gtest/gtest_pred_impl.h"
 #include "util/lru_cache.hpp"
 
 namespace doris {

--- a/be/test/util/md5_test.cpp
+++ b/be/test/util/md5_test.cpp
@@ -17,7 +17,10 @@
 
 #include "util/md5.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/util/metrics_test.cpp
+++ b/be/test/util/metrics_test.cpp
@@ -17,12 +17,14 @@
 
 #include "util/metrics.h"
 
-#include <gtest/gtest.h>
+#include <glog/logging.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <unistd.h>
 
-#include <iostream>
 #include <thread>
 
-#include "common/config.h"
+#include "gtest/gtest_pred_impl.h"
 #include "testutil/test_util.h"
 #include "util/stopwatch.hpp"
 

--- a/be/test/util/mysql_row_buffer_test.cpp
+++ b/be/test/util/mysql_row_buffer_test.cpp
@@ -17,13 +17,14 @@
 
 #include "util/mysql_row_buffer.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 #include <string.h>
-#include <sys/types.h>
 
 #include <string>
 
-#include "gutil/strings/util.h"
+#include "gtest/gtest_pred_impl.h"
+#include "gutil/strings/fastmem.h"
 
 namespace doris {
 

--- a/be/test/util/parse_util_test.cpp
+++ b/be/test/util/parse_util_test.cpp
@@ -17,11 +17,13 @@
 
 #include "util/parse_util.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
 #include <string>
 #include <vector>
 
+#include "gtest/gtest_pred_impl.h"
 #include "util/mem_info.h"
 
 namespace doris {

--- a/be/test/util/path_trie_test.cpp
+++ b/be/test/util/path_trie_test.cpp
@@ -17,9 +17,12 @@
 
 #include "util/path_trie.hpp"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include "common/config.h"
+#include <memory>
+
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/util/path_util_test.cpp
+++ b/be/test/util/path_util_test.cpp
@@ -17,12 +17,13 @@
 
 #include "util/path_util.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
 #include <string>
 #include <vector>
 
-#include "common/config.h"
+#include "gtest/gtest_pred_impl.h"
 
 using std::string;
 using std::vector;

--- a/be/test/util/quantile_state_test.cpp
+++ b/be/test/util/quantile_state_test.cpp
@@ -17,7 +17,10 @@
 
 #include "util/quantile_state.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 using DoubleQuantileState = QuantileState<double>;

--- a/be/test/util/radix_sort_test.cpp
+++ b/be/test/util/radix_sort_test.cpp
@@ -17,15 +17,19 @@
 
 #include "util/radix_sort.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
 #include <algorithm>
+// IWYU pragma: no_include <bits/std_abs.h>
+#include <cmath> // IWYU pragma: keep
+#include <cmath>
 #include <cstdlib>
-#include <iostream>
-#include <iterator>
+#include <limits>
 #include <random>
+#include <vector>
 
-#include "util/tdigest.h"
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/util/rle_encoding_test.cpp
+++ b/be/test/util/rle_encoding_test.cpp
@@ -15,28 +15,28 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// Must come before gtest.h.
+#include "util/rle_encoding.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <time.h>
+
 #include <algorithm>
+#include <boost/utility/binary.hpp>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
-#include <limits>
 #include <ostream>
 #include <string>
 #include <vector>
 
-// Must come before gtest.h.
-#include <glog/logging.h>
-#include <gtest/gtest.h>
-
-#include <boost/utility/binary.hpp>
-
+#include "gtest/gtest_pred_impl.h"
 #include "testutil/test_util.h"
-#include "util/bit_stream_utils.h"
-#include "util/bit_stream_utils.inline.h"
 #include "util/bit_util.h"
 #include "util/debug_util.h"
 #include "util/faststring.h"
-#include "util/rle_encoding.h"
 
 using std::string;
 using std::vector;

--- a/be/test/util/s3_uri_test.cpp
+++ b/be/test/util/s3_uri_test.cpp
@@ -17,9 +17,12 @@
 
 #include "util/s3_uri.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
 #include <string>
+
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/util/scoped_cleanup_test.cpp
+++ b/be/test/util/scoped_cleanup_test.cpp
@@ -17,7 +17,12 @@
 
 #include "util/scoped_cleanup.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+
+#include <memory>
+
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/util/sm3_test.cpp
+++ b/be/test/util/sm3_test.cpp
@@ -17,7 +17,10 @@
 
 #include "util/sm3.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/util/sort_heap_test.cpp
+++ b/be/test/util/sort_heap_test.cpp
@@ -17,11 +17,15 @@
 
 #include "util/sort_heap.h"
 
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+
 #include <algorithm>
 #include <queue>
 #include <random>
+#include <vector>
 
-#include "gtest/gtest.h"
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/util/string_parser_test.cpp
+++ b/be/test/util/string_parser_test.cpp
@@ -17,12 +17,15 @@
 
 #include "util/string_parser.hpp"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
 #include <boost/lexical_cast.hpp>
 #include <cstdint>
 #include <cstdio>
 #include <string>
+
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/util/string_util_test.cpp
+++ b/be/test/util/string_util_test.cpp
@@ -17,9 +17,11 @@
 
 #include "util/string_util.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stdint.h>
 
-#include "util/cpu_info.h"
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/util/system_metrics_test.cpp
+++ b/be/test/util/system_metrics_test.cpp
@@ -17,12 +17,13 @@
 
 #include "util/system_metrics.h"
 
-#include <gtest/gtest.h>
+#include <glog/logging.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include "common/config.h"
+#include "gtest/gtest_pred_impl.h"
 #include "testutil/test_util.h"
 #include "util/metrics.h"
-#include "util/stopwatch.hpp"
 
 namespace doris {
 

--- a/be/test/util/tdigest_test.cpp
+++ b/be/test/util/tdigest_test.cpp
@@ -17,10 +17,13 @@
 
 #include "util/tdigest.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
+#include <memory>
 #include <random>
 
+#include "gtest/gtest_pred_impl.h"
 #include "testutil/test_util.h"
 
 namespace doris {

--- a/be/test/util/thread_test.cpp
+++ b/be/test/util/thread_test.cpp
@@ -17,9 +17,8 @@
 
 #include "util/thread.h"
 
-#include <gtest/gtest.h>
-#include <sys/types.h>
-#include <unistd.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
 #include <ostream>
 #include <string>
@@ -27,9 +26,8 @@
 
 #include "common/logging.h"
 #include "common/status.h"
-#include "gutil/basictypes.h"
+#include "gtest/gtest_pred_impl.h"
 #include "gutil/ref_counted.h"
-#include "util/countdown_latch.h"
 #include "util/runtime_profile.h"
 #include "util/time.h"
 

--- a/be/test/util/threadpool_test.cpp
+++ b/be/test/util/threadpool_test.cpp
@@ -18,17 +18,23 @@
 #include "util/threadpool.h"
 
 #include <gflags/gflags_declare.h>
-#include <gtest/gtest.h>
+#include <gtest/gtest-death-test.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-param-test.h>
+#include <gtest/gtest-test-part.h>
+#include <sched.h>
+#include <stdlib.h>
+#include <time.h>
 #include <unistd.h>
 
 #include <atomic>
 #include <cstdint>
 #include <functional>
+#include <iostream>
 #include <iterator>
 #include <limits>
 #include <memory>
 #include <mutex>
-#include <ostream>
 #include <string>
 #include <thread>
 #include <utility>
@@ -36,13 +42,10 @@
 
 #include "common/logging.h"
 #include "common/status.h"
-#include "gutil/atomicops.h"
-#include "gutil/port.h"
-#include "gutil/ref_counted.h"
+#include "gtest/gtest_pred_impl.h"
 #include "gutil/strings/substitute.h"
 #include "util/barrier.h"
 #include "util/countdown_latch.h"
-#include "util/metrics.h"
 #include "util/random.h"
 #include "util/scoped_cleanup.h"
 #include "util/spinlock.h"

--- a/be/test/util/trace_test.cpp
+++ b/be/test/util/trace_test.cpp
@@ -17,28 +17,20 @@
 
 #include "util/trace.h"
 
-#include <glog/logging.h>
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 #include <rapidjson/document.h>
-#include <rapidjson/rapidjson.h>
 
 #include <cctype>
-#include <cstdint>
-#include <cstring>
-#include <functional>
+// IWYU pragma: no_include <bits/chrono.h>
+#include <chrono> // IWYU pragma: keep
 #include <map>
-#include <ostream>
 #include <string>
 #include <thread>
 #include <vector>
 
-#include "gutil/macros.h"
-#include "gutil/port.h"
+#include "gtest/gtest_pred_impl.h"
 #include "gutil/ref_counted.h"
-#include "util/countdown_latch.h"
-#include "util/scoped_cleanup.h"
-#include "util/stopwatch.hpp"
-#include "util/thread.h"
 #include "util/trace_metrics.h"
 
 using rapidjson::Document;

--- a/be/test/util/uid_util_test.cpp
+++ b/be/test/util/uid_util_test.cpp
@@ -17,9 +17,10 @@
 
 #include "util/uid_util.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include <iostream>
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 class UidUtilTest : public testing::Test {

--- a/be/test/util/utf8_check_test.cpp
+++ b/be/test/util/utf8_check_test.cpp
@@ -17,7 +17,12 @@
 
 #include "util/utf8_check.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+
+#include <vector>
+
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris {
 

--- a/be/test/vec/aggregate_functions/agg_collect_test.cpp
+++ b/be/test/vec/aggregate_functions/agg_collect_test.cpp
@@ -15,20 +15,36 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <memory>
+#include <ostream>
+#include <string>
 
 #include "common/logging.h"
-#include "gtest/gtest.h"
+#include "gtest/gtest_pred_impl.h"
 #include "vec/aggregate_functions/aggregate_function.h"
-#include "vec/aggregate_functions/aggregate_function_collect.h"
 #include "vec/aggregate_functions/aggregate_function_simple_factory.h"
-#include "vec/columns/column_vector.h"
+#include "vec/columns/column_array.h"
+#include "vec/columns/column_string.h"
+#include "vec/common/arena.h"
+#include "vec/common/string_buffer.hpp"
+#include "vec/core/types.h"
 #include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_date.h"
 #include "vec/data_types/data_type_date_time.h"
 #include "vec/data_types/data_type_decimal.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_string.h"
+
+namespace doris {
+namespace vectorized {
+class IColumn;
+} // namespace vectorized
+} // namespace doris
 
 namespace doris::vectorized {
 

--- a/be/test/vec/aggregate_functions/agg_histogram_test.cpp
+++ b/be/test/vec/aggregate_functions/agg_histogram_test.cpp
@@ -15,11 +15,27 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <glog/logging.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stddef.h>
+#include <stdint.h>
 
+#include <memory>
+#include <ostream>
+#include <string>
+
+#include "gtest/gtest_pred_impl.h"
 #include "vec/aggregate_functions/aggregate_function.h"
 #include "vec/aggregate_functions/aggregate_function_simple_factory.h"
+#include "vec/columns/column.h"
+#include "vec/columns/column_string.h"
+#include "vec/columns/column_vector.h"
+#include "vec/columns/columns_number.h"
 #include "vec/common/arena.h"
+#include "vec/common/string_buffer.hpp"
+#include "vec/common/string_ref.h"
+#include "vec/core/types.h"
 #include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_date.h"
 #include "vec/data_types/data_type_date_time.h"

--- a/be/test/vec/aggregate_functions/agg_min_max_by_test.cpp
+++ b/be/test/vec/aggregate_functions/agg_min_max_by_test.cpp
@@ -15,16 +15,32 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <fmt/format.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-param-test.h>
+#include <gtest/gtest-test-part.h>
+#include <stdint.h>
+
 #include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
-#include "gtest/gtest.h"
+#include "gtest/gtest_pred_impl.h"
 #include "vec/aggregate_functions/aggregate_function.h"
 #include "vec/aggregate_functions/aggregate_function_simple_factory.h"
+#include "vec/columns/column_string.h"
 #include "vec/columns/column_vector.h"
-#include "vec/data_types/data_type.h"
+#include "vec/columns/columns_number.h"
+#include "vec/core/field.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_string.h"
+
+namespace doris {
+namespace vectorized {
+class IColumn;
+} // namespace vectorized
+} // namespace doris
 
 const int agg_test_batch_size = 4096;
 

--- a/be/test/vec/aggregate_functions/agg_min_max_test.cpp
+++ b/be/test/vec/aggregate_functions/agg_min_max_test.cpp
@@ -15,16 +15,25 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-param-test.h>
+#include <gtest/gtest-test-part.h>
+#include <stddef.h>
+
 #include <memory>
 #include <string>
+#include <vector>
 
-#include "gtest/gtest.h"
+#include "gtest/gtest_pred_impl.h"
 #include "vec/aggregate_functions/aggregate_function.h"
-#include "vec/aggregate_functions/aggregate_function_min_max.h"
 #include "vec/aggregate_functions/aggregate_function_simple_factory.h"
-#include "vec/columns/column_decimal.h"
+#include "vec/columns/column.h"
+#include "vec/columns/column_string.h"
 #include "vec/columns/column_vector.h"
-#include "vec/data_types/data_type.h"
+#include "vec/columns/columns_number.h"
+#include "vec/common/string_ref.h"
+#include "vec/core/field.h"
+#include "vec/core/types.h"
 #include "vec/data_types/data_type_decimal.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_string.h"

--- a/be/test/vec/aggregate_functions/agg_replace_test.cpp
+++ b/be/test/vec/aggregate_functions/agg_replace_test.cpp
@@ -15,17 +15,37 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <memory>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "common/logging.h"
+#include "gtest/gtest_pred_impl.h"
+#include "olap/hll.h"
+#include "util/bitmap_value.h"
 #include "vec/aggregate_functions/aggregate_function.h"
 #include "vec/aggregate_functions/aggregate_function_reader.h"
 #include "vec/aggregate_functions/aggregate_function_reader_first_last.h"
 #include "vec/aggregate_functions/aggregate_function_simple_factory.h"
+#include "vec/columns/column.h"
 #include "vec/columns/column_array.h"
 #include "vec/columns/column_complex.h"
-#include "vec/columns/column_vector.h"
+#include "vec/columns/column_nullable.h"
+#include "vec/columns/column_string.h"
+#include "vec/columns/columns_number.h"
 #include "vec/common/arena.h"
+#include "vec/common/assert_cast.h"
+#include "vec/common/string_ref.h"
+#include "vec/core/field.h"
+#include "vec/core/types.h"
+#include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_array.h"
 #include "vec/data_types/data_type_bitmap.h"
 #include "vec/data_types/data_type_date.h"
@@ -35,6 +55,7 @@
 #include "vec/data_types/data_type_nullable.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_string.h"
+
 namespace doris::vectorized {
 
 class VAggReplaceTest : public testing::Test {

--- a/be/test/vec/aggregate_functions/agg_test.cpp
+++ b/be/test/vec/aggregate_functions/agg_test.cpp
@@ -15,15 +15,23 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stdint.h>
+
 #include <memory>
 #include <string>
 
-#include "gtest/gtest.h"
+#include "gtest/gtest_pred_impl.h"
 #include "vec/aggregate_functions/aggregate_function.h"
 #include "vec/aggregate_functions/aggregate_function_simple_factory.h"
 #include "vec/aggregate_functions/aggregate_function_topn.h"
+#include "vec/columns/column.h"
+#include "vec/columns/column_string.h"
 #include "vec/columns/column_vector.h"
-#include "vec/data_types/data_type.h"
+#include "vec/columns/columns_number.h"
+#include "vec/core/field.h"
+#include "vec/core/types.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_string.h"
 

--- a/be/test/vec/aggregate_functions/vec_retention_test.cpp
+++ b/be/test/vec/aggregate_functions/vec_retention_test.cpp
@@ -16,18 +16,31 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+
+#include <memory>
+#include <ostream>
 
 #include "common/logging.h"
-#include "gtest/gtest.h"
+#include "gtest/gtest_pred_impl.h"
 #include "vec/aggregate_functions/aggregate_function.h"
 #include "vec/aggregate_functions/aggregate_function_simple_factory.h"
-#include "vec/aggregate_functions/aggregate_function_topn.h"
 #include "vec/columns/column_array.h"
+#include "vec/columns/column_string.h"
 #include "vec/columns/column_vector.h"
+#include "vec/columns/columns_number.h"
+#include "vec/common/assert_cast.h"
+#include "vec/common/string_buffer.hpp"
+#include "vec/core/types.h"
 #include "vec/data_types/data_type.h"
-#include "vec/data_types/data_type_array.h"
 #include "vec/data_types/data_type_number.h"
+
+namespace doris {
+namespace vectorized {
+class IColumn;
+} // namespace vectorized
+} // namespace doris
 
 namespace doris::vectorized {
 

--- a/be/test/vec/aggregate_functions/vec_sequence_match_test.cpp
+++ b/be/test/vec/aggregate_functions/vec_sequence_match_test.cpp
@@ -15,16 +15,28 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include "gtest/gtest.h"
+#include <memory>
+
+#include "gtest/gtest_pred_impl.h"
 #include "vec/aggregate_functions/aggregate_function.h"
 #include "vec/aggregate_functions/aggregate_function_simple_factory.h"
+#include "vec/columns/column_string.h"
 #include "vec/columns/column_vector.h"
-#include "vec/data_types/data_type.h"
+#include "vec/common/string_buffer.hpp"
+#include "vec/core/types.h"
 #include "vec/data_types/data_type_date_time.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_string.h"
+#include "vec/runtime/vdatetime_value.h"
+
+namespace doris {
+namespace vectorized {
+class IColumn;
+} // namespace vectorized
+} // namespace doris
 
 namespace doris::vectorized {
 

--- a/be/test/vec/aggregate_functions/vec_window_funnel_test.cpp
+++ b/be/test/vec/aggregate_functions/vec_window_funnel_test.cpp
@@ -15,16 +15,32 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <glog/logging.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stddef.h>
 
-#include "gtest/gtest.h"
+#include <memory>
+#include <ostream>
+
+#include "gtest/gtest_pred_impl.h"
 #include "vec/aggregate_functions/aggregate_function.h"
 #include "vec/aggregate_functions/aggregate_function_simple_factory.h"
+#include "vec/columns/column_string.h"
 #include "vec/columns/column_vector.h"
-#include "vec/data_types/data_type.h"
+#include "vec/common/string_buffer.hpp"
+#include "vec/core/types.h"
 #include "vec/data_types/data_type_date_time.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_string.h"
+#include "vec/runtime/vdatetime_value.h"
+
+namespace doris {
+namespace vectorized {
+class IColumn;
+} // namespace vectorized
+} // namespace doris
+
 namespace doris::vectorized {
 
 void register_aggregate_function_window_funnel(AggregateFunctionSimpleFactory& factory);

--- a/be/test/vec/columns/column_decimal_test.cpp
+++ b/be/test/vec/columns/column_decimal_test.cpp
@@ -18,11 +18,10 @@
 
 #include "vec/columns/column_decimal.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include <memory>
-#include <string>
-
+#include "gtest/gtest_pred_impl.h"
 #include "vec/columns/columns_number.h"
 
 namespace doris::vectorized {

--- a/be/test/vec/columns/column_fixed_length_object_test.cpp
+++ b/be/test/vec/columns/column_fixed_length_object_test.cpp
@@ -18,10 +18,13 @@
 
 #include "vec/columns/column_fixed_length_object.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stddef.h>
 
 #include <memory>
-#include <string>
+
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris::vectorized {
 

--- a/be/test/vec/core/block_spill_test.cpp
+++ b/be/test/vec/core/block_spill_test.cpp
@@ -15,30 +15,49 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <gen_cpp/PaloInternalService_types.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stdint.h>
+#include <unistd.h>
 
+#include <cmath>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "common/status.h"
+#include "gtest/gtest_pred_impl.h"
 #include "io/fs/local_file_system.h"
+#include "olap/options.h"
 #include "runtime/block_spill_manager.h"
 #include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
-#include "vec/columns/column_array.h"
+#include "util/bitmap_value.h"
+#include "vec/columns/column.h"
+#include "vec/columns/column_complex.h"
 #include "vec/columns/column_decimal.h"
 #include "vec/columns/column_nullable.h"
 #include "vec/columns/column_string.h"
 #include "vec/columns/column_vector.h"
+#include "vec/common/string_ref.h"
+#include "vec/core/block.h"
 #include "vec/core/block_spill_reader.h"
 #include "vec/core/block_spill_writer.h"
+#include "vec/core/column_with_type_and_name.h"
+#include "vec/core/types.h"
 #include "vec/data_types/data_type.h"
-#include "vec/data_types/data_type_array.h"
 #include "vec/data_types/data_type_bitmap.h"
-#include "vec/data_types/data_type_date.h"
-#include "vec/data_types/data_type_date_time.h"
 #include "vec/data_types/data_type_decimal.h"
 #include "vec/data_types/data_type_nullable.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_string.h"
 
 namespace doris {
+class RuntimeProfile;
+
 static const uint32_t MAX_PATH_LEN = 1024;
 
 static const std::string TMP_DATA_DIR = "block_spill_test";

--- a/be/test/vec/core/block_test.cpp
+++ b/be/test/vec/core/block_test.cpp
@@ -17,21 +17,26 @@
 
 #include "vec/core/block.h"
 
-#include <gtest/gtest.h>
+#include <gen_cpp/segment_v2.pb.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
+#include <algorithm>
 #include <cmath>
-#include <iostream>
 #include <string>
 
 #include "agent/be_exec_version_manager.h"
-#include "exec/schema_scanner.h"
+#include "common/config.h"
 #include "gen_cpp/data.pb.h"
+#include "gtest/gtest_pred_impl.h"
+#include "util/bitmap_value.h"
 #include "vec/columns/column_array.h"
+#include "vec/columns/column_complex.h"
 #include "vec/columns/column_decimal.h"
 #include "vec/columns/column_nullable.h"
 #include "vec/columns/column_string.h"
 #include "vec/columns/column_vector.h"
-#include "vec/common/string_ref.h"
+#include "vec/core/field.h"
 #include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_array.h"
 #include "vec/data_types/data_type_bitmap.h"

--- a/be/test/vec/core/column_array_test.cpp
+++ b/be/test/vec/core/column_array_test.cpp
@@ -17,11 +17,13 @@
 
 #include "vec/columns/column_array.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include <memory>
 #include <string>
+#include <vector>
 
+#include "gtest/gtest_pred_impl.h"
 #include "vec/columns/column.h"
 #include "vec/columns/column_string.h"
 #include "vec/columns/column_vector.h"

--- a/be/test/vec/core/column_complex_test.cpp
+++ b/be/test/vec/core/column_complex_test.cpp
@@ -17,16 +17,19 @@
 
 #include "vec/columns/column_complex.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stddef.h>
 
 #include <memory>
 #include <string>
 
 #include "agent/be_exec_version_manager.h"
-#include "agent/heartbeat_server.h"
-#include "vec/core/block.h"
+#include "gtest/gtest_pred_impl.h"
+#include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_bitmap.h"
 #include "vec/data_types/data_type_quantilestate.h"
+
 namespace doris::vectorized {
 TEST(ColumnComplexTest, BasicTest) {
     using ColumnSTLString = ColumnComplexType<std::string>;

--- a/be/test/vec/core/column_nullable_test.cpp
+++ b/be/test/vec/core/column_nullable_test.cpp
@@ -18,11 +18,12 @@
 
 #include "vec/columns/column_nullable.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include <memory>
 #include <string>
 
+#include "gtest/gtest_pred_impl.h"
 #include "vec/columns/column_vector.h"
 #include "vec/common/sip_hash.h"
 

--- a/be/test/vec/core/column_vector_test.cpp
+++ b/be/test/vec/core/column_vector_test.cpp
@@ -18,12 +18,12 @@
 
 #include "vec/columns/column_vector.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include <memory>
 #include <string>
 
-#include "vec/data_types/data_type_date.h"
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris::vectorized {
 

--- a/be/test/vec/data_types/complex_type_test.cpp
+++ b/be/test/vec/data_types/complex_type_test.cpp
@@ -16,12 +16,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
 #include <memory>
-#include <string>
 
+#include "gtest/gtest_pred_impl.h"
+#include "vec/columns/column.h"
 #include "vec/core/field.h"
+#include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_array.h"
 #include "vec/data_types/data_type_map.h"
 #include "vec/data_types/data_type_nullable.h"

--- a/be/test/vec/data_types/serde/data_type_serde_test.cpp
+++ b/be/test/vec/data_types/serde/data_type_serde_test.cpp
@@ -16,14 +16,32 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include "vec/data_types/serde/data_type_serde.h"
 
+#include <gen_cpp/types.pb.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <math.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include <iostream>
 #include <memory>
 #include <string>
+#include <vector>
 
+#include "gtest/gtest_pred_impl.h"
+#include "olap/hll.h"
+#include "util/bitmap_value.h"
+#include "util/quantile_state.h"
+#include "vec/columns/column.h"
 #include "vec/columns/column_complex.h"
 #include "vec/columns/column_decimal.h"
 #include "vec/columns/column_nullable.h"
+#include "vec/columns/column_string.h"
+#include "vec/columns/column_vector.h"
+#include "vec/core/types.h"
+#include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_bitmap.h"
 #include "vec/data_types/data_type_decimal.h"
 #include "vec/data_types/data_type_hll.h"

--- a/be/test/vec/exec/parquet/parquet_reader_test.cpp
+++ b/be/test/vec/exec/parquet/parquet_reader_test.cpp
@@ -15,19 +15,41 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <glog/logging.h>
-#include <gtest/gtest.h>
+#include <cctz/time_zone.h>
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/PaloInternalService_types.h>
+#include <gen_cpp/PlanNodes_types.h>
+#include <gen_cpp/Types_types.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stddef.h>
+
+#include <memory>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include "common/object_pool.h"
+#include "exec/olap_common.h"
+#include "gtest/gtest_pred_impl.h"
+#include "io/fs/file_reader_writer_fwd.h"
+#include "io/fs/file_system.h"
 #include "io/fs/local_file_system.h"
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
-#include "util/runtime_profile.h"
+#include "util/timezone_utils.h"
+#include "vec/columns/column.h"
+#include "vec/core/block.h"
+#include "vec/core/column_with_type_and_name.h"
+#include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_factory.hpp"
 #include "vec/exec/format/parquet/vparquet_reader.h"
 
 namespace doris {
 namespace vectorized {
+class VExprContext;
 
 class ParquetReaderTest : public testing::Test {
 public:

--- a/be/test/vec/exec/parquet/parquet_thrift_test.cpp
+++ b/be/test/vec/exec/parquet/parquet_thrift_test.cpp
@@ -15,28 +15,54 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <cctz/time_zone.h>
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/Types_types.h>
+#include <gen_cpp/parquet_types.h>
 #include <glog/logging.h>
-#include <gtest/gtest.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <math.h>
+#include <stdint.h>
+#include <sys/types.h>
 
+#include <algorithm>
+#include <memory>
+#include <new>
+#include <ostream>
 #include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include "common/object_pool.h"
+#include "common/status.h"
 #include "exec/schema_scanner.h"
+#include "gtest/gtest_pred_impl.h"
 #include "io/fs/buffered_reader.h"
+#include "io/fs/file_reader.h"
+#include "io/fs/file_reader_writer_fwd.h"
+#include "io/fs/file_system.h"
 #include "io/fs/local_file_system.h"
-#include "olap/iterators.h"
+#include "runtime/decimalv2_value.h"
+#include "runtime/define_primitive_type.h"
 #include "runtime/descriptors.h"
-#include "util/runtime_profile.h"
+#include "runtime/types.h"
+#include "util/slice.h"
+#include "util/spinlock.h"
 #include "util/timezone_utils.h"
+#include "vec/aggregate_functions/aggregate_function.h"
+#include "vec/columns/column.h"
+#include "vec/columns/column_nullable.h"
 #include "vec/common/string_ref.h"
 #include "vec/core/block.h"
 #include "vec/core/column_with_type_and_name.h"
+#include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_factory.hpp"
+#include "vec/exec/format/parquet/parquet_common.h"
 #include "vec/exec/format/parquet/parquet_thrift_util.h"
+#include "vec/exec/format/parquet/schema_desc.h"
 #include "vec/exec/format/parquet/vparquet_column_chunk_reader.h"
-#include "vec/exec/format/parquet/vparquet_column_reader.h"
 #include "vec/exec/format/parquet/vparquet_file_metadata.h"
 #include "vec/exec/format/parquet/vparquet_group_reader.h"
 

--- a/be/test/vec/exec/vgeneric_iterators_test.cpp
+++ b/be/test/vec/exec/vgeneric_iterators_test.cpp
@@ -17,13 +17,20 @@
 
 #include "vec/olap/vgeneric_iterators.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
 #include <vector>
 
+#include "gtest/gtest_pred_impl.h"
+#include "olap/field.h"
 #include "olap/olap_common.h"
 #include "olap/schema.h"
-#include "util/slice.h"
+#include "olap/tablet_schema.h"
+#include "vec/columns/column.h"
+#include "vec/core/column_with_type_and_name.h"
+#include "vec/core/field.h"
+#include "vec/data_types/data_type.h"
 
 namespace doris {
 using namespace ErrorCode;

--- a/be/test/vec/exec/vtablet_sink_test.cpp
+++ b/be/test/vec/exec/vtablet_sink_test.cpp
@@ -16,29 +16,44 @@
 // under the License.
 #include "vec/sink/vtablet_sink.h"
 
-#include <gtest/gtest.h>
+#include <brpc/closure_guard.h>
+#include <brpc/server.h>
+#include <gen_cpp/DataSinks_types.h>
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/Exprs_types.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include <map>
 #include <string>
 #include <vector>
 
 #include "common/config.h"
+#include "common/object_pool.h"
 #include "gen_cpp/HeartbeatService_types.h"
 #include "gen_cpp/internal_service.pb.h"
+#include "gtest/gtest_pred_impl.h"
+#include "olap/olap_define.h"
 #include "runtime/decimalv2_value.h"
+#include "runtime/define_primitive_type.h"
 #include "runtime/descriptor_helper.h"
 #include "runtime/descriptors.h"
 #include "runtime/exec_env.h"
-#include "runtime/result_queue_mgr.h"
 #include "runtime/runtime_state.h"
-#include "runtime/types.h"
-#include "service/brpc.h"
 #include "util/brpc_client_cache.h"
-#include "util/cpu_info.h"
 #include "util/debug/leakcheck_disabler.h"
 #include "util/proto_util.h"
+#include "util/threadpool.h"
+#include "vec/core/block.h"
+#include "vec/core/column_with_type_and_name.h"
+
+namespace google {
+namespace protobuf {
+class RpcController;
+} // namespace protobuf
+} // namespace google
 
 namespace doris {
+class PFunctionService_Stub;
 
 namespace stream_load {
 

--- a/be/test/vec/exprs/vexpr_test.cpp
+++ b/be/test/vec/exprs/vexpr_test.cpp
@@ -17,22 +17,32 @@
 
 #include "vec/exprs/vexpr.h"
 
-#include <gtest/gtest.h>
-#include <thrift/protocol/TJSONProtocol.h>
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/PaloInternalService_types.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/types.h>
 
 #include <cmath>
-#include <iostream>
+#include <limits>
+#include <new>
+#include <type_traits>
 
+#include "common/object_pool.h"
 #include "exec/schema_scanner.h"
 #include "gen_cpp/Exprs_types.h"
 #include "gen_cpp/Types_types.h"
+#include "gtest/gtest_pred_impl.h"
 #include "runtime/descriptors.h"
-#include "runtime/exec_env.h"
 #include "runtime/large_int_value.h"
 #include "runtime/memory/chunk_allocator.h"
-#include "runtime/primitive_type.h"
 #include "runtime/runtime_state.h"
 #include "testutil/desc_tbl_builder.h"
+#include "vec/core/field.h"
+#include "vec/core/types.h"
+#include "vec/exprs/vexpr_context.h"
 #include "vec/exprs/vliteral.h"
 #include "vec/runtime/vdatetime_value.h"
 #include "vec/utils/util.hpp"

--- a/be/test/vec/function/function_arithmetic_test.cpp
+++ b/be/test/vec/function/function_arithmetic_test.cpp
@@ -15,14 +15,19 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
-#include <time.h>
+#include <stdint.h>
 
+#include <iomanip>
 #include <string>
+#include <vector>
 
+#include "common/status.h"
 #include "function_test_util.h"
-#include "util/url_coding.h"
-#include "vec/core/field.h"
+#include "gtest/gtest_pred_impl.h"
+#include "testutil/any_type.h"
+#include "vec/core/types.h"
+#include "vec/data_types/data_type_nullable.h"
+#include "vec/data_types/data_type_number.h"
 
 namespace doris::vectorized {
 

--- a/be/test/vec/function/function_array_aggregation_test.cpp
+++ b/be/test/vec/function/function_array_aggregation_test.cpp
@@ -15,14 +15,19 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
-
 #include <cstddef>
+#include <iomanip>
 #include <string>
-#include <type_traits>
+#include <utility>
+#include <vector>
 
+#include "common/status.h"
 #include "function_test_util.h"
+#include "gtest/gtest_pred_impl.h"
+#include "testutil/any_type.h"
 #include "vec/core/field.h"
+#include "vec/core/types.h"
+#include "vec/data_types/data_type_nullable.h"
 #include "vec/data_types/data_type_number.h"
 
 namespace doris {

--- a/be/test/vec/function/function_array_element_test.cpp
+++ b/be/test/vec/function/function_array_element_test.cpp
@@ -15,14 +15,22 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
-#include <time.h>
-
+#include <iomanip>
 #include <string>
+#include <vector>
 
+#include "common/status.h"
 #include "function_test_util.h"
+#include "gtest/gtest_pred_impl.h"
+#include "testutil/any_type.h"
 #include "vec/core/field.h"
+#include "vec/core/types.h"
+#include "vec/data_types/data_type_date.h"
+#include "vec/data_types/data_type_date_time.h"
 #include "vec/data_types/data_type_decimal.h"
+#include "vec/data_types/data_type_nullable.h"
+#include "vec/data_types/data_type_number.h"
+#include "vec/data_types/data_type_string.h"
 
 namespace doris::vectorized {
 

--- a/be/test/vec/function/function_array_index_test.cpp
+++ b/be/test/vec/function/function_array_index_test.cpp
@@ -15,14 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
-#include <time.h>
-
 #include <string>
+#include <vector>
 
+#include "common/status.h"
 #include "function_test_util.h"
-#include "util/url_coding.h"
+#include "gtest/gtest_pred_impl.h"
+#include "testutil/any_type.h"
 #include "vec/core/field.h"
+#include "vec/core/types.h"
+#include "vec/data_types/data_type_nullable.h"
+#include "vec/data_types/data_type_number.h"
 
 namespace doris::vectorized {
 

--- a/be/test/vec/function/function_array_size_test.cpp
+++ b/be/test/vec/function/function_array_size_test.cpp
@@ -15,14 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
-#include <time.h>
-
 #include <string>
+#include <vector>
 
+#include "common/status.h"
 #include "function_test_util.h"
-#include "util/url_coding.h"
+#include "gtest/gtest_pred_impl.h"
+#include "testutil/any_type.h"
 #include "vec/core/field.h"
+#include "vec/core/types.h"
+#include "vec/data_types/data_type_nullable.h"
+#include "vec/data_types/data_type_number.h"
 
 namespace doris::vectorized {
 

--- a/be/test/vec/function/function_arrays_overlap_test.cpp
+++ b/be/test/vec/function/function_arrays_overlap_test.cpp
@@ -15,14 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
-#include <time.h>
-
 #include <string>
 
+#include "common/status.h"
 #include "function_test_util.h"
-#include "util/url_coding.h"
+#include "gtest/gtest_pred_impl.h"
+#include "testutil/any_type.h"
 #include "vec/core/field.h"
+#include "vec/core/types.h"
+#include "vec/data_types/data_type_nullable.h"
+#include "vec/data_types/data_type_number.h"
 
 namespace doris::vectorized {
 

--- a/be/test/vec/function/function_bitmap_test.cpp
+++ b/be/test/vec/function/function_bitmap_test.cpp
@@ -14,11 +14,22 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-#include <gtest/gtest.h>
+#include <stdint.h>
 
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "common/status.h"
 #include "function_test_util.h"
+#include "gtest/gtest_pred_impl.h"
+#include "gutil/integral_types.h"
+#include "testutil/any_type.h"
 #include "util/bitmap_value.h"
-#include "vec/functions/function_totype.h"
+#include "vec/core/types.h"
+#include "vec/data_types/data_type_nullable.h"
+#include "vec/data_types/data_type_number.h"
+#include "vec/data_types/data_type_string.h"
 
 namespace doris::vectorized {
 

--- a/be/test/vec/function/function_geo_test.cpp
+++ b/be/test/vec/function/function_geo_test.cpp
@@ -15,14 +15,24 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
-#include <time.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stdint.h>
 
+#include <iomanip>
+#include <memory>
 #include <string>
+#include <vector>
 
+#include "common/status.h"
 #include "function_test_util.h"
+#include "geo/geo_common.h"
 #include "geo/geo_types.h"
+#include "gtest/gtest_pred_impl.h"
+#include "testutil/any_type.h"
 #include "vec/core/types.h"
+#include "vec/data_types/data_type_nullable.h"
+#include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_string.h"
 
 namespace doris::vectorized {

--- a/be/test/vec/function/function_hash_test.cpp
+++ b/be/test/vec/function/function_hash_test.cpp
@@ -15,11 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
-#include <time.h>
+#include <stdint.h>
 
+#include <string>
+#include <vector>
+
+#include "common/status.h"
 #include "function_test_util.h"
-#include "vec/functions/simple_function_factory.h"
+#include "gtest/gtest_pred_impl.h"
+#include "testutil/any_type.h"
+#include "vec/core/types.h"
+#include "vec/data_types/data_type_nullable.h"
+#include "vec/data_types/data_type_number.h"
 
 namespace doris::vectorized {
 

--- a/be/test/vec/function/function_ifnull_test.cpp
+++ b/be/test/vec/function/function_ifnull_test.cpp
@@ -15,12 +15,19 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
-#include <time.h>
-
+#include <iomanip>
 #include <string>
+#include <vector>
 
+#include "common/status.h"
 #include "function_test_util.h"
+#include "gtest/gtest_pred_impl.h"
+#include "testutil/any_type.h"
+#include "vec/core/types.h"
+#include "vec/data_types/data_type_date_time.h"
+#include "vec/data_types/data_type_nullable.h"
+#include "vec/data_types/data_type_number.h"
+#include "vec/data_types/data_type_string.h"
 
 namespace doris::vectorized {
 

--- a/be/test/vec/function/function_json_test.cpp
+++ b/be/test/vec/function/function_json_test.cpp
@@ -15,9 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <iomanip>
+#include <string>
 
+#include "common/status.h"
 #include "function_test_util.h"
+#include "gtest/gtest_pred_impl.h"
+#include "testutil/any_type.h"
+#include "vec/core/types.h"
+#include "vec/data_types/data_type_nullable.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_string.h"
 

--- a/be/test/vec/function/function_jsonb_test.cpp
+++ b/be/test/vec/function/function_jsonb_test.cpp
@@ -15,10 +15,19 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <stdint.h>
 
+#include <iomanip>
+#include <string>
+#include <vector>
+
+#include "common/status.h"
 #include "function_test_util.h"
+#include "gtest/gtest_pred_impl.h"
+#include "testutil/any_type.h"
+#include "vec/core/types.h"
 #include "vec/data_types/data_type_jsonb.h"
+#include "vec/data_types/data_type_nullable.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_string.h"
 

--- a/be/test/vec/function/function_like_test.cpp
+++ b/be/test/vec/function/function_like_test.cpp
@@ -15,13 +15,19 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <stdint.h>
 
 #include <string>
+#include <vector>
 
+#include "common/status.h"
 #include "function_test_util.h"
-#include "util/cpu_info.h"
+#include "gtest/gtest_pred_impl.h"
+#include "testutil/any_type.h"
 #include "vec/core/types.h"
+#include "vec/data_types/data_type_nullable.h"
+#include "vec/data_types/data_type_number.h"
+#include "vec/data_types/data_type_string.h"
 
 namespace doris::vectorized {
 

--- a/be/test/vec/function/function_math_test.cpp
+++ b/be/test/vec/function/function_math_test.cpp
@@ -15,15 +15,23 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
-#include <time.h>
+#include <limits.h>
+#include <stdint.h>
 
-#include <any>
 #include <cmath>
-#include <iostream>
+#include <iomanip>
+#include <limits>
 #include <string>
+#include <vector>
 
+#include "common/status.h"
 #include "function_test_util.h"
+#include "gtest/gtest_pred_impl.h"
+#include "testutil/any_type.h"
+#include "vec/core/types.h"
+#include "vec/data_types/data_type_nullable.h"
+#include "vec/data_types/data_type_number.h"
+#include "vec/data_types/data_type_string.h"
 
 namespace doris::vectorized {
 

--- a/be/test/vec/function/function_nullif_test.cpp
+++ b/be/test/vec/function/function_nullif_test.cpp
@@ -15,12 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
-#include <time.h>
-
+#include <iomanip>
 #include <string>
+#include <vector>
 
+#include "common/status.h"
 #include "function_test_util.h"
+#include "gtest/gtest_pred_impl.h"
+#include "testutil/any_type.h"
+#include "vec/core/types.h"
+#include "vec/data_types/data_type_date_time.h"
+#include "vec/data_types/data_type_nullable.h"
+#include "vec/data_types/data_type_number.h"
 
 namespace doris::vectorized {
 

--- a/be/test/vec/function/function_running_difference_test.cpp
+++ b/be/test/vec/function/function_running_difference_test.cpp
@@ -15,15 +15,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
-#include <time.h>
+#include <stdint.h>
 
-#include <any>
-#include <cmath>
-#include <iostream>
+#include <iomanip>
 #include <string>
+#include <vector>
 
+#include "common/status.h"
 #include "function_test_util.h"
+#include "gtest/gtest_pred_impl.h"
+#include "testutil/any_type.h"
+#include "vec/core/types.h"
+#include "vec/data_types/data_type_nullable.h"
+#include "vec/data_types/data_type_number.h"
+#include "vec/data_types/data_type_time.h"
+
 namespace doris::vectorized {
 using namespace ut_type;
 TEST(FunctionRunningDifferenceTest, function_running_difference_test) {

--- a/be/test/vec/function/function_string_test.cpp
+++ b/be/test/vec/function/function_string_test.cpp
@@ -15,15 +15,24 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
-#include <time.h>
+#include <stdint.h>
 
+#include <cstring>
+#include <memory>
 #include <string>
+#include <vector>
 
+#include "common/status.h"
 #include "function_test_util.h"
+#include "gtest/gtest_pred_impl.h"
+#include "gutil/integral_types.h"
+#include "testutil/any_type.h"
 #include "util/encryption_util.h"
+#include "vec/core/field.h"
 #include "vec/core/types.h"
-#include "vec/data_types/data_type_array.h"
+#include "vec/data_types/data_type_date_time.h"
+#include "vec/data_types/data_type_nullable.h"
+#include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_string.h"
 
 namespace doris::vectorized {

--- a/be/test/vec/function/function_test_util.cpp
+++ b/be/test/vec/function/function_test_util.cpp
@@ -17,10 +17,24 @@
 
 #include "vec/function/function_test_util.h"
 
+#include <glog/logging.h>
+#include <opentelemetry/common/threadlocal.h>
+
+#include <iostream>
+
 #include "runtime/jsonb_value.h"
+#include "util/binary_cast.hpp"
+#include "util/bitmap_value.h"
 #include "vec/data_types/data_type_array.h"
 #include "vec/data_types/data_type_bitmap.h"
+#include "vec/data_types/data_type_date.h"
+#include "vec/data_types/data_type_date_time.h"
 #include "vec/data_types/data_type_decimal.h"
+#include "vec/data_types/data_type_jsonb.h"
+#include "vec/data_types/data_type_string.h"
+#include "vec/data_types/data_type_time_v2.h"
+#include "vec/exprs/table_function/table_function.h"
+#include "vec/runtime/vdatetime_value.h"
 
 namespace doris::vectorized {
 int64_t str_to_date_time(std::string datetime_str, bool data_time) {

--- a/be/test/vec/function/function_test_util.h
+++ b/be/test/vec/function/function_test_util.h
@@ -15,30 +15,47 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stdint.h>
 #include <time.h>
 
-#include <any>
-#include <iostream>
+#include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
+#include "common/status.h"
+#include "gtest/gtest_pred_impl.h"
+#include "olap/olap_common.h"
+#include "runtime/define_primitive_type.h"
+#include "runtime/types.h"
 #include "testutil/any_type.h"
 #include "testutil/function_utils.h"
 #include "udf/udf.h"
 #include "util/jsonb_utils.h"
 #include "vec/columns/column.h"
 #include "vec/columns/column_const.h"
-#include "vec/core/columns_with_type_and_name.h"
-#include "vec/data_types/data_type_date.h"
-#include "vec/data_types/data_type_date_time.h"
-#include "vec/data_types/data_type_decimal.h"
-#include "vec/data_types/data_type_jsonb.h"
+#include "vec/common/string_ref.h"
+#include "vec/core/block.h"
+#include "vec/core/column_numbers.h"
+#include "vec/core/column_with_type_and_name.h"
+#include "vec/core/field.h"
+#include "vec/core/types.h"
+#include "vec/data_types/data_type.h"
+#include "vec/data_types/data_type_nullable.h"
 #include "vec/data_types/data_type_number.h"
-#include "vec/data_types/data_type_string.h"
-#include "vec/data_types/data_type_time.h"
-#include "vec/data_types/data_type_time_v2.h"
-#include "vec/exprs/table_function/table_function.h"
 #include "vec/functions/simple_function_factory.h"
+
+namespace doris {
+namespace vectorized {
+class DataTypeJsonb;
+class DataTypeTime;
+class TableFunction;
+template <typename T>
+class DataTypeDecimal;
+} // namespace vectorized
+} // namespace doris
 
 namespace doris::vectorized {
 

--- a/be/test/vec/function/function_time_test.cpp
+++ b/be/test/vec/function/function_time_test.cpp
@@ -15,14 +15,24 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
-#include <time.h>
+#include <stdint.h>
 
-#include <any>
-#include <iostream>
+#include <iomanip>
 #include <string>
+#include <vector>
 
+#include "common/status.h"
 #include "function_test_util.h"
+#include "gtest/gtest_pred_impl.h"
+#include "testutil/any_type.h"
+#include "vec/core/types.h"
+#include "vec/data_types/data_type_date.h"
+#include "vec/data_types/data_type_date_time.h"
+#include "vec/data_types/data_type_nullable.h"
+#include "vec/data_types/data_type_number.h"
+#include "vec/data_types/data_type_string.h"
+#include "vec/data_types/data_type_time.h"
+#include "vec/data_types/data_type_time_v2.h"
 
 namespace doris::vectorized {
 using namespace ut_type;

--- a/be/test/vec/function/function_url_test.cpp
+++ b/be/test/vec/function/function_url_test.cpp
@@ -15,11 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <string>
+#include <vector>
 
+#include "common/status.h"
 #include "function_test_util.h"
-#include "vec/data_types/data_type_jsonb.h"
-#include "vec/data_types/data_type_number.h"
+#include "gtest/gtest_pred_impl.h"
+#include "testutil/any_type.h"
+#include "vec/core/types.h"
+#include "vec/data_types/data_type_nullable.h"
 #include "vec/data_types/data_type_string.h"
 
 namespace doris::vectorized {

--- a/be/test/vec/function/table_function_test.cpp
+++ b/be/test/vec/function/table_function_test.cpp
@@ -15,7 +15,22 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <gmock/gmock-actions.h>
+#include <gmock/gmock-matchers.h>
+#include <gmock/gmock-spec-builders.h>
+#include <gtest/gtest-matchers.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common/status.h"
 #include "exprs/mock_vexpr.h"
+#include "gtest/gtest_pred_impl.h"
+#include "testutil/any_type.h"
+#include "vec/core/field.h"
+#include "vec/core/types.h"
 #include "vec/exprs/table_function/vexplode.h"
 #include "vec/exprs/table_function/vexplode_numbers.h"
 #include "vec/exprs/table_function/vexplode_split.h"

--- a/be/test/vec/jsonb/serialize_test.cpp
+++ b/be/test/vec/jsonb/serialize_test.cpp
@@ -17,22 +17,42 @@
 #include "vec/jsonb/serialize.h"
 
 #include <gen_cpp/Descriptors_types.h>
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <math.h>
+#include <stdint.h>
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
 
 #include "gen_cpp/descriptors.pb.h"
+#include "gtest/gtest_pred_impl.h"
+#include "olap/hll.h"
+#include "olap/olap_common.h"
 #include "olap/tablet_schema.h"
+#include "runtime/define_primitive_type.h"
 #include "runtime/descriptors.h"
+#include "runtime/types.h"
+#include "util/bitmap_value.h"
+#include "vec/aggregate_functions/aggregate_function.h"
+#include "vec/columns/column.h"
 #include "vec/columns/column_array.h"
+#include "vec/columns/column_complex.h"
 #include "vec/columns/column_decimal.h"
 #include "vec/columns/column_nullable.h"
 #include "vec/columns/column_string.h"
 #include "vec/columns/column_vector.h"
 #include "vec/core/block.h"
+#include "vec/core/column_with_type_and_name.h"
+#include "vec/core/field.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_array.h"
 #include "vec/data_types/data_type_bitmap.h"
-#include "vec/data_types/data_type_date_time.h"
 #include "vec/data_types/data_type_decimal.h"
 #include "vec/data_types/data_type_hll.h"
 #include "vec/data_types/data_type_nullable.h"

--- a/be/test/vec/olap/char_type_padding_test.cpp
+++ b/be/test/vec/olap/char_type_padding_test.cpp
@@ -15,9 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stddef.h>
 
+#include <string>
+
+#include "gtest/gtest_pred_impl.h"
+#include "vec/columns/column.h"
 #include "vec/columns/column_string.h"
+#include "vec/common/string_ref.h"
 #include "vec/olap/olap_data_convertor.h"
 
 namespace doris::vectorized {

--- a/be/test/vec/olap/vertical_compaction_test.cpp
+++ b/be/test/vec/olap/vertical_compaction_test.cpp
@@ -16,25 +16,56 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <gen_cpp/AgentService_types.h>
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/PaloInternalService_types.h>
+#include <gen_cpp/Types_types.h>
+#include <gen_cpp/olap_common.pb.h>
+#include <gen_cpp/olap_file.pb.h>
+#include <glog/logging.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stdint.h>
+#include <unistd.h>
 
+#include <iostream>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
+#include "common/status.h"
+#include "gtest/gtest_pred_impl.h"
+#include "gutil/stringprintf.h"
 #include "io/fs/local_file_system.h"
+#include "io/io_common.h"
+#include "olap/delete_handler.h"
+#include "olap/field.h"
 #include "olap/merger.h"
+#include "olap/olap_common.h"
+#include "olap/options.h"
 #include "olap/rowid_conversion.h"
 #include "olap/rowset/beta_rowset.h"
 #include "olap/rowset/rowset.h"
 #include "olap/rowset/rowset_factory.h"
+#include "olap/rowset/rowset_meta.h"
 #include "olap/rowset/rowset_reader.h"
 #include "olap/rowset/rowset_reader_context.h"
 #include "olap/rowset/rowset_writer.h"
 #include "olap/rowset/rowset_writer_context.h"
 #include "olap/schema.h"
 #include "olap/storage_engine.h"
+#include "olap/tablet.h"
+#include "olap/tablet_meta.h"
 #include "olap/tablet_schema.h"
-#include "olap/tablet_schema_helper.h"
-#include "vec/olap/vertical_block_reader.h"
+#include "olap/utils.h"
+#include "util/uid_util.h"
+#include "vec/columns/column.h"
+#include "vec/core/block.h"
+#include "vec/core/column_with_type_and_name.h"
+#include "vec/data_types/data_type.h"
 #include "vec/olap/vertical_merge_iterator.h"
 
 namespace doris {

--- a/be/test/vec/runtime/vdata_stream_test.cpp
+++ b/be/test/vec/runtime/vdata_stream_test.cpp
@@ -15,21 +15,56 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
+#include <brpc/controller.h>
+#include <bthread/id.h>
+#include <gen_cpp/DataSinks_types.h>
+#include <gen_cpp/PaloInternalService_types.h>
+#include <gen_cpp/Partitions_types.h>
+#include <gen_cpp/Types_types.h>
+#include <glog/logging.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stddef.h>
 
+#include <memory>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "common/global_types.h"
 #include "common/object_pool.h"
+#include "common/status.h"
 #include "gen_cpp/internal_service.pb.h"
-#include "google/protobuf/descriptor.h"
 #include "google/protobuf/service.h"
+#include "gtest/gtest_pred_impl.h"
+#include "runtime/define_primitive_type.h"
+#include "runtime/descriptors.h"
 #include "runtime/exec_env.h"
-#include "service/brpc.h"
+#include "runtime/query_statistics.h"
+#include "runtime/runtime_state.h"
 #include "testutil/desc_tbl_builder.h"
 #include "util/brpc_client_cache.h"
 #include "util/proto_util.h"
+#include "util/runtime_profile.h"
+#include "util/uid_util.h"
+#include "vec/columns/column_vector.h"
+#include "vec/core/block.h"
+#include "vec/core/column_with_type_and_name.h"
+#include "vec/core/types.h"
+#include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/runtime/vdata_stream_mgr.h"
 #include "vec/runtime/vdata_stream_recvr.h"
 #include "vec/sink/vdata_stream_sender.h"
+
+namespace google {
+namespace protobuf {
+class Closure;
+class Message;
+class MethodDescriptor;
+} // namespace protobuf
+} // namespace google
 
 namespace doris::vectorized {
 

--- a/be/test/vec/runtime/vdatetime_value_test.cpp
+++ b/be/test/vec/runtime/vdatetime_value_test.cpp
@@ -17,10 +17,12 @@
 
 #include "vec/runtime/vdatetime_value.h"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
-#include <any>
 #include <string>
+
+#include "gtest/gtest_pred_impl.h"
 
 namespace doris::vectorized {
 

--- a/be/test/vec/utils/arrow_column_to_doris_column_test.cpp
+++ b/be/test/vec/utils/arrow_column_to_doris_column_test.cpp
@@ -17,33 +17,47 @@
 
 #include "vec/utils/arrow_column_to_doris_column.h"
 
-#include <arrow/array.h>
-#include <arrow/builder.h>
-#include <arrow/memory_pool.h>
-#include <arrow/record_batch.h>
-#include <arrow/status.h>
-#include <arrow/testing/gtest_util.h>
-#include <arrow/testing/util.h>
+#include <arrow/array.h> // IWYU pragma: keep
+#include <arrow/array/array_decimal.h>
+#include <arrow/array/data.h>
+#include <arrow/buffer.h>
+#include <arrow/result.h>
 #include <arrow/util/bit_util.h>
-#include <gtest/gtest.h>
+#include <assert.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+#include <stdint.h>
+#include <string.h>
 
+#include <algorithm>
+#include <limits>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "arrow/array/array_binary.h"
 #include "arrow/array/array_nested.h"
-#include "arrow/array/builder_base.h"
-#include "arrow/scalar.h"
 #include "arrow/type.h"
-#include "arrow/type_fwd.h"
 #include "arrow/type_traits.h"
-#include "gutil/casts.h"
+#include "gtest/gtest_pred_impl.h"
+#include "runtime/decimalv2_value.h"
+#include "runtime/types.h"
+#include "util/binary_cast.hpp"
+#include "vec/aggregate_functions/aggregate_function.h"
+#include "vec/columns/column.h"
 #include "vec/columns/column_array.h"
+#include "vec/columns/column_decimal.h"
 #include "vec/columns/column_nullable.h"
+#include "vec/columns/column_string.h"
+#include "vec/columns/column_vector.h"
+#include "vec/common/pod_array.h"
+#include "vec/common/string_ref.h"
+#include "vec/core/column_with_type_and_name.h"
+#include "vec/core/field.h"
+#include "vec/core/types.h"
 #include "vec/data_types/data_type_decimal.h"
 #include "vec/data_types/data_type_factory.hpp"
-#include "vec/functions/simple_function_factory.h"
 #include "vec/runtime/vdatetime_value.h"
 
 namespace doris::vectorized {

--- a/be/test/vec/utils/histogram_helpers_test.cpp
+++ b/be/test/vec/utils/histogram_helpers_test.cpp
@@ -17,11 +17,15 @@
 
 #include "vec/utils/histogram_helpers.hpp"
 
-#include <gtest/gtest.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
 
+#include <algorithm>
 #include <map>
-#include <numeric>
 #include <vector>
+
+#include "gtest/gtest_pred_impl.h"
+#include "vec/data_types/data_type_number.h"
 
 namespace doris::vectorized {
 


### PR DESCRIPTION
# Proposed changes

~~Issue Number: close #xxx~~

## Problem summary

Currently, there are some useless includes in the codebase. We can use a tool named [include-what-you-use](https://github.com/include-what-you-use/include-what-you-use) to optimize these includes. By using a [strict include-what-you-use policy](https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/WhyIWYU.md), we can get lots of benefits from it.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

