### PR TITLE
[improve](nereids) check be status when column stats is unknown

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -98,6 +98,7 @@ import org.apache.doris.statistics.Histogram;
 import org.apache.doris.statistics.StatisticRange;
 import org.apache.doris.statistics.Statistics;
 import org.apache.doris.statistics.StatisticsBuilder;
+import org.apache.doris.statistics.util.StatisticsUtil;
 
 import com.google.common.collect.Maps;
 import org.apache.commons.collections.CollectionUtils;
@@ -493,8 +494,13 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
             ColumnStatistic cache = Config.enable_stats ? getColumnStatistic(table, colName) : ColumnStatistic.UNKNOWN;
             if (cache == ColumnStatistic.UNKNOWN) {
                 if (forbidUnknownColStats) {
-                    throw new AnalysisException("column stats for " + colName
-                            + " is unknown, `set forbid_unknown_col_stats = false` to execute sql with unknown stats");
+                    if (StatisticsUtil.statsTblAvailable()) {
+                        throw new AnalysisException("column stats for " + colName
+                                + " is unknown,"
+                                + " `set forbid_unknown_col_stats = false` to execute sql with unknown stats");
+                    } else {
+                        throw new AnalysisException("BE is not available!");
+                    }
                 }
                 columnStatisticMap.put(slotReference, cache);
                 continue;


### PR DESCRIPTION
# Proposed changes
when forbid_unknown_col_stats is open and some column stats is unknown,
we will check the be status by StatisticsUtil.statsTblAvailable(), and report error according to be status.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

