### PR TITLE
[FIX](Array)fix be master comapitible with fe1.2

### DIFF
--- a/be/src/runtime/types.cpp
+++ b/be/src/runtime/types.cpp
@@ -66,7 +66,12 @@ TypeDescriptor::TypeDescriptor(const std::vector<TTypeNode>& types, int* idx)
         DCHECK_EQ(node.contains_nulls.size(), 1);
         type = TYPE_ARRAY;
         contains_nulls.reserve(1);
-        contains_nulls.push_back(node.contains_nulls[0]);
+        // here should compatible with fe 1.2, because use contains_null in contains_nulls
+        if (node.__isset.contains_nulls) {
+            contains_nulls.push_back(node.contains_nulls[0]);
+        } else {
+            contains_nulls.push_back(node.contains_null);
+        }
         ++(*idx);
         children.push_back(TypeDescriptor(types, idx));
         break;


### PR DESCRIPTION
# Proposed changes
when upgrade be first , fe is 1.2 , array contains_nulls is set not in thrift  ,so would has core in be 
Issue Number: close #xxx


## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

