### PR TITLE
[typo](docs) replace the wrong field "json_paths" in s3 tvf related docs with the correct one "jsonpaths"

### DIFF
--- a/docs/en/docs/sql-manual/sql-functions/table-functions/s3.md
+++ b/docs/en/docs/sql-manual/sql-functions/table-functions/s3.md
@@ -76,7 +76,7 @@ file format parameter:
 - `read_json_by_line`: (optional) default `"true"`
 - `strip_outer_array`: (optional) default `"false"`
 - `json_root`: (optional) default `""`
-- `json_paths`: (optional) default `""`
+- `jsonpaths`: (optional) default `""`
 - `num_as_string`: (optional) default `"false"`
 - `fuzzy_parse`: (optional) default `"false"`
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/s3.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/s3.md
@@ -78,7 +78,7 @@ S3 tvf中的每一个参数都是一个 `"key"="value"` 对。
 - `read_json_by_line`： (选填) 默认为 `"true"`
 - `strip_outer_array`： (选填) 默认为 `"false"`
 - `json_root`： (选填) 默认为空
-- `json_paths`： (选填) 默认为空
+- `jsonpaths`： (选填) 默认为空
 - `num_as_string`： (选填) 默认为 `false`
 - `fuzzy_parse`： (选填) 默认为 `false`
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
The corresponding field is actually `jsonpaths` rather than json_paths.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [x] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

