### PR TITLE
[fix](regression) add sync after streamload in test_stream_load

### DIFF
--- a/regression-test/suites/load_p0/stream_load/test_stream_load.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_stream_load.groovy
@@ -89,6 +89,7 @@ suite("test_stream_load", "p0") {
         }
     }
 
+    sql "sync"
     sql """ DROP TABLE IF EXISTS ${tableName} """
     sql """
         CREATE TABLE IF NOT EXISTS ${tableName} (
@@ -177,6 +178,7 @@ suite("test_stream_load", "p0") {
             assertEquals(0, json.NumberFilteredRows)
         }
     }
+    sql "sync"
     order_qt_sql1 " SELECT * FROM ${tableName2}"
 
     // test common case
@@ -358,6 +360,7 @@ suite("test_stream_load", "p0") {
             assertEquals(0, json.NumberLoadedRows)
         }
     }
+    sql "sync"
 
     // load with skip 2 columns, with gzip
     streamLoad {


### PR DESCRIPTION
## Proposed changes

Add sync after streamload in test_stream_load to fix following error:

```
Exception in load_p0/stream_load/test_stream_load.groovy(line 180):

                throw exception
            }
            log.info("Stream load result: ${result}".toString())
            def json = parseJson(result)
            assertEquals("success", json.Status.toLowerCase())
            assertEquals(1, json.NumberTotalRows)
            assertEquals(0, json.NumberFilteredRows)
        }
    }
    order_qt_sql1 " SELECT * FROM ${tableName2}"
^^^^^^^^^^^^^^^^^^^^^^^^^^ERROR LINE^^^^^^^^^^^^^^^^^^^^^^^^^^

    // test common case
    def tableName3 = "test_all"
    def tableName4 = "test_less_col"
    def tableName5 = "test_bitmap_and_hll"
    def tableName6 = "test_unique_key"
    def tableName7 = "test_unique_key_with_delete"
    def tableName8 = "test_array"
    def tableName10 = "test_struct"
    sql """ DROP TABLE IF EXISTS ${tableName3} """

Exception:
java.lang.IllegalStateException: Check tag 'sql1' failed:
Check tag 'sql1' failed, line 1 mismatch, real line is empty, but expect is 2019  9  9  9  7.700  a  2019-09-09  1970-01-01T08:33:39  k7  9.0  9.0
sql:
 SELECT * FROM load_nullable_to_not_nullable
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

