### PR TITLE
[fix](revert) data stream sender stop sending data to receiver if it returns eos early (#19847)"

### DIFF
--- a/be/src/pipeline/exec/exchange_sink_buffer.h
+++ b/be/src/pipeline/exec/exchange_sink_buffer.h
@@ -85,7 +85,6 @@ private:
     phmap::flat_hash_map<InstanceLoId, PTransmitDataParams*> _instance_to_request;
     phmap::flat_hash_map<InstanceLoId, PUniqueId> _instance_to_finst_id;
     phmap::flat_hash_map<InstanceLoId, bool> _instance_to_sending_by_pipeline;
-    phmap::flat_hash_map<InstanceLoId, bool> _instance_to_receiver_eof;
 
     std::atomic<bool> _is_finishing;
     PUniqueId _query_id;
@@ -101,8 +100,6 @@ private:
     void _construct_request(InstanceLoId id);
     inline void _ended(InstanceLoId id);
     inline void _failed(InstanceLoId id, const std::string& err);
-    inline void _set_receiver_eof(InstanceLoId id);
-    inline bool _is_receiver_eof(InstanceLoId id);
 };
 
 } // namespace pipeline

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -286,12 +286,7 @@ public:
     Status sink(RuntimeState* state, vectorized::Block* in_block,
                 SourceState source_state) override {
         if (in_block->rows() > 0) {
-            auto st = _sink->send(state, in_block, source_state == SourceState::FINISHED);
-            // TODO: improvement: if sink returned END_OF_FILE, pipeline task can be finished
-            if (st.template is<ErrorCode::END_OF_FILE>()) {
-                return Status::OK();
-            }
-            return st;
+            return _sink->send(state, in_block, source_state == SourceState::FINISHED);
         }
         return Status::OK();
     }

--- a/be/src/vec/runtime/vdata_stream_mgr.cpp
+++ b/be/src/vec/runtime/vdata_stream_mgr.cpp
@@ -102,13 +102,9 @@ Status VDataStreamMgr::transmit_block(const PTransmitDataParams* request,
         // As a consequence, find_recvr() may return an innocuous NULL if a thread
         // calling deregister_recvr() beat the thread calling find_recvr()
         // in acquiring _lock.
-        //
-        // e.g. for broadcast join build side, only one instance will build the hash table,
-        // all other instances don't need build side data and will close the data stream receiver.
-        //
         // TODO: Rethink the lifecycle of DataStreamRecvr to distinguish
         // errors from receiver-initiated teardowns.
-        return Status::EndOfFile("data stream receiver closed");
+        return Status::OK();
     }
 
     // request can only be used before calling recvr's add_batch or when request

--- a/be/src/vec/sink/vdata_stream_sender.h
+++ b/be/src/vec/sink/vdata_stream_sender.h
@@ -28,7 +28,6 @@
 #include <stdint.h>
 
 #include <atomic>
-#include <cstddef>
 #include <memory>
 #include <ostream>
 #include <string>
@@ -158,11 +157,8 @@ protected:
     }
 
     template <typename Channels>
