### PR TITLE
[fix](MySQL) the way Doris handles boolean type is consistent with MySQL

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
@@ -423,7 +423,7 @@ public class BinaryPredicate extends Predicate implements Writable {
             return Type.LARGEINT;
         }
         // MySQL will try to parse string as bigint, if failed, will take string as 0.
-        if (t1 == PrimitiveType.BIGINT && (t2 == PrimitiveType.VARCHAR || t2 == PrimitiveType.STRING)) {
+        if (t1 == PrimitiveType.BIGINT && t2.isCharFamily()) {
             return Type.BIGINT;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
@@ -422,6 +422,10 @@ public class BinaryPredicate extends Predicate implements Writable {
                 && (t2 == PrimitiveType.BIGINT || t2 == PrimitiveType.LARGEINT)) {
             return Type.LARGEINT;
         }
+        // MySQL will try to parse string as bigint, if failed, will take string as 0.
+        if (t1 == PrimitiveType.BIGINT && (t2 == PrimitiveType.VARCHAR || t2 == PrimitiveType.STRING)) {
+            return Type.BIGINT;
+        }
 
         // Implicit conversion affects query performance.
         // For a common example datekey='20200825' which datekey is int type.

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/StringLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/StringLiteral.java
@@ -227,7 +227,14 @@ public class StringLiteral extends LiteralExpr {
                             throw new AnalysisException(e.getMessage());
                         }
                     }
-                    return new IntLiteral(value, targetType);
+                    // MySQL will try to parse string as bigint, if failed, will cast string as 0.
+                    long longValue;
+                    try {
+                        longValue = Long.parseLong(value);
+                    } catch (NumberFormatException e) {
+                        longValue = 0L;
+                    }
+                    return new IntLiteral(longValue, targetType);
                 case LARGEINT:
                     if (VariableVarConverters.hasConverter(beConverted)) {
                         try {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #19415

## Problem summary
When `where` clause contains boolean type and string, the way Doris handles boolean type is not consistent with MySQL.
For example, the table `boolean_test` is as follow:
```
+------------+------------+------------+
| boolean_01 | boolean_02 | boolean_03 |
+------------+------------+------------+
|       NULL |          1 |          0 |
|          0 |          1 |          0 |
|          1 |          0 |       NULL |
+------------+------------+------------+
```
1. For query `select * from boolean_test where boolean_01 = "true"`
```
-- doris will throw error like:
ERROR 5012 (HY000): errCode = 2, detailMessage = 'true' is not a number
-- mysql will take string "true" as integer 0, and cast 0 as false, so the result is:
+------------+------------+------------+
| boolean_01 | boolean_02 | boolean_03 |
+------------+------------+------------+
|          0 |          1 |          0 |
+------------+------------+------------+
```
2. For query `select * from boolean_test where boolean_01 = "1"`
```
-- doris and mysql will parse string "1" as integer 1, and cast 1 as true, so the result is:
+------------+------------+------------+
| boolean_01 | boolean_02 | boolean_03 |
+------------+------------+------------+
|          1 |          0 |       NULL |
+------------+------------+------------+
```
3. For query `select * from boolean_test where boolean_01 = "123"`
```
-- doris and mysql will parse string "123" as integer 123, and use 123 as the compared value, so the result is:
Empty set
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

