### PR TITLE
[feature](S3FileWriter) Reduce network RTT for files that multipart are not applicable

### DIFF
--- a/be/src/io/fs/s3_file_writer.cpp
+++ b/be/src/io/fs/s3_file_writer.cpp
@@ -75,7 +75,7 @@ S3FileWriter::S3FileWriter(Path path, std::shared_ptr<S3Client> client, const S3
         : FileWriter(Path(s3_conf.endpoint) / s3_conf.bucket / path, std::move(fs)),
           _bucket(s3_conf.bucket),
           _key(std::move(path)),
-          _upload_cost_ms(std::make_shared<int64_t>()),
+          _upload_cost_ms(std::make_unique<int64_t>()),
           _client(std::move(client)) {}
 
 S3FileWriter::~S3FileWriter() {

--- a/be/src/io/fs/s3_file_writer.h
+++ b/be/src/io/fs/s3_file_writer.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <aws/core/utils/memory/stl/AWSStringStream.h>
+#include <bthread/countdown_event.h>
 
 #include <cstddef>
 #include <list>
@@ -62,47 +63,8 @@ public:
     int64_t upload_cost_ms() const { return *_upload_cost_ms; }
 
 private:
-    class WaitGroup {
-    public:
-        WaitGroup() = default;
-
-        ~WaitGroup() = default;
-
-        WaitGroup(const WaitGroup&) = delete;
-        WaitGroup(WaitGroup&&) = delete;
-        void operator=(const WaitGroup&) = delete;
-        void operator=(WaitGroup&&) = delete;
-        // add one counter indicating one more concurrent worker
-        void add(int count = 1) { _count += count; }
-
-        // decrease count if one concurrent worker finished it's work
-        void done() {
-            _count--;
-            if (_count.load() <= 0) {
-                _cv.notify_all();
-            }
-        }
-
-        // wait for all concurrent workers finish their work and return true
-        // would return false if timeout, default timeout would be 5min
-        bool wait(int64_t timeout_seconds = 300) {
-            if (_count.load() <= 0) {
-                return true;
-            }
-            std::unique_lock<std::mutex> lck {_lock};
-            _cv.wait_for(lck, std::chrono::seconds(timeout_seconds),
-                         [this]() { return _count.load() <= 0; });
-            return _count.load() <= 0;
-        }
-
-    private:
-        std::mutex _lock;
-        std::condition_variable _cv;
-        std::atomic_int64_t _count {0};
-    };
     void _wait_until_finish(std::string task_name);
     Status _complete();
-    Status _open();
     Status _create_multi_upload_request();
     void _put_object(S3FileBuffer& buf);
     void _upload_one_part(int64_t part_num, S3FileBuffer& buf);
@@ -123,7 +85,7 @@ private:
     std::mutex _completed_lock;
     std::vector<std::unique_ptr<Aws::S3::Model::CompletedPart>> _completed_parts;
 
-    WaitGroup _wait;
+    bthread::CountdownEvent _count;
 
     std::atomic_bool _failed = false;
     Status _st = Status::OK();

--- a/be/src/io/fs/s3_file_writer.h
+++ b/be/src/io/fs/s3_file_writer.h
@@ -121,7 +121,7 @@ private:
     // Current Part Num for CompletedPart
     int _cur_part_num = 1;
     std::mutex _completed_lock;
-    std::vector<std::shared_ptr<Aws::S3::Model::CompletedPart>> _completed_parts;
+    std::vector<std::unique_ptr<Aws::S3::Model::CompletedPart>> _completed_parts;
 
     WaitGroup _wait;
 

--- a/be/src/io/fs/s3_file_writer.h
+++ b/be/src/io/fs/s3_file_writer.h
@@ -48,8 +48,6 @@ public:
                  FileSystemSPtr fs);
     ~S3FileWriter() override;
 
-    Status open();
-
     Status close() override;
 
     Status abort() override;
@@ -102,7 +100,11 @@ private:
         std::condition_variable _cv;
         std::atomic_int64_t _count {0};
     };
+    void _wait_until_finish(std::string task_name);
     Status _complete();
+    Status _open();
+    Status _create_multi_upload_request();
+    void _put_object(S3FileBuffer& buf);
     void _upload_one_part(int64_t part_num, S3FileBuffer& buf);
 
     std::string _bucket;

--- a/be/src/io/fs/s3_file_writer.h
+++ b/be/src/io/fs/s3_file_writer.h
@@ -74,7 +74,7 @@ private:
     bool _closed = true;
     bool _opened = false;
 
-    std::shared_ptr<int64_t> _upload_cost_ms;
+    std::unique_ptr<int64_t> _upload_cost_ms;
 
     std::shared_ptr<Aws::S3::S3Client> _client;
     std::string _upload_id;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
For files less than 5MB, we don't need to use multi part upload which would at least takes 3 network IO. Instead we can just call PutObject which only takes one shot.
## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

