### PR TITLE
[fix](inverted index) fix transaction id changed when light index change

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/IndexChangeJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/IndexChangeJob.java
@@ -216,8 +216,6 @@ public class IndexChangeJob implements Writable {
      */
     public synchronized void run() {
         try {
-            this.watershedTxnId = Env.getCurrentGlobalTransactionMgr()
-                    .getTransactionIDGenerator().getNextTransactionId();
             switch (jobState) {
                 case WAITING_TXN:
                     runWaitingTxnJob();
@@ -245,6 +243,8 @@ public class IndexChangeJob implements Writable {
 
     protected void runWaitingTxnJob() throws AlterCancelException {
         Preconditions.checkState(jobState == JobState.WAITING_TXN, jobState);
+        this.watershedTxnId = Env.getCurrentGlobalTransactionMgr()
+                        .getTransactionIDGenerator().getNextTransactionId();
         try {
             if (!isPreviousLoadFinished()) {
                 LOG.info("wait transactions before {} to be finished, inverted index job: {}", watershedTxnId, jobId);


### PR DESCRIPTION
## Proposed changes

fix the problem of transaction id changed lead to index change job always wait txn.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

