### PR TITLE
[refactor](agg_state) refactor agg_state type to support fixed length object type

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_avg.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_avg.h
@@ -220,6 +220,19 @@ public:
         }
     }
 
+    void deserialize_and_merge_from_column_range(AggregateDataPtr __restrict place,
+                                                 const IColumn& column, size_t begin, size_t end,
+                                                 Arena* arena) const override {
+        DCHECK(end <= column.size() && begin <= end)
+                << ", begin:" << begin << ", end:" << end << ", column.size():" << column.size();
+        auto& col = assert_cast<const ColumnFixedLengthObject&>(column);
+        auto* data = reinterpret_cast<const Data*>(col.get_data().data());
+        for (size_t i = begin; i <= end; ++i) {
+            this->data(place).sum += data[i].sum;
+            this->data(place).count += data[i].count;
+        }
+    }
+
     void serialize_without_key_to_column(ConstAggregateDataPtr __restrict place,
                                          IColumn& to) const override {
         auto& col = assert_cast<ColumnFixedLengthObject&>(to);

--- a/be/src/vec/aggregate_functions/aggregate_function_count.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_count.h
@@ -29,12 +29,14 @@
 
 #include "vec/aggregate_functions/aggregate_function.h"
 #include "vec/columns/column.h"
+#include "vec/columns/column_fixed_length_object.h"
 #include "vec/columns/column_nullable.h"
 #include "vec/columns/column_vector.h"
 #include "vec/columns/columns_number.h"
 #include "vec/common/assert_cast.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type.h"
+#include "vec/data_types/data_type_fixed_length_object.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/io/var_int.h"
 
@@ -91,52 +93,75 @@ public:
 
     void deserialize_from_column(AggregateDataPtr places, const IColumn& column, Arena* arena,
                                  size_t num_rows) const override {
-        auto data = assert_cast<const ColumnUInt64&>(column).get_data().data();
-        auto* dst_data = reinterpret_cast<Data*>(places);
-        for (size_t i = 0; i != num_rows; ++i) {
-            dst_data[i].count = data[i];
-        }
+        auto data = assert_cast<const ColumnFixedLengthObject&>(column).get_data().data();
+        memcpy(places, data, sizeof(Data) * num_rows);
     }
 
     void serialize_to_column(const std::vector<AggregateDataPtr>& places, size_t offset,
                              MutableColumnPtr& dst, const size_t num_rows) const override {
-        auto& col = assert_cast<ColumnUInt64&>(*dst);
+        auto& col = assert_cast<ColumnFixedLengthObject&>(*dst);
+        DCHECK(col.item_size() == sizeof(Data))
+                << "size is not equal: " << col.item_size() << " " << sizeof(Data);
         col.resize(num_rows);
         auto* data = col.get_data().data();
         for (size_t i = 0; i != num_rows; ++i) {
-            data[i] = AggregateFunctionCount::data(places[i] + offset).count;
+            *reinterpret_cast<Data*>(&data[sizeof(Data) * i]) =
+                    *reinterpret_cast<Data*>(places[i] + offset);
         }
     }
 
     void streaming_agg_serialize_to_column(const IColumn** columns, MutableColumnPtr& dst,
                                            const size_t num_rows, Arena* arena) const override {
-        auto& col = assert_cast<ColumnUInt64&>(*dst);
-        col.resize(num_rows);
-        col.get_data().assign(num_rows, assert_cast<UInt64>(1UL));
+        auto& dst_col = assert_cast<ColumnFixedLengthObject&>(*dst);
+        DCHECK(dst_col.item_size() == sizeof(Data))
+                << "size is not equal: " << dst_col.item_size() << " " << sizeof(Data);
+        dst_col.resize(num_rows);
+        auto* data = dst_col.get_data().data();
+        for (size_t i = 0; i != num_rows; ++i) {
+            auto& state = *reinterpret_cast<Data*>(&data[sizeof(Data) * i]);
+            state.count = 1;
+        }
     }
 
     void deserialize_and_merge_from_column(AggregateDataPtr __restrict place, const IColumn& column,
                                            Arena* arena) const override {
-        auto data = assert_cast<const ColumnUInt64&>(column).get_data().data();
+        auto& col = assert_cast<const ColumnFixedLengthObject&>(column);
         const size_t num_rows = column.size();
+        auto* data = reinterpret_cast<const Data*>(col.get_data().data());
         for (size_t i = 0; i != num_rows; ++i) {
-            AggregateFunctionCount::data(place).count += data[i];
+            AggregateFunctionCount::data(place).count += data[i].count;
+        }
+    }
+
+    void deserialize_and_merge_from_column_range(AggregateDataPtr __restrict place,
+                                                 const IColumn& column, size_t begin, size_t end,
+                                                 Arena* arena) const override {
+        DCHECK(end <= column.size() && begin <= end)
+                << ", begin:" << begin << ", end:" << end << ", column.size():" << column.size();
+        auto& col = assert_cast<const ColumnFixedLengthObject&>(column);
+        auto* data = reinterpret_cast<const Data*>(col.get_data().data());
+        for (size_t i = begin; i <= end; ++i) {
+            doris::vectorized::AggregateFunctionCount::data(place).count += data[i].count;
         }
     }
 
     void serialize_without_key_to_column(ConstAggregateDataPtr __restrict place,
                                          IColumn& to) const override {
-        auto& col = assert_cast<ColumnUInt64&>(to);
+        auto& col = assert_cast<ColumnFixedLengthObject&>(to);
+        DCHECK(col.item_size() == sizeof(Data))
+                << "size is not equal: " << col.item_size() << " " << sizeof(Data);
         col.resize(1);
         reinterpret_cast<Data*>(col.get_data().data())->count =
                 AggregateFunctionCount::data(place).count;
     }
 
     MutableColumnPtr create_serialize_column() const override {
-        return ColumnVector<UInt64>::create();
+        return ColumnFixedLengthObject::create(sizeof(Data));
     }
 
-    DataTypePtr get_serialized_type() const override { return std::make_shared<DataTypeUInt64>(); }
+    DataTypePtr get_serialized_type() const override {
+        return std::make_shared<DataTypeFixedLengthObject>();
+    }
 };
 
 // TODO: Maybe AggregateFunctionCountNotNullUnary should be a subclass of AggregateFunctionCount
