### PR TITLE
[fix](function) Fix VcompoundPred execute const column

### DIFF
--- a/be/src/vec/exprs/vcompound_pred.h
+++ b/be/src/vec/exprs/vcompound_pred.h
@@ -65,7 +65,8 @@ public:
         int lhs_id = -1;
         int rhs_id = -1;
         RETURN_IF_ERROR(_children[0]->execute(context, block, &lhs_id));
-        ColumnPtr lhs_column = block->get_by_position(lhs_id).column;
+        ColumnPtr lhs_column =
+                block->get_by_position(lhs_id).column->convert_to_full_column_if_const();
 
         size_t size = lhs_column->size();
         uint8* __restrict data = _get_raw_data(lhs_column);
@@ -81,7 +82,8 @@ public:
         auto get_rhs_colum = [&]() {
             if (rhs_id == -1) {
                 RETURN_IF_ERROR(_children[1]->execute(context, block, &rhs_id));
-                rhs_column = block->get_by_position(rhs_id).column;
+                rhs_column =
+                        block->get_by_position(rhs_id).column->convert_to_full_column_if_const();
                 data_rhs = _get_raw_data(rhs_column);
                 int filted = simd::count_zero_num((int8_t*)data_rhs, size);
                 full_rhs = filted == 0;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

recurrent:
```
./run-regression-test.sh  --run -suiteParallel 1 -actionParallel 1 -parallel 1 -d query_p0/sql_functions/window_functions

select      /*+ SET_VAR(query_timeout = 600) */ subq_0.`c1` as c0 from    (select           ref_1.`s_name` as c0,          ref_1.`s_suppkey` as c1,          ref_1.`s_address` as c2,          ref_1.`s_address` as c3       from          regression_test_query_p0_sql_functions_window_functions.tpch_tiny_supplier as ref_1       where (ref_1.`s_name` is NULL)          or (ref_1.`s_acctbal` is not NULL)) as subq_0 where (subq_0.`c3` is NULL)    or (subq_0.`c2` is not NULL)
```

reason: 
FunctionIsNull and FunctionIsNotNull execute returns a const column, but their VectorizedFnCall::is_constant returns false, which causes problems with const handling when VCompoundPred::execute.

This pr converts const column to full column in VCompoundPred execute. In the future, there will be a more thorough solution to such problems.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

