### PR TITLE
[Fix](schema scanner) Fixed the problem of overflow when multiplying two INT

### DIFF
--- a/be/src/exec/schema_scanner/schema_columns_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_columns_scanner.cpp
@@ -455,7 +455,7 @@ Status SchemaColumnsScanner::_fill_block_impl(vectorized::Block* block) {
             if (data_type == TPrimitiveType::VARCHAR || data_type == TPrimitiveType::CHAR ||
                 data_type == TPrimitiveType::STRING) {
                 if (_desc_result.columns[i].columnDesc.__isset.columnLength) {
-                    srcs[i] = _desc_result.columns[i].columnDesc.columnLength * 4;
+                    srcs[i] = _desc_result.columns[i].columnDesc.columnLength * 4L;
                     datas[i] = srcs + i;
                 } else {
                     datas[i] = nullptr;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

### Before

```
_desc_result.columns[i].columnDesc.columnLength
```

### After

```
static_cast<int64_t>(_desc_result.columns[i].columnDesc.columnLength) * 4
```

avoid 2147483643 * 4 = -20

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

