### PR TITLE
[fix](regression) exclude test_analyze_stats_p1 suite

### DIFF
--- a/regression-test/pipeline/p0/conf/regression-conf.groovy
+++ b/regression-test/pipeline/p0/conf/regression-conf.groovy
@@ -48,7 +48,7 @@ testDirectories = ""
 // this groups will not be executed
 excludeGroups = ""
 // this suites will not be executed
-excludeSuites = "test_broker_load,test_spark_load,analyze_test"
+excludeSuites = "test_broker_load,test_spark_load,test_analyze_stats_p1"
 // this directories will not be executed
 excludeDirectories = ""
 


### PR DESCRIPTION
## Proposed changes

`test_analyze_stats_p1` is failing constantly in regression test, @morrySnow suggests ignoring it first.

http://43.132.222.7:8111/test/-5693062769677098407?currentProjectId=Doris_DorisRegression&expandTestHistoryChartSection=true&expandedTest=build%3A%28id%3A155592%29%2Cid%3A9944

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

