### PR TITLE
[branch1.2](fix) avoiding using broker reader when file size can not be got

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveSplit.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveSplit.java
@@ -23,10 +23,11 @@ import org.apache.hadoop.mapred.FileSplit;
 
 @Data
 public class HiveSplit extends FileSplit {
-    public HiveSplit() {}
+    private long fileSize;
 
-    public HiveSplit(Path file, long start, long length, String[] hosts) {
+    public HiveSplit(Path file, long start, long length, long fileSize, String[] hosts) {
         super(file, start, length, hosts);
+        this.fileSize = fileSize;
     }
 
     protected TableFormatType tableFormatType;

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/iceberg/IcebergScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/iceberg/IcebergScanProvider.java
@@ -175,7 +175,7 @@ public class IcebergScanProvider extends QueryScanProvider {
             for (FileScanTask splitTask : task.split(128 * 1024 * 1024)) {
                 String dataFilePath = splitTask.file().path().toString();
                 IcebergSplit split = new IcebergSplit(new Path(dataFilePath), splitTask.start(),
-                        splitTask.length(), new String[0]);
+                        splitTask.length(), task.file().fileSizeInBytes(), new String[0]);
                 split.setFormatVersion(formatVersion);
                 if (formatVersion >= MIN_DELETE_FILE_SUPPORT_VERSION) {
                     split.setDeleteFileFilters(getDeleteFileFilters(splitTask));

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/iceberg/IcebergSplit.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/iceberg/IcebergSplit.java
@@ -27,8 +27,8 @@ import java.util.List;
 
 @Data
 public class IcebergSplit extends HiveSplit {
-    public IcebergSplit(Path file, long start, long length, String[] hosts) {
-        super(file, start, length, hosts);
+    public IcebergSplit(Path file, long start, long length, long fileSize, String[] hosts) {
+        super(file, start, length, fileSize, hosts);
     }
 
     private Analyzer analyzer;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

The broker reader need file size info.
But for each file type, such as parquet, we can not get file size of `InputFormat.getSplits()`.
So throw exception for this case and recommend to use hdfs or s3 reader.

And also for IcebergSplit, get the right file size.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

