### PR TITLE
[opt](Nereids) remove prunning in OptimizeGroup to avoid recompute on its parent

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/OptimizeGroupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/OptimizeGroupJob.java
@@ -42,8 +42,7 @@ public class OptimizeGroupJob extends Job {
     @Override
     public void execute() {
         COUNTER_TRACER.log(CounterEvent.of(Memo.getStateId(), CounterType.JOB_EXECUTION, group, null, null));
-        if (group.getCostLowerBound() > context.getCostUpperBound()
-                || group.getLowestCostPlan(context.getRequiredProperties()).isPresent()) {
+        if (group.getLowestCostPlan(context.getRequiredProperties()).isPresent()) {
             return;
         }
         if (!group.isExplored()) {

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query33.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query33.out
@@ -8,32 +8,32 @@ PhysicalTopN
 ----------hashAgg[LOCAL]
 ------------PhysicalUnion
 --------------PhysicalProject
-----------------hashAgg[GLOBAL]
-------------------PhysicalDistribute
---------------------hashAgg[LOCAL]
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN](store_sales.ss_item_sk = item.i_item_sk)
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN](store_sales.ss_addr_sk = customer_address.ca_address_sk)
-------------------------------hashJoin[INNER_JOIN](store_sales.ss_sold_date_sk = date_dim.d_date_sk)
---------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[store_sales]
+----------------hashJoin[LEFT_SEMI_JOIN](item.i_manufact_id = item.i_manufact_id)
+------------------hashAgg[GLOBAL]
+--------------------PhysicalDistribute
+----------------------hashAgg[LOCAL]
+------------------------PhysicalProject
+--------------------------hashJoin[INNER_JOIN](store_sales.ss_item_sk = item.i_item_sk)
+----------------------------PhysicalProject
+------------------------------hashJoin[INNER_JOIN](store_sales.ss_addr_sk = customer_address.ca_address_sk)
+--------------------------------hashJoin[INNER_JOIN](store_sales.ss_sold_date_sk = date_dim.d_date_sk)
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[store_sales]
+----------------------------------PhysicalDistribute
+------------------------------------PhysicalProject
+--------------------------------------filter((date_dim.d_moy = 1)(date_dim.d_year = 2002))
+----------------------------------------PhysicalOlapScan[date_dim]
 --------------------------------PhysicalDistribute
 ----------------------------------PhysicalProject
-------------------------------------filter((date_dim.d_moy = 1)(date_dim.d_year = 2002))
---------------------------------------PhysicalOlapScan[date_dim]
-------------------------------PhysicalDistribute
---------------------------------PhysicalProject
-----------------------------------filter((customer_address.ca_gmt_offset = -5.00))
-------------------------------------PhysicalOlapScan[customer_address]
---------------------------PhysicalDistribute
-----------------------------hashJoin[LEFT_SEMI_JOIN](item.i_manufact_id = item.i_manufact_id)
+------------------------------------filter((customer_address.ca_gmt_offset = -5.00))
+--------------------------------------PhysicalOlapScan[customer_address]
+----------------------------PhysicalDistribute
 ------------------------------PhysicalProject
 --------------------------------PhysicalOlapScan[item]
-------------------------------PhysicalDistribute
---------------------------------PhysicalProject
-----------------------------------filter((item.i_category = 'Home'))
-------------------------------------PhysicalOlapScan[item]
+------------------PhysicalDistribute
+--------------------PhysicalProject
+----------------------filter((item.i_category = 'Home'))
+------------------------PhysicalOlapScan[item]
 --------------PhysicalProject
 ----------------hashJoin[LEFT_SEMI_JOIN](item.i_manufact_id = item.i_manufact_id)
 ------------------hashAgg[GLOBAL]


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

we have some prunning path logical in cascades framework. However it do not work as we expected. if we do prunning on one Group, then maybe we need to do thousands of times optimization on its parent without any success result. This PR remove these prunning provisionally. We will add prunning back when we re-design it.


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

