### PR TITLE
[improvement](file cache)Support set min file segment size while use block file cache

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -932,8 +932,16 @@ DEFINE_Bool(enable_file_cache, "false");
 // format: [{"path":"/path/to/file_cache","total_size":21474836480,"query_limit":10737418240},{"path":"/path/to/file_cache2","total_size":21474836480,"query_limit":10737418240}]
 DEFINE_String(file_cache_path, "");
 DEFINE_Int64(file_cache_max_file_segment_size, "4194304"); // 4MB
-DEFINE_Validator(file_cache_max_file_segment_size,
-                 [](const int64_t config) -> bool { return config >= 4096; }); // 4KB
+// 4KB <= file_cache_max_file_segment_size <= 256MB
+DEFINE_Validator(file_cache_max_file_segment_size, [](const int64_t config) -> bool {
+    return config >= 4096 && config <= 268435456;
+});
+DEFINE_Int64(file_cache_min_file_segment_size, "1048576"); // 1MB
+// 4KB <= file_cache_min_file_segment_size <= 256MB
+DEFINE_Validator(file_cache_min_file_segment_size, [](const int64_t config) -> bool {
+    return config >= 4096 && config <= 268435456 &&
+           config <= config::file_cache_max_file_segment_size;
+});
 DEFINE_Bool(clear_file_cache, "false");
 DEFINE_Bool(enable_file_cache_query_limit, "false");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -950,6 +950,7 @@ DECLARE_Bool(enable_file_cache);
 // format: [{"path":"/path/to/file_cache","total_size":21474836480,"query_limit":10737418240}]
 // format: [{"path":"/path/to/file_cache","total_size":21474836480,"query_limit":10737418240},{"path":"/path/to/file_cache2","total_size":21474836480,"query_limit":10737418240}]
 DECLARE_String(file_cache_path);
+DECLARE_Int64(file_cache_min_file_segment_size);
 DECLARE_Int64(file_cache_max_file_segment_size);
 DECLARE_Bool(clear_file_cache);
 DECLARE_Bool(enable_file_cache_query_limit);

--- a/be/src/io/cache/block/cached_remote_file_reader.cpp
+++ b/be/src/io/cache/block/cached_remote_file_reader.cpp
@@ -71,9 +71,9 @@ Status CachedRemoteFileReader::close() {
 
 std::pair<size_t, size_t> CachedRemoteFileReader::_align_size(size_t offset,
                                                               size_t read_size) const {
-    size_t min_size = 1024 * 1024; // 1MB;
-    size_t segment_size = std::min(std::max(read_size, min_size),
-                                   (size_t)config::file_cache_max_file_segment_size);
+    size_t segment_size =
+            std::min(std::max(read_size, (size_t)config::file_cache_min_file_segment_size),
+                     (size_t)config::file_cache_max_file_segment_size);
     segment_size = BitUtil::next_power_of_two(segment_size);
     size_t left = offset;
     size_t right = offset + read_size - 1;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Support set min file segment size while use block file cache.
In olap table, when reading segments, read only a few thousand bytes each time, users can customize the min file segment size to avoid too many open files and optimize performance.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

