### PR TITLE
[fix](ubsan) fix ubsan errors

### DIFF
--- a/be/src/exec/schema_scanner/schema_tables_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_tables_scanner.cpp
@@ -135,6 +135,9 @@ Status SchemaTablesScanner::_get_new_table() {
 Status SchemaTablesScanner::_fill_block_impl(vectorized::Block* block) {
     SCOPED_TIMER(_fill_block_timer);
     auto table_num = _table_result.tables.size();
+    if (table_num == 0) {
+        return Status::OK();
+    }
     std::vector<void*> null_datas(table_num, nullptr);
     std::vector<void*> datas(table_num);
 

--- a/be/src/exec/schema_scanner/schema_views_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_views_scanner.cpp
@@ -132,6 +132,9 @@ Status SchemaViewsScanner::get_next_block(vectorized::Block* block, bool* eos) {
 Status SchemaViewsScanner::_fill_block_impl(vectorized::Block* block) {
     SCOPED_TIMER(_fill_block_timer);
     auto tables_num = _table_result.tables.size();
+    if (tables_num == 0) {
+        return Status::OK();
+    }
     std::vector<void*> null_datas(tables_num, nullptr);
     std::vector<void*> datas(tables_num);
 

--- a/be/src/runtime/decimalv2_value.cpp
+++ b/be/src/runtime/decimalv2_value.cpp
@@ -28,6 +28,8 @@
 
 namespace doris {
 
+const int128_t DecimalV2Value::MAX_DECIMAL_VALUE;
+
 static inline int128_t abs(const int128_t& x) {
     return (x < 0) ? -x : x;
 }

--- a/be/src/util/string_parser.hpp
+++ b/be/src/util/string_parser.hpp
@@ -272,7 +272,7 @@ T StringParser::string_to_int_internal(const char* s, int len, ParseResult* resu
     switch (*s) {
     case '-':
         negative = true;
-        max_val = StringParser::numeric_limits<T>(false) + 1;
+        max_val += 1;
         [[fallthrough]];
     case '+':
         ++i;

--- a/be/src/vec/aggregate_functions/aggregate_function_percentile_approx.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_percentile_approx.h
@@ -442,7 +442,7 @@ public:
 
         AggregateFunctionPercentileArray::data(place).add(
                 sources.get_int(row_num), nested_column_data.get_data(),
-                offset_column_data.data()[row_num] - offset_column_data.data()[row_num - 1]);
+                offset_column_data.data()[row_num] - offset_column_data[(ssize_t)row_num - 1]);
     }
 
     void reset(AggregateDataPtr __restrict place) const override {

--- a/be/src/vec/functions/functions_comparison.h
+++ b/be/src/vec/functions/functions_comparison.h
@@ -209,9 +209,11 @@ struct StringEqualsImpl {
         if (b_size == 0) {
             auto* __restrict data = c.data();
             auto* __restrict offsets = a_offsets.data();
+
+            ColumnString::Offset prev_a_offset = 0;
             for (size_t i = 0; i < size; ++i) {
-                data[i] =
-                        positive ? (offsets[i] == offsets[i - 1]) : (offsets[i] != offsets[i - 1]);
+                data[i] = positive ? (offsets[i] == prev_a_offset) : (offsets[i] != prev_a_offset);
+                prev_a_offset = offsets[i];
             }
         } else {
             ColumnString::Offset prev_a_offset = 0;

--- a/be/src/vec/functions/multiply.cpp
+++ b/be/src/vec/functions/multiply.cpp
@@ -64,9 +64,15 @@ struct MultiplyImpl {
         }
 
         for (int i = 0; i < size; i++) {
-            c[i] = (DecimalV2Value(a[i]).value() * DecimalV2Value(b[i]).value() - sgn[i]) /
-                           DecimalV2Value::ONE_BILLION +
-                   sgn[i];
+            int128_t i128_mul_result;
+            if (common::mul_overflow(DecimalV2Value(a[i]).value(), DecimalV2Value(b[i]).value(),
+                                     i128_mul_result)) {
+                VLOG_DEBUG << "Decimal multiply overflow";
+                c[i] = (sgn[i] == -1) ? -DecimalV2Value::MAX_DECIMAL_VALUE
+                                      : DecimalV2Value::MAX_DECIMAL_VALUE;
+            } else {
+                c[i] = (i128_mul_result - sgn[i]) / DecimalV2Value::ONE_BILLION + sgn[i];
+            }
         }
     }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Fixu ubsan errors:
```
doris/be/src/util/string_parser.hpp:275:58: runtime error: signed integer overflow: 2147483647 + 1 cannot be represented in type 'int'

doris/be/src/vec/functions/functions_comparison.h:214:51: runtime error: addition of unsigned offset to 0x7fea6c6b7010 overflowed to 0x7fea6c6b700c

doris/be/src/vec/functions/multiply.cpp:67:50: runtime error: signed integer overflow: 1295699415680000000 * 0x0000000000015401d0a4cd4890a77700 cannot be represented in type '__int128

doris/be/src/vec/aggregate_functions/aggregate_function_percentile_approx.h:445:73: runtime error: addition of unsigned offset to 0x7feca3343d10 overflowed to 0x7feca3343d08 

doris/be/src/exec/schema_scanner/schema_tables_scanner.cpp:330:24: runtime error: variable length array bound evaluates to non-positive value 0
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

