### PR TITLE
[Fix](single replica load) add inverted index copy for single replica load

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -45,6 +45,7 @@
 #include "olap/rowset/rowset_meta.h"
 #include "olap/rowset/rowset_writer.h"
 #include "olap/rowset/rowset_writer_context.h"
+#include "olap/rowset/segment_v2/inverted_index_desc.h"
 #include "olap/rowset/segment_v2/segment.h"
 #include "olap/schema.h"
 #include "olap/schema_change.h"
@@ -559,6 +560,14 @@ void DeltaWriter::_request_slave_tablet_pull_rowset(PNodeInfo node_info) {
         _unfinished_slave_node.insert(node_info.id());
     }
 
+    std::vector<int64_t> indices_ids;
+    auto tablet_schema = _cur_rowset->rowset_meta()->tablet_schema();
+    for (auto& column : tablet_schema->columns()) {
+        const TabletIndex* index_meta = tablet_schema->get_inverted_index(column.unique_id());
+        if (index_meta) {
+            indices_ids.emplace_back(index_meta->index_id());
+        }
+    }
     PTabletWriteSlaveRequest request;
     RowsetMetaPB rowset_meta_pb = _cur_rowset->rowset_meta()->get_rowset_pb();
     request.set_allocated_rowset_meta(&rowset_meta_pb);
@@ -575,6 +584,22 @@ void DeltaWriter::_request_slave_tablet_pull_rowset(PNodeInfo node_info) {
         segment_name << _cur_rowset->rowset_id() << "_" << segment_id << ".dat";
         int64_t segment_size = std::filesystem::file_size(tablet_path + "/" + segment_name.str());
         request.mutable_segments_size()->insert({segment_id, segment_size});
+
+        if (!indices_ids.empty()) {
+            for (auto index_id : indices_ids) {
+                std::string inverted_index_file = InvertedIndexDescriptor::get_index_file_name(
+                        tablet_path + "/" + segment_name.str(), index_id);
+                int64_t size = std::filesystem::file_size(inverted_index_file);
+                PTabletWriteSlaveRequest::IndexSize index_size;
+                index_size.set_indexid(index_id);
+                index_size.set_size(size);
+                // Fetch the map value for the current segment_id.
+                // If it doesn't exist, this will insert a new default-constructed IndexSizeMapValue
+                auto& index_size_map_value = (*request.mutable_inverted_indices_size())[segment_id];
+                // Add the new index size to the map value.
+                *index_size_map_value.mutable_index_sizes()->Add() = std::move(index_size);
+            }
+        }
     }
     RefCountClosure<PTabletWriteSlaveResult>* closure =
             new RefCountClosure<PTabletWriteSlaveResult>();

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -1187,7 +1187,8 @@ constexpr auto Permissions = S_IRUSR | S_IWUSR;
 
 std::string construct_url(const std::string& host_port, const std::string& token,
                           const std::string& path) {
-    return fmt::format("{}{}{}{}{}{}", HttpProtocol, host_port, DownloadApiPath, token, FileParam, path);
+    return fmt::format("{}{}{}{}{}{}", HttpProtocol, host_port, DownloadApiPath, token, FileParam,
+                       path);
 }
 
 std::string construct_file_path(const std::string& tablet_path, const std::string& rowset_id,
@@ -1308,7 +1309,8 @@ void PInternalServiceImpl::request_slave_tablet_pull_rowset(
                 return;
             }
             VLOG_CRITICAL << "succeed to download file for slave replica. url=" << remote_file_url
-                      << ", local_path=" << local_file_path << ", txn_id=" << rowset_meta->txn_id();
+                          << ", local_path=" << local_file_path
+                          << ", txn_id=" << rowset_meta->txn_id();
             PTabletWriteSlaveRequest_IndexSizeMap segment_indices_size =
                     indices_size.at(segment.first);
             for (auto index_size : segment_indices_size.index_sizes()) {
@@ -1334,9 +1336,9 @@ void PInternalServiceImpl::request_slave_tablet_pull_rowset(
                     return;
                 }
                 VLOG_CRITICAL << "succeed to download inverted index file for slave replica. url="
-                          << remote_inverted_index_file_url
-                          << ", local_path=" << local_inverted_index_file
-                          << ", txn_id=" << rowset_meta->txn_id();
+                              << remote_inverted_index_file_url
+                              << ", local_path=" << local_inverted_index_file
+                              << ", txn_id=" << rowset_meta->txn_id();
             }
         }
 

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -568,6 +568,15 @@ message PResetRPCChannelResponse {
 message PEmptyRequest {};
 
 message PTabletWriteSlaveRequest {
+    message IndexSize {
+        required int64 indexId = 1;
+        required int64 size = 2;
+    };
+
+    message IndexSizeMap{
+        repeated IndexSize index_sizes = 1;
+    };
+
     optional RowsetMetaPB rowset_meta = 1;
     optional string rowset_path = 2;
     map<int64, int64> segments_size = 3;
@@ -576,6 +585,7 @@ message PTabletWriteSlaveRequest {
     optional int32 brpc_port = 6;
     optional string token = 7;
     optional int32 node_id = 8;
+    map<int64, IndexSizeMap> inverted_indices_size = 9;
 };
 
 message PTabletWriteSlaveResult {


### PR DESCRIPTION
# Proposed changes

This PR implements the addition of an inverted index copy for single replica load. 
The changes include updates to three files:

1. be/src/olap/delta_writer.cpp, generate index_id,size pair
2. be/src/service/internal_service.cpp, copy index file from master
3. gensrc/proto/internal_service.proto, adding inverted index_id and size into proto

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