@@ -187,56 +212,77 @@ public:
 
     void deserialize_from_column(AggregateDataPtr places, const IColumn& column, Arena* arena,
                                  size_t num_rows) const override {
-        auto data = assert_cast<const ColumnUInt64&>(column).get_data().data();
-        auto* dst_data = reinterpret_cast<Data*>(places);
-        for (size_t i = 0; i != num_rows; ++i) {
-            dst_data[i].count = data[i];
-        }
+        auto data = assert_cast<const ColumnFixedLengthObject&>(column).get_data().data();
+        memcpy(places, data, sizeof(Data) * num_rows);
     }
 
     void serialize_to_column(const std::vector<AggregateDataPtr>& places, size_t offset,
                              MutableColumnPtr& dst, const size_t num_rows) const override {
-        auto& col = assert_cast<ColumnUInt64&>(*dst);
+        auto& col = assert_cast<ColumnFixedLengthObject&>(*dst);
+        DCHECK(col.item_size() == sizeof(Data))
+                << "size is not equal: " << col.item_size() << " " << sizeof(Data);
         col.resize(num_rows);
         auto* data = col.get_data().data();
         for (size_t i = 0; i != num_rows; ++i) {
-            data[i] = AggregateFunctionCountNotNullUnary::data(places[i] + offset).count;
+            *reinterpret_cast<Data*>(&data[sizeof(Data) * i]) =
+                    *reinterpret_cast<Data*>(places[i] + offset);
         }
     }
 
     void streaming_agg_serialize_to_column(const IColumn** columns, MutableColumnPtr& dst,
                                            const size_t num_rows, Arena* arena) const override {
-        auto& col = assert_cast<ColumnUInt64&>(*dst);
+        auto& col = assert_cast<ColumnFixedLengthObject&>(*dst);
+        DCHECK(col.item_size() == sizeof(Data))
+                << "size is not equal: " << col.item_size() << " " << sizeof(Data);
         col.resize(num_rows);
         auto& data = col.get_data();
         const ColumnNullable& input_col = assert_cast<const ColumnNullable&>(*columns[0]);
         for (size_t i = 0; i < num_rows; i++) {
-            data[i] = !input_col.is_null_at(i);
+            auto& state = *reinterpret_cast<Data*>(&data[sizeof(Data) * i]);
+            state.count = !input_col.is_null_at(i);
         }
     }
 
     void deserialize_and_merge_from_column(AggregateDataPtr __restrict place, const IColumn& column,
                                            Arena* arena) const override {
-        auto data = assert_cast<const ColumnUInt64&>(column).get_data().data();
+        auto& col = assert_cast<const ColumnFixedLengthObject&>(column);
         const size_t num_rows = column.size();
+        auto* data = reinterpret_cast<const Data*>(col.get_data().data());
         for (size_t i = 0; i != num_rows; ++i) {
-            AggregateFunctionCountNotNullUnary::data(place).count += data[i];
+            AggregateFunctionCountNotNullUnary::data(place).count += data[i].count;
+        }
+    }
+
+    void deserialize_and_merge_from_column_range(AggregateDataPtr __restrict place,
+                                                 const IColumn& column, size_t begin, size_t end,
+                                                 Arena* arena) const override {
+        DCHECK(end <= column.size() && begin <= end)
+                << ", begin:" << begin << ", end:" << end << ", column.size():" << column.size();
+        auto& col = assert_cast<const ColumnFixedLengthObject&>(column);
+        auto* data = reinterpret_cast<const Data*>(col.get_data().data());
+        for (size_t i = begin; i <= end; ++i) {
+            doris::vectorized::AggregateFunctionCountNotNullUnary::data(place).count +=
+                    data[i].count;
         }
     }
 
     void serialize_without_key_to_column(ConstAggregateDataPtr __restrict place,
                                          IColumn& to) const override {
-        auto& col = assert_cast<ColumnUInt64&>(to);
+        auto& col = assert_cast<ColumnFixedLengthObject&>(to);
+        DCHECK(col.item_size() == sizeof(Data))
+                << "size is not equal: " << col.item_size() << " " << sizeof(Data);
         col.resize(1);
         reinterpret_cast<Data*>(col.get_data().data())->count =
                 AggregateFunctionCountNotNullUnary::data(place).count;
     }
 
     MutableColumnPtr create_serialize_column() const override {
-        return ColumnVector<UInt64>::create();
+        return ColumnFixedLengthObject::create(sizeof(Data));
     }
 
