### PR TITLE
[fix](build) fix default DORIS_JAVA_HOME in CMakeLists.txt

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -658,7 +658,7 @@ include_directories(
 )
 
 if ("${DORIS_JAVA_HOME}" STREQUAL "") 
-    set(DORIS_JAVA_HOME "$ENV{JAVA_HOME}/include")
+    set(DORIS_JAVA_HOME "$ENV{JAVA_HOME}")
 endif()
 
 include_directories(${DORIS_JAVA_HOME}/include)


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

remove extra `/include` dir in `DORIS_JAVA_HOME`

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

