### PR TITLE
[fix](community): remove some collaborators.

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -78,8 +78,6 @@ github:
         dismiss_stale_reviews: true
         required_approving_review_count: 1
   collaborators:
-    - spaces-X
-    - dataalive
     - LemonLiTree
     - zy-kkk
     - Yukang-Lian


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

ERROR from ASF infra:
An error occurred while running github feature in .asf.yaml!: You can only have a maximum of 10 external triage collaborators.

So I remove two collaborators
- spaces-X （was committer）
- dataalive  (look like no activity for Doris issue some time, may not need permission for a while)

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

