### PR TITLE
[fix](workload-group)  fix workload group non-existence error

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -559,9 +559,9 @@ public class StmtExecutor {
 
     private void handleQueryWithRetry(TUniqueId queryId) throws Exception {
         // queue query here
-        if (!parsedStmt.isExplain() && Config.enable_workload_group && Config.enable_query_queue) {
-            this.queryQueue = analyzer.getEnv().getWorkloadGroupMgr()
-                    .getWorkloadGroupQueryQueue(context.sessionVariable.workloadGroup);
+        if (!parsedStmt.isExplain() && Config.enable_workload_group && Config.enable_query_queue
+                && context.getSessionVariable().enablePipelineEngine()) {
+            this.queryQueue = analyzer.getEnv().getWorkloadGroupMgr().getWorkloadGroupQueryQueue(context);
             try {
                 this.offerRet = queryQueue.offer();
             } catch (InterruptedException e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgr.java
@@ -102,10 +102,7 @@ public class WorkloadGroupMgr implements Writable, GsonPostProcessable {
     }
 
     public List<TPipelineWorkloadGroup> getWorkloadGroup(ConnectContext context) throws UserException {
-        String groupName = context.getSessionVariable().getWorkloadGroup();
-        if (Strings.isNullOrEmpty(groupName)) {
-            groupName = Env.getCurrentEnv().getAuth().getWorkloadGroup(context.getQualifiedUser());
-        }
+        String groupName = getWorkloadGroupName(context);
         List<TPipelineWorkloadGroup> workloadGroups = Lists.newArrayList();
         readLock();
         try {
@@ -120,7 +117,8 @@ public class WorkloadGroupMgr implements Writable, GsonPostProcessable {
         return workloadGroups;
     }
 
-    public QueryQueue getWorkloadGroupQueryQueue(String groupName) throws UserException {
+    public QueryQueue getWorkloadGroupQueryQueue(ConnectContext context) throws UserException {
+        String groupName = getWorkloadGroupName(context);
         readLock();
         try {
             WorkloadGroup workloadGroup = nameToWorkloadGroup.get(groupName);
@@ -131,6 +129,17 @@ public class WorkloadGroupMgr implements Writable, GsonPostProcessable {
         } finally {
             readUnlock();
         }
+    }
+
+    private String getWorkloadGroupName(ConnectContext context) {
+        String groupName = context.getSessionVariable().getWorkloadGroup();
+        if (Strings.isNullOrEmpty(groupName)) {
+            groupName = Env.getCurrentEnv().getAuth().getWorkloadGroup(context.getQualifiedUser());
+        }
+        if (Strings.isNullOrEmpty(groupName)) {
+            groupName = DEFAULT_GROUP_NAME;
+        }
+        return groupName;
     }
 
     private void checkAndCreateDefaultGroup() {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

1. fix getWorkloadGroupQueryQueue does not get the default_workload_name in the user property, which causes the workload group not to be found;
2. check whether to open the pipeline engine when getting the workload group query queue.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

