### PR TITLE
[Fix](Planner) Add tinyint result support in where, having and on clause

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/Type.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/Type.java
@@ -260,6 +260,10 @@ public abstract class Type {
         return isScalarType(PrimitiveType.BOOLEAN);
     }
 
+    public boolean isTinyint() {
+        return isScalarType(PrimitiveType.TINYINT);
+    }
+
     public boolean isDecimalV2() {
         return isScalarType(PrimitiveType.DECIMALV2);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
@@ -1324,7 +1324,7 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
      * The error message only contains this.toSql() if printExpr is true.
      */
     public void checkReturnsBool(String name, boolean printExpr) throws AnalysisException {
-        if (!type.isBoolean() && !type.isNull()) {
+        if (!type.isBoolean() && !type.isNull() && !type.isTinyint()) {
             if (this instanceof BoolLiteral) {
                 return;
             }

--- a/regression-test/suites/query_p0/cast/test_cast.groovy
+++ b/regression-test/suites/query_p0/cast/test_cast.groovy
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite('test_cast') {
+    def date = "date '2020-01-01'"
+    def datev2 = "datev2 '2020-01-01'"
+    def datetime = "timestamp '2020-01-01 12:34:45'"
+    def tbl = "test_cast"
+
+    sql """ DROP TABLE IF EXISTS ${tbl}"""
+    sql """
+        CREATE TABLE IF NOT EXISTS ${tbl} (
+            `k0` int
+        )
+        DISTRIBUTED BY HASH(`k0`) BUCKETS 5 properties("replication_num" = "1")
+        """
+    sql """ INSERT INTO ${tbl} VALUES (101);"""
+
+    test {
+        sql "select * from ${tbl} where case when k0 = 101 then 1 else 0 end"
+        result([[101]])
+    }
+
+    test {
+        sql "select * from ${tbl} where case when k0 = 101 then 0 else 1 end"
+        result([])
+    }
+
+    test {
+        sql "select cast(${date} as int), cast(${date} as bigint), cast(${date} as float), cast(${date} as double)"
+        result([[20200101, 20200101l, ((float) 20200101), ((double) 20200101)]])
+    }
+    test {
+        sql "select cast(${datev2} as int), cast(${datev2} as bigint), cast(${datev2} as float), cast(${datev2} as double)"
+        result([[20200101, 20200101l, ((float) 20200101), ((double) 20200101)]])
+    }
+    test {
+        sql "select cast(${datetime} as int), cast(${datetime} as bigint), cast(${datetime} as float), cast(${datetime} as double)"
+        result([[869930357, 20200101123445l, ((float) 20200101123445l), ((double) 20200101123445l)]])
+    }
+}


### PR DESCRIPTION
## Proposed changes

Issue Number: close #19613

Enable planner of using tinyint as expr return type like: select *** from *** where case when *** then 1 else 0 end;

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

