### PR TITLE
[fix](Nereids) constant folding to null should retain data type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/ExpressionEvaluator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/ExpressionEvaluator.java
@@ -65,6 +65,7 @@ public enum ExpressionEvaluator {
 
         String fnName = null;
         DataType[] args = null;
+        DataType ret = expression.getDataType();
         if (expression instanceof BinaryArithmetic) {
             BinaryArithmetic arithmetic = (BinaryArithmetic) expression;
             fnName = arithmetic.getLegacyOperator().getName();
@@ -82,7 +83,7 @@ public enum ExpressionEvaluator {
         if ((Env.getCurrentEnv().isNullResultWithOneNullParamFunction(fnName))) {
             for (Expression e : expression.children()) {
                 if (e instanceof NullLiteral) {
-                    return Literal.of(null);
+                    return new NullLiteral(ret);
                 }
             }
         }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

