### PR TITLE
[Fix](load) fix request_slave_tablet_pull_rowset get wrong url in case of ipv6 address

### DIFF
--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -89,6 +89,7 @@
 #include "util/doris_metrics.h"
 #include "util/md5.h"
 #include "util/metrics.h"
+#include "util/network_util.h"
 #include "util/proto_util.h"
 #include "util/ref_count_closure.h"
 #include "util/runtime_profile.h"
@@ -1210,7 +1211,7 @@ void PInternalServiceImpl::request_slave_tablet_pull_rowset(
             }
 
             std::stringstream ss;
-            ss << "http://" << host << ":" << http_port << "/api/_tablet/_download?token=" << token
+            ss << "http://" << get_host_port(host, http_port) << "/api/_tablet/_download?token=" << token
                << "&file=" << rowset_path << "/" << remote_rowset_id << "_" << segment.first
                << ".dat";
             std::string remote_file_url = ss.str();

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -1211,9 +1211,9 @@ void PInternalServiceImpl::request_slave_tablet_pull_rowset(
             }
 
             std::stringstream ss;
-            ss << "http://" << get_host_port(host, http_port) << "/api/_tablet/_download?token=" << token
-               << "&file=" << rowset_path << "/" << remote_rowset_id << "_" << segment.first
-               << ".dat";
+            ss << "http://" << get_host_port(host, http_port) 
+               << "/api/_tablet/_download?token=" << token << "&file=" << rowset_path << "/" 
+               << remote_rowset_id << "_" << segment.first << ".dat";
             std::string remote_file_url = ss.str();
             ss.str("");
             ss << tablet->tablet_path() << "/" << rowset_meta->rowset_id() << "_" << segment.first

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -1211,8 +1211,8 @@ void PInternalServiceImpl::request_slave_tablet_pull_rowset(
             }
 
             std::stringstream ss;
-            ss << "http://" << get_host_port(host, http_port) 
-               << "/api/_tablet/_download?token=" << token << "&file=" << rowset_path << "/" 
+            ss << "http://" << get_host_port(host, http_port)
+               << "/api/_tablet/_download?token=" << token << "&file=" << rowset_path << "/"
                << remote_rowset_id << "_" << segment.first << ".dat";
             std::string remote_file_url = ss.str();
             ss.str("");


### PR DESCRIPTION
# Proposed changes

Issue Number: close #19025

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

