### PR TITLE
[fix](FileReader) fix profile of json&csv reader

### DIFF
--- a/be/src/vec/exec/format/csv/csv_reader.cpp
+++ b/be/src/vec/exec/format/csv/csv_reader.cpp
@@ -92,6 +92,10 @@ CsvReader::CsvReader(RuntimeState* state, RuntimeProfile* profile, ScannerCounte
     _file_compress_type = _params.compress_type;
     _size = _range.size;
 
+    const char* csv_profile = "CsvReader";
+    ADD_TIMER(_profile, csv_profile);
+    _csv_parse_timer = ADD_CHILD_TIMER(_profile, "CsvParseTime", csv_profile);
+
     _text_converter.reset(new (std::nothrow) TextConverter('\\'));
     _split_values.reserve(sizeof(Slice) * _file_slot_descs.size());
     _init_system_properties();
@@ -376,6 +380,7 @@ Status CsvReader::_create_decompressor() {
 
 Status CsvReader::_fill_dest_columns(const Slice& line, Block* block,
                                      std::vector<MutableColumnPtr>& columns, size_t* rows) {
+    SCOPED_TIMER(_csv_parse_timer);
     bool is_success = false;
 
     RETURN_IF_ERROR(_line_split_to_values(line, &is_success));

--- a/be/src/vec/exec/format/csv/csv_reader.h
+++ b/be/src/vec/exec/format/csv/csv_reader.h
@@ -124,6 +124,8 @@ private:
     // True if this is a load task
     bool _is_load = false;
 
+    RuntimeProfile::Counter* _csv_parse_timer;
+
     std::shared_ptr<io::FileSystem> _file_system;
     io::FileReaderSPtr _file_reader;
     std::unique_ptr<LineReader> _line_reader;

--- a/be/src/vec/exec/format/file_reader/new_plain_text_line_reader.cpp
+++ b/be/src/vec/exec/format/file_reader/new_plain_text_line_reader.cpp
@@ -72,10 +72,13 @@ NewPlainTextLineReader::NewPlainTextLineReader(RuntimeProfile* profile,
           _read_timer(nullptr),
           _bytes_decompress_counter(nullptr),
           _decompress_timer(nullptr) {
-    _bytes_read_counter = ADD_COUNTER(_profile, "BytesRead", TUnit::BYTES);
-    _read_timer = ADD_TIMER(_profile, "FileReadTime");
-    _bytes_decompress_counter = ADD_COUNTER(_profile, "BytesDecompressed", TUnit::BYTES);
-    _decompress_timer = ADD_TIMER(_profile, "DecompressTime");
+    const char* line_profile = "TextLineReader";
+    ADD_TIMER(_profile, line_profile);
+    _bytes_read_counter = ADD_CHILD_COUNTER(_profile, "FileBytesRead", TUnit::BYTES, line_profile);
+    _read_timer = ADD_CHILD_TIMER(_profile, "FileReadTime", line_profile);
+    _bytes_decompress_counter =
+            ADD_CHILD_COUNTER(_profile, "BytesDecompressed", TUnit::BYTES, line_profile);
+    _decompress_timer = ADD_CHILD_TIMER(_profile, "DecompressTime", line_profile);
 }
 
 NewPlainTextLineReader::~NewPlainTextLineReader() {

--- a/be/src/vec/exec/format/json/new_json_reader.h
+++ b/be/src/vec/exec/format/json/new_json_reader.h
@@ -227,8 +227,8 @@ private:
     io::IOContext* _io_ctx;
 
     RuntimeProfile::Counter* _bytes_read_counter;
-    RuntimeProfile::Counter* _read_timer;
     RuntimeProfile::Counter* _file_read_timer;
+    RuntimeProfile::Counter* _json_parse_timer;
 
     bool _is_dynamic_schema = false;
 


### PR DESCRIPTION
# Proposed changes

`NewJsonReader` and `CsvReader` take the format parse time into file read time. This PR separates format time from file read time, and uses indentation to make the profile more readable.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

