### PR TITLE
[fix](function) fix result column is nullable type when fast execute

### DIFF
--- a/be/src/vec/exprs/vectorized_fn_call.cpp
+++ b/be/src/vec/exprs/vectorized_fn_call.cpp
@@ -156,8 +156,9 @@ bool VectorizedFnCall::fast_execute(FunctionContext* context, Block& block,
             block.get_by_name(result_column_name).column->convert_to_full_column_if_const();
     auto& result_info = block.get_by_position(result);
     if (result_info.type->is_nullable()) {
-        block.replace_by_position(
-                result, ColumnNullable::create(std::move(result_column), ColumnUInt8::create(input_rows_count, 0)));
+        block.replace_by_position(result,
+                                  ColumnNullable::create(std::move(result_column),
+                                                         ColumnUInt8::create(input_rows_count, 0)));
     } else {
         block.replace_by_position(result, std::move(result_column));
     }

--- a/be/src/vec/exprs/vectorized_fn_call.cpp
+++ b/be/src/vec/exprs/vectorized_fn_call.cpp
@@ -154,7 +154,14 @@ bool VectorizedFnCall::fast_execute(FunctionContext* context, Block& block,
 
     auto result_column =
             block.get_by_name(result_column_name).column->convert_to_full_column_if_const();
-    block.replace_by_position(result, std::move(result_column));
+    auto& result_info = block.get_by_position(result);
+    if (result_info.type->is_nullable()) {
+        block.replace_by_position(
+                result, ColumnNullable::create(std::move(result_column), ColumnUInt8::create(input_rows_count, 0)));
+    } else {
+        block.replace_by_position(result, std::move(result_column));
+    }
+
     return true;
 }
 

--- a/be/src/vec/functions/function_helpers.cpp
+++ b/be/src/vec/functions/function_helpers.cpp
@@ -79,7 +79,7 @@ std::tuple<Block, ColumnNumbers> create_block_with_nested_columns(const Block& b
                     res.insert({ColumnConst::create(nested_col, col.column->size()), nested_type,
                                 col.name});
                 } else {
-                    LOG(FATAL) << "Illegal column for DataTypeNullable";
+                    LOG(FATAL) << "Illegal column= " << col.column->get_name() << " for DataTypeNullable";
                 }
             } else {
                 res.insert(col);

--- a/be/src/vec/functions/function_helpers.cpp
+++ b/be/src/vec/functions/function_helpers.cpp
@@ -79,7 +79,8 @@ std::tuple<Block, ColumnNumbers> create_block_with_nested_columns(const Block& b
                     res.insert({ColumnConst::create(nested_col, col.column->size()), nested_type,
                                 col.name});
                 } else {
-                    LOG(FATAL) << "Illegal column= " << col.column->get_name() << " for DataTypeNullable";
+                    LOG(FATAL) << "Illegal column= " << col.column->get_name()
+                               << " for DataTypeNullable";
                 }
             } else {
                 res.insert(col);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

when query do filter_block can do fast execute, if result column is nullable, there insert column type is not correct.

check failed such like:
```
F0519 15:10:37.712373 1341112 function_helpers.cpp:82] Illegal column for DataTypeNullable
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

