### PR TITLE
[Fix](inverted index) add datev2/datetimev2 for inverted index column type

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/Type.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/Type.java
@@ -149,6 +149,10 @@ public abstract class Type {
         numericDateTimeTypes = Lists.newArrayList();
         numericDateTimeTypes.add(DATE);
         numericDateTimeTypes.add(DATETIME);
+        numericDateTimeTypes.add(DATEV2);
+        numericDateTimeTypes.add(DATETIMEV2);
+        numericDateTimeTypes.add(TIME);
+        numericDateTimeTypes.add(TIMEV2);
         numericDateTimeTypes.addAll(numericTypes);
 
         trivialTypes = Lists.newArrayList();


### PR DESCRIPTION
# Proposed changes
When we try to query array of datetimev2 column by inverted index, it returns an error like this:
 ```
CREATE TABLE `nested` (
  `qid` bigint(20) NULL,
  `tag` array<text> NULL,
  `creationDate` datetime NULL,
  `title` text NULL,
  `user` text NULL,
  `answers.user` array<text> NULL,
  `answers.date` array<datetimev2(0)> NULL,
  INDEX tag_idx (`tag`) USING INVERTED PROPERTIES("parser" = "english") COMMENT '',
  INDEX creation_date_idx (`creationDate`) USING INVERTED COMMENT '',
  INDEX title_idx (`title`) USING INVERTED COMMENT '',
  INDEX user_idx (`user`) USING INVERTED COMMENT '',
  INDEX answers_user_idx (`answers.user`) USING INVERTED COMMENT '',
  INDEX answers_date_idx (`answers.date`) USING INVERTED COMMENT ''
) ENGINE=OLAP
DUPLICATE KEY(`qid`)
COMMENT 'OLAP'
DISTRIBUTED BY HASH(`qid`) BUCKETS 18
PROPERTIES (
"replication_allocation" = "tag.location.default: 1",
"storage_format" = "V2",
"compression" = "ZSTD",
"light_schema_change" = "true",
"dynamic_schema" = "true",
"disable_auto_compaction" = "false"
); 

mysql> select * from nested.nested where tag match 'java' and `answers.date` element_le '2012-04-08T21:15:33.873Z' limit 10;
ERROR 1105 (HY000): errCode = 2, detailMessage = no function found for MATCH_ELEMENT_LE,`answers.date` MATCH_ELEMENT_LE '2012-04-08T21:15:33.873Z'
```

## Problem summary

add datetimev2 

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

