### PR TITLE
[fix](Nereids): Should copy JoinReorderContext for PushdownProject

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/JoinExchangeRightProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/JoinExchangeRightProject.java
@@ -101,7 +101,7 @@ public class JoinExchangeRightProject extends OneExplorationRuleFactory {
                             newTopJoinHashJoinConjuncts, newTopJoinOtherJoinConjuncts, JoinHint.NONE,
                             left, right);
                     JoinExchange.setNewLeftJoinReorder(newLeftJoin, leftJoin);
-                    JoinExchange.setNewRightJoinReorder(newRightJoin, leftJoin);
+                    JoinExchange.setNewRightJoinReorder(newRightJoin, rightJoin);
                     JoinExchange.setNewTopJoinReorder(newTopJoin, topJoin);
 
                     return CBOUtils.projectOrSelf(new ArrayList<>(topJoin.getOutput()), newTopJoin);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/PushdownProjectThroughInnerJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/PushdownProjectThroughInnerJoin.java
@@ -121,7 +121,7 @@ public class PushdownProjectThroughInnerJoin implements ExplorationRuleFactory {
         Plan newLeft = CBOUtils.projectOrSelf(newAProject.build(), join.left());
 
         if (!rightContains) {
-            Plan newJoin = join.withChildrenNoContext(newLeft, join.right());
+            Plan newJoin = join.withChildren(newLeft, join.right());
             return CBOUtils.projectOrSelf(new ArrayList<>(project.getOutput()), newJoin);
         }
 
@@ -132,7 +132,7 @@ public class PushdownProjectThroughInnerJoin implements ExplorationRuleFactory {
         bConditionSlots.stream().filter(slot -> !bProjectSlots.contains(slot)).forEach(newBProject::add);
         Plan newRight = CBOUtils.projectOrSelf(newBProject.build(), join.right());
 
-        Plan newJoin = join.withChildrenNoContext(newLeft, newRight);
+        Plan newJoin = join.withChildren(newLeft, newRight);
         return CBOUtils.projectOrSelf(new ArrayList<>(project.getOutput()), newJoin);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/PushdownProjectThroughSemiJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/PushdownProjectThroughSemiJoin.java
@@ -89,7 +89,7 @@ public class PushdownProjectThroughSemiJoin implements ExplorationRuleFactory {
                 .forEach(newProject::add);
         Plan newLeft = CBOUtils.projectOrSelf(newProject, join.left());
 
-        Plan newJoin = join.withChildrenNoContext(newLeft, join.right());
+        Plan newJoin = join.withChildren(newLeft, join.right());
         return CBOUtils.projectOrSelf(new ArrayList<>(project.getOutput()), newJoin);
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

- should copy JoinReorderContext
- verify bushy tree join reorder

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

