### PR TITLE
[typo](docs) fix the wrong description about cte with

### DIFF
--- a/docs/en/docs/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/SELECT.md
+++ b/docs/en/docs/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/SELECT.md
@@ -145,8 +145,8 @@ To specify common table expressions, use the `WITH` clause with one or more comm
 
 ```sql
 WITH
-  cte1 AS（SELECT a，b FROM table1），
-  cte2 AS（SELECT c，d FROM table2）
+  cte1 AS (SELECT a，b FROM table1),
+  cte2 AS (SELECT c，d FROM table2)
 SELECT b，d FROM cte1 JOIN cte2
 WHERE cte1.a = cte2.c;
 ```
@@ -155,7 +155,7 @@ In a statement containing the `WITH` clause, each CTE name can be referenced to 
 
 CTE names can be referenced in other CTEs, allowing CTEs to be defined based on other CTEs.
 
-A CTE can refer to itself to define a recursive CTE. Common applications of recursive CTEs include sequence generation and traversal of hierarchical or tree-structured data.
+Recursive CTE is currently not supported.
 
 ### example
 
@@ -411,4 +411,3 @@ A CTE can refer to itself to define a recursive CTE. Common applications of recu
       - In the inner join condition, in addition to supporting equal-valued joins, it also supports unequal-valued joins. For performance reasons, it is recommended to use equal-valued joins.
       - Other joins only support equivalent joins
 
-   

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/SELECT.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/SELECT.md
@@ -145,8 +145,8 @@ UNION [ALL| DISTINCT] SELECT ......
 
 ```sql
 WITH
-  cte1 AS（SELECT a，b FROM table1），
-  cte2 AS（SELECT c，d FROM table2）
+  cte1 AS (SELECT a，b FROM table1),
+  cte2 AS (SELECT c，d FROM table2)
 SELECT b，d FROM cte1 JOIN cte2
 WHERE cte1.a = cte2.c;
 ```
@@ -155,7 +155,7 @@ WHERE cte1.a = cte2.c;
 
 CTE 名称可以在其他 CTE 中引用，从而可以基于其他 CTE 定义 CTE。
 
-CTE 可以引用自身来定义递归 CTE 。 递归 CTE 的常见应用包括分层或树状结构数据的序列生成和遍历。
+目前不止递归的 CTE。
 
 ### example
 

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/SELECT.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/SELECT.md
@@ -155,7 +155,7 @@ WHERE cte1.a = cte2.c;
 
 CTE 名称可以在其他 CTE 中引用，从而可以基于其他 CTE 定义 CTE。
 
-目前不止递归的 CTE。
+目前不支持递归的 CTE。
 
 ### example
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Recursive `cte with` is not supported yet.

What's Recursive `cte with` ? See the example below

```sql
create table t1(
  id int,
  name varchar(64),
  parent_id int
);

insert into t1 values
(1, '中国', 0),
(2, '北京市', 1),
(3, '广东省', 1),
(4, '深圳市', 3),
(5, '南山区', 4),
(6, '福田区', 4);

with RECURSIVE cte as (
    select id,name,parent_id
    from t1 where id=1
    union all
    select h.id, COALESCE(CONCAT(c.name, '/', h.name), h.name) as name, h.parent_id from t1 h inner join cte c on h.parent_id=c.id -- where c.id!=h.ID
) select * from cte;

-- here is the output
+------+--------------------------------------+-----------+
| id   | name                                 | parent_id |
+------+--------------------------------------+-----------+
|    1 | 中国                                 |         0 |
|    2 | 中国/北京市                          |         1 |
|    3 | 中国/广东省                          |         1 |
|    4 | 中国/广东省/深圳市                   |         3 |
|    5 | 中国/广东省/深圳市/南山区            |         4 |
|    6 | 中国/广东省/深圳市/福田区            |         4 |
+------+--------------------------------------+-----------+

```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [x] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

