### PR TITLE
[typo](docs) format function Syntax desc

### DIFF
--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array.md
@@ -34,9 +34,8 @@ array()
 
 #### Syntax
 
-```
-ARRAY<T> array(T, ...)
-```
+`ARRAY<T> array(T, ...)`
+
 construct an array with variadic elements and return it, T could be column or literal
 
 ### notice

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_avg.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_avg.md
@@ -33,6 +33,9 @@ array_avg
 </version>
 
 ### description
+#### Syntax
+
+`Array<T> array_avg(arr)`
 
 Get the average of all elements in an array (`NULL` values are skipped).
 When the array is empty or all elements in the array are `NULL` values, the function returns `NULL`.

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_compact.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_compact.md
@@ -36,9 +36,7 @@ Removes consecutive duplicate elements from an array. The order of result values
 
 #### Syntax
 
-```sql
-array_compact(arr)
-```
+`Array<T> array_compact(arr)`
 
 #### Arguments
 

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_concat.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_concat.md
@@ -36,9 +36,7 @@ Concat all arrays passed in the arguments
 
 #### Syntax
 
-```sql
-Array<T> array_concat(Array<T>, ...)
-```
+`Array<T> array_concat(Array<T>, ...)`
 
 #### Returned value
 

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_difference.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_difference.md
@@ -36,9 +36,7 @@ array_difference
 
 #### Syntax
 
-```
-ARRAY<T> array_difference(ARRAY<T> arr)
-```
+`ARRAY<T> array_difference(ARRAY<T> arr)`
 
 Calculates the difference between adjacent array elements. 
 Returns an array where the first element will be 0, the second is the difference between a[1] - a[0].

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_distinct.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_distinct.md
@@ -36,9 +36,7 @@ array_distinct
 
 #### Syntax
 
-```
-ARRAY<T> array_distinct(ARRAY<T> arr)
-```
+`ARRAY<T> array_distinct(ARRAY<T> arr)`
 
 Return the array which has been removed duplicate values.
 Return NULL for NULL input.

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_enumerate.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_enumerate.md
@@ -34,6 +34,9 @@ array_enumerate
 </version>
 
 ### description
+#### Syntax
+
+`ARRAY<T> array_enumerate(ARRAY<T> arr)`
 
 Returns array sub item indexes eg. [1, 2, 3, …, length (arr) ]
 

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_enumerate_uniq.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_enumerate_uniq.md
@@ -33,6 +33,9 @@ array_enumerate_uniq
 </version>
 
 ### description
+#### Syntax
+
+`ARRAY<T> array_enumerate_uniq(ARRAY<T> arr)`
 
 Returns an array the same size as the source array, indicating for each element what its position is among elements with the same value. For example, array_enumerate_uniq([1, 2, 1, 4]) = [1, 1, 2, 1].
 The array_enumerate_uniq function can take multiple arrays of the same size as arguments. In this case, uniqueness is considered for tuples of elements in the same positions in all the arrays. For example, array_enumerate_uniq([1, 2, 1, 1, 2], [2, 1, 2, 2, 1]) = [1, 1, 2, 3, 2].

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_except.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_except.md
@@ -36,9 +36,7 @@ array_except
 
 #### Syntax
 
-```
-ARRAY<T> array_except(ARRAY<T> array1, ARRAY<T> array2)
-```
+`ARRAY<T> array_except(ARRAY<T> array1, ARRAY<T> array2)`
 
 Returns an array of the elements in array1 but not in array2, without duplicates. If the input parameter is null, null is returned.
 

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_exists.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_exists.md
@@ -35,6 +35,12 @@ array_exists(array1)
 
 ### description
 
+#### Syntax
+```sql
+BOOLEAN array_exists(lambda, ARRAY<T> arr1, ARRAY<T> arr2, ... )
+BOOLEAN array_exists(ARRAY<T> arr)
+```
+
 Use an optional lambda expression as an input parameter to perform corresponding expression calculations on the internal data of other input ARRAY parameters. Returns 1 when the calculation returns something other than 0; otherwise returns 0.
 There are one or more parameters input in the lambda expression, which must be consistent with the number of input array columns later. Legal scalar functions can be executed in lambda, aggregate functions, etc. are not supported.
 When lambda expression is not used as a parameter, array1 is used as the calculation result.

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_filter.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_filter.md
@@ -34,6 +34,12 @@ array_filter(lambda,array)
 
 ### description
 
+#### Syntax
+```sql
+ARRAY<T> array_filter(lambda, ARRAY<T> arr1, ARRAY<T> arr2, ... )
+ARRAY<T> array_filter(ARRAY<T> arr)
+```
+
 Use the lambda expression as the input parameter to calculate and filter the data of the ARRAY column of the other input parameter.
 And filter out the values of 0 and NULL in the result.
 

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_first_index.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_first_index.md
@@ -32,9 +32,9 @@ array_first_index
 
 ### description
 
-```sql
-array_first_index(lambda, array1, ...)
-```
+#### Syntax
+
+`ARRAY<T> array_first_index(lambda, ARRAY<T> array1, ...)`
 
 Use an lambda expression as an input parameter to perform corresponding expression calculations on the internal data of other input ARRAY parameters. Returns the first index such that the return value of `lambda(array1[i], ...)` is not 0. Return 0 if such index is not found.
 

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_intersect.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_intersect.md
@@ -37,9 +37,7 @@ array_intersect
 
 #### Syntax
 
-```
-ARRAY<T> array_intersect(ARRAY<T> array1, ARRAY<T> array2)
-```
+`ARRAY<T> array_intersect(ARRAY<T> array1, ARRAY<T> array2)`
 
 Returns an array of the elements in the intersection of array1 and array2, without duplicates. If the input parameter is null, null is returned.
 

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_join.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_join.md
@@ -37,9 +37,7 @@ array_join
 
 #### Syntax
 
-```
-VARCHAR array_join(ARRAY<T> arr, VARCHAR sep[, VARCHAR null_replace])
-```
+`VARCHAR array_join(ARRAY<T> arr, VARCHAR sep[, VARCHAR null_replace])`
 
 Combines all elements in the array to generate a new string according to the separator (sep) 
 and the string to replace NULL (null_replace).

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_map.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_map.md
@@ -34,6 +34,9 @@ array_map(lambda,array,....)
 
 ### description
 
+#### Syntax
+`ARRAY<T> array_map(lambda, ARRAY<T> array1, ARRAY<T> array2)`
+
 Use a lambda expression as the input parameter to calculate the corresponding expression for the internal data of other input ARRAY parameters.
 The number of parameters entered in the lambda expression is 1 or more, which must be consistent with the number of input array columns.
 The scalar functions can be executed in lambda, and aggregate functions are not supported.

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_max.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_max.md
@@ -33,6 +33,9 @@ array_max
 
 ### description
 
+#### Syntax
+`T array_max(ARRAY<T> array1)`
+
 Get the maximum element in an array (`NULL` values are skipped).
 When the array is empty or all elements in the array are `NULL` values, the function returns `NULL`.
 

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_min.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_min.md
@@ -34,6 +34,9 @@ array_min
 
 ### description
 
+#### Syntax
+`T array_min(ARRAY<T> array1)`
+
 Get the minimum element in an array (`NULL` values are skipped).
 When the array is empty or all elements in the array are `NULL` values, the function returns `NULL`.
 

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_popback.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_popback.md
@@ -34,9 +34,7 @@ array_popback
 
 #### Syntax
 
-```
-ARRAY<T> array_popback(ARRAY<T> arr)
-```
+`ARRAY<T> array_popback(ARRAY<T> arr)`
 
 Remove the last element from array.
 

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_popfront.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_popfront.md
@@ -34,9 +34,7 @@ array_popfront
 
 #### Syntax
 
-```
-ARRAY<T> array_popfront(ARRAY<T> arr)
-```
+`ARRAY<T> array_popfront(ARRAY<T> arr)`
 
 Remove the first element from array.
 

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_product.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_product.md
@@ -33,6 +33,10 @@ array_product
 
 ### description
 
+#### Syntax
+
+`T array_product(ARRAY<T> arr)`
+
 Get the product of all elements in an array (`NULL` values are skipped).
 When the array is empty or all elements in the array are `NULL` values, the function returns `NULL`.
 

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_pushfront.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_pushfront.md
@@ -34,9 +34,8 @@ array_pushfront
 
 #### Syntax
 
-```sql
-Array<T> array_pushfront(Array<T> arr, T value)
-```
+`Array<T> array_pushfront(Array<T> arr, T value)`
+
 Add the value to the beginning of the array.
 
 #### Returned value

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_range.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_range.md
@@ -36,7 +36,7 @@ array_range
 
 #### Syntax
 
-```
+```sql
 ARRAY<Int> array_range(Int end)
 ARRAY<Int> array_range(Int start, Int end)
 ARRAY<Int> array_range(Int start, Int end, Int step)

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_remove.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_remove.md
@@ -34,9 +34,7 @@ array_remove
 
 #### Syntax
 
-```
-ARRAY<T> array_remove(ARRAY<T> arr, T val)
-```
+`ARRAY<T> array_remove(ARRAY<T> arr, T val)`
 
 Remove all elements that equal to element from array.
 

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_reverse_sort.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_reverse_sort.md
@@ -34,9 +34,7 @@ array_reverse_sort
 
 #### Syntax
 
-```
-ARRAY<T> array_reverse_sort(ARRAY<T> arr)
-```
+`ARRAY<T> array_reverse_sort(ARRAY<T> arr)`
 
 Return the array which has been sorted in descending order. Return NULL for NULL input.
 If the element of array is NULL, it will be placed in the last of the sorted array.

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_shuffle.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_shuffle.md
@@ -28,12 +28,19 @@ under the License.
 
 <version since="2.0">
 
-array_shuffle(array1, [seed])
-shuffle(array1, [seed])
+array_shuffle
+shuffle
 
 </version>
 
 ### description
+
+#### Syntax
+
+```sql
+ARRAY<T> array_shuffle(ARRAY<T> array1, [INT seed])
+ARRAY<T> shuffle(ARRAY<T> array1, [INT seed])
+```
 
 Randomly arrange the elements in the array. Among them, the parameter array1 is the array to be randomly arranged, and the optional parameter seed is to set the initial value used by the pseudo-random number generator to generate pseudo-random numbers.
 Shuffle has the same function as array_shuffle.

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_size.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_size.md
@@ -36,7 +36,7 @@ array_size (size, cardinality)
 
 #### Syntax
 
-```
+```sql
 BIGINT size(ARRAY<T> arr) 
 BIGINT array_size(ARRAY<T> arr) 
 BIGINT cardinality(ARRAY<T> arr)

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_slice.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_slice.md
@@ -34,9 +34,7 @@ array_slice
 
 #### Syntax
 
-```
-ARRAY<T> array_slice(ARRAY<T> arr, BIGINT off, BIGINT len)
-```
+`ARRAY<T> array_slice(ARRAY<T> arr, BIGINT off, BIGINT len)`
 
 Returns a slice of the array.
 

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_sort.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_sort.md
@@ -34,9 +34,7 @@ array_sort
 
 #### Syntax
 
-```
-ARRAY<T> array_sort(ARRAY<T> arr)
-```
+`ARRAY<T> array_sort(ARRAY<T> arr)`
 
 Return the array which has been sorted in ascending order. Return NULL for NULL input.
 If the element of array is NULL, it will be placed in the front of the sorted array.

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_sortby.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_sortby.md
@@ -34,7 +34,7 @@ array_sortby
 
 #### Syntax
 
