### PR TITLE
[Bug](https) Non leader fe fails to start when enable https

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/config/HttpToHttpsJettyConfig.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/config/HttpToHttpsJettyConfig.java
@@ -31,11 +31,29 @@ public class HttpToHttpsJettyConfig extends AbstractConfiguration {
 
         ConstraintSecurityHandler handler = new ConstraintSecurityHandler();
 
-        ConstraintMapping mappingGet = new ConstraintMapping();
-        mappingGet.setConstraint(constraint);
-        mappingGet.setPathSpec("/*");
-        mappingGet.setMethod("GET");
-        handler.addConstraintMapping(mappingGet);
+        ConstraintMapping mappingGetRest = new ConstraintMapping();
+        mappingGetRest.setConstraint(constraint);
+        mappingGetRest.setPathSpec("/rest/*");
+        mappingGetRest.setMethod("GET");
+        handler.addConstraintMapping(mappingGetRest);
+
+        ConstraintMapping mappingGetAPI = new ConstraintMapping();
+        mappingGetAPI.setConstraint(constraint);
+        mappingGetAPI.setPathSpec("/api/*");
+        mappingGetAPI.setMethod("GET");
+        handler.addConstraintMapping(mappingGetAPI);
+
+        ConstraintMapping mappingGetDump = new ConstraintMapping();
+        mappingGetDump.setConstraint(constraint);
+        mappingGetDump.setPathSpec("/dump");
+        mappingGetDump.setMethod("GET");
+        handler.addConstraintMapping(mappingGetDump);
+
+        ConstraintMapping mappingGetMetrics = new ConstraintMapping();
+        mappingGetMetrics.setConstraint(constraint);
+        mappingGetMetrics.setPathSpec("/metrics");
+        mappingGetMetrics.setMethod("GET");
+        handler.addConstraintMapping(mappingGetMetrics);
 
         ConstraintMapping mappingDel = new ConstraintMapping();
         mappingDel.setConstraint(constraint);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #19588

## Problem summary

Http interfaces between FEs are not redirected.
#19588

## Checklist(Required)

* [x] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

