### PR TITLE
[fix](partial update) use correct tablet schema for rowset writer in publish task

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2699,6 +2699,14 @@ Status Tablet::calc_delete_bitmap(RowsetSharedPtr rowset,
     Version dummy_version(end_version + 1, end_version + 1);
     auto rowset_id = rowset->rowset_id();
     auto rowset_schema = rowset->tablet_schema();
+    LOG(INFO) << "DEBUG: rowset schema columns : " << rowset_schema->num_columns();
+    for (auto c : rowset_schema->columns()) {
+        LOG(INFO) << "DEBUG: " << c.name();
+    }
+    LOG(INFO) << "DEBUG: tablet schema columns: " << tablet_schema()->num_columns();
+    for (auto c : tablet_schema()->columns()) {
+        LOG(INFO) << "DEBUG: " << c.name();
+    }
     bool is_partial_update = rowset_schema->is_partial_update();
     // use for partial update
     PartialUpdateReadPlan read_plan_ori;

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2699,14 +2699,6 @@ Status Tablet::calc_delete_bitmap(RowsetSharedPtr rowset,
     Version dummy_version(end_version + 1, end_version + 1);
     auto rowset_id = rowset->rowset_id();
     auto rowset_schema = rowset->tablet_schema();
-    LOG(INFO) << "DEBUG: rowset schema columns : " << rowset_schema->num_columns();
-    for (auto c : rowset_schema->columns()) {
-        LOG(INFO) << "DEBUG: " << c.name();
-    }
-    LOG(INFO) << "DEBUG: tablet schema columns: " << tablet_schema()->num_columns();
-    for (auto c : tablet_schema()->columns()) {
-        LOG(INFO) << "DEBUG: " << c.name();
-    }
     bool is_partial_update = rowset_schema->is_partial_update();
     // use for partial update
     PartialUpdateReadPlan read_plan_ori;

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -438,7 +438,9 @@ Status TxnManager::_create_transient_rowset_writer(std::shared_ptr<Tablet> table
     RowsetWriterContext context;
     context.rowset_state = PREPARED;
     context.segments_overlap = OVERLAPPING;
-    context.tablet_schema = rowset_ptr->tablet_schema();
+    context.tablet_schema = std::make_shared<TabletSchema>();
+    context.tablet_schema->copy_from(*(rowset_ptr->tablet_schema()));
+    context.tablet_schema->set_partial_update_info(false, std::set<std::string>());
     context.newest_write_timestamp = UnixSeconds();
     context.tablet_id = tablet->table_id();
     context.tablet = tablet;

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -445,7 +445,8 @@ Status TxnManager::_create_transient_rowset_writer(std::shared_ptr<Tablet> table
     context.tablet_id = tablet->table_id();
     context.tablet = tablet;
     context.is_direct_write = true;
-    RETURN_IF_ERROR(tablet->create_transient_rowset_writer(context, rowset_ptr->rowset_id(), rowset_writer));
+    RETURN_IF_ERROR(tablet->create_transient_rowset_writer(context, rowset_ptr->rowset_id(),
+                                                           rowset_writer));
     (*rowset_writer)->set_segment_start_id(rowset_ptr->num_segments());
     return Status::OK();
 }

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -213,7 +213,7 @@ private:
     void _clear_txn_partition_map_unlocked(int64_t transaction_id, int64_t partition_id);
 
     Status _create_transient_rowset_writer(std::shared_ptr<Tablet> tablet,
-                                           const RowsetId& rowset_id, int32_t num_segments_ori,
+                                           RowsetSharedPtr rowset_ptr,
                                            std::unique_ptr<RowsetWriter>* rowset_writer);
 
 private:


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

fix core dump
```
F0526 14:30:32.979687 811726 tablet_schema.cpp:879] Check failed: ordinal < _num_columns ordinal:20, _num_columns:20
*** Check failure stack trace: ***
    @     0x563d33ba3d2d  google::LogMessage::Fail()
    @     0x563d33ba6269  google::LogMessage::SendToLog()
    @     0x563d33ba3896  google::LogMessage::Flush()
    @     0x563d33ba68d9  google::LogMessageFatal::~LogMessageFatal()
    @     0x563d167152a9  doris::TabletSchema::column()
    @     0x563d16c26401  doris::segment_v2::SegmentWriter::_create_writers()
    @     0x563d16c24b8b  doris::segment_v2::SegmentWriter::init()
    @     0x563d16c23e2a  doris::segment_v2::SegmentWriter::init()
    @     0x563d16e9ec9c  doris::BetaRowsetWriter::_do_create_segment_writer()
    @     0x563d16e8e1f6  doris::BetaRowsetWriter::_create_segment_writer()
    @     0x563d16e9922c  doris::BetaRowsetWriter::flush_single_memtable()
    @     0x563d16539d8b  doris::Tablet::calc_delete_bitmap()
    @     0x563d16540e65  doris::Tablet::update_delete_bitmap()
    @     0x563d16750d4a  doris::TxnManager::publish_txn()
    @     0x563d1674fd69  doris::TxnManager::publish_txn()
    @     0x563d16e16916  doris::TabletPublishTxnTask::handle()
    @     0x563d16e17a6d  doris::EnginePublishVersionTask::finish()::$_0::operator()()
    @     0x563d16e17a45  std::__invoke_impl<>()
    @     0x563d16e179e5  _ZSt10__invoke_rIvRZN5doris24EnginePublishVersionTask6finishEvE3$_0JEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EES5_E4typeEOS6_DpOS7_
    @     0x563d16e1781d  std::_Function_handler<>::_M_invoke()
    @     0x563d14b11e83  std::function<>::operator()()
    @     0x563d179be2a9  doris::FunctionRunnable::run()
    @     0x563d179abaa7  doris::ThreadPool::dispatch_thread()
    @     0x563d179d1644  std::__invoke_impl<>()
    @     0x563d179d151d  std::__invoke<>()
    @     0x563d179d14a5  _ZNSt5_BindIFMN5doris10ThreadPoolEFvvEPS1_EE6__callIvJEJLm0EEEET_OSt5tupleIJDpT0_EESt12_Index_tupleIJXspT1_EEE
    @     0x563d179d134e  std::_Bind<>::operator()<>()
    @     0x563d179d1265  std::__invoke_impl<>()
    @     0x563d179d1205  _ZSt10__invoke_rIvRSt5_BindIFMN5doris10ThreadPoolEFvvEPS2_EEJEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EESA_E4typeEOSB_DpOSC_
    @     0x563d179d0f2d  std::_Function_handler<>::_M_invoke()
    @     0x563d14b11e83  std::function<>::operator()()
    @     0x563d17983947  doris::Thread::supervise_thread()
*** Query id: 0-0 ***
*** Aborted at 1685082633 (unix time) try "date -d @1685082633" if you are using GNU date ***
*** Current BE git commitID: 9185b202c5 ***
```

The schema in Tablet don't contains __DORIS_DELETE_SIGN__ and __DORIS_SEQUENCE_COL__, should use schema in rowset.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

