### PR TITLE
[chore](build) Fix compilation errors reported by GCC-13

### DIFF
--- a/be/src/olap/olap_common.h
+++ b/be/src/olap/olap_common.h
@@ -267,7 +267,7 @@ class Field;
 class WrapperField;
 using KeyRange = std::pair<WrapperField*, WrapperField*>;
 
-static const int GENERAL_DEBUG_COUNT = 0;
+#define GENERAL_DEBUG_COUNT 0
 
 // ReaderStatistics used to collect statistics when scan data from storage
 struct OlapReaderStatistics {
@@ -360,6 +360,8 @@ struct OlapReaderStatistics {
     int64_t filtered_segment_number = 0;
     // total number of segment
     int64_t total_segment_number = 0;
+
+#if GENERAL_DEBUG_COUNT > 0
     // general_debug_ns is designed for the purpose of DEBUG, to record any infomations of debugging or profiling.
     // different from specific meaningful timer such as index_load_ns, general_debug_ns can be used flexibly.
     // general_debug_ns has associated with OlapScanNode's _general_debug_timer already.
@@ -371,6 +373,7 @@ struct OlapReaderStatistics {
     // usage example:
     //               SCOPED_RAW_TIMER(&_stats->general_debug_ns[1]);
     int64_t general_debug_ns[GENERAL_DEBUG_COUNT] = {};
+#endif
 
     io::FileCacheStatistics file_cache_stats;
     int64_t load_segments_timer = 0;


### PR DESCRIPTION
# Proposed changes

~~Issue Number: close #xxx~~

## Problem summary

GCC-13 can't build the codebase now after merging #19789 .

```shell
/Programs/doris/be/src/olap/olap_common.h: In member function 'doris::OlapReaderStatistics& doris::OlapReaderStatistics::operator=(const doris::OlapReaderStatistics&)':
/Programs/doris/be/src/olap/olap_common.h:273:8: error: statement has no effect [-Werror=unused-value]
  273 | struct OlapReaderStatistics {
      |        ^~~~~~~~~~~~~~~~~~~~
/Programs/doris/be/src/olap/rowset/segcompaction.cpp: In member function 'doris::Status doris::SegcompactionWorker::_do_compact_segments(doris::SegCompactionCandidatesSharedPtr)':
/Programs/doris/be/src/olap/rowset/segcompaction.cpp:250:32: note: synthesized method 'doris::OlapReaderStatistics& doris::OlapReaderStatistics::operator=(const doris::OlapReaderStatistics&)' first required here
  250 |             key_reader_stats = reader_stats;
      |                                ^~~~~~~~~~~~
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

