### PR TITLE
[fix](regression-test) retry more to avoid dynamic partition create timeout

### DIFF
--- a/regression-test/pipeline/p0/conf/fe.conf
+++ b/regression-test/pipeline/p0/conf/fe.conf
@@ -81,4 +81,4 @@ enable_struct_type=true
 # enable mtmv
 enable_mtmv = true
 
-dynamic_partition_check_interval_seconds=5
+dynamic_partition_check_interval_seconds=3

--- a/regression-test/pipeline/p1/conf/fe.conf
+++ b/regression-test/pipeline/p1/conf/fe.conf
@@ -83,4 +83,4 @@ enable_mtmv = true
 enable_auto_collect_statistics=true
 auto_check_statistics_in_sec=60
 
-dynamic_partition_check_interval_seconds=5
+dynamic_partition_check_interval_seconds=3

--- a/regression-test/suites/partition_p0/dynamic_partition/test_dynamic_partition_with_alter.groovy
+++ b/regression-test/suites/partition_p0/dynamic_partition/test_dynamic_partition_with_alter.groovy
@@ -42,12 +42,12 @@ suite("test_dynamic_partition_with_alter") {
     sql """ ADMIN SET FRONTEND CONFIG ('dynamic_partition_check_interval_seconds' = '1') """
     sql """ alter table ${tbl} set('dynamic_partition.end'='5') """
     result = sql "show partitions from ${tbl}"
-    for (def retry = 0; retry < 15; retry++) {
+    for (def retry = 0; retry < 120; retry++) { // at most wait 120s
         if (result.size() == 9) {
             break;
         }
         logger.info("wait dynamic partition scheduler, sleep 1s")
-        sleep(1000);
+        sleep(1000);  // sleep 1s
         result = sql "show partitions from ${tbl}"
     }
     assertEquals(9, result.size())

--- a/regression-test/suites/partition_p0/dynamic_partition/test_dynamic_partition_with_rename.groovy
+++ b/regression-test/suites/partition_p0/dynamic_partition/test_dynamic_partition_with_rename.groovy
@@ -42,12 +42,12 @@ suite("test_dynamic_partition_with_rename") {
     sql """ ADMIN SET FRONTEND CONFIG ('dynamic_partition_check_interval_seconds' = '1') """
     sql """ alter table ${tbl} set('dynamic_partition.end'='5') """
     result = sql "show partitions from ${tbl}"
-    for (def retry = 0; retry < 15; retry++) {
+    for (def retry = 0; retry < 120; retry++) { // at most wait 120s
         if (result.size() == 9) {
             break;
         }
         logger.info("wait dynamic partition scheduler, sleep 1s")
-        sleep(1000);
+        sleep(1000); // sleep 1s
         result = sql "show partitions from ${tbl}"
     }
     assertEquals(9, result.size())


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Now after `alter table ${tbl} set('dynamic_partition.end'='5')`, we add dynamic partition async.
We need to wait dynamic scheduler.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