-```
+```sql
 ARRAY<T> array_sortby(ARRAY<T> src,Array<T> key)
 ARRAY<T> array_sortby(lambda,array....)
 ```

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_sum.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_sum.md
@@ -33,6 +33,13 @@ array_sum
 
 ### description
 
+#### Syntax
+
+```sql
+T array_sum(ARRAY<T> src, Array<T> key)
+T array_sum(lambda, Array<T> arr1, Array<T> arr2 ....)
+```
+
 Get the sum of all elements in an array (`NULL` values are skipped).
 When the array is empty or all elements in the array are `NULL` values, the function returns `NULL`.
 

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_union.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_union.md
@@ -36,9 +36,7 @@ array_union
 
 #### Syntax
 
-```
-ARRAY<T> array_union(ARRAY<T> array1, ARRAY<T> array2)
-```
+`ARRAY<T> array_union(ARRAY<T> array1, ARRAY<T> array2)`
 
 Returns an array of the elements in the union of array1 and array2, without duplicates. If the input parameter is null, null is returned.
 

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_with_constant.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_with_constant.md
@@ -34,7 +34,7 @@ array_with_constant
 
 #### Syntax
 
-```
+```sql
 ARRAY<T> array_with_constant(n, T)
 ARRAY<T> array_repeat(T, n)
 ```

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_zip.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_zip.md
@@ -36,9 +36,7 @@ Combines all all arrays into a single array. The resulting array contains the co
 
 #### Syntax
 
-```sql
-Array<Struct<T1, T2,...>> array_zip(Array<T1>, Array<T2>, ...)
-```
+`Array<Struct<T1, T2,...>> array_zip(Array<T1>, Array<T2>, ...)`
 
 #### Returned value
 

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/element_at.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/element_at.md
@@ -35,9 +35,10 @@ element_at
 
 #### Syntax
 
-`T element_at(ARRAY<T> arr, BIGINT position)`
-
-`T arr[position]`
+```sql
+T element_at(ARRAY<T> arr, BIGINT position)
+T arr[position]
+```
 
 Returns an element of an array located at the input position. If there is no element at the position, return NULL.
 

--- a/docs/en/docs/sql-manual/sql-functions/bitmap-functions/bitmap_hash.md
+++ b/docs/en/docs/sql-manual/sql-functions/bitmap-functions/bitmap_hash.md
@@ -36,9 +36,7 @@ Calculating hash value for what your input and return a BITMAP which contain the
 
 #### Syntax
 
-```
-BITMAP BITMAP_HASH(<any_value>)
-```
+`BITMAP BITMAP_HASH(<any_value>)`
 
 #### Arguments
 

--- a/docs/en/docs/sql-manual/sql-functions/cast.md
+++ b/docs/en/docs/sql-manual/sql-functions/cast.md
@@ -27,22 +27,11 @@ under the License.
 ## CAST
 ### Description
 
+#### Syntax
 
-```
-cast (input as type)
-```
-
-#### BIGINT type
-
-#### Syntax (BIGINT)
-
-``` cast (input as BIGINT) ```
-
+`T cast (input as Type)`
 
 Converts input to the specified type
-
-
-Converting the current column input to BIGINT type
 
 ### example
 

--- a/docs/en/docs/sql-manual/sql-functions/date-time-functions/date_add.md
+++ b/docs/en/docs/sql-manual/sql-functions/date-time-functions/date_add.md
@@ -28,7 +28,7 @@ under the License.
 ### Description
 #### Syntax
 
-`INT DATE_ADD(DATETIME date,INTERVAL expr type)`
+`INT DATE_ADD(DATETIME date, INTERVAL expr type)`
 
 
 Adds a specified time interval to the date.

--- a/docs/en/docs/sql-manual/sql-functions/date-time-functions/date_sub.md
+++ b/docs/en/docs/sql-manual/sql-functions/date-time-functions/date_sub.md
@@ -28,7 +28,7 @@ under the License.
 ### Description
 #### Syntax
 
-`DATETIME DATE_SUB(DATETIME date,INTERVAL expr type)`
+`DATETIME DATE_SUB(DATETIME date, INTERVAL expr type)`
 
 
 Subtract the specified time interval from the date

--- a/docs/en/docs/sql-manual/sql-functions/date-time-functions/date_trunc.md
+++ b/docs/en/docs/sql-manual/sql-functions/date-time-functions/date_trunc.md
@@ -35,7 +35,7 @@ date_trunc
 ### Description
 #### Syntax
 
-`DATETIME DATE_TRUNC(DATETIME datetime,VARCHAR unit)`
+`DATETIME DATE_TRUNC(DATETIME datetime, VARCHAR unit)`
 
 
 Truncates datetime in the specified time unit.

--- a/docs/en/docs/sql-manual/sql-functions/date-time-functions/datediff.md
+++ b/docs/en/docs/sql-manual/sql-functions/date-time-functions/datediff.md
@@ -29,7 +29,7 @@ under the License.
 ### Description
 #### Syntax
 
-`DATETIME DATEDIFF (DATETIME expr1,DATETIME expr2)`
+`DATETIME DATEDIFF (DATETIME expr1, DATETIME expr2)`
 
 
 Expr1 - expr2 is calculated and the result is accurate to the sky.

--- a/docs/en/docs/sql-manual/sql-functions/date-time-functions/time_round.md
+++ b/docs/en/docs/sql-manual/sql-functions/date-time-functions/time_round.md
@@ -28,13 +28,12 @@ under the License.
 ### description
 #### Syntax
 
-`DATETIME TIME_ROUND(DATETIME expr)`
-
-`DATETIME TIME_ROUND(DATETIME expr, INT period)`
-
-`DATETIME TIME_ROUND(DATETIME expr, DATETIME origin)`
-
-`DATETIME TIME_ROUND(DATETIME expr, INT period, DATETIME origin)`
+```sql
+DATETIME TIME_ROUND(DATETIME expr)
+DATETIME TIME_ROUND(DATETIME expr, INT period)
+DATETIME TIME_ROUND(DATETIME expr, DATETIME origin)
+DATETIME TIME_ROUND(DATETIME expr, INT period, DATETIME origin)
+```
 
 The function name `TIME_ROUND` consists of two parts, Each part consists of the following optional values.
 - `TIME`: `SECOND`, `MINUTE`, `HOUR`, `DAY`, `WEEK`, `MONTH`, `YEAR`

--- a/docs/en/docs/sql-manual/sql-functions/date-time-functions/timestampdiff.md
+++ b/docs/en/docs/sql-manual/sql-functions/date-time-functions/timestampdiff.md
@@ -28,7 +28,7 @@ under the License.
 ### description
 #### Syntax
 
-`INT TIMESTAMPDIFF(unit,DATETIME datetime_expr1, DATETIME datetime_expr2)`
+`INT TIMESTAMPDIFF(unit, DATETIME datetime_expr1, DATETIME datetime_expr2)`
 
 Returns datetime_expr2 − datetime_expr1, where datetime_expr1 and datetime_expr2 are date or datetime expressions. 
 

--- a/docs/en/docs/sql-manual/sql-functions/date-time-functions/unix_timestamp.md
+++ b/docs/en/docs/sql-manual/sql-functions/date-time-functions/unix_timestamp.md
@@ -28,7 +28,7 @@ under the License.
 ### Description
 #### Syntax
 
-`INT UNIX_TIMESTAMP(), UNIX_TIMESTAMP(DATETIME date)`
+`INT UNIX_TIMESTAMP([DATETIME date[, STRING fmt]])`
 
 Converting a Date or Datetime type to a UNIX timestamp.
 

--- a/docs/en/docs/sql-manual/sql-functions/date-time-functions/week.md
+++ b/docs/en/docs/sql-manual/sql-functions/date-time-functions/week.md
@@ -28,8 +28,7 @@ under the License.
 ### Description
 #### Syntax
 
-`INT WEEK(DATE date)`
-`INT WEEK(DATE date, INT mode)`
+`INT WEEK(DATE date[, INT mode])`
 
 Returns the week number for date.The value of the mode argument defaults to 0.
 The following table describes how the mode argument works.

--- a/docs/en/docs/sql-manual/sql-functions/date-time-functions/yearweek.md
+++ b/docs/en/docs/sql-manual/sql-functions/date-time-functions/yearweek.md
@@ -28,8 +28,7 @@ under the License.
 ### Description
 #### Syntax
 
-`INT YEARWEEK(DATE date)`
-`INT YEARWEEK(DATE date, INT mode)`
+`INT YEARWEEK(DATE date[, INT mode])`
 
 Returns year and week for a date.The value of the mode argument defaults to 0.
 When the week of the date belongs to the previous year, the year and week of the previous year are returned; 

--- a/docs/en/docs/sql-manual/sql-functions/encrypt-digest-functions/aes.md
+++ b/docs/en/docs/sql-manual/sql-functions/encrypt-digest-functions/aes.md
@@ -40,9 +40,7 @@ Reference: https://dev.mysql.com/doc/refman/8.0/en/encryption-functions.html#fun
 
 #### Syntax
 
-```
-AES_ENCRYPT(str,key_str[,init_vector])
-```
+`AES_ENCRYPT(str, key_str[, init_vector])`
 
 #### Arguments
 

--- a/docs/en/docs/sql-manual/sql-functions/json-functions/jsonb_extract.md
+++ b/docs/en/docs/sql-manual/sql-functions/json-functions/jsonb_extract.md
@@ -34,6 +34,18 @@ jsonb_extract
 
 ### description
 
+#### Syntax
+
+```sql
+JSONB jsonb_extract(JSONB j, VARCHAR json_path)
+BOOLEAN jsonb_extract_isnull(JSONB j, VARCHAR json_path)
+BOOLEAN jsonb_extract_bool(JSONB j, VARCHAR json_path)
+INT jsonb_extract_int(JSONB j, VARCHAR json_path)
+BIGINT jsonb_extract_bigint(JSONB j, VARCHAR json_path)
+DOUBLE jsonb_extract_double(JSONB j, VARCHAR json_path)
+STRING jsonb_extract_string(JSONB j, VARCHAR json_path)
+```
+
 jsonb_extract functions extract field specified by json_path from JSONB. A series of functions are provided for different datatype.
 - jsonb_extract extract and return JSONB datatype
 - jsonb_extract_isnull check if the field is json null and return BOOLEAN datatype
@@ -47,25 +59,16 @@ Exception handling is as follows:
 - if the field specified by json_path does not exist, return NULL
 - if datatype of the field specified by json_path is not the same with type of jsonb_extract_t, return t if it can be cast to t else NULL
 
-#### Syntax
-
-`JSONB jsonb_extract(JSONB j, VARCHAR json_path)`
-
-`BOOLEAN jsonb_extract_isnull(JSONB j, VARCHAR json_path)`
-
-`BOOLEAN jsonb_extract_bool(JSONB j, VARCHAR json_path)`
-
-`INT jsonb_extract_int(JSONB j, VARCHAR json_path)`
-
-`BIGINT jsonb_extract_bigint(JSONB j, VARCHAR json_path)`
-
-`DOUBLE jsonb_extract_double(JSONB j, VARCHAR json_path)`
-
-`STRING jsonb_extract_string(JSONB j, VARCHAR json_path)`
-
 
 ## jsonb_exists_path and jsonb_type
 ### description
+
+#### Syntax
+
+```sql
+BOOLEAN jsonb_exists_path(JSONB j, VARCHAR json_path)
+STRING jsonb_type(JSONB j, VARCHAR json_path)
+```
 
 There are two extra functions to check field existence and type
 - jsonb_exists_path check the existence of the field specified by json_path, return TRUE or FALS
