### PR TITLE
[Feature](block-rule) Support qps for sql block rule

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterSqlBlockRuleStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterSqlBlockRuleStmt.java
@@ -85,7 +85,7 @@ public class AlterSqlBlockRuleStmt extends DdlStmt {
 
         SqlBlockUtil.checkSqlAndSqlHashSetBoth(sql, sqlHash);
         SqlBlockUtil.checkSqlAndLimitationsSetBoth(sql, sqlHash,
-                partitionNumString, tabletNumString, cardinalityString);
+                partitionNumString, tabletNumString, cardinalityString, qpsString);
         this.partitionNum = Util.getLongPropertyOrDefault(partitionNumString, LONG_NOT_SET, null,
                 CreateSqlBlockRuleStmt.SCANNED_PARTITION_NUM + " should be a long");
         this.tabletNum = Util.getLongPropertyOrDefault(tabletNumString, LONG_NOT_SET, null,

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterSqlBlockRuleStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterSqlBlockRuleStmt.java
@@ -35,6 +35,7 @@ import java.util.Map;
 public class AlterSqlBlockRuleStmt extends DdlStmt {
 
     public static final Long LONG_NOT_SET = SqlBlockUtil.LONG_MINUS_ONE;
+    public static final Double DOUBLE_NOT_SET = SqlBlockUtil.DOUBLE_MINUS_ONE;
 
     private final String ruleName;
 
@@ -48,7 +49,7 @@ public class AlterSqlBlockRuleStmt extends DdlStmt {
 
     private Long cardinality;
 
-    private Long qps;
+    private Double qps;
 
     private Boolean global;
 
@@ -91,8 +92,8 @@ public class AlterSqlBlockRuleStmt extends DdlStmt {
                 CreateSqlBlockRuleStmt.SCANNED_TABLET_NUM + " should be a long");
         this.cardinality = Util.getLongPropertyOrDefault(cardinalityString, LONG_NOT_SET, null,
                 CreateSqlBlockRuleStmt.SCANNED_CARDINALITY + " should be a long");
-        this.qps = Util.getLongPropertyOrDefault(qpsString, LONG_NOT_SET, null,
-            CreateSqlBlockRuleStmt.QUERY_PER_SECOND + " should be a long");
+        this.qps = Util.getDoublePropertyOrDefault(qpsString, DOUBLE_NOT_SET, null,
+            CreateSqlBlockRuleStmt.QUERY_PER_SECOND + " should be a double");
         // allow null, represents no modification
         String globalStr = properties.get(CreateSqlBlockRuleStmt.GLOBAL_PROPERTY);
         this.global = StringUtils.isNotEmpty(globalStr) ? Boolean.parseBoolean(globalStr) : null;
@@ -120,7 +121,7 @@ public class AlterSqlBlockRuleStmt extends DdlStmt {
         return cardinality;
     }
 
-    public Long getQps() {
+    public Double getQps() {
         return qps;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterSqlBlockRuleStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterSqlBlockRuleStmt.java
@@ -48,6 +48,8 @@ public class AlterSqlBlockRuleStmt extends DdlStmt {
 
     private Long cardinality;
 
+    private Long qps;
+
     private Boolean global;
 
     private Boolean enable;
@@ -78,6 +80,7 @@ public class AlterSqlBlockRuleStmt extends DdlStmt {
         String partitionNumString = properties.get(CreateSqlBlockRuleStmt.SCANNED_PARTITION_NUM);
         String tabletNumString = properties.get(CreateSqlBlockRuleStmt.SCANNED_TABLET_NUM);
         String cardinalityString = properties.get(CreateSqlBlockRuleStmt.SCANNED_CARDINALITY);
+        String qpsString = properties.get(CreateSqlBlockRuleStmt.QUERY_PER_SECOND);
 
         SqlBlockUtil.checkSqlAndSqlHashSetBoth(sql, sqlHash);
         SqlBlockUtil.checkSqlAndLimitationsSetBoth(sql, sqlHash,
@@ -88,6 +91,8 @@ public class AlterSqlBlockRuleStmt extends DdlStmt {
                 CreateSqlBlockRuleStmt.SCANNED_TABLET_NUM + " should be a long");
         this.cardinality = Util.getLongPropertyOrDefault(cardinalityString, LONG_NOT_SET, null,
                 CreateSqlBlockRuleStmt.SCANNED_CARDINALITY + " should be a long");
+        this.qps = Util.getLongPropertyOrDefault(qpsString, LONG_NOT_SET, null,
+            CreateSqlBlockRuleStmt.QUERY_PER_SECOND + " should be a long");
         // allow null, represents no modification
         String globalStr = properties.get(CreateSqlBlockRuleStmt.GLOBAL_PROPERTY);
         this.global = StringUtils.isNotEmpty(globalStr) ? Boolean.parseBoolean(globalStr) : null;
@@ -113,6 +118,10 @@ public class AlterSqlBlockRuleStmt extends DdlStmt {
 
     public Long getCardinality() {
         return cardinality;
+    }
+
+    public Long getQps() {
+        return qps;
     }
 
     public Boolean getGlobal() {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateSqlBlockRuleStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateSqlBlockRuleStmt.java
@@ -59,6 +59,8 @@ public class CreateSqlBlockRuleStmt extends DdlStmt {
 
     public static final String SCANNED_CARDINALITY = "cardinality";
 
+    public static final String QUERY_PER_SECOND = "qps";
+
     public static final String GLOBAL_PROPERTY = "global";
 
     public static final String ENABLE_PROPERTY = "enable";
@@ -77,6 +79,8 @@ public class CreateSqlBlockRuleStmt extends DdlStmt {
 
     private Long cardinality;
 
+    private Long qps;
+
     // whether effective global, default is false
     private boolean global;
 
@@ -91,7 +95,7 @@ public class CreateSqlBlockRuleStmt extends DdlStmt {
 
     public static final ImmutableSet<String> PROPERTIES_SET = new ImmutableSet.Builder<String>().add(SQL_PROPERTY)
             .add(SQL_HASH_PROPERTY).add(GLOBAL_PROPERTY).add(ENABLE_PROPERTY).add(SCANNED_PARTITION_NUM)
-            .add(SCANNED_TABLET_NUM).add(SCANNED_CARDINALITY).build();
+            .add(SCANNED_TABLET_NUM).add(SCANNED_CARDINALITY).add(QUERY_PER_SECOND).build();
 
     public CreateSqlBlockRuleStmt(String ruleName, Map<String, String> properties) {
         this.ifNotExists = false;
@@ -124,6 +128,7 @@ public class CreateSqlBlockRuleStmt extends DdlStmt {
         String partitionNumString = properties.get(SCANNED_PARTITION_NUM);
         String tabletNumString = properties.get(SCANNED_TABLET_NUM);
         String cardinalityString = properties.get(SCANNED_CARDINALITY);
+        String qpsString = properties.get(QUERY_PER_SECOND);
 
         SqlBlockUtil.checkSqlAndSqlHashSetBoth(sql, sqlHash);
         SqlBlockUtil.checkPropertiesValidate(sql, sqlHash, partitionNumString, tabletNumString, cardinalityString);
@@ -134,6 +139,8 @@ public class CreateSqlBlockRuleStmt extends DdlStmt {
                 SCANNED_TABLET_NUM + " should be a long");
         this.cardinality = Util.getLongPropertyOrDefault(cardinalityString, 0L, null,
                 SCANNED_CARDINALITY + " should be a long");
+        this.qps = Util.getLongPropertyOrDefault(qpsString, 0L, null,
+                QUERY_PER_SECOND + " should be a long");
 
         this.global = Util.getBooleanPropertyOrDefault(properties.get(GLOBAL_PROPERTY), false,
                 GLOBAL_PROPERTY + " should be a boolean");

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateSqlBlockRuleStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateSqlBlockRuleStmt.java
@@ -79,7 +79,7 @@ public class CreateSqlBlockRuleStmt extends DdlStmt {
 
     private Long cardinality;
 
-    private Long qps;
+    private Double qps;
 
     // whether effective global, default is false
     private boolean global;
@@ -139,8 +139,8 @@ public class CreateSqlBlockRuleStmt extends DdlStmt {
                 SCANNED_TABLET_NUM + " should be a long");
         this.cardinality = Util.getLongPropertyOrDefault(cardinalityString, 0L, null,
                 SCANNED_CARDINALITY + " should be a long");
-        this.qps = Util.getLongPropertyOrDefault(qpsString, 0L, null,
-                QUERY_PER_SECOND + " should be a long");
+        this.qps = Util.getDoublePropertyOrDefault(qpsString, 0D, null,
+                QUERY_PER_SECOND + " should be a double");
 
         this.global = Util.getBooleanPropertyOrDefault(properties.get(GLOBAL_PROPERTY), false,
                 GLOBAL_PROPERTY + " should be a boolean");

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateSqlBlockRuleStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateSqlBlockRuleStmt.java
@@ -131,7 +131,8 @@ public class CreateSqlBlockRuleStmt extends DdlStmt {
         String qpsString = properties.get(QUERY_PER_SECOND);
 
         SqlBlockUtil.checkSqlAndSqlHashSetBoth(sql, sqlHash);
-        SqlBlockUtil.checkPropertiesValidate(sql, sqlHash, partitionNumString, tabletNumString, cardinalityString);
+        SqlBlockUtil.checkPropertiesValidate(sql, sqlHash, partitionNumString, tabletNumString,
+                cardinalityString, qpsString);
 
         this.partitionNum = Util.getLongPropertyOrDefault(partitionNumString, 0L, null,
                 SCANNED_PARTITION_NUM + " should be a long");

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowSqlBlockRuleStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowSqlBlockRuleStmt.java
@@ -46,6 +46,7 @@ public class ShowSqlBlockRuleStmt extends ShowStmt {
                     .addColumn(new Column("PartitionNum", ScalarType.createVarchar(10)))
                     .addColumn(new Column("TabletNum", ScalarType.createVarchar(10)))
                     .addColumn(new Column("Cardinality", ScalarType.createVarchar(20)))
+                    .addColumn(new Column("Qps", ScalarType.createVarchar(20)))
                     .addColumn(new Column("Global", ScalarType.createVarchar(4)))
                     .addColumn(new Column("Enable", ScalarType.createVarchar(4)))
                     .build();

--- a/fe/fe-core/src/main/java/org/apache/doris/blockrule/SqlBlockRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/blockrule/SqlBlockRule.java
@@ -65,7 +65,7 @@ public class SqlBlockRule implements Writable {
     private Long cardinality;
 
     @SerializedName(value = "qps")
-    private Long qps;
+    private Double qps;
 
     // whether effective global
     @SerializedName(value = "global")
@@ -81,7 +81,7 @@ public class SqlBlockRule implements Writable {
      * Create SqlBlockRule.
      **/
     public SqlBlockRule(String name, String sql, String sqlHash, Long partitionNum, Long tabletNum, Long cardinality,
-                        Long qps, Boolean global, Boolean enable) {
+                        Double qps, Boolean global, Boolean enable) {
         this.name = name;
         this.sql = sql;
         this.sqlHash = sqlHash;
@@ -134,7 +134,7 @@ public class SqlBlockRule implements Writable {
         return cardinality;
     }
 
-    public Long getQps() {
+    public Double getQps() {
         return qps;
     }
 
@@ -170,7 +170,7 @@ public class SqlBlockRule implements Writable {
         this.cardinality = cardinality;
     }
 
-    public void setQps(Long qps) {
+    public void setQps(Double qps) {
         this.qps = qps;
     }
 
@@ -190,7 +190,7 @@ public class SqlBlockRule implements Writable {
                 this.partitionNum == null ? "0" : Long.toString(this.partitionNum),
                 this.tabletNum == null ? "0" : Long.toString(this.tabletNum),
                 this.cardinality == null ? "0" : Long.toString(this.cardinality),
-                this.qps == null ? "0" : Long.toString(this.qps), String.valueOf(this.global),
+                this.qps == null ? "0" : Double.toString(this.qps), String.valueOf(this.global),
                 String.valueOf(this.enable));
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/blockrule/SqlBlockRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/blockrule/SqlBlockRule.java
@@ -64,6 +64,9 @@ public class SqlBlockRule implements Writable {
     @SerializedName(value = "cardinality")
     private Long cardinality;
 
+    @SerializedName(value = "qps")
+    private Long qps;
+
     // whether effective global
     @SerializedName(value = "global")
     private Boolean global;
@@ -78,13 +81,14 @@ public class SqlBlockRule implements Writable {
      * Create SqlBlockRule.
      **/
     public SqlBlockRule(String name, String sql, String sqlHash, Long partitionNum, Long tabletNum, Long cardinality,
-            Boolean global, Boolean enable) {
+                        Long qps, Boolean global, Boolean enable) {
         this.name = name;
         this.sql = sql;
         this.sqlHash = sqlHash;
         this.partitionNum = partitionNum;
         this.tabletNum = tabletNum;
         this.cardinality = cardinality;
+        this.qps = qps;
         this.global = global;
         this.enable = enable;
         if (StringUtils.isNotEmpty(sql)) {
@@ -94,12 +98,12 @@ public class SqlBlockRule implements Writable {
 
     public static SqlBlockRule fromCreateStmt(CreateSqlBlockRuleStmt stmt) {
         return new SqlBlockRule(stmt.getRuleName(), stmt.getSql(), stmt.getSqlHash(), stmt.getPartitionNum(),
-                stmt.getTabletNum(), stmt.getCardinality(), stmt.isGlobal(), stmt.isEnable());
+                stmt.getTabletNum(), stmt.getCardinality(), stmt.getQps(), stmt.isGlobal(), stmt.isEnable());
     }
 
     public static SqlBlockRule fromAlterStmt(AlterSqlBlockRuleStmt stmt) {
         return new SqlBlockRule(stmt.getRuleName(), stmt.getSql(), stmt.getSqlHash(), stmt.getPartitionNum(),
-                stmt.getTabletNum(), stmt.getCardinality(), stmt.getGlobal(), stmt.getEnable());
+                stmt.getTabletNum(), stmt.getCardinality(), stmt.getQps(), stmt.getGlobal(), stmt.getEnable());
     }
 
     public String getName() {
@@ -128,6 +132,10 @@ public class SqlBlockRule implements Writable {
 
     public Long getCardinality() {
         return cardinality;
+    }
+
+    public Long getQps() {
+        return qps;
     }
 
     public Boolean getGlobal() {
@@ -162,6 +170,10 @@ public class SqlBlockRule implements Writable {
         this.cardinality = cardinality;
     }
 
+    public void setQps(Long qps) {
+        this.qps = qps;
+    }
+
     public void setGlobal(Boolean global) {
         this.global = global;
     }
@@ -177,7 +189,8 @@ public class SqlBlockRule implements Writable {
         return Lists.newArrayList(this.name, this.sql, this.sqlHash,
                 this.partitionNum == null ? "0" : Long.toString(this.partitionNum),
                 this.tabletNum == null ? "0" : Long.toString(this.tabletNum),
-                this.cardinality == null ? "0" : Long.toString(this.cardinality), String.valueOf(this.global),
+                this.cardinality == null ? "0" : Long.toString(this.cardinality),
+                this.qps == null ? "0" : Long.toString(this.qps), String.valueOf(this.global),
                 String.valueOf(this.enable));
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/ErrorCode.java
@@ -1178,7 +1178,7 @@ public enum ErrorCode {
             "data cannot be inserted into table with empty partition. "
                     + "Use `SHOW PARTITIONS FROM %s` to see the currently partitions of this table. "),
     ERROR_SQL_AND_LIMITATIONS_SET_IN_ONE_RULE(5084, new byte[]{'4', '2', '0', '0', '0'},
-            "sql/sqlHash and partition_num/tablet_num/cardinality cannot be set in one rule."),
+            "sql/sqlHash and partition_num/tablet_num/cardinality/qps cannot be set in one rule."),
     ERR_WRONG_CATALOG_NAME(5085, new byte[]{'4', '2', '0', '0', '0'}, "Incorrect catalog name '%s'"),
     ERR_UNKNOWN_CATALOG(5086, new byte[]{'4', '2', '0', '0', '0'}, "Unknown catalog '%s'"),
     ERR_CATALOG_ACCESS_DENIED(5087, new byte[]{'4', '2', '0', '0', '0'},

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/SqlBlockUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/SqlBlockUtil.java
@@ -29,9 +29,9 @@ public class SqlBlockUtil {
     public static final String STRING_DEFAULT = "NULL";
     public static final String LONG_DEFAULT = "0";
     public static final Long LONG_ZERO = 0L;
-    public static final Double DOUBLE_ZERO = 0D;
+    public static final double DOUBLE_ZERO = 0D;
     public static final Long LONG_MINUS_ONE = -1L;
-    public static final Double DOUBLE_MINUS_ONE = -1D;
+    public static final double DOUBLE_MINUS_ONE = -1D;
 
 
     public static void checkSqlAndSqlHashSetBoth(String sql, String sqlHash) throws AnalysisException {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/SqlBlockUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/SqlBlockUtil.java
@@ -42,7 +42,8 @@ public class SqlBlockUtil {
 
     // check (sql or sqlHash) and (limitations: partitioNum, tabletNum, cardinality, qps) are not set both
     public static void checkSqlAndLimitationsSetBoth(String sql, String sqlHash,
-            String partitionNumString, String tabletNumString, String cardinalityString, String qpsString) throws AnalysisException {
+            String partitionNumString, String tabletNumString, String cardinalityString, String qpsString)
+            throws AnalysisException {
         if ((!STRING_DEFAULT.equals(sql) || !STRING_DEFAULT.equals(sqlHash))
                 && !isSqlBlockLimitationsEmpty(partitionNumString, tabletNumString, cardinalityString, qpsString)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERROR_SQL_AND_LIMITATIONS_SET_IN_ONE_RULE);
@@ -71,7 +72,8 @@ public class SqlBlockUtil {
                 && StringUtils.isEmpty(qpsString);
     }
 
-    public static Boolean isSqlBlockLimitationsDefault(Long partitionNum, Long tabletNum, Long cardinality, Double qps) {
+    public static Boolean isSqlBlockLimitationsDefault(Long partitionNum, Long tabletNum,
+                                                       Long cardinality, Double qps) {
         return partitionNum == LONG_ZERO && tabletNum == LONG_ZERO && cardinality == LONG_ZERO && qps == DOUBLE_ZERO;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/SqlBlockUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/SqlBlockUtil.java
@@ -30,6 +30,7 @@ public class SqlBlockUtil {
     public static final String LONG_DEFAULT = "0";
     public static final Long LONG_ZERO = 0L;
     public static final Long LONG_MINUS_ONE = -1L;
+    public static final Double DOUBLE_MINUS_ONE = -1D;
 
 
     public static void checkSqlAndSqlHashSetBoth(String sql, String sqlHash) throws AnalysisException {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -428,12 +428,12 @@ public class StmtExecutor {
         Env.getCurrentEnv().getSqlBlockRuleMgr().matchSql(
                 originStmt.originStmt, context.getSqlHash(), context.getQualifiedUser());
 
-        // limitations: partition_num, tablet_num, cardinality
+        // ScanNode limitations: partition_num, tablet_num, cardinality
         List<ScanNode> scanNodeList = planner.getScanNodes();
         for (ScanNode scanNode : scanNodeList) {
             if (scanNode instanceof OlapScanNode) {
                 OlapScanNode olapScanNode = (OlapScanNode) scanNode;
-                Env.getCurrentEnv().getSqlBlockRuleMgr().checkLimitations(
+                Env.getCurrentEnv().getSqlBlockRuleMgr().checkScanNodeLimitations(
                         olapScanNode.getSelectedPartitionNum().longValue(),
                         olapScanNode.getSelectedTabletsNum(),
                         olapScanNode.getCardinality(),

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -425,9 +425,11 @@ public class StmtExecutor {
     }
 
     private boolean checkBlockRules() throws AnalysisException {
+        // Sql limitations
         Env.getCurrentEnv().getSqlBlockRuleMgr().matchSql(
                 originStmt.originStmt, context.getSqlHash(), context.getQualifiedUser());
-
+        // Statement limitations: qps
+        Env.getCurrentEnv().getSqlBlockRuleMgr().checkStmtLimitations(context.getQualifiedUser());
         // ScanNode limitations: partition_num, tablet_num, cardinality
         List<ScanNode> scanNodeList = planner.getScanNodes();
         for (ScanNode scanNode : scanNodeList) {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/AlterSqlBlockRuleStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/AlterSqlBlockRuleStmtTest.java
@@ -83,7 +83,7 @@ public class AlterSqlBlockRuleStmtTest {
         AlterSqlBlockRuleStmt stmt = new AlterSqlBlockRuleStmt("test_rule", properties);
 
         ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
-                "errCode = 2, detailMessage = sql/sqlHash and partition_num/tablet_num/cardinality cannot be set in one rule.",
+                "errCode = 2, detailMessage = sql/sqlHash and partition_num/tablet_num/cardinality/qps cannot be set in one rule.",
                 () -> stmt.analyze(analyzer));
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateSqlBlockRuleStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateSqlBlockRuleStmtTest.java
@@ -100,7 +100,7 @@ public class CreateSqlBlockRuleStmtTest {
         CreateSqlBlockRuleStmt stmt = new CreateSqlBlockRuleStmt("test_rule", properties);
 
         ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
-                "errCode = 2, detailMessage = sql/sqlHash and partition_num/tablet_num/cardinality cannot be set in one rule.",
+                "errCode = 2, detailMessage = sql/sqlHash and partition_num/tablet_num/cardinality/qps cannot be set in one rule.",
                 () -> stmt.analyze(analyzer));
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/blockrule/SqlBlockRuleMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/blockrule/SqlBlockRuleMgrTest.java
@@ -165,24 +165,24 @@ public class SqlBlockRuleMgrTest extends TestWithFeService {
 
         // create : sql
         // alter : tabletNum
-        // AnalysisException : sql/sqlHash and partition_num/tablet_num/cardinality cannot be set in one rule.
+        // AnalysisException : sql/sqlHash and partition_num/tablet_num/cardinality/qps cannot be set in one rule.
         String alterNumRule =
                 "ALTER SQL_BLOCK_RULE test_rule PROPERTIES(\"partition_num\" = \"10\",\"tablet_num\"=\"300\","
                         + "\"enable\"=\"true\")";
         ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
-                "sql/sqlHash and partition_num/tablet_num/cardinality cannot be set in one rule.",
+                "sql/sqlHash and partition_num/tablet_num/cardinality/qps cannot be set in one rule.",
                 () -> alterSqlBlockRule(alterNumRule));
 
         // create : cardinality
         // alter : sqlHash
-        // AnalysisException : sql/sqlHash and partition_num/tablet_num/cardinality cannot be set in one rule.
+        // AnalysisException : sql/sqlHash and partition_num/tablet_num/cardinality/qps cannot be set in one rule.
         String limitRule1 = "CREATE SQL_BLOCK_RULE test_rule1 PROPERTIES(\"cardinality\"=\"10\", \"global\"=\"true\","
                 + " \"enable\"=\"true\");";
         createSqlBlockRule(limitRule1);
         String alterSqlRule1 = "ALTER SQL_BLOCK_RULE test_rule1 PROPERTIES(\"sqlHash\"=\"" + sqlHash
                 + "\",\"enable\"=\"true\")";
         ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
-                "sql/sqlHash and partition_num/tablet_num/cardinality cannot be set in one rule.",
+                "sql/sqlHash and partition_num/tablet_num/cardinality/qps cannot be set in one rule.",
                 () -> alterSqlBlockRule(alterSqlRule1));
         dropSqlBlockRule("DROP SQL_BLOCK_RULE test_rule,test_rule1");
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/blockrule/SqlBlockRuleMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/blockrule/SqlBlockRuleMgrTest.java
@@ -141,9 +141,9 @@ public class SqlBlockRuleMgrTest extends TestWithFeService {
 
         // test reach qps :
         String limitRule4 = "CREATE SQL_BLOCK_RULE test_rule3 PROPERTIES(\"qps\"=\"-1\", \"global\"=\"true\","
-            + " \"enable\"=\"true\");";
+                + " \"enable\"=\"true\");";
         ExceptionChecker.expectThrowsWithMsg(DdlException.class, "the value of qps can't be negative",
-            () -> createSqlBlockRule(limitRule4));
+                () -> createSqlBlockRule(limitRule4));
     }
 
     @Test
@@ -263,7 +263,7 @@ public class SqlBlockRuleMgrTest extends TestWithFeService {
 
         // test qps
         String sqlRule2 = "CREATE SQL_BLOCK_RULE test_rule2 PROPERTIES(\"qps\"=\"100\", \"global\"=\"true\","
-            + " \"enable\"=\"true\");";
+                + " \"enable\"=\"true\");";
         createSqlBlockRule(sqlRule2);
         ShowSqlBlockRuleStmt showStmt2 = new ShowSqlBlockRuleStmt("test_rule2");
         SqlBlockRule alteredSqlBlockRule2 = mgr.getSqlBlockRule(showStmt2).get(0);

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/ShowExecutorTest.java
@@ -663,14 +663,15 @@ public class ShowExecutorTest {
         ShowSqlBlockRuleStmt stmt = new ShowSqlBlockRuleStmt("test_rule");
         ShowExecutor executor = new ShowExecutor(ctx, stmt);
         ShowResultSet resultSet = executor.execute();
-        Assert.assertEquals(8, resultSet.getMetaData().getColumnCount());
+        Assert.assertEquals(9, resultSet.getMetaData().getColumnCount());
         Assert.assertEquals("Name", resultSet.getMetaData().getColumn(0).getName());
         Assert.assertEquals("Sql", resultSet.getMetaData().getColumn(1).getName());
         Assert.assertEquals("SqlHash", resultSet.getMetaData().getColumn(2).getName());
         Assert.assertEquals("PartitionNum", resultSet.getMetaData().getColumn(3).getName());
         Assert.assertEquals("TabletNum", resultSet.getMetaData().getColumn(4).getName());
         Assert.assertEquals("Cardinality", resultSet.getMetaData().getColumn(5).getName());
-        Assert.assertEquals("Global", resultSet.getMetaData().getColumn(6).getName());
-        Assert.assertEquals("Enable", resultSet.getMetaData().getColumn(7).getName());
+        Assert.assertEquals("Qps", resultSet.getMetaData().getColumn(6).getName());
+        Assert.assertEquals("Global", resultSet.getMetaData().getColumn(7).getName());
+        Assert.assertEquals("Enable", resultSet.getMetaData().getColumn(8).getName());
     }
 }


### PR DESCRIPTION
# Proposed changes

Support qps for sql block rule.

## Problem summary

Sometimes we need to limit users not to submit querys too often, but for some very lightweight and fast querys, user connection limitation is not enough, so we can make a qps limitation for sql block rule to avoid large number of queries being submitted in a short time.
We can use Guava's RateLimiter to implement qps limitation.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

