### PR TITLE
[Fix](multi-catalog) Fix query hms tbl with compressed data files.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileQueryScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileQueryScanNode.java
@@ -217,8 +217,8 @@ public abstract class FileQueryScanNode extends FileScanNode {
         params.setFormatType(fileFormatType);
         TFileCompressType fileCompressType = getFileCompressType(inputSplit);
         params.setCompressType(fileCompressType);
-        boolean isCsvFormat = Util.isCsvFormat(fileFormatType);
-        if (isCsvFormat || fileFormatType == TFileFormatType.FORMAT_JSON) {
+        boolean isCsvOrJson = Util.isCsvFormat(fileFormatType) || fileFormatType == TFileFormatType.FORMAT_JSON;
+        if (isCsvOrJson) {
             params.setFileAttributes(getFileAttributes());
         }
 
@@ -246,10 +246,10 @@ public abstract class FileQueryScanNode extends FileScanNode {
             FileSplit fileSplit = (FileSplit) split;
 
             TFileScanRangeParams scanRangeParams;
-            if (!isCsvFormat) {
+            if (!isCsvOrJson) {
                 scanRangeParams = params;
             } else {
-                // If fileFormatType is csv format, uncompressed files may be coexists with compressed files
+                // If fileFormatType is csv/json format, uncompressed files may be coexists with compressed files
                 // So we need set compressType separately
                 scanRangeParams = new TFileScanRangeParams(params);
                 scanRangeParams.setCompressType(getFileCompressType(fileSplit));

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileQueryScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileQueryScanNode.java
@@ -217,7 +217,8 @@ public abstract class FileQueryScanNode extends FileScanNode {
         params.setFormatType(fileFormatType);
         TFileCompressType fileCompressType = getFileCompressType(inputSplit);
         params.setCompressType(fileCompressType);
-        if (Util.isCsvFormat(fileFormatType) || fileFormatType == TFileFormatType.FORMAT_JSON) {
+        boolean isCsvFormat = Util.isCsvFormat(fileFormatType);
+        if (isCsvFormat || fileFormatType == TFileFormatType.FORMAT_JSON) {
             params.setFileAttributes(getFileAttributes());
         }
 
@@ -242,8 +243,18 @@ public abstract class FileQueryScanNode extends FileScanNode {
 
         List<String> pathPartitionKeys = getPathPartitionKeys();
         for (Split split : inputSplits) {
-            TScanRangeLocations curLocations = newLocations(params, backendPolicy);
             FileSplit fileSplit = (FileSplit) split;
+
+            TFileScanRangeParams scanRangeParams;
+            if (!isCsvFormat) {
+                scanRangeParams = params;
+            } else {
+                // If fileFormatType is csv format, uncompressed files may be coexists with compressed files
+                // So we need set compressType separately
+                scanRangeParams = new TFileScanRangeParams(params);
+                scanRangeParams.setCompressType(getFileCompressType(fileSplit));
+            }
+            TScanRangeLocations curLocations = newLocations(scanRangeParams, backendPolicy);
 
             // If fileSplit has partition values, use the values collected from hive partitions.
             // Otherwise, use the values in file path.


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

If a hms table's file format is csv, uncompressed data files may be coexists with compressed data files, so we need to set compressType separately.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

