### PR TITLE
[test](pipline)Adjust mem limit to 50% for regression

### DIFF
--- a/regression-test/pipeline/p0/conf/be.conf
+++ b/regression-test/pipeline/p0/conf/be.conf
@@ -26,7 +26,7 @@ webserver_port = 8141
 heartbeat_service_port = 9151
 brpc_port = 8161
 
-mem_limit = 33%
+mem_limit = 50%
 disable_minidump = true
 path_gc_check_interval_second=1
 max_garbage_sweep_interval=180

--- a/regression-test/pipeline/p1/conf/be.conf
+++ b/regression-test/pipeline/p1/conf/be.conf
@@ -26,7 +26,7 @@ webserver_port = 8142
 heartbeat_service_port = 9152
 brpc_port = 8162
 
-mem_limit = 33%
+mem_limit = 50%
 disable_minidump = true
 path_gc_check_interval_second=1
 max_garbage_sweep_interval=180


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

load tasks of teamcity regression pipeline are cancelled because of over memory limit recently, so adjust mem limit of be.conf to 50%

## Checklist(Required)

* [NO ] Does it affect the original behavior
* [NO NEED] Has unit tests been added
* [NO NEED] Has document been added or modified
* [NO ] Does it need to update dependencies
* [YES] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

