### PR TITLE
[Fix] Fix the extension mysql_to_doris bug #18985

### DIFF
--- a/extension/mysql_to_doris/bin/e_mysql_to_doris.sh
+++ b/extension/mysql_to_doris/bin/e_mysql_to_doris.sh
@@ -33,7 +33,7 @@ for table in $(cat ../conf/mysql_tables |grep -v '#' | awk -F '\n' '{print $1}')
         do
         d_d=$(echo $table |awk -F '.' '{print $1}')
         d_t=$(echo $table |awk -F '.' '{print $2}')
-        echo "show create table \`$d_d\`.\`$d_t\`;" |mysql -h$mysql_host -uroot -p$mysql_password  >> $path
+        echo "show create table \`$d_d\`.\`$d_t\`;" |mysql -h$mysql_host -u$mysql_user -p$mysql_password -P$mysql_port  >> $path
 done
 
 #adjust sql
@@ -51,7 +51,7 @@ rm -rf ../result/tmp111.sql
 mv ../result/tmp222.sql $path
 
 #start transform tables struct
-sed -i '/ENGINE=/a) ENGINE=ODBC\n COMMENT "ODBC"\nPROPERTIES (\n"host" = "ApacheDorisHostIp",\n"port" = "3306",\n"user" = "root",\n"password" = "ApacheDorisHostPassword",\n"database" = "ApacheDorisDataBases",\n"table" = "ApacheDorisTables",\n"driver" = "MySQL",\n"odbc_type" = "mysql");' $path
+sed -i '/ENGINE=/a) ENGINE=ODBC\n COMMENT "ODBC"\nPROPERTIES (\n"host" = "ApacheDorisHostIp",\n"port" = "'"$mysql_port"'",\n"user" = "'"$mysql_user"'",\n"password" = "'"$mysql_password"'",\n"database" = "ApacheDorisDataBases",\n"table" = "ApacheDorisTables",\n"driver" = "MySQL",\n"odbc_type" = "mysql");' $path
 sed -i "s/\"driver\" = \"MySQL\"/\"driver\" = \"$doris_odbc_name\"/g" $path
 
 
@@ -73,7 +73,6 @@ for t_name in $(cat ../conf/mysql_tables |grep -v '#' | awk -F '\n' '{print $1}'
         d=`echo $t_name | awk -F '.' '{print $1}'`
         t=`echo $t_name | awk -F '.' '{print $2}'`
         sed -i "0,/ApacheDorisHostIp/s/ApacheDorisHostIp/${mysql_host}/" $path
-        sed -i "0,/ApacheDorisHostPassword/s/ApacheDorisHostPassword/${mysql_password}/" $path
         sed -i "0,/ApacheDorisDataBases/s/ApacheDorisDataBases/$d/" $path
         sed -i "0,/ApacheDorisTables/s/ApacheDorisTables/$t/" $path
 done

--- a/extension/mysql_to_doris/conf/mysql.conf
+++ b/extension/mysql_to_doris/conf/mysql.conf
@@ -17,4 +17,6 @@
 
 
 mysql_host=192.168.0.171
+mysql_user=root
 mysql_password=123456
+mysql_port=3306


### PR DESCRIPTION
e_mysql_to_doris.sh: command error,This error causes script execution errors. sed: -e expression #x, char 63: unknown option to `s'

# Proposed changes

Issue Number: close #18985

## Problem summary

Describe your changes.

## Checklist(Required)

* [x] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

