### PR TITLE
[Enhancement](drop) drop multi tables in one drop stmt

### DIFF
--- a/docs/en/docs/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-TABLE.md
+++ b/docs/en/docs/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-TABLE.md
@@ -51,13 +51,19 @@ illustrate:
    
      ```sql
      DROP TABLE my_table;
-     ````
-    
-2. If it exists, delete the table of the specified database
+     ```
+
+2. Delete multiple table
+   
+     ```sql
+     DROP TABLE my_table1, my_table2;
+     ```
+
+3. If it exists, delete the table of the specified database
    
      ```sql
      DROP TABLE IF EXISTS example_db.my_table;
-     ````
+     ```
 
 ### Keywords
 

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-TABLE.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Data-Definition-Statements/Drop/DROP-TABLE.md
@@ -52,8 +52,14 @@ DROP TABLE [IF EXISTS] [db_name.]table_name [FORCE];
     ```sql
     DROP TABLE my_table;
     ```
-    
-2. 如果存在，删除指定 database 的 table
+
+2. 删除多个 table
+   
+    ```sql
+    DROP TABLE my_table1, my_table2;
+    ```
+
+3. 如果存在，删除指定 database 的 table
    
     ```sql
     DROP TABLE IF EXISTS example_db.my_table;

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -760,6 +760,7 @@ nonterminal SlotRef column_ref;
 nonterminal ArrayList<SlotRef> column_ref_list;
 nonterminal FunctionCallExpr column_subscript;
 nonterminal FunctionCallExpr column_slice;
+nonterminal ArrayList<TableName> table_list;
 nonterminal ArrayList<TableRef> table_ref_list, base_table_ref_list;
 nonterminal ArrayList<LateralViewRef> opt_lateral_view_ref_list, lateral_view_ref_list;
 nonterminal FromClause from_clause;
@@ -2916,9 +2917,9 @@ drop_stmt ::=
         RESULT = new DropFunctionStmt(type, ifExists, functionName, args);
     :}
     /* Table */
-    | KW_DROP KW_TABLE opt_if_exists:ifExists table_name:name opt_force:force
+    | KW_DROP KW_TABLE opt_if_exists:ifExists table_list:tableNames opt_force:force
     {:
-        RESULT = new DropTableStmt(ifExists, name, force);
+        RESULT = new DropTableStmt(ifExists, tableNames, force);
     :}
     /* User */
     | KW_DROP KW_USER opt_if_exists:ifExists user_identity:userId
@@ -2926,9 +2927,9 @@ drop_stmt ::=
         RESULT = new DropUserStmt(ifExists, userId);
     :}
     /* View */
-    | KW_DROP KW_VIEW opt_if_exists:ifExists table_name:name
+    | KW_DROP KW_VIEW opt_if_exists:ifExists table_list:tableNames
     {:
-        RESULT = new DropTableStmt(ifExists, name, true, false);
+        RESULT = new DropTableStmt(ifExists, tableNames, true, false);
     :}
     | KW_DROP KW_REPOSITORY ident:repoName
     {:
@@ -5696,6 +5697,20 @@ ident_list ::=
     | ident_list:list COMMA ident:ident
     {:
       list.add(ident);
+      RESULT = list;
+    :}
+    ;
+
+table_list ::=
+    table_name:tbl
+    {:
+      ArrayList<TableName> list = new ArrayList<TableName>();
+      list.add(tbl);
+      RESULT = list;
+    :}
+    | table_list:list COMMA table_name:tbl
+    {:
+      list.add(tbl);
       RESULT = list;
     :}
     ;

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
@@ -89,6 +89,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -150,7 +151,8 @@ public class Alter {
             OlapTable olapTable = (OlapTable) db.getTableOrMetaException(name, TableType.OLAP);
             ((MaterializedViewHandler) materializedViewHandler).processDropMaterializedView(stmt, db, olapTable);
         } else {
-            DropTableStmt dropTableStmt = new DropTableStmt(stmt.isIfExists(), stmt.getMTMVName(), false);
+            DropTableStmt dropTableStmt = new DropTableStmt(stmt.isIfExists(),
+                    Collections.singletonList(stmt.getMTMVName()), false);
             dropTableStmt.setMaterializedView(true);
             Env.getCurrentInternalCatalog().dropTable(dropTableStmt);
         }
@@ -619,7 +621,7 @@ public class Alter {
      * 1.2 rename B to A, drop old A, and add new A to database.
      */
     private void replaceTableInternal(Database db, OlapTable origTable, OlapTable newTbl, boolean swapTable,
-                                      boolean isReplay)
+            boolean isReplay)
             throws DdlException {
         String oldTblName = origTable.getName();
         String newTblName = newTbl.getName();
@@ -755,10 +757,10 @@ public class Alter {
      * caller should hold the table lock
      */
     public void modifyPartitionsProperty(Database db,
-                                         OlapTable olapTable,
-                                         List<String> partitionNames,
-                                         Map<String, String> properties,
-                                         boolean isTempPartition)
+            OlapTable olapTable,
+            List<String> partitionNames,
+            Map<String, String> properties,
+            boolean isTempPartition)
             throws DdlException, AnalysisException {
         Preconditions.checkArgument(olapTable.isWriteLockHeldByCurrentThread());
         List<ModifyPartitionInfo> modifyPartitionInfos = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchemaInitializer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchemaInitializer.java
@@ -42,6 +42,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -243,7 +244,7 @@ public class InternalSchemaInitializer extends Thread {
         // TODO remove this code after the table structure is stable
         if (!isSchemaChanged && isTableChanged(tableName, columnDefs)) {
             isSchemaChanged = true;
-            DropTableStmt dropTableStmt = new DropTableStmt(true, tableName, true);
+            DropTableStmt dropTableStmt = new DropTableStmt(true, Collections.singletonList(tableName), true);
             StatisticsUtil.analyze(dropTableStmt);
             Env.getCurrentEnv().getInternalCatalog().dropTable(dropTableStmt);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
@@ -37,6 +37,7 @@ import com.google.common.collect.Maps;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -111,7 +112,8 @@ public class RefreshManager {
         for (Table table : db.getTables()) {
             if (table instanceof IcebergTable) {
                 DropTableStmt dropTableStmt =
-                        new DropTableStmt(true, new TableName(null, dbName, table.getName()), true);
+                        new DropTableStmt(true, Collections.singletonList(new TableName(null, dbName, table.getName())),
+                                true);
                 env.dropTable(dropTableStmt);
             }
         }
@@ -151,7 +153,7 @@ public class RefreshManager {
         icebergProperties.put(IcebergProperty.ICEBERG_DATABASE, ((IcebergTable) table).getIcebergDb());
 
         // 2. drop old table
-        DropTableStmt dropTableStmt = new DropTableStmt(true, stmt.getTableName(), true);
+        DropTableStmt dropTableStmt = new DropTableStmt(true, Collections.singletonList(stmt.getTableName()), true);
         env.dropTable(dropTableStmt);
 
         // 3. create new table

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -2105,19 +2105,19 @@ public class StmtExecutor {
                 execute();
                 if (MysqlStateType.ERR.equals(context.getState().getStateType())) {
                     LOG.warn("CTAS insert data error, stmt={}", ctasStmt.toSql());
-                    handleCtasRollback(ctasStmt.getCreateTableStmt().getDbTbl());
+                    handleCtasRollback(Collections.singletonList(ctasStmt.getCreateTableStmt().getDbTbl()));
                 }
             } catch (Exception e) {
                 LOG.warn("CTAS insert data error, stmt={}", ctasStmt.toSql(), e);
-                handleCtasRollback(ctasStmt.getCreateTableStmt().getDbTbl());
+                handleCtasRollback(Collections.singletonList(ctasStmt.getCreateTableStmt().getDbTbl()));
             }
         }
     }
 
-    private void handleCtasRollback(TableName table) {
+    private void handleCtasRollback(List<TableName> tableNames) {
         if (context.getSessionVariable().isDropTableIfCtasFailed()) {
             // insert error drop table
-            DropTableStmt dropTableStmt = new DropTableStmt(true, table, true);
+            DropTableStmt dropTableStmt = new DropTableStmt(true, tableNames, true);
             try {
                 DdlExecutor.execute(context.getEnv(), dropTableStmt);
             } catch (Exception ex) {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/DropTableStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/DropTableStmtTest.java
@@ -30,6 +30,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
+
 public class DropTableStmtTest {
     private static final String internalCtl = InternalCatalog.INTERNAL_CATALOG_NAME;
 
@@ -72,32 +74,32 @@ public class DropTableStmtTest {
 
     @Test
     public void testNormal() throws UserException, AnalysisException {
-        DropTableStmt stmt = new DropTableStmt(false, tbl, true);
+        DropTableStmt stmt = new DropTableStmt(false, Collections.singletonList(tbl), true);
         stmt.analyze(analyzer);
-        Assert.assertEquals("testCluster:db1", stmt.getDbName());
-        Assert.assertEquals("table1", stmt.getTableName());
+        Assert.assertEquals("testCluster:db1", stmt.getTableNames().get(0).getDb());
+        Assert.assertEquals("table1", stmt.getTableNames().get(0).getTbl());
         Assert.assertEquals("DROP TABLE `testCluster:db1`.`table1`", stmt.toString());
     }
 
     @Test
     public void testDefaultNormal() throws UserException, AnalysisException {
-        DropTableStmt stmt = new DropTableStmt(false, noDbTbl, true);
+        DropTableStmt stmt = new DropTableStmt(false, Collections.singletonList(noDbTbl), true);
         stmt.analyze(analyzer);
-        Assert.assertEquals("testCluster:testDb", stmt.getDbName());
-        Assert.assertEquals("table1", stmt.getTableName());
+        Assert.assertEquals("testCluster:testDb", stmt.getTableNames().get(0).getDb());
+        Assert.assertEquals("table1", stmt.getTableNames().get(0).getTbl());
         Assert.assertEquals("DROP TABLE `testCluster:testDb`.`table1`", stmt.toSql());
     }
 
     @Test(expected = AnalysisException.class)
     public void testNoDbFail() throws UserException, AnalysisException {
-        DropTableStmt stmt = new DropTableStmt(false, noDbTbl, true);
+        DropTableStmt stmt = new DropTableStmt(false, Collections.singletonList(noDbTbl), true);
         stmt.analyze(noDbAnalyzer);
         Assert.fail("No Exception throws.");
     }
 
     @Test(expected = AnalysisException.class)
     public void testNoTableFail() throws UserException, AnalysisException {
-        DropTableStmt stmt = new DropTableStmt(false, new TableName(internalCtl, "db1", ""), true);
+        DropTableStmt stmt = new DropTableStmt(false, Collections.singletonList(new TableName(internalCtl, "db1", "")), true);
         stmt.analyze(noDbAnalyzer);
         Assert.fail("No Exception throws.");
     }

--- a/regression-test/suites/ddl_p0/test_drop.groovy
+++ b/regression-test/suites/ddl_p0/test_drop.groovy
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_drop") {
+    sql """
+           CREATE TABLE IF NOT EXISTS tbl1(k1 int, k2 bigint) duplicate key(k1) distributed by hash(k2) buckets 1 properties('replication_num' = '1');
+            """
+    sql """
+           CREATE TABLE IF NOT EXISTS tbl2(k1 int, k2 bigint) duplicate key(k1) distributed by hash(k2) buckets 1 properties('replication_num' = '1');
+            """
+    sql """
+           drop table tbl1, tbl2;
+            """
+}


### PR DESCRIPTION
# Proposed changes

Issue Number: https://github.com/apache/doris/issues/19418

## Problem summary

Support drop multi tables in one drop stmt:

```sql
drop table t1, t2;
```

## Checklist(Required)

* [x] Does it affect the original behavior
* [x] Has unit tests been added
* [x] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

