### PR TITLE
[fix] total_time of select_node not include the open phase

### DIFF
--- a/be/src/exec/select_node.cpp
+++ b/be/src/exec/select_node.cpp
@@ -41,6 +41,7 @@ Status SelectNode::prepare(RuntimeState* state) {
 }
 
 Status SelectNode::open(RuntimeState* state) {
+    SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_ERROR(ExecNode::open(state));
     SCOPED_CONSUME_MEM_TRACKER(mem_tracker());
     RETURN_IF_ERROR(child(0)->open(state));

--- a/be/src/vec/exec/vselect_node.cpp
+++ b/be/src/vec/exec/vselect_node.cpp
@@ -33,6 +33,7 @@ Status VSelectNode::prepare(RuntimeState* state) {
 
 Status VSelectNode::open(RuntimeState* state) {
     START_AND_SCOPE_SPAN(state->get_tracer(), span, "VSelectNode::open");
+    SCOPED_TIMER(_runtime_profile->total_time_counter());
     RETURN_IF_ERROR(ExecNode::open(state));
     RETURN_IF_ERROR(child(0)->open(state));
     return Status::OK();


### PR DESCRIPTION
## Proposed changes
Issue Number: close #xxx

<!--Describe your changes.-->
add SCOPED_TIMER at the begin of select_node's open function

## Further comments
when using profile text, i found select_node's total_time(active) is smaller than it's child.
By looking at the code，i found  that total_time of select_node is not include the open phase.
Based on the above description, I propose the PR. Looking for a response^_^

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

