### PR TITLE
[fix](hudi) set default class loader for hudi serializer

### DIFF
--- a/fe/be-java-extensions/hudi-scanner/src/main/java/org/apache/doris/hudi/HudiJniScanner.java
+++ b/fe/be-java-extensions/hudi-scanner/src/main/java/org/apache/doris/hudi/HudiJniScanner.java
@@ -155,6 +155,11 @@ public class HudiJniScanner extends JniScanner {
 
         InputFormat<?, ?> inputFormatClass = HudiScanUtils.createInputFormat(jobConf, hudiScanParam.getInputFormat());
 
+        // org.apache.hudi.common.util.SerializationUtils$KryoInstantiator.newKryo
+        // throws error like `java.lang.IllegalArgumentException: classLoader cannot be null`.
+        // Set the default class loader
+        Thread.currentThread().setContextClassLoader(classLoader);
+
         // RecordReader will use ProcessBuilder to start a hotspot process, which may be stuck,
         // so use another process to kill this stuck process.
         // TODO(gaoxin): better way to solve the stuck process?


### PR DESCRIPTION
## Proposed changes
hudi serializer `org.apache.hudi.common.util.SerializationUtils$KryoInstantiator.newKryo` throws error like `java.lang.IllegalArgumentException: classLoader cannot be null`. Set the default class loader for scan thread.
```
public Kryo newKryo() {
    Kryo kryo = new Kryo();
    ...
    // Thread.currentThread().getContextClassLoader() returns null
    kryo.setClassLoader(Thread.currentThread().getContextClassLoader());
    ...
    return kryo;
}
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

