### PR TITLE
[Enhancement](merge-on-write) parallel calculate delete bitmap when tablet has multi segments

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -145,6 +145,8 @@ DEFINE_Int32(push_worker_count_high_priority, "3");
 DEFINE_Int32(publish_version_worker_count, "8");
 // the count of tablet thread to publish version
 DEFINE_Int32(tablet_publish_txn_max_thread, "32");
+// the count of thread to calc delete bitmap
+DEFINE_Int32(calc_delete_bitmap_max_thread, "32");
 // the count of thread to clear transaction task
 DEFINE_Int32(clear_transaction_task_worker_count, "1");
 // the count of thread to delete

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -185,6 +185,8 @@ DECLARE_Int32(push_worker_count_high_priority);
 DECLARE_Int32(publish_version_worker_count);
 // the count of tablet thread to publish version
 DECLARE_Int32(tablet_publish_txn_max_thread);
+// the count of thread to calc delete bitmap
+DECLARE_Int32(calc_delete_bitmap_max_thread);
 // the count of thread to clear transaction task
 DECLARE_Int32(clear_transaction_task_worker_count);
 // the count of thread to delete

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -239,6 +239,11 @@ Status StorageEngine::start_bg_threads() {
             .set_max_threads(config::tablet_publish_txn_max_thread)
             .build(&_tablet_publish_txn_thread_pool);
 
+    ThreadPoolBuilder("TabletCalcDeleteBitmapThreadPool")
+            .set_min_threads(1)
+            .set_max_threads(config::calc_delete_bitmap_max_thread)
+            .build(&_calc_delete_bitmap_thread_pool);
+
     LOG(INFO) << "all storage engine's background threads are started.";
     return Status::OK();
 }

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <ostream>
+#include <unordered_map>
 #include <utility>
 
 // IWYU pragma: no_include <opentelemetry/common/threadlocal.h>
@@ -42,6 +43,7 @@
 #include "olap/rowset/segment_v2/column_writer.h" // ColumnWriter
 #include "olap/rowset/segment_v2/page_io.h"
 #include "olap/rowset/segment_v2/page_pointer.h"
+#include "olap/segment_loader.h"
 #include "olap/short_key_index.h"
 #include "olap/tablet_schema.h"
 #include "runtime/memory/mem_tracker.h"
@@ -363,6 +365,7 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
     bool has_default = false;
     std::vector<bool> use_default_flag;
     use_default_flag.reserve(num_rows);
