### PR TITLE
[Fix] Fix the extension mysql_to_doris bug (#19034)

### DIFF
--- a/extension/mysql_to_doris/bin/e_auto.sh
+++ b/extension/mysql_to_doris/bin/e_auto.sh
@@ -17,7 +17,7 @@
 #!/bin/bash
 source ../conf/doris.conf
 #Execute the create external table sql
-echo "source ../result/e_mysql_to_doris.sql;" |mysql -h$fe_host -P$fe_master_port -uroot -p$fe_password 2>error.log
+echo "source ../result/mysql_to_doris.sql;" |mysql -h$master_host -P$master_port -u$doris_user -p$doris_password 2>error.log
 
 #Circulation monitoring mysql or conf
 while (( 1 == 1 ))
@@ -27,26 +27,26 @@ do
 sleep 30
 
 #get new create table sql
-sh ./e_mysql_to_doris.sh ../result/new_e_mysql_to_doris.sql 2>error.log
+sh ./e_mysql_to_doris.sh ../result/new_mysql_to_doris.sql 2>error.log
 
 #get a md5 from old create table sql
-old=`md5sum ../result/e_mysql_to_doris.sql |awk -F ' ' '{print $1}'`
+old=`md5sum ../result/mysql_to_doris.sql |awk -F ' ' '{print $1}'`
 
 #get a md5 from new create table sql
-new=`md5sum ../result/new_e_mysql_to_doris.sql |awk -F ' ' '{print $1}'`
+new=`md5sum ../result/new_mysql_to_doris.sql |awk -F ' ' '{print $1}'`
 
         if [[ $old != $new ]];then
 #table charges to drop old table and create new table
                 for table in $(cat ../conf/doris_tables |grep -v '#' | awk -F '\n' '{print $1}')
                 do
-                       echo "drop table if exists ${table};" |mysql -h$fe_host -P$fe_master_port -uroot -p$fe_password
+                       echo "drop table if exists ${table};" |mysql -h$master_host -P$master_port -u$doris_user -p$doris_password
                 done
-                echo "source ../result/new_e_mysql_to_doris.sql;" |mysql -h$fe_host -P$fe_master_port -uroot -p$fe_password 2>error.log
+                echo "source ../result/new_mysql_to_doris.sql;" |mysql -h$master_host -P$master_port -u$doris_user -p$doris_password 2>error.log
 #delete old create table
-                rm -rf ../result/e_mysql_to_doris.sql
-#alter new table sql name 
-                mv ../result/new_e_mysql_to_doris.sql ../result/e_mysql_to_doris.sql
+                rm -rf ../result/mysql_to_doris.sql
+#alter new table sql name
+                mv ../result/new_mysql_to_doris.sql ../result/mysql_to_doris.sql
                 fi
-#if table no charge delete new create table 
-        rm -f ../result/new_e_mysql_to_doris.sql
+#if table no charge delete new create table
+        rm -f ../result/new_mysql_to_doris.sql
 done

--- a/extension/mysql_to_doris/conf/doris.conf
+++ b/extension/mysql_to_doris/conf/doris.conf
@@ -18,5 +18,6 @@
 
 master_host=192.168.0.151
 master_port=9030
+doris_user=root
 doris_password=123456
 doris_odbc_name='MySQL ODBC'


### PR DESCRIPTION
# Proposed changes
e_auto.sh: command error,This error causes script execution errors. :
ERROR at line 1: Failed to open file '../result/e_mysql_to_doris.sql', error: 2.

Issue Number: close #19034

## Problem summary
1. Using extension e_auto.sh. there was an error executing the e_auto.sh script.
ERROR at line 1: Failed to open file '../result/e_mysql_to_doris.sql', error: 2.
2. In e_mysql_to_doris.sh The script path specified in e_auto.sh and  The path of the SQL file generated by the auto.sh script is different.
    ![image](https://user-images.githubusercontent.com/63942121/234174636-2dbbac77-59db-43c7-ad91-6a208654013b.png)

Describe your changes.

## Checklist(Required)

* [x] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