@@ -78,11 +81,6 @@ There are two extra functions to check field existence and type
   - bigint
   - double
   - string
-
-`BOOLEAN jsonb_exists_path(JSONB j, VARCHAR json_path)`
-
-`STRING jsonb_type(JSONB j, VARCHAR json_path)`
-
 
 ### example
 

--- a/docs/en/docs/sql-manual/sql-functions/json-functions/jsonb_parse.md
+++ b/docs/en/docs/sql-manual/sql-functions/json-functions/jsonb_parse.md
@@ -26,6 +26,13 @@ under the License.
 
 ## jsonb_parse
 ### description
+#### Syntax
+
+```sql
+JSONB jsonb_parse(VARCHAR json_str)
+JSONB jsonb_parse_error_to_null(VARCHAR json_str)
+JSONB jsonb_parse_error_to_value(VARCHAR json_str, VARCHAR default_json_str)
+```
 
 jsonb_parse functions parse JSON string to binary format. A series of functions are provided to satisfy different demand for exception handling.
 - all return NULL if json_str is NULL
@@ -33,13 +40,6 @@ jsonb_parse functions parse JSON string to binary format. A series of functions 
   - jsonb_parse will report error
   - jsonb_parse_error_to_null will return NULL
   - jsonb_parse_error_to_value will return the value specified by default_json_str
-
-#### Syntax
-
-`JSONB jsonb_parse(VARCHAR json_str)`
-`JSONB jsonb_parse_error_to_null(VARCHAR json_str)`
-`JSONB jsonb_parse_error_to_value(VARCHAR json_str, VARCHAR default_json_str)`
-
 
 ### example
 

--- a/docs/en/docs/sql-manual/sql-functions/math-functions/abs.md
+++ b/docs/en/docs/sql-manual/sql-functions/math-functions/abs.md
@@ -27,11 +27,16 @@ under the License.
 ### description
 #### Syntax
 
-`DOUBLE abs(DOUBLE x)`  `SMALLINT abs(TINYINT x)`  `INT abs(SMALLINT x)`  
-
-`BIGINT abs(INT x)`  `LARGEINT abs(BIGINT x)`  `LARGEINT abs(LARGEINT x)`  
-
-`DOUBLE abs(DOUBLE x)`  `FLOAT abs(FLOAT x)`  `DECIMAL abs(DECIMAL x)`  
+```sql
+SMALLINT abs(TINYINT x)
+INT abs(SMALLINT x)
+BIGINT abs(INT x)
+LARGEINT abs(BIGINT x)
+LARGEINT abs(LARGEINT x)
+DOUBLE abs(DOUBLE x)
+FLOAT abs(FLOAT x)
+DECIMAL abs(DECIMAL x)` 
+```
 
 Returns the absolute value of `x`.
 

--- a/docs/en/docs/sql-manual/sql-functions/math-functions/conv.md
+++ b/docs/en/docs/sql-manual/sql-functions/math-functions/conv.md
@@ -27,8 +27,10 @@ under the License.
 ### description
 #### Syntax
 
-`VARCHAR CONV(VARCHAR input, TINYINT from_base, TINYINT to_base)`
-`VARCHAR CONV(BIGINT input, TINYINT from_base, TINYINT to_base)`
+```sql
+VARCHAR CONV(VARCHAR input, TINYINT from_base, TINYINT to_base)
+VARCHAR CONV(BIGINT input, TINYINT from_base, TINYINT to_base)
+```
 Convert the input number to the target base. The input base range should be within `[2,36]`. 
 
 ### example

--- a/docs/en/docs/sql-manual/sql-functions/math-functions/negative.md
+++ b/docs/en/docs/sql-manual/sql-functions/math-functions/negative.md
@@ -27,7 +27,11 @@ under the License.
 ### description
 #### Syntax
 
-`BIGINT negative(BIGINT x)`  `DOUBLE negative(DOUBLE x)`  `DECIMAL negative(DECIMAL x)`
+```sql
+BIGINT negative(BIGINT x)
+DOUBLE negative(DOUBLE x)
+DECIMAL negative(DECIMAL x)
+```
 Return `-x`.
 
 ### example

--- a/docs/en/docs/sql-manual/sql-functions/math-functions/pmod.md
+++ b/docs/en/docs/sql-manual/sql-functions/math-functions/pmod.md
@@ -27,8 +27,10 @@ under the License.
 ### description
 #### Syntax
 
-`BIGINT PMOD(BIGINT x, BIGINT y)`
-`DOUBLE PMOD(DOUBLE x, DOUBLE y)`
+```sql
+BIGINT PMOD(BIGINT x, BIGINT y)
+DOUBLE PMOD(DOUBLE x, DOUBLE y)
+```
 Returns the positive result of x mod y in the residue systems.
 Formally, return `(x%y+y)%y`.
 

--- a/docs/en/docs/sql-manual/sql-functions/math-functions/positive.md
+++ b/docs/en/docs/sql-manual/sql-functions/math-functions/positive.md
@@ -27,7 +27,11 @@ under the License.
 ### description
 #### Syntax
 
-`BIGINT positive(BIGINT x)`  `DOUBLE positive(DOUBLE x)`  `DECIMAL positive(DECIMAL x)`
+```sql
+BIGINT positive(BIGINT x)
+DOUBLE positive(DOUBLE x)
+DECIMAL positive(DECIMAL x)
+```
 Return `x`.
 
 ### example

--- a/docs/en/docs/sql-manual/sql-functions/math-functions/round.md
+++ b/docs/en/docs/sql-manual/sql-functions/math-functions/round.md
@@ -27,7 +27,7 @@ under the License.
 ### description
 #### Syntax
 
-`round(x), round(x, d)`
+`T round(T x[, d])`
 Rounds the argument `x` to `d` decimal places. `d` defaults to 0 if not specified. If d is negative, the left d digits of the decimal point are 0. If x or d is null, null is returned.
 
 ### example

--- a/docs/en/docs/sql-manual/sql-functions/math-functions/round_bankers.md
+++ b/docs/en/docs/sql-manual/sql-functions/math-functions/round_bankers.md
@@ -27,7 +27,7 @@ under the License.
 ### description
 #### Syntax
 
-`round_bankers(x), round_bankers(x, d)`
+`T round_bankers(T x[, d])`
 Rounds the argument `x` to `d` specified decimal places. `d` defaults to 0 if not specified. If d is negative, the left d digits of the decimal point are 0. If x or d is null, null is returned.
 
 + If the rounding number is halfway between two numbers, the function uses banker’s rounding.

--- a/docs/en/docs/sql-manual/sql-functions/math-functions/running_difference.md
+++ b/docs/en/docs/sql-manual/sql-functions/math-functions/running_difference.md
@@ -27,7 +27,7 @@ under the License.
 ### description
 #### Syntax
 
-`running_difference(x);`
+`T running_difference(T x)`
 
 Calculates the difference between successive row values ​​in the data block. 
 The result of the function depends on the affected data blocks and the order of data in the block.
@@ -53,18 +53,18 @@ Returns 0 for the first row and the difference from the previous row for each su
 DROP TABLE IF EXISTS running_difference_test;
 
 CREATE TABLE running_difference_test (
-                 `id` int NOT NULL COMMENT 'id' ,
-                `day` date COMMENT 'day', 
-	`time_val` datetime COMMENT 'time_val',
- 	`doublenum` double NULL COMMENT 'doublenum'
-                )
+    `id` int NOT NULL COMMENT 'id',
+    `day` date COMMENT 'day', 
+    `time_val` datetime COMMENT 'time_val',
+    `doublenum` double NULL COMMENT 'doublenum'
+)
 DUPLICATE KEY(id) 
 DISTRIBUTED BY HASH(id) BUCKETS 3 
 PROPERTIES ( 
     "replication_num" = "1"
 ); 
                                                   
-INSERT into running_difference_test (id,day, time_val,doublenum) values ('1', '2022-10-28', '2022-03-12 10:41:00', null),
+INSERT into running_difference_test (id, day, time_val,doublenum) values ('1', '2022-10-28', '2022-03-12 10:41:00', null),
                                                    ('2','2022-10-27', '2022-03-12 10:41:02', 2.6),
                                                    ('3','2022-10-28', '2022-03-12 10:41:03', 2.5),
                                                    ('4','2022-9-29', '2022-03-12 10:41:03', null),

--- a/docs/en/docs/sql-manual/sql-functions/spatial-functions/st_area.md
+++ b/docs/en/docs/sql-manual/sql-functions/spatial-functions/st_area.md
@@ -28,9 +28,10 @@ under the License.
 
 ### Syntax
 
-`DOUBLE ST_Area_Square_Meters(GEOMETRY geo)`
-
-`DOUBLE ST_Area_Square_Km(GEOMETRY geo)`
+```sql
+DOUBLE ST_Area_Square_Meters(GEOMETRY geo)
+DOUBLE ST_Area_Square_Km(GEOMETRY geo)
+```
 
 ### description
 

--- a/docs/en/docs/sql-manual/sql-functions/string-functions/concat_ws.md
+++ b/docs/en/docs/sql-manual/sql-functions/string-functions/concat_ws.md
@@ -28,9 +28,10 @@ under the License.
 ### Description
 #### Syntax
 
-`VARCHAR concat_ws (VARCHAR sep, VARCHAR str,...)`
-`VARCHAR concat_ws(VARCHAR sep, ARRAY array)`
-
+```sql
+VARCHAR concat_ws(VARCHAR sep, VARCHAR str,...)
+VARCHAR concat_ws(VARCHAR sep, ARRAY array)
+```
 
 Using the first parameter SEP as a connector, the second parameter and all subsequent parameters(or all string in an ARRAY) are spliced into a string.
 If the separator is NULL, return NULL.

--- a/docs/en/docs/sql-manual/sql-functions/string-functions/convert_to.md
+++ b/docs/en/docs/sql-manual/sql-functions/string-functions/convert_to.md
@@ -30,7 +30,7 @@ under the License.
 ### description
 #### Syntax
 
-` convert_to(VARCHAR column, VARCHAR character)`
+`VARCHAR convert_to(VARCHAR column, VARCHAR character)`
 
 It is used in the order by clause. eg: order by convert(column using gbk), Now only support character can be converted to 'gbk'.
 Because when the order by column contains Chinese, it is not arranged in the order of Pinyin

--- a/docs/en/docs/sql-manual/sql-functions/string-functions/elt.md
+++ b/docs/en/docs/sql-manual/sql-functions/string-functions/elt.md
@@ -26,7 +26,7 @@ under the License.
 ### Description
 #### Syntax
 
-`VARCHAR elt (INT,VARCHAR,...)`
+`VARCHAR elt(INT, VARCHAR,...)`
 
 Returns the string at specified index. Returns NULL if there is no string at specified index.
 

--- a/docs/en/docs/sql-manual/sql-functions/string-functions/ends_with.md
+++ b/docs/en/docs/sql-manual/sql-functions/string-functions/ends_with.md
@@ -28,7 +28,7 @@ under the License.
 ### Description
 #### Syntax
 
-`BOOLEAN ENDS_WITH (VARCHAR str, VARCHAR suffix)`
+`BOOLEAN ENDS_WITH(VARCHAR str, VARCHAR suffix)`
 
 It returns true if the string ends with the specified suffix, otherwise it returns false. 
 If any parameter is NULL, it returns NULL.

--- a/docs/en/docs/sql-manual/sql-functions/string-functions/mask/mask.md
+++ b/docs/en/docs/sql-manual/sql-functions/string-functions/mask/mask.md
@@ -28,7 +28,7 @@ under the License.
 ### description
 #### syntax
 
-`VARCHAR mask(VARCHAR str, [, VARCHAR upper[, VARCHAR lower[, VARCHAR number]]])`
+`VARCHAR mask(VARCHAR str[, VARCHAR upper[, VARCHAR lower[, VARCHAR number]]])`
 
 Returns a masked version of str . By default, upper case letters are converted to "X", lower case letters are converted to "x" and numbers are converted to "n". For example mask("abcd-EFGH-8765-4321") results in xxxx-XXXX-nnnn-nnnn. You can override the characters used in the mask by supplying additional arguments: the second argument controls the mask character for upper case letters, the third argument for lower case letters and the fourth argument for numbers. For example, mask("abcd-EFGH-8765-4321", "U", "l", "#") results in llll-UUUU-####-####.
 

--- a/docs/en/docs/sql-manual/sql-functions/string-functions/mask/mask_first_n.md
+++ b/docs/en/docs/sql-manual/sql-functions/string-functions/mask/mask_first_n.md
@@ -28,7 +28,7 @@ under the License.
 ### description
 #### syntax
 
-`VARCHAR mask_first_n(VARCHAR str, [, INT n])`
+`VARCHAR mask_first_n(VARCHAR str[, INT n])`
 
 Returns a masked version of str with the first n values masked. Upper case letters are converted to "X", lower case letters are converted to "x" and numbers are converted to "n". For example, mask_first_n("1234-5678-8765-4321", 4) results in nnnn-5678-8765-4321.
 

--- a/docs/en/docs/sql-manual/sql-functions/string-functions/mask/mask_last_n.md
+++ b/docs/en/docs/sql-manual/sql-functions/string-functions/mask/mask_last_n.md
@@ -28,7 +28,7 @@ under the License.
 ### description
 #### syntax
 
-`VARCHAR mask_last_n(VARCHAR str, [, INT n])`
+`VARCHAR mask_last_n(VARCHAR str[, INT n])`
 
 Returns a masked version of str with the last n values masked. Upper case letters are converted to "X", lower case letters are converted to "x" and numbers are converted to "n". For example, mask_last_n("1234-5678-8765-4321", 4) results in 1234-5678-8765-nnnn.
 

--- a/docs/en/docs/sql-manual/sql-functions/string-functions/reverse.md
+++ b/docs/en/docs/sql-manual/sql-functions/string-functions/reverse.md
@@ -28,8 +28,10 @@ under the License.
 ### description
 #### Syntax
 
-`VARCHAR reverse(VARCHAR str)`
-`ARRAY<T> reverse(ARRAY<T> arr)`
+```sql
+VARCHAR reverse(VARCHAR str)
+ARRAY<T> reverse(ARRAY<T> arr)
+```
 
 The REVERSE() function reverses a string or array and returns the result.
 

--- a/docs/en/docs/sql-manual/sql-functions/string-functions/sleep.md
+++ b/docs/en/docs/sql-manual/sql-functions/string-functions/sleep.md
@@ -28,7 +28,7 @@ under the License.
 ### Description
 #### Syntax
 
-`boolean sleep (int num)`
+`BOOLEAN sleep(INT num)`
 
 Make the thread sleep for num seconds.
 

--- a/docs/en/docs/sql-manual/sql-functions/string-functions/split_by_string.md
+++ b/docs/en/docs/sql-manual/sql-functions/string-functions/split_by_string.md
@@ -31,9 +31,8 @@ under the License.
 
 #### Syntax
 
-```
-split_by_string(s, separator)
-```
+`ARRAY<STRING> split_by_string(STRING s, STRING separator)`
+
 Splits a string into substrings separated by a string. It uses a constant string separator of multiple characters as the separator. If the string separator is empty, it will split the string s into an array of single characters.
 
 #### Arguments

--- a/docs/en/docs/sql-manual/sql-functions/string-functions/starts_with.md
+++ b/docs/en/docs/sql-manual/sql-functions/string-functions/starts_with.md
@@ -28,7 +28,7 @@ under the License.
 ### Description
 #### Syntax
 
-`BOOLEAN STARTS_WITH (VARCHAR str, VARCHAR prefix)`
+`BOOLEAN STARTS_WITH(VARCHAR str, VARCHAR prefix)`
 
 It returns true if the string starts with the specified prefix, otherwise it returns false.
 If any parameter is NULL, it returns NULL.

--- a/docs/en/docs/sql-manual/sql-functions/string-functions/sub_replace.md
+++ b/docs/en/docs/sql-manual/sql-functions/string-functions/sub_replace.md
@@ -26,7 +26,7 @@ under the License.
 ### Description
 #### Syntax
 
-`VARCHAR sub_replace(VARCHAR str, VARCHAR new_str, INT start [, INT len])`
+`VARCHAR sub_replace(VARCHAR str, VARCHAR new_str, INT start[, INT len])`
 
 Return with new_str replaces the str with length and starting position from start.
 When start and len are negative integers, return NULL.

--- a/docs/en/docs/sql-manual/sql-functions/table-functions/backends.md
+++ b/docs/en/docs/sql-manual/sql-functions/table-functions/backends.md
@@ -40,11 +40,9 @@ Table-Value-Function, generate a temporary table named `backends`. This tvf is u
 
 This function is used in `FROM` clauses.
 
-grammar:
+#### syntax
 
-```
-backends();
-```
+`backends()`
 
 The table schema of `backends()` tvf：
 ```

