### PR TITLE
[Fix](multi catalog)Fix Iceberg table missing column unique id bug.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
@@ -352,8 +352,7 @@ public class HMSExternalTable extends ExternalTable {
         List<FieldSchema> schema = ((HMSExternalCatalog) catalog).getClient().getSchema(dbName, name);
         if (dlaType.equals(DLAType.ICEBERG)) {
             columns = getIcebergSchema(schema);
-        }
-        if (dlaType.equals(DLAType.HUDI)) {
+        } else if (dlaType.equals(DLAType.HUDI)) {
             columns = getHudiSchema(schema);
         } else {
             List<Column> tmpSchema = Lists.newArrayListWithCapacity(schema.size());


### PR DESCRIPTION
<--Describe your changes.-->

This pr is to fix the bug introduced by PR https://github.com/apache/doris/pull/19909
The bug failed to set column unique id for iceberg table, which will cause the query result for iceberg table are all NULL.

```
mysql> select * from iceberg_partition_lower_case_parquet limit 1;
+------+------+------+---------+
| k1   | k2   | k3   | city    |
+------+------+------+---------+
| NULL | NULL | NULL | Beijing |
+------+------+------+---------+
1 row in set (0.60 sec)
```
After fix:
```
mysql> select * from iceberg_partition_lower_case_parquet limit 1;
+------+------+------+---------+
| k1   | k2   | k3   | city    |
+------+------+------+---------+
|    1 | k2_1 | k3_1 | Beijing |
+------+------+------+---------+
1 row in set (0.35 sec)
```

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

