### PR TITLE
[bugfix](jsonb) cherry-pick for 1.2: fix jsonb parser crash on noavx2 host (#18977)

### DIFF
--- a/be/src/runtime/jsonb_value.h
+++ b/be/src/runtime/jsonb_value.h
@@ -22,7 +22,11 @@
 #include "util/cpu_info.h"
 #include "util/hash_util.hpp"
 #include "util/jsonb_error.h"
+#ifdef __AVX2__
 #include "util/jsonb_parser_simd.h"
+#else
+#include "util/jsonb_parser.h"
+#endif
 #include "util/jsonb_utils.h"
 #include "vec/common/string_ref.h"
 
@@ -38,7 +42,7 @@ struct JsonBinaryValue {
     // default nullprt and size 0 for invalid or NULL value
     const char* ptr = nullptr;
     size_t len = 0;
-    JsonbParserSIMD parser;
+    JsonbParser parser;
 
     JsonBinaryValue() : ptr(nullptr), len(0) {}
     JsonBinaryValue(char* ptr, int len) { from_json_string(const_cast<const char*>(ptr), len); }

--- a/be/src/util/jsonb_document.h
+++ b/be/src/util/jsonb_document.h
@@ -74,6 +74,9 @@
 
 // #include "util/string_parser.hpp"
 
+#include "common/compiler_util.h"
+#include "common/logging.h"
+
 namespace doris {
 
 #pragma pack(push, 1)

--- a/be/src/util/jsonb_parser.h
+++ b/be/src/util/jsonb_parser.h
@@ -665,12 +665,15 @@ private:
             case 4:
                 *--out = ((uc | 0x80) & 0xBF);
                 uc >>= 6;
+                [[fallthrough]];
             case 3:
                 *--out = ((uc | 0x80) & 0xBF);
                 uc >>= 6;
+                [[fallthrough]];
             case 2:
                 *--out = ((uc | 0x80) & 0xBF);
                 uc >>= 6;
+                [[fallthrough]];
             case 1:
                 // Mask the first byte according to the standard.
                 *--out = (uc | firstByteMark[len - 1]);

--- a/be/src/util/jsonb_parser_simd.h
+++ b/be/src/util/jsonb_parser_simd.h
@@ -343,7 +343,7 @@ private:
     JsonbErrType err_;
 };
 
-using JsonbParserSIMD = JsonbParserTSIMD<JsonbOutStream>;
+using JsonbParser = JsonbParserTSIMD<JsonbOutStream>;
 
 } // namespace doris
 

--- a/be/src/vec/functions/function_json.cpp
+++ b/be/src/vec/functions/function_json.cpp
@@ -23,6 +23,11 @@
 #include <vector>
 
 #include "exprs/json_functions.h"
+#ifdef __AVX2__
+#include "util/jsonb_parser_simd.h"
+#else
+#include "util/jsonb_parser.h"
+#endif
 #include "util/string_parser.hpp"
 #include "util/string_util.h"
 #include "vec/columns/column.h"

--- a/be/src/vec/functions/function_jsonb.cpp
+++ b/be/src/vec/functions/function_jsonb.cpp
@@ -18,7 +18,11 @@
 #include <boost/token_functions.hpp>
 #include <vector>
 
-// #include "util/jsonb_parser_simd.h"
+#ifdef __AVX2__
+#include "util/jsonb_parser_simd.h"
+#else
+#include "util/jsonb_parser.h"
+#endif
 #include "util/string_parser.hpp"
 #include "util/string_util.h"
 #include "vec/columns/column.h"
@@ -48,7 +52,7 @@ enum class JsonbParseErrorMode { FAIL = 0, RETURN_NULL, RETURN_VALUE, RETURN_INV
 template <NullalbeMode nullable_mode, JsonbParseErrorMode parse_error_handle_mode>
 class FunctionJsonbParseBase : public IFunction {
 private:
-    JsonbParserSIMD default_value_parser;
+    JsonbParser default_value_parser;
     bool has_const_default_value = false;
 
 public:
@@ -195,7 +199,7 @@ public:
         col_to->reserve(size);
 
         // parser can be reused for performance
-        JsonbParserSIMD parser;
+        JsonbParser parser;
         JsonbErrType error = JsonbErrType::E_NONE;
 
         for (size_t i = 0; i < input_rows_count; ++i) {


### PR DESCRIPTION

# Proposed changes

Issue Number: pick #18977

## Problem summary

support avx2 and noavx2 for jsonb parser using __AVX2__ macro.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

