### PR TITLE
[fix](cooldown) Fix bug when cooldown a dropped tablet

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2039,7 +2039,10 @@ Status Tablet::_cooldown_data() {
         save_meta();
     }
     // upload cooldowned rowset meta to remote fs
-    async_write_cooldown_meta(StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id()));
+    if (auto t = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id());
+        t != nullptr) { // `t` can be nullptr if it has been dropped
+        async_write_cooldown_meta(std::move(t));
+    }
     return Status::OK();
 }
 


### PR DESCRIPTION
## Proposed changes

```
*** SIGSEGV address not mapped to object (@0x10) received by PID 3402534 (TID 3403376 OR 0x7f61da9f3700) from PID 16; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk2/xiaokang/src/doris-2.0-alpha-log/be/src/common/signal_handler.h:413
 1# os::Linux::chained_handler(int, siginfo_t*, void*) in /usr/lib/jvm/java-11-openjdk-amd64/lib/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-11-openjdk-amd64/lib/server/libjvm.so
 3# signalHandler(int, siginfo_t*, void*) in /usr/lib/jvm/java-11-openjdk-amd64/lib/server/libjvm.so
 4# 0x00007F6370552090 in /lib/x86_64-linux-gnu/libc.so.6
 5# doris::WriteCooldownMetaExecutors::submit(std::shared_ptr<doris::Tablet>) at /mnt/disk2/xiaokang/src/doris-2.0-alpha-log/be/src/olap/tablet.cpp:135
 6# doris::Tablet::async_write_cooldown_meta(std::shared_ptr<doris::Tablet>) at /mnt/disk2/xiaokang/src/doris-2.0-alpha-log/be/src/olap/tablet.cpp:2081
 7# doris::Tablet::_cooldown_data() at /mnt/disk2/xiaokang/src/doris-2.0-alpha-log/be/src/olap/tablet.cpp:2039
 8# doris::Tablet::cooldown() at /mnt/disk2/xiaokang/src/doris-2.0-alpha-log/be/src/olap/tablet.cpp:1971
 9# std::_Function_handler<void (), doris::StorageEngine::_cooldown_tasks_producer_callback()::$_1>::_M_invoke(std::_Any_data const&) at /mnt/disk2/xiaokang/opt/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
10# doris::PriorityThreadPool::work_thread(int) at /mnt/disk2/xiaokang/src/doris-2.0-alpha-log/be/src/util/priority_thread_pool.hpp:147
11# execute_native_thread_routine at ../../../../../libstdc++-v3/src/c++11/thread.cc:84
12# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
13# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

