### PR TITLE
[improvement](jdbc catalog) Adapt to hana's special view & Optimize jdbc name format

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OdbcTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OdbcTable.java
@@ -72,6 +72,24 @@ public class OdbcTable extends Table {
         TABLE_TYPE_MAP = Collections.unmodifiableMap(tempMap);
     }
 
+    /**
+     * Formats the provided name (for example, a database, table, or schema name) according to the specified parameters.
+     *
+     * @param name The name to be formatted.
+     * @param wrapStart The character(s) to be added at the start of each name component.
+     * @param wrapEnd The character(s) to be added at the end of each name component.
+     * @param toUpperCase If true, convert the name to upper case.
+     * @param toLowerCase If true, convert the name to lower case.
+     * <p>
+     * Note: If both toUpperCase and toLowerCase are true, the name will ultimately be converted to lower case.
+     * <p>
+     * The name is expected to be in the format of 'schemaName.tableName'. If there is no '.',
+     * the function will treat the entire string as one name component.
+     * If there is a '.', the function will treat the string before the first '.' as the schema name
+     * and the string after the '.' as the table name.
+     *
+     * @return The formatted name.
+     */
     public static String formatName(String name, String wrapStart, String wrapEnd, boolean toUpperCase,
             boolean toLowerCase) {
         int index = name.indexOf(".");

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OdbcTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OdbcTable.java
@@ -37,7 +37,6 @@ import org.apache.logging.log4j.Logger;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -106,6 +105,22 @@ public class OdbcTable extends Table {
         }
     }
 