--- a/docs/en/docs/sql-manual/sql-functions/table-functions/explode-bitmap.md
+++ b/docs/en/docs/sql-manual/sql-functions/table-functions/explode-bitmap.md
@@ -32,11 +32,9 @@ Table functions must be used in conjunction with Lateral View.
 
 Expand a bitmap type.
 
-grammar:
+#### syntax
 
-```
-explode_bitmap(bitmap)
-```
+`explode_bitmap(bitmap)`
 
 ### example
 

--- a/docs/en/docs/sql-manual/sql-functions/table-functions/explode-json-array.md
+++ b/docs/en/docs/sql-manual/sql-functions/table-functions/explode-json-array.md
@@ -32,9 +32,9 @@ Table functions must be used in conjunction with Lateral View.
 
 Expand a json array. According to the array element type, there are three function names. Corresponding to integer, floating point and string arrays respectively.
 
-grammar:
+#### syntax
 
-```
+```sql
 explode_json_array_int(json_str)
 explode_json_array_double(json_str)
 explode_json_array_string(json_str)

--- a/docs/en/docs/sql-manual/sql-functions/table-functions/explode-numbers.md
+++ b/docs/en/docs/sql-manual/sql-functions/table-functions/explode-numbers.md
@@ -32,11 +32,9 @@ Table functions must be used in conjunction with Lateral View.
 
 Get a number sequence [0,n).
 
-grammar:
+#### syntax
 
-```
-explode_numbers(n)
-```
+`explode_numbers(n)`
 
 ### example
 ```

--- a/docs/en/docs/sql-manual/sql-functions/table-functions/explode-split.md
+++ b/docs/en/docs/sql-manual/sql-functions/table-functions/explode-split.md
@@ -27,6 +27,9 @@ under the License.
 ## explode_split
 
 ### description
+#### syntax
+
+`explode_split(str, delimiter)`
 
 Table functions must be used in conjunction with Lateral View.
 

--- a/docs/en/docs/sql-manual/sql-functions/table-functions/explode.md
+++ b/docs/en/docs/sql-manual/sql-functions/table-functions/explode.md
@@ -33,9 +33,8 @@ Table functions must be used in conjunction with Lateral View.
 explode array column to rows. `explode_outer` will return NULL, while `array` is NULL or empty.
 `explode` and `explode_outer` both keep the nested NULL elements of array.
 
-grammar:
-
-```
+#### syntax
+```sql
 explode(expr)
 explode_outer(expr)
 ```

--- a/docs/en/docs/sql-manual/sql-functions/table-functions/hdfs.md
+++ b/docs/en/docs/sql-manual/sql-functions/table-functions/hdfs.md
@@ -34,9 +34,9 @@ hdfs
 
 HDFS table-valued-function(tvf), allows users to read and access file contents on S3-compatible object storage, just like accessing relational table. Currently supports `csv/csv_with_names/csv_with_names_and_types/json/parquet/orc` file format.
 
-**grammer**
+#### syntax
 
