### PR TITLE
[revert](memory) revert page no use Allocator && default disable ChunkAllocator

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -508,7 +508,7 @@ DEFINE_Int32(min_chunk_reserved_bytes, "1024");
 // of gperftools tcmalloc central lock.
 // Jemalloc or google tcmalloc have core cache, Chunk Allocator may no longer be needed after replacing
 // gperftools tcmalloc.
-DEFINE_mBool(disable_chunk_allocator_in_vec, "false");
+DEFINE_mBool(disable_chunk_allocator_in_vec, "true");
 
 // The probing algorithm of partitioned hash table.
 // Enable quadratic probing hash table

--- a/be/src/olap/page_cache.h
+++ b/be/src/olap/page_cache.h
@@ -41,7 +41,7 @@ public:
     PageBase() : _data(nullptr), _size(0), _capacity(0) {}
 
     PageBase(size_t b) : _size(b), _capacity(b) {
-        _data = new char[_capacity];
+        _data = reinterpret_cast<char*>(TAllocator::alloc(_capacity, ALLOCATOR_ALIGNMENT_16));
         ExecEnv::GetInstance()->page_no_cache_mem_tracker()->consume(_capacity);
     }
 
@@ -51,7 +51,7 @@ public:
     ~PageBase() {
         if (_data != nullptr) {
             DCHECK(_capacity != 0 && _size != 0);
-            delete[] _data;
+            TAllocator::free(_data, _capacity);
             ExecEnv::GetInstance()->page_no_cache_mem_tracker()->release(_capacity);
         }
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

default chunk allocator reserve is 0. At this time, it is meaningless to enable chunk allocator, it will only waste memory.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

