### PR TITLE
[Improve](Transaction)Commit operation adds mandatory verification.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -163,6 +163,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
@@ -1236,6 +1237,17 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         }
     }
 
+
+    // check commit request params,only used in loadTxnCommitImpl
+    private void checkCommitRequestParams(TLoadTxnCommitRequest request) throws UserException {
+        if (Strings.isNullOrEmpty(request.getDb())) {
+            throw new UserException("No database selected.");
+        }
+        if (CollectionUtils.isEmpty(request.getCommitInfos())) {
+            throw new UserException("No commit info selected.");
+        }
+    }
+
     @Override
     public TLoadTxnCommitResult loadTxnCommit(TLoadTxnCommitRequest request) throws TException {
         String clientAddr = getClientAddrAsString();
@@ -1265,11 +1277,11 @@ public class FrontendServiceImpl implements FrontendService.Iface {
 
     // return true if commit success and publish success, return false if publish timeout
     private boolean loadTxnCommitImpl(TLoadTxnCommitRequest request) throws UserException {
+        checkCommitRequestParams(request);
         String cluster = request.getCluster();
         if (Strings.isNullOrEmpty(cluster)) {
             cluster = SystemInfoService.DEFAULT_CLUSTER;
         }
-
         if (request.isSetAuthCode()) {
             // TODO(cmy): find a way to check
         } else if (request.isSetToken()) {


### PR DESCRIPTION
When committing and publish, commitInfo can’t be empty, otherwise PUBLISH will succeed but visibleVersion is not updated (due to lack of CommitInfo).
https://github.com/apache/doris/blob/0ff3073fc4166ccc8ba4bb6f06c0904b88766577/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java#L544-L657

https://github.com/apache/doris/blob/0ff3073fc4166ccc8ba4bb6f06c0904b88766577/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java#L1550
## Proposed changes

Issue Number: close #xxx

<--Describe your changes.-->

Add pre-check，Avoid situations where PUBLISH succeeds but the data is not visible, causing ambiguity.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

