### PR TITLE
[opt](Nereids) give the easy understand error message when the window func misses the parameters

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/SlotBinder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/SlotBinder.java
@@ -20,7 +20,6 @@ package org.apache.doris.nereids.rules.analysis;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.analyzer.Scope;
 import org.apache.doris.nereids.analyzer.UnboundAlias;
-import org.apache.doris.nereids.analyzer.UnboundFunction;
 import org.apache.doris.nereids.analyzer.UnboundSlot;
 import org.apache.doris.nereids.analyzer.UnboundStar;
 import org.apache.doris.nereids.exceptions.AnalysisException;
@@ -30,14 +29,11 @@ import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
-import org.apache.doris.nereids.trees.expressions.WindowExpression;
 
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -155,33 +151,6 @@ class SlotBinder extends SubExprAnalyzer {
                 throw new AnalysisException("Not supported qualifier: "
                         + StringUtils.join(qualifier, "."));
         }
-    }
-
-    @Override
-    public Expression visitWindow(WindowExpression windowExpression, CascadesContext context) {
-        if (windowExpression.getFunction() instanceof UnboundFunction) {
-            UnboundFunction windowFunc = (UnboundFunction) windowExpression.getFunction();
-            if ((Objects.equals(windowFunc.getName(), "lag")) || (Objects.equals(windowFunc.getName(), "lead"))) {
-                if (windowFunc.children().size() != 3) {
-                    throw new AnalysisException("Lag/offset must have three parameters");
-                }
-            }
-        }
-
-        List<Expression> newChildren = new ArrayList<>();
-        boolean hasNewChildren = false;
-        for (Expression child : windowExpression.children()) {
-            Expression newChild = child.accept(this, context);
-            if (newChild != child) {
-                hasNewChildren = true;
-            }
-            newChildren.add(newChild);
-        }
-        if (hasNewChildren) {
-            windowExpression = windowExpression.withChildren(newChildren);
-        }
-
-        return windowExpression;
     }
 
     private BoundStar bindQualifiedStar(List<String> qualifierStar, List<Slot> boundSlots) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/window/Lag.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/window/Lag.java
@@ -21,7 +21,6 @@ import org.apache.doris.catalog.FunctionSignature;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
-import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
 import org.apache.doris.nereids.trees.expressions.shape.TernaryExpression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
@@ -48,19 +47,11 @@ public class Lag extends WindowFunction implements TernaryExpression, Explicitly
 
     private static final List<FunctionSignature> SIGNATURES;
 
-    public Lag(Expression child) {
-        this(child, Literal.of(1), Literal.of(null));
-    }
-
-    public Lag(Expression child, Expression offset) {
-        this(child, offset, Literal.of(null));
-    }
-
     public Lag(Expression child, Expression offset, Expression defaultValue) {
         super("lag", child, offset, defaultValue);
     }
 
-    public Lag(List<Expression> children) {
+    private Lag(List<Expression> children) {
         super("lag", children);
     }
 


### PR DESCRIPTION
…e window func miss parameters

# Proposed changes
Add the error message when the window func misses the parameters.

## Problem summary
For the new optimizer, if the window func misses the parameter. It will not give an understandable error message. So add the error message.

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

