### PR TITLE
[fix](testcase) fix wrong use of table in query_stats_test

### DIFF
--- a/regression-test/data/query_p0/stats/query_stats_test.out
+++ b/regression-test/data/query_p0/stats/query_stats_test.out
@@ -32,10 +32,10 @@ k12	0	0
 k13	0	0
 
 -- !sql --
-baseall	2
+stats_table	2
 
 -- !sql --
-baseall	k0	1	1
+stats_table	k0	1	1
 	k1	1	0
 	k2	1	1
 	k3	0	0

--- a/regression-test/suites/query_p0/stats/query_stats_test.groovy
+++ b/regression-test/suites/query_p0/stats/query_stats_test.groovy
@@ -16,21 +16,40 @@
 // under the License.
 
 suite("query_stats_test") {
-    sql "use test_query_db"
+    def tbName = "stats_table"
+    sql """
+        CREATE TABLE IF NOT EXISTS ${tbName} (
+            `k0` boolean null comment "",
+            `k1` tinyint(4) null comment "",
+            `k2` smallint(6) null comment "",
+            `k3` int(11) null comment "",
+            `k4` bigint(20) null comment "",
+            `k5` decimal(9, 3) null comment "",
+            `k6` char(5) null comment "",
+            `k10` date null comment "",
+            `k11` datetime null comment "",
+            `k7` varchar(20) null comment "",
+            `k8` double max null comment "",
+            `k9` float sum null comment "",
+            `k12` string replace null comment "",
+            `k13` largeint(40) replace null comment ""
+        ) engine=olap
+        DISTRIBUTED BY HASH(`k1`) BUCKETS 1 properties("replication_num" = "1")
+        """
     sql "admin set frontend config (\"enable_query_hit_stats\"=\"true\");"
     sql "clean all query stats"
 
     explain {
-        sql("select k1 from baseall where k1 = 1")
+        sql("select k1 from ${tbName} where k1 = 1")
     }
 
-    qt_sql "show query stats from baseall"
+    qt_sql "show query stats from ${tbName}"
 
-    sql "select k1 from baseall where k0 = 1"
-    sql "select k4 from baseall where k2 = 1991"
+    sql "select k1 from ${tbName} where k0 = 1"
+    sql "select k4 from ${tbName} where k2 = 1991"
 
-    qt_sql "show query stats from baseall"
-    qt_sql "show query stats from baseall all"
-    qt_sql "show query stats from baseall all verbose"
+    qt_sql "show query stats from ${tbName}"
+    qt_sql "show query stats from ${tbName} all"
+    qt_sql "show query stats from ${tbName} all verbose"
     sql "admin set frontend config (\"enable_query_hit_stats\"=\"false\");"
 }


### PR DESCRIPTION
# Proposed changes

## Problem summary

In the parallel test, although all query stats were cleaned, the cases run in parallel will affect this.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

