### PR TITLE
[Feature-WIP](inverted index) add inverted index file size method

### DIFF
--- a/be/src/olap/rowset/segment_v2/column_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/column_writer.cpp
@@ -642,6 +642,14 @@ Status ScalarColumnWriter::write_inverted_index() {
     return Status::OK();
 }
 
+size_t ScalarColumnWriter::get_inverted_index_size() {
+    if (_opts.inverted_index) {
+        auto size = _inverted_index_builder->file_size();
+        return size == -1 ? 0 : size;
+    }
+    return 0;
+}
+
 Status ScalarColumnWriter::write_bloom_filter_index() {
     if (_opts.need_bloom_filter) {
         return _bloom_filter_index_builder->finish(_file_writer, _opts.meta->add_indexes());
@@ -754,6 +762,17 @@ Status StructColumnWriter::write_inverted_index() {
         }
     }
     return Status::OK();
+}
+
+size_t StructColumnWriter::get_inverted_index_size() {
+    size_t total_size = 0;
+    if (_opts.inverted_index) {
+        for (auto& column_writer : _sub_column_writers) {
+            auto size = column_writer->get_inverted_index_size();
+            total_size += (size == -1 ? 0 : size);
+        }
+    }
+    return total_size;
 }
 
 Status StructColumnWriter::append_nullable(const uint8_t* null_map, const uint8_t** ptr,
@@ -875,6 +894,14 @@ Status ArrayColumnWriter::write_inverted_index() {
         return _inverted_index_builder->finish();
     }
     return Status::OK();
+}
+
+size_t ArrayColumnWriter::get_inverted_index_size() {
+    if (_opts.inverted_index) {
+        auto size = _inverted_index_builder->file_size();
+        return size == -1 ? 0 : size;
+    }
+    return 0;
 }
 
 // Now we can only write data one by one.
@@ -1126,6 +1153,14 @@ Status MapColumnWriter::write_inverted_index() {
         return _inverted_index_builder->finish();
     }
     return Status::OK();
+}
+
+size_t MapColumnWriter::get_inverted_index_size() {
+    if (_opts.inverted_index) {
+        auto size = _inverted_index_builder->file_size();
+        return size == -1 ? 0 : size;
+    }
+    return 0;
 }
 
 } // namespace segment_v2

--- a/be/src/olap/rowset/segment_v2/column_writer.h
+++ b/be/src/olap/rowset/segment_v2/column_writer.h
@@ -142,6 +142,8 @@ public:
 
     virtual Status write_inverted_index() = 0;
 
+    virtual size_t get_inverted_index_size() = 0;
+
     virtual Status write_bloom_filter_index() = 0;
 
     virtual ordinal_t get_next_rowid() const = 0;
@@ -192,6 +194,7 @@ public:
     Status write_zone_map() override;
     Status write_bitmap_index() override;
     Status write_inverted_index() override;
+    size_t get_inverted_index_size() override;
     Status write_bloom_filter_index() override;
     ordinal_t get_next_rowid() const override { return _next_rowid; }
 
@@ -308,6 +311,7 @@ public:
         return Status::OK();
     }
     Status write_inverted_index() override;
