### PR TITLE
[Enhancement](compaction) support parallel compaction for single tablet

### DIFF
--- a/be/src/http/action/compaction_action.cpp
+++ b/be/src/http/action/compaction_action.cpp
@@ -208,7 +208,7 @@ Status CompactionAction::_execute_compaction_callback(TabletSharedPtr tablet,
                 res = Status::Error<TRY_LOCK_FAILED>();
             } else {
                 StorageEngine::instance()->create_base_compaction(tablet, base_compaction);
-                Status res = base_compaction->prepare_compact();
+                res = base_compaction->prepare_compact();
                 if (res.ok()) {
                     tablet->set_base_compaction(base_compaction);
                     need_reset = true;
@@ -240,7 +240,7 @@ Status CompactionAction::_execute_compaction_callback(TabletSharedPtr tablet,
         bool need_reset = false;
         {
             std::unique_lock compaction_meta_lock(tablet->get_compaction_meta_lock());
-            Status res = cumu_compaction->prepare_compact();
+            res = cumu_compaction->prepare_compact();
             if (res.ok()) {
                 tablet->add_cumulative_compaction_unlocked(cumu_compaction);
                 need_reset = true;
@@ -255,7 +255,7 @@ Status CompactionAction::_execute_compaction_callback(TabletSharedPtr tablet,
         }
 
         if (!res) {
-            if (res.is<BE_NO_SUITABLE_VERSION>()) {
+            if (res.is<CUMULATIVE_NO_SUITABLE_VERSION>()) {
                 // Ignore this error code.
                 VLOG_NOTICE << "failed to init cumulative compaction due to no suitable version,"
                             << "tablet=" << tablet->full_name();

--- a/be/src/olap/base_compaction.h
+++ b/be/src/olap/base_compaction.h
@@ -43,8 +43,6 @@ public:
     Status prepare_compact() override;
     Status execute_compact_impl() override;
 
-    std::vector<RowsetSharedPtr> get_input_rowsets() { return _input_rowsets; }
-
 protected:
     Status pick_rowsets_to_compact() override;
     std::string compaction_name() const override { return "base compaction"; }

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -262,6 +262,7 @@ bool Compaction::handle_ordered_data_compaction() {
             if (i <= input_size / 2) {
                 return false;
             } else {
+                // TODO(ccl): other thread will read _input_rowsets, maybe add a lock
                 _input_rowsets.resize(i);
                 break;
             }

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -64,7 +64,8 @@ Compaction::Compaction(const TabletSharedPtr& tablet, const std::string& label)
           _input_row_num(0),
           _input_num_segments(0),
           _input_index_size(0),
-          _state(CompactionState::INITED) {
+          _state(CompactionState::INITED),
+          _is_clone_occurred(false) {
     _mem_tracker = std::make_shared<MemTrackerLimiter>(MemTrackerLimiter::Type::COMPACTION, label);
 }
 
@@ -82,6 +83,18 @@ Status Compaction::execute_compact() {
         gc_output_rowset();
     }
     return st;
+}
+
+const std::vector<RowsetSharedPtr>& Compaction::get_input_rowsets() const {
+    return _input_rowsets;
+}
+
+void Compaction::set_clone_occurred() {
+    _is_clone_occurred = true;
+}
+
+bool Compaction::get_clone_occurred() {
+    return _is_clone_occurred;
 }
 
 Status Compaction::do_compaction(int64_t permits) {

--- a/be/src/olap/compaction.h
+++ b/be/src/olap/compaction.h
@@ -57,6 +57,12 @@ public:
     virtual Status prepare_compact() = 0;
     Status execute_compact();
     virtual Status execute_compact_impl() = 0;
+
+    const std::vector<RowsetSharedPtr>& get_input_rowsets() const;
+
+    void set_clone_occurred();
+    bool get_clone_occurred();
+
 #ifdef BE_TEST
     void set_input_rowset(const std::vector<RowsetSharedPtr>& rowsets);
     RowsetSharedPtr output_rowset();
@@ -114,6 +120,8 @@ protected:
     int64_t _newest_write_timestamp;
     RowIdConversion _rowid_conversion;
     TabletSchemaSPtr _cur_tablet_schema;
+
+    std::atomic<bool> _is_clone_occurred;
 
     DISALLOW_COPY_AND_ASSIGN(Compaction);
 };

--- a/be/src/olap/cumulative_compaction.h
+++ b/be/src/olap/cumulative_compaction.h
@@ -36,10 +36,11 @@ public:
     CumulativeCompaction(const TabletSharedPtr& tablet);
     ~CumulativeCompaction() override;
 
+    // caller should hold compaction_meta_lock when call this function
     Status prepare_compact() override;
     Status execute_compact_impl() override;
 
-    std::vector<RowsetSharedPtr> get_input_rowsets() { return _input_rowsets; }
+    const std::vector<RowsetSharedPtr>& get_input_rowsets() { return _input_rowsets; }
 
 protected:
     Status pick_rowsets_to_compact() override;

--- a/be/src/olap/cumulative_compaction.h
+++ b/be/src/olap/cumulative_compaction.h
@@ -40,8 +40,6 @@ public:
     Status prepare_compact() override;
     Status execute_compact_impl() override;
 
-    const std::vector<RowsetSharedPtr>& get_input_rowsets() { return _input_rowsets; }
-
 protected:
     Status pick_rowsets_to_compact() override;
 

--- a/be/src/olap/cumulative_compaction_policy.h
+++ b/be/src/olap/cumulative_compaction_policy.h
@@ -66,8 +66,7 @@ public:
     /// return input_rowsets, the vector container as return
     /// return last_delete_version, if has delete rowset, record the delete version from input_rowsets
     /// return compaction_score, calculate the compaction score of picked input rowset
-    virtual int pick_input_rowsets(Tablet* tablet,
-                                   const std::vector<RowsetSharedPtr>& candidate_rowsets,
+    virtual int pick_input_rowsets(Tablet* tablet, std::vector<RowsetSharedPtr>& candidate_rowsets,
                                    const int64_t max_compaction_score,
                                    const int64_t min_compaction_score,
                                    std::vector<RowsetSharedPtr>* input_rowsets,
@@ -130,7 +129,7 @@ public:
     /// Its main policy is picking rowsets from candidate rowsets by comparing accumulative compaction_score,
     /// max_cumulative_compaction_num_singleton_deltas or checking whether there is delete version rowset,
     /// and choose those rowset in the same level to do cumulative compaction.
-    int pick_input_rowsets(Tablet* tablet, const std::vector<RowsetSharedPtr>& candidate_rowsets,
+    int pick_input_rowsets(Tablet* tablet, std::vector<RowsetSharedPtr>& candidate_rowsets,
                            const int64_t max_compaction_score, const int64_t min_compaction_score,
                            std::vector<RowsetSharedPtr>* input_rowsets,
                            Version* last_delete_version, size_t* compaction_score) override;
@@ -155,10 +154,14 @@ private:
 
     /// calculate the disk size belong to which level, the level is divide by power of 2
     /// between compaction_promotion_size_mbytes and 1KB
-    int64_t _level_size(const int64_t size);
+    int64_t _level_size(const int64_t size) const;
 
     /// when policy calculate cumulative_compaction_score, update promotion size at the same time
     void _refresh_tablet_promotion_size(Tablet* tablet, int64_t promotion_size);
+
+    // calculate max compaction score of rowsets, and set max_score_rowsets to successive rowsets with max score
+    uint32_t _calc_max_score(const std::vector<RowsetSharedPtr>& rowsets, int64_t promotion_size,
+                             std::vector<RowsetSharedPtr>* max_score_rowsets = nullptr) const;
 
 private:
     /// cumulative compaction promotion size, unit is byte.

--- a/be/src/olap/olap_common.h
+++ b/be/src/olap/olap_common.h
@@ -462,5 +462,6 @@ struct HashOfRowsetId {
 };
 
 using RowsetIdUnorderedSet = std::unordered_set<RowsetId, HashOfRowsetId>;
+using VersionUnorderedSet = std::unordered_set<Version, HashOfVersion>;
 
 } // namespace doris

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -387,7 +387,7 @@ private:
 
     std::mutex _tablet_submitted_compaction_mutex;
     // a tablet can do base and cumulative compaction at same time
-    std::map<DataDir*, std::unordered_set<TTabletId>> _tablet_submitted_cumu_compaction;
+    std::map<DataDir*, std::unordered_multiset<TTabletId>> _tablet_submitted_cumu_compaction;
     std::map<DataDir*, std::unordered_set<TTabletId>> _tablet_submitted_base_compaction;
 
     std::atomic<int32_t> _wakeup_producer_flag {0};

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -712,10 +712,11 @@ TabletSharedPtr TabletManager::find_best_tablet_to_compaction(
                     continue;
                 }
             } else {
-                std::unique_lock<std::mutex> lock(tablet_ptr->get_cumulative_compaction_lock(),
-                                                  std::try_to_lock);
+                std::shared_lock lock(tablet_ptr->get_cumulative_compaction_lock(),
+                                      std::try_to_lock);
                 if (!lock.owns_lock()) {
-                    LOG(INFO) << "can not get cumu lock: " << tablet_ptr->tablet_id();
+                    // the tablet is under clone
+                    LOG(INFO) << "can not get shared cumu lock: " << tablet_ptr->tablet_id();
                     continue;
                 }
             }

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -559,7 +559,8 @@ Status EngineCloneTask::_finish_clone(Tablet* tablet, const std::string& clone_d
     std::lock_guard base_compaction_lock(tablet->get_base_compaction_lock());
     std::lock_guard cumulative_compaction_lock(tablet->get_cumulative_compaction_lock());
     std::lock_guard cold_compaction_lock(tablet->get_cold_compaction_lock());
-    tablet->set_clone_occurred(true);
+    std::lock_guard compact_meta_lock(tablet->get_compaction_meta_lock());
+    tablet->set_clone_occurred();
     std::lock_guard<std::mutex> push_lock(tablet->get_push_lock());
     std::lock_guard<std::mutex> rwlock(tablet->get_rowset_update_lock());
     std::lock_guard<std::shared_mutex> wrlock(tablet->get_header_lock());


### PR DESCRIPTION
# Proposed changes

Issue Number: close #18742

## Problem summary

### Basic ideas
In this pr, we add support for parallel cumulative compaction for single tablet, and base compaction still runs in single thread.
Firstly, we save all current running cumulative compaction tasks in an array named `cumulative_compactions`, and save current running base compaction task in `base_compaction`.
In the case of multiple cumulative compaction tasks running at the same time, the time and order of completion of the tasks is indeterminate. Therefore, the rowsets that can be compacted by next thread are split into multiple contiguous segments. Every time we want to choose rowsets to compact, we will choose a contiguous segments with maximum score. And in this choose process, we will skip rowsets with large size to avoid their participation in cumulative compaction.
  We also change the behavior of `update_cumulative_point`. In `update_cumulative_point`, we will forward `cumulative_point` as far as possible.

### The use of lock
Since the clone task and the compression task cannot be performed at the same time, we use `shared_mutex` to ensure that the execution of the parallel compression task and the clone task is serialized. We also add a mutex `compaction_meta_lock` to protect the meta data of the compaction such as `cumulative_compactions`, `base_compaction` and `cumulative_point`. 
The following describes the detailed use of locks in each function
1. In `Tablet::calc_compaction_score`, we hold `compaction_meta_lock` and `meta_lock`, thus we can safely access `cumulative_compactions`, `cumulative_point`, etc.
2. In `Tablet::prepare_compaction_and_calculate_permits`, before call `prepare_compact`, we will hold `cumulative_compact_meta_lock`. Thus in `prepare_compact`, we can safely access `cumulative_compactions`, `cumulative_point`, etc. **The reason we hold `cumulative_compact_meta_lock` before calling `prepare_compact` because we need to ensure that choosing the rowsets to compact and adding the compaction task to `cumulative_compactions` must be an atomic operation.** It is the same for base compaction, we also need to get `cumulative_compact_meta_lock` first, and then check whether `base_compaction` is null, if it is not null, it means that base compaction is already running (e.g. triggered by http request).
3. In `CumulativeCompaction::execute_compact_impl`, we will try to get reader lock of `cumulative_compaction_lock` first, and if we can't get it, that means the tablet is under clone. After `do_compaction`, we will hold `compaction_meta_lock` and call `update_cumulative_point` to safely forward `cumulative_point`.
4. In `EngineCloneTask::_finish_clone`, in addition to acquiring `base_compaction_lock`, `cumulative_compaction_lock`(write lock), we also acquire the `cumulative_compact_meta_lock` to access current running compaction tasks and update their `is_clone_occurred` field.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