-    DataTypePtr get_serialized_type() const override { return std::make_shared<DataTypeUInt64>(); }
+    DataTypePtr get_serialized_type() const override {
+        return std::make_shared<DataTypeFixedLengthObject>();
+    }
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/columns/column_fixed_length_object.h
+++ b/be/src/vec/columns/column_fixed_length_object.h
@@ -146,7 +146,6 @@ public:
         const ColumnFixedLengthObject& src_col = assert_cast<const ColumnFixedLengthObject&>(src);
         DCHECK(_item_size == src_col._item_size) << "dst and src should have the same _item_size  "
                                                  << _item_size << " " << src_col._item_size;
-        _item_size = src_col._item_size;
         size_t old_size = size();
         resize(old_size + 1);
         memcpy(&_data[old_size * _item_size], &src_col._data[n * _item_size], _item_size);
@@ -214,7 +213,6 @@ public:
         if (0 == size) {
             return res;
         }
-        // res->_item_size = _item_size;
         res->resize(offsets.back());
         typename Self::Container& res_data = res->get_data();
 

--- a/be/src/vec/columns/column_fixed_length_object.h
+++ b/be/src/vec/columns/column_fixed_length_object.h
@@ -17,6 +17,10 @@
 
 #pragma once
 
+#include <glog/logging.h>
+
+#include <cstddef>
+
 #include "vec/columns/column.h"
 #include "vec/columns/columns_common.h"
 #include "vec/common/arena.h"
@@ -45,6 +49,8 @@ private:
 public:
     const char* get_family_name() const override { return "ColumnFixedLengthObject"; }
 
+    bool can_be_inside_nullable() const override { return true; }
+
     size_t size() const override { return _item_count; }
 
     const Container& get_data() const { return _data; }
@@ -68,7 +74,9 @@ public:
             size_t count = std::min(this->size(), size);
             memcpy(new_data, _data.data(), count * _item_size);
 
-            if (size > count) memset(new_data + count * _item_size, 0, (size - count) * _item_size);
+            if (size > count) {
+                memset(new_data + count * _item_size, 0, (size - count) * _item_size);
+            }
         }
 
         return res;
