### PR TITLE
[improvement](sink) reuse rows buffer in msyql_result_writer

### DIFF
--- a/be/src/util/mysql_row_buffer.cpp
+++ b/be/src/util/mysql_row_buffer.cpp
@@ -81,6 +81,25 @@ MysqlRowBuffer<is_binary_format>::MysqlRowBuffer()
           _len_pos(0) {}
 
 template <bool is_binary_format>
+MysqlRowBuffer<is_binary_format>::MysqlRowBuffer(MysqlRowBuffer<is_binary_format>&& other) {
+    if (other._buf == other._default_buf) {
+        auto other_length = other.length();
+        memcpy(_default_buf, other._buf, other_length);
+        _buf = _default_buf;
+        _pos = _buf + other_length;
+    } else {
+        _buf = other._buf;
+        other._buf = other._default_buf;
+        _pos = other._pos;
+    }
+    _buf_size = other._buf_size;
+    _dynamic_mode = other._dynamic_mode;
+    _field_count = other._field_count;
+    _field_pos = other._field_pos;
+    _len_pos = other._len_pos;
+}
+
+template <bool is_binary_format>
 void MysqlRowBuffer<is_binary_format>::start_binary_row(uint32_t num_cols) {
     assert(is_binary_format);
     int bit_fields = (num_cols + 9) / 8;
@@ -94,6 +113,7 @@ template <bool is_binary_format>
 MysqlRowBuffer<is_binary_format>::~MysqlRowBuffer() {
     if (_buf != _default_buf) {
         delete[] _buf;
+        _buf = _default_buf;
     }
 }
 

--- a/be/src/util/mysql_row_buffer.h
+++ b/be/src/util/mysql_row_buffer.h
@@ -56,6 +56,8 @@ public:
     MysqlRowBuffer();
     ~MysqlRowBuffer();
 
+    MysqlRowBuffer(MysqlRowBuffer&& other);
+
     void reset() { _pos = _buf; }
 
     // Prepare for binary row buffer

--- a/be/src/vec/sink/vmysql_result_writer.h
+++ b/be/src/vec/sink/vmysql_result_writer.h
@@ -69,6 +69,7 @@ private:
     BufferControlBlock* _sinker;
 
     const VExprContextSPtrs& _output_vexpr_ctxs;
+    std::vector<MysqlRowBuffer<is_binary_format>> _rows_buffer;
 
     RuntimeProfile* _parent_profile; // parent profile from result sink. not owned
     // total time cost on append batch operation
@@ -77,6 +78,8 @@ private:
     RuntimeProfile::Counter* _convert_tuple_timer = nullptr;
     // file write timer, child timer of _append_row_batch_timer
     RuntimeProfile::Counter* _result_send_timer = nullptr;
+    // timer of copying buffer to thrift
+    RuntimeProfile::Counter* _copy_buffer_timer = nullptr;
     // number of sent rows
     RuntimeProfile::Counter* _sent_rows_counter = nullptr;
     // size of sent data


### PR DESCRIPTION
## Proposed changes

Creating a rows buffer for each block can impact non-negligible performance.
So it is necessary to reuse the rows buffer.

Test with a total of 1.7M rows, the `AppendBatchTime` reduced from 500ms to 280ms.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

