### PR TITLE
[Fix](Planner) Change return type in where, having and on clause

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TableRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TableRef.java
@@ -22,6 +22,7 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.TableIf;
+import org.apache.doris.catalog.Type;
 import org.apache.doris.catalog.external.HMSExternalTable;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
@@ -651,6 +652,9 @@ public class TableRef implements ParseNode, Writable {
             analyzer.setVisibleSemiJoinedTuple(semiJoinedTupleId);
             onClause.analyze(analyzer);
             analyzer.setVisibleSemiJoinedTuple(null);
+            if (!onClause.getType().isBoolean()) {
+                onClause = onClause.castTo(Type.BOOLEAN);
+            }
             onClause.checkReturnsBool("ON clause", true);
             if (onClause.contains(Expr.isAggregatePredicate())) {
                 throw new AnalysisException(

--- a/regression-test/suites/query_p0/cast/test_cast.groovy
+++ b/regression-test/suites/query_p0/cast/test_cast.groovy
@@ -31,4 +31,60 @@ suite('test_cast') {
         sql "select cast(${datetime} as int), cast(${datetime} as bigint), cast(${datetime} as float), cast(${datetime} as double)"
         result([[869930357, 20200101123445l, ((float) 20200101123445l), ((double) 20200101123445l)]])
     }
+
+    def tbl = "test_cast"
+
+    sql """ DROP TABLE IF EXISTS ${tbl}"""
+    sql """
+        CREATE TABLE IF NOT EXISTS ${tbl} (
+            `k0` int
+        )
+        DISTRIBUTED BY HASH(`k0`) BUCKETS 5 properties("replication_num" = "1")
+        """
+    sql """ INSERT INTO ${tbl} VALUES (101);"""
+
+    test {
+        sql "select * from ${tbl} where case when k0 = 101 then 1 else 0 end"
+        result([[101]])
+    }
+
+    test {
+        sql "select * from ${tbl} where case when k0 = 101 then 12 else 0 end"
+        result([[101]])
+    }
+
+    test {
+        sql "select * from ${tbl} where case when k0 = 101 then -12 else 0 end"
+        result([[101]])
+    }
+
+    test {
+        sql "select * from ${tbl} where case when k0 = 101 then 0 else 1 end"
+        result([])
+    }
+
+    test {
+        sql "select * from ${tbl} where case when k0 != 101 then 0 else 1 end"
+        result([[101]])
+    }
+
+    test {
+        sql "select * from ${tbl} where case when k0 = 101 then '1' else 0 end"
+        result([[101]])
+    }
+
+    test {
+        sql "select * from ${tbl} where case when k0 = 101 then '12' else 0 end"
+        result([])
+    }
+
+    test {
+        sql "select * from ${tbl} where case when k0 = 101 then 'false' else 0 end"
+        result([])
+    }
+
+    test {
+        sql "select * from ${tbl} where case when k0 = 101 then 'true' else 1 end"
+        result([[101]])
+    }
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #19613

Problem: When using no boolean type as return type in where or having clause, the analyzer will check the return type and throw an error. But in some other databases, this usage is enable. 

Solved: Cast return type to boolean in where clause and having clause. select *** from *** where case when *** then 1 else 0 end;

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

