### PR TITLE
[fix](Hive bitmap udf) NPE error when mapreduce task only has map task

### DIFF
--- a/fe/hive-udf/src/main/java/org/apache/doris/udf/BitmapUnionUDAF.java
+++ b/fe/hive-udf/src/main/java/org/apache/doris/udf/BitmapUnionUDAF.java
@@ -64,7 +64,7 @@ public class BitmapUnionUDAF extends AbstractGenericUDAFResolver {
             super.init(m, parameters);
             // init output object inspectors
             // The output of a partial aggregation is a binary
-            if (m == Mode.PARTIAL1) {
+            if (m == Mode.PARTIAL1 || m == Mode.COMPLETE) {
                 this.inputOI = (BinaryObjectInspector) parameters[0];
             } else {
                 this.internalMergeOI = (BinaryObjectInspector) parameters[0];

--- a/fe/hive-udf/src/main/java/org/apache/doris/udf/ToBitmapUDAF.java
+++ b/fe/hive-udf/src/main/java/org/apache/doris/udf/ToBitmapUDAF.java
@@ -70,7 +70,7 @@ public class ToBitmapUDAF extends AbstractGenericUDAFResolver {
             super.init(m, parameters);
             // init output object inspectors
             // The output of a partial aggregation is a binary
-            if (m == Mode.PARTIAL1) {
+            if (m == Mode.PARTIAL1 || m == Mode.COMPLETE) {
                 inputOI = (PrimitiveObjectInspector) parameters[0];
             } else {
                 this.internalMergeOI = (BinaryObjectInspector) parameters[0];


### PR DESCRIPTION
# Proposed changes

Issue Number: close https://github.com/apache/doris/issues/17539

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

