### PR TITLE
[Improve](Scan) add a session variable to make scan run serial

### DIFF
--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -373,6 +373,10 @@ public:
 
     bool enable_profile() const { return _query_options.is_report_success; }
 
+    bool enable_run_serial() const {
+        return _query_options.__isset.enable_run_serial && _query_options.enable_run_serial;
+    }
+
     bool enable_share_hash_table_for_broadcast_join() const {
         return _query_options.__isset.enable_share_hash_table_for_broadcast_join &&
                _query_options.enable_share_hash_table_for_broadcast_join;

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -373,8 +373,9 @@ public:
 
     bool enable_profile() const { return _query_options.is_report_success; }
 
-    bool enable_run_serial() const {
-        return _query_options.__isset.enable_run_serial && _query_options.enable_run_serial;
+    bool enable_scan_node_run_serial() const {
+        return _query_options.__isset.enable_scan_node_run_serial &&
+               _query_options.enable_scan_node_run_serial;
     }
 
     bool enable_share_hash_table_for_broadcast_join() const {

--- a/be/src/vec/exec/scan/vscan_node.h
+++ b/be/src/vec/exec/scan/vscan_node.h
@@ -160,7 +160,7 @@ public:
 
     Status try_close();
 
-    bool should_run_serial() const { return _should_run_serial; }
+    bool should_run_serial() const { return _should_run_serial || _state->enable_run_serial(); }
     bool ready_to_open() { return _shared_scanner_controller->scanner_context_is_ready(id()); }
     bool ready_to_read() { return !_scanner_ctx->empty_in_queue(_context_queue_id); }
 

--- a/be/src/vec/exec/scan/vscan_node.h
+++ b/be/src/vec/exec/scan/vscan_node.h
@@ -160,7 +160,9 @@ public:
 
     Status try_close();
 
-    bool should_run_serial() const { return _should_run_serial || _state->enable_run_serial(); }
+    bool should_run_serial() const {
+        return _should_run_serial || _state->enable_scan_node_run_serial();
+    }
     bool ready_to_open() { return _shared_scanner_controller->scanner_context_is_ready(id()); }
     bool ready_to_read() { return !_scanner_ctx->empty_in_queue(_context_queue_id); }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -401,7 +401,7 @@ public class Coordinator {
         this.queryOptions.setBeExecVersion(Config.be_exec_version);
         this.queryOptions.setQueryTimeout(context.getExecTimeout());
         this.queryOptions.setExecutionTimeout(context.getExecTimeout());
-        this.queryOptions.setEnableRunSerial(context.getSessionVariable().isEnableRunSerial());
+        this.queryOptions.setEnableScanNodeRunSerial(context.getSessionVariable().isEnableScanRunSerial());
     }
 
     public long getJobId() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -401,6 +401,7 @@ public class Coordinator {
         this.queryOptions.setBeExecVersion(Config.be_exec_version);
         this.queryOptions.setQueryTimeout(context.getExecTimeout());
         this.queryOptions.setExecutionTimeout(context.getExecTimeout());
+        this.queryOptions.setEnableRunSerial(context.getSessionVariable().isEnableRunSerial());
     }
 
     public long getJobId() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -340,7 +340,7 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String ENABLE_CTE_MATERIALIZE = "enable_cte_materialize";
 
-    public static final String ENABLE_RUN_SERIAL = "enable_run_serial";
+    public static final String ENABLE_SCAN_RUN_SERIAL = "enable_scan_node_run_serial";
 
     public static final List<String> DEBUG_VARIABLES = ImmutableList.of(
             SKIP_DELETE_PREDICATE,
@@ -533,8 +533,11 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = ENABLE_ODBC_TRANSCATION)
     public boolean enableOdbcTransaction = false;
 
-    @VariableMgr.VarAttr(name = ENABLE_RUN_SERIAL)
-    public boolean enableRunSerial = false;
+    @VariableMgr.VarAttr(name = ENABLE_SCAN_RUN_SERIAL,  description = {
+            "是否开启ScanNode串行读，以避免limit较小的情况下的读放大，可以提高查询的并发能力",
+            "Whether to enable ScanNode serial reading to avoid read amplification in cases of small limits"
+                + "which can improve query concurrency. default is false."})
+    public boolean enableScanRunSerial = false;
 
     @VariableMgr.VarAttr(name = ENABLE_SQL_CACHE)
     public boolean enableSqlCache = false;
@@ -1451,8 +1454,8 @@ public class SessionVariable implements Serializable, Writable {
         this.showHiddenColumns = showHiddenColumns;
     }
 
-    public boolean isEnableRunSerial() {
-        return enableRunSerial;
+    public boolean isEnableScanRunSerial() {
+        return enableScanRunSerial;
     }
 
     public boolean skipStorageEngineMerge() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -340,6 +340,8 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String ENABLE_CTE_MATERIALIZE = "enable_cte_materialize";
 
+    public static final String ENABLE_RUN_SERIAL = "enable_run_serial";
+
     public static final List<String> DEBUG_VARIABLES = ImmutableList.of(
             SKIP_DELETE_PREDICATE,
             SKIP_DELETE_BITMAP,
@@ -530,6 +532,9 @@ public class SessionVariable implements Serializable, Writable {
 
     @VariableMgr.VarAttr(name = ENABLE_ODBC_TRANSCATION)
     public boolean enableOdbcTransaction = false;
+
+    @VariableMgr.VarAttr(name = ENABLE_RUN_SERIAL)
+    public boolean enableRunSerial = false;
 
     @VariableMgr.VarAttr(name = ENABLE_SQL_CACHE)
     public boolean enableSqlCache = false;
@@ -1444,6 +1449,10 @@ public class SessionVariable implements Serializable, Writable {
 
     public void setShowHiddenColumns(boolean showHiddenColumns) {
         this.showHiddenColumns = showHiddenColumns;
+    }
+
+    public boolean isEnableRunSerial() {
+        return enableRunSerial;
     }
 
     public boolean skipStorageEngineMerge() {

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -221,6 +221,8 @@ struct TQueryOptions {
   72: optional bool enable_orc_lazy_mat = true
 
   73: optional i64 scan_queue_mem_limit
+
+  74: optional bool enable_run_serial = false; 
 }
     
 

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -222,7 +222,7 @@ struct TQueryOptions {
 
   73: optional i64 scan_queue_mem_limit
 
-  74: optional bool enable_run_serial = false; 
+  74: optional bool enable_scan_node_run_serial = false; 
 }
     
 


### PR DESCRIPTION
## Proposed changes

Parallel scanning can result in some read amplification, for example, select * from xx where limit 1 actually requires only one row of data. However, due to parallel scanning of multiple tablets, read amplification occurs, leading to performance bottlenecks in high-concurrency scenarios. This PR Adding a SessionVariable to enforce serial scanning can help mitigate this issue.

Issue Number: close #xxx

<--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

