### PR TITLE
[enhancement](profile) add build get child next time

### DIFF
--- a/be/src/vec/exec/join/vhash_join_node.cpp
+++ b/be/src/vec/exec/join/vhash_join_node.cpp
@@ -778,8 +778,10 @@ void HashJoinNode::release_resource(RuntimeState* state) {
 }
 
 Status HashJoinNode::_materialize_build_side(RuntimeState* state) {
-    RETURN_IF_ERROR(child(1)->open(state));
-
+    {
+        SCOPED_TIMER(_build_get_next_timer);
+        RETURN_IF_ERROR(child(1)->open(state));
+    }
     if (_should_build_hash_table) {
         bool eos = false;
         Block block;

--- a/be/src/vec/exec/join/vjoin_node_base.h
+++ b/be/src/vec/exec/join/vjoin_node_base.h
@@ -124,6 +124,7 @@ protected:
     MutableColumnPtr _tuple_is_null_right_flag_column;
 
     RuntimeProfile::Counter* _build_timer;
+    RuntimeProfile::Counter* _build_get_next_timer;
     RuntimeProfile::Counter* _probe_timer;
     RuntimeProfile::Counter* _build_rows_counter;
     RuntimeProfile::Counter* _probe_rows_counter;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Currently, build time not include child(1)->get next time, it is very confusing during shared hash table scenario. So that I add a profile.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

