### PR TITLE
[Function](agg) Support agg function retention_info() and retention_count() for retention analysis

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_retention_analysis.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_retention_analysis.cpp
@@ -1,0 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/aggregate_functions/aggregate_function_retention_analysis.h"
+
+#include "vec/aggregate_functions/aggregate_function_simple_factory.h"
+#include "vec/aggregate_functions/factory_helpers.h"
+#include "vec/aggregate_functions/helpers.h"
+
+namespace doris::vectorized {
+
+AggregateFunctionPtr create_aggregate_function_retention_analysis(const std::string& name,
+                                                                  const DataTypes& argument_types,
+                                                                  const bool result_is_nullable) {
+    return std::make_shared<AggregateFunctionRetentionAnalysis>(argument_types);
+}
+
+void register_aggregate_function_retention_analysis(AggregateFunctionSimpleFactory& factory) {
+    factory.register_function("retention_info", create_aggregate_function_retention_analysis, true);
+    factory.register_function("retention_info", create_aggregate_function_retention_analysis,
+                              false);
+}
+} // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_retention_analysis.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_retention_analysis.h
@@ -1,0 +1,352 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <set>
+#include <string>
+
+#include "vec/aggregate_functions/aggregate_function.h"
+#include "vec/io/io_helper.h"
+#include "vec/utils/util.hpp"
+
+namespace doris::vectorized {
+
+static const int kRetentionEventCount = 101;
+static const uint8_t kRowColShift = 8;
+static const uint8_t kRowColMask = (1 << kRowColShift) - 1;
+
+static const int32_t UTC16 = 16 * 60 * 60;
+static const int32_t UTC8 = 8 * 60 * 60;
+static const int32_t DAY_TIME_SEC = 24 * 60 * 60;
+static const int32_t WEEK_TIME_SEC = 24 * 60 * 60 * 7;
+
+struct RetentionAnalysisData {
+    uint32_t first_event[kRetentionEventCount] = {0};
+    uint32_t retention_event[kRetentionEventCount] = {0};
+    bool same_event = false;
+
+    RetentionAnalysisData() { reset(); }
+
+    void reset() {
+        for (int64_t i = 0; i < kRetentionEventCount; i++) {
+            first_event[i] = 0;
+            retention_event[i] = 0;
+        }
+        same_event = false;
+    }
+
+    void add(const int64_t start_time, const std::string unit, const int64_t event_time,
+             const int32_t event_type) {
+        if (event_type == 0 || unit.empty() || event_time < start_time) {
+            return;
+        }
+
+        uint32_t st = start_time / 1000; // uint32_t is enough to hold a timestamp in seconds
+        uint32_t et = event_time / 1000;
+        int16_t index = get_delta_periods(st, et, unit);
+        if (index < 0 || index >= kRetentionEventCount) {
+            return;
+        }
+
+        switch (event_type) {
+        case 1:
+            add_first_event(index, et);
+            break;
+        case 2:
+            add_retention_event(index, et);
+            break;
+        case 3:
+            add_first_event(index, et);
+            add_retention_event(index, et);
+            same_event = true;
+            break;
+        default:
+            break;
+        }
+    }
+
+    void merge(const RetentionAnalysisData& other) {
+        for (int16_t i = 0; i < kRetentionEventCount; i++) {
+            // make value smaller
+            if (first_event[i] == 0 || (first_event[i] > 0 && other.first_event[i] > 0 &&
+                                        first_event[i] > other.first_event[i])) {
+                first_event[i] = other.first_event[i];
+            }
+
+            // make value larger
+            if (retention_event[i] == 0 ||
+                (retention_event[i] > 0 && other.retention_event[i] > 0 &&
+                 retention_event[i] < other.retention_event[i])) {
+                retention_event[i] = other.retention_event[i];
+            }
+        }
+        if (other.same_event) {
+            same_event = other.same_event;
+        }
+    }
+
+    void write(BufferWritable& out) const {
+        for (int i = 0; i < kRetentionEventCount; i++) {
+            uint64_t tmp = (((uint64_t)first_event[i] << 32) | (uint64_t)retention_event[i]);
+            write_var_uint(tmp, out);
+        }
+        write_binary(same_event, out);
+    }
+
+    void serialize(BufferWritable& out) const {
+        const size_t buffer_size = kRetentionEventCount * 8 + 1;
+        std::string serialized_events;
+        serialized_events.resize(buffer_size);
+        uint8_t* start_ptr = (uint8_t*)serialized_events.c_str();
+        memset(start_ptr, 0, buffer_size);
+        uint64_t* ptr = reinterpret_cast<uint64_t*>(start_ptr);
+        for (int i = 0; i < kRetentionEventCount; i++) {
+            uint64_t tmp_1 = (uint64_t)first_event[i];
+            uint64_t tmp_2 = (uint64_t)retention_event[i];
+            uint64_t tmp = (uint64_t)((tmp_1 << 32) | tmp_2);
+            *ptr = tmp;
+            ++ptr;
+        }
+        bool* p = reinterpret_cast<bool*>(ptr);
+        *p = same_event;
+
+        write_string_binary(serialized_events, out);
+    }
+
+    void read(BufferReadable& in) {
+        uint64_t tmp;
+        for (int i = 0; i < kRetentionEventCount; i++) {
+            read_var_uint(tmp, in);
+            first_event[i] = (uint32_t)(tmp >> 32);
+            retention_event[i] = (uint32_t)(tmp & (((uint64_t)1 << 32) - 1));
+        }
+        read_binary(same_event, in);
+    }
+
+    void deserialize(BufferReadable& in) {
+        std::string serialized_events;
+        read_string_binary(serialized_events, in);
+
+        uint64_t* ptr = (uint64_t*)serialized_events.c_str();
+        for (int i = 0; i < kRetentionEventCount; i++) {
+            uint64_t tmp = *ptr;
+            first_event[i] = (uint32_t)(tmp >> 32);
+            retention_event[i] = (uint32_t)(tmp & (((uint64_t)1 << 32) - 1));
+            ++ptr;
+        }
+        bool* p = reinterpret_cast<bool*>(ptr);
+        same_event = *p;
+    }
+
+    std::string get() const {
+        int8_t row_max_index = kRetentionEventCount - 1;
+        for (; row_max_index >= 0; row_max_index--) {
+            if (first_event[row_max_index] != 0 || row_max_index == 0) {
+                break;
+            }
+        }
+
+        int8_t column_max_index = kRetentionEventCount - 1;
+        for (; column_max_index >= 0; column_max_index--) {
+            if (retention_event[column_max_index] != 0 || column_max_index == 0) {
+                break;
+            }
+        }
+
+        std::set<uint16_t> local_set;
+        for (uint8_t row = 0; row <= row_max_index; row++) {
+            uint32_t first_ts = first_event[row];
+            if (first_ts == 0) {
+                continue;
+            }
+
+            local_set.insert(encode_row_col(row, 0));
+            if (same_event) {
+                local_set.insert(encode_row_col(row, 1));
+            }
+
+            for (uint8_t column = row; column <= column_max_index; column++) {
+                uint32_t retention_ts = retention_event[column];
+                if (retention_ts > first_ts) {
+                    local_set.insert(encode_row_col(row, column - row + 1));
+                }
+            }
+        }
+
+        const size_t buffer_size = local_set.size() * 2;
+        std::string result;
+        result.resize(buffer_size);
+        uint8_t* start_ptr = (uint8_t*)result.c_str();
+        memset(start_ptr, 0, buffer_size);
+        uint16_t* ptr = reinterpret_cast<uint16_t*>(start_ptr);
+        for (const auto& iter : local_set) {
+            *ptr = iter;
+            ++ptr;
+        }
+
+        return result;
+    }
+
+    int16_t get_delta_periods(uint32_t start_time, uint32_t event_time, const std::string& unit) {
+        switch (*(char*)unit.c_str()) {
+        case 'd':
+            return ((int32_t)get_start_of_day(event_time) - (int32_t)get_start_of_day(start_time)) /
+                   DAY_TIME_SEC;
+        case 'w':
+            return ((int32_t)get_start_of_week(event_time) -
+                    (int32_t)get_start_of_week(start_time)) /
+                   WEEK_TIME_SEC;
+        case 'm': {
+            time_t s = start_time;
+            time_t e = event_time;
+            std::tm start_tm = *localtime(&s);
+            std::tm event_tm = *localtime(&e);
+            return event_tm.tm_mon - start_tm.tm_mon;
+        }
+        default:
+            return -1;
+        }
+    }
+
+    uint32_t get_start_of_day(uint32_t ts) {
+        uint32_t mod = (ts - UTC16) % DAY_TIME_SEC;
+        return ts - mod;
+    }
+
+    uint32_t get_start_of_week(uint32_t ts) {
+        // 1970-01-01 is Thursday
+        const static uint32_t week_offset = 4 * 86400;
+        uint32_t mod = (ts + UTC8 - week_offset) % WEEK_TIME_SEC;
+        return ts - mod;
+    }
+
+    void add_first_event(int16_t index, uint32_t event_time) {
+        DCHECK_LT(index, kRetentionEventCount);
+        if (first_event[index] == 0 || first_event[index] > event_time) {
+            first_event[index] = event_time;
+        }
+    }
+
+    void add_retention_event(int16_t index, uint32_t event_time) {
+        DCHECK_LT(index, kRetentionEventCount);
+        if (retention_event[index] == 0 || retention_event[index] < event_time) {
+            retention_event[index] = event_time;
+        }
+    }
+
+    uint16_t encode_row_col(uint8_t row, uint8_t column) const {
+        return (row << kRowColShift) | column;
+    }
+};
+
+class AggregateFunctionRetentionAnalysis
+        : public IAggregateFunctionDataHelper<RetentionAnalysisData,
+                                              AggregateFunctionRetentionAnalysis> {
+public:
+    AggregateFunctionRetentionAnalysis(const DataTypes& argument_types_)
+            : IAggregateFunctionDataHelper<RetentionAnalysisData,
+                                           AggregateFunctionRetentionAnalysis>(argument_types_) {}
+
+    String get_name() const override { return "retention_info"; }
+
+    DataTypePtr get_return_type() const override { return std::make_shared<DataTypeString>(); }
+
+    void reset(AggregateDataPtr __restrict place) const override { this->data(place).reset(); }
+    void add(AggregateDataPtr __restrict place, const IColumn** columns, const size_t row_num,
+             Arena*) const override {
+        DCHECK_EQ(get_argument_types().size(), 4);
+
+        Int64 start_time;
+        if (auto* nullable = check_and_get_column<const ColumnNullable>(*columns[0])) {
+            if (nullable->is_null_at(row_num)) {
+                return;
+            }
+            auto column = nullable->get_nested_column_ptr();
+            start_time = assert_cast<const ColumnVector<Int64>*>(column.get())->get_data()[row_num];
+        } else {
+            start_time = assert_cast<const ColumnVector<Int64>*>(columns[0])->get_data()[row_num];
+        }
+
+        std::string unit;
+        if (auto* nullable = check_and_get_column<const ColumnNullable>(*columns[1])) {
+            auto column = nullable->get_nested_column_ptr();
+            if (nullable->is_null_at(row_num)) {
+                return;
+            }
+            auto str_col = assert_cast<const ColumnString*>(column.get());
+            const auto& offsets = str_col->get_offsets();
+            if ((offsets[row_num] - offsets[row_num - 1]) == 0) {
+                return;
+            }
+            unit = str_col->get_data_at(row_num).to_string();
+        } else {
+            unit = assert_cast<const ColumnString*>(columns[1])->get_data_at(row_num).to_string();
+        }
+
+        Int64 event_time;
+        if (auto* nullable = check_and_get_column<const ColumnNullable>(*columns[2])) {
+            if (nullable->is_null_at(row_num)) {
+                return;
+            }
+            auto column = nullable->get_nested_column_ptr();
+            event_time = assert_cast<const ColumnVector<Int64>*>(column.get())->get_data()[row_num];
+        } else {
+            event_time = assert_cast<const ColumnVector<Int64>*>(columns[2])->get_data()[row_num];
+        }
+
+        Int32 event_type;
+        if (auto* nullable = check_and_get_column<const ColumnNullable>(*columns[3])) {
+            if (nullable->is_null_at(row_num)) {
+                return;
+            }
+            auto column = nullable->get_nested_column_ptr();
+            event_type = assert_cast<const ColumnVector<Int32>*>(column.get())->get_data()[row_num];
+        } else {
+            event_type = assert_cast<const ColumnVector<Int32>*>(columns[3])->get_data()[row_num];
+        }
+
+        this->data(place).add(start_time, unit, event_time, event_type);
+    }
+
+    void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs,
+               Arena*) const override {
+        this->data(place).merge(this->data(rhs));
+    }
+
+    void serialize(ConstAggregateDataPtr __restrict place, BufferWritable& buf) const override {
+        this->data(place).write(buf);
+    }
+
+    void deserialize(AggregateDataPtr __restrict place, BufferReadable& buf,
+                     Arena*) const override {
+        this->data(place).read(buf);
+    }
+
+    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+        std::string result = this->data(place).get();
+        if (to.is_nullable()) {
+            auto& null_column = assert_cast<ColumnNullable&>(to);
+            null_column.get_null_map_data().push_back(0);
+            assert_cast<ColumnString&>(null_column.get_nested_column())
+                    .insert_data(result.c_str(), result.length());
+        } else {
+            assert_cast<ColumnString&>(to).insert_data(result.c_str(), result.length());
+        }
+    }
+};
+} // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_retention_analysis_count.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_retention_analysis_count.cpp
@@ -1,0 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/aggregate_functions/aggregate_function_retention_analysis_count.h"
+
+#include "vec/aggregate_functions/aggregate_function_simple_factory.h"
+#include "vec/aggregate_functions/factory_helpers.h"
+#include "vec/aggregate_functions/helpers.h"
+
+namespace doris::vectorized {
+
+AggregateFunctionPtr create_aggregate_function_retention_analysis_count(
+        const std::string& name, const DataTypes& argument_types, const bool result_is_nullable) {
+    return std::make_shared<AggregateFunctionRetentionAnalysisCount>(argument_types);
+}
+
+void register_aggregate_function_retention_analysis_count(AggregateFunctionSimpleFactory& factory) {
+    factory.register_function("retention_count", create_aggregate_function_retention_analysis_count,
+                              true);
+    factory.register_function("retention_count", create_aggregate_function_retention_analysis_count,
+                              false);
+}
+} // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_retention_analysis_count.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_retention_analysis_count.h
@@ -1,0 +1,216 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <set>
+#include <sstream>
+#include <string>
+
+#include "vec/aggregate_functions/aggregate_function.h"
+#include "vec/io/io_helper.h"
+#include "vec/utils/util.hpp"
+
+namespace doris::vectorized {
+
+static const uint8_t kRowColShift = 8;
+static const uint8_t kRowColMask = (1 << kRowColShift) - 1;
+
+static const uint8_t kRetentionRowCount = 101;
+static const uint8_t kRetentionColumnCount = kRetentionRowCount + 1;
+
+struct RetentionAnalysisCountData {
+    uint32_t retention_info[kRetentionRowCount][kRetentionColumnCount];
+
+    RetentionAnalysisCountData() { reset(); }
+
+    void reset() {
+        for (int i = 0; i < kRetentionRowCount; i++) {
+            for (int j = 0; j < kRetentionColumnCount; j++) {
+                retention_info[i][j] = 0;
+            }
+        }
+    }
+
+    void add(const std::string& retention) {
+        if (retention.empty()) {
+            return;
+        }
+        std::set<uint16_t> src_row_column;
+        parse_from_info(retention, &src_row_column);
+        uint8_t row = 0;
+        uint8_t column = 0;
+        for (const auto& iter : src_row_column) {
+            decode_row_col(iter, &row, &column);
+            if (UNLIKELY(row >= kRetentionRowCount || column >= kRetentionColumnCount)) {
+                continue;
+            }
+            retention_info[row][column]++;
+        }
+    }
+
+    void merge(const RetentionAnalysisCountData& other) {
+        for (int i = 0; i < kRetentionRowCount; i++) {
+            for (int j = 0; j < kRetentionColumnCount; j++) {
+                retention_info[i][j] += other.retention_info[i][j];
+            }
+        }
+    }
+
+    void write(BufferWritable& out) const {
+        for (int i = 0; i < kRetentionRowCount; i++) {
+            for (int j = 0; j < kRetentionColumnCount; j++) {
+                write_var_uint(retention_info[i][j], out);
+            }
+        }
+    }
+
+    void serialize(BufferWritable& out) const {
+        const size_t buffer_size = kRetentionRowCount * kRetentionColumnCount * 4;
+        std::string serialized_events;
+        serialized_events.resize(buffer_size);
+        uint8_t* start_ptr = (uint8_t*)serialized_events.c_str();
+        memset(start_ptr, 0, buffer_size);
+        uint32_t* ptr = reinterpret_cast<uint32_t*>(start_ptr);
+        for (int i = 0; i < kRetentionRowCount; i++) {
+            for (int j = 0; j < kRetentionColumnCount; j++) {
+                *ptr = retention_info[i][j];
+                ++ptr;
+            }
+        }
+
+        write_string_binary(serialized_events, out);
+    }
+
+    void read(BufferReadable& in) {
+        uint64_t tmp;
+        for (int i = 0; i < kRetentionRowCount; i++) {
+            for (int j = 0; j < kRetentionColumnCount; j++) {
+                read_var_uint(tmp, in);
+                retention_info[i][j] = (uint32_t)tmp;
+            }
+        }
+    }
+
+    void deserialize(BufferReadable& in) {
+        std::string serialized_events;
+        read_string_binary(serialized_events, in);
+
+        uint32_t* ptr = (uint32_t*)serialized_events.c_str();
+        for (int i = 0; i < kRetentionRowCount; i++) {
+            for (int j = 0; j < kRetentionColumnCount; j++) {
+                retention_info[i][j] = *ptr;
+                ++ptr;
+            }
+        }
+    }
+
+    std::string get() const {
+        std::ostringstream oss;
+        for (int32_t i = 0; i < kRetentionRowCount; i++) {
+            for (int32_t j = 0; j < kRetentionColumnCount; j++) {
+                uint32_t count = retention_info[i][j];
+                if (count == 0) {
+                    continue;
+                }
+                oss << i << ":" << j - 1 << ":" << count << ";";
+            }
+        }
+        return oss.str();
+    }
+
+    void parse_from_info(const std::string str, std::set<uint16_t>* local) {
+        DCHECK(local);
+        uint16_t* index = (uint16_t*)(str.c_str());
+        uint16_t* end_index = (uint16_t*)((uint8_t*)str.c_str() + str.size());
+        while (index < end_index) {
+            local->insert(*index);
+            ++index;
+        }
+    }
+
+    void decode_row_col(uint16_t v, uint8_t* row, uint8_t* column) {
+        *row = v >> kRowColShift;
+        *column = v & kRowColMask;
+    }
+};
+
+class AggregateFunctionRetentionAnalysisCount
+        : public IAggregateFunctionDataHelper<RetentionAnalysisCountData,
+                                              AggregateFunctionRetentionAnalysisCount> {
+public:
+    AggregateFunctionRetentionAnalysisCount(const DataTypes& argument_types_)
+            : IAggregateFunctionDataHelper<RetentionAnalysisCountData,
+                                           AggregateFunctionRetentionAnalysisCount>(
+                      argument_types_) {}
+
+    String get_name() const override { return "retention_count"; }
+
+    DataTypePtr get_return_type() const override { return std::make_shared<DataTypeString>(); }
+
+    void reset(AggregateDataPtr __restrict place) const override { this->data(place).reset(); }
+    void add(AggregateDataPtr __restrict place, const IColumn** columns, const size_t row_num,
+             Arena*) const override {
+        DCHECK_EQ(get_argument_types().size(), 1);
+
+        std::string retention;
+        if (auto* nullable = check_and_get_column<const ColumnNullable>(*columns[0])) {
+            if (nullable->is_null_at(row_num)) {
+                return;
+            }
+            auto column = nullable->get_nested_column_ptr();
+            auto str_col = assert_cast<const ColumnString*>(column.get());
+            const auto& offsets = str_col->get_offsets();
+            if ((offsets[row_num] - offsets[row_num - 1]) == 0) {
+                return;
+            }
+            retention = str_col->get_data_at(row_num).to_string();
+        } else {
+            retention =
+                    assert_cast<const ColumnString*>(columns[0])->get_data_at(row_num).to_string();
+        }
+
+        this->data(place).add(retention);
+    }
+
+    void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs,
+               Arena*) const override {
+        this->data(place).merge(this->data(rhs));
+    }
+
+    void serialize(ConstAggregateDataPtr __restrict place, BufferWritable& buf) const override {
+        this->data(place).write(buf);
+    }
+
+    void deserialize(AggregateDataPtr __restrict place, BufferReadable& buf,
+                     Arena*) const override {
+        this->data(place).read(buf);
+    }
+
+    void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
+        std::string result = this->data(place).get();
+        if (to.is_nullable()) {
+            auto& null_column = assert_cast<ColumnNullable&>(to);
+            null_column.get_null_map_data().push_back(0);
+            assert_cast<ColumnString&>(null_column.get_nested_column())
+                    .insert_data(result.c_str(), result.length());
+        } else {
+            assert_cast<ColumnString&>(to).insert_data(result.c_str(), result.length());
+        }
+    }
+};
+} // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_simple_factory.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_simple_factory.cpp
@@ -59,6 +59,8 @@ void register_aggregate_function_avg_weighted(AggregateFunctionSimpleFactory& fa
 void register_aggregate_function_histogram(AggregateFunctionSimpleFactory& factory);
 void register_aggregate_function_count_old(AggregateFunctionSimpleFactory& factory);
 void register_aggregate_function_sum_old(AggregateFunctionSimpleFactory& factory);
+void register_aggregate_function_retention_analysis(AggregateFunctionSimpleFactory& factory);
+void register_aggregate_function_retention_analysis_count(AggregateFunctionSimpleFactory& factory);
 
 AggregateFunctionSimpleFactory& AggregateFunctionSimpleFactory::instance() {
     static std::once_flag oc;
@@ -99,6 +101,8 @@ AggregateFunctionSimpleFactory& AggregateFunctionSimpleFactory::instance() {
         register_aggregate_function_window_lead_lag_first_last(instance);
         register_aggregate_function_HLL_union_agg(instance);
         register_aggregate_function_percentile_approx(instance);
+        register_aggregate_function_retention_analysis(instance);
+        register_aggregate_function_retention_analysis_count(instance);
     });
     return instance;
 }

