### PR TITLE
[fix](vertical_compaction) Fix `continuous_agg_count` PODArray wrong boundary judgment

### DIFF
--- a/be/src/vec/common/allocator.h
+++ b/be/src/vec/common/allocator.h
@@ -73,12 +73,6 @@
  * by more detailed test later.
   */
 static constexpr size_t CHUNK_THRESHOLD = 4096;
-/**
-  * In debug build, use small mmap threshold to reproduce more memory
-  * stomping bugs. Along with ASLR it will hopefully detect more issues than
-  * ASan. The program may fail due to the limit on number of memory mappings.
-  */
-static constexpr size_t MMAP_THRESHOLD_DEBUG = 4096; // delete immediately
 
 static constexpr size_t MMAP_MIN_ALIGNMENT = 4096;
 static constexpr size_t MALLOC_MIN_ALIGNMENT = 8;
@@ -111,11 +105,7 @@ public:
         memory_check(size);
         void* buf;
 
-#ifdef NDEBUG
         if (size >= doris::config::mmap_threshold) {
-#else
-        if (size >= MMAP_THRESHOLD_DEBUG) {
-#endif
             if (alignment > MMAP_MIN_ALIGNMENT)
                 throw doris::Exception(
                         doris::ErrorCode::INVALID_ARGUMENT,
@@ -164,11 +154,7 @@ public:
 
     /// Free memory range.
     void free(void* buf, size_t size) {
-#ifdef NDEBUG
         if (size >= doris::config::mmap_threshold) {
-#else
-        if (size >= MMAP_THRESHOLD_DEBUG) {
-#endif
             if (0 != munmap(buf, size)) {
                 throw_bad_alloc(fmt::format("Allocator: Cannot munmap {}.", size));
             } else {
@@ -205,12 +191,8 @@ public:
             if constexpr (clear_memory)
                 if (new_size > old_size)
                     memset(reinterpret_cast<char*>(buf) + old_size, 0, new_size - old_size);
-#ifdef NDEBUG
         } else if (old_size >= doris::config::mmap_threshold &&
                    new_size >= doris::config::mmap_threshold) {
-#else
-        } else if (old_size >= MMAP_THRESHOLD_DEBUG && new_size >= MMAP_THRESHOLD_DEBUG) {
-#endif
             memory_check(new_size);
             /// Resize mmap'd memory region.
             consume_memory(new_size - old_size);

--- a/be/src/vec/olap/vertical_merge_iterator.cpp
+++ b/be/src/vec/olap/vertical_merge_iterator.cpp
@@ -120,7 +120,7 @@ size_t RowSourcesBuffer::continuous_agg_count(uint64_t index) {
     size_t result = 1;
     int start = index + 1;
     int end = _buffer->size();
-    while (index < end) {
+    while (start < end) {
         RowSource next(_buffer->get_element(start++));
         if (next.agg_flag()) {
             ++result;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Assuming that the size of RowSourcesBuffer::_buffer is n, when n is fetched, it just crosses the boundary. If the memory allocated by mmap will return 0 at this time, if it is not mmap, it will return a random value. `next.agg_flag()` in `continuous_agg_count` is According to whether the return value is 0 or not as a condition.

```
doris_be_test: doris/core/be/src/vec/common/pod_array.h:323: T &doris::vectorized::PODArray<unsigned short, 4096, Allocator<false, false>, 15, 16>::operator[](ssize_t) [T = unsigned short, initial_bytes = 4096, TAllocator = Allocator<false, false>, pad_right_ = 15, pad_left_ = 16]: Assertion `(n >= (static_cast<ssize_t>(pad_left_) ? -1 : 0)) && (n <= static_cast<ssize_t>(this->size()))' failed.
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

