### PR TITLE
[Enhancement](meta) Show remote data usage via SHOW DATA #19533

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowDataStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowDataStmt.java
@@ -59,6 +59,7 @@ public class ShowDataStmt extends ShowStmt {
                     .addColumn(new Column("TableName", ScalarType.createVarchar(20)))
                     .addColumn(new Column("Size", ScalarType.createVarchar(30)))
                     .addColumn(new Column("ReplicaCount", ScalarType.createVarchar(20)))
+                    .addColumn(new Column("RemoteSize", ScalarType.createVarchar(30)))
                     .build();
 
     private static final ShowResultSetMetaData SHOW_INDEX_DATA_META_DATA =
@@ -68,13 +69,15 @@ public class ShowDataStmt extends ShowStmt {
                     .addColumn(new Column("Size", ScalarType.createVarchar(30)))
                     .addColumn(new Column("ReplicaCount", ScalarType.createVarchar(20)))
                     .addColumn(new Column("RowCount", ScalarType.createVarchar(20)))
+                    .addColumn(new Column("RemoteSize", ScalarType.createVarchar(30)))
                     .build();
     public static final ImmutableList<String> SHOW_TABLE_DATA_META_DATA_ORIGIN =
-            new ImmutableList.Builder<String>().add("TableName").add("Size").add("ReplicaCount").build();
+            new ImmutableList.Builder<String>().add("TableName").add("Size").add("ReplicaCount")
+            .add("RemoteSize").build();
 
     public static final ImmutableList<String> SHOW_INDEX_DATA_META_DATA_ORIGIN =
             new ImmutableList.Builder<String>().add("TableName").add("IndexName").add("Size").add("ReplicaCount")
-                    .add("RowCount").build();
+                    .add("RowCount").add("RemoteSize").build();
 
     TableName tableName;
     String dbName;
@@ -124,7 +127,7 @@ public class ShowDataStmt extends ShowStmt {
             try {
                 long totalSize = 0;
                 long totalReplicaCount = 0;
-
+                long totalRemoteSize = 0;
                 // sort by table name
                 List<Table> tables = db.getTables();
                 SortedSet<Table> sortedTables = new TreeSet<>(new Comparator<Table>() {
@@ -151,19 +154,22 @@ public class ShowDataStmt extends ShowStmt {
                     OlapTable olapTable = (OlapTable) table;
                     long tableSize = 0;
                     long replicaCount = 0;
+                    long remoteSize = 0;
                     olapTable.readLock();
                     try {
                         tableSize = olapTable.getDataSize();
                         replicaCount = olapTable.getReplicaCount();
+                        remoteSize = olapTable.getRemoteDataSize();
                     } finally {
                         olapTable.readUnlock();
                     }
-                    //|TableName|Size|ReplicaCount|
-                    List<Object> row = Arrays.asList(table.getName(), tableSize, replicaCount);
+                    //|TableName|Size|ReplicaCount|RemoteSize
+                    List<Object> row = Arrays.asList(table.getName(), tableSize, replicaCount, remoteSize);
                     totalRowsObject.add(row);
 
                     totalSize += tableSize;
                     totalReplicaCount += replicaCount;
+                    totalRemoteSize += remoteSize;
                 } // end for tables
 
                 // sort by
@@ -179,19 +185,26 @@ public class ShowDataStmt extends ShowStmt {
 
                 // for output
                 for (List<Object> row : totalRowsObject) {
-                    //|TableName|Size|ReplicaCount|
+                    //|TableName|Size|ReplicaCount|RemoteSize
                     Pair<Double, String> tableSizePair = DebugUtil.getByteUint((long) row.get(1));
                     String readableSize = DebugUtil.DECIMAL_FORMAT_SCALE_3.format(tableSizePair.first) + " "
                             + tableSizePair.second;
+                    Pair<Double, String> remoteSizePair = DebugUtil.getByteUint((long) row.get(3));
+                    String remoteReadableSize = DebugUtil.DECIMAL_FORMAT_SCALE_3.format(remoteSizePair.first) + " "
+                            + remoteSizePair.second;
                     List<String> result = Arrays.asList(String.valueOf(row.get(0)),
-                            readableSize, String.valueOf(row.get(2)));
+                            readableSize, String.valueOf(row.get(2)), remoteReadableSize);
                     totalRows.add(result);
                 }
 
                 Pair<Double, String> totalSizePair = DebugUtil.getByteUint(totalSize);
                 String readableSize = DebugUtil.DECIMAL_FORMAT_SCALE_3.format(totalSizePair.first) + " "
                         + totalSizePair.second;
-                List<String> total = Arrays.asList("Total", readableSize, String.valueOf(totalReplicaCount));
+                Pair<Double, String> totalRemoteSizePair = DebugUtil.getByteUint(totalRemoteSize);
+                String remoteReadableSize = DebugUtil.DECIMAL_FORMAT_SCALE_3.format(totalRemoteSizePair.first) + " "
+                        + totalRemoteSizePair.second;
+                List<String> total = Arrays.asList("Total", readableSize, String.valueOf(totalReplicaCount),
+                         remoteReadableSize);
                 totalRows.add(total);
 
                 // quota
@@ -201,7 +214,7 @@ public class ShowDataStmt extends ShowStmt {
                 String readableQuota = DebugUtil.DECIMAL_FORMAT_SCALE_3.format(quotaPair.first) + " "
                         + quotaPair.second;
 
-                List<String> quotaRow = Arrays.asList("Quota", readableQuota, String.valueOf(replicaQuota));
+                List<String> quotaRow = Arrays.asList("Quota", readableQuota, String.valueOf(replicaQuota), "");
                 totalRows.add(quotaRow);
 
                 // left
@@ -210,13 +223,13 @@ public class ShowDataStmt extends ShowStmt {
                 Pair<Double, String> leftPair = DebugUtil.getByteUint(left);
                 String readableLeft = DebugUtil.DECIMAL_FORMAT_SCALE_3.format(leftPair.first) + " "
                         + leftPair.second;
-                List<String> leftRow = Arrays.asList("Left", readableLeft, String.valueOf(replicaCountLeft));
+                List<String> leftRow = Arrays.asList("Left", readableLeft, String.valueOf(replicaCountLeft), "");
                 totalRows.add(leftRow);
 
                 // txn quota
                 long txnQuota = db.getTransactionQuotaSize();
                 List<String> transactionQuotaList = Arrays.asList("Transaction Quota",
-                        String.valueOf(txnQuota), String.valueOf(txnQuota));
+                        String.valueOf(txnQuota), String.valueOf(txnQuota), "");
                 totalRows.add(transactionQuotaList);
             } finally {
                 db.readUnlock();
@@ -233,7 +246,7 @@ public class ShowDataStmt extends ShowStmt {
             OlapTable olapTable = (OlapTable) db.getTableOrMetaException(tableName.getTbl(), TableType.OLAP);
             long totalSize = 0;
             long totalReplicaCount = 0;
-
+            long totalRemoteSize = 0;
             olapTable.readLock();
             try {
                 // sort by index name
@@ -247,20 +260,25 @@ public class ShowDataStmt extends ShowStmt {
                     long indexSize = 0;
                     long indexReplicaCount = 0;
                     long indexRowCount = 0;
+                    long indexRemoteSize = 0;
                     for (Partition partition : olapTable.getAllPartitions()) {
                         MaterializedIndex mIndex = partition.getIndex(indexId);
                         indexSize += mIndex.getDataSize();
                         indexReplicaCount += mIndex.getReplicaCount();
                         indexRowCount += mIndex.getRowCount();
+                        indexRemoteSize += mIndex.getRemoteDataSize();
                     }
 
                     String indexName = olapTable.getIndexNameById(indexId);
-                    //         .add("TableName").add("IndexName").add("Size").add("ReplicaCount").add("RowCount")
-                    List<Object> row = Arrays.asList(tableName, indexName, indexSize, indexReplicaCount, indexRowCount);
+                    // .add("TableName").add("IndexName").add("Size").add("ReplicaCount").add("RowCount")
+                    //      .add("RemoteSize")
+                    List<Object> row = Arrays.asList(tableName, indexName, indexSize, indexReplicaCount,
+                             indexRowCount, indexRemoteSize);
                     totalRowsObject.add(row);
 
                     totalSize += indexSize;
                     totalReplicaCount += indexReplicaCount;
+                    totalRemoteSize += indexRemoteSize;
                 } // end for indices
 
                 // sort by
@@ -276,20 +294,23 @@ public class ShowDataStmt extends ShowStmt {
 
                 // for output
                 for (int index = 0; index <= totalRowsObject.size() - 1; index++) {
-                    //| TableName| IndexName | Size | ReplicaCount | RowCount |
+                    //| TableName| IndexName | Size | ReplicaCount | RowCount | RemoteSize
                     List<Object> row = totalRowsObject.get(index);
                     List<String> result;
                     Pair<Double, String> tableSizePair = DebugUtil.getByteUint((long) row.get(2));
                     String readableSize = DebugUtil.DECIMAL_FORMAT_SCALE_3.format(tableSizePair.first)
                             + " " + tableSizePair.second;
+                    Pair<Double, String> remoteSizePair = DebugUtil.getByteUint((long) row.get(5));
+                    String remoteReadableSize = DebugUtil.DECIMAL_FORMAT_SCALE_3.format(remoteSizePair.first) + " "
+                            + remoteSizePair.second;
                     if (index == 0) {
                         result = Arrays.asList(tableName.getTbl(), String.valueOf(row.get(1)),
                                 readableSize, String.valueOf(row.get(3)),
-                                String.valueOf(row.get(4)));
+                                String.valueOf(row.get(4)), remoteReadableSize);
                     } else {
                         result = Arrays.asList("", String.valueOf(row.get(1)),
                                 readableSize, String.valueOf(row.get(3)),
-                                String.valueOf(row.get(4)));
+                                String.valueOf(row.get(4)), remoteReadableSize);
                     }
                     totalRows.add(result);
                 }
@@ -297,7 +318,11 @@ public class ShowDataStmt extends ShowStmt {
                 Pair<Double, String> totalSizePair = DebugUtil.getByteUint(totalSize);
                 String readableSize = DebugUtil.DECIMAL_FORMAT_SCALE_3.format(totalSizePair.first) + " "
                         + totalSizePair.second;
-                List<String> row = Arrays.asList("", "Total", readableSize, String.valueOf(totalReplicaCount), "");
+                Pair<Double, String> totalRemoteSizePair = DebugUtil.getByteUint(totalRemoteSize);
+                String remoteReadableSize = DebugUtil.DECIMAL_FORMAT_SCALE_3.format(totalRemoteSizePair.first) + " "
+                        + totalRemoteSizePair.second;
+                List<String> row = Arrays.asList("", "Total", readableSize, String.valueOf(totalReplicaCount), "",
+                         remoteReadableSize);
                 totalRows.add(row);
             } finally {
                 olapTable.readUnlock();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedIndex.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedIndex.java
@@ -179,6 +179,14 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
         return dataSize;
     }
 
+    public long getRemoteDataSize() {
+        long remoteDataSize = 0;
+        for (Tablet tablet : getTablets()) {
+            remoteDataSize += tablet.getRemoteDataSize();
+        }
+        return remoteDataSize;
+    }
+
     public long getReplicaCount() {
         long replicaCount = 0;
         for (Tablet tablet : getTablets()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -1439,6 +1439,14 @@ public class OlapTable extends Table {
         return dataSize;
     }
 
+    public long getRemoteDataSize() {
+        long remoteDataSize = 0;
+        for (Partition partition : getAllPartitions()) {
+            remoteDataSize += partition.getRemoteDataSize();
+        }
+        return remoteDataSize;
+    }
+
     public long getReplicaCount() {
         long replicaCount = 0;
         for (Partition partition : getAllPartitions()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Partition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Partition.java
@@ -261,6 +261,14 @@ public class Partition extends MetaObject implements Writable {
         return dataSize;
     }
 
+    public long getRemoteDataSize() {
+        long remoteDataSize = 0;
+        for (MaterializedIndex mIndex : getMaterializedIndices(IndexExtState.VISIBLE)) {
+            remoteDataSize += mIndex.getRemoteDataSize();
+        }
+        return remoteDataSize;
+    }
+
     public long getReplicaCount() {
         long replicaCount = 0;
         for (MaterializedIndex mIndex : getMaterializedIndices(IndexExtState.VISIBLE)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
@@ -45,6 +45,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -415,6 +416,20 @@ public class Tablet extends MetaObject implements Writable {
         LongStream s = replicas.stream().filter(r -> r.getState() == ReplicaState.NORMAL)
                 .mapToLong(Replica::getDataSize);
         return singleReplica ? Double.valueOf(s.average().orElse(0)).longValue() : s.sum();
+    }
+
+    public long getRemoteDataSize() {
+        // if CooldownReplicaId is not init
+        if (cooldownReplicaId <= 0) {
+            return 0;
+        }
+        for (Replica r : replicas) {
+            if (r.getId() == cooldownReplicaId) {
+                return r.getRemoteDataSize();
+            }
+        }
+        // return replica with max remoteDataSize
+        return replicas.stream().max(Comparator.comparing(Replica::getRemoteDataSize)).get().getRemoteDataSize();
     }
 
     public long getRowCount(boolean singleReplica) {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowDataStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowDataStmtTest.java
@@ -147,7 +147,7 @@ public class ShowDataStmtTest {
         ShowDataStmt stmt = new ShowDataStmt(null, null);
         stmt.analyze(analyzer);
         Assert.assertEquals("SHOW DATA FROM `testCluster:testDb`", stmt.toString());
-        Assert.assertEquals(3, stmt.getMetaData().getColumnCount());
+        Assert.assertEquals(4, stmt.getMetaData().getColumnCount());
         Assert.assertEquals(false, stmt.hasTable());
 
         SlotRef slotRefOne = new SlotRef(null, "ReplicaCount");
@@ -161,7 +161,7 @@ public class ShowDataStmtTest {
         Assert.assertEquals(
                 "SHOW DATA FROM `default_cluster:testDb`.`test_tbl` ORDER BY `ReplicaCount` DESC, `Size` DESC",
                 stmt.toString());
-        Assert.assertEquals(5, stmt.getMetaData().getColumnCount());
+        Assert.assertEquals(6, stmt.getMetaData().getColumnCount());
         Assert.assertEquals(true, stmt.hasTable());
 
         stmt = new ShowDataStmt(null, Arrays.asList(orderByElementOne, orderByElementTwo));


### PR DESCRIPTION
# Proposed changes

Issue Number: close #19533 

## Problem summary

Describe your changes.

SHOW DATA can show both local data usage of the table and remote cold data usage info. 
before 
![image](https://github.com/apache/doris/assets/72728602/7c1e9c60-be8a-400c-9bda-611517326b38)

----------------------------------------------------------------------------------------------------------------------------------------------

after
![c48b72bc85f132b193345becd35685a](https://github.com/apache/doris/assets/72728602/d67aef62-2229-44bb-a93d-f0e0f3ec2a62)
![afebd237ee1c46d687e21a69537d07a](https://github.com/apache/doris/assets/72728602/4662356a-79a5-4437-84f1-50ff5cb4f901)

## Checklist(Required)

* [x] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

