### PR TITLE
[Enchancement](execute) make assert_cast can output derived class name

### DIFF
--- a/be/src/vec/common/assert_cast.h
+++ b/be/src/vec/common/assert_cast.h
@@ -43,6 +43,9 @@ To assert_cast(From&& from) {
                 if (auto ptr = dynamic_cast<To>(from); ptr != nullptr) {
                     return ptr;
                 }
+                LOG(FATAL) << fmt::format("Bad cast from type:{}* to {}",
+                                          demangle(typeid(*from).name()),
+                                          demangle(typeid(To).name()));
             }
         } else {
             if (typeid(from) == typeid(To)) return static_cast<To>(from);

--- a/be/src/vec/common/demangle.cpp
+++ b/be/src/vec/common/demangle.cpp
@@ -43,7 +43,7 @@ std::string demangle(const char* name, int& status) {
 std::string demangle(const char* name, int& status) {
     std::string res;
 
-    char* demangled_str = abi::__cxa_demangle(name, 0, 0, &status);
+    char* demangled_str = abi::__cxa_demangle(name, nullptr, nullptr, &status);
     if (demangled_str) {
         try {
             res = demangled_str;
@@ -52,8 +52,9 @@ std::string demangle(const char* name, int& status) {
             throw;
         }
         free(demangled_str);
-    } else
+    } else {
         res = name;
+    }
 
     return res;
 }


### PR DESCRIPTION
## Proposed changes

before:
F0530 11:02:41.989699 1154607 assert_cast.h:54] Bad cast from type:doris::vectorized::IDataType const* to doris::vectorized::DataTypeAggState const*

after:
F0530 11:24:28.390286 1292475 assert_cast.h:46] Bad cast from type:doris::vectorized::DataTypeNullable* to doris::vectorized::DataTypeAggState const*


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

