### PR TITLE
[bug](MTMV) Fix the wrong interpretation for NEVER REFRESH

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -1730,7 +1730,7 @@ opt_mv_refersh_info ::=
     :}
     | KW_NEVER KW_REFRESH
     {:
-        RESULT = new MVRefreshInfo(false);
+        RESULT = new MVRefreshInfo(true);
     :}
     ;
 

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/MultiTableMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/MultiTableMaterializedViewTest.java
@@ -512,4 +512,26 @@ public class MultiTableMaterializedViewTest extends TestWithFeService {
                 + "INNER JOIN part p ON (p.p_partkey = l.lo_partkey)").execute();
         Assertions.assertNull(connectContext.getState().getErrorCode(), connectContext.getState().getErrorMessage());
     }
+
+    @Test
+    void testCreateNeverRefreshMaterializedView() throws Exception {
+        createTable("create table test.t1 (pk int, v1 int sum) aggregate key (pk) "
+                + "distributed by hash (pk) buckets 1 properties ('replication_num' = '1');");
+        createTable("create table test.t2 (pk int, v2 int sum) aggregate key (pk) "
+                + "distributed by hash (pk) buckets 1 properties ('replication_num' = '1');");
+        new StmtExecutor(connectContext, "create materialized view mv "
+                + "build immediate never refresh key (mpk) distributed by hash (mpk) "
+                + "properties ('replication_num' = '1') "
+                + "as select test.t1.pk as mpk from test.t1, test.t2 where test.t1.pk = test.t2.pk").execute();
+        Assertions.assertNull(connectContext.getState().getErrorCode(), connectContext.getState().getErrorMessage());
+
+        ShowExecutor showExecutor = new ShowExecutor(connectContext,
+                (ShowStmt) parseAndAnalyzeStmt("show create table mv"));
+        ShowResultSet resultSet = showExecutor.execute();
+        String result = resultSet.getResultRows().get(0).get(1);
+        Assertions.assertTrue(result.contains("CREATE MATERIALIZED VIEW `mv`\n"
+                + "BUILD IMMEDIATE NEVER REFRESH \n"
+                + "KEY(`mpk`)\n"
+                + "DISTRIBUTED BY HASH(`mpk`) BUCKETS 10"));
+    }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #19805

## Problem summary

We should pass `true` to the constructor method `public MVRefreshInfo(boolean neverRefresh)` rather than `false` when creating a materialized view with multiple tables which never refreshes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

