### PR TITLE
[Optimize](row store) optimize serialization and deserialization

### DIFF
--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -51,6 +51,7 @@
 #include "vec/common/assert_cast.h"
 #include "vec/core/column_with_type_and_name.h"
 #include "vec/data_types/data_type.h"
+#include "vec/data_types/serde/data_type_serde.h"
 #include "vec/json/path_in_data.h"
 #include "vec/jsonb/serialize.h"
 
@@ -500,8 +501,10 @@ void MemTable::serialize_block_to_row_column(vectorized::Block& block) {
                                                            .assume_mutable()
                                                            .get());
     row_store_column->clear();
+    vectorized::DataTypeSerDeSPtrs serdes =
+            vectorized::create_data_type_serdes(block.get_data_types());
     vectorized::JsonbSerializeUtil::block_to_jsonb(*_tablet_schema, block, *row_store_column,
-                                                   _num_columns);
+                                                   _tablet_schema->num_columns(), serdes);
     VLOG_DEBUG << "serialize , num_rows:" << block.rows() << ", row_column_id:" << row_column_id
                << ", total_byte_size:" << block.allocated_bytes() << ", serialize_cost(us)"
                << watch.elapsed_time() / 1000;

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -339,8 +339,10 @@ void SegmentWriter::_serialize_block_to_row_column(vectorized::Block& block) {
                                                            .assume_mutable()
                                                            .get());
     row_store_column->clear();
