### PR TITLE
[improvement](session variable) add max execution time session variabe like mysql and add setter attributes in variables

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -65,6 +65,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String EXEC_MEM_LIMIT = "exec_mem_limit";
     public static final String SCAN_QUEUE_MEM_LIMIT = "scan_queue_mem_limit";
     public static final String QUERY_TIMEOUT = "query_timeout";
+    public static final String MAX_EXECUTION_TIME = "max_execution_time";
     public static final String INSERT_TIMEOUT = "insert_timeout";
     public static final String ENABLE_PROFILE = "enable_profile";
     public static final String SQL_MODE = "sql_mode";
@@ -366,6 +367,14 @@ public class SessionVariable implements Serializable, Writable {
     // query timeout in second.
     @VariableMgr.VarAttr(name = QUERY_TIMEOUT)
     public int queryTimeoutS = 300;
+
+    // The global max_execution_time value provides the default for the session value for new connections.
+    // The session value applies to SELECT executions executed within the session that include
+    // no MAX_EXECUTION_TIME(N) optimizer hint or for which N is 0.
+    // https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html
+    // So that it is == query timeout in doris
+    @VariableMgr.VarAttr(name = MAX_EXECUTION_TIME, fuzzy = true, setter = "setMaxExecutionTimeMS")
+    public int maxExecutionTimeMS = -1;
 
     @VariableMgr.VarAttr(name = INSERT_TIMEOUT)
     public int insertTimeoutS = 14400;
@@ -1051,6 +1060,10 @@ public class SessionVariable implements Serializable, Writable {
         return queryTimeoutS;
     }
 
+    public int getMaxExecutionTimeMS() {
+        return maxExecutionTimeMS;
+    }
+
     public int getInsertTimeoutS() {
         return insertTimeoutS;
     }
@@ -1208,6 +1221,16 @@ public class SessionVariable implements Serializable, Writable {
 
     public void setQueryTimeoutS(int queryTimeoutS) {
         this.queryTimeoutS = queryTimeoutS;
+    }
+
+    public void setMaxExecutionTimeMS(int maxExecutionTimeMS) {
+        this.maxExecutionTimeMS = maxExecutionTimeMS;
+        this.queryTimeoutS = this.maxExecutionTimeMS / 1000;
+    }
+
+    public void setMaxExecutionTimeMS(String maxExecutionTimeMS) {
+        this.maxExecutionTimeMS = Integer.valueOf(maxExecutionTimeMS);
+        this.queryTimeoutS = this.maxExecutionTimeMS / 1000;
     }
 
     public String getResourceGroup() {

--- a/regression-test/suites/correctness/test_set_session_default_val.groovy
+++ b/regression-test/suites/correctness/test_set_session_default_val.groovy
@@ -28,8 +28,8 @@ suite("test_set_session_default_val") {
     sql """set query_timeout=2;"""
     def query_timeout = sql """show variables where variable_name = 'query_timeout';"""
     def max_execute_timeout = sql """show variables where variable_name = 'max_execution_time';"""
-    assertTrue(query_timeout[0][1] == 2)
-    assertTrue(max_execute_timeout[0][1] == default_max_execute_timeout[0][1])
+    assertEquals(query_timeout[0][1], 2)
+    assertEquals(max_execute_timeout[0][1], default_max_execute_timeout[0][1])
 
     sql """set max_execution_time=3000;"""
     def query_timeout2 = sql """show variables where variable_name = 'query_timeout';"""

--- a/regression-test/suites/correctness/test_set_session_default_val.groovy
+++ b/regression-test/suites/correctness/test_set_session_default_val.groovy
@@ -21,4 +21,20 @@ suite("test_set_session_default_val") {
     sql """set session insert_timeout=${default_timeout[0][1]};"""
     def session_timeout = sql """show variables where variable_name = 'insert_timeout';"""
     assertEquals(default_timeout, session_timeout)
+
+    def default_query_timeout = sql """show variables where variable_name = 'query_timeout';"""
+    def default_max_execute_timeout = sql """show variables where variable_name = 'max_execution_time';"""
+
+    sql """set query_timeout=2;"""
+    def query_timeout = sql """show variables where variable_name = 'query_timeout';"""
+    def max_execute_timeout = sql """show variables where variable_name = 'max_execution_time';"""
+    assertTrue(query_timeout[0][1] == 2)
+    assertTrue(max_execute_timeout[0][1] == default_max_execute_timeout[0][1])
+
+    sql """set max_execution_time=3000;"""
+    def query_timeout2 = sql """show variables where variable_name = 'query_timeout';"""
+    def max_execute_timeout2 = sql """show variables where variable_name = 'max_execution_time';"""
+    assertTrue(query_timeout2[0][1] == 3)
+    assertTrue(max_execute_timeout2[0][1] != default_max_execute_timeout[0][1])
+    assertTrue(max_execute_timeout2[0][1] == 3000)
 }

--- a/regression-test/suites/correctness/test_set_session_default_val.groovy
+++ b/regression-test/suites/correctness/test_set_session_default_val.groovy
@@ -34,7 +34,6 @@ suite("test_set_session_default_val") {
     sql """set max_execution_time=3000;"""
     def query_timeout2 = sql """show variables where variable_name = 'query_timeout';"""
     def max_execute_timeout2 = sql """show variables where variable_name = 'max_execution_time';"""
-    assertTrue(query_timeout2[0][1] == "3")
-    assertTrue(max_execute_timeout2[0][1] != default_max_execute_timeout[0][1])
-    assertTrue(max_execute_timeout2[0][1] == 3000)
+    assertEquals(query_timeout2[0][1], "3")
+    assertEquals(max_execute_timeout2[0][1], "3000")
 }

--- a/regression-test/suites/correctness/test_set_session_default_val.groovy
+++ b/regression-test/suites/correctness/test_set_session_default_val.groovy
@@ -28,13 +28,13 @@ suite("test_set_session_default_val") {
     sql """set query_timeout=2;"""
     def query_timeout = sql """show variables where variable_name = 'query_timeout';"""
     def max_execute_timeout = sql """show variables where variable_name = 'max_execution_time';"""
-    assertEquals(query_timeout[0][1], 2)
+    assertEquals(query_timeout[0][1], "2")
     assertEquals(max_execute_timeout[0][1], default_max_execute_timeout[0][1])
 
     sql """set max_execution_time=3000;"""
     def query_timeout2 = sql """show variables where variable_name = 'query_timeout';"""
     def max_execute_timeout2 = sql """show variables where variable_name = 'max_execution_time';"""
-    assertTrue(query_timeout2[0][1] == 3)
+    assertTrue(query_timeout2[0][1] == "3")
     assertTrue(max_execute_timeout2[0][1] != default_max_execute_timeout[0][1])
     assertTrue(max_execute_timeout2[0][1] == 3000)
 }


### PR DESCRIPTION
# Proposed changes

1. add session variable max_execution_time to an alias of query timeout, if user set max_execution_time, the query timeout will be modified too.
2. add a setter attribute to session variable, so that we could add some logic in setter method instead of field reflection.

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

