### PR TITLE
[Enhancement] show total transactions in show proc "/transactions"

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/TransDbProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/TransDbProcDir.java
@@ -19,15 +19,10 @@ package org.apache.doris.common.proc;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.util.ListComparator;
 import org.apache.doris.transaction.GlobalTransactionMgr;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 public class TransDbProcDir implements ProcDirInterface {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
@@ -44,19 +39,8 @@ public class TransDbProcDir implements ProcDirInterface {
         BaseProcResult result = new BaseProcResult();
         result.setNames(TITLE_NAMES);
         GlobalTransactionMgr transactionMgr = Env.getCurrentGlobalTransactionMgr();
-        List<List<Comparable>> infos = transactionMgr.getDbInfo();
-        // order by dbId, asc
-        ListComparator<List<Comparable>> comparator = new ListComparator<List<Comparable>>(0);
-        Collections.sort(infos, comparator);
-        for (List<Comparable> info : infos) {
-            List<String> row = new ArrayList<String>(info.size());
-            for (Comparable comparable : info) {
-                row.add(comparable.toString());
-            }
-            result.addRow(row);
-        }
+        result.addRows(transactionMgr.getDbInfo());
         return result;
-
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
@@ -55,6 +55,8 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -492,12 +494,14 @@ public class GlobalTransactionMgr implements Writable {
         }
     }
 
-    public List<List<Comparable>> getDbInfo() {
-        List<List<Comparable>> infos = new ArrayList<List<Comparable>>();
+    public List<List<String>> getDbInfo() {
+        List<List<String>> infos = new ArrayList<>();
+        long totalRunningNum = 0;
         List<Long> dbIds = Lists.newArrayList(dbIdToDatabaseTransactionMgrs.keySet());
+        Collections.sort(dbIds);
         for (long dbId : dbIds) {
-            List<Comparable> info = new ArrayList<Comparable>();
-            info.add(dbId);
+            List<String> info = new ArrayList<>();
+            info.add(String.valueOf(dbId));
             Database db = Env.getCurrentInternalCatalog().getDbNullable(dbId);
             if (db == null) {
                 continue;
@@ -507,12 +511,15 @@ public class GlobalTransactionMgr implements Writable {
             try {
                 DatabaseTransactionMgr dbMgr = getDatabaseTransactionMgr(dbId);
                 runningNum = dbMgr.getRunningTxnNums() + dbMgr.getRunningRoutineLoadTxnNums();
+                totalRunningNum += runningNum;
             } catch (AnalysisException e) {
                 LOG.warn("get database running transaction num failed", e);
             }
-            info.add(runningNum);
+            info.add(String.valueOf(runningNum));
             infos.add(info);
         }
+        List<String> info = Arrays.asList("Total", String.valueOf(dbIds.size()), String.valueOf(totalRunningNum));
+        infos.add(info);
         return infos;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
@@ -518,7 +518,7 @@ public class GlobalTransactionMgr implements Writable {
             info.add(String.valueOf(runningNum));
             infos.add(info);
         }
-        List<String> info = Arrays.asList("Total", String.valueOf(dbIds.size()), String.valueOf(totalRunningNum));
+        List<String> info = Arrays.asList("0", "Total", String.valueOf(totalRunningNum));
         infos.add(info);
         return infos;
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

In a scenario where multiple DBs are simultaneously imported with high concurrency, a significant number of transactions will be generated. Without a summary field, we cannot clearly see how many transactions there are in the current cluster. Therefore, I have enhanced this point.

```
mysql> show proc "/transactions";
+-------+-----------------------------------+-----------------------+
| DbId     | DbName                                             | RunningTransactionNum |
+-------+-----------------------------------+-----------------------+
| 10002   | default_cluster:xxxx                         | 0                                     |
| 14005   | default_cluster:__internal_schema | 0                                     |
| Total     |  2                                                         | 0                                     |
+-------+-----------------------------------+-----------------------+
3 rows in set (0.02 sec)
```

![image](https://github.com/apache/doris/assets/24907215/23314348-2a60-48fa-9903-b032fad09a54)

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

