### PR TITLE
[Fix](multi-catalog) fix FE abnormal exit when replay OP_REFRESH_EXTERNAL_TABLE

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -746,6 +746,9 @@ public class HiveMetaStoreCache {
 
         @Override
         public int hashCode() {
+            if (dummyKey != null) {
+                return Objects.hash(dummyKey);
+            }
             return Objects.hash(location, partitionValues);
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -59,7 +59,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
-import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.mapred.FileInputFormat;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.InputSplit;
@@ -361,7 +360,8 @@ public class HiveMetaStoreCache {
         List<FileCacheKey> keys = Lists.newArrayListWithExpectedSize(partitions.size());
         partitions.stream().forEach(p -> {
             FileCacheKey fileCacheKey = p.isDummyPartition()
-                    ? FileCacheKey.createDummyCacheKey(p.getDbName(), p.getTblName(), p.getInputFormat(), useSelfSplitter)
+                    ? FileCacheKey.createDummyCacheKey(p.getDbName(), p.getTblName(),
+                    p.getInputFormat(), useSelfSplitter)
                     : new FileCacheKey(p.getPath(), p.getInputFormat(), p.getPartitionValues());
             fileCacheKey.setUseSelfSplitter(useSelfSplitter);
             keys.add(fileCacheKey);
@@ -725,11 +725,11 @@ public class HiveMetaStoreCache {
                                                        String inputFormat, boolean useSelfSplitter) {
             // we do not use non-partitioned table's real location
             // because we need to use hms client to get the location info
-            // and this method may be invoked when slave FE replays journal logs,
+            // but this method may be invoked when slave FE replays journal logs,
             // it is very dangerous to rely on external components
             String location = String.format(DUMMY_FILE_CACHE_KEY_TEMPLATE, dbName, tblName);
             FileCacheKey dummyKey = new FileCacheKey(location, inputFormat, null);
-            dummyKey.useSelfSplitter= useSelfSplitter;
+            dummyKey.useSelfSplitter = useSelfSplitter;
             return dummyKey;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HivePartition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HivePartition.java
@@ -28,21 +28,19 @@ public class HivePartition {
     private String inputFormat;
     private String path;
     private List<String> partitionValues;
-    private boolean isDummyPartition = false;
+    private boolean isDummyPartition;
 
-    public HivePartition(String dbName, String tblName, String inputFormat, String path, List<String> partitionValues) {
+    public HivePartition(String dbName, String tblName, boolean isDummyPartition,
+                         String inputFormat, String path, List<String> partitionValues) {
         this.dbName = dbName;
         this.tblName = tblName;
+        this.isDummyPartition = isDummyPartition;
         // eg: org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat
         this.inputFormat = inputFormat;
         // eg: hdfs://hk-dev01:8121/user/doris/parquet/partition_table/nation=cn/city=beijing
         this.path = path;
         // eg: cn, beijing
         this.partitionValues = partitionValues;
-    }
-
-    public void setDummyPartition() {
-        this.isDummyPartition = true;
     }
 
     public boolean isDummyPartition() {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HivePartition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HivePartition.java
@@ -23,11 +23,16 @@ import java.util.List;
 
 @Data
 public class HivePartition {
+    private String dbName;
+    private String tblName;
     private String inputFormat;
     private String path;
     private List<String> partitionValues;
+    private boolean isDummyPartition = false;
 
-    public HivePartition(String inputFormat, String path, List<String> partitionValues) {
+    public HivePartition(String dbName, String tblName, String inputFormat, String path, List<String> partitionValues) {
+        this.dbName = dbName;
+        this.tblName = tblName;
         // eg: org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat
         this.inputFormat = inputFormat;
         // eg: hdfs://hk-dev01:8121/user/doris/parquet/partition_table/nation=cn/city=beijing
@@ -36,10 +41,21 @@ public class HivePartition {
         this.partitionValues = partitionValues;
     }
 
+    public void setDummyPartition() {
+        this.isDummyPartition = true;
+    }
+
+    public boolean isDummyPartition() {
+        return this.isDummyPartition;
+    }
+
     @Override
     public String toString() {
         return "HivePartition{"
-                + "inputFormat='" + inputFormat + '\''
+                + "dbName='" + dbName + '\''
+                + ", tblName='" + tblName + '\''
+                + ", isDummyPartition='" + isDummyPartition + '\''
+                + ", inputFormat='" + inputFormat + '\''
                 + ", path='" + path + '\''
                 + ", partitionValues=" + partitionValues + '}';
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveSplitter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveSplitter.java
@@ -115,8 +115,10 @@ public class HiveSplitter implements Splitter {
             } else {
                 // unpartitioned table, create a dummy partition to save location and inputformat,
                 // so that we can unify the interface.
-                HivePartition dummyPartition = new HivePartition(hmsTable.getRemoteTable().getSd().getInputFormat(),
+                HivePartition dummyPartition = new HivePartition(hmsTable.getDbName(), hmsTable.getName(),
+                        hmsTable.getRemoteTable().getSd().getInputFormat(),
                         hmsTable.getRemoteTable().getSd().getLocation(), null);
+                dummyPartition.setDummyPartition();
                 getFileSplitByPartitions(cache, Lists.newArrayList(dummyPartition), allFiles, useSelfSplitter);
                 this.totalPartitionNum = 1;
                 this.readPartitionNum = 1;

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveSplitter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveSplitter.java
@@ -115,10 +115,9 @@ public class HiveSplitter implements Splitter {
             } else {
                 // unpartitioned table, create a dummy partition to save location and inputformat,
                 // so that we can unify the interface.
-                HivePartition dummyPartition = new HivePartition(hmsTable.getDbName(), hmsTable.getName(),
+                HivePartition dummyPartition = new HivePartition(hmsTable.getDbName(), hmsTable.getName(), true,
                         hmsTable.getRemoteTable().getSd().getInputFormat(),
                         hmsTable.getRemoteTable().getSd().getLocation(), null);
-                dummyPartition.setDummyPartition();
                 getFileSplitByPartitions(cache, Lists.newArrayList(dummyPartition), allFiles, useSelfSplitter);
                 this.totalPartitionNum = 1;
                 this.readPartitionNum = 1;


### PR DESCRIPTION
# Proposed changes

## Problem summary

When salve FE nodes replay OP_REFRESH_EXTERNAL_TABLE log, it will invoke `org.apache.doris.datasource.hive.HiveMetaStoreCache#invalidateTableCache`, but if the table is a non-partitioned table, it will invoke  `catalog.getClient().getTable`. If some network problem occurs or this table is not existed, an exception will be thrown and FE will exit right away. The solution is that we can use a dummy key as the file cache key which only contains db name and table name. And when slave FE nodes replay OP_REFRESH_EXTERNAL_TABLE log, it will not rely on the hms client and there will not any exception occurs.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

