### PR TITLE
[Enhancement](storage engine) avoid deleting tablets on unused disk

### DIFF
--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -372,12 +372,8 @@ void StorageEngine::_start_disk_stat_monitor() {
     }
 
     _update_storage_medium_type_count();
-    bool some_tablets_were_dropped = _delete_tablets_on_unused_root_path();
-    // If some tablets were dropped, we should notify disk_state_worker_thread and
-    // tablet_worker_thread (see TaskWorkerPool) to make them report to FE ASAP.
-    if (some_tablets_were_dropped) {
-        notify_listeners();
-    }
+
+    _exit_if_too_many_disks_are_failed();
 }
 
 // TODO(lingbin): Should be in EnvPosix?
@@ -483,8 +479,7 @@ static bool too_many_disks_are_failed(uint32_t unused_num, uint32_t total_num) {
             (unused_num * 100 / total_num > config::max_percentage_of_error_disk));
 }
 
-bool StorageEngine::_delete_tablets_on_unused_root_path() {
-    std::vector<TabletInfo> tablet_info_vec;
+void StorageEngine::_exit_if_too_many_disks_are_failed() {
     uint32_t unused_root_path_num = 0;
     uint32_t total_root_path_num = 0;
 
@@ -492,7 +487,7 @@ bool StorageEngine::_delete_tablets_on_unused_root_path() {
         // TODO(yingchun): _store_map is only updated in main and ~StorageEngine, maybe we can remove it?
         std::lock_guard<std::mutex> l(_store_lock);
         if (_store_map.empty()) {
-            return false;
+            return;
         }
 
         for (auto& it : _store_map) {
@@ -500,7 +495,6 @@ bool StorageEngine::_delete_tablets_on_unused_root_path() {
             if (it.second->is_used()) {
                 continue;
             }
-            it.second->clear_tablets(&tablet_info_vec);
             ++unused_root_path_num;
         }
     }
@@ -512,10 +506,6 @@ bool StorageEngine::_delete_tablets_on_unused_root_path() {
                    << ", total_disk_count=" << total_root_path_num;
         exit(0);
     }
-
-    _tablet_manager->drop_tablets_on_error_root_path(tablet_info_vec);
-    // If tablet_info_vec is not empty, means we have dropped some tablets.
-    return !tablet_info_vec.empty();
 }
 
 void StorageEngine::stop() {

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -209,7 +209,7 @@ private:
     Status _check_all_root_path_cluster_id();
     Status _judge_and_update_effective_cluster_id(int32_t cluster_id);
 
-    bool _delete_tablets_on_unused_root_path();
+    void _exit_if_too_many_disks_are_failed();
 
     void _clean_unused_txns();
 


### PR DESCRIPTION
# Proposed changes

Issue Number: #18982

I’ll handle this issue with 3 PRs, and this is PR1.

## Problem summary

Deleting data on a disk by be itself can be risky, especially if it is the only replica, as data loss may occur. Now, tablets on unused disks are not deleted when `StorageEngine::_start_disk_stat_monitor` is executed.

## Checklist(Required)

* [x] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

