### PR TITLE
[Fix](Nereids) regression test test_bitmap_filter_nereids could not run

### DIFF
--- a/regression-test/suites/query_p0/join/test_bitmap_filter_nereids.groovy
+++ b/regression-test/suites/query_p0/join/test_bitmap_filter_nereids.groovy
@@ -77,16 +77,9 @@ suite("test_bitmap_filter_nereids") {
     qt_sql14 "select k1, k2 from ${tbl1} where k1 in (select bitmap_from_string('1,10')) order by 1, 2"
 
     test {
-        sql15 "select k1, count(*) from ${tbl1} b1 group by k1 having k1 in (select k2 from ${tbl2} b2) order by k1;"
+        sql "select k1, count(*) from ${tbl1} b1 group by k1 having k1 in (select k2 from ${tbl2} b2) order by k1;"
         exception "errCode = 2, detailMessage = Unexpected exception: Doris hll, bitmap, array, map, struct, jsonb column must use with specific function, and don't support filter or group by. please run 'help hll' or 'help bitmap' or 'help array' or 'help map' or 'help struct' or 'help jsonb' in your mysql client."
     }
-
-    sql "set enable_pipeline_engine=true;"
-    test {
-        sql15 "select k1, count(*) from ${tbl1} b1 group by k1 having k1 in (select k2 from ${tbl2} b2) order by k1;"
-        exception "errCode = 2, detailMessage = Unexpected exception: Doris hll, bitmap, array, map, struct, jsonb column must use with specific function, and don't support filter or group by. please run 'help hll' or 'help bitmap' or 'help array' or 'help map' or 'help struct' or 'help jsonb' in your mysql client."
-    }
-    sql "set enable_pipeline_engine=false;"
 
     explain{
         sql "select k1, k2 from ${tbl1} where k1 in (select k2 from ${tbl2}) order by k1;"


### PR DESCRIPTION
## Proposed changes

Fix test cases of using expecting exception. Use sql to expect an exception rather than using sqlxx

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

