### PR TITLE
[Fix] Fix the extension mysql_to_doris bug #18993

### DIFF
--- a/extension/mysql_to_doris/bin/e_mysql_to_doris.sh
+++ b/extension/mysql_to_doris/bin/e_mysql_to_doris.sh
@@ -89,7 +89,8 @@ for table in $(cat ../conf/doris_tables |grep -v '#' | awk -F '\n' '{print $1}')
         do
         let x++
         d_t=`cat ../conf/mysql_tables |grep -v '#' | awk "NR==$x{print}" |awk -F '.' '{print $2}'`
-        sed -i "s/TABLE \`$d_t\`/TABLE if not exists $table/g" $path
+        new_table_name=$(echo $table | awk -F. '{OFS="."; $2="`"$2"`"; print}')
+        sed -i "s/TABLE \`$d_t\`/TABLE if not exists $new_table_name/g" $path
 done
 
 #create database


### PR DESCRIPTION
extension mysql_to_doris: Expected: ADMIN is keyword, maybe ADMIN

# Proposed changes

Issue Number: close #18993

## Problem summary

1. The table names generated by the original code are as follows. If there is a keyword table like admin above, an error will be reported.
    ![image](https://user-images.githubusercontent.com/63942121/234000467-01e9c4a0-547a-410b-b6c4-e3bc20bc8e8f.png)
2.  The modified effect is as follows.
    ![image](https://user-images.githubusercontent.com/63942121/234001422-c4b9b599-14da-4165-a03c-2c3e3a8e500b.png)

## Checklist(Required)

* [x] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...


