### PR TITLE
[improvement](thread) stop threads when BE exit gracefully

### DIFF
--- a/be/src/olap/CMakeLists.txt
+++ b/be/src/olap/CMakeLists.txt
@@ -65,6 +65,7 @@ add_library(Olap STATIC
     tablet_meta.cpp
     tablet_meta_manager.cpp
     tablet_schema.cpp
+    tablet_schema_cache.cpp
     txn_manager.cpp
     types.cpp 
     utils.cpp

--- a/be/src/olap/tablet_schema_cache.cpp
+++ b/be/src/olap/tablet_schema_cache.cpp
@@ -1,0 +1,81 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "olap/tablet_schema_cache.h"
+
+namespace doris {
+
+TabletSchemaSPtr TabletSchemaCache::insert(const std::string& key) {
+    DCHECK(_s_instance != nullptr);
+    std::lock_guard guard(_mtx);
+    auto iter = _cache.find(key);
+    if (iter == _cache.end()) {
+        TabletSchemaSPtr tablet_schema_ptr = std::make_shared<TabletSchema>();
+        TabletSchemaPB pb;
+        pb.ParseFromString(key);
+        tablet_schema_ptr->init_from_pb(pb);
+        _cache[key] = tablet_schema_ptr;
+        DorisMetrics::instance()->tablet_schema_cache_count->increment(1);
+        DorisMetrics::instance()->tablet_schema_cache_memory_bytes->increment(
+                tablet_schema_ptr->mem_size());
+        return tablet_schema_ptr;
+    }
+    return iter->second;
+}
+
+void TabletSchemaCache::stop() {
+    _should_stop = true;
+    while (!_is_stopped) {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+    LOG(INFO) << "xxx stopped";
+}
+
+/**
+ * @brief recycle when TabletSchemaSPtr use_count equals 1.
+ */
+void TabletSchemaCache::_recycle() {
+    int64_t tablet_schema_cache_recycle_interval = 86400; // s, one day
+    int64_t check_interval = 5;
+    int64_t left_second = tablet_schema_cache_recycle_interval;
+    while (!_should_stop) {
+        if (left_second > 0) {
+            std::this_thread::sleep_for(std::chrono::seconds(check_interval));
+            left_second -= check_interval;
+            continue;
+        } else {
+            left_second = tablet_schema_cache_recycle_interval;
+        }
+
+        std::lock_guard guard(_mtx);
+        LOG(INFO) << "Tablet Schema Cache Capacity " << _cache.size();
+        for (auto iter = _cache.begin(), last = _cache.end(); iter != last;) {
+            if (iter->second.unique()) {
+                DorisMetrics::instance()->tablet_schema_cache_memory_bytes->increment(
+                        -iter->second->mem_size());
+                DorisMetrics::instance()->tablet_schema_cache_count->increment(-1);
+                iter = _cache.erase(iter);
+            } else {
+                ++iter;
+            }
+        }
+    }
+    _is_stopped = true;
+    LOG(INFO) << "xxx yyy stopped ";
+}
+
+} // namespace doris

--- a/be/src/olap/tablet_schema_cache.h
+++ b/be/src/olap/tablet_schema_cache.h
@@ -40,51 +40,26 @@ public:
 
     static TabletSchemaCache* instance() { return _s_instance; }
 
-    TabletSchemaSPtr insert(const std::string& key) {
+    static void stop_and_join() {
         DCHECK(_s_instance != nullptr);
-        std::lock_guard guard(_mtx);
-        auto iter = _cache.find(key);
-        if (iter == _cache.end()) {
-            TabletSchemaSPtr tablet_schema_ptr = std::make_shared<TabletSchema>();
-            TabletSchemaPB pb;
-            pb.ParseFromString(key);
-            tablet_schema_ptr->init_from_pb(pb);
-            _cache[key] = tablet_schema_ptr;
-            DorisMetrics::instance()->tablet_schema_cache_count->increment(1);
-            DorisMetrics::instance()->tablet_schema_cache_memory_bytes->increment(
-                    tablet_schema_ptr->mem_size());
-            return tablet_schema_ptr;
-        }
-        return iter->second;
+        _s_instance->stop();
     }
+
+    TabletSchemaSPtr insert(const std::string& key);
+
+    void stop();
 
 private:
     /**
      * @brief recycle when TabletSchemaSPtr use_count equals 1.
      */
-    void _recycle() {
-        int64_t tablet_schema_cache_recycle_interval = 86400; // s, one day
-        for (;;) {
-            std::this_thread::sleep_for(std::chrono::seconds(tablet_schema_cache_recycle_interval));
-            std::lock_guard guard(_mtx);
-            LOG(INFO) << "Tablet Schema Cache Capacity " << _cache.size();
-            for (auto iter = _cache.begin(), last = _cache.end(); iter != last;) {
-                if (iter->second.unique()) {
-                    DorisMetrics::instance()->tablet_schema_cache_memory_bytes->increment(
-                            -iter->second->mem_size());
-                    DorisMetrics::instance()->tablet_schema_cache_count->increment(-1);
-                    iter = _cache.erase(iter);
-                } else {
-                    ++iter;
-                }
-            }
-        }
-    }
-
+    void _recycle();
 private:
     static inline TabletSchemaCache* _s_instance = nullptr;
     std::mutex _mtx;
     std::unordered_map<std::string, TabletSchemaSPtr> _cache;
+    std::atomic_bool _should_stop = { false };
+    std::atomic_bool _is_stopped = { false };
 };
 
 } // namespace doris

--- a/be/src/olap/tablet_schema_cache.h
+++ b/be/src/olap/tablet_schema_cache.h
@@ -54,12 +54,13 @@ private:
      * @brief recycle when TabletSchemaSPtr use_count equals 1.
      */
     void _recycle();
+
 private:
     static inline TabletSchemaCache* _s_instance = nullptr;
     std::mutex _mtx;
     std::unordered_map<std::string, TabletSchemaSPtr> _cache;
-    std::atomic_bool _should_stop = { false };
-    std::atomic_bool _is_stopped = { false };
+    std::atomic_bool _should_stop = {false};
+    std::atomic_bool _is_stopped = {false};
 };
 
 } // namespace doris

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -387,6 +387,13 @@ void ExecEnv::_destroy() {
     SAFE_DELETE(_heartbeat_flags);
     SAFE_DELETE(_scanner_scheduler);
 
+    _send_batch_thread_pool.reset(nullptr);
+    _buffered_reader_prefetch_thread_pool.reset(nullptr);
+    _send_report_thread_pool.reset(nullptr);
+    _join_node_thread_pool.reset(nullptr);
+    _serial_download_cache_thread_token.reset(nullptr);
+    _download_cache_thread_pool.reset(nullptr);
+
     _is_init = false;
 }
 

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -510,6 +510,7 @@ int main(int argc, char** argv) {
         sleep(10);
     }
 
+    doris::TabletSchemaCache::stop_and_join();
     http_service.stop();
     brpc_service.join();
     daemon.stop();
@@ -526,9 +527,9 @@ int main(int argc, char** argv) {
     heartbeat_thrift_server = nullptr;
 
     doris::ExecEnv::destroy(exec_env);
-
     delete engine;
     engine = nullptr;
+
     return 0;
 }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

When stop BE using `stop_be.sh --grace`, some of threads is not cleaned:

1. tablet schema change refresh thread.
2. RocksDB background threads
3. Some thread pool in exec env.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

