### PR TITLE
[chore](macOS) Fix JAVA_OPTS in start_be.sh

### DIFF
--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -287,7 +287,15 @@ else
 fi
 
 if [[ "${MACHINE_OS}" == "Darwin" ]]; then
-    final_java_opt="${final_java_opt} -XX:-MaxFDLimit"
+    max_fd_limit='-XX:-MaxFDLimit'
+
+    if ! echo "${final_java_opt}" | grep "${max_fd_limit/-/\-}" >/dev/null; then
+        final_java_opt="${final_java_opt} ${max_fd_limit}"
+    fi
+
+    if [[ -n "${JAVA_OPTS}" ]] && ! echo "${JAVA_OPTS}" | grep "${max_fd_limit/-/\-}" >/dev/null; then
+        JAVA_OPTS="${JAVA_OPTS} ${max_fd_limit}"
+    fi
 fi
 
 # set LIBHDFS_OPTS for hadoop libhdfs


### PR DESCRIPTION
# Proposed changes

Issue Number: close #19263

## Problem summary

We should set `-XX:-MaxFDLimit` on macOS if we enable java support for BE otherwise BE may fail to start up.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

