### PR TITLE
[enhancement](ldap) Support refresh ldap cache

### DIFF
--- a/docs/en/docs/admin-manual/privilege-ldap/ldap.md
+++ b/docs/en/docs/admin-manual/privilege-ldap/ldap.md
@@ -168,6 +168,9 @@ Then the group name is doris_rd.
 
 If jack also belongs to the LDAP groups doris_qa, doris_pm; Doris exists roles: doris_rd, doris_qa, doris_pm, after logging in using LDAP authentication, the user will not only have the original permissions of the account, but will also get the roles doris_rd, doris_qa and doris _pm privileges.
 
+### LDAP information cache
+To avoid frequent access to LDAP service, Doris will cache LDAP information into memory, you can specify the cache time for LDAP users through the `ldap_user_cache_timeout_s` configuration item in ldap.conf, the default is 12 hours; after modifying the information in LDAP service or modifying the After modifying the information in the LDAP service or modifying the Role permissions of the LDAP user group, the cache may not take effect in time because of the cache, so you can refresh the cache with the refresh ldap statement, see [REFRESH-LDAP](... /... /sql-manual/sql-reference/Utility-Statements/REFRESH-LDAP.md).
+
 ## Limitations of LDAP authentication
 
 * The current LDAP feature of Doris only supports plaintext password authentication, that is, when a user logs in, the password is transmitted in plaintext between client and fe and between fe and LDAP service.

--- a/docs/en/docs/sql-manual/sql-reference/Utility-Statements/REFRESH-LDAP.md
+++ b/docs/en/docs/sql-manual/sql-reference/Utility-Statements/REFRESH-LDAP.md
@@ -1,0 +1,73 @@
+---
+{
+    "title": "REFRESH-LDAP",
+    "language": "en"
+}
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+## REFRESH-LDAP
+
+### Name
+
+<version since="dev">
+
+REFRESH-LDAP
+
+</version>
+
+### Description
+
+This statement is used to refresh the cached information of LDAP in Doris. The default timeout for LDAP information cache in Doris is 12 hours, which can be viewed by `ADMIN SHOW FRONTEND CONFIG LIKE 'ldap_ user_cache_timeout_s';`.
+
+syntax:
+
+```sql
+REFRESH LDAP ALL;
+REFRESH LDAP [for user_name];
+```
+
+### Example
+
+1. refresh all LDAP user cache information
+
+    ```sql
+    REFRESH LDAP ALL;
+    ```
+
+2. refresh the cache information for the current LDAP user
+
+    ```sql
+    REFRESH LDAP;
+    ```
+
+3. refresh the cache information of the specified LDAP user user1
+
+    ```sql
+    REFRESH LDAP for user1;
+    ```
+
+
+### Keywords
+
+REFRESH, LDAP
+
+### Best Practice

--- a/docs/zh-CN/docs/admin-manual/privilege-ldap/ldap.md
+++ b/docs/zh-CN/docs/admin-manual/privilege-ldap/ldap.md
@@ -185,6 +185,9 @@ member: uid=jack,ou=aidp,dc=domain,dc=com
 
 假如jack还属于LDAP组doris_qa、doris_pm；Doris存在role：doris_rd、doris_qa、doris_pm，在使用LDAP验证登录后，用户不但具有该账户原有的权限，还将获得role doris_rd、doris_qa和doris_pm的权限。
 
+### LDAP信息缓存
+为了避免频繁访问LDAP服务，Doris会将LDAP信息缓存到内存中，可以通过ldap.conf中的`ldap_user_cache_timeout_s`配置项指定LDAP用户的缓存时间，默认为12小时；在修改了LDAP服务中的信息或者修改了Doris中LDAP用户组对应的Role权限后，可能因为缓存而没有及时生效，可以通过refresh ldap语句刷新缓存，详细查看[REFRESH-LDAP](../../sql-manual/sql-reference/Utility-Statements/REFRESH-LDAP.md)。
+
 ## LDAP验证的局限
 
 - 目前Doris的LDAP功能只支持明文密码验证，即用户登录时，密码在client与fe之间、fe与LDAP服务之间以明文的形式传输。

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Utility-Statements/REFRESH-LDAP.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Utility-Statements/REFRESH-LDAP.md
@@ -1,0 +1,74 @@
+---
+{
+    "title": "REFRESH-LDAP",
+    "language": "zh-CN"
+}
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+## REFRESH-LDAP
+
+### Name
+
+<version since="dev">
+
+REFRESH-LDAP
+
+</version>
+
+
+### Description
+
+该语句用于刷新Doris中LDAP的缓存信息。修改LDAP服务中用户信息或者修改Doris中LDAP用户组对应的role权限，可能因为缓存的原因不会立即生效，可通过该语句刷新缓存。Doris中LDAP信息缓存默认时间为12小时，可以通过 `ADMIN SHOW FRONTEND CONFIG LIKE 'ldap_user_cache_timeout_s';` 查看。
+
+语法：
+
+```sql
+REFRESH LDAP ALL;
+REFRESH LDAP [for user_name];
+```
+
+### Example
+
+1. 刷新所有LDAP用户缓存信息
+
+    ```sql
+    REFRESH LDAP ALL;
+    ```
+
+2. 刷新当前LDAP用户的缓存信息
+
+    ```sql
+    REFRESH LDAP;
+    ```
+
+3. 刷新指定LDAP用户user1的缓存信息
+
+    ```sql
+    REFRESH LDAP for user1;
+    ```
+
+### Keywords
+
+REFRESH, LDAP
+
+### Best Practice
+

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -430,6 +430,7 @@ terminal String
     KW_LARGEINT,
     KW_LAST,
     KW_LATERAL,
