### PR TITLE
[Feature-WIP](inverted index) support phrase for inverted index writer

### DIFF
--- a/be/src/olap/inverted_index_parser.cpp
+++ b/be/src/olap/inverted_index_parser.cpp
@@ -70,4 +70,13 @@ std::string get_parser_mode_string_from_properties(
         return INVERTED_INDEX_PARSER_FINE_GRANULARITY;
     }
 }
+
+std::string get_parser_phrase_support_string_from_properties(
+        const std::map<std::string, std::string>& properties) {
+    if (properties.find(INVERTED_INDEX_PARSER_PHRASE_SUPPORT_KEY) != properties.end()) {
+        return properties.at(INVERTED_INDEX_PARSER_PHRASE_SUPPORT_KEY);
+    } else {
+        return INVERTED_INDEX_PARSER_PHRASE_SUPPORT_NO;
+    }
+}
 } // namespace doris

--- a/be/src/olap/inverted_index_parser.h
+++ b/be/src/olap/inverted_index_parser.h
@@ -49,12 +49,18 @@ const std::string INVERTED_INDEX_PARSER_STANDARD = "standard";
 const std::string INVERTED_INDEX_PARSER_ENGLISH = "english";
 const std::string INVERTED_INDEX_PARSER_CHINESE = "chinese";
 
+const std::string INVERTED_INDEX_PARSER_PHRASE_SUPPORT_KEY = "support_phrase";
+const std::string INVERTED_INDEX_PARSER_PHRASE_SUPPORT_YES = "true";
+const std::string INVERTED_INDEX_PARSER_PHRASE_SUPPORT_NO = "false";
+
 std::string inverted_index_parser_type_to_string(InvertedIndexParserType parser_type);
 
 InvertedIndexParserType get_inverted_index_parser_type_from_string(const std::string& parser_str);
 
 std::string get_parser_string_from_properties(const std::map<std::string, std::string>& properties);
 std::string get_parser_mode_string_from_properties(
+        const std::map<std::string, std::string>& properties);
+std::string get_parser_phrase_support_string_from_properties(
         const std::map<std::string, std::string>& properties);
 
 } // namespace doris

--- a/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
@@ -182,6 +182,12 @@ public:
             field_config |= int(lucene::document::Field::INDEX_TOKENIZED);
         }
         _field = new lucene::document::Field(_field_name.c_str(), field_config);
+        if (get_parser_phrase_support_string_from_properties(_index_meta->properties()) ==
+            INVERTED_INDEX_PARSER_PHRASE_SUPPORT_YES) {
+            _field->setOmitTermFreqAndPositions(false);
+        } else {
+            _field->setOmitTermFreqAndPositions(true);
+        }
         _doc->add(*_field);
         return Status::OK();
     }


### PR DESCRIPTION
## Proposed changes

We add phrase support for inverted index, usage like this:
```
CREATE TABLE `inverted` (
  `FIELD0` text NULL,
  `FIELD1` text NULL,
  `FIELD2` text NULL,
  `FIELD3` text NULL,
  INDEX idx_name1 (`FIELD0`) USING INVERTED PROPERTIES("parser" = "english", "support_phrase" = "true") COMMENT '',
  INDEX idx_name2 (`FIELD1`) USING INVERTED PROPERTIES("parser" = "chinese", "support_phrase" = "false") COMMENT ''
) ENGINE=OLAP
);
```
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

