### PR TITLE
[Enhancement](data-type) add FE config to prohibit create date and decimalv2 type

### DIFF
--- a/docs/en/docs/sql-manual/sql-reference/Data-Types/DATE.md
+++ b/docs/en/docs/sql-manual/sql-reference/Data-Types/DATE.md
@@ -37,6 +37,8 @@ Date type, the current range of values is ['0000-01-01','9999-12-31'], and the d
 ### note
 If you use version 1.2 and above, it is strongly recommended that you use the DATEV2 type instead of the DATE type as DATEV2 is more efficient than DATE type。
 
+We intend to delete this type in 2024. At this stage, Doris prohibits creating tables containing the `DATE` type by default. If you need to use it, you need to add `disable_datev1 = false` in the FE's config and restart the FE.
+
 ### example
 ```
 SELECT DATE('2003-12-31 01:02:03');

--- a/docs/en/docs/sql-manual/sql-reference/Data-Types/DECIMAL.md
+++ b/docs/en/docs/sql-manual/sql-reference/Data-Types/DECIMAL.md
@@ -35,5 +35,8 @@ in addition, M must be greater than or equal to the value of D.
 
 The default value is DECIMAL(9, 0).
 
+### note
+We intend to delete this type in 2024. At this stage, Doris prohibits creating tables containing the `DECIMAL` type by default. If you need to use it, you need to add `disable_decimalv2 = false` in the FE's config and restart the FE.
+
 ### keywords
 DECIMAL

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Data-Types/DATE.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Data-Types/DATE.md
@@ -35,6 +35,7 @@ under the License.
 
 ### note
     如果您使用1.2及以上版本，强烈推荐您使用DATEV2类型替代DATE类型。相比DATE类型，DATEV2更加高效。
+    我们打算在2024年删除这个类型，目前阶段，Doris默认禁止创建含有DATE类型的表，如果需要使用需要在FE的config中添加`disable_datev1 = false`，并重启FE。
 
 ### example
     mysql> SELECT DATE('2003-12-31 01:02:03');

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Data-Types/DECIMAL.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Data-Types/DECIMAL.md
@@ -33,5 +33,8 @@ under the License.
 
     默认值为 DECIMAL(9, 0)。
 
+### note
+    我们打算在2024年删除这个类型，目前阶段，Doris默认禁止创建含有DECIMAL类型的表，如果需要使用需要在FE的config中添加`disable_decimalv2 = false`，并重启FE。
+
 ### keywords
     DECIMAL

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2162,5 +2162,17 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true, masterOnly = true)
     public static boolean experimental_enable_duplicate_without_keys_by_default = false;
+
+    /**
+     * To prevent different types (V1, V2, V3) of behavioral inconsistencies,
+     * we may delete the DecimalV2 and DateV1 types in the future.
+     * At this stage, we use ‘disable_decimalv2’ and ‘disable_datev1’
+     * to determine whether these two types take effect.
+     */
+    @ConfField(mutable = true)
+    public static boolean disable_decimalv2  = true;
+
+    @ConfField(mutable = true)
+    public static boolean disable_datev1  = true;
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -329,6 +329,13 @@ public class CreateTableStmt extends DdlStmt {
             if (Objects.equals(columnDef.getType(), Type.ALL)) {
                 throw new AnalysisException("Disable to create table with `ALL` type columns.");
             }
+            if (Objects.equals(columnDef.getType(), Type.DATE) && Config.disable_datev1) {
+                throw new AnalysisException("Disable to create table with `DATE` type columns, please use `DATEV2`.");
+            }
+            if (Objects.equals(columnDef.getType(), Type.DECIMALV2) && Config.disable_decimalv2) {
+                throw new AnalysisException("Disable to create table with `DECIMAL` type columns,"
+                                            + "please use `DECIMALV3`.");
+            }
         }
         // analyze key desc
         if (engineName.equalsIgnoreCase("olap")) {

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
@@ -290,6 +290,8 @@ public abstract class TestWithFeService {
         Config.plugin_dir = dorisHome + "/plugins";
         Config.custom_config_dir = dorisHome + "/conf";
         Config.edit_log_type = "local";
+        Config.disable_decimalv2 = false;
+        Config.disable_datev1 = false;
         File file = new File(Config.custom_config_dir);
         if (!file.exists()) {
             file.mkdir();

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/UtFrameUtils.java
@@ -177,6 +177,8 @@ public class UtFrameUtils {
         Config.plugin_dir = dorisHome + "/plugins";
         Config.custom_config_dir = dorisHome + "/conf";
         Config.edit_log_type = "local";
+        Config.disable_decimalv2 = false;
+        Config.disable_datev1 = false;
         File file = new File(Config.custom_config_dir);
         if (!file.exists()) {
             file.mkdir();

--- a/regression-test/pipeline/p0/conf/fe.conf
+++ b/regression-test/pipeline/p0/conf/fe.conf
@@ -42,6 +42,8 @@ sys_log_level = INFO
 # meta_dir = ${DORIS_HOME}/doris-meta
 
 mysql_service_nio_enabled = true
+disable_decimalv2 = false
+disable_datev1 = false
 catalog_trash_expire_second=1
 # Choose one if there are more than one ip except loopback address.
 # Note that there should at most one ip match this list.

--- a/regression-test/pipeline/p1/conf/fe.conf
+++ b/regression-test/pipeline/p1/conf/fe.conf
@@ -42,6 +42,8 @@ sys_log_level = INFO
 # meta_dir = ${DORIS_HOME}/doris-meta
 
 mysql_service_nio_enabled = true
+disable_decimalv2 = false
+disable_datev1 = false
 catalog_trash_expire_second=1
 # Choose one if there are more than one ip except loopback address.
 # Note that there should at most one ip match this list.


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

 FE config 

- `disable_decimalv2`, default is true.
- `disable_datev1`, default is true.

Afterwards, Doris prohibits creating tables containing the `DATE` and `DECIMAL` type by default.

Because of intending to delete these types in the future. At this stage, If you need to use these types, you need to add `disable_datev1 = false` or `disable_decimalv2 = false` in the FE's config and restart the FE.

On regression pipeline, these parameters in FE config is set false.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

