### PR TITLE
[Bug](function) fix equals implements not judge order by elements of function call expr

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -528,18 +528,12 @@ public class FunctionCallExpr extends Expr {
                     || fnName.getFunction().equalsIgnoreCase("sm4_encrypt"))) {
                 result.add("\'***\'");
             } else if (orderByElements.size() > 0 && i == len - orderByElements.size()) {
-                sb.append("ORDER BY ");
-            }
-            sb.append(children.get(i).toSql());
-            if (orderByElements.size() > 0 && i >= len - orderByElements.size()) {
-                if (orderByElements.get(i - len + orderByElements.size()).getIsAsc()) {
-                    sb.append(" ASC");
-                } else {
-                    sb.append(" DESC");
-                }
+                result.add("ORDER BY " + children.get(i).toSql());
+            } else {
+                result.add(children.get(i).toSql());
             }
         }
-        sb.append(")");
+        sb.append(Joiner.on(", ").join(result)).append(")");
         return sb.toString();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -486,6 +486,14 @@ public class FunctionCallExpr extends Expr {
             return false;
         }
         FunctionCallExpr o = (FunctionCallExpr) obj;
+        if (orderByElements.size() != o.orderByElements.size()) {
+            return false;
+        }
+        for (int i = 0; i < orderByElements.size(); i++) {
+            if (!orderByElements.get(i).equals(o.orderByElements.get(i))) {
+                return false;
+            }
+        }
         return /*opcode == o.opcode && aggOp == o.aggOp &&*/ fnName.equals(o.fnName)
                 && fnParams.isDistinct() == o.fnParams.isDistinct()
                 && fnParams.isStar() == o.fnParams.isStar();
@@ -520,12 +528,18 @@ public class FunctionCallExpr extends Expr {
                     || fnName.getFunction().equalsIgnoreCase("sm4_encrypt"))) {
                 result.add("\'***\'");
             } else if (orderByElements.size() > 0 && i == len - orderByElements.size()) {
-                result.add("ORDER BY " + children.get(i).toSql());
-            } else {
-                result.add(children.get(i).toSql());
+                sb.append("ORDER BY ");
+            }
+            sb.append(children.get(i).toSql());
+            if (orderByElements.size() > 0 && i >= len - orderByElements.size()) {
+                if (orderByElements.get(i - len + orderByElements.size()).getIsAsc()) {
+                    sb.append(" ASC");
+                } else {
+                    sb.append(" DESC");
+                }
             }
         }
-        sb.append(Joiner.on(", ").join(result)).append(")");
+        sb.append(")");
         return sb.toString();
     }
 

--- a/regression-test/data/query_p0/group_concat/test_group_concat.out
+++ b/regression-test/data/query_p0/group_concat/test_group_concat.out
@@ -48,3 +48,7 @@ false
 -- !select_group_concat_order_by_desc3 --
 1	3, 21, 2, 11, 1
 2	23, 222, 22, 211, 21
+
+-- !select_group_concat_order_by --
+1,11,2,21,21,211,22,222,23,3	3,23,222,22,211,21,21,2,11,1
+

--- a/regression-test/suites/query_p0/group_concat/test_group_concat.groovy
+++ b/regression-test/suites/query_p0/group_concat/test_group_concat.groovy
@@ -62,4 +62,8 @@ suite("test_group_concat") {
     qt_select_group_concat_order_by_desc3 """
                 SELECT b1, group_concat(cast(abs(b3) as varchar) order by abs(b2) desc, b3 desc) FROM table_group_concat  group by b1 order by b1
               """
+    qt_select_group_concat_order_by """
+                select group_concat(b3,',' order by b3 asc),group_concat(b3,',' order by b3 desc) from table_group_concat;
+    """
+
 }


### PR DESCRIPTION
## Proposed changes
cherry pick from https://github.com/apache/doris/pull/20083

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

