### PR TITLE
[Fix](Nereids) Fix function test case unstable by adding order by

### DIFF
--- a/regression-test/suites/nereids_syntax_p0/function.groovy
+++ b/regression-test/suites/nereids_syntax_p0/function.groovy
@@ -81,7 +81,7 @@ suite("nereids_function") {
                 a.number as num1, b.number as num2
             from
                 numbers("number" = "10") a
-                inner join numbers("number" = "10") b on a.number=b.number;
+                inner join numbers("number" = "10") b on a.number=b.number order by 1,2;
         """
         result([[0L, 0L], [1L, 1L], [2L, 2L], [3L, 3L], [4L, 4L], [5L, 5L], [6L, 6L], [7L, 7L], [8L, 8L], [9L, 9L]])
     }


### PR DESCRIPTION
## Proposed changes

Nereids function case do not have a order by clause, so the result will be unstable, so order by is added to ensure stability.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

