### PR TITLE
[Improvement](meta) support return brief info of restore job

### DIFF
--- a/docs/en/docs/sql-manual/sql-reference/Show-Statements/SHOW-RESTORE.md
+++ b/docs/en/docs/sql-manual/sql-reference/Show-Statements/SHOW-RESTORE.md
@@ -37,7 +37,7 @@ This statement is used to view RESTORE tasks
 grammar:
 
 ````SQL
-SHOW RESTORE [FROM DB_NAME]
+SHOW [BRIEF] RESTORE [FROM DB_NAME]
 ````
 
 illustrate:
@@ -67,6 +67,12 @@ illustrate:
             UnfinishedTasks: Displays unfinished subtask ids during SNAPSHOTING, DOWNLOADING and COMMITING stages
             Status: If the job fails, display the failure message
             Timeout: Job timeout, in seconds
+
+<version since="dev">
+
+        2. brief: only show key information of RESTORE tasks, columns RestoreObjs, Progress, TaskErrMsg will not show
+
+</version>
 
 ### Example
 

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Show-Statements/SHOW-RESTORE.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Show-Statements/SHOW-RESTORE.md
@@ -37,7 +37,7 @@ SHOW RESTORE
 语法：
 
 ```SQL
-SHOW RESTORE [FROM DB_NAME]
+SHOW [BRIEF] RESTORE [FROM DB_NAME]
 ```
 
 说明：
@@ -67,6 +67,12 @@ SHOW RESTORE [FROM DB_NAME]
             UnfinishedTasks：        在 SNAPSHOTING、DOWNLOADING 和 COMMITING 阶段会显示还未完成的子任务id
             Status：                 如果作业失败，显示失败信息
             Timeout：                作业超时时间，单位秒
+
+<version since="dev">
+
+        2. brief: 仅返回精简格式的 RESTORE 任务信息，不包含 RestoreObjs, Progress, TaskErrMsg 三列 
+
+</version>
 
 ### Example
 

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -3903,6 +3903,10 @@ show_param ::=
     {:
         RESULT = new ShowRestoreStmt(db, parser.where);
     :}
