### PR TITLE
[Improvement](Cache) lru support evict expired entries

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -305,6 +305,10 @@ DEFINE_Bool(disable_storage_row_cache, "true");
 // Cache for mow primary key storage page size
 DEFINE_String(pk_storage_page_cache_limit, "10%");
 
+DEFINE_Bool(enable_storage_page_cache_expire, "false");
+DEFINE_mInt32(storage_page_cache_expire_second, "7200");
+DEFINE_mDouble(storage_page_cache_evict_ratio, "0.005");
+
 DEFINE_Bool(enable_low_cardinality_optimize, "true");
 DEFINE_Bool(enable_low_cardinality_cache_code, "true");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -346,9 +346,9 @@ DECLARE_Bool(disable_storage_row_cache);
 // storage_page_cache_limit
 DECLARE_String(pk_storage_page_cache_limit);
 
-CONF_Bool(enable_storage_page_cache_expire, "false");
-CONF_mInt32(storage_page_cache_expire_second, "7200");
-CONF_mDouble(storage_page_cache_evict_ratio, "0.005");
+DECLARE_Bool(enable_storage_page_cache_expire);
+DECLARE_mInt32(storage_page_cache_expire_second);
+DECLARE_mDouble(storage_page_cache_evict_ratio);
 
 DECLARE_Bool(enable_low_cardinality_optimize);
 DECLARE_Bool(enable_low_cardinality_cache_code);

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -346,6 +346,10 @@ DECLARE_Bool(disable_storage_row_cache);
 // storage_page_cache_limit
 DECLARE_String(pk_storage_page_cache_limit);
 
