### PR TITLE
[chore](fe) Fix the build on Centos 6

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -29,6 +29,8 @@ under the License.
     <artifactId>fe-core</artifactId>
     <packaging>jar</packaging>
     <properties>
+        <doris.home>${basedir}/../../</doris.home>
+        <doris.thirdparty>${basedir}/../../thirdparty</doris.thirdparty>
         <fe_ut_parallel>1</fe_ut_parallel>
         <antlr4.version>4.9.3</antlr4.version>
         <awssdk.version>2.17.257</awssdk.version>


### PR DESCRIPTION
# Proposed changes

Issue Number: close #19253 

## Problem summary

#18882 put some common properties to `pom.xml` in directory `fe`. The property `doris.thirdparty` isn't set properly until the plugin `directory-maven-plugin` runs. However, the profile `protoc_command` for `fe-core` depends on the property `doris.thirdparty` at start. That makes the build fail on Centos 6.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

