### PR TITLE
[Optimize](parquet-reader) Add `has_filter` template param in `get_next_run()` to decrease `_has_filter` condition checking count in the loop.

### DIFF
--- a/be/src/vec/exec/format/parquet/bool_plain_decoder.cpp
+++ b/be/src/vec/exec/format/parquet/bool_plain_decoder.cpp
@@ -53,12 +53,22 @@ Status BoolPlainDecoder::skip_values(size_t num_values) {
 
 Status BoolPlainDecoder::decode_values(MutableColumnPtr& doris_column, DataTypePtr& data_type,
                                        ColumnSelectVector& select_vector, bool is_dict_filter) {
+    if (select_vector.has_filter()) {
+        return _decode_values<true>(doris_column, data_type, select_vector, is_dict_filter);
+    } else {
+        return _decode_values<false>(doris_column, data_type, select_vector, is_dict_filter);
+    }
+}
+
+template <bool has_filter>
+Status BoolPlainDecoder::_decode_values(MutableColumnPtr& doris_column, DataTypePtr& data_type,
+                                        ColumnSelectVector& select_vector, bool is_dict_filter) {
     auto& column_data = static_cast<ColumnVector<UInt8>&>(*doris_column).get_data();
     size_t data_index = column_data.size();
     column_data.resize(data_index + select_vector.num_values() - select_vector.num_filtered());
 
     ColumnSelectVector::DataReadType read_type;
-    while (size_t run_length = select_vector.get_next_run(&read_type)) {
+    while (size_t run_length = select_vector.get_next_run<has_filter>(&read_type)) {
         switch (read_type) {
         case ColumnSelectVector::CONTENT: {
             bool value;

--- a/be/src/vec/exec/format/parquet/bool_plain_decoder.h
+++ b/be/src/vec/exec/format/parquet/bool_plain_decoder.h
@@ -54,6 +54,10 @@ public:
     Status decode_values(MutableColumnPtr& doris_column, DataTypePtr& data_type,
                          ColumnSelectVector& select_vector, bool is_dict_filter) override;
 
+    template <bool has_filter>
+    Status _decode_values(MutableColumnPtr& doris_column, DataTypePtr& data_type,
+                          ColumnSelectVector& select_vector, bool is_dict_filter);
+
     Status skip_values(size_t num_values) override;
 
 protected:

--- a/be/src/vec/exec/format/parquet/bool_rle_decoder.h
+++ b/be/src/vec/exec/format/parquet/bool_rle_decoder.h
@@ -45,6 +45,10 @@ public:
     Status decode_values(MutableColumnPtr& doris_column, DataTypePtr& data_type,
                          ColumnSelectVector& select_vector, bool is_dict_filter) override;
 
+    template <bool has_filter>
+    Status _decode_values(MutableColumnPtr& doris_column, DataTypePtr& data_type,
+                          ColumnSelectVector& select_vector, bool is_dict_filter);
+
     Status skip_values(size_t num_values) override;
 
 private:

--- a/be/src/vec/exec/format/parquet/byte_array_plain_decoder.h
+++ b/be/src/vec/exec/format/parquet/byte_array_plain_decoder.h
@@ -51,15 +51,19 @@ public:
     Status decode_values(MutableColumnPtr& doris_column, DataTypePtr& data_type,
                          ColumnSelectVector& select_vector, bool is_dict_filter) override;
 
+    template <bool has_filter>
+    Status _decode_values(MutableColumnPtr& doris_column, DataTypePtr& data_type,
+                          ColumnSelectVector& select_vector, bool is_dict_filter);
+
     Status skip_values(size_t num_values) override;
 
 protected:
-    template <typename DecimalPrimitiveType>
+    template <typename DecimalPrimitiveType, bool has_filter>
     Status _decode_binary_decimal(MutableColumnPtr& doris_column, DataTypePtr& data_type,
                                   ColumnSelectVector& select_vector);
 };
 
-template <typename DecimalPrimitiveType>
+template <typename DecimalPrimitiveType, bool has_filter>
 Status ByteArrayPlainDecoder::_decode_binary_decimal(MutableColumnPtr& doris_column,
                                                      DataTypePtr& data_type,
                                                      ColumnSelectVector& select_vector) {
@@ -70,7 +74,7 @@ Status ByteArrayPlainDecoder::_decode_binary_decimal(MutableColumnPtr& doris_col
     column_data.resize(data_index + select_vector.num_values() - select_vector.num_filtered());
     DecimalScaleParams& scale_params = _decode_params->decimal_scale;
     ColumnSelectVector::DataReadType read_type;
-    while (size_t run_length = select_vector.get_next_run(&read_type)) {
+    while (size_t run_length = select_vector.get_next_run<has_filter>(&read_type)) {
         switch (read_type) {
         case ColumnSelectVector::CONTENT: {
             for (size_t i = 0; i < run_length; ++i) {

--- a/be/src/vec/exec/format/parquet/decoder.h
+++ b/be/src/vec/exec/format/parquet/decoder.h
@@ -173,6 +173,7 @@ protected:
      * Decode dictionary-coded values into doris_column, ensure that doris_column is ColumnDictI32 type,
      * and the coded values must be read into _indexes previously.
      */
+    template <bool has_filter>
     Status _decode_dict_values(MutableColumnPtr& doris_column, ColumnSelectVector& select_vector,
                                bool is_dict_filter) {
         DCHECK(doris_column->is_column_dictionary() || is_dict_filter);
@@ -182,7 +183,7 @@ protected:
                 doris_column->is_column_dictionary()
                         ? assert_cast<ColumnDictI32&>(*doris_column).get_data()
                         : assert_cast<ColumnInt32&>(*doris_column).get_data();
-        while (size_t run_length = select_vector.get_next_run(&read_type)) {
+        while (size_t run_length = select_vector.get_next_run<has_filter>(&read_type)) {
             switch (read_type) {
             case ColumnSelectVector::CONTENT: {
                 uint32_t* start_index = &_indexes[0];

--- a/be/src/vec/exec/format/parquet/delta_bit_pack_decoder.h
+++ b/be/src/vec/exec/format/parquet/delta_bit_pack_decoder.h
@@ -51,8 +51,52 @@ public:
         return _type_converted_decoder->skip_values(num_values);
     }
 
+    template <bool has_filter>
     Status decode_byte_array(const std::vector<Slice>& decoded_vals, MutableColumnPtr& doris_column,
-                             DataTypePtr& data_type, ColumnSelectVector& select_vector);
+                             DataTypePtr& data_type, ColumnSelectVector& select_vector) {
+        TypeIndex logical_type = remove_nullable(data_type)->get_type_id();
+        switch (logical_type) {
+        case TypeIndex::String:
+            [[fallthrough]];
+        case TypeIndex::FixedString: {
+            ColumnSelectVector::DataReadType read_type;
+            while (size_t run_length = select_vector.get_next_run<has_filter>(&read_type)) {
+                switch (read_type) {
+                case ColumnSelectVector::CONTENT: {
+                    std::vector<StringRef> string_values;
+                    string_values.reserve(run_length);
+                    for (size_t i = 0; i < run_length; ++i) {
+                        size_t length = decoded_vals[_current_value_idx].size;
+                        string_values.emplace_back(decoded_vals[_current_value_idx].data, length);
+                        _current_value_idx++;
+                    }
+                    doris_column->insert_many_strings(&string_values[0], run_length);
+                    break;
+                }
+                case ColumnSelectVector::NULL_DATA: {
+                    doris_column->insert_many_defaults(run_length);
+                    break;
+                }
+                case ColumnSelectVector::FILTERED_CONTENT: {
+                    _current_value_idx += run_length;
+                    break;
+                }
+                case ColumnSelectVector::FILTERED_NULL: {
+                    // do nothing
+                    break;
+                }
+                }
+            }
+            _current_value_idx = 0;
+            return Status::OK();
+        }
+        default:
+            break;
+        }
+        return Status::InvalidArgument(
+                "Can't decode parquet physical type BYTE_ARRAY to doris logical type {}",
+                getTypeName(logical_type));
+    }
 
 protected:
     void init_values_converter() {
@@ -175,6 +219,16 @@ public:
 
     Status decode_values(MutableColumnPtr& doris_column, DataTypePtr& data_type,
                          ColumnSelectVector& select_vector, bool is_dict_filter) override {
+        if (select_vector.has_filter()) {
+            return _decode_values<true>(doris_column, data_type, select_vector, is_dict_filter);
+        } else {
+            return _decode_values<false>(doris_column, data_type, select_vector, is_dict_filter);
+        }
+    }
+
+    template <bool has_filter>
+    Status _decode_values(MutableColumnPtr& doris_column, DataTypePtr& data_type,
+                          ColumnSelectVector& select_vector, bool is_dict_filter) {
         size_t num_values = select_vector.num_values();
         size_t null_count = select_vector.num_nulls();
         // init read buffer
@@ -186,7 +240,7 @@ public:
             return Status::IOError("Expected to decode {} values, but decoded {} values.",
                                    num_values - null_count, num_valid_values);
         }
-        return decode_byte_array(_values, doris_column, data_type, select_vector);
+        return decode_byte_array<has_filter>(_values, doris_column, data_type, select_vector);
     }
 
     Status decode(Slice* buffer, int num_values, int* out_num_values) {
@@ -242,13 +296,23 @@ public:
 
     Status decode_values(MutableColumnPtr& doris_column, DataTypePtr& data_type,
                          ColumnSelectVector& select_vector, bool is_dict_filter) override {
+        if (select_vector.has_filter()) {
+            return _decode_values<true>(doris_column, data_type, select_vector, is_dict_filter);
+        } else {
+            return _decode_values<false>(doris_column, data_type, select_vector, is_dict_filter);
+        }
+    }
+
+    template <bool has_filter>
+    Status _decode_values(MutableColumnPtr& doris_column, DataTypePtr& data_type,
+                          ColumnSelectVector& select_vector, bool is_dict_filter) {
         size_t num_values = select_vector.num_values();
         size_t null_count = select_vector.num_nulls();
         _values.resize(num_values - null_count);
         int num_valid_values;
         RETURN_IF_ERROR(_get_internal(_values.data(), num_values - null_count, &num_valid_values));
         DCHECK_EQ(num_values - null_count, num_valid_values);
-        return decode_byte_array(_values, doris_column, data_type, select_vector);
+        return decode_byte_array<has_filter>(_values, doris_column, data_type, select_vector);
     }
 
     void set_data(Slice* slice) override {

--- a/be/src/vec/exec/format/parquet/fix_length_dict_decoder.hpp
+++ b/be/src/vec/exec/format/parquet/fix_length_dict_decoder.hpp
@@ -33,6 +33,16 @@ public:
 
     Status decode_values(MutableColumnPtr& doris_column, DataTypePtr& data_type,
                          ColumnSelectVector& select_vector, bool is_dict_filter) override {
+        if (select_vector.has_filter()) {
+            return _decode_values<true>(doris_column, data_type, select_vector, is_dict_filter);
+        } else {
+            return _decode_values<false>(doris_column, data_type, select_vector, is_dict_filter);
+        }
+    }
+
+    template <bool has_filter>
+    Status _decode_values(MutableColumnPtr& doris_column, DataTypePtr& data_type,
+                          ColumnSelectVector& select_vector, bool is_dict_filter) {
         size_t non_null_size = select_vector.num_values() - select_vector.num_nulls();
         if (doris_column->is_column_dictionary() &&
             assert_cast<ColumnDictI32&>(*doris_column).dict_size() == 0) {
@@ -59,81 +69,84 @@ public:
         _index_batch_decoder->GetBatch(&_indexes[0], non_null_size);
 
         if (doris_column->is_column_dictionary() || is_dict_filter) {
-            return _decode_dict_values(doris_column, select_vector, is_dict_filter);
+            return _decode_dict_values<has_filter>(doris_column, select_vector, is_dict_filter);
         }
 
         TypeIndex logical_type = remove_nullable(data_type)->get_type_id();
         switch (logical_type) {
-#define DISPATCH(NUMERIC_TYPE, CPP_NUMERIC_TYPE, PHYSICAL_TYPE)                    \
-    case NUMERIC_TYPE:                                                             \
-        if constexpr (std::is_same_v<T, PHYSICAL_TYPE>) {                          \
-            return _decode_numeric<CPP_NUMERIC_TYPE>(doris_column, select_vector); \
+#define DISPATCH(NUMERIC_TYPE, CPP_NUMERIC_TYPE, PHYSICAL_TYPE)                                \
+    case NUMERIC_TYPE:                                                                         \
+        if constexpr (std::is_same_v<T, PHYSICAL_TYPE>) {                                      \
+            return _decode_numeric<CPP_NUMERIC_TYPE, has_filter>(doris_column, select_vector); \
         }
             FOR_LOGICAL_NUMERIC_TYPES(DISPATCH)
 #undef DISPATCH
         case TypeIndex::Date:
             if constexpr (std::is_same_v<T, Int32>) {
-                return _decode_date<VecDateTimeValue, Int64>(doris_column, select_vector);
+                return _decode_date<VecDateTimeValue, Int64, has_filter>(doris_column,
+                                                                         select_vector);
             }
             break;
         case TypeIndex::DateV2:
             if constexpr (std::is_same_v<T, Int32>) {
-                return _decode_date<DateV2Value<DateV2ValueType>, UInt32>(doris_column,
-                                                                          select_vector);
+                return _decode_date<DateV2Value<DateV2ValueType>, UInt32, has_filter>(
+                        doris_column, select_vector);
             }
             break;
         case TypeIndex::DateTime:
             if constexpr (std::is_same_v<T, ParquetInt96>) {
-                return _decode_datetime96<VecDateTimeValue, Int64>(doris_column, select_vector);
+                return _decode_datetime96<VecDateTimeValue, Int64, has_filter>(doris_column,
+                                                                               select_vector);
             } else if constexpr (std::is_same_v<T, Int64>) {
-                return _decode_datetime64<VecDateTimeValue, Int64>(doris_column, select_vector);
+                return _decode_datetime64<VecDateTimeValue, Int64, has_filter>(doris_column,
+                                                                               select_vector);
             }
             break;
         case TypeIndex::DateTimeV2:
             // Spark can set the timestamp precision by the following configuration:
             // spark.sql.parquet.outputTimestampType = INT96(NANOS), TIMESTAMP_MICROS, TIMESTAMP_MILLIS
             if constexpr (std::is_same_v<T, ParquetInt96>) {
-                return _decode_datetime96<DateV2Value<DateTimeV2ValueType>, UInt64>(doris_column,
-                                                                                    select_vector);
+                return _decode_datetime96<DateV2Value<DateTimeV2ValueType>, UInt64, has_filter>(
+                        doris_column, select_vector);
             } else if constexpr (std::is_same_v<T, Int64>) {
-                return _decode_datetime64<DateV2Value<DateTimeV2ValueType>, UInt64>(doris_column,
-                                                                                    select_vector);
+                return _decode_datetime64<DateV2Value<DateTimeV2ValueType>, UInt64, has_filter>(
+                        doris_column, select_vector);
             }
             break;
         case TypeIndex::Decimal32:
             if constexpr (std::is_same_v<T, Int32>) {
-                return _decode_primitive_decimal<Int32, Int32>(doris_column, data_type,
-                                                               select_vector);
+                return _decode_primitive_decimal<Int32, Int32, has_filter>(doris_column, data_type,
+                                                                           select_vector);
             } else if constexpr (std::is_same_v<T, Int64>) {
-                return _decode_primitive_decimal<Int32, Int64>(doris_column, data_type,
-                                                               select_vector);
+                return _decode_primitive_decimal<Int32, Int64, has_filter>(doris_column, data_type,
+                                                                           select_vector);
             }
             break;
         case TypeIndex::Decimal64:
             if constexpr (std::is_same_v<T, Int32>) {
-                return _decode_primitive_decimal<Int64, Int32>(doris_column, data_type,
-                                                               select_vector);
+                return _decode_primitive_decimal<Int64, Int32, has_filter>(doris_column, data_type,
+                                                                           select_vector);
             } else if constexpr (std::is_same_v<T, Int64>) {
-                return _decode_primitive_decimal<Int64, Int64>(doris_column, data_type,
-                                                               select_vector);
+                return _decode_primitive_decimal<Int64, Int64, has_filter>(doris_column, data_type,
+                                                                           select_vector);
             }
             break;
         case TypeIndex::Decimal128:
             if constexpr (std::is_same_v<T, Int32>) {
-                return _decode_primitive_decimal<Int128, Int32>(doris_column, data_type,
-                                                                select_vector);
+                return _decode_primitive_decimal<Int128, Int32, has_filter>(doris_column, data_type,
+                                                                            select_vector);
             } else if constexpr (std::is_same_v<T, Int64>) {
-                return _decode_primitive_decimal<Int128, Int64>(doris_column, data_type,
-                                                                select_vector);
+                return _decode_primitive_decimal<Int128, Int64, has_filter>(doris_column, data_type,
+                                                                            select_vector);
             }
             break;
         case TypeIndex::Decimal128I:
             if constexpr (std::is_same_v<T, Int32>) {
-                return _decode_primitive_decimal<Int128, Int32>(doris_column, data_type,
-                                                                select_vector);
+                return _decode_primitive_decimal<Int128, Int32, has_filter>(doris_column, data_type,
+                                                                            select_vector);
             } else if constexpr (std::is_same_v<T, Int64>) {
-                return _decode_primitive_decimal<Int128, Int64>(doris_column, data_type,
-                                                                select_vector);
+                return _decode_primitive_decimal<Int128, Int64, has_filter>(doris_column, data_type,
+                                                                            select_vector);
             }
             break;
         case TypeIndex::String:
@@ -164,14 +177,14 @@ public:
     }
 
 protected:
-    template <typename Numeric>
+    template <typename Numeric, bool has_filter>
     Status _decode_numeric(MutableColumnPtr& doris_column, ColumnSelectVector& select_vector) {
         auto& column_data = static_cast<ColumnVector<Numeric>&>(*doris_column).get_data();
         size_t data_index = column_data.size();
         column_data.resize(data_index + select_vector.num_values() - select_vector.num_filtered());
         size_t dict_index = 0;
         ColumnSelectVector::DataReadType read_type;
-        while (size_t run_length = select_vector.get_next_run(&read_type)) {
+        while (size_t run_length = select_vector.get_next_run<has_filter>(&read_type)) {
             switch (read_type) {
             case ColumnSelectVector::CONTENT: {
                 for (size_t i = 0; i < run_length; ++i) {
@@ -197,14 +210,14 @@ protected:
         return Status::OK();
     }
 
-    template <typename CppType, typename ColumnType>
+    template <typename CppType, typename ColumnType, bool has_filter>
     Status _decode_date(MutableColumnPtr& doris_column, ColumnSelectVector& select_vector) {
         auto& column_data = static_cast<ColumnVector<ColumnType>&>(*doris_column).get_data();
         size_t data_index = column_data.size();
         column_data.resize(data_index + select_vector.num_values() - select_vector.num_filtered());
         size_t dict_index = 0;
         ColumnSelectVector::DataReadType read_type;
-        while (size_t run_length = select_vector.get_next_run(&read_type)) {
+        while (size_t run_length = select_vector.get_next_run<has_filter>(&read_type)) {
             switch (read_type) {
             case ColumnSelectVector::CONTENT: {
                 for (size_t i = 0; i < run_length; ++i) {
@@ -236,14 +249,14 @@ protected:
         return Status::OK();
     }
 
-    template <typename CppType, typename ColumnType>
+    template <typename CppType, typename ColumnType, bool has_filter>
     Status _decode_datetime64(MutableColumnPtr& doris_column, ColumnSelectVector& select_vector) {
         auto& column_data = static_cast<ColumnVector<ColumnType>&>(*doris_column).get_data();
         size_t data_index = column_data.size();
         column_data.resize(data_index + select_vector.num_values() - select_vector.num_filtered());
         size_t dict_index = 0;
         ColumnSelectVector::DataReadType read_type;
-        while (size_t run_length = select_vector.get_next_run(&read_type)) {
+        while (size_t run_length = select_vector.get_next_run<has_filter>(&read_type)) {
             switch (read_type) {
             case ColumnSelectVector::CONTENT: {
                 for (size_t i = 0; i < run_length; ++i) {
@@ -276,14 +289,14 @@ protected:
         return Status::OK();
     }
 
-    template <typename CppType, typename ColumnType>
+    template <typename CppType, typename ColumnType, bool has_filter>
     Status _decode_datetime96(MutableColumnPtr& doris_column, ColumnSelectVector& select_vector) {
         auto& column_data = static_cast<ColumnVector<ColumnType>&>(*doris_column).get_data();
         size_t data_index = column_data.size();
         column_data.resize(data_index + select_vector.num_values() - select_vector.num_filtered());
         size_t dict_index = 0;
         ColumnSelectVector::DataReadType read_type;
-        while (size_t run_length = select_vector.get_next_run(&read_type)) {
+        while (size_t run_length = select_vector.get_next_run<has_filter>(&read_type)) {
             switch (read_type) {
             case ColumnSelectVector::CONTENT: {
                 for (size_t i = 0; i < run_length; ++i) {
@@ -316,7 +329,7 @@ protected:
         return Status::OK();
     }
 
-    template <typename DecimalPrimitiveType, typename DecimalPhysicalType>
+    template <typename DecimalPrimitiveType, typename DecimalPhysicalType, bool has_filter>
     Status _decode_primitive_decimal(MutableColumnPtr& doris_column, DataTypePtr& data_type,
                                      ColumnSelectVector& select_vector) {
         init_decimal_converter<DecimalPrimitiveType>(data_type);
@@ -329,7 +342,7 @@ protected:
         DecimalScaleParams& scale_params = _decode_params->decimal_scale;
 
         ColumnSelectVector::DataReadType read_type;
-        while (size_t run_length = select_vector.get_next_run(&read_type)) {
+        while (size_t run_length = select_vector.get_next_run<has_filter>(&read_type)) {
             switch (read_type) {
             case ColumnSelectVector::CONTENT: {
                 for (size_t i = 0; i < run_length; ++i) {
@@ -377,6 +390,16 @@ public:
 
     Status decode_values(MutableColumnPtr& doris_column, DataTypePtr& data_type,
                          ColumnSelectVector& select_vector, bool is_dict_filter) override {
+        if (select_vector.has_filter()) {
+            return _decode_values<true>(doris_column, data_type, select_vector, is_dict_filter);
+        } else {
+            return _decode_values<false>(doris_column, data_type, select_vector, is_dict_filter);
+        }
+    }
+
+    template <bool has_filter>
+    Status _decode_values(MutableColumnPtr& doris_column, DataTypePtr& data_type,
+                          ColumnSelectVector& select_vector, bool is_dict_filter) {
         size_t non_null_size = select_vector.num_values() - select_vector.num_nulls();
         if (doris_column->is_column_dictionary() &&
             assert_cast<ColumnDictI32&>(*doris_column).dict_size() == 0) {
@@ -392,36 +415,40 @@ public:
         _index_batch_decoder->GetBatch(&_indexes[0], non_null_size);
 
         if (doris_column->is_column_dictionary() || is_dict_filter) {
-            return _decode_dict_values(doris_column, select_vector, is_dict_filter);
+            return _decode_dict_values<has_filter>(doris_column, select_vector, is_dict_filter);
         }
 
         TypeIndex logical_type = remove_nullable(data_type)->get_type_id();
         switch (logical_type) {
         case TypeIndex::Decimal32:
             if (_physical_type == tparquet::Type::FIXED_LEN_BYTE_ARRAY) {
-                return _decode_binary_decimal<Int32>(doris_column, data_type, select_vector);
+                return _decode_binary_decimal<Int32, has_filter>(doris_column, data_type,
+                                                                 select_vector);
             }
             break;
         case TypeIndex::Decimal64:
             if (_physical_type == tparquet::Type::FIXED_LEN_BYTE_ARRAY) {
-                return _decode_binary_decimal<Int64>(doris_column, data_type, select_vector);
+                return _decode_binary_decimal<Int64, has_filter>(doris_column, data_type,
+                                                                 select_vector);
             }
             break;
         case TypeIndex::Decimal128:
             if (_physical_type == tparquet::Type::FIXED_LEN_BYTE_ARRAY) {
-                return _decode_binary_decimal<Int128>(doris_column, data_type, select_vector);
+                return _decode_binary_decimal<Int128, has_filter>(doris_column, data_type,
+                                                                  select_vector);
             }
             break;
         case TypeIndex::Decimal128I:
             if (_physical_type == tparquet::Type::FIXED_LEN_BYTE_ARRAY) {
-                return _decode_binary_decimal<Int128>(doris_column, data_type, select_vector);
+                return _decode_binary_decimal<Int128, has_filter>(doris_column, data_type,
+                                                                  select_vector);
             }
             break;
         case TypeIndex::String:
             [[fallthrough]];
         case TypeIndex::FixedString:
             if (_physical_type == tparquet::Type::FIXED_LEN_BYTE_ARRAY) {
-                return _decode_string(doris_column, select_vector);
+                return _decode_string<has_filter>(doris_column, select_vector);
             }
             break;
         default:
@@ -488,7 +515,7 @@ public:
     }
 
 protected:
-    template <typename DecimalPrimitiveType>
+    template <typename DecimalPrimitiveType, bool has_filter>
     Status _decode_binary_decimal(MutableColumnPtr& doris_column, DataTypePtr& data_type,
                                   ColumnSelectVector& select_vector) {
         init_decimal_converter<DecimalPrimitiveType>(data_type);
@@ -501,7 +528,7 @@ protected:
         DecimalScaleParams& scale_params = _decode_params->decimal_scale;
 
         ColumnSelectVector::DataReadType read_type;
-        while (size_t run_length = select_vector.get_next_run(&read_type)) {
+        while (size_t run_length = select_vector.get_next_run<has_filter>(&read_type)) {
             switch (read_type) {
             case ColumnSelectVector::CONTENT: {
                 for (size_t i = 0; i < run_length; ++i) {
@@ -539,10 +566,11 @@ protected:
         return Status::OK();
     }
 
+    template <bool has_filter>
     Status _decode_string(MutableColumnPtr& doris_column, ColumnSelectVector& select_vector) {
         size_t dict_index = 0;
         ColumnSelectVector::DataReadType read_type;
-        while (size_t run_length = select_vector.get_next_run(&read_type)) {
+        while (size_t run_length = select_vector.get_next_run<has_filter>(&read_type)) {
             switch (read_type) {
             case ColumnSelectVector::CONTENT: {
                 std::vector<StringRef> string_values;

--- a/be/src/vec/exec/format/parquet/fix_length_plain_decoder.cpp
+++ b/be/src/vec/exec/format/parquet/fix_length_plain_decoder.cpp
@@ -58,6 +58,17 @@ Status FixLengthPlainDecoder::skip_values(size_t num_values) {
 Status FixLengthPlainDecoder::decode_values(MutableColumnPtr& doris_column, DataTypePtr& data_type,
                                             ColumnSelectVector& select_vector,
                                             bool is_dict_filter) {
+    if (select_vector.has_filter()) {
+        return _decode_values<true>(doris_column, data_type, select_vector, is_dict_filter);
+    } else {
+        return _decode_values<false>(doris_column, data_type, select_vector, is_dict_filter);
+    }
+}
+
+template <bool has_filter>
+Status FixLengthPlainDecoder::_decode_values(MutableColumnPtr& doris_column, DataTypePtr& data_type,
+                                             ColumnSelectVector& select_vector,
+                                             bool is_dict_filter) {
     size_t non_null_size = select_vector.num_values() - select_vector.num_nulls();
     if (UNLIKELY(_offset + _type_length * non_null_size > _data->size)) {
         return Status::IOError("Out-of-bounds access in parquet data decoder");
@@ -66,78 +77,93 @@ Status FixLengthPlainDecoder::decode_values(MutableColumnPtr& doris_column, Data
     switch (logical_type) {
 #define DISPATCH(NUMERIC_TYPE, CPP_NUMERIC_TYPE, PHYSICAL_TYPE) \
     case NUMERIC_TYPE:                                          \
-        return _decode_numeric<CPP_NUMERIC_TYPE>(doris_column, select_vector);
+        return _decode_numeric<CPP_NUMERIC_TYPE, has_filter>(doris_column, select_vector);
         FOR_LOGICAL_NUMERIC_TYPES(DISPATCH)
 #undef DISPATCH
     case TypeIndex::Date:
         if (_physical_type == tparquet::Type::INT32) {
-            return _decode_date<VecDateTimeValue, Int64>(doris_column, select_vector);
+            return _decode_date<VecDateTimeValue, Int64, has_filter>(doris_column, select_vector);
         }
         break;
     case TypeIndex::DateV2:
         if (_physical_type == tparquet::Type::INT32) {
-            return _decode_date<DateV2Value<DateV2ValueType>, UInt32>(doris_column, select_vector);
+            return _decode_date<DateV2Value<DateV2ValueType>, UInt32, has_filter>(doris_column,
+                                                                                  select_vector);
         }
         break;
     case TypeIndex::DateTime:
         if (_physical_type == tparquet::Type::INT96) {
-            return _decode_datetime96<VecDateTimeValue, Int64>(doris_column, select_vector);
+            return _decode_datetime96<VecDateTimeValue, Int64, has_filter>(doris_column,
+                                                                           select_vector);
         } else if (_physical_type == tparquet::Type::INT64) {
-            return _decode_datetime64<VecDateTimeValue, Int64>(doris_column, select_vector);
+            return _decode_datetime64<VecDateTimeValue, Int64, has_filter>(doris_column,
+                                                                           select_vector);
         }
         break;
     case TypeIndex::DateTimeV2:
         // Spark can set the timestamp precision by the following configuration:
         // spark.sql.parquet.outputTimestampType = INT96(NANOS), TIMESTAMP_MICROS, TIMESTAMP_MILLIS
         if (_physical_type == tparquet::Type::INT96) {
-            return _decode_datetime96<DateV2Value<DateTimeV2ValueType>, UInt64>(doris_column,
-                                                                                select_vector);
+            return _decode_datetime96<DateV2Value<DateTimeV2ValueType>, UInt64, has_filter>(
+                    doris_column, select_vector);
         } else if (_physical_type == tparquet::Type::INT64) {
-            return _decode_datetime64<DateV2Value<DateTimeV2ValueType>, UInt64>(doris_column,
-                                                                                select_vector);
+            return _decode_datetime64<DateV2Value<DateTimeV2ValueType>, UInt64, has_filter>(
+                    doris_column, select_vector);
         }
         break;
     case TypeIndex::Decimal32:
         if (_physical_type == tparquet::Type::FIXED_LEN_BYTE_ARRAY) {
-            return _decode_binary_decimal<Int32>(doris_column, data_type, select_vector);
+            return _decode_binary_decimal<Int32, has_filter>(doris_column, data_type,
+                                                             select_vector);
         } else if (_physical_type == tparquet::Type::INT32) {
-            return _decode_primitive_decimal<Int32, Int32>(doris_column, data_type, select_vector);
+            return _decode_primitive_decimal<Int32, Int32, has_filter>(doris_column, data_type,
+                                                                       select_vector);
         } else if (_physical_type == tparquet::Type::INT64) {
-            return _decode_primitive_decimal<Int32, Int64>(doris_column, data_type, select_vector);
+            return _decode_primitive_decimal<Int32, Int64, has_filter>(doris_column, data_type,
+                                                                       select_vector);
         }
         break;
     case TypeIndex::Decimal64:
         if (_physical_type == tparquet::Type::FIXED_LEN_BYTE_ARRAY) {
-            return _decode_binary_decimal<Int64>(doris_column, data_type, select_vector);
+            return _decode_binary_decimal<Int64, has_filter>(doris_column, data_type,
+                                                             select_vector);
         } else if (_physical_type == tparquet::Type::INT32) {
-            return _decode_primitive_decimal<Int64, Int32>(doris_column, data_type, select_vector);
+            return _decode_primitive_decimal<Int64, Int32, has_filter>(doris_column, data_type,
+                                                                       select_vector);
         } else if (_physical_type == tparquet::Type::INT64) {
-            return _decode_primitive_decimal<Int64, Int64>(doris_column, data_type, select_vector);
+            return _decode_primitive_decimal<Int64, Int64, has_filter>(doris_column, data_type,
+                                                                       select_vector);
         }
         break;
     case TypeIndex::Decimal128:
         if (_physical_type == tparquet::Type::FIXED_LEN_BYTE_ARRAY) {
-            return _decode_binary_decimal<Int128>(doris_column, data_type, select_vector);
+            return _decode_binary_decimal<Int128, has_filter>(doris_column, data_type,
+                                                              select_vector);
         } else if (_physical_type == tparquet::Type::INT32) {
-            return _decode_primitive_decimal<Int128, Int32>(doris_column, data_type, select_vector);
+            return _decode_primitive_decimal<Int128, Int32, has_filter>(doris_column, data_type,
+                                                                        select_vector);
         } else if (_physical_type == tparquet::Type::INT64) {
-            return _decode_primitive_decimal<Int128, Int64>(doris_column, data_type, select_vector);
+            return _decode_primitive_decimal<Int128, Int64, has_filter>(doris_column, data_type,
+                                                                        select_vector);
         }
         break;
     case TypeIndex::Decimal128I:
         if (_physical_type == tparquet::Type::FIXED_LEN_BYTE_ARRAY) {
-            return _decode_binary_decimal<Int128>(doris_column, data_type, select_vector);
+            return _decode_binary_decimal<Int128, has_filter>(doris_column, data_type,
+                                                              select_vector);
         } else if (_physical_type == tparquet::Type::INT32) {
-            return _decode_primitive_decimal<Int128, Int32>(doris_column, data_type, select_vector);
+            return _decode_primitive_decimal<Int128, Int32, has_filter>(doris_column, data_type,
+                                                                        select_vector);
         } else if (_physical_type == tparquet::Type::INT64) {
-            return _decode_primitive_decimal<Int128, Int64>(doris_column, data_type, select_vector);
+            return _decode_primitive_decimal<Int128, Int64, has_filter>(doris_column, data_type,
+                                                                        select_vector);
         }
         break;
     case TypeIndex::String:
         [[fallthrough]];
     case TypeIndex::FixedString:
         if (_physical_type == tparquet::Type::FIXED_LEN_BYTE_ARRAY) {
-            return _decode_string(doris_column, select_vector);
+            return _decode_string<has_filter>(doris_column, select_vector);
         }
         break;
     default:
@@ -148,10 +174,11 @@ Status FixLengthPlainDecoder::decode_values(MutableColumnPtr& doris_column, Data
                                    tparquet::to_string(_physical_type), getTypeName(logical_type));
 }
 
+template <bool has_filter>
 Status FixLengthPlainDecoder::_decode_string(MutableColumnPtr& doris_column,
                                              ColumnSelectVector& select_vector) {
     ColumnSelectVector::DataReadType read_type;
-    while (size_t run_length = select_vector.get_next_run(&read_type)) {
+    while (size_t run_length = select_vector.get_next_run<has_filter>(&read_type)) {
         switch (read_type) {
         case ColumnSelectVector::CONTENT: {
             std::vector<StringRef> string_values;
@@ -180,14 +207,14 @@ Status FixLengthPlainDecoder::_decode_string(MutableColumnPtr& doris_column,
     }
     return Status::OK();
 }
-template <typename Numeric>
+template <typename Numeric, bool has_filter>
 Status FixLengthPlainDecoder::_decode_numeric(MutableColumnPtr& doris_column,
                                               ColumnSelectVector& select_vector) {
     auto& column_data = static_cast<ColumnVector<Numeric>&>(*doris_column).get_data();
     size_t data_index = column_data.size();
     column_data.resize(data_index + select_vector.num_values() - select_vector.num_filtered());
     ColumnSelectVector::DataReadType read_type;
-    while (size_t run_length = select_vector.get_next_run(&read_type)) {
+    while (size_t run_length = select_vector.get_next_run<has_filter>(&read_type)) {
         switch (read_type) {
         case ColumnSelectVector::CONTENT: {
             for (size_t i = 0; i < run_length; ++i) {
@@ -214,14 +241,14 @@ Status FixLengthPlainDecoder::_decode_numeric(MutableColumnPtr& doris_column,
     return Status::OK();
 }
 
-template <typename CppType, typename ColumnType>
+template <typename CppType, typename ColumnType, bool has_filter>
 Status FixLengthPlainDecoder::_decode_date(MutableColumnPtr& doris_column,
                                            ColumnSelectVector& select_vector) {
     auto& column_data = static_cast<ColumnVector<ColumnType>&>(*doris_column).get_data();
     size_t data_index = column_data.size();
     column_data.resize(data_index + select_vector.num_values() - select_vector.num_filtered());
     ColumnSelectVector::DataReadType read_type;
-    while (size_t run_length = select_vector.get_next_run(&read_type)) {
+    while (size_t run_length = select_vector.get_next_run<has_filter>(&read_type)) {
         switch (read_type) {
         case ColumnSelectVector::CONTENT: {
             for (size_t i = 0; i < run_length; ++i) {
@@ -254,14 +281,14 @@ Status FixLengthPlainDecoder::_decode_date(MutableColumnPtr& doris_column,
     return Status::OK();
 }
 
-template <typename CppType, typename ColumnType>
+template <typename CppType, typename ColumnType, bool has_filter>
 Status FixLengthPlainDecoder::_decode_datetime64(MutableColumnPtr& doris_column,
                                                  ColumnSelectVector& select_vector) {
     auto& column_data = static_cast<ColumnVector<ColumnType>&>(*doris_column).get_data();
     size_t data_index = column_data.size();
     column_data.resize(data_index + select_vector.num_values() - select_vector.num_filtered());
     ColumnSelectVector::DataReadType read_type;
-    while (size_t run_length = select_vector.get_next_run(&read_type)) {
+    while (size_t run_length = select_vector.get_next_run<has_filter>(&read_type)) {
         switch (read_type) {
         case ColumnSelectVector::CONTENT: {
             for (size_t i = 0; i < run_length; ++i) {
@@ -296,14 +323,14 @@ Status FixLengthPlainDecoder::_decode_datetime64(MutableColumnPtr& doris_column,
     return Status::OK();
 }
 
-template <typename CppType, typename ColumnType>
+template <typename CppType, typename ColumnType, bool has_filter>
 Status FixLengthPlainDecoder::_decode_datetime96(MutableColumnPtr& doris_column,
                                                  ColumnSelectVector& select_vector) {
     auto& column_data = static_cast<ColumnVector<ColumnType>&>(*doris_column).get_data();
     size_t data_index = column_data.size();
     column_data.resize(data_index + select_vector.num_values() - select_vector.num_filtered());
     ColumnSelectVector::DataReadType read_type;
-    while (size_t run_length = select_vector.get_next_run(&read_type)) {
+    while (size_t run_length = select_vector.get_next_run<has_filter>(&read_type)) {
         switch (read_type) {
         case ColumnSelectVector::CONTENT: {
             for (size_t i = 0; i < run_length; ++i) {
@@ -338,7 +365,7 @@ Status FixLengthPlainDecoder::_decode_datetime96(MutableColumnPtr& doris_column,
     return Status::OK();
 }
 
-template <typename DecimalPrimitiveType>
+template <typename DecimalPrimitiveType, bool has_filter>
 Status FixLengthPlainDecoder::_decode_binary_decimal(MutableColumnPtr& doris_column,
                                                      DataTypePtr& data_type,
                                                      ColumnSelectVector& select_vector) {
@@ -350,7 +377,7 @@ Status FixLengthPlainDecoder::_decode_binary_decimal(MutableColumnPtr& doris_col
     DecimalScaleParams& scale_params = _decode_params->decimal_scale;
 
     ColumnSelectVector::DataReadType read_type;
-    while (size_t run_length = select_vector.get_next_run(&read_type)) {
+    while (size_t run_length = select_vector.get_next_run<has_filter>(&read_type)) {
         switch (read_type) {
         case ColumnSelectVector::CONTENT: {
             for (size_t i = 0; i < run_length; ++i) {
@@ -389,7 +416,7 @@ Status FixLengthPlainDecoder::_decode_binary_decimal(MutableColumnPtr& doris_col
     return Status::OK();
 }
 
-template <typename DecimalPrimitiveType, typename DecimalPhysicalType>
+template <typename DecimalPrimitiveType, typename DecimalPhysicalType, bool has_filter>
 Status FixLengthPlainDecoder::_decode_primitive_decimal(MutableColumnPtr& doris_column,
                                                         DataTypePtr& data_type,
                                                         ColumnSelectVector& select_vector) {
@@ -401,7 +428,7 @@ Status FixLengthPlainDecoder::_decode_primitive_decimal(MutableColumnPtr& doris_
     DecimalScaleParams& scale_params = _decode_params->decimal_scale;
 
     ColumnSelectVector::DataReadType read_type;
-    while (size_t run_length = select_vector.get_next_run(&read_type)) {
+    while (size_t run_length = select_vector.get_next_run<has_filter>(&read_type)) {
         switch (read_type) {
         case ColumnSelectVector::CONTENT: {
             for (size_t i = 0; i < run_length; ++i) {

--- a/be/src/vec/exec/format/parquet/fix_length_plain_decoder.h
+++ b/be/src/vec/exec/format/parquet/fix_length_plain_decoder.h
@@ -40,29 +40,34 @@ public:
     Status decode_values(MutableColumnPtr& doris_column, DataTypePtr& data_type,
                          ColumnSelectVector& select_vector, bool is_dict_filter) override;
 
+    template <bool hasFilter>
+    Status _decode_values(MutableColumnPtr& doris_column, DataTypePtr& data_type,
+                          ColumnSelectVector& select_vector, bool is_dict_filter);
+
     Status skip_values(size_t num_values) override;
 
 protected:
-    template <typename Numeric>
+    template <typename Numeric, bool has_filter>
     Status _decode_numeric(MutableColumnPtr& doris_column, ColumnSelectVector& select_vector);
 
-    template <typename CppType, typename ColumnType>
+    template <typename CppType, typename ColumnType, bool has_filter>
     Status _decode_date(MutableColumnPtr& doris_column, ColumnSelectVector& select_vector);
 
-    template <typename CppType, typename ColumnType>
+    template <typename CppType, typename ColumnType, bool has_filter>
     Status _decode_datetime64(MutableColumnPtr& doris_column, ColumnSelectVector& select_vector);
 
-    template <typename CppType, typename ColumnType>
+    template <typename CppType, typename ColumnType, bool has_filter>
     Status _decode_datetime96(MutableColumnPtr& doris_column, ColumnSelectVector& select_vector);
 
-    template <typename DecimalPrimitiveType>
+    template <typename DecimalPrimitiveType, bool has_filter>
     Status _decode_binary_decimal(MutableColumnPtr& doris_column, DataTypePtr& data_type,
                                   ColumnSelectVector& select_vector);
 
-    template <typename DecimalPrimitiveType, typename DecimalPhysicalType>
+    template <typename DecimalPrimitiveType, typename DecimalPhysicalType, bool has_filter>
     Status _decode_primitive_decimal(MutableColumnPtr& doris_column, DataTypePtr& data_type,
                                      ColumnSelectVector& select_vector);
 
+    template <bool has_filter>
     Status _decode_string(MutableColumnPtr& doris_column, ColumnSelectVector& select_vector);
 
     tparquet::Type::type _physical_type;

--- a/be/src/vec/exec/format/parquet/parquet_common.cpp
+++ b/be/src/vec/exec/format/parquet/parquet_common.cpp
@@ -157,34 +157,4 @@ bool ColumnSelectVector::can_filter_all(size_t remaining_num_values) {
 void ColumnSelectVector::skip(size_t num_values) {
     _filter_map_index += num_values;
 }
-
-size_t ColumnSelectVector::get_next_run(DataReadType* data_read_type) {
-    if (_has_filter) {
-        if (_read_index == _num_values) {
-            return 0;
-        }
-        const DataReadType& type = _data_map[_read_index++];
-        size_t run_length = 1;
-        while (_read_index < _num_values) {
-            if (_data_map[_read_index] == type) {
-                run_length++;
-                _read_index++;
-            } else {
-                break;
-            }
-        }
-        *data_read_type = type;
-        return run_length;
-    } else {
-        size_t run_length = 0;
-        while (run_length == 0) {
-            if (_read_index == (*_run_length_null_map).size()) {
-                return 0;
-            }
-            *data_read_type = _read_index % 2 == 0 ? CONTENT : NULL_DATA;
-            run_length = (*_run_length_null_map)[_read_index++];
-        }
-        return run_length;
-    }
-}
 } // namespace doris::vectorized

--- a/be/src/vec/exec/format/parquet/parquet_common.h
+++ b/be/src/vec/exec/format/parquet/parquet_common.h
@@ -106,7 +106,37 @@ public:
         }
     }
 
-    size_t get_next_run(DataReadType* data_read_type);
+    template <bool has_filter>
+    size_t get_next_run(DataReadType* data_read_type) {
+        DCHECK_EQ(_has_filter, has_filter);
+        if constexpr (has_filter) {
+            if (_read_index == _num_values) {
+                return 0;
+            }
+            const DataReadType& type = _data_map[_read_index++];
+            size_t run_length = 1;
+            while (_read_index < _num_values) {
+                if (_data_map[_read_index] == type) {
+                    run_length++;
+                    _read_index++;
+                } else {
+                    break;
+                }
+            }
+            *data_read_type = type;
+            return run_length;
+        } else {
+            size_t run_length = 0;
+            while (run_length == 0) {
+                if (_read_index == (*_run_length_null_map).size()) {
+                    return 0;
+                }
+                *data_read_type = _read_index % 2 == 0 ? CONTENT : NULL_DATA;
+                run_length = (*_run_length_null_map)[_read_index++];
+            }
+            return run_length;
+        }
+    }
 
     void set_run_length_null_map(const std::vector<uint16_t>& run_length_null_map,
                                  size_t num_values, NullMap* null_map = nullptr);


### PR DESCRIPTION


# Proposed changes

## Problem summary

In `XXXDecoder::decode_values():`
```
while (size_t run_length = select_vector.get_next_run<has_filter>(&read_type)) {
 ... 
}
```
It will call `get_next_run()`,  need to check `_has_filter` in the loop.
```
size_t get_next_run(DataReadType* data_read_type) {
    if (_has_filter) {
    
    } else {
  
    }
}
```

It is unnecessary. So optimize it by adding `has_filter` template param in `get_next_run()` to decrease `_has_filter` condition checking count in the loop.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