+    | KW_BRIEF KW_RESTORE opt_db:db opt_wild_where
+    {:
+        RESULT = new ShowRestoreStmt(db, parser.where, true);
+    :}
     | KW_BROKER
     {:
         RESULT = new ShowBrokerStmt();

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowRestoreStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowRestoreStmt.java
@@ -162,7 +162,11 @@ public class ShowRestoreStmt extends ShowStmt {
     @Override
     public String toSql() {
         StringBuilder builder = new StringBuilder();
-        builder.append("SHOW RESTORE");
+        if (needBriefResult) {
+            builder.append("SHOW BRIEF RESTORE");
+        } else {
+            builder.append("SHOW RESTORE");
+        }
         if (dbName != null) {
             builder.append(" FROM `").append(dbName).append("` ");
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowRestoreStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowRestoreStmt.java
@@ -35,6 +35,7 @@ import org.apache.doris.qe.ShowResultSetMetaData;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 
+import java.util.List;
 import java.util.function.Predicate;
 
 public class ShowRestoreStmt extends ShowStmt {
@@ -45,15 +46,29 @@ public class ShowRestoreStmt extends ShowStmt {
             .add("SnapshotFinishedTime").add("DownloadFinishedTime").add("FinishedTime").add("UnfinishedTasks")
             .add("Progress").add("TaskErrMsg").add("Status").add("Timeout")
             .build();
+    public static final ImmutableList<String> BRIEF_TITLE_NAMES = new ImmutableList.Builder<String>()
+            .add("JobId").add("Label").add("Timestamp").add("DbName").add("State")
+            .add("AllowLoad").add("ReplicationNum").add("ReplicaAllocation").add("ReserveReplica")
+            .add("ReserveDynamicPartitionEnable").add("CreateTime").add("MetaPreparedTime")
+            .add("SnapshotFinishedTime").add("DownloadFinishedTime").add("FinishedTime").add("UnfinishedTasks")
+            .add("Status").add("Timeout")
+            .build();
 
     private String dbName;
     private Expr where;
     private String labelValue;
     private boolean isAccurateMatch;
+    private boolean needBriefResult;
 
     public ShowRestoreStmt(String dbName, Expr where) {
         this.dbName = dbName;
         this.where = where;
+    }
+
+    public ShowRestoreStmt(String dbName, Expr where, boolean needBriefResult) {
+        this.dbName = dbName;
+        this.where = where;
+        this.needBriefResult = needBriefResult;
     }
 
     public String getDbName() {
@@ -136,7 +151,9 @@ public class ShowRestoreStmt extends ShowStmt {
     @Override
     public ShowResultSetMetaData getMetaData() {
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
-        for (String title : TITLE_NAMES) {
+
+        List<String> titleNames = needBriefResult ? BRIEF_TITLE_NAMES : TITLE_NAMES;
+        for (String title : titleNames) {
             builder.addColumn(new Column(title, ScalarType.createVarchar(30)));
         }
         return builder.build();
@@ -166,6 +183,10 @@ public class ShowRestoreStmt extends ShowStmt {
 
     public boolean isAccurateMatch() {
         return isAccurateMatch;
+    }
+
+    public boolean isNeedBriefResult() {
+        return needBriefResult;
     }
 
     public Expr getWhere() {

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -1748,7 +1748,15 @@ public class RestoreJob extends AbstractJob {
         allTabletCommitted(true /* is replay */);
     }
 
-    public List<String> getInfo() {
+    public List<String> getBriefInfo() {
+        return getInfo(true);
+    }
+
+    public List<String> getFullInfo() {
+        return getInfo(false);
+    }
+
+    public List<String> getInfo(boolean isBrief) {
         List<String> info = Lists.newArrayList();
         info.add(String.valueOf(jobId));
         info.add(label);
@@ -1760,18 +1768,22 @@ public class RestoreJob extends AbstractJob {
         info.add(replicaAlloc.toCreateStmt());
         info.add(String.valueOf(reserveReplica));
         info.add(String.valueOf(reserveDynamicPartitionEnable));
-        info.add(getRestoreObjs());
+        if (!isBrief) {
+            info.add(getRestoreObjs());
+        }
         info.add(TimeUtils.longToTimeString(createTime));
         info.add(TimeUtils.longToTimeString(metaPreparedTime));
         info.add(TimeUtils.longToTimeString(snapshotFinishedTime));
         info.add(TimeUtils.longToTimeString(downloadFinishedTime));
         info.add(TimeUtils.longToTimeString(finishedTime));
         info.add(Joiner.on(", ").join(unfinishedSignatureToId.entrySet()));
-        info.add(Joiner.on(", ").join(taskProgress.entrySet().stream().map(
-                e -> "[" + e.getKey() + ": " + e.getValue().first + "/" + e.getValue().second + "]").collect(
-                        Collectors.toList())));
-        info.add(Joiner.on(", ").join(taskErrMsg.entrySet().stream().map(n -> "[" + n.getKey() + ": " + n.getValue()
-                + "]").collect(Collectors.toList())));
+        if (!isBrief) {
+            info.add(Joiner.on(", ").join(taskProgress.entrySet().stream().map(
+                    e -> "[" + e.getKey() + ": " + e.getValue().first + "/" + e.getValue().second + "]").collect(
+                    Collectors.toList())));
+            info.add(Joiner.on(", ").join(taskErrMsg.entrySet().stream().map(n -> "[" + n.getKey() + ": "
+                    + n.getValue() + "]").collect(Collectors.toList())));
+        }
         info.add(status.toString());
         info.add(String.valueOf(timeoutMs / 1000));
         return info;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -1927,7 +1927,12 @@ public class ShowExecutor {
         List<RestoreJob> restoreJobs = jobs.stream().filter(job -> job instanceof RestoreJob)
                 .map(job -> (RestoreJob) job).collect(Collectors.toList());
 
-        List<List<String>> infos = restoreJobs.stream().map(RestoreJob::getInfo).collect(Collectors.toList());
+        List<List<String>> infos;
+        if (showStmt.isNeedBriefResult()) {
+            infos = restoreJobs.stream().map(RestoreJob::getBriefInfo).collect(Collectors.toList());
+        } else {
+            infos = restoreJobs.stream().map(RestoreJob::getFullInfo).collect(Collectors.toList());
+        }
 
         resultSet = new ShowResultSet(showStmt.getMetaData(), infos);
     }


### PR DESCRIPTION
Sometimes, a restore job is huge, which contains a mount of tables and tablets. In such case, if you run show restore stmt,    you will get result which has too many lines that the whole screen will be flushed many times. It's unfriendly to use.
So stmt "show brief restore" is useful is such case.
<img width="774" alt="image" src="https://github.com/apache/doris/assets/28004179/00815f52-981d-4cd4-8ae6-ade946518208">

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