@@ -107,8 +115,8 @@ public:
 
     void get(size_t n, Field& res) const override { LOG(FATAL) << "get not supported"; }
 
-    [[noreturn]] StringRef get_data_at(size_t n) const override {
-        LOG(FATAL) << "get_data_at not supported";
+    StringRef get_data_at(size_t n) const override {
+        return StringRef(reinterpret_cast<const char*>(&_data[n * _item_size]), _item_size);
     }
 
     void insert(const Field& x) override { LOG(FATAL) << "insert not supported"; }
@@ -132,6 +140,16 @@ public:
         resize(old_size + length);
         memcpy(&_data[old_size * _item_size], &src_col._data[start * _item_size],
                length * _item_size);
+    }
+
+    void insert_from(const IColumn& src, size_t n) override {
+        const ColumnFixedLengthObject& src_col = assert_cast<const ColumnFixedLengthObject&>(src);
+        DCHECK(_item_size == src_col._item_size) << "dst and src should have the same _item_size  "
+                                                 << _item_size << " " << src_col._item_size;
+        _item_size = src_col._item_size;
+        size_t old_size = size();
+        resize(old_size + 1);
+        memcpy(&_data[old_size * _item_size], &src_col._data[n * _item_size], _item_size);
     }
 
     void insert_data(const char* pos, size_t length) override {
@@ -189,8 +207,28 @@ public:
         LOG(FATAL) << "get_indices_of_non_default_rows not supported in ColumnDictionary";
     }
 
