### PR TITLE
[improvement](compaction) Duplicate without key table compaction  optimimation

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -327,6 +327,8 @@ DEFINE_mInt64(vertical_compaction_max_segment_size, "268435456");
 // In ordered data compaction, min segment size for input rowset
 DEFINE_mInt32(ordered_data_compaction_min_segment_size, "10485760");
 
+DEFINE_mInt32(dup_without_key_opt_compaction_min_segment_size, "1000");
+
 // This config can be set to limit thread number in compaction thread pool.
 DEFINE_mInt32(max_base_compaction_threads, "4");
 DEFINE_mInt32(max_cumu_compaction_threads, "10");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -367,6 +367,7 @@ DECLARE_mInt64(vertical_compaction_max_segment_size);
 
 // In ordered data compaction, min segment size for input rowset
 DECLARE_mInt32(ordered_data_compaction_min_segment_size);
+DECLARE_mInt32(dup_without_key_opt_compaction_min_segment_size);
 
 // This config can be set to limit thread number in compaction thread pool.
 DECLARE_mInt32(max_base_compaction_threads);

--- a/be/src/olap/compaction.h
+++ b/be/src/olap/compaction.h
@@ -48,6 +48,7 @@ class RowsetWriter;
 //  4. gc output rowset if failed
 class Compaction {
 public:
+    friend class CompactionDupnokeyOpt;
     Compaction(const TabletSharedPtr& tablet, const std::string& label);
     virtual ~Compaction();
 
@@ -86,9 +87,12 @@ protected:
     int64_t get_avg_segment_rows();
 
     bool handle_ordered_data_compaction();
+
     Status do_compact_ordered_rowsets();
     bool is_rowset_tidy(std::string& pre_max_key, const RowsetSharedPtr& rhs);
     void build_basic_info();
+    // duplicate without key optimization
+    bool handle_duplicate_nokey_compaction();
 
 protected:
     // the root tracker for this compaction

--- a/be/src/olap/compaction_dupnokey_opt.cpp
+++ b/be/src/olap/compaction_dupnokey_opt.cpp
@@ -85,8 +85,8 @@ Status CompactionDupnokeyOpt::handle_duplicate_nokey_compaction() {
 
     TRACE_COUNTER_INCREMENT("output_rowset_data_size", _parent._output_rowset->data_disk_size());
     TRACE_COUNTER_INCREMENT("output_row_num", _parent._output_rowset->num_rows());
-    return Status::OK();
     TRACE_COUNTER_INCREMENT("output_segments_num", _parent._output_rowset->num_segments());
+    return Status::OK();
 }
 
 Status CompactionDupnokeyOpt::_do_compact_segments(

--- a/be/src/olap/compaction_dupnokey_opt.cpp
+++ b/be/src/olap/compaction_dupnokey_opt.cpp
@@ -1,0 +1,275 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "olap/compaction_dupnokey_opt.h"
+
+#include <gen_cpp/types.pb.h>
+
+#include "olap/rowset/beta_rowset.h"
+#include "olap/rowset/rowset_writer.h"
+#include "olap/rowset/segment_v2/segment.h"
+#include "olap/storage_engine.h"
+#include "util/trace.h"
+#include "vec/olap/vertical_block_reader.h"
+#include "vec/olap/vertical_merge_iterator.h"
+
+namespace doris {
+using namespace ErrorCode;
+Status CompactionDupnokeyOpt::handle_duplicate_nokey_compaction() {
+    std::map<RowsetSharedPtr, std::vector<size_t>> to_compacts, to_links;
+    size_t link_segment_file_size = 0, compact_segment_file_size = 0, compact_segments = 0,
+           link_segments = 0;
+    if (!_duplicate_nokey_check_and_split_segments(to_compacts, to_links, compact_segments,
+                                                   compact_segment_file_size, link_segments,
+                                                   link_segment_file_size)) {
+        return Status::NotSupported("Too small");
+    }
+
+    _parent.build_basic_info();
+
+    RETURN_IF_ERROR(_parent.construct_output_rowset_writer(_ctx, true));
+    Merger::Statistics stats;
+    if (!to_compacts.empty()) {
+        Status res = _do_compact_segments(to_compacts, &stats);
+        if (!res.ok()) {
+            LOG(WARNING) << "fail to do " << _parent.compaction_name() << ". res=" << res
+                         << ", tablet=" << _parent._tablet->full_name()
+                         << ", output_version=" << _parent._output_version;
+            return res;
+        }
+        VLOG(1) << "Dupnokeyopt merge [" << _parent.compaction_name()
+                << "] tablet:" << _parent._tablet->full_name()
+                << " finished, merge segments : " << compact_segments
+                << " merge file size: " << compact_segment_file_size
+                << " merge_rows:" << stats.merged_rows << " filtered_rows:" << stats.filtered_rows;
+
+        TRACE("merge rowsets finished");
+        TRACE_COUNTER_INCREMENT("merged_rows", stats.merged_rows);
+        TRACE_COUNTER_INCREMENT("filtered_rows", stats.filtered_rows);
+    } else {
+        VLOG(1) << "Dupnokeyopt merge [" << _parent.compaction_name()
+                << "] tablet:" << _parent._tablet->full_name()
+                << "] not needed, merge segments : " << compact_segments
+                << " merge file size: " << compact_segment_file_size;
+    }
+
+    // TODO: will get newest seg id from the writer
+    ///size_t newest_seg_id = _parent._output_rowset->num_segments();
+
+    VLOG(1) << "Dupnokeyopt link [" << _parent.compaction_name()
+            << "] tablet:" << _parent._tablet->full_name() << " segments : " << link_segments
+            << ", link file size: " << link_segment_file_size;
+    Status res = _do_compact_duplicate_nokey_over_size(to_links, link_segment_file_size);
+    if (!res.ok()) {
+        return res;
+    }
+    _parent._output_rowset = _parent._output_rs_writer->build();
+    if (_parent._output_rowset == nullptr) {
+        LOG(WARNING) << "rowset writer build failed. writer version:"
+                     << ", output_version=" << _parent._output_version;
+        return Status::Error<ROWSET_BUILDER_INIT>();
+    }
+
+    TRACE_COUNTER_INCREMENT("output_rowset_data_size", _parent._output_rowset->data_disk_size());
+    TRACE_COUNTER_INCREMENT("output_row_num", _parent._output_rowset->num_rows());
+    TRACE_COUNTER_INCREMENT("output_segments_num", _parent._output_rowset->num_segments());
+    TRACE("output rowset built");
+    return Status::OK();
+}
+
+Status CompactionDupnokeyOpt::_do_compact_segments(
+        const std::map<RowsetSharedPtr, std::vector<size_t>>& to_compacts,
+        Merger::Statistics* output_stats) {
+    auto tablet = _parent._tablet;
+
+    std::vector<std::vector<uint32_t>> column_groups;
+    Merger::vertical_split_columns(_ctx.tablet_schema, &column_groups);
+    vectorized::RowSourcesBuffer row_sources_buf(tablet->tablet_id(), tablet->tablet_path(),
+                                                 READER_SEGMENT_COMPACTION);
+
+    KeyBoundsPB key_bounds;
+    Merger::Statistics key_merger_stats;
+    OlapReaderStatistics key_reader_stats;
+
+    int64_t max_rows_per_segments = _parent.get_avg_segment_rows();
+    /* compact group one by one */
+    for (auto i = 0; i < column_groups.size(); ++i) {
+        VLOG_NOTICE << "row source size: " << row_sources_buf.total_size();
+        bool is_key = (i == 0);
+        std::vector<uint32_t> column_ids = column_groups[i];
+        auto schema = std::make_shared<Schema>(_ctx.tablet_schema->columns(), column_ids);
+        OlapReaderStatistics reader_stats;
+        std::unique_ptr<vectorized::VerticalBlockReader> reader;
+        auto s = _get_segcompaction_reader(to_compacts, tablet, schema, &reader_stats,
+                                           row_sources_buf, is_key, column_ids, &reader);
+        if (UNLIKELY(reader == nullptr || !s.ok())) {
+            LOG(WARNING) << "failed to get segment reader";
+            return Status::Error<SEGCOMPACTION_INIT_READER>();
+        }
+
+        RETURN_IF_ERROR(vertical_compact_one_group(
+                tablet, READER_SEGMENT_COMPACTION, _ctx.tablet_schema, is_key, column_ids, *reader,
+                _parent._output_rs_writer.get(), max_rows_per_segments, &key_merger_stats));
+        if (is_key) {
+            row_sources_buf.flush();
+        }
+        row_sources_buf.seek_to_begin();
+    }
+    // finish compact, build output rowset
+    VLOG_NOTICE << "finish compact groups";
+    RETURN_IF_ERROR(_parent._output_rs_writer->final_flush());
+
+    return Status::OK();
+}
+
+Status CompactionDupnokeyOpt::_get_segcompaction_reader(
+        const std::map<RowsetSharedPtr, std::vector<size_t>>& to_compacts, TabletSharedPtr tablet,
+        std::shared_ptr<Schema> schema, OlapReaderStatistics* stat,
+        vectorized::RowSourcesBuffer& row_sources_buf, bool is_key,
+        std::vector<uint32_t>& return_columns,
+        std::unique_ptr<vectorized::VerticalBlockReader>* reader) {
+    StorageReadOptions read_options;
+    read_options.stats = stat;
+    read_options.use_page_cache = false;
+    read_options.tablet_schema = _ctx.tablet_schema;
+    std::vector<std::unique_ptr<RowwiseIterator>> seg_iterators;
+    for (auto& to_compact : to_compacts) {
+        auto beta_rowset = reinterpret_cast<BetaRowset*>(to_compact.first.get());
+        for (size_t seg_id : to_compact.second) {
+            std::unique_ptr<RowwiseIterator> iter;
+            segment_v2::SegmentSharedPtr seg_ptr;
+            auto s = beta_rowset->load_segment(seg_id, seg_ptr);
+            if (!s.ok()) {
+                LOG(WARNING) << "failed to load segment[" << beta_rowset->rowset_id() << ":"
+                             << seg_ptr->id() << "]: " << s.to_string();
+                return Status::Error<INIT_FAILED>();
+            }
+            s = seg_ptr->new_iterator(*schema, read_options, &iter);
+            if (!s.ok()) {
+                LOG(WARNING) << "failed to create iterator[" << seg_ptr->id()
+                             << "]: " << s.to_string();
+                return Status::Error<INIT_FAILED>();
+            }
+            seg_iterators.push_back(std::move(iter));
+        }
+    }
+
+    *reader = std::unique_ptr<vectorized::VerticalBlockReader> {
+            new vectorized::VerticalBlockReader(&row_sources_buf)};
+
+    TabletReader::ReaderParams reader_params;
+    reader_params.is_segcompaction = true;
+    reader_params.segment_iters_ptr = &seg_iterators;
+    // no reader_params.version shouldn't break segcompaction
+    reader_params.tablet_schema = _ctx.tablet_schema;
+    reader_params.tablet = tablet;
+    reader_params.return_columns = return_columns;
+    reader_params.is_key_column_group = is_key;
+    return (*reader)->init(reader_params);
+}
+
+// return link segments' total size
+bool CompactionDupnokeyOpt::_duplicate_nokey_check_and_split_segments(
+        std::map<RowsetSharedPtr, std::vector<size_t>>& to_compacts,
+        std::map<RowsetSharedPtr, std::vector<size_t>>& to_links, size_t& compact_segments,
+        size_t& compact_segment_file_size, size_t& link_segments, size_t& link_segment_file_size) {
+    size_t min_tidy_size = config::dup_without_key_opt_compaction_min_segment_size;
+
+    for (auto& rowset : _parent._input_rowsets) {
+        std::vector<size_t> segments_size;
+        auto beta_rowset = reinterpret_cast<BetaRowset*>(rowset.get());
+        beta_rowset->get_segments_size(&segments_size);
+        for (size_t i = 0; i < segments_size.size(); i++) {
+            if (segments_size[i] >= min_tidy_size) {
+                to_links[rowset].push_back(i);
+                ++link_segments;
+                link_segment_file_size += segments_size[i];
+            } else {
+                to_compacts[rowset].push_back(i);
+                ++compact_segments;
+                compact_segment_file_size += segments_size[i];
+            }
+        }
+    }
+    if (compact_segments == 1) {
+        auto it = to_compacts.begin();
+        to_links[it->first].push_back(*it->second.begin());
+        to_compacts.clear();
+        link_segment_file_size += compact_segment_file_size;
+        compact_segment_file_size = 0;
+    }
+    return true;
+}
+
+Status CompactionDupnokeyOpt::_do_compact_duplicate_nokey_over_size(
+        std::map<RowsetSharedPtr, std::vector<size_t>>& to_links, size_t link_segment_file_size) {
+    LOG(INFO) << "start to do oversize data compaction, tablet=" << _parent._tablet->full_name()
+              << ", output_version=" << _parent._output_version
+              << ", link size=" << to_links.size();
+    // link data to new rowset
+    KeyBoundsPB empty_key_bound; // TODO: duplicate only need empty key_bound;
+    for (auto to_link : to_links) {
+        for (size_t seg_id : to_link.second) {
+            auto beta_rowset = reinterpret_cast<BetaRowset*>(to_link.first.get());
+            segment_v2::SegmentSharedPtr seg_ptr;
+            RETURN_IF_ERROR(beta_rowset->load_segment(seg_id, seg_ptr));
+            RETURN_IF_ERROR(_parent._output_rs_writer->add_segment(to_link.first, seg_ptr));
+        }
+    }
+    return Status::OK();
+}
+
+Status CompactionDupnokeyOpt::vertical_compact_one_group(
+        TabletSharedPtr tablet, ReaderType reader_type, TabletSchemaSPtr tablet_schema, bool is_key,
+        const std::vector<uint32_t>& column_group, vectorized::VerticalBlockReader& reader,
+        RowsetWriter* dst_rowset_writer, int64_t max_rows_per_segment,
+        Merger::Statistics* stats_output) {
+    // build tablet reader
+    VLOG_NOTICE << "vertical compact one group, max_rows_per_segment=" << max_rows_per_segment;
+    // duplicate table need not to consider rowid_conversion
+
+    vectorized::Block block = tablet_schema->create_block(column_group);
+    size_t output_rows = 0;
+    bool eof = false;
+    while (!eof && !StorageEngine::instance()->stopped()) {
+        // Read one block from block reader
+        RETURN_NOT_OK_STATUS_WITH_WARN(
+                reader.next_block_with_aggregation(&block, &eof),
+                "failed to read next block when merging rowsets of tablet " + tablet->full_name());
+        RETURN_NOT_OK_STATUS_WITH_WARN(
+                dst_rowset_writer->add_columns(&block, column_group, is_key, max_rows_per_segment),
+                "failed to write block when merging rowsets of tablet " + tablet->full_name());
+
+        output_rows += block.rows();
+        block.clear_column_data();
+    }
+    if (StorageEngine::instance()->stopped()) {
+        LOG(INFO) << "tablet " << tablet->full_name() << "failed to do compaction, engine stopped";
+        return Status::Error<doris::ErrorCode::INTERNAL_ERROR>();
+    }
+
+    if (is_key && stats_output != nullptr) {
+        stats_output->output_rows = output_rows;
+        stats_output->merged_rows = reader.merged_rows();
+        stats_output->filtered_rows = reader.filtered_rows();
+    }
+    RETURN_IF_ERROR(dst_rowset_writer->flush_columns(is_key));
+
+    return Status::OK();
+}
+
+} // namespace doris

--- a/be/src/olap/compaction_dupnokey_opt.h
+++ b/be/src/olap/compaction_dupnokey_opt.h
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <butil/macros.h>
+#include <stdint.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common/status.h"
+#include "io/io_common.h"
+#include "olap/compaction.h"
+#include "olap/merger.h"
+#include "olap/olap_common.h"
+#include "olap/rowid_conversion.h"
+#include "olap/rowset/rowset.h"
+#include "olap/rowset/rowset_reader.h"
+#include "olap/rowset/rowset_writer_context.h"
+#include "olap/tablet.h"
+#include "olap/tablet_schema.h"
+
+namespace doris {
+class CompactionDupnokeyOpt {
+public:
+    CompactionDupnokeyOpt(Compaction& parent) : _parent(parent) {};
+    ~CompactionDupnokeyOpt() {};
+    Status handle_duplicate_nokey_compaction();
+
+private:
+    Status _do_compact_segments(const std::map<RowsetSharedPtr, std::vector<size_t>>& to_compacts,
+                                Merger::Statistics* output_stats);
+
+    bool _duplicate_nokey_check_and_split_segments(
+            std::map<RowsetSharedPtr, std::vector<size_t>>& to_compacts,
+            std::map<RowsetSharedPtr, std::vector<size_t>>& to_links, size_t& compact_segments,
+            size_t& compact_segment_file_size, size_t& link_segments,
+            size_t& link_segment_file_size);
+    Status _do_compact_duplicate_nokey_over_size(
+            std::map<RowsetSharedPtr, std::vector<size_t>>& to_links,
+            size_t link_segment_file_size);
+    Status _get_segcompaction_reader(
+            const std::map<RowsetSharedPtr, std::vector<size_t>>& to_compacts,
+            TabletSharedPtr tablet, std::shared_ptr<Schema> schema, OlapReaderStatistics* stat,
+            vectorized::RowSourcesBuffer& row_sources_buf, bool is_key,
+            std::vector<uint32_t>& return_columns,
+            std::unique_ptr<vectorized::VerticalBlockReader>* reader);
+
+    Status vertical_compact_one_group(TabletSharedPtr tablet, ReaderType reader_type,
+                                      TabletSchemaSPtr tablet_schema, bool is_key,
+                                      const std::vector<uint32_t>& column_group,
+                                      vectorized::VerticalBlockReader& src_block_reader,
+                                      RowsetWriter* dst_rowset_writer, int64_t max_rows_per_segment,
+                                      Merger::Statistics* stats_output);
+
+private:
+    Compaction& _parent;
+    RowsetWriterContext _ctx;
+};
+} // namespace doris

--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -132,6 +132,27 @@ Status BetaRowset::get_segments_size(std::vector<size_t>* segments_size) {
     }
     return Status::OK();
 }
+
+Status BetaRowset::load_segment(int64_t seg_id, segment_v2::SegmentSharedPtr& segment) {
+    auto fs = _rowset_meta->fs();
+    if (!fs || _schema == nullptr) {
+        return Status::Error<INIT_FAILED>();
+    }
+    DCHECK(seg_id >= 0);
+    auto seg_path = segment_file_path(seg_id);
+    io::SegmentCachePathPolicy cache_policy;
+    cache_policy.set_cache_path(segment_cache_path(seg_id));
+    auto type = config::enable_file_cache ? config::file_cache_type : "";
+    io::FileReaderOptions reader_options(io::cache_type_from_string(type), cache_policy);
+    auto s = segment_v2::Segment::open(fs, seg_path, seg_id, rowset_id(), _schema, reader_options,
+                                       &segment);
+    if (!s.ok()) {
+        LOG(WARNING) << "failed to open segment. " << seg_path << " under rowset " << unique_id()
+                     << " : " << s.to_string();
+    }
+    return s;
+}
+
 Status BetaRowset::load_segments(std::vector<segment_v2::SegmentSharedPtr>* segments) {
     return load_segments(0, num_segments(), segments);
 }
@@ -217,6 +238,54 @@ Status BetaRowset::remove() {
 
 void BetaRowset::do_close() {
     // do nothing.
+}
+Status BetaRowset::link_segment_to(size_t seg_id, const std::string& dir, RowsetId new_rowset_id,
+                                   size_t new_rowset_seg_id) {
+    DCHECK(is_local());
+    auto fs = _rowset_meta->fs();
+    if (!fs) {
+        return Status::Error<INIT_FAILED>();
+    }
+    if (fs->type() != io::FileSystemType::LOCAL) {
+        return Status::InternalError("should be local file system");
+    }
+    io::LocalFileSystem* local_fs = (io::LocalFileSystem*)fs.get();
+    auto dst_path = segment_file_path(dir, new_rowset_id, new_rowset_seg_id);
+    bool dst_path_exist = false;
+    if (!fs->exists(dst_path, &dst_path_exist).ok() || dst_path_exist) {
+        LOG(WARNING) << "failed to create hard link, file already exist: " << dst_path;
+        return Status::Error<FILE_ALREADY_EXIST>();
+    }
+    auto src_path = segment_file_path(seg_id);
+    // TODO(lingbin): how external storage support link?
+    //     use copy? or keep refcount to avoid being delete?
+    if (!local_fs->link_file(src_path, dst_path).ok()) {
+        LOG(WARNING) << "fail to create hard link. from=" << src_path << ", "
+                     << "to=" << dst_path << ", errno=" << Errno::no();
+        return Status::Error<OS_ERROR>();
+    }
+    for (auto& column : _schema->columns()) {
+        // if (column.has_inverted_index()) {
+        const TabletIndex* index_meta = _schema->get_inverted_index(column.unique_id());
+        if (index_meta) {
+            std::string inverted_index_src_file_path =
+                    InvertedIndexDescriptor::get_index_file_name(src_path, index_meta->index_id());
+            std::string inverted_index_dst_file_path =
+                    InvertedIndexDescriptor::get_index_file_name(dst_path, index_meta->index_id());
+
+            if (!local_fs->link_file(inverted_index_src_file_path, inverted_index_dst_file_path)
+                         .ok()) {
+                LOG(WARNING) << "fail to create hard link. from=" << inverted_index_src_file_path
+                             << ", "
+                             << "to=" << inverted_index_dst_file_path << ", errno=" << Errno::no();
+                return Status::Error<OS_ERROR>();
+            }
+            LOG(INFO) << "success to create hard link. from=" << inverted_index_src_file_path
+                      << ", "
+                      << "to=" << inverted_index_dst_file_path;
+        }
+    }
+    return Status::OK();
 }
 
 Status BetaRowset::link_files_to(const std::string& dir, RowsetId new_rowset_id,

--- a/be/src/olap/rowset/beta_rowset.h
+++ b/be/src/olap/rowset/beta_rowset.h
@@ -70,6 +70,8 @@ public:
 
     Status remove() override;
 
+    Status link_segment_to(size_t seg_id, const std::string& dir, RowsetId new_rowset_id,
+                           size_t new_rowset_seg_id) override;
     Status link_files_to(const std::string& dir, RowsetId new_rowset_id,
                          size_t new_rowset_start_seg_id = 0,
                          std::set<int32_t>* without_index_column_uids = nullptr) override;
@@ -86,6 +88,8 @@ public:
     bool check_path(const std::string& path) override;
 
     bool check_file_exist() override;
+
+    Status load_segment(int64_t seg_id, segment_v2::SegmentSharedPtr& segment);
 
     Status load_segments(std::vector<segment_v2::SegmentSharedPtr>* segments);
 

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -71,7 +71,7 @@ public:
     Status init(const RowsetWriterContext& rowset_writer_context) override;
 
     Status add_block(const vectorized::Block* block) override;
-    Status add_segment(RowsetSharedPtr rowset, segment_v2::SegmentSharedPtr seg);
+    Status add_segment(RowsetSharedPtr rowset, segment_v2::SegmentSharedPtr seg) override;
     Status close_writers();
 
     // add rowset by create hard link

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -71,6 +71,8 @@ public:
     Status init(const RowsetWriterContext& rowset_writer_context) override;
 
     Status add_block(const vectorized::Block* block) override;
+    Status add_segment(RowsetSharedPtr rowset, segment_v2::SegmentSharedPtr seg);
+    Status close_writers();
 
     // add rowset by create hard link
     Status add_rowset(RowsetSharedPtr rowset) override;

--- a/be/src/olap/rowset/rowset.h
+++ b/be/src/olap/rowset/rowset.h
@@ -199,7 +199,9 @@ public:
                     << _rowset_state_machine.rowset_state() << ", version:" << start_version()
                     << "-" << end_version() << ", tabletid:" << _rowset_meta->tablet_id();
     }
-
+    // hard link one segment in this rowset to `dir` to form new rowset's new segment.
+    virtual Status link_segment_to(size_t seg_id, const std::string& dir, RowsetId new_rowset_id,
+                                   size_t new_rowset_seg_id) = 0;
     // hard link all files in this rowset to `dir` to form a new rowset with id `new_rowset_id`.
     virtual Status link_files_to(const std::string& dir, RowsetId new_rowset_id,
                                  size_t new_rowset_start_seg_id = 0,

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -60,6 +60,7 @@ public:
     }
 
     // Precondition: the input `rowset` should have the same type of the rowset we're building
+    virtual Status add_segment(RowsetSharedPtr rowset, segment_v2::SegmentSharedPtr seg) = 0;
     virtual Status add_rowset(RowsetSharedPtr rowset) = 0;
 
     // Precondition: the input `rowset` should have the same type of the rowset we're building

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -221,6 +221,10 @@ Status Segment::_parse_footer() {
     return Status::OK();
 }
 
+uint64_t Segment::size() const {
+    return _file_reader->size();
+}
+
 Status Segment::_load_pk_bloom_filter() {
     DCHECK(_tablet_schema->keys_type() == UNIQUE_KEYS);
     DCHECK(_footer.has_primary_key_index_meta());

--- a/be/src/olap/rowset/segment_v2/segment.h
+++ b/be/src/olap/rowset/segment_v2/segment.h
@@ -82,6 +82,7 @@ public:
                         std::unique_ptr<RowwiseIterator>* iter);
 
     uint32_t id() const { return _segment_id; }
+    uint64_t size() const;
 
     RowsetId rowset_id() const { return _rowset_id; }
 

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -141,7 +141,7 @@ Status SegmentWriter::init(const std::vector<uint32_t>& col_ids, bool has_key,
              flush_ctx->block->bytes() > config::segment_compression_threshold_kb * 1024)
                     ? _tablet_schema->compression_type()
                     : NO_COMPRESSION;
-    auto create_column_writer = [&](uint32_t cid, const auto& column) -> auto {
+    auto create_column_writer = [&](uint32_t cid, const auto& column) -> auto{
         ColumnWriterOptions opts;
         opts.meta = _footer.add_columns();
 
@@ -762,6 +762,8 @@ Status SegmentWriter::finalize_columns_index(uint64_t* index_size) {
         }
         *index_size = _file_writer->bytes_appended() - index_start;
     }
+    // for copmaction dup without key table optimization , add index size in the footer 20230529
+    _footer.set_index_footprint(*index_size);
 
     // reset all column writers and data_conveter
     clear();

--- a/be/src/runtime/memory/thread_mem_tracker_mgr.h
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.h
@@ -168,7 +168,7 @@ inline void ThreadMemTrackerMgr::consume(int64_t size) {
     // After the jemalloc hook is loaded, before ExecEnv init, _limiter_tracker=nullptr.
     if ((_untracked_mem >= config::mem_tracker_consume_min_size_bytes ||
          _untracked_mem <= -config::mem_tracker_consume_min_size_bytes) &&
-        !_stop_consume && ExecEnv::GetInstance()->initialized()) {
+        !_stop_consume) {
         flush_untracked_mem();
     }
     // Large memory alloc should use allocator.h

--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -40,6 +40,7 @@
 #include "olap/rowset/segment_v2/column_reader.h"
 #include "olap/tablet_meta.h"
 #include "olap/tablet_meta_manager.h"
+#include "olap/tablet_schema_cache.h"
 #include "olap/utils.h"
 #include "util/coding.h"
 #include "util/crc32c.h"
@@ -319,6 +320,7 @@ void show_segment_footer(const std::string& file_name) {
 }
 
 int main(int argc, char** argv) {
+    doris::TabletSchemaCache::create_global_schema_cache();
     std::string usage = get_usage(argv[0]);
     gflags::SetUsageMessage(usage);
     google::ParseCommandLineFlags(&argc, &argv, true);

--- a/be/test/testutil/mock_rowset.h
+++ b/be/test/testutil/mock_rowset.h
@@ -34,6 +34,11 @@ class MockRowset : public Rowset {
         return Status::NotSupported("MockRowset not support this method.");
     }
 
+    Status link_segment_to(size_t seg_id, const std::string& dir, RowsetId new_rowset_id,
+                           size_t new_rowset_seg_id) override {
+        return Status::NotSupported("MockRowset not support this method.");
+    }
+
     Status copy_files_to(const std::string& dir, const RowsetId& new_rowset_id) override {
         return Status::NotSupported("MockRowset not support this method.");
     }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #18612

1.Duplicate without keys tables compact need not to iterate the segment oversize.
2.Metatool coredump.


