### PR TITLE
[fix](Nereids) forbid unexpected expression on filter and fix two more bugs

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/Type.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/Type.java
@@ -446,7 +446,7 @@ public abstract class Type {
 
     public static final String OnlyMetricTypeErrorMsg =
             "Doris hll, bitmap, array, map, struct, jsonb column must use with specific function, and don't"
-                    + " support filter or group by. please run 'help hll' or 'help bitmap' or 'help array'"
+                    + " support filter, group by or order by. please run 'help hll' or 'help bitmap' or 'help array'"
                     + " or 'help map' or 'help struct' or 'help jsonb' in your mysql client.";
 
     public boolean isHllType() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/AdjustAggregateNullableForEmptySet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/AdjustAggregateNullableForEmptySet.java
@@ -22,6 +22,8 @@ import org.apache.doris.nereids.rules.RuleType;
 import org.apache.doris.nereids.rules.rewrite.RewriteRuleFactory;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.expressions.OrderExpression;
+import org.apache.doris.nereids.trees.expressions.WindowExpression;
 import org.apache.doris.nereids.trees.expressions.functions.agg.NullableAggregateFunction;
 import org.apache.doris.nereids.trees.expressions.visitor.DefaultExpressionRewriter;
 import org.apache.doris.nereids.trees.plans.logical.LogicalHaving;
@@ -31,6 +33,7 @@ import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * adjust aggregate nullable when: group expr list is empty and function is NullableAggregateFunction,
@@ -68,6 +71,20 @@ public class AdjustAggregateNullableForEmptySet implements RewriteRuleFactory {
 
         public Expression replace(Expression expression, boolean alwaysNullable) {
             return expression.accept(INSTANCE, alwaysNullable);
+        }
+
+        @Override
+        public Expression visitWindow(WindowExpression windowExpression, Boolean alwaysNullable) {
+            return windowExpression.withPartitionKeysOrderKeys(
+                    windowExpression.getPartitionKeys().stream()
+                            .map(k -> k.accept(INSTANCE, alwaysNullable))
+                            .collect(Collectors.toList()),
+                    windowExpression.getOrderKeys().stream()
+                            .map(k -> (OrderExpression) k.withChildren(k.children().stream()
+                                    .map(c -> c.accept(INSTANCE, alwaysNullable))
+                                    .collect(Collectors.toList())))
+                            .collect(Collectors.toList())
+            );
         }
 
         @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CheckAfterRewrite.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CheckAfterRewrite.java
@@ -21,17 +21,20 @@ import org.apache.doris.catalog.Type;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.rules.Rule;
 import org.apache.doris.nereids.rules.RuleType;
+import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotNotFromChildren;
 import org.apache.doris.nereids.trees.expressions.VirtualSlotReference;
+import org.apache.doris.nereids.trees.expressions.WindowExpression;
 import org.apache.doris.nereids.trees.expressions.functions.ExpressionTrait;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
 import org.apache.doris.nereids.trees.plans.logical.LogicalSort;
 import org.apache.doris.nereids.trees.plans.logical.LogicalTopN;
+import org.apache.doris.nereids.trees.plans.logical.LogicalWindow;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -43,6 +46,7 @@ import java.util.stream.Collectors;
  * some check need to do after analyze whole plan.
  */
 public class CheckAfterRewrite extends OneAnalysisRuleFactory {
+
     @Override
     public Rule build() {
         return any().then(plan -> {
@@ -110,6 +114,21 @@ public class CheckAfterRewrite extends OneAnalysisRuleFactory {
                             .isOnlyMetricType()))) {
                 throw new AnalysisException(Type.OnlyMetricTypeErrorMsg);
             }
+        } else if (plan instanceof LogicalWindow) {
+            ((LogicalWindow<?>) plan).getWindowExpressions().forEach(a -> {
+                if (!(a instanceof Alias && ((Alias) a).child() instanceof WindowExpression)) {
+                    return;
+                }
+                WindowExpression windowExpression = (WindowExpression) ((Alias) a).child();
+                if (windowExpression.getOrderKeys().stream().anyMatch((
+                        orderKey -> orderKey.getDataType().isOnlyMetricType()))) {
+                    throw new AnalysisException(Type.OnlyMetricTypeErrorMsg);
+                }
+                if (windowExpression.getPartitionKeys().stream().anyMatch((
+                        partitionKey -> partitionKey.getDataType().isOnlyMetricType()))) {
+                    throw new AnalysisException(Type.OnlyMetricTypeErrorMsg);
+                }
+            });
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CheckAnalysis.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CheckAnalysis.java
@@ -17,38 +17,49 @@
 
 package org.apache.doris.nereids.rules.analysis;
 
-import org.apache.doris.nereids.analyzer.Unbound;
-import org.apache.doris.nereids.analyzer.UnboundFunction;
-import org.apache.doris.nereids.analyzer.UnboundSlot;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.rules.Rule;
 import org.apache.doris.nereids.rules.RuleType;
 import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.WindowExpression;
 import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateFunction;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.GroupingScalarFunction;
 import org.apache.doris.nereids.trees.expressions.typecoercion.TypeCheckResult;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
+import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
+import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 
 import com.google.common.collect.ImmutableList;
-import org.apache.commons.lang3.StringUtils;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Check analysis rule to check semantic correct after analysis by Nereids.
  */
 public class CheckAnalysis implements AnalysisRuleFactory {
 
+    private static final Map<Class<? extends LogicalPlan>, Set<Class<? extends Expression>>>
+            UNEXPECTED_EXPRESSION_TYPE_MAP = ImmutableMap.of(
+                    LogicalFilter.class, ImmutableSet.of(
+                            AggregateFunction.class,
+                            GroupingScalarFunction.class,
+                            WindowExpression.class)
+    );
+
     @Override
     public List<Rule> buildRules() {
         return ImmutableList.of(
             RuleType.CHECK_ANALYSIS.build(
                 any().then(plan -> {
-                    checkBound(plan);
                     checkExpressionInputTypes(plan);
+                    checkUnexpectedExpressions(plan);
                     return null;
                 })
             ),
@@ -61,6 +72,22 @@ public class CheckAnalysis implements AnalysisRuleFactory {
         );
     }
 
+    private void checkUnexpectedExpressions(Plan plan) {
+        Set<Class<? extends Expression>> unexpectedExpressionTypes
+                = UNEXPECTED_EXPRESSION_TYPE_MAP.getOrDefault(plan.getClass(), Collections.emptySet());
+        if (unexpectedExpressionTypes.isEmpty()) {
+            return;
+        }
+        plan.getExpressions().forEach(c -> c.foreachUp(e -> {
+            for (Class<? extends Expression> type : unexpectedExpressionTypes) {
+                if (type.isInstance(e)) {
+                    throw new AnalysisException(plan.getType() + " can not contains "
+                            + type.getSimpleName() + " expression: " + ((Expression) e).toSql());
+                }
+            }
+        }));
+    }
+
     private void checkExpressionInputTypes(Plan plan) {
         final Optional<TypeCheckResult> firstFailed = plan.getExpressions().stream()
                 .map(Expression::checkInputDataTypes)
@@ -69,28 +96,6 @@ public class CheckAnalysis implements AnalysisRuleFactory {
 
         if (firstFailed.isPresent()) {
             throw new AnalysisException(firstFailed.get().getMessage());
-        }
-    }
-
-    private void checkBound(Plan plan) {
-        Set<Unbound> unbounds = plan.getExpressions().stream()
-                .<Set<Unbound>>map(e -> e.collect(Unbound.class::isInstance))
-                .flatMap(Set::stream)
-                .collect(Collectors.toSet());
-        if (!unbounds.isEmpty()) {
-            throw new AnalysisException(String.format("unbounded object %s in %s clause.",
-                StringUtils.join(unbounds.stream()
-                    .map(unbound -> {
-                        if (unbound instanceof UnboundSlot) {
-                            return ((UnboundSlot) unbound).toSql();
-                        } else if (unbound instanceof UnboundFunction) {
-                            return ((UnboundFunction) unbound).toSql();
-                        }
-                        return unbound.toString();
-                    })
-                    .collect(Collectors.toSet()), ", "),
-                plan.getType().toString().substring("LOGICAL_".length())
-            ));
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/WindowFunctionChecker.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/WindowFunctionChecker.java
@@ -416,7 +416,7 @@ public class WindowFunctionChecker extends DefaultExpressionVisitor<Expression, 
                                 new OrderKey(orderKey.getExpr(), !orderKey.isAsc(), !orderKey.isNullFirst()));
                     })
                     .collect(Collectors.toList());
-            windowExpression = windowExpression.withOrderKeyList(newOKList);
+            windowExpression = windowExpression.withOrderKeys(newOKList);
 
             // reverse WindowFrame
             // e.g. (3 preceding, unbounded following) -> (unbounded preceding, 3 following)

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/WindowExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/WindowExpression.java
@@ -108,9 +108,15 @@ public class WindowExpression extends Expression {
         return new WindowExpression(function, partitionKeys, orderKeys, windowFrame);
     }
 
-    public WindowExpression withOrderKeyList(List<OrderExpression> orderKeyList) {
-        return windowFrame.map(frame -> new WindowExpression(function, partitionKeys, orderKeyList, frame))
-                .orElseGet(() -> new WindowExpression(function, partitionKeys, orderKeyList));
+    public WindowExpression withOrderKeys(List<OrderExpression> orderKeys) {
+        return windowFrame.map(frame -> new WindowExpression(function, partitionKeys, orderKeys, frame))
+                .orElseGet(() -> new WindowExpression(function, partitionKeys, orderKeys));
+    }
+
+    public WindowExpression withPartitionKeysOrderKeys(
+            List<Expression> partitionKeys, List<OrderExpression> orderKeys) {
+        return windowFrame.map(frame -> new WindowExpression(function, partitionKeys, orderKeys, frame))
+                .orElseGet(() -> new WindowExpression(function, partitionKeys, orderKeys));
     }
 
     public WindowExpression withFunction(Expression function) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ExpressionTrait.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ExpressionTrait.java
@@ -34,6 +34,10 @@ public interface ExpressionTrait extends TreeNode<Expression> {
 
     boolean nullable();
 
+    default boolean notNullable() {
+        return !nullable();
+    }
+
     // check legality before do type coercion.
     // maybe we should merge checkInputDataTypes and checkLegality later.
     @Developing
@@ -41,10 +45,6 @@ public interface ExpressionTrait extends TreeNode<Expression> {
 
     @Developing
     default void checkLegalityAfterRewrite() {}
-
-    default boolean notNullable() {
-        return !nullable();
-    }
 
     default List<Expression> getArguments() {
         return children();

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/CheckAnalysisTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/CheckAnalysisTest.java
@@ -65,9 +65,9 @@ public class CheckAnalysisTest {
         UnboundFunction func = new UnboundFunction("now", Lists.newArrayList(new IntegerLiteral(1)));
         Plan plan = new LogicalOneRowRelation(
                 ImmutableList.of(new Alias(func, "unboundFunction")));
-        CheckAnalysis checkAnalysis = new CheckAnalysis();
+        CheckBound checkBound = new CheckBound();
         Assertions.assertThrows(AnalysisException.class, () ->
-                checkAnalysis.buildRules().forEach(rule -> rule.transform(plan, cascadesContext)));
+                checkBound.buildRules().forEach(rule -> rule.transform(plan, cascadesContext)));
     }
 
 }

--- a/regression-test/suites/mv_p0/test_create_mv_complex_type/test_create_mv_complex_type.groovy
+++ b/regression-test/suites/mv_p0/test_create_mv_complex_type/test_create_mv_complex_type.groovy
@@ -121,7 +121,7 @@ suite ("create_mv_complex_type") {
         sql """create materialized view mv as select c_bigint, c_int, c_jsonb, count(c_bigint) from base_table group by c_bigint, c_int, c_jsonb;"""
         success = true
     } catch (Exception e) {
-        assertTrue(e.getMessage().contains("don't support filter or group by"), e.getMessage())
+        assertTrue(e.getMessage().contains("don't support filter, group by"), e.getMessage())
     }
     assertFalse(success)
 
@@ -130,7 +130,7 @@ suite ("create_mv_complex_type") {
         sql """create materialized view mv as select c_bigint, c_int, c_array, count(c_bigint) from base_table group by c_bigint, c_int, c_array;"""
         success = true
     } catch (Exception e) {
-        assertTrue(e.getMessage().contains("don't support filter or group by"), e.getMessage())
+        assertTrue(e.getMessage().contains("don't support filter, group by"), e.getMessage())
     }
     assertFalse(success)
 
@@ -139,7 +139,7 @@ suite ("create_mv_complex_type") {
         sql """create materialized view mv as select c_bigint, c_int, c_map, count(c_bigint) from base_table group by c_bigint, c_int, c_map;"""
         success = true
     } catch (Exception e) {
-        assertTrue(e.getMessage().contains("don't support filter or group by"), e.getMessage())
+        assertTrue(e.getMessage().contains("don't support filter, group by"), e.getMessage())
     }
     assertFalse(success)
 
@@ -148,7 +148,7 @@ suite ("create_mv_complex_type") {
         sql """create materialized view mv as select c_bigint, c_int, c_struct, count(c_bigint) from base_table group by c_bigint, c_int, c_struct;"""
         success = true
     } catch (Exception e) {
-        assertTrue(e.getMessage().contains("don't support filter or group by"), e.getMessage())
+        assertTrue(e.getMessage().contains("don't support filter, group by"), e.getMessage())
     }
     assertFalse(success)
 
@@ -159,7 +159,7 @@ suite ("create_mv_complex_type") {
         sql """create materialized view mv as select c_bigint, c_int, c_jsonb from base_table order by c_bigint, c_int, c_jsonb;"""
         success = true
     } catch (Exception e) {
-        assertTrue(e.getMessage().contains("don't support filter or group by"), e.getMessage())
+        assertTrue(e.getMessage().contains("don't support filter, group by"), e.getMessage())
     }
     assertFalse(success)
 
@@ -168,7 +168,7 @@ suite ("create_mv_complex_type") {
         sql """create materialized view mv as select c_bigint, c_int, c_array from base_table order by c_bigint, c_int, c_array;"""
         success = true
     } catch (Exception e) {
-        assertTrue(e.getMessage().contains("don't support filter or group by"), e.getMessage())
+        assertTrue(e.getMessage().contains("don't support filter, group by"), e.getMessage())
     }
     assertFalse(success)
 
@@ -177,7 +177,7 @@ suite ("create_mv_complex_type") {
         sql """create materialized view mv as select c_bigint, c_int, c_map from base_table order by c_bigint, c_int, c_map;"""
         success = true
     } catch (Exception e) {
-        assertTrue(e.getMessage().contains("don't support filter or group by"), e.getMessage())
+        assertTrue(e.getMessage().contains("don't support filter, group by"), e.getMessage())
     }
     assertFalse(success)
 
@@ -186,7 +186,7 @@ suite ("create_mv_complex_type") {
         sql """create materialized view mv as select c_bigint, c_int, c_struct from base_table order by c_bigint, c_int, c_struct;"""
         success = true
     } catch (Exception e) {
-        assertTrue(e.getMessage().contains("don't support filter or group by"), e.getMessage())
+        assertTrue(e.getMessage().contains("don't support filter, group by"), e.getMessage())
     }
     assertFalse(success)
 }

--- a/regression-test/suites/nereids_arith_p0/bitmap.groovy
+++ b/regression-test/suites/nereids_arith_p0/bitmap.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite('nereids_arith_p0_date') {
+suite('bitmap') {
     sql 'use regression_test_nereids_arith_p0'
     sql 'set enable_nereids_planner=true'
     sql 'set enable_fallback_to_original_planner=false'
@@ -23,6 +23,6 @@ suite('nereids_arith_p0_date') {
         sql "select id from (select BITMAP_EMPTY() as c0 from expr_test) as ref0 where c0 = 1 order by id"
         exception "errCode = 2, detailMessage = Unexpected exception: can not cast from origin type BITMAP to target type=DOUBLE"
         sql "select id from expr_test group by id having ktint in (select BITMAP_EMPTY() from expr_test) order by id"
-        exception "errCode = 2, detailMessage = Unexpected exception: Doris hll, bitmap, array, map, struct, jsonb column must use with specific function, and don't support filter or group by. please run 'help hll' or 'help bitmap' or 'help array' or 'help map' or 'help struct' or 'help jsonb' in your mysql client."
+        exception "errCode = 2, detailMessage = Unexpected exception: Doris hll, bitmap, array, map, struct, jsonb column must use with specific function,"
     }
 }

--- a/regression-test/suites/nereids_syntax_p0/forbid_unexpected_type.groovy
+++ b/regression-test/suites/nereids_syntax_p0/forbid_unexpected_type.groovy
@@ -1,0 +1,62 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("forbid_unexpected_type") {
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+
+    sql """drop table if exists forbid_unexpected_types"""
+
+    sql """
+        CREATE TABLE `forbid_unexpected_types` (
+          `c_bigint` bigint(20) NULL,
+          `c_double` double NULL,
+          `c_boolean` boolean NULL
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`c_bigint`)
+        COMMENT 'OLAP'
+        DISTRIBUTED BY HASH(`c_bigint`) BUCKETS 1
+        PROPERTIES (
+          "replication_num" = "1"
+        );
+    """
+
+    // filter could not have agg function
+    test {
+        sql """
+            select * from forbid_unexpected_types where bitmap_union_count(bitmap_empty()) is NULL;
+        """
+        exception "Unexpected exception: LOGICAL_FILTER can not contains AggregateFunction"
+    }
+
+    // window function's partition by could not have bitmap
+    test {
+        sql """
+            select min(version()) over (partition by bitmap_union(bitmap_empty())) as c0 from forbid_unexpected_types
+        """
+        exception "Unexpected exception: Doris hll, bitmap, array, map, struct, jsonb column"
+    }
+
+    // window function's order by could not have bitmap
+    test {
+        sql """
+            select min(version()) over (partition by 1 order by bitmap_union(bitmap_empty())) as c0 from forbid_unexpected_types
+        """
+        exception "Unexpected exception: Doris hll, bitmap, array, map, struct, jsonb column"
+    }
+}
+

--- a/regression-test/suites/query_p0/aggregate/aggregate_group_by_metric_type.groovy
+++ b/regression-test/suites/query_p0/aggregate/aggregate_group_by_metric_type.groovy
@@ -16,7 +16,7 @@
 // under the License.
 
 suite("aggregate_group_by_metric_type") {
-    def error_msg = "column must use with specific function, and don't support filter or group by"
+    def error_msg = "column must use with specific function, and don't support filter"
     sql "DROP TABLE IF EXISTS test_group_by_hll_and_bitmap"
 
     sql """

--- a/regression-test/suites/query_p0/join/test_bitmap_filter_nereids.groovy
+++ b/regression-test/suites/query_p0/join/test_bitmap_filter_nereids.groovy
@@ -78,7 +78,7 @@ suite("test_bitmap_filter_nereids") {
 
     test {
         sql "select k1, count(*) from ${tbl1} b1 group by k1 having k1 in (select k2 from ${tbl2} b2) order by k1;"
-        exception "errCode = 2, detailMessage = Unexpected exception: Doris hll, bitmap, array, map, struct, jsonb column must use with specific function, and don't support filter or group by. please run 'help hll' or 'help bitmap' or 'help array' or 'help map' or 'help struct' or 'help jsonb' in your mysql client."
+        exception "errCode = 2, detailMessage = Unexpected exception: Doris hll, bitmap, array, map, struct, jsonb column must use with specific function, and don't support filter"
     }
 
     explain{


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

fix below bugs:
1. not check filter's expression, aggregate function, grouping scalar function and window expression should not appear in filter
2. show not change nullable of aggregate function when it is window function in window expression
3. bitmap and other metric types should not appear in order by or partition by of window expression

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

