### PR TITLE
[fix](memory) Fix crash at `bthread_setspecific` in `brpc::Socket::CheckHealth()`

### DIFF
--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -22,6 +22,7 @@
 #include <gflags/gflags.h>
 #include <gperftools/malloc_extension.h> // IWYU pragma: keep
 // IWYU pragma: no_include <bits/std_abs.h>
+#include <butil/iobuf.h>
 #include <math.h>
 #include <signal.h>
 #include <stdint.h>
@@ -210,6 +211,9 @@ void Daemon::memory_maintenance_thread() {
                 DorisMetrics::instance()->system_metrics()->update_allocator_metrics();
             }
 #endif
+
+            ExecEnv::GetInstance()->brpc_iobuf_block_memory_tracker()->set_consumption(
+                    butil::IOBuf::block_memory());
             LOG(INFO) << MemTrackerLimiter::
                             process_mem_log_str(); // print mem log when memory state by 256M
         }

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -118,6 +118,7 @@ public:
     MemTrackerLimiter* orphan_mem_tracker_raw() { return _orphan_mem_tracker_raw; }
     MemTrackerLimiter* experimental_mem_tracker() { return _experimental_mem_tracker.get(); }
     MemTracker* page_no_cache_mem_tracker() { return _page_no_cache_mem_tracker.get(); }
+    MemTracker* brpc_iobuf_block_memory_tracker() { return _brpc_iobuf_block_memory_tracker.get(); }
 
     ThreadPool* send_batch_thread_pool() { return _send_batch_thread_pool.get(); }
     ThreadPool* download_cache_thread_pool() { return _download_cache_thread_pool.get(); }
@@ -211,6 +212,7 @@ private:
     std::shared_ptr<MemTrackerLimiter> _experimental_mem_tracker;
     // page size not in cache, data page/index page/etc.
     std::shared_ptr<MemTracker> _page_no_cache_mem_tracker;
+    std::shared_ptr<MemTracker> _brpc_iobuf_block_memory_tracker;
 
     std::unique_ptr<ThreadPool> _send_batch_thread_pool;
 

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -338,6 +338,8 @@ void ExecEnv::init_mem_tracker() {
             MemTrackerLimiter::Type::EXPERIMENTAL, "ExperimentalSet");
     _page_no_cache_mem_tracker =
             std::make_shared<MemTracker>("PageNoCache", _orphan_mem_tracker_raw);
+    _brpc_iobuf_block_memory_tracker =
+            std::make_shared<MemTracker>("IOBufBlockMemory", _orphan_mem_tracker_raw);
 }
 
 void ExecEnv::init_download_cache_buf() {

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -429,8 +429,7 @@ void LoadChannelMgr::_handle_mem_exceed_limit() {
                 << PrettyPrinter::print_bytes(process_soft_mem_limit)
                 << ", total load mem consumption: "
                 << PrettyPrinter::print_bytes(_mem_tracker->consumption())
-                << ", vm_rss: " << PerfCounters::get_vm_rss_str()
-                << ", tc/jemalloc allocator cache: " << MemInfo::allocator_cache_mem_str();
+                << ", vm_rss: " << PerfCounters::get_vm_rss_str();
         }
         LOG(INFO) << oss.str();
     }

--- a/be/src/runtime/thread_context.cpp
+++ b/be/src/runtime/thread_context.cpp
@@ -19,12 +19,14 @@
 
 #include "common/signal_handler.h"
 #include "runtime/runtime_state.h"
