### PR TITLE
[fix](stats) Fix forbid unknown stats

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Column.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Column.java
@@ -45,6 +45,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -71,6 +72,18 @@ public class Column implements Writable, GsonPostProcessable {
 
     public static final Column UNSUPPORTED_COLUMN = new Column("unknown",
             Type.UNSUPPORTED, true, null, true, null, "invalid", true, null, -1, null, null, null, null);
+
+    public static final Set<String> INTERNAL_COLUMN_NAMES = new HashSet<>();
+
+    static {
+        INTERNAL_COLUMN_NAMES.add(DELETE_SIGN);
+        INTERNAL_COLUMN_NAMES.add(WHERE_SIGN);
+        INTERNAL_COLUMN_NAMES.add(SEQUENCE_COL);
+        INTERNAL_COLUMN_NAMES.add(ROWID_COL);
+        INTERNAL_COLUMN_NAMES.add(ROW_STORE_COL);
+        INTERNAL_COLUMN_NAMES.add(DYNAMIC_COLUMN_NAME);
+        INTERNAL_COLUMN_NAMES.add(VERSION_COL);
+    }
 
     @SerializedName(value = "name")
     private String name;
@@ -902,5 +915,9 @@ public class Column implements Writable, GsonPostProcessable {
     public boolean isMaterializedViewColumn() {
         return getName().startsWith(CreateMaterializedViewStmt.MATERIALIZED_VIEW_NAME_PREFIX)
                 || getName().startsWith(CreateMaterializedViewStmt.MATERIALIZED_VIEW_AGGREGATE_NAME_PREFIX);
+    }
+
+    public static boolean isInternalColumn(String name) {
+        return INTERNAL_COLUMN_NAMES.contains(name);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -17,7 +17,10 @@
 
 package org.apache.doris.nereids.stats;
 
+import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.SchemaTable;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.Pair;
@@ -107,6 +110,7 @@ import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.statistics.ColumnStatistic;
 import org.apache.doris.statistics.ColumnStatisticBuilder;
 import org.apache.doris.statistics.Histogram;
+import org.apache.doris.statistics.StatisticConstants;
 import org.apache.doris.statistics.StatisticRange;
 import org.apache.doris.statistics.Statistics;
 import org.apache.doris.statistics.StatisticsBuilder;
@@ -551,12 +555,21 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
                 throw new RuntimeException(String.format("Invalid slot: %s", slotReference.getExprId()));
             }
             ColumnStatistic cache = Config.enable_stats ? getColumnStatistic(table, colName) : ColumnStatistic.UNKNOWN;
-            if (cache == ColumnStatistic.UNKNOWN && !colName.equals("__DORIS_DELETE_SIGN__")) {
+            if (cache == ColumnStatistic.UNKNOWN && !ignoreUnknownError(table, colName)) {
                 if (forbidUnknownColStats) {
                     if (StatisticsUtil.statsTblAvailable()) {
-                        throw new AnalysisException("column stats for " + colName
-                                + " is unknown,"
-                                + " `set forbid_unknown_col_stats = false` to execute sql with unknown stats");
+                        throw new AnalysisException(String.format("Found unknown stats for column:%s.%s.\n"
+                                + "It may caused by:\n"
+                                + "\n"
+                                + "1. This column never got analyzed\n"
+                                + "2. This table is empty\n"
+                                + "3. Stats load failed caused by unstable of backends,"
+                                + "and FE cached the unknown stats by default in this scenario\n"
+                                + "4. There is a bug, please report it to Doris community\n"
+                                + "\n"
+                                + "If an unknown stats for this column is tolerable,"
+                                + "you could set session variable `forbid_unknown_col_stats` to false to make planner"
+                                + " ignore this error and keep planning.", table.getName(), colName));
                     } else {
                         throw new AnalysisException("BE is not available!");
                     }
@@ -947,5 +960,19 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
     public Statistics visitPhysicalCTEAnchor(
             PhysicalCTEAnchor<? extends Plan, ? extends Plan> cteAnchor, Void context) {
         return groupExpression.childStatistics(1);
+    }
+
+    private boolean ignoreUnknownError(TableIf tableIf, String colName) {
+        if (Column.isInternalColumn(colName)) {
+            return true;
+        }
+        if (tableIf instanceof SchemaTable) {
+            return true;
+        }
+        if (tableIf instanceof OlapTable) {
+            OlapTable olapTable = (OlapTable) tableIf;
+            return StatisticConstants.STATISTICS_DB_BLACK_LIST.contains(olapTable.getQualifiedDbName());
+        }
+        return false;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticConstants.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticConstants.java
@@ -17,6 +17,12 @@
 
 package org.apache.doris.statistics;
 
+import org.apache.doris.cluster.ClusterNamespace;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.system.SystemInfoService;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public class StatisticConstants {
@@ -73,5 +79,14 @@ public class StatisticConstants {
     public static final int TABLE_STATS_HEALTH_THRESHOLD = 80;
 
     public static final int ANALYZE_MANAGER_INTERVAL_IN_SECS = 60;
+
+    public static List<String> STATISTICS_DB_BLACK_LIST = new ArrayList<>();
+
+    static {
+        STATISTICS_DB_BLACK_LIST.add(SystemInfoService.DEFAULT_CLUSTER
+                + ClusterNamespace.CLUSTER_DELIMITER + FeConstants.INTERNAL_DB_NAME);
+        STATISTICS_DB_BLACK_LIST.add(SystemInfoService.DEFAULT_CLUSTER
+                + ClusterNamespace.CLUSTER_DELIMITER + "information_schema");
+    }
 
 }


### PR DESCRIPTION
## Proposed changes

The statistics derivation for queries on databases A and B, as well as expressions involving hidden columns, should not throw an exception when the statistics are unknown, even if the forbid_unknown_col_stats parameter is set to true.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

