### PR TITLE
[vectorized](function) fix array_map funtion return type maybe get wrong

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnRefExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnRefExpr.java
@@ -83,7 +83,7 @@ public class ColumnRefExpr extends Expr {
 
     @Override
     protected String toSqlImpl() {
-        return columnName + "(" + columnId + ")";
+        return columnName;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LambdaFunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LambdaFunctionCallExpr.java
@@ -107,7 +107,7 @@ public class LambdaFunctionCallExpr extends FunctionCallExpr {
                         lambda.debugString());
             }
             fn = new Function(fnName, Arrays.asList(argTypes), ArrayType.create(lambda.getChild(0).getType(), true),
-                    false, true, NullableMode.DEPEND_ON_ARGUMENT);
+                    true, true, NullableMode.DEPEND_ON_ARGUMENT);
             if (fn == null) {
                 LOG.warn("fn {} not exists", this.toSqlImpl());
                 throw new AnalysisException(getFunctionNotFoundError(collectChildReturnTypes()));

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LambdaFunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LambdaFunctionCallExpr.java
@@ -20,6 +20,7 @@ package org.apache.doris.analysis;
 import org.apache.doris.catalog.ArrayType;
 import org.apache.doris.catalog.Function;
 import org.apache.doris.catalog.Type;
+import org.apache.doris.catalog.Function.NullableMode;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.thrift.TExprNode;
 import org.apache.doris.thrift.TExprNodeType;
@@ -30,6 +31,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class LambdaFunctionCallExpr extends FunctionCallExpr {
@@ -99,14 +101,17 @@ public class LambdaFunctionCallExpr extends FunctionCallExpr {
                 this.setChild(0, lastChild);
             }
 
-            fn = getBuiltinFunction(fnName.getFunction(), argTypes,
-                    Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
             Expr lambda = this.children.get(0);
+            if (!(lambda instanceof LambdaFunctionExpr)) {
+                throw new AnalysisException("array_map must use lambda as first input params, now is" +
+                        lambda.debugString());
+            }
+            fn = new Function(fnName, Arrays.asList(argTypes), ArrayType.create(lambda.getChild(0).getType(), true),
+                    false, true, NullableMode.DEPEND_ON_ARGUMENT);
             if (fn == null) {
                 LOG.warn("fn {} not exists", this.toSqlImpl());
                 throw new AnalysisException(getFunctionNotFoundError(collectChildReturnTypes()));
             }
-            fn.setReturnType(ArrayType.create(lambda.getChild(0).getType(), true));
         } else if (fnName.getFunction().equalsIgnoreCase("array_exists")
                 || fnName.getFunction().equalsIgnoreCase("array_first_index")
                 || fnName.getFunction().equalsIgnoreCase("array_count")) {
@@ -174,7 +179,6 @@ public class LambdaFunctionCallExpr extends FunctionCallExpr {
                 LOG.warn("fn {} not exists", this.toSqlImpl());
                 throw new AnalysisException(getFunctionNotFoundError(collectChildReturnTypes()));
             }
-            fn.setReturnType(getChild(0).getType());
         } else if (fnName.getFunction().equalsIgnoreCase("array_sortby")) {
             if (fnParams.exprs() == null || fnParams.exprs().size() < 2) {
                 throw new AnalysisException("The " + fnName.getFunction() + " function must have at least two params");
@@ -202,11 +206,6 @@ public class LambdaFunctionCallExpr extends FunctionCallExpr {
             }
             fn = getBuiltinFunction(fnName.getFunction(), argTypes,
                     Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
-            if (fn == null) {
-                LOG.warn("fn {} not exists", this.toSqlImpl());
-                throw new AnalysisException(getFunctionNotFoundError(collectChildReturnTypes()));
-            }
-            fn.setReturnType(getChild(0).getType());
         } else if (fnName.getFunction().equalsIgnoreCase("array_last")) {
             // array_last(lambda,array)--->array_last(array,lambda)--->element_at(array_filter,-1)
             if (getChild(childSize - 1) instanceof LambdaFunctionExpr) {
@@ -227,17 +226,12 @@ public class LambdaFunctionCallExpr extends FunctionCallExpr {
             }
             fnName = new FunctionName(null, "element_at");
             fn = getBuiltinFunction(fnName.getFunction(), argTypes, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
-            if (fn == null) {
-                LOG.warn("fn element_at not exists");
-                throw new AnalysisException(getFunctionNotFoundError(collectChildReturnTypes()));
-            }
-            fn.setReturnType(((ArrayType) argTypes[0]).getItemType());
         }
-        LOG.info("fn string: " + fn.signatureString() + ". return type: " + fn.getReturnType());
         if (fn == null) {
             LOG.warn("fn {} not exists", this.toSqlImpl());
             throw new AnalysisException(getFunctionNotFoundError(collectChildReturnTypes()));
         }
+        LOG.debug("fn string: " + fn.signatureString() + ". return type: " + fn.getReturnType());
         this.type = fn.getReturnType();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LambdaFunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LambdaFunctionCallExpr.java
@@ -108,10 +108,6 @@ public class LambdaFunctionCallExpr extends FunctionCallExpr {
             }
             fn = new Function(fnName, Arrays.asList(argTypes), ArrayType.create(lambda.getChild(0).getType(), true),
                     true, true, NullableMode.DEPEND_ON_ARGUMENT);
-            if (fn == null) {
-                LOG.warn("fn {} not exists", this.toSqlImpl());
-                throw new AnalysisException(getFunctionNotFoundError(collectChildReturnTypes()));
-            }
         } else if (fnName.getFunction().equalsIgnoreCase("array_exists")
                 || fnName.getFunction().equalsIgnoreCase("array_first_index")
                 || fnName.getFunction().equalsIgnoreCase("array_count")) {
@@ -143,10 +139,6 @@ public class LambdaFunctionCallExpr extends FunctionCallExpr {
 
             fn = getBuiltinFunction(fnName.getFunction(), newArgTypes,
                     Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
-            if (fn == null) {
-                LOG.warn("fn {} not exists", this.toSqlImpl());
-                throw new AnalysisException(getFunctionNotFoundError(collectChildReturnTypes()));
-            }
         } else if (fnName.getFunction().equalsIgnoreCase("array_filter")) {
             if (fnParams.exprs() == null || fnParams.exprs().size() != 2) {
                 throw new AnalysisException("The " + fnName.getFunction() + " function must have two params");
@@ -175,10 +167,6 @@ public class LambdaFunctionCallExpr extends FunctionCallExpr {
 
             fn = getBuiltinFunction(fnName.getFunction(), argTypes,
                     Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
-            if (fn == null) {
-                LOG.warn("fn {} not exists", this.toSqlImpl());
-                throw new AnalysisException(getFunctionNotFoundError(collectChildReturnTypes()));
-            }
         } else if (fnName.getFunction().equalsIgnoreCase("array_sortby")) {
             if (fnParams.exprs() == null || fnParams.exprs().size() < 2) {
                 throw new AnalysisException("The " + fnName.getFunction() + " function must have at least two params");

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LambdaFunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LambdaFunctionCallExpr.java
@@ -103,8 +103,8 @@ public class LambdaFunctionCallExpr extends FunctionCallExpr {
 
             Expr lambda = this.children.get(0);
             if (!(lambda instanceof LambdaFunctionExpr)) {
-                throw new AnalysisException("array_map must use lambda as first input params, now is" +
-                        lambda.debugString());
+                throw new AnalysisException("array_map must use lambda as first input params, now is"
+                        + lambda.debugString());
             }
             fn = new Function(fnName, Arrays.asList(argTypes), ArrayType.create(lambda.getChild(0).getType(), true),
                     true, true, NullableMode.DEPEND_ON_ARGUMENT);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LambdaFunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LambdaFunctionCallExpr.java
@@ -19,8 +19,8 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.ArrayType;
 import org.apache.doris.catalog.Function;
-import org.apache.doris.catalog.Type;
 import org.apache.doris.catalog.Function.NullableMode;
+import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.thrift.TExprNode;
 import org.apache.doris.thrift.TExprNodeType;

--- a/gensrc/script/doris_builtins_functions.py
+++ b/gensrc/script/doris_builtins_functions.py
@@ -631,7 +631,6 @@ visible_functions = [
     [['array_popfront'], 'ARRAY_DECIMAL128', ['ARRAY_DECIMAL128'], ''],
     [['array_popfront'], 'ARRAY_VARCHAR', ['ARRAY_VARCHAR'], ''],
     [['array_popfront'], 'ARRAY_STRING', ['ARRAY_STRING'], ''],
-    [['array_map'], 'ARRAY', ['LAMBDA_FUNCTION', 'ARRAY<K>', '...'], '', ['K']],
     [['array_filter'], 'ARRAY_BOOLEAN',['ARRAY_BOOLEAN', 'ARRAY_BOOLEAN'], ''],
     [['array_filter'], 'ARRAY_TINYINT',['ARRAY_TINYINT', 'ARRAY_BOOLEAN'], ''],
     [['array_filter'], 'ARRAY_SMALLINT',['ARRAY_SMALLINT', 'ARRAY_BOOLEAN'], ''],


### PR DESCRIPTION
# Proposed changes
when get function from functionSet, maybe can't change it's any attribute.
but array_map function return type depend on lambda Expr return type,
so new Function object for it.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

