### PR TITLE
[fix](nereids)avoid to derive rowCount NaN

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
@@ -47,6 +47,9 @@ public class Statistics {
      * @return the new ndv after filter
      */
     public static double computeNdv(double ndv, double newRowCount, double oldRowCount) {
+        if (newRowCount > oldRowCount) {
+            return ndv;
+        }
         double selectOneTuple = newRowCount / StatsMathUtil.nonZeroDivisor(oldRowCount);
         double allTuplesOfSameDistinctValueNotSelected = Math.pow((1 - selectOneTuple), oldRowCount / ndv);
         return Math.min(ndv * (1 - allTuplesOfSameDistinctValueNotSelected), newRowCount);

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query72.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query72.out
@@ -7,53 +7,54 @@ PhysicalTopN
 --------PhysicalDistribute
 ----------hashAgg[LOCAL]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN](warehouse.w_warehouse_sk = inventory.inv_warehouse_sk)
+--------------hashJoin[LEFT_OUTER_JOIN](catalog_sales.cs_promo_sk = promotion.p_promo_sk)
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN](catalog_sales.cs_item_sk = inventory.inv_item_sk)(inventory.inv_date_sk = d2.d_date_sk)(inventory.inv_quantity_on_hand < catalog_sales.cs_quantity)
---------------------PhysicalOlapScan[inventory]
---------------------PhysicalDistribute
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN](item.i_item_sk = catalog_sales.cs_item_sk)
+------------------hashJoin[INNER_JOIN](warehouse.w_warehouse_sk = inventory.inv_warehouse_sk)
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN](item.i_item_sk = catalog_sales.cs_item_sk)
+------------------------PhysicalProject
+--------------------------PhysicalOlapScan[item]
+------------------------PhysicalDistribute
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[item]
---------------------------PhysicalDistribute
-----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN](d1.d_week_seq = d2.d_week_seq)
+----------------------------hashJoin[RIGHT_OUTER_JOIN](catalog_returns.cr_item_sk = catalog_sales.cs_item_sk)(catalog_returns.cr_order_number = catalog_sales.cs_order_number)
+------------------------------PhysicalProject
+--------------------------------PhysicalOlapScan[catalog_returns]
+------------------------------PhysicalDistribute
 --------------------------------PhysicalProject
-----------------------------------hashJoin[LEFT_OUTER_JOIN](catalog_sales.cs_promo_sk = promotion.p_promo_sk)
+----------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_ship_date_sk = d3.d_date_sk)(d3.d_date > cast((cast(d_date as BIGINT) + 5) as DATEV2))
 ------------------------------------PhysicalProject
---------------------------------------hashJoin[RIGHT_OUTER_JOIN](catalog_returns.cr_item_sk = catalog_sales.cs_item_sk)(catalog_returns.cr_order_number = catalog_sales.cs_order_number)
+--------------------------------------hashJoin[INNER_JOIN](inventory.inv_date_sk = d2.d_date_sk)(d1.d_week_seq = d2.d_week_seq)
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[catalog_returns]
-----------------------------------------PhysicalProject
-------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_bill_cdemo_sk = customer_demographics.cd_demo_sk)
---------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_ship_date_sk = d3.d_date_sk)(d3.d_date > cast((cast(d_date as BIGINT) + 5) as DATEV2))
-----------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_sold_date_sk = d1.d_date_sk)
-------------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_bill_hdemo_sk = household_demographics.hd_demo_sk)
---------------------------------------------------PhysicalProject
-----------------------------------------------------PhysicalOlapScan[catalog_sales]
+------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_item_sk = inventory.inv_item_sk)(inventory.inv_quantity_on_hand < catalog_sales.cs_quantity)
+--------------------------------------------PhysicalOlapScan[inventory]
+--------------------------------------------PhysicalDistribute
+----------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_bill_cdemo_sk = customer_demographics.cd_demo_sk)
+------------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_sold_date_sk = d1.d_date_sk)
+--------------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_bill_hdemo_sk = household_demographics.hd_demo_sk)
+----------------------------------------------------PhysicalProject
+------------------------------------------------------PhysicalOlapScan[catalog_sales]
+----------------------------------------------------PhysicalDistribute
+------------------------------------------------------PhysicalProject
+--------------------------------------------------------filter((cast(hd_buy_potential as VARCHAR(*)) = '501-1000'))
+----------------------------------------------------------PhysicalOlapScan[household_demographics]
 --------------------------------------------------PhysicalDistribute
 ----------------------------------------------------PhysicalProject
