### PR TITLE
[Fix](multi catalog, nereids)Fix text file required slot bug.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileQueryScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileQueryScanNode.java
@@ -139,7 +139,7 @@ public abstract class FileQueryScanNode extends FileScanNode {
             params.addToRequiredSlots(slotInfo);
         }
         setDefaultValueExprs(getTargetTable(), destSlotDescByName, params, false);
-        setColumnPositionMappingForTextFile();
+        setColumnPositionMapping();
         // For query, set src tuple id to -1.
         params.setSrcTupleId(-1);
     }
@@ -167,6 +167,11 @@ public abstract class FileQueryScanNode extends FileScanNode {
             slotInfo.setIsFileSlot(!getPathPartitionKeys().contains(slot.getColumn().getName()));
             params.addToRequiredSlots(slotInfo);
         }
+        // Update required slots in scanRangeLocations.
+        for (TScanRangeLocations location : scanRangeLocations) {
+            location.getScanRange().getExtScanRange().getFileScanRange()
+                .getParams().setRequiredSlots(params.getRequiredSlots());
+        }
     }
 
     @Override
@@ -184,7 +189,7 @@ public abstract class FileQueryScanNode extends FileScanNode {
         createScanRangeLocations();
     }
 
-    private void setColumnPositionMappingForTextFile()
+    private void setColumnPositionMapping()
             throws UserException {
         TableIf tbl = getTargetTable();
         List<Integer> columnIdxs = Lists.newArrayList();


### PR DESCRIPTION
<--Describe your changes.-->

required_slots in TFileScanRangeParams params for external hive table may be updated after FileQueryScanNode finalize. For text file, we need to use the origin required_slots in params so that the list could be updated later. Otherwise, query text file may get the following error:
[INTERNAL_ERROR]Unknown source slot descriptor, slot_id=3

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

