### PR TITLE
[Fix](inverted index) fix memeory leak when inverted index writer do not finish correctly

### DIFF
--- a/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
@@ -159,7 +159,8 @@ public:
             // ANALYSER_NOT_SET, ANALYSER_NONE use default SimpleAnalyzer
             _analyzer = std::make_unique<lucene::analysis::SimpleAnalyzer<TCHAR>>();
         }
-        _index_writer = std::make_unique<lucene::index::IndexWriter>(_dir.get(), _analyzer.get(), create, true);
+        _index_writer = std::make_unique<lucene::index::IndexWriter>(_dir.get(), _analyzer.get(),
+                                                                     create, true);
         _index_writer->setMaxBufferedDocs(MAX_BUFFER_DOCS);
         _index_writer->setRAMBufferSizeMB(config::inverted_index_ram_buffer_size);
         _index_writer->setMaxFieldLength(MAX_FIELD_LEN);

--- a/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
@@ -85,7 +85,26 @@ public:
         _field_name = std::wstring(field_name.begin(), field_name.end());
     }
 
-    ~InvertedIndexColumnWriterImpl() override = default;
+    ~InvertedIndexColumnWriterImpl() override {
+        // The close function is expected to be called when the column writer finishes its operations.
+        // If it's not called, it indicates that an unexpected event has occurred.
+        // This destructor checks if the close() function has been called. If not, it attempts to release memory.
+        if (_index_writer) {
+            _CLDELETE(_index_writer)
+        }
+
+        if (_doc) {
+            _CLDELETE(_doc)
+        }
+
+        if (_analyzer) {
+            _CLDELETE(_analyzer)
+        }
+
+        if (_char_string_reader) {
+            _CLDELETE(_char_string_reader)
+        }
+    };
 
     Status init() override {
         try {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

The close function in invertedIndex writer is expected to be called when the column writer finished. If it's not called, it indicates that an unexpected event has occurred. In this situation, inverted index writer's destructor needs to check if the close() function has been called. If not, it attempts to release memory.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