-------------------------------------------------------filter((cast(hd_buy_potential as VARCHAR(*)) = '501-1000'))
---------------------------------------------------------PhysicalOlapScan[household_demographics]
+------------------------------------------------------filter((d1.d_year = 2002))
+--------------------------------------------------------PhysicalOlapScan[date_dim]
 ------------------------------------------------PhysicalDistribute
 --------------------------------------------------PhysicalProject
-----------------------------------------------------filter((d1.d_year = 2002))
-------------------------------------------------------PhysicalOlapScan[date_dim]
-----------------------------------------------PhysicalDistribute
-------------------------------------------------PhysicalProject
---------------------------------------------------PhysicalOlapScan[date_dim]
---------------------------------------------PhysicalDistribute
-----------------------------------------------PhysicalProject
-------------------------------------------------filter((cast(cd_marital_status as VARCHAR(*)) = 'W'))
---------------------------------------------------PhysicalOlapScan[customer_demographics]
+----------------------------------------------------filter((cast(cd_marital_status as VARCHAR(*)) = 'W'))
+------------------------------------------------------PhysicalOlapScan[customer_demographics]
+----------------------------------------PhysicalDistribute
+------------------------------------------PhysicalProject
+--------------------------------------------PhysicalOlapScan[date_dim]
 ------------------------------------PhysicalDistribute
 --------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[promotion]
---------------------------------PhysicalDistribute
-----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[date_dim]
+----------------------------------------PhysicalOlapScan[date_dim]
+--------------------PhysicalDistribute
+----------------------PhysicalProject
+------------------------PhysicalOlapScan[warehouse]
 ----------------PhysicalDistribute
 ------------------PhysicalProject
