### PR TITLE
[fix](memory) Fix AggFunc memory leak due to incorrect destroy

### DIFF
--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -227,11 +227,19 @@ void MemTable::_insert_one_row_from_block(RowInBlock* row_in_block) {
         row_in_block->init_agg_places(_arena->aligned_alloc(_total_size_of_aggregate_states, 16),
                                       _offsets_of_aggregate_states.data());
         for (auto cid = _schema->num_key_columns(); cid < _schema->num_columns(); cid++) {
-            auto col_ptr = _input_mutable_block.mutable_columns()[cid].get();
-            auto data = row_in_block->agg_places(cid);
-            _agg_functions[cid]->create(data);
-            _agg_functions[cid]->add(data, const_cast<const doris::vectorized::IColumn**>(&col_ptr),
-                                     row_in_block->_row_pos, nullptr);
+            try {
+                auto col_ptr = _input_mutable_block.mutable_columns()[cid].get();
+                auto data = row_in_block->agg_places(cid);
+                _agg_functions[cid]->create(data);
+                _agg_functions[cid]->add(data,
+                                         const_cast<const doris::vectorized::IColumn**>(&col_ptr),
+                                         row_in_block->_row_pos, nullptr);
+            } catch (...) {
+                for (size_t i = _schema->num_key_columns(); i < cid; ++i) {
+                    _agg_functions[cid]->destroy(row_in_block->agg_places(cid));
+                }
+                throw;
+            }
         }
 
         _vec_skip_list->InsertWithHint(row_in_block, is_exist, &_vec_hint);

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -236,7 +236,7 @@ void MemTable::_insert_one_row_from_block(RowInBlock* row_in_block) {
                                          row_in_block->_row_pos, nullptr);
             } catch (...) {
                 for (size_t i = _schema->num_key_columns(); i < cid; ++i) {
-                    _agg_functions[cid]->destroy(row_in_block->agg_places(cid));
+                    _agg_functions[i]->destroy(row_in_block->agg_places(i));
                 }
                 throw;
             }

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -118,15 +118,31 @@ public:
             std::vector<vectorized::AggregateDataPtr> agg_places;
 
             for (int i = key_number; i < columns; i++) {
-                vectorized::AggregateFunctionPtr function =
-                        tablet_schema->column(i).get_aggregate_function(
-                                {finalized_block.get_data_type(i)}, vectorized::AGG_LOAD_SUFFIX);
-                agg_functions.push_back(function);
-                // create aggregate data
-                vectorized::AggregateDataPtr place = new char[function->size_of_data()];
-                function->create(place);
-                agg_places.push_back(place);
+                try {
+                    vectorized::AggregateFunctionPtr function =
+                            tablet_schema->column(i).get_aggregate_function(
+                                    {finalized_block.get_data_type(i)},
+                                    vectorized::AGG_LOAD_SUFFIX);
+                    agg_functions.push_back(function);
+                    // create aggregate data
+                    vectorized::AggregateDataPtr place = new char[function->size_of_data()];
+                    function->create(place);
+                    agg_places.push_back(place);
+                } catch (...) {
+                    for (int j = 0; j < i - key_number; ++j) {
+                        agg_functions[j]->destroy(agg_places[j]);
+                        delete[] agg_places[j];
+                    }
+                    throw;
+                }
             }
+
+            DEFER({
+                for (int i = 0; i < columns - key_number; i++) {
+                    agg_functions[i]->destroy(agg_places[i]);
+                    delete[] agg_places[i];
+                }
+            });
 
             for (int i = 0; i < rows; i++) {
                 auto row_ref = row_refs[i];
@@ -149,7 +165,7 @@ public:
                         agg_functions[j - key_number]->insert_result_into(
                                 agg_places[j - key_number],
                                 finalized_block.get_by_position(j).column->assume_mutable_ref());
-                        agg_functions[j - key_number]->create(agg_places[j - key_number]);
+                        agg_functions[j - key_number]->reset(agg_places[j - key_number]);
                     }
 
                     if (i == rows - 1 || finalized_block.rows() == ALTER_TABLE_BATCH_SIZE) {
@@ -158,11 +174,6 @@ public:
                         finalized_block.clear_column_data();
                     }
                 }
