### PR TITLE
[fix](multicatalog) fix read parquet file failure from gfs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveScanProvider.java
@@ -127,7 +127,7 @@ public class HiveScanProvider extends HMSTableScanProvider {
             } else if (location.startsWith(FeConstants.FS_PREFIX_OFS)) {
                 return TFileType.FILE_BROKER;
             } else if (location.startsWith(FeConstants.FS_PREFIX_GFS)) {
-                return TFileType.FILE_BROKER;
+                return TFileType.FILE_HDFS;
             } else if (location.startsWith(FeConstants.FS_PREFIX_JFS)) {
                 return TFileType.FILE_BROKER;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/iceberg/IcebergScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/iceberg/IcebergScanProvider.java
@@ -132,7 +132,7 @@ public class IcebergScanProvider extends QueryScanProvider {
             } else if (location.startsWith(FeConstants.FS_PREFIX_OFS)) {
                 return TFileType.FILE_BROKER;
             } else if (location.startsWith(FeConstants.FS_PREFIX_GFS)) {
-                return TFileType.FILE_BROKER;
+                return TFileType.FILE_HDFS;
             } else if (location.startsWith(FeConstants.FS_PREFIX_JFS)) {
                 return TFileType.FILE_BROKER;
             }


### PR DESCRIPTION
fix issue: Invalid magic number in parquet file

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

