### PR TITLE
[fix](inverted index) fix query fail caused by FullTextIndexReader not check index file whether exists

### DIFF
--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.h
@@ -155,46 +155,46 @@ public:
 
 class InvertedIndexVisitor : public lucene::util::bkd::bkd_reader::intersect_visitor {
 private:
-    roaring::Roaring* hits;
-    uint32_t num_hits;
-    bool only_count;
-    lucene::util::bkd::bkd_reader* reader;
-    InvertedIndexQueryType query_type;
+    roaring::Roaring* _hits;
+    uint32_t _num_hits;
+    bool _only_count;
+    lucene::util::bkd::bkd_reader* _reader;
+    InvertedIndexQueryType _query_type;
 
 public:
-    std::string queryMin;
-    std::string queryMax;
+    std::string query_min;
+    std::string query_max;
 
 public:
     InvertedIndexVisitor(roaring::Roaring* hits, InvertedIndexQueryType query_type,
                          bool only_count = false);
     virtual ~InvertedIndexVisitor() = default;
 
-    void set_reader(lucene::util::bkd::bkd_reader* r) { reader = r; }
-    lucene::util::bkd::bkd_reader* get_reader() { return reader; }
+    void set_reader(lucene::util::bkd::bkd_reader* r) { _reader = r; }
+    lucene::util::bkd::bkd_reader* get_reader() { return _reader; }
 
-    void visit(int rowID) override;
+    void visit(int row_id) override;
     void visit(roaring::Roaring& r) override;
     void visit(roaring::Roaring&& r) override;
-    void visit(roaring::Roaring* docID, std::vector<uint8_t>& packedValue) override;
-    void visit(std::vector<char>& docID, std::vector<uint8_t>& packedValue) override;
-    void visit(int rowID, std::vector<uint8_t>& packedValue) override;
+    void visit(roaring::Roaring* doc_id, std::vector<uint8_t>& packed_value) override;
+    void visit(std::vector<char>& doc_id, std::vector<uint8_t>& packed_value) override;
+    void visit(int row_id, std::vector<uint8_t>& packed_value) override;
     void visit(lucene::util::bkd::bkd_docid_set_iterator* iter,
-               std::vector<uint8_t>& packedValue) override;
-    bool matches(uint8_t* packedValue);
-    lucene::util::bkd::relation compare(std::vector<uint8_t>& minPacked,
-                                        std::vector<uint8_t>& maxPacked) override;
-    uint32_t get_num_hits() const { return num_hits; }
+               std::vector<uint8_t>& packed_value) override;
+    bool matches(uint8_t* packed_value);
+    lucene::util::bkd::relation compare(std::vector<uint8_t>& min_packed,
+                                        std::vector<uint8_t>& max_packed) override;
+    uint32_t get_num_hits() const { return _num_hits; }
 };
 
 class BkdIndexReader : public InvertedIndexReader {
 public:
     explicit BkdIndexReader(io::FileSystemSPtr fs, const std::string& path, const uint32_t uniq_id);
     ~BkdIndexReader() override {
-        if (compoundReader != nullptr) {
-            compoundReader->close();
-            delete compoundReader;
-            compoundReader = nullptr;
+        if (_compoundReader != nullptr) {
+            _compoundReader->close();
+            delete _compoundReader;
+            _compoundReader = nullptr;
         }
     }
 
@@ -218,7 +218,7 @@ public:
 private:
     const TypeInfo* _type_info {};
     const KeyCoder* _value_key_coder {};
-    DorisCompoundReader* compoundReader;
+    DorisCompoundReader* _compoundReader;
 };
 
 class InvertedIndexIterator {


### PR DESCRIPTION
# Proposed changes

(1) = predicate should support INVERTED_INDEX_FILE_NOT_FOUND error.
![image](https://user-images.githubusercontent.com/67053339/236658095-89085283-c8ed-4c8f-aca7-91359710dab6.png)

the problem:
FullTextIndexReader doesn't check file and throws CLuceneError directly and lead to query error.
![image](https://user-images.githubusercontent.com/67053339/236657723-276abc97-4388-4fd0-ba66-d27b31018372.png)

(2) refactor some java style code in C++ file

(3) fix MatchPredicate dose not check the error code

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

