### PR TITLE
[chore](toolchain) change doris default toolchain to clang

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -110,7 +110,7 @@ if [[ -z "${DORIS_TOOLCHAIN}" ]]; then
     if [[ "$(uname -s)" == 'Darwin' ]]; then
         DORIS_TOOLCHAIN=clang
     else
-        DORIS_TOOLCHAIN=gcc
+        DORIS_TOOLCHAIN=clang
     fi
 fi
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

GCC is very slow during build and link. Change to clang as we discussed many times.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

