### PR TITLE
[Optimize](Function) Add fast path for col like '%%' or col like '%' or regexp '\\.*'

### DIFF
--- a/be/src/vec/functions/like.cpp
+++ b/be/src/vec/functions/like.cpp
@@ -479,7 +479,7 @@ Status FunctionLikeBase::execute_impl(FunctionContext* context, Block& block,
             context->get_function_state(FunctionContext::THREAD_LOCAL));
     // for constant_substring_fn, use long run length search for performance
     if (constant_substring_fn ==
-        *(state->function.target<doris::Status (*)(LikeSearchState * state, const ColumnString&,
+        *(state->function.target<doris::Status (*)(LikeSearchState* state, const ColumnString&,
                                                    const StringRef&, ColumnUInt8::Container&)>())) {
         RETURN_IF_ERROR(execute_substring(values->get_chars(), values->get_offsets(), vec_res,
                                           &state->search_state));

--- a/be/src/vec/functions/like.h
+++ b/be/src/vec/functions/like.h
@@ -152,6 +152,9 @@ protected:
                              const ColumnString::Offsets& value_offsets,
                              ColumnUInt8::Container& result, LikeSearchState* search_state);
 
+    static Status constant_allpass_fn(LikeSearchState* state, const ColumnString& val,
+                                      const StringRef& pattern, ColumnUInt8::Container& result);
+
     static Status constant_starts_with_fn(LikeSearchState* state, const ColumnString& val,
                                           const StringRef& pattern, ColumnUInt8::Container& result);
 
@@ -182,6 +185,12 @@ protected:
                                       const StringRef& pattern, ColumnUInt8::Container& result,
                                       const uint16_t* sel, size_t sz);
 
+    static Status constant_allpass_fn_predicate(LikeSearchState* state,
+                                                const PredicateColumnType<TYPE_STRING>& val,
+                                                const StringRef& pattern,
+                                                ColumnUInt8::Container& result, const uint16_t* sel,
+                                                size_t sz);
+
     static Status constant_starts_with_fn_predicate(LikeSearchState* state,
                                                     const PredicateColumnType<TYPE_STRING>& val,
                                                     const StringRef& pattern,
@@ -205,6 +214,9 @@ protected:
                                                   const StringRef& pattern,
                                                   ColumnUInt8::Container& result,
                                                   const uint16_t* sel, size_t sz);
+
+    static Status constant_allpass_fn_scalar(LikeSearchState* state, const StringRef& val,
+                                             const StringRef& pattern, unsigned char* result);
 
     static Status constant_starts_with_fn_scalar(LikeSearchState* state, const StringRef& val,
                                                  const StringRef& pattern, unsigned char* result);


### PR DESCRIPTION
## Proposed changes

Add fast path for col like '%%' or col like '%' or regexp '\\\\.*' 
(1) like   about 34%  speed up when use count() test
    support  col like '%%' , col like '%', col not like '%%' , col not like '%'

(2) regexp  about 37%  speed up when use count() test
    support col regexp '\\\\.*',  col not regexp '\\\\.*'

Q1: select count() From hits where url like '%';       
Q2: select count() From hits where url regexp '\\\\.*';

before:
<img width="543" alt="image" src="https://github.com/apache/doris/assets/67053339/caa79ee9-02f0-446b-8940-b7b47c05a7b8">

<img width="578" alt="image" src="https://github.com/apache/doris/assets/67053339/25e8a84c-d4cf-4796-931d-53bd5717292a">

after:
<img width="564" alt="image" src="https://github.com/apache/doris/assets/67053339/7dda3dcd-7055-4f49-a3de-ae9c78584e6d">
<img width="580" alt="image" src="https://github.com/apache/doris/assets/67053339/d4ca39b9-0ec3-4fc0-8015-3c4afb39470c">



## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

