### PR TITLE
[bugfix](s3 fs) fix s3 uri parsing for http/https uri

### DIFF
--- a/be/src/util/s3_uri.h
+++ b/be/src/util/s3_uri.h
@@ -41,6 +41,9 @@ public:
     std::string to_string() const;
 
 private:
+    static const std::string _SCHEME_S3;
+    static const std::string _SCHEME_HTTP;
+    static const std::string _SCHEME_HTTPS;
     static const std::string _SCHEME_DELIM;
     static const std::string _PATH_DELIM;
     static const std::string _QUERY_DELIM;

--- a/be/test/util/s3_uri_test.cpp
+++ b/be/test/util/s3_uri_test.cpp
@@ -56,13 +56,42 @@ TEST_F(S3URITest, EncodedString) {
     EXPECT_EQ("path%20to%20file", uri1.get_key());
 }
 
+TEST_F(S3URITest, HttpURI) {
+    std::string p1 = "http://a.b.com/bucket/path/to/file";
+    S3URI uri1(p1);
+    EXPECT_TRUE(uri1.parse());
+    EXPECT_EQ("bucket", uri1.get_bucket());
+    EXPECT_EQ("path/to/file", uri1.get_key());
+
+    std::string p2 = "https://a.b.com/bucket/path/to/file";
+    S3URI uri2(p2);
+    EXPECT_TRUE(uri2.parse());
+    EXPECT_EQ("bucket", uri2.get_bucket());
+    EXPECT_EQ("path/to/file", uri2.get_key());
+}
+
+TEST_F(S3URITest, InvalidSchema) {
+    std::string p1 = "xxx://a.b.com/bucket/path/to/file";
+    S3URI uri1(p1);
+    EXPECT_FALSE(uri1.parse());
+}
+
 TEST_F(S3URITest, MissingKey) {
     std::string p1 = "https://bucket/";
     S3URI uri1(p1);
     EXPECT_FALSE(uri1.parse());
+
     std::string p2 = "s3://bucket/";
     S3URI uri2(p2);
     EXPECT_FALSE(uri2.parse());
+
+    std::string p3 = "http://a.b.com/bucket/";
+    S3URI uri3(p3);
+    EXPECT_FALSE(uri3.parse());
+
+    std::string p4 = "http://a.b.com/";
+    S3URI uri4(p4);
+    EXPECT_FALSE(uri4.parse());
 }
 
 TEST_F(S3URITest, RelativePathing) {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Now, S3URI::parse() process all uri in format 's3://bucket/path/to/file', which is not true for http/https uri 'http(s)://host/bucket1/path/to/file'. It will parse 'host' as bucket and 'bucket1/path/to/file' as key mistakenly.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

