### PR TITLE
[Fix](multi-catalog) Make BE selection policy works fine when enable prefer_compute_node_for_external_table

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/FeMetaVersion.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/FeMetaVersion.java
@@ -60,9 +60,11 @@ public final class FeMetaVersion {
     public static final int VERSION_119 = 119;
 
     public static final int VERSION_120 = 120;
+    // add nodeRole for BackendHbResponse
+    public static final int VERSION_121 = 121;
 
     // note: when increment meta version, should assign the latest version to VERSION_CURRENT
-    public static final int VERSION_CURRENT = VERSION_120;
+    public static final int VERSION_CURRENT = VERSION_121;
 
     // all logs meta version should >= the minimum version, so that we could remove many if clause, for example
     // if (FE_METAVERSION < VERSION_94) ...

--- a/fe/fe-core/src/main/java/org/apache/doris/system/BackendHbResponse.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/BackendHbResponse.java
@@ -17,6 +17,9 @@
 
 package org.apache.doris.system;
 
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.FeMetaVersion;
+import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.resource.Tag;
 
@@ -111,6 +114,7 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
         out.writeInt(bePort);
         out.writeInt(httpPort);
         out.writeInt(brpcPort);
+        Text.writeString(out, nodeRole);
     }
 
     @Override
@@ -120,6 +124,9 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
         bePort = in.readInt();
         httpPort = in.readInt();
         brpcPort = in.readInt();
+        if (Env.getCurrentEnvJournalVersion() >= FeMetaVersion.VERSION_121) {
+            nodeRole = Text.readString(in);
+        }
     }
 
     @Override
@@ -131,6 +138,7 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
         sb.append(", bePort: ").append(bePort);
         sb.append(", httpPort: ").append(httpPort);
         sb.append(", brpcPort: ").append(brpcPort);
+        sb.append(", nodeRole: ").append(nodeRole);
         return sb.toString();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/system/BeSelectionPolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/BeSelectionPolicy.java
@@ -141,7 +141,7 @@ public class BeSelectionPolicy {
                 storageMedium)) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Backend [{}] is not match by Other rules, policy: [{}]",
-                    backend.getIp(), this);
+                        backend.getIp(), this);
             }
             return false;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/system/BeSelectionPolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/BeSelectionPolicy.java
@@ -22,6 +22,8 @@ import org.apache.doris.thrift.TStorageMedium;
 
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.Sets;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -33,6 +35,7 @@ import java.util.stream.Collectors;
  * Selection policy for building BE nodes
  */
 public class BeSelectionPolicy {
+    private static final Logger LOG = LogManager.getLogger(BeSelectionPolicy.class);
     public String cluster = SystemInfoService.DEFAULT_CLUSTER;
     public boolean needScheduleAvailable = false;
     public boolean needQueryAvailable = false;
@@ -125,6 +128,10 @@ public class BeSelectionPolicy {
     private boolean isMatch(Backend backend) {
         // Compute node is only used when preferComputeNode is set.
         if (!preferComputeNode && backend.isComputeNode()) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Backend [{}] is not match by ComputeNode rule, policy: [{}]",
+                        backend.getIp(), this);
+            }
             return false;
         }
 
@@ -132,14 +139,26 @@ public class BeSelectionPolicy {
                 || needLoadAvailable && !backend.isLoadAvailable() || !resourceTags.isEmpty() && !resourceTags.contains(
                 backend.getLocationTag()) || storageMedium != null && !backend.hasSpecifiedStorageMedium(
                 storageMedium)) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Backend [{}] is not match by Other rules, policy: [{}]",
+                    backend.getIp(), this);
+            }
             return false;
         }
 
         if (checkDiskUsage) {
             if (storageMedium == null && backend.diskExceedLimit()) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Backend [{}] is not match by diskExceedLimit rule, policy: [{}]",
+                            backend.getIp(), this);
+                }
                 return false;
             }
             if (storageMedium != null && backend.diskExceedLimitByStorageMedium(storageMedium)) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Backend [{}] is not match by diskExceedLimitByStorageMedium rule, policy: [{}]",
