### PR TITLE
[enhance] use correct default value for show config action

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1498,7 +1498,11 @@ std::vector<std::vector<std::string>> get_config_info() {
         _config.push_back(it.first);
 
         _config.push_back(field_it->second.type);
-        _config.push_back(it.second);
+        if (0 == strcmp(field_it->second.type, "bool")) {
+            _config.push_back(it.second == "1" ? "true" : "false");
+        } else {
+            _config.push_back(it.second);
+        }
         _config.push_back(field_it->second.valmutable ? "true" : "false");
 
         configs.push_back(_config);

--- a/regression-test/suites/compaction/test_compaction_cumu_delete.groovy
+++ b/regression-test/suites/compaction/test_compaction_cumu_delete.groovy
@@ -50,12 +50,21 @@ suite("test_compaction_cumu_delete") {
         assert configList instanceof List
 
         boolean disableAutoCompaction = true
+        boolean allowDeleteWhenCumu = false
         for (Object ele in (List) configList) {
             assert ele instanceof List<String>
             if (((List<String>) ele)[0] == "disable_auto_compaction") {
                 disableAutoCompaction = Boolean.parseBoolean(((List<String>) ele)[2])
             }
+            if (((List<String>) ele)[0] == "enable_delete_when_cumu_compaction") {
+                allowDeleteWhenCumu = Boolean.parseBoolean(((List<String>) ele)[2])
+            }
         }
+
+        if (!allowDeleteWhenCumu) {
+            logger.info("Skip test compaction when cumu compaction because not enabled this config")
+        }
+
 
         def triggerCompaction = { be_host, be_http_port, compact_type ->
             // trigger compactions for all tablets in ${tableName}

--- a/regression-test/suites/compaction/test_compaction_cumu_delete.groovy
+++ b/regression-test/suites/compaction/test_compaction_cumu_delete.groovy
@@ -63,6 +63,7 @@ suite("test_compaction_cumu_delete") {
 
         if (!allowDeleteWhenCumu) {
             logger.info("Skip test compaction when cumu compaction because not enabled this config")
+            return
         }
 
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
I was writing some regression cases which need call show config action to see the config value of BE, but somewhat i found out that one config with type bool returned one string `0` or `1`. And in groovy it would parse into false if you use `Boolean.parseBoolean(String)`. It confused me a lot and i found out we should return correct default value.
Before this pr:
![image](https://user-images.githubusercontent.com/43750022/236250945-e03fe40d-6b0f-4080-a13f-7dc0cf5c40c8.png)
After this pr:
![image](https://user-images.githubusercontent.com/43750022/236251149-d2e80154-95ee-40cc-9f71-d48214f5bf3a.png)

There were some cases which used this action to get config value, luckily the wrong parsed value would not influence this cases.
![image](https://user-images.githubusercontent.com/43750022/236251630-66923fa0-900e-4141-b8a8-64bfa46d5252.png)


## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

