### PR TITLE
[improvement](executor)Split free block when using shared scan

### DIFF
--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -285,6 +285,8 @@ Status PipelineFragmentContext::prepare(const doris::TPipelineFragmentParams& re
                     find_with_default(local_params.per_node_shared_scans, scan_node->id(), false);
             scan_node->set_scan_ranges(scan_ranges);
             scan_node->set_shared_scan(_runtime_state.get(), shared_scan);
+            scan_node->set_scan_producer_group_num(scan_ranges.get().size(),
+                                                   _runtime_state->query_parallel_instance_num());
         } else {
             ScanNode* scan_node = static_cast<ScanNode*>(node);
             auto scan_ranges = find_with_default(local_params.per_node_scan_ranges, scan_node->id(),

--- a/be/src/vec/exec/scan/new_olap_scan_node.cpp
+++ b/be/src/vec/exec/scan/new_olap_scan_node.cpp
@@ -502,6 +502,7 @@ Status NewOlapScanNode::_init_scanners(std::list<VScannerSPtr>* scanners) {
         }
     }
 
+    int id = 0;
     auto build_new_scanner = [&](const TPaloScanRange& scan_range,
                                  const std::vector<OlapScanRange*>& key_ranges,
                                  const std::vector<RowsetReaderSharedPtr>& rs_readers,
@@ -509,7 +510,7 @@ Status NewOlapScanNode::_init_scanners(std::list<VScannerSPtr>* scanners) {
         std::shared_ptr<NewOlapScanner> scanner = NewOlapScanner::create_shared(
                 _state, this, _limit_per_scanner, _olap_scan_node.is_preaggregation, scan_range,
                 key_ranges, rs_readers, rs_reader_seg_offsets, _need_agg_finalize,
-                _scanner_profile.get());
+                _scanner_profile.get(), id++);
 
         scanner->set_compound_filters(_compound_filters);
         scanners->push_back(scanner);

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -60,7 +60,7 @@ NewOlapScanner::NewOlapScanner(RuntimeState* state, NewOlapScanNode* parent, int
                                const std::vector<OlapScanRange*>& key_ranges,
                                const std::vector<RowsetReaderSharedPtr>& rs_readers,
                                const std::vector<std::pair<int, int>>& rs_reader_seg_offsets,
-                               bool need_agg_finalize, RuntimeProfile* profile)
+                               bool need_agg_finalize, RuntimeProfile* profile, int scanner_id)
         : VScanner(state, static_cast<VScanNode*>(parent), limit, profile),
           _aggregation(aggregation),
           _need_agg_finalize(need_agg_finalize),
@@ -71,6 +71,7 @@ NewOlapScanner::NewOlapScanner(RuntimeState* state, NewOlapScanNode* parent, int
     _tablet_reader_params.rs_readers_segment_offsets = rs_reader_seg_offsets;
     _tablet_schema = std::make_shared<TabletSchema>();
     _is_init = false;
+    _scanner_id = scanner_id;
 }
 
 static std::string read_columns_to_string(TabletSchemaSPtr tablet_schema,

--- a/be/src/vec/exec/scan/new_olap_scanner.h
+++ b/be/src/vec/exec/scan/new_olap_scanner.h
@@ -57,7 +57,7 @@ public:
                    const TPaloScanRange& scan_range, const std::vector<OlapScanRange*>& key_ranges,
                    const std::vector<RowsetReaderSharedPtr>& rs_readers,
                    const std::vector<std::pair<int, int>>& rs_reader_seg_offsets,
-                   bool need_agg_finalize, RuntimeProfile* profile);
+                   bool need_agg_finalize, RuntimeProfile* profile, int id);
 
     Status init() override;
 
@@ -70,6 +70,8 @@ public:
     void set_compound_filters(const std::vector<TCondition>& compound_filters);
 
     doris::TabletStorageType get_storage_type() override;
+
+    int scanner_id() override { return _scanner_id; }
 
 protected:
     Status _get_block_impl(RuntimeState* state, Block* block, bool* eos) override;
@@ -100,6 +102,8 @@ private:
     std::vector<uint32_t> _return_columns;
     std::unordered_set<uint32_t> _tablet_columns_convert_to_null_set;
     std::vector<TCondition> _compound_filters;
+
+    int _scanner_id = 0;
 
     // ========= profiles ==========
     int64_t _compressed_bytes_read = 0;

--- a/be/src/vec/exec/scan/vscanner.h
+++ b/be/src/vec/exec/scan/vscanner.h
@@ -66,6 +66,8 @@ public:
 
     virtual std::string get_name() { return ""; }
 
+    virtual int scanner_id() { return 0; }
+
 protected:
     // Subclass should implement this to return data.
     virtual Status _get_block_impl(RuntimeState* state, Block* block, bool* eof) = 0;


### PR DESCRIPTION
# Proposed changes
When exec shared scan,  multiple scanners visit freeblocks may cause performance bottleneck in tpch q17.
So we need to split free blocks to reduce competition.

# Key Design
Introducing _scan_producer_group_num, it means the group num which shared variables of producer should divied into.
For example, we pre-allocate 100 freeblocks, we should divide them to ```_scan_producer_group_num```  groups.

# Performance Impromvent Test
tpch q17
pipeline + not shared scan:  0.3s
pipeline + force shared scan: 0.6s (this is a bad case)
pipeline + force shared scan after: 0.31s (```after``` means split freeblock)

# Performance Rollback Test

```before ``` means pipline shared scan.

clickbench 1 bucket test
```
c8 before: 43.4
c8 after: 43.69
c16 before: 31.77
c16 after:30.52
```

clickbench 48 bucket test
```
c8 before: 43.4
c8 after: 43.08
c16 before: 29.96
c16 after: 30.83
```

## Checklist(Required)

* [x] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

