### PR TITLE
[fix](Nereids): SemiJoinLogicalJoinTranspose shouldn't throw error when eliminate outer failed

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/SemiJoinLogicalJoinTranspose.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/SemiJoinLogicalJoinTranspose.java
@@ -27,8 +27,6 @@ import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.qe.ConnectContext;
 
-import com.google.common.base.Preconditions;
-
 import java.util.Set;
 
 /**
@@ -69,8 +67,9 @@ public class SemiJoinLogicalJoinTranspose extends OneRewriteRuleFactory {
                          * A      B                A      C
                          */
                         // RIGHT_OUTER_JOIN should be eliminated in rewrite phase
-                        Preconditions.checkState(bottomJoin.getJoinType() != JoinType.RIGHT_OUTER_JOIN);
-
+                        if (bottomJoin.getJoinType() == JoinType.RIGHT_OUTER_JOIN) {
+                            return null;
+                        }
                         Plan newBottomSemiJoin = topSemiJoin.withChildren(a, c);
                         return bottomJoin.withChildren(newBottomSemiJoin, b);
                     } else {
@@ -82,8 +81,9 @@ public class SemiJoinLogicalJoinTranspose extends OneRewriteRuleFactory {
                          * A      B                       B        C
                          */
                         // LEFT_OUTER_JOIN should be eliminated in rewrite phase
-                        Preconditions.checkState(bottomJoin.getJoinType() != JoinType.LEFT_OUTER_JOIN);
-
+                        if (bottomJoin.getJoinType() == JoinType.LEFT_OUTER_JOIN) {
+                            return null;
+                        }
                         Plan newBottomSemiJoin = topSemiJoin.withChildren(b, c);
                         return bottomJoin.withChildren(a, newBottomSemiJoin);
                     }


### PR DESCRIPTION
# Proposed changes

when eliminate outer failed, there will be some failed case.

We shouldn't throw error.

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

