### PR TITLE
[Fix](Nereids) fix minidump parameter name and double not a number serialize bug

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -268,7 +268,7 @@ public class NereidsPlanner extends Planner {
             }
             // serialize optimized plan to dumpfile, dumpfile do not have this part means optimize failed
             serializeOutputToDumpFile(physicalPlan, statementContext.getConnectContext());
-            if (statementContext.getConnectContext().getSessionVariable().isDumpNereids()) {
+            if (statementContext.getConnectContext().getSessionVariable().isEnableMinidump()) {
                 MinidumpUtils.saveMinidumpString(statementContext.getConnectContext().getMinidump(),
                         DebugUtil.printId(statementContext.getConnectContext().queryId()));
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/minidump/Minidump.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/minidump/Minidump.java
@@ -138,7 +138,7 @@ public class Minidump {
         ConnectContext connectContext = new ConnectContext();
         connectContext.setSessionVariable(minidump.getSessionVariable());
         connectContext.setTables(minidump.getTables());
-        connectContext.getSessionVariable().setDumpNereids(false);
+        connectContext.getSessionVariable().setEnableMinidump(false);
         connectContext.setDatabase(minidump.getDbName());
         connectContext.getSessionVariable().setPlanNereidsDump(true);
         connectContext.getSessionVariable().enableNereidsTimeout = true;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -303,7 +303,7 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String SHOW_USER_DEFAULT_ROLE = "show_user_default_role";
 
-    public static final String DUMP_NEREIDS = "dump_nereids";
+    public static final String ENABLE_MINIDUMP = "enable_minidump";
 
     public static final String TRACE_NEREIDS = "trace_nereids";
 
@@ -860,8 +860,8 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = DUMP_NEREIDS_MEMO)
     public boolean dumpNereidsMemo = false;
 
-    @VariableMgr.VarAttr(name = DUMP_NEREIDS)
-    public boolean dumpNereids = false;
+    @VariableMgr.VarAttr(name = ENABLE_MINIDUMP)
+    public boolean enableMinidump = false;
 
     @VariableMgr.VarAttr(name = TRACE_NEREIDS)
     public boolean traceNereids = false;
@@ -2077,12 +2077,12 @@ public class SessionVariable implements Serializable, Writable {
         return "";
     }
 
-    public boolean isDumpNereids() {
-        return dumpNereids;
+    public boolean isEnableMinidump() {
+        return enableMinidump;
     }
 
-    public void setDumpNereids(boolean dumpNereids) {
-        this.dumpNereids = dumpNereids;
+    public void setEnableMinidump(boolean enableMinidump) {
+        this.enableMinidump = enableMinidump;
     }
 
     public boolean isTraceNereids() {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
@@ -276,15 +276,19 @@ public class ColumnStatistic {
         JSONObject statistic = new JSONObject();
         statistic.put("Ndv", ndv);
         if (Double.isInfinite(minValue)) {
-            statistic.put("MinValueInfinite", true);
+            statistic.put("MinValueType", "Infinite");
+        } else if (Double.isNaN(minValue)) {
+            statistic.put("MinValueType", "Invalid");
         } else {
-            statistic.put("MinValueInfinite", false);
+            statistic.put("MinValueType", "Normal");
             statistic.put("MinValue", minValue);
         }
         if (Double.isInfinite(maxValue)) {
-            statistic.put("MaxValueInfinite", true);
+            statistic.put("MaxValueType", "Infinite");
+        } else if (Double.isNaN(maxValue)) {
+            statistic.put("MaxValueType", "Invalid");
         } else {
-            statistic.put("MaxValueInfinite", false);
+            statistic.put("MaxValueType", "Normal");
             statistic.put("MaxValue", maxValue);
         }
         statistic.put("Selectivity", selectivity);
@@ -305,8 +309,34 @@ public class ColumnStatistic {
     // Histogram is got by other place
     public static ColumnStatistic fromJson(String statJson) {
         JSONObject stat = new JSONObject(statJson);
-        Double minValue = stat.getBoolean("MinValueInfinite") ? Double.NEGATIVE_INFINITY : stat.getDouble("MinValue");
-        Double maxValue = stat.getBoolean("MaxValueInfinite") ? Double.POSITIVE_INFINITY : stat.getDouble("MaxValue");
+        Double minValue;
+        switch (stat.getString("MinValueType")) {
+            case "Infinite":
+                minValue = Double.NEGATIVE_INFINITY;
+                break;
+            case "Invalid":
+                minValue = Double.NaN;
+                break;
+            case "Normal":
+                minValue = stat.getDouble("MinValue");
+                break;
+            default:
+                throw new RuntimeException(String.format("Min value does not get anytype"));
+        }
+        Double maxValue;
+        switch (stat.getString("MaxValueType")) {
+            case "Infinite":
+                maxValue = Double.POSITIVE_INFINITY;
+                break;
+            case "Invalid":
+                maxValue = Double.NaN;
+                break;
+            case "Normal":
+                maxValue = stat.getDouble("MaxValue");
+                break;
+            default:
+                throw new RuntimeException(String.format("Min value does not get anytype"));
+        }
         return new ColumnStatistic(
             stat.getDouble("Count"),
             stat.getDouble("Ndv"),


### PR DESCRIPTION
…rialize bug

# Proposed changes

## Problem summary

Change nereids minidump switch from "Dump_nereids" to "enable_minidump" which is more exactly and neat. Also fix bug of Double.NaN (not a number) serialize bug when doing column statistic serialization.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

