### PR TITLE
[Fix](Planner)fix NPE msg when parse error.

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -206,7 +206,7 @@ parser code {:
         String lastToken = SqlScanner.tokenIdMap.get(Integer.valueOf(errorToken.sym));
         if (lastToken != null) {
             result.append(lastToken);
-        } else if (errorToken.value != null && SqlScanner.isKeyword((String) errorToken.value)) {
+        } else if (SqlScanner.isKeyword((String) errorToken.value)) {
             result.append("A reserved word cannot be used as an identifier: ").append((String) errorToken.value);
         } else {
             result.append("Unknown last token with id: " + errorToken.sym);

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -5719,7 +5719,7 @@ opt_plan_hints ::=
         }
         RESULT = hints;
     :}
-    | COMMENTED_PLAN_HINT_START ident_list:l COMMENTED_PLAN_HINT_END
+    | COMMENTED_PLAN_HINT_START expr_list:l COMMENTED_PLAN_HINT_END
     {:
         RESULT = l;
     :}

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -5719,7 +5719,7 @@ opt_plan_hints ::=
         }
         RESULT = hints;
     :}
-    | COMMENTED_PLAN_HINT_START expr_list:l COMMENTED_PLAN_HINT_END
+    | COMMENTED_PLAN_HINT_START ident_list:l COMMENTED_PLAN_HINT_END
     {:
         RESULT = l;
     :}

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -206,7 +206,7 @@ parser code {:
         String lastToken = SqlScanner.tokenIdMap.get(Integer.valueOf(errorToken.sym));
         if (lastToken != null) {
             result.append(lastToken);
-        } else if (SqlScanner.isKeyword((String) errorToken.value)) {
+        } else if (errorToken.value != null && SqlScanner.isKeyword((String) errorToken.value)) {
             result.append("A reserved word cannot be used as an identifier: ").append((String) errorToken.value);
         } else {
             result.append("Unknown last token with id: " + errorToken.sym);

--- a/fe/fe-core/src/main/jflex/sql_scanner.flex
+++ b/fe/fe-core/src/main/jflex/sql_scanner.flex
@@ -553,6 +553,9 @@ import org.apache.doris.qe.SqlModeHelper;
   }
 
   public static boolean isKeyword(String str) {
+        if (str == null) {
+            return false;
+        }
 	    return keywordMap.containsKey(str.toLowerCase());
   }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

some syntax error will cause unclear msg: NPE，because symbol.value is null and cause NPE when call toLowerCase(), we fix it by check if the value is null and return early.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [x] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

