### PR TITLE
[fix](memory) Fix SchemaChange memory leak due to incorrect aggfunc destroy

### DIFF
--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -149,7 +149,7 @@ public:
                         agg_functions[j - key_number]->insert_result_into(
                                 agg_places[j - key_number],
                                 finalized_block.get_by_position(j).column->assume_mutable_ref());
-                        agg_functions[j - key_number]->create(agg_places[j - key_number]);
+                        agg_functions[j - key_number]->reset(agg_places[j - key_number]);
                     }
 
                     if (i == rows - 1 || finalized_block.rows() == ALTER_TABLE_BATCH_SIZE) {

--- a/be/src/vec/aggregate_functions/aggregate_function.h
+++ b/be/src/vec/aggregate_functions/aggregate_function.h
@@ -391,7 +391,10 @@ public:
     /// NOTE: Currently not used (structures with aggregation state are put without alignment).
     size_t align_of_data() const override { return alignof(Data); }
 
-    void reset(AggregateDataPtr place) const override {}
+    void reset(AggregateDataPtr place) const override {
+        destroy(place);
+        create(place);
+    }
 
     void deserialize_and_merge(AggregateDataPtr __restrict place, BufferReadable& buf,
                                Arena* arena) const override {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

```
Direct leak of 192 byte(s) in 6 object(s) allocated from:
    #0 0x5598a4329bee in malloc (/mnt/hdd01/dorisTestEnv/VEC_ASAN/be/lib/doris_be+0x14cd1bee) (BuildId: 0e35cb6207c3ab7c)
    #1 0x5598a48e85c5 in Allocator<false, true>::alloc(unsigned long, unsigned long) /doris/be/src/vec/common/all
ocator.h:157:27
    #2 0x5598a500adb6 in doris::vectorized::Allocator_<void* phmap::priv::Allocate<8ul, doris::vectorized::Allocator_<unsigned long>>(doris::vectorized::Alloc
ator_<unsigned long>*, unsigned long)::M>::allocate(unsigned long) /doris/be/src/vec/common/hash_table/phmap_fwd_
decl.h:39:73
    #3 0x5598a500ad6e in phmap::allocator_traits<doris::vectorized::Allocator_<void* phmap::priv::Allocate<8ul, doris::vectorized::Allocator_<unsigned long>>(
doris::vectorized::Allocator_<unsigned long>*, unsigned long)::M>>::allocate(doris::vectorized::Allocator_<void* phmap::priv::Allocate<8ul, doris::vectorized:
:Allocator_<unsigned long>>(doris::vectorized::Allocator_<unsigned long>*, unsigned long)::M>&, unsigned long) /d
oris/thirdparty/installed/include/parallel_hashmap/phmap_base.h:1468:18
    #4 0x5598a500a919 in void* phmap::priv::Allocate<8ul, doris::vectorized::Allocator_<unsigned long>>(doris::vectorized::Allocator_<unsigned long>*, unsigne
d long) /doris/thirdparty/installed/include/parallel_hashmap/phmap_base.h:4356:13

    #10 0x5598a726fe40 in phmap::flat_hash_set<unsigned long, phmap::Hash<unsigned long>, phmap::EqualTo<unsigned long>, doris::vectorized::Allocator_<unsigne
d long>>::operator=(phmap::flat_hash_set<unsigned long, phmap::Hash<unsigned long>, phmap::EqualTo<unsigned long>, doris::vectorized::Allocator_<unsigned long
>> const&) /doris/thirdparty/installed/include/parallel_hashmap/phmap.h:4577:7
    #11 0x5598a727e7a4 in doris::HyperLogLog::merge(doris::HyperLogLog const&) /doris/be/src/olap/hll.cpp:89:23
    #12 0x5598ab7a544e in doris::vectorized::AggregateFunctionHLLData::add(doris::vectorized::IColumn const*, unsigned long) /mnt/hdd01/repo_center/doris_bran
ch-2.0-alpha/doris/be/src/vec/aggregate_functions/aggregate_function_hll_union_agg.h:59:17
    #13 0x5598ab7a09a0 in doris::vectorized::AggregateFunctionHLLUnion<doris::vectorized::AggregateFunctionHLLUnionImpl<doris::vectorized::AggregateFunctionHL
LData>>::add(char*, doris::vectorized::IColumn const**, unsigned long, doris::vectorized::Arena*) const /doris/be
/src/vec/aggregate_functions/aggregate_function_hll_union_agg.h:104:27
    #14 0x5598a5dfe3b1 in doris::MultiBlockMerger::merge(std::vector<std::unique_ptr<doris::vectorized::Block, std::default_delete<doris::vectorized::Block>>,
 std::allocator<std::unique_ptr<doris::vectorized::Block, std::default_delete<doris::vectorized::Block>>>> const&, doris::RowsetWriter*, unsigned long*) doris/be/src/olap/schema_change.cpp:107:52
    #15 0x5598a5dbc8d2 in doris::VSchemaChangeWithSorting::_internal_sorting(std::vector<std::unique_ptr<doris::vectorized::Block, std::default_delete<doris::
vectorized::Block>>, std::allocator<std::unique_ptr<doris::vectorized::Block, std::default_delete<doris::vectorized::Block>>>> const&, doris::Version const&,
long, std::shared_ptr<doris::Tablet>, doris::RowsetTypePB, doris::SegmentsOverlapPB, std::shared_ptr<doris::Rowset>*) /mnt/hdd01/repo_center/doris_branch-2.0-
alpha/doris/be/src/olap/schema_change.cpp:565:5
    #16 0x5598a5dbb304 in doris::VSchemaChangeWithSorting::_inner_process(std::shared_ptr<doris::RowsetReader>, doris::RowsetWriter*, std::shared_ptr<doris::T
ablet>, std::shared_ptr<doris::TabletSchema>)::$_3::operator()() const /doris/be/src/olap/schema_change.cpp:489:9
    #17 0x5598a5dba862 in doris::VSchemaChangeWithSorting::_inner_process(std::shared_ptr<doris::RowsetReader>, doris::RowsetWriter*, std::shared_ptr<doris::T
ablet>, std::shared_ptr<doris::TabletSchema>) /doris/be/src/olap/schema_change.cpp:533:5
    #18 0x5598a5e0b069 in doris::SchemaChange::process(std::shared_ptr<doris::RowsetReader>, doris::RowsetWriter*, std::shared_ptr<doris::Tablet>, std::shared
_ptr<doris::Tablet>, std::shared_ptr<doris::TabletSchema>) /doris/be/src/olap/schema_change.h:87:9
    #19 0x5598a5dd2db5 in doris::SchemaChangeHandler::_convert_historical_rowsets(doris::SchemaChangeHandler::SchemaChangeParams const&) /mnt/hdd01/repo_cente
r/doris_branch-2.0-alpha/doris/be/src/olap/schema_change.cpp:1598:33
    #20 0x5598a5dcad14 in doris::SchemaChangeHandler::_do_process_alter_tablet_v2(doris::TAlterTabletReqV2 const&) /mnt/hdd01/repo_center/doris_branch-2.0-alp
ha/doris/be/src/olap/schema_change.cpp:1124:15
    #21 0x5598a5dc54db in doris::SchemaChangeHandler::process_alter_tablet_v2(doris::TAlterTabletReqV2 const&) /d
oris/be/src/olap/schema_change.cpp:857:18
    #22 0x5598a69d35ed in doris::EngineAlterTabletTask::execute() /doris/be/src/olap/task/engine_alter_tablet_tas
k.cpp:40:18
    #23 0x5598a5d08d6c in doris::StorageEngine::execute_task(doris::EngineTask*) /doris/be/src/olap/storage_engin
e.cpp:1001:5
    #24 0x5598a5e9a550 in doris::TaskWorkerPool::_alter_tablet(doris::TAgentTaskRequest const&, long, doris::TTaskType::type, doris::TFinishTaskRequest*) /mnt
/hdd01/repo_center/doris_branch-2.0-alpha/doris/be/src/agent/task_worker_pool.cpp:680:42
    #25 0x5598a5e7e44b in doris::TaskWorkerPool::_alter_tablet_worker_thread_callback() /doris/be/src/agent/task_
worker_pool.cpp:640:17
```
...

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

