### PR TITLE
[branch-1.1][Fix](dyncmic-partition) Fix replay TruncateTableInfo missing bucket size

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RandomDistributionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RandomDistributionInfo.java
@@ -20,6 +20,8 @@ package org.apache.doris.catalog;
 import org.apache.doris.analysis.DistributionDesc;
 import org.apache.doris.analysis.RandomDistributionDesc;
 
+import com.google.gson.annotations.SerializedName;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -28,7 +30,7 @@ import java.io.IOException;
  * Random partition.
  */
 public class RandomDistributionInfo extends DistributionInfo {
-    
+    @SerializedName(value = "bucketNum")
     private int bucketNum;
 
     public RandomDistributionInfo() {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #20175

When replay TruncateTableInfo, the nested field `bucketNum` of `RandomDistributionInfo` does not have `@SerializedName` annotation, so after truncate, the bucket size of slave FE is **0**.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

