### PR TITLE
[Fix](multi-catalog) Fix sync hms event failed.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
@@ -95,6 +95,10 @@ public class HMSExternalTable extends ExternalTable {
         return dlaType != DLAType.UNKNOWN;
     }
 
+    public boolean isExists() {
+        return remoteTable != null ? true : ((HMSExternalCatalog) catalog).getClient().tableExists(dbName, name);
+    }
+
     protected synchronized void makeSureInitialized() {
         super.makeSureInitialized();
         if (!objectCreated) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
@@ -95,10 +95,6 @@ public class HMSExternalTable extends ExternalTable {
         return dlaType != DLAType.UNKNOWN;
     }
 
-    public boolean exists() {
-        return remoteTable != null ? true : ((HMSExternalCatalog) catalog).getClient().tableExists(dbName, name);
-    }
-
     protected synchronized void makeSureInitialized() {
         super.makeSureInitialized();
         if (!objectCreated) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
@@ -95,7 +95,7 @@ public class HMSExternalTable extends ExternalTable {
         return dlaType != DLAType.UNKNOWN;
     }
 
-    public boolean isExists() {
+    public boolean exists() {
         return remoteTable != null ? true : ((HMSExternalCatalog) catalog).getClient().tableExists(dbName, name);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
@@ -892,12 +892,13 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
             return;
         }
 
+        Env.getCurrentEnv().getExtMetaCacheMgr().addPartitionsCache(catalog.getId(),
+                (ExternalTable) table, partitionNames);
         ExternalObjectLog log = new ExternalObjectLog();
         log.setCatalogId(catalog.getId());
         log.setDbId(db.getId());
         log.setTableId(table.getId());
         log.setPartitionNames(partitionNames);
-        replayAddExternalPartitions(log);
         Env.getCurrentEnv().getEditLog().logAddExternalPartitions(log);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
@@ -981,23 +981,32 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
     }
 
     public void refreshExternalPartitions(String catalogName, String dbName, String tableName,
-            List<String> partitionNames)
+            List<String> partitionNames, boolean ignoreIfNotExists)
             throws DdlException {
         CatalogIf catalog = nameToCatalog.get(catalogName);
         if (catalog == null) {
-            throw new DdlException("No catalog found with name: " + catalogName);
+            if (!ignoreIfNotExists) {
+                throw new DdlException("No catalog found with name: " + catalogName);
+            }
+            return;
         }
         if (!(catalog instanceof ExternalCatalog)) {
             throw new DdlException("Only support ExternalCatalog");
         }
         DatabaseIf db = catalog.getDbNullable(dbName);
         if (db == null) {
-            throw new DdlException("Database " + dbName + " does not exist in catalog " + catalog.getName());
+            if (!ignoreIfNotExists) {
+                throw new DdlException("Database " + dbName + " does not exist in catalog " + catalog.getName());
+            }
+            return;
         }
 
         TableIf table = db.getTableNullable(tableName);
         if (table == null) {
-            throw new DdlException("Table " + tableName + " does not exist in db " + dbName);
+            if (!ignoreIfNotExists) {
+                throw new DdlException("Table " + tableName + " does not exist in db " + dbName);
+            }
+            return;
         }
 
         ExternalObjectLog log = new ExternalObjectLog();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
@@ -919,8 +919,14 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
             LOG.warn("No table found with id:[{}], it may have been dropped.", log.getTableId());
             return;
         }
-        Env.getCurrentEnv().getExtMetaCacheMgr()
+        try {
+            Env.getCurrentEnv().getExtMetaCacheMgr()
                 .addPartitionsCache(catalog.getId(), table, log.getPartitionNames());
+        } catch (HMSClientException e) {
+            LOG.warn("Network problem occurs or hms table has been deleted, fallback to invalidate table cache", e);
+            Env.getCurrentEnv().getExtMetaCacheMgr().invalidateTableCache(catalog.getId(),
+                    db.getFullName(), table.getName());
+        }
     }
 
     public void dropExternalPartitions(String catalogName, String dbName, String tableName, List<String> partitionNames,

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
@@ -131,8 +131,9 @@ public class ExternalMetaCacheMgr {
         }
         String dbName = ClusterNamespace.getNameFromFullName(table.getDbName());
         HiveMetaStoreCache metaCache = cacheMap.get(catalogId);
-        if (metaCache != null) {
-            metaCache.addPartitionsCache(dbName, table.getName(), partitionNames);
+        if (metaCache != null && ((HMSExternalTable) table).isExists()) {
+            metaCache.addPartitionsCache(dbName, table.getName(), partitionNames,
+                    ((HMSExternalTable) table).getPartitionColumnTypes());
         }
         LOG.debug("add partition cache for {}.{} in catalog {}", dbName, table.getName(), catalogId);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
@@ -131,7 +131,9 @@ public class ExternalMetaCacheMgr {
         }
         String dbName = ClusterNamespace.getNameFromFullName(table.getDbName());
         HiveMetaStoreCache metaCache = cacheMap.get(catalogId);
-        if (metaCache != null && ((HMSExternalTable) table).isExists()) {
+        // before invoke getPartitionColumnTypes we should check if the table exist now
+        // otherwise PooledHiveMetaStoreClient#getCient will throw an exception if table not exist
+        if (metaCache != null && ((HMSExternalTable) table).exists()) {
             metaCache.addPartitionsCache(dbName, table.getName(), partitionNames,
                     ((HMSExternalTable) table).getPartitionColumnTypes());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
@@ -131,8 +131,10 @@ public class ExternalMetaCacheMgr {
         }
         String dbName = ClusterNamespace.getNameFromFullName(table.getDbName());
         HiveMetaStoreCache metaCache = cacheMap.get(catalogId);
-        // before invoke getPartitionColumnTypes we should check if the table exist now
-        // otherwise PooledHiveMetaStoreClient#getCient will throw an exception if table not exist
+        // Before invoking getPartitionColumnTypes we should check if the table exists now.
+        // Otherwise PooledHiveMetaStoreClient.getTable() will throw an exception if table not exists.
+        // Because this is not an atomic process, now we can just try to avoid the exception as much as possible.
+        // TODO: don't invoke any methods in PooledHiveMetaStoreClient when processing hms events
         if (metaCache != null && ((HMSExternalTable) table).exists()) {
             metaCache.addPartitionsCache(dbName, table.getName(), partitionNames,
                     ((HMSExternalTable) table).getPartitionColumnTypes());

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
@@ -131,11 +131,7 @@ public class ExternalMetaCacheMgr {
         }
         String dbName = ClusterNamespace.getNameFromFullName(table.getDbName());
         HiveMetaStoreCache metaCache = cacheMap.get(catalogId);
-        // Before invoking getPartitionColumnTypes we should check if the table exists now.
-        // Otherwise PooledHiveMetaStoreClient.getTable() will throw an exception if table not exists.
-        // Because this is not an atomic process, now we can just try to avoid the exception as much as possible.
-        // TODO: don't invoke any methods in PooledHiveMetaStoreClient when processing hms events
-        if (metaCache != null && ((HMSExternalTable) table).exists()) {
+        if (metaCache != null) {
             metaCache.addPartitionsCache(dbName, table.getName(), partitionNames,
                     ((HMSExternalTable) table).getPartitionColumnTypes());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
@@ -132,8 +132,7 @@ public class ExternalMetaCacheMgr {
         String dbName = ClusterNamespace.getNameFromFullName(table.getDbName());
         HiveMetaStoreCache metaCache = cacheMap.get(catalogId);
         if (metaCache != null) {
-            metaCache.addPartitionsCache(dbName, table.getName(), partitionNames,
-                    ((HMSExternalTable) table).getPartitionColumnTypes());
+            metaCache.addPartitionsCache(dbName, table.getName(), partitionNames);
         }
         LOG.debug("add partition cache for {}.{} in catalog {}", dbName, table.getName(), catalogId);
     }
@@ -146,8 +145,7 @@ public class ExternalMetaCacheMgr {
         String dbName = ClusterNamespace.getNameFromFullName(table.getDbName());
         HiveMetaStoreCache metaCache = cacheMap.get(catalogId);
         if (metaCache != null) {
-            metaCache.dropPartitionsCache(dbName, table.getName(), partitionNames,
-                    ((HMSExternalTable) table).getPartitionColumnTypes(), true);
+            metaCache.dropPartitionsCache(dbName, table.getName(), partitionNames, true);
         }
         LOG.debug("drop partition cache for {}.{} in catalog {}", dbName, table.getName(), catalogId);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -514,8 +514,9 @@ public class HiveMetaStoreCache {
     }
 
     // partition name format: nation=cn/city=beijing
-    public void addPartitionsCache(String dbName, String tblName, List<String> partitionNames) {
-        PartitionValueCacheKey key = new PartitionValueCacheKey(dbName, tblName, null);
+    public void addPartitionsCache(String dbName, String tblName, List<String> partitionNames,
+            List<Type> partitionColumnTypes) {
+        PartitionValueCacheKey key = new PartitionValueCacheKey(dbName, tblName, partitionColumnTypes);
         HivePartitionValues partitionValues = partitionValuesCache.getIfPresent(key);
         if (partitionValues == null) {
             return;
@@ -594,17 +595,19 @@ public class HiveMetaStoreCache {
             idToPartitionItemBefore.remove(partitionId);
             partitionValuesMap.remove(partitionId);
             List<UniqueId> uniqueIds = idToUniqueIdsMapBefore.remove(partitionId);
-            if (key.types.size() > 1) {
-                for (UniqueId uniqueId : uniqueIds) {
-                    Range<PartitionKey> range = uidToPartitionRangeBefore.remove(uniqueId);
+            for (UniqueId uniqueId : uniqueIds) {
+                Range<PartitionKey> range = uidToPartitionRangeBefore.remove(uniqueId);
+                if (range != null) {
                     rangeToIdBefore.remove(range);
                 }
-            } else {
-                for (UniqueId uniqueId : uniqueIds) {
-                    Range<ColumnBound> range = singleUidToColumnRangeMapBefore.remove(uniqueId);
+            }
+            for (UniqueId uniqueId : uniqueIds) {
+                Range<ColumnBound> range = singleUidToColumnRangeMapBefore.remove(uniqueId);
+                if (range != null) {
                     singleColumnRangeMapBefore.remove(range);
                 }
             }
+
             if (invalidPartitionCache) {
                 invalidatePartitionCache(dbName, tblName, partitionName);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -514,9 +514,8 @@ public class HiveMetaStoreCache {
     }
 
     // partition name format: nation=cn/city=beijing
-    public void addPartitionsCache(String dbName, String tblName, List<String> partitionNames,
-            List<Type> partitionColumnTypes) {
-        PartitionValueCacheKey key = new PartitionValueCacheKey(dbName, tblName, partitionColumnTypes);
+    public void addPartitionsCache(String dbName, String tblName, List<String> partitionNames) {
+        PartitionValueCacheKey key = new PartitionValueCacheKey(dbName, tblName, null);
         HivePartitionValues partitionValues = partitionValuesCache.getIfPresent(key);
         if (partitionValues == null) {
             return;
@@ -571,8 +570,8 @@ public class HiveMetaStoreCache {
     }
 
     public void dropPartitionsCache(String dbName, String tblName, List<String> partitionNames,
-            List<Type> partitionColumnTypes, boolean invalidPartitionCache) {
-        PartitionValueCacheKey key = new PartitionValueCacheKey(dbName, tblName, partitionColumnTypes);
+                                    boolean invalidPartitionCache) {
+        PartitionValueCacheKey key = new PartitionValueCacheKey(dbName, tblName, null);
         HivePartitionValues partitionValues = partitionValuesCache.getIfPresent(key);
         if (partitionValues == null) {
             return;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -596,15 +596,18 @@ public class HiveMetaStoreCache {
             partitionValuesMap.remove(partitionId);
             List<UniqueId> uniqueIds = idToUniqueIdsMapBefore.remove(partitionId);
             for (UniqueId uniqueId : uniqueIds) {
-                Range<PartitionKey> range = uidToPartitionRangeBefore.remove(uniqueId);
-                if (range != null) {
-                    rangeToIdBefore.remove(range);
+                if (uidToPartitionRangeBefore != null) {
+                    Range<PartitionKey> range = uidToPartitionRangeBefore.remove(uniqueId);
+                    if (range != null) {
+                        rangeToIdBefore.remove(range);
+                    }
                 }
-            }
-            for (UniqueId uniqueId : uniqueIds) {
-                Range<ColumnBound> range = singleUidToColumnRangeMapBefore.remove(uniqueId);
-                if (range != null) {
-                    singleColumnRangeMapBefore.remove(range);
+
+                if (singleUidToColumnRangeMapBefore != null) {
+                    Range<ColumnBound> range = singleUidToColumnRangeMapBefore.remove(uniqueId);
+                    if (range != null) {
+                        singleColumnRangeMapBefore.remove(range);
+                    }
                 }
             }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterPartitionEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterPartitionEvent.java
@@ -87,7 +87,7 @@ public class AlterPartitionEvent extends MetastoreTableEvent {
             } else {
                 Env.getCurrentEnv().getCatalogMgr()
                         .refreshExternalPartitions(catalogName, dbName, hmsTbl.getTableName(),
-                                Lists.newArrayList(partitionNameAfter));
+                                Lists.newArrayList(partitionNameAfter), true);
             }
         } catch (DdlException e) {
             throw new MetastoreNotificationException(

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreEvent.java
@@ -128,6 +128,9 @@ public abstract class MetastoreEvent {
 
     /**
      * Process the information available in the NotificationEvent.
+     * Better not to call (direct/indirect) apis of {@link org.apache.doris.datasource.hive.PooledHiveMetaStoreClient}
+     * during handling hms events (Reference to https://github.com/apache/doris/pull/19120).
+     * Try to add some fallback strategies if it is highly necessary.
      */
     protected abstract void process() throws MetastoreNotificationException;
 

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/CatalogMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/CatalogMgrTest.java
@@ -450,8 +450,7 @@ public class CatalogMgrTest extends TestWithFeService {
         HivePartitionValues hivePartitionValues = loadPartitionValues(partitionValueCacheKey,
                 Lists.newArrayList("y=2020/m=1", "y=2020/m=2"), metaStoreCache);
         metaStoreCache.putPartitionValuesCacheForTest(partitionValueCacheKey, hivePartitionValues);
-        metaStoreCache.addPartitionsCache("hiveDb", "hiveTable", Lists.newArrayList("y=2020/m=3", "y=2020/m=4"),
-                partitionValueCacheKey.getTypes());
+        metaStoreCache.addPartitionsCache("hiveDb", "hiveTable", Lists.newArrayList("y=2020/m=3", "y=2020/m=4"));
         HivePartitionValues partitionValues = metaStoreCache.getPartitionValues(partitionValueCacheKey);
         Assert.assertEquals(partitionValues.getPartitionNameToIdMap().size(), 4);
     }
@@ -466,7 +465,7 @@ public class CatalogMgrTest extends TestWithFeService {
                 Lists.newArrayList("y=2020/m=1", "y=2020/m=2"), metaStoreCache);
         metaStoreCache.putPartitionValuesCacheForTest(partitionValueCacheKey, hivePartitionValues);
         metaStoreCache.dropPartitionsCache("hiveDb", "hiveTable", Lists.newArrayList("y=2020/m=1", "y=2020/m=2"),
-                partitionValueCacheKey.getTypes(), false);
+                false);
         HivePartitionValues partitionValues = metaStoreCache.getPartitionValues(partitionValueCacheKey);
         Assert.assertEquals(partitionValues.getPartitionNameToIdMap().size(), 0);
     }
@@ -480,8 +479,7 @@ public class CatalogMgrTest extends TestWithFeService {
         HivePartitionValues hivePartitionValues = loadPartitionValues(partitionValueCacheKey,
                 Lists.newArrayList("m=1", "m=2"), metaStoreCache);
         metaStoreCache.putPartitionValuesCacheForTest(partitionValueCacheKey, hivePartitionValues);
-        metaStoreCache.addPartitionsCache("hiveDb", "hiveTable", Lists.newArrayList("m=3", "m=4"),
-                partitionValueCacheKey.getTypes());
+        metaStoreCache.addPartitionsCache("hiveDb", "hiveTable", Lists.newArrayList("m=3", "m=4"));
         HivePartitionValues partitionValues = metaStoreCache.getPartitionValues(partitionValueCacheKey);
         Assert.assertEquals(partitionValues.getPartitionNameToIdMap().size(), 4);
     }
@@ -496,7 +494,7 @@ public class CatalogMgrTest extends TestWithFeService {
                 Lists.newArrayList("m=1", "m=2"), metaStoreCache);
         metaStoreCache.putPartitionValuesCacheForTest(partitionValueCacheKey, hivePartitionValues);
         metaStoreCache.dropPartitionsCache("hiveDb", "hiveTable", Lists.newArrayList("m=1", "m=2"),
-                partitionValueCacheKey.getTypes(), false);
+                false);
         HivePartitionValues partitionValues = metaStoreCache.getPartitionValues(partitionValueCacheKey);
         Assert.assertEquals(partitionValues.getPartitionNameToIdMap().size(), 0);
     }
@@ -515,8 +513,7 @@ public class CatalogMgrTest extends TestWithFeService {
                 pNames, metaStoreCache);
         metaStoreCache.putPartitionValuesCacheForTest(partitionValueCacheKey, hivePartitionValues);
         long start = System.currentTimeMillis();
-        metaStoreCache.addPartitionsCache("hiveDb", "hiveTable", Lists.newArrayList("m=100001"),
-                partitionValueCacheKey.getTypes());
+        metaStoreCache.addPartitionsCache("hiveDb", "hiveTable", Lists.newArrayList("m=100001"));
         //387 in 4c16g
         System.out.println("testAddPartitionsCacheToLargeTable use time mills:" + (System.currentTimeMillis() - start));
         HivePartitionValues partitionValues = metaStoreCache.getPartitionValues(partitionValueCacheKey);

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/CatalogMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/CatalogMgrTest.java
@@ -450,7 +450,8 @@ public class CatalogMgrTest extends TestWithFeService {
         HivePartitionValues hivePartitionValues = loadPartitionValues(partitionValueCacheKey,
                 Lists.newArrayList("y=2020/m=1", "y=2020/m=2"), metaStoreCache);
         metaStoreCache.putPartitionValuesCacheForTest(partitionValueCacheKey, hivePartitionValues);
-        metaStoreCache.addPartitionsCache("hiveDb", "hiveTable", Lists.newArrayList("y=2020/m=3", "y=2020/m=4"));
+        metaStoreCache.addPartitionsCache("hiveDb", "hiveTable", Lists.newArrayList("y=2020/m=3", "y=2020/m=4"),
+                partitionValueCacheKey.getTypes());
         HivePartitionValues partitionValues = metaStoreCache.getPartitionValues(partitionValueCacheKey);
         Assert.assertEquals(partitionValues.getPartitionNameToIdMap().size(), 4);
     }
@@ -479,7 +480,8 @@ public class CatalogMgrTest extends TestWithFeService {
         HivePartitionValues hivePartitionValues = loadPartitionValues(partitionValueCacheKey,
                 Lists.newArrayList("m=1", "m=2"), metaStoreCache);
         metaStoreCache.putPartitionValuesCacheForTest(partitionValueCacheKey, hivePartitionValues);
-        metaStoreCache.addPartitionsCache("hiveDb", "hiveTable", Lists.newArrayList("m=3", "m=4"));
+        metaStoreCache.addPartitionsCache("hiveDb", "hiveTable", Lists.newArrayList("m=3", "m=4"),
+                partitionValueCacheKey.getTypes());
         HivePartitionValues partitionValues = metaStoreCache.getPartitionValues(partitionValueCacheKey);
         Assert.assertEquals(partitionValues.getPartitionNameToIdMap().size(), 4);
     }
@@ -513,7 +515,8 @@ public class CatalogMgrTest extends TestWithFeService {
                 pNames, metaStoreCache);
         metaStoreCache.putPartitionValuesCacheForTest(partitionValueCacheKey, hivePartitionValues);
         long start = System.currentTimeMillis();
-        metaStoreCache.addPartitionsCache("hiveDb", "hiveTable", Lists.newArrayList("m=100001"));
+        metaStoreCache.addPartitionsCache("hiveDb", "hiveTable", Lists.newArrayList("m=100001"),
+                partitionValueCacheKey.getTypes());
         //387 in 4c16g
         System.out.println("testAddPartitionsCacheToLargeTable use time mills:" + (System.currentTimeMillis() - start));
         HivePartitionValues partitionValues = metaStoreCache.getPartitionValues(partitionValueCacheKey);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #19554

## Problem summary

A similar situation with #19344 , because sometimes hms meta info is newer than hms events, if we try to invoke `org.apache.doris.datasource.hive.PooledHiveMetaStoreClient#getTable` and this table is not exists, some error will throws and this event can not be handled.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

