### PR TITLE
[Enhancement] Add an API to query session information for all FEs

### DIFF
--- a/docs/en/docs/admin-manual/http-actions/fe/session-action.md
+++ b/docs/en/docs/admin-manual/http-actions/fe/session-action.md
@@ -28,9 +28,13 @@ under the License.
 
 ## Request
 
-```
-GET /rest/v1/session
-```
+`GET /rest/v1/session`
+
+<version since="dev">
+
+`GET /rest/v1/session/all`
+
+</version>
 
 ## Description
 
@@ -48,6 +52,10 @@ None
 
 None
 
+## Obtain the current session information
+
+`GET /rest/v1/session`
+
 ## Response
 
 ```
@@ -64,6 +72,47 @@ None
 			"Host": "10.81.85.89:31465",
 			"Time": "230",
 			"Id": "0",
+			"Info": "",
+			"Db": "db1"
+		}]
+	},
+	"count": 2
+}
+```
+
+## Obtain all FE session information
+
+`GET /rest/v1/session/all`
+
+## Response
+
+```
+{
+	"msg": "success",
+	"code": 0,
+	"data": {
+		"column_names": ["FE", "Id", "User", "Host", "Cluster", "Db", "Command", "Time", "State", "Info"],
+		"rows": [{
+		    "FE": "10.14.170.23",
+			"User": "root",
+			"Command": "Sleep",
+			"State": "",
+			"Cluster": "default_cluster",
+			"Host": "10.81.85.89:31465",
+			"Time": "230",
+			"Id": "0",
+			"Info": "",
+			"Db": "db1"
+		},
+		{
+            "FE": "10.14.170.24",
+			"User": "root",
+			"Command": "Sleep",
+			"State": "",
+			"Cluster": "default_cluster",
+			"Host": "10.81.85.88:61465",
+			"Time": "460",
+			"Id": "1",
 			"Info": "",
 			"Db": "db1"
 		}]

--- a/docs/zh-CN/docs/admin-manual/http-actions/fe/session-action.md
+++ b/docs/zh-CN/docs/admin-manual/http-actions/fe/session-action.md
@@ -28,9 +28,13 @@ under the License.
 
 ## Request
 
-```
-GET /rest/v1/session
-```
+`GET /rest/v1/session`
+
+<version since="dev">
+
+`GET /rest/v1/session/all`
+
+</version>
 
 ## Description
 
@@ -48,6 +52,10 @@ Session Action 用于获取当前的会话信息。
 
 无
 
+## 获取当前FE的会话信息
+
+`GET /rest/v1/session`
+
 ## Response
 
 ```
@@ -64,6 +72,47 @@ Session Action 用于获取当前的会话信息。
 			"Host": "10.81.85.89:31465",
 			"Time": "230",
 			"Id": "0",
