### PR TITLE
[fix](columnstring) fix bug of columnstring prefetch

### DIFF
--- a/be/src/vec/columns/column_string.cpp
+++ b/be/src/vec/columns/column_string.cpp
@@ -113,7 +113,7 @@ void ColumnString::insert_indices_from(const IColumn& src, const int* indices_be
         if (*x == -1) {
             ColumnString::insert_default();
         } else {
-            if (x + IColumn::PREFETCH_STEP < indices_end) {
+            if (x + IColumn::PREFETCH_STEP < indices_end && (-1 != x[IColumn::PREFETCH_STEP])) {
                 ColumnString::prefetch(src, *(x + IColumn::PREFETCH_STEP));
             }
             ColumnString::insert_from(src, *x);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Fix bug of prefetch in ColumnString::insert_indices_from, in which `*(x + IColumn::PREFETCH_STEP)` could be `-1`, which will result invalid memory access in podarray:
```
void ColumnString::insert_indices_from(const IColumn& src, const int* indices_begin,
                                       const int* indices_end) {
    for (auto x = indices_begin; x != indices_end; ++x) {
        if (*x == -1) {
            ColumnString::insert_default();
        } else {
            if (x + IColumn::PREFETCH_STEP < indices_end) {
                ColumnString::prefetch(src, *(x + IColumn::PREFETCH_STEP));
            }
            ColumnString::insert_from(src, *x);
        }
    }
}

    void prefetch(const IColumn& src_, size_t n) {
        const ColumnString& src = assert_cast<const ColumnString&>(src_);
        __builtin_prefetch(&src.chars[src.offsets[n - 1]], 0, 1);
    }
```

```
#4  0x000056438b7a07d5 in doris::vectorized::PODArray<unsigned int, 4096ul, Allocator<false, false, true>, 15ul, 16ul>::operator[] (this=0x607001aa0200, n=-2)

    at /mnt/hdd01/repo_center/doris_branch-2.0-beta/doris/be/src/vec/common/pod_array.h:326

#5  0x000056439a0e2374 in doris::vectorized::ColumnString::prefetch (this=0x607004790280, src_=...,

    n=18446744073709551615) at /mnt/hdd01/repo_center/doris_branch-2.0-beta/doris/be/src/vec/columns/column_string.h:154

#6  0x000056439a0d42ae in doris::vectorized::ColumnString::insert_indices_from (this=0x607004790280, src=...,

    indices_begin=0x62f003f38400, indices_end=0x62f003f3c348)

    at /mnt/hdd01/repo_center/doris_branch-2.0-beta/doris/be/src/vec/columns/column_string.cpp:117

#7  0x000056439a0b3e0b in doris::vectorized::ColumnNullable::insert_indices_from (this=0x6040039ce290, src=...,

    indices_begin=0x62f003f38400, indices_end=0x62f003f3c348)

    at /mnt/hdd01/repo_center/doris_branch-2.0-beta/doris/be/src/vec/columns/column_nullable.cpp:265

#8  0x000056439d01d4b8 in doris::vectorized::ProcessHashTableProbe<1>::build_side_output_column<false> (

    this=0x6100007be240, mcol=std::vector of length 9, capacity 9 = {...}, column_offset=7, column_length=2,

    output_slot_flags=std::vector<bool> of length 2, capacity 64 = {...}, size=4050)

    at /mnt/hdd01/repo_center/doris_branch-2.0-beta/doris/be/src/vec/exec/join/process_hash_table_probe_impl.h:71

#9  0x000056439d02a6d7 in doris::vectorized::ProcessHashTableProbe<1>::do_process<false, true, doris::vectorized::SerializedHashTableContext<doris::vectorized::RowRefList> > (this=0x6100007be240, hash_table_ctx=..., null_map=0x0,

    mutable_block=..., output_block=0x7fbe983299e0, probe_rows=4050, is_mark_join=false)
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

