### PR TITLE
[fix](load-profile) fix show load profile return empty result

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowLoadProfileStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowLoadProfileStmt.java
@@ -150,5 +150,10 @@ public class ShowLoadProfileStmt extends ShowStmt {
                 return null;
         }
     }
+
+    @Override
+    public RedirectStatus getRedirectStatus() {
+        return RedirectStatus.FORWARD_NO_SYNC;
+    }
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -2160,7 +2160,7 @@ public class ShowExecutor {
             }
             case FRAGMENTS: {
                 ProfileTreeNode treeRoot = ProfileManager.getInstance().getFragmentProfileTree(showStmt.getJobId(),
-                        showStmt.getJobId());
+                        showStmt.getTaskId());
                 if (treeRoot == null) {
                     throw new AnalysisException("Failed to get fragment tree for load: " + showStmt.getJobId());
                 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Fix 2 bugs of `show load profile`:

1. For broker load, the second level should be the sub task' id.
2. `show load profile` stmt should be forwarded to master FE to execute.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

