### PR TITLE
[Fix](k8s) Fix wrong LOG import

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/deploy/impl/K8sDeployManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/deploy/impl/K8sDeployManager.java
@@ -39,7 +39,6 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.WatcherException;
-import jline.internal.Log;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -125,7 +124,7 @@ public class K8sDeployManager extends DeployManager {
             NodeTypeAttr nodeTypeAttr = nodeTypeAttrMap.get(nodeType);
             if (nodeTypeAttr.hasService()) {
                 String statefulSetEnvName = getStatefulSetEnvName(nodeType);
-                Log.info("Env name of: {} is: {}", nodeType.name(), statefulSetEnvName);
+                LOG.info("Env name of: {} is: {}", nodeType.name(), statefulSetEnvName);
                 String statefulSetName = Strings.nullToEmpty(System.getenv(statefulSetEnvName));
                 if (Strings.isNullOrEmpty(statefulSetName)) {
                     LOG.error("failed to init statefulSetName: {}", statefulSetEnvName);


### PR DESCRIPTION
# Proposed changes

This is a hotfix.

We should use `log4j` instead of `jline.internal.Log`.

![image](https://user-images.githubusercontent.com/95013770/236787817-e5e16f14-417e-42e9-8822-7e4ef1e87f1c.png)



## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

