### PR TITLE
[fix](planner)Fix missing kw for workload

### DIFF
--- a/docs/en/docs/admin-manual/workload-group.md
+++ b/docs/en/docs/admin-manual/workload-group.md
@@ -69,3 +69,25 @@ set workload_group = g1.
 ```
 
 5. Execute the query, which will be associated with the g1 workload group.
+
+### Query queue Function
+```
+create workload group if not exists test_group
+properties (
+    "cpu_share"="10",
+    "memory_limit"="30%",
+    "max_concurrency" = "10",
+    "max_queue_size" = "20",
+    "queue_timeout" = "3000"
+);
+```
+The current workload group supports the function of querying queues, which can be specified when creating a new group. The following three parameters are required:
+* max_concurrency，the maximum number of queries allowed by the current group; Queries exceeding the maximum concurrency will enter the queue logic
+* max_queue_size，the length of the query waiting queue; When the queue is full, new queries will be rejected
+* queue_timeout，the time the query waits in the queue. If the query wait time exceeds this value, the query will be rejected, and the time unit is milliseconds
+
+It should be noted that the current queuing design is not aware of the number of FEs, and the queuing parameters only works in a single FE, for example:
+
+A Doris cluster is configured with a work load group and set max_concurrency=1,
+If there is only 1 FE in the cluster, then this workload group will only run one SQL at the same time from the Doris cluster perspective,
+If there are 3 FEs, the maximum number of query that can be run in Doris cluster is 3.

--- a/docs/zh-CN/docs/admin-manual/workload-group.md
+++ b/docs/zh-CN/docs/admin-manual/workload-group.md
@@ -68,3 +68,25 @@ set workload_group = g1;
 ```
 
 5. 执行查询，查询将关联到 g1 资源组。
+
+### 查询排队功能
+```
+create workload group if not exists test_group
+properties (
+    "cpu_share"="10",
+    "memory_limit"="30%",
+    "max_concurrency" = "10",
+    "max_queue_size" = "20",
+    "queue_timeout" = "3000"
+);
+```
+目前的workload group支持查询排队的功能，可以在新建group时进行指定，需要以下三个参数:
+* max_concurrency，当前group允许的最大查询数;超过最大并发的查询到来时会进入排队逻辑
+* max_queue_size，查询排队的长度;当队列满了之后，新来的查询会被拒绝
+* queue_timeout，查询在队列中等待的时间，如果查询等待时间超过这个值，那么查询会被拒绝，时间单位为毫秒
+
+需要注意的是，目前的排队设计是不感知FE的个数的，排队的参数只在单FE粒度生效，例如：
+
+一个Doris集群配置了一个work load group，设置max_concurrency = 1
+如果集群中有1FE，那么这个workload group在Doris集群视角看同时只会运行一个SQL
+如果有3台FE，那么在Doris集群视角看最大可运行的SQL个数为3

--- a/fe/fe-core/src/main/jflex/sql_scanner.flex
+++ b/fe/fe-core/src/main/jflex/sql_scanner.flex
@@ -487,6 +487,7 @@ import org.apache.doris.qe.SqlModeHelper;
         keywordMap.put("whitelist", new Integer(SqlParserSymbols.KW_WHITELIST));
         keywordMap.put("with", new Integer(SqlParserSymbols.KW_WITH));
         keywordMap.put("work", new Integer(SqlParserSymbols.KW_WORK));
+        keywordMap.put("workload", new Integer(SqlParserSymbols.KW_WORKLOAD));
         keywordMap.put("write", new Integer(SqlParserSymbols.KW_WRITE));
         keywordMap.put("year", new Integer(SqlParserSymbols.KW_YEAR));
         keywordMap.put("mtmv", new Integer(SqlParserSymbols.KW_MTMV));


### PR DESCRIPTION
## Proposed changes
1 add usage docment for Workload Group query queue;
2 Fix missing KW for ```workload```, this may cause create workload group failed.