-    [[noreturn]] ColumnPtr replicate(const IColumn::Offsets& offsets) const override {
-        LOG(FATAL) << "replicate not supported";
+    ColumnPtr replicate(const IColumn::Offsets& offsets) const override {
+        size_t size = _item_count;
+        column_match_offsets_size(size, offsets.size());
+        auto res = doris::vectorized::ColumnFixedLengthObject::create(_item_size);
+        if (0 == size) {
+            return res;
+        }
+        // res->_item_size = _item_size;
+        res->resize(offsets.back());
+        typename Self::Container& res_data = res->get_data();
+
+        IColumn::Offset prev_offset = 0;
+        for (size_t i = 0; i < size; ++i) {
+            size_t size_to_replicate = offsets[i] - prev_offset;
+            for (size_t j = 0; j < size_to_replicate; ++j) {
+                memcpy(&res_data[(prev_offset + j) * _item_size], &_data[i * _item_size],
+                       _item_size);
+            }
+            prev_offset = offsets[i];
+        }
+
+        return res;
     }
 
     [[noreturn]] MutableColumns scatter(IColumn::ColumnIndex num_columns,
@@ -200,7 +238,7 @@ public:
 
     void append_data_by_selector(MutableColumnPtr& res,
                                  const IColumn::Selector& selector) const override {
-        LOG(FATAL) << "append_data_by_selector is not supported!";
+        this->template append_data_by_selector_impl<Self>(res, selector);
     }
 
     void get_extremes(Field& min, Field& max) const override {
@@ -219,12 +257,30 @@ public:
 
     size_t allocated_bytes() const override { return _data.allocated_bytes(); }
 
-    void replace_column_data(const IColumn&, size_t row, size_t self_row = 0) override {
-        LOG(FATAL) << "replace_column_data not supported";
+    //NOTICE: here is replace: this[self_row] = rhs[row]
+    //But column string is replaced all when self_row = 0
+    void replace_column_data(const IColumn& rhs, size_t row, size_t self_row = 0) override {
+        DCHECK(size() > self_row);
+        DCHECK(_item_size == assert_cast<const Self&>(rhs)._item_size)
+                << _item_size << " " << assert_cast<const Self&>(rhs)._item_size;
+        auto obj = assert_cast<const Self&>(rhs).get_data_at(row);
+        memcpy(&_data[self_row * _item_size], obj.data, _item_size);
     }
 
     void replace_column_data_default(size_t self_row = 0) override {
         LOG(FATAL) << "replace_column_data_default not supported";
+    }
+
+    void insert_many_continuous_binary_data(const char* data, const uint32_t* offsets,
+                                            const size_t num) override {
+        if (UNLIKELY(num == 0)) {
+            return;
+        }
+        const auto old_size = size();
+        const auto begin_offset = offsets[0];
+        const size_t total_mem_size = offsets[num] - begin_offset;
+        resize(old_size + num);
+        memcpy(_data.data() + old_size, data + begin_offset, total_mem_size);
     }
 
 protected:

--- a/be/src/vec/data_types/data_type_fixed_length_object.h
+++ b/be/src/vec/data_types/data_type_fixed_length_object.h
@@ -44,7 +44,7 @@ class DataTypeFixedLengthObject final : public IDataType {
 public:
     using ColumnType = ColumnFixedLengthObject;
 
-    DataTypeFixedLengthObject() {}
+    DataTypeFixedLengthObject() = default;
 
     DataTypeFixedLengthObject(const DataTypeFixedLengthObject& other) {}
 

--- a/be/src/vec/data_types/serde/data_type_fixedlengthobject_serde.h
+++ b/be/src/vec/data_types/serde/data_type_fixedlengthobject_serde.h
@@ -63,12 +63,23 @@ public:
     Status write_column_to_mysql(const IColumn& column, bool return_object_data_as_binary,
                                  std::vector<MysqlRowBuffer<false>>& result, int row_idx, int start,
                                  int end, bool col_const) const override {
-        LOG(FATAL) << "Not support write object column to mysql";
+        for (ssize_t i = start; i < end; ++i) {
+            // 0x01 is a magic num, not useful actually, just for present ""
+            char* tmp_val = reinterpret_cast<char*>(0x01);
+            result[row_idx].push_string(tmp_val, 0);
+        }
+        return Status::OK();
     }
+    // just print empty when type is column fixed length
     Status write_column_to_mysql(const IColumn& column, bool return_object_data_as_binary,
                                  std::vector<MysqlRowBuffer<true>>& result, int row_idx, int start,
                                  int end, bool col_const) const override {
-        LOG(FATAL) << "Not support write object column to mysql";
+        for (ssize_t i = start; i < end; ++i) {
+            // 0x01 is a magic num, not useful actually, just for present ""
+            char* tmp_val = reinterpret_cast<char*>(0x01);
+            result[row_idx].push_string(tmp_val, 0);
+        }
+        return Status::OK();
     }
 };
 } // namespace vectorized

--- a/be/src/vec/functions/function_agg_state.h
+++ b/be/src/vec/functions/function_agg_state.h
@@ -63,7 +63,7 @@ public:
 
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         size_t result, size_t input_rows_count) override {
-        auto col = _return_type->create_column();
+        auto col = _agg_function->create_serialize_column();
         std::vector<const IColumn*> agg_columns;
         std::vector<ColumnPtr> save_columns;
 
@@ -83,11 +83,8 @@ public:
 
             agg_columns.push_back(column);
         }
-
-        VectorBufferWriter writter(assert_cast<ColumnString&>(*col));
-        _agg_function->streaming_agg_serialize(agg_columns.data(), writter, input_rows_count,
-                                               &arena);
-
+        _agg_function->streaming_agg_serialize_to_column(agg_columns.data(), col, input_rows_count,
+                                                         &arena);
         block.replace_by_position(result, std::move(col));
         return Status::OK();
     }

--- a/be/src/vec/olap/olap_data_convertor.cpp
+++ b/be/src/vec/olap/olap_data_convertor.cpp
@@ -33,6 +33,7 @@
 #include "vec/columns/column_array.h"
 #include "vec/columns/column_complex.h"
 #include "vec/columns/column_decimal.h"
+#include "vec/columns/column_fixed_length_object.h"
 #include "vec/columns/column_map.h"
 #include "vec/columns/column_struct.h"
 #include "vec/columns/column_vector.h"
@@ -76,7 +77,11 @@ OlapBlockDataConvertor::create_olap_column_data_convertor(const TabletColumn& co
         return std::make_unique<OlapColumnDataConvertorQuantileState>();
     }
     case FieldType::OLAP_FIELD_TYPE_AGG_STATE: {
-        return std::make_unique<OlapColumnDataConvertorVarChar>(false);
+        //if (column->agg->string) {
+        if (false) {
+            return std::make_unique<OlapColumnDataConvertorVarChar>(false);
+        }
+        return std::make_unique<OlapColumnDataConvertorAggState>();
     }
     case FieldType::OLAP_FIELD_TYPE_HLL: {
         return std::make_unique<OlapColumnDataConvertorHLL>();
@@ -624,6 +629,75 @@ Status OlapBlockDataConvertor::OlapColumnDataConvertorVarChar::convert_to_olap()
             string_offset = *offset_cur;
             ++slice;
             ++offset_cur;
+        }
+        assert(slice == _slice.get_end_ptr());
+    }
+    return Status::OK();
+}
+
+void OlapBlockDataConvertor::OlapColumnDataConvertorAggState::set_source_column(
+        const ColumnWithTypeAndName& typed_column, size_t row_pos, size_t num_rows) {
+    OlapBlockDataConvertor::OlapColumnDataConvertorBase::set_source_column(typed_column, row_pos,
+                                                                           num_rows);
+    _slice.resize(num_rows);
+}
+
+const void* OlapBlockDataConvertor::OlapColumnDataConvertorAggState::get_data() const {
+    return _slice.data();
+}
+
+const void* OlapBlockDataConvertor::OlapColumnDataConvertorAggState::get_data_at(
+        size_t offset) const {
+    assert(offset < _slice.size());
+    UInt8 null_flag = 0;
+    if (get_nullmap()) {
+        null_flag = get_nullmap()[offset];
+    }
+    return null_flag ? nullptr : _slice.data() + offset;
+}
+
+Status OlapBlockDataConvertor::OlapColumnDataConvertorAggState::convert_to_olap() {
+    assert(_typed_column.column);
+    const vectorized::ColumnFixedLengthObject* column_fixed_object = nullptr;
+    if (_nullmap) {
+        auto nullable_column =
+                assert_cast<const vectorized::ColumnNullable*>(_typed_column.column.get());
+        column_fixed_object = assert_cast<const vectorized::ColumnFixedLengthObject*>(
+                nullable_column->get_nested_column_ptr().get());
+    } else {
+        column_fixed_object =
+                assert_cast<const vectorized::ColumnFixedLengthObject*>(_typed_column.column.get());
+    }
+
+    assert(column_fixed_object);
+    auto item_size = column_fixed_object->item_size();
+
+    auto cur_values = (uint8_t*)(column_fixed_object->get_data().data()) + (item_size * _row_pos);
+    auto end_values = cur_values + (item_size * _num_rows);
+    Slice* slice = _slice.data();
+
+    if (_nullmap) {
+        const UInt8* nullmap_cur = _nullmap + _row_pos;
+        while (cur_values != end_values) {
+            if (!*nullmap_cur) {
+                slice->data = reinterpret_cast<char*>(cur_values);
+                slice->size = item_size;
+            } else {
+                // TODO: this may not be necessary, check and remove later
+                slice->data = nullptr;
+                slice->size = 0;
+            }
+            ++nullmap_cur;
+            ++slice;
+            cur_values = cur_values + item_size;
+        }
+        assert(nullmap_cur == _nullmap + _row_pos + _num_rows && slice == _slice.get_end_ptr());
+    } else {
+        while (cur_values != end_values) {
+            slice->data = reinterpret_cast<char*>(cur_values);
+            slice->size = item_size;
+            ++slice;
+            cur_values = cur_values + item_size;
         }
         assert(slice == _slice.get_end_ptr());
     }

--- a/be/src/vec/olap/olap_data_convertor.h
+++ b/be/src/vec/olap/olap_data_convertor.h
@@ -205,6 +205,18 @@ private:
         PaddedPODArray<Slice> _slice;
     };
 
+    class OlapColumnDataConvertorAggState : public OlapColumnDataConvertorBase {
+    public:
+        void set_source_column(const ColumnWithTypeAndName& typed_column, size_t row_pos,
+                               size_t num_rows) override;
+        const void* get_data() const override;
+        const void* get_data_at(size_t offset) const override;
+        Status convert_to_olap() override;
+
+    private:
+        PaddedPODArray<Slice> _slice;
+    };
+
     template <typename T>
     class OlapColumnDataConvertorPaddedPODArray : public OlapColumnDataConvertorBase {
     public:


### PR DESCRIPTION

## Proposed changes
before the agg_state type only support with datatype string,
But with some agg functions, eg: avg,sum,mix... 
those functions need serialize type is fixed length object type

Issue Number: close #xxx

<--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

