### PR TITLE
[Fix](multi catalog, metadata)Init logType in ExternalCatalog while replay meta data to avoid NPE. Remove type variable in ExternaCatalog

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/EsExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/EsExternalCatalog.java
@@ -49,7 +49,6 @@ public class EsExternalCatalog extends ExternalCatalog {
      */
     public EsExternalCatalog(long catalogId, String name, String resource, Map<String, String> props) {
         super(catalogId, name, InitCatalogLog.Type.ES);
-        this.type = "es";
         this.catalogProperty = new CatalogProperty(resource, processCompatibleProperties(props));
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
@@ -71,7 +71,6 @@ public class HMSExternalCatalog extends ExternalCatalog {
      */
     public HMSExternalCatalog(long catalogId, String name, String resource, Map<String, String> props) {
         super(catalogId, name, InitCatalogLog.Type.HMS);
-        this.type = "hms";
         props = PropertyConverter.convertToMetaProperties(props);
         catalogProperty = new CatalogProperty(resource, props);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/JdbcExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/JdbcExternalCatalog.java
@@ -50,7 +50,6 @@ public class JdbcExternalCatalog extends ExternalCatalog {
     public JdbcExternalCatalog(long catalogId, String name, String resource, Map<String, String> props)
             throws DdlException {
         super(catalogId, name, InitCatalogLog.Type.JDBC);
-        this.type = "jdbc";
         this.catalogProperty = new CatalogProperty(resource, processCompatibleProperties(props));
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/MaxComputeExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/MaxComputeExternalCatalog.java
@@ -38,7 +38,6 @@ public class MaxComputeExternalCatalog extends ExternalCatalog {
 
     public MaxComputeExternalCatalog(long catalogId, String name, String resource, Map<String, String> props) {
         super(catalogId, name, InitCatalogLog.Type.MAX_COMPUTE);
-        this.type = "max_compute";
         catalogProperty = new CatalogProperty(resource, props);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergExternalCatalog.java
@@ -51,7 +51,6 @@ public abstract class IcebergExternalCatalog extends ExternalCatalog {
 
     public IcebergExternalCatalog(long catalogId, String name) {
         super(catalogId, name, InitCatalogLog.Type.ICEBERG);
-        this.type = "iceberg";
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/test/TestExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/test/TestExternalCatalog.java
@@ -43,7 +43,6 @@ public class TestExternalCatalog extends ExternalCatalog {
 
     public TestExternalCatalog(long catalogId, String name, String resource, Map<String, String> props) {
         super(catalogId, name, InitCatalogLog.Type.TEST);
-        this.type = "test";
         this.catalogProperty = new CatalogProperty(resource, props);
         Class<?> providerClazz = null;
         try {


### PR DESCRIPTION
The variable `logType` (introduced in PR https://github.com/apache/doris/pull/19606/files) in ExternalCatalog is not persistent to disk, after refresh, it will be set to NULL and cause NPE. This pr is to fix the bug.
Also, remove the old `type` variable in ExternaCatalog, use `logType` instead.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

