### PR TITLE
[improvement](exception-safe) create and prepare node/sink support exception safe

### DIFF
--- a/be/src/exec/data_sink.cpp
+++ b/be/src/exec/data_sink.cpp
@@ -50,8 +50,6 @@ Status DataSink::create_data_sink(ObjectPool* pool, const TDataSink& thrift_sink
                                   const TPlanFragmentExecParams& params,
                                   const RowDescriptor& row_desc, RuntimeState* state,
                                   std::unique_ptr<DataSink>* sink, DescriptorTbl& desc_tbl) {
-    DataSink* tmp_sink = nullptr;
-
     switch (thrift_sink.type) {
     case TDataSinkType::DATA_STREAM_SINK: {
         if (!thrift_sink.__isset.stream_sink) {
@@ -62,11 +60,10 @@ Status DataSink::create_data_sink(ObjectPool* pool, const TDataSink& thrift_sink
                         ? params.send_query_statistics_with_every_batch
                         : false;
         // TODO: figure out good buffer size based on size of output row
-        tmp_sink = new vectorized::VDataStreamSender(
+        sink->reset(new vectorized::VDataStreamSender(
                 state, pool, params.sender_id, row_desc, thrift_sink.stream_sink,
-                params.destinations, 16 * 1024, send_query_statistics_with_every_batch);
+                params.destinations, 16 * 1024, send_query_statistics_with_every_batch));
         // RETURN_IF_ERROR(sender->prepare(state->obj_pool(), thrift_sink.stream_sink));
-        sink->reset(tmp_sink);
         break;
     }
     case TDataSinkType::RESULT_SINK: {
@@ -75,9 +72,8 @@ Status DataSink::create_data_sink(ObjectPool* pool, const TDataSink& thrift_sink
         }
 
         // TODO: figure out good buffer size based on size of output row
-        tmp_sink = new doris::vectorized::VResultSink(row_desc, output_exprs,
-                                                      thrift_sink.result_sink, 4096);
-        sink->reset(tmp_sink);
+        sink->reset(new doris::vectorized::VResultSink(row_desc, output_exprs,
+                                                       thrift_sink.result_sink, 4096));
         break;
     }
     case TDataSinkType::RESULT_FILE_SINK: {
@@ -92,17 +88,15 @@ Status DataSink::create_data_sink(ObjectPool* pool, const TDataSink& thrift_sink
                         : false;
         // Result file sink is not the top sink
         if (params.__isset.destinations && params.destinations.size() > 0) {
-            tmp_sink = new doris::vectorized::VResultFileSink(
+            sink->reset(new doris::vectorized::VResultFileSink(
                     pool, params.sender_id, row_desc, thrift_sink.result_file_sink,
                     params.destinations, 16 * 1024, send_query_statistics_with_every_batch,
-                    output_exprs, desc_tbl);
+                    output_exprs, desc_tbl));
         } else {
-            tmp_sink = new doris::vectorized::VResultFileSink(
+            sink->reset(new doris::vectorized::VResultFileSink(
                     pool, row_desc, thrift_sink.result_file_sink, 16 * 1024,
-                    send_query_statistics_with_every_batch, output_exprs);
+                    send_query_statistics_with_every_batch, output_exprs));
         }
-
-        sink->reset(tmp_sink);
         break;
     }
     case TDataSinkType::MEMORY_SCRATCH_SINK: {
@@ -110,8 +104,7 @@ Status DataSink::create_data_sink(ObjectPool* pool, const TDataSink& thrift_sink
             return Status::InternalError("Missing data buffer sink.");
         }
 
-        tmp_sink = new vectorized::MemoryScratchSink(row_desc, output_exprs);
-        sink->reset(tmp_sink);
+        sink->reset(new vectorized::MemoryScratchSink(row_desc, output_exprs));
         break;
     }
     case TDataSinkType::MYSQL_TABLE_SINK: {
@@ -193,7 +186,6 @@ Status DataSink::create_data_sink(ObjectPool* pool, const TDataSink& thrift_sink
                                   const size_t& local_param_idx, const RowDescriptor& row_desc,
                                   RuntimeState* state, std::unique_ptr<DataSink>* sink,
                                   DescriptorTbl& desc_tbl) {
-    DataSink* tmp_sink = nullptr;
     const auto& local_params = params.local_params[local_param_idx];
     switch (thrift_sink.type) {
     case TDataSinkType::DATA_STREAM_SINK: {
@@ -205,11 +197,10 @@ Status DataSink::create_data_sink(ObjectPool* pool, const TDataSink& thrift_sink
                         ? params.send_query_statistics_with_every_batch
                         : false;
         // TODO: figure out good buffer size based on size of output row
-        tmp_sink = new vectorized::VDataStreamSender(
+        sink->reset(new vectorized::VDataStreamSender(
                 state, pool, local_params.sender_id, row_desc, thrift_sink.stream_sink,
-                params.destinations, 16 * 1024, send_query_statistics_with_every_batch);
+                params.destinations, 16 * 1024, send_query_statistics_with_every_batch));
         // RETURN_IF_ERROR(sender->prepare(state->obj_pool(), thrift_sink.stream_sink));
-        sink->reset(tmp_sink);
         break;
     }
     case TDataSinkType::RESULT_SINK: {
@@ -218,9 +209,8 @@ Status DataSink::create_data_sink(ObjectPool* pool, const TDataSink& thrift_sink
         }
 
         // TODO: figure out good buffer size based on size of output row
-        tmp_sink = new doris::vectorized::VResultSink(row_desc, output_exprs,
-                                                      thrift_sink.result_sink, 4096);
-        sink->reset(tmp_sink);
+        sink->reset(new doris::vectorized::VResultSink(row_desc, output_exprs,
+                                                       thrift_sink.result_sink, 4096));
         break;
     }
     case TDataSinkType::RESULT_FILE_SINK: {
@@ -235,17 +225,15 @@ Status DataSink::create_data_sink(ObjectPool* pool, const TDataSink& thrift_sink
                         : false;
         // Result file sink is not the top sink
         if (params.__isset.destinations && params.destinations.size() > 0) {
-            tmp_sink = new doris::vectorized::VResultFileSink(
+            sink->reset(new doris::vectorized::VResultFileSink(
                     pool, local_params.sender_id, row_desc, thrift_sink.result_file_sink,
                     params.destinations, 16 * 1024, send_query_statistics_with_every_batch,
-                    output_exprs, desc_tbl);
+                    output_exprs, desc_tbl));
         } else {
-            tmp_sink = new doris::vectorized::VResultFileSink(
+            sink->reset(new doris::vectorized::VResultFileSink(
                     pool, row_desc, thrift_sink.result_file_sink, 16 * 1024,
-                    send_query_statistics_with_every_batch, output_exprs);
+                    send_query_statistics_with_every_batch, output_exprs));
         }
-
-        sink->reset(tmp_sink);
         break;
     }
     case TDataSinkType::MEMORY_SCRATCH_SINK: {
@@ -253,8 +241,7 @@ Status DataSink::create_data_sink(ObjectPool* pool, const TDataSink& thrift_sink
             return Status::InternalError("Missing data buffer sink.");
         }
 
-        tmp_sink = new vectorized::MemoryScratchSink(row_desc, output_exprs);
-        sink->reset(tmp_sink);
+        sink->reset(new vectorized::MemoryScratchSink(row_desc, output_exprs));
         break;
     }
     case TDataSinkType::MYSQL_TABLE_SINK: {

--- a/be/src/olap/rowset/segment_v2/page_io.cpp
+++ b/be/src/olap/rowset/segment_v2/page_io.cpp
@@ -51,7 +51,7 @@ Status PageIO::compress_page_body(BlockCompressionCodec* codec, double min_space
     size_t uncompressed_size = Slice::compute_total_size(body);
     if (codec != nullptr && !codec->exceed_max_compress_len(uncompressed_size)) {
         faststring buf;
-        RETURN_IF_CATCH_EXCEPTION(RETURN_IF_ERROR(codec->compress(body, uncompressed_size, &buf)));
+        RETURN_IF_ERROR_OR_CATCH_EXCEPTION(codec->compress(body, uncompressed_size, &buf));
         double space_saving = 1.0 - static_cast<double>(buf.size()) / uncompressed_size;
         // return compressed body only when it saves more than min_space_saving
         if (space_saving > 0 && space_saving >= min_space_saving) {

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -296,10 +296,10 @@ Status PipelineFragmentContext::prepare(const doris::TPipelineFragmentParams& re
     _runtime_state->set_num_per_fragment_instances(request.num_senders);
 
     if (request.fragment.__isset.output_sink) {
-        RETURN_IF_CATCH_EXCEPTION(RETURN_IF_ERROR(DataSink::create_data_sink(
+        RETURN_IF_ERROR_OR_CATCH_EXCEPTION(DataSink::create_data_sink(
                 _runtime_state->obj_pool(), request.fragment.output_sink,
                 request.fragment.output_exprs, request, idx, _root_plan->row_desc(),
-                _runtime_state.get(), &_sink, *desc_tbl)));
+                _runtime_state.get(), &_sink, *desc_tbl));
     }
 
     _root_pipeline = fragment_context->add_pipeline();

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -296,10 +296,10 @@ Status PipelineFragmentContext::prepare(const doris::TPipelineFragmentParams& re
     _runtime_state->set_num_per_fragment_instances(request.num_senders);
 
     if (request.fragment.__isset.output_sink) {
-        RETURN_IF_ERROR(DataSink::create_data_sink(
+        RETURN_IF_CATCH_EXCEPTION(RETURN_IF_ERROR(DataSink::create_data_sink(
                 _runtime_state->obj_pool(), request.fragment.output_sink,
                 request.fragment.output_exprs, request, idx, _root_plan->row_desc(),
-                _runtime_state.get(), &_sink, *desc_tbl));
+                _runtime_state.get(), &_sink, *desc_tbl)));
     }
 
     _root_pipeline = fragment_context->add_pipeline();

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -160,8 +160,8 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request,
 
     // set up plan
     DCHECK(request.__isset.fragment);
-    RETURN_IF_ERROR(ExecNode::create_tree(_runtime_state.get(), obj_pool(), request.fragment.plan,
-                                          *desc_tbl, &_plan));
+    RETURN_IF_CATCH_EXCEPTION(RETURN_IF_ERROR(ExecNode::create_tree(
+            _runtime_state.get(), obj_pool(), request.fragment.plan, *desc_tbl, &_plan)));
 
     // set #senders of exchange nodes before calling Prepare()
     std::vector<ExecNode*> exch_nodes;
@@ -173,6 +173,7 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request,
         static_cast<doris::vectorized::VExchangeNode*>(exch_node)->set_num_senders(num_senders);
     }
 
+    // TODO Is it exception safe?
     RETURN_IF_ERROR(_plan->prepare(_runtime_state.get()));
     // set scan ranges
     std::vector<ExecNode*> scan_nodes;
@@ -211,10 +212,10 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request,
 
     // set up sink, if required
     if (request.fragment.__isset.output_sink) {
-        RETURN_IF_ERROR(DataSink::create_data_sink(obj_pool(), request.fragment.output_sink,
-                                                   request.fragment.output_exprs, params,
-                                                   row_desc(), runtime_state(), &_sink, *desc_tbl));
-        RETURN_IF_ERROR(_sink->prepare(runtime_state()));
+        RETURN_IF_CATCH_EXCEPTION(RETURN_IF_ERROR(DataSink::create_data_sink(
+                obj_pool(), request.fragment.output_sink, request.fragment.output_exprs, params,
+                row_desc(), runtime_state(), &_sink, *desc_tbl)));
+        RETURN_IF_CATCH_EXCEPTION(RETURN_IF_ERROR(_sink->prepare(runtime_state())));
 
         RuntimeProfile* sink_profile = _sink->profile();
         if (sink_profile != nullptr) {

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -160,8 +160,8 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request,
 
     // set up plan
     DCHECK(request.__isset.fragment);
-    RETURN_IF_CATCH_EXCEPTION(RETURN_IF_ERROR(ExecNode::create_tree(
-            _runtime_state.get(), obj_pool(), request.fragment.plan, *desc_tbl, &_plan)));
+    RETURN_IF_ERROR_OR_CATCH_EXCEPTION(ExecNode::create_tree(
+            _runtime_state.get(), obj_pool(), request.fragment.plan, *desc_tbl, &_plan));
 
     // set #senders of exchange nodes before calling Prepare()
     std::vector<ExecNode*> exch_nodes;
@@ -212,10 +212,10 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request,
 
     // set up sink, if required
     if (request.fragment.__isset.output_sink) {
-        RETURN_IF_CATCH_EXCEPTION(RETURN_IF_ERROR(DataSink::create_data_sink(
+        RETURN_IF_ERROR_OR_CATCH_EXCEPTION(DataSink::create_data_sink(
                 obj_pool(), request.fragment.output_sink, request.fragment.output_exprs, params,
-                row_desc(), runtime_state(), &_sink, *desc_tbl)));
-        RETURN_IF_CATCH_EXCEPTION(RETURN_IF_ERROR(_sink->prepare(runtime_state())));
+                row_desc(), runtime_state(), &_sink, *desc_tbl));
+        RETURN_IF_ERROR_OR_CATCH_EXCEPTION(_sink->prepare(runtime_state()));
 
         RuntimeProfile* sink_profile = _sink->profile();
         if (sink_profile != nullptr) {

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -828,8 +828,8 @@ Status Block::serialize(int be_exec_version, PBlock* pblock,
         RETURN_IF_ERROR(get_block_compression_codec(compression_type, &codec));
 
         faststring buf_compressed;
-        RETURN_IF_CATCH_EXCEPTION(RETURN_IF_ERROR(codec->compress(
-                Slice(column_values.data(), content_uncompressed_size), &buf_compressed)));
+        RETURN_IF_ERROR_OR_CATCH_EXCEPTION(codec->compress(
+                Slice(column_values.data(), content_uncompressed_size), &buf_compressed));
         size_t compressed_size = buf_compressed.size();
         if (LIKELY(compressed_size < content_uncompressed_size)) {
             pblock->set_column_values(buf_compressed.data(), buf_compressed.size());

--- a/be/src/vec/data_types/data_type_decimal.cpp
+++ b/be/src/vec/data_types/data_type_decimal.cpp
@@ -164,13 +164,16 @@ bool DataTypeDecimal<T>::parse_from_string(const std::string& str, T* res) const
 DataTypePtr create_decimal(UInt64 precision_value, UInt64 scale_value, bool use_v2) {
     if (precision_value < min_decimal_precision() ||
         precision_value > max_decimal_precision<Decimal128>()) {
-        LOG(WARNING) << "Wrong precision " << precision_value;
-        return nullptr;
+        throw doris::Exception(doris::ErrorCode::NOT_IMPLEMENTED_ERROR,
+                               "Wrong precision {}, min: {}, max: {}", precision_value,
+                               min_decimal_precision(), max_decimal_precision<Decimal128>());
     }
 
     if (static_cast<UInt64>(scale_value) > precision_value) {
-        LOG(WARNING) << "Negative scales and scales larger than precision are not supported";
-        return nullptr;
+        throw doris::Exception(doris::ErrorCode::NOT_IMPLEMENTED_ERROR,
+                               "Negative scales and scales larger than precision are not "
+                               "supported, scale_value: {}, precision_value: {}",
+                               scale_value, precision_value);
     }
 
     if (use_v2) {

--- a/be/src/vec/data_types/data_type_time_v2.cpp
+++ b/be/src/vec/data_types/data_type_time_v2.cpp
@@ -202,8 +202,8 @@ void DataTypeDateTimeV2::cast_to_date_v2(const UInt64 from, UInt32& to) {
 
 DataTypePtr create_datetimev2(UInt64 scale_value) {
     if (scale_value > 6) {
-        LOG(WARNING) << "Wrong scale " << scale_value;
-        return nullptr;
+        throw doris::Exception(doris::ErrorCode::NOT_IMPLEMENTED_ERROR, "scale_value > 6 {}",
+                               scale_value);
     }
     return std::make_shared<DataTypeDateTimeV2>(scale_value);
 }

--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -1302,8 +1302,8 @@ Status OrcReader::filter(orc::ColumnVectorBatch& data, uint16_t* sel, uint16_t s
     for (auto& conjunct : _lazy_read_ctx.conjuncts) {
         filter_conjuncts.push_back(conjunct);
     }
-    RETURN_IF_CATCH_EXCEPTION(RETURN_IF_ERROR(VExprContext::execute_conjuncts(
-            filter_conjuncts, nullptr, block, _filter.get(), &can_filter_all)));
+    RETURN_IF_ERROR_OR_CATCH_EXCEPTION(VExprContext::execute_conjuncts(
+            filter_conjuncts, nullptr, block, _filter.get(), &can_filter_all));
 
     if (_lazy_read_ctx.resize_first_column) {
         block->get_by_position(0).column->assume_mutable()->clear();

--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
@@ -785,8 +785,8 @@ Status RowGroupReader::_rewrite_dict_predicates() {
             // The following process may be tricky and time-consuming, but we have no other way.
             temp_block.get_by_position(0).column->assume_mutable()->resize(dict_value_column_size);
         }
-        RETURN_IF_CATCH_EXCEPTION(RETURN_IF_ERROR(VExprContext::execute_conjuncts_and_filter_block(
-                ctxs, nullptr, &temp_block, columns_to_filter, column_to_keep)));
+        RETURN_IF_ERROR_OR_CATCH_EXCEPTION(VExprContext::execute_conjuncts_and_filter_block(
+                ctxs, nullptr, &temp_block, columns_to_filter, column_to_keep));
         if (dict_pos != 0) {
             // We have to clean the first column to insert right data.
             temp_block.get_by_position(0).column->assume_mutable()->clear();

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -307,21 +307,13 @@ Status VFileScanner::_init_src_block(Block* block) {
     for (auto& slot : _input_tuple_desc->slots()) {
         DataTypePtr data_type;
         auto it = _name_to_col_type.find(slot->col_name());
-        Status st;
         if (it == _name_to_col_type.end() || _is_dynamic_schema) {
             // not exist in file, using type from _input_tuple_desc
-            CATCH_EXCEPTION(data_type = DataTypeFactory::instance().create_data_type(
-                                    slot->type(), slot->is_nullable()),
-                            st);
+            RETURN_IF_CATCH_EXCEPTION(data_type = DataTypeFactory::instance().create_data_type(
+                                              slot->type(), slot->is_nullable()));
         } else {
-            CATCH_EXCEPTION(
-                    data_type = DataTypeFactory::instance().create_data_type(it->second, true), st);
-        }
-        if (!st) {
-            return Status::NotSupported("Not support data type {} for column {}, reason {}",
-                                        it == _name_to_col_type.end() ? slot->type().debug_string()
-                                                                      : it->second.debug_string(),
-                                        slot->col_name(), st.to_string());
+            RETURN_IF_CATCH_EXCEPTION(
+                    data_type = DataTypeFactory::instance().create_data_type(it->second, true));
         }
         MutableColumnPtr data_column = data_type->create_column();
         _src_block.insert(

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -307,18 +307,21 @@ Status VFileScanner::_init_src_block(Block* block) {
     for (auto& slot : _input_tuple_desc->slots()) {
         DataTypePtr data_type;
         auto it = _name_to_col_type.find(slot->col_name());
+        Status st;
         if (it == _name_to_col_type.end() || _is_dynamic_schema) {
             // not exist in file, using type from _input_tuple_desc
-            data_type =
-                    DataTypeFactory::instance().create_data_type(slot->type(), slot->is_nullable());
+            CATCH_EXCEPTION(data_type = DataTypeFactory::instance().create_data_type(
+                                    slot->type(), slot->is_nullable()),
+                            st);
         } else {
-            data_type = DataTypeFactory::instance().create_data_type(it->second, true);
+            CATCH_EXCEPTION(
+                    data_type = DataTypeFactory::instance().create_data_type(it->second, true), st);
         }
-        if (data_type == nullptr) {
-            return Status::NotSupported("Not support data type {} for column {}",
+        if (!st) {
+            return Status::NotSupported("Not support data type {} for column {}, reason {}",
                                         it == _name_to_col_type.end() ? slot->type().debug_string()
                                                                       : it->second.debug_string(),
-                                        slot->col_name());
+                                        slot->col_name(), st.to_string());
         }
         MutableColumnPtr data_column = data_type->create_column();
         _src_block.insert(

--- a/be/src/vec/exec/vsort_node.cpp
+++ b/be/src/vec/exec/vsort_node.cpp
@@ -179,7 +179,7 @@ Status VSortNode::open(RuntimeState* state) {
                                   ExecNode::get_next,
                           _children[0], std::placeholders::_1, std::placeholders::_2,
                           std::placeholders::_3)));
-        RETURN_IF_CATCH_EXCEPTION(RETURN_IF_ERROR(sink(state, upstream_block.get(), eos)));
+        RETURN_IF_ERROR_OR_CATCH_EXCEPTION(sink(state, upstream_block.get(), eos));
     } while (!eos);
 
     child(0)->close(state);
@@ -191,7 +191,7 @@ Status VSortNode::open(RuntimeState* state) {
 }
 
 Status VSortNode::pull(doris::RuntimeState* state, vectorized::Block* output_block, bool* eos) {
-    RETURN_IF_CATCH_EXCEPTION(RETURN_IF_ERROR(_sorter->get_next(state, output_block, eos)));
+    RETURN_IF_ERROR_OR_CATCH_EXCEPTION(_sorter->get_next(state, output_block, eos));
     reached_limit(output_block, eos);
     if (*eos) {
         _runtime_profile->add_info_string("Spilled", _sorter->is_spilled() ? "true" : "false");


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

motivation is to fix create_data_type exception safety
```
*** Query id: 54ff960ef5cb477c-b4c16aae769a03ce ***
*** Aborted at 1686127430 (unix time) try "date -d @1686127430" if you are using GNU date ***
*** Current BE git commitID: c910e9b78b ***
*** SIGSEGV address not mapped to object (@0x0) received by PID 1889933 (TID 1891124 OR 0x7fb77adc6700) from PID 0; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /doris/core/be/src/common/signal_handler.h:413
 1# 0x00007FB9E08D1400 in /lib64/libc.so.6
 2# doris::vectorized::IDataType::get_name[abi:cxx11]() const at /doris/core/be/src/vec/data_types/data_type.cpp:49
 3# doris::vectorized::VExpr::create_expr(doris::TExprNode const&, std::shared_ptr<doris::vectorized::VExpr>&) at /doris/core/be/src/vec/exprs/vexpr.cpp:143
 4# doris::vectorized::VExpr::create_tree_from_thrift(std::vector<doris::TExprNode, std::allocator<doris::TExprNode> > const&, int*, std::shared_ptr<doris::vectorized::VExpr>&, std::shared_ptr<doris::vectorized::VExprContext>&) at /doris/core/be/src/v
ec/exprs/vexpr.cpp:238
 5# doris::vectorized::VExpr::create_expr_tree(doris::TExpr const&, std::shared_ptr<doris::vectorized::VExprContext>&) at /doris/core/be/src/vec/exprs/vexpr.cpp:281
 6# doris::vectorized::VExpr::create_expr_trees(std::vector<doris::TExpr, std::allocator<doris::TExpr> > const&, std::vector<std::shared_ptr<doris::vectorized::VExprContext>, std::allocator<std::shared_ptr<doris::vectorized::VExprContext> > >&) at /do
ris/core/be/src/vec/exprs/vexpr.cpp:298
 7# doris::vectorized::VResultSink::prepare_exprs(doris::RuntimeState*) at /doris/core/be/src/vec/sink/vresult_sink.cpp:67
 8# doris::vectorized::VResultSink::prepare(doris::RuntimeState*) at /doris/core/be/src/vec/sink/vresult_sink.cpp:87
 9# doris::PlanFragmentExecutor::prepare(doris::TExecPlanFragmentParams const&, doris::QueryContext*) at /doris/core/be/src/runtime/plan_fragment_executor.cpp:217
10# doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&) at /doris/core/be/src/runtime/fragment_mgr.cpp:804
11# doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&) at /doris/core/be/src/runtime/fragment_mgr.cpp:585
12# doris::PInternalServiceImpl::_exec_plan_fragment(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, doris::PFragmentRequestVersion, bool) at /doris/core/be/src/service/internal_service.cpp:449
13# doris::PInternalServiceImpl::exec_plan_fragment(google::protobuf::RpcController*, doris::PExecPlanFragmentRequest const*, doris::PExecPlanFragmentResult*, google::protobuf::Closure*) at /doris/core/be/src/service/internal_service.cpp:285
14# brpc::policy::ProcessHttpRequest(brpc::InputMessageBase*) in /doris/core/output_run/be/lib/doris_be
15# brpc::ProcessInputMessage(void*) in /doris/core/output_run/be/lib/doris_be
ux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
15# doris::PriorityWorkStealingThreadPool::work_thread(int) at /doris/core/be/src/util/priority_work_stealing_thread_pool.hpp:137
16# execute_native_thread_routine at ../../../../../libstdc++-v3/src/c++11/thread.cc:84
17# start_thread in /lib64/libpthread.so.0
18# __GI___clone in /lib64/libc.so.6
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

