### PR TITLE
[fix](stats) Make alter column stats no forward

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterColumnStatsStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterColumnStatsStmt.java
@@ -175,4 +175,9 @@ public class AlterColumnStatsStmt extends DdlStmt {
     public String getValue(StatsType statsType) {
         return statsTypeToValue.get(statsType);
     }
+
+    @Override
+    public RedirectStatus getRedirectStatus() {
+        return RedirectStatus.NO_FORWARD;
+    }
 }


### PR DESCRIPTION
## Proposed changes

For test convenient, since daily regression tests queries would be sent any FE rather than master only.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

