### PR TITLE
[fix](fe)insubquery should always be converted to semi or anti join

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/StmtRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/StmtRewriter.java
@@ -822,11 +822,13 @@ public class StmtRewriter {
             if (expr instanceof ExistsPredicate) {
                 joinOp = ((ExistsPredicate) expr).isNotExists() ? JoinOperator.LEFT_ANTI_JOIN :
                         JoinOperator.LEFT_SEMI_JOIN;
-            } else if (expr instanceof InPredicate && joinConjunct instanceof FunctionCallExpr
-                    && (((FunctionCallExpr) joinConjunct).getFnName().getFunction()
-                    .equalsIgnoreCase(BITMAP_CONTAINS))) {
+            } else if (expr instanceof InPredicate) {
                 joinOp = ((InPredicate) expr).isNotIn() ? JoinOperator.LEFT_ANTI_JOIN : JoinOperator.LEFT_SEMI_JOIN;
-                isInBitmap = true;
+                if (joinConjunct instanceof FunctionCallExpr
+                        && (((FunctionCallExpr) joinConjunct).getFnName().getFunction()
+                        .equalsIgnoreCase(BITMAP_CONTAINS))) {
+                    isInBitmap = true;
+                }
             } else {
                 joinOp = JoinOperator.CROSS_JOIN;
                 // We can equal the aggregate subquery using a cross join. All conjuncts

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/StmtRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/StmtRewriter.java
@@ -822,11 +822,11 @@ public class StmtRewriter {
             if (expr instanceof ExistsPredicate) {
                 joinOp = ((ExistsPredicate) expr).isNotExists() ? JoinOperator.LEFT_ANTI_JOIN :
                         JoinOperator.LEFT_SEMI_JOIN;
-            } else if (expr instanceof InPredicate) {
+            } else if (expr instanceof InPredicate && !(joinConjunct instanceof BitmapFilterPredicate)) {
                 joinOp = ((InPredicate) expr).isNotIn() ? JoinOperator.LEFT_ANTI_JOIN : JoinOperator.LEFT_SEMI_JOIN;
-                if (joinConjunct instanceof FunctionCallExpr
+                if ((joinConjunct instanceof FunctionCallExpr
                         && (((FunctionCallExpr) joinConjunct).getFnName().getFunction()
-                        .equalsIgnoreCase(BITMAP_CONTAINS))) {
+                        .equalsIgnoreCase(BITMAP_CONTAINS)))) {
                     isInBitmap = true;
                 }
             } else {

--- a/regression-test/suites/correctness_p0/test_join_without_condition.groovy
+++ b/regression-test/suites/correctness_p0/test_join_without_condition.groovy
@@ -63,6 +63,12 @@ suite("test_join_without_condition") {
         order by a.a, b.a;
     """
 
+    explain {
+        sql("select * from (select 1 id) t where (1 in (select a from test_join_without_condition_a))")
+        notContains "CROSS JOIN"
+        contains "LEFT SEMI JOIN"
+    }
+
     sql """
         drop table if exists test_join_without_condition_a;
     """


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