+    std::unordered_map<RowsetId, SegmentCacheHandle, HashOfRowsetId> segment_caches;
     // locate rows in base data
     {
         std::shared_lock rlock(_tablet->get_header_lock());
@@ -375,7 +378,7 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
             // save rowset shared ptr so this rowset wouldn't delete
             RowsetSharedPtr rowset;
             auto st = _tablet->lookup_row_key(key, false, &_mow_context->rowset_ids, &loc,
-                                              _mow_context->max_version, &rowset);
+                                              _mow_context->max_version, segment_caches, &rowset);
             if (st.is<NOT_FOUND>()) {
                 if (!_tablet_schema->allow_key_not_exist_in_partial_update()) {
                     return Status::InternalError("partial update key not exist before");

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -210,6 +210,9 @@ public:
     std::unique_ptr<ThreadPool>& tablet_publish_txn_thread_pool() {
         return _tablet_publish_txn_thread_pool;
     }
+    std::unique_ptr<ThreadPool>& calc_delete_bitmap_thread_pool() {
+        return _calc_delete_bitmap_thread_pool;
+    }
     bool stopped() { return _stopped; }
     ThreadPool* get_bg_multiget_threadpool() { return _bg_multi_get_thread_pool.get(); }
 
@@ -411,6 +414,7 @@ private:
     std::unique_ptr<ThreadPool> _cold_data_compaction_thread_pool;
 
     std::unique_ptr<ThreadPool> _tablet_publish_txn_thread_pool;
+    std::unique_ptr<ThreadPool> _calc_delete_bitmap_thread_pool;
 
     std::unique_ptr<ThreadPool> _tablet_meta_checkpoint_thread_pool;
     std::unique_ptr<ThreadPool> _bg_multi_get_thread_pool;

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2844,6 +2844,9 @@ Status Tablet::calc_segment_delete_bitmap(RowsetSharedPtr rowset,
     bool exact_match = false;
     std::string last_key;
     int batch_size = 1024;
+    // The data for each segment may be lookup multiple times. Creating a SegmentCacheHandle
+    // will update the lru cache, and there will be obvious lock competition in multithreading
+    // scenarios, so using a segment_caches to cache SegmentCacheHandle.
     std::unordered_map<RowsetId, SegmentCacheHandle, HashOfRowsetId> segment_caches;
     while (remaining > 0) {
         std::unique_ptr<segment_v2::IndexedColumnIterator> iter;

--- a/be/src/service/point_query_executor.cpp
+++ b/be/src/service/point_query_executor.cpp
@@ -249,6 +249,7 @@ Status PointQueryExecutor::_lookup_row_key() {
     SCOPED_TIMER(&_profile_metrics.lookup_key_ns);
     // 2. lookup row location
     Status st;
+    std::unordered_map<RowsetId, SegmentCacheHandle, HashOfRowsetId> segment_caches;
     for (size_t i = 0; i < _row_read_ctxs.size(); ++i) {
         RowLocation location;
         if (!config::disable_storage_row_cache) {
@@ -264,7 +265,7 @@ Status PointQueryExecutor::_lookup_row_key() {
         // Get rowlocation and rowset, ctx._rowset_ptr will acquire wrap this ptr
         auto rowset_ptr = std::make_unique<RowsetSharedPtr>();
         st = (_tablet->lookup_row_key(_row_read_ctxs[i]._primary_key, true, nullptr, &location,
-                                      INT32_MAX /*rethink?*/, rowset_ptr.get()));
+                                      INT32_MAX /*rethink?*/, segment_caches, rowset_ptr.get()));
         if (st.is_not_found()) {
             continue;
         }

--- a/be/test/olap/tablet_test.cpp
+++ b/be/test/olap/tablet_test.cpp
@@ -423,33 +423,35 @@ TEST_F(TestTablet, rowset_tree_update) {
     id3.init(540081);
     rowset_ids.insert(id3);
 
+    std::unordered_map<RowsetId, SegmentCacheHandle, HashOfRowsetId> segment_caches;
     RowLocation loc;
     // Key not in range.
-    ASSERT_TRUE(
-            tablet->lookup_row_key("99", true, &rowset_ids, &loc, 7).is<ErrorCode::NOT_FOUND>());
+    ASSERT_TRUE(tablet->lookup_row_key("99", true, &rowset_ids, &loc, 7, segment_caches)
+                        .is<ErrorCode::NOT_FOUND>());
     // Version too low.
-    ASSERT_TRUE(
-            tablet->lookup_row_key("101", true, &rowset_ids, &loc, 3).is<ErrorCode::NOT_FOUND>());
+    ASSERT_TRUE(tablet->lookup_row_key("101", true, &rowset_ids, &loc, 3, segment_caches)
+                        .is<ErrorCode::NOT_FOUND>());
     // Hit a segment, but since we don't have real data, return an internal error when loading the
     // segment.
-    LOG(INFO) << tablet->lookup_row_key("101", true, &rowset_ids, &loc, 7).to_string();
-    ASSERT_TRUE(
-            tablet->lookup_row_key("101", true, &rowset_ids, &loc, 7).is<ErrorCode::IO_ERROR>());
+    LOG(INFO) << tablet->lookup_row_key("101", true, &rowset_ids, &loc, 7, segment_caches)
+                         .to_string();
+    ASSERT_TRUE(tablet->lookup_row_key("101", true, &rowset_ids, &loc, 7, segment_caches)
+                        .is<ErrorCode::IO_ERROR>());
     // Key not in range.
-    ASSERT_TRUE(
-            tablet->lookup_row_key("201", true, &rowset_ids, &loc, 7).is<ErrorCode::NOT_FOUND>());
-    ASSERT_TRUE(
-            tablet->lookup_row_key("300", true, &rowset_ids, &loc, 7).is<ErrorCode::IO_ERROR>());
+    ASSERT_TRUE(tablet->lookup_row_key("201", true, &rowset_ids, &loc, 7, segment_caches)
+                        .is<ErrorCode::NOT_FOUND>());
+    ASSERT_TRUE(tablet->lookup_row_key("300", true, &rowset_ids, &loc, 7, segment_caches)
+                        .is<ErrorCode::IO_ERROR>());
     // Key not in range.
-    ASSERT_TRUE(
-            tablet->lookup_row_key("499", true, &rowset_ids, &loc, 7).is<ErrorCode::NOT_FOUND>());
+    ASSERT_TRUE(tablet->lookup_row_key("499", true, &rowset_ids, &loc, 7, segment_caches)
+                        .is<ErrorCode::NOT_FOUND>());
     // Version too low.
-    ASSERT_TRUE(
-            tablet->lookup_row_key("500", true, &rowset_ids, &loc, 7).is<ErrorCode::NOT_FOUND>());
+    ASSERT_TRUE(tablet->lookup_row_key("500", true, &rowset_ids, &loc, 7, segment_caches)
+                        .is<ErrorCode::NOT_FOUND>());
     // Hit a segment, but since we don't have real data, return an internal error when loading the
     // segment.
-    ASSERT_TRUE(
-            tablet->lookup_row_key("500", true, &rowset_ids, &loc, 8).is<ErrorCode::IO_ERROR>());
+    ASSERT_TRUE(tablet->lookup_row_key("500", true, &rowset_ids, &loc, 8, segment_caches)
+                        .is<ErrorCode::IO_ERROR>());
 }
 
 } // namespace doris


### PR DESCRIPTION

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

In order to accelerate the processing time of publish for merge-on-write table，parallel calculate delete bitmap when tablet has multi segments.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