--- a/docs/en/docs/sql-manual/sql-functions/aggregate-functions/retention_count.md
+++ b/docs/en/docs/sql-manual/sql-functions/aggregate-functions/retention_count.md
@@ -1,0 +1,117 @@
+---
+{
+    "title": "RETENTION_COUNT",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+## RETENTION_COUNT
+
+<version since="1.2.0">
+
+RETENTION_INFO
+
+</version>
+
+### description
+#### Syntax
+
+`retention_count(varchar retention) RETURNS varchar`
+
+Retention analysis for all user events.
+
+#### Arguments
+
+Retention event data for each user, output of the `retention_info()` function. This function needs to be used in conjunction with the `retention_info()` function
+
+##### Returned value
+
+Result of retention analysis for all user events.`m:n:count` indicates that the first event occurred on the `m-th` day after the start time, and the number of users who had a retention event on the `n-th` day after the first event occurred is `count`. In addition, `m:-1:count` indicates that the number of users whose first event occurred on the `m-th` day after the start time is `count`, `m:0:count` indicates that the first event occurred on the `m-th` day after the start time, and the number of users with a retention event on that day is `count` (the retention event occurred on the same day with the first event).
+
+### example
+
+```sql
+ CREATE TABLE `retention_analysis_test` (
+  `distinct_id` int(11) NULL,
+  `event_name` varchar(64) NULL,
+  `timestamp` bigint(20) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`distinct_id`)
+COMMENT 'OLAP'
+DISTRIBUTED BY HASH(`distinct_id`) BUCKETS 1
+PROPERTIES (
+"replication_allocation" = "tag.location.default: 1",
+"storage_format" = "V2",
+); 
+
+insert into retention_analysis_test values (1, "view", 1685584800000), (2, "view", 1685584800000), (3, "view", 1685584800000), (4, "view", 1685584800000), (5, "view", 1685584800000), (6, "view", 1685584800000), (7, "view", 1685584800000), (8, "view", 1685584800000), (9, "view", 1685584800000), (10, "view", 1685584800000);
+insert into retention_analysis_test values (1, "download", 1685602800000), (2, "download", 1685602800000), (3, "download", 1685602800000), (4, "download", 1685602800000), (5, "download", 1685602800000), (6, "download", 1685602800000);
+insert into retention_analysis_test values (1, "view", 1685671200000), (2, "view", 1685671200000), (3, "view", 1685671200000), (4, "view", 1685671200000), (5, "view", 1685671200000), (6, "view", 1685671200000), (7, "view", 1685671200000), (8, "view", 1685671200000);
+insert into retention_analysis_test values (1, "download", 1685689200000), (2, "download", 1685689200000), (3, "download", 1685689200000), (4, "download", 1685689200000), (5, "download", 1685689200000);
+insert into retention_analysis_test values (1, "view", 1685757600000), (2, "view", 1685757600000), (3, "view", 1685757600000), (4, "view", 1685757600000), (5, "view", 1685757600000), (6, "view", 1685757600000), (7, "view", 1685757600000), (8, "view", 1685757600000), (9, "view", 1685757600000), (10, "view", 1685757600000), (11, "view", 1685757600000);
+insert into retention_analysis_test values (1, "download", 1685775600000), (2, "download", 1685775600000), (3, "download", 1685775600000);
+
+SELECT retention_count(c.retention_info)
+FROM (
+	SELECT distinct_id
+		, retention_info(1685548800000, "day", timestamp, CASE 
+			WHEN event_name = "view" THEN 1
+			ELSE 0
+		END | CASE 
+			WHEN event_name = "download" THEN 2
+			ELSE 0
+		END) AS retention_info
+	FROM retention_analysis_test
+	WHERE timestamp >= 1685548800000
+	GROUP BY distinct_id
+) c;
+```
+
+the result of query:
+```
++-------------------------------------------------------------+
+| retention_count(`c`.`retention_info`)                       |
++-------------------------------------------------------------+
+| 0:-1:10;0:0:6;0:1:5;0:2:3;1:-1:8;1:0:5;1:1:3;2:-1:11;2:0:3; |
++-------------------------------------------------------------+
+```
+`0:-1:10` means that the number of users whose first event occurred on the 0-th day after the start time is 10.
+
+`0:0:6` means that the first event occurred on the 0-th day after the start time, and the number of users with a retention event on that day is 6.
+
+`0:1:5` means that the first event occurred on the 0-th day after the start time, and the number of users who had a retention event on the 1-th day after the first event occurred is 5.
+
+`0:2:3` means that the first event occurred on the 0-th day after the start time, and the number of users who had a retention event on the 2-th day after the first event occurred is 3.
+
+`1:-1:8` means that the number of users whose first event occurred on the 1-th day after the start time is 8.
+
+`1:0:5` means that the first event occurred on the 1-th day after the start time, and the number of users with a retention event on that day is 5.
+
+`1:1:3` means that the first event occurred on the 1-th day after the start time, and the number of users who had a retention event on the 1-th day after the first event occurred is 3.
+
+`2:-1:11` means that the number of users whose first event occurred on the 2-th day after the start time is 11.
+
+`2:0:3` means that the first event occurred on the 2-th day after the start time, and the number of users with a retention event on that day is 3.
+
+### keywords
+
+RETENTION_COUNT

--- a/docs/en/docs/sql-manual/sql-functions/aggregate-functions/retention_info.md
+++ b/docs/en/docs/sql-manual/sql-functions/aggregate-functions/retention_info.md
@@ -1,0 +1,63 @@
+---
+{
+    "title": "RETENTION_INFO",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+## RETENTION_INFO
+
+<version since="1.2.0">
+
+RETENTION_INFO
+
+</version>
+
+### description
+#### Syntax
+
+`retention_info(bigint start_time, varchar unit, bigint event_time, int event_type) RETURNS varchar retention`
+
+calculate retention event for each user.
+
+#### Arguments
+
+`start_time` — Start time for retention analysis, and events that occur after the start time are considered valid events.
+
+`unit` — Time unit for retention analysis. Currently, only daily retention is supported. This parameter value needs to be passed into `day`.
+
+`event_time` — The timestamp of the event, in the unixtime format, is accurate to milliseconds.
+
+`event_type` — Event type, means whether the event is an initial event or a retention event, 1 indicates the initial event, 2 indicates the retention event, and 0 indicates the invalid event.
+
+
+##### Returned value
+
+The function returns the retention event data for each user as an input parameter to the `retention_count()` function. This function needs to be used in conjunction with the `retention_count()` function, otherwise it is meaningless.
+
+### example
+
+Refer to the example of the `retention_count()` function.
+
+### keywords
+
+RETENTION_INFO

--- a/docs/zh-CN/docs/sql-manual/sql-functions/aggregate-functions/retention_count.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/aggregate-functions/retention_count.md
@@ -1,0 +1,116 @@
+---
+{
+    "title": "RETENTION_COUNT",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+## RETENTION_COUNT
+
+<version since="1.2.0">
+
+RETENTION_INFO
+
+</version>
+
+### description
+#### Syntax
+
+`retention_count(varchar retention) RETURNS varchar`
+
+对全量用户事件进行留存分析。
+
+#### Arguments
+
+`retention` — 每一个用户的留存事件数据，`retention_info()`函数的输出结果。该函数需要和`retention_info()`函数配合使用
+
+##### Returned value
+
+对全量用户事件进行留存分析的结果。`m:n:count` 表示查询开始时间之后的第m天发生了首次事件，同时在该首次事件发生之后的第n天发生了留存事件的用户数量为count。其中，`m:-1:count` 表示查询开始时间之后的第m天发生首次事件的用户数量为count。`m:0:count` 表示查询开始时间之后的第m天发生首次事件，同时当天发生了留存事件的用户数量为count（留存事件发生的时间在当天发生首次事件之后）。
+
+### example
+
+```sql
+ CREATE TABLE `retention_analysis_test` (
+  `distinct_id` int(11) NULL,
+  `event_name` varchar(64) NULL,
+  `timestamp` bigint(20) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`distinct_id`)
+COMMENT 'OLAP'
+DISTRIBUTED BY HASH(`distinct_id`) BUCKETS 1
+PROPERTIES (
+"replication_allocation" = "tag.location.default: 1",
+"storage_format" = "V2",
+); 
+
+insert into retention_analysis_test values (1, "view", 1685584800000), (2, "view", 1685584800000), (3, "view", 1685584800000), (4, "view", 1685584800000), (5, "view", 1685584800000), (6, "view", 1685584800000), (7, "view", 1685584800000), (8, "view", 1685584800000), (9, "view", 1685584800000), (10, "view", 1685584800000);
+insert into retention_analysis_test values (1, "download", 1685602800000), (2, "download", 1685602800000), (3, "download", 1685602800000), (4, "download", 1685602800000), (5, "download", 1685602800000), (6, "download", 1685602800000);
+insert into retention_analysis_test values (1, "view", 1685671200000), (2, "view", 1685671200000), (3, "view", 1685671200000), (4, "view", 1685671200000), (5, "view", 1685671200000), (6, "view", 1685671200000), (7, "view", 1685671200000), (8, "view", 1685671200000);
+insert into retention_analysis_test values (1, "download", 1685689200000), (2, "download", 1685689200000), (3, "download", 1685689200000), (4, "download", 1685689200000), (5, "download", 1685689200000);
+insert into retention_analysis_test values (1, "view", 1685757600000), (2, "view", 1685757600000), (3, "view", 1685757600000), (4, "view", 1685757600000), (5, "view", 1685757600000), (6, "view", 1685757600000), (7, "view", 1685757600000), (8, "view", 1685757600000), (9, "view", 1685757600000), (10, "view", 1685757600000), (11, "view", 1685757600000);
+insert into retention_analysis_test values (1, "download", 1685775600000), (2, "download", 1685775600000), (3, "download", 1685775600000);
+
+SELECT retention_count(c.retention_info)
+FROM (
+	SELECT distinct_id
+		, retention_info(1685548800000, "day", timestamp, CASE 
+			WHEN event_name = "view" THEN 1
+			ELSE 0
+		END | CASE 
+			WHEN event_name = "download" THEN 2
+			ELSE 0
+		END) AS retention_info
+	FROM retention_analysis_test
+	WHERE timestamp >= 1685548800000
+	GROUP BY distinct_id
+) c;
+```
+查询结果
+```
++-------------------------------------------------------------+
+| retention_count(`c`.`retention_info`)                       |
++-------------------------------------------------------------+
+| 0:-1:10;0:0:6;0:1:5;0:2:3;1:-1:8;1:0:5;1:1:3;2:-1:11;2:0:3; |
++-------------------------------------------------------------+
+```
+`0:-1:10`表示第0天（留存分析起始时间当天）发生了初次事件的用户数为10。
+
+`0:0:6`表示第0天发生了初次事件的用户中，之后第0天（当日）发生了留存事件的用户数为6。
+
+`0:1:5`表示第0天发生了初次事件的用户中，之后第1天发生了留存事件的用户数为5。
+
+`0:2:3`表示第0天发生了初次事件的用户中，之后第2天发生了留存事件的用户数为3。
+
+`1:-1:8`表示第1天（留存分析起始时间之后的第1天）发生了初次事件的用户数为8。
+
+`1:0:5`表示第1天发生了初次事件的用户中，之后第0天（当日）发生了留存事件的用户数为5。
+
+`1:1:3`表示第1天发生了初次事件的用户中，之后第1天发生了留存事件的用户数为3。
+
+`2:-1:11`表示第2天（留存分析起始时间之后的第2天）发生了初次事件的用户数为1。
+
+`2:0:3`表示第2天发生了初次事件的用户中，之后第0天（当日）发生了留存事件的用户数为3。
+
+### keywords
+
+RETENTION_COUNT

--- a/docs/zh-CN/docs/sql-manual/sql-functions/aggregate-functions/retention_info.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/aggregate-functions/retention_info.md
@@ -1,0 +1,63 @@
+---
+{
+    "title": "RETENTION_INFO",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+## RETENTION_INFO
+
+<version since="1.2.0">
+
+RETENTION_INFO
+
+</version>
+
+### description
+#### Syntax
+
+`retention_info(bigint start_time, varchar unit, bigint event_time, int event_type) RETURNS varchar retention`
+
+统计每一个用户的留存事件数据。
+
+#### Arguments
+
+`start_time` — 进行留存分析的事件起始时间，起始时间之后发生的事件才会作为有效事件。
+
+`unit` — 进行留存分析的时间单位，目前只支持按天计算留存，该参数值需要传入`day`。
+
+`event_time` — 事件发生的时间，采用unixtime格式，精确到毫秒。
+
+`event_type` — 事件类型，表示事件为初始事件还是留存事件，1表示初次事件，2表示留存事件，0表示无效事件。
+
+
+##### Returned value
+
+函数返回值为每一个用户的留存事件数据，作为`retention_count()`函数的输入参数。该函数需要和`retention_count()`函数配合使用，否则没有实际意义。
+
+### example
+
+参见`retention_count()`函数的的示例。
+
+### keywords
+
+RETENTION_INFO

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -1342,6 +1342,45 @@ public class FunctionCallExpr extends Expr {
             }
             fn = getBuiltinFunction(fnName.getFunction(), childTypes,
                     Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+        } else if (fnName.getFunction().equalsIgnoreCase(FunctionSet.RETENTION_ANALYSIS)) {
+            if (fnParams.exprs() == null || fnParams.exprs().size() != 4) {
+                throw new AnalysisException("The " + fnName + " function must have 4 params");
+            }
+
+            if (!children.get(0).type.isIntegerType()) {
+                throw new AnalysisException("The 1st params of " + fnName + " function must be bigint");
+            }
+            if (!children.get(1).type.isStringType()) {
+                throw new AnalysisException("The 2nd param of " + fnName + " function must be varchar");
+            }
+            if (!children.get(2).type.isIntegerType()) {
+                throw new AnalysisException("The 3rd params of " + fnName + " function must be bigint");
+            }
+            if (!children.get(3).type.isIntegerType()) {
+                throw new AnalysisException("The 4th param of " + fnName + " function must be integer");
+            }
+
+            Type[] childTypes = new Type[children.size()];
+            for (int i = 0; i < children.size(); i++) {
+                childTypes[i] = children.get(i).type;
+            }
+            fn = getBuiltinFunction(fnName.getFunction(), childTypes,
+                    Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+        } else if (fnName.getFunction().equalsIgnoreCase(FunctionSet.RETENTION_ANALYSIS_COUNT)) {
+            if (fnParams.exprs() == null || fnParams.exprs().size() != 1) {
+                throw new AnalysisException("The " + fnName + " function must have 1 params");
+            }
+
+            if (!children.get(0).type.isStringType()) {
+                throw new AnalysisException("The params of " + fnName + " function must be varchar");
+            }
+
+            Type[] childTypes = new Type[children.size()];
+            for (int i = 0; i < children.size(); i++) {
+                childTypes[i] = children.get(i).type;
+            }
+            fn = getBuiltinFunction(fnName.getFunction(), childTypes,
+                    Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
         } else if (fnName.getFunction().equalsIgnoreCase(FunctionSet.SEQUENCE_MATCH)
                 || fnName.getFunction().equalsIgnoreCase(FunctionSet.SEQUENCE_COUNT)) {
             if (fnParams.exprs() == null || fnParams.exprs().size() < 4) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/AggregateFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/AggregateFunction.java
@@ -54,7 +54,8 @@ public class AggregateFunction extends Function {
             FunctionSet.INTERSECT_COUNT, FunctionSet.ORTHOGONAL_BITMAP_UNION_COUNT,
             FunctionSet.COUNT, "approx_count_distinct", "ndv", FunctionSet.BITMAP_UNION_INT,
             FunctionSet.BITMAP_UNION_COUNT, "ndv_no_finalize", FunctionSet.WINDOW_FUNNEL, FunctionSet.RETENTION,
-            FunctionSet.SEQUENCE_MATCH, FunctionSet.SEQUENCE_COUNT);
+            FunctionSet.SEQUENCE_MATCH, FunctionSet.SEQUENCE_COUNT, FunctionSet.RETENTION_ANALYSIS,
+            FunctionSet.RETENTION_ANALYSIS_COUNT);
 
     public static ImmutableSet<String> ALWAYS_NULLABLE_AGGREGATE_FUNCTION_NAME_SET =
             ImmutableSet.of("stddev_samp", "variance_samp", "var_samp", "percentile_approx");

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
@@ -1304,6 +1304,10 @@ public class FunctionSet<T> {
 
     public static final String GROUP_ARRAY = "group_array";
 
+    public static final String RETENTION_ANALYSIS = "retention_info";
+    public static final String RETENTION_ANALYSIS_COUNT = "retention_count";
+
+
     // Populate all the aggregate builtins in the catalog.
     // null symbols indicate the function does not need that step of the evaluation.
     // An empty symbol indicates a TODO for the BE to implement the function.
@@ -1505,6 +1509,36 @@ public class FunctionSet<T> {
                         "",
                         "",
                         true, false, true, true));
+
+        // retention_analysis vectorization
+        addBuiltin(AggregateFunction.createBuiltin(FunctionSet.RETENTION_ANALYSIS,
+                        Lists.newArrayList(Type.BIGINT, Type.VARCHAR, Type.BIGINT, Type.INT),
+                        Type.VARCHAR,
+                        Type.VARCHAR,
+                        true,
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        true, false, true, true));
+
+        addBuiltin(AggregateFunction.createBuiltin(FunctionSet.RETENTION_ANALYSIS_COUNT,
+                        Lists.newArrayList(Type.VARCHAR),
+                        Type.VARCHAR,
+                        Type.VARCHAR,
+                        true,
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        true, false, true, true));
+
 
         for (Type t : Type.getTrivialTypes()) {
             if (t.isNull()) {


### PR DESCRIPTION

## Proposed changes

Issue Number: close #20618 

Support agg function retention_info() and retention_count for retention analysis

Function used to calculate retention event for each user:
`retention_info(bigint start_time, varchar unit, bigint event_time, int event_type) RETURNS varchar retention`

Function used to analysis retention for all user events:
`retention_count(varchar retention) RETURNS varchar`
