### PR TITLE
[chore](stacktrace) Make crash information clearer

### DIFF
--- a/be/src/vec/exprs/vexpr_context.cpp
+++ b/be/src/vec/exprs/vexpr_context.cpp
@@ -49,8 +49,7 @@ VExprContext::VExprContext(VExpr* expr)
 VExprContext::~VExprContext() {
     // Do not delete this code, this code here is used to check if forget to close the opened context
     // Or there will be memory leak
-    DCHECK(!_prepared || _closed) << get_stack_trace() << " prepare:" << _prepared
-                                  << " closed:" << _closed << " expr:" << _root->debug_string();
+    DCHECK(!_prepared || _closed);
 }
 
 doris::Status VExprContext::execute(doris::vectorized::Block* block, int* result_column_id) {


### PR DESCRIPTION
# Proposed changes

## Problem summary

`DCHECK` only runs in DEBUG mode which already has a stack trace. No need to print it again.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

