### PR TITLE
[Enhancement](multi-catalog) Try to use hdfs short circuit read as po…

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsResource.java
@@ -73,7 +73,7 @@ public class HdfsResource extends Resource {
     protected void setProperties(Map<String, String> properties) throws DdlException {
         // `dfs.client.read.shortcircuit` and `dfs.domain.socket.path` should be both set to enable short circuit read.
         // We should disable short circuit read if they are not both set because it will cause performance down.
-        if (!properties.containsKey(HADOOP_SHORT_CIRCUIT) || !properties.containsKey(HADOOP_SOCKET_PATH)) {
+        if (!enableShortcircuitRead(properties)) {
             properties.put(HADOOP_SHORT_CIRCUIT, "false");
         }
         this.properties = properties;
@@ -90,6 +90,10 @@ public class HdfsResource extends Resource {
         for (Map.Entry<String, String> entry : properties.entrySet()) {
             result.addRow(Lists.newArrayList(name, lowerCaseType, entry.getKey(), entry.getValue()));
         }
+    }
+
+    public static boolean enableShortcircuitRead(Map<String, String> properties) {
+        return properties.containsKey(HADOOP_SHORT_CIRCUIT) && properties.containsKey(HADOOP_SOCKET_PATH);
     }
 
     // Will be removed after BE unified storage params

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/FederationBackendPolicyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/FederationBackendPolicyTest.java
@@ -1,0 +1,87 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.planner;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.UserException;
+import org.apache.doris.planner.external.FederationBackendPolicy;
+import org.apache.doris.system.Backend;
+import org.apache.doris.system.SystemInfoService;
+
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class FederationBackendPolicyTest {
+    @Mocked
+    private Env env;
+
+    @Before
+    public void setUp() {
+        Backend backend1 = new Backend(1L, "192.168.1.1", 9050);
+        backend1.setAlive(true);
+
+        Backend backend2 = new Backend(2L, "192.168.1.2", 9050);
+        backend2.setAlive(true);
+
+        Backend backend3 = new Backend(3L, "192.168.1.3", 9050);
+        backend3.setAlive(true);
+
+        Backend backend4 = new Backend(4L, "192.168.1.4", 9050);
+        backend4.setAlive(false);
+
+        SystemInfoService service = new SystemInfoService();
+        service.addBackend(backend1);
+        service.addBackend(backend2);
+        service.addBackend(backend3);
+        service.addBackend(backend4);
+
+        new MockUp<Env>() {
+            @Mock
+            public SystemInfoService getCurrentSystemInfo() {
+                return service;
+            }
+        };
+
+    }
+
+    @Test
+    public void testGetNextBe() throws UserException {
+        FederationBackendPolicy policy = new FederationBackendPolicy();
+        policy.init();
+        Assertions.assertTrue(policy.numBackends() == 3);
+        for (int i = 0; i < policy.numBackends(); i++) {
+            Assertions.assertNotEquals(policy.getNextBe().getHost(), "192.168.1.4");
+        }
+    }
+
+    @Test
+    public void testGetNextBeWithPreLocations() throws UserException {
+        FederationBackendPolicy policy = new FederationBackendPolicy();
+        policy.init();
+        Assertions.assertTrue(policy.numBackends() == 3);
+        List<String> preferredLocations = Arrays.asList("192.168.1.3");
+        Assertions.assertEquals(policy.getNextBe(preferredLocations).getHost(), "192.168.1.3");
+    }
+}


### PR DESCRIPTION
…ssible in FederationBackendPolicy.

## Proposed changes

According to [Short-Circuit-LocalReads](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/ShortCircuitLocalReads.html) , we can use hdfs short circuit read to minimize global bandwidth consumption and read latency if the BE node is at the same host with the relevant file split.

Issue Number: close #xxx

Add preferred locations option when invoke `getNextBe` in `FederationBackendPolicy`, try to choose one BE if the relevant file split is on the same host, otherwise use the previous round-robin algo. 

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

