### PR TITLE
[chore](workflow) Improve the robustness of BE UT (Clang)

### DIFF
--- a/.github/workflows/be-ut-clang.yml
+++ b/.github/workflows/be-ut-clang.yml
@@ -31,6 +31,21 @@ jobs:
     name: BE UT (Clang)
     runs-on: ubuntu-22.04
     steps:
+      - name: Checkout easimon/maximize-build-space
+        run: |
+          git clone -b v7 https://github.com/easimon/maximize-build-space
+
+      - name: Maximize build space
+        uses: ./maximize-build-space
+        with:
+            root-reserve-mb: 4096
+            swap-size-mb: 8192
+            remove-dotnet: 'true'
+            remove-android: 'true'
+            remove-haskell: 'true'
+            remove-codeql: 'true'
+            remove-docker-images: 'true'
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -65,6 +80,7 @@ jobs:
           wget https://github.com/amosbird/ldb_toolchain_gen/releases/download/v0.17/ldb_toolchain_gen.sh \
             -q -O /tmp/ldb_toolchain_gen.sh
           bash /tmp/ldb_toolchain_gen.sh "${DEFAULT_DIR}/ldb-toolchain"
+          rm /tmp/ldb_toolchain_gen.sh
 
           sudo apt update
           sudo DEBIAN_FRONTEND=noninteractive apt install --yes tzdata byacc
@@ -77,12 +93,11 @@ jobs:
           branch="${{ github.base_ref }}"
           if [[ -z "${branch}" ]] || [[ "${branch}" == 'master' ]]; then
             curl -L https://github.com/apache/doris-thirdparty/releases/download/automation/doris-thirdparty-prebuilt-linux-x86_64.tar.xz \
-              -o doris-thirdparty-prebuilt-linux-x86_64.tar.xz
+              -o - | tar -Jxf -
           else
             curl -L "https://github.com/apache/doris-thirdparty/releases/download/automation-${branch/branch-/}/doris-thirdparty-prebuilt-linux-x86_64.tar.xz" \
-              -o doris-thirdparty-prebuilt-linux-x86_64.tar.xz
+              -o - | tar -Jxf -
           fi
-          tar -xvf doris-thirdparty-prebuilt-linux-x86_64.tar.xz
           popd
 
           export PATH="${DEFAULT_DIR}/ldb-toolchain/bin/:$(pwd)/thirdparty/installed/bin/:${PATH}"


### PR DESCRIPTION
## Proposed changes

~~Issue Number: close #xxx~~

Recently the workflow `BE UT (Clang)` failed frequently. It seems that the workflow reaches the limitation of GitHub (memory, disk space and etc).

This PR tries to improve the robustness of the workflow `BE UT (Clang)`. The following changes are made.
1. Increase the size of swap to 8G.
2. Increase the size of disk space to around 50G.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

