### PR TITLE
[Improvement](column) reduce cache miss for data copy

### DIFF
--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -98,6 +98,7 @@ protected:
     using Offsets64 = PaddedPODArray<Offset64>;
 
 public:
+    static constexpr int PREFETCH_STEP = 64;
     // 32bit offsets for string
     using Offset = UInt32;
     using Offsets = PaddedPODArray<Offset>;

--- a/be/src/vec/columns/column_decimal.h
+++ b/be/src/vec/columns/column_decimal.h
@@ -129,6 +129,9 @@ public:
         const T* src_data = reinterpret_cast<const T*>(src.get_raw_data().data);
 
         for (int i = 0; i < new_size; ++i) {
+            if (i + IColumn::PREFETCH_STEP < new_size) {
+                __builtin_prefetch(&src_data[indices_begin[i + IColumn::PREFETCH_STEP]], 0, 1);
+            }
             data[origin_size + i] = src_data[indices_begin[i]];
         }
     }

--- a/be/src/vec/columns/column_string.cpp
+++ b/be/src/vec/columns/column_string.cpp
@@ -113,8 +113,8 @@ void ColumnString::insert_indices_from(const IColumn& src, const int* indices_be
         if (*x == -1) {
             ColumnString::insert_default();
         } else {
-            if (x + 64 < indices_end) {
-                ColumnString::prefetch(src, *(x + 64));
+            if (x + IColumn::PREFETCH_STEP < indices_end) {
+                ColumnString::prefetch(src, *(x + IColumn::PREFETCH_STEP));
             }
             ColumnString::insert_from(src, *x);
         }

--- a/be/src/vec/columns/column_string.cpp
+++ b/be/src/vec/columns/column_string.cpp
@@ -113,6 +113,9 @@ void ColumnString::insert_indices_from(const IColumn& src, const int* indices_be
         if (*x == -1) {
             ColumnString::insert_default();
         } else {
+            if (x + 64 < indices_end) {
+                ColumnString::prefetch(src, *(x + 64));
+            }
             ColumnString::insert_from(src, *x);
         }
     }

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -149,6 +149,11 @@ public:
         offsets.push_back(new_size);
     }
 
+    void prefetch(const IColumn& src_, size_t n) {
+        const ColumnString& src = assert_cast<const ColumnString&>(src_);
+        __builtin_prefetch(&src.chars[src.offsets[n - 1]], 0, 1);
+    }
+
     void insert_from(const IColumn& src_, size_t n) override {
         const ColumnString& src = assert_cast<const ColumnString&>(src_);
         const size_t size_to_append =

--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -376,12 +376,18 @@ void ColumnVector<T>::insert_indices_from(const IColumn& src, const int* indices
     if constexpr (std::is_same_v<T, UInt8>) {
         // nullmap : indices_begin[i] == -1 means is null at the here, set true here
         for (int i = 0; i < new_size; ++i) {
+            if (i + IColumn::PREFETCH_STEP < new_size) {
+                __builtin_prefetch(&src_data[indices_begin[i + IColumn::PREFETCH_STEP]], 0, 1);
+            }
             data[origin_size + i] = (indices_begin[i] == -1) +
                                     (indices_begin[i] != -1) * src_data[indices_begin[i]];
         }
     } else {
         // real data : indices_begin[i] == -1 what at is meaningless
         for (int i = 0; i < new_size; ++i) {
+            if (i + IColumn::PREFETCH_STEP < new_size) {
+                __builtin_prefetch(&src_data[indices_begin[i + IColumn::PREFETCH_STEP]], 0, 1);
+            }
             data[origin_size + i] = src_data[indices_begin[i]];
         }
     }

--- a/be/src/vec/exec/join/vhash_join_node.cpp
+++ b/be/src/vec/exec/join/vhash_join_node.cpp
@@ -469,6 +469,8 @@ Status HashJoinNode::prepare(RuntimeState* state) {
     _build_rows_counter = ADD_COUNTER(record_profile, "BuildRows", TUnit::UNIT);
     _build_side_compute_hash_timer = ADD_TIMER(record_profile, "BuildSideHashComputingTime");
     _build_runtime_filter_timer = ADD_TIMER(record_profile, "BuildRuntimeFilterTime");
+    _push_down_timer = ADD_TIMER(record_profile, "PublishRuntimeFilterTime");
+    _push_compute_timer = ADD_TIMER(record_profile, "PushDownComputeTime");
 
     // Probe phase
     auto probe_phase_profile = runtime_profile()->create_child("ProbePhase", true, true);
@@ -484,8 +486,6 @@ Status HashJoinNode::prepare(RuntimeState* state) {
     _open_timer = ADD_TIMER(runtime_profile(), "OpenTime");
     _allocate_resource_timer = ADD_TIMER(runtime_profile(), "AllocateResourceTime");
 
-    _push_down_timer = ADD_TIMER(runtime_profile(), "PublishRuntimeFilterTime");
-    _push_compute_timer = ADD_TIMER(runtime_profile(), "PushDownComputeTime");
     _build_buckets_counter = ADD_COUNTER(runtime_profile(), "BuildBuckets", TUnit::UNIT);
     _build_buckets_fill_counter = ADD_COUNTER(runtime_profile(), "FilledBuckets", TUnit::UNIT);
 


### PR DESCRIPTION
## Proposed changes

query:
select  count(*) from (
    select /*+SET_VAR(disable_join_reorder=true)*/distinct c_last_name, c_first_name, d_date
    from store_sales
         join
         date_dim
         on store_sales.ss_sold_date_sk = date_dim.d_date_sk
         join[shuffle]
         customer
         on store_sales.ss_customer_sk = customer.c_customer_sk
         where d_month_seq between 1183 and 1183 + 11
  intersect
    select /*+SET_VAR(disable_join_reorder=true)*/distinct c_last_name, c_first_name, d_date
    from catalog_sales
         join
         date_dim on catalog_sales.cs_sold_date_sk = date_dim.d_date_sk
         join[shuffle]
         customer on catalog_sales.cs_bill_customer_sk = customer.c_customer_sk
         where d_month_seq between 1183 and 1183 + 11
  intersect
    select /*+SET_VAR(disable_join_reorder=true)*/distinct c_last_name, c_first_name, d_date
    from web_sales
         join
         date_dim on web_sales.ws_sold_date_sk = date_dim.d_date_sk
         join[shuffle]
         customer on web_sales.ws_bill_customer_sk = customer.c_customer_sk
         where d_month_seq between 1183 and 1183 + 11
) hot_cust
limit 100;

2.2s->1.9s

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

