### PR TITLE
[chore](build) avoid generating generated code every time

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -75,6 +75,7 @@ Usage: $0 <options>
 clean_gensrc() {
     pushd "${DORIS_HOME}/gensrc"
     make clean
+    rm -rf "${DORIS_HOME}/gensrc/build"
     rm -rf "${DORIS_HOME}/fe/fe-common/target"
     rm -rf "${DORIS_HOME}/fe/fe-core/target"
     popd
@@ -394,7 +395,7 @@ echo "Get params:
 if [[ "${CLEAN}" -eq 1 ]]; then
     clean_gensrc
 fi
-"${DORIS_HOME}"/generated-source.sh
+"${DORIS_HOME}"/generated-source.sh noclean
 
 # Assesmble FE modules
 FE_MODULES=''

--- a/generated-source.sh
+++ b/generated-source.sh
@@ -30,7 +30,15 @@ export DORIS_HOME="${ROOT}"
 
 echo "Build generated code"
 cd "${DORIS_HOME}/gensrc"
-rm -rf "${DORIS_HOME}/gensrc/build"
+
+# if calling from build.sh, no need to clean build/ dir.
+# it will be removed by using `build.sh --clean`.
+# when run this script along, it will always remove the build/ dir.
+if [[ "$#" == 0 ]]; then
+    echo "rm -rf ${DORIS_HOME}/gensrc/build"
+    rm -rf "${DORIS_HOME}/gensrc/build"
+fi
+
 # DO NOT using parallel make(-j) for gensrc
 make
 rm -rf "${DORIS_HOME}/fe/fe-common/src/main/java/org/apache/doris/thrift ${DORIS_HOME}/fe/fe-common/src/main/java/org/apache/parquet"


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

When calling `generated-source.sh` in `build.sh`, not to remove the `gensrc/build` dir.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

