### PR TITLE
[opt](Nereids) support use the string as the hint name key

### DIFF
--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -182,8 +182,14 @@ hintStatement
     ;
 
 hintAssignment
-    : key=identifier (EQ (constantValue=constant | identifierValue=identifier))?
+    : key=hintKey (EQ (constantValue=constant | identifierValue=identifier))?
     ;
+
+hintKey
+    : identifier
+    | STRING
+    ;
+
 
 lateralView
     : LATERAL VIEW functionName=identifier LEFT_PAREN (expression (COMMA expression)*)? RIGHT_PAREN

--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -182,14 +182,8 @@ hintStatement
     ;
 
 hintAssignment
-    : key=hintKey (EQ (constantValue=constant | identifierValue=identifier))?
+    : key=identifierOrText (EQ (constantValue=constant | identifierValue=identifier))?
     ;
-
-hintKey
-    : identifier
-    | STRING
-    ;
-
 
 lateralView
     : LATERAL VIEW functionName=identifier LEFT_PAREN (expression (COMMA expression)*)? RIGHT_PAREN

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -1564,7 +1564,7 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
             String hintName = hintStatement.hintName.getText().toLowerCase(Locale.ROOT);
             Map<String, Optional<String>> parameters = Maps.newLinkedHashMap();
             for (HintAssignmentContext kv : hintStatement.parameters) {
-                String parameterName = kv.key.getText();
+                String parameterName = visitIdentifierOrText(kv.key);
                 Optional<String> value = Optional.empty();
                 if (kv.constantValue != null) {
                     Literal literal = (Literal) visit(kv.constantValue);


### PR DESCRIPTION

## Problem summary
We can not use the string as the variable key to use in the hint.
Before this PR
```
mysql> SET enable_nereids_planner=true;
Query OK, 0 rows affected (0.01 sec)

mysql> set enable_fallback_to_original_planner=false;
Query OK, 0 rows affected (0.10 sec)

mysql> explain select /*+ SET_var("enable_nereids_planner" = "false") */ 1;
ERROR 1105 (HY000): Exception, msg: Nereids cannot parse the SQL, and fallback disabled. caused by: 


no viable alternative at input 'select /*+ SET_var("enable_nereids_planner"'(line 1, pos 27)
```

After this PR
```
mysql> SET enable_nereids_planner=true;
Query OK, 0 rows affected (0.01 sec)

mysql> set enable_fallback_to_original_planner=false;
Query OK, 0 rows affected (0.10 sec)

mysql> select /*+ SET_var("enable_nereids_planner" = "false") */ 1; 
+------+
| 1    |
+------+
|    1 |
+------+
1 row in set (0.00 sec)
```

Describe your changes.
Support the string for the hint key in the Parser.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

