### PR TITLE
[fix](executor)Fix emptyoperator may cause node not close

### DIFF
--- a/be/src/pipeline/exec/empty_source_operator.cpp
+++ b/be/src/pipeline/exec/empty_source_operator.cpp
@@ -21,7 +21,7 @@
 
 namespace doris::pipeline {
 OperatorPtr EmptySourceOperatorBuilder::build_operator() {
-    return std::make_shared<EmptySourceOperator>(this);
+    return std::make_shared<EmptySourceOperator>(this, _exec_node);
 }
 
 } // namespace doris::pipeline

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -596,7 +596,7 @@ Status PipelineFragmentContext::_build_pipelines(ExecNode* node, PipelinePtr cur
             RETURN_IF_ERROR(_build_pipelines(node->child(1), new_pipe));
         } else {
             OperatorBuilderPtr builder = std::make_shared<EmptySourceOperatorBuilder>(
-                    next_operator_builder_id(), node->child(1)->row_desc());
+                    next_operator_builder_id(), node->child(1)->row_desc(), node->child(1));
             new_pipe->add_operator(builder);
         }
         OperatorBuilderPtr join_sink =


### PR DESCRIPTION
## Proposed changes
When PipelineTask generate an EmptyOperator, it doesn't transfer ExecNode to EmptyOperator, this may cause ExecNode's resource may not released correctly.
So we need to close the node which is replaced of EmptyOperator.