### PR TITLE
[Fix](Nereids) Fix duplicated name in view does not throw exception

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/ExplainInsertCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/ExplainInsertCommandTest.java
@@ -105,12 +105,6 @@ public class ExplainInsertCommandTest extends TestWithFeService {
     }
 
     @Test
-    public void testInsertIntoDuplicateKeyTableWithCast() throws Exception {
-        String sql = "explain insert into t1 select * from (select cast(k1 as varchar), 1, 1, 1 from src) t";
-        Assertions.assertEquals(4, getOutputFragment(sql).getOutputExprs().size());
-    }
-
-    @Test
     public void testInsertIntoSomeColumns() throws Exception {
         String sql = "explain insert into t1 (v1, v2) select v1 + 1, v2 + 4 from src";
         Assertions.assertEquals(4, getOutputFragment(sql).getOutputExprs().size());

--- a/regression-test/suites/nereids_p0/subquery/test_duplicate_name_in_view.groovy
+++ b/regression-test/suites/nereids_p0/subquery/test_duplicate_name_in_view.groovy
@@ -1,0 +1,69 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("inlineview_with_project") {
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+    sql """
+        drop table if exists issue_19611_t0;
+    """
+
+    sql """
+        drop table if exists issue_19611_t1;
+    """
+
+    sql """
+        create table issue_19611_t0 (c0 int)
+        ENGINE=OLAP
+        DISTRIBUTED BY HASH(c0) BUCKETS 5
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1",
+        "in_memory" = "false",
+        "storage_format" = "V2"
+        );
+    """
+
+    sql """
+        create table issue_19611_t1 (c0 int)
+        ENGINE=OLAP
+        DISTRIBUTED BY HASH(c0) BUCKETS 5
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1",
+        "in_memory" = "false",
+        "storage_format" = "V2"
+        );
+    """
+
+    test {
+        sql """
+             select * from (
+                select * from issue_19611_t0, issue_19611_t1 where issue_19611_t1.c0 != 0 
+                    union select * from issue_19611_t0, issue_19611_t1 where issue_19611_t1.c0 = 0) tmp;
+        """
+        exception "errCode = 2, detailMessage = Unexpected exception: Duplicated inline view column alias: 'c0' in inline view: 'tmp'"
+
+    }
+
+
+    sql """
+        drop table if exists issue_19611_t0;
+    """
+
+    sql """
+        drop table if exists issue_19611_t1;
+    """
+}


### PR DESCRIPTION
## Proposed changes

Issue Number: close #19611 

When using nereids, if we have duplicated name in output of view, we need to throw an exception. A check rule was added in bindExpression rule set

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

