### PR TITLE
[fix](Nereids) give clean error message when there are subquery in the on clause

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleType.java
@@ -86,7 +86,6 @@ public enum RuleType {
 
     // check analysis rule
     CHECK_AGGREGATE_ANALYSIS(RuleTypeClass.CHECK),
-    CHECK_JOIN_ANALYSIS(RuleTypeClass.CHECK),
     CHECK_ANALYSIS(RuleTypeClass.CHECK),
     CHECK_OBJECT_TYPE_ANALYSIS(RuleTypeClass.CHECK),
     CHECK_BOUND(RuleTypeClass.CHECK),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleType.java
@@ -86,6 +86,7 @@ public enum RuleType {
 
     // check analysis rule
     CHECK_AGGREGATE_ANALYSIS(RuleTypeClass.CHECK),
+    CHECK_JOIN_ANALYSIS(RuleTypeClass.CHECK),
     CHECK_ANALYSIS(RuleTypeClass.CHECK),
     CHECK_OBJECT_TYPE_ANALYSIS(RuleTypeClass.CHECK),
     CHECK_BOUND(RuleTypeClass.CHECK),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CheckAnalysis.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CheckAnalysis.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.rules.Rule;
 import org.apache.doris.nereids.rules.RuleType;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.WindowExpression;
+import org.apache.doris.nereids.trees.expressions.SubqueryExpr;
 import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateFunction;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.GroupingScalarFunction;
 import org.apache.doris.nereids.trees.expressions.typecoercion.TypeCheckResult;
@@ -29,6 +30,7 @@ import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -46,12 +48,13 @@ import java.util.Set;
 public class CheckAnalysis implements AnalysisRuleFactory {
 
     private static final Map<Class<? extends LogicalPlan>, Set<Class<? extends Expression>>>
-            UNEXPECTED_EXPRESSION_TYPE_MAP = ImmutableMap.of(
-                    LogicalFilter.class, ImmutableSet.of(
-                            AggregateFunction.class,
-                            GroupingScalarFunction.class,
-                            WindowExpression.class)
-    );
+            UNEXPECTED_EXPRESSION_TYPE_MAP = ImmutableMap.<Class<? extends LogicalPlan>, Set<Class<? extends Expression>>>builder()
+            .put(LogicalFilter.class, ImmutableSet.of(
+                AggregateFunction.class,
+                GroupingScalarFunction.class,
+                WindowExpression.class))
+            .put(LogicalJoin.class, ImmutableSet.of(SubqueryExpr.class))
+            .build();
 
     @Override
     public List<Rule> buildRules() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CheckAnalysis.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CheckAnalysis.java
@@ -64,7 +64,7 @@ public class CheckAnalysis implements AnalysisRuleFactory {
                 any().then(plan -> {
                     checkExpressionInputTypes(plan);
                     checkUnexpectedExpressions(plan);
-                    return plan;
+                    return null;
                 })
             ),
             RuleType.CHECK_AGGREGATE_ANALYSIS.build(

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CheckAnalysis.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CheckAnalysis.java
@@ -21,16 +21,16 @@ import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.rules.Rule;
 import org.apache.doris.nereids.rules.RuleType;
 import org.apache.doris.nereids.trees.expressions.Expression;
-import org.apache.doris.nereids.trees.expressions.WindowExpression;
 import org.apache.doris.nereids.trees.expressions.SubqueryExpr;
+import org.apache.doris.nereids.trees.expressions.WindowExpression;
 import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateFunction;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.GroupingScalarFunction;
 import org.apache.doris.nereids.trees.expressions.typecoercion.TypeCheckResult;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
-import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
+import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -48,7 +48,8 @@ import java.util.Set;
 public class CheckAnalysis implements AnalysisRuleFactory {
 
     private static final Map<Class<? extends LogicalPlan>, Set<Class<? extends Expression>>>
-            UNEXPECTED_EXPRESSION_TYPE_MAP = ImmutableMap.<Class<? extends LogicalPlan>, Set<Class<? extends Expression>>>builder()
+            UNEXPECTED_EXPRESSION_TYPE_MAP = ImmutableMap.<Class<? extends LogicalPlan>,
+                Set<Class<? extends Expression>>>builder()
             .put(LogicalFilter.class, ImmutableSet.of(
                 AggregateFunction.class,
                 GroupingScalarFunction.class,
@@ -63,7 +64,7 @@ public class CheckAnalysis implements AnalysisRuleFactory {
                 any().then(plan -> {
                     checkExpressionInputTypes(plan);
                     checkUnexpectedExpressions(plan);
-                    return null;
+                    return plan;
                 })
             ),
             RuleType.CHECK_AGGREGATE_ANALYSIS.build(


### PR DESCRIPTION


## Proposed changes
Before this PR
```
mysql> select a.k1 from baseall a join test b on b.k2 in (select 49);
ERROR 1105 (HY000): errCode = 2, detailMessage = Unexpected exception: nul
```

After this PR
```
mysql> select a.k1 from baseall a join test b on b.k2 in (select 49);
ERROR 1105 (HY000): errCode = 2, detailMessage = Unexpected exception: Not support OnClause contain Subquery, expr:k2 IN (INSUBQUERY) (LogicalOneRowRelation ( projects=[49 AS `49`#28], buildUnionNode=true ))
```

<--Describe your changes.-->
Add the rule for checking the join node in `analysis/CheckAnalysis.java` file. When we check the join node, we should check its' on clause. If there are some subquery expression, we should throw exception.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

