### PR TITLE
[fix](merge-on-write) fix that delete bitmap calculation error when clone tablet

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2962,8 +2962,8 @@ Status Tablet::update_delete_bitmap_without_lock(const RowsetSharedPtr& rowset) 
 
     RowsetIdUnorderedSet cur_rowset_ids = all_rs_id(cur_version - 1);
     DeleteBitmapPtr delete_bitmap = std::make_shared<DeleteBitmap>(tablet_id());
-    RETURN_IF_ERROR(
-            calc_delete_bitmap(rowset, segments, nullptr, delete_bitmap, cur_version - 1, true));
+    RETURN_IF_ERROR(calc_delete_bitmap(rowset, segments, &cur_rowset_ids, delete_bitmap,
+                                       cur_version - 1, true));
     for (auto iter = delete_bitmap->delete_bitmap.begin();
          iter != delete_bitmap->delete_bitmap.end(); ++iter) {
         _tablet_meta->delete_bitmap().merge(


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

```
F0516 14:24:15.818387 1727197 compaction.cpp:528] Check failed: false cumulative compaction: the merged rows(1826) is not equal to missed rows(0) in rowid conversion, tablet_id: 1766259, table_id:1766015
*** Check failure stack trace: ***
    @     0x5651b82e6f0d  google::LogMessage::Fail()
    @     0x5651b82e9449  google::LogMessage::SendToLog()
    @     0x5651b82e6a76  google::LogMessage::Flush()
    @     0x5651b82e9ab9  google::LogMessageFatal::~LogMessageFatal()
    @     0x5651993b14e2  doris::Compaction::modify_rowsets()
    @     0x5651993aa2d8  doris::Compaction::do_compaction_impl()
    @     0x5651993a4ed9  doris::Compaction::do_compaction()
    @     0x56519aa0bd7b  doris::CumulativeCompaction::execute_compact_impl()
    @     0x5651993a44eb  doris::Compaction::execute_compact()
    @     0x56519aacd46b  doris::Tablet::execute_compaction()
    @     0x565199289cd6  doris::StorageEngine::_submit_compaction_task()::$_0::operator()()
```

The `rowset_ids_to_add` parameter passed in to the `calc_delete_bitmap` function is null, resulting in the delete bitmap of previous rowset not being calculated. 
This problem was introduced by: #17542 

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

