### PR TITLE
[enhance](FileWriter)enhance s3 file writer bvar to avoid adding abort bytes

### DIFF
--- a/be/src/io/fs/s3_file_write_bufferpool.cpp
+++ b/be/src/io/fs/s3_file_write_bufferpool.cpp
@@ -69,6 +69,7 @@ S3FileBufferPool::S3FileBufferPool() {
     DCHECK((config::s3_write_buffer_size >= 5 * 1024 * 1024) &&
            (config::s3_write_buffer_whole_size > config::s3_write_buffer_size));
     LOG_INFO("S3 file buffer pool with {} buffers", buf_num);
+    _whole_mem_buffer = std::make_unique<char[]>(config::s3_write_buffer_whole_size);
     for (size_t i = 0; i < buf_num; i++) {
         Slice s {_whole_mem_buffer.get() + i * config::s3_write_buffer_size,
                  static_cast<size_t>(config::s3_write_buffer_size)};

--- a/be/src/io/fs/s3_file_writer.cpp
+++ b/be/src/io/fs/s3_file_writer.cpp
@@ -91,7 +91,9 @@ S3FileWriter::~S3FileWriter() {
         // if we don't abort multi part upload, the uploaded part in object
         // store will not automatically reclaim itself, it would cost more money
         abort();
+        _bytes_written = 0;
     }
+    s3_bytes_written_total << _bytes_written;
     CHECK(_closed) << ", closed: " << _closed;
     // in case there are task which might run after this object is destroyed
     // for example, if the whole task failed and some task are still pending
@@ -358,7 +360,7 @@ void S3FileWriter::_put_object(S3FileBuffer& buf) {
         buf._on_failed(_st);
         LOG(WARNING) << _st;
     }
-    s3_bytes_written_total << buf.get_size();
+    _bytes_written += buf.get_size();
     s3_file_created_total << 1;
 }
 

--- a/be/src/io/fs/s3_file_writer.h
+++ b/be/src/io/fs/s3_file_writer.h
@@ -108,7 +108,7 @@ private:
 
     std::string _bucket;
     std::string _key;
-    bool _closed = true;
+    bool _closed = false;
     bool _aborted = false;
 
     std::unique_ptr<int64_t> _upload_cost_ms;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
Should not add aborted bytes into s3_bytes_written_total bvar since it would not appear in S3.
## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

