### PR TITLE
[fix](compound_predicate) fix function _all_child_is_compound_and_not_const always return false

### DIFF
--- a/be/src/vec/exprs/vcompound_pred.h
+++ b/be/src/vec/exprs/vcompound_pred.h
@@ -151,7 +151,7 @@ private:
                 return false;
             }
         }
-        return false;
+        return true;
     }
 
     uint8* _get_raw_data(ColumnPtr column) const {


### PR DESCRIPTION


# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

