### PR TITLE
[improvement](regression-test) add max_failure_num to skip tests when too much failure

### DIFF
--- a/regression-test/conf/regression-conf.groovy
+++ b/regression-test/conf/regression-conf.groovy
@@ -126,3 +126,8 @@ extEsPassword = "***********"
 s3Endpoint = "cos.ap-hongkong.myqcloud.com"
 s3BucketName = "doris-build-hk-1308700295"
 s3Region = "ap-hongkong"
+
+// If the failure suite num exceeds this config
+// all following suite will be skipped to fast quit the run.
+// <=0 means no limit.
+max_failure_num=0

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/util/Recorder.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/util/Recorder.groovy
@@ -18,14 +18,32 @@
 package org.apache.doris.regression.util
 
 import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
 import org.apache.doris.regression.suite.ScriptInfo
 import org.apache.doris.regression.suite.SuiteInfo
 
+import java.util.concurrent.atomic.AtomicLong;
+
+@Slf4j
 @CompileStatic
 class Recorder {
     public final List<SuiteInfo> successList = new Vector<>()
     public final List<SuiteInfo> failureList = new Vector<>()
+    public final List<String> skippedList = new Vector<>()
     public final List<ScriptInfo> fatalScriptList = new Vector<>()
+
+    public static AtomicLong failureCounter = new AtomicLong(0);
+
+    public static boolean isFailureExceedLimit(int limit) {
+        if (limit <=0) {
+            return false;
+        }
+        return failureCounter.get() > limit;
+    }
+
+    public static int getFailureOrFatalNum() {
+        return failureCounter.get()
+    }
 
     void onSuccess(SuiteInfo suiteInfo) {
         successList.add(suiteInfo)
@@ -33,9 +51,15 @@ class Recorder {
 
     void onFailure(SuiteInfo suiteInfo) {
         failureList.add(suiteInfo)
+        failureCounter.incrementAndGet();
+    }
+
+    void onSkip(String skippedFile) {
+        skippedList.add(skippedFile)
     }
 
     void onFatal(ScriptInfo scriptInfo) {
         fatalScriptList.add(scriptInfo)
+        failureCounter.incrementAndGet();
     }
 }

--- a/regression-test/pipeline/p0/conf/regression-conf.groovy
+++ b/regression-test/pipeline/p0/conf/regression-conf.groovy
@@ -82,3 +82,5 @@ cacheDataPath = "/data/regression/"
 s3Endpoint = "cos.ap-hongkong.myqcloud.com"
 s3BucketName = "doris-build-hk-1308700295"
 s3Region = "ap-hongkong"
+
+max_failure_num=50

--- a/regression-test/pipeline/p1/conf/regression-conf.groovy
+++ b/regression-test/pipeline/p1/conf/regression-conf.groovy
@@ -46,3 +46,5 @@ cacheDataPath="/data/regression/"
 s3Endpoint = "cos.ap-hongkong.myqcloud.com"
 s3BucketName = "doris-build-hk-1308700295"
 s3Region = "ap-hongkong"
+
+max_failure_num=0


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Add a new config `max_failure_num` for regression test.
If the failure tests num exceeds this config, all following test cases will be skipped.
This is to save the test env resource and do fast quit when encountering error.

And for p0/p1, the `max_failure_num` is set to 50.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

