### PR TITLE
[branch-1.1][Fix](dyncmic-partition) Check bucket size before find tablet

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -1000,6 +1000,11 @@ Status OlapTableSink::send(RuntimeState* state, RowBatch* input_batch) {
             continue;
         }
         uint32_t tablet_index = 0;
+        if (partition->num_buckets <= 0) {
+            std::stringstream ss;
+            ss << "num_buckets must be greater than 0, num_buckets=" << partition->num_buckets;
+            return Status::InternalError(ss.str());
+        }
         if (findTabletMode != FindTabletMode::FIND_TABLET_EVERY_ROW) {
             if (_partition_to_tablet_map.find(partition->id) == _partition_to_tablet_map.end()) {
                 tablet_index = _partition->find_tablet(tuple, *partition);


### PR DESCRIPTION

## Proposed changes

Issue Number: #20175

A fallback to avoid BE crash when buckst size is 0, but not resolved

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

