### PR TITLE
[Chore](docs)Remove the Committer-related description in the contribution guide

### DIFF
--- a/docs/en/community/how-to-contribute/contributor-guide.md
+++ b/docs/en/community/how-to-contribute/contributor-guide.md
@@ -33,19 +33,6 @@ under the License.
 If you haven’t yet, subscribe to {dev,commits}@doris.apache.org mailing lists.
 Commits mailing list is especially important because all of Github Issue, Pull Request and build notifications are sent there.
 
-### Subscribe to the private mailing list
-
-Subscribe to private@doris.apache.org by sending an email to private-subscribe@doris.apache.org.
-Keep in mind that this list is private and your subscription needs to be approved by a moderator.
-If you are PPMC, you can subscribe the mailing list through [Subscription Helper](https://whimsy.apache.org/committers/subscribe)
-
-### Link your ASF and Github account
-
-We use Github for managing issues and user contributions (pull requests).
-As such, you need to link your Github.com account with your ASF account using [Gitbox](https://gitbox.apache.org/setup/).
-This way you will get write access to [Doris](https://github.com/apache/doris) repository
-and you will be able to manage issues and pull request directly through our Github repository.
-
 ## Code Review Guidelines
 
 1. Always maintain a high standard of review so that the quality of the entire product can be better guaranteed.

--- a/docs/zh-CN/community/how-to-contribute/contributor-guide.md
+++ b/docs/zh-CN/community/how-to-contribute/contributor-guide.md
@@ -33,12 +33,6 @@ under the License.
 请订阅{dev,commits}@doris.apache.org邮件列表，通过发送邮件到{dev,commits}-subscribe@doris.apache.org完成订阅。
 commits邮件非常重要，因为所有的GitHub Issue，PR提交都会发往这个邮件列表。
 
-### 订阅private邮件列表
-
-订阅private@doris.apache.org通过发送邮件到private-subscribe@doris.apache.org完成订阅。
-这个订阅操作需要邮件列表的moderator进行审核才能订阅成功。
-如果你是PPMC的话, 可以通过通过[邮件列表订阅帮手](https://whimsy.apache.org/committers/subscribe)直接完成订阅。
-
 ### 关联你的 ASF 账号与 Github 账号
 
 我们用GitHub来管理我们的Issue以及用户贡献。

--- a/docs/zh-CN/community/how-to-contribute/contributor-guide.md
+++ b/docs/zh-CN/community/how-to-contribute/contributor-guide.md
@@ -33,12 +33,6 @@ under the License.
 请订阅{dev,commits}@doris.apache.org邮件列表，通过发送邮件到{dev,commits}-subscribe@doris.apache.org完成订阅。
 commits邮件非常重要，因为所有的GitHub Issue，PR提交都会发往这个邮件列表。
 
-### 关联你的 ASF 账号与 Github 账号
-
-我们用GitHub来管理我们的Issue以及用户贡献。
-所以你需要把你的ASF账号与GitHub账号进行关联来获得[Doris仓库](https://github.com/apache/doris)的写入权限。
-通过在[Gitbox](https://gitbox.apache.org/setup/)完成操作后，你就可以对GitHub仓库中的Issue，PR进行管理。
-
 ## Code Review指南
 
 1. 始终保持一个较高的标准来进行review，这样才能更好地保证整个产品的质量。


### PR DESCRIPTION

Only PMC members can subscribe to the mailing list, including this in the contributor guide would create ambiguity and unnecessary subscriptions.

Gitbox is also limited to Committer members.

We'd better create new Committer/PMC wizard docs if we can, but anyway, the description here is always inappropriate.