### PR TITLE
[bug](parse) fix can't create aggregate column with agg_state

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -3472,6 +3472,13 @@ column_definition ::=
         ColumnDef columnDef = new ColumnDef(columnName, typeDef, isKey, aggType, isAllowNull, defaultValue, comment);
         RESULT = columnDef;
     :}
+    | ident:columnName type_def:typeDef opt_is_key:isKey opt_agg_type:aggType LPAREN type_def_nullable_list:list RPAREN opt_default_value:defaultValue opt_comment:comment
+    {:
+        ColumnDef columnDef = new ColumnDef(columnName, typeDef, isKey, AggregateType.GENERIC_AGGREGATION, false, defaultValue, comment);
+        columnDef.setGenericAggregationName(aggType);
+        columnDef.setGenericAggregationArguments(list);
+        RESULT = columnDef;
+    :}
     ;
 
 index_definition ::=

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
@@ -212,6 +212,10 @@ public class ColumnDef {
         this.genericAggregationName = genericAggregationName;
     }
 
+    public void setGenericAggregationName(AggregateType aggregateType) {
+        this.genericAggregationName = aggregateType.name();
+    }
+
     public void setGenericAggregationArguments(List<TypeDef> genericAggregationArguments) {
         this.genericAggregationArguments = genericAggregationArguments;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
@@ -213,7 +213,7 @@ public class ColumnDef {
     }
 
     public void setGenericAggregationName(AggregateType aggregateType) {
-        this.genericAggregationName = aggregateType.name();
+        this.genericAggregationName = aggregateType.name().toLowerCase();
     }
 
     public void setGenericAggregationArguments(List<TypeDef> genericAggregationArguments) {


### PR DESCRIPTION
## Proposed changes
before create agg column of sum, max,min with agg_state will failed:
```
mysql [test_query_qa]>create table agg_table2(
    -> k1 int null,
    -> k2 agg_state max(int)
    -> )
    -> AGGREGATE KEY(`k1`)
    -> COMMENT 'OLAP'
    -> DISTRIBUTED BY HASH(`k1`) BUCKETS 5
    -> PROPERTIES (
    -> "replication_allocation" = "tag.location.default: 1",
    -> "storage_format" = "V2",
    -> "light_schema_change" = "true",
    -> "disable_auto_compaction" = "false"
    -> );
ERROR 1105 (HY000): errCode = 2, detailMessage = Syntax error in line 3:
k2 agg_state max(int)
                ^
Encountered: (
Expected: COMMA
```




Issue Number: close #xxx

<--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

