### PR TITLE
[bugfix](rpc) fix read-after-free problem of DeleteClosure.

### DIFF
--- a/be/src/pipeline/exec/exchange_sink_buffer.cpp
+++ b/be/src/pipeline/exec/exchange_sink_buffer.cpp
@@ -61,6 +61,9 @@ public:
     void Run() noexcept override {
         std::unique_ptr<SelfDeleteClosure> self_guard(this);
         try {
+            if (_data) {
+                _data->unref();
+            }
             if (cntl.Failed()) {
                 std::string err = fmt::format(
                         "failed to send brpc when exchange, error={}, error_text={}, client: {}, "
@@ -70,9 +73,6 @@ public:
                 _fail_fn(_id, err);
             } else {
                 _suc_fn(_id, _eos, result);
-            }
-            if (_data) {
-                _data->unref();
             }
         } catch (const std::exception& exp) {
             LOG(FATAL) << "brpc callback error: " << exp.what();

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -305,9 +305,6 @@ public:
 
 protected:
     void _fresh_exec_timer(NodeType* node) {
-        if (_runtime_profile == nullptr) {
-            return;
-        }
         node->profile()->total_time_counter()->update(
                 _runtime_profile->total_time_counter()->value());
     }
@@ -381,9 +378,6 @@ public:
 
 protected:
     void _fresh_exec_timer(NodeType* node) {
-        if (_runtime_profile == nullptr) {
-            return;
-        }
         node->runtime_profile()->total_time_counter()->update(
                 _runtime_profile->total_time_counter()->value());
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close DORIS-3902

## Problem summary

1. fix read-after-free problem of DeleteClosure.
2. modified fresh_exec_timer for operators

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments