### PR TITLE
[Enhance](2PC) disable info log when holding table write lock in 2pc

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -426,9 +426,9 @@ public class DatabaseTransactionMgr {
         unprotectedPreCommitTransaction2PC(transactionState, errorReplicaIds, tableToPartition,
                 totalInvolvedBackends, db);
 
-        // disable this log, as this logging is in table write lock
+        // change this log from info to debug, as this logging is in table write lock
         // some-times, this logging will cost much time and impact the flink job with 2pc stream load
-        // LOG.info("transaction:[{}] successfully pre-committed", transactionState);
+        LOG.debug("transaction:[{}] successfully pre-committed", transactionState);
     }
 
     private void checkCommitStatus(List<Table> tableList, TransactionState transactionState,
@@ -678,11 +678,9 @@ public class DatabaseTransactionMgr {
 
         // update nextVersion because of the failure of persistent transaction resulting in error version
         updateCatalogAfterCommitted(transactionState, db);
-        // do not log this info when enable 2pc, as 2pc will hold table write lock outside
+        // change this logging from info to debug, as 2pc will hold table write lock outside
         // which will cause holding lock long time, and impact the parallelism of flink job
-        if (!is2PC) {
-            LOG.info("transaction:[{}] successfully committed", transactionState);
-        }
+        LOG.debug("transaction:[{}] successfully committed", transactionState);
     }
 
     public boolean waitForTransactionFinished(DatabaseIf db, long transactionId, long timeoutMillis)

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -675,7 +675,11 @@ public class DatabaseTransactionMgr {
 
         // update nextVersion because of the failure of persistent transaction resulting in error version
         updateCatalogAfterCommitted(transactionState, db);
-        LOG.info("transaction:[{}] successfully committed", transactionState);
+        // do not log this info when enable 2pc, as 2pc will hold table write lock outside
+        // which will cause holding lock long time, and impact the parallelism of flink job
+        if (!is2PC) {
+            LOG.info("transaction:[{}] successfully committed", transactionState);
+        }
     }
 
     public boolean waitForTransactionFinished(DatabaseIf db, long transactionId, long timeoutMillis)

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -425,7 +425,10 @@ public class DatabaseTransactionMgr {
 
         unprotectedPreCommitTransaction2PC(transactionState, errorReplicaIds, tableToPartition,
                 totalInvolvedBackends, db);
-        LOG.info("transaction:[{}] successfully pre-committed", transactionState);
+
+        // disable this log, as this logging is in table write lock
+        // some-times, this logging will cost much time and impact the flink job with 2pc stream load
+        // LOG.info("transaction:[{}] successfully pre-committed", transactionState);
     }
 
     private void checkCommitStatus(List<Table> tableList, TransactionState transactionState,

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
@@ -199,8 +199,8 @@ public class GlobalTransactionMgr implements Writable {
             MetaLockUtils.writeUnlockTables(tableList);
         }
         stopWatch.stop();
-        LOG.info("stream load tasks are pre-committed successfully. txns: {}. time cost: {} ms."
-                + " data will be visible later.", transactionId, stopWatch.getTime());
+        LOG.info("stream load tasks are pre-committed successfully. txns: {}. time cost: {} ms.",
+            transactionId, stopWatch.getTime());
     }
 
     public void preCommitTransaction2PC(long dbId, List<Table> tableList, long transactionId,

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
@@ -200,7 +200,7 @@ public class GlobalTransactionMgr implements Writable {
         }
         stopWatch.stop();
         LOG.info("stream load tasks are pre-committed successfully. txns: {}. time cost: {} ms."
-            + " data will be visible later.", transactionId, stopWatch.getTime());
+                + " data will be visible later.", transactionId, stopWatch.getTime());
     }
 
     public void preCommitTransaction2PC(long dbId, List<Table> tableList, long transactionId,

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
@@ -200,7 +200,7 @@ public class GlobalTransactionMgr implements Writable {
         }
         stopWatch.stop();
         LOG.info("stream load tasks are pre-committed successfully. txns: {}. time cost: {} ms.",
-            transactionId, stopWatch.getTime());
+                transactionId, stopWatch.getTime());
     }
 
     public void preCommitTransaction2PC(long dbId, List<Table> tableList, long transactionId,


### PR DESCRIPTION
## Proposed changes

in our case,   when the parallelism of flink job up to 60, sometime times
we will get ""Commit failed {
"status": "Fail",
 "msg": "errCode = 2, detailMessage = get tableList write lock timeout, tableList=(Table [id=677476, name=ad_wxt_data, type=OLAP])"
}"，"
,  and we find the logging will take more than 20ms, which maybe the major cause of the timeout.
 
so disable the logging in 2pc commit phase.


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