+    KW_LDAP,
     KW_LDAP_ADMIN_PASSWORD,
     KW_LEFT,
     KW_LESS,
@@ -1196,6 +1197,14 @@ refresh_stmt ::=
     | KW_REFRESH KW_CATALOG ident:catalogName opt_properties:properties
     {:
         RESULT = new RefreshCatalogStmt(catalogName, properties);
+    :}
+    | KW_REFRESH KW_LDAP KW_ALL
+    {:
+        RESULT = new RefreshLdapStmt(true, "");
+    :}
+    | KW_REFRESH KW_LDAP opt_user:user
+    {:
+        RESULT = new RefreshLdapStmt(false, user);
     :}
     ;
 
@@ -7339,6 +7348,8 @@ keyword ::=
     | KW_PASSWORD_HISTORY:id
     {: RESULT = id; :}
     | KW_PASSWORD_LOCK_TIME:id
+    {: RESULT = id; :}
+    | KW_LDAP:id
     {: RESULT = id; :}
     | KW_LDAP_ADMIN_PASSWORD:id
     {: RESULT = id; :}

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/RefreshLdapStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/RefreshLdapStmt.java
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.cluster.ClusterNamespace;
+import org.apache.doris.common.ErrorCode;
+import org.apache.doris.common.ErrorReport;
+import org.apache.doris.common.UserException;
+import org.apache.doris.mysql.privilege.PrivPredicate;
+import org.apache.doris.qe.ConnectContext;
+
+import com.google.common.base.Strings;
+
+public class RefreshLdapStmt extends DdlStmt {
+
+    private boolean isAll;
+
+    private String user;
+
+    RefreshLdapStmt(boolean isAll, String user) {
+        this.isAll = isAll;
+        this.user = user;
+    }
+
+    public boolean getIsAll() {
+        return isAll;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    @Override
+    public void analyze(Analyzer analyzer) throws UserException {
+        super.analyze(analyzer);
+        if (isAll || !Strings.isNullOrEmpty(user)) {
+            if (!Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ConnectContext.get(), PrivPredicate.ADMIN)) {
+                ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "ADMIN");
+            }
+            if (!isAll) {
+                user = ClusterNamespace.getFullName(getClusterName(), user);
+            }
+        } else {
+            user = analyzer.getQualifiedUser();
+        }
+    }
+
+    @Override
+    public String toSql() {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("REFRESH LDAP ");
+        if (isAll) {
+            stringBuilder.append("ALL");
+        } else {
+            stringBuilder.append("`").append(user).append("`");
+        }
+        return stringBuilder.toString();
+    }
+
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/ldap/LdapPrivsChecker.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/ldap/LdapPrivsChecker.java
@@ -128,7 +128,7 @@ public class LdapPrivsChecker {
     }
 
     private static Role getUserLdapPrivs(String fullName) {
-        return Env.getCurrentEnv().getAuth().getLdapManager().getUserInfo(fullName).getPaloRole();
+        return Env.getCurrentEnv().getAuth().getLdapManager().getUserRole(fullName);
     }
 
     // Temporary user has information_schema 'Select_priv' priv by default.

