### PR TITLE
[fix](mtmv)Fix tablet not found when restart fe

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowDataStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowDataStmt.java
@@ -147,7 +147,7 @@ public class ShowDataStmt extends ShowStmt {
                 }
 
                 for (Table table : sortedTables) {
-                    if (table.getType() != TableType.OLAP) {
+                    if (!table.isManagedTable()) {
                         continue;
                     }
 
@@ -243,7 +243,7 @@ public class ShowDataStmt extends ShowStmt {
                         dbName + ": " + tableName);
             }
 
-            OlapTable olapTable = (OlapTable) db.getTableOrMetaException(tableName.getTbl(), TableType.OLAP);
+            OlapTable olapTable = (OlapTable) db.getTableOrMetaException(tableName.getTbl(), TableType.OLAP, TableType.MATERIALIZED_VIEW);
             long totalSize = 0;
             long totalReplicaCount = 0;
             long totalRemoteSize = 0;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowDataStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowDataStmt.java
@@ -243,7 +243,8 @@ public class ShowDataStmt extends ShowStmt {
                         dbName + ": " + tableName);
             }
 
-            OlapTable olapTable = (OlapTable) db.getTableOrMetaException(tableName.getTbl(), TableType.OLAP, TableType.MATERIALIZED_VIEW);
+            OlapTable olapTable = (OlapTable) db
+                    .getTableOrMetaException(tableName.getTbl(), TableType.OLAP, TableType.MATERIALIZED_VIEW);
             long totalSize = 0;
             long totalReplicaCount = 0;
             long totalRemoteSize = 0;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowPartitionsStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowPartitionsStmt.java
@@ -23,6 +23,7 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.TableIf;
+import org.apache.doris.catalog.TableIf.TableType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
@@ -125,7 +126,7 @@ public class ShowPartitionsStmt extends ShowStmt {
         }
 
         DatabaseIf db = catalog.getDbOrAnalysisException(dbName);
-        TableIf table = db.getTableOrMetaException(tblName, Table.TableType.OLAP);
+        TableIf table = db.getTableOrMetaException(tblName, Table.TableType.OLAP, TableType.MATERIALIZED_VIEW);
         table.readLock();
         try {
             // build proc path

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/DatabaseIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/DatabaseIf.java
@@ -172,6 +172,19 @@ public interface DatabaseIf<T extends TableIf> {
         return table;
     }
 
+    default T getTableOrMetaException(String tableName, TableIf.TableType... tableTypes)
+            throws MetaNotFoundException {
+        T table = getTableOrMetaException(tableName);
+        for (TableIf.TableType tableType : tableTypes) {
+            if (table.getType() == tableType) {
+                return table;
+            }
+        }
+        throw new MetaNotFoundException(
+                "Tye type of " + tableName + " doesn't match, expected data tables=" + tableTypes);
+
+    }
+
     default T getTableOrMetaException(long tableId, TableIf.TableType tableType) throws MetaNotFoundException {
         T table = getTableOrMetaException(tableId);
         if (table.getType() != tableType) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/DatabaseIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/DatabaseIf.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Sets;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -174,15 +175,7 @@ public interface DatabaseIf<T extends TableIf> {
 
     default T getTableOrMetaException(String tableName, TableIf.TableType... tableTypes)
             throws MetaNotFoundException {
-        T table = getTableOrMetaException(tableName);
-        for (TableIf.TableType tableType : tableTypes) {
-            if (table.getType() == tableType) {
-                return table;
-            }
-        }
-        throw new MetaNotFoundException(
-                "Tye type of " + tableName + " doesn't match, expected data tables=" + tableTypes);
-
+        return getTableOrMetaException(tableName, Arrays.asList(tableTypes));
     }
 
     default T getTableOrMetaException(long tableId, TableIf.TableType tableType) throws MetaNotFoundException {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
@@ -214,5 +214,9 @@ public interface TableIf {
     default Partition getPartition(String name) {
         return null;
     }
+
+    default boolean isManagedTable() {
+        return getType() == TableType.OLAP || getType() == TableType.MATERIALIZED_VIEW;
+    }
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/PartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/PartitionsProcDir.java
@@ -33,7 +33,6 @@ import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.PartitionInfo;
 import org.apache.doris.catalog.PartitionType;
-import org.apache.doris.catalog.TableIf.TableType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
@@ -219,7 +218,7 @@ public class PartitionsProcDir implements ProcDirInterface {
     private List<List<Comparable>> getPartitionInfos() {
         Preconditions.checkNotNull(db);
         Preconditions.checkNotNull(olapTable);
-        Preconditions.checkState(olapTable.getType() == TableType.OLAP);
+        Preconditions.checkState(olapTable.isManagedTable());
 
         // get info
         List<List<Comparable>> partitionInfos = new ArrayList<List<Comparable>>();

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/TableProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/TableProcDir.java
@@ -78,7 +78,7 @@ public class TableProcDir implements ProcDirInterface {
         }
 
         if (entryName.equals(PARTITIONS)) {
-            if (table.getType() == TableType.OLAP) {
+            if (table.isManagedTable()) {
                 return new PartitionsProcDir((Database) db, (OlapTable) table, false);
             } else if (table.getType() == TableType.ELASTICSEARCH) {
                 return new EsPartitionsProcDir((Database) db, (EsTable) table);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -356,7 +356,7 @@ public class InternalCatalog implements CatalogIf<Database> {
         for (Database db : this.fullNameToDb.values()) {
             long dbId = db.getId();
             for (Table table : db.getTables()) {
-                if (table.getType() != TableType.OLAP) {
+                if (!(table instanceof OlapTable)) {
                     continue;
                 }
 
@@ -1228,7 +1228,7 @@ public class InternalCatalog implements CatalogIf<Database> {
         }
         if (!Env.isCheckpointThread()) {
             // add to inverted index
-            if (table.getType() == TableType.OLAP) {
+            if (table instanceof OlapTable) {
                 TabletInvertedIndex invertedIndex = Env.getCurrentInvertedIndex();
                 OlapTable olapTable = (OlapTable) table;
                 long dbId = db.getId();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -356,7 +356,7 @@ public class InternalCatalog implements CatalogIf<Database> {
         for (Database db : this.fullNameToDb.values()) {
             long dbId = db.getId();
             for (Table table : db.getTables()) {
-                if (!(table instanceof OlapTable)) {
+                if (!table.isManagedTable()) {
                     continue;
                 }
 
@@ -498,7 +498,7 @@ public class InternalCatalog implements CatalogIf<Database> {
                 try {
                     if (!stmt.isForceDrop()) {
                         for (Table table : tableList) {
-                            if (table.getType() == TableType.OLAP) {
+                            if (table.isManagedTable()) {
                                 OlapTable olapTable = (OlapTable) table;
                                 if (olapTable.getState() != OlapTableState.NORMAL) {
                                     throw new DdlException("The table [" + olapTable.getState() + "]'s state is "
@@ -1228,7 +1228,7 @@ public class InternalCatalog implements CatalogIf<Database> {
         }
         if (!Env.isCheckpointThread()) {
             // add to inverted index
-            if (table instanceof OlapTable) {
+            if (table.isManagedTable()) {
                 TabletInvertedIndex invertedIndex = Env.getCurrentInvertedIndex();
                 OlapTable olapTable = (OlapTable) table;
                 long dbId = db.getId();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #20094 

## Problem summary

Describe your changes.

The replayCreateTable restriction must be olapTable. If mv is used, nothing will be done, resulting in no call to invertedIndex.addReplica

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

