### PR TITLE
[improvement](storage) Avoid copying when bitmap deserialization

### DIFF
--- a/be/src/util/bitmap_value.h
+++ b/be/src/util/bitmap_value.h
@@ -131,7 +131,7 @@ public:
 
     Roaring64Map(const Roaring64Map& r) : roarings(r.roarings), copyOnWrite(r.copyOnWrite) {}
 
-    Roaring64Map(Roaring64Map&& r) : roarings(r.roarings), copyOnWrite(r.copyOnWrite) {}
+    Roaring64Map(Roaring64Map&& r) : roarings(std::move(r.roarings)), copyOnWrite(r.copyOnWrite) {}
 
     /**
      * Copy assignment operator.

--- a/be/src/util/bitmap_value.h
+++ b/be/src/util/bitmap_value.h
@@ -134,10 +134,22 @@ public:
     Roaring64Map(Roaring64Map&& r) : roarings(r.roarings), copyOnWrite(r.copyOnWrite) {}
 
     /**
-     * Assignment operator.
+     * Copy assignment operator.
      */
     Roaring64Map& operator=(const Roaring64Map& r) {
         roarings = r.roarings;
+        return *this;
+    }
+
+    /**
+     * Move assignment operator.
+     */
+    Roaring64Map& operator=(Roaring64Map&& r) {
+        if (this != &r) {
+            this->roarings = std::move(r.roarings);
+            this->copyOnWrite = r.copyOnWrite;
+            r.copyOnWrite = false;
+        }
         return *this;
     }
 
@@ -1617,7 +1629,7 @@ public:
         case BitmapTypeCode::BITMAP32:
         case BitmapTypeCode::BITMAP64:
             _type = BITMAP;
-            _bitmap = detail::Roaring64Map::read(src);
+            _bitmap = std::move(detail::Roaring64Map::read(src));
             break;
         default:
             LOG(ERROR) << "BitmapTypeCode invalid, should between: " << BitmapTypeCode::EMPTY


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
Avoid copying when bitmap deserialization.

## Problem summary
Tested based on version 1.1.5

test sql:
```sql
set enable_vectorized_engine=true;
set parallel_fragment_exec_instance_num = 1;
SELECT flow_key
    , bitmap_union_count(user_id)
  FROM db1.tbl1
  WHERE partition_date BETWEEN '2022-06-20' AND '2022-07-25'
group by flow_key
```


before:
```
                            SegmentIterator:
                                  -  Id:  0
                                  -  Table  Name:  tbl1
                                  -  BitmapIndexFilterTimer:  58.477us
                                  -  BlockLoadTime:  14s123ms
                                  -  BlockSeekCount:  95
                                  -  BlockSeekTime:  15.566ms
                                  -  BlocksLoad:  966
                                  -  CachedPagesNum:  0
                                  -  CompressedBytesRead:  304.42  MB
                                  -  DecompressorTimer:  429.259ms
                                  -  IOTimer:  193.780ms
                                  -  IndexLoadTime_V1:  0ns
                                  -  NumSegmentFiltered:  0
                                  -  NumSegmentTotal:  95
                                  -  RawRowsRead:  3.371003M  (3371003)
                                  -  RowsBitmapIndexFiltered:  0
                                  -  RowsBloomFilterFiltered:  0
                                  -  RowsConditionsFiltered:  0
                                  -  RowsKeyRangeFiltered:  0
                                  -  RowsStatsFiltered:  0
                                  -  RowsVectorPredFiltered:  0
                                  -  TotalPagesNum:  6.774K  (6774)
                                  -  UncompressedBytesRead:  399.61  MB
                                  -  VectorPredEvalTime:  0ns
```


after:
```
                            SegmentIterator:
                                  -  Id:  0
                                  -  Table  Name: tbl1
                                  -  BitmapIndexFilterTimer:  63.642us
                                  -  BlockLoadTime:  6s572ms
                                  -  BlockSeekCount:  94
                                  -  BlockSeekTime:  12.363ms
                                  -  BlocksLoad:  933
                                  -  CachedPagesNum:  0
                                  -  CompressedBytesRead:  297.09  MB
                                  -  DecompressorTimer:  260.559ms
                                  -  IOTimer:  142.114ms
                                  -  IndexLoadTime_V1:  0ns
                                  -  NumSegmentFiltered:  0
                                  -  NumSegmentTotal:  94
                                  -  RawRowsRead:  3.249427M  (3249427)
                                  -  RowsBitmapIndexFiltered:  0
                                  -  RowsBloomFilterFiltered:  0
                                  -  RowsConditionsFiltered:  0
                                  -  RowsKeyRangeFiltered:  0
                                  -  RowsStatsFiltered:  0
                                  -  RowsVectorPredFiltered:  0
                                  -  TotalPagesNum:  6.625K  (6625)
                                  -  UncompressedBytesRead:  389.85  MB
                                  -  VectorPredEvalTime:  0ns
```
BlockLoadTime dropped from 14s123ms to 6s572ms

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

