### PR TITLE
[bugfix](topn opt) fix pick conflict for last commit 3f0b9c069a7ab7753a24ff533afa99d3d77c6f7e

### DIFF
--- a/be/src/vec/exec/vsort_node.cpp
+++ b/be/src/vec/exec/vsort_node.cpp
@@ -58,6 +58,7 @@ Status VSortNode::init(const TPlanNode& tnode, RuntimeState* state) {
         _sorter.reset(new FullSorter(_vsort_exec_exprs, _limit, _offset, _pool, _is_asc_order,
                                      _nulls_first, row_desc, state, _runtime_profile.get()));
     }
+
     // init runtime predicate
     _use_topn_opt = tnode.sort_node.use_topn_opt;
     if (_use_topn_opt) {
@@ -71,8 +72,8 @@ Status VSortNode::init(const TPlanNode& tnode, RuntimeState* state) {
                 }
                 for (auto slot : tuple_desc->slots()) {
                     if (slot->id() == first_sort_slot.slot_id) {
-                        RETURN_IF_ERROR(query_ctx->get_runtime_predicate().init(slot->type().type,
-                                                                                _nulls_first[0]));
+                        RETURN_IF_ERROR(
+                                query_ctx->get_runtime_predicate().init(slot->type().type));
                         break;
                     }
                 }


### PR DESCRIPTION
[Bug](topn opt) Fix be crash when enable topn opt with larger threshold (#18858)

    topn opt should be inited when update it

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

