### PR TITLE
[opt](MergedIO) optimize merge small IO and prevent amplified read

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -856,6 +856,7 @@ DEFINE_mInt32(parquet_header_max_size_mb, "1");
 DEFINE_mInt32(parquet_rowgroup_max_buffer_mb, "128");
 // Max buffer size for parquet chunk column
 DEFINE_mInt32(parquet_column_max_buffer_mb, "8");
+DEFINE_mDouble(max_amplified_read_ratio, "0.8");
 
 // OrcReader
 DEFINE_mInt32(orc_natural_read_size_mb, "8");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -884,6 +884,8 @@ DECLARE_mInt32(parquet_header_max_size_mb);
 DECLARE_mInt32(parquet_rowgroup_max_buffer_mb);
 // Max buffer size for parquet chunk column
 DECLARE_mInt32(parquet_column_max_buffer_mb);
+// Merge small IO, the max amplified read ratio
+DECLARE_mDouble(max_amplified_read_ratio);
 
 // OrcReader
 DECLARE_mInt32(orc_natural_read_size_mb);

--- a/be/src/io/fs/buffered_reader.h
+++ b/be/src/io/fs/buffered_reader.h
@@ -123,6 +123,7 @@ public:
     static constexpr size_t BOX_SIZE = 1 * 1024 * 1024;             // 1MB
     static constexpr size_t SMALL_IO = 2 * 1024 * 1024;             // 2MB
     static constexpr size_t NUM_BOX = TOTAL_BUFFER_SIZE / BOX_SIZE; // 128
+    static constexpr size_t MIN_READ_SIZE = 4096;                   // 4KB
 
     MergeRangeFileReader(RuntimeProfile* profile, io::FileReaderSPtr reader,
                          const std::vector<PrefetchRange>& random_access_ranges)


### PR DESCRIPTION
## Proposed changes

Optimize the strategy of merging small IO to prevent severe read amplification, and turn off merged IO when file cache enabled.
Adjustable parameters:
```
// the max amplified read ratio when merging small IO
max_amplified_read_ratio=0.8
// the min segment size
file_cache_min_file_segment_size = 1048576
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

