### PR TITLE
[Log](query) Add log of fragment instance num to recognize large query

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -186,6 +186,7 @@ public class Coordinator {
     private final Map<PlanFragmentId, FragmentExecParams> fragmentExecParamsMap = Maps.newHashMap();
 
     private final List<PlanFragment> fragments;
+    private int instanceTotalNum;
 
     private Map<Long, BackendExecStates> beToExecStates = Maps.newHashMap();
     private Map<Long, PipelineExecContexts> beToPipelineExecCtxs = Maps.newHashMap();
@@ -481,6 +482,10 @@ public class Coordinator {
         return result;
     }
 
+    public int getInstanceTotalNum() {
+        return instanceTotalNum;
+    }
+
     // Initialize
     private void prepare() {
         for (PlanFragment fragment : fragments) {
@@ -663,6 +668,7 @@ public class Coordinator {
                 // 1. set up exec states
                 int instanceNum = params.instanceExecParams.size();
                 Preconditions.checkState(instanceNum > 0);
+                instanceTotalNum += instanceNum;
                 List<TExecPlanFragmentParams> tParams = params.toThrift(backendIdx);
 
                 // 2. update memory limit for colocate join

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1371,6 +1371,18 @@ public class StmtExecutor {
         }
         profile.getSummaryProfile().setQueryScheduleFinishTime();
         updateProfile(false);
+        if (coord.getInstanceTotalNum() > 1 && LOG.isDebugEnabled()) {
+            try {
+                LOG.debug("Start to execute fragment. user: {}, db: {}, sql: {}, fragment instance num: {}",
+                        context.getQualifiedUser(), context.getDatabase(),
+                        parsedStmt.getOrigStmt().originStmt.replace("\n", " "),
+                        coord.getInstanceTotalNum());
+            } catch (Exception e) {
+                LOG.warn("Fail to print fragment concurrency for Query.", e);
+            }
+        }
+
+
         Span fetchResultSpan = context.getTracer().spanBuilder("fetch result").setParent(Context.current()).startSpan();
         try (Scope scope = fetchResultSpan.makeCurrent()) {
             while (true) {
@@ -1449,6 +1461,16 @@ public class StmtExecutor {
             throw e;
         } finally {
             fetchResultSpan.end();
+            if (coord.getInstanceTotalNum() > 1 && LOG.isDebugEnabled()) {
+                try {
+                    LOG.debug("Finish to execute fragment. user: {}, db: {}, sql: {}, fragment instance num: {}",
+                            context.getQualifiedUser(), context.getDatabase(),
+                            parsedStmt.getOrigStmt().originStmt.replace("\n", " "),
+                            coord.getInstanceTotalNum());
+                } catch (Exception e) {
+                    LOG.warn("Fail to print fragment concurrency for Query.", e);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Proposed changes

Large queries usually cause cluster instability, but it can be difficult to locate specific SQL. In general, large queries have a very large number of fragment instances.
![2023-06-08 17-00-35 的屏幕截图](https://github.com/apache/doris/assets/68884553/87cb6222-2e8a-4bc7-a2ee-5a2099fce078)

 This patch adds log to print fragment instance number for a query to recognize large queries.

```
2023-06-08 08:27:19,419 DEBUG (mysql-nio-pool-1|1030) [StmtExecutor.sendResult():1378] Start to execute fragment. user: root, db: default_cluster:test_db, sql: select sum(lo_revenue) as revenue from lineorder join dates on lo_orderdate = d_datekey where d_year = 1993 and lo_discount between 1 and 3 and lo_quantity < 25, fragment instance num: 18
2023-06-08 08:27:19,478 DEBUG (mysql-nio-pool-1|1030) [StmtExecutor.sendResult():1468] Finish to execute fragment. user: root, db: default_cluster:test_db, sql: select sum(lo_revenue) as revenue from lineorder join dates on lo_orderdate = d_datekey where d_year = 1993 and lo_discount between 1 and 3 and lo_quantity < 25, fragment instance num: 18
```