### PR TITLE
[feature](system) support decommission disk on backend

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1309,6 +1309,7 @@ void TaskWorkerPool::_report_disk_state_worker_thread_callback() {
             disk.__set_remote_used_capacity(root_path_info.remote_used_capacity);
             disk.__set_disk_available_capacity(root_path_info.available);
             disk.__set_used(root_path_info.is_used);
+            disk.__set_decommissioned(root_path_info.is_decommissioned);
             request.disks[root_path_info.path] = disk;
         }
 

--- a/be/src/olap/data_dir.h
+++ b/be/src/olap/data_dir.h
@@ -62,6 +62,8 @@ public:
     const io::FileSystemSPtr& fs() const { return _fs; }
 
     bool is_used() const { return _is_used; }
+    bool is_decommissioned() const { return _is_decommissioned; }
+    bool is_available() const { return _is_used && !_is_decommissioned; }
     int32_t cluster_id() const { return _cluster_id; }
     bool cluster_id_incomplete() const { return _cluster_id_incomplete; }
 
@@ -72,6 +74,7 @@ public:
         info.disk_capacity = _disk_capacity_bytes;
         info.available = _available_bytes;
         info.is_used = _is_used;
+        info.is_decommissioned = _is_decommissioned;
         info.storage_medium = _storage_medium;
         return info;
     }
@@ -80,6 +83,9 @@ public:
     // invalid be config for example two be use the same
     // data path
     Status set_cluster_id(int32_t cluster_id);
+
+    Status set_decommissioned(bool value);
+
     void health_check();
 
     Status get_shard(uint64_t* shard);
@@ -150,11 +156,14 @@ private:
     Status _init_cluster_id();
     Status _init_capacity_and_create_shards();
     Status _init_meta();
+    Status _init_decommission();
 
     Status _check_disk();
     Status _read_and_write_test_file();
     Status read_cluster_id(const std::string& cluster_id_path, int32_t* cluster_id);
     Status _write_cluster_id_to_path(const std::string& path, int32_t cluster_id);
+    Status _create_decommission_file(const std::string& path);
+    Status _delete_decommission_file(const std::string& path);
     // Check whether has old format (hdr_ start) in olap. When doris updating to current version,
     // it may lead to data missing. When conf::storage_strict_check_incompatible_old_format is true,
     // process will log fatal.
@@ -179,6 +188,7 @@ private:
     size_t _disk_capacity_bytes;
     TStorageMedium::type _storage_medium;
     bool _is_used;
+    bool _is_decommissioned;
 
     TabletManager* _tablet_manager;
     TxnManager* _txn_manager;

--- a/be/src/olap/olap_common.h
+++ b/be/src/olap/olap_common.h
@@ -57,7 +57,8 @@ struct DataDirInfo {
     int64_t available = 0;     // available space, in bytes unit
     int64_t local_used_capacity = 0;
     int64_t remote_used_capacity = 0;
-    bool is_used = false;                                      // whether available mark
+    bool is_used = false; // whether available mark
+    bool is_decommissioned = false;
     TStorageMedium::type storage_medium = TStorageMedium::HDD; // Storage medium type: SSD|HDD
 };
 

