### PR TITLE
[improve](nereids)derive analytics node stats

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/JoinEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/JoinEstimation.java
@@ -193,7 +193,7 @@ public class JoinEstimation {
         double rowCount;
         if (join.getJoinType().isLeftSemiOrAntiJoin()) {
             double semiRowCount = StatsMathUtil.divide(leftStats.getRowCount() * buildColStats.ndv,
-                    buildColStats.originalNdv);
+                    buildColStats.getOriginalNdv());
             if (join.getJoinType().isSemiJoin()) {
                 rowCount = semiRowCount;
             } else {
@@ -202,7 +202,7 @@ public class JoinEstimation {
         } else {
             //right semi or anti
             double semiRowCount = StatsMathUtil.divide(rightStats.getRowCount() * probColStats.ndv,
-                    probColStats.originalNdv);
+                    probColStats.getOriginalNdv());
             if (join.getJoinType().isSemiJoin()) {
                 rowCount = semiRowCount;
             } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
@@ -96,7 +96,7 @@ public class ColumnStatistic {
     but originalNdv is not. It is used to trace the change of a column's ndv through serials
     of sql operators.
      */
-    public final double originalNdv;
+    public final ColumnStatistic original;
 
     // For display only.
     public final LiteralExpr minExpr;
@@ -105,12 +105,12 @@ public class ColumnStatistic {
     // assign value when do stats estimation.
     public final Histogram histogram;
 
-    public ColumnStatistic(double count, double ndv, double originalNdv, double avgSizeByte,
+    public ColumnStatistic(double count, double ndv, ColumnStatistic original, double avgSizeByte,
             double numNulls, double dataSize, double minValue, double maxValue,
             double selectivity, LiteralExpr minExpr, LiteralExpr maxExpr, boolean isUnKnown, Histogram histogram) {
         this.count = count;
         this.ndv = ndv;
-        this.originalNdv = originalNdv;
+        this.original = original;
         this.avgSizeByte = avgSizeByte;
         this.numNulls = numNulls;
         this.dataSize = dataSize;
@@ -165,7 +165,6 @@ public class ColumnStatistic {
                 columnStatisticBuilder.setMaxValue(Double.MAX_VALUE);
             }
             columnStatisticBuilder.setSelectivity(1.0);
-            columnStatisticBuilder.setOriginalNdv(ndv);
             Histogram histogram = Env.getCurrentEnv().getStatisticsCache().getHistogram(tblId, idxId, colName)
                     .orElse(null);
             columnStatisticBuilder.setHistogram(histogram);
@@ -308,7 +307,7 @@ public class ColumnStatistic {
         statistic.put("MaxExpr", maxExpr);
         statistic.put("IsUnKnown", isUnKnown);
         statistic.put("Histogram", Histogram.serializeToJson(histogram));
-        statistic.put("OriginalNdv", originalNdv);
+        statistic.put("Original", original);
         return statistic;
     }
 
@@ -347,7 +346,7 @@ public class ColumnStatistic {
         return new ColumnStatistic(
             stat.getDouble("Count"),
             stat.getDouble("Ndv"),
-            stat.getDouble("OriginalNdv"),
+            null,
             stat.getDouble("AvgSizeByte"),
             stat.getDouble("NumNulls"),
             stat.getDouble("DataSize"),
@@ -367,5 +366,17 @@ public class ColumnStatistic {
 
     public boolean hasHistogram() {
         return histogram != null && histogram != Histogram.UNKNOWN;
+    }
+
+    public double getOriginalNdv() {
+        if (original != null) {
+            return original.ndv;
+        }
+        return ndv;
+    }
+
+    // TODO expanded this function to support more cases, help to compute the change of ndv density
+    public boolean rangeChanged() {
+        return original != null && (minValue != original.minValue || maxValue != original.maxValue);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatisticBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatisticBuilder.java
@@ -35,7 +35,7 @@ public class ColumnStatisticBuilder {
 
     private Histogram histogram;
 
-    private double originalNdv;
+    private ColumnStatistic original;
 
     public ColumnStatisticBuilder() {
     }
@@ -53,7 +53,7 @@ public class ColumnStatisticBuilder {
         this.maxExpr = columnStatistic.maxExpr;
         this.isUnknown = columnStatistic.isUnKnown;
         this.histogram = columnStatistic.histogram;
-        this.originalNdv = columnStatistic.originalNdv;
+        this.original = columnStatistic.original;
     }
 
     public ColumnStatisticBuilder setCount(double count) {
@@ -66,8 +66,8 @@ public class ColumnStatisticBuilder {
         return this;
     }
 
-    public ColumnStatisticBuilder setOriginalNdv(double originalNdv) {
-        this.originalNdv = originalNdv;
+    public ColumnStatisticBuilder setOriginal(ColumnStatistic original) {
+        this.original = original;
         return this;
     }
 
@@ -171,7 +171,11 @@ public class ColumnStatisticBuilder {
 
     public ColumnStatistic build() {
         dataSize = Math.max((count - numNulls + 1) * avgSizeByte, 0);
-        return new ColumnStatistic(count, ndv, originalNdv, avgSizeByte, numNulls,
+        if (original == null) {
+            original = new ColumnStatistic(count, ndv, null, avgSizeByte, numNulls,
+                    dataSize, minValue, maxValue, selectivity, minExpr, maxExpr, isUnknown, histogram);
+        }
+        return new ColumnStatistic(count, ndv, original, avgSizeByte, numNulls,
             dataSize, minValue, maxValue, selectivity, minExpr, maxExpr, isUnknown, histogram);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsRepository.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsRepository.java
@@ -275,7 +275,7 @@ public class StatisticsRepository {
         if (ndv != null) {
             double dNdv = Double.parseDouble(ndv);
             builder.setNdv(dNdv);
-            builder.setOriginalNdv(dNdv);
+            builder.setOriginal(null);
         }
         if (nullCount != null) {
             builder.setNumNulls(Double.parseDouble(nullCount));

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/HyperGraphBuilder.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/HyperGraphBuilder.java
@@ -190,7 +190,7 @@ public class HyperGraphBuilder {
             int count = rowCounts.get(Integer.parseInt(scanPlan.getTable().getName()));
             for (Slot slot : scanPlan.getOutput()) {
                 slotIdToColumnStats.put(slot,
-                        new ColumnStatistic(count, count, 0, 0, 0, 0, 0,
+                        new ColumnStatistic(count, count, null, 0, 0, 0, 0,
                                 0, 0, null, null, true, null));
             }
             Statistics stats = new Statistics(count, slotIdToColumnStats);

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/StatsDeriveResultTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/StatsDeriveResultTest.java
@@ -26,7 +26,7 @@ public class StatsDeriveResultTest {
     @Test
     public void testUpdateRowCountByLimit() {
         StatsDeriveResult stats = new StatsDeriveResult(100);
-        ColumnStatistic a = new ColumnStatistic(100, 10,  10, 1, 5, 10,
+        ColumnStatistic a = new ColumnStatistic(100, 10,  null, 1, 5, 10,
                 1, 100, 0.5, null, null, false, null);
         Id id = new Id(1);
         stats.addColumnStats(id, a);

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query11.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query11.out
@@ -45,21 +45,21 @@ CteAnchor[cteId= ( CTEId#4=] )
 ------PhysicalTopN
 --------PhysicalProject
 ----------hashJoin[INNER_JOIN](t_s_firstyear.customer_id = t_w_firstyear.customer_id)(CASE WHEN (year_total > 0.00) THEN (cast(year_total as DECIMALV3(38, 8)) / year_total) ELSE 0.000000 END > CASE WHEN (year_total > 0.00) THEN (cast(year_total as DECIMALV3(38, 8)) / year_total) ELSE 0.000000 END)
-------------hashJoin[INNER_JOIN](t_s_firstyear.customer_id = t_w_secyear.customer_id)
---------------PhysicalProject
-----------------filter((t_w_secyear.dyear = 2002)(t_w_secyear.sale_type = 'w'))
-------------------CteConsumer[cteId= ( CTEId#4=] )
---------------PhysicalDistribute
-----------------hashJoin[INNER_JOIN](t_s_secyear.customer_id = t_s_firstyear.customer_id)
-------------------PhysicalProject
---------------------filter((t_s_secyear.sale_type = 's')(t_s_secyear.dyear = 2002))
-----------------------CteConsumer[cteId= ( CTEId#4=] )
-------------------PhysicalDistribute
---------------------PhysicalProject
-----------------------filter((t_s_firstyear.dyear = 2001)(t_s_firstyear.sale_type = 's')(t_s_firstyear.year_total > 0.00))
-------------------------CteConsumer[cteId= ( CTEId#4=] )
+------------PhysicalProject
+--------------filter((t_w_firstyear.year_total > 0.00)(t_w_firstyear.sale_type = 'w')(t_w_firstyear.dyear = 2001))
+----------------CteConsumer[cteId= ( CTEId#4=] )
 ------------PhysicalDistribute
---------------PhysicalProject
-----------------filter((t_w_firstyear.year_total > 0.00)(t_w_firstyear.sale_type = 'w')(t_w_firstyear.dyear = 2001))
-------------------CteConsumer[cteId= ( CTEId#4=] )
+--------------hashJoin[INNER_JOIN](t_s_firstyear.customer_id = t_w_secyear.customer_id)
+----------------PhysicalProject
+------------------filter((t_w_secyear.dyear = 2002)(t_w_secyear.sale_type = 'w'))
+--------------------CteConsumer[cteId= ( CTEId#4=] )
+----------------PhysicalDistribute
+------------------hashJoin[INNER_JOIN](t_s_secyear.customer_id = t_s_firstyear.customer_id)
+--------------------PhysicalProject
+----------------------filter((t_s_secyear.sale_type = 's')(t_s_secyear.dyear = 2002))
+------------------------CteConsumer[cteId= ( CTEId#4=] )
+--------------------PhysicalDistribute
+----------------------PhysicalProject
+------------------------filter((t_s_firstyear.dyear = 2001)(t_s_firstyear.sale_type = 's')(t_s_firstyear.year_total > 0.00))
+--------------------------CteConsumer[cteId= ( CTEId#4=] )
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query4.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query4.out
@@ -77,21 +77,21 @@ CteAnchor[cteId= ( CTEId#6=] )
 ----------------PhysicalDistribute
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN](t_s_firstyear.customer_id = t_c_firstyear.customer_id)(CASE WHEN (year_total > 0.000000) THEN (cast(year_total as DECIMALV3(38, 16)) / year_total) ELSE NULL END > CASE WHEN (year_total > 0.000000) THEN (cast(year_total as DECIMALV3(38, 16)) / year_total) ELSE NULL END)
-----------------------hashJoin[INNER_JOIN](t_s_secyear.customer_id = t_s_firstyear.customer_id)
-------------------------PhysicalProject
---------------------------filter((t_s_secyear.sale_type = 's')(t_s_secyear.dyear = 2000))
-----------------------------CteConsumer[cteId= ( CTEId#6=] )
-------------------------PhysicalDistribute
---------------------------hashJoin[INNER_JOIN](t_s_firstyear.customer_id = t_c_secyear.customer_id)
-----------------------------PhysicalProject
-------------------------------filter((t_c_secyear.sale_type = 'c')(t_c_secyear.dyear = 2000))
---------------------------------CteConsumer[cteId= ( CTEId#6=] )
-----------------------------PhysicalDistribute
-------------------------------PhysicalProject
---------------------------------filter((t_s_firstyear.year_total > 0.000000)(t_s_firstyear.dyear = 1999)(t_s_firstyear.sale_type = 's'))
-----------------------------------CteConsumer[cteId= ( CTEId#6=] )
+----------------------PhysicalProject
+------------------------filter((t_c_firstyear.year_total > 0.000000)(t_c_firstyear.dyear = 1999)(t_c_firstyear.sale_type = 'c'))
+--------------------------CteConsumer[cteId= ( CTEId#6=] )
 ----------------------PhysicalDistribute
-------------------------PhysicalProject
---------------------------filter((t_c_firstyear.year_total > 0.000000)(t_c_firstyear.dyear = 1999)(t_c_firstyear.sale_type = 'c'))
-----------------------------CteConsumer[cteId= ( CTEId#6=] )
+------------------------hashJoin[INNER_JOIN](t_s_secyear.customer_id = t_s_firstyear.customer_id)
+--------------------------PhysicalProject
+----------------------------filter((t_s_secyear.sale_type = 's')(t_s_secyear.dyear = 2000))
+------------------------------CteConsumer[cteId= ( CTEId#6=] )
+--------------------------PhysicalDistribute
+----------------------------hashJoin[INNER_JOIN](t_s_firstyear.customer_id = t_c_secyear.customer_id)
+------------------------------PhysicalProject
+--------------------------------filter((t_c_secyear.sale_type = 'c')(t_c_secyear.dyear = 2000))
+----------------------------------CteConsumer[cteId= ( CTEId#6=] )
+------------------------------PhysicalDistribute
+--------------------------------PhysicalProject
+----------------------------------filter((t_s_firstyear.year_total > 0.000000)(t_s_firstyear.dyear = 1999)(t_s_firstyear.sale_type = 's'))
+------------------------------------CteConsumer[cteId= ( CTEId#6=] )
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query44.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query44.out
@@ -4,11 +4,11 @@ PhysicalTopN
 --PhysicalDistribute
 ----PhysicalTopN
 ------PhysicalProject
---------hashJoin[INNER_JOIN](asceding.rnk = descending.rnk)
-----------hashJoin[INNER_JOIN](i2.i_item_sk = descending.item_sk)
-------------PhysicalProject
---------------PhysicalOlapScan[item]
-------------PhysicalDistribute
+--------hashJoin[INNER_JOIN](i1.i_item_sk = asceding.item_sk)
+----------PhysicalProject
+------------PhysicalOlapScan[item]
+----------PhysicalDistribute
+------------hashJoin[INNER_JOIN](asceding.rnk = descending.rnk)
 --------------PhysicalProject
 ----------------filter((rnk < 11))
 ------------------PhysicalWindow
@@ -33,33 +33,33 @@ PhysicalTopN
 --------------------------------------------PhysicalProject
 ----------------------------------------------filter(ss_addr_sk IS NULL(store_sales.ss_store_sk = 146))
 ------------------------------------------------PhysicalOlapScan[store_sales]
-----------PhysicalDistribute
-------------hashJoin[INNER_JOIN](i1.i_item_sk = asceding.item_sk)
---------------PhysicalProject
-----------------PhysicalOlapScan[item]
 --------------PhysicalDistribute
-----------------PhysicalProject
-------------------filter((rnk < 11))
---------------------PhysicalWindow
-----------------------PhysicalQuickSort
-------------------------PhysicalDistribute
+----------------hashJoin[INNER_JOIN](i2.i_item_sk = descending.item_sk)
+------------------PhysicalProject
+--------------------PhysicalOlapScan[item]
+------------------PhysicalDistribute
+--------------------PhysicalProject
+----------------------filter((rnk < 11))
+------------------------PhysicalWindow
 --------------------------PhysicalQuickSort
-----------------------------PhysicalProject
-------------------------------NestedLoopJoin[INNER_JOIN](cast(rank_col as DOUBLE) > cast((0.9 * rank_col) as DOUBLE))
---------------------------------hashAgg[GLOBAL]
-----------------------------------PhysicalDistribute
-------------------------------------hashAgg[LOCAL]
---------------------------------------PhysicalProject
-----------------------------------------filter((ss1.ss_store_sk = 146))
-------------------------------------------PhysicalOlapScan[store_sales]
---------------------------------PhysicalDistribute
-----------------------------------PhysicalAssertNumRows
+----------------------------PhysicalDistribute
+------------------------------PhysicalQuickSort
+--------------------------------PhysicalProject
+----------------------------------NestedLoopJoin[INNER_JOIN](cast(rank_col as DOUBLE) > cast((0.9 * rank_col) as DOUBLE))
+------------------------------------hashAgg[GLOBAL]
+--------------------------------------PhysicalDistribute
+----------------------------------------hashAgg[LOCAL]
+------------------------------------------PhysicalProject
+--------------------------------------------filter((ss1.ss_store_sk = 146))
+----------------------------------------------PhysicalOlapScan[store_sales]
 ------------------------------------PhysicalDistribute
---------------------------------------PhysicalProject
-----------------------------------------hashAgg[GLOBAL]
-------------------------------------------PhysicalDistribute
---------------------------------------------hashAgg[LOCAL]
-----------------------------------------------PhysicalProject
-------------------------------------------------filter(ss_addr_sk IS NULL(store_sales.ss_store_sk = 146))
---------------------------------------------------PhysicalOlapScan[store_sales]
+--------------------------------------PhysicalAssertNumRows
+----------------------------------------PhysicalDistribute
+------------------------------------------PhysicalProject
+--------------------------------------------hashAgg[GLOBAL]
+----------------------------------------------PhysicalDistribute
+------------------------------------------------hashAgg[LOCAL]
+--------------------------------------------------PhysicalProject
+----------------------------------------------------filter(ss_addr_sk IS NULL(store_sales.ss_store_sk = 146))
+------------------------------------------------------PhysicalOlapScan[store_sales]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query70.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query70.out
@@ -14,36 +14,36 @@ PhysicalProject
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalRepeat
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN](d1.d_date_sk = store_sales.ss_sold_date_sk)
-------------------------------PhysicalProject
---------------------------------filter((d1.d_month_seq <= 1224)(d1.d_month_seq >= 1213))
-----------------------------------PhysicalOlapScan[date_dim]
-------------------------------PhysicalDistribute
---------------------------------hashJoin[INNER_JOIN](store.s_store_sk = store_sales.ss_store_sk)
+----------------------------hashJoin[INNER_JOIN](store.s_store_sk = store_sales.ss_store_sk)
+------------------------------hashJoin[INNER_JOIN](d1.d_date_sk = store_sales.ss_sold_date_sk)
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[store_sales]
+--------------------------------PhysicalDistribute
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[store_sales]
+------------------------------------filter((d1.d_month_seq <= 1224)(d1.d_month_seq >= 1213))
+--------------------------------------PhysicalOlapScan[date_dim]
+------------------------------PhysicalDistribute
+--------------------------------hashJoin[LEFT_SEMI_JOIN](store.s_state = tmp1.s_state)
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[store]
 ----------------------------------PhysicalDistribute
-------------------------------------hashJoin[LEFT_SEMI_JOIN](store.s_state = tmp1.s_state)
---------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[store]
---------------------------------------PhysicalDistribute
-----------------------------------------PhysicalProject
-------------------------------------------filter((ranking <= 5))
---------------------------------------------PhysicalWindow
-----------------------------------------------PhysicalQuickSort
-------------------------------------------------hashAgg[GLOBAL]
---------------------------------------------------PhysicalDistribute
-----------------------------------------------------hashAgg[LOCAL]
-------------------------------------------------------PhysicalProject
---------------------------------------------------------hashJoin[INNER_JOIN](store.s_store_sk = store_sales.ss_store_sk)
-----------------------------------------------------------hashJoin[INNER_JOIN](date_dim.d_date_sk = store_sales.ss_sold_date_sk)
-------------------------------------------------------------PhysicalProject
---------------------------------------------------------------PhysicalOlapScan[store_sales]
-------------------------------------------------------------PhysicalDistribute
---------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------filter((date_dim.d_month_seq >= 1213)(date_dim.d_month_seq <= 1224))
-------------------------------------------------------------------PhysicalOlapScan[date_dim]
-----------------------------------------------------------PhysicalDistribute
-------------------------------------------------------------PhysicalProject
---------------------------------------------------------------PhysicalOlapScan[store]
+------------------------------------PhysicalProject
+--------------------------------------filter((ranking <= 5))
+----------------------------------------PhysicalWindow
+------------------------------------------PhysicalQuickSort
+--------------------------------------------hashAgg[GLOBAL]
+----------------------------------------------PhysicalDistribute
+------------------------------------------------hashAgg[LOCAL]
+--------------------------------------------------PhysicalProject
+----------------------------------------------------hashJoin[INNER_JOIN](store.s_store_sk = store_sales.ss_store_sk)
+------------------------------------------------------hashJoin[INNER_JOIN](date_dim.d_date_sk = store_sales.ss_sold_date_sk)
+--------------------------------------------------------PhysicalProject
+----------------------------------------------------------PhysicalOlapScan[store_sales]
+--------------------------------------------------------PhysicalDistribute
+----------------------------------------------------------PhysicalProject
+------------------------------------------------------------filter((date_dim.d_month_seq >= 1213)(date_dim.d_month_seq <= 1224))
+--------------------------------------------------------------PhysicalOlapScan[date_dim]
+------------------------------------------------------PhysicalDistribute
+--------------------------------------------------------PhysicalProject
+----------------------------------------------------------PhysicalOlapScan[store]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query74.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query74.out
@@ -44,22 +44,21 @@ CteAnchor[cteId= ( CTEId#4=] )
 ------PhysicalTopN
 --------PhysicalProject
 ----------hashJoin[INNER_JOIN](t_s_firstyear.customer_id = t_w_firstyear.customer_id)(CASE WHEN (year_total > 0.0) THEN (year_total / year_total) ELSE NULL END > CASE WHEN (year_total > 0.0) THEN (year_total / year_total) ELSE NULL END)
-------------hashJoin[INNER_JOIN](t_s_firstyear.customer_id = t_w_secyear.customer_id)
---------------hashJoin[INNER_JOIN](t_s_secyear.customer_id = t_s_firstyear.customer_id)
-----------------PhysicalDistribute
-------------------PhysicalProject
---------------------filter((t_s_firstyear.year = 1999)(t_s_firstyear.sale_type = 's')(t_s_firstyear.year_total > 0.0))
-----------------------CteConsumer[cteId= ( CTEId#4=] )
-----------------PhysicalDistribute
-------------------PhysicalProject
---------------------filter((t_s_secyear.sale_type = 's')(t_s_secyear.year = 2000))
-----------------------CteConsumer[cteId= ( CTEId#4=] )
---------------PhysicalDistribute
+------------PhysicalProject
+--------------filter((t_w_firstyear.year = 1999)(t_w_firstyear.year_total > 0.0)(t_w_firstyear.sale_type = 'w'))
+----------------CteConsumer[cteId= ( CTEId#4=] )
+------------PhysicalDistribute
+--------------hashJoin[INNER_JOIN](t_s_firstyear.customer_id = t_w_secyear.customer_id)
 ----------------PhysicalProject
 ------------------filter((t_w_secyear.year = 2000)(t_w_secyear.sale_type = 'w'))
 --------------------CteConsumer[cteId= ( CTEId#4=] )
-------------PhysicalDistribute
---------------PhysicalProject
-----------------filter((t_w_firstyear.year = 1999)(t_w_firstyear.year_total > 0.0)(t_w_firstyear.sale_type = 'w'))
-------------------CteConsumer[cteId= ( CTEId#4=] )
+----------------PhysicalDistribute
+------------------hashJoin[INNER_JOIN](t_s_secyear.customer_id = t_s_firstyear.customer_id)
+--------------------PhysicalProject
+----------------------filter((t_s_firstyear.year = 1999)(t_s_firstyear.sale_type = 's')(t_s_firstyear.year_total > 0.0))
+------------------------CteConsumer[cteId= ( CTEId#4=] )
+--------------------PhysicalDistribute
+----------------------PhysicalProject
+------------------------filter((t_s_secyear.sale_type = 's')(t_s_secyear.year = 2000))
+--------------------------CteConsumer[cteId= ( CTEId#4=] )
 


### PR DESCRIPTION
## Proposed changes
1. derive analytic node stats, add support for rank()
2. filter estimation stats derive updated. update row count of filter column.
3. use ColumnStatistics.orginal to replace ColumnStatistics.orginalNdv, where ColumnStatistics.orginal is the column statisics get from TableScan.

TPCDS 70 on tpcds_sf100 improved from 23sec to 2 sec
This pr has no performance downgrade on other tpcds queries and tpch queries.

Issue Number: close #xxx

<--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

