### PR TITLE
[Enhancement](file system) mark disk as unused only when an EIO from kernel happens.

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -63,6 +63,7 @@ E(DIR_NOT_EXIST, -101);
 E(FILE_NOT_EXIST, -102);
 E(CREATE_FILE_ERROR, -103);
 E(STL_ERROR, -105);
+E(EIO_ERROR, -106);
 E(MUTEX_ERROR, -107);
 E(PTHREAD_ERROR, -108);
 E(NETWORK_ERROR, -109);
@@ -79,6 +80,8 @@ E(EVAL_CONJUNCTS_ERROR, -120);
 E(COPY_FILE_ERROR, -121);
 E(FILE_ALREADY_EXIST, -122);
 E(BAD_CAST, -123);
+E(FILE_OR_DIR_NOT_EXIST, -124);
+E(PERMISSION_DENIED, -125);
 E(CALL_SEQUENCE_ERROR, -202);
 E(BUFFER_OVERFLOW, -204);
 E(CONFIG_ERROR, -205);
@@ -419,7 +422,10 @@ public:
     bool is_io_error() const {
         return ErrorCode::IO_ERROR == _code || ErrorCode::READ_UNENOUGH == _code ||
                ErrorCode::CHECKSUM_ERROR == _code || ErrorCode::FILE_DATA_ERROR == _code ||
-               ErrorCode::TEST_FILE_ERROR == _code;
+               ErrorCode::TEST_FILE_ERROR == _code || ErrorCode::EIO_ERROR == _code ||
+               ErrorCode::FILE_ALREADY_EXIST == _code || ErrorCode::PERMISSION_DENIED == _code ||
+               ErrorCode::FILE_NOT_EXIST == _code || ErrorCode::DIR_NOT_EXIST ||
+               ErrorCode::FILE_OR_DIR_NOT_EXIST == _code;
     }
 
     bool is_invalid_argument() const { return ErrorCode::INVALID_ARGUMENT == _code; }

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -428,6 +428,8 @@ public:
                ErrorCode::FILE_OR_DIR_NOT_EXIST == _code;
     }
 
+    bool is_eio_error() const { return ErrorCode::EIO_ERROR == _code; }
+
     bool is_invalid_argument() const { return ErrorCode::INVALID_ARGUMENT == _code; }
 
     bool is_not_found() const { return _code == ErrorCode::NOT_FOUND; }

--- a/be/src/io/fs/err_utils.h
+++ b/be/src/io/fs/err_utils.h
@@ -20,12 +20,48 @@
 #include <string>
 #include <system_error>
 
+#include "common/status.h"
+
 namespace doris {
 namespace io {
 
 std::string errno_to_str();
 std::string errcode_to_str(const std::error_code& ec);
 std::string hdfs_error();
+
+template <typename... Args>
+Status error_from_errno_impl(int _errno, std::string_view msg, Args&&... args) {
+    int error_code = ErrorCode::IO_ERROR;
+    switch (_errno) {
+    case ENOENT:
+        // No such file or directory.
+        error_code = ErrorCode::FILE_OR_DIR_NOT_EXIST;
+        break;
+    case EIO:
+        // I/O error.
+        error_code = ErrorCode::EIO_ERROR;
+        break;
+    case EEXIST:
+        // File exists.
+        error_code = ErrorCode::FILE_ALREADY_EXIST;
+        break;
+    case EACCES:
+        // Permission denied.
+        error_code = ErrorCode::PERMISSION_DENIED;
+        break;
+    }
+    return Status::Error(error_code, msg, args...);
+}
+
+template <typename... Args>
+Status error_from_errno(std::string_view msg, Args&&... args) {
+    return error_from_errno_impl(errno, msg, args...);
+}
+
+template <typename... Args>
+Status error_from_ec(const std::error_code& ec, std::string_view msg, Args&&... args) {
+    return error_from_errno_impl(ec.value(), msg, args...);
+}
 
 } // namespace io
 } // namespace doris

