### PR TITLE
[typo](docs)correct the standard-deployment document

### DIFF
--- a/docs/en/docs/install/standard-deployment.md
+++ b/docs/en/docs/install/standard-deployment.md
@@ -198,7 +198,7 @@ See the `lower_case_table_names` section in [Variables](../advanced/variables.md
   Modify be/conf/be.conf, which mainly involves configuring `storage_root_path`: data storage directory. By default, under be/storage, the directory needs to be **created manually**. Use `;` to separate multiple paths (do not add `;` after the last directory).
 
 
-  You may specify the directory storage medium in the path: HDD or SSD. You may also add capacility limit to the end of every path and use `,` for separation. Unless you use a mix of SSD and HDD disks, you do not need to follow the configuration methods in Example 1 and Example 2 below, but only need to specify the storage directory; you do not need to modify the default storage medium configuration of FE, either.  
+  You may specify the directory storage medium in the path: HDD or SSD. You may also add capacity limit to the end of every path and use `,` for separation. Unless you use a mix of SSD and HDD disks, you do not need to follow the configuration methods in Example 1 or Example 2 below, but only need to specify the storage directory; you do not need to modify the default storage medium configuration of FE, either.  
 
   Example 1: 
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

According to the Chinese version the word 'capacility' should be 'capacity' and it can't be found in a dictionary. The  word 'and' should be 'or' for the context of nagative expression.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

