### PR TITLE
[Chore](build) upgrade clang-format version to 16 && move thrift to fe-common

### DIFF
--- a/.github/workflows/be-ut-clang.yml
+++ b/.github/workflows/be-ut-clang.yml
@@ -62,7 +62,7 @@ jobs:
           export DEFAULT_DIR='/opt/doris'
 
           mkdir "${DEFAULT_DIR}"
-          wget https://github.com/amosbird/ldb_toolchain_gen/releases/download/v0.14.2/ldb_toolchain_gen.sh \
+          wget https://github.com/amosbird/ldb_toolchain_gen/releases/download/v0.17/ldb_toolchain_gen.sh \
             -q -O /tmp/ldb_toolchain_gen.sh
           bash /tmp/ldb_toolchain_gen.sh "${DEFAULT_DIR}/ldb-toolchain"
 

--- a/.github/workflows/build-thirdparty.yml
+++ b/.github/workflows/build-thirdparty.yml
@@ -95,7 +95,7 @@ jobs:
           sudo DEBIAN_FRONTEND=noninteractive apt install --yes "${packages[@]}"
 
           mkdir -p "${DEFAULT_DIR}"
-          wget https://github.com/amosbird/ldb_toolchain_gen/releases/download/v0.14.2/ldb_toolchain_gen.sh \
+          wget https://github.com/amosbird/ldb_toolchain_gen/releases/download/v0.17/ldb_toolchain_gen.sh \
             -q -O /tmp/ldb_toolchain_gen.sh
           bash /tmp/ldb_toolchain_gen.sh "${DEFAULT_DIR}/ldb-toolchain"
 

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -47,7 +47,7 @@ jobs:
         id: be_clang_format
         with:
           source: "be/src be/test"
-          clangFormatVersion: 15
+          clangFormatVersion: 16
           inplace: False
 
       - name: Ignore it!

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -78,7 +78,7 @@ jobs:
           export DEFAULT_DIR='/opt/doris'
 
           mkdir "${DEFAULT_DIR}"
-          wget https://github.com/amosbird/ldb_toolchain_gen/releases/download/v0.14.2/ldb_toolchain_gen.sh \
+          wget https://github.com/amosbird/ldb_toolchain_gen/releases/download/v0.17/ldb_toolchain_gen.sh \
             -q -O /tmp/ldb_toolchain_gen.sh
           bash /tmp/ldb_toolchain_gen.sh "${DEFAULT_DIR}/ldb-toolchain"
 

--- a/.gitignore
+++ b/.gitignore
@@ -74,8 +74,8 @@ fe/fe-core/gen/
 fe/fe-core/src/main/resources/static/
 fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisLexer.tokens
 fe/fe-core/src/main/antlr4/org/apache/doris/nereids/gen/
-fe/fe-core/src/main/java/org/apache/doris/thrift
-fe/fe-core/src/main/java/org/apache/parquet
+fe/fe-common/src/main/java/org/apache/doris/thrift
+fe/fe-common/src/main/java/org/apache/parquet
 
 # BE
 be/build*/

--- a/be/src/common/factory_creator.h
+++ b/be/src/common/factory_creator.h
@@ -35,21 +35,33 @@
 // during inherits
 // TODO try to allow make_unique
 //
