### PR TITLE
[Fix](orc-reader) Fix the inner reader of `MergeRangeFileReader` is not correct when creating `MergeRangeFileReader` in orc reader. 

### DIFF
--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -1342,7 +1342,7 @@ void ORCFileInputStream::beforeReadStripe(
         offset += length;
     }
     // The underlying page reader will prefetch data in column.
-    _file_reader.reset(new io::MergeRangeFileReader(_profile, _file_reader, prefetch_ranges));
+    _file_reader.reset(new io::MergeRangeFileReader(_profile, _inner_reader, prefetch_ranges));
 }
 
 } // namespace doris::vectorized

--- a/be/src/vec/exec/format/orc/vorc_reader.h
+++ b/be/src/vec/exec/format/orc/vorc_reader.h
@@ -466,11 +466,12 @@ private:
 
 class ORCFileInputStream : public orc::InputStream {
 public:
-    ORCFileInputStream(const std::string& file_name, io::FileReaderSPtr file_reader,
+    ORCFileInputStream(const std::string& file_name, io::FileReaderSPtr inner_reader,
                        OrcReader::Statistics* statistics, const io::IOContext* io_ctx,
                        RuntimeProfile* profile)
             : _file_name(file_name),
-              _file_reader(file_reader),
+              _inner_reader(inner_reader),
+              _file_reader(inner_reader),
               _statistics(statistics),
               _io_ctx(io_ctx),
               _profile(profile) {}
@@ -490,6 +491,7 @@ public:
 
 private:
     const std::string& _file_name;
+    io::FileReaderSPtr _inner_reader;
     io::FileReaderSPtr _file_reader;
     // Owned by OrcReader
     OrcReader::Statistics* _statistics;


### PR DESCRIPTION

## Proposed changes

Fix the inner reader of `MergeRangeFileReader` is not correct when creating `MergeRangeFileReader` in orc reader. 

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

