### PR TITLE
[runtimeFilter](nereids)generate in-bloom filter if target is local for pipeline mode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/FragmentProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/FragmentProcessor.java
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.processor.post;
+
+import org.apache.doris.nereids.CascadesContext;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalDistribute;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalHashJoin;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalOlapScan;
+
+/**
+ * generate fragment id for nereids physical plan
+ */
+public class FragmentProcessor extends PlanPostProcessor {
+    private int frId = 0;
+
+    public PhysicalDistribute visitPhysicalDistribute(PhysicalDistribute<? extends Plan> distribute,
+            CascadesContext ctx) {
+        frId++;
+        distribute.child().accept(this, ctx);
+        return distribute;
+    }
+
+    public PhysicalHashJoin visitPhysicalHashJoin(PhysicalHashJoin<? extends Plan, ? extends Plan> join,
+            CascadesContext ctx) {
+        join.setMutableState(AbstractPlan.FRAGMENT_ID, frId);
+        join.left().accept(this, ctx);
+        join.right().accept(this, ctx);
+        return join;
+    }
+
+    public PhysicalOlapScan visitPhysicalOlapScan(PhysicalOlapScan scan, CascadesContext ctx) {
+        scan.setMutableState(AbstractPlan.FRAGMENT_ID, frId);
+        return scan;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/PlanPostProcessors.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/PlanPostProcessors.java
@@ -60,6 +60,7 @@ public class PlanPostProcessors {
         Builder<PlanPostProcessor> builder = ImmutableList.builder();
         builder.add(new MergeProjectPostProcessor());
         builder.add(new PushdownFilterThroughProject());
+        builder.add(new FragmentProcessor());
         if (!cascadesContext.getConnectContext().getSessionVariable().getRuntimeFilterMode()
                         .toUpperCase().equals(TRuntimeFilterMode.OFF.name())) {
             builder.add(new RuntimeFilterGenerator());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterContext.java
@@ -77,8 +77,6 @@ public class RuntimeFilterContext {
     private final Map<Slot, ScanNode> scanNodeOfLegacyRuntimeFilterTarget = Maps.newHashMap();
 
     private final Set<Plan> effectiveSrcNodes = Sets.newHashSet();
-    // collect the first column of tables. min-max/in RF on the first column could be used to shrink scan range.
-    private final Set<Slot> firstKeyOfTable = Sets.newHashSet();
     private final SessionVariable sessionVariable;
 
     private final FilterSizeLimits limits;
@@ -196,14 +194,6 @@ public class RuntimeFilterContext {
 
     public List<ExprId> getTargetExprIdByFilterJoin(AbstractPhysicalJoin join) {
         return joinToTargetExprId.get(join);
-    }
-
-    public boolean isFirstKeyOfTable(Slot slot) {
-        return firstKeyOfTable.contains(slot);
-    }
-
-    public void addFistKeyOfTable(Slot slot) {
-        firstKeyOfTable.add(slot);
     }
 
     public SlotReference getCorrespondingOlapSlotReference(SlotReference slot) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.processor.post;
 
+import org.apache.doris.catalog.Column;
 import org.apache.doris.common.IdGenerator;
 import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.CascadesContext;
@@ -27,13 +28,14 @@ import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Not;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.BitmapContains;
 import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.JoinType;
-import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalHashJoin;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalNestedLoopJoin;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalOlapScan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalProject;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalRelation;
@@ -44,6 +46,7 @@ import org.apache.doris.planner.RuntimeFilterId;
 import org.apache.doris.statistics.ColumnStatistic;
 import org.apache.doris.thrift.TRuntimeFilterType;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.Arrays;
@@ -85,7 +88,7 @@ public class RuntimeFilterGenerator extends PlanPostProcessor {
     public PhysicalPlan visitPhysicalHashJoin(PhysicalHashJoin<? extends Plan, ? extends Plan> join,
             CascadesContext context) {
         RuntimeFilterContext ctx = context.getRuntimeFilterContext();
-        Map<NamedExpression, Pair<ObjectId, Slot>> aliasTransferMap = ctx.getAliasTransferMap();
+        Map<NamedExpression, Pair<PhysicalRelation, Slot>> aliasTransferMap = ctx.getAliasTransferMap();
         join.right().accept(this, context);
         join.left().accept(this, context);
         if (DENIED_JOIN_TYPES.contains(join.getJoinType()) || join.isMarkJoin()) {
@@ -105,10 +108,6 @@ public class RuntimeFilterGenerator extends PlanPostProcessor {
                     if (type == TRuntimeFilterType.BITMAP) {
                         continue;
                     }
-                    // in-filter is not friendly to pipeline
-                    if (type == TRuntimeFilterType.IN_OR_BLOOM && ctx.getSessionVariable().enablePipelineEngine()) {
-                        type = TRuntimeFilterType.BLOOM;
-                    }
                     // currently, we can ensure children in the two side are corresponding to the equal_to's.
                     // so right maybe an expression and left is a slot
                     Slot unwrappedSlot = checkTargetChild(equalTo.left());
@@ -118,16 +117,34 @@ public class RuntimeFilterGenerator extends PlanPostProcessor {
                         continue;
                     }
                     Slot olapScanSlot = aliasTransferMap.get(unwrappedSlot).second;
+                    PhysicalRelation scan = aliasTransferMap.get(unwrappedSlot).first;
+                    // in-filter is not friendly to pipeline
+                    if (type == TRuntimeFilterType.IN_OR_BLOOM
+                            && ctx.getSessionVariable().enablePipelineEngine()
+                            //&& !ctx.isFirstKeyOfTable(olapScanSlot)
+                            && hasRemoteTarget(join, scan)) {
+                        type = TRuntimeFilterType.BLOOM;
+                    }
+
                     long buildSideNdv = getBuildSideNdv(join, equalTo);
                     RuntimeFilter filter = new RuntimeFilter(generator.getNextId(),
                             equalTo.right(), olapScanSlot, type, i, join, buildSideNdv);
                     ctx.addJoinToTargetMap(join, olapScanSlot.getExprId());
                     ctx.setTargetExprIdToFilter(olapScanSlot.getExprId(), filter);
-                    ctx.setTargetsOnScanNode(aliasTransferMap.get(unwrappedSlot).first, olapScanSlot);
+                    ctx.setTargetsOnScanNode(aliasTransferMap.get(unwrappedSlot).first.getId(), olapScanSlot);
                 }
             }
         }
         return join;
+    }
+
+    private boolean hasRemoteTarget(AbstractPlan join, AbstractPlan scan) {
+        Preconditions.checkArgument(join.getMutableState(AbstractPlan.FRAGMENT_ID).isPresent(),
+                "cannot find fragment id for Join node");
+        Preconditions.checkArgument(scan.getMutableState(AbstractPlan.FRAGMENT_ID).isPresent(),
+                "cannot find fragment id for scan node");
+        return join.getMutableState(AbstractPlan.FRAGMENT_ID).get()
+                != scan.getMutableState(AbstractPlan.FRAGMENT_ID).get();
     }
 
     private long getBuildSideNdv(PhysicalHashJoin<? extends Plan, ? extends Plan> join, EqualTo equalTo) {
@@ -151,7 +168,7 @@ public class RuntimeFilterGenerator extends PlanPostProcessor {
             return join;
         }
         RuntimeFilterContext ctx = context.getRuntimeFilterContext();
-        Map<NamedExpression, Pair<ObjectId, Slot>> aliasTransferMap = ctx.getAliasTransferMap();
+        Map<NamedExpression, Pair<PhysicalRelation, Slot>> aliasTransferMap = ctx.getAliasTransferMap();
 
         if ((ctx.getSessionVariable().getRuntimeFilterType() & TRuntimeFilterType.BITMAP.getValue()) == 0) {
             //only generate BITMAP filter for nested loop join
@@ -185,7 +202,8 @@ public class RuntimeFilterGenerator extends PlanPostProcessor {
                             bitmapContains.child(1), type, i, join, isNot, -1L);
                     ctx.addJoinToTargetMap(join, olapScanSlot.getExprId());
                     ctx.setTargetExprIdToFilter(olapScanSlot.getExprId(), filter);
-                    ctx.setTargetsOnScanNode(aliasTransferMap.get(targetSlot).first, olapScanSlot);
+                    ctx.setTargetsOnScanNode(aliasTransferMap.get(targetSlot).first.getId(),
+                            olapScanSlot);
                     join.addBitmapRuntimeFilterCondition(bitmapRuntimeFilterCondition);
                 }
             }
@@ -196,7 +214,7 @@ public class RuntimeFilterGenerator extends PlanPostProcessor {
     @Override
     public PhysicalPlan visitPhysicalProject(PhysicalProject<? extends Plan> project, CascadesContext context) {
         project.child().accept(this, context);
-        Map<NamedExpression, Pair<ObjectId, Slot>> aliasTransferMap
+        Map<NamedExpression, Pair<PhysicalRelation, Slot>> aliasTransferMap
                 = context.getRuntimeFilterContext().getAliasTransferMap();
         // change key when encounter alias.
         for (Expression expression : project.getProjects()) {
@@ -218,7 +236,31 @@ public class RuntimeFilterGenerator extends PlanPostProcessor {
     public PhysicalRelation visitPhysicalScan(PhysicalRelation scan, CascadesContext context) {
         // add all the slots in map.
         RuntimeFilterContext ctx = context.getRuntimeFilterContext();
-        scan.getOutput().forEach(slot -> ctx.getAliasTransferMap().put(slot, Pair.of(scan.getId(), slot)));
+        scan.getOutput().forEach(slot -> ctx.getAliasTransferMap().put(slot, Pair.of(scan, slot)));
+        Slot first = scan.getOutput().get(0);
+        //collect first duplicate-key(unique-key) for min-max/in filter
+        if (first instanceof SlotReference) {
+            SlotReference firstSlotRef = (SlotReference) first;
+            if (firstSlotRef.getColumn().isPresent()
+                    && firstSlotRef.getColumn().get().isKey()) {
+                ctx.addFistKeyOfTable(firstSlotRef);
+            }
+        }
+        if (scan instanceof PhysicalOlapScan) {
+            // collect first partition key
+            PhysicalOlapScan olapScan = (PhysicalOlapScan) scan;
+            if (!olapScan.getTable().getPartitionInfo().getPartitionColumns().isEmpty()) {
+                Column firstPartitionColumn = olapScan.getTable().getPartitionInfo().getPartitionColumns().get(0);
+                for (Slot slot : scan.getOutput()) {
+                    SlotReference slotReference = (SlotReference) slot;
+                    if (slotReference.getColumn().isPresent()
+                            && slotReference.getColumn().get().equals(firstPartitionColumn)) {
+                        ctx.addFistKeyOfTable(slotReference);
+                        break;
+                    }
+                }
+            }
+        }
         return scan;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/AbstractPlan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/AbstractPlan.java
@@ -52,6 +52,7 @@ import javax.annotation.Nullable;
  * Abstract class for all concrete plan node.
  */
 public abstract class AbstractPlan extends AbstractTreeNode<Plan> implements Plan {
+    public static final String FRAGMENT_ID = "fragment";
     private static final EventProducer PLAN_CONSTRUCT_TRACER = new EventProducer(CounterEvent.class,
             EventChannel.getDefaultChannel()
                     .addEnhancers(new AddCounterEventEnhancer())

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
@@ -24,6 +24,7 @@ import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.MarkJoinSlotReference;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.JoinHint;
 import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.Plan;
@@ -132,7 +133,8 @@ public class PhysicalHashJoin<
         List<Object> args = Lists.newArrayList("type", joinType,
                 "hashJoinCondition", hashJoinConjuncts,
                 "otherJoinCondition", otherJoinConjuncts,
-                "stats", statistics);
+                "stats", statistics,
+                "fr", getMutableState(AbstractPlan.FRAGMENT_ID));
         if (markJoinSlotReference.isPresent()) {
             args.add("isMarkJoin");
             args.add("true");

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalOlapScan.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.properties.DistributionSpec;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.PreAggStatus;
@@ -119,7 +120,7 @@ public class PhysicalOlapScan extends PhysicalRelation implements OlapScan {
     public String toString() {
         return Utils.toSqlString("PhysicalOlapScan[" + id.asInt() + "]" + getGroupIdAsString(),
                 "qualified", Utils.qualifiedName(qualifier, olapTable.getName()),
-                "stats", statistics
+                "stats", statistics, "fr", getMutableState(AbstractPlan.FRAGMENT_ID)
         );
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -635,7 +635,7 @@ public class SessionVariable implements Serializable, Writable {
     private int runtimeFilterType = 8;
 
     @VariableMgr.VarAttr(name = RUNTIME_FILTER_MAX_IN_NUM)
-    private int runtimeFilterMaxInNum = 102400;
+    private int runtimeFilterMaxInNum = 1024;
 
     public int getBeNumberForTest() {
         return beNumberForTest;


### PR DESCRIPTION
# Proposed changes
update in-filter usage in pipeline mode
1. if the target is local, we use in-bloom filter. Let BE choose in or bloom according to actual distinctive number
2. set default runtime_filter_max_in_num to 1024
after this change, 
1. on ssb_sf100 test, nereids + pipeline is as good as original planner
2. tpch_sf500, neredis + pipeline benefits about 2 second improve.
## test results:
### ssb sf100:
N: nereids, P: pipeline, +: open, -:close
<img width="1212" alt="image" src="https://github.com/apache/doris/assets/1747806/69b6c98e-2ab4-49bd-9e4e-1be89526b741">


### tpch_sf500:
<img width="446" alt="image" src="https://github.com/apache/doris/assets/1747806/ced57c80-10e5-47ab-af94-171730af4f2f">

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