--- a/fe/fe-core/src/main/java/org/apache/doris/ldap/LdapUserInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/ldap/LdapUserInfo.java
@@ -28,6 +28,7 @@ import java.util.Objects;
 public class LdapUserInfo {
     public LdapUserInfo(String userName, boolean isSetPasswd, String passwd, Role role) {
         this.userName = userName;
+        this.isExists = true;
         this.isSetPasswd = isSetPasswd;
         this.passwd = passwd;
         this.role = role;
@@ -36,13 +37,25 @@ public class LdapUserInfo {
 
     private LdapUserInfo(String userName, boolean isSetPasswd, String passwd, Role role, long lastTimeStamp) {
         this.userName = userName;
+        this.isExists = true;
         this.isSetPasswd = isSetPasswd;
         this.passwd = passwd;
         this.role = role;
         this.lastTimeStamp = lastTimeStamp;
     }
 
+    public LdapUserInfo(String notExistsUserName) {
+        this.userName = notExistsUserName;
+        this.isExists = false;
+        this.isSetPasswd = false;
+        this.passwd = null;
+        this.role = null;
+        this.lastTimeStamp = System.currentTimeMillis();
+    }
+
     private final String userName;
+
+    private final boolean isExists;
 
     private final boolean isSetPasswd;
 
@@ -67,6 +80,10 @@ public class LdapUserInfo {
 
     public Role getPaloRole() {
         return role;
+    }
+
+    public boolean isExists() {
+        return isExists;
     }
 
     public LdapUserInfo cloneWithPasswd(String passwd) {

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
@@ -25,6 +25,7 @@ import org.apache.doris.analysis.DropRoleStmt;
 import org.apache.doris.analysis.DropUserStmt;
 import org.apache.doris.analysis.GrantStmt;
 import org.apache.doris.analysis.PasswordOptions;
+import org.apache.doris.analysis.RefreshLdapStmt;
 import org.apache.doris.analysis.ResourcePattern;
 import org.apache.doris.analysis.RevokeStmt;
 import org.apache.doris.analysis.SetLdapPassVar;
@@ -770,6 +771,10 @@ public class Auth implements Writable {
         LOG.debug("finish replaying ldap admin password.");
     }
 
+    public void refreshLdap(RefreshLdapStmt refreshLdapStmt) {
+        ldapManager.refresh(refreshLdapStmt.getIsAll(), refreshLdapStmt.getUser());
+    }
+
     // create role
     public void createRole(CreateRoleStmt stmt) throws DdlException {
         createRoleInternal(stmt.getQualifiedRole(), stmt.isSetIfNotExists(), false);
@@ -1082,7 +1087,7 @@ public class Auth implements Writable {
             table.merge(roleManager.getRole(roleName).getGlobalPrivTable());
         }
         if (isLdapAuthEnabled() && ldapManager.doesUserExist(userIdentity.getQualifiedUser())) {
-            table.merge(ldapManager.getUserInfo(userIdentity.getQualifiedUser()).getPaloRole().getGlobalPrivTable());
+            table.merge(ldapManager.getUserRole(userIdentity.getQualifiedUser()).getGlobalPrivTable());
         }
         return table;
     }
@@ -1094,7 +1099,7 @@ public class Auth implements Writable {
             table.merge(roleManager.getRole(roleName).getCatalogPrivTable());
         }
         if (isLdapAuthEnabled() && ldapManager.doesUserExist(userIdentity.getQualifiedUser())) {
-            table.merge(ldapManager.getUserInfo(userIdentity.getQualifiedUser()).getPaloRole().getCatalogPrivTable());
+            table.merge(ldapManager.getUserRole(userIdentity.getQualifiedUser()).getCatalogPrivTable());
         }
         return table;
     }
@@ -1106,7 +1111,7 @@ public class Auth implements Writable {
             table.merge(roleManager.getRole(roleName).getDbPrivTable());
         }
         if (isLdapAuthEnabled() && ldapManager.doesUserExist(userIdentity.getQualifiedUser())) {
-            table.merge(ldapManager.getUserInfo(userIdentity.getQualifiedUser()).getPaloRole().getDbPrivTable());
+            table.merge(ldapManager.getUserRole(userIdentity.getQualifiedUser()).getDbPrivTable());
         }
         return table;
     }
@@ -1118,7 +1123,7 @@ public class Auth implements Writable {
             table.merge(roleManager.getRole(roleName).getTablePrivTable());
         }
         if (isLdapAuthEnabled() && ldapManager.doesUserExist(userIdentity.getQualifiedUser())) {
-            table.merge(ldapManager.getUserInfo(userIdentity.getQualifiedUser()).getPaloRole().getTablePrivTable());
+            table.merge(ldapManager.getUserRole(userIdentity.getQualifiedUser()).getTablePrivTable());
         }
         return table;
     }
@@ -1130,7 +1135,7 @@ public class Auth implements Writable {
             table.merge(roleManager.getRole(roleName).getResourcePrivTable());
         }
         if (isLdapAuthEnabled() && ldapManager.doesUserExist(userIdentity.getQualifiedUser())) {
-            table.merge(ldapManager.getUserInfo(userIdentity.getQualifiedUser()).getPaloRole().getResourcePrivTable());
+            table.merge(ldapManager.getUserRole(userIdentity.getQualifiedUser()).getResourcePrivTable());
         }
         return table;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserManager.java
@@ -128,7 +128,7 @@ public class UserManager implements Writable {
 
     public List<UserIdentity> getUserIdentityUncheckPasswd(String remoteUser, String remoteHost) {
         List<UserIdentity> userIdentities = Lists.newArrayList();
-        List<User> users = nameToUsers.get(remoteUser);
+        List<User> users = nameToUsers.getOrDefault(remoteUser, Lists.newArrayList());
         for (User user : users) {
             if (!user.getUserIdentity().isDomain() && (user.isAnyHost() || user.getHostPattern().match(remoteHost))) {
                 userIdentities.add(user.getUserIdentity());

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/DdlExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/DdlExecutor.java
@@ -100,6 +100,7 @@ import org.apache.doris.analysis.RecoverPartitionStmt;
 import org.apache.doris.analysis.RecoverTableStmt;
 import org.apache.doris.analysis.RefreshCatalogStmt;
 import org.apache.doris.analysis.RefreshDbStmt;
+import org.apache.doris.analysis.RefreshLdapStmt;
 import org.apache.doris.analysis.RefreshMaterializedViewStmt;
 import org.apache.doris.analysis.RefreshTableStmt;
 import org.apache.doris.analysis.RestoreStmt;
@@ -324,6 +325,8 @@ public class DdlExecutor {
             env.refreshMaterializedView((RefreshMaterializedViewStmt) ddlStmt);
         } else if (ddlStmt instanceof RefreshCatalogStmt) {
             env.getCatalogMgr().refreshCatalog((RefreshCatalogStmt) ddlStmt);
+        } else if (ddlStmt instanceof RefreshLdapStmt) {
+            env.getAuth().refreshLdap((RefreshLdapStmt) ddlStmt);
         } else if (ddlStmt instanceof AlterUserStmt) {
             env.getAuth().alterUser((AlterUserStmt) ddlStmt);
         } else if (ddlStmt instanceof CleanProfileStmt) {

--- a/fe/fe-core/src/main/jflex/sql_scanner.flex
+++ b/fe/fe-core/src/main/jflex/sql_scanner.flex
@@ -287,6 +287,7 @@ import org.apache.doris.qe.SqlModeHelper;
         keywordMap.put("largeint", new Integer(SqlParserSymbols.KW_LARGEINT));
         keywordMap.put("last", new Integer(SqlParserSymbols.KW_LAST));
         keywordMap.put("lateral", new Integer(SqlParserSymbols.KW_LATERAL));
+        keywordMap.put("ldap", new Integer(SqlParserSymbols.KW_LDAP));
         keywordMap.put("ldap_admin_password", new Integer(SqlParserSymbols.KW_LDAP_ADMIN_PASSWORD));
         keywordMap.put("left", new Integer(SqlParserSymbols.KW_LEFT));
         keywordMap.put("less", new Integer(SqlParserSymbols.KW_LESS));

--- a/fe/fe-core/src/test/java/org/apache/doris/ldap/LdapPrivsCheckerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/ldap/LdapPrivsCheckerTest.java
@@ -130,6 +130,10 @@ public class LdapPrivsCheckerTest {
                 minTimes = 0;
                 result = true;
 
+                ldapManager.getUserRole(USER);
+                minTimes = 0;
+                result = ldapRole;
+
                 context.getCurrentUserIdentity();
                 minTimes = 0;
                 result = userIdentity;
@@ -177,8 +181,8 @@ public class LdapPrivsCheckerTest {
 
     @Test
     public void testGetResourcePrivFromLdap() {
-        Assert.assertEquals(PrivBitSet.of(Privilege.USAGE_PRIV).toString(),
-                LdapPrivsChecker.getResourcePrivFromLdap(userIdent, RESOURCE1).toString());
+        Assert.assertTrue(
+                LdapPrivsChecker.getResourcePrivFromLdap(userIdent, RESOURCE1).satisfy(PrivPredicate.USAGE));
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

1. Support refreshing ldap cache:
```
refresh ldap all;
refresh ldap;
refresh ldap for user1;
```
2. Support for caching non-existent ldap users.
When logging in with a doris user that does not exist in the Ldap service after ldap is enabled, avoid accessing the ldap service every time in scenarios such as `show databases;` that require a lot of authentication.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

