### PR TITLE
[Enhancement](cmake) refine build option for clucene

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -457,17 +457,34 @@ endif()
 
 add_subdirectory(${SRC_DIR}/clucene EXCLUDE_FROM_ALL)
 
-set(clucene_options -w -Wall)
+set(clucene_c_options -w -Wall)
+set(clucene_cxx_options -w -Wall -Wno-non-virtual-dtor)
+
 if (COMPILER_CLANG)
-    set(clucene_options ${clucene_options} -Wno-c++11-narrowing)
+    set(clucene_cxx_options ${clucene_cxx_options} -Wno-c++11-narrowing)
 else ()
-    set(clucene_options ${clucene_options} -Wno-narrowing)
+    set(clucene_cxx_options ${clucene_cxx_options} -Wno-narrowing)
 endif()
 
-target_compile_options(clucene-core-static PRIVATE ${clucene_options})
-target_compile_options(clucene-shared-static PRIVATE ${clucene_options})
-target_compile_options(clucene-contribs-lib PRIVATE ${clucene_options})
-target_compile_options(ic PRIVATE ${clucene_options})
+target_compile_options(clucene-core-static PRIVATE
+    $<$<COMPILE_LANGUAGE:C>:${clucene_c_options}>
+    $<$<COMPILE_LANGUAGE:CXX>:${clucene_cxx_options}>
+)
+
+target_compile_options(clucene-shared-static PRIVATE
+    $<$<COMPILE_LANGUAGE:C>:${clucene_c_options}>
+    $<$<COMPILE_LANGUAGE:CXX>:${clucene_cxx_options}>
+)
+
+target_compile_options(clucene-contribs-lib PRIVATE
+    $<$<COMPILE_LANGUAGE:C>:${clucene_c_options}>
+    $<$<COMPILE_LANGUAGE:CXX>:${clucene_cxx_options}>
+)
+
+target_compile_options(ic PRIVATE
+    $<$<COMPILE_LANGUAGE:C>:${clucene_c_options}>
+    $<$<COMPILE_LANGUAGE:CXX>:${clucene_cxx_options}>
+)
 
 install(DIRECTORY
     ${SRC_DIR}/clucene/src/contribs-lib/CLucene/analysis/jieba/dict 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

fix build warning message like "cc1: warning: command-line option '-Wno-non-virtual-dtor' is valid for C++/ObjC++ but not for C"

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

