### PR TITLE
[enhance](Cold&Heat separation) use file block cache for cold heat separation rowset

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -871,8 +871,7 @@ DEFINE_mInt64(file_cache_alive_time_sec, "604800");  // 1 week
 // "whole_file_cache": the whole file.
 DEFINE_mString(file_cache_type, "");
 DEFINE_Validator(file_cache_type, [](const std::string config) -> bool {
-    return config == "sub_file_cache" || config == "whole_file_cache" || config == "" ||
-           config == "file_block_cache";
+    return config == "" || config == "file_block_cache";
 });
 DEFINE_mInt64(file_cache_max_size_per_disk, "0"); // zero for no limit
 

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -869,9 +869,10 @@ DEFINE_mInt64(file_cache_alive_time_sec, "604800");  // 1 week
 // file_cache_type is used to set the type of file cache for remote files.
 // "": no cache, "sub_file_cache": split sub files from remote file.
 // "whole_file_cache": the whole file.
-DEFINE_mString(file_cache_type, "");
+DEFINE_mString(file_cache_type, "file_block_cache");
 DEFINE_Validator(file_cache_type, [](const std::string config) -> bool {
-    return config == "" || config == "file_block_cache";
+    return config == "sub_file_cache" || config == "whole_file_cache" || config == "" ||
+           config == "file_block_cache";
 });
 DEFINE_mInt64(file_cache_max_size_per_disk, "0"); // zero for no limit
 

