### PR TITLE
[chore](maven) Prefer protoc in thirdparty to the one in maven artifacts (#17596)

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -61,6 +61,7 @@ under the License.
             </properties>
         </profile>
         <profile>
+            <id>protoc_rosetta</id>
             <activation>
                 <os>
                     <name>Mac OS X</name>
@@ -70,6 +71,17 @@ under the License.
             <properties>
                 <protoc.artifact>com.google.protobuf:protoc:${protobuf.version}:exe:osx-x86_64</protoc.artifact>
                 <grpc.java.artifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:osx-x86_64</grpc.java.artifact>
+            </properties>
+        </profile>
+        <profile>
+            <id>protoc_command</id>
+            <activation>
+                <file>
+                    <exists>${doris.thirdparty}/installed/bin/protoc</exists>
+                </file>
+            </activation>
+            <properties>
+                <protoc.command>${doris.thirdparty}/installed/bin/protoc</protoc.command>
             </properties>
         </profile>
     </profiles>
@@ -907,7 +919,7 @@ under the License.
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <!-- <protocCommand>${doris.thirdparty}/installed/bin/protoc</protocCommand> -->
+                            <protocCommand>${protoc.command}</protocCommand>
                             <!--You can use following protocArtifact instead of protocCommand, so that you don't need to install protobuf tools-->
                             <protocArtifact>${protoc.artifact}</protocArtifact>
                             <protocVersion>${protobuf.version}</protocVersion>


### PR DESCRIPTION
The prebuilt protoc-gen-grpc-java binary uses glibc on Linux and the version of glibc which Centos 6 uses is too old.

# Proposed changes

Backport #17596

## Problem summary

~~Describe your changes.~~

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

