### PR TITLE
[performance](bitmap) Support CRoaring COW feature to reduce bitmap copying

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -998,6 +998,9 @@ DEFINE_mInt32(s3_write_buffer_whole_size, "524288000");
 //disable shrink memory by default
 DEFINE_Bool(enable_shrink_memory, "false");
 
+// enable croaring cow
+DEFINE_mBool(enable_croaring_cow, "false");
+
 #ifdef BE_TEST
 // test s3
 DEFINE_String(test_s3_resource, "resource");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1014,6 +1014,9 @@ DECLARE_mInt32(s3_write_buffer_whole_size);
 //enable shrink memory
 DECLARE_Bool(enable_shrink_memory);
 
+// enable croaring cow
+DECLARE_mBool(enable_croaring_cow);
+
 #ifdef BE_TEST
 // test s3
 DECLARE_String(test_s3_resource);

--- a/be/src/vec/exec/join/process_hash_table_probe_impl.h
+++ b/be/src/vec/exec/join/process_hash_table_probe_impl.h
@@ -502,6 +502,7 @@ Status ProcessHashTableProbe<JoinOpType>::do_process_with_other_join_conjuncts(
         }
         int multi_matched_output_row_count = 0;
         if (current_offset < _batch_size) {
+            SCOPED_TIMER(_search_hashtable_timer);
             while (probe_index < probe_rows) {
                 // ignore null rows
                 if constexpr (ignore_null && need_null_map_for_probe) {

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -412,3 +412,13 @@ if [[ "${BRPC_SOURCE}" == 'brpc-1.5.0' ]]; then
     cd -
 fi
 echo "Finished patching ${BRPC_SOURCE}"
+
+if [[ "${CROARINGBITMAP_SOURCE}" == 'CRoaring-0.4.0' ]]; then
+    cd "${TP_SOURCE_DIR}/${CROARINGBITMAP_SOURCE}"
+    if [[ ! -f "${PATCHED_MARK}" ]]; then
+        patch -p1 <"${TP_PATCH_DIR}/croaring-0.4.0_cow.patch"
+        touch "${PATCHED_MARK}"
+    fi
+    cd -
+fi
+echo "Finished patching ${CROARINGBITMAP_SOURCE}"

--- a/thirdparty/patches/croaring-0.4.0_cow.patch
+++ b/thirdparty/patches/croaring-0.4.0_cow.patch
@@ -1,0 +1,221 @@
+Subject: [PATCH] Using atomic counters on shared containers Ref: https://github.com/RoaringBitmap/CRoaring/pull/473
+---
+Index: CMakeLists.txt
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	(revision 3cc92d1e19b12ad8b4213d82af181499e46cae4f)
++++ b/CMakeLists.txt	(revision d052b11b4298521ed798c97948ff7e2f913e767a)
+@@ -44,6 +44,8 @@
+ option(ROARING_BUILD_C_AS_CPP "Build library C files using C++ compilation" OFF)
+ option(ROARING_BUILD_C_TESTS_AS_CPP "Build test C files using C++ compilation" OFF)
+ option(ROARING_SANITIZE "Sanitize addresses" OFF)
++option(ROARING_SANITIZE_THREADS "Sanitize threads" OFF)
++
+ option(ENABLE_ROARING_TESTS "If OFF, disable unit tests altogether" ON)
+ 
+ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake")
+Index: include/roaring/containers/containers.h
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/include/roaring/containers/containers.h b/include/roaring/containers/containers.h
+--- a/include/roaring/containers/containers.h	(revision 3cc92d1e19b12ad8b4213d82af181499e46cae4f)
++++ b/include/roaring/containers/containers.h	(revision d052b11b4298521ed798c97948ff7e2f913e767a)
+@@ -55,12 +55,25 @@
+  * A shared container is a wrapper around a container
+  * with reference counting.
+  */
+-
++#if CROARING_C_ATOMIC
++STRUCT_CONTAINER(shared_container_s) {
++    container_t *container;
++    uint8_t typecode;
++    _Atomic(uint32_t) counter;  // to be managed atomically
++};
++#elif CROARING_CPP_ATOMIC
++STRUCT_CONTAINER(shared_container_s) {
++    container_t *container;
++    uint8_t typecode;
++    std::atomic<uint32_t> counter;  // to be managed atomically
++};
++#else
+ STRUCT_CONTAINER(shared_container_s) {
+     container_t *container;
+     uint8_t typecode;
+     uint32_t counter;  // to be managed atomically
+ };
++#endif
+ 
+ typedef struct shared_container_s shared_container_t;
+ 
+Index: include/roaring/portability.h
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/include/roaring/portability.h b/include/roaring/portability.h
+--- a/include/roaring/portability.h	(revision 3cc92d1e19b12ad8b4213d82af181499e46cae4f)
++++ b/include/roaring/portability.h	(revision d052b11b4298521ed798c97948ff7e2f913e767a)
+@@ -13,6 +13,16 @@
+ #define __STDC_FORMAT_MACROS 1
+ #endif // __STDC_FORMAT_MACROS
+ 
++#ifndef CROARING_VISUAL_STUDIO
++#define CROARING_VISUAL_STUDIO 0
++#endif
++#ifndef CROARING_CLANG_VISUAL_STUDIO
++#define CROARING_CLANG_VISUAL_STUDIO 0
++#endif
++#ifndef CROARING_REGULAR_VISUAL_STUDIO
++#define CROARING_REGULAR_VISUAL_STUDIO 0
++#endif
++
+ #if !(defined(_POSIX_C_SOURCE)) || (_POSIX_C_SOURCE < 200809L)
+ #define _POSIX_C_SOURCE 200809L
+ #endif // !(defined(_POSIX_C_SOURCE)) || (_POSIX_C_SOURCE < 200809L)
+@@ -293,5 +303,19 @@
+ #undef CROARING_UNTARGET_REGION
+ #define CROARING_UNTARGET_REGION
+ #endif
++
++#if defined(__cplusplus)
++#define CROARING_CPP_ATOMIC 1
++#define CROARING_C_ATOMIC 0
++#include <atomic>
++#elif defined(__STDC_NO_ATOMICS__) || CROARING_REGULAR_VISUAL_STUDIO
++// https://www.technetworkhub.com/c11-atomics-in-visual-studio-2022-version-17/
++#define CROARING_ATOMIC 0
++#define CROARING_CPP_ATOMIC 0
++#else // C
++#define CROARING_C_ATOMIC 1
++#define CROARING_CPP_ATOMIC 0
++#include <stdatomic.h>
++#endif
+ 
+ #endif /* INCLUDE_PORTABILITY_H_ */
+Index: src/containers/containers.c
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/src/containers/containers.c b/src/containers/containers.c
+--- a/src/containers/containers.c	(revision 3cc92d1e19b12ad8b4213d82af181499e46cae4f)
++++ b/src/containers/containers.c	(revision d052b11b4298521ed798c97948ff7e2f913e767a)
+@@ -136,7 +136,13 @@
+         shared_container_t *shared_container;
+         if (*typecode == SHARED_CONTAINER_TYPE) {
+             shared_container = CAST_shared(c);
++#if CROARING_C_ATOMIC
++            atomic_fetch_add(&(shared_container->counter), 1);
++#elif CROARING_CPP_ATOMIC
++            std::atomic_fetch_add(&(shared_container->counter), 1);
++#else
+             shared_container->counter += 1;
++#endif
+             return shared_container;
+         }
+         assert(*typecode != SHARED_CONTAINER_TYPE);
+@@ -148,8 +154,13 @@
+ 
+         shared_container->container = c;
+         shared_container->typecode = *typecode;
+-
++#if CROARING_C_ATOMIC
++        atomic_store(&(shared_container->counter), 2);
++#elif CROARING_CPP_ATOMIC
++        std::atomic_store(&(shared_container->counter), 2);
++#else
+         shared_container->counter = 2;
++#endif
+         *typecode = SHARED_CONTAINER_TYPE;
+ 
+         return shared_container;
+@@ -187,12 +198,18 @@
+ container_t *shared_container_extract_copy(
+     shared_container_t *sc, uint8_t *typecode
+ ){
+-    assert(sc->counter > 0);
+     assert(sc->typecode != SHARED_CONTAINER_TYPE);
+-    sc->counter--;
+     *typecode = sc->typecode;
+     container_t *answer;
++#if CROARING_C_ATOMIC
++    if(atomic_fetch_sub(&(sc->counter), 1) == 1) {
++#elif CROARING_CPP_ATOMIC
++    if(std::atomic_fetch_sub(&(sc->counter), 1) == 1) {
++#else
++    assert(sc->counter > 0);
++    sc->counter--;
+     if (sc->counter == 0) {
++#endif
+         answer = sc->container;
+         sc->container = NULL;  // paranoid
+         free(sc);
+@@ -204,9 +221,15 @@
+ }
+ 
+ void shared_container_free(shared_container_t *container) {
++#if CROARING_C_ATOMIC
++    if(atomic_fetch_sub(&(container->counter), 1) == 1) {
++#elif CROARING_CPP_ATOMIC
++    if(std::atomic_fetch_sub(&(container->counter), 1) == 1) {
++#else
+     assert(container->counter > 0);
+     container->counter--;
+     if (container->counter == 0) {
++#endif
+         assert(container->typecode != SHARED_CONTAINER_TYPE);
+         container_free(container->container, container->typecode);
+         container->container = NULL;  // paranoid
+Index: src/roaring.c
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/src/roaring.c b/src/roaring.c
+--- a/src/roaring.c	(revision 3cc92d1e19b12ad8b4213d82af181499e46cae4f)
++++ b/src/roaring.c	(revision d052b11b4298521ed798c97948ff7e2f913e767a)
+@@ -301,9 +301,20 @@
+                get_full_container_name(ra->containers[i], ra->typecodes[i]),
+                container_get_cardinality(ra->containers[i], ra->typecodes[i]));
+         if (ra->typecodes[i] == SHARED_CONTAINER_TYPE) {
++#if CROARING_C_ATOMIC
++            printf(
++                "(shared count = %" PRIu32 " )",
++                    atomic_load(&(CAST_shared(ra->containers[i])->counter)));
++#elif CROARING_CPP_ATOMIC
++            printf(
++                "(shared count = %" PRIu32 " )",
++                    std::atomic_load(&(CAST_shared(ra->containers[i])->counter)));
++#else
+             printf(
+                 "(shared count = %" PRIu32 " )",
+                     CAST_shared(ra->containers[i])->counter);
++#endif
++
+         }
+ 
+         if (i + 1 < ra->size) {
+Index: tools/cmake/FindOptions.cmake
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/tools/cmake/FindOptions.cmake b/tools/cmake/FindOptions.cmake
+--- a/tools/cmake/FindOptions.cmake	(revision 3cc92d1e19b12ad8b4213d82af181499e46cae4f)
++++ b/tools/cmake/FindOptions.cmake	(revision d052b11b4298521ed798c97948ff7e2f913e767a)
+@@ -12,7 +12,9 @@
+     append(CMAKE_SHARED_LINKER_FLAGS "-fuse-ld=gold")
+   endif()
+ endif()
+-
++if(ROARING_SANITIZE_THREADS)
++  set(ROARING_SANITIZE_FLAGS "-fsanitize=thread -fno-sanitize-recover=all")
++endif()
+ if((NOT MSVC) AND ROARING_ARCH)
+ set(OPT_FLAGS "-march=${ROARING_ARCH}")
+ endif()


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
Support CRoaring COW feature to reduce bitmap copying

## Problem summary
In some current scenarios, bitmap column copying occurs, for example, multiple derived columns are derived from the same bitmap column, or the build/probe column is copied to the join_block during join. Generally, the copy performance of bitmap is relatively slow, and the CRoaring CopyOnWrite feature can reduce copying, thereby improving query performance.
Note: CRoaring-0.4.0 COW is thread-unsafe, so it needs to be patched to make it thread-safe.

The following is the simplified sql of our production scenario:
```sql
SELECT `t2`.`page`
  , `t2`.`entrance`
  , `t1`.`partition_date`
  , `t1`.`entrance_code`
  , BITMAP_UNION_COUNT(CASE WHEN t1.type = 3 THEN t1.device_id END) AS `dau`
FROM `doris_vec_stage`.`tbl1` `t1`
  LEFT JOIN `doris_vec_stage`.`tbl2` `t2`
  ON `t1`.`first_entrance` = `t2`.`second_join_key`
    AND `t1`.`page_id` = `t2`.`first_join_key`
WHERE `t2`.`entrance` IN ('******', '******')
  AND `t2`.`page` = '******'
  AND `t1`.`partition_date` BETWEEN '2023-02-27' AND '2023-03-19'
GROUP BY 1, 2, 3, 4
```

(The following tests are based on doris 1.1.5)
Before, the query took 112756 ms:
```
ProbePhase:
      -  ProbeExprCallTime:  1.836ms
      -  ProbeFindNextTime:  5s934ms
      -  ProbeRows:  90.048K  (90048)
      -  ProbeTime:  1m52s
      -  ProbeWhenBuildSideOutputTime:  62.457ms
      -  ProbeWhenProbeSideOutputTime:  54s431ms
      -  ProbeWhenSearchHashTableTime:  27.254ms
```
Column copy time: `ProbeWhenProbeSideOutputTime: 54s431ms`
Column clear time is not printed here, the actual value is probably: (112000-5934-54431) ms = 51653 ms

After (open croaing cow), the query takes 53585 ms:
```
ProbePhase:
      -  ProbeExprCallTime:  1.331ms
      -  ProbeFindNextTime:  40s635ms
      -  ProbeRows:  37.348K  (37348)
      -  ProbeTime:  53s96ms
      -  ProbeWhenBuildSideOutputTime:  17.399ms
      -  ProbeWhenProbeSideOutputTime:  6s247ms
      -  ProbeWhenSearchHashTableTime:  6.700ms
```
Column copy time: `ProbeWhenProbeSideOutputTime:  6s247ms`
Column clear time: (53096-40635-6247) ms = 6214 ms

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [x] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

