### PR TITLE
[fix](Jdbc Catalog) fix Druid Pool parameter and set `testWhileIdle  = true`

### DIFF
--- a/conf/be.conf
+++ b/conf/be.conf
@@ -19,7 +19,7 @@ CUR_DATE=`date +%Y%m%d-%H%M%S`
 
 PPROF_TMPDIR="$DORIS_HOME/log/"
 
-JAVA_OPTS="-Xmx1024m -DlogPath=$DORIS_HOME/log/jni.log -Xlog:gc:$DORIS_HOME/log/be.gc.log.$CUR_DATE -Dsun.java.command=DorisBE -XX:-CriticalJNINatives -DJDBC_MIN_POOL=1 -DJDBC_MAX_POOL=100 -DJDBC_MAX_IDEL_TIME=600000"
+JAVA_OPTS="-Xmx1024m -DlogPath=$DORIS_HOME/log/jni.log -Xlog:gc:$DORIS_HOME/log/be.gc.log.$CUR_DATE -Dsun.java.command=DorisBE -XX:-CriticalJNINatives -DJDBC_MIN_POOL=1 -DJDBC_MAX_POOL=100 -DJDBC_MAX_IDEL_TIME=300000"
 
 # since 1.2, the JAVA_HOME need to be set to run BE process.
 # JAVA_HOME=/path/to/jdk/

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
@@ -306,6 +306,8 @@ public class JdbcExecutor {
     private void setValidationQuery(DruidDataSource ds, TOdbcTableType tableType) {
         if (tableType == TOdbcTableType.ORACLE) {
             ds.setValidationQuery("SELECT 1 FROM dual");
+        } else if (tableType == TOdbcTableType.SAP_HANA) {
+            ds.setValidationQuery("SELECT 1 FROM DUMMY");
         } else {
             ds.setValidationQuery("SELECT 1");
         }

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
@@ -88,7 +88,7 @@ public class JdbcExecutor {
         }
         minPoolSize = Integer.valueOf(System.getProperty("JDBC_MIN_POOL", "1"));
         maxPoolSize = Integer.valueOf(System.getProperty("JDBC_MAX_POOL", "100"));
-        maxIdelTime = Integer.valueOf(System.getProperty("JDBC_MAX_IDEL_TIME", "600000"));
+        maxIdelTime = Integer.valueOf(System.getProperty("JDBC_MAX_IDEL_TIME", "300000"));
         minIdleSize = minPoolSize > 0 ? 1 : 0;
         LOG.info("JdbcExecutor set minPoolSize = " + minPoolSize
                 + ", maxPoolSize = " + maxPoolSize
@@ -268,8 +268,11 @@ public class JdbcExecutor {
                 ds.setInitialSize(minPoolSize);
                 ds.setMaxActive(maxPoolSize);
                 ds.setMaxWait(5000);
-                ds.setTimeBetweenEvictionRunsMillis(maxIdelTime);
-                ds.setMinEvictableIdleTimeMillis(maxIdelTime / 2);
+                ds.setTestWhileIdle(true);
+                ds.setTestOnBorrow(false);
+                setValidationQuery(ds, tableType);
+                ds.setTimeBetweenEvictionRunsMillis(maxIdelTime / 5);
+                ds.setMinEvictableIdleTimeMillis(maxIdelTime);
                 druidDataSource = ds;
                 // here is a cache of datasource, which using the string(jdbcUrl + jdbcUser +
                 // jdbcPassword) as key.
@@ -297,6 +300,14 @@ public class JdbcExecutor {
             throw new UdfRuntimeException("Initialize datasource failed: ", e);
         } catch (FileNotFoundException e) {
             throw new UdfRuntimeException("FileNotFoundException failed: ", e);
+        }
+    }
+
+    private void setValidationQuery(DruidDataSource ds, TOdbcTableType tableType) {
+        if (tableType == TOdbcTableType.ORACLE) {
+            ds.setValidationQuery("SELECT 1 FROM dual");
+        } else {
+            ds.setValidationQuery("SELECT 1");
         }
     }
 


### PR DESCRIPTION
# Proposed changes

Set `testWhileIdle` for the druid pool to true

## Problem summary

If the external data source closes the connection for some reason，but druid still uses this invalid connection. It will cause error:
```
INTERNAL_ERROR]UdfRuntimeException: JDBC executor sql has error:
CAUSED BY: SQLRecoverableException: No more data to read from socket
```

So we set `testWhileIdle = true`

The function of this parameter is: 
When the application obtains a connection from the druid pool, it will check the validity of the connection (provided that the idle time of the connection is longer than `timeBetweenEvictionRunsMillis`).




## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

