### PR TITLE
[Fix](hive-catalog) Fallback to refresh catalog when hms events are missing

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
@@ -33,6 +33,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.CurrentNotificationEventId;
 import org.apache.hadoop.hive.metastore.api.NotificationEventResponse;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -229,8 +230,20 @@ public class HMSExternalCatalog extends ExternalCatalog {
             LOG.info("Event id not updated when pulling events on catalog [{}]", hmsExternalCatalog.getName());
             return null;
         }
-        return client.getNextNotification(lastSyncedEventId, Config.hms_events_batch_size_per_rpc, null);
-    }
+
+        try {
+            return client.getNextNotification(lastSyncedEventId, Config.hms_events_batch_size_per_rpc, null);
+        } catch (IllegalStateException e) {
+            // Need a fallback to handle this because this error state can not be recovered until restarting FE
+            if (HiveMetaStoreClient.REPL_EVENTS_MISSING_IN_METASTORE.equals(e.getMessage())) {
+                lastSyncedEventId = getCurrentEventId();
+                refreshCatalog(hmsExternalCatalog);
+                LOG.warn("Notification events are missing, maybe an event can not be handled "
+                        + "or processing rate is too low, fallback to refresh the catalog");
+                return null;
+            }
+            throw e;
+        }    }
 
     private void refreshCatalog(HMSExternalCatalog hmsExternalCatalog) {
         CatalogLog log = new CatalogLog();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
@@ -243,7 +243,8 @@ public class HMSExternalCatalog extends ExternalCatalog {
                 return null;
             }
             throw e;
-        }    }
+        }
+    }
 
     private void refreshCatalog(HMSExternalCatalog hmsExternalCatalog) {
         CatalogLog log = new CatalogLog();

--- a/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -319,7 +319,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
   static final protected Logger LOG = LoggerFactory.getLogger(HiveMetaStoreClient.class);
 
   //copied from ErrorMsg.java
-  private static final String REPL_EVENTS_MISSING_IN_METASTORE = "Notification events are missing in the meta store.";
+  public static final String REPL_EVENTS_MISSING_IN_METASTORE = "Notification events are missing in the meta store.";
 
   public HiveMetaStoreClient(Configuration conf) throws MetaException {
     this(conf, null, true);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

same with https://github.com/apache/doris/pull/20227

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

