### PR TITLE
[Fix](parquet-reader) Fix partition field conjuncts not work.

### DIFF
--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
@@ -167,6 +167,17 @@ Status RowGroupReader::init(
             }
         }
     }
+    // Add predicate_partition_columns in _slot_id_to_filter_conjuncts(single slot conjuncts)
+    // to _filter_conjuncts, others should be added from not_single_slot_filter_conjuncts.
+    for (auto& kv : _lazy_read_ctx.predicate_partition_columns) {
+        auto& [value, slot_desc] = kv.second;
+        auto iter = _slot_id_to_filter_conjuncts->find(slot_desc->id());
+        if (iter != _slot_id_to_filter_conjuncts->end()) {
+            for (VExprContext* ctx : iter->second) {
+                _filter_conjuncts.push_back(ctx);
+            }
+        }
+    }
     RETURN_IF_ERROR(_rewrite_dict_predicates());
     return Status::OK();
 }

--- a/regression-test/data/external_table_emr_p2/iceberg/iceberg_partition_upper_case.out
+++ b/regression-test/data/external_table_emr_p2/iceberg/iceberg_partition_upper_case.out
@@ -80,6 +80,10 @@ Shanghai
 -- !parquetupper5 --
 2	k2_2	k3_2	Beijing
 
+-- !parquetupper6 --
+3	k2_3	k3_3	Shanghai
+4	k2_4	k3_4	Shanghai
+
 -- !parquetlower1 --
 1	k2_1	k3_1	Beijing
 2	k2_2	k3_2	Beijing
@@ -106,4 +110,8 @@ Shanghai
 
 -- !parquetlower5 --
 2	k2_2	k3_2	Beijing
+
+-- !parquetlower6 --
+3	k2_3	k3_3	Shanghai
+4	k2_4	k3_4	Shanghai
 

--- a/regression-test/suites/external_table_emr_p2/iceberg/iceberg_partition_upper_case.groovy
+++ b/regression-test/suites/external_table_emr_p2/iceberg/iceberg_partition_upper_case.groovy
@@ -33,12 +33,14 @@ suite("iceberg_partition_upper_case", "p2") {
     def parquet_upper3 = """select k1, k2 from iceberg_partition_upper_case_parquet order by k1;"""
     def parquet_upper4 = """select city from iceberg_partition_upper_case_parquet order by city;"""
     def parquet_upper5 = """select * from iceberg_partition_upper_case_parquet where k1>1 and city='Beijing' order by k1;"""
+    def parquet_upper6 = """select * from iceberg_partition_upper_case_parquet where substring(city, 6)='hai' order by k1;"""
 
     def parquet_lower1 = """select * from iceberg_partition_lower_case_parquet order by k1;"""
     def parquet_lower2 = """select k1, city from iceberg_partition_lower_case_parquet order by k1;"""
     def parquet_lower3 = """select k1, k2 from iceberg_partition_lower_case_parquet order by k1;"""
     def parquet_lower4 = """select city from iceberg_partition_lower_case_parquet order by city;"""
     def parquet_lower5 = """select * from iceberg_partition_lower_case_parquet where k1>1 and city='Beijing' order by k1;"""
+    def parquet_lower6 = """select * from iceberg_partition_lower_case_parquet where substring(city, 6)='hai' order by k1;"""
 
     String enabled = context.config.otherConfigs.get("enableExternalHiveTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
@@ -71,12 +73,13 @@ suite("iceberg_partition_upper_case", "p2") {
         qt_parquetupper3 parquet_upper3
         qt_parquetupper4 parquet_upper4
         qt_parquetupper5 parquet_upper5
+        qt_parquetupper6 parquet_upper6
         qt_parquetlower1 parquet_lower1
         qt_parquetlower2 parquet_lower2
         qt_parquetlower3 parquet_lower3
         qt_parquetlower4 parquet_lower4
         qt_parquetlower5 parquet_lower5
-
+        qt_parquetlower6 parquet_lower6
     }
 }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #19836

## Problem summary

Fix partition field conjuncts not work. 
Add `predicate_partition_columns` in `_slot_id_to_filter_conjuncts`(single slot conjuncts) to `_filter_conjuncts`, others should had been added from `not_single_slot_filter_conjuncts`.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

