### PR TITLE
[fix](mtmv) fix bug that should not write edit log when replaying alter mtmv

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
@@ -529,7 +529,7 @@ public class Alter {
             olapTable = (MaterializedView) db.getTableOrMetaException(tbl.getTbl(), TableType.MATERIALIZED_VIEW);
 
             // 2. drop old job and kill the associated tasks
-            Env.getCurrentEnv().getMTMVJobManager().dropJobByName(tbl.getDb(), tbl.getTbl());
+            Env.getCurrentEnv().getMTMVJobManager().dropJobByName(tbl.getDb(), tbl.getTbl(), isReplay);
 
             // 3. overwrite the refresh info in the memory of fe.
             olapTable.writeLock();

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVJobManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVJobManager.java
@@ -367,11 +367,11 @@ public class MTMVJobManager {
         LOG.info("change job:{}", changeJob.getJobId());
     }
 
-    public void dropJobByName(String dbName, String mvName) {
+    public void dropJobByName(String dbName, String mvName, boolean isReplay) {
         for (String jobName : nameToJobMap.keySet()) {
             MTMVJob job = nameToJobMap.get(jobName);
             if (job.getMVName().equals(mvName) && job.getDBName().equals(dbName)) {
-                dropJobs(Collections.singletonList(job.getId()), false);
+                dropJobs(Collections.singletonList(job.getId()), isReplay);
                 return;
             }
         }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

```
2023-05-18 10:55:16,161 ERROR (replayer|90) [BDBJEJournal.write():159] catch an exception when writing to database. sleep and retry. journal id 1128119
com.sleepycat.je.rep.ReplicaWriteException: (JE 18.3.12) Problem closing transaction 1139. The current state is:REPLICA. The node transitioned to this state at:Thu May 18 10:55:04 CST 2023
        at com.sleepycat.je.rep.txn.ReadonlyTxn.disallowReplicaWrite(ReadonlyTxn.java:114) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.rep.txn.ReadonlyTxn.preLogWithoutLock(ReadonlyTxn.java:102) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.dbi.CursorImpl.insertRecordInternal(CursorImpl.java:1371) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.dbi.CursorImpl.insertOrUpdateRecord(CursorImpl.java:1242) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.Cursor.putNoNotify(Cursor.java:2938) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.Cursor.putNotify(Cursor.java:2776) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.Cursor.putNoDups(Cursor.java:2623) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.Cursor.putInternal(Cursor.java:2454) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.Cursor.putInternal(Cursor.java:841) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.Database.put(Database.java:1635) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at com.sleepycat.je.Database.put(Database.java:1688) ~[je-18.3.14-doris-SNAPSHOT.jar:18.3.14-doris-SNAPSHOT]
        at org.apache.doris.journal.bdbje.BDBJEJournal.write(BDBJEJournal.java:150) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.persist.EditLog.logEdit(EditLog.java:1064) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.persist.EditLog.logDropMTMVTasks(EditLog.java:1655) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.mtmv.MTMVTaskManager.dropTasks(MTMVTaskManager.java:475) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.mtmv.MTMVTaskManager.clearTasksByJobName(MTMVTaskManager.java:429) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.mtmv.MTMVJobManager.dropJobs(MTMVJobManager.java:403) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.mtmv.MTMVJobManager.dropJobByName(MTMVJobManager.java:374) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.alter.Alter.processAlterMaterializedView(Alter.java:532) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.persist.EditLog.loadJournal(EditLog.java:913) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.Env.replayJournal(Env.java:2486) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.Env$3.runOneCycle(Env.java:2269) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.common.util.Daemon.run(Daemon.java:116) ~[doris-fe.jar:1.2-SNAPSHOT]
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

