### PR TITLE
[fix](sink) fix END_OF_FILE error for pipeline caused by VDataStreamSender eof

### DIFF
--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -286,7 +286,11 @@ public:
     Status sink(RuntimeState* state, vectorized::Block* in_block,
                 SourceState source_state) override {
         if (in_block->rows() > 0) {
-            return _sink->send(state, in_block, source_state == SourceState::FINISHED);
+            auto st = _sink->send(state, in_block, source_state == SourceState::FINISHED);
+            if (st.template is<ErrorCode::END_OF_FILE>()) {
+                return Status::OK();
+            }
+            return st;
         }
         return Status::OK();
     }

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -287,6 +287,7 @@ public:
                 SourceState source_state) override {
         if (in_block->rows() > 0) {
             auto st = _sink->send(state, in_block, source_state == SourceState::FINISHED);
+            // TODO: improvement: if sink returned END_OF_FILE, pipeline task can be finished
             if (st.template is<ErrorCode::END_OF_FILE>()) {
                 return Status::OK();
             }

--- a/be/src/vec/sink/vresult_file_sink.cpp
+++ b/be/src/vec/sink/vresult_file_sink.cpp
@@ -179,10 +179,9 @@ Status VResultFileSink::close(RuntimeState* state, Status exec_status) {
     } else {
         if (final_status.ok()) {
             auto st = _stream_sender->send(state, _output_block.get(), true);
-            if (st.template is<ErrorCode::END_OF_FILE>()) {
-                return Status::OK();
+            if (!st.template is<ErrorCode::END_OF_FILE>()) {
+                RETURN_IF_ERROR(st);
             }
-            RETURN_IF_ERROR(st);
         }
         RETURN_IF_ERROR(_stream_sender->close(state, final_status));
         _output_block->clear();

--- a/be/src/vec/sink/vresult_file_sink.cpp
+++ b/be/src/vec/sink/vresult_file_sink.cpp
@@ -178,7 +178,11 @@ Status VResultFileSink::close(RuntimeState* state, Status exec_status) {
                 state->fragment_instance_id());
     } else {
         if (final_status.ok()) {
-            RETURN_IF_ERROR(_stream_sender->send(state, _output_block.get(), true));
+            auto st = _stream_sender->send(state, _output_block.get(), true);
+            if (st.template is<ErrorCode::END_OF_FILE>()) {
+                return Status::OK();
+            }
+            RETURN_IF_ERROR(st);
         }
         RETURN_IF_ERROR(_stream_sender->close(state, final_status));
         _output_block->clear();


### PR DESCRIPTION

# Proposed changes

Issue Number: close #xxx

## Problem summary

Fix bug of #19847. Some test case fail with error "CANCELLED][END_OF_FILE]all data stream channels EOF"

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