+    size_t get_inverted_index_size() override;
     Status write_bloom_filter_index() override {
         if (_opts.need_bloom_filter) {
             return Status::NotSupported("struct not support bloom filter index");
@@ -358,6 +362,7 @@ public:
         return Status::OK();
     }
     Status write_inverted_index() override;
+    size_t get_inverted_index_size() override;
     Status write_bloom_filter_index() override {
         if (_opts.need_bloom_filter) {
             return Status::NotSupported("array not support bloom filter index");
@@ -397,6 +402,7 @@ public:
     Status write_data() override;
     Status write_ordinal_index() override;
     Status write_inverted_index() override;
+    size_t get_inverted_index_size() override;
     Status append_nulls(size_t num_rows) override;
 
     Status finish_current_page() override;

--- a/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
@@ -328,15 +328,17 @@ public:
     }
 
     int64_t file_size() const override {
-        auto file_name = InvertedIndexDescriptor::get_index_file_name(_segment_file_name, _index_meta->index_id());
+        std::filesystem::path dir(_directory);
+        dir /= _segment_file_name;
+        auto file_name = InvertedIndexDescriptor::get_index_file_name(dir.string(), _index_meta->index_id());
         int64_t size = -1;
         auto st = _fs->file_size(file_name.c_str(), &size);
-        if (st.ok()){
-            return size;
+        if (!st.ok()){
+            LOG(ERROR) << "try to get file:" << file_name << " size error:" << st;
         }
-        LOG(ERROR) << "try to get file:" << file_name << " size error:" << st;
-        return -1;
+        return size;
     }
+
     void write_null_bitmap(lucene::store::IndexOutput* null_bitmap_out,
                            lucene::store::Directory* dir) {
         // write null_bitmap file

--- a/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
@@ -330,10 +330,11 @@ public:
     int64_t file_size() const override {
         std::filesystem::path dir(_directory);
         dir /= _segment_file_name;
-        auto file_name = InvertedIndexDescriptor::get_index_file_name(dir.string(), _index_meta->index_id());
+        auto file_name =
+                InvertedIndexDescriptor::get_index_file_name(dir.string(), _index_meta->index_id());
         int64_t size = -1;
         auto st = _fs->file_size(file_name.c_str(), &size);
-        if (!st.ok()){
+        if (!st.ok()) {
             LOG(ERROR) << "try to get file:" << file_name << " size error:" << st;
         }
         return size;

--- a/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
@@ -322,9 +322,14 @@ public:
         _rid++;
     }
 
-    uint64_t size() const override {
-        //TODO: get size of inverted index
+    int64_t size() const override {
+        //TODO: get memory size of inverted index
         return 0;
+    }
+
+    int64_t file_size() const override {
+        auto file_name = InvertedIndexDescriptor::get_index_file_name(_segment_file_name, _index_meta->index_id());
+        return _dir->fileLength(file_name.c_str());
     }
     void write_null_bitmap(lucene::store::IndexOutput* null_bitmap_out,
                            lucene::store::Directory* dir) {

--- a/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
@@ -329,7 +329,13 @@ public:
 
     int64_t file_size() const override {
         auto file_name = InvertedIndexDescriptor::get_index_file_name(_segment_file_name, _index_meta->index_id());
-        return _dir->fileLength(file_name.c_str());
+        int64_t size = -1;
+        auto st = _fs->file_size(file_name.c_str(), &size);
+        if (st.ok()){
+            return size;
+        }
+        LOG(ERROR) << "try to get file:" << file_name << " size error:" << st;
+        return -1;
     }
     void write_null_bitmap(lucene::store::IndexOutput* null_bitmap_out,
                            lucene::store::Directory* dir) {

--- a/be/src/olap/rowset/segment_v2/inverted_index_writer.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_writer.h
@@ -52,7 +52,9 @@ public:
 
     virtual Status finish() = 0;
 
-    virtual uint64_t size() const = 0;
+    virtual int64_t size() const = 0;
+
+    virtual int64_t file_size() const = 0;
 
 private:
     DISALLOW_COPY_AND_ASSIGN(InvertedIndexColumnWriter);

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -721,6 +721,14 @@ uint64_t SegmentWriter::estimate_segment_size() {
     return size;
 }
 
+size_t SegmentWriter::get_inverted_index_file_size() {
+    size_t total_size = 0;
+    for (auto& column_writer: _column_writers) {
+        total_size += column_writer->get_inverted_index_size();
+    }
+    return total_size;
+}
+
 Status SegmentWriter::finalize_columns_data() {
     if (_has_key) {
         _row_count = _num_rows_written;

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -723,7 +723,7 @@ uint64_t SegmentWriter::estimate_segment_size() {
 
 size_t SegmentWriter::get_inverted_index_file_size() {
     size_t total_size = 0;
-    for (auto& column_writer: _column_writers) {
+    for (auto& column_writer : _column_writers) {
         total_size += column_writer->get_inverted_index_size();
     }
     return total_size;

--- a/be/src/olap/rowset/segment_v2/segment_writer.h
+++ b/be/src/olap/rowset/segment_v2/segment_writer.h
@@ -105,6 +105,7 @@ public:
     int64_t max_row_to_add(size_t row_avg_size_in_bytes);
 
     uint64_t estimate_segment_size();
+    size_t get_inverted_index_file_size();
 
     uint32_t num_rows_written() const { return _num_rows_written; }
     uint32_t row_count() const { return _row_count; }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

This PR calculates the size of the inverted index files. The changes consist of:

Introduction of a new get_inverted_index_size() method in different column writers such as ScalarColumnWriter, StructColumnWriter, ArrayColumnWriter, and MapColumnWriter. This method will fetch the size of the inverted index file associated with that column. If the file size cannot be fetched, it defaults to 0.

A new method file_size() has been added in InvertedIndexColumnWriter class which retrieves the size of the file stored on disk. If the file size cannot be fetched, it logs an error and returns -1.

Additionally, a new method get_inverted_index_file_size() is introduced in SegmentWriter which aggregates the inverted index file sizes of all the column writers.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

