### PR TITLE
[bug](udaf) fix java-udaf can't exectue add function

### DIFF
--- a/be/src/vec/exprs/vectorized_agg_fn.cpp
+++ b/be/src/vec/exprs/vectorized_agg_fn.cpp
@@ -273,6 +273,7 @@ std::string AggFnEvaluator::debug_string(const std::vector<AggFnEvaluator*>& exp
 std::string AggFnEvaluator::debug_string() const {
     std::stringstream out;
     out << "AggFnEvaluator(";
+    out << _fn.signature;
     out << ")";
     return out.str();
 }


### PR DESCRIPTION
## Proposed changes
In some case of agg function, maybe running as streaming agg firstly, 
this will call the add function when serialize, so need implement add function also.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

