### PR TITLE
[enhancement](JNI) Provide default environment variables if it is unset

### DIFF
--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -44,31 +44,51 @@ namespace {
 JavaVM* g_vm;
 [[maybe_unused]] std::once_flag g_vm_once;
 
-const std::string GetDorisJNIClasspath() {
+const std::string GetDorisJNIDefaultClasspath() {
+    const auto* doris_home = getenv("DORIS_HOME");
+    DCHECK(doris_home) << "Environment variable DORIS_HOME is not set.";
+
+    std::ostringstream out;
+    std::string path(doris_home);
+    path += "/lib";
+    for (const auto& entry : std::filesystem::recursive_directory_iterator(path)) {
+        if (entry.path().extension() != ".jar") {
+            continue;
+        }
+        if (out.str().empty()) {
+            out << entry.path().string();
+        } else {
+            out << ":" << entry.path().string();
+        }
+    }
+
+    DCHECK(!out.str().empty()) << "Empty classpath is invalid.";
+    return out.str();
+}
+
+const std::string GetDorisJNIClasspathOption() {
     const auto* classpath = getenv("DORIS_CLASSPATH");
     if (classpath) {
         return classpath;
     } else {
-        const auto* doris_home = getenv("DORIS_HOME");
-        DCHECK(doris_home) << "Environment variable DORIS_HOME is not set.";
-
-        std::ostringstream out;
-        std::string path(doris_home);
-        path += "/lib";
-        for (const auto& entry : std::filesystem::directory_iterator(path)) {
-            if (entry.path().extension() != ".jar") {
-                continue;
-            }
-            if (out.str().empty()) {
-                out << "-Djava.class.path=" << entry.path().string();
-            } else {
-                out << ":" << entry.path().string();
-            }
-        }
-
-        DCHECK(!out.str().empty()) << "Empty classpath is invalid.";
-        return out.str();
+        return "-Djava.class.path=" + GetDorisJNIDefaultClasspath();
     }
+}
+
+[[maybe_unused]] void SetEnvIfNecessary() {
+    const auto* doris_home = getenv("DORIS_HOME");
+    DCHECK(doris_home) << "Environment variable DORIS_HOME is not set.";
+
+    // CLASSPATH
+    static const std::string classpath =
+            fmt::format("{}/conf:{}", doris_home, GetDorisJNIDefaultClasspath());
+    setenv("CLASSPATH", classpath.c_str(), 0);
+
+    // LIBHDFS_OPTS
+    setenv("LIBHDFS_OPTS",
+           fmt::format("-Djava.library.path={}/lib/hadoop_hdfs/native", getenv("DORIS_HOME"))
+                   .c_str(),
+           0);
 }
 
 // Only used on non-x86 platform
@@ -81,7 +101,7 @@ const std::string GetDorisJNIClasspath() {
         char* java_opts = getenv("JAVA_OPTS");
         if (java_opts == nullptr) {
             options = {
-                    GetDorisJNIClasspath(), fmt::format("-Xmx{}", "1g"),
+                    GetDorisJNIClasspathOption(), fmt::format("-Xmx{}", "1g"),
                     fmt::format("-DlogPath={}/log/jni.log", getenv("DORIS_HOME")),
                     fmt::format("-Dsun.java.command={}", "DorisBE"), "-XX:-CriticalJNINatives",
 #ifdef __APPLE__
@@ -96,7 +116,7 @@ const std::string GetDorisJNIClasspath() {
             std::istringstream stream(java_opts);
             options = std::vector<std::string>(std::istream_iterator<std::string> {stream},
                                                std::istream_iterator<std::string>());
-            options.push_back(GetDorisJNIClasspath());
+            options.push_back(GetDorisJNIClasspathOption());
         }
         std::unique_ptr<JavaVMOption[]> jvm_options(new JavaVMOption[options.size()]);
         for (int i = 0; i < options.size(); ++i) {
@@ -178,6 +198,7 @@ Status JniUtil::GetJNIEnvSlowPath(JNIEnv** env) {
     }
 #else
     // the hadoop libhdfs will do all the stuff
+    SetEnvIfNecessary();
     tls_env_ = getJNIEnv();
 #endif
     *env = tls_env_;

--- a/be/src/vec/functions/uuid.cpp
+++ b/be/src/vec/functions/uuid.cpp
@@ -18,8 +18,8 @@
 #include <glog/logging.h>
 #include <stddef.h>
 
-// IWYU pragma: no_include <boost/uuid/random_generator.hpp>
-// IWYU pragma: no_include <boost/uuid/uuid_io.hpp>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
 #include <memory>
 #include <string>
 #include <utility>


### PR DESCRIPTION
# Proposed changes

Issue Number: close #19044 

## Problem summary

BE with java support needs some environment variables to start up and we have set them up in the start scripts (such as `start_be.sh`). However, if we debug BE directly, these environment variables are not set by default. For the convenience, we should provide default environment variables under this scenario.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

