### PR TITLE
[Improvement](runtimefilter) Build bloom filter according to the exact build size for IN_OR_BLOOM_FILTER

### DIFF
--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -1018,9 +1018,7 @@ public:
         return Status::OK();
     }
 
-    PrimitiveType column_type() {
-        return _column_return_type;
-    }
+    PrimitiveType column_type() { return _column_return_type; }
 
     void ready_for_publish() {
         if (_filter_type == RuntimeFilterType::MINMAX_FILTER) {

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -422,6 +422,7 @@ public:
             _context.hybrid_set.reset(create_set(_column_return_type));
             _context.bloom_filter_func.reset(create_bloom_filter(_column_return_type));
             _context.bloom_filter_func->set_length(params->bloom_filter_size);
+            _context.bloom_filter_func->set_build_bf_exactly(params->build_bf_exactly);
             return Status::OK();
         }
         case RuntimeFilterType::BITMAP_FILTER: {
@@ -446,7 +447,8 @@ public:
     }
 
     Status init_bloom_filter(const size_t build_bf_cardinality) {
-        DCHECK(_filter_type == RuntimeFilterType::BLOOM_FILTER);
+        DCHECK(_filter_type == RuntimeFilterType::BLOOM_FILTER ||
+               _filter_type == RuntimeFilterType::IN_OR_BLOOM_FILTER);
         return _context.bloom_filter_func->init_with_cardinality(build_bf_cardinality);
     }
 
@@ -1016,7 +1018,9 @@ public:
         return Status::OK();
     }
 
-    PrimitiveType column_type() { return _column_return_type; }
+    PrimitiveType column_type() {
+        return _column_return_type;
+    }
 
     void ready_for_publish() {
         if (_filter_type == RuntimeFilterType::MINMAX_FILTER) {
@@ -1361,7 +1365,8 @@ Status IRuntimeFilter::init_with_desc(const TRuntimeFilterDesc* desc, const TQue
     // 2. Do not have remote target (e.g. do not need to merge)
     // 3. Bloom filter
     params.build_bf_exactly = build_bf_exactly && !_has_remote_target &&
-                              _runtime_filter_type == RuntimeFilterType::BLOOM_FILTER;
+                              (_runtime_filter_type == RuntimeFilterType::BLOOM_FILTER ||
+                               _runtime_filter_type == RuntimeFilterType::IN_OR_BLOOM_FILTER);
     if (desc->__isset.bloom_filter_size_bytes) {
         params.bloom_filter_size = desc->bloom_filter_size_bytes;
     }

--- a/be/src/exprs/runtime_filter_slots.h
+++ b/be/src/exprs/runtime_filter_slots.h
@@ -104,7 +104,7 @@ public:
                 runtime_filter->change_to_bloom_filter();
             }
 
-            if (runtime_filter->type() == RuntimeFilterType::BLOOM_FILTER) {
+            if (runtime_filter->is_bloomfilter()) {
                 RETURN_IF_ERROR(runtime_filter->init_bloom_filter(build_bf_cardinality));
             }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Build bloom filter according to the exact build size for IN_OR_BLOOM_FILTER

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

