### PR TITLE
[fix](chore) fix BE compile and FE protoc artifact issue (#18120)

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -34,7 +34,7 @@ under the License.
         <doris.thirdparty>${basedir}/../../thirdparty</doris.thirdparty>
         <antlr4.version>4.9.3</antlr4.version>
         <awssdk.version>2.17.257</awssdk.version>
-        <protoc.artifact>com.google.protobuf:protoc:${protobuf.version}</protoc.artifact>
+        <protoc.artifact>com.google.protobuf:protoc:${protoc.artifact.version}</protoc.artifact>
         <grpc.java.artifact>io.grpc:protoc-gen-grpc-java:${grpc.version}</grpc.java.artifact>
     </properties>
     <profiles>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -218,9 +218,12 @@ under the License.
         <metrics-core.version>4.0.2</metrics-core.version>
         <netty-all.version>4.1.89.Final</netty-all.version>
         <objenesis.version>2.1</objenesis.version>
-        <grpc.version>1.39.0</grpc.version>
+        <grpc.version>1.30.0</grpc.version>
         <check.freamework.version>3.32.0</check.freamework.version>
         <protobuf.version>3.21.12</protobuf.version>
+        <!-- we use protoc-jar-maven-plugin to generate protobuf generated code -->
+        <!-- see https://repo.maven.apache.org/maven2/com/google/protobuf/protoc/ to get correct version -->
+        <protoc.artifact.version>3.21.9</protoc.artifact.version>
         <protoparser.version>3.1.5</protoparser.version>
         <snappy-java.version>1.1.7.2</snappy-java.version>
         <automaton.version>1.11-8</automaton.version>


### PR DESCRIPTION
add <optional> head to solve the compilation issue use 3.12.9 as the protoc.artifact's version, because there is no 3.12.21 See: https://repo.maven.apache.org/maven2/com/google/protobuf/protoc/ Remove --show-progress arguments of wget because it is not supported in low version wget

# Proposed changes

Backport #18120 .
Downgrade `grpc.version` to `1.30.0` (See #8250).

## Problem summary

~~Describe your changes.~~

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

