### PR TITLE
[bugfix](topn) fix memory leak in topn AcceptNullPredicate

### DIFF
--- a/be/src/olap/accept_null_predicate.h
+++ b/be/src/olap/accept_null_predicate.h
@@ -18,7 +18,9 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 
+#include "common/factory_creator.h"
 #include "olap/column_predicate.h"
 #include "olap/rowset/segment_v2/bloom_filter.h"
 #include "olap/rowset/segment_v2/inverted_index_reader.h"
@@ -34,6 +36,8 @@ namespace doris {
  * At parent, it's used for topn runtime predicate.
 */
 class AcceptNullPredicate : public ColumnPredicate {
+    ENABLE_FACTORY_CREATOR(AcceptNullPredicate);
+
 public:
     AcceptNullPredicate(ColumnPredicate* nested)
             : ColumnPredicate(nested->column_id(), nested->opposite()), _nested {nested} {}
@@ -201,7 +205,7 @@ private:
         return "passnull predicate for " + _nested->debug_string();
     }
 
-    ColumnPredicate* _nested;
+    std::unique_ptr<ColumnPredicate> _nested;
 };
 
 } //namespace doris

--- a/be/src/runtime/runtime_predicate.cpp
+++ b/be/src/runtime/runtime_predicate.cpp
@@ -18,6 +18,7 @@
 #include "runtime/runtime_predicate.h"
 
 #include <stdint.h>
+#include <memory>
 
 // IWYU pragma: no_include <opentelemetry/common/threadlocal.h>
 #include "common/compiler_util.h" // IWYU pragma: keep
@@ -161,26 +162,26 @@ Status RuntimePredicate::update(const Field& value, const String& col_name, bool
     const TabletColumn& column = _tablet_schema->column_by_uid(col_unique_id);
     uint32_t index = _tablet_schema->field_index(col_unique_id);
     auto val = _get_value_fn(_orderby_extrem);
-    ColumnPredicate* pred = nullptr;
+    std::unique_ptr<ColumnPredicate> pred {nullptr};
     if (is_reverse) {
         // For DESC sort, create runtime predicate col_name >= min_top_value
         // since values that < min_top_value are less than any value in current topn values
-        pred = create_comparison_predicate<PredicateType::GE>(column, index, val, false,
-                                                              _predicate_arena.get());
+        pred.reset(create_comparison_predicate<PredicateType::GE>(column, index, val, false,
+                                                              _predicate_arena.get()));
     } else {
         // For ASC  sort, create runtime predicate col_name <= max_top_value
         // since values that > min_top_value are large than any value in current topn values
-        pred = create_comparison_predicate<PredicateType::LE>(column, index, val, false,
-                                                              _predicate_arena.get());
+        pred.reset(create_comparison_predicate<PredicateType::LE>(column, index, val, false,
+                                                              _predicate_arena.get()));
     }
 
     // For NULLS FIRST, wrap a AcceptNullPredicate to return true for NULL
     // since ORDER BY ASC/DESC should get NULL first but pred returns NULL
     // and NULL in where predicate will be treated as FALSE
     if (_nulls_first) {
-        pred = new AcceptNullPredicate(pred);
+        pred = AcceptNullPredicate::create_unique(pred.release());
     }
-    _predictate.reset(pred);
+    _predictate.reset(pred.release());
 
     return Status::OK();
 }

--- a/be/src/runtime/runtime_predicate.cpp
+++ b/be/src/runtime/runtime_predicate.cpp
@@ -18,6 +18,7 @@
 #include "runtime/runtime_predicate.h"
 
 #include <stdint.h>
+
 #include <memory>
 
 // IWYU pragma: no_include <opentelemetry/common/threadlocal.h>
