### PR TITLE
[Fix](executor) Fix comparator of ResouceGroupSet

### DIFF
--- a/be/src/pipeline/task_queue.cpp
+++ b/be/src/pipeline/task_queue.cpp
@@ -213,9 +213,9 @@ bool TaskGroupTaskQueue::TaskGroupSchedEntityComparator::operator()(
         auto l_share = lhs_ptr->cpu_share();
         auto r_share = rhs_ptr->cpu_share();
         if (l_share != r_share) {
-            return l_share < rhs_val;
+            return l_share < r_share;
         } else {
-            return lhs_ptr < rhs_ptr;
+            return lhs_ptr->task_group_id() < rhs_ptr->task_group_id();
         }
     }
 }

--- a/be/src/runtime/task_group/task_group.cpp
+++ b/be/src/runtime/task_group/task_group.cpp
@@ -58,6 +58,10 @@ uint64_t TaskGroupEntity::cpu_share() const {
     return _tg->cpu_share();
 }
 
+uint64_t TaskGroupEntity::task_group_id() const {
+    return _tg->id();
+}
+
 std::string TaskGroupEntity::debug_string() const {
     return fmt::format("TGE[id = {}, cpu_share = {}, task size: {}, v_time:{}ns]", _tg->id(),
                        cpu_share(), _queue.size(), _vruntime_ns);

--- a/be/src/runtime/task_group/task_group.h
+++ b/be/src/runtime/task_group/task_group.h
@@ -61,6 +61,8 @@ public:
 
     std::string debug_string() const;
 
+    uint64_t task_group_id() const;
+
 private:
     // TODO pipeline use MLFQ
     std::queue<pipeline::PipelineTask*> _queue;


### PR DESCRIPTION
# Proposed changes

1 Fix a typo of ResouceGroupSet's comparator, this may cause query hang when there are two ResourceGroup runs
2 Using GroupId instead of Ptr Addr to make semantics more clear .

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

