### PR TITLE
[fix](multi-catalog) values in sqlserver should be enclosed by single quotes

### DIFF
--- a/be/src/exec/table_connector.cpp
+++ b/be/src/exec/table_connector.cpp
@@ -231,6 +231,9 @@ Status TableConnector::convert_column_data(const vectorized::ColumnPtr& column_p
             }
         } else if (table_type == TOdbcTableType::POSTGRESQL) {
             fmt::format_to(_insert_stmt_buffer, "'{}'::date", str);
+        } else if (table_type == TOdbcTableType::SQLSERVER) {
+            // Values in sqlserver should be enclosed by single quotes
+            fmt::format_to(_insert_stmt_buffer, "'{}'", str);
         } else {
             fmt::format_to(_insert_stmt_buffer, "\"{}\"", str);
         }


### PR DESCRIPTION
# Proposed changes
Fix errors when inserting string/date/datetime values into SQLServer:
```
ERROR 1105 (HY000): errCode = 2, detailMessage = (172.21.0.101)[INTERNAL_ERROR]UdfRuntimeException: JDBC executor sql has error:
CAUSED BY: SQLServerException: Invalid column name '2021-10-30'.
```
When using double quotes enclose string values, it will be parsed as column name, so we should enclose string values with single quotes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

