### PR TITLE
[fix](load tablet) Fix restart slowly due to  load deleted tablet error (#20552)

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -298,6 +298,7 @@ constexpr bool capture_stacktrace() {
         && code != ErrorCode::INVERTED_INDEX_EVALUATE_SKIPPED
         && code != ErrorCode::META_KEY_NOT_FOUND
         && code != ErrorCode::PUSH_VERSION_ALREADY_EXIST
+        && code != ErrorCode::TABLE_ALREADY_DELETED_ERROR
         && code != ErrorCode::TRANSACTION_NOT_EXIST
         && code != ErrorCode::TRANSACTION_ALREADY_VISIBLE
         && code != ErrorCode::TOO_MANY_TRANSACTIONS


### PR DESCRIPTION
## Proposed changes

Issue Number: close #20552

<!--Describe your changes.-->

Error TABLE_ALREADY_DELETED_ERROR do not print stack trace.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

