### PR TITLE
[refactor](exprcontext) move close to expr context's dector method

### DIFF
--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -182,12 +182,6 @@ void ExecNode::release_resource(doris::RuntimeState* state) {
             COUNTER_SET(_rows_returned_counter, _num_rows_returned);
         }
 
-        for (auto& conjunct : _conjuncts) {
-            conjunct->close(state);
-        }
-
-        vectorized::VExpr::close(_projections, state);
-
         runtime_profile()->add_to_span(_span);
         _is_resource_released = true;
     }

--- a/be/src/olap/push_handler.cpp
+++ b/be/src/olap/push_handler.cpp
@@ -413,29 +413,6 @@ Status PushBrokerReader::next(vectorized::Block* block) {
 
 Status PushBrokerReader::close() {
     _ready = false;
-    for (auto ctx : _dest_expr_ctxs) {
-        if (ctx != nullptr) {
-            ctx->close(_runtime_state.get());
-        }
-    }
-
-    for (auto& expr : _push_down_exprs) {
-        expr->close(_runtime_state.get());
-    }
-
-    for (auto& [k, v] : _slot_id_to_filter_conjuncts) {
-        for (auto& ctx : v) {
-            if (ctx != nullptr) {
-                ctx->close(_runtime_state.get());
-            }
-        }
-    }
-
-    for (auto& ctx : _not_single_slot_filter_conjuncts) {
-        if (ctx != nullptr) {
-            ctx->close(_runtime_state.get());
-        }
-    }
     return Status::OK();
 }
 

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -272,7 +272,6 @@ Status BlockChanger::change_block(vectorized::Block* ref_block,
     if (_where_expr != nullptr) {
         vectorized::VExprContextSPtr ctx = nullptr;
         RETURN_IF_ERROR(vectorized::VExpr::create_expr_tree(*_where_expr, ctx));
-        Defer defer {[&]() { ctx->close(state); }};
         RETURN_IF_ERROR(ctx->prepare(state, row_desc));
         RETURN_IF_ERROR(ctx->open(state));
 
@@ -304,7 +303,6 @@ Status BlockChanger::change_block(vectorized::Block* ref_block,
         } else if (_schema_mapping[idx].expr != nullptr) {
             vectorized::VExprContextSPtr ctx;
             RETURN_IF_ERROR(vectorized::VExpr::create_expr_tree(*_schema_mapping[idx].expr, ctx));
-            Defer defer {[&]() { ctx->close(state); }};
             RETURN_IF_ERROR(ctx->prepare(state, row_desc));
             RETURN_IF_ERROR(ctx->open(state));
 

--- a/be/src/runtime/fold_constant_executor.cpp
+++ b/be/src/runtime/fold_constant_executor.cpp
@@ -83,9 +83,6 @@ Status FoldConstantExecutor::fold_constant_vexpr(const TFoldConstantParams& para
             const TExpr& texpr = n.second;
             // create expr tree from TExpr
             RETURN_IF_ERROR(vectorized::VExpr::create_expr_tree(texpr, ctx));
-
-            // close context expr
-            Defer defer {[&]() { ctx->close(_runtime_state.get()); }};
             // prepare and open context
             RETURN_IF_ERROR(_prepare_and_open(ctx.get()));
 

--- a/be/src/service/point_query_executor.cpp
+++ b/be/src/service/point_query_executor.cpp
@@ -47,9 +47,6 @@
 namespace doris {
 
 Reusable::~Reusable() {
-    for (auto& ctx : _output_exprs_ctxs) {
-        ctx->close(_runtime_state.get());
-    }
 }
 
 Status Reusable::init(const TDescriptorTable& t_desc_tbl, const std::vector<TExpr>& output_exprs,

--- a/be/src/service/point_query_executor.cpp
+++ b/be/src/service/point_query_executor.cpp
@@ -46,8 +46,7 @@
 
 namespace doris {
 
-Reusable::~Reusable() {
-}
+Reusable::~Reusable() {}
 
 Status Reusable::init(const TDescriptorTable& t_desc_tbl, const std::vector<TExpr>& output_exprs,
                       size_t block_size) {

--- a/be/src/vec/common/sort/vsort_exec_exprs.cpp
+++ b/be/src/vec/common/sort/vsort_exec_exprs.cpp
@@ -84,12 +84,6 @@ Status VSortExecExprs::open(RuntimeState* state) {
     return Status::OK();
 }
 
-void VSortExecExprs::close(RuntimeState* state) {
-    if (_materialize_tuple) {
-        VExpr::close(_sort_tuple_slot_expr_ctxs, state);
-    }
-    VExpr::close(_lhs_ordering_expr_ctxs, state);
-    VExpr::close(_rhs_ordering_expr_ctxs, state);
-}
+void VSortExecExprs::close(RuntimeState* state) {}
 
 } // namespace doris::vectorized

--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
@@ -97,11 +97,6 @@ RowGroupReader::RowGroupReader(io::FileReaderSPtr file_reader,
 
 RowGroupReader::~RowGroupReader() {
     _column_readers.clear();
-    for (auto& ctx : _dict_filter_conjuncts) {
-        if (ctx) {
-            ctx->close(_state);
-        }
-    }
     _obj_pool->clear();
 }
 

--- a/be/src/vec/exec/join/vhash_join_node.cpp
+++ b/be/src/vec/exec/join/vhash_join_node.cpp
@@ -763,12 +763,6 @@ Status HashJoinNode::alloc_resource(doris::RuntimeState* state) {
 }
 
 void HashJoinNode::release_resource(RuntimeState* state) {
-    VExpr::close(_build_expr_ctxs, state);
-    VExpr::close(_probe_expr_ctxs, state);
-
-    for (auto& conjunct : _other_join_conjuncts) {
-        conjunct->close(state);
-    }
     _release_mem();
     VJoinNodeBase::release_resource(state);
 }

--- a/be/src/vec/exec/join/vjoin_node_base.cpp
+++ b/be/src/vec/exec/join/vjoin_node_base.cpp
@@ -130,7 +130,6 @@ Status VJoinNodeBase::close(RuntimeState* state) {
 }
 
 void VJoinNodeBase::release_resource(RuntimeState* state) {
-    VExpr::close(_output_expr_ctxs, state);
     _join_block.clear();
     ExecNode::release_resource(state);
 }

--- a/be/src/vec/exec/join/vnested_loop_join_node.cpp
+++ b/be/src/vec/exec/join/vnested_loop_join_node.cpp
@@ -710,10 +710,6 @@ bool VNestedLoopJoinNode::need_more_input_data() const {
 
 void VNestedLoopJoinNode::release_resource(doris::RuntimeState* state) {
     VJoinNodeBase::release_resource(state);
-    VExpr::close(_filter_src_expr_ctxs, state);
-    for (auto& conjunct : _join_conjuncts) {
-        conjunct->close(state);
-    }
 }
 
 } // namespace doris::vectorized

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -910,40 +910,6 @@ Status VFileScanner::close(RuntimeState* state) {
         return Status::OK();
     }
 
-    for (auto ctx : _dest_vexpr_ctx) {
-        if (ctx != nullptr) {
-            ctx->close(state);
-        }
-    }
-
-    for (auto& it : _col_default_value_ctx) {
-        if (it.second != nullptr) {
-            it.second->close(state);
-        }
-    }
-
-    for (auto& conjunct : _pre_conjunct_ctxs) {
-        conjunct->close(state);
-    }
-
-    for (auto& conjunct : _push_down_conjuncts) {
-        conjunct->close(state);
-    }
-
-    for (auto& [k, v] : _slot_id_to_filter_conjuncts) {
-        for (auto& ctx : v) {
-            if (ctx != nullptr) {
-                ctx->close(state);
-            }
-        }
-    }
-
-    for (auto ctx : _not_single_slot_filter_conjuncts) {
-        if (ctx != nullptr) {
-            ctx->close(state);
-        }
-    }
-
     if (config::enable_file_cache && _state->query_options().enable_file_cache) {
         io::FileCacheProfileReporter cache_profile(_profile);
         cache_profile.update(_file_cache_statistics.get());

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -418,14 +418,6 @@ void VScanNode::release_resource(RuntimeState* state) {
         }
     }
 
-    for (auto& ctx : _stale_expr_ctxs) {
-        ctx->close(state);
-    }
-
-    for (auto& ctx : _common_expr_ctxs_push_down) {
-        ctx->close(state);
-    }
-
     ExecNode::release_resource(state);
 }
 

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -630,16 +630,16 @@ Status VScanNode::_normalize_predicate(const VExprSPtr& conjunct_expr_root, VExp
                 return Status::OK();
             } else {
                 if (left_child == nullptr) {
-                    conjunct_expr_root->children()[0]->close(_state, context,
+                    conjunct_expr_root->children()[0]->close(context,
                                                              context->get_function_state_scope());
                 }
                 if (right_child == nullptr) {
-                    conjunct_expr_root->children()[1]->close(_state, context,
+                    conjunct_expr_root->children()[1]->close(context,
                                                              context->get_function_state_scope());
                 }
                 // here only close the and expr self, do not close the child
                 conjunct_expr_root->set_children({});
-                conjunct_expr_root->close(_state, context, context->get_function_state_scope());
+                conjunct_expr_root->close(context, context->get_function_state_scope());
             }
 
             // here do not close VExpr* now

--- a/be/src/vec/exec/scan/vscanner.cpp
+++ b/be/src/vec/exec/scan/vscanner.cpp
@@ -145,17 +145,6 @@ Status VScanner::close(RuntimeState* state) {
     if (_is_closed) {
         return Status::OK();
     }
-    for (auto& ctx : _stale_expr_ctxs) {
-        ctx->close(state);
-    }
-
-    for (auto& conjunct : _conjuncts) {
-        conjunct->close(state);
-    }
-
-    for (auto& ctx : _common_expr_ctxs_push_down) {
-        ctx->close(state);
-    }
 
     COUNTER_UPDATE(_parent->_scanner_wait_worker_timer, _scanner_wait_worker_timer);
     _is_closed = true;

--- a/be/src/vec/exec/vaggregation_node.cpp
+++ b/be/src/vec/exec/vaggregation_node.cpp
@@ -601,7 +601,6 @@ Status AggregationNode::sink(doris::RuntimeState* state, vectorized::Block* in_b
 
 void AggregationNode::release_resource(RuntimeState* state) {
     for (auto* aggregate_evaluator : _aggregate_evaluators) aggregate_evaluator->close(state);
-    VExpr::close(_probe_expr_ctxs, state);
     if (_executor.close) _executor.close();
 
     /// _hash_table_size_counter may be null if prepare failed.

--- a/be/src/vec/exec/vanalytic_eval_node.cpp
+++ b/be/src/vec/exec/vanalytic_eval_node.cpp
@@ -293,12 +293,6 @@ void VAnalyticEvalNode::release_resource(RuntimeState* state) {
     if (is_closed()) {
         return;
     }
-
-    VExpr::close(_partition_by_eq_expr_ctxs, state);
-    VExpr::close(_order_by_eq_expr_ctxs, state);
-    for (size_t i = 0; i < _agg_functions_size; ++i) {
-        VExpr::close(_agg_expr_ctxs[i], state);
-    }
     for (auto* agg_function : _agg_functions) {
         agg_function->close(state);
     }

--- a/be/src/vec/exec/vpartition_sort_node.cpp
+++ b/be/src/vec/exec/vpartition_sort_node.cpp
@@ -335,7 +335,6 @@ Status VPartitionSortNode::close(RuntimeState* state) {
 }
 
 void VPartitionSortNode::release_resource(RuntimeState* state) {
-    VExpr::close(_partition_expr_ctxs, state);
     _vsort_exec_exprs.close(state);
     ExecNode::release_resource(state);
 }

--- a/be/src/vec/exec/vrepeat_node.cpp
+++ b/be/src/vec/exec/vrepeat_node.cpp
@@ -279,7 +279,6 @@ Status VRepeatNode::close(RuntimeState* state) {
 }
 
 void VRepeatNode::release_resource(RuntimeState* state) {
-    VExpr::close(_expr_ctxs, state);
     ExecNode::release_resource(state);
 }
 

--- a/be/src/vec/exec/vset_operation_node.cpp
+++ b/be/src/vec/exec/vset_operation_node.cpp
@@ -176,9 +176,6 @@ VSetOperationNode<is_intersect>::VSetOperationNode(ObjectPool* pool, const TPlan
 
 template <bool is_intersect>
 void VSetOperationNode<is_intersect>::release_resource(RuntimeState* state) {
-    for (auto& exprs : _child_expr_lists) {
-        VExpr::close(exprs, state);
-    }
     release_mem();
     ExecNode::release_resource(state);
 }

--- a/be/src/vec/exec/vtable_function_node.h
+++ b/be/src/vec/exec/vtable_function_node.h
@@ -63,8 +63,6 @@ public:
     bool need_more_input_data() const { return !_child_block.rows() && !_child_eos; }
 
     void release_resource(doris::RuntimeState* state) override {
-        VExpr::close(_vfn_ctxs, state);
-
         if (_num_rows_filtered_counter != nullptr) {
             COUNTER_SET(_num_rows_filtered_counter, static_cast<int64_t>(_num_rows_filtered));
         }

--- a/be/src/vec/exec/vunion_node.cpp
+++ b/be/src/vec/exec/vunion_node.cpp
@@ -317,12 +317,6 @@ void VUnionNode::release_resource(RuntimeState* state) {
     if (is_closed()) {
         return;
     }
-    for (auto& exprs : _const_expr_lists) {
-        VExpr::close(exprs, state);
-    }
-    for (auto& exprs : _child_expr_lists) {
-        VExpr::close(exprs, state);
-    }
     return ExecNode::release_resource(state);
 }
 

--- a/be/src/vec/exprs/vbitmap_predicate.cpp
+++ b/be/src/vec/exprs/vbitmap_predicate.cpp
@@ -117,10 +117,9 @@ doris::Status vectorized::VBitmapPredicate::execute(vectorized::VExprContext* co
     return Status::OK();
 }
 
-void vectorized::VBitmapPredicate::close(doris::RuntimeState* state,
-                                         vectorized::VExprContext* context,
+void vectorized::VBitmapPredicate::close(vectorized::VExprContext* context,
                                          FunctionContext::FunctionStateScope scope) {
-    VExpr::close(state, context, scope);
+    VExpr::close(context, scope);
 }
 
 const std::string& vectorized::VBitmapPredicate::expr_name() const {

--- a/be/src/vec/exprs/vbitmap_predicate.h
+++ b/be/src/vec/exprs/vbitmap_predicate.h
@@ -58,8 +58,7 @@ public:
     doris::Status open(doris::RuntimeState* state, VExprContext* context,
                        FunctionContext::FunctionStateScope scope) override;
 
-    void close(doris::RuntimeState* state, VExprContext* context,
-               FunctionContext::FunctionStateScope scope) override;
+    void close(VExprContext* context, FunctionContext::FunctionStateScope scope) override;
 
     VExprSPtr clone() const override { return VBitmapPredicate::create_shared(*this); }
 

--- a/be/src/vec/exprs/vbloom_predicate.cpp
+++ b/be/src/vec/exprs/vbloom_predicate.cpp
@@ -69,9 +69,8 @@ Status VBloomPredicate::open(RuntimeState* state, VExprContext* context,
     return Status::OK();
 }
 
-void VBloomPredicate::close(RuntimeState* state, VExprContext* context,
-                            FunctionContext::FunctionStateScope scope) {
-    VExpr::close(state, context, scope);
+void VBloomPredicate::close(VExprContext* context, FunctionContext::FunctionStateScope scope) {
+    VExpr::close(context, scope);
 }
 
 Status VBloomPredicate::execute(VExprContext* context, Block* block, int* result_column_id) {

--- a/be/src/vec/exprs/vbloom_predicate.h
+++ b/be/src/vec/exprs/vbloom_predicate.h
@@ -49,8 +49,7 @@ public:
                           VExprContext* context) override;
     doris::Status open(doris::RuntimeState* state, VExprContext* context,
                        FunctionContext::FunctionStateScope scope) override;
-    void close(doris::RuntimeState* state, VExprContext* context,
-               FunctionContext::FunctionStateScope scope) override;
+    void close(VExprContext* context, FunctionContext::FunctionStateScope scope) override;
     VExprSPtr clone() const override { return VBloomPredicate::create_shared(*this); }
     const std::string& expr_name() const override;
     void set_filter(std::shared_ptr<BloomFilterFuncBase>& filter);

--- a/be/src/vec/exprs/vcase_expr.cpp
+++ b/be/src/vec/exprs/vcase_expr.cpp
@@ -84,10 +84,9 @@ Status VCaseExpr::open(RuntimeState* state, VExprContext* context,
     return Status::OK();
 }
 
-void VCaseExpr::close(RuntimeState* state, VExprContext* context,
-                      FunctionContext::FunctionStateScope scope) {
+void VCaseExpr::close(VExprContext* context, FunctionContext::FunctionStateScope scope) {
     VExpr::close_function_context(context, scope, _function);
-    VExpr::close(state, context, scope);
+    VExpr::close(context, scope);
 }
 
 Status VCaseExpr::execute(VExprContext* context, Block* block, int* result_column_id) {

--- a/be/src/vec/exprs/vcase_expr.h
+++ b/be/src/vec/exprs/vcase_expr.h
@@ -49,8 +49,7 @@ public:
                            VExprContext* context) override;
     virtual Status open(RuntimeState* state, VExprContext* context,
                         FunctionContext::FunctionStateScope scope) override;
-    virtual void close(RuntimeState* state, VExprContext* context,
-                       FunctionContext::FunctionStateScope scope) override;
+    virtual void close(VExprContext* context, FunctionContext::FunctionStateScope scope) override;
     VExprSPtr clone() const override { return VCaseExpr::create_shared(*this); }
     virtual const std::string& expr_name() const override;
     virtual std::string debug_string() const override;

--- a/be/src/vec/exprs/vcast_expr.cpp
+++ b/be/src/vec/exprs/vcast_expr.cpp
@@ -83,10 +83,9 @@ doris::Status VCastExpr::open(doris::RuntimeState* state, VExprContext* context,
     return Status::OK();
 }
 
-void VCastExpr::close(doris::RuntimeState* state, VExprContext* context,
-                      FunctionContext::FunctionStateScope scope) {
+void VCastExpr::close(VExprContext* context, FunctionContext::FunctionStateScope scope) {
     VExpr::close_function_context(context, scope, _function);
-    VExpr::close(state, context, scope);
+    VExpr::close(context, scope);
 }
 
 doris::Status VCastExpr::execute(VExprContext* context, doris::vectorized::Block* block,

--- a/be/src/vec/exprs/vcast_expr.h
+++ b/be/src/vec/exprs/vcast_expr.h
@@ -49,8 +49,7 @@ public:
                                   VExprContext* context) override;
     virtual doris::Status open(doris::RuntimeState* state, VExprContext* context,
                                FunctionContext::FunctionStateScope scope) override;
-    virtual void close(doris::RuntimeState* state, VExprContext* context,
-                       FunctionContext::FunctionStateScope scope) override;
+    virtual void close(VExprContext* context, FunctionContext::FunctionStateScope scope) override;
     virtual VExprSPtr clone() const override { return VCastExpr::create_shared(*this); }
     virtual const std::string& expr_name() const override;
     virtual std::string debug_string() const override;

--- a/be/src/vec/exprs/vectorized_agg_fn.cpp
+++ b/be/src/vec/exprs/vectorized_agg_fn.cpp
@@ -207,7 +207,6 @@ Status AggFnEvaluator::open(RuntimeState* state) {
 }
 
 void AggFnEvaluator::close(RuntimeState* state) {
-    VExpr::close(_input_exprs_ctxs, state);
 }
 void AggFnEvaluator::create(AggregateDataPtr place) {
     _function->create(place);

--- a/be/src/vec/exprs/vectorized_agg_fn.cpp
+++ b/be/src/vec/exprs/vectorized_agg_fn.cpp
@@ -206,11 +206,12 @@ Status AggFnEvaluator::open(RuntimeState* state) {
     return VExpr::open(_input_exprs_ctxs, state);
 }
 
-void AggFnEvaluator::close(RuntimeState* state) {
-}
+void AggFnEvaluator::close(RuntimeState* state) {}
+
 void AggFnEvaluator::create(AggregateDataPtr place) {
     _function->create(place);
 }
+
 void AggFnEvaluator::destroy(AggregateDataPtr place) {
     _function->destroy(place);
 }

--- a/be/src/vec/exprs/vectorized_fn_call.cpp
+++ b/be/src/vec/exprs/vectorized_fn_call.cpp
@@ -130,10 +130,9 @@ Status VectorizedFnCall::open(RuntimeState* state, VExprContext* context,
     return Status::OK();
 }
 
-void VectorizedFnCall::close(RuntimeState* state, VExprContext* context,
-                             FunctionContext::FunctionStateScope scope) {
+void VectorizedFnCall::close(VExprContext* context, FunctionContext::FunctionStateScope scope) {
     VExpr::close_function_context(context, scope, _function);
-    VExpr::close(state, context, scope);
+    VExpr::close(context, scope);
 }
 
 Status VectorizedFnCall::execute(VExprContext* context, vectorized::Block* block,

--- a/be/src/vec/exprs/vectorized_fn_call.h
+++ b/be/src/vec/exprs/vectorized_fn_call.h
@@ -49,8 +49,7 @@ public:
     Status prepare(RuntimeState* state, const RowDescriptor& desc, VExprContext* context) override;
     Status open(RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;
-    void close(RuntimeState* state, VExprContext* context,
-               FunctionContext::FunctionStateScope scope) override;
+    void close(VExprContext* context, FunctionContext::FunctionStateScope scope) override;
     VExprSPtr clone() const override { return VectorizedFnCall::create_shared(*this); }
     const std::string& expr_name() const override;
     std::string debug_string() const override;

--- a/be/src/vec/exprs/vexpr.cpp
+++ b/be/src/vec/exprs/vexpr.cpp
@@ -123,7 +123,7 @@ Status VExpr::open(RuntimeState* state, VExprContext* context,
 
 void VExpr::close(VExprContext* context, FunctionContext::FunctionStateScope scope) {
     for (int i = 0; i < _children.size(); ++i) {
-        _children[i]->close(, context, scope);
+        _children[i]->close(context, scope);
     }
 }
 

--- a/be/src/vec/exprs/vexpr.cpp
+++ b/be/src/vec/exprs/vexpr.cpp
@@ -121,10 +121,9 @@ Status VExpr::open(RuntimeState* state, VExprContext* context,
     return Status::OK();
 }
 
-void VExpr::close(RuntimeState* state, VExprContext* context,
-                  FunctionContext::FunctionStateScope scope) {
+void VExpr::close(VExprContext* context, FunctionContext::FunctionStateScope scope) {
     for (int i = 0; i < _children.size(); ++i) {
-        _children[i]->close(state, context, scope);
+        _children[i]->close(, context, scope);
     }
 }
 

--- a/be/src/vec/exprs/vexpr.cpp
+++ b/be/src/vec/exprs/vexpr.cpp
@@ -309,12 +309,6 @@ Status VExpr::prepare(const VExprContextSPtrs& ctxs, RuntimeState* state,
     return Status::OK();
 }
 
-void VExpr::close(const VExprContextSPtrs& ctxs, RuntimeState* state) {
-    for (auto ctx : ctxs) {
-        ctx->close(state);
-    }
-}
-
 Status VExpr::open(const VExprContextSPtrs& ctxs, RuntimeState* state) {
     for (int i = 0; i < ctxs.size(); ++i) {
         RETURN_IF_ERROR(ctxs[i]->open(state));

--- a/be/src/vec/exprs/vexpr.h
+++ b/be/src/vec/exprs/vexpr.h
@@ -111,8 +111,7 @@ public:
     /// If scope if FRAGMENT_LOCAL, both fragment- and thread-local state should be torn
     /// down. Otherwise, if scope is THREAD_LOCAL, only thread-local state should be torn
     /// down.
-    virtual void close(RuntimeState* state, VExprContext* context,
-                       FunctionContext::FunctionStateScope scope);
+    virtual void close(VExprContext* context, FunctionContext::FunctionStateScope scope);
 
     DataTypePtr& data_type() { return _data_type; }
 

--- a/be/src/vec/exprs/vexpr.h
+++ b/be/src/vec/exprs/vexpr.h
@@ -139,8 +139,6 @@ public:
     static Status clone_if_not_exists(const VExprContextSPtrs& ctxs, RuntimeState* state,
                                       VExprContextSPtrs& new_ctxs);
 
-    static void close(const VExprContextSPtrs& ctxs, RuntimeState* state);
-
     bool is_nullable() const { return _data_type->is_nullable(); }
 
     PrimitiveType result_type() const { return _type.type; }

--- a/be/src/vec/exprs/vexpr_context.cpp
+++ b/be/src/vec/exprs/vexpr_context.cpp
@@ -85,7 +85,7 @@ doris::Status VExprContext::open(doris::RuntimeState* state) {
     return _root->open(state, this, scope);
 }
 
-void VExprContext::close(doris::RuntimeState* state) {
+void VExprContext::close() {
     // Sometimes expr context may not have a root, then it need not call close
     if (_root == nullptr) {
         return;

--- a/be/src/vec/exprs/vexpr_context.cpp
+++ b/be/src/vec/exprs/vexpr_context.cpp
@@ -45,15 +45,10 @@ VExprContext::VExprContext(const VExprSPtr& expr)
           _is_clone(false),
           _prepared(false),
           _opened(false),
-          _closed(false),
           _last_result_column_id(-1) {}
 
 VExprContext::~VExprContext() {
-    // Do not delete this code, this code here is used to check if forget to close the opened context
-    // Or there will be memory leak
-    DCHECK(!_prepared || _closed || k_doris_exit)
-            << " prepare:" << _prepared << " closed:" << _closed
-            << " expr:" << _root->debug_string();
+    close();
 }
 
 doris::Status VExprContext::execute(doris::vectorized::Block* block, int* result_column_id) {
@@ -84,12 +79,10 @@ doris::Status VExprContext::open(doris::RuntimeState* state) {
     return _root->open(state, this, scope);
 }
 
-void VExprContext::close(doris::RuntimeState* state) {
-    DCHECK(!_closed);
+void VExprContext::close() {
     FunctionContext::FunctionStateScope scope =
             _is_clone ? FunctionContext::THREAD_LOCAL : FunctionContext::FRAGMENT_LOCAL;
-    _root->close(state, this, scope);
-    _closed = true;
+    _root->close(this, scope);
 }
 
 doris::Status VExprContext::clone(RuntimeState* state, VExprContextSPtr& new_ctx) {

--- a/be/src/vec/exprs/vexpr_context.h
+++ b/be/src/vec/exprs/vexpr_context.h
@@ -44,7 +44,6 @@ public:
     ~VExprContext();
     [[nodiscard]] Status prepare(RuntimeState* state, const RowDescriptor& row_desc);
     [[nodiscard]] Status open(RuntimeState* state);
-    void close(RuntimeState* state);
     [[nodiscard]] Status clone(RuntimeState* state, VExprContextSPtr& new_ctx);
     [[nodiscard]] Status execute(Block* block, int* result_column_id);
 
@@ -117,7 +116,6 @@ public:
         _is_clone = other._is_clone;
         _prepared = other._prepared;
         _opened = other._opened;
-        _closed = other._closed;
 
         for (auto& fn : other._fn_contexts) {
             _fn_contexts.emplace_back(fn->clone());
@@ -134,12 +132,15 @@ public:
         _is_clone = other._is_clone;
         _prepared = other._prepared;
         _opened = other._opened;
-        _closed = other._closed;
         _fn_contexts = std::move(other._fn_contexts);
         _last_result_column_id = other._last_result_column_id;
         _depth_num = other._depth_num;
         return *this;
     }
+
+private:
+    // Close method is called in vexpr context dector, not need call expicility
+    void close(RuntimeState* state);
 
 private:
     friend class VExpr;
@@ -153,7 +154,6 @@ private:
     /// Variables keeping track of current state.
     bool _prepared;
     bool _opened;
-    bool _closed;
 
     /// FunctionContexts for each registered expression. The FunctionContexts are created
     /// and owned by this VExprContext.

--- a/be/src/vec/exprs/vexpr_context.h
+++ b/be/src/vec/exprs/vexpr_context.h
@@ -140,7 +140,7 @@ public:
 
 private:
     // Close method is called in vexpr context dector, not need call expicility
-    void close(RuntimeState* state);
+    void close();
 
 private:
     friend class VExpr;

--- a/be/src/vec/exprs/vin_predicate.cpp
+++ b/be/src/vec/exprs/vin_predicate.cpp
@@ -83,10 +83,9 @@ Status VInPredicate::open(RuntimeState* state, VExprContext* context,
     return Status::OK();
 }
 
-void VInPredicate::close(RuntimeState* state, VExprContext* context,
-                         FunctionContext::FunctionStateScope scope) {
+void VInPredicate::close(VExprContext* context, FunctionContext::FunctionStateScope scope) {
     VExpr::close_function_context(context, scope, _function);
-    VExpr::close(state, context, scope);
+    VExpr::close(context, scope);
 }
 
 Status VInPredicate::execute(VExprContext* context, Block* block, int* result_column_id) {

--- a/be/src/vec/exprs/vin_predicate.h
+++ b/be/src/vec/exprs/vin_predicate.h
@@ -48,7 +48,7 @@ public:
                           VExprContext* context) override;
     doris::Status open(doris::RuntimeState* state, VExprContext* context,
                        FunctionContext::FunctionStateScope scope) override;
-    void close(doris::RuntimeState* state, VExprContext* context,
+    void close(VExprContext* context,
                FunctionContext::FunctionStateScope scope) override;
     VExprSPtr clone() const override { return VInPredicate::create_shared(*this); }
     const std::string& expr_name() const override;

--- a/be/src/vec/exprs/vin_predicate.h
+++ b/be/src/vec/exprs/vin_predicate.h
@@ -48,8 +48,7 @@ public:
                           VExprContext* context) override;
     doris::Status open(doris::RuntimeState* state, VExprContext* context,
                        FunctionContext::FunctionStateScope scope) override;
-    void close(VExprContext* context,
-               FunctionContext::FunctionStateScope scope) override;
+    void close(VExprContext* context, FunctionContext::FunctionStateScope scope) override;
     VExprSPtr clone() const override { return VInPredicate::create_shared(*this); }
     const std::string& expr_name() const override;
 

--- a/be/src/vec/exprs/vmatch_predicate.cpp
+++ b/be/src/vec/exprs/vmatch_predicate.cpp
@@ -93,10 +93,9 @@ Status VMatchPredicate::open(RuntimeState* state, VExprContext* context,
     return Status::OK();
 }
 
-void VMatchPredicate::close(RuntimeState* state, VExprContext* context,
-                            FunctionContext::FunctionStateScope scope) {
+void VMatchPredicate::close(VExprContext* context, FunctionContext::FunctionStateScope scope) {
     VExpr::close_function_context(context, scope, _function);
-    VExpr::close(state, context, scope);
+    VExpr::close(context, scope);
 }
 
 Status VMatchPredicate::execute(VExprContext* context, Block* block, int* result_column_id) {

--- a/be/src/vec/exprs/vmatch_predicate.h
+++ b/be/src/vec/exprs/vmatch_predicate.h
@@ -50,8 +50,7 @@ public:
                           VExprContext* context) override;
     doris::Status open(doris::RuntimeState* state, VExprContext* context,
                        FunctionContext::FunctionStateScope scope) override;
-    void close(doris::RuntimeState* state, VExprContext* context,
-               FunctionContext::FunctionStateScope scope) override;
+    void close(VExprContext* context, FunctionContext::FunctionStateScope scope) override;
     VExprSPtr clone() const override { return VMatchPredicate::create_shared(*this); }
     const std::string& expr_name() const override;
     const std::string& function_name() const;

--- a/be/src/vec/exprs/vruntimefilter_wrapper.cpp
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.cpp
@@ -66,9 +66,9 @@ Status VRuntimeFilterWrapper::open(RuntimeState* state, VExprContext* context,
     return _impl->open(state, context, scope);
 }
 
-void VRuntimeFilterWrapper::close(RuntimeState* state, VExprContext* context,
+void VRuntimeFilterWrapper::close(VExprContext* context,
                                   FunctionContext::FunctionStateScope scope) {
-    _impl->close(state, context, scope);
+    _impl->close(context, scope);
 }
 
 bool VRuntimeFilterWrapper::is_constant() const {

--- a/be/src/vec/exprs/vruntimefilter_wrapper.h
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.h
@@ -55,8 +55,7 @@ public:
                        FunctionContext::FunctionStateScope scope) override;
     std::string debug_string() const override { return _impl->debug_string(); }
     bool is_constant() const override;
-    void close(doris::RuntimeState* state, VExprContext* context,
-               FunctionContext::FunctionStateScope scope) override;
+    void close(VExprContext* context, FunctionContext::FunctionStateScope scope) override;
     VExprSPtr clone() const override { return VRuntimeFilterWrapper::create_shared(*this); }
     const std::string& expr_name() const override;
     const VExprSPtrs& children() const override { return _impl->children(); }

--- a/be/src/vec/exprs/vschema_change_expr.cpp
+++ b/be/src/vec/exprs/vschema_change_expr.cpp
@@ -73,9 +73,9 @@ Status VSchemaChangeExpr::open(doris::RuntimeState* state, VExprContext* context
     return Status::OK();
 }
 
-void VSchemaChangeExpr::close(doris::RuntimeState* state, VExprContext* context,
+void VSchemaChangeExpr::close(VExprContext* context,
                               FunctionContext::FunctionStateScope scope) {
-    VExpr::close(state, context, scope);
+    VExpr::close(context, scope);
 }
 
 Status VSchemaChangeExpr::execute(VExprContext* context, doris::vectorized::Block* block,

--- a/be/src/vec/exprs/vschema_change_expr.cpp
+++ b/be/src/vec/exprs/vschema_change_expr.cpp
@@ -73,8 +73,7 @@ Status VSchemaChangeExpr::open(doris::RuntimeState* state, VExprContext* context
     return Status::OK();
 }
 
-void VSchemaChangeExpr::close(VExprContext* context,
-                              FunctionContext::FunctionStateScope scope) {
+void VSchemaChangeExpr::close(VExprContext* context, FunctionContext::FunctionStateScope scope) {
     VExpr::close(context, scope);
 }
 

--- a/be/src/vec/exprs/vschema_change_expr.h
+++ b/be/src/vec/exprs/vschema_change_expr.h
@@ -53,8 +53,7 @@ public:
                    VExprContext* context) override;
     Status open(doris::RuntimeState* state, VExprContext* context,
                 FunctionContext::FunctionStateScope scope) override;
-    void close(doris::RuntimeState* state, VExprContext* context,
-               FunctionContext::FunctionStateScope scope) override;
+    void close(VExprContext* context, FunctionContext::FunctionStateScope scope) override;
     VExprSPtr clone() const override { return VSchemaChangeExpr::create_shared(*this); }
     const std::string& expr_name() const override;
     std::string debug_string() const override;

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -696,7 +696,6 @@ Status VDataStreamSender::close(RuntimeState* state, Status exec_status) {
             final_st = st;
         }
     }
-    VExpr::close(_partition_expr_ctxs, state);
     DataSink::close(state, exec_status);
     return final_st;
 }

--- a/be/src/vec/sink/vmemory_scratch_sink.cpp
+++ b/be/src/vec/sink/vmemory_scratch_sink.cpp
@@ -98,7 +98,6 @@ Status MemoryScratchSink::close(RuntimeState* state, Status exec_status) {
     if (_queue != nullptr) {
         _queue->blocking_put(nullptr);
     }
-    VExpr::close(_output_vexpr_ctxs, state);
     return DataSink::close(state, exec_status);
 }
 

--- a/be/src/vec/sink/vresult_file_sink.cpp
+++ b/be/src/vec/sink/vresult_file_sink.cpp
@@ -186,8 +186,6 @@ Status VResultFileSink::close(RuntimeState* state, Status exec_status) {
         _output_block->clear();
     }
 
-    VExpr::close(_output_vexpr_ctxs, state);
-
     _closed = true;
     return Status::OK();
 }

--- a/be/src/vec/sink/vresult_sink.cpp
+++ b/be/src/vec/sink/vresult_sink.cpp
@@ -161,8 +161,6 @@ Status VResultSink::close(RuntimeState* state, Status exec_status) {
     state->exec_env()->result_mgr()->cancel_at_time(
             time(nullptr) + config::result_buffer_cancelled_interval_time,
             state->fragment_instance_id());
-
-    VExpr::close(_output_vexpr_ctxs, state);
     return DataSink::close(state, exec_status);
 }
 

--- a/be/src/vec/sink/vtable_sink.cpp
+++ b/be/src/vec/sink/vtable_sink.cpp
@@ -69,7 +69,6 @@ Status VTableSink::close(RuntimeState* state, Status exec_status) {
     if (_closed) {
         return Status::OK();
     }
-    VExpr::close(_output_vexpr_ctxs, state);
     return Status::OK();
 }
 } // namespace vectorized

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -127,8 +127,7 @@ public:
     int64_t partition_id;
 };
 
-IndexChannel::~IndexChannel() {
-}
+IndexChannel::~IndexChannel() {}
 
 Status IndexChannel::init(RuntimeState* state, const std::vector<TTabletWithPartition>& tablets) {
     SCOPED_CONSUME_MEM_TRACKER(_index_channel_tracker.get());

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -128,9 +128,6 @@ public:
 };
 
 IndexChannel::~IndexChannel() {
-    if (_where_clause != nullptr) {
-        _where_clause->close(_parent->_state);
-    }
 }
 
 Status IndexChannel::init(RuntimeState* state, const std::vector<TTabletWithPartition>& tablets) {

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -1402,7 +1402,6 @@ Status VOlapTableSink::close(RuntimeState* state, Status exec_status) {
         return _close_status;
     }
     SCOPED_TIMER(_close_timer);
-    vectorized::VExpr::close(_output_vexpr_ctxs, state);
     Status status = exec_status;
     if (status.ok()) {
         // only if status is ok can we call this _profile->total_time_counter().

--- a/be/test/vec/data_types/serde/data_type_serde_mysql_test.cpp
+++ b/be/test/vec/data_types/serde/data_type_serde_mysql_test.cpp
@@ -281,9 +281,6 @@ void serialize_and_deserialize_mysql_test() {
 
     Status st = mysql_writer.append_block(block);
     EXPECT_TRUE(st.ok());
-    for (auto expr : _output_vexpr_ctxs) {
-        expr->close(&runtime_stat);
-    }
 }
 
 TEST(DataTypeSerDeMysqlTest, ScalaSerDeTest) {

--- a/be/test/vec/exprs/vexpr_test.cpp
+++ b/be/test/vec/exprs/vexpr_test.cpp
@@ -72,7 +72,6 @@ TEST(TEST_VEXPR, ABSTEST) {
     ASSERT_TRUE(state.ok());
     state = context->open(&runtime_stat);
     ASSERT_TRUE(state.ok());
-    context->close(&runtime_stat);
 }
 
 // Only the unit test depend on this, but it is wrong, should not use TTupleDesc to create tuple desc, not
@@ -168,7 +167,6 @@ TEST(TEST_VEXPR, ABSTEST2) {
     ASSERT_TRUE(state.ok());
     state = context->open(&runtime_stat);
     ASSERT_TRUE(state.ok());
-    context->close(&runtime_stat);
 }
 
 namespace doris {


### PR DESCRIPTION
## Proposed changes
The close method does nothing. But I am not sure we could remove it. So that I add it to dector method and remove many many calls.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

