### PR TITLE
[fix](regression) tests in unique_with_mow_p0/partial_update are flaky

### DIFF
--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update.groovy
@@ -52,8 +52,11 @@ suite("test_primary_key_partial_update", "p0") {
         file 'basic.csv'
         time 10000 // limit inflight 10s
     }
+
+    sql "sync"
+
     qt_select_default """
-        select * from ${tableName}
+        select * from ${tableName} order by id;
     """
 
     // drop drop

--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_default_value.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_default_value.groovy
@@ -52,8 +52,11 @@ suite("test_primary_key_partial_update_default_value", "p0") {
         file 'default.csv'
         time 10000 // limit inflight 10s
     }
+
+    sql "sync"
+
     qt_select_default """
-        select * from ${tableName}
+        select * from ${tableName} order by id;
     """
 
     // drop drop

--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_orc.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_orc.groovy
@@ -51,8 +51,11 @@ suite("test_primary_key_partial_update_orc", "p0") {
         file 'update.orc'
         time 10000 // limit inflight 10s
     }
+
+    sql "sync"
+
     qt_select_0 """
-        select * from ${tableName};
+        select * from ${tableName} order by col_0;
     """
 
     // drop drop

--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_publish.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_publish.groovy
@@ -61,6 +61,8 @@ suite("test_primary_key_partial_update_publish", "p0") {
         time 10000 // limit inflight 10s
     }
 
+    sql "sync"
+
     qt_select_default """
         select * from ${tableName} order by id;
     """

--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_with_row_column.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_with_row_column.groovy
@@ -53,6 +53,9 @@ suite("test_primary_key_partial_update_with_row_column", "p0") {
         file 'basic.csv'
         time 10000 // limit inflight 10s
     }
+
+    sql "sync"
+
     qt_select_default """
         select * from ${tableName} order by id
     """


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

tests in unique_with_mow_p0/partial_update are flaky
add sync and order by

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

