### PR TITLE
[bug](jdbc) fix trino date/datetime filter

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OdbcScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OdbcScanNode.java
@@ -85,6 +85,25 @@ public class OdbcScanNode extends ScanNode {
                 return filter;
             }
         }
+        if (tableType.equals(TOdbcTableType.TRINO) && expr.contains(DateLiteral.class)
+                && (expr instanceof BinaryPredicate)) {
+            ArrayList<Expr> children = expr.getChildren();
+            if (children.get(1).isConstant() && (children.get(1).getType().isDate()) || children
+                    .get(1).getType().isDateV2()) {
+                String filter = children.get(0).toSql();
+                filter += ((BinaryPredicate) expr).getOp().toString();
+                filter += "date '" + children.get(1).getStringValue() + "'";
+                return filter;
+            }
+            if (children.get(1).isConstant() && (children.get(1).getType().isDatetime() || children
+                    .get(1).getType().isDatetimeV2())) {
+                String filter = children.get(0).toSql();
+                filter += ((BinaryPredicate) expr).getOp().toString();
+                filter += "timestamp '" + children.get(1).getStringValue() + "'";
+                return filter;
+            }
+        }
+
         return expr.toMySql();
     }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

When querying Trino's JDBC catalog, if our WHERE filter condition is k1 >= '2022-01-01', this format is incorrect. In Trino, the correct format should be k1 >= date '2022-01-01' or k1 >= timestamp '2022-01-01 00:00:00'. Therefore, the date string in the WHERE condition needs to be converted to the date or timestamp format supported by Trino.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

