### PR TITLE
[Bug](planner) fix pre condition check fail on max(null)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
@@ -986,14 +986,6 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
 
     // Convert this expr, including all children, to its Thrift representation.
     public TExpr treeToThrift() {
-        if (type.isNull()) {
-            // Hack to ensure BE never sees TYPE_NULL. If an expr makes it this far without
-            // being cast to a non-NULL type, the type doesn't matter and we can cast it
-            // arbitrarily.
-            Preconditions.checkState(this instanceof NullLiteral || this instanceof SlotRef
-                    || this instanceof VariableExpr);
-            return NullLiteral.create(ScalarType.BOOLEAN).treeToThrift();
-        }
         TExpr result = new TExpr();
         treeToThriftHelper(result);
         return result;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/StringLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/StringLiteral.java
@@ -136,15 +136,12 @@ public class StringLiteral extends LiteralExpr {
 
     @Override
     protected void toThrift(TExprNode msg) {
-        msg.node_type = TExprNodeType.STRING_LITERAL;
-        msg.string_literal = new TStringLiteral(getUnescapedValue());
-    }
-
-    // FIXME: modify by zhaochun
-    public String getUnescapedValue() {
-        // Unescape string exactly like Hive does. Hive's method assumes
-        // quotes so we add them here to reuse Hive's code.
-        return value;
+        if (value == null) {
+            msg.node_type = TExprNodeType.NULL_LITERAL;
+        } else {
+            msg.string_literal = new TStringLiteral(value);
+            msg.node_type = TExprNodeType.STRING_LITERAL;
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/VariableExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/VariableExpr.java
@@ -178,8 +178,12 @@ public class VariableExpr extends Expr {
                 msg.float_literal = new TFloatLiteral(floatValue);
                 break;
             default:
-                msg.node_type = TExprNodeType.STRING_LITERAL;
-                msg.string_literal = new TStringLiteral(strValue);
+                if (strValue == null) {
+                    msg.node_type = TExprNodeType.NULL_LITERAL;
+                } else {
+                    msg.node_type = TExprNodeType.STRING_LITERAL;
+                    msg.string_literal = new TStringLiteral(strValue);
+                }
         }
     }
 

--- a/regression-test/data/nereids_function_p0/agg_function/agg.out
+++ b/regression-test/data/nereids_function_p0/agg_function/agg.out
@@ -6077,3 +6077,5 @@ true
 -- !sql_window_funnel_BigInt_String_DateTimeV2_Boolean_agg_phase_4_notnull --
 12	1
 
+-- !max_null --
+\N

--- a/regression-test/suites/nereids_function_p0/agg_function/agg.groovy
+++ b/regression-test/suites/nereids_function_p0/agg_function/agg.groovy
@@ -2735,4 +2735,6 @@ suite("nereids_agg_fn") {
 	qt_sql_window_funnel_BigInt_String_DateTimeV2_Boolean_agg_phase_4_notnull '''
 		select /*+SET_VAR(disable_nereids_rules='THREE_PHASE_AGGREGATE_WITH_DISTINCT, TWO_PHASE_AGGREGATE_WITH_DISTINCT')*/ count(distinct id), window_funnel(3600 * 3, 'default', kdtmv2s1, kint = 1, kint = 2) from fn_test'''
 
+	qt_max_null "select max(null) from fn_test;"
+
 }


### PR DESCRIPTION
## Proposed changes

fix pre condition check fail on max(null)

```sql
enable_nereids_planner=true;

mysql [regression_test_datatype_p0_agg_state]>select max(null) from d_table;
ERROR 1105 (HY000): IllegalStateException, msg: null
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

