### PR TITLE
[Chore](ub) fix some undefined behaviors

### DIFF
--- a/be/src/io/cache/sub_file_cache.cpp
+++ b/be/src/io/cache/sub_file_cache.cpp
@@ -58,7 +58,7 @@ SubFileCache::~SubFileCache() {}
 Status SubFileCache::read_at_impl(size_t offset, Slice result, size_t* bytes_read,
                                   const IOContext* io_ctx) {
     RETURN_IF_ERROR(_init());
-    if (io_ctx != nullptr && io_ctx->reader_type != READER_QUERY) {
+    if (io_ctx != nullptr && io_ctx->reader_type != ReaderType::READER_QUERY) {
         return _remote_file_reader->read_at(offset, result, bytes_read, io_ctx);
     }
     std::vector<size_t> need_cache_offsets;

--- a/be/src/io/cache/whole_file_cache.cpp
+++ b/be/src/io/cache/whole_file_cache.cpp
@@ -44,11 +44,11 @@ WholeFileCache::WholeFileCache(const Path& cache_dir, int64_t alive_time_sec,
           _remote_file_reader(remote_file_reader),
           _cache_file_reader(nullptr) {}
 
-WholeFileCache::~WholeFileCache() {}
+WholeFileCache::~WholeFileCache() = default;
 
 Status WholeFileCache::read_at_impl(size_t offset, Slice result, size_t* bytes_read,
                                     const IOContext* io_ctx) {
-    if (io_ctx != nullptr && io_ctx->reader_type != READER_QUERY) {
+    if (io_ctx != nullptr && io_ctx->reader_type != ReaderType::READER_QUERY) {
         return _remote_file_reader->read_at(offset, result, bytes_read, io_ctx);
     }
     if (_cache_file_reader == nullptr) {

--- a/be/src/io/io_common.h
+++ b/be/src/io/io_common.h
@@ -29,6 +29,7 @@ enum class ReaderType {
     READER_CHECKSUM = 4,
     READER_COLD_DATA_COMPACTION = 5,
     READER_SEGMENT_COMPACTION = 6,
+    UNKNOWN = 7
 };
 
 namespace io {
@@ -55,7 +56,7 @@ public:
               is_disposable(use_disposable_cache),
               read_segment_index(read_segment_index),
               file_cache_stats(stats) {}
-    ReaderType reader_type;
+    ReaderType reader_type = ReaderType::UNKNOWN;
     const TUniqueId* query_id = nullptr;
     bool is_disposable = false;
     bool read_segment_index = false;

--- a/be/src/io/io_common.h
+++ b/be/src/io/io_common.h
@@ -21,7 +21,7 @@
 
 namespace doris {
 
-enum ReaderType {
+enum class ReaderType {
     READER_QUERY = 0,
     READER_ALTER_TABLE = 1,
     READER_BASE_COMPACTION = 2,

--- a/be/src/olap/block_column_predicate.cpp
+++ b/be/src/olap/block_column_predicate.cpp
@@ -79,6 +79,9 @@ uint16_t OrBlockColumnPredicate::evaluate(vectorized::MutableColumns& block, uin
     if (num_of_column_predicate() == 1) {
         return _block_column_predicate_vec[0]->evaluate(block, sel, selected_size);
     } else {
+        if (!selected_size) {
+            return 0;
+        }
         bool ret_flags[selected_size];
         memset(ret_flags, false, selected_size);
         for (int i = 0; i < num_of_column_predicate(); ++i) {

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -518,7 +518,7 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
                 _input_rowsets, _rowid_conversion, 0, version.second + 1, &missed_rows,
                 &location_map, &output_rowset_delete_bitmap);
         std::size_t missed_rows_size = missed_rows.size();
-        if (compaction_type() == READER_CUMULATIVE_COMPACTION) {
+        if (compaction_type() == ReaderType::READER_CUMULATIVE_COMPACTION) {
             if (stats != nullptr && stats->merged_rows != missed_rows_size) {
                 std::string err_msg = fmt::format(
                         "cumulative compaction: the merged rows({}) is not equal to missed "
@@ -541,7 +541,7 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
             _tablet->calc_compaction_output_rowset_delete_bitmap(
                     _input_rowsets, _rowid_conversion, version.second, UINT64_MAX, &missed_rows,
                     &location_map, &output_rowset_delete_bitmap);
-            if (compaction_type() == READER_CUMULATIVE_COMPACTION) {
+            if (compaction_type() == ReaderType::READER_CUMULATIVE_COMPACTION) {
                 DCHECK_EQ(missed_rows.size(), missed_rows_size);
                 if (missed_rows.size() != missed_rows_size) {
                     LOG(WARNING) << "missed rows don't match, before: " << missed_rows_size

--- a/be/src/olap/reader.h
+++ b/be/src/olap/reader.h
@@ -95,7 +95,7 @@ public:
     struct ReaderParams {
         TabletSharedPtr tablet;
         TabletSchemaSPtr tablet_schema;
-        ReaderType reader_type = READER_QUERY;
+        ReaderType reader_type = ReaderType::READER_QUERY;
         bool direct_mode = false;
         bool aggregation = false;
         bool need_agg_finalize = true;
@@ -265,7 +265,7 @@ protected:
     bool _aggregation = false;
     // for agg query, we don't need to finalize when scan agg object data
     bool _need_agg_finalize = true;
-    ReaderType _reader_type = READER_QUERY;
+    ReaderType _reader_type = ReaderType::READER_QUERY;
     bool _next_delete_flag = false;
     bool _filter_delete = false;
     int32_t _sequence_col_idx = -1;

--- a/be/src/olap/rowset/rowset_reader_context.h
+++ b/be/src/olap/rowset/rowset_reader_context.h
@@ -33,7 +33,7 @@ class DeleteHandler;
 class TabletSchema;
 
 struct RowsetReaderContext {
-    ReaderType reader_type = READER_QUERY;
+    ReaderType reader_type = ReaderType::READER_QUERY;
     Version version {-1, -1};
     TabletSchemaSPtr tablet_schema = nullptr;
     // flag for enable topn opt

--- a/be/src/olap/rowset/segcompaction.cpp
+++ b/be/src/olap/rowset/segcompaction.cpp
@@ -215,7 +215,7 @@ Status SegcompactionWorker::_do_compact_segments(SegCompactionCandidatesSharedPt
     std::vector<std::vector<uint32_t>> column_groups;
     Merger::vertical_split_columns(ctx.tablet_schema, &column_groups);
     vectorized::RowSourcesBuffer row_sources_buf(tablet->tablet_id(), tablet->tablet_path(),
-                                                 READER_SEGMENT_COMPACTION);
+                                                 ReaderType::READER_SEGMENT_COMPACTION);
 
     KeyBoundsPB key_bounds;
     Merger::Statistics key_merger_stats;
@@ -240,8 +240,8 @@ Status SegcompactionWorker::_do_compact_segments(SegCompactionCandidatesSharedPt
 
         Merger::Statistics merger_stats;
         RETURN_IF_ERROR(Merger::vertical_compact_one_group(
-                tablet, READER_SEGMENT_COMPACTION, ctx.tablet_schema, is_key, column_ids,
-                &row_sources_buf, *reader, *writer, INT_MAX, &merger_stats, &index_size,
+                tablet, ReaderType::READER_SEGMENT_COMPACTION, ctx.tablet_schema, is_key,
+                column_ids, &row_sources_buf, *reader, *writer, INT_MAX, &merger_stats, &index_size,
                 key_bounds));
         total_index_size += index_size;
         if (is_key) {

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -622,7 +622,7 @@ Status VSchemaChangeWithSorting::_external_sorting(vector<RowsetSharedPtr>& src_
     }
 
     Merger::Statistics stats;
-    RETURN_IF_ERROR(Merger::vmerge_rowsets(new_tablet, READER_ALTER_TABLE,
+    RETURN_IF_ERROR(Merger::vmerge_rowsets(new_tablet, ReaderType::READER_ALTER_TABLE,
                                            new_tablet->tablet_schema(), rs_readers, rowset_writer,
                                            &stats));
 
@@ -1096,7 +1096,7 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletReqV2&
                 break;
             }
 
-            reader_context.reader_type = READER_ALTER_TABLE;
+            reader_context.reader_type = ReaderType::READER_ALTER_TABLE;
             reader_context.tablet_schema = base_tablet_schema;
             reader_context.need_ordered_result = true;
             reader_context.delete_handler = &delete_handler;
@@ -1393,7 +1393,7 @@ Status SchemaChangeHandler::_get_rowset_readers(TabletSharedPtr tablet,
 
             // reader_context is stack variables, it's lifetime should keep the same with rs_readers
             RowsetReaderContext reader_context;
-            reader_context.reader_type = READER_ALTER_TABLE;
+            reader_context.reader_type = ReaderType::READER_ALTER_TABLE;
             reader_context.tablet_schema = tablet_schema;
             reader_context.need_ordered_result = false;
             reader_context.delete_handler = &delete_handler;

--- a/be/src/olap/task/engine_checksum_task.cpp
+++ b/be/src/olap/task/engine_checksum_task.cpp
@@ -85,7 +85,7 @@ Status EngineChecksumTask::_compute_checksum() {
     TabletReader::ReaderParams reader_params;
     vectorized::Block block;
     RETURN_IF_ERROR(TabletReader::init_reader_params_and_create_block(
-            tablet, READER_CHECKSUM, input_rowsets, &reader_params, &block));
+            tablet, ReaderType::READER_CHECKSUM, input_rowsets, &reader_params, &block));
 
     auto res = reader.init(reader_params);
     if (!res.ok()) {

--- a/be/src/vec/columns/column_decimal.cpp
+++ b/be/src/vec/columns/column_decimal.cpp
@@ -257,7 +257,7 @@ void ColumnDecimal<T>::insert_many_fix_len_data(const char* data_ptr, size_t num
         DecimalV2Value* target = (DecimalV2Value*)(data.data() + old_size);
         for (int i = 0; i < num; i++) {
             const char* cur_ptr = data_ptr + sizeof(decimal12_t) * i;
-            int64_t int_value = *(int64_t*)(cur_ptr);
+            int64_t int_value = unaligned_load<int64_t>(cur_ptr);
             int32_t frac_value = *(int32_t*)(cur_ptr + sizeof(int64_t));
             target[i].from_olap_decimal(int_value, frac_value);
         }

--- a/be/src/vec/columns/column_dictionary.h
+++ b/be/src/vec/columns/column_dictionary.h
@@ -535,7 +535,6 @@ public:
         }
 
     private:
-        StringRef _null_value = StringRef();
         StringRef::Comparator _comparator;
         // dict code -> dict value
         std::unique_ptr<DictContainer> _dict_data;

--- a/be/src/vec/columns/column_dictionary.h
+++ b/be/src/vec/columns/column_dictionary.h
@@ -346,7 +346,7 @@ public:
 
         void reserve(size_t n) { _dict_data->reserve(n); }
 
-        void insert_value(StringRef& value) {
+        void insert_value(const StringRef& value) {
             _dict_data->push_back_without_reserve(value);
             _total_str_len += value.size;
         }

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -222,6 +222,7 @@ public:
             if (i != num - 1 && strings[i].data + len == strings[i + 1].data) {
                 continue;
             }
+            DCHECK(ptr != nullptr);
             memcpy(data, ptr, length);
             data += length;
             if (LIKELY(i != num - 1)) {

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -222,9 +222,11 @@ public:
             if (i != num - 1 && strings[i].data + len == strings[i + 1].data) {
                 continue;
             }
-            DCHECK(ptr != nullptr);
-            memcpy(data, ptr, length);
-            data += length;
+            if (length != 0) {
+                DCHECK(ptr != nullptr);
+                memcpy(data, ptr, length);
+                data += length;
+            }
             if (LIKELY(i != num - 1)) {
                 ptr = strings[i + 1].data;
                 length = 0;

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -222,11 +222,13 @@ public:
             if (i != num - 1 && strings[i].data + len == strings[i + 1].data) {
                 continue;
             }
+
             if (length != 0) {
                 DCHECK(ptr != nullptr);
                 memcpy(data, ptr, length);
                 data += length;
             }
+
             if (LIKELY(i != num - 1)) {
                 ptr = strings[i + 1].data;
                 length = 0;
@@ -307,7 +309,6 @@ public:
         }
     }
 
-#define MAX_STRINGS_OVERFLOW_SIZE 128
     template <typename T, size_t copy_length>
     void insert_many_strings_fixed_length(const StringRef* strings, size_t num)
             __attribute__((noinline));

--- a/be/src/vec/exec/format/parquet/byte_array_dict_decoder.cpp
+++ b/be/src/vec/exec/format/parquet/byte_array_dict_decoder.cpp
@@ -29,6 +29,8 @@
 
 namespace doris::vectorized {
 
+constexpr int MAX_STRINGS_OVERFLOW_SIZE = 128;
+
 Status ByteArrayDictDecoder::set_dict(std::unique_ptr<uint8_t[]>& dict, int32_t length,
                                       size_t num_values) {
     _dict = std::move(dict);

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -257,7 +257,7 @@ Status NewOlapScanner::_init_tablet_reader_params(
 
     _tablet_reader_params.tablet = _tablet;
     _tablet_reader_params.tablet_schema = _tablet_schema;
-    _tablet_reader_params.reader_type = READER_QUERY;
+    _tablet_reader_params.reader_type = ReaderType::READER_QUERY;
     _tablet_reader_params.aggregation = _aggregation;
     if (real_parent->_olap_scan_node.__isset.push_down_agg_type_opt) {
         _tablet_reader_params.push_down_agg_type_opt =

--- a/be/src/vec/olap/block_reader.cpp
+++ b/be/src/vec/olap/block_reader.cpp
@@ -91,7 +91,7 @@ Status BlockReader::_init_collect_iter(const ReaderParams& read_params) {
         LOG(WARNING) << "fail to init reader when _capture_rs_readers. res:" << res
                      << ", tablet_id:" << read_params.tablet->tablet_id()
                      << ", schema_hash:" << read_params.tablet->schema_hash()
-                     << ", reader_type:" << read_params.reader_type
+                     << ", reader_type:" << int(read_params.reader_type)
                      << ", version:" << read_params.version;
         return res;
     }

--- a/be/src/vec/olap/vcollect_iterator.cpp
+++ b/be/src/vec/olap/vcollect_iterator.cpp
@@ -71,7 +71,7 @@ void VCollectIterator::init(TabletReader* reader, bool ori_data_overlapping, boo
 
     // when aggregate is enabled or key_type is DUP_KEYS, we don't merge
     // multiple data to aggregate for better performance
-    if (_reader->_reader_type == READER_QUERY &&
+    if (_reader->_reader_type == ReaderType::READER_QUERY &&
         (_reader->_direct_mode || _reader->_tablet->keys_type() == KeysType::DUP_KEYS ||
          (_reader->_tablet->keys_type() == KeysType::UNIQUE_KEYS &&
           _reader->_tablet->enable_unique_key_merge_on_write()))) {

--- a/be/src/vec/olap/vertical_block_reader.cpp
+++ b/be/src/vec/olap/vertical_block_reader.cpp
@@ -58,7 +58,7 @@ Status VerticalBlockReader::_get_segment_iterators(const ReaderParams& read_para
         LOG(WARNING) << "fail to init reader when _capture_rs_readers. res:" << res
                      << ", tablet_id:" << read_params.tablet->tablet_id()
                      << ", schema_hash:" << read_params.tablet->schema_hash()
-                     << ", reader_type:" << read_params.reader_type
+                     << ", reader_type:" << int(read_params.reader_type)
                      << ", version:" << read_params.version;
         return res;
     }

--- a/be/src/vec/olap/vertical_merge_iterator.cpp
+++ b/be/src/vec/olap/vertical_merge_iterator.cpp
@@ -151,12 +151,12 @@ Status RowSourcesBuffer::_create_buffer_file() {
     }
     std::stringstream file_path_ss;
     file_path_ss << _tablet_path << "/compaction_row_source_" << _tablet_id;
-    if (_reader_type == READER_BASE_COMPACTION) {
+    if (_reader_type == ReaderType::READER_BASE_COMPACTION) {
         file_path_ss << "_base";
-    } else if (_reader_type == READER_CUMULATIVE_COMPACTION ||
-               _reader_type == READER_SEGMENT_COMPACTION) {
+    } else if (_reader_type == ReaderType::READER_CUMULATIVE_COMPACTION ||
+               _reader_type == ReaderType::READER_SEGMENT_COMPACTION) {
         file_path_ss << "_cumu";
-    } else if (_reader_type == READER_COLD_DATA_COMPACTION) {
+    } else if (_reader_type == ReaderType::READER_COLD_DATA_COMPACTION) {
         file_path_ss << "_cold";
     } else {
         DCHECK(false);

--- a/be/src/vec/olap/vertical_merge_iterator.h
+++ b/be/src/vec/olap/vertical_merge_iterator.h
@@ -109,8 +109,8 @@ public:
         _buf_idx += step;
     }
 
-    uint64_t buf_idx() { return _buf_idx; }
-    uint64_t total_size() { return _total_size; }
+    uint64_t buf_idx() const { return _buf_idx; }
+    uint64_t total_size() const { return _total_size; }
     uint64_t buffered_size() { return _buffer->size(); }
     void set_agg_flag(uint64_t index, bool agg);
 
@@ -132,10 +132,9 @@ private:
         _buf_idx = 0;
     }
 
-private:
     int64_t _tablet_id;
     std::string _tablet_path;
-    ReaderType _reader_type;
+    ReaderType _reader_type = ReaderType::UNKNOWN;
     uint64_t _buf_idx = 0;
     int _fd = -1;
     ColumnUInt16::MutablePtr _buffer;
@@ -160,7 +159,7 @@ public:
     VerticalMergeIteratorContext& operator=(const VerticalMergeIteratorContext&) = delete;
     VerticalMergeIteratorContext& operator=(VerticalMergeIteratorContext&&) = delete;
 
-    ~VerticalMergeIteratorContext() {}
+    ~VerticalMergeIteratorContext() = default;
     Status block_reset(const std::shared_ptr<Block>& block);
     Status init(const StorageReadOptions& opts);
     bool compare(const VerticalMergeIteratorContext& rhs) const;
@@ -178,7 +177,7 @@ public:
 
     void set_is_same(bool is_same) const { _is_same = is_same; }
 
-    bool is_same() { return _is_same; }
+    bool is_same() const { return _is_same; }
 
     void add_cur_batch() { _cur_batch_num++; }
 
@@ -186,7 +185,7 @@ public:
 
     size_t remain_rows() { return _block->rows() - _index_in_block; }
 
-    bool is_first_row() { return _is_first_row; }
+    bool is_first_row() const { return _is_first_row; }
     void set_is_first_row(bool is_first_row) { _is_first_row = is_first_row; }
     void set_cur_row_ref(vectorized::IteratorRowRef* ref) {
         ref->block = _block;
@@ -267,7 +266,6 @@ public:
 private:
     int _get_size(Block* block) { return block->rows(); }
 
-private:
     // It will be released after '_merge_heap' has been built.
     std::vector<RowwiseIteratorUPtr> _origin_iters;
     std::vector<bool> _iterator_init_flags;
@@ -316,7 +314,7 @@ public:
               _seq_col_idx(seq_col_idx),
               _row_sources_buf(row_sources_buf) {}
 
-    ~VerticalFifoMergeIterator() override {}
+    ~VerticalFifoMergeIterator() override = default;
 
     Status init(const StorageReadOptions& opts) override;
     Status next_batch(Block* block) override;
@@ -331,7 +329,6 @@ public:
 private:
     int _get_size(Block* block) { return block->rows(); }
 
-private:
     // It will be released after '_merge_heap' has been built.
     std::vector<RowwiseIteratorUPtr> _origin_iters;
     std::vector<bool> _iterator_init_flags;
@@ -382,7 +379,6 @@ private:
 
     Status check_all_iter_finished();
 
-private:
     // released after build ctx
     std::vector<RowwiseIteratorUPtr> _origin_iters;
     size_t _ori_return_cols = 0;

--- a/be/test/olap/rowid_conversion_test.cpp
+++ b/be/test/olap/rowid_conversion_test.cpp
@@ -358,11 +358,11 @@ protected:
         RowIdConversion rowid_conversion;
         stats.rowid_conversion = &rowid_conversion;
         if (is_vertical_merger) {
-            s = Merger::vertical_merge_rowsets(tablet, READER_BASE_COMPACTION, tablet_schema,
-                                               input_rs_readers, output_rs_writer.get(), 10000000,
-                                               &stats);
+            s = Merger::vertical_merge_rowsets(tablet, ReaderType::READER_BASE_COMPACTION,
+                                               tablet_schema, input_rs_readers,
+                                               output_rs_writer.get(), 10000000, &stats);
         } else {
-            s = Merger::vmerge_rowsets(tablet, READER_BASE_COMPACTION, tablet_schema,
+            s = Merger::vmerge_rowsets(tablet, ReaderType::READER_BASE_COMPACTION, tablet_schema,
                                        input_rs_readers, output_rs_writer.get(), &stats);
         }
         EXPECT_TRUE(s.ok());

--- a/be/test/vec/olap/vertical_compaction_test.cpp
+++ b/be/test/vec/olap/vertical_compaction_test.cpp
@@ -393,7 +393,7 @@ private:
 };
 
 TEST_F(VerticalCompactionTest, TestRowSourcesBuffer) {
-    RowSourcesBuffer buffer(100, absolute_dir, READER_CUMULATIVE_COMPACTION);
+    RowSourcesBuffer buffer(100, absolute_dir, ReaderType::READER_CUMULATIVE_COMPACTION);
     RowSource s1(0, 0);
     RowSource s2(0, 0);
     RowSource s3(1, 1);
@@ -425,7 +425,7 @@ TEST_F(VerticalCompactionTest, TestRowSourcesBuffer) {
         buffer.advance(same);
     }
 
-    RowSourcesBuffer buffer1(101, absolute_dir, READER_CUMULATIVE_COMPACTION);
+    RowSourcesBuffer buffer1(101, absolute_dir, ReaderType::READER_CUMULATIVE_COMPACTION);
     EXPECT_TRUE(buffer1.append(tmp_row_source).ok());
     EXPECT_TRUE(buffer1.append(tmp_row_source).ok());
     buffer1.set_agg_flag(2, false);
@@ -502,7 +502,7 @@ TEST_F(VerticalCompactionTest, TestDupKeyVerticalMerge) {
     Merger::Statistics stats;
     RowIdConversion rowid_conversion;
     stats.rowid_conversion = &rowid_conversion;
-    s = Merger::vertical_merge_rowsets(tablet, READER_BASE_COMPACTION, tablet_schema,
+    s = Merger::vertical_merge_rowsets(tablet, ReaderType::READER_BASE_COMPACTION, tablet_schema,
                                        input_rs_readers, output_rs_writer.get(), 100, &stats);
     EXPECT_TRUE(s.ok());
     RowsetSharedPtr out_rowset = output_rs_writer->build();
@@ -609,7 +609,7 @@ TEST_F(VerticalCompactionTest, TestDupWithoutKeyVerticalMerge) {
     Merger::Statistics stats;
     RowIdConversion rowid_conversion;
     stats.rowid_conversion = &rowid_conversion;
-    s = Merger::vertical_merge_rowsets(tablet, READER_BASE_COMPACTION, tablet_schema,
+    s = Merger::vertical_merge_rowsets(tablet, ReaderType::READER_BASE_COMPACTION, tablet_schema,
                                        input_rs_readers, output_rs_writer.get(), 100, &stats);
     EXPECT_TRUE(s.ok());
     RowsetSharedPtr out_rowset = output_rs_writer->build();
@@ -717,7 +717,7 @@ TEST_F(VerticalCompactionTest, TestUniqueKeyVerticalMerge) {
     Merger::Statistics stats;
     RowIdConversion rowid_conversion;
     stats.rowid_conversion = &rowid_conversion;
-    s = Merger::vertical_merge_rowsets(tablet, READER_BASE_COMPACTION, tablet_schema,
+    s = Merger::vertical_merge_rowsets(tablet, ReaderType::READER_BASE_COMPACTION, tablet_schema,
                                        input_rs_readers, output_rs_writer.get(), 100, &stats);
     EXPECT_TRUE(s.ok());
     RowsetSharedPtr out_rowset = output_rs_writer->build();
@@ -817,7 +817,7 @@ TEST_F(VerticalCompactionTest, TestDupKeyVerticalMergeWithDelete) {
     Merger::Statistics stats;
     RowIdConversion rowid_conversion;
     stats.rowid_conversion = &rowid_conversion;
-    s = Merger::vertical_merge_rowsets(tablet, READER_BASE_COMPACTION, tablet_schema,
+    s = Merger::vertical_merge_rowsets(tablet, ReaderType::READER_BASE_COMPACTION, tablet_schema,
                                        input_rs_readers, output_rs_writer.get(), 100, &stats);
     EXPECT_TRUE(s.ok());
     RowsetSharedPtr out_rowset = output_rs_writer->build();
@@ -911,7 +911,7 @@ TEST_F(VerticalCompactionTest, TestDupWithoutKeyVerticalMergeWithDelete) {
     Merger::Statistics stats;
     RowIdConversion rowid_conversion;
     stats.rowid_conversion = &rowid_conversion;
-    s = Merger::vertical_merge_rowsets(tablet, READER_BASE_COMPACTION, tablet_schema,
+    s = Merger::vertical_merge_rowsets(tablet, ReaderType::READER_BASE_COMPACTION, tablet_schema,
                                        input_rs_readers, output_rs_writer.get(), 100, &stats);
     EXPECT_TRUE(s.ok());
     RowsetSharedPtr out_rowset = output_rs_writer->build();
@@ -1005,7 +1005,7 @@ TEST_F(VerticalCompactionTest, TestAggKeyVerticalMerge) {
     Merger::Statistics stats;
     RowIdConversion rowid_conversion;
     stats.rowid_conversion = &rowid_conversion;
-    s = Merger::vertical_merge_rowsets(tablet, READER_BASE_COMPACTION, tablet_schema,
+    s = Merger::vertical_merge_rowsets(tablet, ReaderType::READER_BASE_COMPACTION, tablet_schema,
                                        input_rs_readers, output_rs_writer.get(), 100, &stats);
     EXPECT_TRUE(s.ok());
     RowsetSharedPtr out_rowset = output_rs_writer->build();


### PR DESCRIPTION
# Proposed changes
```cpp
/home/zcp/repo_center/doris_master/doris/be/src/olap/rowset/segment_v2/column_reader.cpp:895:21: runtime error: load of value 423208544, which is not a valid value for type 'doris::ReaderType'

/home/zcp/repo_center/doris_master/doris/be/src/vec/columns/column_decimal.cpp:260:33: runtime error: load of misaligned address 0x7fa3348b301c for type 'int64_t' (aka 'long'), which requires 8 byte alignment

/home/zcp/repo_center/doris_master/doris/be/src/olap/block_column_predicate.cpp:82:24: runtime error: variable length array bound evaluates to non-positive value 0

/home/zcp/repo_center/doris_master/doris/be/src/vec/columns/column_string.h:225:26: runtime error: null pointer passed as argument 2, which is declared to never be null
```
## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

