### PR TITLE
[Chore](thrift) prevent BE to be recompiled many files

### DIFF
--- a/generated-source.sh
+++ b/generated-source.sh
@@ -30,7 +30,6 @@ export DORIS_HOME="${ROOT}"
 
 echo "Build generated code"
 cd "${DORIS_HOME}/gensrc"
-rm -rf "${DORIS_HOME}/gensrc/build"
 # DO NOT using parallel make(-j) for gensrc
 make
 rm -rf "${DORIS_HOME}/fe/fe-common/src/main/java/org/apache/doris/thrift ${DORIS_HOME}/fe/fe-common/src/main/java/org/apache/parquet"


### PR DESCRIPTION
# Proposed changes

Prevent BE to be recompiled many files:

When we execute build.sh, it clean thrift code so that BE will be recompiled many files.   It is added by this pr 
 https://github.com/apache/doris/pull/19217
We can use build.sh --clean to clean the thrift code.  No need to clean it every time.

 

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