---------------------PhysicalOlapScan[warehouse]
+--------------------PhysicalOlapScan[promotion]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query75.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query75.out
@@ -2,76 +2,73 @@
 -- !ds_shape_75 --
 CteAnchor[cteId= ( CTEId#3=] )
 --CteProducer[cteId= ( CTEId#3=] )
-----hashAgg[GLOBAL]
-------PhysicalDistribute
---------hashAgg[LOCAL]
-----------hashAgg[GLOBAL]
-------------PhysicalDistribute
---------------hashAgg[LOCAL]
-----------------PhysicalUnion
-------------------hashAgg[GLOBAL]
---------------------PhysicalDistribute
-----------------------hashAgg[LOCAL]
-------------------------PhysicalUnion
+----hashAgg[LOCAL]
+------hashAgg[GLOBAL]
+--------PhysicalDistribute
+----------hashAgg[LOCAL]
+------------PhysicalUnion
+--------------hashAgg[GLOBAL]
+----------------PhysicalDistribute
+------------------hashAgg[LOCAL]
+--------------------PhysicalUnion
+----------------------PhysicalProject
+------------------------hashJoin[RIGHT_OUTER_JOIN](catalog_sales.cs_item_sk = catalog_returns.cr_item_sk)(catalog_sales.cs_order_number = catalog_returns.cr_order_number)
 --------------------------PhysicalProject
-----------------------------hashJoin[RIGHT_OUTER_JOIN](catalog_sales.cs_item_sk = catalog_returns.cr_item_sk)(catalog_sales.cs_order_number = catalog_returns.cr_order_number)
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[catalog_returns]
-------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN](date_dim.d_date_sk = catalog_sales.cs_sold_date_sk)
-----------------------------------hashJoin[INNER_JOIN](item.i_item_sk = catalog_sales.cs_item_sk)
-------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[catalog_sales]
-------------------------------------PhysicalDistribute
---------------------------------------PhysicalProject
-----------------------------------------filter((cast(i_category as VARCHAR(*)) = 'Home'))
-------------------------------------------PhysicalOlapScan[item]
-----------------------------------PhysicalDistribute
-------------------------------------PhysicalProject
---------------------------------------filter(((date_dim.d_year = 1998) OR (date_dim.d_year = 1999)))
-----------------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalOlapScan[catalog_returns]
 --------------------------PhysicalProject
-----------------------------hashJoin[RIGHT_OUTER_JOIN](store_sales.ss_item_sk = store_returns.sr_item_sk)(store_sales.ss_ticket_number = store_returns.sr_ticket_number)
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[store_returns]
-------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN](date_dim.d_date_sk = store_sales.ss_sold_date_sk)
-----------------------------------hashJoin[INNER_JOIN](item.i_item_sk = store_sales.ss_item_sk)
-------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[store_sales]
-------------------------------------PhysicalDistribute
---------------------------------------PhysicalProject
-----------------------------------------filter((cast(i_category as VARCHAR(*)) = 'Home'))
-------------------------------------------PhysicalOlapScan[item]
-----------------------------------PhysicalDistribute
-------------------------------------PhysicalProject
---------------------------------------filter(((date_dim.d_year = 1998) OR (date_dim.d_year = 1999)))
-----------------------------------------PhysicalOlapScan[date_dim]
+----------------------------hashJoin[INNER_JOIN](date_dim.d_date_sk = catalog_sales.cs_sold_date_sk)
+------------------------------hashJoin[INNER_JOIN](item.i_item_sk = catalog_sales.cs_item_sk)
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[catalog_sales]
+--------------------------------PhysicalDistribute
+----------------------------------PhysicalProject
+------------------------------------filter((cast(i_category as VARCHAR(*)) = 'Home'))
+--------------------------------------PhysicalOlapScan[item]
+------------------------------PhysicalDistribute
+--------------------------------PhysicalProject
+----------------------------------filter(((date_dim.d_year = 1998) OR (date_dim.d_year = 1999)))
+------------------------------------PhysicalOlapScan[date_dim]
+----------------------PhysicalProject
+------------------------hashJoin[RIGHT_OUTER_JOIN](store_sales.ss_item_sk = store_returns.sr_item_sk)(store_sales.ss_ticket_number = store_returns.sr_ticket_number)
+--------------------------PhysicalProject
+----------------------------PhysicalOlapScan[store_returns]
+--------------------------PhysicalProject
+----------------------------hashJoin[INNER_JOIN](date_dim.d_date_sk = store_sales.ss_sold_date_sk)
+------------------------------hashJoin[INNER_JOIN](item.i_item_sk = store_sales.ss_item_sk)
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[store_sales]
+--------------------------------PhysicalDistribute
+----------------------------------PhysicalProject
+------------------------------------filter((cast(i_category as VARCHAR(*)) = 'Home'))
+--------------------------------------PhysicalOlapScan[item]
+------------------------------PhysicalDistribute
+--------------------------------PhysicalProject
+----------------------------------filter(((date_dim.d_year = 1998) OR (date_dim.d_year = 1999)))
+------------------------------------PhysicalOlapScan[date_dim]
+--------------PhysicalProject
+----------------hashJoin[RIGHT_OUTER_JOIN](web_sales.ws_item_sk = web_returns.wr_item_sk)(web_sales.ws_order_number = web_returns.wr_order_number)
 ------------------PhysicalProject
---------------------hashJoin[RIGHT_OUTER_JOIN](web_sales.ws_item_sk = web_returns.wr_item_sk)(web_sales.ws_order_number = web_returns.wr_order_number)
-----------------------PhysicalProject
-------------------------PhysicalOlapScan[web_returns]
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN](date_dim.d_date_sk = web_sales.ws_sold_date_sk)
---------------------------hashJoin[INNER_JOIN](item.i_item_sk = web_sales.ws_item_sk)
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[web_sales]
-----------------------------PhysicalDistribute
-------------------------------PhysicalProject
---------------------------------filter((cast(i_category as VARCHAR(*)) = 'Home'))
-----------------------------------PhysicalOlapScan[item]
---------------------------PhysicalDistribute
-----------------------------PhysicalProject
-------------------------------filter(((date_dim.d_year = 1998) OR (date_dim.d_year = 1999)))
---------------------------------PhysicalOlapScan[date_dim]
+--------------------PhysicalOlapScan[web_returns]
+------------------PhysicalProject
+--------------------hashJoin[INNER_JOIN](date_dim.d_date_sk = web_sales.ws_sold_date_sk)
+----------------------hashJoin[INNER_JOIN](item.i_item_sk = web_sales.ws_item_sk)
+------------------------PhysicalProject
+--------------------------PhysicalOlapScan[web_sales]
+------------------------PhysicalDistribute
+--------------------------PhysicalProject
+----------------------------filter((cast(i_category as VARCHAR(*)) = 'Home'))
+------------------------------PhysicalOlapScan[item]
+----------------------PhysicalDistribute
+------------------------PhysicalProject
+--------------------------filter(((date_dim.d_year = 1998) OR (date_dim.d_year = 1999)))
+----------------------------PhysicalOlapScan[date_dim]
 --PhysicalTopN
 ----PhysicalDistribute
 ------PhysicalTopN
 --------PhysicalProject
 ----------hashJoin[INNER_JOIN](curr_yr.i_brand_id = prev_yr.i_brand_id)(curr_yr.i_class_id = prev_yr.i_class_id)(curr_yr.i_category_id = prev_yr.i_category_id)(curr_yr.i_manufact_id = prev_yr.i_manufact_id)((cast(cast(sales_cnt as DECIMALV3(17, 2)) as DECIMALV3(23, 8)) / cast(sales_cnt as DECIMALV3(17, 2))) < 0.900000)
-------------PhysicalDistribute
---------------filter((curr_yr.d_year = 1999))
-----------------CteConsumer[cteId= ( CTEId#3=] )
+------------filter((curr_yr.d_year = 1999))
+--------------CteConsumer[cteId= ( CTEId#3=] )
 ------------PhysicalDistribute
 --------------filter((prev_yr.d_year = 1998))
 ----------------CteConsumer[cteId= ( CTEId#3=] )

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query80.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query80.out
@@ -14,89 +14,92 @@ PhysicalTopN
 ----------------------PhysicalDistribute
 ------------------------hashAgg[LOCAL]
 --------------------------PhysicalProject
-----------------------------hashJoin[RIGHT_OUTER_JOIN](store_sales.ss_item_sk = store_returns.sr_item_sk)(store_sales.ss_ticket_number = store_returns.sr_ticket_number)
+----------------------------hashJoin[INNER_JOIN](store_sales.ss_store_sk = store.s_store_sk)
 ------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[store_returns]
-------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN](store_sales.ss_store_sk = store.s_store_sk)
-----------------------------------hashJoin[INNER_JOIN](store_sales.ss_promo_sk = promotion.p_promo_sk)
-------------------------------------hashJoin[INNER_JOIN](store_sales.ss_item_sk = item.i_item_sk)
---------------------------------------hashJoin[INNER_JOIN](store_sales.ss_sold_date_sk = date_dim.d_date_sk)
-----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[store_sales]
+--------------------------------hashJoin[RIGHT_OUTER_JOIN](store_sales.ss_item_sk = store_returns.sr_item_sk)(store_sales.ss_ticket_number = store_returns.sr_ticket_number)
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[store_returns]
+----------------------------------PhysicalProject
+------------------------------------hashJoin[INNER_JOIN](store_sales.ss_promo_sk = promotion.p_promo_sk)
+--------------------------------------hashJoin[INNER_JOIN](store_sales.ss_item_sk = item.i_item_sk)
+----------------------------------------hashJoin[INNER_JOIN](store_sales.ss_sold_date_sk = date_dim.d_date_sk)
+------------------------------------------PhysicalProject
+--------------------------------------------PhysicalOlapScan[store_sales]
+------------------------------------------PhysicalDistribute
+--------------------------------------------PhysicalProject
+----------------------------------------------filter((date_dim.d_date >= 1998-08-28)(date_dim.d_date <= 1998-09-27))
+------------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------------PhysicalDistribute
 ------------------------------------------PhysicalProject
---------------------------------------------filter((date_dim.d_date >= 1998-08-28)(date_dim.d_date <= 1998-09-27))
-----------------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------------------filter((item.i_current_price > 50.00))
+----------------------------------------------PhysicalOlapScan[item]
 --------------------------------------PhysicalDistribute
 ----------------------------------------PhysicalProject
-------------------------------------------filter((item.i_current_price > 50.00))
---------------------------------------------PhysicalOlapScan[item]
-------------------------------------PhysicalDistribute
---------------------------------------PhysicalProject
-----------------------------------------filter((cast(p_channel_tv as VARCHAR(*)) = 'N'))
-------------------------------------------PhysicalOlapScan[promotion]
-----------------------------------PhysicalDistribute
-------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[store]
+------------------------------------------filter((cast(p_channel_tv as VARCHAR(*)) = 'N'))
+--------------------------------------------PhysicalOlapScan[promotion]
+------------------------------PhysicalDistribute
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[store]
 ------------------PhysicalProject
 --------------------hashAgg[GLOBAL]
 ----------------------PhysicalDistribute
 ------------------------hashAgg[LOCAL]
 --------------------------PhysicalProject
-----------------------------hashJoin[RIGHT_OUTER_JOIN](catalog_sales.cs_item_sk = catalog_returns.cr_item_sk)(catalog_sales.cs_order_number = catalog_returns.cr_order_number)
+----------------------------hashJoin[INNER_JOIN](catalog_sales.cs_catalog_page_sk = catalog_page.cp_catalog_page_sk)
 ------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[catalog_returns]
-------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_catalog_page_sk = catalog_page.cp_catalog_page_sk)
-----------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_promo_sk = promotion.p_promo_sk)
-------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_item_sk = item.i_item_sk)
---------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)
-----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[catalog_sales]
+--------------------------------hashJoin[RIGHT_OUTER_JOIN](catalog_sales.cs_item_sk = catalog_returns.cr_item_sk)(catalog_sales.cs_order_number = catalog_returns.cr_order_number)
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[catalog_returns]
+----------------------------------PhysicalProject
+------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_promo_sk = promotion.p_promo_sk)
+--------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_item_sk = item.i_item_sk)
+----------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)
+------------------------------------------PhysicalProject
+--------------------------------------------PhysicalOlapScan[catalog_sales]
+------------------------------------------PhysicalDistribute
+--------------------------------------------PhysicalProject
+----------------------------------------------filter((date_dim.d_date >= 1998-08-28)(date_dim.d_date <= 1998-09-27))
+------------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------------PhysicalDistribute
 ------------------------------------------PhysicalProject
