### PR TITLE
[fix](ui)(fe-system) fix fe System Info query error when the fe serve…

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/SystemController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/SystemController.java
@@ -190,6 +190,10 @@ public class SystemController extends BaseController {
         if (path == null) {
             return "/rest/v1/system";
         } else {
+            final String windowsFileSystemSeparator = "\\";
+            if (windowsFileSystemSeparator.equals(path.getFileSystem().getSeparator())) {
+                return "/rest/v1/system?path=" + path.toString().replace("\\", "/");
+            }
             return "/rest/v1/system?path=" + path.toString();
         }
     }

--- a/ui/src/components/table/table.utils.tsx
+++ b/ui/src/components/table/table.utils.tsx
@@ -30,7 +30,10 @@ function getLinkItem(text, record, index, isInner, item, hrefColumn, path){
         if (record.__hrefPaths[hrefColumn.indexOf(item)].includes('http')) {
             return <a href={record.__hrefPaths[hrefColumn.indexOf(item)]} target="_blank">{text}</a>;
         }
-        return <Link  to={path+(location.search?location.search:isInner)+'/'+text}>{text}</Link>;
+        if (location.search[location.search.length -1] === '/') {
+            return <Link to={path+location.search+text}>{text}</Link>;
+        }
+        return <Link to={path+(location.search?location.search:isInner)+'/'+text}>{text}</Link>;
     }
     return text === '\\N' ? '-' : text;
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: #20072

## Problem summary

Describe your changes.
1. Fix duplicate '/' in front-end request URI.
2. When the FileSystemSeparator is '\\', replace '\\' as '/'

## Checklist(Required)

* [x] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

