### PR TITLE
[Improvement](scan) support maximum block num returned by each scanning thread

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -235,8 +235,6 @@ DEFINE_mInt32(doris_scan_range_max_mb, "1024");
 DEFINE_mInt32(doris_scan_block_max_mb, "67108864");
 // size of scanner queue between scanner thread and compute thread
 DEFINE_mInt32(doris_scanner_queue_size, "1024");
-// single read execute fragment row number
-DEFINE_mInt32(doris_scanner_row_num, "16384");
 // single read execute fragment row bytes
 DEFINE_mInt32(doris_scanner_row_bytes, "10485760");
 // number of max scan keys

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -273,8 +273,6 @@ DECLARE_mInt32(doris_scan_range_max_mb);
 DECLARE_mInt32(doris_scan_block_max_mb);
 // size of scanner queue between scanner thread and compute thread
 DECLARE_mInt32(doris_scanner_queue_size);
-// single read execute fragment row number
-DECLARE_mInt32(doris_scanner_row_num);
 // single read execute fragment row bytes
 DECLARE_mInt32(doris_scanner_row_bytes);
 // number of max scan keys

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -137,6 +137,11 @@ public:
                _query_options.enable_common_expr_pushdown;
     }
 
+    int scanner_once_block_num() const {
+        return _query_options.__isset.scanner_once_block_num ? _query_options.scanner_once_block_num
+                                                             : 5;
+    }
+
     Status query_status() {
         std::lock_guard<std::mutex> l(_process_status_lock);
         return _process_status;

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -137,8 +137,8 @@ public:
                _query_options.enable_common_expr_pushdown;
     }
 
