### PR TITLE
[fix](delete) notify all when there is no high priority task

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -749,7 +749,7 @@ void TaskWorkerPool::_push_worker_thread_callback() {
 
             if (index < 0) {
                 // there is no high priority task. notify other thread to handle normal task
-                _worker_thread_condition_variable.notify_one();
+                _worker_thread_condition_variable.notify_all();
                 break;
             }
 


### PR DESCRIPTION
In somecases high priority threads are waked but normal are not. We notify_all as a workaround.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

