### PR TITLE
[fix](merge-on-write) return error st if check_pk_in_pre_segments failed

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -717,8 +717,8 @@ void TaskWorkerPool::_publish_version_worker_thread_callback() {
                     _tasks.push_back(agent_task_req);
                     _worker_thread_condition_variable.notify_one();
                 }
-                LOG(INFO) << "wait for previous publish version task to be done"
-                          << "transaction_id: " << publish_version_req.transaction_id;
+                LOG_EVERY_SECOND(INFO) << "wait for previous publish version task to be done"
+                                       << "transaction_id: " << publish_version_req.transaction_id;
                 break;
             } else {
                 LOG_WARNING("failed to publish version")

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2723,15 +2723,16 @@ Status Tablet::calc_delete_bitmap(RowsetSharedPtr rowset,
                                                         &loc);
                     if (st.ok()) {
                         delete_bitmap->add({rowset_id, loc.segment_id, 0}, loc.row_id);
-                        ++row_id;
-                        continue;
                     } else if (st.is<ALREADY_EXIST>()) {
                         delete_bitmap->add({rowset_id, seg->id(), 0}, row_id);
-                        ++row_id;
-                        continue;
+                    } else if (!st.is_not_found()) {
+                        // some unexpected error
+                        LOG(WARNING) << "some unexpected error happen while looking up keys "
+                                     << "in pre segments: " << st;
+                        return st;
                     }
-                    // some unexpected error
-                    return st;
+                    ++row_id;
+                    continue;
                 }
                 // same row in segments should be filtered
                 if (delete_bitmap->contains({rowset_id, seg->id(), 0}, row_id)) {

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2730,6 +2730,8 @@ Status Tablet::calc_delete_bitmap(RowsetSharedPtr rowset,
                         ++row_id;
                         continue;
                     }
+                    // some unexpected error
+                    return st;
                 }
                 // same row in segments should be filtered
                 if (delete_bitmap->contains({rowset_id, seg->id(), 0}, row_id)) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1. If check_pk_in_pre_segments failed, we should return error status
2. In MoW table, if the version is not continuous, the publish version task will retry in very high frequency and print quite a lot of logs, change the log to log_every_second

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