--- a/be/src/io/fs/local_file_reader.cpp
+++ b/be/src/io/fs/local_file_reader.cpp
@@ -70,7 +70,7 @@ Status LocalFileReader::close() {
         if (-1 == res) {
             std::string err = errno_to_str();
             LOG(WARNING) << fmt::format("failed to close {}: {}", _path.native(), err);
-            return Status::IOError("failed to close {}: {}", _path.native(), err);
+            return error_from_errno("failed to close {}: {}", _path.native(), err);
         }
         _fd = -1;
     }
@@ -92,7 +92,8 @@ Status LocalFileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_
     while (bytes_req != 0) {
         auto res = ::pread(_fd, to, bytes_req, offset);
         if (UNLIKELY(-1 == res && errno != EINTR)) {
-            return Status::IOError("cannot read from {}: {}", _path.native(), std::strerror(errno));
+            return error_from_errno("cannot read from {}: {}", _path.native(),
+                                    std::strerror(errno));
         }
         if (UNLIKELY(res == 0)) {
             return Status::IOError("cannot read from {}: unexpected EOF", _path.native());

--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -235,7 +235,7 @@ void DataDir::health_check() {
         if (!res) {
             LOG(WARNING) << "store read/write test file occur IO Error. path=" << _path
                          << ", err: " << res;
-            if (res.is_io_error()) {
+            if (res.is_eio_error()) {
                 _is_used = false;
             }
         }

--- a/be/test/olap/tablet_test.cpp
+++ b/be/test/olap/tablet_test.cpp
@@ -424,13 +424,13 @@ TEST_F(TestTablet, rowset_tree_update) {
     // Hit a segment, but since we don't have real data, return an internal error when loading the
     // segment.
     LOG(INFO) << tablet->lookup_row_key("101", true, &rowset_ids, &loc, 7).to_string();
-    ASSERT_TRUE(
-            tablet->lookup_row_key("101", true, &rowset_ids, &loc, 7).is<ErrorCode::IO_ERROR>());
+    ASSERT_TRUE(tablet->lookup_row_key("101", true, &rowset_ids, &loc, 7)
+                        .is<ErrorCode::FILE_OR_DIR_NOT_EXIST>());
     // Key not in range.
     ASSERT_TRUE(
             tablet->lookup_row_key("201", true, &rowset_ids, &loc, 7).is<ErrorCode::NOT_FOUND>());
-    ASSERT_TRUE(
-            tablet->lookup_row_key("300", true, &rowset_ids, &loc, 7).is<ErrorCode::IO_ERROR>());
+    ASSERT_TRUE(tablet->lookup_row_key("300", true, &rowset_ids, &loc, 7)
+                        .is<ErrorCode::FILE_OR_DIR_NOT_EXIST>());
     // Key not in range.
     ASSERT_TRUE(
             tablet->lookup_row_key("499", true, &rowset_ids, &loc, 7).is<ErrorCode::NOT_FOUND>());
@@ -439,8 +439,8 @@ TEST_F(TestTablet, rowset_tree_update) {
             tablet->lookup_row_key("500", true, &rowset_ids, &loc, 7).is<ErrorCode::NOT_FOUND>());
     // Hit a segment, but since we don't have real data, return an internal error when loading the
     // segment.
-    ASSERT_TRUE(
-            tablet->lookup_row_key("500", true, &rowset_ids, &loc, 8).is<ErrorCode::IO_ERROR>());
+    ASSERT_TRUE(tablet->lookup_row_key("500", true, &rowset_ids, &loc, 8)
+                        .is<ErrorCode::FILE_OR_DIR_NOT_EXIST>());
 }
 
 } // namespace doris


### PR DESCRIPTION
# Proposed changes

Issue Number: close #18982

I’ll handle this issue with 3 PRs, and this is PR3.

## Problem summary

Mark disk as unused only when an EIO from kernel happens.

## Checklist(Required)

* [x] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

