### PR TITLE
[tpcds](nereids) estimate distribution cost by byte size instead of row count

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
@@ -161,27 +161,27 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
     @Override
     public Cost visitPhysicalDistribute(
             PhysicalDistribute<? extends Plan> distribute, PlanContext context) {
+        int kBytes = 1024;
         Statistics childStatistics = context.getChildStatistics(0);
         DistributionSpec spec = distribute.getDistributionSpec();
+        int beNumber = ConnectContext.get().getEnv().getClusterInfo().getBackendsNumber(true);
+        beNumber = Math.max(1, beNumber);
+        double dataSize = childStatistics.computeSize() / kBytes; // in K bytes
         // shuffle
         if (spec instanceof DistributionSpecHash) {
             return CostV1.of(
                     0,
                     0,
-                    childStatistics.getRowCount());
+                    dataSize / beNumber);
         }
 
         // replicate
         if (spec instanceof DistributionSpecReplicated) {
-            int beNumber = ConnectContext.get().getEnv().getClusterInfo().getBackendsNumber(true);
-            int instanceNumber = ConnectContext.get().getSessionVariable().getParallelExecInstanceNum();
-            beNumber = Math.max(1, beNumber);
             double memLimit = ConnectContext.get().getSessionVariable().getMaxExecMemByte();
             //if build side is big, avoid use broadcast join
             double rowsLimit = ConnectContext.get().getSessionVariable().getBroadcastRowCountLimit();
             double brMemlimit = ConnectContext.get().getSessionVariable().getBroadcastHashtableMemLimitPercentage();
-            double buildSize = childStatistics.computeSize();
-            if (buildSize * instanceNumber > memLimit * brMemlimit
+            if (dataSize > memLimit * brMemlimit / kBytes
                     || childStatistics.getRowCount() > rowsLimit) {
                 return CostV1.of(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
             }
@@ -191,7 +191,7 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
             return CostV1.of(
                     0,
                     0,
-                    childStatistics.getRowCount() * Math.pow(beNumber, 0.5));
+                    dataSize, 0.0);
 
         }
 
@@ -200,7 +200,7 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
             return CostV1.of(
                     0,
                     0,
-                    childStatistics.getRowCount());
+                    dataSize / beNumber);
         }
 
         // any

