### PR TITLE
[improvement](jdbc catalog) Add adaptation to Oracle special character  `/` table names

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/external/jdbc/JdbcClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/jdbc/JdbcClient.java
@@ -403,6 +403,8 @@ public class JdbcClient {
         try {
             DatabaseMetaData databaseMetaData = conn.getMetaData();
             String catalogName = conn.getCatalog();
+            String modifiedTableName;
+            boolean isModify = false;
             // getColumns(String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern)
             // catalog - the catalog of this table, `null` means all catalogs
             // schema - The schema of the table; corresponding to tablespace in Oracle
@@ -418,12 +420,18 @@ public class JdbcClient {
                     rs = databaseMetaData.getColumns(dbName, null, tableName, null);
                     break;
                 case JdbcResource.POSTGRESQL:
-                case JdbcResource.ORACLE:
                 case JdbcResource.CLICKHOUSE:
                 case JdbcResource.SQLSERVER:
                 case JdbcResource.SAP_HANA:
                 case JdbcResource.OCEANBASE_ORACLE:
                     rs = databaseMetaData.getColumns(null, dbName, tableName, null);
+                    break;
+                case JdbcResource.ORACLE:
+                    modifiedTableName = tableName.replace("/", "%");
+                    if (!modifiedTableName.equals(tableName)) {
+                        isModify = true;
+                    }
+                    rs = databaseMetaData.getColumns(null, dbName, modifiedTableName, null);
                     break;
                 case JdbcResource.TRINO:
                 case JdbcResource.PRESTO:
@@ -433,6 +441,14 @@ public class JdbcClient {
                     throw new JdbcClientException("Unknown database type");
             }
             while (rs.next()) {
+                // for oracle special table name
+                if (isModify) {
+                    String actualTableName = rs.getString("TABLE_NAME");
+                    if (!tableName.equals(actualTableName)) {
+                        continue;
+                    }
+                }
+
                 JdbcFieldSchema field = new JdbcFieldSchema();
                 field.setColumnName(rs.getString("COLUMN_NAME"));
                 field.setDataType(rs.getInt("DATA_TYPE"));
@@ -450,6 +466,7 @@ public class JdbcClient {
                 field.setRemarks(rs.getString("REMARKS"));
                 field.setCharOctetLength(rs.getInt("CHAR_OCTET_LENGTH"));
                 tableSchema.add(field);
+                isModify = false;
             }
         } catch (SQLException e) {
             throw new JdbcClientException("failed to get table name list from jdbc for table %s:%s", e, tableName,

--- a/fe/fe-core/src/main/java/org/apache/doris/external/jdbc/JdbcClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/jdbc/JdbcClient.java
@@ -466,7 +466,6 @@ public class JdbcClient {
                 field.setRemarks(rs.getString("REMARKS"));
                 field.setCharOctetLength(rs.getInt("CHAR_OCTET_LENGTH"));
                 tableSchema.add(field);
-                isModify = false;
             }
         } catch (SQLException e) {
             throw new JdbcClientException("failed to get table name list from jdbc for table %s:%s", e, tableName,


### PR DESCRIPTION
# Proposed changes

Issue Number: close #18195

## Problem summary

在Oracle数据库中，我们可以创建带有 `/` 字符的表名，正常情况下我们需要加双引号来适配，但是在java的Metadata database中，加双引号是无效的，所以这里我做了模糊匹配，经过测试是可以的

```sql
mysql> show tables;
+----------------------+
| Tables_in_DORIS_TEST |
+----------------------+
| /AFS/MARM            |
| STUDENT              |
| TEST_CHAR            |
| TEST_DATE            |
| TEST_INSERT          |
| TEST_INT             |
| TEST_NUM             |
| TEST_NUMBER          |
| TEST_NUMBER2         |
| TEST_NUMBER3         |
| TEST_NUMBER4         |
| TEST_RAW             |
| TEST_TIMESTAMP       |
+----------------------+
13 rows in set (0.01 sec)

mysql> select * from `/AFS/MARM`;
Empty set (0.36 sec)

mysql> desc `/AFS/MARM`;
+----------+------------------+------+------+---------+-------+
| Field    | Type             | Null | Key  | Default | Extra |
+----------+------------------+------+------+---------+-------+
| MANDT    | TEXT             | No   | true | NULL    |       |
| MATNR    | TEXT             | No   | true | NULL    |       |
| MEINH    | TEXT             | No   | true | NULL    |       |
| J_3ASIZE | TEXT             | No   | true | NULL    |       |
| J_4KSCAT | TEXT             | No   | true | NULL    |       |
| VOLUM    | DECIMALV3(13, 3) | No   | true | NULL    |       |
| BRGEW    | DECIMALV3(13, 3) | No   | true | NULL    |       |
| NTGEW    | DECIMALV3(13, 3) | No   | true | NULL    |       |
| REFDIM   | TEXT             | No   | true | NULL    |       |
| ZZYYBM   | TEXT             | No   | true | NULL    |       |
| ZZBDBM   | TEXT             | No   | true | NULL    |       |
| ZZSSRQ   | TEXT             | No   | true | NULL    |       |
| YYLZD1   | TEXT             | No   | true | NULL    |       |
| YYLZD2   | TEXT             | No   | true | NULL    |       |
| YYLZD3   | TEXT             | No   | true | NULL    |       |
| YYLZD4   | TEXT             | No   | true | NULL    |       |
| YYLZD5   | TEXT             | No   | true | NULL    |       |
| ZZXZBM   | TEXT             | No   | true | NULL    |       |
+----------+------------------+------+------+---------+-------+
18 rows in set (0.04 sec)
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