+CONF_Bool(enable_storage_page_cache_expire, "false");
+CONF_mInt32(storage_page_cache_expire_second, "7200");
+CONF_mDouble(storage_page_cache_evict_ratio, "0.005");
+
 DECLARE_Bool(enable_low_cardinality_optimize);
 DECLARE_Bool(enable_low_cardinality_cache_code);
 

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -483,7 +483,7 @@ void Daemon::start() {
 
     if (config::enable_storage_page_cache_expire && !config::disable_storage_page_cache) {
         st = Thread::create(
-                "Daemon", "evict_expire_thread", [this]() { this->evict_expire_thread(); },
+                "Daemon", "evict_page_cache_thread", [this]() { this->evict_page_cache_thread(); },
                 &_insert_sentinel_thread);
 
         CHECK(st.ok()) << st.to_string();

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -484,7 +484,7 @@ void Daemon::start() {
     if (config::enable_storage_page_cache_expire && !config::disable_storage_page_cache) {
         st = Thread::create(
                 "Daemon", "evict_page_cache_thread", [this]() { this->evict_page_cache_thread(); },
-                &_insert_sentinel_thread);
+                &_evict_page_cache_thread);
 
         CHECK(st.ok()) << st.to_string();
     }
@@ -518,6 +518,9 @@ void Daemon::stop() {
     }
     if (_memory_tracker_profile_refresh_thread) {
         _memory_tracker_profile_refresh_thread->join();
+    }
+    if (_evict_page_cache_thread) {
+        _evict_page_cache_thread->join();
     }
     if (_calculate_metrics_thread) {
         _calculate_metrics_thread->join();

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -297,8 +297,8 @@ void Daemon::evict_page_cache_thread() {
             index_cache->evict_expired(ratio, expire_before);
         }
         auto* pk_cache = cache->get_pk_index_page_cache();
-        if (index_cache != nullptr) {
-            index_cache->evict_expired(ratio, expire_before);
+        if (pk_cache != nullptr) {
+            pk_cache->evict_expired(ratio, expire_before);
         }
     }
 }

--- a/be/src/common/daemon.h
+++ b/be/src/common/daemon.h
@@ -48,6 +48,7 @@ private:
     void memory_gc_thread();
     void load_channel_tracker_refresh_thread();
     void memory_tracker_profile_refresh_thread();
+    void evict_page_cache_thread();
     void calculate_metrics_thread();
     void block_spill_gc_thread();
 
@@ -57,6 +58,7 @@ private:
     scoped_refptr<Thread> _memory_gc_thread;
     scoped_refptr<Thread> _load_channel_tracker_refresh_thread;
     scoped_refptr<Thread> _memory_tracker_profile_refresh_thread;
+    scoped_refptr<Thread> _evict_page_cache_thread;
     scoped_refptr<Thread> _calculate_metrics_thread;
     scoped_refptr<Thread> _block_spill_gc_thread;
 };

--- a/be/src/olap/lru_cache.cpp
+++ b/be/src/olap/lru_cache.cpp
@@ -356,7 +356,7 @@ void LRUCache::_evict_from_lru(size_t total_size, LRUHandle** to_remove_head,
            _lru_normal.next != &_lru_normal) {
         LRUHandle* old = _lru_normal.next;
         DCHECK(old->priority == CachePriority::NORMAL);
-        if (before_seconds > 0 && remove_handle->use_time > before_seconds) {
+        if (before_seconds > 0 && old->use_time > before_seconds) {
             break;
         }
         _evict_one_entry(old);
@@ -368,7 +368,7 @@ void LRUCache::_evict_from_lru(size_t total_size, LRUHandle** to_remove_head,
            _lru_durable.next != &_lru_durable) {
         LRUHandle* old = _lru_durable.next;
         DCHECK(old->priority == CachePriority::DURABLE);
-        if (before_seconds > 0 && remove_handle->use_time > before_seconds) {
+        if (before_seconds > 0 && old->use_time > before_seconds) {
             break;
         }
         _evict_one_entry(old);

--- a/be/src/olap/lru_cache.cpp
+++ b/be/src/olap/lru_cache.cpp
@@ -226,7 +226,7 @@ void LRUCache::_lru_append(LRUHandle* list, LRUHandle* e) {
         if (e->priority == CachePriority::NORMAL) {
             _sorted_normal_entries_with_timestamp.insert(std::make_pair(value_time, e));
         } else if (e->priority == CachePriority::DURABLE) {
-            _sorted_durable_entries_with_timestamp.insert(value_time, e));
+            _sorted_durable_entries_with_timestamp.insert(std::make_pair(value_time, e));
         }
         // convert mills to seconds.
         e->use_time = value_time / 1000;
@@ -569,8 +569,7 @@ ShardedLRUCache::ShardedLRUCache(const std::string& name, size_t total_capacity,
           _num_shards(num_shards),
           _shards(nullptr),
           _last_id(1),
-          _total_capacity(total_capacity),
-          _evict_expire(evict_expire) {
+          _total_capacity(total_capacity) {
     _mem_tracker = std::make_unique<MemTrackerLimiter>(MemTrackerLimiter::Type::GLOBAL, name);
     CHECK(num_shards > 0) << "num_shards cannot be 0";
     CHECK_EQ((num_shards & (num_shards - 1)), 0)

--- a/be/src/olap/lru_cache.h
+++ b/be/src/olap/lru_cache.h
@@ -363,7 +363,7 @@ private:
     void _lru_remove(LRUHandle* e);
     void _lru_append(LRUHandle* list, LRUHandle* e);
     bool _unref(LRUHandle* e);
-    void _evict_from_lru(size_t total_size, LRUHandle** to_remove_head);
+    void _evict_from_lru(size_t total_size, LRUHandle** to_remove_head, int64_t before_seconds = 0);
     void _evict_from_lru_with_time(size_t total_size, LRUHandle** to_remove_head,
                                    int64_t before_seconds = 0);
     void _evict_one_entry(LRUHandle* e);

--- a/be/src/olap/page_cache.cpp
+++ b/be/src/olap/page_cache.cpp
@@ -36,25 +36,27 @@ void StoragePageCache::create_global_cache(size_t capacity, int32_t index_cache_
 StoragePageCache::StoragePageCache(size_t capacity, int32_t index_cache_percentage,
                                    int64_t pk_index_cache_capacity, uint32_t num_shards)
         : _index_cache_percentage(index_cache_percentage) {
+    auto evict_expire = config::enable_storage_page_cache_expire;
     if (index_cache_percentage == 0) {
-        _data_page_cache = std::unique_ptr<Cache>(
-                new_lru_cache("DataPageCache", capacity, LRUCacheType::SIZE, num_shards));
+        _data_page_cache = std::unique_ptr<Cache>(new_lru_cache(
+                "DataPageCache", capacity, LRUCacheType::SIZE, num_shards, evict_expire));
     } else if (index_cache_percentage == 100) {
-        _index_page_cache = std::unique_ptr<Cache>(
-                new_lru_cache("IndexPageCache", capacity, LRUCacheType::SIZE, num_shards));
+        _index_page_cache = std::unique_ptr<Cache>(new_lru_cache(
+                "IndexPageCache", capacity, LRUCacheType::SIZE, num_shards, evict_expire));
     } else if (index_cache_percentage > 0 && index_cache_percentage < 100) {
         _data_page_cache = std::unique_ptr<Cache>(
                 new_lru_cache("DataPageCache", capacity * (100 - index_cache_percentage) / 100,
-                              LRUCacheType::SIZE, num_shards));
+                              LRUCacheType::SIZE, num_shards, evict_expire));
         _index_page_cache = std::unique_ptr<Cache>(
                 new_lru_cache("IndexPageCache", capacity * index_cache_percentage / 100,
-                              LRUCacheType::SIZE, num_shards));
+                              LRUCacheType::SIZE, num_shards, evict_expire));
     } else {
         CHECK(false) << "invalid index page cache percentage";
     }
     if (pk_index_cache_capacity > 0) {
-        _pk_index_page_cache = std::unique_ptr<Cache>(new_lru_cache(
-                "PkIndexPageCache", pk_index_cache_capacity, LRUCacheType::SIZE, num_shards));
+        _pk_index_page_cache =
+                std::unique_ptr<Cache>(new_lru_cache("PkIndexPageCache", pk_index_cache_capacity,
+                                                     LRUCacheType::SIZE, num_shards, evict_expire));
     }
 }
 

--- a/be/src/olap/page_cache.h
+++ b/be/src/olap/page_cache.h
@@ -146,6 +146,23 @@ public:
         return _get_page_cache(page_type)->mem_consumption();
     }
 
+    Cache* get_page_cache(segment_v2::PageTypePB page_type) {
+        switch (page_type) {
+        case segment_v2::DATA_PAGE: {
+            return _data_page_cache.get();
+        }
+        case segment_v2::INDEX_PAGE:
+            return _index_page_cache.get();
+        case segment_v2::PRIMARY_KEY_INDEX_PAGE:
+            return _pk_index_page_cache.get();
+        default:
+            return nullptr;
+        }
+    }
+    Cache* get_data_page_cache() { return _get_page_cache(segment_v2::DATA_PAGE); }
+    Cache* get_index_page_cache() { return _get_page_cache(segment_v2::INDEX_PAGE); }
+    Cache* get_pk_index_page_cache() { return _get_page_cache(segment_v2::PRIMARY_KEY_INDEX_PAGE); }
+
 private:
     StoragePageCache();
     static StoragePageCache* _s_instance;

--- a/be/src/olap/page_cache.h
+++ b/be/src/olap/page_cache.h
@@ -146,19 +146,6 @@ public:
         return _get_page_cache(page_type)->mem_consumption();
     }
 
-    Cache* get_page_cache(segment_v2::PageTypePB page_type) {
-        switch (page_type) {
-        case segment_v2::DATA_PAGE: {
-            return _data_page_cache.get();
-        }
-        case segment_v2::INDEX_PAGE:
-            return _index_page_cache.get();
-        case segment_v2::PRIMARY_KEY_INDEX_PAGE:
-            return _pk_index_page_cache.get();
-        default:
-            return nullptr;
-        }
-    }
     Cache* get_data_page_cache() { return _get_page_cache(segment_v2::DATA_PAGE); }
     Cache* get_index_page_cache() { return _get_page_cache(segment_v2::INDEX_PAGE); }
     Cache* get_pk_index_page_cache() { return _get_page_cache(segment_v2::PRIMARY_KEY_INDEX_PAGE); }

--- a/be/test/olap/lru_cache_test.cpp
+++ b/be/test/olap/lru_cache_test.cpp
@@ -81,7 +81,7 @@ public:
     std::vector<int> _deleted_values;
     Cache* _cache;
 
-    CacheTest() : _cache(new_lru_cache("test", kCacheSize)) { _s_current = this; }
+    CacheTest() : _cache(new_lru_cache("test", kCacheSize, 16, true)) { _s_current = this; }
 
     ~CacheTest() { delete _cache; }
 
@@ -237,7 +237,7 @@ TEST_F(CacheTest, Usage) {
     cache.set_capacity(1040);
 
     // The lru usage is handle_size + charge.
-    // handle_size = sizeof(handle) - 1 + key size = 104 - 1 + 3 = 106
+    // handle_size = sizeof(handle) - 1 + key size = 112 - 1 + 3 = 114
     CacheKey key1("100");
     insert_LRUCache(cache, key1, 100, CachePriority::NORMAL);
     ASSERT_EQ(214, cache.get_usage()); // 100 + 114
@@ -248,7 +248,7 @@ TEST_F(CacheTest, Usage) {
 
     CacheKey key3("300");
     insert_LRUCache(cache, key3, 300, CachePriority::NORMAL);
-    ASSERT_EQ(934, cache.get_usage()); // 214 + 314(d) + 406
+    ASSERT_EQ(942, cache.get_usage()); // 214 + 314(d) + 414
 
     CacheKey key4("400");
     insert_LRUCache(cache, key4, 400, CachePriority::NORMAL);
@@ -256,11 +256,11 @@ TEST_F(CacheTest, Usage) {
 
     CacheKey key5("500");
     insert_LRUCache(cache, key5, 500, CachePriority::NORMAL);
-    ASSERT_EQ(928, cache.get_usage()); // 314(d) + 614, evict 506
+    ASSERT_EQ(928, cache.get_usage()); // 314(d) + 614, evict 514
 
     CacheKey key6("600");
     insert_LRUCache(cache, key6, 600, CachePriority::NORMAL);
-    ASSERT_EQ(1028, cache.get_usage()); // 314(d) + 714, evict 506
+    ASSERT_EQ(1028, cache.get_usage()); // 314(d) + 714, evict 514
 
     CacheKey key7("950");
     insert_LRUCache(cache, key7, 950, CachePriority::DURABLE);

--- a/be/test/olap/lru_cache_test.cpp
+++ b/be/test/olap/lru_cache_test.cpp
@@ -27,6 +27,7 @@
 #include "gtest/gtest_pred_impl.h"
 #include "runtime/memory/mem_tracker_limiter.h"
 #include "testutil/test_util.h"
+#include "util/time.h"
 
 using namespace doris;
 using namespace std;

--- a/be/test/olap/lru_cache_test.cpp
+++ b/be/test/olap/lru_cache_test.cpp
@@ -373,7 +373,7 @@ TEST_F(CacheTest, EvictExpired) {
     Insert(101, 101, 1);
     sleep(1);
     auto t1 = MonotonicSeconds();
-    Insert(k2, 102, 1);
+    Insert(102, 102, 1);
     _cache->evict_expired(1.0, t1);
     ASSERT_EQ(-1, Lookup(100));
     ASSERT_EQ(-1, Lookup(101));

--- a/be/test/olap/lru_cache_test.cpp
+++ b/be/test/olap/lru_cache_test.cpp
@@ -369,22 +369,19 @@ TEST_F(CacheTest, PruneIfLazyMode) {
 }
 
 TEST_F(CacheTest, EvictExpired) {
-    CacheKey k0("100");
-    CacheKey k1("101");
-    CacheKey kw("102");
-    Insert(k0, 100, 1);
-    Insert(k1, 101, 1);
+    Insert(100, 100, 1);
+    Insert(101, 101, 1);
     sleep(1);
     auto t1 = MonotonicSeconds();
     Insert(k2, 102, 1);
     _cache->evict_expired(1.0, t1);
-    ASSERT_EQ(-1, Lookup(k0));
-    ASSERT_EQ(-1, Lookup(k1));
-    ASSERT_EQ(102, Lookup(k2));
+    ASSERT_EQ(-1, Lookup(100));
+    ASSERT_EQ(-1, Lookup(101));
+    ASSERT_EQ(102, Lookup(102));
     sleep(1);
     auto t2 = MonotonicSeconds();
     _cache->evict_expired(1.0, t2);
-    ASSERT_EQ(-1, Lookup(k2));
+    ASSERT_EQ(-1, Lookup(102));
 }
 
 TEST_F(CacheTest, HeavyEntries) {

--- a/be/test/olap/lru_cache_test.cpp
+++ b/be/test/olap/lru_cache_test.cpp
@@ -81,7 +81,9 @@ public:
     std::vector<int> _deleted_values;
     Cache* _cache;
 
-    CacheTest() : _cache(new_lru_cache("test", kCacheSize, 16, true)) { _s_current = this; }
+    CacheTest() : _cache(new_lru_cache("test", kCacheSize, LRUCacheType::SIZE, 16, true)) {
+        _s_current = this;
+    }
 
     ~CacheTest() { delete _cache; }
 


### PR DESCRIPTION
# Proposed changes
Lru cache support evict expired entries.

## Problem summary
When the LRUCache is full and there are slow queries which scan a lot of bytes, the LRUCache may have side effect. We can avoid this by evict expired entries using background thread every minute.

## Checklist(Required)

* [x] Does it affect the original behavior
* [x] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

