### PR TITLE
[regression-test](test) fix mv_p0/test_drop_partition_from_index/test_drop_partition_from_index.groovy

### DIFF
--- a/regression-test/suites/mv_p0/test_drop_partition_from_index/test_drop_partition_from_index.groovy
+++ b/regression-test/suites/mv_p0/test_drop_partition_from_index/test_drop_partition_from_index.groovy
@@ -57,8 +57,8 @@ suite("sql_drop_partition_from_index") {
      sql""" ALTER TABLE ${testTable} DROP PARTITION p1 FROM INDEX ${testTable} """
      qt_select """ SELECT k1, k2+k3 FROM ${testTable} PARTITION(p1) """
     } finally {
-     sql """ DROP MATERIALIZED VIEW ${testMv} ON ${testTable} """
-     sql """ DROP TABLE ${testTable} """
+     sql """ DROP MATERIALIZED VIEW IF EXISTS ${testMv} ON ${testTable} """
+     sql """ DROP TABLE IF EXISTS ${testTable} """
      sql """ DROP DATABASE ${testDb} """
     }
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

finally {
     sql """ DROP MATERIALIZED VIEW ${testMv} ON ${testTable} """
     sql """ DROP TABLE ${testTable} """
     sql """ DROP DATABASE ${testDb} """
    }

in this case, there maybe some error before create materialized view. so when they failed, drop materialized view will be executed, but it does not created at that time. This will cause another exception, and the real failure will be hiden by regression-test.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

