### PR TITLE
[fix](memory) Print all query/load memory before memory GC when `memory_debug=true`

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -706,9 +706,6 @@ DEFINE_Int32(aws_log_level, "3");
 // the buffer size when read data from remote storage like s3
 DEFINE_mInt32(remote_storage_read_buffer_mb, "16");
 
-// Print more detailed logs, more detailed records, etc.
-DEFINE_mBool(memory_debug, "false");
-
 // The minimum length when TCMalloc Hook consumes/releases MemTracker, consume size
 // smaller than this value will continue to accumulate. specified as number of bytes.
 // Decreasing this value will increase the frequency of consume/release.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -742,9 +742,6 @@ DECLARE_Int32(aws_log_level);
 // the buffer size when read data from remote storage like s3
 DECLARE_mInt32(remote_storage_read_buffer_mb);
 
-// Print more detailed logs, more detailed records, etc.
-DECLARE_mBool(memory_debug);
-
 // The minimum length when TCMalloc Hook consumes/releases MemTracker, consume size
 // smaller than this value will continue to accumulate. specified as number of bytes.
 // Decreasing this value will increase the frequency of consume/release.

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -189,7 +189,7 @@ void Daemon::memory_maintenance_thread() {
     int64_t last_print_proc_mem = PerfCounters::get_vm_rss();
     while (!_stop_background_threads_latch.wait_for(
             std::chrono::milliseconds(interval_milliseconds))) {
-        if (!MemInfo::initialized()) {
+        if (!MemInfo::initialized() || !ExecEnv::GetInstance()->initialized()) {
             continue;
         }
         // Refresh process memory metrics.

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -214,10 +214,6 @@ void Daemon::memory_maintenance_thread() {
 #endif
             LOG(INFO) << MemTrackerLimiter::
                             process_mem_log_str(); // print mem log when memory state by 100M
-            if (doris::config::memory_debug) {
-                LOG_EVERY_N(INFO, 10)
-                        << doris::MemTrackerLimiter::log_process_usage_str("memory debug", false);
-            }
         }
     }
 }

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -188,6 +188,19 @@ std::string MemTrackerLimiter::type_log_usage(MemTracker::Snapshot snapshot) {
                        print_bytes(snapshot.peak_consumption), snapshot.peak_consumption);
 }
 
