### PR TITLE
[Fix](Planner)fix incorrect pattern when format pattern contains %x%v

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
@@ -51,6 +51,7 @@ import java.time.format.DateTimeParseException;
 import java.time.format.ResolverStyle;
 import java.time.format.TextStyle;
 import java.time.temporal.ChronoField;
+import java.time.temporal.IsoFields;
 import java.time.temporal.TemporalAccessor;
 import java.util.Collections;
 import java.util.List;
@@ -922,30 +923,33 @@ public class DateLiteral extends LiteralExpr {
                     case 'T': // %T Time, 24-hour (HH:mm:ss)
                         builder.appendPattern("HH:mm:ss");
                         break;
-                    case 'v': // %v Week (01..53), where Monday is the first day of the week; used with %x
+                    case 'V': // %V Week (01..53), where Sunday is the first day of the week; used with %X
                         builder.appendValue(ChronoField.ALIGNED_WEEK_OF_YEAR, 2);
                         break;
-                    case 'x':
-                    case 'Y': // %Y Year, numeric, four digits
-                        // %x Year for the week, where Monday is the first day of the week,
-                        // numeric, four digits; used with %v
-                        builder.appendValue(ChronoField.YEAR, 4);
+                    case 'v': // %v Week (01..53), where Monday is the first day of the week; used with %x
+                        builder.appendValue(IsoFields.WEEK_OF_WEEK_BASED_YEAR, 2);
                         break;
                     case 'W': // %W Weekday name (Sunday..Saturday)
                         builder.appendText(ChronoField.DAY_OF_WEEK, TextStyle.FULL);
+                        break;
+                    case 'x': // %x Year for the week where Monday is the first day of the week,
+                        builder.appendValue(IsoFields.WEEK_BASED_YEAR, 4);
+                        break;
+                    case 'X':
+                    case 'Y': // %Y Year, numeric, four digits
+                        // %X Year for the week, where Sunday is the first day of the week,
+                        // numeric, four digits; used with %v
+                        builder.appendValue(ChronoField.YEAR, 4);
                         break;
                     case 'y': // %y Year, numeric (two digits)
                         builder.appendValueReduced(ChronoField.YEAR, 2, 2, 1970);
                         break;
                     // TODO(Gabriel): support microseconds in date literal
+                    case 'D': // %D Day of the month with English suffix (0th, 1st, 2nd, 3rd, …)
                     case 'f': // %f Microseconds (000000..999999)
-                    case 'w': // %w Day of the week (0=Sunday..6=Saturday)
                     case 'U': // %U Week (00..53), where Sunday is the first day of the week
                     case 'u': // %u Week (00..53), where Monday is the first day of the week
-                    case 'V': // %V Week (01..53), where Sunday is the first day of the week; used with %X
-                    case 'X': // %X Year for the week where Sunday is the first day of the week,
-                        // numeric, four digits; used with %V
-                    case 'D': // %D Day of the month with English suffix (0th, 1st, 2nd, 3rd, …)
+                    case 'w': // %w Day of the week (0=Sunday..6=Saturday)
                         throw new AnalysisException(String.format("%%%s not supported in date format string",
                                 character));
                     case '%': // %% A literal "%" character

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/DateUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/DateUtils.java
@@ -24,6 +24,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.TextStyle;
 import java.time.temporal.ChronoField;
+import java.time.temporal.IsoFields;
 import java.time.temporal.TemporalAccessor;
 
 /**
@@ -94,33 +95,36 @@ public class DateUtils {
                     case 's': // %s Seconds (00..59)
                         builder.appendValue(ChronoField.SECOND_OF_MINUTE, 2);
                         break;
-                    case 'T': // %T Time, 24-hour (hh:mm:ss)
+                    case 'T': // %T Time, 24-hour (HH:mm:ss)
                         builder.appendPattern("HH:mm:ss");
                         break;
-                    case 'v': // %v Week (01..53), where Monday is the first day of the week; used with %x
+                    case 'V': // %V Week (01..53), where Sunday is the first day of the week; used with %X
                         builder.appendValue(ChronoField.ALIGNED_WEEK_OF_YEAR, 2);
                         break;
-                    case 'x':
-                    case 'Y': // %Y Year, numeric, four digits
-                        // %x Year for the week, where Monday is the first day of the week,
-                        // numeric, four digits; used with %v
-                        builder.appendValue(ChronoField.YEAR, 4);
+                    case 'v': // %v Week (01..53), where Monday is the first day of the week; used with %x
+                        builder.appendValue(IsoFields.WEEK_OF_WEEK_BASED_YEAR, 2);
                         break;
                     case 'W': // %W Weekday name (Sunday..Saturday)
                         builder.appendText(ChronoField.DAY_OF_WEEK, TextStyle.FULL);
+                        break;
+                    case 'x': // %x Year for the week where Monday is the first day of the week,
+                        builder.appendValue(IsoFields.WEEK_BASED_YEAR, 4);
+                        break;
+                    case 'X':
+                    case 'Y': // %Y Year, numeric, four digits
+                        // %X Year for the week, where Sunday is the first day of the week,
+                        // numeric, four digits; used with %v
+                        builder.appendValue(ChronoField.YEAR, 4);
                         break;
                     case 'y': // %y Year, numeric (two digits)
                         builder.appendValueReduced(ChronoField.YEAR, 2, 2, 1970);
                         break;
                     // TODO(Gabriel): support microseconds in date literal
+                    case 'D': // %D Day of the month with English suffix (0th, 1st, 2nd, 3rd, …)
                     case 'f': // %f Microseconds (000000..999999)
-                    case 'w': // %w Day of the week (0=Sunday..6=Saturday)
                     case 'U': // %U Week (00..53), where Sunday is the first day of the week
                     case 'u': // %u Week (00..53), where Monday is the first day of the week
-                    case 'V': // %V Week (01..53), where Sunday is the first day of the week; used with %X
-                    case 'X': // %X Year for the week where Sunday is the first day of the week,
-                        // numeric, four digits; used with %V
-                    case 'D': // %D Day of the month with English suffix (0th, 1st, 2nd, 3rd, …)
+                    case 'w': // %w Day of the week (0=Sunday..6=Saturday)
                         throw new AnalysisException(String.format("%%%s not supported in date format string",
                                 character));
                     case '%': // %% A literal "%" character

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
@@ -484,6 +484,13 @@ public class FoldConstantTest extends ExpressionRewriteTestHelper {
         Assertions.assertEquals(DateTimeExtractAndTransform.toDays(dateLiteral).toSql(), answer[answerIdx++]);
         Assertions.assertEquals(DateTimeExtractAndTransform.date(dateLiteral).toSql(), answer[answerIdx++]);
         Assertions.assertEquals(DateTimeExtractAndTransform.dateV2(dateLiteral).toSql(), answer[answerIdx]);
+
+        Assertions.assertEquals("'2021 52 2022 01'", DateTimeExtractAndTransform.dateFormat(
+                new DateLiteral("2022-01-01 00:12:42"),
+                new VarcharLiteral("%x %v %X %V")).toSql());
+        Assertions.assertEquals("'2023 18 2023 19'", DateTimeExtractAndTransform.dateFormat(
+                new DateLiteral("2023-05-07 02:41:42"),
+                new VarcharLiteral("%x %v %X %V")).toSql());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/rewrite/FEFunctionsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/rewrite/FEFunctionsTest.java
@@ -255,86 +255,92 @@ public class FEFunctionsTest {
     }
 
     @Test
-    public void dateFormatUtilTest() {
-        try {
-            Locale.setDefault(Locale.ENGLISH);
-            DateLiteral testDate = new DateLiteral("2001-01-09 13:04:05", Type.DATETIME);
-            Assert.assertEquals("Tue", FEFunctions.dateFormat(testDate, new StringLiteral("%a")).getStringValue());
-            Assert.assertEquals("Jan", FEFunctions.dateFormat(testDate, new StringLiteral("%b")).getStringValue());
-            Assert.assertEquals("1", FEFunctions.dateFormat(testDate, new StringLiteral("%c")).getStringValue());
-            Assert.assertEquals("09", FEFunctions.dateFormat(testDate, new StringLiteral("%d")).getStringValue());
-            Assert.assertEquals("9", FEFunctions.dateFormat(testDate, new StringLiteral("%e")).getStringValue());
-            Assert.assertEquals("13", FEFunctions.dateFormat(testDate, new StringLiteral("%H")).getStringValue());
-            Assert.assertEquals("01", FEFunctions.dateFormat(testDate, new StringLiteral("%h")).getStringValue());
-            Assert.assertEquals("01", FEFunctions.dateFormat(testDate, new StringLiteral("%I")).getStringValue());
-            Assert.assertEquals("04", FEFunctions.dateFormat(testDate, new StringLiteral("%i")).getStringValue());
-            Assert.assertEquals("009", FEFunctions.dateFormat(testDate, new StringLiteral("%j")).getStringValue());
-            Assert.assertEquals("13", FEFunctions.dateFormat(testDate, new StringLiteral("%k")).getStringValue());
-            Assert.assertEquals("1", FEFunctions.dateFormat(testDate, new StringLiteral("%l")).getStringValue());
-            Assert.assertEquals("January", FEFunctions.dateFormat(testDate, new StringLiteral("%M")).getStringValue());
-            Assert.assertEquals("01", FEFunctions.dateFormat(testDate, new StringLiteral("%m")).getStringValue());
-            Assert.assertEquals("PM", FEFunctions.dateFormat(testDate, new StringLiteral("%p")).getStringValue());
-            Assert.assertEquals("01:04:05 PM", FEFunctions.dateFormat(testDate,
-                    new StringLiteral("%r")).getStringValue());
-            Assert.assertEquals("05", FEFunctions.dateFormat(testDate, new StringLiteral("%S")).getStringValue());
-            Assert.assertEquals("05", FEFunctions.dateFormat(testDate, new StringLiteral("%s")).getStringValue());
-            Assert.assertEquals("13:04:05", FEFunctions.dateFormat(testDate,
-                    new StringLiteral("%T")).getStringValue());
-            Assert.assertEquals("02", FEFunctions.dateFormat(testDate, new StringLiteral("%v")).getStringValue());
-            Assert.assertEquals("Tuesday", FEFunctions.dateFormat(testDate, new StringLiteral("%W")).getStringValue());
-            Assert.assertEquals("2001", FEFunctions.dateFormat(testDate, new StringLiteral("%Y")).getStringValue());
-            Assert.assertEquals("01", FEFunctions.dateFormat(testDate, new StringLiteral("%y")).getStringValue());
-            Assert.assertEquals("%", FEFunctions.dateFormat(testDate, new StringLiteral("%%")).getStringValue());
-            Assert.assertEquals("foo", FEFunctions.dateFormat(testDate, new StringLiteral("foo")).getStringValue());
-            Assert.assertEquals("g", FEFunctions.dateFormat(testDate, new StringLiteral("%g")).getStringValue());
-            Assert.assertEquals("4", FEFunctions.dateFormat(testDate, new StringLiteral("%4")).getStringValue());
-            Assert.assertEquals("2001 02", FEFunctions.dateFormat(testDate,
-                    new StringLiteral("%x %v")).getStringValue());
-        } catch (AnalysisException e) {
-            e.printStackTrace();
-        }
+    public void dateFormatUtilTest() throws AnalysisException {
+        Locale.setDefault(Locale.ENGLISH);
+        DateLiteral testDate = new DateLiteral("2001-01-09 13:04:05", Type.DATETIME);
+        Assert.assertEquals("Tue", FEFunctions.dateFormat(testDate, new StringLiteral("%a")).getStringValue());
+        Assert.assertEquals("Jan", FEFunctions.dateFormat(testDate, new StringLiteral("%b")).getStringValue());
+        Assert.assertEquals("1", FEFunctions.dateFormat(testDate, new StringLiteral("%c")).getStringValue());
+        Assert.assertEquals("09", FEFunctions.dateFormat(testDate, new StringLiteral("%d")).getStringValue());
+        Assert.assertEquals("9", FEFunctions.dateFormat(testDate, new StringLiteral("%e")).getStringValue());
+        Assert.assertEquals("13", FEFunctions.dateFormat(testDate, new StringLiteral("%H")).getStringValue());
+        Assert.assertEquals("01", FEFunctions.dateFormat(testDate, new StringLiteral("%h")).getStringValue());
+        Assert.assertEquals("01", FEFunctions.dateFormat(testDate, new StringLiteral("%I")).getStringValue());
+        Assert.assertEquals("04", FEFunctions.dateFormat(testDate, new StringLiteral("%i")).getStringValue());
+        Assert.assertEquals("009", FEFunctions.dateFormat(testDate, new StringLiteral("%j")).getStringValue());
+        Assert.assertEquals("13", FEFunctions.dateFormat(testDate, new StringLiteral("%k")).getStringValue());
+        Assert.assertEquals("1", FEFunctions.dateFormat(testDate, new StringLiteral("%l")).getStringValue());
+        Assert.assertEquals("January", FEFunctions.dateFormat(testDate, new StringLiteral("%M")).getStringValue());
+        Assert.assertEquals("01", FEFunctions.dateFormat(testDate, new StringLiteral("%m")).getStringValue());
+        Assert.assertEquals("PM", FEFunctions.dateFormat(testDate, new StringLiteral("%p")).getStringValue());
+        Assert.assertEquals("01:04:05 PM", FEFunctions.dateFormat(testDate,
+                new StringLiteral("%r")).getStringValue());
+        Assert.assertEquals("05", FEFunctions.dateFormat(testDate, new StringLiteral("%S")).getStringValue());
+        Assert.assertEquals("05", FEFunctions.dateFormat(testDate, new StringLiteral("%s")).getStringValue());
+        Assert.assertEquals("13:04:05", FEFunctions.dateFormat(testDate,
+                new StringLiteral("%T")).getStringValue());
+        Assert.assertEquals("02", FEFunctions.dateFormat(testDate, new StringLiteral("%v")).getStringValue());
+        Assert.assertEquals("Tuesday", FEFunctions.dateFormat(testDate, new StringLiteral("%W")).getStringValue());
+        Assert.assertEquals("2001", FEFunctions.dateFormat(testDate, new StringLiteral("%Y")).getStringValue());
+        Assert.assertEquals("01", FEFunctions.dateFormat(testDate, new StringLiteral("%y")).getStringValue());
+        Assert.assertEquals("%", FEFunctions.dateFormat(testDate, new StringLiteral("%%")).getStringValue());
+        Assert.assertEquals("foo", FEFunctions.dateFormat(testDate, new StringLiteral("foo")).getStringValue());
+        Assert.assertEquals("g", FEFunctions.dateFormat(testDate, new StringLiteral("%g")).getStringValue());
+        Assert.assertEquals("4", FEFunctions.dateFormat(testDate, new StringLiteral("%4")).getStringValue());
+        Assert.assertEquals("2001 02", FEFunctions.dateFormat(testDate,
+                new StringLiteral("%x %v")).getStringValue());
+        Assert.assertEquals("Tue-Jan-1-9th-09-9-01-13-04-009-13-1-L-01-January-PM-01:04:05 PM-05-05-13:04:05-05-01-02-Tuesday-2-2001-2001-2001-01",
+                FEFunctions.dateFormat(testDate, new StringLiteral("%a-%b-%c-%D-%d-%e-%h-%H-%i-%j-%k-%l-%L-%m-%M-%p-%r-%S-%s-%T-%s-%U-%u-%V-%v-%W-%w-%X-%x-%Y-%y"))
+                        .getStringValue());
+        Assert.assertEquals("Sun-Jan-1-2nd-02-2-12-00-00-002-0-12-L-01-January-AM-12:00:00 AM-00-00-00:00:00-00-01-00-01-52-Sunday-0-2022-2021-2022-22",
+                FEFunctions.dateFormat(new DateLiteral("2022-01-02 13:04:06", Type.DATETIME),
+                                new StringLiteral("%a-%b-%c-%D-%d-%e-%h-%H-%i-%j-%k-%l-%L-%m-%M-%p-%r-%S-%s-%T-%s-%U-%u-%V-%v-%W-%w-%X-%x-%Y-%y"))
+                        .getStringValue());
     }
 
     @Test
-    public void dateV2FormatUtilTest() {
-        try {
-            Locale.setDefault(Locale.ENGLISH);
-            DateLiteral testDate = new DateLiteral("2001-01-09 13:04:05", Type.DATETIMEV2);
-            Assert.assertEquals("Tue", FEFunctions.dateFormat(testDate, new StringLiteral("%a")).getStringValue());
-            Assert.assertEquals("Jan", FEFunctions.dateFormat(testDate, new StringLiteral("%b")).getStringValue());
-            Assert.assertEquals("1", FEFunctions.dateFormat(testDate, new StringLiteral("%c")).getStringValue());
-            Assert.assertEquals("09", FEFunctions.dateFormat(testDate, new StringLiteral("%d")).getStringValue());
-            Assert.assertEquals("9", FEFunctions.dateFormat(testDate, new StringLiteral("%e")).getStringValue());
-            Assert.assertEquals("13", FEFunctions.dateFormat(testDate, new StringLiteral("%H")).getStringValue());
-            Assert.assertEquals("01", FEFunctions.dateFormat(testDate, new StringLiteral("%h")).getStringValue());
-            Assert.assertEquals("01", FEFunctions.dateFormat(testDate, new StringLiteral("%I")).getStringValue());
-            Assert.assertEquals("04", FEFunctions.dateFormat(testDate, new StringLiteral("%i")).getStringValue());
-            Assert.assertEquals("009", FEFunctions.dateFormat(testDate, new StringLiteral("%j")).getStringValue());
-            Assert.assertEquals("13", FEFunctions.dateFormat(testDate, new StringLiteral("%k")).getStringValue());
-            Assert.assertEquals("1", FEFunctions.dateFormat(testDate, new StringLiteral("%l")).getStringValue());
-            Assert.assertEquals("January", FEFunctions.dateFormat(testDate, new StringLiteral("%M")).getStringValue());
-            Assert.assertEquals("01", FEFunctions.dateFormat(testDate, new StringLiteral("%m")).getStringValue());
-            Assert.assertEquals("PM", FEFunctions.dateFormat(testDate, new StringLiteral("%p")).getStringValue());
-            Assert.assertEquals("01:04:05 PM", FEFunctions.dateFormat(testDate,
-                    new StringLiteral("%r")).getStringValue());
-            Assert.assertEquals("05", FEFunctions.dateFormat(testDate, new StringLiteral("%S")).getStringValue());
-            Assert.assertEquals("05", FEFunctions.dateFormat(testDate, new StringLiteral("%s")).getStringValue());
-            Assert.assertEquals("13:04:05", FEFunctions.dateFormat(testDate,
-                    new StringLiteral("%T")).getStringValue());
-            Assert.assertEquals("02", FEFunctions.dateFormat(testDate, new StringLiteral("%v")).getStringValue());
-            Assert.assertEquals("Tuesday", FEFunctions.dateFormat(testDate, new StringLiteral("%W")).getStringValue());
-            Assert.assertEquals("2001", FEFunctions.dateFormat(testDate, new StringLiteral("%Y")).getStringValue());
-            Assert.assertEquals("01", FEFunctions.dateFormat(testDate, new StringLiteral("%y")).getStringValue());
-            Assert.assertEquals("%", FEFunctions.dateFormat(testDate, new StringLiteral("%%")).getStringValue());
-            Assert.assertEquals("foo", FEFunctions.dateFormat(testDate, new StringLiteral("foo")).getStringValue());
-            Assert.assertEquals("g", FEFunctions.dateFormat(testDate, new StringLiteral("%g")).getStringValue());
-            Assert.assertEquals("4", FEFunctions.dateFormat(testDate, new StringLiteral("%4")).getStringValue());
-            Assert.assertEquals("2001 02", FEFunctions.dateFormat(testDate, new StringLiteral("%x %v")).getStringValue());
-            Assert.assertEquals("2001 02", FEFunctions.dateFormat(testDate,
-                    new StringLiteral("%x %v")).getStringValue());
-        } catch (AnalysisException e) {
-            e.printStackTrace();
-        }
+    public void dateV2FormatUtilTest() throws AnalysisException {
+        Locale.setDefault(Locale.ENGLISH);
+        DateLiteral testDate = new DateLiteral("2001-01-09 13:04:05", Type.DATETIMEV2);
+        Assert.assertEquals("Tue", FEFunctions.dateFormat(testDate, new StringLiteral("%a")).getStringValue());
+        Assert.assertEquals("Jan", FEFunctions.dateFormat(testDate, new StringLiteral("%b")).getStringValue());
+        Assert.assertEquals("1", FEFunctions.dateFormat(testDate, new StringLiteral("%c")).getStringValue());
+        Assert.assertEquals("09", FEFunctions.dateFormat(testDate, new StringLiteral("%d")).getStringValue());
+        Assert.assertEquals("9", FEFunctions.dateFormat(testDate, new StringLiteral("%e")).getStringValue());
+        Assert.assertEquals("13", FEFunctions.dateFormat(testDate, new StringLiteral("%H")).getStringValue());
+        Assert.assertEquals("01", FEFunctions.dateFormat(testDate, new StringLiteral("%h")).getStringValue());
+        Assert.assertEquals("01", FEFunctions.dateFormat(testDate, new StringLiteral("%I")).getStringValue());
+        Assert.assertEquals("04", FEFunctions.dateFormat(testDate, new StringLiteral("%i")).getStringValue());
+        Assert.assertEquals("009", FEFunctions.dateFormat(testDate, new StringLiteral("%j")).getStringValue());
+        Assert.assertEquals("13", FEFunctions.dateFormat(testDate, new StringLiteral("%k")).getStringValue());
+        Assert.assertEquals("1", FEFunctions.dateFormat(testDate, new StringLiteral("%l")).getStringValue());
+        Assert.assertEquals("January", FEFunctions.dateFormat(testDate, new StringLiteral("%M")).getStringValue());
+        Assert.assertEquals("01", FEFunctions.dateFormat(testDate, new StringLiteral("%m")).getStringValue());
+        Assert.assertEquals("PM", FEFunctions.dateFormat(testDate, new StringLiteral("%p")).getStringValue());
+        Assert.assertEquals("01:04:05 PM", FEFunctions.dateFormat(testDate,
+                new StringLiteral("%r")).getStringValue());
+        Assert.assertEquals("05", FEFunctions.dateFormat(testDate, new StringLiteral("%S")).getStringValue());
+        Assert.assertEquals("05", FEFunctions.dateFormat(testDate, new StringLiteral("%s")).getStringValue());
+        Assert.assertEquals("13:04:05", FEFunctions.dateFormat(testDate,
+                new StringLiteral("%T")).getStringValue());
+        Assert.assertEquals("02", FEFunctions.dateFormat(testDate, new StringLiteral("%v")).getStringValue());
+        Assert.assertEquals("Tuesday", FEFunctions.dateFormat(testDate, new StringLiteral("%W")).getStringValue());
+        Assert.assertEquals("2001", FEFunctions.dateFormat(testDate, new StringLiteral("%Y")).getStringValue());
+        Assert.assertEquals("01", FEFunctions.dateFormat(testDate, new StringLiteral("%y")).getStringValue());
+        Assert.assertEquals("%", FEFunctions.dateFormat(testDate, new StringLiteral("%%")).getStringValue());
+        Assert.assertEquals("foo", FEFunctions.dateFormat(testDate, new StringLiteral("foo")).getStringValue());
+        Assert.assertEquals("g", FEFunctions.dateFormat(testDate, new StringLiteral("%g")).getStringValue());
+        Assert.assertEquals("4", FEFunctions.dateFormat(testDate, new StringLiteral("%4")).getStringValue());
+        Assert.assertEquals("2001 02", FEFunctions.dateFormat(testDate, new StringLiteral("%x %v")).getStringValue());
+        Assert.assertEquals("2001 02", FEFunctions.dateFormat(testDate,
+                new StringLiteral("%x %v")).getStringValue());
+        Assert.assertEquals("Tue-Jan-1-9th-09-9-01-13-04-009-13-1-L-01-January-PM-01:04:05 PM-05-05-13:04:05-05-01-02-Tuesday-2-2001-2001-2001-01",
+                FEFunctions.dateFormat(testDate, new StringLiteral("%a-%b-%c-%D-%d-%e-%h-%H-%i-%j-%k-%l-%L-%m-%M-%p-%r-%S-%s-%T-%s-%U-%u-%V-%v-%W-%w-%X-%x-%Y-%y"))
+                        .getStringValue());
+        Assert.assertEquals("Sun-Jan-1-2nd-02-2-12-00-00-002-0-12-L-01-January-AM-12:00:00 AM-00-00-00:00:00-00-01-00-01-52-Sunday-0-2022-2021-2022-22",
+                FEFunctions.dateFormat(new DateLiteral("2022-01-02 13:04:06", Type.DATETIME),
+                                new StringLiteral("%a-%b-%c-%D-%d-%e-%h-%H-%i-%j-%k-%l-%L-%m-%M-%p-%r-%S-%s-%T-%s-%U-%u-%V-%v-%W-%w-%X-%x-%Y-%y"))
+                        .getStringValue());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/rewrite/FEFunctionsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/rewrite/FEFunctionsTest.java
@@ -287,15 +287,11 @@ public class FEFunctionsTest {
         Assert.assertEquals("foo", FEFunctions.dateFormat(testDate, new StringLiteral("foo")).getStringValue());
         Assert.assertEquals("g", FEFunctions.dateFormat(testDate, new StringLiteral("%g")).getStringValue());
         Assert.assertEquals("4", FEFunctions.dateFormat(testDate, new StringLiteral("%4")).getStringValue());
-        Assert.assertEquals("2001 02", FEFunctions.dateFormat(testDate,
-                new StringLiteral("%x %v")).getStringValue());
-        Assert.assertEquals("Tue-Jan-1-9th-09-9-01-13-04-009-13-1-L-01-January-PM-01:04:05 PM-05-05-13:04:05-05-01-02-Tuesday-2-2001-2001-2001-01",
-                FEFunctions.dateFormat(testDate, new StringLiteral("%a-%b-%c-%D-%d-%e-%h-%H-%i-%j-%k-%l-%L-%m-%M-%p-%r-%S-%s-%T-%s-%U-%u-%V-%v-%W-%w-%X-%x-%Y-%y"))
-                        .getStringValue());
-        Assert.assertEquals("Sun-Jan-1-2nd-02-2-12-00-00-002-0-12-L-01-January-AM-12:00:00 AM-00-00-00:00:00-00-01-00-01-52-Sunday-0-2022-2021-2022-22",
-                FEFunctions.dateFormat(new DateLiteral("2022-01-02 13:04:06", Type.DATETIME),
-                                new StringLiteral("%a-%b-%c-%D-%d-%e-%h-%H-%i-%j-%k-%l-%L-%m-%M-%p-%r-%S-%s-%T-%s-%U-%u-%V-%v-%W-%w-%X-%x-%Y-%y"))
-                        .getStringValue());
+        Assert.assertEquals("2001 02", FEFunctions.dateFormat(testDate, new StringLiteral("%x %v")).getStringValue());
+        Assert.assertEquals("2021 52 2022 01", FEFunctions.dateFormat(new DateLiteral("2022-01-02 12:04:05", Type.DATETIME),
+                new StringLiteral("%x %v %X %V")).getStringValue());
+        Assert.assertEquals("2023 18 2023 19", FEFunctions.dateFormat(new DateLiteral("2023-05-07 12:04:54", Type.DATETIME),
+                new StringLiteral("%x %v %X %V")).getStringValue());
     }
 
     @Test
@@ -332,15 +328,10 @@ public class FEFunctionsTest {
         Assert.assertEquals("g", FEFunctions.dateFormat(testDate, new StringLiteral("%g")).getStringValue());
         Assert.assertEquals("4", FEFunctions.dateFormat(testDate, new StringLiteral("%4")).getStringValue());
         Assert.assertEquals("2001 02", FEFunctions.dateFormat(testDate, new StringLiteral("%x %v")).getStringValue());
-        Assert.assertEquals("2001 02", FEFunctions.dateFormat(testDate,
-                new StringLiteral("%x %v")).getStringValue());
-        Assert.assertEquals("Tue-Jan-1-9th-09-9-01-13-04-009-13-1-L-01-January-PM-01:04:05 PM-05-05-13:04:05-05-01-02-Tuesday-2-2001-2001-2001-01",
-                FEFunctions.dateFormat(testDate, new StringLiteral("%a-%b-%c-%D-%d-%e-%h-%H-%i-%j-%k-%l-%L-%m-%M-%p-%r-%S-%s-%T-%s-%U-%u-%V-%v-%W-%w-%X-%x-%Y-%y"))
-                        .getStringValue());
-        Assert.assertEquals("Sun-Jan-1-2nd-02-2-12-00-00-002-0-12-L-01-January-AM-12:00:00 AM-00-00-00:00:00-00-01-00-01-52-Sunday-0-2022-2021-2022-22",
-                FEFunctions.dateFormat(new DateLiteral("2022-01-02 13:04:06", Type.DATETIME),
-                                new StringLiteral("%a-%b-%c-%D-%d-%e-%h-%H-%i-%j-%k-%l-%L-%m-%M-%p-%r-%S-%s-%T-%s-%U-%u-%V-%v-%W-%w-%X-%x-%Y-%y"))
-                        .getStringValue());
+        Assert.assertEquals("2021 52 2022 01", FEFunctions.dateFormat(new DateLiteral("2022-01-02 12:04:05", Type.DATETIME),
+                new StringLiteral("%x %v %X %V")).getStringValue());
+        Assert.assertEquals("2023 18 2023 19", FEFunctions.dateFormat(new DateLiteral("2023-05-07 12:04:54", Type.DATETIME),
+                new StringLiteral("%x %v %X %V")).getStringValue());
     }
 
     @Test
@@ -395,6 +386,10 @@ public class FEFunctionsTest {
                     new StringLiteral("2013-05-17 08:07:05 PM"), new StringLiteral("%Y-%m-%d %r")).getStringValue());
             Assert.assertEquals("2013-05-17 08:07:05", FEFunctions.dateParse(new StringLiteral("2013-05-17 08:07:05"),
                     new StringLiteral("%Y-%m-%d %T")).getStringValue());
+            Assert.assertEquals("2021 52 2022 01", FEFunctions.dateFormat(new DateLiteral("2022-01-01 00:12:42", Type.DATETIMEV2),
+                    new StringLiteral("%x %v %X %V")).getStringValue());
+            Assert.assertEquals("2023 18 2023 19", FEFunctions.dateFormat(new DateLiteral("2023-05-07 02:41:42", Type.DATETIMEV2),
+                    new StringLiteral("%x %v %X %V")).getStringValue());
         } catch (AnalysisException e) {
             e.printStackTrace();
             Assert.fail("Junit test dateParse fail");


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

MySQL datetime format rule is not corresponding to the Java8 DateTimeFormatter, so we use ChronoFields and IsoFields to handle week start on Monday and Sunday.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

