### PR TITLE
[enhancement](merge-on-write) avoid unecessary pk index iteration

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -400,8 +400,11 @@ Status DeltaWriter::close_wait(const PSlaveTabletNodes& slave_tablet_nodes,
             SchemaChangeHandler::tablet_in_converting(_tablet->tablet_id())) {
             return Status::OK();
         }
-        RETURN_IF_ERROR(_tablet->calc_delete_bitmap(_cur_rowset, segments, nullptr, _delete_bitmap,
-                                                    _cur_max_version, true));
+        if (segments.size() > 1) {
+            // calculate delete bitmap between segments
+            RETURN_IF_ERROR(_tablet->calc_delete_bitmap(_cur_rowset, segments, nullptr,
+                                                        _delete_bitmap, _cur_max_version, true));
+        }
         _storage_engine->txn_manager()->set_txn_related_delete_bitmap(
                 _req.partition_id, _req.txn_id, _tablet->tablet_id(), _tablet->schema_hash(),
                 _tablet->tablet_uid(), true, _delete_bitmap, _rowset_ids);

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2644,6 +2644,9 @@ Status Tablet::calc_delete_bitmap(RowsetSharedPtr rowset,
                                   const RowsetIdUnorderedSet* specified_rowset_ids,
                                   DeleteBitmapPtr delete_bitmap, int64_t end_version,
                                   bool check_pre_segments, RowsetWriter* rowset_writer) {
+    if (check_pre_segments && segments.size() == 1) {
+        return Status::OK();
+    }
     std::vector<segment_v2::SegmentSharedPtr> pre_segments;
     OlapStopWatch watch;
 

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2644,9 +2644,6 @@ Status Tablet::calc_delete_bitmap(RowsetSharedPtr rowset,
                                   const RowsetIdUnorderedSet* specified_rowset_ids,
                                   DeleteBitmapPtr delete_bitmap, int64_t end_version,
                                   bool check_pre_segments, RowsetWriter* rowset_writer) {
-    if (check_pre_segments && segments.size() == 1) {
-        return Status::OK();
-    }
     std::vector<segment_v2::SegmentSharedPtr> pre_segments;
     OlapStopWatch watch;
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

When there is only one segment, we don't need to calculate delete bitmap between segments

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

