### PR TITLE
[chore](third-party) Bump the version of hadoop_libs

### DIFF
--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -453,10 +453,10 @@ FAST_FLOAT_SOURCE=fast_float-3.9.0
 FAST_FLOAT_MD5SUM="5656b0d8b150a3b157cfb092d214f6ea"
 
 # libhdfs
-HADOOP_LIBS_DOWNLOAD="https://github.com/apache/doris-thirdparty/archive/refs/tags/hadoop-3.3.4.3-for-doris.tar.gz"
-HADOOP_LIBS_NAME="hadoop-3.3.4.3-for-doris.tar.gz"
-HADOOP_LIBS_SOURCE="doris-thirdparty-hadoop-3.3.4.3-for-doris"
-HADOOP_LIBS_MD5SUM="4f9eeb4f8e05d2b2ae4541b12d78fb2c"
+HADOOP_LIBS_DOWNLOAD="https://github.com/apache/doris-thirdparty/archive/refs/tags/hadoop-3.3.4.4-for-doris.tar.gz"
+HADOOP_LIBS_NAME="hadoop-3.3.4.4-for-doris.tar.gz"
+HADOOP_LIBS_SOURCE="doris-thirdparty-hadoop-3.3.4.4-for-doris"
+HADOOP_LIBS_MD5SUM="00f0042dd3900ba016f079ee9c550efb"
 
 # all thirdparties which need to be downloaded is set in array TP_ARCHIVES
 export TP_ARCHIVES=(


### PR DESCRIPTION
## Proposed changes

~~Issue Number: close #xxx~~

Bump the version of hadoop_libs to build HDFS related libraries only.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

