### PR TITLE
[improvement](load)disable  shrink memory by default

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -984,7 +984,7 @@ DEFINE_mInt32(s3_write_buffer_size, "5242880");
 // s3_write_buffer_whole_size / s3_write_buffer_size
 DEFINE_mInt32(s3_write_buffer_whole_size, "524288000");
 
-//disable shrink memory by default 
+//disable shrink memory by default
 DEFINE_Bool(enable_shrink_memory, "false");
 
 #ifdef BE_TEST

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -984,6 +984,9 @@ DEFINE_mInt32(s3_write_buffer_size, "5242880");
 // s3_write_buffer_whole_size / s3_write_buffer_size
 DEFINE_mInt32(s3_write_buffer_whole_size, "524288000");
 
+//disable shrink memory by default 
+DEFINE_Bool(enable_shrink_memory, "false");
+
 #ifdef BE_TEST
 // test s3
 DEFINE_String(test_s3_resource, "resource");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1004,6 +1004,9 @@ DECLARE_mInt32(s3_write_buffer_size);
 // s3_write_buffer_whole_size / s3_write_buffer_size
 DECLARE_mInt32(s3_write_buffer_whole_size);
 
+//enable shrink memory
+DECLARE_Bool(enable_shrink_memory);
+
 #ifdef BE_TEST
 // test s3
 DECLARE_String(test_s3_resource);

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -225,7 +225,7 @@ Status DeltaWriter::write(const vectorized::Block* block, const std::vector<int>
     }
     _mem_table->insert(block, row_idxs, is_append);
 
-    if (UNLIKELY(_mem_table->need_agg())) {
+    if (UNLIKELY(_mem_table->need_agg() && config::enable_shrink_memory)) {
         _mem_table->shrink_memtable_by_agg();
     }
     if (UNLIKELY(_mem_table->need_flush())) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close https://github.com/apache/doris/issues/19204

## Problem summary

disable  shrink memory by default, it becomes very slow when importing large amounts of data

more defails see issue 

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

