### PR TITLE
[Improvement](multicatalog) avoid load default hdfs config to reduce time cost

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
@@ -928,7 +928,7 @@ public class HiveMetaStoreClientHelper {
     }
 
     public static Configuration getConfiguration(HMSExternalTable table) {
-        Configuration conf = new HdfsConfiguration();
+        Configuration conf = new HdfsConfiguration(false);
         for (Map.Entry<String, String> entry : table.getHadoopProperties().entrySet()) {
             conf.set(entry.getKey(), entry.getValue());
         }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

hadoop have so many configurations which will cost a lot of time to load them, while default configs have no need to load, it's ok to ignore them. 
<img width="1525" alt="image" src="https://github.com/apache/doris/assets/28004179/119697a0-8ba8-462c-9fa8-c9270271ec23">

after this update, a sql only read 10 records from a iceberg table on GooseFS will reduce time cost from 35s to 12s.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

