### PR TITLE
[Fix](planner)fix type incompatible after fold constant by be.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/FoldConstantsRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/FoldConstantsRule.java
@@ -316,7 +316,7 @@ public class FoldConstantsRule implements ExprRewriteRule {
      * @param literalExpr
      * @return
      */
-    private Expr replaceExpr(Expr expr, String key, LiteralExpr literalExpr) {
+    private Expr replaceExpr(Expr expr, String key, LiteralExpr literalExpr) throws AnalysisException {
         if (expr.getId().toString().equals(key)) {
             return literalExpr;
         }
@@ -325,7 +325,12 @@ public class FoldConstantsRule implements ExprRewriteRule {
             Expr child = expr.getChild(i);
             if (literalExpr.equals(replaceExpr(child, key, literalExpr))) {
                 literalExpr.setId(child.getId());
-                expr.setChild(i, literalExpr);
+                if (!expr.getChild(i).getType().equals(literalExpr.getType())) {
+                    Expr cast = literalExpr.castTo(expr.getChild(i).getType());
+                    expr.setChild(i, cast);
+                } else {
+                    expr.setChild(i, literalExpr);
+                }
                 break;
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/FoldConstantsRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/FoldConstantsRule.java
@@ -292,14 +292,15 @@ public class FoldConstantsRule implements ExprRewriteRule {
      * @param exprMap
      * @param resultMap
      */
-    private void putBackConstExpr(Map<String, Expr> exprMap, Map<String, Map<String, Expr>> resultMap) {
+    private void putBackConstExpr(Map<String, Expr> exprMap, Map<String, Map<String, Expr>> resultMap)
+            throws AnalysisException {
         for (Map.Entry<String, Map<String, Expr>> entry : resultMap.entrySet()) {
             Expr rewrittenExpr = putBackConstExpr(exprMap.get(entry.getKey()), entry.getValue());
             exprMap.put(entry.getKey(), rewrittenExpr);
         }
     }
 
-    private Expr putBackConstExpr(Expr expr, Map<String, Expr> resultMap) {
+    private Expr putBackConstExpr(Expr expr, Map<String, Expr> resultMap) throws AnalysisException {
         for (Map.Entry<String, Expr> entry : resultMap.entrySet()) {
             if (entry.getValue() instanceof LiteralExpr) {
                 expr = replaceExpr(expr, entry.getKey(), (LiteralExpr) entry.getValue());

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/FoldConstantsRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/FoldConstantsRule.java
@@ -326,6 +326,7 @@ public class FoldConstantsRule implements ExprRewriteRule {
             if (!(child instanceof LiteralExpr) && literalExpr.equals(replaceExpr(child, key, literalExpr))) {
                 literalExpr.setId(child.getId());
                 expr.setChild(i, literalExpr);
+                break;
             }
         }
         return expr;

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/FoldConstantsRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/FoldConstantsRule.java
@@ -292,15 +292,14 @@ public class FoldConstantsRule implements ExprRewriteRule {
      * @param exprMap
      * @param resultMap
      */
-    private void putBackConstExpr(Map<String, Expr> exprMap, Map<String, Map<String, Expr>> resultMap)
-            throws AnalysisException {
+    private void putBackConstExpr(Map<String, Expr> exprMap, Map<String, Map<String, Expr>> resultMap) {
         for (Map.Entry<String, Map<String, Expr>> entry : resultMap.entrySet()) {
             Expr rewrittenExpr = putBackConstExpr(exprMap.get(entry.getKey()), entry.getValue());
             exprMap.put(entry.getKey(), rewrittenExpr);
         }
     }
 
-    private Expr putBackConstExpr(Expr expr, Map<String, Expr> resultMap) throws AnalysisException {
+    private Expr putBackConstExpr(Expr expr, Map<String, Expr> resultMap) {
         for (Map.Entry<String, Expr> entry : resultMap.entrySet()) {
             if (entry.getValue() instanceof LiteralExpr) {
                 expr = replaceExpr(expr, entry.getKey(), (LiteralExpr) entry.getValue());
@@ -317,22 +316,16 @@ public class FoldConstantsRule implements ExprRewriteRule {
      * @param literalExpr
      * @return
      */
-    private Expr replaceExpr(Expr expr, String key, LiteralExpr literalExpr) throws AnalysisException {
+    private Expr replaceExpr(Expr expr, String key, LiteralExpr literalExpr) {
         if (expr.getId().toString().equals(key)) {
             return literalExpr;
         }
         // ATTN: make sure the child order of expr keep unchanged
         for (int i = 0; i < expr.getChildren().size(); i++) {
             Expr child = expr.getChild(i);
-            if (literalExpr.equals(replaceExpr(child, key, literalExpr))) {
+            if (!(child instanceof LiteralExpr) && literalExpr.equals(replaceExpr(child, key, literalExpr))) {
                 literalExpr.setId(child.getId());
-                if (!expr.getChild(i).getType().equals(literalExpr.getType())) {
-                    Expr cast = literalExpr.castTo(expr.getChild(i).getType());
-                    expr.setChild(i, cast);
-                } else {
-                    expr.setChild(i, literalExpr);
-                }
-                break;
+                expr.setChild(i, literalExpr);
             }
         }
         return expr;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

after fold constant by be, the original expression will be replaced directly by the constant. we all cast if type is not compatible. 

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

