### PR TITLE
[fix](stats) Fix auto analyze

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/StatisticsAutoAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/StatisticsAutoAnalyzerTest.java
@@ -177,7 +177,7 @@ public class StatisticsAutoAnalyzerTest {
 
         new MockUp<StatisticsAutoAnalyzer>() {
             @Mock
-            public Set<String> findReAnalyzeNeededPartitions(TableIf table, long lastExecTimeInMs) {
+            protected Set<String> findReAnalyzeNeededPartitions(TableIf table, TableStats tableStats)  {
                 Set<String> partitionNames = new HashSet<>();
                 partitionNames.add("p1");
                 partitionNames.add("p2");


### PR DESCRIPTION
## Proposed changes

We only reanalyze those partition that lastVisibleTime is later than job's updatetime, so we shouldn't set this field when creat e system jobs

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

