### PR TITLE
[fix](load) exclude canceled  job when canceling load

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
@@ -666,7 +666,8 @@ public class LoadManager implements Writable {
             Map<String, List<LoadJob>> labelToLoadJobs = dbIdToLabelToLoadJobs.get(dbId);
             if (labelToLoadJobs.containsKey(label)) {
                 List<LoadJob> labelLoadJobs = labelToLoadJobs.get(label);
-                Optional<LoadJob> loadJobOptional = labelLoadJobs.stream().findFirst();
+                Optional<LoadJob> loadJobOptional = labelLoadJobs.stream()
+                        .filter(entity -> entity.getState() != JobState.CANCELLED).findFirst();
                 if (loadJobOptional.isPresent()) {
                     LOG.warn("Failed to add load job when label {} has been used.", label);
                     throw new LabelAlreadyUsedException(label);

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
@@ -666,8 +666,7 @@ public class LoadManager implements Writable {
             Map<String, List<LoadJob>> labelToLoadJobs = dbIdToLabelToLoadJobs.get(dbId);
             if (labelToLoadJobs.containsKey(label)) {
                 List<LoadJob> labelLoadJobs = labelToLoadJobs.get(label);
-                Optional<LoadJob> loadJobOptional = labelLoadJobs.stream()
-                        .filter(entity -> entity.getState() != JobState.CANCELLED).findFirst();
+                Optional<LoadJob> loadJobOptional = labelLoadJobs.stream().findFirst();
                 if (loadJobOptional.isPresent()) {
                     LOG.warn("Failed to add load job when label {} has been used.", label);
                     throw new LabelAlreadyUsedException(label);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #19215

## Problem summary

after fix:
```
mysql> show load;
+-------+---------------+-----------+-------------------+--------+---------+-----------------------------------------------------+----------------------------------------------------------------------------------------------------------+---------------------+---------------------+---------------------+---------------------+---------------------+------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------+--------------+------+---------+
| JobId | Label         | State     | Progress          | Type   | EtlInfo | TaskInfo                                            | ErrorMsg                                                                                                 | CreateTime          | EtlStartTime        | EtlFinishTime       | LoadStartTime       | LoadFinishTime      | URL  | JobDetails                                                                                                                                                                                                                         | TransactionId | ErrorTablets | User | Comment |
+-------+---------------+-----------+-------------------+--------+---------+-----------------------------------------------------+----------------------------------------------------------------------------------------------------------+---------------------+---------------------+---------------------+---------------------+---------------------+------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------+--------------+------+---------+
| 11001 | lineitem_load | CANCELLED | ETL:N/A; LOAD:N/A | BROKER | NULL    | cluster:N/A; timeout(s):14400; max_filter_ratio:0.0 | type:ETL_RUN_FAIL; msg:errCode = 2, detailMessage = Scan bytes per file scanner exceed limit: 3221225472 | 2023-05-04 19:19:47 | NULL                | NULL                | NULL                | 2023-05-04 19:19:49 | NULL | {"Unfinished backends":{},"ScannedRows":0,"TaskNumber":0,"LoadBytes":0,"All backends":{},"FileNumber":1,"FileSize":7895697364}                                                                                                     | 1002          | {}           | root |         |
| 11004 | lineitem_load | LOADING   | ETL:100%; LOAD:2% | BROKER | NULL    | cluster:N/A; timeout(s):14400; max_filter_ratio:0.0 | NULL                                                                                                     | 2023-05-04 19:20:52 | 2023-05-04 19:20:53 | 2023-05-04 19:20:53 | 2023-05-04 19:20:53 | NULL                | NULL | {"Unfinished backends":{"3782926ace6f45c5-b199d1091cae9cc8":[10021]},"ScannedRows":1341120,"TaskNumber":1,"LoadBytes":227694824,"All backends":{"3782926ace6f45c5-b199d1091cae9cc8":[10021]},"FileNumber":1,"FileSize":7895697364} | 1003          | {}           | root |         |
+-------+---------------+-----------+-------------------+--------+---------+-----------------------------------------------------+----------------------------------------------------------------------------------------------------------+---------------------+---------------------+---------------------+---------------------+---------------------+------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------+--------------+------+---------+

mysql> CANCEL LOAD FROM test WHERE LABEL="lineitem_load";
Query OK, 0 rows affected (0.01 sec)

mysql> show load;
+-------+---------------+-----------+-------------------+--------+---------+-----------------------------------------------------+----------------------------------------------------------------------------------------------------------+---------------------+---------------------+---------------------+---------------------+---------------------+------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------+--------------+------+---------+
| JobId | Label         | State     | Progress          | Type   | EtlInfo | TaskInfo                                            | ErrorMsg                                                                                                 | CreateTime          | EtlStartTime        | EtlFinishTime       | LoadStartTime       | LoadFinishTime      | URL  | JobDetails                                                                                                                                                                                                                         | TransactionId | ErrorTablets | User | Comment |
+-------+---------------+-----------+-------------------+--------+---------+-----------------------------------------------------+----------------------------------------------------------------------------------------------------------+---------------------+---------------------+---------------------+---------------------+---------------------+------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------+--------------+------+---------+
| 11001 | lineitem_load | CANCELLED | ETL:N/A; LOAD:N/A | BROKER | NULL    | cluster:N/A; timeout(s):14400; max_filter_ratio:0.0 | type:ETL_RUN_FAIL; msg:errCode = 2, detailMessage = Scan bytes per file scanner exceed limit: 3221225472 | 2023-05-04 19:19:47 | NULL                | NULL                | NULL                | 2023-05-04 19:19:49 | NULL | {"Unfinished backends":{},"ScannedRows":0,"TaskNumber":0,"LoadBytes":0,"All backends":{},"FileNumber":1,"FileSize":7895697364}                                                                                                     | 1002          | {}           | root |         |
| 11004 | lineitem_load | CANCELLED | ETL:N/A; LOAD:N/A | BROKER | NULL    | cluster:N/A; timeout(s):14400; max_filter_ratio:0.0 | type:USER_CANCEL; msg:user cancel                                                                        | 2023-05-04 19:20:52 | 2023-05-04 19:20:53 | 2023-05-04 19:20:53 | 2023-05-04 19:20:53 | 2023-05-04 19:22:24 | NULL | {"Unfinished backends":{"3782926ace6f45c5-b199d1091cae9cc8":[10021]},"ScannedRows":2865120,"TaskNumber":1,"LoadBytes":486453189,"All backends":{"3782926ace6f45c5-b199d1091cae9cc8":[10021]},"FileNumber":1,"FileSize":7895697364} | 1003          | {}           | root |         |
+-------+---------------+-----------+-------------------+--------+---------+-----------------------------------------------------+----------------------------------------------------------------------------------------------------------+---------------------+---------------------+---------------------+---------------------+---------------------+------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------+--------------+------+---------+
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

