### PR TITLE
[fix](stats) Analysis info lost after checkpoint

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AnalyzeTblStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AnalyzeTblStmt.java
@@ -144,10 +144,10 @@ public class AnalyzeTblStmt extends AnalyzeStmt {
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_WRONG_COLUMN_NAME,
                         columnName, FeNameFormat.getColumnNameRegex());
             }
+            checkColumn();
         } finally {
             table.readUnlock();
         }
-        checkColumn();
         analyzeProperties.check();
 
         // TODO support external table
@@ -160,23 +160,28 @@ public class AnalyzeTblStmt extends AnalyzeStmt {
     }
 
     private void checkColumn() throws AnalysisException {
-        table.readLock();
-        try {
-            for (String colName : columnNames) {
-                Column column = table.getColumn(colName);
-                if (column == null) {
-                    ErrorReport.reportAnalysisException(ErrorCode.ERR_WRONG_COLUMN_NAME,
-                            colName, FeNameFormat.getColumnNameRegex());
-                }
-                if (ColumnStatistic.UNSUPPORTED_TYPE.contains(column.getType())) {
-                    throw new AnalysisException(String.format("Column[%s] with type[%s] is not supported to analyze",
-                            colName, column.getType().toString()));
+        for (String colName : columnNames) {
+            Column column = table.getColumn(colName);
+            if (column == null) {
+                ErrorReport.reportAnalysisException(ErrorCode.ERR_WRONG_COLUMN_NAME,
+                        colName, FeNameFormat.getColumnNameRegex());
+            }
+            if (ColumnStatistic.UNSUPPORTED_TYPE.contains(column.getType())) {
+                if (ConnectContext.get().getSessionVariable().ignoreColumnWithComplexType) {
+                    columnNames = columnNames.stream()
+                            .filter(c -> !ColumnStatistic.UNSUPPORTED_TYPE.contains(
+                                    table.getColumn(colName).getType()))
+                            .collect(Collectors.toList());
+                } else {
+                    throw new AnalysisException(
+                            String.format("Column[%s] with type[%s] is not supported to analyze,"
+                                            + "if you want ignore them and analyze rest"
+                                            + "columns, please set session variable "
+                                            + "`ignore_column_with_complex_type` to true",
+                                    colName, column.getType().toString()));
                 }
             }
-        } finally {
-            table.readUnlock();
         }
-
     }
 
     public String getCatalogName() {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -2006,6 +2006,12 @@ public class Env {
         return checksum;
     }
 
+    public long loadAnalysisManager(DataInputStream in, long checksum) throws IOException {
+        this.analysisManager = AnalysisManager.readFields(in);
+        LOG.info("finished replay AnalysisMgr from image");
+        return checksum;
+    }
+
     // Only called by checkpoint thread
     // return the latest image file's absolute path
     public String saveImage() throws IOException {
@@ -2261,6 +2267,11 @@ public class Env {
 
         this.binlogManager.write(out, checksum);
         LOG.info("Save binlogs to image");
+        return checksum;
+    }
+
+    public long saveAnalysisMgr(CountingDataOutputStream dos, long checksum) throws IOException {
+        analysisManager.write(dos);
         return checksum;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/meta/MetaPersistMethod.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/meta/MetaPersistMethod.java
@@ -224,6 +224,12 @@ public class MetaPersistMethod {
                 metaPersistMethod.writeMethod =
                         Env.class.getDeclaredMethod("saveBinlogs", CountingDataOutputStream.class, long.class);
                 break;
+            case "AnalysisMgr":
+                metaPersistMethod.readMethod =
+                        Env.class.getDeclaredMethod("loadAnalysisManager", DataInputStream.class, long.class);
+                metaPersistMethod.writeMethod =
+                        Env.class.getDeclaredMethod("saveAnalysisMgr", CountingDataOutputStream.class, long.class);
+                break;
             default:
                 break;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/meta/PersistMetaModules.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/meta/PersistMetaModules.java
@@ -39,7 +39,7 @@ public class PersistMetaModules {
             "globalVariable", "cluster", "broker", "resources", "exportJob", "syncJob", "backupHandler",
             "paloAuth", "transactionState", "colocateTableIndex", "routineLoadJobs", "loadJobV2", "smallFiles",
             "plugins", "deleteHandler", "sqlBlockRule", "policy", "mtmvJobManager", "globalFunction", "workloadGroups",
-            "binlogs", "resourceGroups");
+            "binlogs", "resourceGroups", "AnalysisMgr");
 
     // Modules in this list is deprecated and will not be saved in meta file. (also should not be in MODULE_NAMES)
     public static final ImmutableList<String> DEPRECATED_MODULE_NAMES = ImmutableList.of(

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -343,6 +343,8 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String ENABLE_SCAN_RUN_SERIAL = "enable_scan_node_run_serial";
 
+    public static final String IGNORE_COMPLEX_TYPE_COLUMN = "ignore_column_with_complex_type";
+
     public static final List<String> DEBUG_VARIABLES = ImmutableList.of(
             SKIP_DELETE_PREDICATE,
             SKIP_DELETE_BITMAP,
@@ -951,6 +953,11 @@ public class SessionVariable implements Serializable, Writable {
             name = ENABLE_CTE_MATERIALIZE
     )
     public boolean enableCTEMaterialize = true;
+
+    @VariableMgr.VarAttr(
+            name = IGNORE_COMPLEX_TYPE_COLUMN
+    )
+    public boolean ignoreColumnWithComplexType = false;
 
     // If this fe is in fuzzy mode, then will use initFuzzyModeVariables to generate some variables,
     // not the default value set in the code.


### PR DESCRIPTION
## Proposed changes
1. Implement write/read for AnalysisManager 
2. If database or table has any column with complex type, the analyze stmt would fail directly. Enable to ignore complex type columns and analyze rest of them in this PR

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

