### PR TITLE
[improvement](profile)Add the build output block time in join node 

### DIFF
--- a/be/src/vec/exec/join/vhash_join_node.cpp
+++ b/be/src/vec/exec/join/vhash_join_node.cpp
@@ -460,7 +460,7 @@ Status HashJoinNode::prepare(RuntimeState* state) {
     _join_filter_timer = ADD_TIMER(runtime_profile(), "JoinFilterTimer");
     _open_timer = ADD_TIMER(runtime_profile(), "OpenTime");
     _allocate_resource_timer = ADD_TIMER(runtime_profile(), "AllocateResourceTime");
-
+    _build_output_timer = ADD_TIMER(runtime_profile(), "BuildOutputTime");
     _push_down_timer = ADD_TIMER(runtime_profile(), "PublishRuntimeFilterTime");
     _push_compute_timer = ADD_TIMER(runtime_profile(), "PushDownComputeTime");
     _build_buckets_counter = ADD_COUNTER(runtime_profile(), "BuildBuckets", TUnit::UNIT);
@@ -617,7 +617,10 @@ Status HashJoinNode::pull(doris::RuntimeState* state, vectorized::Block* output_
         SCOPED_TIMER(_join_filter_timer);
         RETURN_IF_ERROR(VExprContext::filter_block(_conjuncts, &temp_block, temp_block.columns()));
     }
-    RETURN_IF_ERROR(_build_output_block(&temp_block, output_block));
+    {
+        SCOPED_TIMER(_build_output_timer);
+        RETURN_IF_ERROR(_build_output_block(&temp_block, output_block));
+    }
     _reset_tuple_is_null_column();
     reached_limit(output_block, eos);
     return Status::OK();

--- a/be/src/vec/exec/join/vjoin_node_base.h
+++ b/be/src/vec/exec/join/vjoin_node_base.h
@@ -131,6 +131,7 @@ protected:
     RuntimeProfile::Counter* _push_down_timer;
     RuntimeProfile::Counter* _push_compute_timer;
     RuntimeProfile::Counter* _join_filter_timer;
+    RuntimeProfile::Counter* _build_output_timer;
 };
 
 } // namespace doris::vectorized


### PR DESCRIPTION
## Proposed changes

Record the time taken by _build_output_block, maybe we can reuse the memory for this portion?

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