--- a/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
@@ -359,7 +359,7 @@ public class SystemInfoService {
 
     public int getBackendsNumber(boolean needAlive) {
         int beNumber = ConnectContext.get().getSessionVariable().getBeNumberForTest();
-        if (beNumber == -1) {
+        if (beNumber < 0) {
             beNumber = getAllBackendIds(needAlive).size();
         }
         return beNumber;

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query11.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query11.out
@@ -44,22 +44,24 @@ CteAnchor[cteId= ( CTEId#4=] )
 ----PhysicalDistribute
 ------PhysicalTopN
 --------PhysicalProject
-----------hashJoin[INNER_JOIN](t_s_firstyear.customer_id = t_w_firstyear.customer_id)(CASE WHEN (year_total > 0.00) THEN (cast(year_total as DECIMALV3(38, 8)) / year_total) ELSE 0.000000 END > CASE WHEN (year_total > 0.00) THEN (cast(year_total as DECIMALV3(38, 8)) / year_total) ELSE 0.000000 END)
+----------hashJoin[INNER_JOIN](t_s_firstyear.customer_id = t_w_secyear.customer_id)(CASE WHEN (year_total > 0.00) THEN (cast(year_total as DECIMALV3(38, 8)) / year_total) ELSE 0.000000 END > CASE WHEN (year_total > 0.00) THEN (cast(year_total as DECIMALV3(38, 8)) / year_total) ELSE 0.000000 END)
 ------------PhysicalProject
---------------filter((t_w_firstyear.year_total > 0.00)(t_w_firstyear.sale_type = 'w')(t_w_firstyear.dyear = 2001))
+--------------filter((t_w_secyear.dyear = 2002)(t_w_secyear.sale_type = 'w'))
 ----------------CteConsumer[cteId= ( CTEId#4=] )
 ------------PhysicalDistribute
---------------hashJoin[INNER_JOIN](t_s_firstyear.customer_id = t_w_secyear.customer_id)
-----------------PhysicalProject
-------------------filter((t_w_secyear.dyear = 2002)(t_w_secyear.sale_type = 'w'))
---------------------CteConsumer[cteId= ( CTEId#4=] )
-----------------PhysicalDistribute
-------------------hashJoin[INNER_JOIN](t_s_secyear.customer_id = t_s_firstyear.customer_id)
---------------------PhysicalProject
-----------------------filter((t_s_secyear.sale_type = 's')(t_s_secyear.dyear = 2002))
-------------------------CteConsumer[cteId= ( CTEId#4=] )
---------------------PhysicalDistribute
-----------------------PhysicalProject
-------------------------filter((t_s_firstyear.dyear = 2001)(t_s_firstyear.sale_type = 's')(t_s_firstyear.year_total > 0.00))
---------------------------CteConsumer[cteId= ( CTEId#4=] )
+--------------PhysicalProject
+----------------hashJoin[INNER_JOIN](t_s_secyear.customer_id = t_s_firstyear.customer_id)
+------------------PhysicalProject
+--------------------filter((t_s_secyear.sale_type = 's')(t_s_secyear.dyear = 2002))
+----------------------CteConsumer[cteId= ( CTEId#4=] )
+------------------PhysicalDistribute
+--------------------hashJoin[INNER_JOIN](t_s_firstyear.customer_id = t_w_firstyear.customer_id)
+----------------------PhysicalDistribute
+------------------------PhysicalProject
+--------------------------filter((t_s_firstyear.dyear = 2001)(t_s_firstyear.sale_type = 's')(t_s_firstyear.year_total > 0.00))
+----------------------------CteConsumer[cteId= ( CTEId#4=] )
+----------------------PhysicalDistribute
+------------------------PhysicalProject
+--------------------------filter((t_w_firstyear.year_total > 0.00)(t_w_firstyear.sale_type = 'w')(t_w_firstyear.dyear = 2001))
+----------------------------CteConsumer[cteId= ( CTEId#4=] )
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query18.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query18.out
@@ -9,14 +9,14 @@ PhysicalTopN
 ------------hashAgg[LOCAL]
 --------------PhysicalRepeat
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN](customer.c_current_cdemo_sk = cd2.cd_demo_sk)
+------------------hashJoin[INNER_JOIN](catalog_sales.cs_item_sk = item.i_item_sk)
 --------------------PhysicalProject
-----------------------PhysicalOlapScan[customer_demographics]
+----------------------PhysicalOlapScan[item]
 --------------------PhysicalDistribute
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN](catalog_sales.cs_item_sk = item.i_item_sk)
+------------------------hashJoin[INNER_JOIN](customer.c_current_cdemo_sk = cd2.cd_demo_sk)
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[item]
+----------------------------PhysicalOlapScan[customer_demographics]
 --------------------------PhysicalDistribute
 ----------------------------PhysicalProject
 ------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query2.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query2.out
@@ -19,21 +19,23 @@ CteAnchor[cteId= ( CTEId#4=] )
 ----PhysicalDistribute
 ------PhysicalQuickSort
 --------PhysicalProject
-----------hashJoin[INNER_JOIN](date_dim.d_week_seq = d_week_seq2)
-------------hashJoin[INNER_JOIN](expr_cast(d_week_seq1 as BIGINT) = expr_(d_week_seq2 - 53))
---------------PhysicalProject
-----------------CteConsumer[cteId= ( CTEId#4=] )
---------------PhysicalDistribute
-----------------PhysicalProject
-------------------hashJoin[INNER_JOIN](date_dim.d_week_seq = d_week_seq1)
---------------------PhysicalProject
-----------------------CteConsumer[cteId= ( CTEId#4=] )
---------------------PhysicalDistribute
-----------------------PhysicalProject
-------------------------filter((date_dim.d_year = 1998))
---------------------------PhysicalOlapScan[date_dim]
+----------hashJoin[INNER_JOIN](expr_cast(d_week_seq1 as BIGINT) = expr_(d_week_seq2 - 53))
 ------------PhysicalDistribute
 --------------PhysicalProject
-----------------filter((date_dim.d_year = 1999))
-------------------PhysicalOlapScan[date_dim]
+----------------hashJoin[INNER_JOIN](date_dim.d_week_seq = d_week_seq1)
+------------------PhysicalProject
+--------------------CteConsumer[cteId= ( CTEId#4=] )
+------------------PhysicalDistribute
+--------------------PhysicalProject
+----------------------filter((date_dim.d_year = 1998))
+------------------------PhysicalOlapScan[date_dim]
+------------PhysicalDistribute
+--------------PhysicalProject
+----------------hashJoin[INNER_JOIN](date_dim.d_week_seq = d_week_seq2)
+------------------PhysicalProject
+--------------------CteConsumer[cteId= ( CTEId#4=] )
+------------------PhysicalDistribute
+--------------------PhysicalProject
+----------------------filter((date_dim.d_year = 1999))
+------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query26.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query26.out
@@ -9,8 +9,8 @@ PhysicalTopN
 ------------PhysicalProject
 --------------hashJoin[INNER_JOIN](catalog_sales.cs_item_sk = item.i_item_sk)
 ----------------PhysicalDistribute
-------------------PhysicalProject
---------------------hashJoin[INNER_JOIN](catalog_sales.cs_promo_sk = promotion.p_promo_sk)
+------------------hashJoin[INNER_JOIN](catalog_sales.cs_promo_sk = promotion.p_promo_sk)
+--------------------PhysicalProject
 ----------------------hashJoin[INNER_JOIN](catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)
 ------------------------hashJoin[INNER_JOIN](catalog_sales.cs_bill_cdemo_sk = customer_demographics.cd_demo_sk)
 --------------------------PhysicalProject
@@ -23,10 +23,10 @@ PhysicalTopN
 --------------------------PhysicalProject
 ----------------------------filter((date_dim.d_year = 2001))
 ------------------------------PhysicalOlapScan[date_dim]
-----------------------PhysicalDistribute
-------------------------PhysicalProject
---------------------------filter(((cast(p_channel_email as VARCHAR(*)) = 'N') OR (cast(p_channel_event as VARCHAR(*)) = 'N')))
-----------------------------PhysicalOlapScan[promotion]
+--------------------PhysicalDistribute
+----------------------PhysicalProject
+------------------------filter(((cast(p_channel_email as VARCHAR(*)) = 'N') OR (cast(p_channel_event as VARCHAR(*)) = 'N')))
+--------------------------PhysicalOlapScan[promotion]
 ----------------PhysicalProject
 ------------------PhysicalOlapScan[item]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query30.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query30.out
@@ -8,13 +8,14 @@ CteAnchor[cteId= ( CTEId#2=] )
 ----------PhysicalProject
 ------------hashJoin[INNER_JOIN](web_returns.wr_returning_addr_sk = customer_address.ca_address_sk)
 --------------PhysicalDistribute
-----------------hashJoin[INNER_JOIN](web_returns.wr_returned_date_sk = date_dim.d_date_sk)
-------------------PhysicalProject
---------------------PhysicalOlapScan[web_returns]
-------------------PhysicalDistribute
+----------------PhysicalProject
+------------------hashJoin[INNER_JOIN](web_returns.wr_returned_date_sk = date_dim.d_date_sk)
 --------------------PhysicalProject
-----------------------filter((date_dim.d_year = 2002))
-------------------------PhysicalOlapScan[date_dim]
+----------------------PhysicalOlapScan[web_returns]
+--------------------PhysicalDistribute
+----------------------PhysicalProject
+------------------------filter((date_dim.d_year = 2002))
+--------------------------PhysicalOlapScan[date_dim]
 --------------PhysicalProject
 ----------------PhysicalOlapScan[customer_address]
 --PhysicalTopN

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query31.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query31.out
@@ -49,27 +49,27 @@ CteAnchor[cteId= ( CTEId#6=] )
 --------------PhysicalDistribute
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN](ss2.ca_county = ss3.ca_county)
---------------------PhysicalProject
-----------------------filter((ss3.d_year = 2000)(ss3.d_qoy = 3))
-------------------------CteConsumer[cteId= ( CTEId#6=] )
 --------------------PhysicalDistribute
-----------------------hashJoin[INNER_JOIN](ss1.ca_county = ss2.ca_county)(CASE WHEN (web_sales > 0.00) THEN (cast(web_sales as DECIMALV3(38, 8)) / web_sales) ELSE NULL END > CASE WHEN (store_sales > 0.00) THEN (cast(store_sales as DECIMALV3(38, 8)) / store_sales) ELSE NULL END)
+----------------------PhysicalProject
+------------------------filter((ss3.d_year = 2000)(ss3.d_qoy = 3))
+--------------------------CteConsumer[cteId= ( CTEId#6=] )
+--------------------hashJoin[INNER_JOIN](ss1.ca_county = ss2.ca_county)(CASE WHEN (web_sales > 0.00) THEN (cast(web_sales as DECIMALV3(38, 8)) / web_sales) ELSE NULL END > CASE WHEN (store_sales > 0.00) THEN (cast(store_sales as DECIMALV3(38, 8)) / store_sales) ELSE NULL END)
+----------------------PhysicalDistribute
 ------------------------PhysicalProject
 --------------------------filter((ss2.d_year = 2000)(ss2.d_qoy = 2))
 ----------------------------CteConsumer[cteId= ( CTEId#6=] )
+----------------------hashJoin[INNER_JOIN](ss1.ca_county = ws1.ca_county)
 ------------------------PhysicalDistribute
---------------------------hashJoin[INNER_JOIN](ss1.ca_county = ws1.ca_county)
-----------------------------PhysicalDistribute
-------------------------------PhysicalProject
---------------------------------filter((ss1.d_year = 2000)(ss1.d_qoy = 1))
-----------------------------------CteConsumer[cteId= ( CTEId#6=] )
-----------------------------hashJoin[INNER_JOIN](ws1.ca_county = ws2.ca_county)
-------------------------------PhysicalDistribute
---------------------------------PhysicalProject
-----------------------------------filter((ws1.d_year = 2000)(ws1.d_qoy = 1))
-------------------------------------CteConsumer[cteId= ( CTEId#7=] )
-------------------------------PhysicalDistribute
---------------------------------PhysicalProject
-----------------------------------filter((ws2.d_qoy = 2)(ws2.d_year = 2000))
-------------------------------------CteConsumer[cteId= ( CTEId#7=] )
+--------------------------PhysicalProject
+----------------------------filter((ss1.d_year = 2000)(ss1.d_qoy = 1))
+------------------------------CteConsumer[cteId= ( CTEId#6=] )
+------------------------hashJoin[INNER_JOIN](ws1.ca_county = ws2.ca_county)
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------filter((ws1.d_year = 2000)(ws1.d_qoy = 1))
+--------------------------------CteConsumer[cteId= ( CTEId#7=] )
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------filter((ws2.d_qoy = 2)(ws2.d_year = 2000))
+--------------------------------CteConsumer[cteId= ( CTEId#7=] )
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query33.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query33.out
@@ -41,22 +41,22 @@ PhysicalTopN
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
 --------------------------hashJoin[INNER_JOIN](catalog_sales.cs_item_sk = item.i_item_sk)
-----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)
---------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)
-----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[catalog_sales]
-----------------------------------PhysicalDistribute
-------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 1)(date_dim.d_year = 2002))
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalDistribute
-----------------------------------PhysicalProject
-------------------------------------filter((customer_address.ca_gmt_offset = -5.00))
---------------------------------------PhysicalOlapScan[customer_address]
 ----------------------------PhysicalDistribute
 ------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[item]
+--------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)
+----------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)
+------------------------------------PhysicalProject
+--------------------------------------PhysicalOlapScan[catalog_sales]
+------------------------------------PhysicalDistribute
+--------------------------------------PhysicalProject
+----------------------------------------filter((date_dim.d_moy = 1)(date_dim.d_year = 2002))
+------------------------------------------PhysicalOlapScan[date_dim]
+----------------------------------PhysicalDistribute
+------------------------------------PhysicalProject
+--------------------------------------filter((customer_address.ca_gmt_offset = -5.00))
+----------------------------------------PhysicalOlapScan[customer_address]
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[item]
 ------------------PhysicalDistribute
 --------------------PhysicalProject
 ----------------------filter((item.i_category = 'Home'))

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query35.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query35.out
@@ -11,28 +11,31 @@ PhysicalTopN
 ----------------filter(($c$1 OR $c$2))
 ------------------hashJoin[LEFT_SEMI_JOIN](c.c_customer_sk = catalog_sales.cs_ship_customer_sk)
 --------------------hashJoin[LEFT_SEMI_JOIN](c.c_customer_sk = web_sales.ws_bill_customer_sk)
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN](customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)
---------------------------hashJoin[RIGHT_SEMI_JOIN](c.c_customer_sk = store_sales.ss_customer_sk)
+----------------------PhysicalDistribute
+------------------------PhysicalProject
+--------------------------hashJoin[INNER_JOIN](customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)
 ----------------------------PhysicalDistribute
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN](store_sales.ss_sold_date_sk = date_dim.d_date_sk)
-----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[store_sales]
+--------------------------------hashJoin[INNER_JOIN](c.c_current_addr_sk = ca.ca_address_sk)
 ----------------------------------PhysicalDistribute
-------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_qoy < 4)(date_dim.d_year = 2001))
-----------------------------------------PhysicalOlapScan[date_dim]
-----------------------------PhysicalDistribute
-------------------------------hashJoin[INNER_JOIN](c.c_current_addr_sk = ca.ca_address_sk)
---------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[customer]
---------------------------------PhysicalDistribute
+------------------------------------hashJoin[RIGHT_SEMI_JOIN](c.c_customer_sk = store_sales.ss_customer_sk)
+--------------------------------------PhysicalDistribute
+----------------------------------------PhysicalProject
+------------------------------------------hashJoin[INNER_JOIN](store_sales.ss_sold_date_sk = date_dim.d_date_sk)
+--------------------------------------------PhysicalProject
+----------------------------------------------PhysicalOlapScan[store_sales]
+--------------------------------------------PhysicalDistribute
+----------------------------------------------PhysicalProject
+------------------------------------------------filter((date_dim.d_qoy < 4)(date_dim.d_year = 2001))
+--------------------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------------PhysicalDistribute
+----------------------------------------PhysicalProject
+------------------------------------------PhysicalOlapScan[customer]
 ----------------------------------PhysicalProject
 ------------------------------------PhysicalOlapScan[customer_address]
---------------------------PhysicalDistribute
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[customer_demographics]
+----------------------------PhysicalDistribute
+------------------------------PhysicalProject
+--------------------------------PhysicalOlapScan[customer_demographics]
 ----------------------PhysicalDistribute
 ------------------------PhysicalProject
 --------------------------hashJoin[INNER_JOIN](web_sales.ws_sold_date_sk = date_dim.d_date_sk)

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query38.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query38.out
@@ -45,13 +45,15 @@ PhysicalLimit
 --------------------hashAgg[LOCAL]
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN](web_sales.ws_bill_customer_sk = customer.c_customer_sk)
---------------------------hashJoin[INNER_JOIN](web_sales.ws_sold_date_sk = date_dim.d_date_sk)
+--------------------------PhysicalDistribute
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[web_sales]
-----------------------------PhysicalDistribute
-------------------------------PhysicalProject
---------------------------------filter((date_dim.d_month_seq <= 1194)(date_dim.d_month_seq >= 1183))
-----------------------------------PhysicalOlapScan[date_dim]
+------------------------------hashJoin[INNER_JOIN](web_sales.ws_sold_date_sk = date_dim.d_date_sk)
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[web_sales]
+--------------------------------PhysicalDistribute
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_month_seq <= 1194)(date_dim.d_month_seq >= 1183))
+--------------------------------------PhysicalOlapScan[date_dim]
 --------------------------PhysicalDistribute
 ----------------------------PhysicalProject
 ------------------------------PhysicalOlapScan[customer]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query4.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query4.out
@@ -76,22 +76,24 @@ CteAnchor[cteId= ( CTEId#6=] )
 --------------------CteConsumer[cteId= ( CTEId#6=] )
 ----------------PhysicalDistribute
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN](t_s_firstyear.customer_id = t_c_firstyear.customer_id)(CASE WHEN (year_total > 0.000000) THEN (cast(year_total as DECIMALV3(38, 16)) / year_total) ELSE NULL END > CASE WHEN (year_total > 0.000000) THEN (cast(year_total as DECIMALV3(38, 16)) / year_total) ELSE NULL END)
+--------------------hashJoin[INNER_JOIN](t_s_secyear.customer_id = t_s_firstyear.customer_id)(CASE WHEN (year_total > 0.000000) THEN (cast(year_total as DECIMALV3(38, 16)) / year_total) ELSE NULL END > CASE WHEN (year_total > 0.000000) THEN (cast(year_total as DECIMALV3(38, 16)) / year_total) ELSE NULL END)
 ----------------------PhysicalProject
-------------------------filter((t_c_firstyear.year_total > 0.000000)(t_c_firstyear.dyear = 1999)(t_c_firstyear.sale_type = 'c'))
+------------------------filter((t_s_secyear.sale_type = 's')(t_s_secyear.dyear = 2000))
 --------------------------CteConsumer[cteId= ( CTEId#6=] )
 ----------------------PhysicalDistribute
-------------------------hashJoin[INNER_JOIN](t_s_secyear.customer_id = t_s_firstyear.customer_id)
---------------------------PhysicalProject
-----------------------------filter((t_s_secyear.sale_type = 's')(t_s_secyear.dyear = 2000))
-------------------------------CteConsumer[cteId= ( CTEId#6=] )
---------------------------PhysicalDistribute
-----------------------------hashJoin[INNER_JOIN](t_s_firstyear.customer_id = t_c_secyear.customer_id)
-------------------------------PhysicalProject
---------------------------------filter((t_c_secyear.sale_type = 'c')(t_c_secyear.dyear = 2000))
-----------------------------------CteConsumer[cteId= ( CTEId#6=] )
-------------------------------PhysicalDistribute
---------------------------------PhysicalProject
-----------------------------------filter((t_s_firstyear.year_total > 0.000000)(t_s_firstyear.dyear = 1999)(t_s_firstyear.sale_type = 's'))
-------------------------------------CteConsumer[cteId= ( CTEId#6=] )
+------------------------PhysicalProject
+--------------------------hashJoin[INNER_JOIN](t_s_firstyear.customer_id = t_c_secyear.customer_id)
+----------------------------PhysicalProject
+------------------------------filter((t_c_secyear.sale_type = 'c')(t_c_secyear.dyear = 2000))
+--------------------------------CteConsumer[cteId= ( CTEId#6=] )
+----------------------------PhysicalDistribute
+------------------------------hashJoin[INNER_JOIN](t_s_firstyear.customer_id = t_c_firstyear.customer_id)
+--------------------------------PhysicalDistribute
+----------------------------------PhysicalProject
+------------------------------------filter((t_s_firstyear.year_total > 0.000000)(t_s_firstyear.dyear = 1999)(t_s_firstyear.sale_type = 's'))
+--------------------------------------CteConsumer[cteId= ( CTEId#6=] )
+--------------------------------PhysicalDistribute
+----------------------------------PhysicalProject
+------------------------------------filter((t_c_firstyear.year_total > 0.000000)(t_c_firstyear.dyear = 1999)(t_c_firstyear.sale_type = 'c'))
+--------------------------------------CteConsumer[cteId= ( CTEId#6=] )
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query44.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query44.out
@@ -9,57 +9,57 @@ PhysicalTopN
 ------------PhysicalOlapScan[item]
 ----------PhysicalDistribute
 ------------hashJoin[INNER_JOIN](asceding.rnk = descending.rnk)
---------------PhysicalProject
-----------------filter((rnk < 11))
-------------------PhysicalWindow
---------------------PhysicalQuickSort
-----------------------PhysicalDistribute
-------------------------PhysicalQuickSort
---------------------------PhysicalProject
-----------------------------NestedLoopJoin[INNER_JOIN](cast(rank_col as DOUBLE) > cast((0.9 * rank_col) as DOUBLE))
-------------------------------hashAgg[GLOBAL]
---------------------------------PhysicalDistribute
-----------------------------------hashAgg[LOCAL]
-------------------------------------PhysicalProject
---------------------------------------filter((ss1.ss_store_sk = 146))
-----------------------------------------PhysicalOlapScan[store_sales]
-------------------------------PhysicalDistribute
---------------------------------PhysicalAssertNumRows
-----------------------------------PhysicalDistribute
-------------------------------------PhysicalProject
---------------------------------------hashAgg[GLOBAL]
-----------------------------------------PhysicalDistribute
-------------------------------------------hashAgg[LOCAL]
---------------------------------------------PhysicalProject
-----------------------------------------------filter(ss_addr_sk IS NULL(store_sales.ss_store_sk = 146))
-------------------------------------------------PhysicalOlapScan[store_sales]
---------------PhysicalDistribute
-----------------hashJoin[INNER_JOIN](i2.i_item_sk = descending.item_sk)
+--------------hashJoin[INNER_JOIN](i2.i_item_sk = descending.item_sk)
+----------------PhysicalProject
+------------------PhysicalOlapScan[item]
+----------------PhysicalDistribute
 ------------------PhysicalProject
---------------------PhysicalOlapScan[item]
-------------------PhysicalDistribute
---------------------PhysicalProject
-----------------------filter((rnk < 11))
-------------------------PhysicalWindow
---------------------------PhysicalQuickSort
-----------------------------PhysicalDistribute
-------------------------------PhysicalQuickSort
---------------------------------PhysicalProject
-----------------------------------NestedLoopJoin[INNER_JOIN](cast(rank_col as DOUBLE) > cast((0.9 * rank_col) as DOUBLE))
-------------------------------------hashAgg[GLOBAL]
---------------------------------------PhysicalDistribute
-----------------------------------------hashAgg[LOCAL]
-------------------------------------------PhysicalProject
---------------------------------------------filter((ss1.ss_store_sk = 146))
-----------------------------------------------PhysicalOlapScan[store_sales]
+--------------------filter((rnk < 11))
+----------------------PhysicalWindow
+------------------------PhysicalQuickSort
+--------------------------PhysicalDistribute
+----------------------------PhysicalQuickSort
+------------------------------PhysicalProject
+--------------------------------NestedLoopJoin[INNER_JOIN](cast(rank_col as DOUBLE) > cast((0.9 * rank_col) as DOUBLE))
+----------------------------------hashAgg[GLOBAL]
 ------------------------------------PhysicalDistribute
---------------------------------------PhysicalAssertNumRows
-----------------------------------------PhysicalDistribute
-------------------------------------------PhysicalProject
---------------------------------------------hashAgg[GLOBAL]
-----------------------------------------------PhysicalDistribute
-------------------------------------------------hashAgg[LOCAL]
---------------------------------------------------PhysicalProject
-----------------------------------------------------filter(ss_addr_sk IS NULL(store_sales.ss_store_sk = 146))
-------------------------------------------------------PhysicalOlapScan[store_sales]
+--------------------------------------hashAgg[LOCAL]
+----------------------------------------PhysicalProject
+------------------------------------------filter((ss1.ss_store_sk = 146))
+--------------------------------------------PhysicalOlapScan[store_sales]
+----------------------------------PhysicalDistribute
+------------------------------------PhysicalAssertNumRows
+--------------------------------------PhysicalDistribute
+----------------------------------------PhysicalProject
+------------------------------------------hashAgg[GLOBAL]
+--------------------------------------------PhysicalDistribute
+----------------------------------------------hashAgg[LOCAL]
+------------------------------------------------PhysicalProject
+--------------------------------------------------filter(ss_addr_sk IS NULL(store_sales.ss_store_sk = 146))
+----------------------------------------------------PhysicalOlapScan[store_sales]
+--------------PhysicalDistribute
+----------------PhysicalProject
+------------------filter((rnk < 11))
+--------------------PhysicalWindow
+----------------------PhysicalQuickSort
+------------------------PhysicalDistribute
+--------------------------PhysicalQuickSort
+----------------------------PhysicalProject
+------------------------------NestedLoopJoin[INNER_JOIN](cast(rank_col as DOUBLE) > cast((0.9 * rank_col) as DOUBLE))
+--------------------------------hashAgg[GLOBAL]
+----------------------------------PhysicalDistribute
+------------------------------------hashAgg[LOCAL]
+--------------------------------------PhysicalProject
+----------------------------------------filter((ss1.ss_store_sk = 146))
+------------------------------------------PhysicalOlapScan[store_sales]
+--------------------------------PhysicalDistribute
+----------------------------------PhysicalAssertNumRows
+------------------------------------PhysicalDistribute
+--------------------------------------PhysicalProject
+----------------------------------------hashAgg[GLOBAL]
+------------------------------------------PhysicalDistribute
+--------------------------------------------hashAgg[LOCAL]
+----------------------------------------------PhysicalProject
+------------------------------------------------filter(ss_addr_sk IS NULL(store_sales.ss_store_sk = 146))
+--------------------------------------------------PhysicalOlapScan[store_sales]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query45.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query45.out
@@ -11,25 +11,27 @@ PhysicalTopN
 ----------------hashJoin[LEFT_SEMI_JOIN](item.i_item_id = item.i_item_id)
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN](web_sales.ws_bill_customer_sk = customer.c_customer_sk)
-----------------------hashJoin[INNER_JOIN](web_sales.ws_item_sk = item.i_item_sk)
-------------------------hashJoin[INNER_JOIN](web_sales.ws_sold_date_sk = date_dim.d_date_sk)
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[web_sales]
---------------------------PhysicalDistribute
-----------------------------PhysicalProject
-------------------------------filter((date_dim.d_qoy = 2)(date_dim.d_year = 2000))
---------------------------------PhysicalOlapScan[date_dim]
-------------------------PhysicalDistribute
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[item]
+----------------------PhysicalDistribute
+------------------------PhysicalProject
+--------------------------hashJoin[INNER_JOIN](web_sales.ws_item_sk = item.i_item_sk)
+----------------------------hashJoin[INNER_JOIN](web_sales.ws_sold_date_sk = date_dim.d_date_sk)
+------------------------------PhysicalProject
+--------------------------------PhysicalOlapScan[web_sales]
+------------------------------PhysicalDistribute
+--------------------------------PhysicalProject
+----------------------------------filter((date_dim.d_qoy = 2)(date_dim.d_year = 2000))
+------------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalDistribute
+------------------------------PhysicalProject
+--------------------------------PhysicalOlapScan[item]
 ----------------------PhysicalDistribute
 ------------------------PhysicalProject
 --------------------------hashJoin[INNER_JOIN](customer.c_current_addr_sk = customer_address.ca_address_sk)
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[customer]
 ----------------------------PhysicalDistribute
 ------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[customer_address]
+--------------------------------PhysicalOlapScan[customer]
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[customer_address]
 ------------------PhysicalDistribute
 --------------------PhysicalProject
 ----------------------filter(i_item_sk IN (2, 3, 5, 7, 11, 13, 17, 19, 23, 29))

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query46.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query46.out
@@ -5,33 +5,6 @@ PhysicalTopN
 ----PhysicalTopN
 ------PhysicalProject
 --------hashJoin[INNER_JOIN](dn.ss_customer_sk = customer.c_customer_sk)( not (ca_city = bought_city))
-----------PhysicalProject
-------------hashAgg[GLOBAL]
---------------PhysicalDistribute
-----------------hashAgg[LOCAL]
-------------------PhysicalProject
---------------------hashJoin[INNER_JOIN](store_sales.ss_addr_sk = customer_address.ca_address_sk)
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN](store_sales.ss_store_sk = store.s_store_sk)
---------------------------hashJoin[INNER_JOIN](store_sales.ss_hdemo_sk = household_demographics.hd_demo_sk)
-----------------------------hashJoin[INNER_JOIN](store_sales.ss_sold_date_sk = date_dim.d_date_sk)
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[store_sales]
-------------------------------PhysicalDistribute
---------------------------------PhysicalProject
-----------------------------------filter(((date_dim.d_dow = 0) OR (date_dim.d_dow = 6))d_year IN (1999, 2000, 2001))
-------------------------------------PhysicalOlapScan[date_dim]
-----------------------------PhysicalDistribute
-------------------------------PhysicalProject
---------------------------------filter(((household_demographics.hd_dep_count = 6) OR (household_demographics.hd_vehicle_count = 0)))
-----------------------------------PhysicalOlapScan[household_demographics]
---------------------------PhysicalDistribute
-----------------------------PhysicalProject
-------------------------------filter(s_city IN ('Five Points', 'Centerville', 'Oak Grove', 'Fairview', 'Liberty'))
---------------------------------PhysicalOlapScan[store]
-----------------------PhysicalDistribute
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[customer_address]
 ----------PhysicalDistribute
 ------------hashJoin[INNER_JOIN](customer.c_current_addr_sk = current_addr.ca_address_sk)
 --------------PhysicalProject
@@ -39,4 +12,32 @@ PhysicalTopN
 --------------PhysicalDistribute
 ----------------PhysicalProject
 ------------------PhysicalOlapScan[customer]
+----------PhysicalDistribute
+------------PhysicalProject
+--------------hashAgg[GLOBAL]
+----------------PhysicalDistribute
+------------------hashAgg[LOCAL]
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN](store_sales.ss_addr_sk = customer_address.ca_address_sk)
+------------------------PhysicalProject
+--------------------------hashJoin[INNER_JOIN](store_sales.ss_store_sk = store.s_store_sk)
+----------------------------hashJoin[INNER_JOIN](store_sales.ss_hdemo_sk = household_demographics.hd_demo_sk)
+------------------------------hashJoin[INNER_JOIN](store_sales.ss_sold_date_sk = date_dim.d_date_sk)
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[store_sales]
+--------------------------------PhysicalDistribute
+----------------------------------PhysicalProject
+------------------------------------filter(((date_dim.d_dow = 0) OR (date_dim.d_dow = 6))d_year IN (1999, 2000, 2001))
+--------------------------------------PhysicalOlapScan[date_dim]
+------------------------------PhysicalDistribute
+--------------------------------PhysicalProject
+----------------------------------filter(((household_demographics.hd_dep_count = 6) OR (household_demographics.hd_vehicle_count = 0)))
+------------------------------------PhysicalOlapScan[household_demographics]
+----------------------------PhysicalDistribute
+------------------------------PhysicalProject
+--------------------------------filter(s_city IN ('Five Points', 'Centerville', 'Oak Grove', 'Fairview', 'Liberty'))
+----------------------------------PhysicalOlapScan[store]
+------------------------PhysicalDistribute
+--------------------------PhysicalProject
+----------------------------PhysicalOlapScan[customer_address]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query56.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query56.out
@@ -40,27 +40,27 @@ PhysicalTopN
 --------------------hashAgg[LOCAL]
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN](catalog_sales.cs_bill_addr_sk = customer_address.ca_address_sk)
+--------------------------hashJoin[INNER_JOIN](catalog_sales.cs_item_sk = item.i_item_sk)
+----------------------------PhysicalProject
+------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[catalog_sales]
+--------------------------------PhysicalDistribute
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_year = 2000)(date_dim.d_moy = 2))
+--------------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalDistribute
+------------------------------hashJoin[LEFT_SEMI_JOIN](item.i_item_id = item.i_item_id)
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[item]
+--------------------------------PhysicalDistribute
+----------------------------------PhysicalProject
+------------------------------------filter(i_color IN ('powder', 'green', 'cyan'))
+--------------------------------------PhysicalOlapScan[item]
 --------------------------PhysicalDistribute
-----------------------------hashJoin[INNER_JOIN](catalog_sales.cs_item_sk = item.i_item_sk)
-------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)
-----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[catalog_sales]
-----------------------------------PhysicalDistribute
-------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_year = 2000)(date_dim.d_moy = 2))
-----------------------------------------PhysicalOlapScan[date_dim]
-------------------------------PhysicalDistribute
---------------------------------hashJoin[LEFT_SEMI_JOIN](item.i_item_id = item.i_item_id)
-----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[item]
-----------------------------------PhysicalDistribute
-------------------------------------PhysicalProject
---------------------------------------filter(i_color IN ('powder', 'green', 'cyan'))
-----------------------------------------PhysicalOlapScan[item]
---------------------------PhysicalProject
-----------------------------filter((customer_address.ca_gmt_offset = -6.00))
-------------------------------PhysicalOlapScan[customer_address]
+----------------------------PhysicalProject
+------------------------------filter((customer_address.ca_gmt_offset = -6.00))
+--------------------------------PhysicalOlapScan[customer_address]
 --------------PhysicalProject
 ----------------hashAgg[GLOBAL]
 ------------------PhysicalDistribute

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query59.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query59.out
@@ -18,13 +18,15 @@ CteAnchor[cteId= ( CTEId#4=] )
 ------PhysicalTopN
 --------PhysicalProject
 ----------hashJoin[INNER_JOIN](d.d_week_seq = d_week_seq2)
-------------PhysicalProject
---------------filter((d.d_month_seq <= 1219)(d.d_month_seq >= 1208))
-----------------PhysicalOlapScan[date_dim]
+------------PhysicalDistribute
+--------------PhysicalProject
+----------------filter((d.d_month_seq <= 1219)(d.d_month_seq >= 1208))
+------------------PhysicalOlapScan[date_dim]
 ------------PhysicalDistribute
 --------------hashJoin[INNER_JOIN](y.s_store_id1 = x.s_store_id2)(wss.ss_store_sk = store.s_store_sk)
-----------------PhysicalProject
-------------------PhysicalOlapScan[store]
+----------------PhysicalDistribute
+------------------PhysicalProject
+--------------------PhysicalOlapScan[store]
 ----------------PhysicalDistribute
 ------------------hashJoin[INNER_JOIN](expr_cast(d_week_seq1 as BIGINT) = expr_(d_week_seq2 - 52))
 --------------------PhysicalProject
@@ -32,8 +34,9 @@ CteAnchor[cteId= ( CTEId#4=] )
 --------------------PhysicalDistribute
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN](wss.ss_store_sk = store.s_store_sk)
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[store]
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[store]
 --------------------------PhysicalDistribute
 ----------------------------hashJoin[INNER_JOIN](d.d_week_seq = d_week_seq1)
 ------------------------------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query59.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query59.out
@@ -24,9 +24,8 @@ CteAnchor[cteId= ( CTEId#4=] )
 ------------------PhysicalOlapScan[date_dim]
 ------------PhysicalDistribute
 --------------hashJoin[INNER_JOIN](y.s_store_id1 = x.s_store_id2)(wss.ss_store_sk = store.s_store_sk)
-----------------PhysicalDistribute
-------------------PhysicalProject
---------------------PhysicalOlapScan[store]
+----------------PhysicalProject
+------------------PhysicalOlapScan[store]
 ----------------PhysicalDistribute
 ------------------hashJoin[INNER_JOIN](expr_cast(d_week_seq1 as BIGINT) = expr_(d_week_seq2 - 52))
 --------------------PhysicalProject
@@ -34,9 +33,8 @@ CteAnchor[cteId= ( CTEId#4=] )
 --------------------PhysicalDistribute
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN](wss.ss_store_sk = store.s_store_sk)
---------------------------PhysicalDistribute
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[store]
+--------------------------PhysicalProject
+----------------------------PhysicalOlapScan[store]
 --------------------------PhysicalDistribute
 ----------------------------hashJoin[INNER_JOIN](d.d_week_seq = d_week_seq1)
 ------------------------------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query6.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query6.out
@@ -11,8 +11,8 @@ PhysicalTopN
 ----------------hashJoin[LEFT_SEMI_JOIN](j.i_category = i.i_category)(cast(i_current_price as DECIMALV3(38, 5)) > (1.2 * avg(i_current_price)))
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN](c.c_customer_sk = s.ss_customer_sk)
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN](s.ss_item_sk = i.i_item_sk)
+----------------------hashJoin[INNER_JOIN](s.ss_item_sk = i.i_item_sk)
+------------------------PhysicalProject
 --------------------------hashJoin[INNER_JOIN](s.ss_sold_date_sk = d.d_date_sk)
 ----------------------------PhysicalProject
 ------------------------------PhysicalOlapScan[store_sales]
@@ -28,14 +28,15 @@ PhysicalTopN
 ------------------------------------------PhysicalProject
 --------------------------------------------filter((date_dim.d_year = 2002)(date_dim.d_moy = 3))
 ----------------------------------------------PhysicalOlapScan[date_dim]
---------------------------PhysicalDistribute
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[item]
-----------------------PhysicalDistribute
-------------------------hashJoin[INNER_JOIN](a.ca_address_sk = c.c_current_addr_sk)
+------------------------PhysicalDistribute
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[customer]
---------------------------PhysicalDistribute
+----------------------------PhysicalOlapScan[item]
+----------------------PhysicalDistribute
+------------------------PhysicalProject
+--------------------------hashJoin[INNER_JOIN](a.ca_address_sk = c.c_current_addr_sk)
+----------------------------PhysicalDistribute
+------------------------------PhysicalProject
+--------------------------------PhysicalOlapScan[customer]
 ----------------------------PhysicalProject
 ------------------------------PhysicalOlapScan[customer_address]
 ------------------PhysicalDistribute

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query60.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query60.out
@@ -66,26 +66,26 @@ PhysicalTopN
 ------------------PhysicalDistribute
 --------------------hashAgg[LOCAL]
 ----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN](web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)
---------------------------PhysicalDistribute
-----------------------------hashJoin[INNER_JOIN](web_sales.ws_item_sk = item.i_item_sk)
-------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN](web_sales.ws_sold_date_sk = date_dim.d_date_sk)
-----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[web_sales]
-----------------------------------PhysicalDistribute
-------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_year = 2000)(date_dim.d_moy = 8))
-----------------------------------------PhysicalOlapScan[date_dim]
-------------------------------PhysicalDistribute
---------------------------------hashJoin[LEFT_SEMI_JOIN](item.i_item_id = item.i_item_id)
-----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[item]
-----------------------------------PhysicalDistribute
-------------------------------------PhysicalProject
---------------------------------------filter((item.i_category = 'Children'))
-----------------------------------------PhysicalOlapScan[item]
+------------------------hashJoin[INNER_JOIN](web_sales.ws_item_sk = item.i_item_sk)
 --------------------------PhysicalProject
-----------------------------filter((customer_address.ca_gmt_offset = -7.00))
-------------------------------PhysicalOlapScan[customer_address]
+----------------------------hashJoin[INNER_JOIN](web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)
+------------------------------hashJoin[INNER_JOIN](web_sales.ws_sold_date_sk = date_dim.d_date_sk)
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[web_sales]
+--------------------------------PhysicalDistribute
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_year = 2000)(date_dim.d_moy = 8))
+--------------------------------------PhysicalOlapScan[date_dim]
+------------------------------PhysicalDistribute
+--------------------------------PhysicalProject
+----------------------------------filter((customer_address.ca_gmt_offset = -7.00))
+------------------------------------PhysicalOlapScan[customer_address]
+--------------------------PhysicalDistribute
+----------------------------hashJoin[LEFT_SEMI_JOIN](item.i_item_id = item.i_item_id)
+------------------------------PhysicalProject
+--------------------------------PhysicalOlapScan[item]
+------------------------------PhysicalDistribute
+--------------------------------PhysicalProject
+----------------------------------filter((item.i_category = 'Children'))
+------------------------------------PhysicalOlapScan[item]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query65.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query65.out
@@ -4,40 +4,41 @@ PhysicalTopN
 --PhysicalDistribute
 ----PhysicalTopN
 ------PhysicalProject
---------hashJoin[INNER_JOIN](store.s_store_sk = sc.ss_store_sk)
-----------hashJoin[INNER_JOIN](item.i_item_sk = sc.ss_item_sk)
+--------hashJoin[INNER_JOIN](item.i_item_sk = sc.ss_item_sk)
+----------PhysicalProject
+------------PhysicalOlapScan[item]
+----------PhysicalDistribute
 ------------PhysicalProject
---------------PhysicalOlapScan[item]
-------------PhysicalDistribute
---------------hashJoin[INNER_JOIN](sb.ss_store_sk = sc.ss_store_sk)(cast(revenue as DOUBLE) <= cast((0.1 * ave) as DOUBLE))
-----------------hashAgg[GLOBAL]
-------------------PhysicalDistribute
---------------------hashAgg[LOCAL]
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN](store_sales.ss_sold_date_sk = date_dim.d_date_sk)
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[store_sales]
---------------------------PhysicalDistribute
-----------------------------PhysicalProject
-------------------------------filter((date_dim.d_month_seq <= 1232)(date_dim.d_month_seq >= 1221))
---------------------------------PhysicalOlapScan[date_dim]
-----------------PhysicalDistribute
+--------------hashJoin[INNER_JOIN](store.s_store_sk = sc.ss_store_sk)
+----------------hashJoin[INNER_JOIN](sb.ss_store_sk = sc.ss_store_sk)(cast(revenue as DOUBLE) <= cast((0.1 * ave) as DOUBLE))
 ------------------hashAgg[GLOBAL]
 --------------------PhysicalDistribute
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashAgg[GLOBAL]
+--------------------------hashJoin[INNER_JOIN](store_sales.ss_sold_date_sk = date_dim.d_date_sk)
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[store_sales]
 ----------------------------PhysicalDistribute
-------------------------------hashAgg[LOCAL]
---------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN](store_sales.ss_sold_date_sk = date_dim.d_date_sk)
-------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[store_sales]
-------------------------------------PhysicalDistribute
+------------------------------PhysicalProject
+--------------------------------filter((date_dim.d_month_seq <= 1232)(date_dim.d_month_seq >= 1221))
+----------------------------------PhysicalOlapScan[date_dim]
+------------------PhysicalDistribute
+--------------------hashAgg[GLOBAL]
+----------------------PhysicalDistribute
+------------------------hashAgg[LOCAL]
+--------------------------PhysicalProject
+----------------------------hashAgg[GLOBAL]
+------------------------------PhysicalDistribute
+--------------------------------hashAgg[LOCAL]
+----------------------------------PhysicalProject
+------------------------------------hashJoin[INNER_JOIN](store_sales.ss_sold_date_sk = date_dim.d_date_sk)
 --------------------------------------PhysicalProject
-----------------------------------------filter((date_dim.d_month_seq >= 1221)(date_dim.d_month_seq <= 1232))
-------------------------------------------PhysicalOlapScan[date_dim]
-----------PhysicalDistribute
-------------PhysicalProject
---------------PhysicalOlapScan[store]
+----------------------------------------PhysicalOlapScan[store_sales]
+--------------------------------------PhysicalDistribute
+----------------------------------------PhysicalProject
+------------------------------------------filter((date_dim.d_month_seq >= 1221)(date_dim.d_month_seq <= 1232))
+--------------------------------------------PhysicalOlapScan[date_dim]
+----------------PhysicalDistribute
+------------------PhysicalProject
+--------------------PhysicalOlapScan[store]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query72.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query72.out
@@ -7,54 +7,54 @@ PhysicalTopN
 --------PhysicalDistribute
 ----------hashAgg[LOCAL]
 ------------PhysicalProject
---------------hashJoin[LEFT_OUTER_JOIN](catalog_sales.cs_promo_sk = promotion.p_promo_sk)
+--------------hashJoin[INNER_JOIN](item.i_item_sk = catalog_sales.cs_item_sk)
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN](warehouse.w_warehouse_sk = inventory.inv_warehouse_sk)
---------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN](item.i_item_sk = catalog_sales.cs_item_sk)
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[item]
-------------------------PhysicalDistribute
---------------------------PhysicalProject
-----------------------------hashJoin[RIGHT_OUTER_JOIN](catalog_returns.cr_item_sk = catalog_sales.cs_item_sk)(catalog_returns.cr_order_number = catalog_sales.cs_order_number)
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[catalog_returns]
-------------------------------PhysicalDistribute
---------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_ship_date_sk = d3.d_date_sk)(d3.d_date > cast((cast(d_date as BIGINT) + 5) as DATEV2))
-------------------------------------PhysicalProject
---------------------------------------hashJoin[INNER_JOIN](inventory.inv_date_sk = d2.d_date_sk)(d1.d_week_seq = d2.d_week_seq)
-----------------------------------------PhysicalProject
-------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_item_sk = inventory.inv_item_sk)(inventory.inv_quantity_on_hand < catalog_sales.cs_quantity)
---------------------------------------------PhysicalOlapScan[inventory]
---------------------------------------------PhysicalDistribute
-----------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_bill_cdemo_sk = customer_demographics.cd_demo_sk)
-------------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_sold_date_sk = d1.d_date_sk)
---------------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_bill_hdemo_sk = household_demographics.hd_demo_sk)
-----------------------------------------------------PhysicalProject
-------------------------------------------------------PhysicalOlapScan[catalog_sales]
-----------------------------------------------------PhysicalDistribute
-------------------------------------------------------PhysicalProject
---------------------------------------------------------filter((cast(hd_buy_potential as VARCHAR(*)) = '501-1000'))
-----------------------------------------------------------PhysicalOlapScan[household_demographics]
---------------------------------------------------PhysicalDistribute
-----------------------------------------------------PhysicalProject
-------------------------------------------------------filter((d1.d_year = 2002))
---------------------------------------------------------PhysicalOlapScan[date_dim]
-------------------------------------------------PhysicalDistribute
---------------------------------------------------PhysicalProject
-----------------------------------------------------filter((cast(cd_marital_status as VARCHAR(*)) = 'W'))
-------------------------------------------------------PhysicalOlapScan[customer_demographics]
-----------------------------------------PhysicalDistribute
-------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[date_dim]
-------------------------------------PhysicalDistribute
---------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[date_dim]
---------------------PhysicalDistribute
-----------------------PhysicalProject
-------------------------PhysicalOlapScan[warehouse]
+------------------PhysicalOlapScan[item]
 ----------------PhysicalDistribute
 ------------------PhysicalProject
---------------------PhysicalOlapScan[promotion]
+--------------------hashJoin[RIGHT_OUTER_JOIN](catalog_returns.cr_item_sk = catalog_sales.cs_item_sk)(catalog_returns.cr_order_number = catalog_sales.cs_order_number)
+----------------------PhysicalProject
+------------------------PhysicalOlapScan[catalog_returns]
+----------------------PhysicalDistribute
+------------------------PhysicalProject
+--------------------------hashJoin[LEFT_OUTER_JOIN](catalog_sales.cs_promo_sk = promotion.p_promo_sk)
+----------------------------PhysicalProject
+------------------------------hashJoin[INNER_JOIN](warehouse.w_warehouse_sk = inventory.inv_warehouse_sk)
+--------------------------------PhysicalProject
+----------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_item_sk = inventory.inv_item_sk)(inventory.inv_date_sk = d2.d_date_sk)(inventory.inv_quantity_on_hand < catalog_sales.cs_quantity)
+------------------------------------PhysicalDistribute
+--------------------------------------PhysicalOlapScan[inventory]
+------------------------------------PhysicalDistribute
+--------------------------------------PhysicalProject
+----------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_bill_cdemo_sk = customer_demographics.cd_demo_sk)
+------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_bill_hdemo_sk = household_demographics.hd_demo_sk)
+--------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_sold_date_sk = d1.d_date_sk)(catalog_sales.cs_ship_date_sk = d3.d_date_sk)
+----------------------------------------------PhysicalProject
+------------------------------------------------PhysicalOlapScan[catalog_sales]
+----------------------------------------------PhysicalDistribute
+------------------------------------------------hashJoin[INNER_JOIN](d1.d_week_seq = d2.d_week_seq)
+--------------------------------------------------NestedLoopJoin[INNER_JOIN](d3.d_date > cast((cast(d_date as BIGINT) + 5) as DATEV2))
+----------------------------------------------------PhysicalProject
+------------------------------------------------------PhysicalOlapScan[date_dim]
+----------------------------------------------------PhysicalDistribute
+------------------------------------------------------PhysicalProject
+--------------------------------------------------------filter((d1.d_year = 2002))
+----------------------------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------------------------PhysicalDistribute
+----------------------------------------------------PhysicalProject
+------------------------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------------------PhysicalDistribute
+----------------------------------------------PhysicalProject
+------------------------------------------------filter((cast(hd_buy_potential as VARCHAR(*)) = '501-1000'))
+--------------------------------------------------PhysicalOlapScan[household_demographics]
+------------------------------------------PhysicalDistribute
+--------------------------------------------PhysicalProject
+----------------------------------------------filter((cast(cd_marital_status as VARCHAR(*)) = 'W'))
+------------------------------------------------PhysicalOlapScan[customer_demographics]
+--------------------------------PhysicalDistribute
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[warehouse]
+----------------------------PhysicalDistribute
+------------------------------PhysicalProject
+--------------------------------PhysicalOlapScan[promotion]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query74.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query74.out
@@ -43,22 +43,24 @@ CteAnchor[cteId= ( CTEId#4=] )
 ----PhysicalDistribute
 ------PhysicalTopN
 --------PhysicalProject
-----------hashJoin[INNER_JOIN](t_s_firstyear.customer_id = t_w_firstyear.customer_id)(CASE WHEN (year_total > 0.0) THEN (year_total / year_total) ELSE NULL END > CASE WHEN (year_total > 0.0) THEN (year_total / year_total) ELSE NULL END)
+----------hashJoin[INNER_JOIN](t_s_secyear.customer_id = t_s_firstyear.customer_id)(CASE WHEN (year_total > 0.0) THEN (year_total / year_total) ELSE NULL END > CASE WHEN (year_total > 0.0) THEN (year_total / year_total) ELSE NULL END)
 ------------PhysicalProject
---------------filter((t_w_firstyear.year = 1999)(t_w_firstyear.year_total > 0.0)(t_w_firstyear.sale_type = 'w'))
+--------------filter((t_s_secyear.sale_type = 's')(t_s_secyear.year = 2000))
 ----------------CteConsumer[cteId= ( CTEId#4=] )
 ------------PhysicalDistribute
---------------hashJoin[INNER_JOIN](t_s_firstyear.customer_id = t_w_secyear.customer_id)
-----------------PhysicalProject
-------------------filter((t_w_secyear.year = 2000)(t_w_secyear.sale_type = 'w'))
---------------------CteConsumer[cteId= ( CTEId#4=] )
-----------------PhysicalDistribute
-------------------hashJoin[INNER_JOIN](t_s_secyear.customer_id = t_s_firstyear.customer_id)
+--------------PhysicalProject
+----------------hashJoin[INNER_JOIN](t_s_firstyear.customer_id = t_w_firstyear.customer_id)
+------------------PhysicalDistribute
 --------------------PhysicalProject
-----------------------filter((t_s_firstyear.year = 1999)(t_s_firstyear.sale_type = 's')(t_s_firstyear.year_total > 0.0))
+----------------------filter((t_w_firstyear.year = 1999)(t_w_firstyear.year_total > 0.0)(t_w_firstyear.sale_type = 'w'))
 ------------------------CteConsumer[cteId= ( CTEId#4=] )
+------------------hashJoin[INNER_JOIN](t_s_firstyear.customer_id = t_w_secyear.customer_id)
 --------------------PhysicalDistribute
 ----------------------PhysicalProject
-------------------------filter((t_s_secyear.sale_type = 's')(t_s_secyear.year = 2000))
+------------------------filter((t_s_firstyear.year = 1999)(t_s_firstyear.sale_type = 's')(t_s_firstyear.year_total > 0.0))
+--------------------------CteConsumer[cteId= ( CTEId#4=] )
+--------------------PhysicalDistribute
+----------------------PhysicalProject
+------------------------filter((t_w_secyear.year = 2000)(t_w_secyear.sale_type = 'w'))
 --------------------------CteConsumer[cteId= ( CTEId#4=] )
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query75.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query75.out
@@ -67,8 +67,9 @@ CteAnchor[cteId= ( CTEId#3=] )
 ------PhysicalTopN
 --------PhysicalProject
 ----------hashJoin[INNER_JOIN](curr_yr.i_brand_id = prev_yr.i_brand_id)(curr_yr.i_class_id = prev_yr.i_class_id)(curr_yr.i_category_id = prev_yr.i_category_id)(curr_yr.i_manufact_id = prev_yr.i_manufact_id)((cast(cast(sales_cnt as DECIMALV3(17, 2)) as DECIMALV3(23, 8)) / cast(sales_cnt as DECIMALV3(17, 2))) < 0.900000)
-------------filter((curr_yr.d_year = 1999))
---------------CteConsumer[cteId= ( CTEId#3=] )
+------------PhysicalDistribute
+--------------filter((curr_yr.d_year = 1999))
+----------------CteConsumer[cteId= ( CTEId#3=] )
 ------------PhysicalDistribute
 --------------filter((prev_yr.d_year = 1998))
 ----------------CteConsumer[cteId= ( CTEId#3=] )

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query81.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query81.out
@@ -7,16 +7,17 @@ CteAnchor[cteId= ( CTEId#2=] )
 --------hashAgg[LOCAL]
 ----------PhysicalProject
 ------------hashJoin[INNER_JOIN](catalog_returns.cr_returning_addr_sk = customer_address.ca_address_sk)
---------------hashJoin[INNER_JOIN](catalog_returns.cr_returned_date_sk = date_dim.d_date_sk)
-----------------PhysicalProject
-------------------PhysicalOlapScan[catalog_returns]
-----------------PhysicalDistribute
-------------------PhysicalProject
---------------------filter((date_dim.d_year = 2002))
-----------------------PhysicalOlapScan[date_dim]
 --------------PhysicalDistribute
 ----------------PhysicalProject
-------------------PhysicalOlapScan[customer_address]
+------------------hashJoin[INNER_JOIN](catalog_returns.cr_returned_date_sk = date_dim.d_date_sk)
+--------------------PhysicalProject
+----------------------PhysicalOlapScan[catalog_returns]
+--------------------PhysicalDistribute
+----------------------PhysicalProject
+------------------------filter((date_dim.d_year = 2002))
+--------------------------PhysicalOlapScan[date_dim]
+--------------PhysicalProject
+----------------PhysicalOlapScan[customer_address]
 --PhysicalTopN
 ----PhysicalDistribute
 ------PhysicalTopN

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query84.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query84.out
@@ -15,20 +15,20 @@ PhysicalTopN
 ----------------PhysicalDistribute
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN](household_demographics.hd_demo_sk = customer.c_current_hdemo_sk)
-----------------------PhysicalDistribute
-------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN](customer.c_current_addr_sk = customer_address.ca_address_sk)
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[customer]
-----------------------------PhysicalDistribute
-------------------------------PhysicalProject
---------------------------------filter((customer_address.ca_city = 'Oakwood'))
-----------------------------------PhysicalOlapScan[customer_address]
-----------------------hashJoin[INNER_JOIN](income_band.ib_income_band_sk = household_demographics.hd_income_band_sk)
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[household_demographics]
-------------------------PhysicalDistribute
+----------------------PhysicalProject
+------------------------hashJoin[INNER_JOIN](customer.c_current_addr_sk = customer_address.ca_address_sk)
 --------------------------PhysicalProject
-----------------------------filter((cast(ib_upper_bound as BIGINT) <= 55806)(income_band.ib_lower_bound >= 5806))
-------------------------------PhysicalOlapScan[income_band]
+----------------------------PhysicalOlapScan[customer]
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------filter((customer_address.ca_city = 'Oakwood'))
+--------------------------------PhysicalOlapScan[customer_address]
+----------------------PhysicalDistribute
+------------------------hashJoin[INNER_JOIN](income_band.ib_income_band_sk = household_demographics.hd_income_band_sk)
+--------------------------PhysicalProject
+----------------------------PhysicalOlapScan[household_demographics]
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------filter((cast(ib_upper_bound as BIGINT) <= 55806)(income_band.ib_lower_bound >= 5806))
+--------------------------------PhysicalOlapScan[income_band]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query87.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query87.out
@@ -43,13 +43,15 @@ hashAgg[GLOBAL]
 ----------------hashAgg[LOCAL]
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN](web_sales.ws_bill_customer_sk = customer.c_customer_sk)
-----------------------hashJoin[INNER_JOIN](web_sales.ws_sold_date_sk = date_dim.d_date_sk)
+----------------------PhysicalDistribute
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[web_sales]
-------------------------PhysicalDistribute
---------------------------PhysicalProject
-----------------------------filter((date_dim.d_month_seq <= 1195)(date_dim.d_month_seq >= 1184))
-------------------------------PhysicalOlapScan[date_dim]
+--------------------------hashJoin[INNER_JOIN](web_sales.ws_sold_date_sk = date_dim.d_date_sk)
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[web_sales]
+----------------------------PhysicalDistribute
+------------------------------PhysicalProject
+--------------------------------filter((date_dim.d_month_seq <= 1195)(date_dim.d_month_seq >= 1184))
+----------------------------------PhysicalOlapScan[date_dim]
 ----------------------PhysicalDistribute
 ------------------------PhysicalProject
 --------------------------PhysicalOlapScan[customer]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query91.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query91.out
@@ -8,16 +8,17 @@ PhysicalQuickSort
 ----------PhysicalDistribute
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN](customer_demographics.cd_demo_sk = customer.c_current_cdemo_sk)
+----------------hashJoin[INNER_JOIN](customer_address.ca_address_sk = customer.c_current_addr_sk)
 ------------------PhysicalProject
---------------------filter((((cast(cd_marital_status as VARCHAR(*)) = 'M') AND (cast(cd_education_status as VARCHAR(*)) = 'Unknown')) OR ((cast(cd_marital_status as VARCHAR(*)) = 'W') AND (cast(cd_education_status as VARCHAR(*)) = 'Advanced Degree'))))
-----------------------PhysicalOlapScan[customer_demographics]
+--------------------filter((customer_address.ca_gmt_offset = -6.00))
+----------------------PhysicalOlapScan[customer_address]
 ------------------PhysicalDistribute
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN](customer_address.ca_address_sk = customer.c_current_addr_sk)
-------------------------PhysicalProject
---------------------------filter((customer_address.ca_gmt_offset = -6.00))
-----------------------------PhysicalOlapScan[customer_address]
+----------------------hashJoin[INNER_JOIN](customer_demographics.cd_demo_sk = customer.c_current_cdemo_sk)
+------------------------PhysicalDistribute
+--------------------------PhysicalProject
+----------------------------filter((((cast(cd_marital_status as VARCHAR(*)) = 'M') AND (cast(cd_education_status as VARCHAR(*)) = 'Unknown')) OR ((cast(cd_marital_status as VARCHAR(*)) = 'W') AND (cast(cd_education_status as VARCHAR(*)) = 'Advanced Degree'))))
+------------------------------PhysicalOlapScan[customer_demographics]
 ------------------------PhysicalDistribute
 --------------------------hashJoin[INNER_JOIN](household_demographics.hd_demo_sk = customer.c_current_hdemo_sk)
 ----------------------------PhysicalProject

--- a/regression-test/data/nereids_tpch_shape_sf1000_p0/shape/q10.out
+++ b/regression-test/data/nereids_tpch_shape_sf1000_p0/shape/q10.out
@@ -7,11 +7,11 @@ PhysicalTopN
 --------hashAgg[LOCAL]
 ----------PhysicalProject
 ------------hashJoin[INNER_JOIN](customer.c_nationkey = nation.n_nationkey)
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN](customer.c_custkey = orders.o_custkey)
+--------------hashJoin[INNER_JOIN](customer.c_custkey = orders.o_custkey)
+----------------PhysicalProject
+------------------PhysicalOlapScan[customer]
+----------------PhysicalDistribute
 ------------------PhysicalProject
---------------------PhysicalOlapScan[customer]
-------------------PhysicalDistribute
 --------------------hashJoin[INNER_JOIN](lineitem.l_orderkey = orders.o_orderkey)
 ----------------------PhysicalProject
 ------------------------filter((lineitem.l_returnflag = 'R'))

--- a/regression-test/data/nereids_tpch_shape_sf1000_p0/shape/q16.out
+++ b/regression-test/data/nereids_tpch_shape_sf1000_p0/shape/q16.out
@@ -3,20 +3,19 @@
 PhysicalQuickSort
 --PhysicalDistribute
 ----PhysicalQuickSort
-------hashAgg[DISTINCT_LOCAL]
---------hashAgg[GLOBAL]
+------hashAgg[GLOBAL]
+--------hashAgg[LOCAL]
 ----------PhysicalDistribute
-------------hashAgg[LOCAL]
---------------PhysicalProject
-----------------hashJoin[LEFT_ANTI_JOIN](partsupp.ps_suppkey = supplier.s_suppkey)
-------------------hashJoin[INNER_JOIN](part.p_partkey = partsupp.ps_partkey)
---------------------PhysicalProject
-----------------------PhysicalOlapScan[partsupp]
---------------------PhysicalProject
-----------------------filter(( not (p_type like 'MEDIUM POLISHED%'))( not (p_brand = 'Brand#45'))p_size IN (3, 9, 14, 19, 23, 36, 45, 49))
-------------------------PhysicalOlapScan[part]
-------------------PhysicalDistribute
---------------------PhysicalProject
-----------------------filter((s_comment like '%Customer%Complaints%'))
-------------------------PhysicalOlapScan[supplier]
+------------PhysicalProject
+--------------hashJoin[LEFT_ANTI_JOIN](partsupp.ps_suppkey = supplier.s_suppkey)
+----------------hashJoin[INNER_JOIN](part.p_partkey = partsupp.ps_partkey)
+------------------PhysicalProject
+--------------------PhysicalOlapScan[partsupp]
+------------------PhysicalProject
+--------------------filter(( not (p_type like 'MEDIUM POLISHED%'))( not (p_brand = 'Brand#45'))p_size IN (3, 9, 14, 19, 23, 36, 45, 49))
+----------------------PhysicalOlapScan[part]
+----------------PhysicalDistribute
+------------------PhysicalProject
+--------------------filter((s_comment like '%Customer%Complaints%'))
+----------------------PhysicalOlapScan[supplier]
 

--- a/regression-test/data/nereids_tpch_shape_sf1000_p0/shape/q2.out
+++ b/regression-test/data/nereids_tpch_shape_sf1000_p0/shape/q2.out
@@ -11,21 +11,21 @@ PhysicalTopN
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN](supplier.s_suppkey = partsupp.ps_suppkey)
 --------------------PhysicalDistribute
-----------------------hashJoin[INNER_JOIN](part.p_partkey = partsupp.ps_partkey)
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[partsupp]
-------------------------PhysicalProject
---------------------------filter((part.p_size = 15)(p_type like '%BRASS'))
-----------------------------PhysicalOlapScan[part]
---------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN](supplier.s_nationkey = nation.n_nationkey)
-------------------------PhysicalOlapScan[supplier]
-------------------------PhysicalDistribute
---------------------------hashJoin[INNER_JOIN](nation.n_regionkey = region.r_regionkey)
+----------------------PhysicalProject
+------------------------hashJoin[INNER_JOIN](part.p_partkey = partsupp.ps_partkey)
+--------------------------PhysicalProject
+----------------------------PhysicalOlapScan[partsupp]
+--------------------------PhysicalProject
+----------------------------filter((part.p_size = 15)(p_type like '%BRASS'))
+------------------------------PhysicalOlapScan[part]
+--------------------hashJoin[INNER_JOIN](supplier.s_nationkey = nation.n_nationkey)
+----------------------PhysicalOlapScan[supplier]
+----------------------PhysicalDistribute
+------------------------hashJoin[INNER_JOIN](nation.n_regionkey = region.r_regionkey)
+--------------------------PhysicalProject
+----------------------------PhysicalOlapScan[nation]
+--------------------------PhysicalDistribute
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[nation]
-----------------------------PhysicalDistribute
-------------------------------PhysicalProject
---------------------------------filter((region.r_name = 'EUROPE'))
-----------------------------------PhysicalOlapScan[region]
+------------------------------filter((region.r_name = 'EUROPE'))
+--------------------------------PhysicalOlapScan[region]
 

--- a/regression-test/data/nereids_tpch_shape_sf500_p0/shape/q10.out
+++ b/regression-test/data/nereids_tpch_shape_sf500_p0/shape/q10.out
@@ -7,11 +7,11 @@ PhysicalTopN
 --------hashAgg[LOCAL]
 ----------PhysicalProject
 ------------hashJoin[INNER_JOIN](customer.c_nationkey = nation.n_nationkey)
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN](customer.c_custkey = orders.o_custkey)
+--------------hashJoin[INNER_JOIN](customer.c_custkey = orders.o_custkey)
+----------------PhysicalProject
+------------------PhysicalOlapScan[customer]
+----------------PhysicalDistribute
 ------------------PhysicalProject
---------------------PhysicalOlapScan[customer]
-------------------PhysicalDistribute
 --------------------hashJoin[INNER_JOIN](lineitem.l_orderkey = orders.o_orderkey)
 ----------------------PhysicalProject
 ------------------------filter((lineitem.l_returnflag = 'R'))

--- a/regression-test/data/nereids_tpch_shape_sf500_p0/shape/q16.out
+++ b/regression-test/data/nereids_tpch_shape_sf500_p0/shape/q16.out
@@ -3,20 +3,19 @@
 PhysicalQuickSort
 --PhysicalDistribute
 ----PhysicalQuickSort
-------hashAgg[DISTINCT_LOCAL]
---------hashAgg[GLOBAL]
+------hashAgg[GLOBAL]
+--------hashAgg[LOCAL]
 ----------PhysicalDistribute
-------------hashAgg[LOCAL]
---------------PhysicalProject
-----------------hashJoin[LEFT_ANTI_JOIN](partsupp.ps_suppkey = supplier.s_suppkey)
-------------------hashJoin[INNER_JOIN](part.p_partkey = partsupp.ps_partkey)
---------------------PhysicalProject
-----------------------PhysicalOlapScan[partsupp]
---------------------PhysicalProject
-----------------------filter(( not (p_type like 'MEDIUM POLISHED%'))( not (p_brand = 'Brand#45'))p_size IN (3, 9, 14, 19, 23, 36, 45, 49))
-------------------------PhysicalOlapScan[part]
-------------------PhysicalDistribute
---------------------PhysicalProject
-----------------------filter((s_comment like '%Customer%Complaints%'))
-------------------------PhysicalOlapScan[supplier]
+------------PhysicalProject
+--------------hashJoin[LEFT_ANTI_JOIN](partsupp.ps_suppkey = supplier.s_suppkey)
+----------------hashJoin[INNER_JOIN](part.p_partkey = partsupp.ps_partkey)
+------------------PhysicalProject
+--------------------PhysicalOlapScan[partsupp]
+------------------PhysicalProject
+--------------------filter(( not (p_type like 'MEDIUM POLISHED%'))( not (p_brand = 'Brand#45'))p_size IN (3, 9, 14, 19, 23, 36, 45, 49))
+----------------------PhysicalOlapScan[part]
+----------------PhysicalDistribute
+------------------PhysicalProject
+--------------------filter((s_comment like '%Customer%Complaints%'))
+----------------------PhysicalOlapScan[supplier]
 

--- a/regression-test/data/nereids_tpch_shape_sf500_p0/shape/q2.out
+++ b/regression-test/data/nereids_tpch_shape_sf500_p0/shape/q2.out
@@ -11,21 +11,21 @@ PhysicalTopN
 ----------------PhysicalProject
 ------------------hashJoin[INNER_JOIN](supplier.s_suppkey = partsupp.ps_suppkey)
 --------------------PhysicalDistribute
-----------------------hashJoin[INNER_JOIN](part.p_partkey = partsupp.ps_partkey)
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[partsupp]
-------------------------PhysicalProject
---------------------------filter((part.p_size = 15)(p_type like '%BRASS'))
-----------------------------PhysicalOlapScan[part]
---------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN](supplier.s_nationkey = nation.n_nationkey)
-------------------------PhysicalOlapScan[supplier]
-------------------------PhysicalDistribute
---------------------------hashJoin[INNER_JOIN](nation.n_regionkey = region.r_regionkey)
+----------------------PhysicalProject
+------------------------hashJoin[INNER_JOIN](part.p_partkey = partsupp.ps_partkey)
+--------------------------PhysicalProject
+----------------------------PhysicalOlapScan[partsupp]
+--------------------------PhysicalProject
+----------------------------filter((part.p_size = 15)(p_type like '%BRASS'))
+------------------------------PhysicalOlapScan[part]
+--------------------hashJoin[INNER_JOIN](supplier.s_nationkey = nation.n_nationkey)
+----------------------PhysicalOlapScan[supplier]
+----------------------PhysicalDistribute
+------------------------hashJoin[INNER_JOIN](nation.n_regionkey = region.r_regionkey)
+--------------------------PhysicalProject
+----------------------------PhysicalOlapScan[nation]
+--------------------------PhysicalDistribute
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[nation]
-----------------------------PhysicalDistribute
-------------------------------PhysicalProject
---------------------------------filter((region.r_name = 'EUROPE'))
-----------------------------------PhysicalOlapScan[region]
+------------------------------filter((region.r_name = 'EUROPE'))
+--------------------------------PhysicalOlapScan[region]
 


### PR DESCRIPTION
## Proposed changes
this pr impacts tpch q16 Agg strategy, but no performance issue
this pr improves tpcds sf100
before: 
cold 141 sec
hot 133 sec 

after:
code 137 sec
hot 128 sec
Issue Number: close #xxx

<!--Describe your changes.-->
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

