### PR TITLE
[fix](stats) Fix potential NPE when loading Histogram

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
@@ -173,7 +173,7 @@ public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationCo
 
     private Statistics updateLessThanLiteral(Expression leftExpr, ColumnStatistic statsForLeft,
             double val, EstimationContext context, boolean contains) {
-        if (statsForLeft.histogram != null) {
+        if (statsForLeft.hasHistogram()) {
             return estimateLessThanLiteralWithHistogram(leftExpr, statsForLeft, val, context, contains);
         }
         //rightRange.distinctValues should not be used
@@ -186,7 +186,7 @@ public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationCo
 
     private Statistics updateGreaterThanLiteral(Expression leftExpr, ColumnStatistic statsForLeft,
             double val, EstimationContext context, boolean contains) {
-        if (statsForLeft.histogram != null) {
+        if (statsForLeft.hasHistogram()) {
             return estimateGreaterThanLiteralWithHistogram(leftExpr, statsForLeft, val, context, contains);
         }
         //rightRange.distinctValues should not be used
@@ -228,7 +228,7 @@ public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationCo
         } else {
             selectivity = StatsMathUtil.minNonNaN(1.0, 1.0 / ndv);
         }
-        if (statsForLeft.histogram != null) {
+        if (statsForLeft.hasHistogram()) {
             return estimateEqualToWithHistogram(cp.left(), statsForLeft, val, context);
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
@@ -271,4 +271,8 @@ public class ColumnStatistic {
     public boolean minOrMaxIsInf() {
         return Double.isInfinite(maxValue) || Double.isInfinite(minValue);
     }
+
+    public boolean hasHistogram() {
+        return histogram != null && histogram != Histogram.UNKNOWN;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/Histogram.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/Histogram.java
@@ -109,7 +109,7 @@ public class Histogram {
      */
     public static Histogram deserializeFromJson(String json) {
         if (Strings.isNullOrEmpty(json)) {
-            return null;
+            return Histogram.UNKNOWN;
         }
 
         try {
@@ -140,7 +140,7 @@ public class Histogram {
             LOG.error("deserialize from json error.", e);
         }
 
-        return null;
+        return Histogram.UNKNOWN;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCache.java
@@ -93,7 +93,7 @@ public class StatisticsCache {
         StatisticsCacheKey k = new StatisticsCacheKey(tblId, idxId, colName);
         try {
             CompletableFuture<Optional<ColumnStatistic>> f = columnStatisticsCache.get(k);
-            if (f.isDone() && f.get() != null) {
+            if (f.isDone()) {
                 return f.get();
             }
         } catch (Exception e) {
@@ -114,7 +114,7 @@ public class StatisticsCache {
         StatisticsCacheKey k = new StatisticsCacheKey(tblId, idxId, colName);
         try {
             CompletableFuture<Optional<Histogram>> f = histogramCache.get(k);
-            if (f.isDone() && f.get() != null) {
+            if (f.isDone()) {
                 return f.get();
             }
         } catch (Exception e) {


### PR DESCRIPTION
# Proposed changes

Return `UNKNOWN` as default when error occurred during loding

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

