### PR TITLE
[fix](heartbeat) fix update BE last start time

### DIFF
--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -61,7 +61,7 @@ void HeartbeatServer::heartbeat(THeartbeatResult& heartbeat_result,
                           << "host:" << master_info.network_address.hostname
                           << ", port:" << master_info.network_address.port
                           << ", cluster id:" << master_info.cluster_id
-                          << ", counter:" << google::COUNTER;
+                          << ", counter:" << google::COUNTER << ", BE start time: " << _be_epoch;
 
     // do heartbeat
     Status st = _heartbeat(master_info);

--- a/fe/fe-core/src/main/java/org/apache/doris/system/BackendHbResponse.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/BackendHbResponse.java
@@ -42,19 +42,6 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
     }
 
     public BackendHbResponse(long beId, int bePort, int httpPort, int brpcPort,
-            long hbTime, long beStartTime, String version) {
-        super(HeartbeatResponse.Type.BACKEND);
-        this.beId = beId;
-        this.status = HbStatus.OK;
-        this.bePort = bePort;
-        this.httpPort = httpPort;
-        this.brpcPort = brpcPort;
-        this.hbTime = hbTime;
-        this.beStartTime = beStartTime;
-        this.version = version;
-    }
-
-    public BackendHbResponse(long beId, int bePort, int httpPort, int brpcPort,
             long hbTime, long beStartTime, String version, String nodeRole) {
         super(HeartbeatResponse.Type.BACKEND);
         this.beId = beId;

--- a/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
@@ -250,9 +250,7 @@ public class HeartbeatMgr extends MasterDaemon {
                     if (tBackendInfo.isSetVersion()) {
                         version = tBackendInfo.getVersion();
                     }
-                    long beStartTime = tBackendInfo.isSetBeStartTime()
-                            ? tBackendInfo.getBeStartTime() : System.currentTimeMillis();
-                    // backend.updateOnce(bePort, httpPort, beRpcPort, brpcPort);
+                    long beStartTime = tBackendInfo.getBeStartTime();
                     String nodeRole = Tag.VALUE_MIX;
                     if (tBackendInfo.isSetBeNodeRole()) {
                         nodeRole = tBackendInfo.getBeNodeRole();

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/BackendTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/BackendTest.java
@@ -39,6 +39,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public class BackendTest {
     private Backend backend;
@@ -116,7 +117,7 @@ public class BackendTest {
     @Test
     public void testSerialization() throws Exception {
         // Write 100 objects to file
-        Path path = Paths.get("./backendTest");
+        Path path = Paths.get("./backendTest" + UUID.randomUUID());
         Files.createFile(path);
         DataOutputStream dos = new DataOutputStream(Files.newOutputStream(path));
 
@@ -200,8 +201,7 @@ public class BackendTest {
         back2.setTagMap(tagMap);
         Assert.assertNotEquals(back1, back2);
 
-        Assert.assertEquals("Backend [id=1, host=a, heartbeatPort=1, alive=true, tags: {location=default}]",
-                back1.toString());
+        Assert.assertTrue(back1.toString().contains("tags: {location=default}"));
         Assert.assertEquals("{\"compute\" : \"c1\", \"location\" : \"l1\"}", back2.getTagMapString());
 
         // 3. delete files


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Sometimes the LastStartTime info in `show backends` result is unchanged even if BE restart.
This PR fix it

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

