### PR TITLE
[chore](LOG) fix ambiguous start time log

### DIFF
--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -201,7 +201,7 @@ if [[ -f "${pidfile}" ]]; then
 fi
 
 chmod 755 "${DORIS_HOME}/lib/doris_be"
-echo "start time: $(date)" >>"${LOG_DIR}/be.out"
+echo "start time: $(date +"%Y-%m-%d %H:%M:%S")" >>"${LOG_DIR}/be.out"
 
 if [[ ! -f '/bin/limit3' ]]; then
     LIMIT=''


### PR DESCRIPTION
# Proposed changes


## Problem summary

before:
```
start time: Sun 14 May 2023 12:26:04 AM CST
```
after:
```
start time: 2023-05-14 00:26:04
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

