### PR TITLE
[Optimize](parquet-reader) Opt by filtering null count statistics in the row group and page level.

### DIFF
--- a/be/src/vec/exec/format/parquet/vparquet_page_index.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_page_index.cpp
@@ -67,9 +67,10 @@ Status PageIndex::collect_skipped_page_range(tparquet::ColumnIndex* column_index
 
     const int num_of_pages = column_index->null_pages.size();
     for (int page_id = 0; page_id < num_of_pages; page_id++) {
-        if (ParquetPredicate::filter_by_min_max(col_val_range, col_schema,
-                                                encoded_min_vals[page_id],
-                                                encoded_max_vals[page_id], ctz)) {
+        bool is_all_null = column_index->null_pages[page_id];
+        if (ParquetPredicate::filter_by_stats(col_val_range, col_schema, !is_all_null,
+                                              encoded_min_vals[page_id], encoded_max_vals[page_id],
+                                              is_all_null, ctz)) {
             skipped_ranges.emplace_back(page_id);
         }
     }


### PR DESCRIPTION
# Proposed changes

## Problem summary

Issue Number: About #19038, we found in this case,  `l_orderkey` has many nulls,  so we can filter it by null count statistics in the row group and page level, then it can improve a lot of performance in this case.

## Test Result:
Before opt:
```
mysql> select l_quantity from test_external_catalog_hive.tpch_1000_parquet.lineitem where l_orderkey = 599614241 and l_partkey = 59018738 and l_suppkey = 1518744 limit 2;
+------------+
| l_quantity |
+------------+
|      16.00 |
+------------+
1 row in set (41.95 sec)
```

After opt:
```
mysql> select l_quantity from test_external_catalog_hive.tpch_1000_parquet.lineitem where l_orderkey = 599614241 and l_partkey = 59018738 and l_suppkey = 1518744 limit 2;
+------------+
| l_quantity |
+------------+
|      16.00 |
+------------+
1 row in set (1.23 sec)
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