-#define ENABLE_FACTORY_CREATOR(TypeName)                                                     \
-private:                                                                                     \
-    void* operator new(std::size_t size) { return ::operator new(size); }                    \
-    void* operator new[](std::size_t size) { return ::operator new[](size); }                \
-                                                                                             \
-public:                                                                                      \
-    void* operator new(std::size_t count, void* ptr) { return ::operator new(count, ptr); }  \
-    void operator delete(void* ptr) noexcept { ::operator delete(ptr); }                     \
-    void operator delete[](void* ptr) noexcept { ::operator delete[](ptr); }                 \
-    void operator delete(void* ptr, void* place) noexcept { ::operator delete(ptr, place); } \
-    template <typename... Args>                                                              \
-    static std::shared_ptr<TypeName> create_shared(Args&&... args) {                         \
-        return std::make_shared<TypeName>(std::forward<Args>(args)...);                      \
-    }                                                                                        \
-    template <typename... Args>                                                              \
-    static std::unique_ptr<TypeName> create_unique(Args&&... args) {                         \
-        return std::unique_ptr<TypeName>(new TypeName(std::forward<Args>(args)...));         \
+#define ENABLE_FACTORY_CREATOR(TypeName)                                             \
+private:                                                                             \
+    void* operator new(std::size_t size) {                                           \
+        return ::operator new(size);                                                 \
+    }                                                                                \
+    void* operator new[](std::size_t size) {                                         \
+        return ::operator new[](size);                                               \
+    }                                                                                \
+                                                                                     \
+public:                                                                              \
+    void* operator new(std::size_t count, void* ptr) {                               \
+        return ::operator new(count, ptr);                                           \
+    }                                                                                \
+    void operator delete(void* ptr) noexcept {                                       \
+        ::operator delete(ptr);                                                      \
+    }                                                                                \
+    void operator delete[](void* ptr) noexcept {                                     \
+        ::operator delete[](ptr);                                                    \
+    }                                                                                \
+    void operator delete(void* ptr, void* place) noexcept {                          \
+        ::operator delete(ptr, place);                                               \
+    }                                                                                \
+    template <typename... Args>                                                      \
+    static std::shared_ptr<TypeName> create_shared(Args&&... args) {                 \
+        return std::make_shared<TypeName>(std::forward<Args>(args)...);              \
+    }                                                                                \
+    template <typename... Args>                                                      \
+    static std::unique_ptr<TypeName> create_unique(Args&&... args) {                 \
+        return std::unique_ptr<TypeName>(new TypeName(std::forward<Args>(args)...)); \
     }

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -134,7 +134,7 @@ Status SegmentWriter::init(const std::vector<uint32_t>& col_ids, bool has_key,
     _column_writers.reserve(_tablet_schema->columns().size());
     _column_ids.insert(_column_ids.end(), col_ids.begin(), col_ids.end());
     _olap_data_convertor = std::make_unique<vectorized::OlapBlockDataConvertor>();
-    auto create_column_writer = [&](uint32_t cid, const auto& column) -> auto{
+    auto create_column_writer = [&](uint32_t cid, const auto& column) -> auto {
         ColumnWriterOptions opts;
         opts.meta = _footer.add_columns();
 

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -42,13 +42,15 @@ class RuntimeState;
 class TDataSink;
 } // namespace doris
 
-#define OPERATOR_CODE_GENERATOR(NAME, SUBCLASS)                                                 \
-    NAME##Builder::NAME##Builder(int32_t id, ExecNode* exec_node)                               \
-            : OperatorBuilder(id, #NAME, exec_node) {}                                          \
-                                                                                                \
-    OperatorPtr NAME##Builder::build_operator() { return std::make_shared<NAME>(this, _node); } \
-                                                                                                \
-    NAME::NAME(OperatorBuilderBase* operator_builder, ExecNode* node)                           \
+#define OPERATOR_CODE_GENERATOR(NAME, SUBCLASS)                       \
+    NAME##Builder::NAME##Builder(int32_t id, ExecNode* exec_node)     \
+            : OperatorBuilder(id, #NAME, exec_node) {}                \
+                                                                      \
+    OperatorPtr NAME##Builder::build_operator() {                     \
+        return std::make_shared<NAME>(this, _node);                   \
+    }                                                                 \
+                                                                      \
+    NAME::NAME(OperatorBuilderBase* operator_builder, ExecNode* node) \
             : SUBCLASS(operator_builder, node) {};
 
 namespace doris::pipeline {

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -309,6 +309,9 @@ public:
 
 protected:
     void _fresh_exec_timer(NodeType* node) {
+        if (_runtime_profile == nullptr) {
+            return;
+        }
         node->profile()->total_time_counter()->update(
                 _runtime_profile->total_time_counter()->value());
     }
@@ -387,6 +390,9 @@ public:
 
 protected:
     void _fresh_exec_timer(NodeType* node) {
+        if (_runtime_profile == nullptr) {
+            return;
+        }
         node->runtime_profile()->total_time_counter()->update(
                 _runtime_profile->total_time_counter()->value());
     }

--- a/be/src/vec/common/hash_table/hash.h
+++ b/be/src/vec/common/hash_table/hash.h
@@ -122,10 +122,12 @@ inline size_t hash_crc32(doris::vectorized::Int128 u) {
             doris::vectorized::UInt128((u >> 64) & int64_t(-1), u & int64_t(-1)));
 }
 
-#define DEFINE_HASH(T)                                                \
-    template <>                                                       \
-    struct HashCRC32<T> {                                             \
-        size_t operator()(T key) const { return hash_crc32<T>(key); } \
+#define DEFINE_HASH(T)                   \
+    template <>                          \
+    struct HashCRC32<T> {                \
+        size_t operator()(T key) const { \
+            return hash_crc32<T>(key);   \
+        }                                \
     };
 
 DEFINE_HASH(doris::vectorized::UInt8)

--- a/be/src/vec/functions/like.cpp
+++ b/be/src/vec/functions/like.cpp
@@ -451,7 +451,7 @@ Status FunctionLikeBase::execute_impl(FunctionContext* context, Block& block,
             context->get_function_state(FunctionContext::THREAD_LOCAL));
     // for constant_substring_fn, use long run length search for performance
     if (constant_substring_fn ==
-        *(state->function.target<doris::Status (*)(LikeSearchState * state, const ColumnString&,
+        *(state->function.target<doris::Status (*)(LikeSearchState* state, const ColumnString&,
                                                    const StringRef&, ColumnUInt8::Container&)>())) {
         RETURN_IF_ERROR(execute_substring(values->get_chars(), values->get_offsets(), vec_res,
                                           &state->search_state));

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -108,7 +108,7 @@ if [[ -e "${DORIS_HOME}/bin/palo_env.sh" ]]; then
 fi
 
 if [[ -z "${JAVA_HOME}" ]]; then
-    JAVA="$(which java)"
+    JAVA="$(command -v java)"
 else
     JAVA="${JAVA_HOME}/bin/java"
 fi

--- a/build-for-release.sh
+++ b/build-for-release.sh
@@ -91,7 +91,7 @@ else
     done
 fi
 
-if [[ ${HELP} -eq 1 ]]; then
+if [[ "${HELP}" -eq 1 ]]; then
     usage
     exit 0
 fi

--- a/build-for-release.sh
+++ b/build-for-release.sh
@@ -58,7 +58,6 @@ eval set -- "${OPTS}"
 
 _USE_AVX2=1
 TAR=0
-VERSION=
 if [[ "$#" == 1 ]]; then
     _USE_AVX2=1
 else
@@ -92,9 +91,9 @@ else
     done
 fi
 
-if [[ "${HELP}" -eq 1 ]]; then
+if [[ ${HELP} -eq 1 ]]; then
     usage
-    exit
+    exit 0
 fi
 
 if [[ -z ${VERSION} ]]; then

--- a/build-for-release.sh
+++ b/build-for-release.sh
@@ -58,6 +58,8 @@ eval set -- "${OPTS}"
 
 _USE_AVX2=1
 TAR=0
+HELP=0
+VERSION=
 if [[ "$#" == 1 ]]; then
     _USE_AVX2=1
 else
@@ -93,13 +95,11 @@ fi
 
 if [[ "${HELP}" -eq 1 ]]; then
     usage
-    exit 0
 fi
 
 if [[ -z ${VERSION} ]]; then
     echo "Must specify version"
     usage
-    exit 1
 fi
 
 echo "Get params:

--- a/build-support/check-format.sh
+++ b/build-support/check-format.sh
@@ -31,6 +31,6 @@ DORIS_HOME=$(
 )
 export DORIS_HOME
 
-CLANG_FORMAT="${CLANG_FORMAT_BINARY:=$(which clang-format)}"
+CLANG_FORMAT="${CLANG_FORMAT_BINARY:=$(command -v clang-format)}"
 
 python "${DORIS_HOME}/build-support/run_clang_format.py" "--clang-format-executable" "${CLANG_FORMAT}" "-r" "--style" "file" "--inplace" "false" "--extensions" "c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx" "--exclude" "none" "be/src be/test"

--- a/build-support/clang-format.sh
+++ b/build-support/clang-format.sh
@@ -31,6 +31,6 @@ DORIS_HOME=$(
 )
 export DORIS_HOME
 
-CLANG_FORMAT="${CLANG_FORMAT_BINARY:=$(which clang-format)}"
+CLANG_FORMAT="${CLANG_FORMAT_BINARY:=$(command -v clang-format)}"
 
 python "${DORIS_HOME}/build-support/run_clang_format.py" "--clang-format-executable" "${CLANG_FORMAT}" "-r" "--style" "file" "--inplace" "true" "--extensions" "c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx" "--exclude" "none" "be/src be/test"

--- a/build.sh
+++ b/build.sh
@@ -230,7 +230,7 @@ else
     fi
 fi
 
-if [[ "${HELP}" -eq 1 ]]; then
+if [[ ${HELP} -eq 1 ]]; then
     usage
     exit
 fi
@@ -432,7 +432,7 @@ if [[ "${BUILD_BE}" -eq 1 ]]; then
     if [[ "${CLEAN}" -eq 1 ]]; then
         clean_be
     fi
-    MAKE_PROGRAM="$(which "${BUILD_SYSTEM}")"
+    MAKE_PROGRAM="$(command -v "${BUILD_SYSTEM}")"
     echo "-- Make program: ${MAKE_PROGRAM}"
     echo "-- Use ccache: ${CMAKE_USE_CCACHE}"
     echo "-- Extra cxx flags: ${EXTRA_CXX_FLAGS:-}"

--- a/build.sh
+++ b/build.sh
@@ -391,9 +391,9 @@ echo "Build generated code"
 cd "${DORIS_HOME}/gensrc"
 # DO NOT using parallel make(-j) for gensrc
 make
-rm -rf "${DORIS_HOME}/fe/fe-core/src/main/java/org/apache/doris/thrift ${DORIS_HOME}/fe/fe-core/src/main/java/org/apache/parquet"
-cp -r "build/gen_java/org/apache/doris/thrift" "${DORIS_HOME}/fe/fe-core/src/main/java/org/apache/doris"
-cp -r "build/gen_java/org/apache/parquet" "${DORIS_HOME}/fe/fe-core/src/main/java/org/apache/"
+rm -rf "${DORIS_HOME}/fe/fe-common/src/main/java/org/apache/doris/thrift ${DORIS_HOME}/fe/fe-common/src/main/java/org/apache/parquet"
+cp -r "build/gen_java/org/apache/doris/thrift" "${DORIS_HOME}/fe/fe-common/src/main/java/org/apache/doris"
+cp -r "build/gen_java/org/apache/parquet" "${DORIS_HOME}/fe/fe-common/src/main/java/org/apache/"
 
 # Assesmble FE modules
 FE_MODULES=''

--- a/build.sh
+++ b/build.sh
@@ -232,7 +232,6 @@ fi
 
 if [[ "${HELP}" -eq 1 ]]; then
     usage
-    exit
 fi
 # build thirdparty libraries if necessary
 if [[ ! -f "${DORIS_THIRDPARTY}/installed/lib/libbacktrace.a" ]]; then

--- a/build.sh
+++ b/build.sh
@@ -230,7 +230,7 @@ else
     fi
 fi
 
-if [[ ${HELP} -eq 1 ]]; then
+if [[ "${HELP}" -eq 1 ]]; then
     usage
     exit
 fi

--- a/build_plugin.sh
+++ b/build_plugin.sh
@@ -87,7 +87,7 @@ else
     done
 fi
 
-if [[ "${HELP}" -eq 1 ]]; then
+if [[ ${HELP} -eq 1 ]]; then
     usage
     exit
 fi

--- a/build_plugin.sh
+++ b/build_plugin.sh
@@ -52,6 +52,7 @@ eval set -- "${OPTS}"
 
 ALL_PLUGIN=1
 CLEAN=0
+HELP=0
 if [[ "$#" == 1 ]]; then
     # defuat
     ALL_PLUGIN=1
@@ -87,7 +88,7 @@ else
     done
 fi
 
-if [[ ${HELP} -eq 1 ]]; then
+if [[ "${HELP}" -eq 1 ]]; then
     usage
     exit
 fi

--- a/build_plugin.sh
+++ b/build_plugin.sh
@@ -90,7 +90,6 @@ fi
 
 if [[ "${HELP}" -eq 1 ]]; then
     usage
-    exit
 fi
 
 echo "Get params:

--- a/contrib/udf/build_udf.sh
+++ b/contrib/udf/build_udf.sh
@@ -102,7 +102,6 @@ fi
 
 if [[ "${HELP}" -eq 1 ]]; then
     usage
-    exit
 fi
 
 echo "Get params:

--- a/contrib/udf/build_udf.sh
+++ b/contrib/udf/build_udf.sh
@@ -100,7 +100,7 @@ else
     done
 fi
 
-if [[ ${HELP} -eq 1 ]]; then
+if [[ "${HELP}" -eq 1 ]]; then
     usage
     exit
 fi

--- a/contrib/udf/build_udf.sh
+++ b/contrib/udf/build_udf.sh
@@ -100,7 +100,7 @@ else
     done
 fi
 
-if [[ "${HELP}" -eq 1 ]]; then
+if [[ ${HELP} -eq 1 ]]; then
     usage
     exit
 fi

--- a/dist/download_scripts/download_base.sh
+++ b/dist/download_scripts/download_base.sh
@@ -39,7 +39,7 @@ DOWNLOAD_DIR="$5"
 FILE_SUFFIX=".tar.xz"
 
 # Check if curl cmd exists
-if [[ -n $(which curl >/dev/null 2>&1) ]]; then
+if [[ -n $(command -v curl >/dev/null 2>&1) ]]; then
     echo "curl command not found on the system"
     exit 1
 fi

--- a/docker/thirdparties/run-thirdparties-docker.sh
+++ b/docker/thirdparties/run-thirdparties-docker.sh
@@ -99,13 +99,11 @@ fi
 
 if [[ "${HELP}" -eq 1 ]]; then
     usage
-    exit 0
 fi
 
 if [[ "${COMPONENTS}"x == ""x ]]; then
     echo "Invalid arguments"
     usage
-    exit 1
 fi
 
 if [[ "${CONTAINER_UID}"x == "doris--"x ]]; then
@@ -150,7 +148,6 @@ for element in "${COMPONENTS_ARR[@]}"; do
     else
         echo "Invalid component: ${element}"
         usage
-        exit 1
     fi
 done
 

--- a/docker/thirdparties/run-thirdparties-docker.sh
+++ b/docker/thirdparties/run-thirdparties-docker.sh
@@ -97,7 +97,7 @@ else
     fi
 fi
 
-if [[ ${HELP} -eq 1 ]]; then
+if [[ "${HELP}" -eq 1 ]]; then
     usage
     exit 0
 fi

--- a/docker/thirdparties/run-thirdparties-docker.sh
+++ b/docker/thirdparties/run-thirdparties-docker.sh
@@ -97,7 +97,7 @@ else
     fi
 fi
 
-if [[ "${HELP}" -eq 1 ]]; then
+if [[ ${HELP} -eq 1 ]]; then
     usage
     exit 0
 fi

--- a/docs/en/docs/install/source-install/compilation-win.md
+++ b/docs/en/docs/install/source-install/compilation-win.md
@@ -73,7 +73,7 @@ This topic is about how to compile Doris from source with Windows.
     - [Java8](https://doris-thirdparty-repo.bj.bcebos.com/thirdparty/jdk-8u131-linux-x64.tar.gz)
     - [Apache Maven 3.6.3](https://doris-thirdparty-repo.bj.bcebos.com/thirdparty/apache-maven-3.6.3-bin.tar.gz)
     - [Node v12.13.0](https://doris-thirdparty-repo.bj.bcebos.com/thirdparty/node-v12.13.0-linux-x64.tar.gz)
-    - [LDB_TOOLCHAIN](https://github.com/amosbird/ldb_toolchain_gen/releases/download/v0.14.2/ldb_toolchain_gen.sh)
+    - [LDB_TOOLCHAIN](https://github.com/amosbird/ldb_toolchain_gen/releases/download/v0.17/ldb_toolchain_gen.sh)
 
 5. Configure environment variables
 

--- a/docs/zh-CN/docs/install/source-install/compilation-win.md
+++ b/docs/zh-CN/docs/install/source-install/compilation-win.md
@@ -73,7 +73,7 @@ under the License.
     - [Java8](https://doris-thirdparty-repo.bj.bcebos.com/thirdparty/jdk-8u131-linux-x64.tar.gz)
     - [Apache Maven 3.6.3](https://doris-thirdparty-repo.bj.bcebos.com/thirdparty/apache-maven-3.6.3-bin.tar.gz)
     - [Node v12.13.0](https://doris-thirdparty-repo.bj.bcebos.com/thirdparty/node-v12.13.0-linux-x64.tar.gz)
-    - [LDB_TOOLCHAIN](https://github.com/amosbird/ldb_toolchain_gen/releases/download/v0.14.2/ldb_toolchain_gen.sh)
+    - [LDB_TOOLCHAIN](https://github.com/amosbird/ldb_toolchain_gen/releases/download/v0.17/ldb_toolchain_gen.sh)
 
 5. 配置环境变量
 

--- a/env.sh
+++ b/env.sh
@@ -117,7 +117,7 @@ fi
 if [[ "${DORIS_TOOLCHAIN}" == "gcc" ]]; then
     # set GCC HOME
     if [[ -z "${DORIS_GCC_HOME}" ]]; then
-        DORIS_GCC_HOME="$(dirname "$(which gcc)")"/..
+        DORIS_GCC_HOME="$(dirname "$(command -v gcc)")"/..
         export DORIS_GCC_HOME
     fi
 
@@ -135,7 +135,7 @@ if [[ "${DORIS_TOOLCHAIN}" == "gcc" ]]; then
 elif [[ "${DORIS_TOOLCHAIN}" == "clang" ]]; then
     # set CLANG HOME
     if [[ -z "${DORIS_CLANG_HOME}" ]]; then
-        DORIS_CLANG_HOME="$(dirname "$(which clang)")"/..
+        DORIS_CLANG_HOME="$(dirname "$(command -v clang)")"/..
         export DORIS_CLANG_HOME
     fi
 
@@ -163,7 +163,7 @@ if [[ -z "${DORIS_BIN_UTILS}" ]]; then
 fi
 
 if [[ -z "${DORIS_GCC_HOME}" ]]; then
-    DORIS_GCC_HOME="$(dirname "$(which gcc)")/.."
+    DORIS_GCC_HOME="$(dirname "$(command -v gcc)")/.."
     export DORIS_GCC_HOME
 fi
 
@@ -191,8 +191,8 @@ if test -z "${BUILD_THIRDPARTY_WIP:-}"; then
 
     # check java home
     if [[ -z "${JAVA_HOME}" ]]; then
-        JAVA="$(which java)"
-        JAVAP="$(which javap)"
+        JAVA="$(command -v java)"
+        JAVAP="$(command -v javap)"
     else
         JAVA="${JAVA_HOME}/bin/java"
         JAVAP="${JAVA_HOME}/bin/javap"

--- a/fe/fe-common/pom.xml
+++ b/fe/fe-common/pom.xml
@@ -99,26 +99,6 @@ under the License.
     <build>
         <finalName>doris-fe-common</finalName>
         <plugins>
-            <!--thrift-->
-            <plugin>
-                <groupId>org.apache.thrift.tools</groupId>
-                <artifactId>maven-thrift-plugin</artifactId>
-                <version>0.1.11</version>
-                <configuration>
-                    <thriftExecutable>${doris.thirdparty}/installed/bin/thrift</thriftExecutable>
-                    <thriftSourceRoot>${doris.home}/gensrc/thrift</thriftSourceRoot>
-                    <generator>java:fullcamel</generator>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>thrift-sources</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
@@ -415,7 +415,6 @@ public abstract class TestWithFeService {
         try {
             cleanDir(dorisHome + "/" + runningDir);
             cleanDir(Config.plugin_dir);
-            cleanDir(Config.custom_config_dir);
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -470,7 +469,8 @@ public abstract class TestWithFeService {
         if (connectContext.getState().getStateType() != QueryState.MysqlStateType.ERR) {
             return stmtExecutor.planner();
         } else {
-            return null;
+            throw new Exception(
+                    connectContext.getState().toString() + ", " + connectContext.getState().getErrorMessage());
         }
     }
 
@@ -597,7 +597,8 @@ public abstract class TestWithFeService {
     protected void assertSQLPlanOrErrorMsgContains(String sql, String expect) throws Exception {
         // Note: adding `EXPLAIN` is necessary for non-query SQL, e.g., DDL, DML, etc.
         // TODO: Use a graceful way to get explain plan string, rather than modifying the SQL string.
-        Assertions.assertTrue(getSQLPlanOrErrorMsg("EXPLAIN " + sql).contains(expect));
+        Assertions.assertTrue(getSQLPlanOrErrorMsg("EXPLAIN " + sql).contains(expect),
+                getSQLPlanOrErrorMsg("EXPLAIN " + sql));
     }
 
     protected void assertSQLPlanOrErrorMsgContains(String sql, String... expects) throws Exception {

--- a/fs_brokers/apache_hdfs_broker/bin/start_broker.sh
+++ b/fs_brokers/apache_hdfs_broker/bin/start_broker.sh
@@ -67,7 +67,7 @@ export JAVA_OPTS="-Xmx1024m -Dfile.encoding=UTF-8"
 export BROKER_LOG_DIR="${BROKER_HOME}/log"
 # java
 if [[ -z "${JAVA_HOME}" ]]; then
-    JAVA="$(which java)"
+    JAVA="$(command -v java)"
 else
     JAVA="${JAVA_HOME}/bin/java"
 fi

--- a/gensrc/script/gen_build_version.sh
+++ b/gensrc/script/gen_build_version.sh
@@ -76,7 +76,7 @@ build_time="${date}"
 build_info="${hostname}"
 
 if [[ -z "${JAVA_HOME}" ]]; then
-    java_cmd="$(which java)"
+    java_cmd="$(command -v java)"
 else
     java_cmd="${JAVA_HOME}/bin/java"
 fi

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -178,7 +178,7 @@ if [[ -z "${USE_DWARF}" ]]; then
     USE_DWARF='OFF'
 fi
 
-MAKE_PROGRAM="$(which "${BUILD_SYSTEM}")"
+MAKE_PROGRAM="$(command -v "${BUILD_SYSTEM}")"
 echo "-- Make program: ${MAKE_PROGRAM}"
 echo "-- Use ccache: ${CMAKE_USE_CCACHE}"
 echo "-- Extra cxx flags: ${EXTRA_CXX_FLAGS:-}"

--- a/run-fe-ut.sh
+++ b/run-fe-ut.sh
@@ -96,6 +96,14 @@ cd "${DORIS_HOME}/docs"
 cp build/help-resource.zip "${DORIS_HOME}"/fe/fe-core/src/test/resources/real-help-resource.zip
 cd "${DORIS_HOME}"
 
+echo "Build generated code"
+cd "${DORIS_HOME}/gensrc"
+make
+rm -rf "${DORIS_HOME}/fe/fe-common/src/main/java/org/apache/doris/thrift ${DORIS_HOME}/fe/fe-common/src/main/java/org/apache/parquet"
+cp -r "build/gen_java/org/apache/doris/thrift" "${DORIS_HOME}/fe/fe-common/src/main/java/org/apache/doris"
+cp -r "build/gen_java/org/apache/parquet" "${DORIS_HOME}/fe/fe-common/src/main/java/org/apache/"
+cd "${DORIS_HOME}"
+
 cd "${DORIS_HOME}/fe"
 mkdir -p build/compile
 

--- a/run-regression-test.sh
+++ b/run-regression-test.sh
@@ -111,7 +111,6 @@ fi
 
 if [[ ${WRONG_CMD} -eq 1 ]]; then
     usage
-    exit 1
 fi
 
 # set maven

--- a/run-regression-test.sh
+++ b/run-regression-test.sh
@@ -109,7 +109,7 @@ else
     done
 fi
 
-if [[ "${WRONG_CMD}" -eq 1 ]]; then
+if [[ ${WRONG_CMD} -eq 1 ]]; then
     usage
     exit 1
 fi

--- a/samples/insert/shell/insert_utils.sh
+++ b/samples/insert/shell/insert_utils.sh
@@ -34,7 +34,7 @@ function check_insert_load_doris_func() {
     fi
 
     wait_seconds=3600
-    while [[ "${wait_seconds}" -gt 0 ]]; do
+    while [[ ${wait_seconds} -gt 0 ]]; do
         echo "${wait_seconds}"
         echo "${doris} -e show load where label = '${label}' order by createtime desc limit 1"
         result=$(${doris} -e "show load where label = '${label}' order by createtime desc limit 1" -N)

--- a/samples/insert/shell/insert_utils.sh
+++ b/samples/insert/shell/insert_utils.sh
@@ -47,7 +47,6 @@ function check_insert_load_doris_func() {
             else
                 return 1
             fi
-            break
         else
             echo "insert status: ${load_status}"
             sleep 5s

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -106,7 +106,7 @@ if [[ "$#" -ne 1 ]]; then
     done
 fi
 
-if [[ ${HELP} -eq 1 ]]; then
+if [[ "${HELP}" -eq 1 ]]; then
     usage
 fi
 

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -106,7 +106,7 @@ if [[ "$#" -ne 1 ]]; then
     done
 fi
 
-if [[ "${HELP}" -eq 1 ]]; then
+if [[ ${HELP} -eq 1 ]]; then
     usage
 fi
 

--- a/tools/clickbench-tools/create-clickbench-table.sh
+++ b/tools/clickbench-tools/create-clickbench-table.sh
@@ -68,7 +68,7 @@ while true; do
   esac
 done
 
-if [[ ${HELP} -eq 1 ]]; then
+if [[ "${HELP}" -eq 1 ]]; then
   usage
   exit
 fi

--- a/tools/clickbench-tools/load-clickbench-data.sh
+++ b/tools/clickbench-tools/load-clickbench-data.sh
@@ -66,7 +66,7 @@ while true; do
     esac
 done
 
-if [[ ${HELP} -eq 1 ]]; then
+if [[ "${HELP}" -eq 1 ]]; then
     usage
     exit
 fi

--- a/tools/clickbench-tools/load-clickbench-data.sh
+++ b/tools/clickbench-tools/load-clickbench-data.sh
@@ -68,7 +68,6 @@ done
 
 if [[ "${HELP}" -eq 1 ]]; then
     usage
-    exit
 fi
 
 check_prerequest() {

--- a/tools/clickbench-tools/run-clickbench-queries.sh
+++ b/tools/clickbench-tools/run-clickbench-queries.sh
@@ -70,7 +70,7 @@ while true; do
   esac
 done
 
-if [[ ${HELP} -eq 1 ]]; then
+if [[ "${HELP}" -eq 1 ]]; then
   usage
   exit
 fi

--- a/tools/restore_tablet_tool.sh
+++ b/tools/restore_tablet_tool.sh
@@ -86,7 +86,6 @@ while true; do
         ;;
     -h | --help)
         usage
-        shift
         ;;
     --)
         shift

--- a/tools/ssb-tools/bin/create-ssb-tables.sh
+++ b/tools/ssb-tools/bin/create-ssb-tables.sh
@@ -73,7 +73,6 @@ done
 
 if [[ "${HELP}" -eq 1 ]]; then
     usage
-    exit
 fi
 
 check_prerequest() {

--- a/tools/ssb-tools/bin/create-ssb-tables.sh
+++ b/tools/ssb-tools/bin/create-ssb-tables.sh
@@ -71,7 +71,7 @@ while true; do
     esac
 done
 
-if [[ ${HELP} -eq 1 ]]; then
+if [[ "${HELP}" -eq 1 ]]; then
     usage
     exit
 fi

--- a/tools/ssb-tools/bin/gen-ssb-data.sh
+++ b/tools/ssb-tools/bin/gen-ssb-data.sh
@@ -88,7 +88,7 @@ while true; do
     esac
 done
 
-if [[ ${HELP} -eq 1 ]]; then
+if [[ "${HELP}" -eq 1 ]]; then
     usage
     exit
 fi

--- a/tools/ssb-tools/bin/gen-ssb-data.sh
+++ b/tools/ssb-tools/bin/gen-ssb-data.sh
@@ -90,7 +90,6 @@ done
 
 if [[ "${HELP}" -eq 1 ]]; then
     usage
-    exit
 fi
 
 echo "Scale Factor: ${SCALE_FACTOR}"

--- a/tools/ssb-tools/bin/load-ssb-data.sh
+++ b/tools/ssb-tools/bin/load-ssb-data.sh
@@ -81,7 +81,7 @@ while true; do
     esac
 done
 
-if [[ ${HELP} -eq 1 ]]; then
+if [[ "${HELP}" -eq 1 ]]; then
     usage
     exit
 fi

--- a/tools/ssb-tools/bin/load-ssb-data.sh
+++ b/tools/ssb-tools/bin/load-ssb-data.sh
@@ -83,7 +83,6 @@ done
 
 if [[ "${HELP}" -eq 1 ]]; then
     usage
-    exit
 fi
 
 echo "Parallelism: ${PARALLEL}"

--- a/tools/ssb-tools/bin/run-ssb-flat-queries.sh
+++ b/tools/ssb-tools/bin/run-ssb-flat-queries.sh
@@ -70,7 +70,7 @@ while true; do
     esac
 done
 
-if [[ ${HELP} -eq 1 ]]; then
+if [[ "${HELP}" -eq 1 ]]; then
     usage
     exit
 fi

--- a/tools/ssb-tools/bin/run-ssb-flat-queries.sh
+++ b/tools/ssb-tools/bin/run-ssb-flat-queries.sh
@@ -72,7 +72,6 @@ done
 
 if [[ "${HELP}" -eq 1 ]]; then
     usage
-    exit
 fi
 
 check_prerequest() {

--- a/tools/ssb-tools/bin/run-ssb-queries.sh
+++ b/tools/ssb-tools/bin/run-ssb-queries.sh
@@ -70,7 +70,7 @@ while true; do
     esac
 done
 
-if [[ ${HELP} -eq 1 ]]; then
+if [[ "${HELP}" -eq 1 ]]; then
     usage
     exit
 fi

--- a/tools/ssb-tools/bin/run-ssb-queries.sh
+++ b/tools/ssb-tools/bin/run-ssb-queries.sh
@@ -72,7 +72,6 @@ done
 
 if [[ "${HELP}" -eq 1 ]]; then
     usage
-    exit
 fi
 
 check_prerequest() {

--- a/tools/tpcds-tools/bin/create-tpcds-tables.sh
+++ b/tools/tpcds-tools/bin/create-tpcds-tables.sh
@@ -68,7 +68,7 @@ while true; do
     esac
 done
 
-if [[ ${HELP} -eq 1 ]]; then
+if [[ "${HELP}" -eq 1 ]]; then
     usage
 fi
 

--- a/tools/tpcds-tools/bin/gen-tpcds-data.sh
+++ b/tools/tpcds-tools/bin/gen-tpcds-data.sh
@@ -87,7 +87,7 @@ while true; do
     esac
 done
 
-if [[ ${HELP} -eq 1 ]]; then
+if [[ "${HELP}" -eq 1 ]]; then
     usage
 fi
 

--- a/tools/tpcds-tools/bin/gen-tpcds-queries.sh
+++ b/tools/tpcds-tools/bin/gen-tpcds-queries.sh
@@ -79,7 +79,7 @@ while true; do
     esac
 done
 
-if [[ ${HELP} -eq 1 ]]; then
+if [[ "${HELP}" -eq 1 ]]; then
     usage
 fi
 

--- a/tools/tpcds-tools/bin/load-tpcds-data.sh
+++ b/tools/tpcds-tools/bin/load-tpcds-data.sh
@@ -80,7 +80,7 @@ while true; do
     esac
 done
 
-if [[ ${HELP} -eq 1 ]]; then
+if [[ "${HELP}" -eq 1 ]]; then
     usage
 fi
 

--- a/tools/tpcds-tools/bin/run-tpcds-queries.sh
+++ b/tools/tpcds-tools/bin/run-tpcds-queries.sh
@@ -69,7 +69,7 @@ while true; do
     esac
 done
 
-if [[ ${HELP} -eq 1 ]]; then
+if [[ "${HELP}" -eq 1 ]]; then
     usage
 fi
 

--- a/tools/tpch-tools/bin/create-tpch-tables.sh
+++ b/tools/tpch-tools/bin/create-tpch-tables.sh
@@ -68,7 +68,7 @@ while true; do
     esac
 done
 
-if [[ ${HELP} -eq 1 ]]; then
+if [[ "${HELP}" -eq 1 ]]; then
     usage
     exit
 fi

--- a/tools/tpch-tools/bin/create-tpch-tables.sh
+++ b/tools/tpch-tools/bin/create-tpch-tables.sh
@@ -70,7 +70,6 @@ done
 
 if [[ "${HELP}" -eq 1 ]]; then
     usage
-    exit
 fi
 
 check_prerequest() {

--- a/tools/tpch-tools/bin/gen-tpch-data.sh
+++ b/tools/tpch-tools/bin/gen-tpch-data.sh
@@ -88,7 +88,7 @@ while true; do
     esac
 done
 
-if [[ ${HELP} -eq 1 ]]; then
+if [[ "${HELP}" -eq 1 ]]; then
     usage
     exit
 fi

--- a/tools/tpch-tools/bin/gen-tpch-data.sh
+++ b/tools/tpch-tools/bin/gen-tpch-data.sh
@@ -90,7 +90,6 @@ done
 
 if [[ "${HELP}" -eq 1 ]]; then
     usage
-    exit
 fi
 
 echo "Scale Factor: ${SCALE_FACTOR}"

--- a/tools/tpch-tools/bin/load-tpch-data.sh
+++ b/tools/tpch-tools/bin/load-tpch-data.sh
@@ -81,7 +81,7 @@ while true; do
     esac
 done
 
-if [[ ${HELP} -eq 1 ]]; then
+if [[ "${HELP}" -eq 1 ]]; then
     usage
     exit
 fi

--- a/tools/tpch-tools/bin/load-tpch-data.sh
+++ b/tools/tpch-tools/bin/load-tpch-data.sh
@@ -83,7 +83,6 @@ done
 
 if [[ "${HELP}" -eq 1 ]]; then
     usage
-    exit
 fi
 
 echo "Parallelism: ${PARALLEL}"

--- a/tools/tpch-tools/bin/run-tpch-queries.sh
+++ b/tools/tpch-tools/bin/run-tpch-queries.sh
@@ -71,7 +71,6 @@ done
 
 if [[ "${HELP}" -eq 1 ]]; then
     usage
-    exit
 fi
 
 check_prerequest() {

--- a/tools/tpch-tools/bin/run-tpch-queries.sh
+++ b/tools/tpch-tools/bin/run-tpch-queries.sh
@@ -69,7 +69,7 @@ while true; do
     esac
 done
 
-if [[ ${HELP} -eq 1 ]]; then
+if [[ "${HELP}" -eq 1 ]]; then
     usage
     exit
 fi


### PR DESCRIPTION
# Proposed changes

1. upgrade clang-format version to 16
2. move thrift to fe-common
3. fix core dump on pipeline engine when operator canceled and not prepared

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

