### PR TITLE
[Bug](point query) check point query  before check two phase read

### DIFF
--- a/be/src/service/point_query_executor.h
+++ b/be/src/service/point_query_executor.h
@@ -274,6 +274,9 @@ struct Metrics {
     RuntimeProfile::Counter lookup_data_ns;
     RuntimeProfile::Counter output_data_ns;
     OlapReaderStatistics read_stats;
+    size_t row_cache_hits = 0;
+    bool hit_lookup_cache = false;
+    size_t result_data_bytes;
 };
 
 // An util to do tablet lookup
@@ -319,8 +322,6 @@ private:
     std::shared_ptr<Reusable> _reusable;
     std::unique_ptr<vectorized::Block> _result_block;
     Metrics _profile_metrics;
-    size_t _row_cache_hits = 0;
-    bool _hit_lookup_cache = false;
     bool _binary_row_format = false;
 };
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -645,6 +645,7 @@ public class SelectStmt extends QueryStmt {
         analyzeAggregation(analyzer);
         createAnalyticInfo(analyzer);
         eliminatingSortNode();
+        checkAndSetPointQuery();
         if (checkEnableTwoPhaseRead(analyzer)) {
             // If optimize enabled, we try our best to read less columns from ScanNode,
             // here we analyze conjunct exprs and ordering exprs before resultExprs,
@@ -677,7 +678,6 @@ public class SelectStmt extends QueryStmt {
             LOG.debug("orderingSlots {}", orderingSlots);
             LOG.debug("conjuntSlots {}", conjuntSlots);
         }
-        checkAndSetPointQuery();
         if (evaluateOrderBy) {
             createSortTupleInfo(analyzer);
         }

--- a/regression-test/data/point_query_p0/test_point_query.out
+++ b/regression-test/data/point_query_p0/test_point_query.out
@@ -22,6 +22,7 @@
 
 -- !point_select --
 1235	991129292901.111380000	dd	\N	2120-01-02	2020-01-01 12:36:38	652.692	5022-01-01	false	90696620686827832.374	[119181.111100000]	["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]
+1235	991129292901.111380000	dd	\N	2120-01-02	2020-01-01 12:36:38	652.692	5022-01-01	false	90696620686827832.374	[119181.111100000]	['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']
 
 -- !point_select --
 646464	6C616F6F71
@@ -33,6 +34,7 @@
 646464	6C616F6F71
 
 -- !point_select --
+<<<<<<< HEAD
 1235	120939.111300000	a    ddd	laooq	2030-01-02	2020-01-01 12:36:38	22.822	7022-01-01	true	1.111	[119291.192910000]	["111", "222", "333"]	1
 
 -- !point_select --
@@ -46,6 +48,21 @@
 
 -- !point_select --
 1235	120939.111300000	a    ddd	xxxxxx	2030-01-02	2020-01-01 12:36:38	22.822	7022-01-01	false	1929111.111	[119291.192910000]	["111", "222", "333"]	2
+=======
+1235	120939.111300000	a    ddd	laooq	2030-01-02	2020-01-01 12:36:38	22.822	7022-01-01	true	1.111	[119291.192910000]	['111', '222', '333']	1
+
+-- !point_select --
+1235	120939.111300000	a    ddd	laooq	2030-01-02	2020-01-01 12:36:38	22.822	7022-01-01	true	1.111	[119291.192910000]	['111', '222', '333']	1
+
+-- !point_select --
+1235	120939.111300000	a    ddd	xxxxxx	2030-01-02	2020-01-01 12:36:38	22.822	7022-01-01	false	1929111.111	[119291.192910000]	['111', '222', '333']	2
+
+-- !point_select --
+1235	120939.111300000	a    ddd	xxxxxx	2030-01-02	2020-01-01 12:36:38	22.822	7022-01-01	false	1929111.111	[119291.192910000]	['111', '222', '333']	2
+
+-- !point_select --
+1235	120939.111300000	a    ddd	xxxxxx	2030-01-02	2020-01-01 12:36:38	22.822	7022-01-01	false	1929111.111	[119291.192910000]	['111', '222', '333']	2
+>>>>>>> 47bafd5eaa ([Bug](point query) checkAndSetPointQuery before checkEnableTwoPhaseRead)
 
 -- !point_select --
 1235	120939.111300000	a    ddd	xxxxxx	2030-01-02	2020-01-01 12:36:38	22.822	7022-01-01	false	1929111.111	[119291.192910000]	\N	5630	0
@@ -54,10 +71,17 @@
 1235	120939.111300000	a    ddd	xxxxxx	2030-01-02	2020-01-01 12:36:38	22.822	7022-01-01	false	1929111.111	[119291.192910000]	\N	5630	0
 
 -- !point_select --
+<<<<<<< HEAD
 1235	120939.111300000	a    ddd	xxxxxx	2030-01-02	2020-01-01 12:36:38	22.822	7022-01-01	false	1929111.111	[119291.192910000]	["111", "222", "333"]	2
 
 -- !point_select --
 1235	120939.111300000	a    ddd	xxxxxx	2030-01-02	2020-01-01 12:36:38	22.822	7022-01-01	false	1929111.111	[119291.192910000]	["111", "222", "333"]	2
+=======
+1235	120939.111300000	a    ddd	xxxxxx	2030-01-02	2020-01-01 12:36:38	22.822	7022-01-01	false	1929111.111	[119291.192910000]	['111', '222', '333']	2
+
+-- !point_select --
+1235	120939.111300000	a    ddd	xxxxxx	2030-01-02	2020-01-01 12:36:38	22.822	7022-01-01	false	1929111.111	[119291.192910000]	['111', '222', '333']	2
+>>>>>>> 47bafd5eaa ([Bug](point query) checkAndSetPointQuery before checkEnableTwoPhaseRead)
 
 -- !sql --
 1231	119291.110000000	ddd	laooq	\N	2020-01-01T12:36:38	\N	1022-01-01	\N	1.111	[119181.111100000, 819019.119100000, NULL]	\N	\N
@@ -79,4 +103,7 @@
 
 -- !sql --
 1237	120939.111300000	a    ddd	laooq	2030-01-02	2020-01-01T12:36:38	22.822	7022-01-01	false	90696620686827832.374	[1.100000000, 2.200000000, 3.300000000, 4.400000000, 5.500000000]	[]	\N
+
+-- !sql --
+0	1	2	3
 

--- a/regression-test/data/point_query_p0/test_point_query.out
+++ b/regression-test/data/point_query_p0/test_point_query.out
@@ -22,7 +22,6 @@
 
 -- !point_select --
 1235	991129292901.111380000	dd	\N	2120-01-02	2020-01-01 12:36:38	652.692	5022-01-01	false	90696620686827832.374	[119181.111100000]	["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]
-1235	991129292901.111380000	dd	\N	2120-01-02	2020-01-01 12:36:38	652.692	5022-01-01	false	90696620686827832.374	[119181.111100000]	['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']
 
 -- !point_select --
 646464	6C616F6F71
@@ -34,7 +33,6 @@
 646464	6C616F6F71
 
 -- !point_select --
-<<<<<<< HEAD
 1235	120939.111300000	a    ddd	laooq	2030-01-02	2020-01-01 12:36:38	22.822	7022-01-01	true	1.111	[119291.192910000]	["111", "222", "333"]	1
 
 -- !point_select --
@@ -48,21 +46,6 @@
 
 -- !point_select --
 1235	120939.111300000	a    ddd	xxxxxx	2030-01-02	2020-01-01 12:36:38	22.822	7022-01-01	false	1929111.111	[119291.192910000]	["111", "222", "333"]	2
-=======
-1235	120939.111300000	a    ddd	laooq	2030-01-02	2020-01-01 12:36:38	22.822	7022-01-01	true	1.111	[119291.192910000]	['111', '222', '333']	1
-
--- !point_select --
-1235	120939.111300000	a    ddd	laooq	2030-01-02	2020-01-01 12:36:38	22.822	7022-01-01	true	1.111	[119291.192910000]	['111', '222', '333']	1
-
--- !point_select --
-1235	120939.111300000	a    ddd	xxxxxx	2030-01-02	2020-01-01 12:36:38	22.822	7022-01-01	false	1929111.111	[119291.192910000]	['111', '222', '333']	2
-
--- !point_select --
-1235	120939.111300000	a    ddd	xxxxxx	2030-01-02	2020-01-01 12:36:38	22.822	7022-01-01	false	1929111.111	[119291.192910000]	['111', '222', '333']	2
-
--- !point_select --
-1235	120939.111300000	a    ddd	xxxxxx	2030-01-02	2020-01-01 12:36:38	22.822	7022-01-01	false	1929111.111	[119291.192910000]	['111', '222', '333']	2
->>>>>>> 47bafd5eaa ([Bug](point query) checkAndSetPointQuery before checkEnableTwoPhaseRead)
 
 -- !point_select --
 1235	120939.111300000	a    ddd	xxxxxx	2030-01-02	2020-01-01 12:36:38	22.822	7022-01-01	false	1929111.111	[119291.192910000]	\N	5630	0
@@ -71,17 +54,10 @@
 1235	120939.111300000	a    ddd	xxxxxx	2030-01-02	2020-01-01 12:36:38	22.822	7022-01-01	false	1929111.111	[119291.192910000]	\N	5630	0
 
 -- !point_select --
-<<<<<<< HEAD
 1235	120939.111300000	a    ddd	xxxxxx	2030-01-02	2020-01-01 12:36:38	22.822	7022-01-01	false	1929111.111	[119291.192910000]	["111", "222", "333"]	2
 
 -- !point_select --
 1235	120939.111300000	a    ddd	xxxxxx	2030-01-02	2020-01-01 12:36:38	22.822	7022-01-01	false	1929111.111	[119291.192910000]	["111", "222", "333"]	2
-=======
-1235	120939.111300000	a    ddd	xxxxxx	2030-01-02	2020-01-01 12:36:38	22.822	7022-01-01	false	1929111.111	[119291.192910000]	['111', '222', '333']	2
-
--- !point_select --
-1235	120939.111300000	a    ddd	xxxxxx	2030-01-02	2020-01-01 12:36:38	22.822	7022-01-01	false	1929111.111	[119291.192910000]	['111', '222', '333']	2
->>>>>>> 47bafd5eaa ([Bug](point query) checkAndSetPointQuery before checkEnableTwoPhaseRead)
 
 -- !sql --
 1231	119291.110000000	ddd	laooq	\N	2020-01-01T12:36:38	\N	1022-01-01	\N	1.111	[119181.111100000, 819019.119100000, NULL]	\N	\N

--- a/regression-test/suites/point_query_p0/test_point_query.groovy
+++ b/regression-test/suites/point_query_p0/test_point_query.groovy
@@ -202,5 +202,26 @@ suite("test_point_query") {
         sql """prepare stmt2 from  select * from ${tableName} where k1 = % and k2 = % and k3 = %""" 
         qt_sql """execute stmt2 using (1231, 119291.11, 'ddd')"""
         qt_sql """execute stmt2 using (1237, 120939.11130, 'a    ddd')"""
+        tableName = "test_query"
+        sql """DROP TABLE IF EXISTS ${tableName}"""
+        sql """CREATE TABLE ${tableName} (
+                `customer_key` bigint(20) NULL,
+                `customer_btm_value_0` text NULL,
+                `customer_btm_value_1` text NULL,
+                `customer_btm_value_2` text NULL
+            ) ENGINE=OLAP
+            UNIQUE KEY(`customer_key`)
+            COMMENT 'OLAP'
+            DISTRIBUTED BY HASH(`customer_key`) BUCKETS 16
+            PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "storage_format" = "V2",
+            "light_schema_change" = "true",
+            "store_row_column" = "true",
+            "enable_unique_key_merge_on_write" = "true",
+            "disable_auto_compaction" = "false"
+            );"""
+        sql """insert into ${tableName} values (0, "1", "2", "3")"""
+        qt_sql "select * from test_query where customer_key = 0"
     }
 }


### PR DESCRIPTION
1. checkEnableTwoPhaseRead rely on thr short circuit flag
2. add more metric to display lookup profile

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

