### PR TITLE
[bugfix](core) be will core when coordinator callback

### DIFF
--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -395,6 +395,13 @@ void PInternalServiceImpl::tablet_writer_cancel(google::protobuf::RpcController*
 
 Status PInternalServiceImpl::_exec_plan_fragment(const std::string& ser_request,
                                                  PFragmentRequestVersion version, bool compact) {
+    // Sometimes the BE do not receive the first heartbeat message and it receives request from FE
+    // If BE execute this fragment, it will core when it wants to get some property from master info.
+    if (ExecEnv::GetInstance()->master_info() == nullptr) {
+        return Status::InternalError(
+                "Have not receive the first heartbeat message from master, not ready to provide "
+                "service");
+    }
     if (version == PFragmentRequestVersion::VERSION_1) {
         // VERSION_1 should be removed in v1.2
         TExecPlanFragmentParams t_request;


### PR DESCRIPTION
# Proposed changes

#0  0x000055d13177e8e1 in doris::FragmentMgr::coordinator_callback(doris::ReportStatusRequest const&) ()
#1  0x000055d13185333f in void std::__invoke_impl<void, void (doris::FragmentMgr::* const&)(doris::ReportStatusRequest const&), doris::FragmentMgr*&, doris::ReportStatusRequest>(std::__invoke_memfun_deref, void (doris::FragmentMgr::* const&)(doris::ReportStatusRequest const&), doris::FragmentMgr*&, doris::ReportStatusRequest&&) ()
#2  0x000055d13185315b in std::__invoke_result<void (doris::FragmentMgr::* const&)(doris::ReportStatusRequest const&), doris::FragmentMgr*&, doris::ReportStatusRequest>::type std::__invoke<void (doris::FragmentMgr::* const&)(doris::ReportStatusRequest const&), doris::FragmentMgr*&, doris::ReportStatusRequest>(void (doris::FragmentMgr::* const&)(doris::ReportStatusRequest const&), doris::FragmentMgr*&, doris::ReportStatusRequest&&) ()
#3  0x000055d131853073 in std::_Mem_fn_base<void (doris::FragmentMgr::*)(doris::ReportStatusRequest const&), true>::operator()<doris::FragmentMgr*&, doris::ReportStatusRequest> ()
#4  0x000055d131852f5d in void std::__invoke_impl<void, std::_Mem_fn<void (doris::FragmentMgr::*)(doris::ReportStatusRequest const&)>&, doris::FragmentMgr*&, doris::ReportStatusRequest>(std::__invoke_other, std::_Mem_fn<void (doris::FragmentMgr::*)(doris::ReportStatusRequest const&)>&, doris::FragmentMgr*&, doris::ReportStatusRequest&&) ()
#5  0x000055d131852b7d in std::enable_if<is_invocable_r_v<void, std::_Mem_fn<void (doris::FragmentMgr::*)(doris::ReportStatusRequest const&)>&, doris::FragmentMgr*&, doris::ReportStatusRequest>, void>::type std::__invoke_r<void, std::_Mem_fn<void (doris::FragmentMgr::*)(doris::ReportStatusRequest const&)>&, doris::FragmentMgr*&, doris::ReportStatusRequest>(std::_Mem_fn<void (doris::FragmentMgr::*)(doris::ReportStatusRequest const&)>&, doris::FragmentMgr*&, doris::ReportStatusRequest&&) ()
#6  0x000055d1318529d0 in void std::_Bind_result<void, std::_Mem_fn<void (doris::FragmentMgr::*)(doris::ReportStatusRequest const&)> (doris::FragmentMgr*, std::_Placeholder<1>)>::__call<void, doris::ReportStatusRequest&&, 0ul, 1ul>(std::tuple<doris::ReportStatusRequest&&>&&, std::_Index_tuple<0ul, 1ul>) ()
#7  0x000055d131852784 in void std::_Bind_result<void, std::_Mem_fn<void (doris::FragmentMgr::*)(doris::ReportStatusRequest const&)> (doris::FragmentMgr*, std::_Placeholder<1>)>::operator()<doris::ReportStatusRequest>(doris::ReportStatusRequest&&) ()
#8  0x000055d1318526cf in void std::__invoke_impl<void, std::_Bind_result<void, std::_Mem_fn<void (doris::FragmentMgr::*)(doris::ReportStatusRequest const&)> (doris::FragmentMgr*, std::_Placeholder<1>)>&, doris::ReportStatusRequest>(std::__invoke_other, std::_Bind_result<void, std::_Mem_fn<void (doris::FragmentMgr::*)(doris::ReportStatusRequest const&)> (doris::FragmentMgr*, std::_Placeholder<1>)>&, doris::ReportStatusRequest&&) ()
#9  0x000055d131852581 in std::enable_if<is_invocable_r_v<void, std::_Bind_result<void, std::_Mem_fn<void (doris::FragmentMgr::*)(doris::ReportStatusRequest const&)> (doris::FragmentMgr*, std::_Placeholder<1>)>&, doris::ReportStatusRequest>, void>::type std::__invoke_r<void, std::_Bind_result<void, std::_Mem_fn<void (doris::FragmentMgr::*)(doris::ReportStatusRequest const&)> (doris::FragmentMgr*, std::_Placeholder<1>)>&, doris::ReportStatusRequest>(std::_Bind_result<void, std::_Mem_fn<void (doris::FragmentMgr::*)(doris::ReportStatusRequest const&)> (doris::FragmentMgr*, std::_Placeholder<1>)>&, doris::ReportStatusRequest&&) ()
#10 0x000055d131851aeb in std::_Function_handler<void (doris::ReportStatusRequest), std::_Bind_result<void, std::_Mem_fn<void (doris::FragmentMgr::*)(doris::ReportStatusRequest const&)> (doris::FragmentMgr*, std::_Placeholder<1>)> >::_M_invoke(std::_Any_data const&, doris::ReportStatusRequest&&) ()
#11 0x000055d1317a2ce5 in std::function<void (doris::ReportStatusRequest)>::operator()(doris::ReportStatusRequest) const ()
#12 0x000055d131775f75 in doris::FragmentExecState::coordinator_callback(doris::Status const&, doris::RuntimeProfile*, bool) ()
#13 0x000055d131829eec in void std::__invoke_impl<void, void (doris::FragmentExecState::* const&)(doris::Status const&, doris::RuntimeProfile*, bool), doris::FragmentExecState*&, doris::Status const&, doris::RuntimeProfile*, bool>(std::__invoke_memfun_deref, void (doris::FragmentExecState::* const&)(doris::Status const&, doris::RuntimeProfile*, bool), doris::FragmentExecState*&, doris::Status const&, doris::RuntimeProfile*&&, bool&&) ()
#14 0x000055d131829d01 in std::__invoke_result<void (doris::FragmentExecState::* const&)(doris::Status const&, doris::RuntimeProfile*, bool), doris::FragmentExecState*&, doris::Status const&, doris::RuntimeProfile*, bool>::type std::__invoke<void (doris::FragmentExecState::* const&)(doris::Status const&, doris::RuntimeProfile*, bool), doris::FragmentExecState*&, doris::Status const&, doris::RuntimeProfile*, bool>(void (doris::FragmentExecState::* const&)(doris::Status const&, doris::RuntimeProfile*, bool), doris::FragmentExecState*&, doris::Status const&, doris::RuntimeProfile*&&, bool&&) ()
#15 0x000055d131829bb9 in std::_Mem_fn_base<void (doris::FragmentExecState::*)(doris::Status const&, doris::RuntimeProfile*, bool), true>::operator()<doris::FragmentExecState*&, doris::Status const&, doris::RuntimeProfile*, bool> ()
#16 0x000055d131829a43 in void std::__invoke_impl<void, std::_Mem_fn<void (doris::FragmentExecState::*)(doris::Status const&, doris::RuntimeProfile*, bool)>&, doris::FragmentExecState*&, doris::Status const&, doris::RuntimeProfile*, bool>(std::__invoke_other, std::_Mem_fn<void (doris::FragmentExecState::*)(doris::Status const&, doris::RuntimeProfile*, bool)>&, doris::FragmentExecState*&, doris::Status const&, doris::RuntimeProfile*&&, bool&&) ()
#17 0x000055d131829343 in std::enable_if<is_invocable_r_v<void, std::_Mem_fn<void (doris::FragmentExecState::*)(doris::Status const&, doris::RuntimeProfile*, bool)>&, doris::FragmentExecState*&, doris::Status const&, doris::RuntimeProfile*, bool>, void>::type std::__invoke_r<void, std::_Mem_fn<void (doris::FragmentExecState::*)(doris::Status const&, doris::RuntimeProfile*, bool)>&, doris::FragmentExecState*&, doris::Status const&, doris::RuntimeProfile*, bool>(std::_Mem_fn<void (doris::FragmentExecState::*)(doris::Status const&, doris::RuntimeProfile*, bool)>&, doris::FragmentExecState*&, doris::Status const&, doris::RuntimeProfile*&&, bool&&) ()
#18 0x000055d1318290c2 in void std::_Bind_result<void, std::_Mem_fn<void (doris::FragmentExecState::*)(doris::Status const&, doris::RuntimeProfile*, bool)> (doris::FragmentExecState*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>)>::__call<void, doris::Status const&, doris::RuntimeProfile*&&, bool&&, 0ul, 1ul, 2ul, 3ul>(std::tuple<doris::Status const&, doris::RuntimeProfile*&&, bool&&>&&, std::_Index_tuple<0ul, 1ul, 2ul, 3ul>) ()
#19 0x000055d131828cca in void std::_Bind_result<void, std::_Mem_fn<void (doris::FragmentExecState::*)(doris::Status const&, doris::RuntimeProfile*, bool)> (doris::FragmentExecState*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>)>::operator()<doris::Status const&, doris::RuntimeProfile*, bool>(doris::Status const&, doris::RuntimeProfile*&&, bool&&) ()
#20 0x000055d131828bb5 in void std::__invoke_impl<void, std::_Bind_result<void, std::_Mem_fn<void (doris::FragmentExecState::*)(doris::Status const&, doris::RuntimeProfile*, bool)> (doris::FragmentExecState*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>)>&, doris::Status const&, doris::RuntimeProfile*, bool>(std::__invoke_other, std::_Bind_result<void, std::_Mem_fn<void (doris::FragmentExecState::*)(doris::Status const&, doris::RuntimeProfile*, bool)> (doris::FragmentExecState*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>)>&, doris::Status const&, doris::RuntimeProfile*&&, bool&&) ()
#21 0x000055d131828a07 in std::enable_if<is_invocable_r_v<void, std::_Bind_result<void, std::_Mem_fn<void (doris::FragmentExecState::*)(doris::Status const&, doris::RuntimeProfile*, bool)> (doris::FragmentExecState*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>)>&, doris::Status const&, doris::RuntimeProfile*, bool>, void>::type std::__invoke_r<void, std::_Bind_result<void, std::_Mem_fn<void (doris::FragmentExecState::*)(doris::Status const&, doris::RuntimeProfile*, bool)> (doris::FragmentExecState*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>)>&, doris::Status const&, doris::RuntimeProfile*, bool>(std::_Bind_result<void, std::_Mem_fn<void (doris::FragmentExecState::*)(doris::Status const&, doris::RuntimeProfile*, bool)> (doris::FragmentExecState*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>)>&, doris::Status const&, doris::RuntimeProfile*&&, bool&&) ()
#22 0x000055d1318278d1 in std::_Function_handler<void (doris::Status const&, doris::RuntimeProfile*, bool), std::_Bind_result<void, std::_Mem_fn<void (doris::FragmentExecState::*)(doris::Status const&, doris::RuntimeProfile*, bool)> (doris::FragmentExecState*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>)> >::_M_invoke(std::_Any_data const&, doris::Status const&, doris::RuntimeProfile*&&, bool&&) ()
#23 0x000055d13188288c in std::function<void (doris::Status const&, doris::RuntimeProfile*, bool)>::operator()(doris::Status const&, doris::RuntimeProfile*, bool) const ()
#24 0x000055d13187607f in doris::PlanFragmentExecutor::send_report(bool) ()
#25 0x000055d1318743f2 in doris::PlanFragmentExecutor::open() ()
#26 0x000055d131776c17 in doris::FragmentExecState::execute() ()
#27 0x000055d131781538 in doris::FragmentMgr::_exec_actual(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::RuntimeState*, doris::Status*)> const&) ()
#28 0x000055d13179df16 in doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_3::operator()() const ()
#29 0x000055d13179dd63 in void std::__invoke_impl<void, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_3&>(std::__invoke_other, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_3&) ()
#30 0x000055d13179dc55 in std::enable_if<is_invocable_r_v<void, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_3&>, void>::type std::__invoke_r<void, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_3&>(doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_3&) ()
#31 0x000055d13179d4df in std::_Function_handler<void (), doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_3>::_M_invoke(std::_Any_data const&) ()
#32 0x000055d12d8ade5d in std::function<void ()>::operator()() const ()
#33 0x000055d13214adcb in doris::FunctionRunnable::run() ()
#34 0x000055d1321334d7 in doris::ThreadPool::dispatch_thread() ()
#35 0x000055d132169aab in void std::__invoke_impl<void, void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) ()
#36 0x000055d13216984f in std::__invoke_result<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>::type std::__invoke<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) ()
#37 0x000055d13216979d in void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) ()

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