---------------------------------------------filter((date_dim.d_date >= 1998-08-28)(date_dim.d_date <= 1998-09-27))
-----------------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------------------filter((item.i_current_price > 50.00))
+----------------------------------------------PhysicalOlapScan[item]
 --------------------------------------PhysicalDistribute
 ----------------------------------------PhysicalProject
-------------------------------------------filter((item.i_current_price > 50.00))
---------------------------------------------PhysicalOlapScan[item]
-------------------------------------PhysicalDistribute
---------------------------------------PhysicalProject
-----------------------------------------filter((cast(p_channel_tv as VARCHAR(*)) = 'N'))
-------------------------------------------PhysicalOlapScan[promotion]
-----------------------------------PhysicalDistribute
-------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[catalog_page]
+------------------------------------------filter((cast(p_channel_tv as VARCHAR(*)) = 'N'))
+--------------------------------------------PhysicalOlapScan[promotion]
+------------------------------PhysicalDistribute
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[catalog_page]
 ------------------PhysicalProject
 --------------------hashAgg[GLOBAL]
 ----------------------PhysicalDistribute
 ------------------------hashAgg[LOCAL]
 --------------------------PhysicalProject
-----------------------------hashJoin[RIGHT_OUTER_JOIN](web_sales.ws_item_sk = web_returns.wr_item_sk)(web_sales.ws_order_number = web_returns.wr_order_number)
+----------------------------hashJoin[INNER_JOIN](web_sales.ws_web_site_sk = web_site.web_site_sk)
 ------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[web_returns]
