### PR TITLE
[enhance](PrefetchReader) abort load task when data size returned by S3 is smaller than requested

### DIFF
--- a/be/src/io/fs/buffered_reader.cpp
+++ b/be/src/io/fs/buffered_reader.cpp
@@ -416,7 +416,8 @@ void PrefetchBuffer::prefetch_buffer() {
         // which seems to be a violation of the S3 protocol since our request range was valid.
         // We currently consider this situation a bug and will treat this task as a failure.
         s = Status::InternalError("Data size returned by S3 is smaller than requested");
-        LOG(WARNING) << "Data size returned by S3 is smaller than requested" << _reader->path();
+        LOG(WARNING) << "Data size returned by S3 is smaller than requested" << _reader->path()
+                     << " request bytes " << buf_size << " returned size " << _len;
     }
     g_bytes_downloaded << _len;
     _statis.prefetch_request_io += 1;

--- a/be/src/io/fs/buffered_reader.cpp
+++ b/be/src/io/fs/buffered_reader.cpp
@@ -26,6 +26,7 @@
 // IWYU pragma: no_include <opentelemetry/common/threadlocal.h>
 #include "common/compiler_util.h" // IWYU pragma: keep
 #include "common/config.h"
+#include "common/status.h"
 #include "runtime/exec_env.h"
 #include "util/runtime_profile.h"
 #include "util/threadpool.h"
@@ -409,6 +410,13 @@ void PrefetchBuffer::prefetch_buffer() {
     {
         SCOPED_RAW_TIMER(&_statis.read_time);
         s = _reader->read_at(_offset, Slice {_buf.get(), buf_size}, &_len, _io_ctx);
+    }
+    if (UNLIKELY(buf_size != _len)) {
+        // This indicates that the data size returned by S3 object storage is smaller than what we requested,
+        // which seems to be a violation of the S3 protocol since our request range was valid.
+        // We currently consider this situation a bug and will treat this task as a failure.
+        s = Status::InternalError("Data size returned by S3 is smaller than requested");
+        LOG(WARNING) << "Data size returned by S3 is smaller than requested" << _reader->path();
     }
     g_bytes_downloaded << _len;
     _statis.prefetch_request_io += 1;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
We encountered one confusing situation where buffered reader were trapped in one endless loop when calling readat. Then we found out that it was all due to the return data size is less than requested.
As the following picture shows, the actual data size is about 2M, and when we called readat it only retrieved about 1MB.
![image](https://github.com/apache/doris/assets/43750022/b472c3a7-acf7-4f0b-918f-2139cbf33b91)

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

