### PR TITLE
[Fix](multi catalog)Fix Iceberg table query return NULL bug.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/IcebergExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/IcebergExternalTable.java
@@ -28,6 +28,7 @@ import org.apache.doris.thrift.TTableDescriptor;
 import org.apache.doris.thrift.TTableType;
 
 import com.google.common.collect.Lists;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Types;
 
 import java.util.HashMap;
@@ -52,13 +53,13 @@ public class IcebergExternalTable extends ExternalTable {
 
     @Override
     public List<Column> initSchema() {
-        List<Types.NestedField> columns = ((IcebergExternalCatalog) catalog).getIcebergTable(dbName, name).schema()
-                .columns();
+        Schema schema = ((IcebergExternalCatalog) catalog).getIcebergTable(dbName, name).schema();
+        List<Types.NestedField> columns = schema.columns();
         List<Column> tmpSchema = Lists.newArrayListWithCapacity(columns.size());
         for (Types.NestedField field : columns) {
             tmpSchema.add(new Column(field.name(),
-                    icebergTypeToDorisType(field.type()), true, null,
-                    true, field.doc(), true, -1));
+                    icebergTypeToDorisType(field.type()), true, null, true, field.doc(), true,
+                    schema.caseInsensitiveFindField(field.name()).fieldId()));
         }
         return tmpSchema;
     }


### PR DESCRIPTION
For Iceberg External Table, FE need to set Column unique id correctly to handle schema change case. This pr is to set the unique id of Column correctly, this will solve the query result return NULL bug.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

