### PR TITLE
[pipeline](rpc) support closure reuse in pipeline exec engine

### DIFF
--- a/be/src/pipeline/exec/exchange_sink_buffer.h
+++ b/be/src/pipeline/exec/exchange_sink_buffer.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <brpc/controller.h>
 #include <gen_cpp/data.pb.h>
 #include <gen_cpp/types.pb.h>
 #include <parallel_hashmap/phmap.h>
@@ -31,18 +32,55 @@
 
 #include "common/global_types.h"
 #include "common/status.h"
+#include "service/backend_options.h"
 
 namespace doris {
 class PTransmitDataParams;
 class TUniqueId;
 
+using InstanceLoId = int64_t;
+
 namespace vectorized {
 class PipChannel;
-class BroadcastPBlockHolder;
+
+template <typename T>
+struct AtomicWrapper {
+    std::atomic<T> _value;
+
+    AtomicWrapper() : _value() {}
+
+    AtomicWrapper(const std::atomic<T>& a) : _value(a.load()) {}
+
+    AtomicWrapper(const AtomicWrapper& other) : _value(other._value.load()) {}
+
+    AtomicWrapper& operator=(const AtomicWrapper& other) { _value.store(other._a.load()); }
+};
+
+// We use BroadcastPBlockHolder to hold a broadcasted PBlock. For broadcast shuffle, one PBlock
+// will be shared between different channel, so we have to use a ref count to mark if this
+// PBlock is available for next serialization.
+class BroadcastPBlockHolder {
+public:
+    BroadcastPBlockHolder() : _ref_count(0) {}
+    ~BroadcastPBlockHolder() noexcept = default;
+
+    void unref() noexcept {
+        DCHECK_GT(_ref_count._value, 0);
+        _ref_count._value.fetch_sub(1);
+    }
+    void ref() noexcept { _ref_count._value.fetch_add(1); }
+
+    bool available() { return _ref_count._value == 0; }
+
+    PBlock* get_block() { return &pblock; }
+
+private:
+    AtomicWrapper<uint32_t> _ref_count;
+    PBlock pblock;
+};
 } // namespace vectorized
 
 namespace pipeline {
-using InstanceLoId = int64_t;
 struct TransmitInfo {
     vectorized::PipChannel* channel;
     std::unique_ptr<PBlock> block;
@@ -56,6 +94,62 @@ struct BroadcastTransmitInfo {
 };
 
 class PipelineFragmentContext;
+
+template <typename T>
+class SelfDeleteClosure : public google::protobuf::Closure {
+public:
+    SelfDeleteClosure() = default;
+
+    void init(InstanceLoId id, bool eos, vectorized::BroadcastPBlockHolder* data) {
+        _id = id;
+        _eos = eos;
+        _data = data;
+    }
+
+    ~SelfDeleteClosure() override = default;
+    SelfDeleteClosure(const SelfDeleteClosure& other) = delete;
+    SelfDeleteClosure& operator=(const SelfDeleteClosure& other) = delete;
+    void addFailedHandler(
+            const std::function<void(const InstanceLoId&, const std::string&)>& fail_fn) {
+        _fail_fn = fail_fn;
+    }
+    void addSuccessHandler(
+            const std::function<void(const InstanceLoId&, const bool&, const T&)>& suc_fn) {
+        _suc_fn = suc_fn;
+    }
+
+    void Run() noexcept override {
+        try {
+            if (_data) {
+                _data->unref();
+            }
+            if (cntl.Failed()) {
+                std::string err = fmt::format(
+                        "failed to send brpc when exchange, error={}, error_text={}, client: {}, "
+                        "latency = {}",
+                        berror(cntl.ErrorCode()), cntl.ErrorText(), BackendOptions::get_localhost(),
+                        cntl.latency_us());
+                _fail_fn(_id, err);
+            } else {
+                _suc_fn(_id, _eos, result);
+            }
+        } catch (const std::exception& exp) {
+            LOG(FATAL) << "brpc callback error: " << exp.what();
+        } catch (...) {
+            LOG(FATAL) << "brpc callback error.";
+        }
+    }
+
+    brpc::Controller cntl;
+    T result;
+
+private:
+    std::function<void(const InstanceLoId&, const std::string&)> _fail_fn;
+    std::function<void(const InstanceLoId&, const bool&, const T&)> _suc_fn;
+    InstanceLoId _id;
+    bool _eos;
+    vectorized::BroadcastPBlockHolder* _data;
+};
 
 // Each ExchangeSinkOperator have one ExchangeSinkBuffer
 class ExchangeSinkBuffer {

--- a/be/src/vec/sink/vdata_stream_sender.h
+++ b/be/src/vec/sink/vdata_stream_sender.h
@@ -420,9 +420,6 @@ public:
         if (_ch_cur_pb_block) {
             delete _ch_cur_pb_block;
         }
-        if (_closure) {
-            delete _closure;
-        }
     }
 
     void ch_roll_pb_block() override {
@@ -495,12 +492,12 @@ public:
     pipeline::SelfDeleteClosure<PTransmitDataResult>* get_closure(
             InstanceLoId id, bool eos, vectorized::BroadcastPBlockHolder* data) {
         if (!_closure) {
-            _closure = new pipeline::SelfDeleteClosure<PTransmitDataResult>();
+            _closure.reset(new pipeline::SelfDeleteClosure<PTransmitDataResult>());
         } else {
             _closure->cntl.Reset();
         }
         _closure->init(id, eos, data);
-        return _closure;
+        return _closure.get();
     }
 
 private:
@@ -508,7 +505,7 @@ private:
 
     pipeline::ExchangeSinkBuffer* _buffer = nullptr;
     bool _eos_send = false;
-    pipeline::SelfDeleteClosure<PTransmitDataResult>* _closure = nullptr;
+    std::unique_ptr<pipeline::SelfDeleteClosure<PTransmitDataResult>> _closure = nullptr;
 };
 
 } // namespace vectorized


### PR DESCRIPTION
## Proposed changes

Support closure reuse like no pipeline exec engine reduce new operator in exchange sink buffer

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

