### PR TITLE
[fix](nereids)column prune should use slots from children

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/ColumnPruning.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/ColumnPruning.java
@@ -250,7 +250,8 @@ public class ColumnPruning extends DefaultPlanRewriter<PruneContext> implements 
         boolean hasNewChildren = false;
         for (Plan child : plan.children()) {
             Set<Slot> childOutputSet = child.getOutputSet();
-            Set<Slot> childRequiredSlots = Sets.intersection(childrenRequiredSlots, childOutputSet);
+            Set<Slot> childRequiredSlots = childOutputSet.stream()
+                    .filter(childrenRequiredSlots::contains).collect(Collectors.toSet());
             Plan prunedChild = doPruneChild(plan, child, childRequiredSlots);
             if (prunedChild != child) {
                 hasNewChildren = true;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

the slots' nullable property may different between parent and children. So column prune should always use slots of children

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

