### PR TITLE
Use keytab and principal to login kerberos

### DIFF
--- a/be/src/io/hdfs_builder.cpp
+++ b/be/src/io/hdfs_builder.cpp
@@ -49,9 +49,17 @@ Status HDFSCommonBuilder::run_kinit() {
         return Status::InvalidArgument("Invalid hdfs_kerberos_principal or hdfs_kerberos_keytab");
     }
     std::string ticket_path = TICKET_CACHE_PATH + generate_uuid_string();
+    const char *krb_home = getenv("KRB_HOME");
+    std::string krb_home_str(krb_home ? krb_home : "");
     fmt::memory_buffer kinit_command;
-    fmt::format_to(kinit_command, "kinit -c {} -R -t {} -k {}", ticket_path, hdfs_kerberos_keytab,
-                   hdfs_kerberos_principal);
+    if (krb_home_str.empty()) {
+        fmt::format_to(kinit_command, "kinit -c {} -R -t {} -k {}", ticket_path, hdfs_kerberos_keytab,
+                hdfs_kerberos_principal);
+    }else {
+        // Assign kerberos home in env, get kinit in kerberos home
+        fmt::format_to(kinit_command, krb_home_str + "/bin/kinit -c {} -R -t {} -k {}", ticket_path,
+                       hdfs_kerberos_keytab, hdfs_kerberos_principal);
+    }
     VLOG_NOTICE << "kinit command: " << fmt::to_string(kinit_command);
     std::string msg;
     AgentUtils util;
@@ -59,10 +67,10 @@ Status HDFSCommonBuilder::run_kinit() {
     if (!rc) {
         return Status::InternalError("Kinit failed, errMsg: " + msg);
     }
-#ifdef USE_LIBHDFS3
-    hdfsBuilderSetPrincipal(hdfs_builder, hdfs_kerberos_principal.c_str());
-    hdfsBuilderSetKerbTicketCachePath(hdfs_builder, ticket_path.c_str());
-#endif
+    #ifdef USE_LIBHDFS3
+        hdfsBuilderSetPrincipal(hdfs_builder, hdfs_kerberos_principal.c_str());
+    #endif
+        hdfsBuilderConfSetStr(hdfs_builder, "hadoop.security.kerberos.ticket.cache.path", ticket_path.c_str());
     return Status::OK();
 }
 
