### PR TITLE
[Fix](Planner) Fix function do not have equal function and substitutition failed

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Function.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Function.java
@@ -38,7 +38,9 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Base class for all functions.
@@ -833,5 +835,22 @@ public class Function implements Writable {
         } catch (Throwable t) {
             throw new UserException("failed to serialize function: " + functionName(), t);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Function function = (Function) o;
+        return id == function.id && hasVarArgs == function.hasVarArgs && userVisible == function.userVisible
+            && vectorized == function.vectorized && Objects.equals(name, function.name)
+            && Objects.equals(retType, function.retType) && Arrays.equals(argTypes,
+            function.argTypes) && Objects.equals(location, function.location)
+            && binaryType == function.binaryType && nullableMode == function.nullableMode && Objects.equals(
+            checksum, function.checksum);
     }
 }

--- a/regression-test/suites/query_p0/aggregate/aggregate_grouping_function.groovy
+++ b/regression-test/suites/query_p0/aggregate/aggregate_grouping_function.groovy
@@ -90,4 +90,48 @@ suite("aggregate_grouping_function") {
     """
 
     sql "DROP TABLE test_aggregate_grouping_function"
+
+    sql "DROP TABLE IF EXISTS test_aggregate_collect_set"
+ 
+    sql """
+        CREATE table test_aggregate_collect_set (
+		custr_nbr varchar(30),   
+		bar_code varchar(36),
+       		audit_id varchar(255),
+		case_id text,
+		into_time text,
+		audit_time text,
+		apply_type text,
+		node_code text,
+		audit_code1 text,
+		audit_code2 text,
+		audit_code3 text
+	) UNIQUE KEY (custr_nbr,bar_code,audit_id )
+	distributed by hash (custr_nbr,bar_code,audit_id ) buckets 10
+	properties(
+		  "replication_num" = "1"
+	);"""
+
+    sql """ INSERT into test_aggregate_collect_set values ('custr_nbr', 'barcode', 'audit_id', 'case_id', '2007-11-30 10:30:19', '2007-11-30 10:30:19', '2', 'Decline', 'c1', 'c2', 'c3');"""
+
+    sql """ 
+	SELECT
+	    tt.tag_value
+	FROM (
+	    SELECT
+	        d.custr_nbr,
+	        concat_ws('|', collect_set(d.is_code1)) as tag_value
+	    FROM (
+	        SELECT
+	            b.custr_nbr,
+	            1 as is_code1
+	        FROM test_aggregate_collect_set b
+	    ) d
+	    GROUP BY d.custr_nbr
+	) tt
+	GROUP BY tt.tag_value
+	;
+	"""
+
+    sql "DROP TABLE test_aggregate_collect_set"
 }


### PR DESCRIPTION

## Proposed changes

The problem this pr want to solved is when generating merge aggregate using original planner, partition expressions need to be substitude, but when comparing two castExpr function, it fails because super.Function does not implement equals function.

<!--Describe your changes.-->

Add equals implementation to Fucntion Expr

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

