### PR TITLE
[Improve](BloomFilter) Suport caching bloom filters and filter segmen…

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1005,7 +1005,7 @@ DEFINE_mInt32(s3_write_buffer_whole_size, "524288000");
 
 //disable shrink memory by default
 DEFINE_Bool(enable_shrink_memory, "false");
-DEFINE_mInt32(schema_cache_capacity, "1024");
+DEFINE_mInt32(schema_cache_capacity, "10240");
 DEFINE_mInt32(schema_cache_sweep_time_sec, "100");
 
 // enable feature binlog, default false
@@ -1013,6 +1013,8 @@ DEFINE_Bool(enable_feature_binlog, "false");
 
 // enable set in BitmapValue
 DEFINE_Bool(enable_set_in_bitmap_value, "false");
+// enable caching parsed BloomFilter in segment
+DEFINE_Bool(enable_caching_bloom_filters, "true");
 
 #ifdef BE_TEST
 // test s3

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1029,6 +1029,8 @@ DECLARE_Bool(enable_feature_binlog);
 
 // enable set in BitmapValue
 DECLARE_Bool(enable_set_in_bitmap_value);
+// enable caching parsed BloomFilter in segment
+DECLARE_Bool(enable_caching_bloom_filters);
 
 #ifdef BE_TEST
 // test s3

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -437,7 +437,8 @@ Status SegmentIterator::_get_row_ranges_from_conditions(RowRanges* condition_row
         DCHECK(_opts.col_id_to_predicates.count(cid) > 0);
         uint32_t unique_cid = _schema->unique_id(cid);
         RETURN_IF_ERROR(_column_iterators[unique_cid]->get_row_ranges_by_bloom_filter(
-                _opts.col_id_to_predicates.at(cid).get(), &column_bf_row_ranges));
+                _opts.col_id_to_predicates.at(cid).get(), &column_bf_row_ranges,
+                _segment->bloom_filter_for_column(unique_cid)));
         RowRanges::ranges_intersection(bf_row_ranges, column_bf_row_ranges, &bf_row_ranges);
     }
 


### PR DESCRIPTION
…t by bloomfilter

1. Caching parsed BloomFilters will reduce parse bloom filter each time read BloomFilter index, this could save lots of CPU overhead in high concurrent workload.
2. Pruning segment by BloomFilter could save CPU of initializing segment iterator and index reading.

```
SELECT * FROM table_bf WHERE column_with_bf = 9559 LIMIT 1;

before:
380.36 QPS
- NumSegmentFiltered: 0
- NumSegmentTotal: 598

after:
729.5 QPS
- NumSegmentFiltered: 450
- NumSegmentTotal: 598
```

![image](https://github.com/apache/doris/assets/64513324/75ce42a2-3d4f-4e2d-b93e-05473da5174b)


## Proposed changes

Issue Number: close #xxx

<--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

