### PR TITLE
[Enhancement](merge-on-write) optimize bloom filter for primary key index

### DIFF
--- a/be/src/olap/primary_key_index.cpp
+++ b/be/src/olap/primary_key_index.cpp
@@ -26,6 +26,7 @@
 #include "common/config.h"
 #include "olap/olap_common.h"
 #include "olap/rowset/segment_v2/bloom_filter_index_reader.h"
+#include "olap/rowset/segment_v2/bloom_filter_index_writer.h"
 #include "olap/rowset/segment_v2/encoding_info.h"
 #include "olap/types.h"
 
@@ -44,8 +45,9 @@ Status PrimaryKeyIndexBuilder::init() {
             new segment_v2::IndexedColumnWriter(options, type_info, _file_writer));
     RETURN_IF_ERROR(_primary_key_index_builder->init());
 
-    return segment_v2::BloomFilterIndexWriter::create(segment_v2::BloomFilterOptions(), type_info,
-                                                      &_bloom_filter_index_builder);
+    _bloom_filter_index_builder.reset(new segment_v2::PrimaryKeyBloomFilterIndexWriterImpl(
+            segment_v2::BloomFilterOptions(), type_info));
+    return Status::OK();
 }
 
 Status PrimaryKeyIndexBuilder::add_item(const Slice& key) {

--- a/be/src/olap/rowset/segment_v2/bloom_filter_index_writer.h
+++ b/be/src/olap/rowset/segment_v2/bloom_filter_index_writer.h
@@ -27,6 +27,7 @@
 #include "common/status.h"
 #include "olap/itoken_extractor.h"
 #include "olap/rowset/segment_v2/bloom_filter.h"
+#include "util/slice.h"
 #include "vec/common/arena.h"
 
 namespace doris {
@@ -61,6 +62,41 @@ public:
 
 private:
     DISALLOW_COPY_AND_ASSIGN(BloomFilterIndexWriter);
+};
+
+// For unique key with merge on write, the data for each segment is deduplicated.
+// Bloom filter doesn't need to use `set` for deduplication like
+// `BloomFilterIndexWriterImpl`, so vector can be used to accelerate.
+class PrimaryKeyBloomFilterIndexWriterImpl : public BloomFilterIndexWriter {
+public:
+    explicit PrimaryKeyBloomFilterIndexWriterImpl(const BloomFilterOptions& bf_options,
+                                                  const TypeInfo* type_info)
+            : _bf_options(bf_options),
+              _type_info(type_info),
+              _has_null(false),
+              _bf_buffer_size(0) {}
+
+    ~PrimaryKeyBloomFilterIndexWriterImpl() override = default;
+
+    void add_values(const void* values, size_t count) override;
+
+    void add_nulls(uint32_t count) override { _has_null = true; }
+
+    Status flush() override;
+
+    Status finish(io::FileWriter* file_writer, ColumnIndexMetaPB* index_meta) override;
+
+    uint64_t size() override;
+
+private:
+    BloomFilterOptions _bf_options;
+    const TypeInfo* _type_info;
+    vectorized::Arena _arena;
+    bool _has_null;
+    uint64_t _bf_buffer_size;
+    // distinct values
+    std::vector<Slice> _values;
+    std::vector<std::unique_ptr<BloomFilter>> _bfs;
 };
 
 class NGramBloomFilterIndexWriterImpl : public BloomFilterIndexWriter {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

For unique key with merge on write, the data for each segment is deduplicated. Bloom filter doesn't need to use `set` for deduplication like`BloomFilterIndexWriterImpl`,  so vector can be used to accelerate.


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

