### PR TITLE
[Feature](Inverted index) add MATCH_ PHRASE query

### DIFF
--- a/be/src/olap/rowset/segment_v2/inverted_index_compound_directory.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_compound_directory.cpp
@@ -349,6 +349,11 @@ void DorisCompoundDirectory::FSIndexInput::readInternal(uint8_t* b, const int32_
     CND_PRECONDITION(_handle->_reader != nullptr, "file is not open");
     std::lock_guard<doris::Mutex> wlock(*_handle->_shared_lock);
 
+    int64_t position = getFilePointer();
+    if (_pos != position) {
+        _pos = position;
+    }
+
     if (_handle->_fpos != _pos) {
         _handle->_fpos = _pos;
     }


### PR DESCRIPTION
# Proposed changes

add match phrase query, usage like this:
```
select * from tbl;

id                       | url
23969194503 | https://api.github.com/users/owais-redhunt
23969194503 | https://api.github.com/users/owais-redhunt
23969194503 | https://avatars.githubusercontent.com/u/107148599?
23969194503 | https://avatars.githubusercontent.com/u/107148599?
23969194503 | https://api.github.com/users/danikaze
23969194503 | https://api.github.com/users/danikaze

select * from tbl where url match_any "users/owais-redhunt";
(If a token is matched after word segmentation, it is returned)

id                       | url
23969194503 | https://api.github.com/users/owais-redhunt
23969194503 | https://api.github.com/users/owais-redhunt
23969194503 | https://api.github.com/users/danikaze
23969194503 | https://api.github.com/users/danikaze

select * from tbl where url match_phrase "users/owais-redhunt";
(After word segmentation matches the same position is returned)

id                       | url
23969194503 | https://api.github.com/users/owais-redhunt
23969194503 | https://api.github.com/users/owais-redhunt
```
## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