-```
+```sql
 hdfs(
   "uri" = "..",
   "fs.defaultFS" = "...",

--- a/docs/en/docs/sql-manual/sql-functions/table-functions/iceberg_meta.md
+++ b/docs/en/docs/sql-manual/sql-functions/table-functions/iceberg_meta.md
@@ -38,7 +38,7 @@ iceberg_meta
 
 iceberg_meta table-valued-function(tvf), Use for read iceberg metadata，operation history, snapshots of table, file metadata etc.
 
-**grammer**
+#### syntax
 
 ```sql
 iceberg_meta(

--- a/docs/en/docs/sql-manual/sql-functions/table-functions/numbers.md
+++ b/docs/en/docs/sql-manual/sql-functions/table-functions/numbers.md
@@ -32,8 +32,9 @@ Table-Value-Function, generate a temporary table with only one column named 'num
 
 This function is used in FROM clauses.
 
-grammar:
-```
+#### syntax
+
+```sql
 numbers(
   "number" = "n",
   "backend_num" = "m"

--- a/docs/en/docs/sql-manual/sql-functions/table-functions/outer-combinator.md
+++ b/docs/en/docs/sql-manual/sql-functions/table-functions/outer-combinator.md
@@ -28,6 +28,9 @@ under the License.
 
 ### description
 
+#### syntax
+`explode_numbers(INT x)`
+
 Adding the `_outer` suffix after the function name of the table function changes the function behavior from `non-outer` to `outer`, and adds a row of `Null` data when the table function generates 0 rows of data.
 
 ### example

--- a/docs/en/docs/sql-manual/sql-functions/table-functions/resource-group.md
+++ b/docs/en/docs/sql-manual/sql-functions/table-functions/resource-group.md
@@ -40,11 +40,9 @@ Table-Value-Function, generate a temporary table named `resource_groups`. This t
 
 This function is used in `FROM` clauses.
 
-grammar:
+#### syntax
 
-```
-resource_groups();
-```
+`resource_groups()`
 
 The table schema of `resource_groups()` tvf:
 ```

--- a/docs/en/docs/sql-manual/sql-functions/table-functions/s3.md
+++ b/docs/en/docs/sql-manual/sql-functions/table-functions/s3.md
@@ -33,7 +33,7 @@ S3
 
 S3 table-valued-function(tvf), allows users to read and access file contents on S3-compatible object storage, just like accessing relational table. Currently supports `csv/csv_with_names/csv_with_names_and_types/json/parquet/orc` file format.
 
-**grammer**
+#### syntax
 
 ```sql
 s3(

--- a/docs/en/docs/sql-manual/sql-functions/width-bucket.md
+++ b/docs/en/docs/sql-manual/sql-functions/width-bucket.md
@@ -32,9 +32,7 @@ Constructs equi-width histograms, in which the histogram range is divided into i
 
 #### Syntax
 
-```sql
-width_bucket(expr, min_value, max_value, num_buckets)
-```
+`INT width_bucket(Expr expr, T min_value, T max_value, INT num_buckets)`
 
 #### Arguments
 `expr` -

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array.md
@@ -34,9 +34,7 @@ array()
 
 #### Syntax
 
-```
-ARRAY<T> array(T, ...)
-```
+`ARRAY<T> array(T, ...)`
 根据参数构造并返回array, 参数可以是多列或者常量
 
 ### notice

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_avg.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_avg.md
@@ -36,6 +36,10 @@ array_avg
 
 返回数组中所有元素的平均值，数组中的`NULL`值会被跳过。空数组以及元素全为`NULL`值的数组，结果返回`NULL`值。
 
+#### Syntax
+
+`Array<T> array_avg(arr)`
+
 ### example
 
 ```shell

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_compact.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_compact.md
@@ -36,9 +36,7 @@ array_compact
 
 #### Syntax
 
-```sql
-array_compact(arr)
-```
+`Array<T> array_compact(arr)`
 
 #### Arguments
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_concat.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_concat.md
@@ -36,9 +36,7 @@ array_concat
 
 #### Syntax
 
-```sql
-Array<T> array_concat(Array<T>, ...)
-```
+`Array<T> array_concat(Array<T>, ...)`
 
 #### Returned value
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_contains.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_contains.md
@@ -33,11 +33,6 @@ array_contains
 </version>
 
 ### description
-
-#### Syntax
-
-`BOOLEAN array_contains(ARRAY<T> arr, T value)`
-
 判断数组中是否包含value。返回结果如下：
 
 ```
@@ -45,6 +40,10 @@ array_contains
 0    - value不存在数组arr中；
 NULL - arr为NULL时。
 ```
+
+#### Syntax
+
+`BOOLEAN array_contains(ARRAY<T> arr, T value)`
 
 ### notice
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_contains.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_contains.md
@@ -33,6 +33,11 @@ array_contains
 </version>
 
 ### description
+
+#### Syntax
+
+`BOOLEAN array_contains(ARRAY<T> arr, T value)`
+
 判断数组中是否包含value。返回结果如下：
 
 ```
@@ -40,10 +45,6 @@ array_contains
 0    - value不存在数组arr中；
 NULL - arr为NULL时。
 ```
-
-#### Syntax
-
-`BOOLEAN array_contains(ARRAY<T> arr, T value)`
 
 ### notice
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_difference.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_difference.md
@@ -36,9 +36,7 @@ array_difference
 
 #### Syntax
 
-```
-ARRAY<T> array_difference(ARRAY<T> arr)
-```
+`ARRAY<T> array_difference(ARRAY<T> arr)`
 
 计算相邻数组元素之间的差异。返回一个数组，其中第一个元素将为0，第二个元素是a[1]-a[0]之间的差值。
 注意若 NULL 值存在，返回结果为NULL

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_distinct.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_distinct.md
@@ -36,9 +36,7 @@ array_distinct
 
 #### Syntax
 
-```
-ARRAY<T> array_distinct(ARRAY<T> arr)
-```
+`ARRAY<T> array_distinct(ARRAY<T> arr)`
 
 返回去除了重复元素的数组，如果输入数组为NULL，则返回NULL。
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_enumerate.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_enumerate.md
@@ -33,8 +33,13 @@ array_enumerate
 </version>
 
 ### description
+#### Syntax
+
+`ARRAY<T> array_enumerate(ARRAY<T> arr)`
 
 返回数组下标, 例如  [1, 2, 3, …, length (arr) ]
+
+
 
 ### example
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_enumerate.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_enumerate.md
@@ -39,8 +39,6 @@ array_enumerate
 
 返回数组下标, 例如  [1, 2, 3, …, length (arr) ]
 
-
-
 ### example
 
 ```shell

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_enumerate_uniq.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_enumerate_uniq.md
@@ -33,9 +33,13 @@ array_enumerate_uniq
 </version>
 
 ### description
+#### Syntax
+
+`ARRAY<T> array_enumerate_uniq(ARRAY<T> arr)`
 
 返回与源数组大小相同的数组，指示每个元素在具有相同值的元素中的位置，例如 array_enumerate_uniq([1, 2, 1, 4]) = [1, 1, 2, 1]
 该函数也可接受多个大小相同的数组作为参数，这种情况下，返回的是数组中相同位置的元素组成的元组在具有相同值的元组中的位置。例如 array_enumerate_uniq([1, 2, 1, 1, 2], [2, 1, 2, 2, 1]) = [1, 1, 2, 3, 2]
+
 
 ### example
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_except.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_except.md
@@ -36,9 +36,7 @@ array_except
 
 #### Syntax
 
-```
-ARRAY<T> array_except(ARRAY<T> array1, ARRAY<T> array2)
-```
+`ARRAY<T> array_except(ARRAY<T> array1, ARRAY<T> array2)`
 
 返回一个数组，包含所有在array1内但不在array2内的元素，不包含重复项，如果输入参数为NULL，则返回NULL
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_exists.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_exists.md
@@ -35,6 +35,12 @@ array_exists(array1)
 
 ### description
 
+#### Syntax
+```sql
+BOOLEAN array_exists(lambda, ARRAY<T> arr1, ARRAY<T> arr2, ... )
+BOOLEAN array_exists(ARRAY<T> arr)
+```
+
 使用一个可选lambda表达式作为输入参数，对其他的输入ARRAY参数的内部数据做对应表达式计算。当计算返回非0时，返回1；否则返回0。
 在lambda表达式中输入的参数为1个或多个，必须和后面的输入array列数量一致。在lambda中可以执行合法的标量函数，不支持聚合函数等。
 在没有使用lambda作为参数时，array1作为计算结果。

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_filter.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_filter.md
@@ -34,6 +34,12 @@ array_filter(lambda,array)
 
 ### description
 
+#### Syntax
+```sql
+ARRAY<T> array_filter(lambda, ARRAY<T> arr1, ARRAY<T> arr2, ... )
+ARRAY<T> array_filter(ARRAY<T> arr)
+```
+
 使用lambda表达式作为输入参数，计算筛选另外的输入参数ARRAY列的数据。
 并过滤掉在结果中0和NULL的值。
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_first_index.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_first_index.md
@@ -32,9 +32,9 @@ array_first_index
 
 ### description
 
-```sql
-array_first_index(lambda, array1, ...)
-```
+#### Syntax
+
+`ARRAY<T> array_first_index(lambda, ARRAY<T> array1, ...)`
 
 使用lambda表达式作为输入参数，对其他输入ARRAY参数的内部数据进行相应的表达式计算。 返回第一个使得 `lambda(array1[i], ...)` 返回值不为 0 的索引。如果没找到满足此条件的索引，则返回 0。
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_intersect.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_intersect.md
@@ -36,9 +36,7 @@ array_intersect
 
 #### Syntax
 
-```
-ARRAY<T> array_intersect(ARRAY<T> array1, ARRAY<T> array2)
-```
+`ARRAY<T> array_intersect(ARRAY<T> array1, ARRAY<T> array2)`
 
 返回一个数组，包含array1和array2的交集中的所有元素，不包含重复项，如果输入参数为NULL，则返回NULL
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_join.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_join.md
@@ -36,9 +36,7 @@ array_join
 
 #### Syntax
 
-```
-VARCHAR array_join(ARRAY<T> arr, VARCHAR sep[, VARCHAR null_replace])
-```
+`VARCHAR array_join(ARRAY<T> arr, VARCHAR sep[, VARCHAR null_replace])`
 
 根据分隔符(sep)和替换NULL的字符串(null_replace), 将数组中的所有元素组合成一个新的字符串。
 若sep为NULL，则返回值为NULL。

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_map.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_map.md
@@ -34,6 +34,9 @@ array_map(lambda,array1,array2....)
 
 ### description
 
+#### Syntax
+`ARRAY<T> array_map(lambda, ARRAY<T> array1, ARRAY<T> array2)`
+
 使用一个lambda表达式作为输入参数，对其他的输入ARRAY参数的内部数据做对应表达式计算。
 在lambda表达式中输入的参数为1个或多个，必须和后面的输入array列数量一致。
 在lambda中可以执行合法的标量函数，不支持聚合函数等。

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_max.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_max.md
@@ -34,6 +34,9 @@ array_max
 
 ### description
 
+#### Syntax
+`T array_max(ARRAY<T> array1)`
+
 返回数组中最大的元素，数组中的`NULL`值会被跳过。空数组以及元素全为`NULL`值的数组，结果返回`NULL`值。
 
 ### example

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_min.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_min.md
@@ -34,6 +34,9 @@ array_min
 
 ### description
 
+#### Syntax
+`T array_min(ARRAY<T> array1)`
+
 返回数组中最小的元素，数组中的`NULL`值会被跳过。空数组以及元素全为`NULL`值的数组，结果返回`NULL`值。
 
 ### example

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_popback.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_popback.md
@@ -34,9 +34,7 @@ array_popback
 
 #### Syntax
 
-```
-ARRAY<T> array_popback(ARRAY<T> arr)
-```
+`ARRAY<T> array_popback(ARRAY<T> arr)`
 
 返回移除最后一个元素后的数组，如果输入参数为NULL，则返回NULL
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_popfront.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_popfront.md
@@ -33,9 +33,7 @@ array_popfront
 
 #### Syntax
 
-```
-ARRAY<T> array_popfront(ARRAY<T> arr)
-```
+`ARRAY<T> array_popfront(ARRAY<T> arr)`
 
 返回移除第一个元素后的数组，如果输入参数为NULL，则返回NULL
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_product.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_product.md
@@ -34,6 +34,10 @@ array_product
 
 ### description
 
+#### Syntax
+
+`T array_product(ARRAY<T> arr)`
+
 返回数组中所有元素的乘积，数组中的`NULL`值会被跳过。空数组以及元素全为`NULL`值的数组，结果返回`NULL`值。
 
 ### example

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_pushfront.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_pushfront.md
@@ -34,9 +34,7 @@ array_pushfront
 
 #### Syntax
 
-```sql
-Array<T> array_pushfront(Array<T> arr, T value)
-```
+`Array<T> array_pushfront(Array<T> arr, T value)`
 将value添加到数组的开头.
 
 #### Returned value

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_range.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_range.md
@@ -36,7 +36,7 @@ array_range
 
 #### Syntax
 
-```
+```sql
 ARRAY<Int> array_range(Int end)
 ARRAY<Int> array_range(Int start, Int end)
 ARRAY<Int> array_range(Int start, Int end, Int step)

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_remove.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_remove.md
@@ -34,9 +34,7 @@ array_remove
 
 #### Syntax
 
-```
-ARRAY<T> array_remove(ARRAY<T> arr, T val)
-```
+`ARRAY<T> array_remove(ARRAY<T> arr, T val)`
 
 返回移除所有的指定元素后的数组，如果输入参数为NULL，则返回NULL
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_reverse_sort.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_reverse_sort.md
@@ -34,9 +34,7 @@ array_reverse_sort
 
 #### Syntax
 
-```
-ARRAY<T> array_reverse_sort(ARRAY<T> arr)
-```
+`ARRAY<T> array_reverse_sort(ARRAY<T> arr)`
 
 返回按降序排列后的数组，如果输入数组为NULL，则返回NULL。
 如果数组元素包含NULL, 则输出的排序数组会将NULL放在最后面。

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_shuffle.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_shuffle.md
@@ -28,12 +28,19 @@ under the License.
 
 <version since="2.0">
 
-array_shuffle(array1, [seed])
-shuffle(array1, [seed])
+array_shuffle
+shuffle
 
 </version>
 
 ### description
+
+#### Syntax
+
+```sql
+ARRAY<T> array_shuffle(ARRAY<T> array1, [INT seed])
+ARRAY<T> shuffle(ARRAY<T> array1, [INT seed])
+```
 
 将数组中元素进行随机排列。其中，参数array1为要进行随机排列的数组，可选参数seed是设定伪随机数生成器用于生成伪随机数的初始数值。
 shuffle与array_shuffle功能相同。

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_size.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_size.md
@@ -36,7 +36,7 @@ array_size (size, cardinality)
 
 #### Syntax
 
-```
+```sql
 BIGINT size(ARRAY<T> arr)
 BIGINT array_size(ARRAY<T> arr) 
 BIGINT cardinality(ARRAY<T> arr)

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_slice.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_slice.md
@@ -34,9 +34,7 @@ array_slice
 
 #### Syntax
 
-```
-ARRAY<T> array_slice(ARRAY<T> arr, BIGINT off, BIGINT len)
-```
+`ARRAY<T> array_slice(ARRAY<T> arr, BIGINT off, BIGINT len)`
 
 返回一个子数组，包含所有从指定位置开始的指定长度的元素，如果输入参数为NULL，则返回NULL
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_sort.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_sort.md
@@ -34,9 +34,7 @@ array_sort
 
 #### Syntax
 
-```
-ARRAY<T> array_sort(ARRAY<T> arr)
-```
+`ARRAY<T> array_sort(ARRAY<T> arr)`
 
 返回按升序排列后的数组，如果输入数组为NULL，则返回NULL。
 如果数组元素包含NULL, 则输出的排序数组会将NULL放在最前面。

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_sortby.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_sortby.md
@@ -34,7 +34,7 @@ array_sortby
 
 #### Syntax
 
-```
+```sql
 ARRAY<T> array_sortby(ARRAY<T> src,Array<T> key)
 ARRAY<T> array_sortby(lambda,array....)
 ```

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_sum.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_sum.md
@@ -34,6 +34,13 @@ array_sum
 
 ### description
 
+#### Syntax
+
+```sql
+T array_sum(ARRAY<T> src, Array<T> key)
+T array_sum(lambda, Array<T> arr1, Array<T> arr2 ....)
+```
+
 返回数组中所有元素之和，数组中的`NULL`值会被跳过。空数组以及元素全为`NULL`值的数组，结果返回`NULL`值。
 
 ### example

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_union.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_union.md
@@ -36,9 +36,7 @@ array_union
 
 #### Syntax
 
-```
-ARRAY<T> array_union(ARRAY<T> array1, ARRAY<T> array2)
-```
+`ARRAY<T> array_union(ARRAY<T> array1, ARRAY<T> array2)`
 
 返回一个数组，包含array1和array2的并集中的所有元素，不包含重复项，如果输入参数为NULL，则返回NULL
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_with_constant.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_with_constant.md
@@ -35,7 +35,7 @@ array_repeat
 
 #### Syntax
 
-```
+```sql
 ARRAY<T> array_with_constant(n, T)
 ARRAY<T> array_repeat(T, n)
 ```

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_zip.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_zip.md
@@ -36,9 +36,7 @@ array_zip
 
 #### Syntax
 
-```sql
-Array<Struct<T1, T2,...>> array_zip(Array<T1>, Array<T2>, ...)
-```
+`Array<Struct<T1, T2,...>> array_zip(Array<T1>, Array<T2>, ...)`
 
 #### Returned value
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/element_at.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/element_at.md
@@ -36,13 +36,12 @@ element_at
 
 #### Syntax
 
-`T element_at(ARRAY<T> arr, BIGINT position)`
+```sql
+T element_at(ARRAY<T> arr, BIGINT position)
+T arr[position]
+```
 
-`T arr[position]`
-
-返回数组中位置为 `position` 的元素。如果该位置上元素不存在，返回NULL。
-
-`position` 从1开始，并且支持负数。
+返回数组中位置为 `position` 的元素。如果该位置上元素不存在，返回NULL。`position` 从1开始，并且支持负数。
 
 ### notice
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/bitmap-functions/bitmap_hash.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/bitmap-functions/bitmap_hash.md
@@ -36,9 +36,7 @@ BITMAP_HASH
 
 #### Syntax
 
-```
-BITMAP BITMAP_HASH(<any_value>)
-```
+`BITMAP BITMAP_HASH(<any_value>)`
 
 #### Arguments
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/cast.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/cast.md
@@ -28,9 +28,7 @@ under the License.
 ### description
 #### Syntax
 
-```
-T cast (input as Type)
-```
+`T cast (input as Type)`
 
 将 input 转成 指定的 Type类型
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/cast.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/cast.md
@@ -29,20 +29,10 @@ under the License.
 #### Syntax
 
 ```
-cast (input as type)
+T cast (input as Type)
 ```
 
-#### BIGINT type 
-
-#### Syntax(BIGINT)
-
-``` cast (input as BIGINT) ```
-
-
-将 input 转成 指定的 type 
-
-
-将当前列 input 转换为 BIGINT 类型
+将 input 转成 指定的 Type类型
 
 ### example
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/date-time-functions/date_add.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/date-time-functions/date_add.md
@@ -28,7 +28,7 @@ under the License.
 ### description
 #### Syntax
 
-`INT DATE_ADD(DATETIME date,INTERVAL expr type)`
+`INT DATE_ADD(DATETIME date, INTERVAL expr type)`
 
 
 向日期添加指定的时间间隔。

--- a/docs/zh-CN/docs/sql-manual/sql-functions/date-time-functions/date_sub.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/date-time-functions/date_sub.md
@@ -28,7 +28,7 @@ under the License.
 ### description
 #### Syntax
 
-`DATETIME DATE_SUB(DATETIME date,INTERVAL expr type)`
+`DATETIME DATE_SUB(DATETIME date, INTERVAL expr type)`
 
 
 从日期减去指定的时间间隔

--- a/docs/zh-CN/docs/sql-manual/sql-functions/date-time-functions/date_trunc.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/date-time-functions/date_trunc.md
@@ -35,7 +35,7 @@ date_trunc
 ### description
 #### Syntax
 
-`DATETIME DATE_TRUNC(DATETIME datetime,VARCHAR unit)`
+`DATETIME DATE_TRUNC(DATETIME datetime, VARCHAR unit)`
 
 
 将datetime按照指定的时间单位截断。

--- a/docs/zh-CN/docs/sql-manual/sql-functions/date-time-functions/datediff.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/date-time-functions/datediff.md
@@ -28,7 +28,7 @@ under the License.
 ### description
 #### Syntax
 
-`DATETIME DATEDIFF(DATETIME expr1,DATETIME expr2)`
+`DATETIME DATEDIFF(DATETIME expr1, DATETIME expr2)`
 
 
 计算expr1 - expr2，结果精确到天。

--- a/docs/zh-CN/docs/sql-manual/sql-functions/date-time-functions/time_round.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/date-time-functions/time_round.md
@@ -28,13 +28,12 @@ under the License.
 ### description
 #### Syntax
 
-`DATETIME TIME_ROUND(DATETIME expr)`
-
-`DATETIME TIME_ROUND(DATETIME expr, INT period)`
-
-`DATETIME TIME_ROUND(DATETIME expr, DATETIME origin)`
-
-`DATETIME TIME_ROUND(DATETIME expr, INT period, DATETIME origin)`
+```sql
+DATETIME TIME_ROUND(DATETIME expr)
+DATETIME TIME_ROUND(DATETIME expr, INT period)
+DATETIME TIME_ROUND(DATETIME expr, DATETIME origin)
+DATETIME TIME_ROUND(DATETIME expr, INT period, DATETIME origin)
+```
 
 函数名 `TIME_ROUND` 由两部分组成，每部分由以下可选值组成
 - `TIME`: `SECOND`, `MINUTE`, `HOUR`, `DAY`, `WEEK`, `MONTH`, `YEAR`

--- a/docs/zh-CN/docs/sql-manual/sql-functions/date-time-functions/timestampdiff.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/date-time-functions/timestampdiff.md
@@ -28,7 +28,7 @@ under the License.
 ### description
 #### Syntax
 
-`INT TIMESTAMPDIFF(unit,DATETIME datetime_expr1, DATETIME datetime_expr2)`
+`INT TIMESTAMPDIFF(unit, DATETIME datetime_expr1, DATETIME datetime_expr2)`
 
 返回datetime_expr2−datetime_expr1，其中datetime_expr1和datetime_expr2是日期或日期时间表达式。
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/date-time-functions/unix_timestamp.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/date-time-functions/unix_timestamp.md
@@ -28,7 +28,10 @@ under the License.
 ### description
 #### Syntax
 
-`INT UNIX_TIMESTAMP(), UNIX_TIMESTAMP(DATETIME date), UNIX_TIMESTAMP(DATETIME date, STRING fmt),`
+```sql
+INT UNIX_TIMESTAMP()
+INT UNIX_TIMESTAMP(DATETIME date[, STRING fmt])
+```
 
 将 Date 或者 Datetime 类型转化为 unix 时间戳。
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/date-time-functions/unix_timestamp.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/date-time-functions/unix_timestamp.md
@@ -28,10 +28,7 @@ under the License.
 ### description
 #### Syntax
 
-```sql
-INT UNIX_TIMESTAMP()
-INT UNIX_TIMESTAMP(DATETIME date[, STRING fmt])
-```
+`INT UNIX_TIMESTAMP([DATETIME date[, STRING fmt]])`
 
 将 Date 或者 Datetime 类型转化为 unix 时间戳。
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/date-time-functions/week.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/date-time-functions/week.md
@@ -27,9 +27,7 @@ under the License.
 ## week
 ### description
 #### Syntax
-
-`INT WEEK(DATE date)`
-`INT WEEK(DATE date, INT mode)`
+`INT WEEK(DATE date[, INT mode])`
 
 返回指定日期的星期数。mode的值默认为0。
 参数mode的作用参见下面的表格：

--- a/docs/zh-CN/docs/sql-manual/sql-functions/date-time-functions/yearweek.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/date-time-functions/yearweek.md
@@ -28,8 +28,7 @@ under the License.
 ### description
 #### Syntax
 
-`INT YEARWEEK(DATE date)`
-`INT YEARWEEK(DATE date, INT mode)`
+`INT YEARWEEK(DATE date[, INT mode])`
 
 返回指定日期的年份和星期数。mode的值默认为0。
 当日期所在的星期属于上一年时，返回的是上一年的年份和星期数；

--- a/docs/zh-CN/docs/sql-manual/sql-functions/encrypt-digest-functions/aes.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/encrypt-digest-functions/aes.md
@@ -40,9 +40,7 @@ Reference: https://dev.mysql.com/doc/refman/8.0/en/encryption-functions.html#fun
 
 #### Syntax
 
-```
-AES_ENCRYPT(str,key_str[,init_vector])
-```
+`AES_ENCRYPT(str,key_str[,init_vector])`
 
 #### Arguments
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/encrypt-digest-functions/aes.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/encrypt-digest-functions/aes.md
@@ -40,7 +40,7 @@ Reference: https://dev.mysql.com/doc/refman/8.0/en/encryption-functions.html#fun
 
 #### Syntax
 
-`AES_ENCRYPT(str,key_str[,init_vector])`
+`AES_ENCRYPT(str, key_str[, init_vector])`
 
 #### Arguments
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/json-functions/jsonb_extract.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/json-functions/jsonb_extract.md
@@ -35,19 +35,15 @@ jsonb_extract
 ### description
 #### Syntax
 
-`JSONB jsonb_extract(JSONB j, VARCHAR json_path)`
-
-`BOOLEAN jsonb_extract_isnull(JSONB j, VARCHAR json_path)`
-
-`BOOLEAN jsonb_extract_bool(JSONB j, VARCHAR json_path)`
-
-`INT jsonb_extract_int(JSONB j, VARCHAR json_path)`
-
-`BIGINT jsonb_extract_bigint(JSONB j, VARCHAR json_path)`
-
-`DOUBLE jsonb_extract_double(JSONB j, VARCHAR json_path)`
-
-`STRING jsonb_extract_string(JSONB j, VARCHAR json_path)`
+```sql
+JSONB jsonb_extract(JSONB j, VARCHAR json_path)
+BOOLEAN jsonb_extract_isnull(JSONB j, VARCHAR json_path)
+BOOLEAN jsonb_extract_bool(JSONB j, VARCHAR json_path)
+INT jsonb_extract_int(JSONB j, VARCHAR json_path)
+BIGINT jsonb_extract_bigint(JSONB j, VARCHAR json_path)
+DOUBLE jsonb_extract_double(JSONB j, VARCHAR json_path)
+STRING jsonb_extract_string(JSONB j, VARCHAR json_path)
+```
 
 
 jsonb_extract是一系列函数，从JSONB类型的数据中提取json_path指定的字段，根据要提取的字段类型不同提供不同的系列函数。
@@ -64,9 +60,10 @@ jsonb_extract是一系列函数，从JSONB类型的数据中提取json_path指�
 - 如果json_path指定的字段在JSON中的实际类型和jsonb_extract_t指定的类型不一致，如果能无损转换成指定类型返回指定类型t，如果不能则返回NULL
 
 
-`BOOLEAN jsonb_exists_path(JSONB j, VARCHAR json_path)`
-
-`STRING jsonb_type(JSONB j, VARCHAR json_path)`
+```sql
+BOOLEAN jsonb_exists_path(JSONB j, VARCHAR json_path)
+STRING jsonb_type(JSONB j, VARCHAR json_path)
+```
 
 这两个jsonb函数用来判断字段是否存在和字段类型
 - jsonb_exists_path用来判断json_path指定的字段在JSONB数据中是否存在，如果存在返回TRUE，不存在返回FALSE

--- a/docs/zh-CN/docs/sql-manual/sql-functions/json-functions/jsonb_extract.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/json-functions/jsonb_extract.md
@@ -45,7 +45,6 @@ DOUBLE jsonb_extract_double(JSONB j, VARCHAR json_path)
 STRING jsonb_extract_string(JSONB j, VARCHAR json_path)
 ```
 
-
 jsonb_extract是一系列函数，从JSONB类型的数据中提取json_path指定的字段，根据要提取的字段类型不同提供不同的系列函数。
 - jsonb_extract返回JSONB类型
 - jsonb_extract_isnull返回是否为json null的BOOLEAN类型
@@ -59,6 +58,11 @@ jsonb_extract是一系列函数，从JSONB类型的数据中提取json_path指�
 - 如果json_path指定的字段在JSON中不存在，返回NULL
 - 如果json_path指定的字段在JSON中的实际类型和jsonb_extract_t指定的类型不一致，如果能无损转换成指定类型返回指定类型t，如果不能则返回NULL
 
+
+## jsonb_exists_path and jsonb_type
+### description
+
+#### Syntax
 
 ```sql
 BOOLEAN jsonb_exists_path(JSONB j, VARCHAR json_path)

--- a/docs/zh-CN/docs/sql-manual/sql-functions/json-functions/jsonb_parse.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/json-functions/jsonb_parse.md
@@ -28,9 +28,11 @@ under the License.
 ### description
 #### Syntax
 
-`JSONB jsonb_parse(VARCHAR json_str)`
-`JSONB jsonb_parse_error_to_null(VARCHAR json_str)`
-`JSONB jsonb_parse_error_to_value(VARCHAR json_str, VARCHAR default_json_str)`
+```sql
+JSONB jsonb_parse(VARCHAR json_str)
+JSONB jsonb_parse_error_to_null(VARCHAR json_str)
+JSONB jsonb_parse_error_to_value(VARCHAR json_str, VARCHAR default_json_str)
+```
 
 将原始JSON字符串解析成JSONB二进制格式。为了满足不同的异常数据处理需求，提供不同的jsonb_parse系列函数，具体行为如下：
 - json_str为NULL时，都返回NULL

--- a/docs/zh-CN/docs/sql-manual/sql-functions/math-functions/abs.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/math-functions/abs.md
@@ -27,11 +27,17 @@ under the License.
 ### description
 #### Syntax
 
-`DOUBLE abs(DOUBLE x)`  `SMALLINT abs(TINYINT x)`  `INT abs(SMALLINT x)`  
-
-`BIGINT abs(INT x)`  `LARGEINT abs(BIGINT x)`  `LARGEINT abs(LARGEINT x)`  
-
-`DOUBLE abs(DOUBLE x)`  `FLOAT abs(FLOAT x)`  `DECIMAL abs(DECIMAL x)`  
+```sql
+DOUBLE abs(DOUBLE x)
+SMALLINT abs(TINYINT x)
+INT abs(SMALLINT x)
+BIGINT abs(INT x)
+LARGEINT abs(BIGINT x)
+LARGEINT abs(LARGEINT x)
+DOUBLE abs(DOUBLE x)
+FLOAT abs(FLOAT x)
+DECIMAL abs(DECIMAL x)` 
+```
 
 返回`x`的绝对值.
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/math-functions/abs.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/math-functions/abs.md
@@ -28,7 +28,6 @@ under the License.
 #### Syntax
 
 ```sql
-DOUBLE abs(DOUBLE x)
 SMALLINT abs(TINYINT x)
 INT abs(SMALLINT x)
 BIGINT abs(INT x)

--- a/docs/zh-CN/docs/sql-manual/sql-functions/math-functions/conv.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/math-functions/conv.md
@@ -27,8 +27,10 @@ under the License.
 ### description
 #### Syntax
 
-`VARCHAR CONV(VARCHAR input, TINYINT from_base, TINYINT to_base)`
-`VARCHAR CONV(BIGINT input, TINYINT from_base, TINYINT to_base)`
+```sql
+VARCHAR CONV(VARCHAR input, TINYINT from_base, TINYINT to_base)
+VARCHAR CONV(BIGINT input, TINYINT from_base, TINYINT to_base)
+```
 对输入的数字进行进制转换，输入的进制范围应该在`[2,36]`以内。
 
 ### example

--- a/docs/zh-CN/docs/sql-manual/sql-functions/math-functions/negative.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/math-functions/negative.md
@@ -27,7 +27,11 @@ under the License.
 ### description
 #### Syntax
 
-`BIGINT negative(BIGINT x)`  `DOUBLE negative(DOUBLE x)`  `DECIMAL negative(DECIMAL x)`
+```sql
+BIGINT negative(BIGINT x)
+DOUBLE negative(DOUBLE x)
+DECIMAL negative(DECIMAL x)
+```
 返回`-x`.
 
 ### example

--- a/docs/zh-CN/docs/sql-manual/sql-functions/math-functions/pmod.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/math-functions/pmod.md
@@ -27,8 +27,10 @@ under the License.
 ### description
 #### Syntax
 
-`BIGINT PMOD(BIGINT x, BIGINT y)`
-`DOUBLE PMOD(DOUBLE x, DOUBLE y)`
+```sql
+BIGINT PMOD(BIGINT x, BIGINT y)
+DOUBLE PMOD(DOUBLE x, DOUBLE y)
+```
 返回在模系下`x mod y`的最小正数解.
 具体地来说, 返回 `(x%y+y)%y`.
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/math-functions/positive.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/math-functions/positive.md
@@ -27,7 +27,11 @@ under the License.
 ### description
 #### Syntax
 
-`BIGINT positive(BIGINT x)`  `DOUBLE positive(DOUBLE x)`  `DECIMAL positive(DECIMAL x)`
+```sql
+BIGINT positive(BIGINT x)
+DOUBLE positive(DOUBLE x)
+DECIMAL positive(DECIMAL x)
+```
 返回`x`.
 
 ### example

--- a/docs/zh-CN/docs/sql-manual/sql-functions/math-functions/round.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/math-functions/round.md
@@ -27,7 +27,7 @@ under the License.
 ### description
 #### Syntax
 
-`round(x), round(x, d)`
+`T round(T x[, d])`
 将`x`四舍五入后保留d位小数，d默认为0。如果d为负数，则小数点左边d位为0。如果x或d为null，返回null。
 
 ### example

--- a/docs/zh-CN/docs/sql-manual/sql-functions/math-functions/round_bankers.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/math-functions/round_bankers.md
@@ -27,7 +27,7 @@ under the License.
 ### description
 #### Syntax
 
-`round_bankers(x), round_bankers(x, d)`
+`T round_bankers(T x[, d])`
 将`x`使用银行家舍入法后，保留d位小数，`d`默认为0。如果`d`为负数，则小数点左边`d`位为0。如果`x`或`d`为null，返回null。
 
 + 如果舍入数介于两个数字之间，则该函数使用银行家的舍入

--- a/docs/zh-CN/docs/sql-manual/sql-functions/math-functions/running_difference.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/math-functions/running_difference.md
@@ -26,7 +26,7 @@ under the License.
 ### description
 #### Syntax
 
-`running_difference(x);`
+`T running_difference(T x)`
 计算数据块中连续行值的差值。该函数的结果取决于受影响的数据块和块中数据的顺序。
 
 计算 running_difference 期间使用的行顺序可能与返回给用户的行顺序不同。所以结果是不稳定的。**此函数会在后续版本中废弃**。
@@ -51,18 +51,18 @@ SELECT x - lag(x, 1, 0) OVER (ORDER BY k) FROM t;
 DROP TABLE IF EXISTS running_difference_test;
 
 CREATE TABLE running_difference_test (
-                 `id` int NOT NULL COMMENT 'id' ,
-                `day` date COMMENT 'day', 
+    `id` int NOT NULL COMMENT 'id' ,
+    `day` date COMMENT 'day', 
 	`time_val` datetime COMMENT 'time_val',
  	`doublenum` double NULL COMMENT 'doublenum'
-                )
+)
 DUPLICATE KEY(id) 
 DISTRIBUTED BY HASH(id) BUCKETS 3 
 PROPERTIES ( 
     "replication_num" = "1"
 ); 
                                                   
-INSERT into running_difference_test (id,day, time_val,doublenum) values ('1', '2022-10-28', '2022-03-12 10:41:00', null),
+INSERT into running_difference_test (id, day, time_val,doublenum) values ('1', '2022-10-28', '2022-03-12 10:41:00', null),
                                                    ('2','2022-10-27', '2022-03-12 10:41:02', 2.6),
                                                    ('3','2022-10-28', '2022-03-12 10:41:03', 2.5),
                                                    ('4','2022-9-29', '2022-03-12 10:41:03', null),

--- a/docs/zh-CN/docs/sql-manual/sql-functions/math-functions/running_difference.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/math-functions/running_difference.md
@@ -51,10 +51,10 @@ SELECT x - lag(x, 1, 0) OVER (ORDER BY k) FROM t;
 DROP TABLE IF EXISTS running_difference_test;
 
 CREATE TABLE running_difference_test (
-    `id` int NOT NULL COMMENT 'id' ,
+    `id` int NOT NULL COMMENT 'id',
     `day` date COMMENT 'day', 
-	`time_val` datetime COMMENT 'time_val',
- 	`doublenum` double NULL COMMENT 'doublenum'
+    `time_val` datetime COMMENT 'time_val',
+    `doublenum` double NULL COMMENT 'doublenum'
 )
 DUPLICATE KEY(id) 
 DISTRIBUTED BY HASH(id) BUCKETS 3 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/spatial-functions/st_area.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/spatial-functions/st_area.md
@@ -28,9 +28,10 @@ under the License.
 
 ### Syntax
 
-`DOUBLE ST_Area_Square_Meters(GEOMETRY geo)`
-
-`DOUBLE ST_Area_Square_Km(GEOMETRY geo)`
+```sql
+DOUBLE ST_Area_Square_Meters(GEOMETRY geo)
+DOUBLE ST_Area_Square_Km(GEOMETRY geo)
+```
 
 ### description
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/concat_ws.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/concat_ws.md
@@ -28,8 +28,10 @@ under the License.
 ### description
 #### Syntax
 
-`VARCHAR concat_ws(VARCHAR sep, VARCHAR str,...)`
-`VARCHAR concat_ws(VARCHAR sep, ARRAY array)`
+```sql
+VARCHAR concat_ws(VARCHAR sep, VARCHAR str,...)
+VARCHAR concat_ws(VARCHAR sep, ARRAY array)
+```
 
 
 使用第一个参数 sep 作为连接符，将第二个参数以及后续所有参数(或ARRAY中的所有字符串)拼接成一个字符串。

--- a/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/convert_to.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/convert_to.md
@@ -30,7 +30,7 @@ under the License.
 ### description
 #### Syntax
 
-` convert_to(VARCHAR column, VARCHAR character)`
+`VARCHAR convert_to(VARCHAR column, VARCHAR character)`
 在order by子句中使用，例如order by convert(column using gbk), 现在仅支持character转为'gbk'.
 因为当order by column中包含中文时，其排列不是按照汉语拼音的顺序.
 将column的字符编码转为gbk后，可实现按拼音的排列的效果.

--- a/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/elt.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/elt.md
@@ -26,7 +26,7 @@ under the License.
 ### Description
 #### Syntax
 
-`VARCHAR elt (INT,VARCHAR,...)`
+`VARCHAR elt(INT, VARCHAR,...)`
 
 在指定的索引处返回一个字符串。如果指定的索引处没有字符串，则返回NULL。
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/ends_with.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/ends_with.md
@@ -28,7 +28,7 @@ under the License.
 ### description
 #### Syntax
 
-`BOOLEAN ENDS_WITH (VARCHAR str, VARCHAR suffix)`
+`BOOLEAN ENDS_WITH(VARCHAR str, VARCHAR suffix)`
 
 如果字符串以指定后缀结尾，返回true。否则，返回false。任意参数为NULL，返回NULL。
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/mask/mask.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/mask/mask.md
@@ -28,7 +28,7 @@ under the License.
 ### description
 #### syntax
 
-`VARCHAR mask(VARCHAR str, [, VARCHAR upper[, VARCHAR lower[, VARCHAR number]]])`
+`VARCHAR mask(VARCHAR str[, VARCHAR upper[, VARCHAR lower[, VARCHAR number]]])`
 
 返回 str 的掩码版本。 默认情况下，大写字母转换为“X”，小写字母转换为“x”，数字转换为“n”。 例如 mask("abcd-EFGH-8765-4321") 结果为 xxxx-XXXX-nnnn-nnnn。 您可以通过提供附加参数来覆盖掩码中使用的字符：第二个参数控制大写字母的掩码字符，第三个参数控制小写字母，第四个参数控制数字。 例如，mask("abcd-EFGH-8765-4321", "U", "l", "#") 会得到 llll-UUUU-####-####。
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/mask/mask_first_n.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/mask/mask_first_n.md
@@ -28,7 +28,7 @@ under the License.
 ### description
 #### syntax
 
-`VARCHAR mask_first_n(VARCHAR str, [, INT n])`
+`VARCHAR mask_first_n(VARCHAR str[, INT n])`
 
 返回带有掩码的前 n 个值的 str 的掩码版本。 大写字母转换为“X”，小写字母转换为“x”，数字转换为“n”。 例如，mask_first_n("1234-5678-8765-4321", 4) 结果为 nnnn-5678-8765-4321。
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/mask/mask_last_n.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/mask/mask_last_n.md
@@ -28,7 +28,7 @@ under the License.
 ### description
 #### syntax
 
-`VARCHAR mask_last_n(VARCHAR str, [, INT n])`
+`VARCHAR mask_last_n(VARCHAR str[, INT n])`
 
 返回 str 的掩码版本，其中最后 n 个字符被转换为掩码。 大写字母转换为“X”，小写字母转换为“x”，数字转换为“n”。 例如，mask_last_n("1234-5678-8765-4321", 4) 结果为 1234-5678-8765-nnnn。
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/reverse.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/reverse.md
@@ -28,8 +28,10 @@ under the License.
 ### description
 #### Syntax
 
-`VARCHAR reverse(VARCHAR str)`
-`ARRAY<T> reverse(ARRAY<T> arr)`
+```sql
+VARCHAR reverse(VARCHAR str)
+ARRAY<T> reverse(ARRAY<T> arr)
+```
 
 将字符串或数组反转，返回的字符串或者数组的顺序和原来的顺序相反。
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/sleep.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/sleep.md
@@ -28,7 +28,7 @@ under the License.
 ### description
 #### Syntax
 
-`boolean sleep(Int num)`
+`BOOLEAN sleep(INT num)`
 
 使该线程休眠num秒。
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/split_by_string.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/split_by_string.md
@@ -31,9 +31,7 @@ under the License.
 
 #### Syntax
 
-```
-split_by_string(s, separator)
-```
+`ARRAY<STRING> split_by_string(STRING s, STRING separator)`
 将字符串拆分为由字符串分隔的子字符串。它使用多个字符的常量字符串分隔符作为分隔符。如果字符串分隔符为空，它将字符串拆分为单个字符数组。
 
 #### Arguments

--- a/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/starts_with.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/starts_with.md
@@ -28,7 +28,7 @@ under the License.
 ### description
 #### Syntax
 
-`BOOLEAN STARTS_WITH (VARCHAR str, VARCHAR prefix)`
+`BOOLEAN STARTS_WITH(VARCHAR str, VARCHAR prefix)`
 
 如果字符串以指定前缀开头，返回true。否则，返回false。任意参数为NULL，返回NULL。
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/sub_replace.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/sub_replace.md
@@ -26,7 +26,7 @@ under the License.
 ### description
 #### Syntax
 
-`VARCHAR sub_replace(VARCHAR str, VARCHAR new_str, INT start [, INT len])`
+`VARCHAR sub_replace(VARCHAR str, VARCHAR new_str, INT start[, INT len])`
 
 返回用new_str字符串替换str中从start开始长度为len的新字符串。
 其中start,len为负整数，返回NULL, 且len的默认值为new_str的长度。

--- a/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/backends.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/backends.md
@@ -40,11 +40,8 @@ backends
 
 该函数用于from子句中。
 
-语法：
-
-```
-backends();
-```
+#### syntax
+`backends()`
 
 backends()表结构：
 ```

--- a/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/explode-bitmap.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/explode-bitmap.md
@@ -32,11 +32,8 @@ under the License.
 
 展开一个bitmap类型。
 
-语法：
-
-```
-explode_bitmap(bitmap)
-```
+#### syntax
+`explode_bitmap(bitmap)`
 
 ### example
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/explode-json-array.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/explode-json-array.md
@@ -32,9 +32,8 @@ under the License.
 
 展开一个 json 数组。根据数组元素类型，有三种函数名称。分别对应整型、浮点和字符串数组。
 
-语法：
-
-```
+#### syntax
+```sql
 explode_json_array_int(json_str)
 explode_json_array_double(json_str)
 explode_json_array_string(json_str)

--- a/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/explode-numbers.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/explode-numbers.md
@@ -32,11 +32,8 @@ under the License.
 
 获得一个[0,n)的序列。
 
-语法：
-
-```
-explode_numbers(n)
-```
+#### syntax
+`explode_numbers(n)`
 
 ### example
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/explode-split.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/explode-split.md
@@ -32,11 +32,8 @@ under the License.
 
 将一个字符串按指定的分隔符分割成多个子串。
 
-语法：
-
-```
-explode_split(str, delimiter)
-```
+#### syntax
+`explode_split(str, delimiter)`
 
 ### example
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/explode.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/explode.md
@@ -33,9 +33,8 @@ under the License.
 将 array 列展开成多行。当 array 为NULL或者为空时，`explode_outer` 返回NULL。
 `explode` 和 `explode_outer` 均会返回 array 内部的NULL元素。
 
-语法：
-
-```
+#### syntax
+```sql
 explode(expr)
 explode_outer(expr)
 ```

--- a/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/hdfs.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/hdfs.md
@@ -38,9 +38,8 @@ hdfs
 
 HDFS表函数（table-valued-function,tvf），可以让用户像访问关系表格式数据一样，读取并访问 HDFS 上的文件内容。目前支持`csv/csv_with_names/csv_with_names_and_types/json/parquet/orc`文件格式。
 
-**语法**
-
-```
+#### syntax
+```sql
 hdfs(
   "uri" = "..",
   "fs.defaultFS" = "...",

--- a/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/iceberg_meta.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/iceberg_meta.md
@@ -38,8 +38,7 @@ iceberg_meta
 
 iceberg_meta表函数（table-valued-function,tvf），可以用于读取iceberg表的各类元数据信息，如操作历史、生成的快照、文件元数据等。
 
-**语法**
-
+#### syntax
 ```sql
 iceberg_meta(
   "table" = "ctl.db.tbl", 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/numbers.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/numbers.md
@@ -32,9 +32,8 @@ under the License.
 
 该函数用于from子句中。
 
-语法：
-
-```
+#### syntax
+```sql
 numbers(
   "number" = "n",
   "backend_num" = "m"

--- a/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/outer-combinator.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/outer-combinator.md
@@ -29,6 +29,8 @@ under the License.
 ### description
 
 在table function的函数名后面添加`_outer`后缀使得函数行为从`non-outer`变为`outer`,在表函数生成0行数据时添加一行`Null`数据。
+#### syntax
+`explode_numbers(INT x)`
 
 ### example
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/resource-group.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/resource-group.md
@@ -40,11 +40,8 @@ resource_groups
 
 该函数用于from子句中。
 
-语法：
-
-```
-resource_groups();
-```
+#### syntax
+`resource_groups()`
 
 resource_groups()表结构：
 ```

--- a/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/s3.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/s3.md
@@ -38,8 +38,7 @@ s3
 
 S3表函数（table-valued-function,tvf），可以让用户像访问关系表格式数据一样，读取并访问 S3 兼容的对象存储上的文件内容。目前支持`csv/csv_with_names/csv_with_names_and_types/json/parquet/orc`文件格式。
 
-**语法**
-
+#### syntax
 ```sql
 s3(
   "uri" = "..",

--- a/docs/zh-CN/docs/sql-manual/sql-functions/width-bucket.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/width-bucket.md
@@ -32,7 +32,7 @@ under the License.
 
 #### Syntax
 
-`width_bucket(expr, min_value, max_value, num_buckets)`
+`INT width_bucket(Expr expr, T min_value, T max_value, INT num_buckets)`
 
 #### Arguments
 `expr` -

--- a/docs/zh-CN/docs/sql-manual/sql-functions/width-bucket.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/width-bucket.md
@@ -32,9 +32,7 @@ under the License.
 
 #### Syntax
 
-```sql
-width_bucket(expr, min_value, max_value, num_buckets)
-```
+`width_bucket(expr, min_value, max_value, num_buckets)`
 
 #### Arguments
 `expr` -


### PR DESCRIPTION
# Proposed changes

Format function Syntax desc:
(1)  one line syntax desc use ' '，  more than one line use   ''' sql     '''
(2) option argument use [, xxx]
(3) add Syntax desc when missing
(4) add argument and return type when missing
    

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