--- a/be/src/olap/olap_define.h
+++ b/be/src/olap/olap_define.h
@@ -88,6 +88,7 @@ enum OLAPDataVersion {
 // storage_root_path下不同类型文件夹名称
 static const std::string MINI_PREFIX = "mini_download";
 static const std::string CLUSTER_ID_PREFIX = "cluster_id";
+static const std::string DECOMMISSION_PREFIX = "decommission";
 static const std::string DATA_PREFIX = "data";
 static const std::string DPP_PREFIX = "dpp_download";
 static const std::string SNAPSHOT_PREFIX = "snapshot";

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -104,6 +104,7 @@ public:
     // for avoiding that all the tablet would be deployed one disk.
     std::vector<DataDir*> get_stores_for_create_tablet(TStorageMedium::type storage_medium);
     DataDir* get_store(const std::string& path);
+    DataDir* get_store(size_t hash_path);
 
     uint32_t available_storage_medium_type_count() const {
         return _available_storage_medium_type_count;
@@ -197,6 +198,8 @@ public:
     }
     bool stopped() { return _stopped; }
     ThreadPool* get_bg_multiget_threadpool() { return _bg_multi_get_thread_pool.get(); }
+
+    Status set_decommissioned(string store_path, bool value);
 
 private:
     // Instance should be inited from `static open()`

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -116,11 +116,12 @@ Status EngineCloneTask::_do_clone() {
     // Check local tablet exist or not
     TabletSharedPtr tablet =
             StorageEngine::instance()->tablet_manager()->get_tablet(_clone_req.tablet_id);
+    DataDir* src_store = StorageEngine::instance()->get_store(_clone_req.src_path_hash);
     bool is_new_tablet = tablet == nullptr;
     // try to incremental clone
     std::vector<Version> missed_versions;
     // try to repair a tablet with missing version
-    if (tablet != nullptr) {
+    if (tablet != nullptr && src_store != nullptr && !src_store->is_decommissioned()) {
         std::shared_lock migration_rlock(tablet->get_migration_lock(), std::try_to_lock);
         if (!migration_rlock.owns_lock()) {
             return Status::Error<TRY_LOCK_FAILED>();

--- a/be/src/service/backend_service.cpp
+++ b/be/src/service/backend_service.cpp
@@ -373,4 +373,16 @@ void BackendService::clean_trash() {
 void BackendService::check_storage_format(TCheckStorageFormatResult& result) {
     StorageEngine::instance()->tablet_manager()->get_all_tablets_storage_format(&result);
 }
+
+void BackendService::decommission_disk(TStatus& t_status, const TDecommissionDiskReq& request) {
+    for (const string& root_path : request.root_paths) {
+        Status status = StorageEngine::instance()->set_decommissioned(root_path, request.value);
+        if (!status.ok()) {
+            LOG(WARNING) << "decommission disk failed! root_path: " << root_path
+                         << ", value: " << request.value;
+            return status.to_thrift(&t_status);
+        }
+    }
+    return Status::OK().to_thrift(&t_status);
+}
 } // namespace doris

--- a/be/src/service/backend_service.h
+++ b/be/src/service/backend_service.h
@@ -127,6 +127,8 @@ public:
 
     void check_storage_format(TCheckStorageFormatResult& result) override;
 
+    void decommission_disk(TStatus& t_status, const TDecommissionDiskReq& request) override;
+
 private:
     Status start_plan_fragment_execution(const TExecPlanFragmentParams& exec_params);
     ExecEnv* _exec_env;

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1086,6 +1086,15 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, masterOnly = true)
     public static int decommission_tablet_check_threshold = 5000;
 
+    /**  priority of scheduling tablet on decommissioned disks
+     *   0: LOW;
+     *   1: NORMAL;
+     *   2: HIGH;
+     *   3: VERY_HIGH;
+     */
+    @ConfField(mutable = true, masterOnly = true)
+    public static int decommission_tablet_sched_priority = 1;
+
     /**
      * Define thrift server's server model, default is TThreadPoolServer model
      */

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -332,6 +332,7 @@ terminal String
     KW_DESCRIBE,
     KW_DIAGNOSE,
     KW_DISK,
+    KW_DISKS,
     KW_DISTINCT,
     KW_DISTINCTPC,
     KW_DISTINCTPCSA,
@@ -1578,6 +1579,10 @@ alter_system_clause ::=
     | KW_DECOMMISSION KW_BACKEND string_list:hostPorts
     {:
         RESULT = new DecommissionBackendClause(hostPorts);
+    :}
+    | KW_DECOMMISSION KW_DISK string_list:rootPaths KW_ON STRING_LITERAL:hostPort
+    {:
+        RESULT = new DecommissionDiskClause(hostPort, rootPaths);
     :}
     | KW_ADD KW_OBSERVER STRING_LITERAL:hostPort
     {:
@@ -3846,6 +3851,10 @@ show_param ::=
     {:
         RESULT = new ShowBackendsStmt();
     :}
+    | KW_DISKS KW_ON STRING_LITERAL:backend
+    {:
+        RESULT = new ShowDisksStmt(backend);
+    :}
     | KW_TRASH KW_ON STRING_LITERAL:backend
     {:
         RESULT = new ShowTrashDiskStmt(backend);
@@ -4212,7 +4221,11 @@ cancel_param ::=
     :}
     | KW_DECOMMISSION KW_BACKEND string_list:hostPorts
     {:
-        RESULT = new CancelAlterSystemStmt(hostPorts);
+        RESULT = new CancelDecommissionBackendStmt(hostPorts);
+    :}
+    | KW_DECOMMISSION KW_DISK string_list:rootPaths KW_ON STRING_LITERAL:hostPort
+    {:
+        RESULT = new CancelDecommissionDiskStmt(hostPort, rootPaths);
     :}
     | KW_BACKUP opt_db:db
     {:
@@ -7035,6 +7048,8 @@ keyword ::=
     | KW_HDFS:id
     {: RESULT = id; :}
     | KW_BACKENDS:id
+    {: RESULT = id; :}
+    | KW_DISKS:id
     {: RESULT = id; :}
     | KW_BUILTIN:id
     {: RESULT = id; :}

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterSystemStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterSystemStmt.java
@@ -49,6 +49,7 @@ public class AlterSystemStmt extends DdlStmt {
         Preconditions.checkState((alterClause instanceof AddBackendClause)
                 || (alterClause instanceof DropBackendClause)
                 || (alterClause instanceof DecommissionBackendClause)
+                || (alterClause instanceof DecommissionDiskClause)
                 || (alterClause instanceof AddObserverClause)
                 || (alterClause instanceof DropObserverClause)
                 || (alterClause instanceof AddFollowerClause)

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CancelAlterSystemStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CancelAlterSystemStmt.java
@@ -17,51 +17,5 @@
 
 package org.apache.doris.analysis;
 
-import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.Config;
-import org.apache.doris.system.SystemInfoService;
-import org.apache.doris.system.SystemInfoService.HostInfo;
-
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
-
-import java.util.List;
-
 public class CancelAlterSystemStmt extends CancelStmt {
-
-    protected List<String> hostPorts;
-    private List<HostInfo> hostInfos;
-
-    public CancelAlterSystemStmt(List<String> hostPorts) {
-        this.hostPorts = hostPorts;
-        this.hostInfos = Lists.newArrayList();
-    }
-
-    public List<HostInfo> getHostInfos() {
-        return hostInfos;
-    }
-
-    @Override
-    public void analyze(Analyzer analyzer) throws AnalysisException {
-        for (String hostPort : hostPorts) {
-            HostInfo hostInfo = SystemInfoService.getIpHostAndPort(hostPort,
-                    !Config.enable_fqdn_mode);
-            this.hostInfos.add(hostInfo);
-        }
-        Preconditions.checkState(!this.hostInfos.isEmpty());
-    }
-
-    @Override
-    public String toSql() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("CANCEL DECOMMISSION BACKEND ");
-        for (int i = 0; i < hostPorts.size(); i++) {
-            sb.append("\"").append(hostPorts.get(i)).append("\"");
-            if (i != hostPorts.size() - 1) {
-                sb.append(", ");
-            }
-        }
-
-        return sb.toString();
-    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CancelDecommissionBackendStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CancelDecommissionBackendStmt.java
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
+import org.apache.doris.system.SystemInfoService;
+import org.apache.doris.system.SystemInfoService.HostInfo;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+
+import java.util.List;
+
+public class CancelDecommissionBackendStmt extends CancelAlterSystemStmt {
+
+    protected List<String> hostPorts;
+    private List<HostInfo> hostInfos;
+
+    public CancelDecommissionBackendStmt(List<String> hostPorts) {
+        this.hostPorts = hostPorts;
+        this.hostInfos = Lists.newArrayList();
+    }
+
+    public List<HostInfo> getHostInfos() {
+        return hostInfos;
+    }
+
+    @Override
+    public void analyze(Analyzer analyzer) throws AnalysisException {
+        for (String hostPort : hostPorts) {
+            HostInfo hostInfo = SystemInfoService.getIpHostAndPort(hostPort,
+                    !Config.enable_fqdn_mode);
+            this.hostInfos.add(hostInfo);
+        }
+        Preconditions.checkState(!this.hostInfos.isEmpty());
+    }
+
+    @Override
+    public String toSql() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("CANCEL DECOMMISSION BACKEND ");
+        for (int i = 0; i < hostPorts.size(); i++) {
+            sb.append("\"").append(hostPorts.get(i)).append("\"");
+            if (i != hostPorts.size() - 1) {
+                sb.append(", ");
+            }
+        }
+
+        return sb.toString();
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CancelDecommissionDiskStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CancelDecommissionDiskStmt.java
@@ -1,0 +1,70 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.system.SystemInfoService;
+import org.apache.doris.system.SystemInfoService.HostInfo;
+
+import com.google.common.base.Preconditions;
+
+import java.util.List;
+
+public class CancelDecommissionDiskStmt extends CancelAlterSystemStmt {
+
+    protected String hostPort;
+
+    protected HostInfo hostInfo;
+
+    protected List<String> rootPaths;
+
+    protected CancelDecommissionDiskStmt(String hostPort, List<String> rootPaths) {
+        this.hostPort = hostPort;
+        this.rootPaths = rootPaths;
+        this.hostInfo = null;
+    }
+
+    public HostInfo getHostInfo() {
+        return hostInfo;
+    }
+
+    public List<String> getRootPaths() {
+        return rootPaths;
+    }
+
+    @Override
+    public void analyze(Analyzer analyzer) throws AnalysisException {
+        hostInfo = SystemInfoService.getIpHostAndPort(hostPort, true);
+        Preconditions.checkState(hostInfo != null);
+        Preconditions.checkState(!rootPaths.isEmpty());
+    }
+
+    @Override
+    public String toSql() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("CANCEL DECOMMISSION BACKEND DISK ");
+        sb.append("\"").append(hostPort).append("\" ");
+        for (int i = 0; i < rootPaths.size(); i++) {
+            sb.append("\"").append(rootPaths.get(i)).append("\"");
+            if (i != rootPaths.size() - 1) {
+                sb.append(", ");
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DecommissionDiskClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DecommissionDiskClause.java
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.alter.DecommissionType;
+
+import java.util.List;
+
+public class DecommissionDiskClause extends DiskClause {
+
+    private DecommissionType type;
+
+    public DecommissionDiskClause(String hostPorts, List<String> rootPaths) {
+        super(hostPorts, rootPaths);
+        type = DecommissionType.SystemDecommission;
+    }
+
+    @Override
+    public String toSql() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("DECOMMISSION BACKEND DISK ");
+        sb.append("\"").append(hostPort).append("\" ");
+        for (int i = 0; i < rootPaths.size(); i++) {
+            sb.append("\"").append(rootPaths.get(i)).append("\"");
+            if (i != rootPaths.size() - 1) {
+                sb.append(", ");
+            }
+        }
+        return sb.toString();
+    }
+
+    public void setType(DecommissionType type) {
+        this.type = type;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DiskClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DiskClause.java
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.alter.AlterOpType;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.system.SystemInfoService;
+import org.apache.doris.system.SystemInfoService.HostInfo;
+
+import com.google.common.base.Preconditions;
+import org.apache.commons.lang3.NotImplementedException;
+
+import java.util.List;
+import java.util.Map;
+
+public class DiskClause extends AlterClause {
+    protected String hostPort;
+    protected HostInfo hostInfo;
+    protected List<String> rootPaths;
+
+    protected DiskClause(String hostPort, List<String> rootPaths) {
+        super(AlterOpType.ALTER_OTHER);
+        this.hostPort = hostPort;
+        this.rootPaths = rootPaths;
+        this.hostInfo = null;
+    }
+
+    @Override
+    public void analyze(Analyzer analyzer) throws AnalysisException {
+        hostInfo = SystemInfoService.getIpHostAndPort(hostPort, true);
+        Preconditions.checkState(hostInfo != null);
+        Preconditions.checkState(!rootPaths.isEmpty());
+    }
+
+    @Override
+    public String toSql() {
+        throw new NotImplementedException("Not support toSql for DiskClause");
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        throw new NotImplementedException("Not support getProperties for DiskClause");
+    }
+
+    public List<String> getRootPaths() {
+        return rootPaths;
+    }
+
+    public HostInfo getHostInfo() {
+        return hostInfo;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowDisksStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowDisksStmt.java
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.ScalarType;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.ErrorCode;
+import org.apache.doris.common.ErrorReport;
+import org.apache.doris.common.proc.DisksProcDir;
+import org.apache.doris.mysql.privilege.PrivPredicate;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.ShowResultSetMetaData;
+import org.apache.doris.system.SystemInfoService;
+
+import com.google.common.base.Preconditions;
+
+public class ShowDisksStmt extends ShowStmt {
+
+    private String hostPort;
+
+    private SystemInfoService.HostInfo hostInfo;
+
+    public ShowDisksStmt(String hostPort) {
+        this.hostPort = hostPort;
+        this.hostInfo = null;
+    }
+
+    @Override
+    public void analyze(Analyzer analyzer) throws AnalysisException {
+        if (!Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ConnectContext.get(), PrivPredicate.ADMIN)
+                && !Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ConnectContext.get(),
+                                                                          PrivPredicate.OPERATOR)) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "ADMIN/OPERATOR");
+        }
+        hostInfo = SystemInfoService.getIpHostAndPort(hostPort, true);
+        Preconditions.checkState(hostInfo != null);
+    }
+
+    @Override
+    public ShowResultSetMetaData getMetaData() {
+        ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
+        for (String title : DisksProcDir.TITLE_NAMES) {
+            builder.addColumn(new Column(title, ScalarType.createVarchar(30)));
+        }
+        return builder.build();
+    }
+
+    @Override
+    public RedirectStatus getRedirectStatus() {
+        if (ConnectContext.get().getSessionVariable().getForwardToMaster()) {
+            return RedirectStatus.FORWARD_NO_SYNC;
+        } else {
+            return RedirectStatus.NO_FORWARD;
+        }
+    }
+
+    public SystemInfoService.HostInfo getHostInfo() {
+        return hostInfo;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
@@ -660,6 +660,22 @@ public class TabletInvertedIndex {
         return 0;
     }
 
+    public long getTabletIdNumByBackendIdAndPathHash(long backendId, long pathHash) {
+        long stamp = readLock();
+        try {
+            Map<Long, Replica> replicaMetaWithBackend = backingReplicaMetaTable.row(backendId);
+            if (replicaMetaWithBackend != null) {
+                return replicaMetaWithBackend.entrySet().stream()
+                    .filter(a -> a.getValue().getPathHash() == pathHash)
+                    .map(Map.Entry::getKey)
+                    .count();
+            }
+        } finally {
+            readUnlock(stamp);
+        }
+        return 0;
+    }
+
     public Map<TStorageMedium, Long> getReplicaNumByBeIdAndStorageMedium(long backendId) {
         Map<TStorageMedium, Long> replicaNumMap = Maps.newHashMap();
         long hddNum = 0;

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/BackendLoadStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/BackendLoadStatistic.java
@@ -188,8 +188,8 @@ public class BackendLoadStatistic {
             }
 
             RootPathLoadStatistic pathStatistic = new RootPathLoadStatistic(beId, diskInfo.getRootPath(),
-                    diskInfo.getPathHash(), diskInfo.getStorageMedium(),
-                    diskInfo.getTotalCapacityB(), diskInfo.getDiskUsedCapacityB(), diskInfo.getState());
+                    diskInfo.getPathHash(), diskInfo.getStorageMedium(), diskInfo.getTotalCapacityB(),
+                    diskInfo.getDiskUsedCapacityB(), diskInfo.getState(), diskInfo.isDecommissioned());
             pathStatistics.add(pathStatistic);
         }
 
@@ -303,6 +303,10 @@ public class BackendLoadStatistic {
             RootPathLoadStatistic pathStatistic = pathStatistics.get(i);
             // if this is a supplement task, ignore the storage medium
             if (!isSupplement && pathStatistic.getStorageMedium() != medium) {
+                continue;
+            }
+
+            if (pathStatistic.isDecommissioned()) {
                 continue;
             }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/RootPathLoadStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/RootPathLoadStatistic.java
@@ -32,11 +32,12 @@ public class RootPathLoadStatistic implements Comparable<RootPathLoadStatistic> 
     private long capacityB;
     private long usedCapacityB;
     private DiskState diskState;
+    private boolean decommissioned;
 
     private Classification clazz = Classification.INIT;
 
     public RootPathLoadStatistic(long beId, String path, Long pathHash, TStorageMedium storageMedium,
-            long capacityB, long usedCapacityB, DiskState diskState) {
+            long capacityB, long usedCapacityB, DiskState diskState, boolean decommissioned) {
         this.beId = beId;
         this.path = path;
         this.pathHash = pathHash;
@@ -44,6 +45,7 @@ public class RootPathLoadStatistic implements Comparable<RootPathLoadStatistic> 
         this.capacityB = capacityB <= 0 ? 1 : capacityB;
         this.usedCapacityB = usedCapacityB;
         this.diskState = diskState;
+        this.decommissioned = decommissioned;
     }
 
     public long getBeId() {
@@ -84,6 +86,10 @@ public class RootPathLoadStatistic implements Comparable<RootPathLoadStatistic> 
 
     public DiskState getDiskState() {
         return diskState;
+    }
+
+    public boolean isDecommissioned() {
+        return this.decommissioned;
     }
 
     public BalanceStatus isFit(long tabletSize, boolean isSupplement) {

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletChecker.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletChecker.java
@@ -359,7 +359,6 @@ public class TabletChecker extends MasterDaemon {
                         partition.getVisibleVersion(),
                         tbl.getPartitionInfo().getReplicaAllocation(partition.getId()),
                         aliveBeIdsInCluster);
-
                 if (statusWithPrio.first == TabletStatus.HEALTHY) {
                     // Only set last status check time when status is healthy.
                     tablet.setLastStatusCheckTime(startTime);

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -833,6 +833,7 @@ public class TabletScheduler extends MasterDaemon {
         if (deleteBackendDropped(tabletCtx, force)
                 || deleteBadReplica(tabletCtx, force)
                 || deleteBackendUnavailable(tabletCtx, force)
+                || deleteDiskUnavailable(tabletCtx, force)
                 || deleteTooSlowReplica(tabletCtx, force)
                 || deleteCloneOrDecommissionReplica(tabletCtx, force)
                 || deleteReplicaWithFailedVersion(tabletCtx, force)
@@ -889,6 +890,20 @@ public class TabletScheduler extends MasterDaemon {
             }
             if (!be.isScheduleAvailable()) {
                 deleteReplicaInternal(tabletCtx, replica, "backend unavailable", force);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean deleteDiskUnavailable(TabletSchedCtx tabletCtx, boolean force) throws SchedException {
+        for (Replica replica : tabletCtx.getReplicas()) {
+            DiskInfo disk = infoService.getDisk(replica.getPathHash());
+            if (disk == null) {
+                continue;
+            }
+            if (!disk.isScheduleAvailable()) {
+                deleteReplicaInternal(tabletCtx, replica, "disk unavailable", force);
                 return true;
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -713,8 +713,9 @@ public class TabletScheduler extends MasterDaemon {
         Map<Tag, Short> currentAllocMap = Maps.newHashMap();
         for (Replica replica : replicas) {
             Backend be = infoService.getBackend(replica.getBackendId());
-            if (be != null && be.isScheduleAvailable() && replica.isAlive() && !replica.tooSlow()
-                    && be.isMixNode()) {
+            DiskInfo disk = infoService.getDisk(replica.getPathHash());
+            if (be != null && be.isScheduleAvailable() && replica.isAlive() && !replica.tooSlow() && be.isMixNode()
+                    && disk != null && disk.isScheduleAvailable()) {
                 Short num = currentAllocMap.getOrDefault(be.getLocationTag(), (short) 0);
                 currentAllocMap.put(be.getLocationTag(), (short) (num + 1));
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/DisksProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/DisksProcDir.java
@@ -1,0 +1,136 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.proc;
+
+import org.apache.doris.catalog.DiskInfo;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Pair;
+import org.apache.doris.common.util.DebugUtil;
+import org.apache.doris.system.Backend;
+import org.apache.doris.system.SystemInfoService;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+public class DisksProcDir implements ProcDirInterface  {
+    public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
+            .add("RootPath").add("UsedCapacity").add("AvailCapacity").add("TotalCapacity")
+            .add("TotalUsedPct").add("TabletNum").add("State").add("isDecommissioned")
+            .build();
+
+    private Backend backend;
+
+    private SystemInfoService clusterInfoService;
+
+    public DisksProcDir(SystemInfoService clusterInfoService) {
+        this.clusterInfoService = clusterInfoService;
+    }
+
+    @Override
+    public ProcResult fetchResult() throws AnalysisException {
+        Preconditions.checkNotNull(backend);
+
+        BaseProcResult result = new BaseProcResult();
+        result.setNames(TITLE_NAMES);
+
+        for (Map.Entry<String, DiskInfo> entry : backend.getDisks().entrySet()) {
+            List<String> info = Lists.newArrayList();
+            info.add(entry.getKey());
+
+            // data used
+            long dataUsedB = entry.getValue().getDataUsedCapacityB();
+            Pair<Double, String> dataUsedUnitPair = DebugUtil.getByteUint(dataUsedB);
+            info.add(DebugUtil.DECIMAL_FORMAT_SCALE_3.format(dataUsedUnitPair.first) + " "
+                    + dataUsedUnitPair.second);
+
+            // avail
+            long availB = entry.getValue().getAvailableCapacityB();
+            Pair<Double, String> availUnitPair = DebugUtil.getByteUint(availB);
+            // total
+            long totalB = entry.getValue().getTotalCapacityB();
+            Pair<Double, String> totalUnitPair = DebugUtil.getByteUint(totalB);
+            // other
+            long otherB = totalB - availB - dataUsedB;
+            Pair<Double, String> otherUnitPair = DebugUtil.getByteUint(otherB);
+
+            info.add(DebugUtil.DECIMAL_FORMAT_SCALE_3.format(otherUnitPair.first) + " " + otherUnitPair.second);
+            info.add(DebugUtil.DECIMAL_FORMAT_SCALE_3.format(availUnitPair.first) + " " + availUnitPair.second);
+            info.add(DebugUtil.DECIMAL_FORMAT_SCALE_3.format(totalUnitPair.first) + " "  + totalUnitPair.second);
+
+            // total used percent
+            double used = 0.0;
+            if (totalB <= 0) {
+                used = 0.0;
+            } else {
+                used = (double) (totalB - availB) * 100 / totalB;
+            }
+            info.add(String.format("%.2f", used) + " %");
+
+            info.add(entry.getValue().getState().name());
+            info.add(String.valueOf(entry.getValue().getPathHash()));
+
+            result.addRow(info);
+        }
+
+        return result;
+    }
+
+    public static List<List<String>> getDiskInfos(SystemInfoService.HostInfo hostInfo) throws AnalysisException {
+        SystemInfoService infoService = Env.getCurrentSystemInfo();
+        Backend backend = infoService.getBackendWithHeartbeatPort(hostInfo.getIp(), hostInfo.getHostName(),
+                hostInfo.getPort());
+        List<List<String>> result = new LinkedList<>();
+        if (backend == null) {
+            throw new AnalysisException("Backend" + hostInfo + " does not exist.");
+        }
+        backend.getDisks().forEach((rootPath, diskInfo) -> {
+            List<String> row = new LinkedList<>();
+            row.add(diskInfo.getRootPath());
+            row.add(String.valueOf(diskInfo.getDiskUsedCapacityB()));
+            row.add(String.valueOf(diskInfo.getAvailableCapacityB()));
+            row.add(String.valueOf(diskInfo.getTotalCapacityB()));
+            row.add(String.valueOf(diskInfo.getUsedPct()));
+            if (diskInfo.hasPathHash()) {
+                row.add(String.valueOf(Env.getCurrentInvertedIndex().getTabletIdNumByBackendIdAndPathHash(
+                        backend.getId(), diskInfo.getPathHash())));
+            } else {
+                row.add("?");
+            }
+            row.add(diskInfo.getState().toString());
+            row.add(String.valueOf(diskInfo.isDecommissioned()));
+            result.add(row);
+        });
+        return result;
+    }
+
+    @Override
+    public boolean register(String name, ProcNodeInterface node) {
+        return false;
+    }
+
+    @Override
+    public ProcNodeInterface lookup(String beIdStr) throws AnalysisException {
+        return null;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/ProcService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/ProcService.java
@@ -37,6 +37,7 @@ public final class ProcService {
         root = new BaseProcDir();
         root.register("auth", new AuthProcDir(Env.getCurrentEnv().getAuth()));
         root.register("backends", new BackendsProcDir(Env.getCurrentSystemInfo()));
+        root.register("disks", new DisksProcDir(Env.getCurrentSystemInfo()));
         root.register("catalogs", new CatalogsProcDir(Env.getCurrentEnv()));
         root.register("dbs", new DbsProcDir(Env.getCurrentEnv(), Env.getCurrentInternalCatalog()));
         root.register("jobs", new JobsDbProcDir(Env.getCurrentEnv()));

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -52,6 +52,7 @@ import org.apache.doris.analysis.ShowDataTypesStmt;
 import org.apache.doris.analysis.ShowDbIdStmt;
 import org.apache.doris.analysis.ShowDbStmt;
 import org.apache.doris.analysis.ShowDeleteStmt;
+import org.apache.doris.analysis.ShowDisksStmt;
 import org.apache.doris.analysis.ShowDynamicPartitionStmt;
 import org.apache.doris.analysis.ShowEncryptKeysStmt;
 import org.apache.doris.analysis.ShowEnginesStmt;
@@ -149,6 +150,7 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.common.PatternMatcher;
 import org.apache.doris.common.PatternMatcherWrapper;
 import org.apache.doris.common.proc.BackendsProcDir;
+import org.apache.doris.common.proc.DisksProcDir;
 import org.apache.doris.common.proc.FrontendsProcNode;
 import org.apache.doris.common.proc.LoadProcDir;
 import org.apache.doris.common.proc.PartitionsProcDir;
@@ -329,6 +331,8 @@ public class ShowExecutor {
             handleShowExport();
         } else if (stmt instanceof ShowBackendsStmt) {
             handleShowBackends();
+        } else if (stmt instanceof ShowDisksStmt) {
+            handleShowDisks();
         } else if (stmt instanceof ShowFrontendsStmt) {
             handleShowFrontends();
         } else if (stmt instanceof ShowRepositoriesStmt) {
@@ -1804,6 +1808,20 @@ public class ShowExecutor {
         });
 
         resultSet = new ShowResultSet(showStmt.getMetaData(), backendInfos);
+    }
+
+    private void handleShowDisks() throws AnalysisException {
+        final ShowDisksStmt showStmt = (ShowDisksStmt) stmt;
+        List<List<String>> diskInfos = DisksProcDir.getDiskInfos(showStmt.getHostInfo());
+
+        diskInfos.sort(new Comparator<List<String>>() {
+            @Override
+            public int compare(List<String> o1, List<String> o2) {
+                return o1.get(0).compareTo(o2.get(0));
+            }
+        });
+
+        resultSet = new ShowResultSet(showStmt.getMetaData(), diskInfos);
     }
 
     private void handleShowFrontends() {

--- a/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
@@ -513,6 +513,7 @@ public class Backend implements Writable {
             long dataUsedCapacityB = tDisk.getDataUsedCapacity();
             long diskAvailableCapacityB = tDisk.getDiskAvailableCapacity();
             boolean isUsed = tDisk.isUsed();
+            boolean isDecommissioned = tDisk.isDecommissioned();
 
             DiskInfo diskInfo = disks.get(rootPath);
             if (diskInfo == null) {
@@ -547,6 +548,11 @@ public class Backend implements Writable {
                     isChanged = true;
                 }
             }
+
+            if (diskInfo.setDecommissioned(isDecommissioned)) {
+                isChanged = true;
+            }
+
             LOG.debug("update disk info. backendId: {}, diskInfo: {}", id, diskInfo.toString());
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
@@ -311,6 +311,10 @@ public class SystemInfoService {
         return idToBackendRef.get(backendId);
     }
 
+    public DiskInfo getDisk(long pathHash) {
+        return pathHashToDishInfoRef.get(pathHash);
+    }
+
     public boolean checkBackendLoadAvailable(long backendId) {
         Backend backend = idToBackendRef.get(backendId);
         if (backend == null || !backend.isLoadAvailable()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/task/AgentClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/AgentClient.java
@@ -22,6 +22,7 @@ import org.apache.doris.common.Status;
 import org.apache.doris.thrift.BackendService;
 import org.apache.doris.thrift.TAgentResult;
 import org.apache.doris.thrift.TCheckStorageFormatResult;
+import org.apache.doris.thrift.TDecommissionDiskReq;
 import org.apache.doris.thrift.TExportStatusResult;
 import org.apache.doris.thrift.TExportTaskRequest;
 import org.apache.doris.thrift.TNetworkAddress;
@@ -31,6 +32,8 @@ import org.apache.doris.thrift.TUniqueId;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.util.List;
 
 public class AgentClient {
     private static final Logger LOG = LogManager.getLogger(AgentClient.class);
@@ -138,6 +141,22 @@ public class AgentClient {
             ok = true;
         } catch (Exception e) {
             LOG.warn("checkStorageFormat error", e);
+        } finally {
+            returnClient();
+        }
+        return result;
+    }
+
+    public Status decommissionDisk(List<String> rootPaths, boolean value) {
+        Status result = Status.CANCELLED;
+        LOG.debug("decommission disk {}, value: {}", rootPaths, value);
+        try {
+            borrowClient();
+            TDecommissionDiskReq request = new TDecommissionDiskReq(rootPaths, value);
+            TStatus status = client.decommissionDisk(request);
+            result = new Status(status);
+        } catch (Exception e) {
+            LOG.warn("decommission disk error", e);
         } finally {
             returnClient();
         }

--- a/fe/fe-core/src/main/jflex/sql_scanner.flex
+++ b/fe/fe-core/src/main/jflex/sql_scanner.flex
@@ -186,6 +186,7 @@ import org.apache.doris.qe.SqlModeHelper;
         keywordMap.put("describe", new Integer(SqlParserSymbols.KW_DESCRIBE));
         keywordMap.put("diagnose", new Integer(SqlParserSymbols.KW_DIAGNOSE));
         keywordMap.put("disk", new Integer(SqlParserSymbols.KW_DISK));
+        keywordMap.put("disks", new Integer(SqlParserSymbols.KW_DISKS));
         keywordMap.put("distinct", new Integer(SqlParserSymbols.KW_DISTINCT));
         keywordMap.put("distinctpc", new Integer(SqlParserSymbols.KW_DISTINCTPC));
         keywordMap.put("distinctpc", new Integer(SqlParserSymbols.KW_DISTINCTPC));

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/BackendTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/BackendTest.java
@@ -91,9 +91,9 @@ public class BackendTest {
     public void diskInfoTest() {
         Map<String, TDisk> diskInfos = new HashMap<String, TDisk>();
 
-        TDisk disk1 = new TDisk("/data1/", 1000, 800, true);
-        TDisk disk2 = new TDisk("/data2/", 2000, 700, true);
-        TDisk disk3 = new TDisk("/data3/", 3000, 600, false);
+        TDisk disk1 = new TDisk("/data1/", 1000, 800, true, false);
+        TDisk disk2 = new TDisk("/data2/", 2000, 700, true, false);
+        TDisk disk3 = new TDisk("/data3/", 3000, 600, false, false);
 
         diskInfos.put(disk1.getRootPath(), disk1);
         diskInfos.put(disk2.getRootPath(), disk2);

--- a/fe/fe-core/src/test/java/org/apache/doris/clone/RootPathLoadStatisticTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/clone/RootPathLoadStatisticTest.java
@@ -32,9 +32,9 @@ public class RootPathLoadStatisticTest {
     @Test
     public void test() {
         RootPathLoadStatistic usageLow = new RootPathLoadStatistic(0L, "/home/disk1", 12345L, TStorageMedium.HDD, 4096L,
-                1024L, DiskState.ONLINE);
+                1024L, DiskState.ONLINE, false);
         RootPathLoadStatistic usageHigh = new RootPathLoadStatistic(0L, "/home/disk2", 67890L, TStorageMedium.HDD,
-                4096L, 2048L, DiskState.ONLINE);
+                4096L, 2048L, DiskState.ONLINE, false);
 
         List<RootPathLoadStatistic> list = Lists.newArrayList();
         list.add(usageLow);

--- a/fe/fe-core/src/test/java/org/apache/doris/cluster/DecommissionDiskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cluster/DecommissionDiskTest.java
@@ -1,0 +1,118 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.cluster;
+
+import org.apache.doris.analysis.AlterSystemStmt;
+import org.apache.doris.catalog.DiskInfo;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.system.Backend;
+import org.apache.doris.thrift.TDisk;
+import org.apache.doris.utframe.TestWithFeService;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DecommissionDiskTest extends TestWithFeService {
+
+    @Override
+    protected int backendNum() {
+        return 3;
+    }
+
+    @Override
+    protected void beforeCluster() {
+        FeConstants.runningUnitTest = true;
+    }
+
+    @BeforeAll
+    public void beforeClass() {
+        FeConstants.runningUnitTest = true;
+    }
+
+    @Override
+    protected void beforeCreatingConnectContext() throws Exception {
+        FeConstants.default_scheduler_interval_millisecond = 1000;
+        FeConstants.tablet_checker_interval_ms = 1000;
+        Config.tablet_repair_delay_factor_second = 1;
+        Config.allow_replica_on_same_host = true;
+    }
+
+    @Test
+    public void testDecommissionDisk() throws Exception {
+        // 1. create connect context
+        connectContext = createDefaultCtx();
+
+        ImmutableMap<Long, Backend> idToBackendRef = Env.getCurrentSystemInfo().getIdToBackend();
+        Assertions.assertEquals(backendNum(), idToBackendRef.size());
+
+        // 2. create database db1
+        createDatabase("db1");
+        System.out.println(Env.getCurrentInternalCatalog().getDbNames());
+
+        // 3. create table tbl1
+        createTable("create table db1.tbl1(k1 int) distributed by hash(k1) buckets 3 properties('replication_num' = '1');");
+
+        // 4. query tablet num
+        int tabletNum = Env.getCurrentInvertedIndex().getTabletMetaMap().size();
+
+        // 5. execute decommission
+        Backend srcBackend = null;
+        for (Backend backend : idToBackendRef.values()) {
+            if (Env.getCurrentInvertedIndex().getTabletIdsByBackendId(backend.getId()).size() > 0) {
+                srcBackend = backend;
+                break;
+            }
+        }
+
+        List<DiskInfo> disks = srcBackend.getDisks().values().asList();
+        Assertions.assertEquals(1, disks.size());
+        DiskInfo disk = disks.get(0);
+
+        Assertions.assertTrue(srcBackend != null);
+        String decommissionStmtStr = "alter system decommission disk \"" + disk.getRootPath()
+                + "\" on \"127.0.0.1:" + srcBackend.getBePort() + "\"";
+        AlterSystemStmt decommissionStmt = (AlterSystemStmt) parseAndAnalyzeStmt(decommissionStmtStr);
+        Env.getCurrentEnv().getAlterInstance().processAlterCluster(decommissionStmt);
+
+        // 6. be heartbeat to fe
+        Map<String, TDisk> diskInfos = new HashMap<>();
+        TDisk disk1 = new TDisk(disk.getRootPath(), disk.getTotalCapacityB(), disk.getDiskUsedCapacityB(), true, true);
+        diskInfos.put(disk1.getRootPath(), disk1);
+        srcBackend.updateDisks(diskInfos);
+
+        // 7. clone replica from decommission disk to others, and delete decommissioned replica;
+        long startTimestamp = System.currentTimeMillis();
+        while (System.currentTimeMillis() - startTimestamp < 90000
+                && 0 < Env.getCurrentInvertedIndex().getTabletIdNumByBackendIdAndPathHash(
+                        srcBackend.getId(), disk.getPathHash())) {
+            Thread.sleep(1000);
+        }
+        Assertions.assertEquals(0, Env.getCurrentInvertedIndex().getTabletIdNumByBackendIdAndPathHash(
+                srcBackend.getId(), disk.getPathHash()));
+        Assertions.assertEquals(tabletNum,
+                Env.getCurrentInvertedIndex().getTabletMetaMap().size());
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/common/GenericPoolTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/GenericPoolTest.java
@@ -24,6 +24,7 @@ import org.apache.doris.thrift.TAgentTaskRequest;
 import org.apache.doris.thrift.TCancelPlanFragmentParams;
 import org.apache.doris.thrift.TCancelPlanFragmentResult;
 import org.apache.doris.thrift.TCheckStorageFormatResult;
+import org.apache.doris.thrift.TDecommissionDiskReq;
 import org.apache.doris.thrift.TDiskTrashInfo;
 import org.apache.doris.thrift.TExecPlanFragmentParams;
 import org.apache.doris.thrift.TExecPlanFragmentResult;
@@ -39,6 +40,7 @@ import org.apache.doris.thrift.TScanOpenParams;
 import org.apache.doris.thrift.TScanOpenResult;
 import org.apache.doris.thrift.TSnapshotRequest;
 import org.apache.doris.thrift.TStatus;
+import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.thrift.TStreamLoadRecordResult;
 import org.apache.doris.thrift.TTabletStatResult;
 import org.apache.doris.thrift.TTransmitDataParams;
@@ -214,6 +216,11 @@ public class GenericPoolTest {
         @Override
         public TCheckStorageFormatResult checkStorageFormat() throws TException {
             return new TCheckStorageFormatResult();
+        }
+
+        @Override
+        public TStatus decommissionDisk(TDecommissionDiskReq request) throws TException {
+            return new TStatus(TStatusCode.OK);
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/UnitTestUtil.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/UnitTestUtil.java
@@ -138,7 +138,7 @@ public class UnitTestUtil {
         Backend backend = createBackend(id, host, heartPort, bePort, httpPort);
         Map<String, TDisk> backendDisks = new HashMap<String, TDisk>();
         String rootPath = "root_path";
-        TDisk disk = new TDisk(rootPath, totalCapacityB, availableCapacityB, true);
+        TDisk disk = new TDisk(rootPath, totalCapacityB, availableCapacityB, true, false);
         backendDisks.put(rootPath, disk);
         backend.updateDisks(backendDisks);
         return backend;

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/MockedBackendFactory.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/MockedBackendFactory.java
@@ -34,6 +34,7 @@ import org.apache.doris.thrift.TCancelPlanFragmentParams;
 import org.apache.doris.thrift.TCancelPlanFragmentResult;
 import org.apache.doris.thrift.TCheckStorageFormatResult;
 import org.apache.doris.thrift.TCloneReq;
+import org.apache.doris.thrift.TDecommissionDiskReq;
 import org.apache.doris.thrift.TDiskTrashInfo;
 import org.apache.doris.thrift.TExecPlanFragmentParams;
 import org.apache.doris.thrift.TExecPlanFragmentResult;
@@ -294,6 +295,11 @@ public class MockedBackendFactory {
         @Override
         public TCheckStorageFormatResult checkStorageFormat() throws TException {
             return new TCheckStorageFormatResult();
+        }
+
+        @Override
+        public TStatus decommissionDisk(TDecommissionDiskReq request) throws TException {
+            return new TStatus(TStatusCode.OK);
         }
     }
 

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -457,3 +457,8 @@ struct TAgentPublishRequest {
     2: required list<TTopicUpdate> updates
 }
 
+struct TDecommissionDiskReq {
+    1: required list<string> root_paths;
+    2: required bool value;
+    3: optional i32 timeout_s;
+}

--- a/gensrc/thrift/BackendService.thrift
+++ b/gensrc/thrift/BackendService.thrift
@@ -174,4 +174,6 @@ service BackendService {
 
     // check tablet rowset type
     TCheckStorageFormatResult check_storage_format();
+
+    Status.TStatus decommission_disk(1: AgentService.TDecommissionDiskReq request);
 }

--- a/gensrc/thrift/MasterService.thrift
+++ b/gensrc/thrift/MasterService.thrift
@@ -81,6 +81,7 @@ struct TDisk {
     6: optional i64 path_hash
     7: optional Types.TStorageMedium storage_medium
     8: optional Types.TSize remote_used_capacity
+    9: required bool decommissioned;
 }
 
 struct TPluginInfo {


### PR DESCRIPTION
# Proposed changes

Issue Number: none

## Summary

### Steps of decommission disk:
1. FE parse sql and send TDecommissionDiskReq to BE;
2. BE create a file named decommission on the disk, and heartbeat to FE;
3. FE make the disk decommissioned，TS move replica to another disk based logic of cloning

### Sql

1. query tablets on disk
`show disks on "127.0.0.1:8572";`

2. decommission
`alter system decommission disk "/home/palo.HDD" on "127.0.0.1:8562";`

3. cancel decommission
`cancel decommission disk "/home/palo.HDD" on "127.0.0.1:8562";`

## Checklist(Required)

* [x] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

