### PR TITLE
[cherry-pick-1.2][improvement](load)disable shrink memory by default

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -918,6 +918,9 @@ CONF_Int32(max_depth_of_expr_tree, "600");
 
 CONF_mBool(enable_stack_trace, "true");
 
+// enable shrink memory, default is false
+CONF_Bool(enable_shrink_memory, "false");
+
 #ifdef BE_TEST
 // test s3
 CONF_String(test_s3_resource, "resource");

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -231,7 +231,9 @@ Status DeltaWriter::write(const vectorized::Block* block, const std::vector<int>
     _mem_table->insert(block, row_idxs);
 
     if (_mem_table->need_to_agg()) {
-        _mem_table->shrink_memtable_by_agg();
+        if (config::enable_shrink_memory) {
+            _mem_table->shrink_memtable_by_agg();
+        }
         if (_mem_table->is_flush()) {
             auto s = _flush_memtable_async();
             _reset_mem_table();


### PR DESCRIPTION
## Proposed changes

cherry-pick https://github.com/apache/doris/pull/19714 into 1.2-lts

Issue Number: close #19204
disable shrink memory by default to avoid load slow

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

