### PR TITLE
[performance](executor) remove repeated call within the loop in validate_column

### DIFF
--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -1689,7 +1689,8 @@ Status VOlapTableSink::_validate_column(RuntimeState* state, const TypeDescripto
         auto column_decimal = const_cast<vectorized::ColumnDecimal<vectorized::Decimal128>*>(
                 assert_cast<const vectorized::ColumnDecimal<vectorized::Decimal128>*>(
                         real_column_ptr.get()));
-
+        const auto& max_decimalv2 = _get_decimalv2_min_or_max<false>(type);
+        const auto& min_decimalv2 = _get_decimalv2_min_or_max<true>(type);
         for (size_t j = 0; j < column->size(); ++j) {
             auto row = rows ? (*rows)[j] : j;
             if (row == last_invalid_row) {
@@ -1710,8 +1711,6 @@ Status VOlapTableSink::_validate_column(RuntimeState* state, const TypeDescripto
                         invalid = true;
                     }
                 }
-                const auto& max_decimalv2 = _get_decimalv2_min_or_max<false>(type);
-                const auto& min_decimalv2 = _get_decimalv2_min_or_max<true>(type);
                 if (dec_val > max_decimalv2 || dec_val < min_decimalv2) {
                     fmt::format_to(error_msg, "{}", "decimal value is not valid for definition");
                     fmt::format_to(error_msg, ", value={}", dec_val.to_string());
@@ -1735,6 +1734,8 @@ Status VOlapTableSink::_validate_column(RuntimeState* state, const TypeDescripto
     auto column_decimal = const_cast<vectorized::ColumnDecimal<vectorized::ColumnDecimalType>*>(   \
             assert_cast<const vectorized::ColumnDecimal<vectorized::ColumnDecimalType>*>(          \
                     real_column_ptr.get()));                                                       \
+    const auto& max_decimal = _get_decimalv3_min_or_max<vectorized::DecimalType, false>(type);     \
+    const auto& min_decimal = _get_decimalv3_min_or_max<vectorized::DecimalType, true>(type);      \
     for (size_t j = 0; j < column->size(); ++j) {                                                  \
         auto row = rows ? (*rows)[j] : j;                                                          \
         if (row == last_invalid_row) {                                                             \
@@ -1743,10 +1744,6 @@ Status VOlapTableSink::_validate_column(RuntimeState* state, const TypeDescripto
         if (need_to_validate(j, row)) {                                                            \
             auto dec_val = column_decimal->get_data()[j];                                          \
             bool invalid = false;                                                                  \
-            const auto& max_decimal =                                                              \
-                    _get_decimalv3_min_or_max<vectorized::DecimalType, false>(type);               \
-            const auto& min_decimal =                                                              \
-                    _get_decimalv3_min_or_max<vectorized::DecimalType, true>(type);                \
             if (dec_val > max_decimal || dec_val < min_decimal) {                                  \
                 fmt::format_to(error_msg, "{}", "decimal value is not valid for definition");      \
                 fmt::format_to(error_msg, ", value={}", dec_val);                                  \


### PR DESCRIPTION
## Proposed changes

before
<img width="336" alt="image" src="https://github.com/apache/doris/assets/59914473/f7ff87f8-9c6e-4399-9dd7-8d03757a07ef">

after
<img width="376" alt="image" src="https://github.com/apache/doris/assets/59914473/77bb1031-6946-46eb-b213-9c97d63fd345">




<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

