### PR TITLE
[fix](StorageEngine) release DataDir after the thread pool has been shutdown

### DIFF
--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -140,7 +140,6 @@ StorageEngine::StorageEngine(const EngineOptions& options)
 
 StorageEngine::~StorageEngine() {
     DEREGISTER_HOOK_METRIC(unused_rowsets_count);
-    _clear();
 
     if (_base_compaction_thread_pool) {
         _base_compaction_thread_pool->shutdown();
@@ -155,6 +154,7 @@ StorageEngine::~StorageEngine() {
     if (_tablet_meta_checkpoint_thread_pool) {
         _tablet_meta_checkpoint_thread_pool->shutdown();
     }
+    _clear();
     _s_instance = nullptr;
 }
 


### PR DESCRIPTION
# Proposed changes

release `DataDir` in `_store_map` of `StorageEngine` after the thread pool has been shutdown, or the worker thread in threadpool `_cumu_compaction_thread_pool` may use `DataDir`  in `Compaction::do_compaction()` after it has been deleted

## Problem summary

Describe your changes.

## Checklist(Required)

* [x] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

