### PR TITLE
[Refact](scanner_context) move increase num_scheduling_ctx into submit function

### DIFF
--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -115,6 +115,8 @@ public:
 
     int get_num_scheduling_ctx() const { return _num_scheduling_ctx; }
 
+    void incr_num_scheduling_ctx() { ++_num_scheduling_ctx; }
+
     void get_next_batch_of_scanners(std::list<VScannerSPtr>* current_run);
 
     void clear_and_join(VScanNode* node, RuntimeState* state);

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -120,6 +120,7 @@ Status ScannerScheduler::submit(ScannerContext* ctx) {
     if (!_pending_queues[ctx->queue_idx]->blocking_put(ctx)) {
         return Status::InternalError("failed to submit scanner context to scheduler");
     }
+    ctx->incr_num_scheduling_ctx();
     return Status::OK();
 }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

I found that the `num_scheduling_ctx` variable is always incremented by one before calling the submit function, so we can move it into the submit function.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

