### PR TITLE
[fix](memory) Remind log if `vm/overcommit_memory`=2 when be start

### DIFF
--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -300,13 +300,28 @@ void MemInfo::init() {
         _s_sys_mem_available_warning_water_mark = _s_sys_mem_available_low_water_mark + p1;
     }
 
+    // Expect vm overcommit memory value to be 1, system will no longer throw bad_alloc, memory alloc are always accepted,
+    // memory limit check is handed over to Doris Allocator, make sure throw exception position is controllable,
+    // otherwise bad_alloc can be thrown anywhere and it will be difficult to achieve exception safety.
+    std::ifstream sys_vm("/proc/sys/vm/overcommit_memory", std::ios::in);
+    std::string vm_overcommit;
+    getline(sys_vm, vm_overcommit);
+    if (sys_vm.is_open()) sys_vm.close();
+    if (std::stoi(vm_overcommit) == 2) {
+        std::cout << "/proc/sys/vm/overcommit_memory: " << vm_overcommit
+                  << ", expect is 1, memory limit check is handed over to Doris Allocator, "
+                     "otherwise BE may crash even with remaining memory"
+                  << std::endl;
+    }
+
     LOG(INFO) << "Physical Memory: " << PrettyPrinter::print(_s_physical_mem, TUnit::BYTES)
               << ", Mem Limit: " << _s_mem_limit_str
               << ", origin config value: " << config::mem_limit
               << ", System Mem Available Min Reserve: "
               << PrettyPrinter::print(_s_sys_mem_available_low_water_mark, TUnit::BYTES)
               << ", Vm Min Free KBytes: "
-              << PrettyPrinter::print(_s_vm_min_free_kbytes, TUnit::BYTES);
+              << PrettyPrinter::print(_s_vm_min_free_kbytes, TUnit::BYTES)
+              << ", Vm Overcommit Memory: " << vm_overcommit;
     _s_initialized = true;
 }
 #else

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -20,6 +20,13 @@ set -eo pipefail
 
 curdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
+if [ $(id -u) -eq 0 ]; then # current user has root privileges
+    # system will no longer throw bad_alloc, memory alloc are always accepted,
+    # memory limit check is handed over to Doris Allocator, make sure throw exception position is controllable,
+    # otherwise bad_alloc can be thrown anywhere and it will be difficult to achieve exception safety.
+    sudo echo 1 > /proc/sys/vm/overcommit_memory
+fi
+
 MACHINE_OS=$(uname -s)
 if [[ "$(uname -s)" == 'Darwin' ]] && command -v brew &>/dev/null; then
     PATH="$(brew --prefix)/opt/gnu-getopt/bin:${PATH}"

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -20,11 +20,11 @@ set -eo pipefail
 
 curdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-if [ $(id -u) -eq 0 ]; then # current user has root privileges
+if [[ $(id -u) -eq 0 ]]; then # current user has root privileges
     # system will no longer throw bad_alloc, memory alloc are always accepted,
     # memory limit check is handed over to Doris Allocator, make sure throw exception position is controllable,
     # otherwise bad_alloc can be thrown anywhere and it will be difficult to achieve exception safety.
-    sudo echo 1 > /proc/sys/vm/overcommit_memory
+    sudo echo 1 >/proc/sys/vm/overcommit_memory
 fi
 
 MACHINE_OS=$(uname -s)

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -20,13 +20,6 @@ set -eo pipefail
 
 curdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-if [[ $(id -u) -eq 0 ]]; then # current user has root privileges
-    # system will no longer throw bad_alloc, memory alloc are always accepted,
-    # memory limit check is handed over to Doris Allocator, make sure throw exception position is controllable,
-    # otherwise bad_alloc can be thrown anywhere and it will be difficult to achieve exception safety.
-    sudo echo 1 >/proc/sys/vm/overcommit_memory
-fi
-
 MACHINE_OS=$(uname -s)
 if [[ "$(uname -s)" == 'Darwin' ]] && command -v brew &>/dev/null; then
     PATH="$(brew --prefix)/opt/gnu-getopt/bin:${PATH}"


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Expect vm overcommit memory value to be 1,  system will no longer throw bad_alloc, memory alloc are always accepted,
memory limit check is handed over to Doris Allocator, make sure throw exception position is controllable,
otherwise bad_alloc can be thrown anywhere and it will be difficult to achieve exception safety.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

