### PR TITLE
 [Improve](performance) introduce SchemaCache to cache TabletSchame & Schema

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1000,6 +1000,8 @@ DEFINE_mInt32(s3_write_buffer_whole_size, "524288000");
 
 //disable shrink memory by default
 DEFINE_Bool(enable_shrink_memory, "false");
+DEFINE_mInt32(schema_cache_cacity, "1024");
+DEFINE_mInt32(schema_cache_sweep_time_sec, "100");
 
 // enable feature binlog, default false
 DEFINE_Bool(enable_feature_binlog, "false");

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1000,7 +1000,7 @@ DEFINE_mInt32(s3_write_buffer_whole_size, "524288000");
 
 //disable shrink memory by default
 DEFINE_Bool(enable_shrink_memory, "false");
-DEFINE_mInt32(schema_cache_cacity, "1024");
+DEFINE_mInt32(schema_cache_capacity, "1024");
 DEFINE_mInt32(schema_cache_sweep_time_sec, "100");
 
 // enable feature binlog, default false

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1013,9 +1013,11 @@ DECLARE_mInt32(s3_write_buffer_size);
 // can at most buffer 50MB data. And the num of multi part upload task is
 // s3_write_buffer_whole_size / s3_write_buffer_size
 DECLARE_mInt32(s3_write_buffer_whole_size);
-
 //enable shrink memory
 DECLARE_Bool(enable_shrink_memory);
+// enable cache for high concurrent point query work load
+DECLARE_mInt32(schema_cache_cacity);
+DECLARE_mInt32(schema_cache_sweep_time_sec);
 
 // enable binlog
 DECLARE_Bool(enable_feature_binlog);

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1016,7 +1016,7 @@ DECLARE_mInt32(s3_write_buffer_whole_size);
 //enable shrink memory
 DECLARE_Bool(enable_shrink_memory);
 // enable cache for high concurrent point query work load
-DECLARE_mInt32(schema_cache_cacity);
+DECLARE_mInt32(schema_cache_capacity);
 DECLARE_mInt32(schema_cache_sweep_time_sec);
 
 // enable binlog

--- a/be/src/olap/CMakeLists.txt
+++ b/be/src/olap/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(Olap STATIC
     null_predicate.cpp
     olap_meta.cpp
     olap_server.cpp
+    schema_cache.cpp
     options.cpp
     page_cache.cpp
     push_handler.cpp

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -17,9 +17,11 @@
 
 #include "beta_rowset_reader.h"
 
+#include <gen_cpp/PaloInternalService_types.h>
 #include <stddef.h>
 
 #include <algorithm>
+#include <memory>
 #include <ostream>
 #include <roaring/roaring.hh>
 #include <set>
@@ -28,6 +30,7 @@
 #include <utility>
 
 #include "common/logging.h"
+#include "common/status.h"
 #include "io/io_common.h"
 #include "olap/block_column_predicate.h"
 #include "olap/column_predicate.h"
@@ -38,6 +41,7 @@
 #include "olap/rowset/rowset_reader_context.h"
 #include "olap/rowset/segment_v2/segment.h"
 #include "olap/schema.h"
+#include "olap/schema_cache.h"
 #include "olap/tablet_meta.h"
 #include "olap/tablet_schema.h"
 #include "util/runtime_profile.h"
@@ -124,7 +128,13 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
         }
     }
     VLOG_NOTICE << "read columns size: " << read_columns.size();