+			"Info": "",
+			"Db": "db1"
+		}]
+	},
+	"count": 2
+}
+```
+
+## 获取所有FE的会话信息
+
+`GET /rest/v1/session/all`
+
+## Response
+
+```
+{
+	"msg": "success",
+	"code": 0,
+	"data": {
+		"column_names": ["FE", "Id", "User", "Host", "Cluster", "Db", "Command", "Time", "State", "Info"],
+		"rows": [{
+		    "FE": "10.14.170.23",
+			"User": "root",
+			"Command": "Sleep",
+			"State": "",
+			"Cluster": "default_cluster",
+			"Host": "10.81.85.89:31465",
+			"Time": "230",
+			"Id": "0",
+			"Info": "",
+			"Db": "db1"
+		},
+		{
+            "FE": "10.14.170.24",
+			"User": "root",
+			"Command": "Sleep",
+			"State": "",
+			"Cluster": "default_cluster",
+			"Host": "10.81.85.88:61465",
+			"Time": "460",
+			"Id": "1",
 			"Info": "",
 			"Db": "db1"
 		}]

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/SessionController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/SessionController.java
@@ -17,27 +17,45 @@
 
 package org.apache.doris.httpv2.controller;
 
+import org.apache.doris.catalog.Env;
 import org.apache.doris.httpv2.entity.ResponseBody;
 import org.apache.doris.httpv2.entity.ResponseEntityBuilder;
+import org.apache.doris.httpv2.rest.RestBaseController;
+import org.apache.doris.httpv2.rest.manager.HttpUtils;
+import org.apache.doris.httpv2.rest.manager.NodeAction;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.service.ExecuteEnv;
+import org.apache.doris.system.Frontend;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.IOException;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import javax.servlet.http.HttpServletRequest;
 
 @RestController
 @RequestMapping("/rest/v1")
-public class SessionController extends BaseController {
+public class SessionController extends RestBaseController {
 
     private static final List<String> SESSION_TABLE_HEADER = Lists.newArrayList();
+
+    private static final List<String> ALL_SESSION_TABLE_HEADER = Lists.newArrayList("FE");
+
+    private static final Logger LOG = LogManager.getLogger(SessionController.class);
 
     static {
         SESSION_TABLE_HEADER.add("Id");
@@ -49,37 +67,72 @@ public class SessionController extends BaseController {
         SESSION_TABLE_HEADER.add("Time");
         SESSION_TABLE_HEADER.add("State");
         SESSION_TABLE_HEADER.add("Info");
+        ALL_SESSION_TABLE_HEADER.addAll(SESSION_TABLE_HEADER);
+    }
+
+    @RequestMapping(path = "/session/all", method = RequestMethod.GET)
+    public Object allSession(HttpServletRequest request) {
+        Map<String, Object> result = Maps.newHashMap();
+        result.put("column_names", ALL_SESSION_TABLE_HEADER);
+        List<Map<String, String>> sessionInfo = Env.getCurrentEnv().getFrontends(null)
+                .stream()
+                .filter(Frontend::isAlive)
+                .map(frontend -> {
+                    try {
+                        return Env.getCurrentEnv().getSelfNode().getHost().equals(frontend.getHost())
+                            ? getSessionInfo(true)
+                            : getOtherSessionInfo(request, frontend);
+                    } catch (IOException e) {
+                        LOG.warn("", e);
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+        result.put("rows", sessionInfo);
+        ResponseEntity entity = ResponseEntityBuilder.ok(result);
+        ((ResponseBody) entity.getBody()).setCount(sessionInfo.size());
+        return entity;
     }
 
     @RequestMapping(path = "/session", method = RequestMethod.GET)
     public Object session() {
         Map<String, Object> result = Maps.newHashMap();
-        appendSessionInfo(result);
+        result.put("column_names", SESSION_TABLE_HEADER);
+        result.put("rows", getSessionInfo(false));
         ResponseEntity entity = ResponseEntityBuilder.ok(result);
         ((ResponseBody) entity.getBody()).setCount(result.size());
         return entity;
     }
 
-    private void appendSessionInfo(Map<String, Object> result) {
+    private List<Map<String, String>> getSessionInfo(boolean showFe) {
         List<ConnectContext.ThreadInfo> threadInfos = ExecuteEnv.getInstance().getScheduler()
                 .listConnection("root", false);
-        List<List<String>> rows = Lists.newArrayList();
-
-        result.put("column_names", SESSION_TABLE_HEADER);
-        List<Map<String, String>> list = Lists.newArrayList();
-        result.put("rows", list);
-
         long nowMs = System.currentTimeMillis();
-        for (ConnectContext.ThreadInfo info : threadInfos) {
-            rows.add(info.toRow(nowMs));
-        }
+        return threadInfos.stream()
+                .map(info -> info.toRow(nowMs, showFe))
+                .map(row -> {
+                    Map<String, String> record = new HashMap<>();
+                    for (int i = 0; i < row.size(); i++) {
+                        record.put(showFe ? ALL_SESSION_TABLE_HEADER.get(i) : SESSION_TABLE_HEADER.get(i), row.get(i));
+                    }
+                    return record;
+                })
+                .collect(Collectors.toList());
+    }
 
-        for (List<String> row : rows) {
-            Map<String, String> record = new HashMap<>();
-            for (int i = 0; i < row.size(); i++) {
-                record.put(SESSION_TABLE_HEADER.get(i), row.get(i));
-            }
-            list.add(record);
-        }
+    private List<Map<String, String>> getOtherSessionInfo(HttpServletRequest request,
+                                                          Frontend frontend) throws IOException {
+        Map<String, String> header = Maps.newHashMap();
+        header.put(NodeAction.AUTHORIZATION, request.getHeader(NodeAction.AUTHORIZATION));
+        String res = HttpUtils.doGet(String.format("http://%s:%s/rest/v1/session",
+                frontend.getHost(), Env.getCurrentEnv().getMasterHttpPort()), header);
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map<String, Object> jsonMap = objectMapper.readValue(res,
+            new TypeReference<Map<String, Object>>() {});
+        List<Map<String, String>> maps = (List<Map<String, String>>)
+                ((Map<String, Object>) jsonMap.get("data")).get("rows");
+        return maps;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -755,8 +755,11 @@ public class ConnectContext {
     public class ThreadInfo {
         public boolean isFull;
 
-        public List<String> toRow(long nowMs) {
+        public List<String> toRow(long nowMs, boolean showFe) {
             List<String> row = Lists.newArrayList();
+            if (showFe) {
+                row.add(Env.getCurrentEnv().getSelfNode().getHost());
+            }
             row.add("" + connectionId);
             row.add(ClusterNamespace.getNameFromFullName(qualifiedUser));
             row.add(getMysqlChannel().getRemoteHostPortString());

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -456,7 +456,7 @@ public class ShowExecutor {
                 .listConnection(ctx.getQualifiedUser(), showStmt.isFull());
         long nowMs = System.currentTimeMillis();
         for (ConnectContext.ThreadInfo info : threadInfos) {
-            rowSet.add(info.toRow(nowMs));
+            rowSet.add(info.toRow(nowMs, false));
         }
 
         resultSet = new ShowResultSet(showStmt.getMetaData(), rowSet);

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectContextTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectContextTest.java
@@ -111,6 +111,7 @@ public class ConnectContextTest {
         Assert.assertEquals("Ping", row.get(5));
         Assert.assertEquals("1", row.get(6));
         Assert.assertEquals("", row.get(7));
+        Assert.assertEquals("", row.get(8));
 
         // Start time
         Assert.assertEquals(0, ctx.getStartTime());

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectContextTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectContextTest.java
@@ -101,7 +101,7 @@ public class ConnectContextTest {
 
         // Thread info
         Assert.assertNotNull(ctx.toThreadInfo(false));
-        List<String> row = ctx.toThreadInfo(false).toRow(1000);
+        List<String> row = ctx.toThreadInfo(false).toRow(1000, false);
         Assert.assertEquals(9, row.size());
         Assert.assertEquals("101", row.get(0));
         Assert.assertEquals("testUser", row.get(1));
@@ -111,7 +111,6 @@ public class ConnectContextTest {
         Assert.assertEquals("Ping", row.get(5));
         Assert.assertEquals("1", row.get(6));
         Assert.assertEquals("", row.get(7));
-        Assert.assertEquals("", row.get(8));
 
         // Start time
         Assert.assertEquals(0, ctx.getStartTime());

--- a/ui/src/api/api.ts
+++ b/ui/src/api/api.ts
@@ -5,9 +5,9 @@
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/ui/src/api/api.ts
+++ b/ui/src/api/api.ts
@@ -5,9 +5,9 @@
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.  You may obtain a copy of the License at
-//
+// 
 //   http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY


### PR DESCRIPTION
# Proposed changes

Currently, Doris only has one interface for querying specific FE session information, and many times we need to know how many session information there are in the current cluster, so I added this API.

`
GET /rest/v1/session/all


{
	"msg": "success",
	"code": 0,
	"data": {
		"column_names": ["FE", "Id", "User", "Host", "Cluster", "Db", "Command", "Time", "State", "Info"],
		"rows": [{
		    "FE": "10.14.170.23",
			"User": "root",
			"Command": "Sleep",
			"State": "",
			"Cluster": "default_cluster",
			"Host": "10.81.85.89:31465",
			"Time": "230",
			"Id": "0",
			"Info": "",
			"Db": "db1"
		},
		{
            "FE": "10.14.170.24",
			"User": "root",
			"Command": "Sleep",
			"State": "",
			"Cluster": "default_cluster",
			"Host": "10.81.85.88:61465",
			"Time": "460",
			"Id": "1",
			"Info": "",
			"Db": "db1"
		}]
	},
	"count": 2
}
`

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