+    /**
+     * Formats a database name according to the database type.
+     *
+     * Rules:
+     * - MYSQL, OCEANBASE: Wrap with backticks (`), case unchanged. Example: mySchema.myTable -> `mySchema.myTable`
+     * - SQLSERVER: Wrap with square brackets ([]), case unchanged. Example: mySchema.myTable -> [mySchema].[myTable]
+     * - POSTGRESQL, CLICKHOUSE, TRINO, OCEANBASE_ORACLE, SAP_HANA: Wrap with double quotes ("), case unchanged.
+     *   Example: mySchema.myTable -> "mySchema"."myTable"
+     * - ORACLE: Wrap with double quotes ("), convert to upper case. Example: mySchema.myTable -> "MYSCHEMA"."MYTABLE"
+     * For other types, the name is returned as is.
+     *
+     * @param tableType The database type.
+     * @param name The name to be formatted, expected in 'schemaName.tableName' format. If no '.', treats entire string
+     *   as one name component. If '.', treats string before first '.' as schema name and after as table name.
+     * @return The formatted name.
+     */
     public static String databaseProperName(TOdbcTableType tableType, String name) {
         switch (tableType) {
             case MYSQL:

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OdbcTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OdbcTable.java
@@ -72,7 +72,8 @@ public class OdbcTable extends Table {
         TABLE_TYPE_MAP = Collections.unmodifiableMap(tempMap);
     }
 
-    public static String formatName(String name, String wrapStart, String wrapEnd, boolean toUpperCase, boolean toLowerCase) {
+    public static String formatName(String name, String wrapStart, String wrapEnd, boolean toUpperCase,
+            boolean toLowerCase) {
         int index = name.indexOf(".");
         if (index == -1) { // No dot in the name
             String newName = toUpperCase ? name.toUpperCase() : name;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OdbcTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OdbcTable.java
@@ -103,8 +103,14 @@ public class OdbcTable extends Table {
     }
 
     private static String saphanaProperName(String name) {
-        List<String> list = Arrays.asList(name.split("\\."));
-        return list.stream().map(s -> "\"" + s + "\"").collect(Collectors.joining("."));
+        int index = name.indexOf(".");
+        if (index == -1) {
+            return "\"" + name + "\"";
+        } else {
+            String schemaName = name.substring(0, index);
+            String tableName = name.substring(index + 1);
+            return "\"" + schemaName + "\".\"" + tableName + "\"";
+        }
     }
 
     private static String trinoProperName(String name) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OdbcTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OdbcTable.java
@@ -72,57 +72,6 @@ public class OdbcTable extends Table {
         TABLE_TYPE_MAP = Collections.unmodifiableMap(tempMap);
     }
 
-    // For different databases, special characters need to be escaped
-    private static String mysqlProperName(String name) {
-        // In JdbcExternalTable, the name contains databaseName, like: db.table
-        // So, we should split db and table, then switch to `db`.`table`.
-        List<String> list = Arrays.asList(name.split("\\."));
-        return list.stream().map(s -> "`" + s + "`").collect(Collectors.joining("."));
-    }
-
-    private static String mssqlProperName(String name) {
-        // In JdbcExternalTable, the name contains databaseName, like: db.table
-        // So, we should split db and table, then switch to [db].[table].
-        List<String> list = Arrays.asList(name.split("\\."));
-        return list.stream().map(s -> "[" + s + "]").collect(Collectors.joining("."));
-    }
-
-    private static String psqlProperName(String name) {
-        List<String> list = Arrays.asList(name.split("\\."));
-        return list.stream().map(s -> "\"" + s + "\"").collect(Collectors.joining("."));
-    }
-
-    private static String oracleProperName(String name) {
-        List<String> list = Arrays.asList(name.split("\\."));
-        return list.stream().map(s -> "\"" + s.toUpperCase() + "\"").collect(Collectors.joining("."));
-    }
-
-    private static String clickhouseProperName(String name) {
-        List<String> list = Arrays.asList(name.split("\\."));
-        return list.stream().map(s -> "\"" + s + "\"").collect(Collectors.joining("."));
-    }
-
-    private static String saphanaProperName(String name) {
-        int index = name.indexOf(".");
-        if (index == -1) {
-            return "\"" + name + "\"";
-        } else {
-            String schemaName = name.substring(0, index);
-            String tableName = name.substring(index + 1);
-            return "\"" + schemaName + "\".\"" + tableName + "\"";
-        }
-    }
-
-    private static String trinoProperName(String name) {
-        List<String> list = Arrays.asList(name.split("\\."));
-        return list.stream().map(s -> "\"" + s + "\"").collect(Collectors.joining("."));
-    }
-
-    private static String oceanbaseOracleProperName(String name) {
-        List<String> list = Arrays.asList(name.split("\\."));
-        return list.stream().map(s -> "\"" + s + "\"").collect(Collectors.joining("."));
-    }
-
     public static String formatName(String name, String wrapStart, String wrapEnd, boolean toUpperCase, boolean toLowerCase) {
         int index = name.indexOf(".");
         if (index == -1) { // No dot in the name

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OdbcTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OdbcTable.java
@@ -123,25 +123,36 @@ public class OdbcTable extends Table {
         return list.stream().map(s -> "\"" + s + "\"").collect(Collectors.joining("."));
     }
 
+    public static String formatName(String name, String wrapStart, String wrapEnd, boolean toUpperCase, boolean toLowerCase) {
+        int index = name.indexOf(".");
+        if (index == -1) { // No dot in the name
+            String newName = toUpperCase ? name.toUpperCase() : name;
+            newName = toLowerCase ? newName.toLowerCase() : newName;
+            return wrapStart + newName + wrapEnd;
+        } else {
+            String schemaName = toUpperCase ? name.substring(0, index).toUpperCase() : name.substring(0, index);
+            schemaName = toLowerCase ? schemaName.toLowerCase() : schemaName;
+            String tableName = toUpperCase ? name.substring(index + 1).toUpperCase() : name.substring(index + 1);
+            tableName = toLowerCase ? tableName.toLowerCase() : tableName;
+            return wrapStart + schemaName + wrapEnd + "." + wrapStart + tableName + wrapEnd;
+        }
+    }
+
     public static String databaseProperName(TOdbcTableType tableType, String name) {
         switch (tableType) {
             case MYSQL:
             case OCEANBASE:
-                return mysqlProperName(name);
+                return formatName(name, "`", "`", false, false);
             case SQLSERVER:
-                return mssqlProperName(name);
+                return formatName(name, "[", "]", false, false);
             case POSTGRESQL:
-                return psqlProperName(name);
-            case ORACLE:
-                return oracleProperName(name);
             case CLICKHOUSE:
-                return clickhouseProperName(name);
-            case SAP_HANA:
-                return saphanaProperName(name);
             case TRINO:
-                return trinoProperName(name);
             case OCEANBASE_ORACLE:
-                return oceanbaseOracleProperName(name);
+            case SAP_HANA:
+                return formatName(name, "\"", "\"", false, false);
+            case ORACLE:
+                return formatName(name, "\"", "\"", true, false);
             default:
                 return name;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/external/jdbc/JdbcClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/jdbc/JdbcClient.java
@@ -280,6 +280,7 @@ public class JdbcClient {
         ResultSet rs = null;
         List<String> tablesName = Lists.newArrayList();
         String[] types = {"TABLE", "VIEW"};
+        String[] hanaTypes = {"TABLE", "VIEW", "OLAP VIEW", "JOIN VIEW", "HIERARCHY VIEW", "CALC VIEW"};
         try {
             DatabaseMetaData databaseMetaData = conn.getMetaData();
             String catalogName = conn.getCatalog();
@@ -292,9 +293,11 @@ public class JdbcClient {
                 case JdbcResource.ORACLE:
                 case JdbcResource.CLICKHOUSE:
                 case JdbcResource.SQLSERVER:
-                case JdbcResource.SAP_HANA:
                 case JdbcResource.OCEANBASE_ORACLE:
                     rs = databaseMetaData.getTables(null, dbName, null, types);
+                    break;
+                case JdbcResource.SAP_HANA:
+                    rs = databaseMetaData.getTables(null, dbName, null, hanaTypes);
                     break;
                 case JdbcResource.TRINO:
                 case JdbcResource.PRESTO:
@@ -323,6 +326,7 @@ public class JdbcClient {
         Connection conn = getConnection();
         ResultSet rs = null;
         String[] types = {"TABLE", "VIEW"};
+        String[] hanaTypes = {"TABLE", "VIEW", "OLAP VIEW", "JOIN VIEW", "HIERARCHY VIEW", "CALC VIEW"};
         try {
             DatabaseMetaData databaseMetaData = conn.getMetaData();
             String catalogName = conn.getCatalog();
@@ -335,9 +339,11 @@ public class JdbcClient {
                 case JdbcResource.ORACLE:
                 case JdbcResource.CLICKHOUSE:
                 case JdbcResource.SQLSERVER:
-                case JdbcResource.SAP_HANA:
                 case JdbcResource.OCEANBASE_ORACLE:
                     rs = databaseMetaData.getTables(null, dbName, null, types);
+                    break;
+                case JdbcResource.SAP_HANA:
+                    rs = databaseMetaData.getTables(null, dbName, null, hanaTypes);
                     break;
                 case JdbcResource.TRINO:
                 case JdbcResource.PRESTO:


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1. Because in SAP HANA, there are many types of views, as follows:
  ![image](https://github.com/apache/doris/assets/70795751/7fe0fa0f-5298-44bf-964c-703dad5f8b08)
  So in order to allow these views to be queried in Doris, I made an adaptation

2. In order to adapt to the warp of table name in different databases, we have written many processing methods, but these processing methods have many problems,I optimized this

  -   For the table name itself with `.`, it cannot be handled correctly
  -   here are many methods and it is not easy to maintain

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

