### PR TITLE
[Fix](hive-catalog) Fallback to refresh catalog when hms events are missing

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
@@ -35,6 +35,7 @@ import com.google.common.collect.Lists;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.CurrentNotificationEventId;
 import org.apache.hadoop.hive.metastore.api.NotificationEventResponse;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -215,7 +216,20 @@ public class HMSExternalCatalog extends ExternalCatalog {
             LOG.info("Event id not updated when pulling events on catalog [{}]", hmsExternalCatalog.getName());
             return null;
         }
-        return client.getNextNotification(lastSyncedEventId, Config.hms_events_batch_size_per_rpc, null);
+
+        try {
+            return client.getNextNotification(lastSyncedEventId, Config.hms_events_batch_size_per_rpc, null);
+        } catch (IllegalStateException e) {
+            // Need a fallback to handle this because this error state can not be recovered until restarting FE
+            if (HiveMetaStoreClient.REPL_EVENTS_MISSING_IN_METASTORE.equals(e.getMessage())) {
+                lastSyncedEventId = getCurrentEventId();
+                refreshCatalog(hmsExternalCatalog);
+                LOG.warn("Notification events are missing, maybe an event can not be handled " +
+                        "or processing rate is too low, fallback to refresh the catalog");
+                return null;
+            }
+            throw e;
+        }
     }
 
     private void refreshCatalog(HMSExternalCatalog hmsExternalCatalog) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
@@ -224,8 +224,8 @@ public class HMSExternalCatalog extends ExternalCatalog {
             if (HiveMetaStoreClient.REPL_EVENTS_MISSING_IN_METASTORE.equals(e.getMessage())) {
                 lastSyncedEventId = getCurrentEventId();
                 refreshCatalog(hmsExternalCatalog);
-                LOG.warn("Notification events are missing, maybe an event can not be handled " +
-                        "or processing rate is too low, fallback to refresh the catalog");
+                LOG.warn("Notification events are missing, maybe an event can not be handled "
+                        + "or processing rate is too low, fallback to refresh the catalog");
                 return null;
             }
             throw e;

--- a/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -320,7 +320,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
   static final protected Logger LOG = LoggerFactory.getLogger(HiveMetaStoreClient.class);
 
   //copied from ErrorMsg.java
-  private static final String REPL_EVENTS_MISSING_IN_METASTORE = "Notification events are missing in the meta store.";
+  public static final String REPL_EVENTS_MISSING_IN_METASTORE = "Notification events are missing in the meta store.";
 
   public HiveMetaStoreClient(Configuration conf) throws MetaException {
     this(conf, null, true);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

This error can not be recovered (the relevant events in hms may have been deleted and can not recovered), so we need a fallback.
```
2023-03-30 15:12:49,340 WARN (org.apache.doris.datasource.hive.event.MetastoreEventsProcessor|34) [PooledHiveMetaStoreClient.getNextNotification():170] Failed to get next notification based on last evv
ent id 0
java.lang.IllegalStateException: Notification events are missing in the meta store.
        at org.apache.hadoop.hive.metastore.HiveMetaStoreClient.getNextNotification(HiveMetaStoreClient.java:2709) ~[hive-standalone-metastore-3.1.3.jar:3.1.3]
        at sun.reflect.GeneratedMethodAccessor57.invoke(Unknown Source) ~[?:?]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_231]
        at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_231]
        at org.apache.hadoop.hive.metastore.RetryingMetaStoreClient.invoke(RetryingMetaStoreClient.java:208) ~[hive-standalone-metastore-3.1.3.jar:3.1.3]
        at com.sun.proxy.$Proxy37.getNextNotification(Unknown Source) ~[?:?]
        at org.apache.doris.datasource.hive.PooledHiveMetaStoreClient.getNextNotification(PooledHiveMetaStoreClient.java:168) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.datasource.HMSExternalCatalog.getNextEventResponse(HMSExternalCatalog.java:194) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.datasource.hive.event.MetastoreEventsProcessor.getNextHMSEvents(MetastoreEventsProcessor.java:80) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.datasource.hive.event.MetastoreEventsProcessor.realRun(MetastoreEventsProcessor.java:132) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.datasource.hive.event.MetastoreEventsProcessor.runAfterCatalogReady(MetastoreEventsProcessor.java:117) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.common.util.MasterDaemon.runOneCycle(MasterDaemon.java:58) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.common.util.Daemon.run(Daemon.java:116) ~[doris-fe.jar:1.2-SNAPSHOT]
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

