### PR TITLE
[performance](load) support parallel memtable flush for unique key tables

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -209,9 +209,9 @@ Status DeltaWriter::init() {
     _reset_mem_table();
 
     // create flush handler
-    // unique key should flush serial because we need to make sure same key should sort
-    // in the same order in all replica.
-    bool should_serial = _tablet->keys_type() == KeysType::UNIQUE_KEYS;
+    // by assigning seq_id to memtable before submiting to flush executor,
+    // we can make sure same keys sort in the same order in all replicas.
+    bool should_serial = false;
     RETURN_IF_ERROR(_storage_engine->memtable_flush_executor()->create_flush_token(
             &_flush_token, _rowset_writer->type(), should_serial, _req.is_high_priority));
 
@@ -267,6 +267,7 @@ Status DeltaWriter::write(const vectorized::Block* block, const std::vector<int>
 }
 
 Status DeltaWriter::_flush_memtable_async() {
+    _mem_table->assign_seq_id();
     return _flush_token->submit(std::move(_mem_table));
 }
 

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -483,9 +483,14 @@ Status MemTable::_do_flush() {
         // Unfold variant column
         RETURN_IF_ERROR(unfold_variant_column(block, &ctx));
     }
+    ctx.seq = _seq_id;
     SCOPED_RAW_TIMER(&_stat.segment_writer_ns);
     RETURN_IF_ERROR(_rowset_writer->flush_single_memtable(&block, &_flush_size, &ctx));
     return Status::OK();
+}
+
+void MemTable::assign_seq_id() {
+    _seq_id = std::optional<int32_t> {_rowset_writer->allocate_seq_id()};
 }
 
 Status MemTable::close() {

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -22,6 +22,7 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <vector>
 
@@ -145,6 +146,8 @@ public:
         _delta_writer_callback = callback;
     }
 
+    void assign_seq_id();
+
 private:
     Status _do_flush();
 
@@ -225,6 +228,7 @@ private:
     void _put_into_output(vectorized::Block& in_block);
     bool _is_first_insertion;
     std::function<void(MemTableStat&)> _delta_writer_callback;
+    std::optional<int32_t> _seq_id = std::nullopt;
 
     void _init_agg_functions(const vectorized::Block* block);
     std::vector<vectorized::AggregateFunctionPtr> _agg_functions;

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -60,6 +60,7 @@ using namespace ErrorCode;
 
 BetaRowsetWriter::BetaRowsetWriter()
         : _rowset_meta(nullptr),
+          _next_seq(0),
           _num_segment(0),
           _num_flushed_segment(0),
           _segment_start_id(0),
