### PR TITLE
[fix](publish) dot use wait_for for publish synchorization

### DIFF
--- a/be/src/olap/task/engine_publish_version_task.cpp
+++ b/be/src/olap/task/engine_publish_version_task.cpp
@@ -47,7 +47,8 @@ using std::map;
 EnginePublishVersionTask::EnginePublishVersionTask(TPublishVersionRequest& publish_version_req,
                                                    std::vector<TTabletId>* error_tablet_ids,
                                                    std::vector<TTabletId>* succ_tablet_ids)
-        : _publish_version_req(publish_version_req),
+        : _total_task_num(0),
+          _publish_version_req(publish_version_req),
           _error_tablet_ids(error_tablet_ids),
           _succ_tablet_ids(succ_tablet_ids) {}
 
@@ -62,13 +63,17 @@ void EnginePublishVersionTask::add_succ_tablet_id(int64_t tablet_id) {
 }
 
 void EnginePublishVersionTask::wait() {
-    std::unique_lock<std::mutex> lock(_tablet_finish_sleep_mutex);
-    _tablet_finish_sleep_cond.wait_for(lock, std::chrono::milliseconds(10));
+    std::unique_lock<std::mutex> lock(_tablet_finish_mutex);
+    _tablet_finish_cond.wait(lock);
 }
 
 void EnginePublishVersionTask::notify() {
-    std::unique_lock<std::mutex> lock(_tablet_finish_sleep_mutex);
-    _tablet_finish_sleep_cond.notify_one();
+    std::unique_lock<std::mutex> lock(_tablet_finish_mutex);
+    _tablet_finish_cond.notify_one();
+}
+
+int64_t EnginePublishVersionTask::finish_task() {
+    return _total_task_num.fetch_sub(1);
 }
 
 Status EnginePublishVersionTask::finish() {
@@ -78,7 +83,6 @@ Status EnginePublishVersionTask::finish() {
     VLOG_NOTICE << "begin to process publish version. transaction_id=" << transaction_id;
 
     // each partition
-    std::atomic<int64_t> total_task_num(0);
     for (auto& par_ver_info : _publish_version_req.partition_version_infos) {
         int64_t partition_id = par_ver_info.partition_id;
         // get all partition related tablets and check whether the tablet have the related version
@@ -154,10 +158,9 @@ Status EnginePublishVersionTask::finish() {
                     continue;
                 }
             }
-            total_task_num.fetch_add(1);
+            _total_task_num.fetch_add(1);
             auto tablet_publish_txn_ptr = std::make_shared<TabletPublishTxnTask>(
-                    this, tablet, rowset, partition_id, transaction_id, version, tablet_info,
-                    &total_task_num);
+                    this, tablet, rowset, partition_id, transaction_id, version, tablet_info);
             auto submit_st =
                     StorageEngine::instance()->tablet_publish_txn_thread_pool()->submit_func(
                             [=]() { tablet_publish_txn_ptr->handle(); });
@@ -165,7 +168,7 @@ Status EnginePublishVersionTask::finish() {
         }
     }
     // wait for all publish txn finished
-    while (total_task_num.load() != 0) {
+    while (_total_task_num.load() != 0) {
         wait();
     }
 
@@ -209,20 +212,18 @@ Status EnginePublishVersionTask::finish() {
 TabletPublishTxnTask::TabletPublishTxnTask(EnginePublishVersionTask* engine_task,
                                            TabletSharedPtr tablet, RowsetSharedPtr rowset,
                                            int64_t partition_id, int64_t transaction_id,
-                                           Version version, const TabletInfo& tablet_info,
-                                           std::atomic<int64_t>* total_task_num)
+                                           Version version, const TabletInfo& tablet_info)
         : _engine_publish_version_task(engine_task),
           _tablet(tablet),
           _rowset(rowset),
           _partition_id(partition_id),
           _transaction_id(transaction_id),
           _version(version),
-          _tablet_info(tablet_info),
-          _total_task_num(total_task_num) {}
+          _tablet_info(tablet_info) {}
 
 void TabletPublishTxnTask::handle() {
     Defer defer {[&] {
-        if (_total_task_num->fetch_sub(1) == 1) {
+        if (_engine_publish_version_task->finish_task() == 1) {
             _engine_publish_version_task->notify();
         }
     }};

--- a/be/src/olap/task/engine_publish_version_task.h
+++ b/be/src/olap/task/engine_publish_version_task.h
@@ -41,8 +41,7 @@ class TabletPublishTxnTask {
 public:
     TabletPublishTxnTask(EnginePublishVersionTask* engine_task, TabletSharedPtr tablet,
                          RowsetSharedPtr rowset, int64_t partition_id, int64_t transaction_id,
-                         Version version, const TabletInfo& tablet_info,
-                         std::atomic<int64_t>* total_task_num);
+                         Version version, const TabletInfo& tablet_info);
     ~TabletPublishTxnTask() {}
 
     void handle();
@@ -56,8 +55,6 @@ private:
     int64_t _transaction_id;
     Version _version;
     TabletInfo _tablet_info;
-
-    std::atomic<int64_t>* _total_task_num;
 };
 
 class EnginePublishVersionTask : public EngineTask {
@@ -75,14 +72,17 @@ public:
     void notify();
     void wait();
 
+    int64_t finish_task();
+
 private:
+    std::atomic<int64_t> _total_task_num;
     const TPublishVersionRequest& _publish_version_req;
     std::mutex _tablet_ids_mutex;
     vector<TTabletId>* _error_tablet_ids;
     vector<TTabletId>* _succ_tablet_ids;
 
-    std::mutex _tablet_finish_sleep_mutex;
-    std::condition_variable _tablet_finish_sleep_cond;
+    std::mutex _tablet_finish_mutex;
+    std::condition_variable _tablet_finish_cond;
 };
 
 } // namespace doris


### PR DESCRIPTION
When waiting thread reaches timeout and wait_num is zero then it goes ahead and free this(PublishVersionTask), however another thread may use it via notify.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

