### PR TITLE
[Fix] Fix the extension mysql_to_doris bug #18993

### DIFF
--- a/extension/mysql_to_doris/bin/e_mysql_to_doris.sh
+++ b/extension/mysql_to_doris/bin/e_mysql_to_doris.sh
@@ -89,7 +89,8 @@ for table in $(cat ../conf/doris_tables |grep -v '#' | awk -F '\n' '{print $1}')
         do
         let x++
         d_t=`cat ../conf/mysql_tables |grep -v '#' | awk "NR==$x{print}" |awk -F '.' '{print $2}'`
-        sed -i "s/TABLE \`$d_t\`/TABLE if not exists $table/g" $path
+        new_table_name=$(echo $table | awk -F. '{OFS="."; $2="`"$2"`"; print}')
+        sed -i "s/TABLE \`$d_t\`/TABLE if not exists $new_table_name/g" $path
 done
 
 #create database


### PR DESCRIPTION
extension mysql_to_doris: Expected: ADMIN is keyword, maybe ADMIN
# Proposed changes

Issue Number: close #18993

## Problem summary

1. The table names generated by the original code are as follows. If there is a keyword table like admin above, an error will be reported.
    ![0c7cfa6d7e80fda2cb5f8c063e379fd](https://user-images.githubusercontent.com/63942121/234005129-c0f99726-66d8-4ca4-9c14-224b6e3eb26f.png)
2. The modified effect is as follows.
    ![6b69622e269cd31e1c9284f057b441c](https://user-images.githubusercontent.com/63942121/234005260-cd943af9-ac0b-4492-bb85-f51917b14fa0.png)


## Checklist(Required)

* [x] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

