### PR TITLE
[fix](planner)strip trailing zeros when cast string literal to decimal literal

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/StringLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/StringLiteral.java
@@ -248,7 +248,7 @@ public class StringLiteral extends LiteralExpr {
                 case DECIMAL64:
                 case DECIMAL128:
                     try {
-                        DecimalLiteral res = new DecimalLiteral(new BigDecimal(value));
+                        DecimalLiteral res = new DecimalLiteral(new BigDecimal(value).stripTrailingZeros());
                         res.setType(targetType);
                         return res;
                     } catch (Exception e) {

--- a/regression-test/suites/correctness_p0/test_string_to_decimal.groovy
+++ b/regression-test/suites/correctness_p0/test_string_to_decimal.groovy
@@ -1,0 +1,40 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_string_to_decimal") {
+    sql """
+        drop table if exists string_decimal_table;
+    """
+    
+    sql """
+        CREATE TABLE `string_decimal_table` (
+        `bskrf` decimal(16, 9) NULL 
+        ) ENGINE=OLAP
+        UNIQUE KEY(`bskrf`)
+        DISTRIBUTED BY HASH(`bskrf`) BUCKETS 3
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1",
+        "in_memory" = "false",
+        "storage_format" = "V2",
+        "disable_auto_compaction" = "false"
+        ); 
+    """
+
+    sql """
+        insert into string_decimal_table values('0.000000000000000E+00');
+    """
+}


### PR DESCRIPTION

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

