### PR TITLE
[fix](load) fix generate delete bitmap in memtable flush

### DIFF
--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -216,8 +216,7 @@ private:
     void _aggregate_two_row_in_block(vectorized::MutableBlock& mutable_block, RowInBlock* new_row,
                                      RowInBlock* row_in_skiplist);
 
-    Status _generate_delete_bitmap(int64_t atomic_num_segments_before_flush,
-                                   int64_t atomic_num_segments_after_flush);
+    Status _generate_delete_bitmap(int32_t segment_id);
 
     // serialize block to row store format and append serialized data into row store column
     // in block

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -493,6 +493,7 @@ Status BetaRowsetWriter::flush_single_memtable(const vectorized::Block* block, i
     RETURN_IF_ERROR(_create_segment_writer(&writer, ctx));
     RETURN_IF_ERROR(_add_block(block, &writer));
     RETURN_IF_ERROR(_flush_segment_writer(&writer, flush_size));
+    RETURN_IF_ERROR(ctx->generate_delete_bitmap(writer->get_segment_id()));
     RETURN_IF_ERROR(_segcompaction_if_necessary());
     return Status::OK();
 }

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -491,9 +491,10 @@ Status BetaRowsetWriter::flush_single_memtable(const vectorized::Block* block, i
 
     std::unique_ptr<segment_v2::SegmentWriter> writer;
     RETURN_IF_ERROR(_create_segment_writer(&writer, ctx));
+    int32_t segment_id = writer->get_segment_id();
     RETURN_IF_ERROR(_add_block(block, &writer));
     RETURN_IF_ERROR(_flush_segment_writer(&writer, flush_size));
-    RETURN_IF_ERROR(ctx->generate_delete_bitmap(writer->get_segment_id()));
+    RETURN_IF_ERROR(ctx->generate_delete_bitmap(segment_id));
     RETURN_IF_ERROR(_segcompaction_if_necessary());
     return Status::OK();
 }

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -106,8 +106,6 @@ public:
         return Status::OK();
     }
 
-    int32_t get_atomic_num_segment() const override { return _num_segment.load(); }
-
     int32_t allocate_segment_id() override { return _next_segment_id.fetch_add(1); };
 
     // Maybe modified by local schema change

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -41,7 +41,9 @@ struct FlushContext {
     TabletSchemaSPtr flush_schema = nullptr;
     const vectorized::Block* block = nullptr;
     std::optional<int32_t> segment_id = std::nullopt;
-    std::function<Status(int32_t)> generate_delete_bitmap = [](int32_t segment_id) { return Status::OK(); };
+    std::function<Status(int32_t)> generate_delete_bitmap = [](int32_t segment_id) {
+        return Status::OK();
+    };
 };
 
 class RowsetWriter {

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -20,6 +20,7 @@
 #include <gen_cpp/olap_file.pb.h>
 #include <gen_cpp/types.pb.h>
 
+#include <functional>
 #include <optional>
 
 #include "common/factory_creator.h"
@@ -40,6 +41,7 @@ struct FlushContext {
     TabletSchemaSPtr flush_schema = nullptr;
     const vectorized::Block* block = nullptr;
     std::optional<int32_t> segment_id = std::nullopt;
+    std::function<Status(int32_t)> generate_delete_bitmap = [](int32_t segment_id) { return Status::OK(); };
 };
 
 class RowsetWriter {
@@ -99,8 +101,6 @@ public:
     virtual Status get_segment_num_rows(std::vector<uint32_t>* segment_num_rows) const {
         return Status::NotSupported("to be implemented");
     }
-
-    virtual int32_t get_atomic_num_segment() const = 0;
 
     virtual int32_t allocate_segment_id() = 0;
 


### PR DESCRIPTION
## Proposed changes

1. Generate delete bitmap for one segment at a time.
2. Generate delete bitmap before segment compaction.

Fix #20445

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