+                            backend.getIp(), this);
+                }
                 return false;
             }
         }
@@ -186,7 +205,9 @@ public class BeSelectionPolicy {
 
     @Override
     public String toString() {
-        return String.format("cluster=%s | query=%s | load=%s | schedule=%s | tags=%s | medium=%s",
-                cluster, needLoadAvailable, needLoadAvailable, needScheduleAvailable, resourceTags, storageMedium);
+        return String.format("computeNode=%s | cluster=%s | query=%s | load=%s | schedule=%s | tags=%s | medium=%s",
+                preferComputeNode, cluster, needQueryAvailable, needLoadAvailable, needScheduleAvailable,
+                resourceTags.stream().map(tag -> tag.toString()).collect(Collectors.joining(",")),
+                storageMedium);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/system/SystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/system/SystemInfoServiceTest.java
@@ -109,6 +109,9 @@ public class SystemInfoServiceTest {
                 // Before meta version 121, nodeRole will not be read, so readResponse is not equal to writeResponse
                 Assert.assertFalse(readResponse.toString().equals(writeResponse.toString()));
                 Assert.assertTrue(Tag.VALUE_MIX.equals(readResponse.getNodeRole()));
+            } catch (IOException e) {
+                e.printStackTrace();
+                Assert.fail();
             }
 
         } finally {
@@ -134,6 +137,9 @@ public class SystemInfoServiceTest {
                 BackendHbResponse readResponse = BackendHbResponse.read(dis);
                 // After meta version 121, nodeRole will be read, so readResponse is equal to writeResponse
                 Assert.assertTrue(readResponse.toString().equals(writeResponse.toString()));
+            } catch (IOException e) {
+                e.printStackTrace();
+                Assert.fail();
             }
 
         } finally {

--- a/fe/fe-core/src/test/java/org/apache/doris/system/SystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/system/SystemInfoServiceTest.java
@@ -20,6 +20,8 @@ package org.apache.doris.system;
 import org.apache.doris.catalog.DiskInfo;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.ReplicaAllocation;
+import org.apache.doris.common.FeMetaVersion;
+import org.apache.doris.meta.MetaContext;
 import org.apache.doris.persist.EditLog;
 import org.apache.doris.resource.Tag;
 import org.apache.doris.thrift.TStorageMedium;
@@ -34,6 +36,12 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -71,6 +79,66 @@ public class SystemInfoServiceTest {
     private void addBackend(long beId, String host, int hbPort) {
         Backend backend = new Backend(beId, host, hbPort);
         infoService.addBackend(backend);
+    }
+
+    @Test
+    public void testBackendHbResponseSerialization() throws IOException {
+        MetaContext metaContext = new MetaContext();
+        metaContext.setMetaVersion(FeMetaVersion.VERSION_120);
+        metaContext.setThreadLocalInfo();
+
+        BackendHbResponse writeResponse = new BackendHbResponse(1L, 1234, 1234, 1234,
+            1234, 1234, "test", Tag.VALUE_COMPUTATION);
+
+        // Write objects to file
+        File file1 = new File("./SystemInfoServiceTest1");
+        try {
+            file1.createNewFile();
+
+            try (DataOutputStream dos = new DataOutputStream(new FileOutputStream(file1))) {
+                writeResponse.write(dos);
+                dos.flush();
+            } catch (IOException e) {
+                e.printStackTrace();
+                Assert.fail();
+            }
+
+            // Read objects from file
+            try(DataInputStream dis = new DataInputStream(new FileInputStream(file1))) {
+                BackendHbResponse readResponse = BackendHbResponse.read(dis);
+                // Before meta version 121, nodeRole was not read, so readResponse is not equal to writeResponse
+                Assert.assertFalse(readResponse.toString().equals(writeResponse.toString()));
+                Assert.assertTrue(Tag.VALUE_MIX.equals(readResponse.getNodeRole()));
+            }
+
+        } finally {
+            file1.delete();
+        }
+
+        metaContext.setMetaVersion(FeMetaVersion.VERSION_121);
+        // Write objects to file
+        File file2 = new File("./SystemInfoServiceTest2");
+        try {
+            file2.createNewFile();
+
+            try (DataOutputStream dos = new DataOutputStream(new FileOutputStream(file2))) {
+                writeResponse.write(dos);
+                dos.flush();
+            } catch (IOException e) {
+                e.printStackTrace();
+                Assert.fail();
+            }
+
+            // Read objects from file
+            try(DataInputStream dis = new DataInputStream(new FileInputStream(file2))) {
+                BackendHbResponse readResponse = BackendHbResponse.read(dis);
+                // After meta version 121, nodeRole was read, so readResponse is equal to writeResponse
+                Assert.assertTrue(readResponse.toString().equals(writeResponse.toString()));
+            }
+
+        } finally {
+            file2.delete();
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/system/SystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/system/SystemInfoServiceTest.java
@@ -88,7 +88,7 @@ public class SystemInfoServiceTest {
         metaContext.setThreadLocalInfo();
 
         BackendHbResponse writeResponse = new BackendHbResponse(1L, 1234, 1234, 1234,
-            1234, 1234, "test", Tag.VALUE_COMPUTATION);
+                1234, 1234, "test", Tag.VALUE_COMPUTATION);
 
         // Write objects to file
         File file1 = new File("./SystemInfoServiceTest1");
@@ -104,7 +104,7 @@ public class SystemInfoServiceTest {
             }
 
             // Read objects from file
-            try(DataInputStream dis = new DataInputStream(new FileInputStream(file1))) {
+            try (DataInputStream dis = new DataInputStream(new FileInputStream(file1))) {
                 BackendHbResponse readResponse = BackendHbResponse.read(dis);
                 // Before meta version 121, nodeRole will not be read, so readResponse is not equal to writeResponse
                 Assert.assertFalse(readResponse.toString().equals(writeResponse.toString()));
@@ -133,7 +133,7 @@ public class SystemInfoServiceTest {
             }
 
             // Read objects from file
-            try(DataInputStream dis = new DataInputStream(new FileInputStream(file2))) {
+            try (DataInputStream dis = new DataInputStream(new FileInputStream(file2))) {
                 BackendHbResponse readResponse = BackendHbResponse.read(dis);
                 // After meta version 121, nodeRole will be read, so readResponse is equal to writeResponse
                 Assert.assertTrue(readResponse.toString().equals(writeResponse.toString()));

--- a/fe/fe-core/src/test/java/org/apache/doris/system/SystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/system/SystemInfoServiceTest.java
@@ -106,7 +106,7 @@ public class SystemInfoServiceTest {
             // Read objects from file
             try(DataInputStream dis = new DataInputStream(new FileInputStream(file1))) {
                 BackendHbResponse readResponse = BackendHbResponse.read(dis);
-                // Before meta version 121, nodeRole was not read, so readResponse is not equal to writeResponse
+                // Before meta version 121, nodeRole will not be read, so readResponse is not equal to writeResponse
                 Assert.assertFalse(readResponse.toString().equals(writeResponse.toString()));
                 Assert.assertTrue(Tag.VALUE_MIX.equals(readResponse.getNodeRole()));
             }
@@ -132,7 +132,7 @@ public class SystemInfoServiceTest {
             // Read objects from file
             try(DataInputStream dis = new DataInputStream(new FileInputStream(file2))) {
                 BackendHbResponse readResponse = BackendHbResponse.read(dis);
-                // After meta version 121, nodeRole was read, so readResponse is equal to writeResponse
+                // After meta version 121, nodeRole will be read, so readResponse is equal to writeResponse
                 Assert.assertTrue(readResponse.toString().equals(writeResponse.toString()));
             }
 


### PR DESCRIPTION

# Proposed changes

Issue Number: close #19235

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