@@ -167,12 +168,12 @@ Status RuntimePredicate::update(const Field& value, const String& col_name, bool
         // For DESC sort, create runtime predicate col_name >= min_top_value
         // since values that < min_top_value are less than any value in current topn values
         pred.reset(create_comparison_predicate<PredicateType::GE>(column, index, val, false,
-                                                              _predicate_arena.get()));
+                                                                  _predicate_arena.get()));
     } else {
         // For ASC  sort, create runtime predicate col_name <= max_top_value
         // since values that > min_top_value are large than any value in current topn values
         pred.reset(create_comparison_predicate<PredicateType::LE>(column, index, val, false,
-                                                              _predicate_arena.get()));
+                                                                  _predicate_arena.get()));
     }
 
     // For NULLS FIRST, wrap a AcceptNullPredicate to return true for NULL


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

fix the memory leak reported by ASAN as follows.

```
#0 0x5598a4363ded in operator new(unsigned long) (/mnt/hdd01/dorisTestEnv/VEC_ASAN/be/lib/doris_be+0x14d0bded) (BuildId: 0e35cb6207c3ab7c)
    #1 0x5598a593f841 in doris::IntegerPredicateCreator<(doris::PrimitiveType)3, (doris::PredicateType)6, std::__cxx11::basic_string<char, std::char_traits<ch
ar>, std::allocator<char>>>::create(doris::TabletColumn const&, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, bo
ol, doris::vectorized::Arena*) /mnt/hdd01/repo_center/doris_branch-2.0-alpha/doris/be/src/olap/predicate_creator.h:60:20
    #2 0x5598a593bd56 in doris::ColumnPredicate* doris::create_predicate<(doris::PredicateType)6, std::__cxx11::basic_string<char, std::char_traits<char>, std
::allocator<char>>>(doris::TabletColumn const&, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, bool, doris::vecto
rized::Arena*) /mnt/hdd01/repo_center/doris_branch-2.0-alpha/doris/be/src/olap/predicate_creator.h:247:15
    #3 0x5598a48693eb in doris::ColumnPredicate* doris::create_comparison_predicate<(doris::PredicateType)6>(doris::TabletColumn const&, int, std::__cxx11::ba
sic_string<char, std::char_traits<char>, std::allocator<char>> const&, bool, doris::vectorized::Arena*) /mnt/hdd01/repo_center/doris_branch-2.0-alpha/doris/be
/src/olap/predicate_creator.h:255:12
    #4 0x5598aec70dac in doris::vectorized::RuntimePredicate::update(doris::vectorized::Field const&, std::__cxx11::basic_string<char, std::char_traits<char>,
 std::allocator<char>> const&, bool) /mnt/hdd01/repo_center/doris_branch-2.0-alpha/doris/be/src/runtime/runtime_predicate.cpp:163:16
    #5 0x5598aebf0bfc in doris::vectorized::VSortNode::sink(doris::RuntimeState*, doris::vectorized::Block*, bool) /mnt/hdd01/repo_center/doris_branch-2.0-alp
ha/doris/be/src/vec/exec/vsort_node.cpp:143:17
    #6 0x5598aebf1f1a in doris::vectorized::VSortNode::open(doris::RuntimeState*) /mnt/hdd01/repo_center/doris_branch-2.0-alpha/doris/be/src/vec/exec/vsort_no
de.cpp:179:9
    #7 0x5598a6de89e6 in doris::PlanFragmentExecutor::open_vectorized_internal() /mnt/hdd01/repo_center/doris_branch-2.0-alpha/doris/be/src/runtime/plan_fragm
ent_executor.cpp:283:9
    #8 0x5598a6de7857 in doris::PlanFragmentExecutor::open() /mnt/hdd01/repo_center/doris_branch-2.0-alpha/doris/be/src/runtime/plan_fragment_executor.cpp:245
:14
    #9 0x5598a6d2eb65 in doris::FragmentExecState::execute() /mnt/hdd01/repo_center/doris_branch-2.0-alpha/doris/be/src/runtime/fragment_mgr.cpp:232:31

```

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

