### PR TITLE
[Fix](load)Make insert timeout accurate in `show load` statistics 

### DIFF
--- a/docs/en/docs/data-operate/import/import-way/insert-into-manual.md
+++ b/docs/en/docs/data-operate/import/import-way/insert-into-manual.md
@@ -187,7 +187,7 @@ This command returns the insert results and the details of the corresponding tra
 
   The timeout time of the import task (in seconds) will be cancelled by the system if the import task is not completed within the set timeout time, and will become CANCELLED.
 
-  At present, Insert Into does not support custom import timeout time. All Insert Into imports have a uniform timeout time. The default timeout time is 1 hour. If the imported source file cannot complete the import within the specified time, the parameter `insert_load_default_timeout_second` of FE needs to be adjusted.
+  At present, Insert Into does not support custom import timeout time. All Insert Into imports have a uniform timeout time. The default timeout time is 4 hours. If the imported source file cannot complete the import within the specified time, the parameter `insert_load_default_timeout_second` of FE needs to be adjusted.
 
   <version since="dev"></version>
   At the same time, the Insert Into statement receives the restriction of the Session variable `insert_timeout`. You can increase the timeout time by `SET insert_timeout = xxx;` in seconds.

--- a/docs/zh-CN/docs/data-operate/import/import-way/insert-into-manual.md
+++ b/docs/zh-CN/docs/data-operate/import/import-way/insert-into-manual.md
@@ -190,7 +190,7 @@ TransactionStatus: VISIBLE
 
   导入任务的超时时间(以秒为单位)，导入任务在设定的 timeout 时间内未完成则会被系统取消，变成 CANCELLED。
 
-  目前 Insert Into 并不支持自定义导入的 timeout 时间，所有 Insert Into 导入的超时时间是统一的，默认的 timeout 时间为1小时。如果导入的源文件无法在规定时间内完成导入，则需要调整 FE 的参数```insert_load_default_timeout_second```。
+  目前 Insert Into 并不支持自定义导入的 timeout 时间，所有 Insert Into 导入的超时时间是统一的，默认的 timeout 时间为4小时。如果导入的源文件无法在规定时间内完成导入，则需要调整 FE 的参数```insert_load_default_timeout_second```。
   
   <version since="dev"></version>
   同时 Insert Into 语句受到 Session 变量 `insert_timeout`的限制。可以通过 `SET insert_timeout = xxx;` 来增加超时时间，单位是秒。

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -452,7 +452,7 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true, masterOnly = true, description = {"Insert load 的默认超时时间，单位是秒。",
             "Default timeout for insert load job, in seconds."})
-    public static int insert_load_default_timeout_second = 3600; // 1 hour
+    public static int insert_load_default_timeout_second = 14400; // 4 hour
 
     @ConfField(mutable = true, masterOnly = true, description = {"Stream load 的默认超时时间，单位是秒。",
             "Default timeout for stream load job, in seconds."})

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -77,6 +77,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -416,8 +417,8 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
                 break;
             case INSERT:
                 timeout = Optional.ofNullable(ConnectContext.get())
-                .map(ConnectContext::getExecTimeout)
-                .orElse(Config.insert_load_default_timeout_second)
+                                    .map(ConnectContext::getExecTimeout)
+                                    .orElse(Config.insert_load_default_timeout_second);
                 break;
             case MINI:
                 timeout = Config.stream_load_default_timeout_second;

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -415,7 +415,11 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
                 timeout = Config.broker_load_default_timeout_second;
                 break;
             case INSERT:
-                timeout = Config.insert_load_default_timeout_second;
+                if (ConnectContext.get() != null) {
+                    timeout = ConnectContext.get().getExecTimeout();
+                } else {
+                    timeout = Config.insert_load_default_timeout_second;
+                }
                 break;
             case MINI:
                 timeout = Config.stream_load_default_timeout_second;

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -415,11 +415,9 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
                 timeout = Config.broker_load_default_timeout_second;
                 break;
             case INSERT:
-                if (ConnectContext.get() != null) {
-                    timeout = ConnectContext.get().getExecTimeout();
-                } else {
-                    timeout = Config.insert_load_default_timeout_second;
-                }
+                timeout = Optional.ofNullable(ConnectContext.get())
+                .map(ConnectContext::getExecTimeout)
+                .orElse(Config.insert_load_default_timeout_second)
                 break;
             case MINI:
                 timeout = Config.stream_load_default_timeout_second;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #19940 

## Problem summary

* The default val of `insert_timeout` will be the same as session var if it has not been modified
```
*************************** 1. row ***************************
         JobId: 10139
         Label: insert_89bbe1c60dc244f4_bf759e6305c8114b
         State: FINISHED
      Progress: Unknown id: 10139
          Type: INSERT
       EtlInfo: NULL
      TaskInfo: cluster:N/A; timeout(s):14400; max_filter_ratio:0.0
      ErrorMsg: NULL
    CreateTime: 2023-05-25 20:11:01
  EtlStartTime: 2023-05-25 20:11:01
 EtlFinishTime: 2023-05-25 20:11:01
 LoadStartTime: 2023-05-25 20:11:01
LoadFinishTime: 2023-05-25 20:11:01
           URL:
    JobDetails: {"Unfinished backends":{},"ScannedRows":0,"TaskNumber":0,"LoadBytes":0,"All backends":{},"FileNumber":0,"FileSize":0}
 TransactionId: 2
  ErrorTablets: {}
          User: root
       Comment:
```


* After `show load` command , the `timeout(s)` will be correct  

```
mysql> set insert_timeout = 4800;
Query OK, 0 rows affected (0.00 sec)

mysql> insert into example.example_tbl values (10000,"2017-10-01","北京",20,0,"2017-10-02 06:00:00",20,10,10);
Query OK, 1 row affected (0.04 sec)
{'label':'insert_c1f81d88105444f_8f015541ee992fe0', 'status':'VISIBLE', 'txnId':'3'}

mysql> show load\G;
*************************** 1. row ***************************
         JobId: 10140
         Label: insert_c1f81d88105444f_8f015541ee992fe0
         State: FINISHED
      Progress: Unknown id: 10140
          Type: INSERT
       EtlInfo: NULL
      TaskInfo: cluster:N/A; timeout(s):4800; max_filter_ratio:0.0
      ErrorMsg: NULL
    CreateTime: 2023-05-25 20:11:39
  EtlStartTime: 2023-05-25 20:11:39
 EtlFinishTime: 2023-05-25 20:11:39
 LoadStartTime: 2023-05-25 20:11:39
LoadFinishTime: 2023-05-25 20:11:39
           URL:
    JobDetails: {"Unfinished backends":{},"ScannedRows":0,"TaskNumber":0,"LoadBytes":0,"All backends":{},"FileNumber":0,"FileSize":0}
 TransactionId: 3
  ErrorTablets: {}
          User: root
       Comment:
```



## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [x] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

