### PR TITLE
[Enhancement](scanner) allocate blocks in scanner_context on demand and free them on close

### DIFF
--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -124,7 +124,7 @@ vectorized::BlockUPtr ScannerContext::get_free_block(bool* has_free_block,
         *has_free_block = _free_blocks_capacity > 0;
         // Always reduce _free_blocks_capacity by one since we always return a block
         if (_free_blocks_capacity > 0) {
-            -- _free_blocks_capacity;
+            --_free_blocks_capacity;
         }
 
         if (!_free_blocks.empty()) {
@@ -147,7 +147,7 @@ void ScannerContext::return_free_block(std::unique_ptr<vectorized::Block> block)
     _free_blocks_memory_usage->add(block->allocated_bytes());
     std::lock_guard l(_free_blocks_lock);
     _free_blocks.emplace_back(std::move(block));
-    ++ _free_blocks_capacity;
+    ++_free_blocks_capacity;
 }
 
 void ScannerContext::append_blocks_to_queue(std::vector<vectorized::BlockUPtr>& blocks) {

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -281,6 +281,7 @@ void ScannerContext::clear_and_join(VScanNode* node, RuntimeState* state) {
     _close_and_clear_scanners(node, state);
 
     _blocks_queue.clear();
+    std::unique_lock lock(_free_blocks_lock);
     _free_blocks.clear();
 }
 

--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -194,9 +194,13 @@ protected:
     std::atomic_bool _should_stop = false;
     std::atomic_bool _is_finished = false;
 
-    // Pre-allocated blocks for all scanners to share, for memory reuse.
+    // Lazy-allocated blocks for all scanners to share, for memory reuse.
     doris::Mutex _free_blocks_lock;
     std::vector<vectorized::BlockUPtr> _free_blocks;
+    // The current number of free blocks available to the scanners.
+    // Used to limit the memory usage of the scanner.
+    // NOTE: this is NOT the size of `_free_blocks`.
+    int32_t _free_blocks_capacity = 0;
 
     int _batch_size;
     // The limit from SQL's limit clause

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -288,8 +288,6 @@ Status VScanNode::_init_profile() {
     // time of scan thread to wait for worker thread of the thread pool
     _scanner_wait_worker_timer = ADD_TIMER(_runtime_profile, "ScannerWorkerWaitTime");
 
-    _pre_alloc_free_blocks_num =
-            ADD_COUNTER(_runtime_profile, "PreAllocFreeBlocksNum", TUnit::UNIT);
     _max_scanner_thread_num = ADD_COUNTER(_runtime_profile, "MaxScannerThreadNum", TUnit::UNIT);
 
     return Status::OK();

--- a/be/src/vec/exec/scan/vscan_node.h
+++ b/be/src/vec/exec/scan/vscan_node.h
@@ -356,8 +356,6 @@ protected:
     RuntimeProfile::Counter* _scanner_ctx_sched_counter = nullptr;
     RuntimeProfile::Counter* _scanner_wait_batch_timer = nullptr;
     RuntimeProfile::Counter* _scanner_wait_worker_timer = nullptr;
-    // Num of pre allocated free blocks
-    RuntimeProfile::Counter* _pre_alloc_free_blocks_num = nullptr;
     // Num of newly created free blocks when running query
     RuntimeProfile::Counter* _newly_create_free_blocks_num = nullptr;
     // Max num of scanner thread


### PR DESCRIPTION
# Proposed changes

Issue Number: close #19283 
## Problem summary
Firstly, to reduce memory usage, we do not pre-allocate blocks, instead we lazily allocate block when upper call `get_free_block`. And when upper call `return_free_block` to return free block, we add the block to a queue for memory reuse, and we will free the blocks in the queue when the scanner_context was closed instead of destructed.
Secondly, to limit the memory usage of the scanner, we introduce a variable `_free_blocks_capacity` to indicate the current number of free blocks available to the scanners. The number of scanners that can be scheduled will be calculated based on this value.

### ssb flat test
#### previous

- lineorder 1.2G: 
  - load time: 3s, query time: 0.355s
- lineorder 5.8G:
  - load time: 330s, query time: 0.970s
  - load time: 349s, query time: 0.949s
  - load time: 349s, query time: 0.955s
  - load time: 360s, query time: 0.889s (pipeline enabled)

#### after
- lineorder 1.2G: 
  - load time: 3s, query time: 0.349s
- lineorder 5.8G:
  - load time: 342s, query time: 0.929s
  - load time: 337s, query time: 0.913s
  - load time: 345s, query time: 0.946s
  - load time: 346s, query time: 0.865s  (pipeline enabled)

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [X] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

