### PR TITLE
[Fix](Nereids) Using switch to control minidump input serialize

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -200,7 +200,8 @@ public class NereidsPlanner extends Planner {
             }
 
             // minidump of input must be serialized first, this process ensure minidump string not null
-            if (!statementContext.getConnectContext().getSessionVariable().isPlayNereidsDump()) {
+            if (!statementContext.getConnectContext().getSessionVariable().isPlayNereidsDump()
+                    && statementContext.getConnectContext().getSessionVariable().isEnableMinidump()) {
                 MinidumpUtils.init();
                 String queryId = DebugUtil.printId(statementContext.getConnectContext().queryId());
                 try {
@@ -380,14 +381,16 @@ public class NereidsPlanner extends Planner {
     }
 
     private void serializeOutputToDumpFile(Plan resultPlan, ConnectContext connectContext) {
-        if (connectContext.getSessionVariable().isPlayNereidsDump()) {
+        if (connectContext.getSessionVariable().isPlayNereidsDump()
+                || !statementContext.getConnectContext().getSessionVariable().isEnableMinidump()) {
             return;
         }
         connectContext.getMinidump().put("ResultPlan", ((AbstractPlan) resultPlan).toJson());
     }
 
     private void serializeStatUsed(ConnectContext connectContext) {
-        if (connectContext.getSessionVariable().isPlayNereidsDump()) {
+        if (connectContext.getSessionVariable().isPlayNereidsDump()
+                || !statementContext.getConnectContext().getSessionVariable().isEnableMinidump()) {
             return;
         }
         JSONObject jsonObj = connectContext.getMinidump();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/minidump/NereidsTracer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/minidump/NereidsTracer.java
@@ -64,7 +64,7 @@ public class NereidsTracer {
     }
 
     public static String getCurrentTime() {
-        return TimeUtils.getElapsedTimeMs(NereidsTracer.startTime) / 1000 + "us";
+        return TimeUtils.getElapsedTimeMs(NereidsTracer.startTime) + "ms";
     }
 
     /** log rewrite event when open switch */

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExplainCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExplainCommand.java
@@ -70,6 +70,7 @@ public class ExplainCommand extends Command implements NoForward {
         executor.setParsedStmt(logicalPlanAdapter);
         NereidsPlanner planner = new NereidsPlanner(ctx.getStatementContext());
         planner.plan(logicalPlanAdapter, ctx.getSessionVariable().toThrift());
+        executor.setPlanner(planner);
         executor.handleExplainStmt(planner.getExplainString(new ExplainOptions(level)));
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -325,6 +325,10 @@ public class StmtExecutor {
         return planner;
     }
 
+    public void setPlanner(Planner planner) {
+        this.planner = planner;
+    }
+
     public boolean isForwardToMaster() {
         if (Env.getCurrentEnv().isMaster()) {
             return false;

--- a/fe/fe-core/src/test/java/org/apache/doris/policy/PolicyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/policy/PolicyTest.java
@@ -123,10 +123,10 @@ public class PolicyTest extends TestWithFeService {
         createPolicy("CREATE ROW POLICY test_row_policy ON test.table1 AS PERMISSIVE TO test_policy USING (k1 = 1)");
         String queryStr = "EXPLAIN select * from test.table1 a";
         String explainString = getSQLPlanOrErrorMsg(queryStr);
-        Assertions.assertTrue(explainString.contains("`a`.`k1` = 1"));
+        Assertions.assertTrue(explainString.contains("k1[#0] = 1"));
         queryStr = "EXPLAIN select * from test.table1 b";
         explainString = getSQLPlanOrErrorMsg(queryStr);
-        Assertions.assertTrue(explainString.contains("`b`.`k1` = 1"));
+        Assertions.assertTrue(explainString.contains("k1[#0] = 1"));
         dropPolicy("DROP ROW POLICY test_row_policy ON test.table1 FOR test_policy");
         connectContext.getSessionVariable().setEnableNereidsPlanner(beforeConfig);
     }


### PR DESCRIPTION
# Proposed changes

## Problem summary

Before change, when doing optimize use Nereids planner, input will serialize to memory first. And when bug happen, it would be dump to minidump file when catching the exception.
We found that serialization process will cause the performance when statistic message too large or when optimization time be small enough.
So the user minidump using should change to ONLY YOU OPEN MINIDUMP SWITCH(set enable_minidump=true;) can you use it.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

