### PR TITLE
[enhancement](compaction) not core when init failed

### DIFF
--- a/be/src/vec/olap/vertical_block_reader.cpp
+++ b/be/src/vec/olap/vertical_block_reader.cpp
@@ -141,6 +141,10 @@ Status VerticalBlockReader::_init_collect_iter(const ReaderParams& read_params) 
     // In agg keys value columns compact, get first row for _init_agg_state
     if (!read_params.is_key_column_group && read_params.tablet->keys_type() == KeysType::AGG_KEYS) {
         auto st = _vcollect_iter->next_row(&_next_row);
+        if (!st.ok() && !st.is<END_OF_FILE>()) {
+            LOG(WARNING) << "failed to init first row for agg key";
+            return st;
+        }
         _eof = st.is<END_OF_FILE>();
     }
 


### PR DESCRIPTION
# Proposed changes
When mem not enough, segment iterator init failed and then compaction will core。
Return error when get first row failed.

W0517 11:39:55.700457 4188911 compaction.cpp:326] fail to do cumulative compaction. res=[MEM_LIMIT_EXCEEDED]PreCatch error code:11, [E11] Allocato
r sys memory check failed: Cannot alloc:64, consuming tracker:<CumulativeCompaction:9512847>, exec node:<>, process memory used 51.40 GB exceed li
mit 49.85 GB or sys mem available 11.69 GB less than low water mark 0, failed alloc size 64.00 B.
    @     0x55888a317318  doris::Exception::Exception()
    @     0x55888c94276d  Allocator<>::sys_memory_check()
    @     0x55888c942b82  Allocator<>::memory_check()
    @     0x55888a3133b5  Allocator<>::alloc()
    @     0x55888c874994  doris::vectorized::ColumnString::insert_many_continuous_binary_data()
    @     0x55888aa41f26  doris::segment_v2::BinaryPlainPageDecoder<>::next_batch()
    @     0x55888aa47596  doris::segment_v2::IndexedColumnIterator::next_batch()
    @     0x55888aab8faa  doris::segment_v2::ZoneMapIndexReader::load()
    @     0x55888aa011de  _ZZN5doris10segment_v212ColumnReader20_ensure_index_loadedEvENKUlvE_clEv
    @     0x55888aa00ffa  ZN5doris13DorisCallOnceINS_6StatusEE4callIZNS_10segment_v212ColumnReader20_ensure_index_loadedEvEUlvE_EES1_T
    @     0x55888a9f901d  doris::segment_v2::ColumnReader::seek_at_or_before()
    @     0x55888a9fbd7b  doris::segment_v2::FileColumnIterator::seek_to_ordinal()
    @     0x55888aa6cea8  doris::segment_v2::SegmentIterator::_seek_columns()
    @     0x55888aa6d672  doris::segment_v2::SegmentIterator::_read_columns_by_index()
    @     0x55888aa6ef93  doris::segment_v2::SegmentIterator::_next_batch_internal()
    @     0x55888aa6eb9b  doris::segment_v2::SegmentIterator::next_batch()
    @     0x558890d1b61f  doris::vectorized::VerticalMergeIteratorContext::_load_next_block()
    @     0x558890d1c845  doris::vectorized::VerticalHeapMergeIterator::init()
    @     0x558890d2155f  doris::vectorized::VerticalBlockReader::_init_collect_iter()
    @     0x558890d220bd  doris::vectorized::VerticalBlockReader::init()
    @     0x55888a30e761  doris::Merger::vertical_compact_one_group()
    @     0x55888a310036  doris::Merger::vertical_merge_rowsets()
    @     0x55888a2f7b84  doris::Compaction::do_compaction_impl()
    @     0x55888a2f6ed7  doris::Compaction::do_compaction()
    @     0x55888a8eadb2  doris::CumulativeCompaction::execute_compact_impl()
    @     0x55888a2f6b73  doris::Compaction::execute_compact()
    @     0x55888a923bf0  doris::Tablet::execute_compaction()
    @     0x55888a2c420d  std::_Function_handler<>::_M_invoke()
    @     0x55888ad76a2f  doris::ThreadPool::dispatch_thread()
    @     0x55888ad6f76c  doris::Thread::supervise_thread()
    @     0x7ff40abf1609  start_thread
    @     0x7ff40ae80163  clone

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