@@ -89,9 +90,9 @@ BetaRowsetWriter::~BetaRowsetWriter() {
         if (!fs) {
             return;
         }
-        for (int i = 0; i < _num_segment; ++i) {
-            std::string seg_path =
-                    BetaRowset::segment_file_path(_context.rowset_dir, _context.rowset_id, i);
+        for (int i = 0; i < _next_seq; ++i) {
+            std::string seg_path = BetaRowset::segment_file_path(
+                    _context.rowset_dir, _context.rowset_id, _segment_start_id + i);
             // Even if an error is encountered, these files that have not been cleaned up
             // will be cleaned up by the GC background. So here we only print the error
             // message when we encounter an error.
@@ -416,6 +417,17 @@ Status BetaRowsetWriter::_add_block(const vectorized::Block* block,
     size_t row_avg_size_in_bytes = std::max((size_t)1, block_size_in_bytes / block_row_num);
     size_t row_offset = 0;
 
+    if (flush_ctx->seq.has_value()) {
+        // the entire block (memtable) should be flushed into single segment
+        auto s = (*segment_writer)->append_block(block, row_offset, block_row_num);
+        if (UNLIKELY(!s.ok())) {
+            LOG(WARNING) << "failed to append block: " << s.to_string();
+            return Status::Error<WRITER_DATA_WRITE_ERROR>();
+        }
+        _raw_num_rows_written += block_row_num;
+        return Status::OK();
+    }
+
     do {
         auto max_row_add = (*segment_writer)->max_row_to_add(row_avg_size_in_bytes);
         if (UNLIKELY(max_row_add < 1)) {
@@ -679,7 +691,19 @@ Status BetaRowsetWriter::_do_create_segment_writer(
         path = BetaRowset::local_segment_path_segcompacted(_context.rowset_dir, _context.rowset_id,
                                                            begin, end);
     } else {
-        segment_id = _num_segment.fetch_add(1) + _segment_start_id;
+        int32_t seq_id = flush_ctx->seq.has_value() ? flush_ctx->seq.value() : allocate_seq_id();
+        segment_id = seq_id + _segment_start_id;
+        {
+            std::lock_guard<std::mutex> lock(_seq_set_mutex);
+            if (UNLIKELY(_seq_set.contains(seq_id))) {
+                LOG(WARNING) << "seq id " << seq_id << " already exists";
+            } else {
+                _seq_set.add(seq_id);
+            }
+            while (_seq_set.contains(_num_segment)) {
+                _num_segment++;
+            }
+        }
         path = BetaRowset::segment_file_path(_context.rowset_dir, _context.rowset_id, segment_id);
     }
     auto fs = _rowset_meta->fs();
@@ -751,6 +775,7 @@ Status BetaRowsetWriter::_flush_segment_writer(std::unique_ptr<segment_v2::Segme
                                                int64_t* flush_size) {
     uint32_t segid = (*writer)->get_segment_id();
     uint32_t row_num = (*writer)->num_rows_written();
+    uint32_t seq_id = segid - _segment_start_id;
 
     if ((*writer)->num_rows_written() == 0) {
         return Status::OK();
@@ -782,8 +807,8 @@ Status BetaRowsetWriter::_flush_segment_writer(std::unique_ptr<segment_v2::Segme
         std::lock_guard<std::mutex> lock(_segid_statistics_map_mutex);
         CHECK_EQ(_segid_statistics_map.find(segid) == _segid_statistics_map.end(), true);
         _segid_statistics_map.emplace(segid, segstat);
-        _segment_num_rows.resize(_num_segment);
-        _segment_num_rows[_num_segment - 1] = row_num;
+        _segment_num_rows.resize(_next_seq);
+        _segment_num_rows[seq_id] = row_num;
     }
     VLOG_DEBUG << "_segid_statistics_map add new record. segid:" << segid << " row_num:" << row_num
                << " data_size:" << segment_size << " index_size:" << index_size;
@@ -792,7 +817,13 @@ Status BetaRowsetWriter::_flush_segment_writer(std::unique_ptr<segment_v2::Segme
     if (flush_size) {
         *flush_size = segment_size + index_size;
     }
-    _num_flushed_segment.fetch_add(1);
+    {
+        std::lock_guard<std::mutex> lock(_flushed_set_mutex);
+        _flushed_set.add(seq_id);
+        while (_flushed_set.contains(_num_flushed_segment)) {
+            _num_flushed_segment++;
+        }
+    }
     return Status::OK();
 }
 

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -417,7 +417,7 @@ Status BetaRowsetWriter::_add_block(const vectorized::Block* block,
     size_t row_avg_size_in_bytes = std::max((size_t)1, block_size_in_bytes / block_row_num);
     size_t row_offset = 0;
 
-    if (flush_ctx->seq.has_value()) {
+    if (flush_ctx != nullptr && flush_ctx->seq.has_value()) {
         // the entire block (memtable) should be flushed into single segment
         auto s = (*segment_writer)->append_block(block, row_offset, block_row_num);
         if (UNLIKELY(!s.ok())) {
@@ -691,7 +691,8 @@ Status BetaRowsetWriter::_do_create_segment_writer(
         path = BetaRowset::local_segment_path_segcompacted(_context.rowset_dir, _context.rowset_id,
                                                            begin, end);
     } else {
-        int32_t seq_id = flush_ctx->seq.has_value() ? flush_ctx->seq.value() : allocate_seq_id();
+        int32_t seq_id = flush_ctx != nullptr && flush_ctx->seq.has_value() ? flush_ctx->seq.value()
+                                                                            : allocate_seq_id();
         segment_id = seq_id + _segment_start_id;
         {
             std::lock_guard<std::mutex> lock(_seq_set_mutex);

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -20,6 +20,8 @@
 #include <gen_cpp/olap_file.pb.h>
 #include <gen_cpp/types.pb.h>
 
+#include <optional>
+
 #include "common/factory_creator.h"
 #include "gutil/macros.h"
 #include "olap/column_mapping.h"
@@ -37,6 +39,7 @@ struct FlushContext {
     ENABLE_FACTORY_CREATOR(FlushContext);
     TabletSchemaSPtr flush_schema = nullptr;
     const vectorized::Block* block = nullptr;
+    std::optional<int32_t> seq = std::nullopt;
 };
 
 class RowsetWriter {
@@ -98,6 +101,8 @@ public:
     }
 
     virtual int32_t get_atomic_num_segment() const = 0;
+
+    virtual int32_t allocate_seq_id() = 0;
 
     virtual bool is_doing_segcompaction() const = 0;
 


### PR DESCRIPTION
## Proposed changes

Assign a `flush_serial_id` to `MemTable` early in `DeltaWriter`, and exec the flush in parallel.

In this way, we can improve the stream load peformance of 1 tablet unique key tables by around 100%.

Stream load 7.5G tpch lineitem table into a 1 tablet unique key table (3 BE, 16C 64G):

| replicas | load time (before) | load time (after) |
| --- | --- | --- |
| 1 | 118s | 48s |
| 3 | 161s | 60s |

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

