### PR TITLE
[fix](multi-catalog) when endpoint has no region, need a suggestion

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/S3Properties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/S3Properties.java
@@ -113,7 +113,7 @@ public class S3Properties extends BaseProperties {
             throw new IllegalArgumentException("Missing 'AWS_ENDPOINT' property. ");
         }
         String endpoint = props.get(Env.ENDPOINT);
-        String region = props.getOrDefault(S3Properties.REGION, S3Properties.getRegionOfEndpoint(endpoint));
+        String region = props.getOrDefault(Env.REGION, S3Properties.getRegionOfEndpoint(endpoint));
         return new CloudCredentialWithEndpoint(endpoint, region, credential);
     }
 


### PR DESCRIPTION
# Proposed changes
solve the problem

```
 mysql> CREATE CATALOG iceberg PROPERTIES (  
    'type'='iceberg', 
    'iceberg.catalog.type'='rest',                                                                                                                                         
    'uri' = 'http://0.0.0.0:8888,  
    "AWS_ACCESS_KEY" = "admin",                                                                                                                                           
    "AWS_SECRET_KEY" = "password", 
    "AWS_REGION" = "us-east-1",                  
    "AWS_ENDPOINT" = "http://minio:9000"
);  
show databases; 

ERROR 1105 (HY000): IllegalArgumentException, msg: java.lang.IllegalArgumentException: The value of property fs.s3a.endpoint.region must not be null   

```

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

