### PR TITLE
[Bug](segment iterator) remove DCHECK for block row count

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -1892,13 +1892,6 @@ Status SegmentIterator::_next_batch_internal(vectorized::Block* block) {
         _update_max_row(block);
     }
 
-#ifndef NDEBUG
-    size_t row_cnt = block->rows();
-    for (size_t i = 0; i < block->columns(); ++i) {
-        DCHECK_EQ(row_cnt, block->get_by_position(i).column->size());
-    }
-#endif
-
     // reverse block row order
     if (_opts.read_orderby_key_reverse) {
         size_t num_rows = block->rows();


### PR DESCRIPTION
CHECK rows count of block at segment iterator is not ready when `enable_common_expr_pushdown`

## Proposed changes

Issue Number: close #20198

<--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

