### PR TITLE
[fix](pipeline) fix query returns empty result occasionally instead of an error after being cancelled

### DIFF
--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -32,6 +32,7 @@
 #include "common/status.h"
 #include "exec/exec_node.h"
 #include "runtime/memory/mem_tracker.h"
+#include "runtime/runtime_state.h"
 #include "util/runtime_profile.h"
 #include "vec/core/block.h"
 
@@ -296,7 +297,7 @@ public:
             return Status::OK();
         }
         _fresh_exec_timer(_sink);
-        RETURN_IF_ERROR(_sink->close(state, Status::OK()));
+        RETURN_IF_ERROR(_sink->close(state, state->query_status()));
         _is_closed = true;
         return Status::OK();
     }

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -154,6 +154,7 @@ void PipelineFragmentContext::cancel(const PPlanFragmentCancelReason& reason,
             _exec_status = Status::Cancelled(msg);
         }
         _runtime_state->set_is_cancelled(true);
+        _runtime_state->set_process_status(_exec_status);
         // Get pipe from new load stream manager and send cancel to it or the fragment may hang to wait read from pipe
         // For stream load the fragment's query_id == load id, it is set in FE.
         auto stream_load_ctx = _exec_env->new_load_stream_mgr()->get(_query_id);


### PR DESCRIPTION

# Proposed changes

Issue Number: close #19560

## Problem summary

There are two ways for fe to get the cancel msg after be cancels a query:
1.  be's report thread reports to fe;
2. fe updates the status when it gets the query data from be vresult_sink via receiver.

The reason for this problem is that the cancel status is not passed in vresult_sink when it closed after the cancel, causing fe to think that the query has ended normally.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

