### PR TITLE
[enhance](load) add one backoff algorithm to control the load speed

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1038,7 +1038,7 @@ DEFINE_Bool(enable_set_in_bitmap_value, "false");
 
 DEFINE_Int64(max_hdfs_file_handle_cache_num, "20000");
 DEFINE_Int64(max_external_file_meta_cache_num, "20000");
-DEFINE_mInt64(max_load_pressure_wait_time, "400");
+DEFINE_mInt64(max_load_pressure_wait_time_ms, "3000");
 
 #ifdef BE_TEST
 // test s3

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1038,6 +1038,7 @@ DEFINE_Bool(enable_set_in_bitmap_value, "false");
 
 DEFINE_Int64(max_hdfs_file_handle_cache_num, "20000");
 DEFINE_Int64(max_external_file_meta_cache_num, "20000");
+DEFINE_mInt64(max_load_pressure_wait_time, "400");
 
 #ifdef BE_TEST
 // test s3

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1039,7 +1039,7 @@ DECLARE_mInt32(s3_write_buffer_size);
 DECLARE_mInt32(s3_write_buffer_whole_size);
 
 // the max sleep time when encountering high load workload
-DECLARE_mInt64(max_load_pressure_wait_time);
+DECLARE_mInt64(max_load_pressure_wait_time_ms);
 
 //enable shrink memory
 DECLARE_Bool(enable_shrink_memory);

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1037,6 +1037,10 @@ DECLARE_mInt32(s3_write_buffer_size);
 // can at most buffer 50MB data. And the num of multi part upload task is
 // s3_write_buffer_whole_size / s3_write_buffer_size
 DECLARE_mInt32(s3_write_buffer_whole_size);
+
+// the max sleep time when encountering high load workload
+DECLARE_mInt64(max_load_pressure_wait_time);
+
 //enable shrink memory
 DECLARE_Bool(enable_shrink_memory);
 // enable cache for high concurrent point query work load

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -572,6 +572,16 @@ int64_t DeltaWriter::partition_id() const {
     return _req.partition_id;
 }
 