-#include "util/doris_metrics.h" // IWYU pragma: keep
 
 namespace doris {
 class MemTracker;
 
 DEFINE_STATIC_THREAD_LOCAL(ThreadContext, ThreadContextPtr, _ptr);
+
+SwitchBthreadLocal::SwitchBthreadLocalGroup SwitchBthreadLocal::switch_bthread_local_group =
+        SwitchBthreadLocal::SwitchBthreadLocalGroup();
 
 ThreadContextPtr::ThreadContextPtr() {
     INIT_STATIC_THREAD_LOCAL(ThreadContext, _ptr);
@@ -33,10 +35,12 @@ ThreadContextPtr::ThreadContextPtr() {
 
 AttachTask::AttachTask(const std::shared_ptr<MemTrackerLimiter>& mem_tracker,
                        const TUniqueId& task_id, const TUniqueId& fragment_instance_id) {
+    _switch_bthread_local = SwitchBthreadLocal::switch_to_bthread_local();
     thread_context()->attach_task(task_id, fragment_instance_id, mem_tracker);
 }
 
 AttachTask::AttachTask(RuntimeState* runtime_state) {
+    _switch_bthread_local = SwitchBthreadLocal::switch_to_bthread_local();
     doris::signal::query_id_hi = runtime_state->query_id().hi;
     doris::signal::query_id_lo = runtime_state->query_id().lo;
     thread_context()->attach_task(runtime_state->query_id(), runtime_state->fragment_instance_id(),
@@ -45,29 +49,35 @@ AttachTask::AttachTask(RuntimeState* runtime_state) {
 
 AttachTask::~AttachTask() {
     thread_context()->detach_task();
-#ifndef NDEBUG
-    DorisMetrics::instance()->attach_task_thread_count->increment(1);
-#endif // NDEBUG
+    if (_switch_bthread_local) {
+        SwitchBthreadLocal::switch_back_pthread_local();
+    }
 }
 
 AddThreadMemTrackerConsumer::AddThreadMemTrackerConsumer(MemTracker* mem_tracker) {
-    if (mem_tracker)
+    _switch_bthread_local = SwitchBthreadLocal::switch_to_bthread_local();
+    if (mem_tracker) {
         _need_pop = thread_context()->thread_mem_tracker_mgr->push_consumer_tracker(mem_tracker);
+    }
 }
 
 AddThreadMemTrackerConsumer::AddThreadMemTrackerConsumer(
         const std::shared_ptr<MemTracker>& mem_tracker)
         : _mem_tracker(mem_tracker) {
-    if (_mem_tracker)
+    _switch_bthread_local = SwitchBthreadLocal::switch_to_bthread_local();
+    if (_mem_tracker) {
         _need_pop =
                 thread_context()->thread_mem_tracker_mgr->push_consumer_tracker(_mem_tracker.get());
+    }
 }
 
 AddThreadMemTrackerConsumer::~AddThreadMemTrackerConsumer() {
-#ifndef NDEBUG
-    DorisMetrics::instance()->add_thread_mem_tracker_consumer_count->increment(1);
-#endif // NDEBUG
-    if (_need_pop) thread_context()->thread_mem_tracker_mgr->pop_consumer_tracker();
+    if (_need_pop) {
+        thread_context()->thread_mem_tracker_mgr->pop_consumer_tracker();
+    }
+    if (_switch_bthread_local) {
+        SwitchBthreadLocal::switch_back_pthread_local();
+    }
 }
 
 } // namespace doris

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -1620,7 +1620,6 @@ void PInternalServiceImpl::get_tablet_rowset_versions(google::protobuf::RpcContr
                                                       const PGetTabletVersionsRequest* request,
                                                       PGetTabletVersionsResponse* response,
                                                       google::protobuf::Closure* done) {
-    //SCOPED_SWITCH_BTHREAD_TLS();
     brpc::ClosureGuard closure_guard(done);
     VLOG_DEBUG << "receive get tablet versions request: " << request->DebugString();
     ExecEnv::GetInstance()->storage_engine()->get_tablet_rowset_versions(request, response);

--- a/be/src/util/doris_metrics.cpp
+++ b/be/src/util/doris_metrics.cpp
@@ -135,11 +135,6 @@ DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(load_bytes, MetricUnit::BYTES);
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(memtable_flush_total, MetricUnit::OPERATIONS);
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(memtable_flush_duration_us, MetricUnit::MICROSECONDS);
 
-DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(attach_task_thread_count, MetricUnit::NOUNIT);
-DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(add_thread_mem_tracker_consumer_count, MetricUnit::NOUNIT);
-DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(thread_mem_tracker_exceed_call_back_count, MetricUnit::NOUNIT);
-DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(switch_bthread_count, MetricUnit::NOUNIT);
-
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(memory_pool_bytes_total, MetricUnit::BYTES);
 DEFINE_GAUGE_CORE_METRIC_PROTOTYPE_2ARG(process_thread_num, MetricUnit::NOUNIT);
 DEFINE_GAUGE_CORE_METRIC_PROTOTYPE_2ARG(process_fd_num_used, MetricUnit::NOUNIT);
@@ -297,11 +292,6 @@ DorisMetrics::DorisMetrics() : _metric_registry(_s_registry_name) {
 
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, load_rows);
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, load_bytes);
-
-    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, attach_task_thread_count);
-    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, add_thread_mem_tracker_consumer_count);
-    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, thread_mem_tracker_exceed_call_back_count);
-    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, switch_bthread_count);
 
     INT_UGAUGE_METRIC_REGISTER(_server_metric_entity, upload_total_byte);
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, upload_rowset_count);