-    _input_schema = std::make_shared<Schema>(_context->tablet_schema->columns(), read_columns);
+    std::string schema_key =
+            SchemaCache::get_schema_key(_read_options.tablet_id, _context->tablet_schema,
+                                        read_columns, SchemaCache::Type::SCHEMA);
+    if ((_input_schema = SchemaCache::instance()->get_schema<SchemaSPtr>(schema_key)) == nullptr) {
+        _input_schema = std::make_shared<Schema>(_context->tablet_schema->columns(), read_columns);
+        SchemaCache::instance()->insert_schema(schema_key, _input_schema);
+    }
 
     if (read_context->predicates != nullptr) {
         _read_options.column_predicates.insert(_read_options.column_predicates.end(),
@@ -207,7 +217,7 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
     for (int i = seg_start; i < seg_end; i++) {
         auto& seg_ptr = segments[i];
         std::unique_ptr<RowwiseIterator> iter;
-        auto s = seg_ptr->new_iterator(*_input_schema, _read_options, &iter);
+        auto s = seg_ptr->new_iterator(_input_schema, _read_options, &iter);
         if (!s.ok()) {
             LOG(WARNING) << "failed to create iterator[" << seg_ptr->id() << "]: " << s.to_string();
             return Status::Error<ROWSET_READER_INIT>();
@@ -224,6 +234,7 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
 Status BetaRowsetReader::init(RowsetReaderContext* read_context,
                               const std::pair<int, int>& segment_offset) {
     _context = read_context;
+    _context->rowset_id = _rowset->rowset_id();
     std::vector<RowwiseIteratorUPtr> iterators;
     RETURN_IF_ERROR(get_segment_iterators(_context, &iterators, segment_offset));
 
@@ -309,4 +320,5 @@ Status BetaRowsetReader::get_segment_num_rows(std::vector<uint32_t>* segment_num
     }
     return Status::OK();
 }
+
 } // namespace doris

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -17,7 +17,6 @@
 
 #include "beta_rowset_reader.h"
 
-#include <gen_cpp/PaloInternalService_types.h>
 #include <stddef.h>
 
 #include <algorithm>

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -128,9 +128,9 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
         }
     }
     VLOG_NOTICE << "read columns size: " << read_columns.size();
-    std::string schema_key =
-            SchemaCache::get_schema_key(_read_options.tablet_id, _context->tablet_schema,
-                                        read_columns, SchemaCache::Type::SCHEMA);
+    std::string schema_key = SchemaCache::get_schema_key(
+            _read_options.tablet_id, _context->tablet_schema, read_columns,
+            _context->tablet_schema->schema_version(), SchemaCache::Type::SCHEMA);
     if ((_input_schema = SchemaCache::instance()->get_schema<SchemaSPtr>(schema_key)) == nullptr) {
         _input_schema = std::make_shared<Schema>(_context->tablet_schema->columns(), read_columns);
         SchemaCache::instance()->insert_schema(schema_key, _input_schema);

--- a/be/src/olap/rowset/beta_rowset_reader.h
+++ b/be/src/olap/rowset/beta_rowset_reader.h
@@ -30,6 +30,7 @@
 #include "olap/rowset/beta_rowset.h"
 #include "olap/rowset/rowset.h"
 #include "olap/rowset/rowset_reader.h"
+#include "olap/schema.h"
 #include "olap/segment_loader.h"
 #include "vec/core/block.h"
 
@@ -87,7 +88,7 @@ public:
 private:
     bool _should_push_down_value_predicates() const;
 
-    std::shared_ptr<Schema> _input_schema;
+    SchemaSPtr _input_schema;
     RowsetReaderContext* _context;
     BetaRowsetSharedPtr _rowset;
 

--- a/be/src/olap/rowset/rowset_reader_context.h
+++ b/be/src/olap/rowset/rowset_reader_context.h
@@ -79,6 +79,7 @@ struct RowsetReaderContext {
     bool is_vertical_compaction = false;
     bool is_key_column_group = false;
     const std::set<int32_t>* output_columns = nullptr;
+    RowsetId rowset_id;
 };
 
 } // namespace doris

--- a/be/src/olap/rowset/segcompaction.cpp
+++ b/be/src/olap/rowset/segcompaction.cpp
@@ -79,7 +79,7 @@ Status SegcompactionWorker::_get_segcompaction_reader(
     std::vector<std::unique_ptr<RowwiseIterator>> seg_iterators;
     for (auto& seg_ptr : *segments) {
         std::unique_ptr<RowwiseIterator> iter;
-        auto s = seg_ptr->new_iterator(*schema, read_options, &iter);
+        auto s = seg_ptr->new_iterator(schema, read_options, &iter);
         if (!s.ok()) {
             LOG(WARNING) << "failed to create iterator[" << seg_ptr->id() << "]: " << s.to_string();
             return Status::Error<INIT_FAILED>();

--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -19,7 +19,6 @@
 
 #include <assert.h>
 #include <gen_cpp/segment_v2.pb.h>
-#include <glog/logging.h>
 
 #include <algorithm>
 #include <memory>

--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -19,8 +19,10 @@
 
 #include <assert.h>
 #include <gen_cpp/segment_v2.pb.h>
+#include <glog/logging.h>
 
 #include <algorithm>
+#include <memory>
 #include <ostream>
 #include <set>
 
@@ -259,7 +261,7 @@ Status ColumnReader::read_page(const ColumnIteratorOptions& iter_opts, const Pag
 
 Status ColumnReader::get_row_ranges_by_zone_map(
         const AndBlockColumnPredicate* col_predicates,
-        std::vector<const ColumnPredicate*>* delete_predicates, RowRanges* row_ranges) {
+        const std::vector<const ColumnPredicate*>* delete_predicates, RowRanges* row_ranges) {
     RETURN_IF_ERROR(_ensure_index_loaded());
 
     std::vector<uint32_t> page_indexes;
@@ -353,9 +355,10 @@ bool ColumnReader::_zone_map_match_condition(const ZoneMapPB& zone_map,
     return col_predicates->evaluate_and({min_value_container, max_value_container});
 }
 
-Status ColumnReader::_get_filtered_pages(const AndBlockColumnPredicate* col_predicates,
-                                         std::vector<const ColumnPredicate*>* delete_predicates,
-                                         std::vector<uint32_t>* page_indexes) {
+Status ColumnReader::_get_filtered_pages(
+        const AndBlockColumnPredicate* col_predicates,
+        const std::vector<const ColumnPredicate*>* delete_predicates,
+        std::vector<uint32_t>* page_indexes) {
     FieldType type = _type_info->type();
     const std::vector<ZoneMapPB>& zone_maps = _zone_map_index->page_zone_maps();
     int32_t page_size = _zone_map_index->num_pages();
@@ -764,7 +767,7 @@ Status OffsetFileColumnIterator::next_batch(size_t* n, vectorized::MutableColumn
 
 Status OffsetFileColumnIterator::_peek_one_offset(ordinal_t* offset) {
     if (_offset_iterator->get_current_page()->has_remaining()) {
-        PageDecoder* offset_page_decoder = _offset_iterator->get_current_page()->data_decoder;
+        PageDecoder* offset_page_decoder = _offset_iterator->get_current_page()->data_decoder.get();
         vectorized::MutableColumnPtr offset_col = vectorized::ColumnUInt64::create();
         size_t n = 1;
         RETURN_IF_ERROR(offset_page_decoder->peek_next_batch(&n, offset_col)); // not null
@@ -1131,7 +1134,7 @@ Status FileColumnIterator::_read_data_page(const OrdinalPageIndexIterator& iter)
     // note that concurrent iterators for the same column won't repeatedly read dictionary page
     // because of page cache.
     if (_reader->encoding_info()->encoding() == DICT_ENCODING) {
-        auto dict_page_decoder = reinterpret_cast<BinaryDictPageDecoder*>(_page.data_decoder);
+        auto dict_page_decoder = reinterpret_cast<BinaryDictPageDecoder*>(_page.data_decoder.get());
         if (dict_page_decoder->is_dict_encoding()) {
             if (_dict_decoder == nullptr) {
                 // read dictionary page
@@ -1161,7 +1164,7 @@ Status FileColumnIterator::_read_data_page(const OrdinalPageIndexIterator& iter)
 
 Status FileColumnIterator::get_row_ranges_by_zone_map(
         const AndBlockColumnPredicate* col_predicates,
-        std::vector<const ColumnPredicate*>* delete_predicates, RowRanges* row_ranges) {
+        const std::vector<const ColumnPredicate*>* delete_predicates, RowRanges* row_ranges) {
     if (_reader->has_zone_map()) {
         RETURN_IF_ERROR(
                 _reader->get_row_ranges_by_zone_map(col_predicates, delete_predicates, row_ranges));

--- a/be/src/olap/rowset/segment_v2/column_reader.h
+++ b/be/src/olap/rowset/segment_v2/column_reader.h
@@ -34,7 +34,6 @@
 #include "io/fs/file_reader_writer_fwd.h"
 #include "io/io_common.h"
 #include "olap/olap_common.h"
-#include "olap/rowset/segment_v2/bloom_filter.h"
 #include "olap/rowset/segment_v2/common.h"
 #include "olap/rowset/segment_v2/ordinal_page_index.h" // for OrdinalPageIndexIterator
 #include "olap/rowset/segment_v2/page_handle.h"        // for PageHandle
@@ -308,8 +307,6 @@ public:
     }
 
     virtual bool is_all_dict_encoding() const { return false; }
-
-    virtual void clear() {};
 
 protected:
     ColumnIteratorOptions _opts;
@@ -586,8 +583,6 @@ public:
 
     ordinal_t get_current_ordinal() const override { return _current_rowid; }
 
-    void clear() override { _current_rowid = 0; }
-
 private:
     rowid_t _current_rowid = 0;
     int32_t _tablet_id = 0;
@@ -639,8 +634,6 @@ public:
 
     static void insert_default_data(const TypeInfo* type_info, size_t type_size, void* mem_value,
                                     vectorized::MutableColumnPtr& dst, size_t n);
-
-    void clear() override { _current_rowid = 0; }
 
 private:
     void _insert_many_default(vectorized::MutableColumnPtr& dst, size_t n);

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -22,9 +22,12 @@
 #include <gen_cpp/segment_v2.pb.h>
 #include <string.h>
 
+#include <algorithm>
 #include <memory>
 #include <utility>
 
+#include "common/logging.h"
+#include "common/status.h"
 #include "io/fs/file_reader.h"
 #include "io/fs/file_system.h"
 #include "io/io_common.h"
@@ -32,12 +35,17 @@
 #include "olap/column_predicate.h"
 #include "olap/iterators.h"
 #include "olap/primary_key_index.h"
+#include "olap/rowset/beta_rowset_reader.h"
+#include "olap/rowset/rowset_reader_context.h"
+#include "olap/rowset/segment_v2/bloom_filter.h"
 #include "olap/rowset/segment_v2/empty_segment_iterator.h"
 #include "olap/rowset/segment_v2/indexed_column_reader.h"
 #include "olap/rowset/segment_v2/page_io.h"
 #include "olap/rowset/segment_v2/page_pointer.h"
 #include "olap/rowset/segment_v2/segment_iterator.h"
 #include "olap/rowset/segment_v2/segment_writer.h" // k_segment_magic_length
+#include "olap/schema.h"
+#include "olap/schema_cache.h"
 #include "olap/short_key_index.h"
 #include "olap/storage_engine.h"
 #include "olap/tablet_schema.h"
@@ -110,7 +118,7 @@ Status Segment::_open() {
     return Status::OK();
 }
 
-Status Segment::new_iterator(const Schema& schema, const StorageReadOptions& read_options,
+Status Segment::new_iterator(SchemaSPtr schema, const StorageReadOptions& read_options,
                              std::unique_ptr<RowwiseIterator>* iter) {
     read_options.stats->total_segment_number++;
     // trying to prune the current segment by segment-level zone map
@@ -127,7 +135,7 @@ Status Segment::new_iterator(const Schema& schema, const StorageReadOptions& rea
         if (read_options.col_id_to_predicates.count(column_id) > 0 &&
             !_column_readers.at(uid)->match_condition(entry.second.get())) {
             // any condition not satisfied, return.
-            iter->reset(new EmptySegmentIterator(schema));
+            iter->reset(new EmptySegmentIterator(*schema));
             read_options.stats->filtered_segment_number++;
             return Status::OK();
         }
@@ -144,7 +152,7 @@ Status Segment::new_iterator(const Schema& schema, const StorageReadOptions& rea
             and_predicate.add_column_predicate(single_predicate);
             if (!_column_readers.at(uid)->match_condition(&and_predicate)) {
                 // any condition not satisfied, return.
-                iter->reset(new EmptySegmentIterator(schema));
+                iter->reset(new EmptySegmentIterator(*schema));
                 read_options.stats->filtered_segment_number++;
                 return Status::OK();
             }
@@ -154,7 +162,7 @@ Status Segment::new_iterator(const Schema& schema, const StorageReadOptions& rea
     RETURN_IF_ERROR(load_index());
     if (read_options.delete_condition_predicates->num_of_column_predicate() == 0 &&
         read_options.push_down_agg_type_opt != TPushAggOp::NONE) {
-        iter->reset(vectorized::new_vstatistics_iterator(this->shared_from_this(), schema));
+        iter->reset(vectorized::new_vstatistics_iterator(this->shared_from_this(), *schema));
     } else {
         iter->reset(new SegmentIterator(this->shared_from_this(), schema));
     }
@@ -297,7 +305,8 @@ Status Segment::_create_column_readers() {
 // in the new schema column c's cid == 2
 // but in the old schema column b's cid == 2
 // but they are not the same column
-Status Segment::new_column_iterator(const TabletColumn& tablet_column, ColumnIterator** iter) {
+Status Segment::new_column_iterator(const TabletColumn& tablet_column,
+                                    std::unique_ptr<ColumnIterator>* iter) {
     if (_column_readers.count(tablet_column.unique_id()) < 1) {
         if (!tablet_column.has_default_value() && !tablet_column.is_nullable()) {
             return Status::InternalError("invalid nonexistent column without default value.");
@@ -311,18 +320,24 @@ Status Segment::new_column_iterator(const TabletColumn& tablet_column, ColumnIte
         ColumnIteratorOptions iter_opts;
 
         RETURN_IF_ERROR(default_value_iter->init(iter_opts));
-        *iter = default_value_iter.release();
+        *iter = std::move(default_value_iter);
         return Status::OK();
     }
-    return _column_readers.at(tablet_column.unique_id())->new_iterator(iter);
+    ColumnIterator* it;
+    RETURN_IF_ERROR(_column_readers.at(tablet_column.unique_id())->new_iterator(&it));
+    iter->reset(it);
+    return Status::OK();
 }
 
 Status Segment::new_bitmap_index_iterator(const TabletColumn& tablet_column,
-                                          BitmapIndexIterator** iter) {
+                                          std::unique_ptr<BitmapIndexIterator>* iter) {
     auto col_unique_id = tablet_column.unique_id();
     if (_column_readers.count(col_unique_id) > 0 &&
         _column_readers.at(col_unique_id)->has_bitmap_index()) {
-        return _column_readers.at(col_unique_id)->new_bitmap_index_iterator(iter);
+        BitmapIndexIterator* it;
+        RETURN_IF_ERROR(_column_readers.at(col_unique_id)->new_bitmap_index_iterator(&it));
+        iter->reset(it);
+        return Status::OK();
     }
     return Status::OK();
 }
@@ -330,11 +345,14 @@ Status Segment::new_bitmap_index_iterator(const TabletColumn& tablet_column,
 Status Segment::new_inverted_index_iterator(const TabletColumn& tablet_column,
                                             const TabletIndex* index_meta,
                                             OlapReaderStatistics* stats,
-                                            InvertedIndexIterator** iter) {
+                                            std::unique_ptr<InvertedIndexIterator>* iter) {
     auto col_unique_id = tablet_column.unique_id();
     if (_column_readers.count(col_unique_id) > 0 && index_meta) {
-        return _column_readers.at(col_unique_id)
-                ->new_inverted_index_iterator(index_meta, stats, iter);
+        InvertedIndexIterator* it;
+        RETURN_IF_ERROR(_column_readers.at(col_unique_id)
+                                ->new_inverted_index_iterator(index_meta, stats, &it));
+        iter->reset(it);
+        return Status::OK();
     }
     return Status::OK();
 }

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -35,9 +35,7 @@
 #include "olap/column_predicate.h"
 #include "olap/iterators.h"
 #include "olap/primary_key_index.h"
-#include "olap/rowset/beta_rowset_reader.h"
 #include "olap/rowset/rowset_reader_context.h"
-#include "olap/rowset/segment_v2/bloom_filter.h"
 #include "olap/rowset/segment_v2/empty_segment_iterator.h"
 #include "olap/rowset/segment_v2/indexed_column_reader.h"
 #include "olap/rowset/segment_v2/page_io.h"
@@ -45,7 +43,6 @@
 #include "olap/rowset/segment_v2/segment_iterator.h"
 #include "olap/rowset/segment_v2/segment_writer.h" // k_segment_magic_length
 #include "olap/schema.h"
-#include "olap/schema_cache.h"
 #include "olap/short_key_index.h"
 #include "olap/storage_engine.h"
 #include "olap/tablet_schema.h"

--- a/be/src/olap/rowset/segment_v2/segment.h
+++ b/be/src/olap/rowset/segment_v2/segment.h
@@ -33,8 +33,6 @@
 #include "io/fs/file_reader_writer_fwd.h"
 #include "io/fs/file_system.h"
 #include "olap/olap_common.h"
-#include "olap/rowset/rowset_reader_context.h"
-#include "olap/rowset/segment_v2/bloom_filter.h"
 #include "olap/rowset/segment_v2/column_reader.h" // ColumnReader
 #include "olap/rowset/segment_v2/page_handle.h"
 #include "olap/schema.h"

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -207,11 +207,11 @@ SegmentIterator::SegmentIterator(std::shared_ptr<Segment> segment, SchemaSPtr sc
           _pool(new ObjectPool) {}
 
 Status SegmentIterator::init(const StorageReadOptions& opts) {
+    // get file handle from file descriptor of segment
     if (_inited) {
         return Status::OK();
     }
     _inited = true;
-    // get file handle from file descriptor of segment
     _file_reader = _segment->_file_reader;
     _opts = opts;
     _col_predicates.clear();
@@ -232,19 +232,9 @@ Status SegmentIterator::init(const StorageReadOptions& opts) {
         _col_preds_except_leafnode_of_andnode = opts.column_predicates_except_leafnode_of_andnode;
     }
 
-<<<<<<< HEAD
-    if (opts.output_columns != nullptr) {
-        _output_columns = *(opts.output_columns);
-    }
-
     _remaining_conjunct_roots = opts.remaining_conjunct_roots;
     _common_expr_ctxs_push_down = opts.common_expr_ctxs_push_down;
     _enable_common_expr_pushdown = !_common_expr_ctxs_push_down.empty();
-=======
-    _remaining_vconjunct_root = opts.remaining_vconjunct_root;
-    _common_vexpr_ctxs_pushdown = opts.common_vexpr_ctxs_pushdown;
-    _enable_common_expr_pushdown = _common_vexpr_ctxs_pushdown ? true : false;
->>>>>>> ce8392a710 ([Improve](performance) introduce SchemaCache to cache TabletSchame & Schema)
     _column_predicate_info.reset(new ColumnPredicateInfo());
 
     for (auto& expr : _remaining_conjunct_roots) {
@@ -747,13 +737,8 @@ Status SegmentIterator::_apply_index_except_leafnode_of_andnode() {
     }
 
     for (auto pred : _col_preds_except_leafnode_of_andnode) {
-<<<<<<< HEAD
-        auto column_name = _schema.column(pred->column_id())->name();
-        if (!_remaining_conjunct_roots.empty() &&
-=======
         auto column_name = _schema->column(pred->column_id())->name();
-        if (_remaining_vconjunct_root != nullptr &&
->>>>>>> ce8392a710 ([Improve](performance) introduce SchemaCache to cache TabletSchame & Schema)
+        if (!_remaining_conjunct_roots.empty() &&
             _check_column_pred_all_push_down(column_name, true) &&
             !pred->predicate_params()->marked_by_runtime_filter) {
             int32_t unique_id = _schema->unique_id(pred->column_id());
@@ -1304,17 +1289,11 @@ Status SegmentIterator::_vec_init_lazy_materialization() {
     }
 
     // Step2: extract columns that can execute expr context
-<<<<<<< HEAD
-    _is_common_expr_column.resize(_schema.columns().size(), false);
+    _is_common_expr_column.resize(_schema->columns().size(), false);
     if (_enable_common_expr_pushdown && !_remaining_conjunct_roots.empty()) {
         for (auto expr : _remaining_conjunct_roots) {
             RETURN_IF_ERROR(_extract_common_expr_columns(expr));
         }
-=======
-    _is_common_expr_column.resize(_schema->columns().size(), false);
-    if (_enable_common_expr_pushdown && _remaining_vconjunct_root != nullptr) {
-        RETURN_IF_ERROR(_extract_common_expr_columns(_remaining_vconjunct_root));
->>>>>>> ce8392a710 ([Improve](performance) introduce SchemaCache to cache TabletSchame & Schema)
         if (!_common_expr_columns.empty()) {
             _is_need_expr_eval = true;
             for (auto cid : _schema->column_ids()) {

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -1010,9 +1010,8 @@ Status SegmentIterator::_init_inverted_index_iterators() {
         int32_t unique_id = _schema->unique_id(cid);
         if (_inverted_index_iterators.count(unique_id) < 1) {
             RETURN_IF_ERROR(_segment->new_inverted_index_iterator(
-                    _opts.tablet_schema->column(cid),
-                    _opts.tablet_schema->get_inverted_index(cid), _opts.stats,
-                    &_inverted_index_iterators[unique_id]));
+                    _opts.tablet_schema->column(cid), _opts.tablet_schema->get_inverted_index(cid),
+                    _opts.stats, &_inverted_index_iterators[unique_id]));
         }
     }
     return Status::OK();
@@ -1244,8 +1243,8 @@ Status SegmentIterator::_vec_init_lazy_materialization() {
     //  but runtime predicate will filter some rows and read more than N rows.
     // should add add for order by none-key column, since none-key column is not sorted and
     //  all rows should be read, so runtime predicate will reduce rows for topn node
-    if (_opts.use_topn_opt && !(_opts.read_orderby_key_columns != nullptr &&
-                                 !_opts.read_orderby_key_columns->empty())) {
+    if (_opts.use_topn_opt &&
+        !(_opts.read_orderby_key_columns != nullptr && !_opts.read_orderby_key_columns->empty())) {
         auto& runtime_predicate = _opts.runtime_state->get_query_ctx()->get_runtime_predicate();
         _runtime_predicate = runtime_predicate.get_predictate();
         if (_runtime_predicate) {
@@ -1664,7 +1663,7 @@ uint16_t SegmentIterator::_evaluate_short_circuit_predicate(uint16_t* vec_sel_ro
     // evaluate delete condition
     original_size = selected_size;
     selected_size = _opts.delete_condition_predicates->evaluate(_current_return_columns,
-                                                                 vec_sel_rowid_idx, selected_size);
+                                                                vec_sel_rowid_idx, selected_size);
     _opts.stats->rows_vec_del_cond_filtered += original_size - selected_size;
     return selected_size;
 }

--- a/be/src/olap/rowset/segment_v2/segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.h
@@ -101,9 +101,10 @@ struct ColumnPredicateInfo {
 
 class SegmentIterator : public RowwiseIterator {
 public:
-    SegmentIterator(std::shared_ptr<Segment> segment, const Schema& _schema);
+    SegmentIterator(std::shared_ptr<Segment> segment, SchemaSPtr schema);
     ~SegmentIterator() override;
 
+    [[nodiscard]] Status init_iterators();
     [[nodiscard]] Status init(const StorageReadOptions& opts) override;
     [[nodiscard]] Status next_batch(vectorized::Block* block) override;
 
@@ -113,9 +114,11 @@ public:
     [[nodiscard]] Status current_block_row_locations(
             std::vector<RowLocation>* block_row_locations) override;
 
-    const Schema& schema() const override { return _schema; }
+    const Schema& schema() const override { return *_schema; }
     bool is_lazy_materialization_read() const override { return _lazy_materialization_read; }
     uint64_t data_id() const override { return _segment->id(); }
+    RowsetId rowset_id() const { return _segment->rowset_id(); }
+    int32_t tablet_id() const { return _tablet_id; }
 
     bool update_profile(RuntimeProfile* profile) override {
         bool updated = false;
@@ -148,7 +151,7 @@ private:
         return true;
     }
 
-    [[nodiscard]] Status _init();
+    [[nodiscard]] Status _lazy_init();
 
     [[nodiscard]] Status _init_return_column_iterators();
     [[nodiscard]] Status _init_bitmap_index_iterators();
@@ -270,7 +273,7 @@ private:
 
     // todo(wb) remove this method after RowCursor is removed
     void _convert_rowcursor_to_short_key(const RowCursor& key, size_t num_keys) {
-        if (_short_key.capacity() == 0) {
+        if (_short_key.size() == 0) {
             _short_key.resize(num_keys);
             for (auto cid = 0; cid < num_keys; cid++) {
                 auto* field = key.schema()->column(cid);
@@ -325,13 +328,13 @@ private:
     class BackwardBitmapRangeIterator;
 
     std::shared_ptr<Segment> _segment;
-    const Schema& _schema;
+    SchemaSPtr _schema;
     // _column_iterators_map.size() == _schema.num_columns()
     // map<unique_id, ColumnIterator*> _column_iterators_map/_bitmap_index_iterators;
     // can use _schema get unique_id by cid
-    std::map<int32_t, ColumnIterator*> _column_iterators;
-    std::map<int32_t, BitmapIndexIterator*> _bitmap_index_iterators;
-    std::map<int32_t, InvertedIndexIterator*> _inverted_index_iterators;
+    std::map<int32_t, std::unique_ptr<ColumnIterator>> _column_iterators;
+    std::map<int32_t, std::unique_ptr<BitmapIndexIterator>> _bitmap_index_iterators;
+    std::map<int32_t, std::unique_ptr<InvertedIndexIterator>> _inverted_index_iterators;
     // after init(), `_row_bitmap` contains all rowid to scan
     roaring::Roaring _row_bitmap;
     // "column_name+operator+value-> <in_compound_query, rowid_result>
@@ -360,7 +363,7 @@ private:
             _vec_pred_column_ids; // keep columnId of columns for vectorized predicate evaluation
     std::vector<ColumnId>
             _short_cir_pred_column_ids; // keep columnId of columns for short circuit predicate evaluation
-    std::vector<bool> _is_pred_column; // columns hold by segmentIter
+    std::vector<bool> _is_pred_column; // columns hold _init segmentIter
     std::map<uint32_t, bool> _need_read_data_indices;
     std::vector<bool> _is_common_expr_column;
     vectorized::MutableColumns _current_return_columns;
@@ -378,6 +381,7 @@ private:
     std::vector<int> _schema_block_id_map; // map from schema column id to column idx in Block
 
     // the actual init process is delayed to the first call to next_batch()
+    bool _lazy_inited;
     bool _inited;
     bool _estimate_row_size;
     // Read up to 100 rows at a time while waiting for the estimated row size.
@@ -397,7 +401,6 @@ private:
     std::set<ColumnId> _not_apply_index_pred;
 
     std::shared_ptr<ColumnPredicate> _runtime_predicate {nullptr};
-    std::set<int32_t> _output_columns;
 
     // row schema of the key to seek
     // only used in `_get_row_ranges_by_keys`
@@ -425,6 +428,9 @@ private:
 
     // used to collect filter information.
     std::vector<ColumnPredicate*> _filter_info_id;
+    bool _record_rowids = false;
+    uint32_t _block_row_max = 0;
+    int32_t _tablet_id = 0;
 };
 
 } // namespace segment_v2

--- a/be/src/olap/rowset/segment_v2/segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.h
@@ -429,7 +429,6 @@ private:
     // used to collect filter information.
     std::vector<ColumnPredicate*> _filter_info_id;
     bool _record_rowids = false;
-    uint32_t _block_row_max = 0;
     int32_t _tablet_id = 0;
 };
 

--- a/be/src/olap/schema.cpp
+++ b/be/src/olap/schema.cpp
@@ -25,6 +25,8 @@
 #include <utility>
 
 #include "common/config.h"
+#include "olap/field.h"
+#include "olap/olap_common.h"
 #include "runtime/define_primitive_type.h"
 #include "util/trace.h"
 #include "vec/columns/column_array.h"

--- a/be/src/olap/schema.cpp
+++ b/be/src/olap/schema.cpp
@@ -25,8 +25,6 @@
 #include <utility>
 
 #include "common/config.h"
-#include "olap/field.h"
-#include "olap/olap_common.h"
 #include "runtime/define_primitive_type.h"
 #include "util/trace.h"
 #include "vec/columns/column_array.h"

--- a/be/src/olap/schema_cache.cpp
+++ b/be/src/olap/schema_cache.cpp
@@ -37,26 +37,35 @@ namespace doris {
 
 SchemaCache* SchemaCache::_s_instance = nullptr;
 
+// format: tabletId-unique_id1-uniqueid2...-version-type
 std::string SchemaCache::get_schema_key(int32_t tablet_id, const TabletSchemaSPtr& schema,
-                                        const std::vector<uint32_t>& column_ids, Type type) {
+                                        const std::vector<uint32_t>& column_ids, int32_t version,
+                                        Type type) {
+    if (column_ids.empty() || schema->column(column_ids[0]).unique_id() < 0) {
+        return "";
+    }
     std::string key = fmt::format("{}-", tablet_id);
     std::for_each(column_ids.begin(), column_ids.end(), [&](const ColumnId& cid) {
         uint32_t col_unique_id = schema->column(cid).unique_id();
         key.append(fmt::format("{}", col_unique_id));
         key.append("-");
     });
-    key.append(fmt::format("{}", type));
+    key.append(fmt::format("{}-{}", version, type));
     return key;
 }
 
+// format: tabletId-unique_id1-uniqueid2...-version-type
 std::string SchemaCache::get_schema_key(int32_t tablet_id, const std::vector<TColumn>& columns,
-                                        Type type) {
+                                        int32_t version, Type type) {
+    if (columns.empty() || columns[0].col_unique_id < 0) {
+        return "";
+    }
     std::string key = fmt::format("{}-", tablet_id);
     std::for_each(columns.begin(), columns.end(), [&](const TColumn& col) {
         key.append(fmt::format("{}", col.col_unique_id));
         key.append("-");
     });
-    key.append(fmt::format("{}", type));
+    key.append(fmt::format("{}-{}", version, type));
     return key;
 }
 

--- a/be/src/olap/schema_cache.cpp
+++ b/be/src/olap/schema_cache.cpp
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "olap/schema_cache.h"
+
+#include <butil/logging.h>
+#include <fmt/core.h>
+#include <gen_cpp/Descriptors_types.h>
+#include <glog/logging.h>
+
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "common/config.h"
+#include "olap/schema.h"
+#include "olap/tablet.h"
+#include "olap/tablet_schema.h"
+#include "util/defer_op.h"
+#include "util/time.h"
+
+namespace doris {
+
+SchemaCache* SchemaCache::_s_instance = nullptr;
+
+std::string SchemaCache::get_schema_key(int32_t tablet_id, const TabletSchemaSPtr& schema,
+                                        const std::vector<uint32_t>& column_ids, Type type) {
+    std::string key = fmt::format("{}-", tablet_id);
+    std::for_each(column_ids.begin(), column_ids.end(), [&](const ColumnId& cid) {
+        uint32_t col_unique_id = schema->column(cid).unique_id();
+        key.append(fmt::format("{}", col_unique_id));
+        key.append("-");
+    });
+    key.append(fmt::format("{}", type));
+    return key;
+}
+
+std::string SchemaCache::get_schema_key(int32_t tablet_id, const std::vector<TColumn>& columns,
+                                        Type type) {
+    std::string key = fmt::format("{}-", tablet_id);
+    std::for_each(columns.begin(), columns.end(), [&](const TColumn& col) {
+        key.append(fmt::format("{}", col.col_unique_id));
+        key.append("-");
+    });
+    key.append(fmt::format("{}", type));
+    return key;
+}
+
+void SchemaCache::create_global_instance(size_t capacity) {
+    DCHECK(_s_instance == nullptr);
+    static SchemaCache instance(capacity);
+    _s_instance = &instance;
+}
+
+SchemaCache::SchemaCache(size_t capacity) {
+    _schema_cache =
+            std::unique_ptr<Cache>(new_lru_cache("SchemaCache", capacity, LRUCacheType::NUMBER));
+}
+
+Status SchemaCache::prune() {
+    const int64_t curtime = UnixMillis();
+    auto pred = [curtime](const void* value) -> bool {
+        CacheValue* cache_value = (CacheValue*)value;
+        return (cache_value->last_visit_time + config::schema_cache_sweep_time_sec * 1000) <
+               curtime;
+    };
+
+    MonotonicStopWatch watch;
+    watch.start();
+    // Prune cache in lazy mode to save cpu and minimize the time holding write lock
+    int64_t prune_num = _schema_cache->prune_if(pred, true);
+    LOG(INFO) << "prune " << prune_num
+              << " entries in SchemaCache cache. cost(ms): " << watch.elapsed_time() / 1000 / 1000;
+    return Status::OK();
+}
+
+} // namespace doris

--- a/be/src/olap/schema_cache.h
+++ b/be/src/olap/schema_cache.h
@@ -1,0 +1,124 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <fmt/core.h>
+#include <parallel_hashmap/phmap.h>
+
+#include <algorithm>
+#include <memory>
+#include <mutex>
+#include <type_traits>
+#include <vector>
+
+#include "olap/iterators.h"
+#include "olap/olap_common.h"
+#include "olap/schema.h"
+#include "olap/tablet.h"
+#include "olap/tablet_schema.h"
+#include "util/time.h"
+
+namespace doris {
+
+namespace segment_v2 {
+class Segment;
+class SegmentIterator;
+using SegmentIteratorUPtr = std::unique_ptr<SegmentIterator>;
+} // namespace segment_v2
+
+// The SchemaCache is utilized to cache pre-allocated data structures,
+// eliminating the need for frequent allocation and deallocation during usage.
+// This caching mechanism proves immensely advantageous, particularly in scenarios
+// with high concurrency, where queries are executed simultaneously.
+class SchemaCache {
+public:
+    enum class Type { TABLET_SCHEMA = 0, SCHEMA = 1 };
+
+    static SchemaCache* instance() { return _s_instance; }
+
+    static void create_global_instance(size_t capacity);
+
+    // get cache schema key, delimiter with SCHEMA_DELIMITER
+    static std::string get_schema_key(int32_t tablet_id, const TabletSchemaSPtr& schema,
+                                      const std::vector<uint32_t>& column_ids, Type type);
+    static std::string get_schema_key(int32_t tablet_id, const std::vector<TColumn>& columns,
+                                      Type type);
+
+    // Get a shared cached Schema from resource pool, schema_key is a subset of column unique ids
+    template <typename SchemaType>
+    SchemaType get_schema(const std::string& schema_key) {
+        if (!_s_instance) {
+            return {};
+        }
+        auto lru_handle = _schema_cache->lookup(schema_key);
+        if (lru_handle) {
+            Defer release(
+                    [cache = _schema_cache.get(), lru_handle] { cache->release(lru_handle); });
+            auto value = (CacheValue*)_schema_cache->value(lru_handle);
+            value->last_visit_time = UnixMillis();
+            if constexpr (std::is_same_v<SchemaType, TabletSchemaSPtr>) {
+                return value->tablet_schema;
+            }
+            if constexpr (std::is_same_v<SchemaType, SchemaSPtr>) {
+                return value->schema;
+            }
+        }
+        return {};
+    }
+
+    // Get a shared cached tablet Schema from resource pool, schema_key is full column unique ids
+    template <typename SchemaType>
+    void insert_schema(const std::string& key, SchemaType schema) {
+        if (!_s_instance) {
+            return; 
+        }
+        CacheValue* value = new CacheValue;
+        value->last_visit_time = UnixMillis();
+        if constexpr (std::is_same_v<SchemaType, TabletSchemaSPtr>) {
+            value->type = Type::TABLET_SCHEMA;
+            value->tablet_schema = schema;
+        } else if constexpr (std::is_same_v<SchemaType, SchemaSPtr>) {
+            value->type = Type::SCHEMA;
+            value->schema = schema;
+        }
+        auto deleter = [](const doris::CacheKey& key, void* value) {
+            CacheValue* cache_value = (CacheValue*)value;
+            delete cache_value;
+        };
+        auto lru_handle = _schema_cache->insert(key, value, sizeof(CacheValue), deleter,
+                                                CachePriority::NORMAL, schema->mem_size());
+        _schema_cache->release(lru_handle);
+    }
+
+    // Try to prune the cache if expired.
+    Status prune();
+
+    struct CacheValue {
+        Type type;
+        std::atomic<int64_t> last_visit_time = 0;
+        // either tablet_schema or schema
+        TabletSchemaSPtr tablet_schema = nullptr;
+        SchemaSPtr schema = nullptr;
+    };
+
+private:
+    SchemaCache(size_t capacity);
+    static constexpr char SCHEMA_DELIMITER = '-';
+    std::unique_ptr<Cache> _schema_cache = nullptr;
+    static SchemaCache* _s_instance;
+};
+
+} // namespace doris

--- a/be/src/olap/schema_cache.h
+++ b/be/src/olap/schema_cache.h
@@ -59,7 +59,7 @@ public:
     static std::string get_schema_key(int32_t tablet_id, const std::vector<TColumn>& columns,
                                       int32_t version, Type type);
 
-    // Get a shared cached Schema from resource pool, schema_key is a subset of column unique ids
+    // Get a shared cached schema from cache, schema_key is a subset of column unique ids
     template <typename SchemaType>
     SchemaType get_schema(const std::string& schema_key) {
         if (!_s_instance || schema_key.empty()) {
@@ -82,7 +82,7 @@ public:
         return {};
     }
 
-    // Get a shared cached tablet Schema from resource pool, schema_key is full column unique ids
+    // Insert a shared Schema into cache, schema_key is full column unique ids
     template <typename SchemaType>
     void insert_schema(const std::string& key, SchemaType schema) {
         if (!_s_instance || key.empty()) {

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -58,7 +58,9 @@
 #include "olap/olap_meta.h"
 #include "olap/rowset/rowset_meta.h"
 #include "olap/rowset/rowset_meta_manager.h"
+#include "olap/rowset/segment_v2/segment_iterator.h"
 #include "olap/rowset/unique_rowset_id_generator.h"
+#include "olap/schema_cache.h"
 #include "olap/segment_loader.h"
 #include "olap/tablet_manager.h"
 #include "olap/tablet_meta.h"
@@ -617,6 +619,7 @@ void StorageEngine::clear_transaction_task(const TTransactionId transaction_id,
 
 void StorageEngine::_start_clean_cache() {
     SegmentLoader::instance()->prune();
+    SchemaCache::instance()->prune();
 }
 
 Status StorageEngine::start_trash_sweep(double* usage, bool ignore_guard) {

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -58,7 +58,6 @@
 #include "olap/olap_meta.h"
 #include "olap/rowset/rowset_meta.h"
 #include "olap/rowset/rowset_meta_manager.h"
-#include "olap/rowset/segment_v2/segment_iterator.h"
 #include "olap/rowset/unique_rowset_id_generator.h"
 #include "olap/schema_cache.h"
 #include "olap/segment_loader.h"

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2451,10 +2451,9 @@ Status Tablet::fetch_value_through_row_column(RowsetSharedPtr input_rowset, uint
     });
     CHECK(tablet_schema->store_row_column());
     // create _source column
-    segment_v2::ColumnIterator* column_iterator = nullptr;
+    std::unique_ptr<segment_v2::ColumnIterator> column_iterator;
     RETURN_IF_ERROR(segment->new_column_iterator(tablet_schema->column(BeConsts::ROW_STORE_COL),
                                                  &column_iterator));
-    std::unique_ptr<segment_v2::ColumnIterator> ptr_guard(column_iterator);
     segment_v2::ColumnIteratorOptions opt;
     OlapReaderStatistics stats;
     opt.file_reader = segment->file_reader().get();
@@ -2508,10 +2507,9 @@ Status Tablet::fetch_value_by_rowids(RowsetSharedPtr input_rowset, uint32_t segi
                                << ", row_batch_size:" << rowids.size();
     });
     // create _source column
-    segment_v2::ColumnIterator* column_iterator = nullptr;
+    std::unique_ptr<segment_v2::ColumnIterator> column_iterator = nullptr;
     RETURN_IF_ERROR(
             segment->new_column_iterator(tablet_schema->column(column_name), &column_iterator));
-    std::unique_ptr<segment_v2::ColumnIterator> ptr_guard(column_iterator);
     segment_v2::ColumnIteratorOptions opt;
     OlapReaderStatistics stats;
     opt.file_reader = segment->file_reader().get();
@@ -2557,10 +2555,9 @@ Status Tablet::lookup_row_data(const Slice& encoded_key, const RowLocation& row_
     });
     CHECK(tablet_schema->store_row_column());
     // create _source column
-    segment_v2::ColumnIterator* column_iterator = nullptr;
+    std::unique_ptr<segment_v2::ColumnIterator> column_iterator;
     RETURN_IF_ERROR(segment->new_column_iterator(tablet_schema->column(BeConsts::ROW_STORE_COL),
                                                  &column_iterator));
-    std::unique_ptr<segment_v2::ColumnIterator> ptr_guard(column_iterator);
     segment_v2::ColumnIteratorOptions opt;
     opt.file_reader = segment->file_reader().get();
     opt.stats = &stats;

--- a/be/src/olap/tablet_schema_cache.h
+++ b/be/src/olap/tablet_schema_cache.h
@@ -17,9 +17,7 @@
 
 #pragma once
 
-#include <fmt/core.h>
 #include <gen_cpp/olap_file.pb.h>
-#include <glog/logging.h>
 
 #include <memory>
 #include <mutex>

--- a/be/src/olap/tablet_schema_cache.h
+++ b/be/src/olap/tablet_schema_cache.h
@@ -17,7 +17,9 @@
 
 #pragma once
 
+#include <fmt/core.h>
 #include <gen_cpp/olap_file.pb.h>
+#include <glog/logging.h>
 
 #include <memory>
 #include <mutex>

--- a/be/src/olap/task/index_builder.cpp
+++ b/be/src/olap/task/index_builder.cpp
@@ -176,10 +176,10 @@ Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta
             OlapReaderStatistics stats;
             read_options.stats = &stats;
             read_options.tablet_schema = output_rowset_schema;
-            std::unique_ptr<Schema> schema =
-                    std::make_unique<Schema>(output_rowset_schema->columns(), return_columns);
+            std::shared_ptr<Schema> schema =
+                    std::make_shared<Schema>(output_rowset_schema->columns(), return_columns);
             std::unique_ptr<RowwiseIterator> iter;
-            auto res = seg_ptr->new_iterator(*schema, read_options, &iter);
+            auto res = seg_ptr->new_iterator(schema, read_options, &iter);
             if (!res.ok()) {
                 LOG(WARNING) << "failed to create iterator[" << seg_ptr->id()
                              << "]: " << res.to_string();

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -280,7 +280,7 @@ Status ExecEnv::_init_mem_env() {
               << " segment_cache_capacity: " << segment_cache_capacity;
     SegmentLoader::create_global_instance(segment_cache_capacity);
 
-    SchemaCache::create_global_instance(config::schema_cache_cacity);
+    SchemaCache::create_global_instance(config::schema_cache_capacity);
 
     // use memory limit
     int64_t inverted_index_cache_limit =

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -40,6 +40,7 @@
 #include "olap/options.h"
 #include "olap/page_cache.h"
 #include "olap/rowset/segment_v2/inverted_index_cache.h"
+#include "olap/schema_cache.h"
 #include "olap/segment_loader.h"
 #include "pipeline/task_queue.h"
 #include "pipeline/task_scheduler.h"
@@ -278,6 +279,8 @@ Status ExecEnv::_init_mem_env() {
     LOG(INFO) << "segment_cache_capacity = fd_number / 3 * 2, fd_number: " << fd_number
               << " segment_cache_capacity: " << segment_cache_capacity;
     SegmentLoader::create_global_instance(segment_cache_capacity);
+
+    SchemaCache::create_global_instance(config::schema_cache_cacity);
 
     // use memory limit
     int64_t inverted_index_cache_limit =

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -1562,12 +1562,11 @@ Status PInternalServiceImpl::_multi_get(const PMultiGetRequest& request,
                    << ", field_name_to_index=" << full_read_schema.get_all_field_names();
                 return Status::InternalError(ss.str());
             }
-            segment_v2::ColumnIterator* column_iterator = nullptr;
+            std::unique_ptr<segment_v2::ColumnIterator> column_iterator;
             vectorized::MutableColumnPtr column =
                     result_block.get_by_position(x).column->assume_mutable();
             RETURN_IF_ERROR(
                     segment->new_column_iterator(full_read_schema.column(index), &column_iterator));
-            std::unique_ptr<segment_v2::ColumnIterator> ptr_guard(column_iterator);
             segment_v2::ColumnIteratorOptions opt;
             OlapReaderStatistics stats;
             opt.file_reader = segment->file_reader().get();

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -41,9 +41,12 @@
 #include "olap/olap_tuple.h"
 #include "olap/rowset/rowset.h"
 #include "olap/rowset/rowset_meta.h"
+#include "olap/schema_cache.h"
 #include "olap/storage_engine.h"
 #include "olap/tablet_manager.h"
 #include "olap/tablet_meta.h"
+#include "olap/tablet_schema.h"
+#include "olap/tablet_schema_cache.h"
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
 #include "service/backend_options.h"
@@ -121,44 +124,37 @@ Status NewOlapScanner::init() {
     // Get olap table
     TTabletId tablet_id = _scan_range.tablet_id;
     _version = strtoul(_scan_range.version.c_str(), nullptr, 10);
+    TabletSchemaSPtr cached_schema;
+    std::string schema_key;
     {
         auto [tablet, status] =
                 StorageEngine::instance()->tablet_manager()->get_tablet_and_status(tablet_id, true);
         RETURN_IF_ERROR(status);
         _tablet = std::move(tablet);
-        _tablet_schema->copy_from(*_tablet->tablet_schema());
-
         TOlapScanNode& olap_scan_node = ((NewOlapScanNode*)_parent)->_olap_scan_node;
         if (olap_scan_node.__isset.columns_desc && !olap_scan_node.columns_desc.empty() &&
             olap_scan_node.columns_desc[0].col_unique_id >= 0) {
-            // Originally scanner get TabletSchema from tablet object in BE.
-            // To support lightweight schema change for adding / dropping columns,
-            // tabletschema is bounded to rowset and tablet's schema maybe outdated,
-            //  so we have to use schema from a query plan witch FE puts it in query plans.
-            _tablet_schema->clear_columns();
-            for (const auto& column_desc : olap_scan_node.columns_desc) {
-                _tablet_schema->append_column(TabletColumn(column_desc));
+            schema_key = SchemaCache::get_schema_key(tablet_id, olap_scan_node.columns_desc,
+                                                     SchemaCache::Type::TABLET_SCHEMA);
+            cached_schema = SchemaCache::instance()->get_schema<TabletSchemaSPtr>(schema_key);
+        }
+        if (cached_schema) {
+            _tablet_schema = cached_schema;
+        } else {
+            _tablet_schema->copy_from(*_tablet->tablet_schema());
+            if (olap_scan_node.__isset.columns_desc && !olap_scan_node.columns_desc.empty() &&
+                olap_scan_node.columns_desc[0].col_unique_id >= 0) {
+                // Originally scanner get TabletSchema from tablet object in BE.
+                // To support lightweight schema change for adding / dropping columns,
+                // tabletschema is bounded to rowset and tablet's schema maybe outdated,
+                //  so we have to use schema from a query plan witch FE puts it in query plans.
+                _tablet_schema->clear_columns();
+                for (const auto& column_desc : olap_scan_node.columns_desc) {
+                    _tablet_schema->append_column(TabletColumn(column_desc));
+                }
             }
-        }
-
-        if (olap_scan_node.__isset.indexes_desc) {
-            _tablet_schema->update_indexes_from_thrift(olap_scan_node.indexes_desc);
-        }
-
-        {
-            if (_output_tuple_desc->slots().back()->col_name() == BeConsts::ROWID_COL) {
-                // inject ROWID_COL
-                TabletColumn rowid_column;
-                rowid_column.set_is_nullable(false);
-                rowid_column.set_name(BeConsts::ROWID_COL);
-                // avoid column reader init error
-                rowid_column.set_has_default_value(true);
-                // fake unique id
-                rowid_column.set_unique_id(INT32_MAX);
-                rowid_column.set_aggregation_method(
-                        FieldAggregationMethod::OLAP_FIELD_AGGREGATION_REPLACE);
-                rowid_column.set_type(FieldType::OLAP_FIELD_TYPE_STRING);
-                _tablet_schema->append_column(rowid_column);
+            if (olap_scan_node.__isset.indexes_desc) {
+                _tablet_schema->update_indexes_from_thrift(olap_scan_node.indexes_desc);
             }
         }
 
@@ -200,6 +196,10 @@ Status NewOlapScanner::init() {
     if (_state->enable_profile()) {
         _profile->add_info_string("ReadColumns",
                                   read_columns_to_string(_tablet_schema, _return_columns));
+    }
+
+    if (!cached_schema && !schema_key.empty()) {
+        SchemaCache::instance()->insert_schema(schema_key, _tablet_schema);
     }
 
     return Status::OK();

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -135,6 +135,7 @@ Status NewOlapScanner::init() {
         if (olap_scan_node.__isset.columns_desc && !olap_scan_node.columns_desc.empty() &&
             olap_scan_node.columns_desc[0].col_unique_id >= 0) {
             schema_key = SchemaCache::get_schema_key(tablet_id, olap_scan_node.columns_desc,
+                                                     olap_scan_node.schema_version,
                                                      SchemaCache::Type::TABLET_SCHEMA);
             cached_schema = SchemaCache::instance()->get_schema<TabletSchemaSPtr>(schema_key);
         }
@@ -152,6 +153,7 @@ Status NewOlapScanner::init() {
                 for (const auto& column_desc : olap_scan_node.columns_desc) {
                     _tablet_schema->append_column(TabletColumn(column_desc));
                 }
+                _tablet_schema->set_schema_version(olap_scan_node.schema_version);
             }
             if (olap_scan_node.__isset.indexes_desc) {
                 _tablet_schema->update_indexes_from_thrift(olap_scan_node.indexes_desc);

--- a/be/src/vec/olap/vgeneric_iterators.h
+++ b/be/src/vec/olap/vgeneric_iterators.h
@@ -51,7 +51,7 @@ public:
     VStatisticsIterator(std::shared_ptr<Segment> segment, const Schema& schema)
             : _segment(std::move(segment)), _schema(schema) {}
 
-    ~VStatisticsIterator() override;
+    ~VStatisticsIterator() override = default;
 
     Status init(const StorageReadOptions& opts) override;
 
@@ -66,7 +66,7 @@ private:
     size_t _output_rows = 0;
     bool _init = false;
     TPushAggOp::type _push_down_agg_type_opt;
-    std::map<int32_t, ColumnIterator*> _column_iterators_map;
+    std::map<int32_t, std::unique_ptr<ColumnIterator>> _column_iterators_map;
     std::vector<ColumnIterator*> _column_iterators;
 
     static constexpr size_t MAX_ROW_SIZE_IN_COUNT = 65535;
@@ -99,7 +99,7 @@ public:
     VMergeIteratorContext& operator=(const VMergeIteratorContext&) = delete;
     VMergeIteratorContext& operator=(VMergeIteratorContext&&) = delete;
 
-    ~VMergeIteratorContext() {}
+    ~VMergeIteratorContext() = default;
 
     Status block_reset(const std::shared_ptr<Block>& block);
 

--- a/be/test/olap/delta_writer_test.cpp
+++ b/be/test/olap/delta_writer_test.cpp
@@ -25,6 +25,7 @@
 
 #include <iostream>
 #include <map>
+#include <memory>
 #include <string>
 #include <utility>
 
@@ -747,7 +748,7 @@ TEST_F(TestDeltaWriter, vec_sequence_col) {
     opts.tablet_schema = rowset->tablet_schema();
 
     std::unique_ptr<RowwiseIterator> iter;
-    Schema schema(rowset->tablet_schema());
+    std::shared_ptr<Schema> schema = std::make_shared<Schema>(rowset->tablet_schema());
     auto s = segments[0]->new_iterator(schema, opts, &iter);
     ASSERT_TRUE(s.ok());
     auto read_block = rowset->tablet_schema()->create_block();

--- a/be/test/vec/exec/vgeneric_iterators_test.cpp
+++ b/be/test/vec/exec/vgeneric_iterators_test.cpp
@@ -25,6 +25,7 @@
 #include "gtest/gtest_pred_impl.h"
 #include "olap/field.h"
 #include "olap/olap_common.h"
+#include "olap/rowset/segment_v2/column_reader.h"
 #include "olap/schema.h"
 #include "olap/tablet_schema.h"
 #include "vec/columns/column.h"

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -1817,6 +1817,11 @@ public class OlapTable extends Table {
         return baseIndexMeta.getSchemaVersion();
     }
 
+    public int getIndexSchemaVersion(long indexId) {
+        MaterializedIndexMeta indexMeta = indexIdToMeta.get(indexId);
+        return indexMeta.getSchemaVersion();
+    }
+
     public void setDataSortInfo(DataSortInfo dataSortInfo) {
         TableProperty tableProperty = getOrCreatTableProperty();
         tableProperty.modifyDataSortInfoProperties(dataSortInfo);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -35,6 +35,7 @@ import org.apache.doris.analysis.SortInfo;
 import org.apache.doris.analysis.TableSample;
 import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.analysis.TupleId;
+import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.ColocateTableIndex;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.DistributionInfo;
@@ -51,6 +52,7 @@ import org.apache.doris.catalog.PartitionInfo;
 import org.apache.doris.catalog.PartitionItem;
 import org.apache.doris.catalog.PartitionType;
 import org.apache.doris.catalog.Replica;
+import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
@@ -1288,6 +1290,22 @@ public class OlapScanNode extends ScanNode {
         List<TColumn> columnsDesc = new ArrayList<TColumn>();
         getColumnDesc(columnsDesc, keyColumnNames, keyColumnTypes);
         List<TOlapTableIndex> indexDesc = Lists.newArrayList();
+
+        // Add extra row id column
+        ArrayList<SlotDescriptor> slots = desc.getSlots();
+        Column lastColumn = slots.get(slots.size() - 1).getColumn();
+        if (lastColumn != null && lastColumn.getName().equalsIgnoreCase(Column.ROWID_COL)) {
+            TColumn tColumn = new TColumn();
+            tColumn.setColumnName(Column.ROWID_COL);
+            tColumn.setColumnType(ScalarType.createStringType().toColumnTypeThrift());
+            tColumn.setAggregationType(AggregateType.NONE.toThrift());
+            tColumn.setIsKey(false);
+            tColumn.setIsAllowNull(false);
+            // keep compatibility
+            tColumn.setVisible(false);
+            tColumn.setColUniqueId(Integer.MAX_VALUE);
+            columnsDesc.add(tColumn);
+        }
 
         for (Index index : olapTable.getIndexes()) {
             TOlapTableIndex tIndex = index.toThrift();

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -1298,7 +1298,7 @@ public class OlapScanNode extends ScanNode {
             TColumn tColumn = new TColumn();
             tColumn.setColumnName(Column.ROWID_COL);
             tColumn.setColumnType(ScalarType.createStringType().toColumnTypeThrift());
-            tColumn.setAggregationType(AggregateType.NONE.toThrift());
+            tColumn.setAggregationType(AggregateType.REPLACE.toThrift());
             tColumn.setIsKey(false);
             tColumn.setIsAllowNull(false);
             // keep compatibility
@@ -1316,6 +1316,9 @@ public class OlapScanNode extends ScanNode {
         msg.olap_scan_node = new TOlapScanNode(desc.getId().asInt(), keyColumnNames, keyColumnTypes, isPreAggregation);
         msg.olap_scan_node.setColumnsDesc(columnsDesc);
         msg.olap_scan_node.setIndexesDesc(indexDesc);
+        if (selectedIndexId != -1) {
+            msg.olap_scan_node.setSchemaVersion(olapTable.getIndexSchemaVersion(selectedIndexId));
+        }
         if (null != sortColumn) {
             msg.olap_scan_node.setSortColumn(sortColumn);
         }

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -596,6 +596,7 @@ struct TOlapScanNode {
   14: optional list<Descriptors.TOlapTableIndex> indexes_desc
   15: optional set<i32> output_column_unique_ids
   16: optional list<i32> distribute_column_ids
+  17: optional i32 schema_version
 }
 
 struct TEqJoinCondition {


### PR DESCRIPTION
… and Schema

1. When the system is under high-concurrency load with wide table point queries, the frequent memory allocation and deallocation of Schema become evident system bottlenecks. Additionally, the initialization of TabletSchema and Schema also becomes a CPU hotspot.Therefore, the introduction of a SchemaCache is implemented to cache these resources for reuse.
    
2. Make some variables wrapped with std::unique<unique_ptr>
        
Performance:


| 状态              | QPS | 平均响应时间 (avg) | P99 响应时间 |
|------------------|-----|------------------|-------------|
| 开启 SchemaCachel | 501 | 20ms             | 34ms        |
| 关闭 SchemaCache | 321 | 31ms             | 61ms        |

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