--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -147,8 +147,8 @@ Status BetaRowset::load_segments(int64_t seg_id_begin, int64_t seg_id_end,
         std::shared_ptr<segment_v2::Segment> segment;
         io::SegmentCachePathPolicy cache_policy;
         cache_policy.set_cache_path(segment_cache_path(seg_id));
-        io::FileReaderOptions reader_options(io::cache_type_from_string(config::file_cache_type),
-                                             cache_policy);
+        auto type = config::enable_file_cache ? config::file_cache_type : "";
+        io::FileReaderOptions reader_options(io::cache_type_from_string(type), cache_policy);
         auto s = segment_v2::Segment::open(fs, seg_path, seg_id, rowset_id(), _schema,
                                            reader_options, &segment);
         if (!s.ok()) {
@@ -380,8 +380,8 @@ bool BetaRowset::check_current_rowset_segment() {
         std::shared_ptr<segment_v2::Segment> segment;
         io::SegmentCachePathPolicy cache_policy;
         cache_policy.set_cache_path(segment_cache_path(seg_id));
-        io::FileReaderOptions reader_options(io::cache_type_from_string(config::file_cache_type),
-                                             cache_policy);
+        auto type = config::enable_file_cache ? config::file_cache_type : "";
+        io::FileReaderOptions reader_options(io::cache_type_from_string(type), cache_policy);
         auto s = segment_v2::Segment::open(fs, seg_path, seg_id, rowset_id(), _schema,
                                            reader_options, &segment);
         if (!s.ok()) {

--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -149,7 +149,7 @@ Status BetaRowset::load_segments(int64_t seg_id_begin, int64_t seg_id_end,
         cache_policy.set_cache_path(segment_cache_path(seg_id));
         io::FileReaderOptions reader_options(io::cache_type_from_string(config::file_cache_type),
                                              cache_policy);
-        if (!is_local()) {
+        if (!is_local() && reader_options.cache_type != io::FileCachePolicy::NO_CACHE) {
             reader_options.cache_type = io::FileCachePolicy::FILE_BLOCK_CACHE;
         }
         auto s = segment_v2::Segment::open(fs, seg_path, seg_id, rowset_id(), _schema,
@@ -385,7 +385,7 @@ bool BetaRowset::check_current_rowset_segment() {
         cache_policy.set_cache_path(segment_cache_path(seg_id));
         io::FileReaderOptions reader_options(io::cache_type_from_string(config::file_cache_type),
                                              cache_policy);
-        if (!is_local()) {
+        if (!is_local() && reader_options.cache_type != io::FileCachePolicy::NO_CACHE) {
             reader_options.cache_type = io::FileCachePolicy::FILE_BLOCK_CACHE;
         }
         auto s = segment_v2::Segment::open(fs, seg_path, seg_id, rowset_id(), _schema,

--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -149,9 +149,6 @@ Status BetaRowset::load_segments(int64_t seg_id_begin, int64_t seg_id_end,
         cache_policy.set_cache_path(segment_cache_path(seg_id));
         io::FileReaderOptions reader_options(io::cache_type_from_string(config::file_cache_type),
                                              cache_policy);
-        if (!is_local() && reader_options.cache_type != io::FileCachePolicy::NO_CACHE) {
-            reader_options.cache_type = io::FileCachePolicy::FILE_BLOCK_CACHE;
-        }
         auto s = segment_v2::Segment::open(fs, seg_path, seg_id, rowset_id(), _schema,
                                            reader_options, &segment);
         if (!s.ok()) {
@@ -385,9 +382,6 @@ bool BetaRowset::check_current_rowset_segment() {
         cache_policy.set_cache_path(segment_cache_path(seg_id));
         io::FileReaderOptions reader_options(io::cache_type_from_string(config::file_cache_type),
                                              cache_policy);
-        if (!is_local() && reader_options.cache_type != io::FileCachePolicy::NO_CACHE) {
-            reader_options.cache_type = io::FileCachePolicy::FILE_BLOCK_CACHE;
-        }
         auto s = segment_v2::Segment::open(fs, seg_path, seg_id, rowset_id(), _schema,
                                            reader_options, &segment);
         if (!s.ok()) {

--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -149,6 +149,9 @@ Status BetaRowset::load_segments(int64_t seg_id_begin, int64_t seg_id_end,
         cache_policy.set_cache_path(segment_cache_path(seg_id));
         io::FileReaderOptions reader_options(io::cache_type_from_string(config::file_cache_type),
                                              cache_policy);
+        if (!is_local()) {
+            reader_options.cache_type = io::FileCachePolicy::FILE_BLOCK_CACHE;
+        }
         auto s = segment_v2::Segment::open(fs, seg_path, seg_id, rowset_id(), _schema,
                                            reader_options, &segment);
         if (!s.ok()) {
@@ -382,6 +385,9 @@ bool BetaRowset::check_current_rowset_segment() {
         cache_policy.set_cache_path(segment_cache_path(seg_id));
         io::FileReaderOptions reader_options(io::cache_type_from_string(config::file_cache_type),
                                              cache_policy);
+        if (!is_local()) {
+            reader_options.cache_type = io::FileCachePolicy::FILE_BLOCK_CACHE;
+        }
         auto s = segment_v2::Segment::open(fs, seg_path, seg_id, rowset_id(), _schema,
                                            reader_options, &segment);
         if (!s.ok()) {

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -149,6 +149,9 @@ Status BetaRowsetWriter::_load_noncompacted_segments(
         std::shared_ptr<segment_v2::Segment> segment;
         io::FileReaderOptions reader_options(io::cache_type_from_string(config::file_cache_type),
                                              io::SegmentCachePathPolicy());
+        if (!_rowset_meta->is_local()) {
+            reader_options.cache_type = io::FileCachePolicy::FILE_BLOCK_CACHE;
+        }
         auto s = segment_v2::Segment::open(fs, seg_path, seg_id, rowset_id(),
                                            _context.tablet_schema, reader_options, &segment);
         if (!s.ok()) {

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -149,7 +149,7 @@ Status BetaRowsetWriter::_load_noncompacted_segments(
         std::shared_ptr<segment_v2::Segment> segment;
         io::FileReaderOptions reader_options(io::cache_type_from_string(config::file_cache_type),
                                              io::SegmentCachePathPolicy());
-        if (!_rowset_meta->is_local()) {
+        if (!_rowset_meta->is_local() && reader_options.cache_type != io::FileCachePolicy::NO_CACHE) {
             reader_options.cache_type = io::FileCachePolicy::FILE_BLOCK_CACHE;
         }
         auto s = segment_v2::Segment::open(fs, seg_path, seg_id, rowset_id(),

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -149,9 +149,6 @@ Status BetaRowsetWriter::_load_noncompacted_segments(
         std::shared_ptr<segment_v2::Segment> segment;
         io::FileReaderOptions reader_options(io::cache_type_from_string(config::file_cache_type),
                                              io::SegmentCachePathPolicy());
-        if (!_rowset_meta->is_local() && reader_options.cache_type != io::FileCachePolicy::NO_CACHE) {
-            reader_options.cache_type = io::FileCachePolicy::FILE_BLOCK_CACHE;
-        }
         auto s = segment_v2::Segment::open(fs, seg_path, seg_id, rowset_id(),
                                            _context.tablet_schema, reader_options, &segment);
         if (!s.ok()) {

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -147,7 +147,8 @@ Status BetaRowsetWriter::_load_noncompacted_segments(
         auto seg_path =
                 BetaRowset::segment_file_path(_context.rowset_dir, _context.rowset_id, seg_id);
         std::shared_ptr<segment_v2::Segment> segment;
-        io::FileReaderOptions reader_options(io::cache_type_from_string(config::file_cache_type),
+        auto type = config::enable_file_cache ? config::file_cache_type : "";
+        io::FileReaderOptions reader_options(io::cache_type_from_string(type),
                                              io::SegmentCachePathPolicy());
         auto s = segment_v2::Segment::open(fs, seg_path, seg_id, rowset_id(),
                                            _context.tablet_schema, reader_options, &segment);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
For performance issue, we would specify rowset included by cold heat separation table to use file block cache no matter what config user has set.
I've tested the config using cold_heat_seperation_case_p2 and it works well.
![image](https://github.com/apache/doris/assets/43750022/bf1d8385-3e0b-4abc-bdc0-e3b3ee615136)

![image](https://github.com/apache/doris/assets/43750022/661571b8-c82a-4c3f-bac3-94c7e260c6ee)


![image](https://github.com/apache/doris/assets/43750022/69e0f1fa-2f77-4a9e-9752-9ecfd718e66c)

![image](https://github.com/apache/doris/assets/43750022/403a7804-b1bd-4b0a-8909-d29df07f805d)


## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

