### PR TITLE
[fix](scan) fix scanner mem tracker

### DIFF
--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -41,8 +41,6 @@
             doris::enable_thread_catch_bad_alloc++;                                          \
             Defer defer {[&]() { doris::enable_thread_catch_bad_alloc--; }};                 \
             { stmt; }                                                                        \
-        } catch (std::bad_alloc const& e) {                                                  \
-            return Status::MemoryLimitExceeded(fmt::format("PreCatch {}", e.what()));        \
         } catch (const doris::Exception& e) {                                                \
             if (e.code() == doris::ErrorCode::MEM_ALLOC_FAILED) {                            \
                 return Status::MemoryLimitExceeded(                                          \

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -262,12 +262,11 @@ void ScannerScheduler::_schedule_scanners(ScannerContext* ctx) {
 void ScannerScheduler::_scanner_scan(ScannerScheduler* scheduler, ScannerContext* ctx,
                                      VScannerSPtr scanner) {
     SCOPED_ATTACH_TASK(scanner->runtime_state());
-    auto tracker_config = [&] { Thread::set_self_name("_scanner_scan"); };
 #if !defined(USE_BTHREAD_SCANNER)
-    tracker_config();
+    Thread::set_self_name("_scanner_scan");
 #else
     if (dynamic_cast<NewOlapScanner*>(scanner) == nullptr) {
-        tracker_config();
+        Thread::set_self_name("_scanner_scan");
     }
 #endif
     scanner->update_wait_worker_timer();

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -261,10 +261,8 @@ void ScannerScheduler::_schedule_scanners(ScannerContext* ctx) {
 
 void ScannerScheduler::_scanner_scan(ScannerScheduler* scheduler, ScannerContext* ctx,
                                      VScannerSPtr scanner) {
-    auto tracker_config = [&] {
-        SCOPED_ATTACH_TASK(scanner->runtime_state());
-        Thread::set_self_name("_scanner_scan");
-    };
+    SCOPED_ATTACH_TASK(scanner->runtime_state());
+    auto tracker_config = [&] { Thread::set_self_name("_scanner_scan"); };
 #if !defined(USE_BTHREAD_SCANNER)
     tracker_config();
 #else


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Scanner memory was not tracked into the query before

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

