### PR TITLE
 [enhancement](function) Compatible with python 2.6 and keep the codestyle consistent

### DIFF
--- a/gensrc/script/gen_builtins_functions.py
+++ b/gensrc/script/gen_builtins_functions.py
@@ -169,7 +169,7 @@ def generate_fe_registry_init(filename):
 
     # Generate initialization calls for each category
     for category, functions in doris_builtins_functions.visible_functions.items():
-        java_registry_file.write("        init{}Builtins(functionSet);\n".format(category.capitalize()))
+        java_registry_file.write("        init{0}Builtins(functionSet);\n".format(category.capitalize()))
 
     # add non_null_result_with_null_param_functions
     java_registry_file.write("        Set<String> funcNames = Sets.newHashSet();\n")
@@ -199,7 +199,7 @@ def generate_fe_registry_init(filename):
     java_registry_file.close()
 
 def generate_fe_category(category, functions, java_registry_file, user_visible):
-    java_registry_file.write("    private static void init{}Builtins(FunctionSet functionSet) {{\n".format(category.capitalize()))
+    java_registry_file.write("    private static void init{0}Builtins(FunctionSet functionSet) {{\n".format(category.capitalize()))
     for function in functions:
         assert len(function) >= 4, \
             "Invalid function entry in doris_builtins_functions.py:\n\t" + repr(function)


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Explicit numbering of format fields is required in python 2.6 and earlier, and we have done this before in doris.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

