### PR TITLE
[fix](planner) ctas should not clone queryStmt after parse

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableAsSelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableAsSelectStmt.java
@@ -51,7 +51,7 @@ public class CreateTableAsSelectStmt extends DdlStmt {
         this.createTableStmt = createTableStmt;
         this.columnNames = columnNames;
         this.queryStmt = queryStmt;
-        this.insertStmt = new InsertStmt(createTableStmt.getDbTbl(), queryStmt.clone());
+        this.insertStmt = new InsertStmt(createTableStmt.getDbTbl(), queryStmt);
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -1630,11 +1630,6 @@ public class FunctionCallExpr extends Expr {
         }
         // rewrite return type if is nested type function
         analyzeNestedFunction();
-        for (OrderByElement o : orderByElements) {
-            if (!o.getExpr().isAnalyzed) {
-                o.getExpr().analyzeImpl(analyzer);
-            }
-        }
     }
 
     // if return type is nested type, need to be determined the sub-element type


### PR DESCRIPTION
# Proposed changes

Remove redundant clone in the constructor of CTAS stmt

Error message:

```
NullPointerException, msg: java.lang.NullPointerException: null
```

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

