### PR TITLE
[config](mem) change default mem_limit from 90% to 80%

### DIFF
--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -246,7 +246,7 @@ void MemInfo::init() {
 
     bool is_percent = true;
     if (config::mem_limit == "auto") {
-        _s_mem_limit = std::max<int64_t>(_s_physical_mem * 0.9, _s_physical_mem - 6871947672);
+        _s_mem_limit = std::max<int64_t>(_s_physical_mem * 0.8, _s_physical_mem - 6871947672);
     } else {
         _s_mem_limit =
                 ParseUtil::parse_mem_spec(config::mem_limit, -1, _s_physical_mem, &is_percent);
@@ -325,7 +325,7 @@ void MemInfo::init() {
     }
 
     if (config::mem_limit == "auto") {
-        _s_mem_limit = std::max<int64_t>(_s_physical_mem * 0.9, _s_physical_mem - 6871947672);
+        _s_mem_limit = std::max<int64_t>(_s_physical_mem * 0.8, _s_physical_mem - 6871947672);
     } else {
         bool is_percent = true;
         _s_mem_limit =


### PR DESCRIPTION
# Proposed changes

With the default config of 90%, be may meet OOM when the load pressure is big.
when set to 80%, be works well with the same load pressure in my cluster.

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

