### PR TITLE
[fix](fe)hll_raw_agg function's return type should be always not nullable

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/AggregateFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/AggregateFunction.java
@@ -48,7 +48,7 @@ public class AggregateFunction extends Function {
 
     public static ImmutableSet<String> NOT_NULLABLE_AGGREGATE_FUNCTION_NAME_SET = ImmutableSet.of("row_number", "rank",
             "dense_rank", "multi_distinct_count", "multi_distinct_sum", FunctionSet.HLL_UNION_AGG,
-            FunctionSet.HLL_UNION, FunctionSet.BITMAP_UNION, FunctionSet.BITMAP_INTERSECT,
+            FunctionSet.HLL_UNION, FunctionSet.HLL_RAW_AGG, FunctionSet.BITMAP_UNION, FunctionSet.BITMAP_INTERSECT,
             FunctionSet.ORTHOGONAL_BITMAP_INTERSECT, FunctionSet.ORTHOGONAL_BITMAP_INTERSECT_COUNT,
             FunctionSet.INTERSECT_COUNT, FunctionSet.ORTHOGONAL_BITMAP_UNION_COUNT,
             FunctionSet.COUNT, "approx_count_distinct", "ndv", FunctionSet.BITMAP_UNION_INT,

--- a/regression-test/data/types/complex_types/basic_agg_test.out
+++ b/regression-test/data/types/complex_types/basic_agg_test.out
@@ -14,3 +14,8 @@
 2	1
 3	2
 
+-- !sql_hll_cardinality2 --
+1	0
+2	1
+3	2
+

--- a/regression-test/suites/types/complex_types/basic_agg_test.groovy
+++ b/regression-test/suites/types/complex_types/basic_agg_test.groovy
@@ -26,7 +26,9 @@ suite("basic_agg_test", "types") {
 
     qt_sql_bitmap """select * from bitmap_basic_agg;"""
 
-    qt_sql_hll """select * from hll_basic_agg;"""
+    qt_sql_hll """select * from hll_basic_agg order by k1;"""
 
     qt_sql_hll_cardinality """select k1, hll_cardinality(hll_union(k2)) from hll_basic_agg group by k1 order by k1;"""
+
+    qt_sql_hll_cardinality2 """select k1, hll_cardinality(hll_raw_agg(k2)) from hll_basic_agg group by k1 order by k1;"""
 }


### PR DESCRIPTION


# Proposed changes
pick from master https://github.com/apache/doris/pull/19115

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

