### PR TITLE
[enhancement](exprcontext) modify get_output_block_after_execute_expr method more clear to avoid mis usage

### DIFF
--- a/be/src/vec/exprs/vexpr_context.cpp
+++ b/be/src/vec/exprs/vexpr_context.cpp
@@ -127,22 +127,19 @@ Status VExprContext::filter_block(VExprContext* vexpr_ctx, Block* block, int col
     return Block::filter_block(block, result_column_id, column_to_keep);
 }
 
-Block VExprContext::get_output_block_after_execute_exprs(
+Status VExprContext::get_output_block_after_execute_exprs(
         const std::vector<vectorized::VExprContext*>& output_vexpr_ctxs, const Block& input_block,
-        Status& status) {
+        Block* output_block) {
     vectorized::Block tmp_block(input_block.get_columns_with_type_and_name());
     vectorized::ColumnsWithTypeAndName result_columns;
     for (auto vexpr_ctx : output_vexpr_ctxs) {
         int result_column_id = -1;
-        status = vexpr_ctx->execute(&tmp_block, &result_column_id);
-        if (UNLIKELY(!status)) {
-            return {};
-        }
+        RETURN_IF_ERROR(vexpr_ctx->execute(&tmp_block, &result_column_id));
         DCHECK(result_column_id != -1);
         result_columns.emplace_back(tmp_block.get_by_position(result_column_id));
     }
-
-    return {result_columns};
+    *output_block = {result_columns};
+    return Status::OK();
 }
 
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/vexpr_context.h
+++ b/be/src/vec/exprs/vexpr_context.h
@@ -69,7 +69,7 @@ public:
     [[nodiscard]] static Status filter_block(VExprContext* vexpr_ctx, Block* block,
                                              int column_to_keep);
 
-    static [[nodiscard]] Status get_output_block_after_execute_exprs(
+    [[nodiscard]] static Status get_output_block_after_execute_exprs(
             const std::vector<vectorized::VExprContext*>&, const Block&, Block*);
 
     int get_last_result_column_id() const {

--- a/be/src/vec/exprs/vexpr_context.h
+++ b/be/src/vec/exprs/vexpr_context.h
@@ -69,8 +69,8 @@ public:
     [[nodiscard]] static Status filter_block(VExprContext* vexpr_ctx, Block* block,
                                              int column_to_keep);
 
-    static Block get_output_block_after_execute_exprs(const std::vector<vectorized::VExprContext*>&,
-                                                      const Block&, Status&);
+    static [[nodiscard]] Status get_output_block_after_execute_exprs(
+            const std::vector<vectorized::VExprContext*>&, const Block&, Block*);
 
     int get_last_result_column_id() const {
         DCHECK(_last_result_column_id != -1);

--- a/be/src/vec/runtime/vfile_result_writer.cpp
+++ b/be/src/vec/runtime/vfile_result_writer.cpp
@@ -229,12 +229,9 @@ Status VFileResultWriter::append_block(Block& block) {
     Status status = Status::OK();
     // Exec vectorized expr here to speed up, block.rows() == 0 means expr exec
     // failed, just return the error status
-    auto output_block =
-            VExprContext::get_output_block_after_execute_exprs(_output_vexpr_ctxs, block, status);
-    auto num_rows = output_block.rows();
-    if (UNLIKELY(num_rows == 0)) {
-        return status;
-    }
+    Block output_block;
+    RETURN_IF_ERROR(VExprContext::get_output_block_after_execute_exprs(_output_vexpr_ctxs, block,
+                                                                       &output_block));
     if (_vfile_writer) {
         _write_file(output_block);
     } else {

--- a/be/src/vec/sink/vjdbc_table_sink.cpp
+++ b/be/src/vec/sink/vjdbc_table_sink.cpp
@@ -82,9 +82,9 @@ Status VJdbcTableSink::send(RuntimeState* state, Block* block, bool eos) {
     if (block == nullptr || block->rows() == 0) {
         return status;
     }
-
-    auto output_block = vectorized::VExprContext::get_output_block_after_execute_exprs(
-            _output_vexpr_ctxs, *block, status);
+    Block output_block;
+    RETURN_IF_ERROR(vectorized::VExprContext::get_output_block_after_execute_exprs(
+            _output_vexpr_ctxs, *block, &output_block));
     materialize_block_inplace(output_block);
 
     uint32_t start_send_row = 0;

--- a/be/src/vec/sink/vmysql_result_writer.cpp
+++ b/be/src/vec/sink/vmysql_result_writer.cpp
@@ -591,6 +591,7 @@ Status VMysqlResultWriter<is_binary_format>::append_block(Block& input_block) {
     Block block;
     RETURN_IF_ERROR(VExprContext::get_output_block_after_execute_exprs(_output_vexpr_ctxs,
                                                                        input_block, &block));
+    auto num_rows = block.rows();
     std::vector<MysqlRowBuffer<is_binary_format>> rows_buffer;
     rows_buffer.resize(num_rows);
     if constexpr (is_binary_format) {

--- a/be/src/vec/sink/vmysql_result_writer.cpp
+++ b/be/src/vec/sink/vmysql_result_writer.cpp
@@ -588,12 +588,9 @@ Status VMysqlResultWriter<is_binary_format>::append_block(Block& input_block) {
 
     // Exec vectorized expr here to speed up, block.rows() == 0 means expr exec
     // failed, just return the error status
-    auto block = VExprContext::get_output_block_after_execute_exprs(_output_vexpr_ctxs, input_block,
-                                                                    status);
-    auto num_rows = block.rows();
-    if (UNLIKELY(num_rows == 0)) {
-        return status;
-    }
+    Block block;
+    RETURN_IF_ERROR(VExprContext::get_output_block_after_execute_exprs(_output_vexpr_ctxs,
+                                                                       input_block, &block));
     std::vector<MysqlRowBuffer<is_binary_format>> rows_buffer;
     rows_buffer.resize(num_rows);
     if constexpr (is_binary_format) {

--- a/be/src/vec/sink/vmysql_table_writer.cpp
+++ b/be/src/vec/sink/vmysql_table_writer.cpp
@@ -102,14 +102,10 @@ Status VMysqlTableWriter::append(vectorized::Block* block) {
     if (block == nullptr || block->rows() == 0) {
         return status;
     }
-
-    auto output_block = vectorized::VExprContext::get_output_block_after_execute_exprs(
-            _vec_output_expr_ctxs, *block, status);
-
+    Block output_block;
+    RETURN_IF_ERROR(vectorized::VExprContext::get_output_block_after_execute_exprs(
+            _vec_output_expr_ctxs, *block, &output_block));
     auto num_rows = output_block.rows();
-    if (UNLIKELY(num_rows == 0)) {
-        return status;
-    }
     materialize_block_inplace(output_block);
     for (int i = 0; i < num_rows; ++i) {
         RETURN_IF_ERROR(insert_row(output_block, i));

--- a/be/src/vec/sink/vodbc_table_sink.cpp
+++ b/be/src/vec/sink/vodbc_table_sink.cpp
@@ -71,9 +71,9 @@ Status VOdbcTableSink::send(RuntimeState* state, Block* block, bool eos) {
     if (block == nullptr || block->rows() == 0) {
         return status;
     }
-
-    auto output_block = vectorized::VExprContext::get_output_block_after_execute_exprs(
-            _output_vexpr_ctxs, *block, status);
+    Block output_block;
+    RETURN_IF_ERROR(vectorized::VExprContext::get_output_block_after_execute_exprs(
+            _output_vexpr_ctxs, *block, &output_block));
     materialize_block_inplace(output_block);
 
     uint32_t start_send_row = 0;

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -1184,11 +1184,8 @@ Status VOlapTableSink::send(RuntimeState* state, vectorized::Block* input_block,
     vectorized::Block block(input_block->get_columns_with_type_and_name());
     if (!_output_vexpr_ctxs.empty()) {
         // Do vectorized expr here to speed up load
-        block = vectorized::VExprContext::get_output_block_after_execute_exprs(
-                _output_vexpr_ctxs, *input_block, status);
-        if (UNLIKELY(block.rows() == 0)) {
-            return status;
-        }
+        RETURN_IF_ERROR(vectorized::VExprContext::get_output_block_after_execute_exprs(
+                _output_vexpr_ctxs, *input_block, &block));
     }
 
     auto num_rows = block.rows();


### PR DESCRIPTION
# Proposed changes

The original method signature is Block VExprContext::get_output_block_after_execute_exprs(
        const std::vector<vectorized::VExprContext*>& output_vexpr_ctxs, const Block& input_block,
        Status& status)
It return error status as a out parameter and the block as return value. It has to check the block.rows == 0 and then check error status. 
It is not conforming to the convention.

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

