### PR TITLE
[improvement](MOW) compact all segments of one load

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -392,16 +392,6 @@ Status DeltaWriter::close_wait(const PSlaveTabletNodes& slave_tablet_nodes,
         return res;
     }
     if (_tablet->enable_unique_key_merge_on_write()) {
-        auto beta_rowset = reinterpret_cast<BetaRowset*>(_cur_rowset.get());
-        std::vector<segment_v2::SegmentSharedPtr> segments;
-        RETURN_IF_ERROR(beta_rowset->load_segments(&segments));
-        // tablet is under alter process. The delete bitmap will be calculated after conversion.
-        if (_tablet->tablet_state() == TABLET_NOTREADY &&
-            SchemaChangeHandler::tablet_in_converting(_tablet->tablet_id())) {
-            return Status::OK();
-        }
-        RETURN_IF_ERROR(_tablet->calc_delete_bitmap(_cur_rowset, segments, nullptr, _delete_bitmap,
-                                                    _cur_max_version, true));
         _storage_engine->txn_manager()->set_txn_related_delete_bitmap(
                 _req.partition_id, _req.txn_id, _tablet->tablet_id(), _tablet->schema_hash(),
                 _tablet->tablet_uid(), true, _delete_bitmap, _rowset_ids,

--- a/be/src/olap/merger.h
+++ b/be/src/olap/merger.h
@@ -86,6 +86,13 @@ public:
                                              segment_v2::SegmentWriter& dst_segment_writer,
                                              int64_t max_rows_per_segment, Statistics* stats_output,
                                              uint64_t* index_size, KeyBoundsPB& key_bounds);
+    static Status vertical_compact_one_group(TabletSharedPtr tablet, ReaderType reader_type,
+                                             TabletSchemaSPtr tablet_schema, bool is_key,
+                                             const std::vector<uint32_t>& column_group,
+                                             vectorized::RowSourcesBuffer* row_source_buf,
+                                             vectorized::VerticalBlockReader& src_block_reader,
+                                             segment_v2::SegmentWriter& dst_segment_writer,
+                                             int64_t max_rows_per_segment, bool& eof);
 };
 
 } // namespace doris

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -723,16 +723,18 @@ Status StorageEngine::submit_compaction_task(TabletSharedPtr tablet,
 }
 
 Status StorageEngine::_handle_seg_compaction(BetaRowsetWriter* writer,
-                                             SegCompactionCandidatesSharedPtr segments) {
-    writer->get_segcompaction_worker().compact_segments(segments);
+                                             SegCompactionCandidatesSharedPtr segments,
+                                             bool compact_all) {
+    writer->get_segcompaction_worker().compact_segments(segments, compact_all);
     // return OK here. error will be reported via BetaRowsetWriter::_segcompaction_status
     return Status::OK();
 }
 
 Status StorageEngine::submit_seg_compaction_task(BetaRowsetWriter* writer,
-                                                 SegCompactionCandidatesSharedPtr segments) {
-    return _seg_compaction_thread_pool->submit_func(
-            std::bind<void>(&StorageEngine::_handle_seg_compaction, this, writer, segments));
+                                                 SegCompactionCandidatesSharedPtr segments,
+                                                 bool compact_all) {
+    return _seg_compaction_thread_pool->submit_func(std::bind<void>(
+            &StorageEngine::_handle_seg_compaction, this, writer, segments, compact_all));
 }
 
 void StorageEngine::_cooldown_tasks_producer_callback() {

--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -90,9 +90,9 @@ std::string BetaRowset::remote_segment_path(int64_t tablet_id, const std::string
 
 std::string BetaRowset::local_segment_path_segcompacted(const std::string& tablet_path,
                                                         const RowsetId& rowset_id, int64_t begin,
-                                                        int64_t end) {
+                                                        int64_t end, int64_t idx) {
     // {root_path}/data/{shard_id}/{tablet_id}/{schema_hash}/{rowset_id}_{begin_seg}-{end_seg}.dat
-    return fmt::format("{}/{}_{}-{}.dat", tablet_path, rowset_id.to_string(), begin, end);
+    return fmt::format("{}/{}_{}-{}-{}.dat", tablet_path, rowset_id.to_string(), begin, end, idx);
 }
 
 BetaRowset::BetaRowset(const TabletSchemaSPtr& schema, const std::string& tablet_path,

--- a/be/src/olap/rowset/beta_rowset.h
+++ b/be/src/olap/rowset/beta_rowset.h
@@ -60,7 +60,7 @@ public:
 
     static std::string local_segment_path_segcompacted(const std::string& tablet_path,
                                                        const RowsetId& rowset_id, int64_t begin,
-                                                       int64_t end);
+                                                       int64_t end, int64_t idx);
 
     static std::string remote_segment_path(int64_t tablet_id, const RowsetId& rowset_id,
                                            int segment_id);

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -143,7 +143,7 @@ Status SegmentWriter::init(const std::vector<uint32_t>& col_ids, bool has_key,
     _column_writers.reserve(_tablet_schema->columns().size());
     _column_ids.insert(_column_ids.end(), col_ids.begin(), col_ids.end());
     _olap_data_convertor = std::make_unique<vectorized::OlapBlockDataConvertor>();
-    auto create_column_writer = [&](uint32_t cid, const auto& column) -> auto {
+    auto create_column_writer = [&](uint32_t cid, const auto& column) -> auto{
         ColumnWriterOptions opts;
         opts.meta = _footer.add_columns();
 

--- a/be/src/olap/rowset/segment_v2/segment_writer.h
+++ b/be/src/olap/rowset/segment_v2/segment_writer.h
@@ -113,6 +113,7 @@ public:
     Status finalize(uint64_t* segment_file_size, uint64_t* index_size);
 
     uint32_t get_segment_id() { return _segment_id; }
+    void set_segment_id(uint32_t id) { _segment_id = id; }
 
     Status finalize_columns_data();
     Status finalize_columns_index(uint64_t* index_size);

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -190,7 +190,8 @@ public:
 
     Status submit_compaction_task(TabletSharedPtr tablet, CompactionType compaction_type);
     Status submit_seg_compaction_task(BetaRowsetWriter* writer,
-                                      SegCompactionCandidatesSharedPtr segments);
+                                      SegCompactionCandidatesSharedPtr segments,
+                                      bool compact_all = false);
 
     std::unique_ptr<ThreadPool>& tablet_publish_txn_thread_pool() {
         return _tablet_publish_txn_thread_pool;
@@ -282,7 +283,7 @@ private:
     void _cache_file_cleaner_tasks_producer_callback();
 
     Status _handle_seg_compaction(BetaRowsetWriter* writer,
-                                  SegCompactionCandidatesSharedPtr segments);
+                                  SegCompactionCandidatesSharedPtr segments, bool compact_all);
 
 private:
     struct CompactionCandidate {

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -424,7 +424,6 @@ public:
                               const std::vector<segment_v2::SegmentSharedPtr>& segments,
                               const RowsetIdUnorderedSet* specified_rowset_ids,
                               DeleteBitmapPtr delete_bitmap, int64_t version,
-                              bool check_pre_segments = false,
                               RowsetWriter* rowset_writer = nullptr);
     Status read_columns_by_plan(TabletSchemaSPtr tablet_schema,
                                 const std::vector<uint32_t> cids_to_read,


### PR DESCRIPTION
In unique key with merge on write, we calc delete bitmap of segments in one rowset in DeltaWriter::close_wait, we have to traverse all key and compare to key in pre segment, this logic introduce a lot of bugs and also cost a lot of time.
In this pr, we directly do compact all segments of one load, this will make sure that no same key in this load and then we can ignore delete bitmaps between segments.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