+std::string MemTrackerLimiter::type_detail_usage(const std::string& msg, Type type) {
+    std::string detail = fmt::format("{}, Type:{}, Memory Tracker Summary", msg, type_string(type));
+    for (unsigned i = 1; i < mem_tracker_limiter_pool.size(); ++i) {
+        std::lock_guard<std::mutex> l(mem_tracker_limiter_pool[i].group_lock);
+        for (auto tracker : mem_tracker_limiter_pool[i].trackers) {
+            if (tracker->type() == type) {
+                detail += "\n    " + MemTrackerLimiter::log_usage(tracker->make_snapshot());
+            }
+        }
+    }
+    return detail;
+}
+
 void MemTrackerLimiter::print_log_usage(const std::string& msg) {
     if (_enable_print_log_usage) {
         _enable_print_log_usage = false;

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -161,6 +161,7 @@ public:
     static std::string log_usage(MemTracker::Snapshot snapshot);
     std::string log_usage() { return log_usage(make_snapshot()); }
     static std::string type_log_usage(MemTracker::Snapshot snapshot);
+    static std::string type_detail_usage(const std::string& msg, Type type);
     void print_log_usage(const std::string& msg);
     void enable_print_log_usage() { _enable_print_log_usage = true; }
     static void enable_print_log_process_usage() { _enable_print_log_process_usage = true; }

--- a/be/src/runtime/memory/thread_mem_tracker_mgr.h
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.h
@@ -173,10 +173,8 @@ inline void ThreadMemTrackerMgr::consume(int64_t size) {
     if (size > 4294967296) { // 4G
         _stop_consume = true;
         LOG(WARNING) << fmt::format("MemHook alloc large memory: {}.", size);
-        if (config::memory_debug) {
-            doris::MemTrackerLimiter::print_log_process_usage(
-                    fmt::format("MemHook alloc large memory: {}.", size));
-        }
+        doris::MemTrackerLimiter::print_log_process_usage(
+                fmt::format("MemHook alloc large memory: {}.", size));
         _stop_consume = false;
     }
 }

--- a/be/src/runtime/memory/thread_mem_tracker_mgr.h
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.h
@@ -32,6 +32,7 @@
 #include "runtime/exec_env.h"
 #include "runtime/memory/mem_tracker.h"
 #include "runtime/memory/mem_tracker_limiter.h"
+#include "util/stack_util.h"
 
 namespace doris {
 
@@ -172,9 +173,8 @@ inline void ThreadMemTrackerMgr::consume(int64_t size) {
     // Direct malloc or new large memory, unable to catch std::bad_alloc, BE may OOM.
     if (size > 4294967296) { // 4G
         _stop_consume = true;
-        LOG(WARNING) << fmt::format("MemHook alloc large memory: {}.", size);
-        doris::MemTrackerLimiter::print_log_process_usage(
-                fmt::format("MemHook alloc large memory: {}.", size));
+        LOG(WARNING) << fmt::format("MemHook alloc large memory: {}, stacktrace:\n{}", size,
+                                    get_stack_trace());
         _stop_consume = false;
     }
 }

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -138,6 +138,11 @@ bool MemInfo::process_minor_gc() {
     // TODO add freed_mem
     SegmentLoader::instance()->prune();
 
+    if (doris::config::memory_debug) {
+        LOG(INFO) << MemTrackerLimiter::type_detail_usage(
+                "Before free top memory overcommit query in Minor GC",
+                MemTrackerLimiter::Type::QUERY);
+    }
     if (config::enable_query_memroy_overcommit) {
         freed_mem += MemTrackerLimiter::free_top_overcommit_query(
                 _s_process_minor_gc_size - freed_mem, vm_rss_str, mem_available_str);
@@ -179,10 +184,18 @@ bool MemInfo::process_full_gc() {
         }
     }
 
+    if (doris::config::memory_debug) {
+        LOG(INFO) << MemTrackerLimiter::type_detail_usage("Before free top memory query in Full GC",
+                                                          MemTrackerLimiter::Type::QUERY);
+    }
     freed_mem += MemTrackerLimiter::free_top_memory_query(_s_process_full_gc_size - freed_mem,
                                                           vm_rss_str, mem_available_str);
     if (freed_mem > _s_process_full_gc_size) {
         return true;
+    }
+    if (doris::config::memory_debug) {
+        LOG(INFO) << MemTrackerLimiter::type_detail_usage(
+                "Before free top memory overcommit load in Full GC", MemTrackerLimiter::Type::LOAD);
     }
     if (config::enable_query_memroy_overcommit) {
         freed_mem += MemTrackerLimiter::free_top_overcommit_load(
@@ -190,6 +203,10 @@ bool MemInfo::process_full_gc() {
         if (freed_mem > _s_process_full_gc_size) {
             return true;
         }
+    }
+    if (doris::config::memory_debug) {
+        LOG(INFO) << MemTrackerLimiter::type_detail_usage("Before free top memory load in Full GC",
+                                                          MemTrackerLimiter::Type::LOAD);
     }
     freed_mem += MemTrackerLimiter::free_top_memory_load(_s_process_full_gc_size - freed_mem,
                                                          vm_rss_str, mem_available_str);

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -138,11 +138,8 @@ bool MemInfo::process_minor_gc() {
     // TODO add freed_mem
     SegmentLoader::instance()->prune();
 
-    if (doris::config::memory_debug) {
-        LOG(INFO) << MemTrackerLimiter::type_detail_usage(
-                "Before free top memory overcommit query in Minor GC",
-                MemTrackerLimiter::Type::QUERY);
-    }
+    VLOG_NOTICE << MemTrackerLimiter::type_detail_usage(
+            "Before free top memory overcommit query in Minor GC", MemTrackerLimiter::Type::QUERY);
     if (config::enable_query_memroy_overcommit) {
         freed_mem += MemTrackerLimiter::free_top_overcommit_query(
                 _s_process_minor_gc_size - freed_mem, vm_rss_str, mem_available_str);
@@ -184,19 +181,16 @@ bool MemInfo::process_full_gc() {
         }
     }
 
-    if (doris::config::memory_debug) {
-        LOG(INFO) << MemTrackerLimiter::type_detail_usage("Before free top memory query in Full GC",
-                                                          MemTrackerLimiter::Type::QUERY);
-    }
+    VLOG_NOTICE << MemTrackerLimiter::type_detail_usage("Before free top memory query in Full GC",
+                                                        MemTrackerLimiter::Type::QUERY);
     freed_mem += MemTrackerLimiter::free_top_memory_query(_s_process_full_gc_size - freed_mem,
                                                           vm_rss_str, mem_available_str);
     if (freed_mem > _s_process_full_gc_size) {
         return true;
     }
-    if (doris::config::memory_debug) {
-        LOG(INFO) << MemTrackerLimiter::type_detail_usage(
-                "Before free top memory overcommit load in Full GC", MemTrackerLimiter::Type::LOAD);
-    }
+
+    VLOG_NOTICE << MemTrackerLimiter::type_detail_usage(
+            "Before free top memory overcommit load in Full GC", MemTrackerLimiter::Type::LOAD);
     if (config::enable_query_memroy_overcommit) {
         freed_mem += MemTrackerLimiter::free_top_overcommit_load(
                 _s_process_full_gc_size - freed_mem, vm_rss_str, mem_available_str);
@@ -204,10 +198,9 @@ bool MemInfo::process_full_gc() {
             return true;
         }
     }
-    if (doris::config::memory_debug) {
-        LOG(INFO) << MemTrackerLimiter::type_detail_usage("Before free top memory load in Full GC",
-                                                          MemTrackerLimiter::Type::LOAD);
-    }
+
+    VLOG_NOTICE << MemTrackerLimiter::type_detail_usage("Before free top memory load in Full GC",
+                                                        MemTrackerLimiter::Type::LOAD);
     freed_mem += MemTrackerLimiter::free_top_memory_load(_s_process_full_gc_size - freed_mem,
                                                          vm_rss_str, mem_available_str);
     if (freed_mem > _s_process_full_gc_size) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Print the mem tracker list of all query/load

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

