### PR TITLE
[fix](regression) fix information schema test CHARACTER_OCTET_LENGTH overflow error

### DIFF
--- a/be/src/exec/schema_scanner/schema_columns_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_columns_scanner.cpp
@@ -455,7 +455,7 @@ Status SchemaColumnsScanner::_fill_block_impl(vectorized::Block* block) {
             if (data_type == TPrimitiveType::VARCHAR || data_type == TPrimitiveType::CHAR ||
                 data_type == TPrimitiveType::STRING) {
                 if (_desc_result.columns[i].columnDesc.__isset.columnLength) {
-                    srcs[i] = _desc_result.columns[i].columnDesc.columnLength * 4;
+                    srcs[i] = (int64_t)_desc_result.columns[i].columnDesc.columnLength * 4;
                     datas[i] = srcs + i;
                 } else {
                     datas[i] = nullptr;


### PR DESCRIPTION
# Proposed changes
Fix information schema p0 test CHARACTER_OCTET_LENGTH overflow error.

![image](https://user-images.githubusercontent.com/67053339/234418505-dc257a1c-240d-464e-8fab-3f494e069529.png)


Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

