### PR TITLE
[Chore](build) update some doc about build enviroment

### DIFF
--- a/.github/workflows/be-ut-mac.yml
+++ b/.github/workflows/be-ut-mac.yml
@@ -79,7 +79,7 @@ jobs:
             'openjdk@11'
             'maven'
             'node'
-            'llvm@15'
+            'llvm@16'
           )
           brew install "${cellars[@]}"
 

--- a/.github/workflows/build-thirdparty.yml
+++ b/.github/workflows/build-thirdparty.yml
@@ -145,7 +145,7 @@ jobs:
             'openjdk@11'
             'maven'
             'node'
-            'llvm@15'
+            'llvm@16'
           )
 
           brew install "${packages[@]}"

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -506,6 +506,10 @@ if (COMPILER_CLANG)
         message(FATAL_ERROR "Need Clang version at least 13")
     endif()
 
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "16")
+        message(WARNING "Doris recommended to use Clang-16 to build backend")
+    endif()
+
     add_compile_options(-fcolor-diagnostics 
                         -Wpedantic
                         -Wunused-template

--- a/be/test/util/threadpool_test.cpp
+++ b/be/test/util/threadpool_test.cpp
@@ -69,9 +69,7 @@ static const char* kDefaultPoolName = "test";
 
 class ThreadPoolTest : public ::testing::Test {
 public:
-    virtual void SetUp() override {
-        EXPECT_TRUE(ThreadPoolBuilder(kDefaultPoolName).build(&_pool).ok());
-    }
+    void SetUp() override { EXPECT_TRUE(ThreadPoolBuilder(kDefaultPoolName).build(&_pool).ok()); }
 
     Status rebuild_pool_with_builder(const ThreadPoolBuilder& builder) {
         return builder.build(&_pool);
@@ -108,7 +106,7 @@ static void simple_task_method(int n, std::atomic<int32_t>* counter) {
             rqtp.tv_sec = 0;
             rqtp.tv_nsec = 1000;
 
-            nanosleep(&rqtp, 0);
+            nanosleep(&rqtp, nullptr);
         }
     }
 }
@@ -335,9 +333,8 @@ TEST_F(ThreadPoolTest, TestDeadlocks) {
 #elif defined(__APPLE__)
     const char* death_msg =
             "_ZNSt3__1L8__invokeIRNS_6__bindIMN5doris10ThreadPoolEFvvEJPS3_EEEJEEEDTclscT_fp_"
-            "spscT0_fp0_EEOS9_DpOSA_|_ZNSt3__18__invokeB6v15007IRNS_6__"
-            "bindIMN5doris10ThreadPoolEFvvEJPS3_EEEJEEEDTclclsr3stdE7declvalIT_"
-            "EEspclsr3stdE7declvalIT0_EEEEOS9_DpOSA_";
+            "spscT0_fp0_EEOS9_DpOSA_|6__bindIMN5doris10ThreadPoolEFvvEJPS3_"
+            "EEEJEEEDTclclsr3stdE7declvalIT_EEspclsr3stdE7declvalIT0_EEEEOS9_DpOSA_";
 #else
     const char* death_msg =
             "_ZNSt5_BindIFMN5doris10ThreadPoolEFvvEPS1_EE6__callIvJEJLm0EEEET_OSt5tupleIJDpT0_"
@@ -366,7 +363,7 @@ class SlowDestructorRunnable : public Runnable {
 public:
     void run() override {}
 
-    virtual ~SlowDestructorRunnable() {
+    ~SlowDestructorRunnable() override {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 };

--- a/build-support/check-format.sh
+++ b/build-support/check-format.sh
@@ -31,7 +31,7 @@ DORIS_HOME=$(
 )
 export DORIS_HOME
 
-if [[ ! $(command -v clang-format-16) ]]; then
+if [[ ! -n $(command -v clang-format-16) ]]; then
     echo "clang-format-16 not founded, please install clang-format-16 or upgrade your clang-format version to 16"
     exit 1
 fi

--- a/build-support/check-format.sh
+++ b/build-support/check-format.sh
@@ -31,6 +31,11 @@ DORIS_HOME=$(
 )
 export DORIS_HOME
 
+if [[ ! $(command -v clang-format-16) ]]; then
+    echo "clang-format-16 not founded, please install clang-format-16 or upgrade your clang-format version to 16"
+    exit 1
+fi
+
 CLANG_FORMAT="${CLANG_FORMAT_BINARY:=$(command -v clang-format-16)}"
 
 python "${DORIS_HOME}/build-support/run_clang_format.py" "--clang-format-executable" "${CLANG_FORMAT}" "-r" "--style" "file" "--inplace" "false" "--extensions" "c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx" "--exclude" "none" "be/src be/test"

--- a/build-support/check-format.sh
+++ b/build-support/check-format.sh
@@ -31,7 +31,7 @@ DORIS_HOME=$(
 )
 export DORIS_HOME
 
-if [[ ! -n $(command -v clang-format-16) ]]; then
+if [[ -z $(command -v clang-format-16) ]]; then
     echo "clang-format-16 not founded, please install clang-format-16 or upgrade your clang-format version to 16"
     exit 1
 fi

--- a/build-support/check-format.sh
+++ b/build-support/check-format.sh
@@ -31,6 +31,6 @@ DORIS_HOME=$(
 )
 export DORIS_HOME
 
-CLANG_FORMAT="${CLANG_FORMAT_BINARY:=$(command -v clang-format)}"
+CLANG_FORMAT="${CLANG_FORMAT_BINARY:=$(command -v clang-format-16)}"
 
 python "${DORIS_HOME}/build-support/run_clang_format.py" "--clang-format-executable" "${CLANG_FORMAT}" "-r" "--style" "file" "--inplace" "false" "--extensions" "c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx" "--exclude" "none" "be/src be/test"

--- a/build-support/clang-format.sh
+++ b/build-support/clang-format.sh
@@ -31,7 +31,7 @@ DORIS_HOME=$(
 )
 export DORIS_HOME
 
-if [[ ! $(command -v clang-format-16) ]]; then
+if [[ ! -n $(command -v clang-format-16) ]]; then
     echo "clang-format-16 not founded, please install clang-format-16 or upgrade your clang-format version to 16"
     exit 1
 fi

--- a/build-support/clang-format.sh
+++ b/build-support/clang-format.sh
@@ -31,6 +31,11 @@ DORIS_HOME=$(
 )
 export DORIS_HOME
 
+if [[ ! $(command -v clang-format-16) ]]; then
+    echo "clang-format-16 not founded, please install clang-format-16 or upgrade your clang-format version to 16"
+    exit 1
+fi
+
 CLANG_FORMAT="${CLANG_FORMAT_BINARY:=$(command -v clang-format-16)}"
 
 python "${DORIS_HOME}/build-support/run_clang_format.py" "--clang-format-executable" "${CLANG_FORMAT}" "-r" "--style" "file" "--inplace" "true" "--extensions" "c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx" "--exclude" "none" "be/src be/test"

--- a/build-support/clang-format.sh
+++ b/build-support/clang-format.sh
@@ -31,6 +31,6 @@ DORIS_HOME=$(
 )
 export DORIS_HOME
 
-CLANG_FORMAT="${CLANG_FORMAT_BINARY:=$(command -v clang-format)}"
+CLANG_FORMAT="${CLANG_FORMAT_BINARY:=$(command -v clang-format-16)}"
 
 python "${DORIS_HOME}/build-support/run_clang_format.py" "--clang-format-executable" "${CLANG_FORMAT}" "-r" "--style" "file" "--inplace" "true" "--extensions" "c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx" "--exclude" "none" "be/src be/test"

--- a/build-support/clang-format.sh
+++ b/build-support/clang-format.sh
@@ -31,7 +31,7 @@ DORIS_HOME=$(
 )
 export DORIS_HOME
 
-if [[ ! -n $(command -v clang-format-16) ]]; then
+if [[ -z $(command -v clang-format-16) ]]; then
     echo "clang-format-16 not founded, please install clang-format-16 or upgrade your clang-format version to 16"
     exit 1
 fi

--- a/docs/en/community/developer-guide/cpp-format-code.md
+++ b/docs/en/community/developer-guide/cpp-format-code.md
@@ -40,7 +40,7 @@ Doris uses clang-format for code formatting, and provides a package script in th
 
 The code style of Doris is slightly modified on the basis of Google Style and is customized as a `.clang-format` file located in the root directory of Doris.
 
-Currently, the `.clang-format` configuration file is adapted to versions above clang-format-15.0.1.
+Currently, the `.clang-format` configuration file is adapted to versions above clang-format-16.0.0.
 
 The code that you do not want to be formatted is recorded in the `.clang-format-ignore` file. These codes usually come from third-party code bases, and it is recommended to keep the original code style.
 
@@ -50,29 +50,22 @@ You need to download and install clang-format, or you can use the clang-format p
 
 ### Download and install clang-format
 
-It is recommended to use NPM to install clang-format 15 (different versions of clang-format may produce different code formats, it is recommended to use version 15):
+The current doris uses clang-format 16 for code formatting (different versions of clang-format may produce different code formats).
 
-`npm install clang-format@1.8.0`
 
-Ubuntu: `apt-get install clang-format`
 
-The current version is 10.0, you can also specify the old version, for example: `apt-get install clang-format-9`. It is recommended to compile version 15.0 from source code.
+Linux: You can use the LDB toolchain directly, which already comes with a corresponding version of clang-format. Or install or compile the binary by yourself in other ways.
 
-Mac: `brew install clang-format`
-
-Centos 7:
-
-The version of clang-format installed by centos yum is too old and supports too few StyleOptions. It is recommended to compile version 15.0 from source code.
+Mac: `brew install clang-format@16`
 
 LDB toolchain:
 
 If you are using [LDB toolchain](/docs/install/source-install/compilation-with-ldb-toolchain),
-the latest version (>= v0.13) of [LDB toolchain](https://github.com/amosbird/ldb_toolchain_gen/releases) has already included clang-format with 15.0.1 version.
+the latest version (>= v0.17) of [LDB toolchain](https://github.com/amosbird/ldb_toolchain_gen/releases) has already included clang-format with 16.0.0 version.
 
 ### clang-format plugin
 
-Clion IDE can use the plug-in "ClangFormat", search and download in `File->Setting->Plugins`. But the version can’t match
-The version of the clang-format program matches, judging from the supported StyleOption, it should be lower than clang-format-9.0.
+Clion IDE can use the plug-in "ClangFormat", search and download in `File->Setting->Plugins`. However, you need to confirm whether the clang-format version is 16.
 
 ## How to use
 

--- a/docs/en/docs/install/source-install/compilation-with-ldb-toolchain.md
+++ b/docs/en/docs/install/source-install/compilation-with-ldb-toolchain.md
@@ -27,6 +27,7 @@ under the License.
 # Compile With ldb-toolchain
 
 This topic is about how to compile Doris using the LDB toolchain. This method is an alternative to the Docker method so developers and users without a Docker environment can compile Doris from source.
+The LDB toolchain version currently recommended by Doris is 0.17, which contains clang-16 and gcc-11.
 
 > You can still compile the latest code using the Docker development image: `apache/doris:build-env-ldb-toolchain-latest`
 

--- a/docs/zh-CN/community/developer-guide/cpp-format-code.md
+++ b/docs/zh-CN/community/developer-guide/cpp-format-code.md
@@ -40,7 +40,7 @@ Doris使用clang-format进行代码格式化，并在build-support目录下提�
 
 Doris的代码风格在Google Style的基础上稍有改动，定制为 `.clang-format` 文件，位于Doris根目录。
 
-目前，`.clang-format` 配置文件适配clang-format-15.0.1以上的版本。
+目前，`.clang-format` 配置文件适配clang-format-16.0.0以上的版本。
 
 `.clang-format-ignore` 文件中记录了不希望被格式化的代码。这些代码通常来自第三方代码库，建议保持原有代码风格。
 
@@ -50,30 +50,22 @@ Doris的代码风格在Google Style的基础上稍有改动，定制为 `.clang-
 
 ### 下载安装clang-format
 
-推荐使用 NPM 安装 clang-format 15（不同版本的 clang-format 可能产生不同的代码格式，建议使用 15 版本）：
+目前的doris采用 clang-format 16进行代码格式化(不同版本的 clang-format 可能产生不同的代码格式)。
 
-`npm install clang-format@1.8.0`
+Linux: 可以直接使用 LDB toolchain，其中已经附带了对应版本的 clang-format。或者通过其他方式自行安装或者编译二进制。
 
-Ubuntu: `apt-get install clang-format` 
+Mac: `brew install clang-format@16`
 
-当前版本为10.0，也可指定旧版本，例如: `apt-get install clang-format-9`，建议源码编译15.0版本。
-
-Mac: `brew install clang-format`
-
-Centos 7: 
-
-centos yum安装的clang-format版本过老，支持的StyleOption太少，建议源码编译15.0版本。
 
 LDB toolchain:
 
-如果使用 [LDB toolchain](/docs/install/source-install/compilation-with-ldb-toolchain)，
-最新版本的 [LDB toolchain](https://github.com/amosbird/ldb_toolchain_gen/releases)（>= v0.13）已经包含了预编译的clang-format
-15.0.1的二进制文件。
+如何使用 [LDB toolchain](/docs/install/source-install/compilation-with-ldb-toolchain)，
+最新版本的 [LDB toolchain](https://github.com/amosbird/ldb_toolchain_gen/releases)（>= v0.17）已经包含了预编译的clang-format
+16.0.0的二进制文件。
 
 ### clang-format插件
 
-Clion IDE可使用插件"ClangFormat"，`File->Setting->Plugins`搜索下载。但版本无法和
-clang-format程序的版本匹配，从支持的StyleOption上看，应该是低于clang-format-9.0。
+Clion IDE可使用插件"ClangFormat"，`File->Setting->Plugins`搜索下载。不过需要确认其中的 clang-format 版本是否为16。
 
 ## 使用方式
 

--- a/docs/zh-CN/docs/install/source-install/compilation-with-ldb-toolchain.md
+++ b/docs/zh-CN/docs/install/source-install/compilation-with-ldb-toolchain.md
@@ -27,6 +27,7 @@ under the License.
 # 使用 LDB toolchain 编译
 
 本文档主要介绍如何使用 LDB toolchain 编译 Doris。该方式目前作为 Docker 编译方式的补充，方便没有 Docker 环境的开发者和用户编译 Doris 源码。
+Doris目前推荐的LDB toolchain版本为 0.17, 其中含有clang-16和gcc-11。
 
 > 您依然可以使用 Docker 开发镜像编译最新代码：`apache/doris:build-env-ldb-toolchain-latest`
 

--- a/env.sh
+++ b/env.sh
@@ -61,7 +61,7 @@ CELLARS=(
     wget
     pcre
     maven
-    llvm@15
+    llvm@16
 )
 for cellar in "\${CELLARS[@]}"; do
     EXPORT_CELLARS="\${HOMEBREW_REPO_PREFIX}/opt/\${cellar}/bin:\${EXPORT_CELLARS}"


### PR DESCRIPTION
# Proposed changes
@morningman  PTAL
1. update some doc about build enviroment(Now we use ldb_toolchain-0.17 and clang-16 uniformly)
2. Mandatory clang-format version 16. If the version is wrong, the format in `build-support` script cannot be run

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

