### PR TITLE
[chore](third-party) Fix the checksums of mysql (#19047)

### DIFF
--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -183,7 +183,7 @@ BOOST_MD5SUM="4036cd27ef7548b8d29c30ea10956196"
 MYSQL_DOWNLOAD="https://github.com/mysql/mysql-server/archive/mysql-5.7.18.tar.gz"
 MYSQL_NAME=mysql-5.7.18.tar.gz
 MYSQL_SOURCE=mysql-server-mysql-5.7.18
-MYSQL_MD5SUM="58598b10dce180e4d1fbdd7cf5fa68d6"
+MYSQL_MD5SUM="11403c628c5e5101e6bf22453dbb2d34"
 
 # unix odbc
 ODBC_DOWNLOAD="http://www.unixodbc.org/unixODBC-2.3.7.tar.gz"


### PR DESCRIPTION
The checksum of MySQL changed which makes the workflows fail.

See https://github.com/apache/doris-thirdparty/actions/runs/4794208534/jobs/8527425262.

# Proposed changes

~~Issue Number: close #xxx~~

## Problem summary

Backport #19047

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

