### PR TITLE
[bugfix](aggregate_function) Fix wrong registration for percentile_approx

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_percentile_approx.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_percentile_approx.cpp
@@ -49,9 +49,9 @@ void register_aggregate_function_percentile(AggregateFunctionSimpleFactory& fact
 }
 
 void register_aggregate_function_percentile_approx(AggregateFunctionSimpleFactory& factory) {
-    factory.register_function_both("percentile_approx",
-                                   create_aggregate_function_percentile_approx<false>);
-    factory.register_function_both("percentile_approx",
-                                   create_aggregate_function_percentile_approx<true>);
+    factory.register_function("percentile_approx",
+                              create_aggregate_function_percentile_approx<false>, false);
+    factory.register_function("percentile_approx",
+                              create_aggregate_function_percentile_approx<true>, true);
 }
 } // namespace doris::vectorized


### PR DESCRIPTION
# Proposed changes

## Problem summary

the overloads of `percentile_approx` were registered wrongly. According to a coincidence of registration order, it has never lead to crash.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)
