### PR TITLE
[fix](Nereids) normalize repeat generate push down project with error nullable

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/NormalizeRepeat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/NormalizeRepeat.java
@@ -226,17 +226,9 @@ public class NormalizeRepeat extends OneAnalysisRuleFactory {
         }
 
         List<Expression> groupingSetExpressions = ExpressionUtils.flatExpressions(repeat.getGroupingSets());
-
-        // nullable will be different from grouping set and output expressions,
-        // so we can not use the slot in grouping set，but use the equivalent slot in output expressions.
-        List<NamedExpression> outputs = repeat.getOutputExpressions();
-
         Map<Expression, NormalizeToSlotTriplet> normalizeToSlotMap = Maps.newLinkedHashMap();
         for (Expression expression : sourceExpressions) {
             Optional<NormalizeToSlotTriplet> pushDownTriplet;
-            if (expression instanceof NamedExpression && outputs.contains(expression)) {
-                expression = outputs.get(outputs.indexOf(expression));
-            }
             if (groupingSetExpressions.contains(expression)) {
                 pushDownTriplet = toGroupingSetExpressionPushDownTriplet(expression, existsAliasMap.get(expression));
             } else {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1. When we do NormalizeRepeat, the nullable of SlotReference should follow with Repeat's child not Repeat's output.
2. AdjustNullable cannot rewrite the root Expression, so some SlotReference's nullable not be adjust after this rule.
3. should not adjust the nullable of SlotReference in repeat's group sets

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