-            }
-
-            for (int i = 0; i < columns - key_number; i++) {
-                agg_functions[i]->destroy(agg_places[i]);
-                delete[] agg_places[i];
             }
         } else {
             std::vector<RowRef> pushed_row_refs;

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -165,7 +165,7 @@ public:
                         agg_functions[j - key_number]->insert_result_into(
                                 agg_places[j - key_number],
                                 finalized_block.get_by_position(j).column->assume_mutable_ref());
-                        agg_functions[j - key_number]->reset(agg_places[j - key_number]);
+                        agg_functions[j - key_number]->create(agg_places[j - key_number]);
                     }
 
                     if (i == rows - 1 || finalized_block.rows() == ALTER_TABLE_BATCH_SIZE) {

--- a/be/src/util/defer_op.h
+++ b/be/src/util/defer_op.h
@@ -40,4 +40,9 @@ private:
     T _closure;
 };
 
+// Nested use Defer, variable name concat line number
+#define DEFER_CONCAT(n, ...) const auto defer##n = Defer([&]() { __VA_ARGS__; })
+#define DEFER_FWD(n, ...) DEFER_CONCAT(n, __VA_ARGS__)
+#define DEFER(...) DEFER_FWD(__LINE__, __VA_ARGS__)
+
 } // namespace doris

--- a/be/src/vec/aggregate_functions/aggregate_function.h
+++ b/be/src/vec/aggregate_functions/aggregate_function.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "util/defer_op.h"
 #include "vec/columns/column_complex.h"
 #include "vec/common/hash_table/phmap_fwd_decl.h"
 #include "vec/common/string_buffer.hpp"
@@ -46,6 +47,16 @@ using DataTypes = std::vector<DataTypePtr>;
 
 using AggregateDataPtr = char*;
 using ConstAggregateDataPtr = const char*;
