### PR TITLE
[Bug](memtable) fix a bug occurred when we were inserting data into duplicate table without keys

### DIFF
--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -238,11 +238,6 @@ void MemTable::_aggregate_two_row_in_block(vectorized::MutableBlock& mutable_blo
 }
 void MemTable::_put_into_output(vectorized::Block& in_block) {
     SCOPED_RAW_TIMER(&_stat.put_into_output_ns);
-    if (_keys_type == KeysType::DUP_KEYS && _schema->num_key_columns() == 0) {
-        // skip sort if the table is dup table without keys
-        _output_mutable_block.swap(_input_mutable_block);
-        return;
-    }
     std::vector<int> row_pos_vec;
     DCHECK(in_block.rows() <= std::numeric_limits<int>::max());
     row_pos_vec.reserve(in_block.rows());
@@ -470,8 +465,12 @@ Status MemTable::_do_flush() {
     SCOPED_CONSUME_MEM_TRACKER(_flush_mem_tracker);
     int same_keys_num = _sort();
     if (_keys_type == KeysType::DUP_KEYS || same_keys_num == 0) {
-        vectorized::Block in_block = _input_mutable_block.to_block();
-        _put_into_output(in_block);
+        if (_keys_type == KeysType::DUP_KEYS && _schema->num_key_columns() == 0) {
+            _output_mutable_block.swap(_input_mutable_block);
+        } else {
+            vectorized::Block in_block = _input_mutable_block.to_block();
+            _put_into_output(in_block);
+        }
     } else {
         _aggregate<true>();
     }

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1925,7 +1925,7 @@ public class Config extends ConfigBase {
      * when creating a table which not set key type and key columns
      */
     @ConfField(mutable = true, masterOnly = true)
-    public static boolean experimental_enable_duplicate_without_keys_by_default = false;
+    public static boolean experimental_enable_duplicate_without_keys_by_default = true;
 
     /**
      * To prevent different types (V1, V2, V3) of behavioral inconsistencies,

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1925,7 +1925,7 @@ public class Config extends ConfigBase {
      * when creating a table which not set key type and key columns
      */
     @ConfField(mutable = true, masterOnly = true)
-    public static boolean experimental_enable_duplicate_without_keys_by_default = true;
+    public static boolean experimental_enable_duplicate_without_keys_by_default = false;
 
     /**
      * To prevent different types (V1, V2, V3) of behavioral inconsistencies,


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

## Describe your changes
Before this pr, if we insert data into a table which is duplicate table without keys, BE Code (in the memtable module) will report an error.
After this pr, we can insert data normally into a duplicate table without keys.
this pr has passed the ssb benchmark (I turn all tables into duplicate tables without keys).

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

