### PR TITLE
[enhance](regression) add timeout for cold&heat case

### DIFF
--- a/regression-test/suites/cold_heat_separation_p2/create_table_use_partition_policy.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/create_table_use_partition_policy.groovy
@@ -227,7 +227,8 @@ suite("create_table_use_partition_policy") {
     assertTrue(tablets.size() > 0)
     LocalDataSize1 = sizes[0]
     RemoteDataSize1 = sizes[1]
-    while (RemoteDataSize1 != originLocalDataSize1) {
+    Long sleepTimes = 0;
+    while (RemoteDataSize1 != originLocalDataSize1 && sleepTimes < 60) {
         log.info( "test remote size is same with origin size, sleep 10s")
         sleep(10000)
         tablets = sql """
@@ -236,6 +237,7 @@ suite("create_table_use_partition_policy") {
         fetchDataSize(sizes, tablets[0])
         LocalDataSize1 = sizes[0]
         RemoteDataSize1 = sizes[1]
+        sleepTimes += 1
     }
     log.info( "test local size is  zero")
     assertEquals(LocalDataSize1, 0)
@@ -336,7 +338,8 @@ suite("create_table_use_partition_policy") {
     assertTrue(tablets.size() > 0)
     LocalDataSize1 = sizes[0]
     RemoteDataSize1 = sizes[1]
-    while (RemoteDataSize1 != originLocalDataSize1) {
+    sleepTimes = 0
+    while (RemoteDataSize1 != originLocalDataSize1 && sleepTimes < 60) {
         log.info( "test remote size is same with origin size, sleep 10s")
         sleep(10000)
         tablets = sql """
@@ -345,6 +348,7 @@ suite("create_table_use_partition_policy") {
         fetchDataSize(sizes, tablets[0])
         LocalDataSize1 = sizes[0]
         RemoteDataSize1 = sizes[1]
+        sleepTimes += 1
     }
     log.info( "test local size is zero")
     assertEquals(LocalDataSize1, 0)


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
Before this pr, the `cold_heat_separation_p2/create_table_use_partition_policy.groovy` case might result in one endless loop.

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

