### PR TITLE
[fix](Nereids) should allow identity project when generate bitmap runtime filter

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterTranslator.java
@@ -84,6 +84,8 @@ public class RuntimeFilterTranslator {
 
         @Override
         public Expr visitSlotReference(SlotReference slotReference, PlanTranslatorContext context) {
+            slotReference = context.getRuntimeTranslator().get()
+                    .context.getCorrespondingOlapSlotReference(slotReference);
             SlotRef slot = nereidsExprIdToSlotRef.get(slotReference.getExprId());
             if (slot == null) {
                 throw new AnalysisException("cannot find SlotRef for " + slotReference);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterContext.java
@@ -23,6 +23,7 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.physical.AbstractPhysicalJoin;
@@ -192,5 +193,13 @@ public class RuntimeFilterContext {
 
     public List<ExprId> getTargetExprIdByFilterJoin(AbstractPhysicalJoin join) {
         return joinToTargetExprId.get(join);
+    }
+
+    public SlotReference getCorrespondingOlapSlotReference(SlotReference slot) {
+        SlotReference olapSlot = slot;
+        if (aliasTransferMap.containsKey(olapSlot)) {
+            olapSlot = (SlotReference) aliasTransferMap.get(olapSlot).second;
+        }
+        return olapSlot;
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

