### PR TITLE
[bug](compile) fix fe compile error

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -813,6 +813,11 @@ under the License.
                 <artifactId>grpc-stub</artifactId>
                 <version>${grpc.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-core</artifactId>
+                <version>${grpc.version}</version>
+            </dependency>
             <!-- https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java -->
             <dependency>
                 <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
# Proposed changes

Fix fe maven package has a version conflict for package `grpc-core`.

![image](https://github.com/apache/doris/assets/22125576/4736c70d-4d4e-4d43-8f46-8b24d686abd9)


## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [x] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