--- a/be/src/util/doris_metrics.h
+++ b/be/src/util/doris_metrics.h
@@ -121,12 +121,6 @@ public:
     IntCounter* memtable_flush_total;
     IntCounter* memtable_flush_duration_us;
 
-    IntCounter* attach_task_thread_count;
-    IntCounter* add_thread_mem_tracker_consumer_count;
-    IntCounter* thread_mem_tracker_exceed_call_back_count;
-    // brpc server response count
-    IntCounter* switch_bthread_count;
-
     IntGauge* memory_pool_bytes_total;
     IntGauge* process_thread_num;
     IntGauge* process_fd_num_used;

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -77,7 +77,6 @@ int64_t MemInfo::_s_process_full_gc_size = -1;
 
 void MemInfo::refresh_allocator_mem() {
 #if defined(ADDRESS_SANITIZER) || defined(LEAK_SANITIZER) || defined(THREAD_SANITIZER)
-    LOG(INFO) << "Memory tracking is not available with address sanitizer builds.";
 #elif defined(USE_JEMALLOC)
     uint64_t epoch = 0;
     size_t sz = sizeof(epoch);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

1. Only switch to bthread local when modifying the mem tracker in the thread context. No longer switches to bthread local by default when bthread starts
2. mem tracker increases brpc `IOBufBlockMemory` memory
3. remove thread mem tracker metrics

core stack:
```
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007f9220937859 in __GI_abort () at abort.c:79
#2  0x000056079b8365e9 in ?? ()
#3  0x000056079b82bbfd in google::LogMessage::Fail() ()
#4  0x000056079b82e139 in google::LogMessage::SendToLog() ()
#5  0x000056079b82b766 in google::LogMessage::Flush() ()
#6  0x000056079b82e7a9 in google::LogMessageFatal::~LogMessageFatal() ()
#7  0x000056079bff62af in bthread_setspecific ()
#8  0x00005607950e15db in doris::pthread_attach_bthread ()
    at doris_master/doris/be/src/runtime/thread_context.h:219
#9  doris::thread_context ()
    at doris_master/doris/be/src/runtime/thread_context.h:228
#10 0x00005607950e131c in doris_malloc (size=30504)
    at doris_master/doris/be/src/runtime/memory/jemalloc_hook.cpp:44
#11 0x000056079e4b5ef8 in operator new (sz=30504) at ../../../../libstdc+-v3/libsupc+/new_op.cc:50
#12 0x000056079b82ade0 in google::LogMessage::Init(char const*, int, int, void (google::LogMessage::*)()) ()
#13 0x000056079c1a6e60 in brpc::Socket::CheckHealth() ()
#14 0x000056079c1ae55b in brpc::HealthCheckTask::OnTriggeringTask(timespec*) ()
-Type <RET> for more, q to quit, c to continue without paging-
#15 0x000056079c1af61b in ?? ()
#16 0x000056079c009daf in bthread::TaskGroup::task_runner(long) ()
#17 0x000056079bff53e1 in bthread_make_fcontext ()
#18 0x0000000000000000 in ?? ()
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