+
+#define SAFE_CREATE(create, destroy) \
+    do {                             \
+        try {                        \
+            create;                  \
+        } catch (...) {              \
+            destroy;                 \
+            throw;                   \
+        }                            \
+    } while (0)
 
 /** Aggregate functions interface.
   * Instances of classes with this interface do not contain the data itself for aggregation,
@@ -307,10 +318,10 @@ public:
         char place[size_of_data()];
         for (size_t i = 0; i != num_rows; ++i) {
             static_cast<const Derived*>(this)->create(place);
+            DEFER({ static_cast<const Derived*>(this)->destroy(place); });
             static_cast<const Derived*>(this)->add(place, columns, i, arena);
             static_cast<const Derived*>(this)->serialize(place, buf);
             buf.commit();
-            static_cast<const Derived*>(this)->destroy(place);
         }
     }
 
@@ -331,10 +342,18 @@ public:
                          size_t num_rows) const override {
         const auto size_of_data = static_cast<const Derived*>(this)->size_of_data();
         for (size_t i = 0; i != num_rows; ++i) {
-            auto place = places + size_of_data * i;
-            VectorBufferReader buffer_reader(column->get_data_at(i));
-            static_cast<const Derived*>(this)->create(place);
-            static_cast<const Derived*>(this)->deserialize(place, buffer_reader, arena);
+            try {
+                auto place = places + size_of_data * i;
+                VectorBufferReader buffer_reader(column->get_data_at(i));
+                static_cast<const Derived*>(this)->create(place);
+                static_cast<const Derived*>(this)->deserialize(place, buffer_reader, arena);
+            } catch (...) {
+                for (int j = 0; j < i; ++j) {
+                    auto place = places + size_of_data * j;
+                    static_cast<const Derived*>(this)->destroy(place);
+                }
+                throw;
+            }
         }
     }
 
@@ -400,9 +419,9 @@ public:
 
         auto derived = static_cast<const Derived*>(this);
         derived->create(deserialized_place);
+        DEFER({ derived->destroy(deserialized_place); });
         derived->deserialize(deserialized_place, buf, arena);
         derived->merge(place, deserialized_place, arena);
-        derived->destroy(deserialized_place);
     }
 
     void deserialize_and_merge_from_column(AggregateDataPtr __restrict place, const IColumn& column,

--- a/be/src/vec/aggregate_functions/aggregate_function.h
+++ b/be/src/vec/aggregate_functions/aggregate_function.h
@@ -410,7 +410,10 @@ public:
     /// NOTE: Currently not used (structures with aggregation state are put without alignment).
     size_t align_of_data() const override { return alignof(Data); }
 
-    void reset(AggregateDataPtr place) const override {}
+    void reset(AggregateDataPtr place) const override {
+        destroy(place);
+        create(place);
+    }
 
     void deserialize_and_merge(AggregateDataPtr __restrict place, BufferReadable& buf,
                                Arena* arena) const override {

--- a/be/src/vec/aggregate_functions/aggregate_function_distinct.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_distinct.h
@@ -243,7 +243,7 @@ public:
 
     void create(AggregateDataPtr __restrict place) const override {
         new (place) Data;
-        nested_func->create(get_nested_place(place));
+        SAFE_CREATE(nested_func->create(get_nested_place(place)), this->data(place).~Data());
     }
 
     void destroy(AggregateDataPtr __restrict place) const noexcept override {

--- a/be/src/vec/aggregate_functions/aggregate_function_java_udaf.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_java_udaf.h
@@ -433,7 +433,12 @@ public:
         if (_first_created) {
             new (place) Data(argument_types.size());
             Status status = Status::OK();
-            RETURN_IF_STATUS_ERROR(status, this->data(place).init_udaf(_fn, _local_location));
+            SAFE_CREATE(RETURN_IF_STATUS_ERROR(status,
+                                               this->data(place).init_udaf(_fn, _local_location)),
+                        {
+                            this->data(place).destroy();
+                            this->data(place).~Data();
+                        });
             _first_created = false;
             _exec_place = place;
         }

--- a/be/src/vec/aggregate_functions/aggregate_function_rpc.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_rpc.h
@@ -349,7 +349,8 @@ public:
     void create(AggregateDataPtr __restrict place) const override {
         new (place) Data(argument_types.size());
         Status status = Status::OK();
-        RETURN_IF_STATUS_ERROR(status, data(place).init(_fn));
+        SAFE_CREATE(RETURN_IF_STATUS_ERROR(status, data(place).init(_fn)),
+                    this->data(place).~Data());
     }
 
     String get_name() const override { return _fn.name.function_name; }

--- a/be/src/vec/aggregate_functions/aggregate_function_sort.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_sort.h
@@ -179,7 +179,7 @@ public:
 
     void create(AggregateDataPtr __restrict place) const override {
         new (place) Data(_sort_desc, _block);
-        _nested_func->create(get_nested_place(place));
+        SAFE_CREATE(_nested_func->create(get_nested_place(place)), this->data(place).~Data());
     }
 
     void destroy(AggregateDataPtr __restrict place) const noexcept override {

--- a/be/src/vec/aggregate_functions/aggregate_function_window.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window.h
@@ -52,7 +52,7 @@ class BufferWritable;
 namespace doris::vectorized {
 
 struct RowNumberData {
-    int64_t count;
+    int64_t count = 0;
 };
 
 class WindowFunctionRowNumber final
@@ -89,9 +89,9 @@ public:
 };
 
 struct RankData {
-    int64_t rank;
-    int64_t count;
-    int64_t peer_group_start;
+    int64_t rank = 0;
+    int64_t count = 0;
+    int64_t peer_group_start = 0;
 };
 
 class WindowFunctionRank final : public IAggregateFunctionDataHelper<RankData, WindowFunctionRank> {
@@ -134,8 +134,8 @@ public:
 };
 
 struct DenseRankData {
-    int64_t rank;
-    int64_t peer_group_start;
+    int64_t rank = 0;
+    int64_t peer_group_start = 0;
 };
 class WindowFunctionDenseRank final
         : public IAggregateFunctionDataHelper<DenseRankData, WindowFunctionDenseRank> {
@@ -175,8 +175,8 @@ public:
 };
 
 struct NTileData {
-    int64_t bucket_index;
-    int64_t rows;
+    int64_t bucket_index = 0;
+    int64_t rows = 0;
 };
 
 class WindowFunctionNTile final

--- a/be/src/vec/exec/vaggregation_node.cpp
+++ b/be/src/vec/exec/vaggregation_node.cpp
@@ -631,7 +631,14 @@ Status AggregationNode::close(RuntimeState* state) {
 
 Status AggregationNode::_create_agg_status(AggregateDataPtr data) {
     for (int i = 0; i < _aggregate_evaluators.size(); ++i) {
-        _aggregate_evaluators[i]->create(data + _offsets_of_aggregate_states[i]);
+        try {
+            _aggregate_evaluators[i]->create(data + _offsets_of_aggregate_states[i]);
+        } catch (...) {
+            for (int j = 0; j < i; ++j) {
+                _aggregate_evaluators[j]->destroy(data + _offsets_of_aggregate_states[j]);
+            }
+            throw;
+        }
     }
     return Status::OK();
 }

--- a/be/src/vec/exec/vaggregation_node.h
+++ b/be/src/vec/exec/vaggregation_node.h
@@ -1125,13 +1125,15 @@ private:
                                 _deserialize_buffer.data(), (ColumnString*)(column.get()),
                                 _agg_arena_pool.get(), rows);
                     }
+
+                    DEFER({
+                        _aggregate_evaluators[i]->function()->destroy_vec(
+                                _deserialize_buffer.data(), rows);
+                    });
+
                     _aggregate_evaluators[i]->function()->merge_vec_selected(
                             _places.data(), _offsets_of_aggregate_states[i],
                             _deserialize_buffer.data(), _agg_arena_pool.get(), rows);
-
-                    _aggregate_evaluators[i]->function()->destroy_vec(_deserialize_buffer.data(),
-                                                                      rows);
-
                 } else {
                     RETURN_IF_ERROR(_aggregate_evaluators[i]->execute_batch_add_selected(
                             block, _offsets_of_aggregate_states[i], _places.data(),
@@ -1170,13 +1172,15 @@ private:
                                 _deserialize_buffer.data(), (ColumnString*)(column.get()),
                                 _agg_arena_pool.get(), rows);
                     }
+
+                    DEFER({
+                        _aggregate_evaluators[i]->function()->destroy_vec(
+                                _deserialize_buffer.data(), rows);
+                    });
+
                     _aggregate_evaluators[i]->function()->merge_vec(
                             _places.data(), _offsets_of_aggregate_states[i],
                             _deserialize_buffer.data(), _agg_arena_pool.get(), rows);
-
-                    _aggregate_evaluators[i]->function()->destroy_vec(_deserialize_buffer.data(),
-                                                                      rows);
-
                 } else {
                     RETURN_IF_ERROR(_aggregate_evaluators[i]->execute_batch_add(
                             block, _offsets_of_aggregate_states[i], _places.data(),

--- a/be/src/vec/exec/vanalytic_eval_node.h
+++ b/be/src/vec/exec/vanalytic_eval_node.h
@@ -165,6 +165,7 @@ private:
     int64_t _rows_start_offset = 0;
     int64_t _rows_end_offset = 0;
     size_t _agg_functions_size = 0;
+    bool _agg_functions_created = false;
 
     /// The offset of the n-th functions.
     std::vector<size_t> _offsets_of_aggregate_states;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Asan memory leak:
```
  #0 0x5598a4363ded in operator new(unsigned long) (/mnt/hdd01/dorisTestEnv/VEC_ASAN/be/lib/doris_be+0x14d0bded) (BuildId: 0e35cb6207c3ab7c)
    #1 0x5598ae1606a1 in COW<doris::vectorized::IColumn>::mutable_ptr<doris::vectorized::ColumnVector<long>> COWHelper<doris::vectorized::ColumnVectorHelper,
doris::vectorized::ColumnVector<long>>::create<>() /doris/be/src/vec/common/cow.h:412:27
    #2 0x5598ae160268 in doris::vectorized::ColumnVector<long>::clone_resized(unsigned long) const /doris/be/src/
vec/columns/column_vector.cpp:319:16
    #3 0x5598a477c0f9 in doris::vectorized::IColumn::clone_empty() const /doris/be/src/vec/columns/column.h:117:5
3
    #4 0x5598ae632232 in doris::vectorized::ColumnWithTypeAndName::clone_empty() const /doris/be/src/vec/core/col
umn_with_type_and_name.cpp:34:30
    #5 0x5598ae5e1d41 in doris::vectorized::Block::clone_empty() const /doris/be/src/vec/core/block.cpp:508:25
    #6 0x5598b32ac19e in doris::vectorized::AggregateFunctionSortData::AggregateFunctionSortData(std::vector<doris::vectorized::SortColumnDescription, std::al
locator<doris::vectorized::SortColumnDescription>>, doris::vectorized::Block const&) /doris/be/src/vec/aggregate_
functions/aggregate_function_sort.h:39:60
    #7 0x5598b32a895f in doris::vectorized::AggregateFunctionSort<doris::vectorized::AggregateFunctionSortData>::create(char*) const /mnt/hdd01/repo_center/do
ris_branch-2.0-alpha/doris/be/src/vec/aggregate_functions/aggregate_function_sort.h:160:21
    #8 0x5598b32a9d3f in doris::vectorized::IAggregateFunctionHelper<doris::vectorized::AggregateFunctionSort<doris::vectorized::AggregateFunctionSortData>>::
deserialize_vec(char*, doris::vectorized::ColumnString const*, doris::vectorized::Arena*, unsigned long) const /d
oris/be/src/vec/aggregate_functions/aggregate_function.h:335:48
    #9 0x5598b32aa00f in doris::vectorized::IAggregateFunctionHelper<doris::vectorized::AggregateFunctionSort<doris::vectorized::AggregateFunctionSortData>>::
deserialize_from_column(char*, doris::vectorized::IColumn const&, doris::vectorized::Arena*, unsigned long) const /mnt/hdd01/repo_center/doris_branch-2.0-alph
a/doris/be/src/vec/aggregate_functions/aggregate_function.h:342:9
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