@@ -105,23 +113,30 @@ Status createHDFSBuilder(const THdfsParams& hdfsParams, HDFSCommonBuilder* build
     if (hdfsParams.__isset.hdfs_kerberos_principal) {
         builder->need_kinit = true;
         builder->hdfs_kerberos_principal = hdfsParams.hdfs_kerberos_principal;
+        hdfsBuilderSetUserName(builder->get(), hdfsParams.hdfs_kerberos_principal.c_str());
+    } else if (hdfsParams.__isset.user) {
+        hdfsBuilderSetUserName(builder->get(), hdfsParams.user.c_str());
+        hdfsBuilderSetKerb5Conf(builder->get(), nullptr);
+        hdfsBuilderSetKeyTabFile(builder->get(), nullptr);
     }
     if (hdfsParams.__isset.hdfs_kerberos_keytab) {
         builder->need_kinit = true;
         builder->hdfs_kerberos_keytab = hdfsParams.hdfs_kerberos_keytab;
+        hdfsBuilderSetKeyTabFile(builder->get(), hdfsParams.hdfs_kerberos_keytab.c_str());
     }
     // set other conf
     if (hdfsParams.__isset.hdfs_conf) {
         for (const THdfsConf& conf : hdfsParams.hdfs_conf) {
             hdfsBuilderConfSetStr(builder->get(), conf.key.c_str(), conf.value.c_str());
+            // Set krb5.conf, we should define java.security.krb5.conf in catalog properties
+            if (strcmp(conf.key.c_str(), "java.security.krb5.conf") == 0) {
+                hdfsBuilderSetKerb5Conf(builder->get(), conf.value.c_str());
+            }
         }
     }
 
     if (builder->is_need_kinit()) {
         RETURN_IF_ERROR(builder->run_kinit());
-    } else if (hdfsParams.__isset.user) {
-        // set hdfs user
-        hdfsBuilderSetUserName(builder->get(), hdfsParams.user.c_str());
     }
 
     return Status::OK();

--- a/be/src/io/hdfs_builder.cpp
+++ b/be/src/io/hdfs_builder.cpp
@@ -49,12 +49,12 @@ Status HDFSCommonBuilder::run_kinit() {
         return Status::InvalidArgument("Invalid hdfs_kerberos_principal or hdfs_kerberos_keytab");
     }
     std::string ticket_path = TICKET_CACHE_PATH + generate_uuid_string();
-    const char *krb_home = getenv("KRB_HOME");
+    const char* krb_home = getenv("KRB_HOME");
     std::string krb_home_str(krb_home ? krb_home : "");
     fmt::memory_buffer kinit_command;
     if (krb_home_str.empty()) {
-        fmt::format_to(kinit_command, "kinit -c {} -R -t {} -k {}", ticket_path, hdfs_kerberos_keytab,
-                hdfs_kerberos_principal);
+        fmt::format_to(kinit_command, "kinit -c {} -R -t {} -k {}", ticket_path,
+                       hdfs_kerberos_keytab, hdfs_kerberos_principal);
     } else {
         // Assign kerberos home in env, get kinit in kerberos home
         fmt::format_to(kinit_command, krb_home_str + "/bin/kinit -c {} -R -t {} -k {}", ticket_path,
@@ -67,10 +67,11 @@ Status HDFSCommonBuilder::run_kinit() {
     if (!rc) {
         return Status::InternalError("Kinit failed, errMsg: " + msg);
     }
-    #ifdef USE_LIBHDFS3
-        hdfsBuilderSetPrincipal(hdfs_builder, hdfs_kerberos_principal.c_str());
-    #endif
-        hdfsBuilderConfSetStr(hdfs_builder, "hadoop.security.kerberos.ticket.cache.path", ticket_path.c_str());
+#ifdef USE_LIBHDFS3
+    hdfsBuilderSetPrincipal(hdfs_builder, hdfs_kerberos_principal.c_str());
+#endif
+    hdfsBuilderConfSetStr(hdfs_builder, "hadoop.security.kerberos.ticket.cache.path",
+                          ticket_path.c_str());
     return Status::OK();
 }
 
@@ -116,22 +117,28 @@ Status createHDFSBuilder(const THdfsParams& hdfsParams, HDFSCommonBuilder* build
         hdfsBuilderSetUserName(builder->get(), hdfsParams.hdfs_kerberos_principal.c_str());
     } else if (hdfsParams.__isset.user) {
         hdfsBuilderSetUserName(builder->get(), hdfsParams.user.c_str());
+#ifdef USE_HADOOP_HDFS
         hdfsBuilderSetKerb5Conf(builder->get(), nullptr);
         hdfsBuilderSetKeyTabFile(builder->get(), nullptr);
+#endif
     }
     if (hdfsParams.__isset.hdfs_kerberos_keytab) {
         builder->need_kinit = true;
         builder->hdfs_kerberos_keytab = hdfsParams.hdfs_kerberos_keytab;
+#ifdef USE_HADOOP_HDFS
         hdfsBuilderSetKeyTabFile(builder->get(), hdfsParams.hdfs_kerberos_keytab.c_str());
+#endif
     }
     // set other conf
     if (hdfsParams.__isset.hdfs_conf) {
         for (const THdfsConf& conf : hdfsParams.hdfs_conf) {
             hdfsBuilderConfSetStr(builder->get(), conf.key.c_str(), conf.value.c_str());
+#ifdef USE_HADOOP_HDFS
             // Set krb5.conf, we should define java.security.krb5.conf in catalog properties
             if (strcmp(conf.key.c_str(), "java.security.krb5.conf") == 0) {
                 hdfsBuilderSetKerb5Conf(builder->get(), conf.value.c_str());
             }
+#endif
         }
     }
 

--- a/be/src/io/hdfs_builder.cpp
+++ b/be/src/io/hdfs_builder.cpp
@@ -55,7 +55,7 @@ Status HDFSCommonBuilder::run_kinit() {
     if (krb_home_str.empty()) {
         fmt::format_to(kinit_command, "kinit -c {} -R -t {} -k {}", ticket_path, hdfs_kerberos_keytab,
                 hdfs_kerberos_principal);
-    }else {
+    } else {
         // Assign kerberos home in env, get kinit in kerberos home
         fmt::format_to(kinit_command, krb_home_str + "/bin/kinit -c {} -R -t {} -k {}", ticket_path,
                        hdfs_kerberos_keytab, hdfs_kerberos_principal);

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -308,6 +308,11 @@ export LIBHDFS_OPTS="${final_java_opt}"
 # see https://github.com/apache/doris/blob/master/docs/zh-CN/community/developer-guide/debug-tool.md#jemalloc-heap-profile
 export JEMALLOC_CONF="percpu_arena:percpu,background_thread:true,metadata_thp:auto,muzzy_decay_ms:30000,dirty_decay_ms:30000,oversize_threshold:0,lg_tcache_max:16,prof_prefix:jeprof.out"
 
+# We can use env vars and not need /etc/krb5.conf when KRB5_CONFIG value in env
+if [[ ${KRB5_CONFIG} ]]; then
+    export KRB5_CONFIG="${KRB5_CONFIG}"
+fi
+
 if [[ "${RUN_DAEMON}" -eq 1 ]]; then
     nohup ${LIMIT:+${LIMIT}} "${DORIS_HOME}/lib/doris_be" "$@" >>"${LOG_DIR}/be.out" 2>&1 </dev/null &
 else

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -308,11 +308,6 @@ export LIBHDFS_OPTS="${final_java_opt}"
 # see https://github.com/apache/doris/blob/master/docs/zh-CN/community/developer-guide/debug-tool.md#jemalloc-heap-profile
 export JEMALLOC_CONF="percpu_arena:percpu,background_thread:true,metadata_thp:auto,muzzy_decay_ms:30000,dirty_decay_ms:30000,oversize_threshold:0,lg_tcache_max:16,prof_prefix:jeprof.out"
 
-# We can use env vars and not need /etc/krb5.conf when KRB5_CONFIG value in env
-if [[ ${KRB5_CONFIG} ]]; then
-    export KRB5_CONFIG="${KRB5_CONFIG}"
-fi
-
 if [[ "${RUN_DAEMON}" -eq 1 ]]; then
     nohup ${LIMIT:+${LIMIT}} "${DORIS_HOME}/lib/doris_be" "$@" >>"${LOG_DIR}/be.out" 2>&1 </dev/null &
 else


### PR DESCRIPTION
# Proposed changes

Issue Number: close https://github.com/apache/doris/issues/19580

## Problem summary

Describe your changes.
User keytab and princpal to login kerberos.
And user does not need to execute `kinit` manually anymore.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

