### PR TITLE
[fix](planner)the common type of floating and decimal should be floating type

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/ScalarType.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/ScalarType.java
@@ -1015,7 +1015,7 @@ public class ScalarType extends Type {
 
         if (t1.isDecimalV2() || t2.isDecimalV2()) {
             if (t1.isFloatingPointType() || t2.isFloatingPointType()) {
-                return MAX_DECIMALV2_TYPE;
+                return Type.DOUBLE;
             }
             return t1.isDecimalV2() ? t1 : t2;
         }


### PR DESCRIPTION

## Proposed changes

pick from master for old planner https://github.com/apache/doris/pull/20634

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

