### PR TITLE
[improvement](tracing) Remove useless span levels from be side tracing

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -523,19 +523,6 @@ inline std::string Status::to_string() const {
 #define RETURN_ERROR_IF_NON_VEC \
     return Status::NotSupported("Non-vectorized engine is not supported since Doris 2.0.");
 
-// End _get_next_span after last call to get_next method
-#define RETURN_IF_ERROR_AND_CHECK_SPAN(stmt, get_next_span, done) \
-    do {                                                          \
-        Status _status_ = (stmt);                                 \
-        auto _span = (get_next_span);                             \
-        if (UNLIKELY(_span && (!_status_.ok() || done))) {        \
-            _span->End();                                         \
-        }                                                         \
-        if (UNLIKELY(!_status_.ok())) {                           \
-            return _status_;                                      \
-        }                                                         \
-    } while (false)
-
 #define RETURN_IF_STATUS_ERROR(status, stmt) \
     do {                                     \
         status = (stmt);                     \

--- a/be/src/exec/data_sink.h
+++ b/be/src/exec/data_sink.h
@@ -71,7 +71,7 @@ public:
     // It must be okay to call this multiple times. Subsequent calls should
     // be ignored.
     virtual Status close(RuntimeState* state, Status exec_status) {
-        profile()->add_to_span();
+        profile()->add_to_span(_span);
         _closed = true;
         return Status::OK();
     }
@@ -98,12 +98,6 @@ public:
         _query_statistics = statistics;
     }
 
-    void end_send_span() {
-        if (_send_span) {
-            _send_span->End();
-        }
-    }
-
 protected:
     // Set to true after close() has been called. subclasses should check and set this in
     // close().
@@ -113,7 +107,7 @@ protected:
     // Maybe this will be transferred to BufferControlBlock.
     std::shared_ptr<QueryStatistics> _query_statistics;
 
-    OpentelemetrySpan _send_span {};
+    OpentelemetrySpan _span {};
 };
 
 } // namespace doris

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -120,6 +120,8 @@ Status ExecNode::init(const TPlanNode& tnode, RuntimeState* state) {
 
 Status ExecNode::prepare(RuntimeState* state) {
     DCHECK(_runtime_profile.get() != nullptr);
+    _span = state->get_tracer()->StartSpan(get_name());
+    OpentelemetryScope scope {_span};
     _rows_returned_counter = ADD_COUNTER(_runtime_profile, "RowsReturned", TUnit::UNIT);
     _projection_timer = ADD_TIMER(_runtime_profile, "ProjectionTime");
     _rows_returned_rate = runtime_profile()->add_derived_counter(
@@ -182,7 +184,7 @@ void ExecNode::release_resource(doris::RuntimeState* state) {
         }
         vectorized::VExpr::close(_projections, state);
 
-        runtime_profile()->add_to_span();
+        runtime_profile()->add_to_span(_span);
         _is_resource_released = true;
     }
 }

--- a/be/src/exec/exec_node.h
+++ b/be/src/exec/exec_node.h
@@ -235,7 +235,7 @@ public:
 
     MemTracker* mem_tracker() const { return _mem_tracker.get(); }
 
-    OpentelemetrySpan get_next_span() { return _get_next_span; }
+    OpentelemetrySpan get_next_span() { return _span; }
 
     virtual std::string get_name();
 
@@ -289,13 +289,8 @@ protected:
     RuntimeProfile::Counter* _memory_used_counter;
     RuntimeProfile::Counter* _projection_timer;
 
-    /// Since get_next is a frequent operation, it is not necessary to generate a span for each call
-    /// to the get_next method. Therefore, the call of the get_next method in the ExecNode is
-    /// merged into this _get_next_span. The _get_next_span is initialized by
-    /// INIT_AND_SCOPE_GET_NEXT_SPAN when the get_next method is called for the first time
-    /// (recording the start timestamp), and is ended by RETURN_IF_ERROR_AND_CHECK_SPAN after the
-    /// last call to the get_next method (the record is terminated timestamp).
-    OpentelemetrySpan _get_next_span;
+    //
+    OpentelemetrySpan _span;
 
     // Execution options that are determined at runtime.  This is added to the
     // runtime profile at close().  Examples for options logged here would be

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -199,7 +199,6 @@ Status PipelineFragmentContext::prepare(const doris::TPipelineFragmentParams& re
     if (opentelemetry::trace::Tracer::GetCurrentSpan()->GetContext().IsValid()) {
         tracer = telemetry::get_tracer(print_id(_query_id));
     }
-    START_AND_SCOPE_SPAN(tracer, span, "PipelineFragmentExecutor::prepare");
 
     LOG_INFO("PipelineFragmentContext::prepare")
             .tag("query_id", _query_id)

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -99,7 +99,8 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request,
     if (opentelemetry::trace::Tracer::GetCurrentSpan()->GetContext().IsValid()) {
         tracer = telemetry::get_tracer(print_id(_query_id));
     }
-    START_AND_SCOPE_SPAN(tracer, span, "PlanFragmentExecutor::prepare");
+    _span = tracer->StartSpan("Plan_fragment_executor");
+    OpentelemetryScope scope {_span};
 
     const TPlanFragmentExecParams& params = request.params;
     _query_id = params.query_id;
@@ -305,7 +306,6 @@ Status PlanFragmentExecutor::open_vectorized_internal() {
             return Status::OK();
         }
         RETURN_IF_ERROR(_sink->open(runtime_state()));
-        auto sink_send_span_guard = Defer {[this]() { this->_sink->end_send_span(); }};
         doris::vectorized::Block block;
         bool eos = false;
 
@@ -348,14 +348,12 @@ Status PlanFragmentExecutor::open_vectorized_internal() {
 Status PlanFragmentExecutor::get_vectorized_internal(::doris::vectorized::Block* block, bool* eos) {
     while (!_done) {
         block->clear_column_data(_plan->row_desc().num_materialized_slots());
-        RETURN_IF_ERROR_AND_CHECK_SPAN(
-                _plan->get_next_after_projects(
-                        _runtime_state.get(), block, &_done,
-                        std::bind((Status(ExecNode::*)(RuntimeState*, vectorized::Block*, bool*)) &
-                                          ExecNode::get_next,
-                                  _plan, std::placeholders::_1, std::placeholders::_2,
-                                  std::placeholders::_3)),
-                _plan->get_next_span(), _done);
+        RETURN_IF_ERROR(_plan->get_next_after_projects(
+                _runtime_state.get(), block, &_done,
+                std::bind((Status(ExecNode::*)(RuntimeState*, vectorized::Block*, bool*)) &
+                                  ExecNode::get_next,
+                          _plan, std::placeholders::_1, std::placeholders::_2,
+                          std::placeholders::_3)));
 
         if (block->rows() > 0) {
             COUNTER_UPDATE(_rows_produced_counter, block->rows());
@@ -564,7 +562,7 @@ void PlanFragmentExecutor::close() {
                   << print_id(_runtime_state->fragment_instance_id());
     }
 
-    profile()->add_to_span();
+    profile()->add_to_span(_span);
     _closed = true;
 }
 

--- a/be/src/runtime/plan_fragment_executor.h
+++ b/be/src/runtime/plan_fragment_executor.h
@@ -206,6 +206,8 @@ private:
     PPlanFragmentCancelReason _cancel_reason;
     std::string _cancel_msg;
 
+    OpentelemetrySpan _span;
+
     ObjectPool* obj_pool() { return _runtime_state->obj_pool(); }
 
     // typedef for TPlanFragmentExecParams.per_node_scan_ranges

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -43,6 +43,8 @@ static const std::string THREAD_SYS_TIME = "SysTime";
 static const std::string THREAD_VOLUNTARY_CONTEXT_SWITCHES = "VoluntaryContextSwitches";
 static const std::string THREAD_INVOLUNTARY_CONTEXT_SWITCHES = "InvoluntaryContextSwitches";
 
+static const std::string SPAN_ATTRIBUTE_KEY_SEPARATOR = "-";
+
 // The root counter name for all top level counters.
 static const std::string ROOT_COUNTER;
 
@@ -546,9 +548,8 @@ void RuntimeProfile::pretty_print(std::ostream* s, const std::string& prefix) co
     }
 }
 
-void RuntimeProfile::add_to_span() {
-    auto span = opentelemetry::trace::Tracer::GetCurrentSpan();
-    if (!span->IsRecording() || _added_to_span) {
+void RuntimeProfile::add_to_span(OpentelemetrySpan span) {
+    if (!span || !span->IsRecording() || _added_to_span) {
         return;
     }
     _added_to_span = true;
@@ -568,7 +569,8 @@ void RuntimeProfile::add_to_span() {
     // to "VDataBufferSender"
     auto i = _name.find_first_of("(: ");
     auto short_name = _name.substr(0, i);
-    span->SetAttribute("TotalTime", print_json_counter(short_name, total_time->second));
+    span->SetAttribute(short_name + SPAN_ATTRIBUTE_KEY_SEPARATOR + "TotalTime",
+                       print_counter(total_time->second));
 
     {
         std::lock_guard<std::mutex> l(_info_strings_lock);
@@ -577,7 +579,8 @@ void RuntimeProfile::add_to_span() {
             if (key.compare("KeyRanges") == 0) {
                 continue;
             }
-            span->SetAttribute(key, print_json_info(short_name, _info_strings.find(key)->second));
+            span->SetAttribute(short_name + SPAN_ATTRIBUTE_KEY_SEPARATOR + key,
+                               _info_strings.find(key)->second);
         }
     }
 
@@ -590,9 +593,8 @@ void RuntimeProfile::add_to_span() {
         children = _children;
     }
 
-    for (int i = 0; i < children.size(); ++i) {
-        RuntimeProfile* profile = children[i].first;
-        profile->add_to_span();
+    for (auto& [profile, flag] : children) {
+        profile->add_to_span(span);
     }
 }
 
@@ -608,24 +610,12 @@ void RuntimeProfile::add_child_counters_to_span(OpentelemetrySpan span,
         for (const std::string& child_counter : child_counters) {
             CounterMap::const_iterator iter = counter_map.find(child_counter);
             DCHECK(iter != counter_map.end());
-            span->SetAttribute(iter->first, print_json_counter(profile_name, iter->second));
+            span->SetAttribute(profile_name + SPAN_ATTRIBUTE_KEY_SEPARATOR + iter->first,
+                               print_counter(iter->second));
             RuntimeProfile::add_child_counters_to_span(span, profile_name, child_counter,
                                                        counter_map, child_counter_map);
         }
     }
-}
-
-std::string RuntimeProfile::print_json_info(const std::string& profile_name, std::string value) {
-    rapidjson::StringBuffer s;
-    rapidjson::Writer<rapidjson::StringBuffer> writer(s);
-
-    writer.StartObject();
-    writer.Key("profile");
-    writer.String(profile_name.c_str());
-    writer.Key("pretty");
-    writer.String(value.c_str());
-    writer.EndObject();
-    return s.GetString();
 }
 
 void RuntimeProfile::to_thrift(TRuntimeProfileTree* tree) {

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -321,7 +321,7 @@ public:
     // Does not hold locks when it makes any function calls.
     void pretty_print(std::ostream* s, const std::string& prefix = "") const;
 
-    void add_to_span();
+    void add_to_span(OpentelemetrySpan span);
 
     // Serializes profile to thrift.
     // Does not hold locks when it makes any function calls.
@@ -507,12 +507,9 @@ private:
                                            const CounterMap& counter_map,
                                            const ChildCounterMap& child_counter_map);
 
-    static std::string print_json_counter(const std::string& profile_name, Counter* counter) {
-        return print_json_info(profile_name,
-                               PrettyPrinter::print(counter->value(), counter->type()));
+    static std::string print_counter(Counter* counter) {
+        return PrettyPrinter::print(counter->value(), counter->type());
     }
-
-    static std::string print_json_info(const std::string& profile_name, std::string value);
 };
 
 // Utility class to update the counter at object construction and destruction.

--- a/be/src/util/telemetry/telemetry.h
+++ b/be/src/util/telemetry/telemetry.h
@@ -40,18 +40,6 @@ using OpentelemetryTracer = opentelemetry::nostd::shared_ptr<opentelemetry::trac
 using OpentelemetrySpan = opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span>;
 using OpentelemetryScope = opentelemetry::trace::Scope;
 
-/// Used to initialize get_next_span and add Scope.
-#define INIT_AND_SCOPE_GET_NEXT_SPAN(tracer, get_next_span, name) \
-    do {                                                          \
-        if (UNLIKELY(!get_next_span)) {                           \
-            get_next_span = tracer->StartSpan(name);              \
-        }                                                         \
-    } while (false);                                              \
-    OpentelemetryScope scope {get_next_span};
-
-#define INIT_AND_SCOPE_SEND_SPAN(tracer, send_span, name) \
-    INIT_AND_SCOPE_GET_NEXT_SPAN(tracer, send_span, name)
-
 /// Start a span with the specified tracer, name, and variable name, and create a Scope for this
 /// span.
 ///
@@ -72,12 +60,6 @@ using OpentelemetryScope = opentelemetry::trace::Scope;
 #define START_AND_SCOPE_SPAN(tracer, span, name) \
     auto span = tracer->StartSpan(name);         \
     OpentelemetryScope scope {span};
-
-#define START_AND_SCOPE_SPAN_IF(enable, tracer, name) \
-    OpenTelemetryScopeWrapper(enable, tracer, name)
-
-#define INIT_AND_SCOPE_REENTRANT_SPAN_IF(enable, tracer, reentrant_span, name) \
-    OpenTelemetryScopeWrapper(enable, tracer, reentrant_span, name)
 
 namespace telemetry {
 

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -154,7 +154,6 @@ Status VScanNode::prepare(RuntimeState* state) {
 }
 
 Status VScanNode::open(RuntimeState* state) {
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VScanNode::open");
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_CANCELLED(state);
     return ExecNode::open(state);
@@ -166,7 +165,6 @@ Status VScanNode::alloc_resource(RuntimeState* state) {
     }
     _input_tuple_desc = state->desc_tbl().get_tuple_descriptor(_input_tuple_id);
     _output_tuple_desc = state->desc_tbl().get_tuple_descriptor(_output_tuple_id);
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VScanNode::alloc_resource");
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_ERROR(ExecNode::alloc_resource(state));
     RETURN_IF_ERROR(_acquire_runtime_filter());
@@ -208,7 +206,6 @@ Status VScanNode::alloc_resource(RuntimeState* state) {
 }
 
 Status VScanNode::get_next(RuntimeState* state, vectorized::Block* block, bool* eos) {
-    INIT_AND_SCOPE_GET_NEXT_SPAN(state->get_tracer(), _get_next_span, "VScanNode::get_next");
     SCOPED_TIMER(_get_next_timer);
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     // in inverted index apply logic, in order to optimize query performance,
@@ -445,13 +442,11 @@ Status VScanNode::close(RuntimeState* state) {
     if (is_closed()) {
         return Status::OK();
     }
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VScanNode::close");
     RETURN_IF_ERROR(ExecNode::close(state));
     return Status::OK();
 }
 
 void VScanNode::release_resource(RuntimeState* state) {
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VScanNode::release_resource");
     if (_scanner_ctx.get()) {
         if (!state->enable_pipeline_exec() || _should_create_scanner) {
             // stop and wait the scanner scheduler to be done

--- a/be/src/vec/exec/vaggregation_node.cpp
+++ b/be/src/vec/exec/vaggregation_node.cpp
@@ -511,7 +511,6 @@ Status AggregationNode::alloc_resource(doris::RuntimeState* state) {
 }
 
 Status AggregationNode::open(RuntimeState* state) {
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "AggregationNode::open");
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_ERROR(ExecNode::open(state));
     RETURN_IF_ERROR(_children[0]->open(state));
@@ -523,14 +522,12 @@ Status AggregationNode::open(RuntimeState* state) {
     while (!eos) {
         RETURN_IF_CANCELLED(state);
         release_block_memory(block);
-        RETURN_IF_ERROR_AND_CHECK_SPAN(
-                _children[0]->get_next_after_projects(
-                        state, &block, &eos,
-                        std::bind((Status(ExecNode::*)(RuntimeState*, vectorized::Block*, bool*)) &
-                                          ExecNode::get_next,
-                                  _children[0], std::placeholders::_1, std::placeholders::_2,
-                                  std::placeholders::_3)),
-                _children[0]->get_next_span(), eos);
+        RETURN_IF_ERROR(_children[0]->get_next_after_projects(
+                state, &block, &eos,
+                std::bind((Status(ExecNode::*)(RuntimeState*, vectorized::Block*, bool*)) &
+                                  ExecNode::get_next,
+                          _children[0], std::placeholders::_1, std::placeholders::_2,
+                          std::placeholders::_3)));
         RETURN_IF_ERROR(sink(state, &block, eos));
     }
     _children[0]->close(state);
@@ -551,22 +548,18 @@ Status AggregationNode::do_pre_agg(vectorized::Block* input_block,
 }
 
 Status AggregationNode::get_next(RuntimeState* state, Block* block, bool* eos) {
-    INIT_AND_SCOPE_GET_NEXT_SPAN(state->get_tracer(), _get_next_span, "AggregationNode::get_next");
     SCOPED_TIMER(_runtime_profile->total_time_counter());
 
     if (_is_streaming_preagg) {
         RETURN_IF_CANCELLED(state);
         release_block_memory(_preagg_block);
         while (_preagg_block.rows() == 0 && !_child_eos) {
-            RETURN_IF_ERROR_AND_CHECK_SPAN(
-                    _children[0]->get_next_after_projects(
-                            state, &_preagg_block, &_child_eos,
-                            std::bind((Status(ExecNode::*)(RuntimeState*, vectorized::Block*,
-                                                           bool*)) &
-                                              ExecNode::get_next,
-                                      _children[0], std::placeholders::_1, std::placeholders::_2,
-                                      std::placeholders::_3)),
-                    _children[0]->get_next_span(), _child_eos);
+            RETURN_IF_ERROR(_children[0]->get_next_after_projects(
+                    state, &_preagg_block, &_child_eos,
+                    std::bind((Status(ExecNode::*)(RuntimeState*, vectorized::Block*, bool*)) &
+                                      ExecNode::get_next,
+                              _children[0], std::placeholders::_1, std::placeholders::_2,
+                              std::placeholders::_3)));
         };
         {
             if (_preagg_block.rows() != 0) {
@@ -626,7 +619,6 @@ void AggregationNode::release_resource(RuntimeState* state) {
 
 Status AggregationNode::close(RuntimeState* state) {
     if (is_closed()) return Status::OK();
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "AggregationNode::close");
     return ExecNode::close(state);
 }
 

--- a/be/src/vec/exec/vassert_num_rows_node.cpp
+++ b/be/src/vec/exec/vassert_num_rows_node.cpp
@@ -53,7 +53,6 @@ VAssertNumRowsNode::VAssertNumRowsNode(ObjectPool* pool, const TPlanNode& tnode,
 }
 
 Status VAssertNumRowsNode::open(RuntimeState* state) {
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VAssertNumRowsNode::open");
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_ERROR(ExecNode::open(state));
     // ISSUE-3435
@@ -108,17 +107,13 @@ Status VAssertNumRowsNode::pull(doris::RuntimeState* state, vectorized::Block* b
 }
 
 Status VAssertNumRowsNode::get_next(RuntimeState* state, Block* block, bool* eos) {
-    INIT_AND_SCOPE_GET_NEXT_SPAN(state->get_tracer(), _get_next_span,
-                                 "VAssertNumRowsNode::get_next");
     SCOPED_TIMER(_runtime_profile->total_time_counter());
-    RETURN_IF_ERROR_AND_CHECK_SPAN(
-            child(0)->get_next_after_projects(
-                    state, block, eos,
-                    std::bind((Status(ExecNode::*)(RuntimeState*, vectorized::Block*, bool*)) &
-                                      ExecNode::get_next,
-                              _children[0], std::placeholders::_1, std::placeholders::_2,
-                              std::placeholders::_3)),
-            child(0)->get_next_span(), *eos);
+    RETURN_IF_ERROR(child(0)->get_next_after_projects(
+            state, block, eos,
+            std::bind((Status(ExecNode::*)(RuntimeState*, vectorized::Block*, bool*)) &
+                              ExecNode::get_next,
+                      _children[0], std::placeholders::_1, std::placeholders::_2,
+                      std::placeholders::_3)));
 
     return pull(state, block, eos);
 }

--- a/be/src/vec/exec/vempty_set_node.cpp
+++ b/be/src/vec/exec/vempty_set_node.cpp
@@ -34,7 +34,6 @@ VEmptySetNode::VEmptySetNode(ObjectPool* pool, const TPlanNode& tnode, const Des
         : ExecNode(pool, tnode, descs) {}
 
 Status VEmptySetNode::get_next(RuntimeState* state, Block* block, bool* eos) {
-    INIT_AND_SCOPE_GET_NEXT_SPAN(state->get_tracer(), _get_next_span, "VEmptySetNode::get_next");
     *eos = true;
     return Status::OK();
 }

--- a/be/src/vec/exec/vexchange_node.cpp
+++ b/be/src/vec/exec/vexchange_node.cpp
@@ -88,7 +88,6 @@ Status VExchangeNode::alloc_resource(RuntimeState* state) {
 }
 
 Status VExchangeNode::open(RuntimeState* state) {
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VExchangeNode::open");
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_ERROR(ExecNode::open(state));
 
@@ -96,7 +95,6 @@ Status VExchangeNode::open(RuntimeState* state) {
 }
 
 Status VExchangeNode::get_next(RuntimeState* state, Block* block, bool* eos) {
-    INIT_AND_SCOPE_GET_NEXT_SPAN(state->get_tracer(), _get_next_span, "VExchangeNode::get_next");
     SCOPED_TIMER(runtime_profile()->total_time_counter());
     if (_is_merging && state->enable_pipeline_exec() && !_is_ready) {
         RETURN_IF_ERROR(_stream_recvr->create_merger(_vsort_exec_exprs.lhs_ordering_expr_ctxs(),
@@ -152,8 +150,6 @@ Status VExchangeNode::close(RuntimeState* state) {
     if (is_closed()) {
         return Status::OK();
     }
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VExchangeNode::close");
-
     return ExecNode::close(state);
 }
 

--- a/be/src/vec/exec/vmysql_scan_node.cpp
+++ b/be/src/vec/exec/vmysql_scan_node.cpp
@@ -93,7 +93,6 @@ Status VMysqlScanNode::open(RuntimeState* state) {
     if (nullptr == state) {
         return Status::InternalError("input pointer is nullptr.");
     }
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VMysqlScanNode::open");
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_ERROR(ExecNode::open(state));
     VLOG_CRITICAL << "MysqlScanNode::Open";
@@ -126,7 +125,6 @@ Status VMysqlScanNode::get_next(RuntimeState* state, vectorized::Block* block, b
     if (state == nullptr || block == nullptr || eos == nullptr) {
         return Status::InternalError("input is nullptr");
     }
-    INIT_AND_SCOPE_GET_NEXT_SPAN(state->get_tracer(), _get_next_span, "VMysqlScanNode::get_next");
     VLOG_CRITICAL << "VMysqlScanNode::GetNext";
 
     if (!_is_init) {
@@ -219,7 +217,6 @@ Status VMysqlScanNode::close(RuntimeState* state) {
     if (is_closed()) {
         return Status::OK();
     }
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VMysqlScanNode::close");
     SCOPED_TIMER(_runtime_profile->total_time_counter());
 
     return ExecNode::close(state);

--- a/be/src/vec/exec/vschema_scan_node.cpp
+++ b/be/src/vec/exec/vschema_scan_node.cpp
@@ -21,8 +21,6 @@
 #include <gen_cpp/PlanNodes_types.h>
 #include <gen_cpp/Types_types.h>
 #include <opentelemetry/nostd/shared_ptr.h>
-#include <opentelemetry/trace/span.h>
-#include <opentelemetry/trace/span_metadata.h>
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <ostream>
@@ -111,14 +109,11 @@ Status VSchemaScanNode::open(RuntimeState* state) {
         return Status::InternalError("input pointer is nullptr.");
     }
 
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VSchemaScanNode::open");
     if (!_is_init) {
-        span->SetStatus(opentelemetry::trace::StatusCode::kError, "Open before Init.");
         return Status::InternalError("Open before Init.");
     }
 
     if (nullptr == state) {
-        span->SetStatus(opentelemetry::trace::StatusCode::kError, "input pointer is nullptr.");
         return Status::InternalError("input pointer is nullptr.");
     }
 
@@ -145,7 +140,6 @@ Status VSchemaScanNode::prepare(RuntimeState* state) {
     if (nullptr == state) {
         return Status::InternalError("state pointer is nullptr.");
     }
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VSchemaScanNode::prepare");
     RETURN_IF_ERROR(ScanNode::prepare(state));
 
     // get dest tuple desc
@@ -219,7 +213,6 @@ Status VSchemaScanNode::get_next(RuntimeState* state, vectorized::Block* block, 
     if (state == nullptr || block == nullptr || eos == nullptr) {
         return Status::InternalError("input is NULL pointer");
     }
-    INIT_AND_SCOPE_GET_NEXT_SPAN(state->get_tracer(), _get_next_span, "VSchemaScanNode::get_next");
     SCOPED_TIMER(_runtime_profile->total_time_counter());
 
     VLOG_CRITICAL << "VSchemaScanNode::GetNext";
@@ -290,7 +283,6 @@ Status VSchemaScanNode::close(RuntimeState* state) {
     if (is_closed()) {
         return Status::OK();
     }
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VSchemaScanNode::close");
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     return ExecNode::close(state);
 }

--- a/be/src/vec/exec/vselect_node.cpp
+++ b/be/src/vec/exec/vselect_node.cpp
@@ -48,26 +48,22 @@ Status VSelectNode::prepare(RuntimeState* state) {
 }
 
 Status VSelectNode::open(RuntimeState* state) {
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VSelectNode::open");
     RETURN_IF_ERROR(ExecNode::open(state));
     RETURN_IF_ERROR(child(0)->open(state));
     return Status::OK();
 }
 
 Status VSelectNode::get_next(RuntimeState* state, vectorized::Block* block, bool* eos) {
-    INIT_AND_SCOPE_GET_NEXT_SPAN(state->get_tracer(), _get_next_span, "VSelectNode::get_next");
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_CANCELLED(state);
     do {
         RETURN_IF_CANCELLED(state);
-        RETURN_IF_ERROR_AND_CHECK_SPAN(
-                _children[0]->get_next_after_projects(
-                        state, block, &_child_eos,
-                        std::bind((Status(ExecNode::*)(RuntimeState*, vectorized::Block*, bool*)) &
-                                          ExecNode::get_next,
-                                  _children[0], std::placeholders::_1, std::placeholders::_2,
-                                  std::placeholders::_3)),
-                _children[0]->get_next_span(), _child_eos);
+        RETURN_IF_ERROR(_children[0]->get_next_after_projects(
+                state, block, &_child_eos,
+                std::bind((Status(ExecNode::*)(RuntimeState*, vectorized::Block*, bool*)) &
+                                  ExecNode::get_next,
+                          _children[0], std::placeholders::_1, std::placeholders::_2,
+                          std::placeholders::_3)));
         if (_child_eos) {
             *eos = true;
             break;
@@ -78,7 +74,6 @@ Status VSelectNode::get_next(RuntimeState* state, vectorized::Block* block, bool
 }
 
 Status VSelectNode::pull(RuntimeState* state, vectorized::Block* output_block, bool* eos) {
-    INIT_AND_SCOPE_GET_NEXT_SPAN(state->get_tracer(), _get_next_span, "VSelectNode::pull");
     RETURN_IF_CANCELLED(state);
     RETURN_IF_ERROR(
             VExprContext::filter_block(_vconjunct_ctx_ptr, output_block, output_block->columns()));
@@ -91,7 +86,6 @@ Status VSelectNode::close(RuntimeState* state) {
     if (is_closed()) {
         return Status::OK();
     }
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VSelectNode::close");
     return ExecNode::close(state);
 }
 

--- a/be/src/vec/exec/vsort_node.cpp
+++ b/be/src/vec/exec/vsort_node.cpp
@@ -164,7 +164,6 @@ Status VSortNode::sink(RuntimeState* state, vectorized::Block* input_block, bool
 }
 
 Status VSortNode::open(RuntimeState* state) {
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VSortNode::open");
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_ERROR(ExecNode::open(state));
     RETURN_IF_ERROR(child(0)->open(state));
@@ -174,14 +173,12 @@ Status VSortNode::open(RuntimeState* state) {
     bool eos = false;
     std::unique_ptr<Block> upstream_block = Block::create_unique();
     do {
-        RETURN_IF_ERROR_AND_CHECK_SPAN(
-                child(0)->get_next_after_projects(
-                        state, upstream_block.get(), &eos,
-                        std::bind((Status(ExecNode::*)(RuntimeState*, vectorized::Block*, bool*)) &
-                                          ExecNode::get_next,
-                                  _children[0], std::placeholders::_1, std::placeholders::_2,
-                                  std::placeholders::_3)),
-                child(0)->get_next_span(), eos);
+        RETURN_IF_ERROR(child(0)->get_next_after_projects(
+                state, upstream_block.get(), &eos,
+                std::bind((Status(ExecNode::*)(RuntimeState*, vectorized::Block*, bool*)) &
+                                  ExecNode::get_next,
+                          _children[0], std::placeholders::_1, std::placeholders::_2,
+                          std::placeholders::_3)));
         RETURN_IF_ERROR(sink(state, upstream_block.get(), eos));
     } while (!eos);
 
@@ -203,7 +200,6 @@ Status VSortNode::pull(doris::RuntimeState* state, vectorized::Block* output_blo
 }
 
 Status VSortNode::get_next(RuntimeState* state, Block* block, bool* eos) {
-    INIT_AND_SCOPE_GET_NEXT_SPAN(state->get_tracer(), _get_next_span, "VSortNode::get_next");
     SCOPED_TIMER(_runtime_profile->total_time_counter());
 
     return pull(state, block, eos);
@@ -214,7 +210,6 @@ Status VSortNode::reset(RuntimeState* state) {
 }
 
 void VSortNode::release_resource(doris::RuntimeState* state) {
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VSortNode::close");
     _vsort_exec_exprs.close(state);
     _sorter = nullptr;
     ExecNode::release_resource(state);

--- a/be/src/vec/exec/vtable_function_node.h
+++ b/be/src/vec/exec/vtable_function_node.h
@@ -55,7 +55,6 @@ public:
     Status init(const TPlanNode& tnode, RuntimeState* state = nullptr) override;
     Status prepare(RuntimeState* state) override;
     Status open(RuntimeState* state) override {
-        START_AND_SCOPE_SPAN(state->get_tracer(), span, "TableFunctionNode::open");
         RETURN_IF_ERROR(alloc_resource(state));
         return _children[0]->open(state);
     }

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -480,7 +480,6 @@ Status VDataStreamSender::prepare(RuntimeState* state) {
 }
 
 Status VDataStreamSender::open(RuntimeState* state) {
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VDataStreamSender::open");
     DCHECK(state != nullptr);
     int local_size = 0;
     for (int i = 0; i < _channels.size(); ++i) {
@@ -498,7 +497,6 @@ Status VDataStreamSender::open(RuntimeState* state) {
 }
 
 Status VDataStreamSender::send(RuntimeState* state, Block* block, bool eos) {
-    INIT_AND_SCOPE_SEND_SPAN(state->get_tracer(), _send_span, "VDataStreamSender::send")
     SCOPED_TIMER(_profile->total_time_counter());
     if (_part_type == TPartitionType::UNPARTITIONED || _channels.size() == 1) {
         // 1. serialize depends on it is not local exchange
@@ -635,7 +633,6 @@ Status VDataStreamSender::close(RuntimeState* state, Status exec_status) {
         return Status::OK();
     }
 
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VDataStreamSender::close");
     Status final_st = Status::OK();
     for (int i = 0; i < _channels.size(); ++i) {
         Status st = _channels[i]->close(state);

--- a/be/src/vec/sink/vjdbc_table_sink.cpp
+++ b/be/src/vec/sink/vjdbc_table_sink.cpp
@@ -62,7 +62,6 @@ Status VJdbcTableSink::init(const TDataSink& t_sink) {
 }
 
 Status VJdbcTableSink::open(RuntimeState* state) {
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VJdbcTableSink::open");
     RETURN_IF_ERROR(VTableSink::open(state));
 
     // create writer
@@ -77,7 +76,6 @@ Status VJdbcTableSink::open(RuntimeState* state) {
 }
 
 Status VJdbcTableSink::send(RuntimeState* state, Block* block, bool eos) {
-    INIT_AND_SCOPE_SEND_SPAN(state->get_tracer(), _send_span, "VJdbcTableSink::send");
     Status status = Status::OK();
     if (block == nullptr || block->rows() == 0) {
         return status;
@@ -100,7 +98,6 @@ Status VJdbcTableSink::send(RuntimeState* state, Block* block, bool eos) {
 }
 
 Status VJdbcTableSink::close(RuntimeState* state, Status exec_status) {
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VJdbcTableSink::close");
     RETURN_IF_ERROR(VTableSink::close(state, exec_status));
     if (exec_status.ok() && _use_transaction) {
         RETURN_IF_ERROR(_writer->finish_trans());

--- a/be/src/vec/sink/vmysql_table_sink.cpp
+++ b/be/src/vec/sink/vmysql_table_sink.cpp
@@ -52,7 +52,6 @@ Status VMysqlTableSink::init(const TDataSink& t_sink) {
 }
 
 Status VMysqlTableSink::open(RuntimeState* state) {
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VMysqlTableSink::open");
     // Prepare the exprs to run.
     RETURN_IF_ERROR(VTableSink::open(state));
     // create writer
@@ -62,12 +61,10 @@ Status VMysqlTableSink::open(RuntimeState* state) {
 }
 
 Status VMysqlTableSink::send(RuntimeState* state, Block* block, bool eos) {
-    INIT_AND_SCOPE_SEND_SPAN(state->get_tracer(), _send_span, "VMysqlTableSink::send");
     return _writer->append(block);
 }
 
 Status VMysqlTableSink::close(RuntimeState* state, Status exec_status) {
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VMysqlTableSink::close");
     RETURN_IF_ERROR(VTableSink::close(state, exec_status));
     return Status::OK();
 }

--- a/be/src/vec/sink/vodbc_table_sink.cpp
+++ b/be/src/vec/sink/vodbc_table_sink.cpp
@@ -52,7 +52,6 @@ Status VOdbcTableSink::init(const TDataSink& t_sink) {
 }
 
 Status VOdbcTableSink::open(RuntimeState* state) {
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VOdbcTableSink::open");
     RETURN_IF_ERROR(VTableSink::open(state));
 
     // create writer
@@ -66,7 +65,6 @@ Status VOdbcTableSink::open(RuntimeState* state) {
 }
 
 Status VOdbcTableSink::send(RuntimeState* state, Block* block, bool eos) {
-    INIT_AND_SCOPE_SEND_SPAN(state->get_tracer(), _send_span, "VOdbcTableSink::send");
     Status status = Status::OK();
     if (block == nullptr || block->rows() == 0) {
         return status;
@@ -89,7 +87,6 @@ Status VOdbcTableSink::send(RuntimeState* state, Block* block, bool eos) {
 }
 
 Status VOdbcTableSink::close(RuntimeState* state, Status exec_status) {
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VOdbcTableSink::close");
     RETURN_IF_ERROR(VTableSink::close(state, exec_status));
     if (exec_status.ok() && _use_transaction) {
         RETURN_IF_ERROR(_writer->finish_trans());

--- a/be/src/vec/sink/vresult_file_sink.cpp
+++ b/be/src/vec/sink/vresult_file_sink.cpp
@@ -142,7 +142,6 @@ Status VResultFileSink::prepare(RuntimeState* state) {
 }
 
 Status VResultFileSink::open(RuntimeState* state) {
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VResultFileSink::open");
     if (!_is_top_sink) {
         RETURN_IF_ERROR(_stream_sender->open(state));
     }
@@ -150,7 +149,6 @@ Status VResultFileSink::open(RuntimeState* state) {
 }
 
 Status VResultFileSink::send(RuntimeState* state, Block* block, bool eos) {
-    INIT_AND_SCOPE_SEND_SPAN(state->get_tracer(), _send_span, "VResultFileSink::send");
     RETURN_IF_ERROR(_writer->append_block(*block));
     return Status::OK();
 }
@@ -160,7 +158,6 @@ Status VResultFileSink::close(RuntimeState* state, Status exec_status) {
         return Status::OK();
     }
 
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VResultFileSink::close");
     Status final_status = exec_status;
     // close the writer
     if (_writer) {

--- a/be/src/vec/sink/vresult_sink.cpp
+++ b/be/src/vec/sink/vresult_sink.cpp
@@ -107,7 +107,6 @@ Status VResultSink::prepare(RuntimeState* state) {
 }
 
 Status VResultSink::open(RuntimeState* state) {
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VResultSink::open");
     return VExpr::open(_output_vexpr_ctxs, state);
 }
 
@@ -126,7 +125,6 @@ Status VResultSink::second_phase_fetch_data(RuntimeState* state, Block* final_bl
 }
 
 Status VResultSink::send(RuntimeState* state, Block* block, bool eos) {
-    INIT_AND_SCOPE_SEND_SPAN(state->get_tracer(), _send_span, "VResultSink::send");
     if (_fetch_option.use_two_phase_fetch && block->rows() > 0) {
         RETURN_IF_ERROR(second_phase_fetch_data(state, block));
     }
@@ -144,7 +142,6 @@ Status VResultSink::close(RuntimeState* state, Status exec_status) {
         return Status::OK();
     }
 
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VResultSink::close");
     Status final_status = exec_status;
 
     if (_writer) {

--- a/be/src/vec/sink/vtable_sink.cpp
+++ b/be/src/vec/sink/vtable_sink.cpp
@@ -57,14 +57,12 @@ Status VTableSink::prepare(RuntimeState* state) {
 }
 
 Status VTableSink::open(RuntimeState* state) {
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VTableSink::open");
     // Prepare the exprs to run.
     RETURN_IF_ERROR(VExpr::open(_output_vexpr_ctxs, state));
     return Status::OK();
 }
 
 Status VTableSink::send(RuntimeState* state, Block* block, bool eos) {
-    INIT_AND_SCOPE_SEND_SPAN(state->get_tracer(), _send_span, "VTableSink::send");
     return Status::OK();
 }
 Status VTableSink::close(RuntimeState* state, Status exec_status) {

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -1098,7 +1098,6 @@ Status VOlapTableSink::prepare(RuntimeState* state) {
 }
 
 Status VOlapTableSink::open(RuntimeState* state) {
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VOlapTableSink::open");
     // Prepare the exprs to run.
     RETURN_IF_ERROR(vectorized::VExpr::open(_output_vexpr_ctxs, state));
     SCOPED_TIMER(_profile->total_time_counter());
@@ -1255,7 +1254,6 @@ void VOlapTableSink::_generate_row_distribution_payload(
 }
 
 Status VOlapTableSink::send(RuntimeState* state, vectorized::Block* input_block, bool eos) {
-    INIT_AND_SCOPE_SEND_SPAN(state->get_tracer(), _send_span, "VOlapTableSink::send");
     SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
     Status status = Status::OK();
 
@@ -1373,7 +1371,6 @@ Status VOlapTableSink::close(RuntimeState* state, Status exec_status) {
     if (_closed) {
         return _close_status;
     }
-    START_AND_SCOPE_SPAN(state->get_tracer(), span, "VOlapTableSink::close");
     vectorized::VExpr::close(_output_vexpr_ctxs, state);
     Status status = exec_status;
     if (status.ok()) {


### PR DESCRIPTION
1. Remove an exec node method corresponding to a span and replace it with an exec node corresponding to a span;
2. Fix some problems with tracing in pipeline.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