+    vectorized::DataTypeSerDeSPtrs serdes =
+            vectorized::create_data_type_serdes(block.get_data_types());
     vectorized::JsonbSerializeUtil::block_to_jsonb(*_tablet_schema, block, *row_store_column,
-                                                   _tablet_schema->num_columns());
+                                                   _tablet_schema->num_columns(), serdes);
     VLOG_DEBUG << "serialize , num_rows:" << block.rows() << ", row_column_id:" << row_column_id
                << ", total_byte_size:" << block.allocated_bytes() << ", serialize_cost(us)"
                << watch.elapsed_time() / 1000;

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2431,7 +2431,7 @@ Status Tablet::fetch_value_through_row_column(RowsetSharedPtr input_rowset, uint
     assert(column_ptr->size() == rowids.size());
     auto string_column = static_cast<vectorized::ColumnString*>(column_ptr.get());
     vectorized::DataTypeSerDeSPtrs serdes;
-    serdes.reserve(cids.size());
+    serdes.resize(cids.size());
     std::unordered_map<uint32_t, uint32_t> col_uid_to_idx;
     for (int i = 0; i < cids.size(); ++i) {
         const TabletColumn& column = tablet_schema->column(cids[i]);

--- a/be/src/olap/tablet_schema.h
+++ b/be/src/olap/tablet_schema.h
@@ -40,7 +40,7 @@
 namespace doris {
 namespace vectorized {
 class Block;
-}
+} // namespace vectorized
 
 struct OlapTableIndexSchema;
 class TColumn;

--- a/be/src/service/point_query_executor.cpp
+++ b/be/src/service/point_query_executor.cpp
@@ -23,8 +23,10 @@
 #include <gen_cpp/internal_service.pb.h>
 #include <stdlib.h>
 
+#include <unordered_map>
 #include <vector>
 
+#include "gutil/integral_types.h"
 #include "olap/lru_cache.h"
 #include "olap/olap_tuple.h"
 #include "olap/row_cursor.h"
@@ -35,6 +37,7 @@
 #include "util/key_util.h"
 #include "util/runtime_profile.h"
 #include "util/thrift_util.h"
+#include "vec/data_types/serde/data_type_serde.h"
 #include "vec/exprs/vexpr.h"
 #include "vec/exprs/vexpr_context.h"
 #include "vec/jsonb/serialize.h"
@@ -65,6 +68,10 @@ Status Reusable::init(const TDescriptorTable& t_desc_tbl, const std::vector<TExp
     // Prepare the exprs to run.
     RETURN_IF_ERROR(vectorized::VExpr::prepare(_output_exprs_ctxs, _runtime_state.get(), row_desc));
     _create_timestamp = butil::gettimeofday_ms();
+    _data_type_serdes = vectorized::create_data_type_serdes(tuple_desc()->slots());
+    for (int i = 0; i < tuple_desc()->slots().size(); ++i) {
+        _col_uid_to_idx[tuple_desc()->slots()[i]->col_unique_id()] = i;
+    }
     return Status::OK();
 }
 
@@ -279,8 +286,10 @@ Status PointQueryExecutor::_lookup_row_data() {
     for (size_t i = 0; i < _row_read_ctxs.size(); ++i) {
         if (_row_read_ctxs[i]._cached_row_data.valid()) {
             vectorized::JsonbSerializeUtil::jsonb_to_block(
-                    *_reusable->tuple_desc(), _row_read_ctxs[i]._cached_row_data.data().data,
-                    _row_read_ctxs[i]._cached_row_data.data().size, *_result_block);
+                    _reusable->get_data_type_serdes(),
+                    _row_read_ctxs[i]._cached_row_data.data().data,
+                    _row_read_ctxs[i]._cached_row_data.data().size, _reusable->get_col_uid_to_idx(),
+                    *_result_block);
             continue;
         }
         if (!_row_read_ctxs[i]._row_location.has_value()) {
@@ -293,8 +302,9 @@ Status PointQueryExecutor::_lookup_row_data() {
                 _profile_metrics.read_stats, value,
                 !config::disable_storage_row_cache /*whether write row cache*/));
         // serilize value to block, currently only jsonb row formt
-        vectorized::JsonbSerializeUtil::jsonb_to_block(*_reusable->tuple_desc(), value.data(),
-                                                       value.size(), *_result_block);
+        vectorized::JsonbSerializeUtil::jsonb_to_block(
+                _reusable->get_data_type_serdes(), value.data(), value.size(),
+                _reusable->get_col_uid_to_idx(), *_result_block);
     }
     return Status::OK();
 }

--- a/be/src/service/point_query_executor.h
+++ b/be/src/service/point_query_executor.h
@@ -31,6 +31,7 @@
 #include <optional>
 #include <ostream>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -49,6 +50,7 @@
 #include "util/runtime_profile.h"
 #include "util/slice.h"
 #include "vec/core/block.h"
+#include "vec/data_types/serde/data_type_serde.h"
 
 namespace doris {
 
@@ -76,6 +78,12 @@ public:
 
     std::unique_ptr<vectorized::Block> get_block();
 
+    const vectorized::DataTypeSerDeSPtrs& get_data_type_serdes() const { return _data_type_serdes; }
+
+    const std::unordered_map<uint32_t, uint32_t>& get_col_uid_to_idx() const {
+        return _col_uid_to_idx;
+    }
+
     // do not touch block after returned
     void return_block(std::unique_ptr<vectorized::Block>& block);
 
@@ -92,6 +100,8 @@ private:
     std::vector<std::unique_ptr<vectorized::Block>> _block_pool;
     std::vector<vectorized::VExprContext*> _output_exprs_ctxs;
     int64_t _create_timestamp = 0;
+    vectorized::DataTypeSerDeSPtrs _data_type_serdes;
+    std::unordered_map<uint32_t, uint32_t> _col_uid_to_idx;
 };
 
 // RowCache is a LRU cache for row store

--- a/be/src/vec/data_types/serde/data_type_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_serde.cpp
@@ -16,9 +16,30 @@
 // under the License.
 #include "data_type_serde.h"
 
+#include "runtime/descriptors.h"
+#include "vec/data_types/data_type.h"
+
 namespace doris {
 namespace vectorized {
 DataTypeSerDe::DataTypeSerDe() = default;
 DataTypeSerDe::~DataTypeSerDe() = default;
+
+DataTypeSerDeSPtrs create_data_type_serdes(const DataTypes& types) {
+    DataTypeSerDeSPtrs serdes;
+    serdes.reserve(types.size());
+    for (const DataTypePtr& type : types) {
+        serdes.push_back(type->get_serde());
+    }
+    return serdes;
+}
+
+DataTypeSerDeSPtrs create_data_type_serdes(const std::vector<SlotDescriptor*>& slots) {
+    DataTypeSerDeSPtrs serdes;
+    serdes.reserve(slots.size());
+    for (const SlotDescriptor* slot : slots) {
+        serdes.push_back(slot->get_data_type_ptr()->get_serde());
+    }
+    return serdes;
+}
 } // namespace vectorized
 } // namespace doris

--- a/be/src/vec/data_types/serde/data_type_serde.h
+++ b/be/src/vec/data_types/serde/data_type_serde.h
@@ -39,10 +39,12 @@ class time_zone;
 namespace doris {
 class PValues;
 class JsonbValue;
+class SlotDescriptor;
 
 namespace vectorized {
 class IColumn;
 class Arena;
+class IDataType;
 // Deserialize means read from different file format or memory format,
 // for example read from arrow, read from parquet.
 // Serialize means write the column cell or the total column into another
@@ -98,6 +100,10 @@ inline void checkArrowStatus(const arrow::Status& status, const std::string& col
 
 using DataTypeSerDeSPtr = std::shared_ptr<DataTypeSerDe>;
 using DataTypeSerDeSPtrs = std::vector<DataTypeSerDeSPtr>;
+
+DataTypeSerDeSPtrs create_data_type_serdes(
+        const std::vector<std::shared_ptr<const IDataType>>& types);
+DataTypeSerDeSPtrs create_data_type_serdes(const std::vector<SlotDescriptor*>& slots);
 
 } // namespace vectorized
 } // namespace doris

--- a/be/src/vec/jsonb/serialize.h
+++ b/be/src/vec/jsonb/serialize.h
@@ -18,6 +18,8 @@
 #pragma once
 #include <stddef.h>
 
+#include <unordered_map>
+
 #include "olap/tablet_schema.h"
 #include "runtime/descriptors.h"
 #include "vec/columns/column_string.h"
@@ -37,20 +39,14 @@ namespace doris::vectorized {
 class JsonbSerializeUtil {
 public:
     static void block_to_jsonb(const TabletSchema& schema, const Block& block, ColumnString& dst,
-                               int num_cols);
+                               int num_cols, const DataTypeSerDeSPtrs& serdes);
     // batch rows
-    static void jsonb_to_block(const TupleDescriptor& desc, const ColumnString& jsonb_column,
+    static void jsonb_to_block(const DataTypeSerDeSPtrs& serdes, const ColumnString& jsonb_column,
+                               const std::unordered_map<uint32_t, uint32_t>& col_id_to_idx,
                                Block& dst);
     // single row
-    static void jsonb_to_block(const TupleDescriptor& desc, const char* data, size_t size,
+    static void jsonb_to_block(const DataTypeSerDeSPtrs& serdes, const char* data, size_t size,
+                               const std::unordered_map<uint32_t, uint32_t>& col_id_to_idx,
                                Block& dst);
-
-    static void jsonb_to_block(TabletSchemaSPtr schema, const std::vector<uint32_t>& col_ids,
-                               const ColumnString& jsonb_column, Block& dst);
-
-    static void jsonb_to_block(TabletSchemaSPtr schema, const std::vector<uint32_t>& col_ids,
-                               const char* data, size_t size, Block& dst);
-
-    static PrimitiveType get_primity_type(FieldType type);
 };
 } // namespace doris::vectorized


### PR DESCRIPTION
1. get DataTypeSerde in advance to avoid get temporary DataTypeSerde  iterate each column
2. iterate the original row once is enoungh for deserializing, introdcue a map for record the index of each column's unique id


# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

