### PR TITLE
[branch1.2](fix) fix hdfs file not found bug

### DIFF
--- a/be/src/io/hdfs_builder.cpp
+++ b/be/src/io/hdfs_builder.cpp
@@ -115,6 +115,7 @@ Status createHDFSBuilder(const THdfsParams& hdfsParams, HDFSCommonBuilder* build
         }
     }
 
+    hdfsBuilderConfSetStr(builder->get(), "ipc.client.fallback-to-simple-auth-allowed", "true");
     if (builder->is_need_kinit()) {
         RETURN_IF_ERROR(builder->run_kinit());
     } else if (hdfsParams.__isset.user) {

--- a/be/src/io/hdfs_file_reader.cpp
+++ b/be/src/io/hdfs_file_reader.cpp
@@ -78,7 +78,8 @@ Status HdfsFileReader::open() {
 #ifdef USE_HADOOP_HDFS
         char* root_cause = hdfsGetLastExceptionRootCause();
         if (root_cause != nullptr) {
-            return Status::InternalError("fail to check path exist {}, reason: {}", _path, root_cause);
+            return Status::InternalError("fail to check path exist {}, reason: {}", _path,
+                                         root_cause);
         }
 #endif
         if (_fs_handle->from_cache) {
@@ -92,7 +93,8 @@ Status HdfsFileReader::open() {
 #ifdef USE_HADOOP_HDFS
                 root_cause = hdfsGetLastExceptionRootCause();
                 if (root_cause != nullptr) {
-                    return Status::InternalError("fail to check path exist {}, reason: {}", _path, root_cause);
+                    return Status::InternalError("fail to check path exist {}, reason: {}", _path,
+                                                 root_cause);
                 }
 #endif
                 // code != 0 and root_cause is nullptr, mean this file does not exist.

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalFileScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalFileScanNode.java
@@ -623,7 +623,7 @@ public class ExternalFileScanNode extends ExternalScanNode {
                     TFileRangeDesc file = files.get(i);
                     output.append(prefix).append("    ").append(file.getPath())
                             .append(" start: ").append(file.getStartOffset())
-                            .append(" length: ").append(file.getFileSize())
+                            .append(" length: ").append(file.getSize())
                             .append("\n");
                 }
             }
@@ -641,6 +641,7 @@ public class ExternalFileScanNode extends ExternalScanNode {
         return output.toString();
     }
 }
+
 
 
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

This PR mainly changes:

1. add `"ipc.client.fallback-to-simple-auth-allowed" = "true"` on BE side to make sure a hdfs client can connect both kerberos and simple auth hdfs.

2. Fix bug that when calling `hdfsExists()` with internal error, it will return "FILE_NOT_FOUND" and continue processing.
    Should distinguish "not exist" and "error".

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

