### PR TITLE
[Bug](Load) fix lazy open null point

### DIFF
--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -143,11 +143,15 @@ Status LoadChannelMgr::open(const PTabletWriterOpenRequest& params) {
 Status LoadChannelMgr::open_partition(const OpenPartitionRequest& params) {
     UniqueId load_id(params.id());
     std::shared_ptr<LoadChannel> channel;
-    auto it = _load_channels.find(load_id);
-    if (it != _load_channels.end()) {
-        channel = it->second;
-    } else {
-        return Status::InternalError("unknown load id, load id=" + load_id.to_string());
+    {
+        std::lock_guard<std::mutex> l(_lock);
+        auto it = _load_channels.find(load_id);
+        if (it != _load_channels.end()) {
+            channel = it->second;
+        } else {
+            DCHECK(false);
+            return Status::InternalError("unknown load id, load id=" + load_id.to_string());
+        }
     }
     RETURN_IF_ERROR(channel->open_partition(params));
     return Status::OK();


### PR DESCRIPTION
## Problem
When lazy open operation occur in load channel, a cancel operation will happen, which causes null point question.

## The pull Request Work  
- Add lock to avoid this problem.
- Add DCHECK to make dug easier when load id not found.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

