### PR TITLE
[fix](resource-group) Fix resource group memory isolation may release too much memory

### DIFF
--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -381,8 +381,7 @@ int64_t MemTrackerLimiter::free_top_memory_query(
         std::lock_guard<std::mutex> l(tracker_groups[i].group_lock);
         for (auto tracker : tracker_groups[i].trackers) {
             if (tracker->type() == type) {
-                if (ExecEnv::GetInstance()->fragment_mgr()->query_is_canceled(
-                            label_to_queryid(tracker->label()))) {
+                if (tracker->is_query_cancelled()) {
                     continue;
                 }
                 if (tracker->consumption() > min_free_mem) {
@@ -441,8 +440,7 @@ int64_t MemTrackerLimiter::free_top_overcommit_query(
                 if (tracker->consumption() <= 33554432) { // 32M small query does not cancel
                     continue;
                 }
-                if (ExecEnv::GetInstance()->fragment_mgr()->query_is_canceled(
-                            label_to_queryid(tracker->label()))) {
+                if (tracker->is_query_cancelled()) {
                     continue;
                 }
                 int64_t overcommit_ratio =

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -138,6 +138,10 @@ public:
     // this tracker limiter.
     int64_t spare_capacity() const { return _limit - consumption(); }
 
+    bool is_query_cancelled() { return _is_query_cancelled; }
+
+    void set_is_query_cancelled(bool is_cancelled) { _is_query_cancelled.store(is_cancelled); }
+
     static void disable_oom_avoidance() { _oom_avoidance = false; }
 
 public:
@@ -253,6 +257,9 @@ private:
     // Consume size smaller than mem_tracker_consume_min_size_bytes will continue to accumulate
     // to avoid frequent calls to consume/release of MemTracker.
     std::atomic<int64_t> _untracked_mem = 0;
+
+    // query or load
+    std::atomic<bool> _is_query_cancelled = false;
 
     // Avoid frequent printing.
     bool _enable_print_log_usage = false;

--- a/be/src/runtime/query_context.h
+++ b/be/src/runtime/query_context.h
@@ -109,6 +109,9 @@ public:
             _is_cancelled = is_cancelled;
             _ready_to_execute = true;
         }
+        if (query_mem_tracker && is_cancelled) {
+            query_mem_tracker->set_is_query_cancelled(is_cancelled);
+        }
         _start_cond.notify_all();
     }
     void set_ready_to_execute_only() {

--- a/be/src/runtime/task_group/task_group.cpp
+++ b/be/src/runtime/task_group/task_group.cpp
@@ -128,7 +128,7 @@ int64_t TaskGroup::memory_used() {
     for (auto& mem_tracker_group : _mem_tracker_limiter_pool) {
         std::lock_guard<std::mutex> l(mem_tracker_group.group_lock);
         for (const auto& tracker : mem_tracker_group.trackers) {
-            used_memory += tracker->consumption();
+            used_memory += tracker->is_query_cancelled() ? 0 : tracker->consumption();
         }
     }
     return used_memory;


### PR DESCRIPTION

# Proposed changes

Issue Number: close #xxx

## Problem summary

Suppose three queries are executed in a resource group with a memory_limit of 8G, and they consume memory of query_a = 3G, query_b = 3G, and query_c = 3G. The total memory used is counted as 9G when the resource group GC is executed, which exceeds the resource group limit and cancels query_a. 

When the resource group is next GC, the memory of query_a may not be freed yet, and it will be counted again in the total memory consumed by that resource group, which again exceeds the resource group limit and cancels query_b. 

From the user's perspective, it is fine to execute query_a and query_b at the same time, but executing query_ a, query_b and query_c will be cancelled for two queries, which is not as expected.

This pr skips the queries that are cancelled when counting the memory used by the resource group. If this causes the process memory to grow, the process gc will handle it.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

