### PR TITLE
[fix](memory) Fix memory leak due to incorrect block reuse of `AggregateFunctionSortData`

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_sort.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_sort.h
@@ -87,7 +87,7 @@ struct AggregateFunctionSortData {
 
         PBlock pblock;
         pblock.ParseFromString(data);
-        new (&block) Block(pblock);
+        block = Block(pblock);
     }
 
     void add(const IColumn** columns, size_t columns_num, size_t row_num) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

#### Reproduce
```
./run-regression-test.sh --run -d query_p0/group_concat -s test_group_concat
kill -15 be.pid
memory leak in be.out
```

```
Indirect leak of 160 byte(s) in 4 object(s) allocated from:
    #0 0x555abf85fded in operator new(unsigned long) (/mnt/hdd01/dorisTestEnv/VEC_ASAN/be/lib/doris_be+0x154c0ded) (BuildId: d965f86d23ba98c0)
    #1 0x555aca66f42c in __gnu_cxx::new_allocator<std::_Sp_counted_ptr_inplace<doris::vectorized::DataTypeNullable, std::allocator<doris::vectorized::DataType
Nullable>, (__gnu_cxx::_Lock_policy)2>>::allocate(unsigned long, void const*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/
c++/11/ext/new_allocator.h:121:27
    #2 0x555aca66f2e2 in std::allocator_traits<std::allocator<std::_Sp_counted_ptr_inplace<doris::vectorized::DataTypeNullable, std::allocator<doris::vectoriz
ed::DataTypeNullable>, (__gnu_cxx::_Lock_policy)2>>>::allocate(std::allocator<std::_Sp_counted_ptr_inplace<doris::vectorized::DataTypeNullable, std::allocator
<doris::vectorized::DataTypeNullable>, (__gnu_cxx::_Lock_policy)2>>&, unsigned long) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../i
nclude/c++/11/bits/alloc_traits.h:460:20
    #3 0x555aca66ede2 in std::__allocated_ptr<std::allocator<std::_Sp_counted_ptr_inplace<doris::vectorized::DataTypeNullable, std::allocator<doris::vectorize
d::DataTypeNullable>, (__gnu_cxx::_Lock_policy)2>>> std::__allocate_guarded<std::allocator<std::_Sp_counted_ptr_inplace<doris::vectorized::DataTypeNullable, s
td::allocator<doris::vectorized::DataTypeNullable>, (__gnu_cxx::_Lock_policy)2>>>(std::allocator<std::_Sp_counted_ptr_inplace<doris::vectorized::DataTypeNulla
ble, std::allocator<doris::vectorized::DataTypeNullable>, (__gnu_cxx::_Lock_policy)2>>&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../
../include/c++/11/bits/allocated_ptr.h:97:21
    #4 0x555aca66ead1 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<doris::vectorized::DataTypeNullable, std::allocator<doris::vectorized
::DataTypeNullable>, std::shared_ptr<doris::vectorized::IDataType const>&>(doris::vectorized::DataTypeNullable*&, std::_Sp_alloc_shared_tag<std::allocator<dor
is::vectorized::DataTypeNullable>>, std::shared_ptr<doris::vectorized::IDataType const>&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../..
/../include/c++/11/bits/shared_ptr_base.h:648:19
    #5 0x555aca66e877 in std::__shared_ptr<doris::vectorized::DataTypeNullable, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<doris::vectorized::Da
taTypeNullable>, std::shared_ptr<doris::vectorized::IDataType const>&>(std::_Sp_alloc_shared_tag<std::allocator<doris::vectorized::DataTypeNullable>>, std::sh
ared_ptr<doris::vectorized::IDataType const>&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1
337:14
    #6 0x555aca66e657 in std::shared_ptr<doris::vectorized::DataTypeNullable>::shared_ptr<std::allocator<doris::vectorized::DataTypeNullable>, std::shared_ptr
<doris::vectorized::IDataType const>&>(std::_Sp_alloc_shared_tag<std::allocator<doris::vectorized::DataTypeNullable>>, std::shared_ptr<doris::vectorized::IDat
aType const>&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr.h:409:4
    #7 0x555aca66e424 in std::shared_ptr<doris::vectorized::DataTypeNullable> std::allocate_shared<doris::vectorized::DataTypeNullable, std::allocator<doris::
vectorized::DataTypeNullable>, std::shared_ptr<doris::vectorized::IDataType const>&>(std::allocator<doris::vectorized::DataTypeNullable> const&, std::shared_p
tr<doris::vectorized::IDataType const>&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr.h:860:14
    #8 0x555aca66717c in std::shared_ptr<doris::vectorized::DataTypeNullable> std::make_shared<doris::vectorized::DataTypeNullable, std::shared_ptr<doris::vec
torized::IDataType const>&>(std::shared_ptr<doris::vectorized::IDataType const>&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../incl
ude/c++/11/bits/shared_ptr.h:876:14
    #9 0x555aca65beca in doris::vectorized::DataTypeFactory::create_data_type(doris::TypeDescriptor const&, bool) /mnt/hdd01/repo_center/doris_branch-2.0-alph
a/doris/be/src/vec/data_types/data_type_factory.cpp:212:16
    #10 0x555acf2205e0 in doris::vectorized::DataTypeFactory::create_data_type(doris::TTypeDesc const&) /mnt/hdd01/repo_center/doris_branch-2.0-alpha/doris/be
/src/vec/data_types/data_type_factory.hpp:72:16
    #11 0x555acf215ac1 in doris::vectorized::AggFnEvaluator::AggFnEvaluator(doris::TExprNode const&) /mnt/hdd01/repo_center/doris_branch-2.0-alpha/doris/be/sr
c/vec/exprs/vectorized_agg_fn.cpp:52:49
    #12 0x555acf215e8e in doris::vectorized::AggFnEvaluator::create(doris::ObjectPool*, doris::TExpr const&, doris::TSortInfo const&, doris::vectorized::AggFn
Evaluator**) /mnt/hdd01/repo_center/doris_branch-2.0-alpha/doris/be/src/vec/exprs/vectorized_agg_fn.cpp:59:29
    #12 0x555acf215e8e in doris::vectorized::AggFnEvaluator::create(doris::ObjectPool*, doris::TExpr const&, doris::TSortInfo const&, doris::vectorized::AggFn
Evaluator**) /mnt/hdd01/repo_center/doris_branch-2.0-alpha/doris/be/src/vec/exprs/vectorized_agg_fn.cpp:59:29
    #13 0x555aca7ccc63 in doris::vectorized::AggregationNode::init(doris::TPlanNode const&, doris::RuntimeState*) /mnt/hdd01/repo_center/doris_branch-2.0-alph
a/doris/be/src/vec/exec/vaggregation_node.cpp:135:9
    #14 0x555ac2309fb6 in doris::ExecNode::create_tree_helper(doris::RuntimeState*, doris::ObjectPool*, std::vector<doris::TPlanNode, std::allocator<doris::TP
lanNode>> const&, doris::DescriptorTbl const&, doris::ExecNode*, int*, doris::ExecNode**) /mnt/hdd01/repo_center/doris_branch-2.0-alpha/doris/be/src/exec/exec
_node.cpp:276:5
    #15 0x555ac2309cfc in doris::ExecNode::create_tree_helper(doris::RuntimeState*, doris::ObjectPool*, std::vector<doris::TPlanNode, std::allocator<doris::TP
lanNode>> const&, doris::DescriptorTbl const&, doris::ExecNode*, int*, doris::ExecNode**) /mnt/hdd01/repo_center/doris_branch-2.0-alpha/doris/be/src/exec/exec
_node.cpp:266:9
    #16 0x555ac2309cfc in doris::ExecNode::create_tree_helper(doris::RuntimeState*, doris::ObjectPool*, std::vector<doris::TPlanNode, std::allocator<doris::TP
lanNode>> const&, doris::DescriptorTbl const&, doris::ExecNode*, int*, doris::ExecNode**) /mnt/hdd01/repo_center/doris_branch-2.0-alpha/doris/be/src/exec/exec
_node.cpp:266:9
    #17 0x555ac23092f7 in doris::ExecNode::create_tree(doris::RuntimeState*, doris::ObjectPool*, doris::TPlan const&, doris::DescriptorTbl const&, doris::Exec
Node**) /mnt/hdd01/repo_center/doris_branch-2.0-alpha/doris/be/src/exec/exec_node.cpp:231:5
    #18 0x555ac22e1b3b in doris::PlanFragmentExecutor::prepare(doris::TExecPlanFragmentParams const&, doris::QueryFragmentsCtx*) /mnt/hdd01/repo_center/doris_
branch-2.0-alpha/doris/be/src/runtime/plan_fragment_executor.cpp:137:5
    #19 0x555ac222c7f3 in doris::FragmentExecState::prepare(doris::TExecPlanFragmentParams const&) /mnt/hdd01/repo_center/doris_branch-2.0-alpha/doris/be/src/
runtime/fragment_mgr.cpp:211:26
    #20 0x555ac223af51 in doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Statu
s*)> const&) /mnt/hdd01/repo_center/doris_branch-2.0-alpha/doris/be/src/runtime/fragment_mgr.cpp:721:9
    #21 0x555ac2238cb5 in doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&) /mnt/hdd01/repo_center/doris_branch-2.0-alpha/doris/be
/src/runtime/fragment_mgr.cpp:555:16
    #22 0x555ac27946ec in doris::PInternalServiceImpl::_exec_plan_fragment(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> cons
t&, doris::PFragmentRequestVersion, bool) /mnt/hdd01/repo_center/doris_branch-2.0-alpha/doris/be/src/service/internal_service.cpp:415:13
    #23 0x555ac2793a19 in doris::PInternalServiceImpl::exec_plan_fragment(google::protobuf::RpcController*, doris::PExecPlanFragmentRequest const*, doris::PEx
ecPlanFragmentResult*, google::protobuf::Closure*) /mnt/hdd01/repo_center/doris_branch-2.0-alpha/doris/be/src/service/internal_service.cpp:258:10
    #24 0x555ac27b6dfb in doris::PInternalServiceImpl::exec_plan_fragment_prepare(google::protobuf::RpcController*, doris::PExecPlanFragmentRequest const*, do
ris::PExecPlanFragmentResult*, google::protobuf::Closure*)::$_9::operator()() const /mnt/hdd01/repo_center/doris_branch-2.0-alpha/doris/be/src/service/interna
l_service.cpp:270:9
    #25 0x555ac27b6c86 in void std::__invoke_impl<void, doris::PInternalServiceImpl::exec_plan_fragment_prepare(google::protobuf::RpcController*, doris::PExec
PlanFragmentRequest const*, doris::PExecPlanFragmentResult*, google::protobuf::Closure*)::$_9&>(std::__invoke_other, doris::PInternalServiceImpl::exec_plan_fr
agment_prepare(google::protobuf::RpcController*, doris::PExecPlanFragmentRequest const*, doris::PExecPlanFragmentResult*, google::protobuf::Closure*)::$_9&) /
var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #26 0x555ac27b6bf8 in std::enable_if<is_invocable_r_v<void, doris::PInternalServiceImpl::exec_plan_fragment_prepare(google::protobuf::RpcController*, dori
s::PExecPlanFragmentRequest const*, doris::PExecPlanFragmentResult*, google::protobuf::Closure*)::$_9&>, void>::type std::__invoke_r<void, doris::PInternalSer
viceImpl::exec_plan_fragment_prepare(google::protobuf::RpcController*, doris::PExecPlanFragmentRequest const*, doris::PExecPlanFragmentResult*, google::protob
uf::Closure*)::$_9&>(doris::PInternalServiceImpl::exec_plan_fragment_prepare(google::protobuf::RpcController*, doris::PExecPlanFragmentRequest const*, doris::
PExecPlanFragmentResult*, google::protobuf::Closure*)::$_9&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invok
e.h:111:2
    #27 0x555ac27b69ce in std::_Function_handler<void (), doris::PInternalServiceImpl::exec_plan_fragment_prepare(google::protobuf::RpcController*, doris::PEx
ecPlanFragmentRequest const*, doris::PExecPlanFragmentResult*, google::protobuf::Closure*)::$_9>::_M_invoke(std::_Any_data const&) /var/local/ldb_toolchain/bi
n/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #28 0x555abf99a836 in std::function<void ()>::operator()() const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bi
ts/std_function.h:560:9
    #29 0x555abf99c645 in doris::PriorityThreadPool::work_thread(int) /mnt/hdd01/repo_center/doris_branch-2.0-alpha/doris/be/src/util/priority_thread_pool.hpp
:146:17
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