+void DeltaWriter::set_tablet_load_rowset_num_info(
+        google::protobuf::RepeatedPtrField<PTabletLoadRowsetInfo>* tablet_infos) {
+    if (auto version_cnt = _tablet->version_count() + _mem_table_num.load();
+        UNLIKELY(version_cnt > (config::max_tablet_version_num / 2))) {
+        auto load_info = tablet_infos->Add();
+        load_info->set_current_rowset_nums(version_cnt);
+        load_info->set_max_config_rowset_nums(config::max_tablet_version_num);
+    }
+}
+
 void DeltaWriter::_build_current_tablet_schema(int64_t index_id,
                                                const OlapTableSchemaParam* table_schema_param,
                                                const TabletSchema& ori_tablet_schema) {

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -164,7 +164,7 @@ Status DeltaWriter::init() {
 
     // check tablet version number
     if (!config::disable_auto_compaction &&
-        _tablet->exceed_version_limit(config::max_tablet_version_num - 100) &&
+        _tablet->exceed_version_limit(config::max_tablet_version_num / 2) &&
         !MemInfo::is_exceed_soft_mem_limit(GB_EXCHANGE_BYTE)) {
         //trigger compaction
         StorageEngine::instance()->submit_compaction_task(

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -163,6 +163,9 @@ Status DeltaWriter::init() {
     }
 
     // check tablet version number
+    // to cooperate with load backoff algorithm,  we try to make sure submit one
+    // compaction task to reduce the load pressure each time we meet high load
+    // pressure condition
     if (!config::disable_auto_compaction &&
         _tablet->exceed_version_limit(config::max_tablet_version_num / 2) &&
         !MemInfo::is_exceed_soft_mem_limit(GB_EXCHANGE_BYTE)) {

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -129,6 +129,9 @@ public:
 
     int64_t total_received_rows() const { return _total_received_rows; }
 
+    void set_tablet_load_rowset_num_info(
+            google::protobuf::RepeatedPtrField<PTabletLoadRowsetInfo>* tablet_info);
+
 private:
     DeltaWriter(WriteRequest* req, StorageEngine* storage_engine, RuntimeProfile* profile,
                 const UniqueId& load_id);

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -63,7 +63,7 @@ void LoadChannel::_init_profile() {
     _add_batch_times = ADD_COUNTER(_self_profile, "AddBatchTimes", TUnit::UNIT);
 }
 
-Status LoadChannel::open(const PTabletWriterOpenRequest& params) {
+Status LoadChannel::open(const PTabletWriterOpenRequest& params, PTabletWriterOpenResult* response) {
     int64_t index_id = params.index_id();
     std::shared_ptr<TabletsChannel> channel;
     {
@@ -83,7 +83,7 @@ Status LoadChannel::open(const PTabletWriterOpenRequest& params) {
         }
     }
 
-    RETURN_IF_ERROR(channel->open(params));
+    RETURN_IF_ERROR(channel->open(params, response));
 
     _opened = true;
     _last_updated_time.store(time(nullptr));

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -58,7 +58,7 @@ public:
     ~LoadChannel();
 
     // open a new load channel if not exist
-    Status open(const PTabletWriterOpenRequest& request);
+    Status open(const PTabletWriterOpenRequest& request, PTabletWriterOpenResult* response);
 
     Status open_partition(const OpenPartitionRequest& params);
 

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -104,7 +104,7 @@ Status LoadChannelMgr::init(int64_t process_mem_limit) {
     return Status::OK();
 }
 
-Status LoadChannelMgr::open(const PTabletWriterOpenRequest& params) {
+Status LoadChannelMgr::open(const PTabletWriterOpenRequest& params, PTabletWriterOpenResult* response) {
     UniqueId load_id(params.id());
     std::shared_ptr<LoadChannel> channel;
     {
@@ -136,7 +136,7 @@ Status LoadChannelMgr::open(const PTabletWriterOpenRequest& params) {
         }
     }
 
-    RETURN_IF_ERROR(channel->open(params));
+    RETURN_IF_ERROR(channel->open(params, response));
     return Status::OK();
 }
 

--- a/be/src/runtime/load_channel_mgr.h
+++ b/be/src/runtime/load_channel_mgr.h
@@ -52,7 +52,7 @@ public:
     Status init(int64_t process_mem_limit);
 
     // open a new load channel if not exist
-    Status open(const PTabletWriterOpenRequest& request);
+    Status open(const PTabletWriterOpenRequest& request, PTabletWriterOpenResult* response);
 
     Status open_partition(const OpenPartitionRequest& params);
 

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -528,6 +528,7 @@ Status TabletsChannel::add_batch(const PTabletWriterAddBlockRequest& request,
         google::protobuf::RepeatedPtrField<PTabletError>* tablet_errors =
                 response->mutable_tablet_errors();
         bool open_partition_flag = false;
+        auto tablet_load_infos = response->mutable_tablet_load_rowset_num_infos();
         {
             std::lock_guard<SpinLock> l(_tablet_writers_lock);
             auto tablet_writer_it = _tablet_writers.find(tablet_id);
@@ -560,6 +561,7 @@ Status TabletsChannel::add_batch(const PTabletWriterAddBlockRequest& request,
                 // continue write to other tablet.
                 // the error will return back to sender.
             }
+            tablet_writer_it->second->set_tablet_load_rowset_num_info(tablet_load_infos);
         }
         return Status::OK();
     };

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -88,7 +88,7 @@ public:
 
     ~TabletsChannel();
 
-    Status open(const PTabletWriterOpenRequest& request);
+    Status open(const PTabletWriterOpenRequest& request, PTabletWriterOpenResult* response);
 
     // Open specific partition all writers
     Status open_all_writers_for_partition(const OpenPartitionRequest& request);
@@ -131,7 +131,7 @@ private:
     Status _open_all_writers_for_partition(const int64_t& tablet_id,
                                            const TabletWriterAddRequest& request);
     // open all writer
-    Status _open_all_writers(const PTabletWriterOpenRequest& request);
+    Status _open_all_writers(const PTabletWriterOpenRequest& request, PTabletWriterOpenResult* response);
 
     // deal with DeltaWriter close_wait(), add tablet to list for return.
     void _close_wait(DeltaWriter* writer,

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -233,7 +233,7 @@ void PInternalServiceImpl::tablet_writer_open(google::protobuf::RpcController* c
         VLOG_RPC << "tablet writer open, id=" << request->id()
                  << ", index_id=" << request->index_id() << ", txn_id=" << request->txn_id();
         brpc::ClosureGuard closure_guard(done);
-        auto st = _exec_env->load_channel_mgr()->open(*request);
+        auto st = _exec_env->load_channel_mgr()->open(*request, response);
         if (!st.ok()) {
             LOG(WARNING) << "load channel open failed, message=" << st << ", id=" << request->id()
                          << ", index_id=" << request->index_id()

--- a/be/src/vec/sink/vtablet_sink.h
+++ b/be/src/vec/sink/vtablet_sink.h
@@ -289,6 +289,8 @@ public:
 protected:
     void _close_check();
     void _cancel_with_msg(const std::string& msg);
+    void _refresh_load_wait_time(
+            const ::google::protobuf::RepeatedPtrField<::doris::PTabletLoadRowsetInfo>& response);
 
     VOlapTableSink* _parent = nullptr;
     IndexChannel* _index_channel = nullptr;

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -96,6 +96,7 @@ message PTabletWriterOpenRequest {
 
 message PTabletWriterOpenResult {
     required PStatus status = 1;
+    repeated PTabletLoadRowsetInfo tablet_load_rowset_num_infos = 2;
 };
 
 message OpenPartitionRequest {

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -61,6 +61,11 @@ message PTabletWithPartition {
     required int64 tablet_id = 2;
 }
 
+message PTabletLoadRowsetInfo {
+    required int32 current_rowset_nums = 1;
+    required int32 max_config_rowset_nums = 2;
+}
+
 message PTabletInfo {
     required int64 tablet_id = 1;
     required int32 schema_hash = 2;
@@ -193,6 +198,8 @@ message PTabletWriterAddBlockResult {
     repeated PTabletError tablet_errors = 6;
     map<int64, PSuccessSlaveTabletNodeIds> success_slave_tablet_node_ids = 7;
     optional bytes load_channel_profile = 8;
+    // Used to indicate if the corresponding tablet is under high load pressure
+    repeated PTabletLoadRowsetInfo tablet_load_rowset_num_infos = 9;
 };
 
 // tablet writer cancel


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
If Doris is under high load pressure(too much load in short time), there would be too many rowsets which would bring a lot chance to -235. Doris uses compaction to reduce the nums of rowsets, the former logic would trigger one compaction when the rowsets num is bigger than max_tablets_verson - 100, it might not be enough when encountering extreme high load pressure, so this pr adapts it to trigger compaction when the num is larger then max_tablet_version / 2 and it would make the send block rpc procedure sleep one short time period(based on the rowsets num) to wait for the triggered compaction task to be done.
## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

