### PR TITLE
[fix](partial-update) should hold tablet meta lock before calling lookup_row_key()

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -393,33 +393,37 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
     bool has_default = false;
     std::vector<bool> use_default_flag;
     use_default_flag.reserve(num_rows);
-    for (size_t pos = row_pos; pos < num_rows; pos++) {
-        std::string key = _full_encode_keys(key_columns, pos);
-        RETURN_IF_ERROR(_primary_key_index_builder->add_item(key));
-        _maybe_invalid_row_cache(key);
+    // locate rows in base data
+    {
+        std::shared_lock rlock(_tablet->get_header_lock());
+        for (size_t pos = row_pos; pos < num_rows; pos++) {
+            std::string key = _full_encode_keys(key_columns, pos);
+            RETURN_IF_ERROR(_primary_key_index_builder->add_item(key));
+            _maybe_invalid_row_cache(key);
 
-        RowLocation loc;
-        // save rowset shared ptr so this rowset wouldn't delete
-        RowsetSharedPtr rowset;
-        auto st = _tablet->lookup_row_key(key, false, &_mow_context->rowset_ids, &loc,
-                                          _mow_context->max_version, &rowset);
-        if (st.is<NOT_FOUND>()) {
-            if (!_tablet_schema->allow_key_not_exist_in_partial_update()) {
-                return Status::InternalError("partial update key not exist before");
+            RowLocation loc;
+            // save rowset shared ptr so this rowset wouldn't delete
+            RowsetSharedPtr rowset;
+            auto st = _tablet->lookup_row_key(key, false, &_mow_context->rowset_ids, &loc,
+                                              _mow_context->max_version, &rowset);
+            if (st.is<NOT_FOUND>()) {
+                if (!_tablet_schema->allow_key_not_exist_in_partial_update()) {
+                    return Status::InternalError("partial update key not exist before");
+                }
+                has_default = true;
+                use_default_flag.emplace_back(true);
+                continue;
             }
-            has_default = true;
-            use_default_flag.emplace_back(true);
-            continue;
+            if (!st.ok()) {
+                LOG(WARNING) << "failed to lookup row key, error: " << st;
+                return st;
+            }
+            // partial update should not contain invisible columns
+            use_default_flag.emplace_back(false);
+            _rsid_to_rowset.emplace(rowset->rowset_id(), rowset);
+            _tablet->prepare_to_read(loc, pos, &_rssid_to_rid);
+            _mow_context->delete_bitmap->add({loc.rowset_id, loc.segment_id, 0}, loc.row_id);
         }
-        if (!st.ok()) {
-            LOG(WARNING) << "failed to lookup row key";
-            return st;
-        }
-        // partial update should not contain invisible columns
-        use_default_flag.emplace_back(false);
-        _rsid_to_rowset.emplace(rowset->rowset_id(), rowset);
-        _tablet->prepare_to_read(loc, pos, &_rssid_to_rid);
-        _mow_context->delete_bitmap->add({loc.rowset_id, loc.segment_id, 0}, loc.row_id);
     }
     CHECK(use_default_flag.size() == num_rows);
 

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2545,6 +2545,7 @@ Status Tablet::lookup_row_data(const Slice& encoded_key, const RowLocation& row_
     return Status::OK();
 }
 
+// ATTN: caller should hold the meta lock.
 Status Tablet::lookup_row_key(const Slice& encoded_key, bool with_seq_col,
                               const RowsetIdUnorderedSet* rowset_ids, RowLocation* row_location,
                               uint32_t version, RowsetSharedPtr* rowset) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

we need to hold the read lock while calling lookup_row_key(), lookup_row_key depends on the RowsetTree structure, which might be modified by other threads in any time

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

