### PR TITLE
[fix](odbc) fix odbc connection may fall in dead lock because of wrong abort transaction

### DIFF
--- a/be/src/exec/odbc_connector.cpp
+++ b/be/src/exec/odbc_connector.cpp
@@ -61,6 +61,7 @@ ODBCConnector::ODBCConnector(const ODBCConnectorParam& param)
           _tuple_desc(param.tuple_desc),
           _output_expr_ctxs(param.output_expr_ctxs),
           _is_open(false),
+          _is_in_transaction(false),
           _field_num(0),
           _env(nullptr),
           _dbc(nullptr),


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