-    int scanner_once_block_num() const {
-        return _query_options.__isset.scanner_once_block_num ? _query_options.scanner_once_block_num
+    int max_block_num_per_scan() const {
+        return _query_options.__isset.max_block_num_per_scan ? _query_options.max_block_num_per_scan
                                                              : 5;
     }
 

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -93,8 +93,8 @@ Status ScannerContext::init() {
     int real_block_size =
             limit == -1 ? _batch_size : std::min(static_cast<int64_t>(_batch_size), limit);
     _block_per_scanner = limit == -1
-                                 ? _state->scanner_once_block_num()
-                                 : std::min(static_cast<int64_t>(_state->scanner_once_block_num()),
+                                 ? _state->max_block_num_per_scan()
+                                 : std::min(static_cast<int64_t>(_state->max_block_num_per_scan()),
                                             (limit + (real_block_size - 1)) / real_block_size);
     auto pre_alloc_block_count = _max_thread_num * _block_per_scanner;
 

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -300,7 +300,7 @@ void ScannerScheduler::_scanner_scan(ScannerScheduler* scheduler, ScannerContext
     // judge if we need to yield. So we record all raw data read in this round
     // scan, if this exceeds row number or bytes threshold, we yield this thread.
     std::vector<vectorized::BlockUPtr> blocks;
-    int64_t remain_scan_block_num = state->scanner_once_block_num();
+    int64_t remain_scan_block_num = state->max_block_num_per_scan();
     int64_t raw_bytes_read = 0;
     int64_t raw_bytes_threshold = config::doris_scanner_row_bytes;
     bool has_free_block = true;

--- a/be/src/vec/exec/scan/vscanner.cpp
+++ b/be/src/vec/exec/scan/vscanner.cpp
@@ -52,7 +52,6 @@ Status VScanner::get_block(RuntimeState* state, Block* block, bool* eof) {
     // only empty block should be here
     DCHECK(block->rows() == 0);
     SCOPED_RAW_TIMER(&_per_scanner_timer);
-    int64_t rows_read_threshold = _num_rows_read + config::doris_scanner_row_num;
     if (!block->mem_reuse()) {
         for (const auto slot_desc : _output_tuple_desc->slots()) {
             if (!slot_desc->need_materialize()) {
@@ -88,8 +87,7 @@ Status VScanner::get_block(RuntimeState* state, Block* block, bool* eof) {
             }
             // record rows return (after filter) for _limit check
             _num_rows_return += block->rows();
-        } while (!state->is_cancelled() && block->rows() == 0 && !(*eof) &&
-                 _num_rows_read < rows_read_threshold);
+        } while (!state->is_cancelled() && block->rows() == 0 && !(*eof));
     }
 
     if (state->is_cancelled()) {

--- a/docs/en/docs/admin-manual/config/be-config.md
+++ b/docs/en/docs/admin-manual/config/be-config.md
@@ -357,11 +357,6 @@ There are two ways to configure BE configuration items:
 * Description: The length of the RowBatch buffer queue between TransferThread and OlapScanner. When Doris performs data scanning, it is performed asynchronously. The Rowbatch scanned by OlapScanner will be placed in the scanner buffer queue, waiting for the upper TransferThread to take it away.
 * Default value: 1024
 
-#### `doris_scanner_row_num`
-
-* Description: The maximum number of data rows returned by each scanning thread in a single execution
-* Default value: 16384
-
 #### `doris_scanner_row_bytes`
 
 * Description: single read execute fragment row bytes

--- a/docs/en/docs/advanced/variables.md
+++ b/docs/en/docs/advanced/variables.md
@@ -321,6 +321,10 @@ Translated with www.DeepL.com/Translator (free version)
 
     For the specific meaning of this variable, please refer to the description of `doris_max_scan_key_num` in [BE Configuration](../admin-manual/config/be-config.md). This variable is set to -1 by default, which means that the configuration value in `be.conf` is used. If the setting is greater than 0, the query in the current session will use the variable value, and ignore the configuration value in `be.conf`.
 
+* `scanner_once_block_num`
+
+    The maximum number of blocks returned by each scan thread in a single execution, the default is 5.
+
 * `net_buffer_length`
 
     Used for compatibility with MySQL clients. No practical effect.

--- a/docs/en/docs/advanced/variables.md
+++ b/docs/en/docs/advanced/variables.md
@@ -321,7 +321,7 @@ Translated with www.DeepL.com/Translator (free version)
 
     For the specific meaning of this variable, please refer to the description of `doris_max_scan_key_num` in [BE Configuration](../admin-manual/config/be-config.md). This variable is set to -1 by default, which means that the configuration value in `be.conf` is used. If the setting is greater than 0, the query in the current session will use the variable value, and ignore the configuration value in `be.conf`.
 
-* `scanner_once_block_num`
+* `max_block_num_per_scan`
 
     The maximum number of blocks returned by each scan thread in a single execution, the default is 5.
 

--- a/docs/zh-CN/docs/admin-manual/config/be-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/be-config.md
@@ -368,11 +368,6 @@ BE 重启后该配置将失效。如果想持久化修改结果，使用如下�
 * 描述：TransferThread与OlapScanner之间RowBatch的缓存队列的长度。Doris进行数据扫描时是异步进行的，OlapScanner扫描上来的Rowbatch会放入缓存队列之中，等待上层TransferThread取走。
 * 默认值：1024
 
-#### `doris_scanner_row_num`
-
-* 描述：每个扫描线程单次执行最多返回的数据行数
-* 默认值：16384
-
 #### `doris_scanner_row_bytes`
 
 * 描述：每个扫描线程单次执行最多返回的数据字节

--- a/docs/zh-CN/docs/advanced/variables.md
+++ b/docs/zh-CN/docs/advanced/variables.md
@@ -318,7 +318,7 @@ SELECT /*+ SET_VAR(query_timeout = 1, enable_partition_cache=true) */ sleep(3);
 
   该变量的具体含义请参阅 [BE 配置项](../admin-manual/config/be-config.md) 中 `doris_max_scan_key_num` 的说明。该变量默认置为 -1，表示使用 `be.conf` 中的配置值。如果设置大于 0，则当前会话中的查询会使用该变量值，而忽略 `be.conf` 中的配置值。
 
-- `scanner_once_block_num`
+- `max_block_num_per_scan`
 
   每个扫描线程单次执行最多返回的Block个数，默认为 5。
 

--- a/docs/zh-CN/docs/advanced/variables.md
+++ b/docs/zh-CN/docs/advanced/variables.md
@@ -318,6 +318,10 @@ SELECT /*+ SET_VAR(query_timeout = 1, enable_partition_cache=true) */ sleep(3);
 
   该变量的具体含义请参阅 [BE 配置项](../admin-manual/config/be-config.md) 中 `doris_max_scan_key_num` 的说明。该变量默认置为 -1，表示使用 `be.conf` 中的配置值。如果设置大于 0，则当前会话中的查询会使用该变量值，而忽略 `be.conf` 中的配置值。
 
+- `scanner_once_block_num`
+
+  每个扫描线程单次执行最多返回的Block个数，默认为 5。
+
 - `net_buffer_length`
 
   用于兼容 MySQL 客户端。无实际作用。

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -131,6 +131,8 @@ public class SessionVariable implements Serializable, Writable {
 
     // see comment of `doris_max_scan_key_num` and `max_pushdown_conditions_per_column` in BE config
     public static final String MAX_SCAN_KEY_NUM = "max_scan_key_num";
+    // single read execute fragment block number
+    public static final String SCANNER_ONCE_BLOCK_NUM = "scanner_once_block_num";
     public static final String MAX_PUSHDOWN_CONDITIONS_PER_COLUMN = "max_pushdown_conditions_per_column";
 
     // when true, the partition column must be set to NOT NULL.
@@ -541,6 +543,8 @@ public class SessionVariable implements Serializable, Writable {
     // -1 means unset, BE will use its config value
     @VariableMgr.VarAttr(name = MAX_SCAN_KEY_NUM)
     public int maxScanKeyNum = -1;
+    @VariableMgr.VarAttr(name = SCANNER_ONCE_BLOCK_NUM, fuzzy = true)
+    public int scannerOnceBlockNum = 5;
     @VariableMgr.VarAttr(name = MAX_PUSHDOWN_CONDITIONS_PER_COLUMN)
     public int maxPushdownConditionsPerColumn = -1;
     @VariableMgr.VarAttr(name = SHOW_HIDDEN_COLUMNS, flag = VariableMgr.SESSION_ONLY)
@@ -904,6 +908,7 @@ public class SessionVariable implements Serializable, Writable {
         Random random = new Random(System.currentTimeMillis());
         this.parallelExecInstanceNum = random.nextInt(8) + 1;
         this.enableCommonExprPushdown = random.nextBoolean();
+        this.scannerOnceBlockNum = random.nextInt(8);
         this.enableLocalExchange = random.nextBoolean();
         // This will cause be dead loop, disable it first
         // this.disableJoinReorder = random.nextBoolean();
@@ -1811,6 +1816,7 @@ public class SessionVariable implements Serializable, Writable {
         if (maxScanKeyNum > -1) {
             tResult.setMaxScanKeyNum(maxScanKeyNum);
         }
+        tResult.setScannerOnceBlockNum(scannerOnceBlockNum);
         if (maxPushdownConditionsPerColumn > -1) {
             tResult.setMaxPushdownConditionsPerColumn(maxPushdownConditionsPerColumn);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -132,7 +132,7 @@ public class SessionVariable implements Serializable, Writable {
     // see comment of `doris_max_scan_key_num` and `max_pushdown_conditions_per_column` in BE config
     public static final String MAX_SCAN_KEY_NUM = "max_scan_key_num";
     // single read execute fragment block number
-    public static final String SCANNER_ONCE_BLOCK_NUM = "scanner_once_block_num";
+    public static final String MAX_BLOCK_NUM_PER_SCAN = "max_block_num_per_scan";
     public static final String MAX_PUSHDOWN_CONDITIONS_PER_COLUMN = "max_pushdown_conditions_per_column";
 
     // when true, the partition column must be set to NOT NULL.
@@ -543,8 +543,8 @@ public class SessionVariable implements Serializable, Writable {
     // -1 means unset, BE will use its config value
     @VariableMgr.VarAttr(name = MAX_SCAN_KEY_NUM)
     public int maxScanKeyNum = -1;
-    @VariableMgr.VarAttr(name = SCANNER_ONCE_BLOCK_NUM, fuzzy = true)
-    public int scannerOnceBlockNum = 5;
+    @VariableMgr.VarAttr(name = MAX_BLOCK_NUM_PER_SCAN, fuzzy = true)
+    public int maxBlockNumPerScan = 5;
     @VariableMgr.VarAttr(name = MAX_PUSHDOWN_CONDITIONS_PER_COLUMN)
     public int maxPushdownConditionsPerColumn = -1;
     @VariableMgr.VarAttr(name = SHOW_HIDDEN_COLUMNS, flag = VariableMgr.SESSION_ONLY)
@@ -908,7 +908,7 @@ public class SessionVariable implements Serializable, Writable {
         Random random = new Random(System.currentTimeMillis());
         this.parallelExecInstanceNum = random.nextInt(8) + 1;
         this.enableCommonExprPushdown = random.nextBoolean();
-        this.scannerOnceBlockNum = random.nextInt(8);
+        this.maxBlockNumPerScan = random.nextInt(8);
         this.enableLocalExchange = random.nextBoolean();
         // This will cause be dead loop, disable it first
         // this.disableJoinReorder = random.nextBoolean();
@@ -1816,7 +1816,7 @@ public class SessionVariable implements Serializable, Writable {
         if (maxScanKeyNum > -1) {
             tResult.setMaxScanKeyNum(maxScanKeyNum);
         }
-        tResult.setScannerOnceBlockNum(scannerOnceBlockNum);
+        tResult.setMaxBlockNumPerScan(maxBlockNumPerScan);
         if (maxPushdownConditionsPerColumn > -1) {
             tResult.setMaxPushdownConditionsPerColumn(maxPushdownConditionsPerColumn);
         }

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -221,6 +221,8 @@ struct TQueryOptions {
   72: optional bool enable_orc_lazy_mat = true
 
   73: optional i64 scan_queue_mem_limit
+
+  74: optional i32 scanner_once_block_num
 }
     
 

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -222,7 +222,7 @@ struct TQueryOptions {
 
   73: optional i64 scan_queue_mem_limit
 
-  74: optional i32 scanner_once_block_num
+  74: optional i32 max_block_num_per_scan
 }
     
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

session variable `scanner_once_block_num` support the maximum number of blocks returned by each scanning. Instead of maximum number of data rows returned by each scanning thread in a single execution.

In some scenarios, modify `scanner_once_block_num` which will be faster and use less memory.

The default `scanner_once_block_num=5`, which is the same behavior as the previous `doris_scanner_row_num=16384`.

For large and wide table queries with 800 columns, modify `scanner_once_block_num=1`, 
```
select * from tbl where str1="" and str2="" and str3=""
```
the time-cost is from `0.6s -> 0.4s`, 
![image](https://user-images.githubusercontent.com/13197424/236617020-5a1e1e34-8825-441c-be3d-74371a27b988.png)
![image](https://user-images.githubusercontent.com/13197424/236617034-00476995-dc1a-4a2b-a571-ca4802c00bd6.png)
and the memory is only used by `40%` of the previous one, because the number of `free_block` is reduced from 60 to 18, once block 22M

Modify doris_scanner_row_num to 1 and 5, no change in performance on Clickbench.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

