### PR TITLE
[branch-1.2-lts] Support datetimeV2 for min/max-by

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_min_max_by.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max_by.cpp
@@ -123,6 +123,16 @@ static IAggregateFunction* create_aggregate_function_min_max_by(const String& na
                                                          SingleValueDataDecimal<Decimal128I>>(
                 argument_types);
     }
+    if (which.idx == TypeIndex::DateV2) {
+        return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
+                                                         SingleValueDataFixed<UInt32>>(
+                argument_types);
+    }
+    if (which.idx == TypeIndex::DateTimeV2) {
+        return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
+                                                         SingleValueDataFixed<UInt64>>(
+                argument_types);
+    }
     return nullptr;
 }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close [#17606 ](https://github.com/apache/doris/issues/17606)

## Problem summary

add support for calling `min/max_by` with `DateV2` or `DatetimeV2`. It's a part of https://github.com/apache/doris/pull/17228