### PR TITLE
[fix](nereids)use same decimalv3 type for params and return types

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ArithmeticExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ArithmeticExpr.java
@@ -512,8 +512,16 @@ public class ArithmeticExpr extends Expr {
                     }
                     castChild(ScalarType.createDecimalV3Type(precision, targetScale), 0);
                 } else if (op == Operator.MOD) {
-                    castChild(type, 0);
-                    castChild(type, 1);
+                    // TODO use max int part + max scale of two operands as result type
+                    // because BE require the result and operands types are the exact the same decimalv3 type
+                    precision = Math.max(widthOfIntPart1, widthOfIntPart2) + scale;
+                    if (precision > ScalarType.MAX_DECIMAL128_PRECISION) {
+                        type = castBinaryOp(Type.DOUBLE);
+                    } else {
+                        type = ScalarType.createDecimalV3Type(precision, scale);
+                        castChild(type, 0);
+                        castChild(type, 1);
+                    }
                 }
                 break;
             case INT_DIVIDE:

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Mod.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Mod.java
@@ -44,8 +44,10 @@ public class Mod extends BinaryArithmetic implements AlwaysNullable {
 
     @Override
     public DecimalV3Type getDataTypeForDecimalV3(DecimalV3Type t1, DecimalV3Type t2) {
+        // TODO use max int part + max scale of two operands as result type
+        // because BE require the result and operands types are the exact the same decimalv3 type
         int scale = Math.max(t1.getScale(), t2.getScale());
-        int precision = t2.getRange() + scale;
+        int precision = Math.max(t1.getRange(), t2.getRange()) + scale;
         return DecimalV3Type.createDecimalV3Type(precision, scale);
     }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