-------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN](web_sales.ws_web_site_sk = web_site.web_site_sk)
-----------------------------------hashJoin[INNER_JOIN](web_sales.ws_promo_sk = promotion.p_promo_sk)
-------------------------------------hashJoin[INNER_JOIN](web_sales.ws_item_sk = item.i_item_sk)
---------------------------------------hashJoin[INNER_JOIN](web_sales.ws_sold_date_sk = date_dim.d_date_sk)
-----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[web_sales]
+--------------------------------hashJoin[RIGHT_OUTER_JOIN](web_sales.ws_item_sk = web_returns.wr_item_sk)(web_sales.ws_order_number = web_returns.wr_order_number)
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[web_returns]
+----------------------------------PhysicalProject
+------------------------------------hashJoin[INNER_JOIN](web_sales.ws_promo_sk = promotion.p_promo_sk)
+--------------------------------------hashJoin[INNER_JOIN](web_sales.ws_item_sk = item.i_item_sk)
+----------------------------------------hashJoin[INNER_JOIN](web_sales.ws_sold_date_sk = date_dim.d_date_sk)
+------------------------------------------PhysicalProject
+--------------------------------------------PhysicalOlapScan[web_sales]
+------------------------------------------PhysicalDistribute
+--------------------------------------------PhysicalProject
+----------------------------------------------filter((date_dim.d_date >= 1998-08-28)(date_dim.d_date <= 1998-09-27))
+------------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------------PhysicalDistribute
 ------------------------------------------PhysicalProject
---------------------------------------------filter((date_dim.d_date >= 1998-08-28)(date_dim.d_date <= 1998-09-27))
-----------------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------------------filter((item.i_current_price > 50.00))
+----------------------------------------------PhysicalOlapScan[item]
 --------------------------------------PhysicalDistribute
 ----------------------------------------PhysicalProject
-------------------------------------------filter((item.i_current_price > 50.00))
---------------------------------------------PhysicalOlapScan[item]
-------------------------------------PhysicalDistribute
---------------------------------------PhysicalProject
-----------------------------------------filter((cast(p_channel_tv as VARCHAR(*)) = 'N'))
-------------------------------------------PhysicalOlapScan[promotion]
-----------------------------------PhysicalDistribute
-------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[web_site]
+------------------------------------------filter((cast(p_channel_tv as VARCHAR(*)) = 'N'))
+--------------------------------------------PhysicalOlapScan[promotion]
+------------------------------PhysicalDistribute
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[web_site]
 


### PR DESCRIPTION
## Proposed changes
the formula used to compute ndv after filter implies that the new rowCount is smaller than the original rowCount. When we apply this formula to join, we should add branch if new row count is bigger than original row count.
when new row count is bigger, the ndv is not changed.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

