### PR TITLE
[fix](expr) Make VExprContext exit gracefully

### DIFF
--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -64,8 +64,6 @@
 
 namespace doris {
 
-bool k_doris_exit = false;
-
 void Daemon::tcmalloc_gc_thread() {
     // TODO All cache GC wish to be supported
 #if !defined(ADDRESS_SANITIZER) && !defined(LEAK_SANITIZER) && !defined(THREAD_SANITIZER) && \

--- a/be/src/common/daemon.h
+++ b/be/src/common/daemon.h
@@ -26,6 +26,7 @@
 namespace doris {
 
 struct StorePath;
+inline bool k_doris_exit = false;
 
 class Daemon {
 public:

--- a/be/src/vec/exprs/vexpr_context.cpp
+++ b/be/src/vec/exprs/vexpr_context.cpp
@@ -21,6 +21,8 @@
 #include <ostream>
 #include <string>
 
+#include "common/daemon.h"
+
 // IWYU pragma: no_include <opentelemetry/common/threadlocal.h>
 #include "common/compiler_util.h" // IWYU pragma: keep
 #include "common/object_pool.h"
@@ -49,8 +51,9 @@ VExprContext::VExprContext(VExpr* expr)
 VExprContext::~VExprContext() {
     // Do not delete this code, this code here is used to check if forget to close the opened context
     // Or there will be memory leak
-    DCHECK(!_prepared || _closed) << get_stack_trace() << " prepare:" << _prepared
-                                  << " closed:" << _closed << " expr:" << _root->debug_string();
+    DCHECK(!_prepared || _closed || k_doris_exit)
+            << " prepare:" << _prepared << " closed:" << _closed
+            << " expr:" << _root->debug_string();
 }
 
 doris::Status VExprContext::execute(doris::vectorized::Block* block, int* result_column_id) {


### PR DESCRIPTION
# Proposed changes

## Problem summary

Skip DCHECK when BE exits. So that there won't be crash if we stop BE with singal 15 we there's queries running.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

may need a better way to refactor `close` of VExprContext to straighten out its lifetime