### PR TITLE
[compatibility](schema cache) ensure schema version when using schema…

### DIFF
--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -130,7 +130,11 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
     std::string schema_key = SchemaCache::get_schema_key(
             _read_options.tablet_id, _context->tablet_schema, read_columns,
             _context->tablet_schema->schema_version(), SchemaCache::Type::SCHEMA);
-    if ((_input_schema = SchemaCache::instance()->get_schema<SchemaSPtr>(schema_key)) == nullptr) {
+    // It is necessary to ensure that there is a schema version when using a cache
+    // because the absence of a schema version can result in reading a stale version
+    // of the schema after a schema change.
+    if (_context->tablet_schema->schema_version() < 0 ||
+        (_input_schema = SchemaCache::instance()->get_schema<SchemaSPtr>(schema_key)) == nullptr) {
         _input_schema = std::make_shared<Schema>(_context->tablet_schema->columns(), read_columns);
         SchemaCache::instance()->insert_schema(schema_key, _input_schema);
     }

--- a/be/src/olap/tablet_schema.h
+++ b/be/src/olap/tablet_schema.h
@@ -264,7 +264,7 @@ public:
     bool has_ngram_bf_index(int32_t col_unique_id) const;
     const TabletIndex* get_ngram_bf_index(int32_t col_unique_id) const;
     void update_indexes_from_thrift(const std::vector<doris::TOlapTableIndex>& indexes);
-
+    // If schema version is not set, it should be -1
     int32_t schema_version() const { return _schema_version; }
     void clear_columns();
     vectorized::Block create_block(

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -135,7 +135,8 @@ Status NewOlapScanner::init() {
         RETURN_IF_ERROR(status);
         _tablet = std::move(tablet);
         TOlapScanNode& olap_scan_node = ((NewOlapScanNode*)_parent)->_olap_scan_node;
-        if (olap_scan_node.__isset.columns_desc && !olap_scan_node.columns_desc.empty() &&
+        if (olap_scan_node.__isset.schema_version && olap_scan_node.__isset.columns_desc &&
+            !olap_scan_node.columns_desc.empty() &&
             olap_scan_node.columns_desc[0].col_unique_id >= 0) {
             schema_key = SchemaCache::get_schema_key(tablet_id, olap_scan_node.columns_desc,
                                                      olap_scan_node.schema_version,
@@ -156,7 +157,9 @@ Status NewOlapScanner::init() {
                 for (const auto& column_desc : olap_scan_node.columns_desc) {
                     _tablet_schema->append_column(TabletColumn(column_desc));
                 }
-                _tablet_schema->set_schema_version(olap_scan_node.schema_version);
+                if (olap_scan_node.__isset.schema_version) {
+                    _tablet_schema->set_schema_version(olap_scan_node.schema_version);
+                }
             }
             if (olap_scan_node.__isset.indexes_desc) {
                 _tablet_schema->update_indexes_from_thrift(olap_scan_node.indexes_desc);


### PR DESCRIPTION
… cache

When FE is old version, be is new version, issue a schema change(add column) and then query, old version of FE query without schema version could result in reading stale schema from schema cache

related PR:
#20037
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