-    Status channel_add_rows(RuntimeState* state, Channels& channels, int num_channels,
-                            const uint64_t* channel_ids, int rows, Block* block);
-
-    template <typename ChannelPtrType>
-    void _handle_eof_channel(RuntimeState* state, ChannelPtrType channel, Status st);
+    Status channel_add_rows(Channels& channels, int num_channels, const uint64_t* channel_ids,
+                            int rows, Block* block);
 
     struct hash_128 {
         uint64_t high;
@@ -253,7 +249,6 @@ public:
               _num_data_bytes_sent(0),
               _packet_seq(0),
               _need_close(false),
-              _closed(false),
               _brpc_dest_addr(brpc_dest),
               _is_transfer_chain(is_transfer_chain),
               _send_query_statistics_with_every_batch(send_query_statistics_with_every_batch) {
@@ -329,18 +324,8 @@ public:
                _local_recvr->sender_queue_empty(_parent->_sender_id);
     }
 
-    bool is_receiver_eof() const { return receiver_status_.is<ErrorCode::END_OF_FILE>(); }
-
-    void set_receiver_eof(Status st) { receiver_status_ = st; }
-
 protected:
-    bool _recvr_is_valid() {
-        if (_local_recvr && !_local_recvr->is_closed()) {
-            return true;
-        }
-        receiver_status_ = Status::EndOfFile("local data stream receiver closed");
-        return false;
-    }
+    bool _recvr_is_valid() { return _local_recvr && !_local_recvr->is_closed(); }
 
     Status _wait_last_brpc() {
         SCOPED_TIMER(_parent->_brpc_wait_timer);
@@ -350,7 +335,6 @@ protected:
         auto cntl = &_closure->cntl;
         auto call_id = _closure->cntl.call_id();
         brpc::Join(call_id);
-        receiver_status_ = _closure->result.status();
         if (cntl->Failed()) {
             std::string err = fmt::format(
                     "failed to send brpc batch, error={}, error_text={}, client: {}, "
@@ -360,7 +344,7 @@ protected:
             LOG(WARNING) << err;
             return Status::RpcError(err);
         }
-        return receiver_status_;
+        return Status::OK();
     }
 
     // Serialize _batch into _thrift_batch and send via send_batch().
@@ -382,7 +366,6 @@ protected:
     std::unique_ptr<MutableBlock> _mutable_block;
 
     bool _need_close;
-    bool _closed;
     int _be_number;
 
     TNetworkAddress _brpc_dest_addr;
@@ -393,7 +376,6 @@ protected:
     PTransmitDataParams _brpc_request;
     std::shared_ptr<PBackendService_Stub> _brpc_stub = nullptr;
     RefCountClosure<PTransmitDataResult>* _closure = nullptr;
-    Status receiver_status_;
     int32_t _brpc_timeout_ms = 500;
     // whether the dest can be treated as query statistics transfer chain.
     bool _is_transfer_chain;
@@ -411,30 +393,19 @@ protected:
     PBlock _ch_pb_block2;
 };
 
-#define HANDLE_CHANNEL_STATUS(state, channel, status)    \
-    do {                                                 \
-        if (status.is<ErrorCode::END_OF_FILE>()) {       \
-            _handle_eof_channel(state, channel, status); \
-        } else {                                         \
-            RETURN_IF_ERROR(status);                     \
-        }                                                \
-    } while (0)
-
 template <typename Channels>
-Status VDataStreamSender::channel_add_rows(RuntimeState* state, Channels& channels,
-                                           int num_channels, const uint64_t* __restrict channel_ids,
-                                           int rows, Block* block) {
+Status VDataStreamSender::channel_add_rows(Channels& channels, int num_channels,
+                                           const uint64_t* __restrict channel_ids, int rows,
+                                           Block* block) {
     std::vector<int> channel2rows[num_channels];
 
     for (int i = 0; i < rows; i++) {
         channel2rows[channel_ids[i]].emplace_back(i);
     }
 
-    Status status;
     for (int i = 0; i < num_channels; ++i) {
-        if (!channels[i]->is_receiver_eof() && !channel2rows[i].empty()) {
-            status = channels[i]->add_rows(block, channel2rows[i]);
-            HANDLE_CHANNEL_STATUS(state, channels[i], status);
+        if (!channel2rows[i].empty()) {
+            RETURN_IF_ERROR(channels[i]->add_rows(block, channel2rows[i]));
         }
     }
 

--- a/be/src/vec/sink/vresult_file_sink.cpp
+++ b/be/src/vec/sink/vresult_file_sink.cpp
@@ -178,10 +178,7 @@ Status VResultFileSink::close(RuntimeState* state, Status exec_status) {
                 state->fragment_instance_id());
     } else {
         if (final_status.ok()) {
-            auto st = _stream_sender->send(state, _output_block.get(), true);
-            if (!st.template is<ErrorCode::END_OF_FILE>()) {
-                RETURN_IF_ERROR(st);
-            }
+            RETURN_IF_ERROR(_stream_sender->send(state, _output_block.get(), true));
         }
         RETURN_IF_ERROR(_stream_sender->close(state, final_status));
         _output_block->clear();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Revert "[improvement](exchange) data stream sender stop sending data to receiver if it returns eos early (#19847)" since it will cause wrong query result for broad cast join of some test case.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

