### PR TITLE
[fix](audit) Fix the error of peakMemoryBytes in the audit log

### DIFF
--- a/be/src/runtime/buffer_control_block.h
+++ b/be/src/runtime/buffer_control_block.h
@@ -93,8 +93,6 @@ public:
         }
     }
 
-    // TODO: The value of query peak mem usage in fe.audit.log comes from a random BE,
-    // not the BE with the largest peak mem usage
     void update_max_peak_memory_bytes() {
         if (_query_statistics != nullptr) {
             int64_t max_peak_memory_bytes = _query_statistics->calculate_max_peak_memory_bytes();

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -390,7 +390,7 @@ void PlanFragmentExecutor::_collect_node_statistics() {
     DCHECK(_runtime_state->backend_id() != -1);
     NodeStatistics* node_statistics =
             _query_statistics->add_nodes_statistics(_runtime_state->backend_id());
-    node_statistics->add_peak_memory(_runtime_state->query_mem_tracker()->peak_consumption());
+    node_statistics->set_peak_memory(_runtime_state->query_mem_tracker()->peak_consumption());
 }
 
 void PlanFragmentExecutor::report_profile() {

--- a/be/src/runtime/query_statistics.cpp
+++ b/be/src/runtime/query_statistics.cpp
@@ -23,7 +23,7 @@
 namespace doris {
 
 void NodeStatistics::merge(const NodeStatistics& other) {
-    peak_memory_bytes += other.peak_memory_bytes;
+    peak_memory_bytes = std::max(other.peak_memory_bytes, peak_memory_bytes);
 }
 
 void NodeStatistics::to_pb(PNodeStatistics* node_statistics) {
@@ -72,13 +72,13 @@ void QueryStatistics::from_pb(const PQueryStatistics& statistics) {
 }
 
 int64_t QueryStatistics::calculate_max_peak_memory_bytes() {
-    int64_t max_peak_memory_bytes = 0;
+    int64_t max_peak_memory = 0;
     for (auto iter = _nodes_statistics_map.begin(); iter != _nodes_statistics_map.end(); ++iter) {
-        if (max_peak_memory_bytes < iter->second->peak_memory_bytes) {
-            max_peak_memory_bytes = iter->second->peak_memory_bytes;
+        if (max_peak_memory < iter->second->peak_memory_bytes) {
+            max_peak_memory = iter->second->peak_memory_bytes;
         }
     }
-    return max_peak_memory_bytes;
+    return max_peak_memory;
 }
 
 void QueryStatistics::merge(QueryStatisticsRecvr* recvr) {

--- a/be/src/runtime/query_statistics.h
+++ b/be/src/runtime/query_statistics.h
@@ -36,7 +36,9 @@ class NodeStatistics {
 public:
     NodeStatistics() : peak_memory_bytes(0) {}
 
-    void add_peak_memory(int64_t peak_memory) { this->peak_memory_bytes += peak_memory; }
+    void set_peak_memory(int64_t peak_memory) {
+        this->peak_memory_bytes = std::max(this->peak_memory_bytes, peak_memory);
+    }
 
     void merge(const NodeStatistics& other);
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

In the current mem tracker implementation, peak_consumption is the peak memory of all instances on the be node for that query and does not need to be summed again.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

