### PR TITLE
[pipeline](bug) DCHECK may failed in pip sender queue

### DIFF
--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -62,9 +62,6 @@ class TRuntimeProfileTree;
     ScopedTimer<ThreadCpuStopWatch> MACRO_CONCAT(SCOPED_TIMER, __COUNTER__)(c)
 #define CANCEL_SAFE_SCOPED_TIMER(c, is_cancelled) \
     ScopedTimer<MonotonicStopWatch> MACRO_CONCAT(SCOPED_TIMER, __COUNTER__)(c, is_cancelled)
-#define CANCEL_SAFE_SCOPED_TIMER_ATOMIC(c, is_cancelled)                                       \
-    ScopedTimer<MonotonicStopWatch, std::atomic_bool> MACRO_CONCAT(SCOPED_TIMER, __COUNTER__)( \
-            c, is_cancelled)
 #define SCOPED_RAW_TIMER(c)                                                                  \
     doris::ScopedRawTimer<doris::MonotonicStopWatch, int64_t> MACRO_CONCAT(SCOPED_RAW_TIMER, \
                                                                            __COUNTER__)(c)


### PR DESCRIPTION
# Proposed changes

```
F0505 22:46:41.875746 497986 vdata_stream_recvr.cpp:87] Check failed: _num_remaining_senders == 0 (26 vs. 0)

Check failure stack trace: ***
@ 0x55c8198dc95d google::LogMessage::Fail()
@ 0x55c8198dee99 google::LogMessage::SendToLog()
@ 0x55c8198dc4c6 google::LogMessage::Flush()
@ 0x55c8198df509 google::LogMessageFatal::~LogMessageFatal()
@ 0x55c81814cccb doris::vectorized::VDataStreamRecvr::SenderQueue::_inner_get_batch()
@ 0x55c81815fa74 doris::vectorized::VDataStreamRecvr::PipSenderQueue::get_batch()
@ 0x55c818155072 doris::vectorized::VDataStreamRecvr::get_next()
@ 0x55c808360620 doris::vectorized::VExchangeNode::get_next()
@ 0x55c80071a114 doris::ExecNode::pull()
@ 0x55c818e68e8d std::__invoke_impl<>()
@ 0x55c818e68c30 std::__invoke<>()
@ 0x55c818e68b67 ZNSt5_BindIFMN5doris8ExecNodeEFNS0_6StatusEPNS0_12RuntimeStateEPNS0_10vectorized5BlockEPbEPNS5_13VExchangeNodeESt12_PlaceholderILi1EESD_ILi2EESD_ILi3EEEE6_callIS2_JOS4_OS7_OS8_EJLm0ELm1ELm2ELm3EEEET_OSt5tupleIJDpT0_EESt12_Index_tupleIJXspT1_EEE
@ 0x55c818e688f8 std::_Bind<>::operator()<>()
@ 0x55c818e687a8 std::__invoke_impl<>()
@ 0x55c818e68718 ZSt10invoke_rIN5doris6StatusERSt5_BindIFMNS0_8ExecNodeEFS1_PNS0_12RuntimeStateEPNS0_10vectorized5BlockEPbEPNS6_13VExchangeNodeESt12_PlaceholderILi1EESE_ILi2EESE_ILi3EEEEJS5_S8_S9_EENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EESM_E4typeEOSN_DpOSO
@ 0x55c818e68368 std::_Function_handler<>::_M_invoke()
@ 0x55c800719fff std::function<>::operator()()
@ 0x55c80070e18a doris::ExecNode::get_next_after_projects()
@ 0x55c818e655f3 doris::pipeline::SourceOperator<>::get_block()
@ 0x55c818e05c3f doris::pipeline::PipelineTask::execute()
@ 0x55c818e2429a doris::pipeline::TaskScheduler::_do_work()
```

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

