### PR TITLE
[vectorized](function) suppoort date_trunc function truncate week mod…

### DIFF
--- a/be/src/vec/functions/function_timestamp.cpp
+++ b/be/src/vec/functions/function_timestamp.cpp
@@ -298,6 +298,8 @@ struct DateTrunc {
                 null_map[i] = !dt.template datetime_trunc<MINUTE>();
             } else if (std::strncmp("second", str_data, 6) == 0) {
                 null_map[i] = !dt.template datetime_trunc<SECOND>();
+            } else if (std::strncmp("week", str_data, 4) == 0) {
+                null_map[i] = !dt.template datetime_trunc<WEEK>();
             } else {
                 null_map[i] = 1;
             }

--- a/be/src/vec/runtime/vdatetime_value.cpp
+++ b/be/src/vec/runtime/vdatetime_value.cpp
@@ -1691,6 +1691,14 @@ bool VecDateTimeValue::datetime_trunc() {
         _hour = 0;
         break;
     }
+    case WEEK: {
+        _second = 0;
+        _minute = 0;
+        _hour = 0;
+        TimeInterval interval(DAY, weekday(), true);
+        date_add_interval<DAY>(interval);
+        break;
+    }
     case MONTH: {
         _second = 0;
         _minute = 0;
@@ -2702,6 +2710,15 @@ bool DateV2Value<T>::datetime_trunc() {
             date_v2_value_.second_ = 0;
             date_v2_value_.minute_ = 0;
             date_v2_value_.hour_ = 0;
+            break;
+        }
+        case WEEK: {
+            date_v2_value_.microsecond_ = 0;
+            date_v2_value_.second_ = 0;
+            date_v2_value_.minute_ = 0;
+            date_v2_value_.hour_ = 0;
+            TimeInterval interval(DAY, weekday(), true);
+            date_add_interval<DAY>(interval);
             break;
         }
         case MONTH: {


### PR DESCRIPTION
…e (#18334)

support date_trunc could truncate week eg:
select date_trunc('2023-4-3 19:28:30', 'week');

(cherry picked from commit 50e6c4216a26ec6a667060bf1bae6fc6dee217df)

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

