### PR TITLE
[fix](checksum) delete predicates might be inconsistent with rowset readers in checksum task

### DIFF
--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -643,13 +643,12 @@ Status TabletReader::init_reader_params_and_create_block(
             tablet->rowset_meta_with_max_schema_version(rowset_metas)->tablet_schema();
     TabletSchemaSPtr merge_tablet_schema = std::make_shared<TabletSchema>();
     merge_tablet_schema->copy_from(*read_tablet_schema);
-    {
-        std::shared_lock rdlock(tablet->get_header_lock());
-        auto& delete_preds = tablet->delete_predicates();
-        std::copy(delete_preds.cbegin(), delete_preds.cend(),
-                  std::inserter(reader_params->delete_predicates,
-                                reader_params->delete_predicates.begin()));
-    }
+
+    auto& delete_preds = tablet->delete_predicates();
+    std::copy(delete_preds.cbegin(), delete_preds.cend(),
+              std::inserter(reader_params->delete_predicates,
+                            reader_params->delete_predicates.begin()));
+
     // Merge the columns in delete predicate that not in latest schema in to current tablet schema
     for (auto& del_pred_pb : reader_params->delete_predicates) {
         merge_tablet_schema->merge_dropped_columns(tablet->tablet_schema(del_pred_pb->version()));

--- a/be/src/olap/task/engine_checksum_task.cpp
+++ b/be/src/olap/task/engine_checksum_task.cpp
@@ -71,21 +71,24 @@ Status EngineChecksumTask::_compute_checksum() {
 
     std::vector<RowsetSharedPtr> input_rowsets;
     Version version(0, _version);
-    Status acquire_reader_st = tablet->capture_consistent_rowsets(version, &input_rowsets);
-    if (acquire_reader_st != Status::OK()) {
-        LOG(WARNING) << "fail to captute consistent rowsets. tablet=" << tablet->full_name()
-                     << "res=" << acquire_reader_st;
-        return acquire_reader_st;
+    vectorized::BlockReader reader;
+    TabletReader::ReaderParams reader_params;
+    vectorized::Block block;
+    {
+        std::shared_lock rdlock(tablet->get_header_lock());
+        Status acquire_reader_st = tablet->capture_consistent_rowsets(version, &input_rowsets);
+        if (acquire_reader_st != Status::OK()) {
+            LOG(WARNING) << "fail to captute consistent rowsets. tablet=" << tablet->full_name()
+                         << "res=" << acquire_reader_st;
+            return acquire_reader_st;
+        }
+        RETURN_IF_ERROR(TabletReader::init_reader_params_and_create_block(
+                tablet, ReaderType::READER_CHECKSUM, input_rowsets, &reader_params, &block));
     }
     size_t input_size = 0;
     for (const auto& rowset : input_rowsets) {
         input_size += rowset->data_disk_size();
     }
-    vectorized::BlockReader reader;
-    TabletReader::ReaderParams reader_params;
-    vectorized::Block block;
-    RETURN_IF_ERROR(TabletReader::init_reader_params_and_create_block(
-            tablet, ReaderType::READER_CHECKSUM, input_rowsets, &reader_params, &block));
 
     auto res = reader.init(reader_params);
     if (!res.ok()) {


### PR DESCRIPTION

## Proposed changes

Issue Number: close #xxx

The BlockReader  capture rowsets and init delete_handler in different place. If there is a base compaction, it may result in obtaining inconsistent delete handlers. Therefore, place these two operations under the same lock.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

