### PR TITLE
[Improvement](memory) faststring use Allocator

### DIFF
--- a/be/src/common/exception.h
+++ b/be/src/common/exception.h
@@ -76,18 +76,19 @@ inline std::string Exception::to_string() const {
 
 } // namespace doris
 
-#define RETURN_IF_CATCH_EXCEPTION(stmt)                                                      \
-    do {                                                                                     \
-        try {                                                                                \
-            doris::enable_thread_catch_bad_alloc++;                                          \
-            Defer defer {[&]() { doris::enable_thread_catch_bad_alloc--; }};                 \
-            { stmt; }                                                                        \
-        } catch (const doris::Exception& e) {                                                \
-            if (e.code() == doris::ErrorCode::MEM_ALLOC_FAILED) {                            \
-                return Status::MemoryLimitExceeded(                                          \
-                        fmt::format("PreCatch error code:{}, {}", e.code(), e.to_string())); \
-            } else {                                                                         \
-                return Status::Error(e.code(), e.to_string());                               \
-            }                                                                                \
-        }                                                                                    \
+#define RETURN_IF_CATCH_EXCEPTION(stmt)                                                          \
+    do {                                                                                         \
+        try {                                                                                    \
+            doris::enable_thread_catch_bad_alloc++;                                              \
+            Defer defer {[&]() { doris::enable_thread_catch_bad_alloc--; }};                     \
+            { stmt; }                                                                            \
+        } catch (const doris::Exception& e) {                                                    \
+            if (e.code() == doris::ErrorCode::MEM_ALLOC_FAILED) {                                \
+                return Status::MemoryLimitExceeded(fmt::format(                                  \
+                        "PreCatch error code:{}, {}, __FILE__:{}, __LINE__:{}, __FUNCTION__:{}", \
+                        e.code(), e.to_string(), __FILE__, __LINE__, __PRETTY_FUNCTION__));      \
+            } else {                                                                             \
+                return Status::Error(e.code(), e.to_string());                                   \
+            }                                                                                    \
+        }                                                                                        \
     } while (0)

--- a/be/src/olap/rowset/segment_v2/page_io.cpp
+++ b/be/src/olap/rowset/segment_v2/page_io.cpp
@@ -51,13 +51,13 @@ Status PageIO::compress_page_body(BlockCompressionCodec* codec, double min_space
     size_t uncompressed_size = Slice::compute_total_size(body);
     if (codec != nullptr && !codec->exceed_max_compress_len(uncompressed_size)) {
         faststring buf;
-        RETURN_IF_ERROR(codec->compress(body, uncompressed_size, &buf));
+        RETURN_IF_CATCH_EXCEPTION(RETURN_IF_ERROR(codec->compress(body, uncompressed_size, &buf)));
         double space_saving = 1.0 - static_cast<double>(buf.size()) / uncompressed_size;
         // return compressed body only when it saves more than min_space_saving
         if (space_saving > 0 && space_saving >= min_space_saving) {
             // shrink the buf to fit the len size to avoid taking
             // up the memory of the size MAX_COMPRESSED_SIZE
-            *compressed_body = buf.build();
+            RETURN_IF_CATCH_EXCEPTION(*compressed_body = buf.build());
             return Status::OK();
         }
     }

--- a/be/src/runtime/memory/chunk_allocator.cpp
+++ b/be/src/runtime/memory/chunk_allocator.cpp
@@ -83,9 +83,8 @@ public:
     ~ChunkArena() {
         for (int i = 0; i < 64; ++i) {
             if (_chunk_lists[i].empty()) continue;
-            size_t size = (uint64_t)1 << i;
             for (auto ptr : _chunk_lists[i]) {
-                SystemAllocator::free(ptr, size);
+                SystemAllocator::free(ptr);
             }
         }
     }
@@ -228,7 +227,7 @@ void ChunkAllocator::free(const Chunk& chunk) {
     DCHECK(chunk.core_id != -1);
     CHECK((chunk.size & (chunk.size - 1)) == 0);
     if (config::disable_mem_pools || _reserve_bytes_limit < 1) {
-        SystemAllocator::free(chunk.data, chunk.size);
+        SystemAllocator::free(chunk.data);
         return;
     }
 
@@ -241,7 +240,7 @@ void ChunkAllocator::free(const Chunk& chunk) {
             int64_t cost_ns = 0;
             {
                 SCOPED_RAW_TIMER(&cost_ns);
-                SystemAllocator::free(chunk.data, chunk.size);
+                SystemAllocator::free(chunk.data);
             }
             chunk_pool_system_free_count->increment(1);
             chunk_pool_system_free_cost_ns->increment(cost_ns);

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -233,6 +233,7 @@ std::string MemTrackerLimiter::log_process_usage_str(const std::string& msg, boo
 }
 
 void MemTrackerLimiter::print_log_process_usage(const std::string& msg, bool with_stacktrace) {
+    // The default interval between two prints is 100ms (config::memory_maintenance_sleep_time_ms).
     if (MemTrackerLimiter::_enable_print_log_process_usage) {
         MemTrackerLimiter::_enable_print_log_process_usage = false;
         LOG(WARNING) << log_process_usage_str(msg, with_stacktrace);
@@ -273,14 +274,13 @@ std::string MemTrackerLimiter::process_mem_log_str() {
             MemInfo::refresh_interval_memory_growth);
 }
 
-std::string MemTrackerLimiter::process_limit_exceeded_errmsg_str(int64_t bytes) {
+std::string MemTrackerLimiter::process_limit_exceeded_errmsg_str() {
     return fmt::format(
             "process memory used {} exceed limit {} or sys mem available {} less than low "
-            "water mark {}, failed alloc size {}",
+            "water mark {}",
             PerfCounters::get_vm_rss_str(), MemInfo::mem_limit_str(),
             MemInfo::sys_mem_available_str(),
-            PrettyPrinter::print(MemInfo::sys_mem_available_low_water_mark(), TUnit::BYTES),
-            print_bytes(bytes));
+            PrettyPrinter::print(MemInfo::sys_mem_available_low_water_mark(), TUnit::BYTES));
 }
 
 std::string MemTrackerLimiter::query_tracker_limit_exceeded_str(

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -214,7 +214,7 @@ public:
     }
 
     static std::string process_mem_log_str();
-    static std::string process_limit_exceeded_errmsg_str(int64_t bytes);
+    static std::string process_limit_exceeded_errmsg_str();
     // Log the memory usage when memory limit is exceeded.
     std::string query_tracker_limit_exceeded_str(const std::string& tracker_limit_exceeded,
                                                  const std::string& last_consumer_tracker,

--- a/be/src/runtime/memory/system_allocator.cpp
+++ b/be/src/runtime/memory/system_allocator.cpp
@@ -37,7 +37,7 @@ uint8_t* SystemAllocator::allocate(size_t length) {
     return allocate_via_malloc(length);
 }
 
-void SystemAllocator::free(uint8_t* ptr, size_t length) {
+void SystemAllocator::free(uint8_t* ptr) {
     ::free(ptr);
 }
 

--- a/be/src/runtime/memory/system_allocator.h
+++ b/be/src/runtime/memory/system_allocator.h
@@ -28,7 +28,7 @@ class SystemAllocator {
 public:
     static uint8_t* allocate(size_t length);
 
-    static void free(uint8_t* ptr, size_t length);
+    static void free(uint8_t* ptr);
 
 private:
     static uint8_t* allocate_via_mmap(size_t length);

--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -45,6 +45,7 @@ namespace doris {
 
 using strings::Substitute;
 
+// exception safe
 Status BlockCompressionCodec::compress(const std::vector<Slice>& inputs, size_t uncompressed_size,
                                        faststring* output) {
     faststring buf;

--- a/be/src/util/faststring.cc
+++ b/be/src/util/faststring.cc
@@ -37,13 +37,13 @@ void faststring::GrowToAtLeast(size_t newcapacity) {
 
 void faststring::GrowArray(size_t newcapacity) {
     DCHECK_GE(newcapacity, capacity_);
-    std::unique_ptr<uint8_t[]> newdata(new uint8_t[newcapacity]);
+    std::unique_ptr<uint8_t[]> newdata(reinterpret_cast<uint8_t*>(Allocator::alloc(newcapacity)));
     if (len_ > 0) {
         memcpy(&newdata[0], &data_[0], len_);
     }
     capacity_ = newcapacity;
     if (data_ != initial_data_) {
-        delete[] data_;
+        Allocator::free_no_munmap(data_);
     } else {
         ASAN_POISON_MEMORY_REGION(initial_data_, arraysize(initial_data_));
     }
@@ -57,13 +57,13 @@ void faststring::ShrinkToFitInternal() {
     if (len_ <= kInitialCapacity) {
         ASAN_UNPOISON_MEMORY_REGION(initial_data_, len_);
         memcpy(initial_data_, &data_[0], len_);
-        delete[] data_;
+        Allocator::free_no_munmap(data_);
         data_ = initial_data_;
         capacity_ = kInitialCapacity;
     } else {
-        std::unique_ptr<uint8_t[]> newdata(new uint8_t[len_]);
+        std::unique_ptr<uint8_t[]> newdata(reinterpret_cast<uint8_t*>(Allocator::alloc(len_)));
         memcpy(&newdata[0], &data_[0], len_);
-        delete[] data_;
+        Allocator::free_no_munmap(data_);
         data_ = newdata.release();
         capacity_ = len_;
     }

--- a/be/src/util/faststring.h
+++ b/be/src/util/faststring.h
@@ -27,13 +27,15 @@
 #include "gutil/port.h"
 #include "gutil/strings/fastmem.h"
 #include "util/slice.h"
+#include "vec/common/allocator.h"
 
 namespace doris {
 
 // A faststring is similar to a std::string, except that it is faster for many
 // common use cases (in particular, resize() will fill with uninitialized data
 // instead of memsetting to \0)
-class faststring {
+// only build() can transfer data to the outside.
+class faststring : private Allocator<false, false, false> {
 public:
     enum { kInitialCapacity = 32 };
 
@@ -43,7 +45,7 @@ public:
     explicit faststring(size_t capacity)
             : data_(initial_data_), len_(0), capacity_(kInitialCapacity) {
         if (capacity > capacity_) {
-            data_ = new uint8_t[capacity];
+            data_ = reinterpret_cast<uint8_t*>(Allocator::alloc(capacity));
             capacity_ = capacity;
         }
         ASAN_POISON_MEMORY_REGION(data_, capacity_);
@@ -52,7 +54,7 @@ public:
     ~faststring() {
         ASAN_UNPOISON_MEMORY_REGION(initial_data_, arraysize(initial_data_));
         if (data_ != initial_data_) {
-            delete[] data_;
+            Allocator::free_no_munmap(data_);
         }
     }
 
@@ -83,7 +85,7 @@ public:
     OwnedSlice build() {
         uint8_t* ret = data_;
         if (ret == initial_data_) {
-            ret = new uint8_t[len_];
+            ret = reinterpret_cast<uint8_t*>(Allocator::alloc(len_));
             memcpy(ret, data_, len_);
         }
         OwnedSlice result(ret, len_);

--- a/be/src/util/slice.h
+++ b/be/src/util/slice.h
@@ -28,6 +28,8 @@
 #include <utility>
 #include <vector>
 
+#include "vec/common/allocator.h"
+
 namespace doris {
 
 class faststring;
@@ -259,11 +261,11 @@ struct SliceMap {
 //     return page_data; // transfer ownership of buffer into the caller
 //   }
 //
-class OwnedSlice {
+// only receive the memory allocated by Allocator and disables mmap,
+// otherwise the memory may not be freed correctly, currently only be constructed by faststring.
+class OwnedSlice : private Allocator<false, false, false> {
 public:
     OwnedSlice() : _slice((uint8_t*)nullptr, 0) {}
-
-    OwnedSlice(uint8_t* _data, size_t size) : _slice(_data, size) {}
 
     OwnedSlice(OwnedSlice&& src) : _slice(src._slice) {
         src._slice.data = nullptr;
@@ -277,9 +279,15 @@ public:
         return *this;
     }
 
-    ~OwnedSlice() { delete[] _slice.data; }
+    ~OwnedSlice() { Allocator::free_no_munmap(_slice.data); }
 
     const Slice& slice() const { return _slice; }
+
+private:
+    // faststring also inherits Allocator and disables mmap.
+    friend class faststring;
+
+    OwnedSlice(uint8_t* _data, size_t size) : _slice(_data, size) {}
 
 private:
     // disable copy constructor and copy assignment

--- a/be/src/vec/common/allocator.h
+++ b/be/src/vec/common/allocator.h
@@ -92,7 +92,7 @@ static constexpr int ALLOCATOR_ALIGNMENT_16 = 16;
   * - random hint address for mmap
   * - mmap_threshold for using mmap less or more
   */
-template <bool clear_memory_, bool mmap_populate>
+template <bool clear_memory_, bool mmap_populate, bool use_mmap>
 class Allocator {
 public:
     void sys_memory_check(size_t size) const;
@@ -110,7 +110,7 @@ public:
         memory_check(size);
         void* buf;
 
-        if (size >= doris::config::mmap_threshold) {
+        if (size >= doris::config::mmap_threshold && use_mmap) {
             if (alignment > MMAP_MIN_ALIGNMENT)
                 throw doris::Exception(
                         doris::ErrorCode::INVALID_ARGUMENT,
@@ -159,7 +159,7 @@ public:
 
     /// Free memory range.
     void free(void* buf, size_t size) {
-        if (size >= doris::config::mmap_threshold) {
+        if (size >= doris::config::mmap_threshold && use_mmap) {
             if (0 != munmap(buf, size)) {
                 throw_bad_alloc(fmt::format("Allocator: Cannot munmap {}.", size));
             } else {
@@ -172,6 +172,12 @@ public:
         } else {
             ::free(buf);
         }
+    }
+
+    // Free memory range by ::free.
+    void free_no_munmap(void* buf) {
+        CHECK(!use_mmap);
+        ::free(buf);
     }
 
     /** Enlarge memory range.
@@ -197,7 +203,7 @@ public:
                 if (new_size > old_size)
                     memset(reinterpret_cast<char*>(buf) + old_size, 0, new_size - old_size);
         } else if (old_size >= doris::config::mmap_threshold &&
-                   new_size >= doris::config::mmap_threshold) {
+                   new_size >= doris::config::mmap_threshold && use_mmap) {
             memory_check(new_size);
             /// Resize mmap'd memory region.
             consume_memory(new_size - old_size);

--- a/be/src/vec/common/allocator_fwd.h
+++ b/be/src/vec/common/allocator_fwd.h
@@ -24,7 +24,7 @@
 #pragma once
 
 #include <cstddef>
-template <bool clear_memory_, bool mmap_populate = false>
+template <bool clear_memory_, bool mmap_populate = false, bool use_mmap = true>
 class Allocator;
 
 template <typename Base, size_t N = 64, size_t Alignment = 1>

--- a/be/src/vec/common/hash_table/phmap_fwd_decl.h
+++ b/be/src/vec/common/hash_table/phmap_fwd_decl.h
@@ -26,7 +26,7 @@ namespace doris::vectorized {
 /// `Allocator_` implements several interfaces of `std::allocator`
 /// which `phmap::flat_hash_map` will use.
 template <typename T>
-class Allocator_ : private Allocator<false, true> {
+class Allocator_ : private Allocator<false, true, true> {
 public:
     using value_type = T;
     using pointer = T*;

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -828,8 +828,8 @@ Status Block::serialize(int be_exec_version, PBlock* pblock,
         RETURN_IF_ERROR(get_block_compression_codec(compression_type, &codec));
 
         faststring buf_compressed;
-        RETURN_IF_ERROR(codec->compress(Slice(column_values.data(), content_uncompressed_size),
-                                        &buf_compressed));
+        RETURN_IF_CATCH_EXCEPTION(RETURN_IF_ERROR(codec->compress(
+                Slice(column_values.data(), content_uncompressed_size), &buf_compressed)));
         size_t compressed_size = buf_compressed.size();
         if (LIKELY(compressed_size < content_uncompressed_size)) {
             pblock->set_column_values(buf_compressed.data(), buf_compressed.size());

--- a/be/test/runtime/memory/system_allocator_test.cpp
+++ b/be/test/runtime/memory/system_allocator_test.cpp
@@ -31,13 +31,13 @@ void test_normal() {
         auto ptr = SystemAllocator::allocate(4096);
         EXPECT_NE(nullptr, ptr);
         EXPECT_EQ(0, (uint64_t)ptr % 4096);
-        SystemAllocator::free(ptr, 4096);
+        SystemAllocator::free(ptr);
     }
     {
         auto ptr = SystemAllocator::allocate(100);
         EXPECT_NE(nullptr, ptr);
         EXPECT_EQ(0, (uint64_t)ptr % 4096);
-        SystemAllocator::free(ptr, 100);
+        SystemAllocator::free(ptr);
     }
 }
 


### PR DESCRIPTION
# Proposed changes

After the outer catch exception, faststring `resize` `reserve` `build` may throw a memory alloc failure exception from the Allocator.

Currently page body compress will catch memory alloc failure exception

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

