### PR TITLE
[branch1.2](parquet) optimize parquet reader profile

### DIFF
--- a/.github/workflows/title-checker.yml
+++ b/.github/workflows/title-checker.yml
@@ -35,5 +35,5 @@ jobs:
       - name: Check Title
         uses: ./.github/actions/action-pr-title
         with:
-          regex: '\[([a-zA-Z0-9 \-_])+\]\(([a-zA-Z0-9 \-_])+\)(.*)'
+          regex: '\[([a-zA-Z0-9 \-_\.])+\]\(([a-zA-Z0-9 \-_])+\)(.*)'
           github_token: ${{ github.token }}

--- a/be/src/vec/exec/format/parquet/vparquet_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.h
@@ -52,6 +52,7 @@ public:
         int64_t parse_meta_time = 0;
         int64_t row_group_filter_time = 0;
         int64_t page_index_filter_time = 0;
+        int64_t open_reader_time = 0;
     };
 
     ParquetReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
@@ -128,6 +129,7 @@ private:
         RuntimeProfile::Counter* decode_dict_time;
         RuntimeProfile::Counter* decode_level_time;
         RuntimeProfile::Counter* decode_null_map_time;
+        RuntimeProfile::Counter* open_reader_time;
     };
 
     Status _open_file();

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -73,6 +73,8 @@ Status VFileScanner::prepare(
     _pre_filter_timer = ADD_TIMER(_parent->_scanner_profile, "FileScannerPreFilterTimer");
     _convert_to_output_block_timer =
             ADD_TIMER(_parent->_scanner_profile, "FileScannerConvertOuputBlockTime");
+    _file_counter =
+            ADD_COUNTER(_parent->_scanner_profile, "FileReaderCounter", TUnit::UNIT);
 
     if (vconjunct_ctx_ptr != nullptr) {
         // Copy vconjunct_ctx_ptr from scan node to this scanner's _vconjunct_ctx.
@@ -465,6 +467,7 @@ Status VFileScanner::_get_next_reader() {
             return Status::OK();
         }
         const TFileRangeDesc& range = _ranges[_next_range++];
+        COUNTER_UPDATE(_file_counter, 1);
 
         // create reader for specific format
         // TODO: add json, avro

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -73,8 +73,7 @@ Status VFileScanner::prepare(
     _pre_filter_timer = ADD_TIMER(_parent->_scanner_profile, "FileScannerPreFilterTimer");
     _convert_to_output_block_timer =
             ADD_TIMER(_parent->_scanner_profile, "FileScannerConvertOuputBlockTime");
-    _file_counter =
-            ADD_COUNTER(_parent->_scanner_profile, "FileReaderCounter", TUnit::UNIT);
+    _file_counter = ADD_COUNTER(_parent->_scanner_profile, "FileReaderCounter", TUnit::UNIT);
 
     if (vconjunct_ctx_ptr != nullptr) {
         // Copy vconjunct_ctx_ptr from scan node to this scanner's _vconjunct_ctx.

--- a/be/src/vec/exec/scan/vfile_scanner.h
+++ b/be/src/vec/exec/scan/vfile_scanner.h
@@ -125,6 +125,7 @@ private:
     RuntimeProfile::Counter* _fill_missing_columns_timer = nullptr;
     RuntimeProfile::Counter* _pre_filter_timer = nullptr;
     RuntimeProfile::Counter* _convert_to_output_block_timer = nullptr;
+    RuntimeProfile::Counter* _file_counter = nullptr;
 
 private:
     Status _init_expr_ctxes();

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -152,7 +152,7 @@ Status VScanNode::_init_profile() {
             runtime_profile()->add_rate_counter("TotalReadThroughput", _rows_read_counter);
     _num_scanners = ADD_COUNTER(_runtime_profile, "NumScanners", TUnit::UNIT);
     _get_next_timer = ADD_TIMER(_runtime_profile, "GetNextTime");
-    _acquire_runtime_filter_timer = ADD_TIMER(_runtime_profile, "AcuireRuntimeFilterTime");
+    _acquire_runtime_filter_timer = ADD_TIMER(_runtime_profile, "AcquireRuntimeFilterTime");
 
     // 2. counters for scanners
     _scanner_profile.reset(new RuntimeProfile("VScanner"));

--- a/be/test/vec/exec/parquet/parquet_reader_test.cpp
+++ b/be/test/vec/exec/parquet/parquet_reader_test.cpp
@@ -91,6 +91,7 @@ TEST_F(ParquetReaderTest, normal) {
     auto slot_descs = desc_tbl->get_tuple_descriptor(0)->slots();
     LocalFileReader* reader =
             new LocalFileReader("./be/test/exec/test_data/parquet_scanner/type-decoder.parquet", 0);
+    reader->open();
 
     cctz::time_zone ctz;
     TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalFileScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalFileScanNode.java
@@ -66,11 +66,15 @@ import org.apache.doris.thrift.TScanRangeLocations;
 import org.apache.doris.thrift.TUniqueId;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -621,10 +625,48 @@ public class ExternalFileScanNode extends ExternalScanNode {
                         break;
                     }
                     TFileRangeDesc file = files.get(i);
-                    output.append(prefix).append("    ").append(file.getPath())
-                            .append(" start: ").append(file.getStartOffset())
-                            .append(" length: ").append(file.getSize())
-                            .append("\n");
+                    output.append(prefix).append("    ").append(file.getPath()).append(" start: ")
+                            .append(file.getStartOffset()).append(" length: ").append(file.getSize()).append("\n");
+                }
+            }
+        }
+
+        if (detailLevel == TExplainLevel.VERBOSE) {
+            output.append(prefix).append("backends:").append("\n");
+            Multimap<Long, TFileRangeDesc> scanRangeLocationsMap = ArrayListMultimap.create();
+            // 1. group by backend id
+            for (TScanRangeLocations locations : scanRangeLocations) {
+                scanRangeLocationsMap.putAll(locations.getLocations().get(0).backend_id,
+                        locations.getScanRange().getExtScanRange().getFileScanRange().getRanges());
+            }
+            for (long beId : scanRangeLocationsMap.keySet()) {
+                output.append(prefix).append("  ").append(beId).append("\n");
+                List<TFileRangeDesc> fileRangeDescs = Lists.newArrayList(scanRangeLocationsMap.get(beId));
+                // 2. sort by file start offset
+                Collections.sort(fileRangeDescs, new Comparator<TFileRangeDesc>() {
+                    @Override
+                    public int compare(TFileRangeDesc o1, TFileRangeDesc o2) {
+                        return Long.compare(o1.getStartOffset(), o2.getStartOffset());
+                    }
+                });
+                // 3. if size <= 4, print all. if size > 4, print first 3 and last 1
+                int size = fileRangeDescs.size();
+                if (size <= 4) {
+                    for (TFileRangeDesc file : fileRangeDescs) {
+                        output.append(prefix).append("    ").append(file.getPath()).append(" start: ")
+                                .append(file.getStartOffset()).append(" length: ").append(file.getSize()).append("\n");
+                    }
+                } else {
+                    for (int i = 0; i < 3; i++) {
+                        TFileRangeDesc file = fileRangeDescs.get(i);
+                        output.append(prefix).append("    ").append(file.getPath()).append(" start: ")
+                                .append(file.getStartOffset()).append(" length: ").append(file.getSize()).append("\n");
+                    }
+                    int other = size - 4;
+                    output.append(prefix).append("    ... other ").append(other).append(" files ...\n");
+                    TFileRangeDesc file = fileRangeDescs.get(size - 1);
+                    output.append(prefix).append("    ").append(file.getPath()).append(" start: ")
+                            .append(file.getStartOffset()).append(" length: ").append(file.getSize()).append("\n");
                 }
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalFileScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalFileScanNode.java
@@ -617,22 +617,6 @@ public class ExternalFileScanNode extends ExternalScanNode {
 
         if (detailLevel == TExplainLevel.VERBOSE) {
             output.append(prefix).append("backends:").append("\n");
-            for (TScanRangeLocations locations : scanRangeLocations) {
-                output.append(prefix).append("  ").append(locations.getLocations().get(0).backend_id).append("\n");
-                List<TFileRangeDesc> files = locations.getScanRange().getExtScanRange().getFileScanRange().getRanges();
-                for (int i = 0; i < 3; i++) {
-                    if (i >= files.size()) {
-                        break;
-                    }
-                    TFileRangeDesc file = files.get(i);
-                    output.append(prefix).append("    ").append(file.getPath()).append(" start: ")
-                            .append(file.getStartOffset()).append(" length: ").append(file.getSize()).append("\n");
-                }
-            }
-        }
-
-        if (detailLevel == TExplainLevel.VERBOSE) {
-            output.append(prefix).append("backends:").append("\n");
             Multimap<Long, TFileRangeDesc> scanRangeLocationsMap = ArrayListMultimap.create();
             // 1. group by backend id
             for (TScanRangeLocations locations : scanRangeLocations) {
@@ -640,7 +624,6 @@ public class ExternalFileScanNode extends ExternalScanNode {
                         locations.getScanRange().getExtScanRange().getFileScanRange().getRanges());
             }
             for (long beId : scanRangeLocationsMap.keySet()) {
-                output.append(prefix).append("  ").append(beId).append("\n");
                 List<TFileRangeDesc> fileRangeDescs = Lists.newArrayList(scanRangeLocationsMap.get(beId));
                 // 2. sort by file start offset
                 Collections.sort(fileRangeDescs, new Comparator<TFileRangeDesc>() {
@@ -651,6 +634,7 @@ public class ExternalFileScanNode extends ExternalScanNode {
                 });
                 // 3. if size <= 4, print all. if size > 4, print first 3 and last 1
                 int size = fileRangeDescs.size();
+                output.append(prefix).append("  ").append(beId).append(": ").append(size).append(" files\n");
                 if (size <= 4) {
                     for (TFileRangeDesc file : fileRangeDescs) {
                         output.append(prefix).append("    ").append(file.getPath()).append(" start: ")


### PR DESCRIPTION
## Proposed changes

Only for branch 1.2.
1. Optimize parquet reader profile, separate the open reader time and meta parse time.
2. Optimize the result of `explain verbose` for external file scan node.(already on master branch)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

