### PR TITLE
[fix](pipeline) refactor olap table sink close

### DIFF
--- a/be/src/exec/data_sink.h
+++ b/be/src/exec/data_sink.h
@@ -69,7 +69,7 @@ public:
 
     virtual void try_close(RuntimeState* state, Status exec_status) {}
 
-    virtual bool is_pending_finish() { return false; }
+    virtual bool is_close_done() { return true; }
 
     // Releases all resources that were allocated in prepare()/send().
     // Further send() calls are illegal after calling close().

--- a/be/src/exec/data_sink.h
+++ b/be/src/exec/data_sink.h
@@ -66,6 +66,11 @@ public:
     virtual Status send(RuntimeState* state, vectorized::Block* block, bool eos = false) {
         return Status::NotSupported("Not support send block");
     }
+
+    virtual void try_close(RuntimeState* state, Status exec_status) {}
+
+    virtual bool is_pending_finish() { return false; }
+
     // Releases all resources that were allocated in prepare()/send().
     // Further send() calls are illegal after calling close().
     // It must be okay to call this multiple times. Subsequent calls should

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -231,7 +231,7 @@ public:
      */
     virtual bool is_pending_finish() const { return false; }
 
-    virtual Status try_close() { return Status::OK(); }
+    virtual Status try_close(RuntimeState* state) { return Status::OK(); }
 
     bool is_closed() const { return _is_closed; }
 
@@ -283,6 +283,13 @@ public:
         }
         return Status::OK();
     }
+
+    Status try_close(RuntimeState* state) override {
+        _sink->try_close(state, state->query_status());
+        return Status::OK();
+    }
+
+    bool is_pending_finish() const override { return _sink->is_pending_finish(); }
 
     Status close(RuntimeState* state) override {
         if (is_closed()) {

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -289,7 +289,7 @@ public:
         return Status::OK();
     }
 
-    bool is_pending_finish() const override { return _sink->is_pending_finish(); }
+    bool is_pending_finish() const override { return !_sink->is_close_done(); }
 
     Status close(RuntimeState* state) override {
         if (is_closed()) {

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -289,7 +289,7 @@ public:
         return Status::OK();
     }
 
-    bool is_pending_finish() const override { return !_sink->is_close_done(); }
+    [[nodiscard]] bool is_pending_finish() const override { return !_sink->is_close_done(); }
 
     Status close(RuntimeState* state) override {
         if (is_closed()) {

--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -56,8 +56,8 @@ bool ScanOperator::is_pending_finish() const {
     return _node->_scanner_ctx && !_node->_scanner_ctx->no_schedule();
 }
 
-Status ScanOperator::try_close() {
-    return _node->try_close();
+Status ScanOperator::try_close(RuntimeState* state) {
+    return _node->try_close(state);
 }
 
 bool ScanOperator::runtime_filters_are_ready_or_timeout() {

--- a/be/src/pipeline/exec/scan_operator.h
+++ b/be/src/pipeline/exec/scan_operator.h
@@ -50,7 +50,7 @@ public:
 
     std::string debug_string() const override;
 
-    Status try_close() override;
+    Status try_close(RuntimeState* state) override;
 };
 
 } // namespace doris::pipeline

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -265,7 +265,8 @@ Status PipelineTask::finalize() {
 }
 
 Status PipelineTask::try_close() {
-    return _source->try_close();
+    _sink->try_close(_state);
+    return _source->try_close(_state);
 }
 
 Status PipelineTask::close() {

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -334,7 +334,7 @@ void VScanNode::release_resource(RuntimeState* state) {
     ExecNode::release_resource(state);
 }
 
-Status VScanNode::try_close() {
+Status VScanNode::try_close(RuntimeState* state) {
     if (_scanner_ctx.get()) {
         // mark this scanner ctx as should_stop to make sure scanners will not be scheduled anymore
         // TODO: there is a lock in `set_should_stop` may cause some slight impact

--- a/be/src/vec/exec/scan/vscan_node.h
+++ b/be/src/vec/exec/scan/vscan_node.h
@@ -154,7 +154,7 @@ public:
     Status alloc_resource(RuntimeState* state) override;
     void release_resource(RuntimeState* state) override;
 
-    Status try_close();
+    Status try_close(RuntimeState* state);
 
     bool should_run_serial() const {
         return _should_run_serial || _state->enable_scan_node_run_serial();

--- a/be/src/vec/sink/vtablet_sink.h
+++ b/be/src/vec/sink/vtablet_sink.h
@@ -250,7 +250,7 @@ public:
     // 2. just cancel()
     void mark_close();
 
-    bool is_pending_finish() const;
+    bool is_close_done() const;
 
     bool is_closed() const { return _is_closed; }
     bool is_cancelled() const { return _cancelled; }
@@ -269,7 +269,6 @@ public:
     // two ways to stop channel:
     // 1. mark_close()->close_wait() PS. close_wait() will block waiting for the last AddBatch rpc response.
     // 2. just cancel()
-    // if is_pending_finish() return false, close_wait() will not block, otherwise close_wait() will block
     Status close_wait(RuntimeState* state);
 
     void cancel(const std::string& cancel_msg);
@@ -487,7 +486,7 @@ public:
     Status open(RuntimeState* state) override;
 
     void try_close(RuntimeState* state, Status exec_status) override;
-    bool is_pending_finish() override { return _pending_finish; }
+    bool is_close_done() override { return _close_done; }
     Status close(RuntimeState* state, Status close_status) override;
     Status send(RuntimeState* state, vectorized::Block* block, bool eos = false) override;
 
@@ -646,8 +645,8 @@ private:
     int32_t _send_batch_parallelism = 1;
     // Save the status of try_close() and close() method
     Status _close_status;
-    // Use in pipeline, if false, all node channels are done or canceled, can start close().
-    bool _pending_finish = true;
+    // Use in pipeline, if true, all node channels are done or canceled, can start close().
+    bool _close_done = false;
 
     // User can change this config at runtime, avoid it being modified during query or loading process.
     bool _transfer_large_data_by_brpc = false;

--- a/be/src/vec/sink/vtablet_sink.h
+++ b/be/src/vec/sink/vtablet_sink.h
@@ -234,6 +234,8 @@ public:
 
     void open_partition_wait();
 
+    bool open_partition_finished() const;
+
     Status add_block(vectorized::Block* block, const Payload* payload, bool is_append = false);
 
     int try_send_and_fetch_status(RuntimeState* state,
@@ -246,7 +248,7 @@ public:
     // two ways to stop channel:
     // 1. mark_close()->close_wait() PS. close_wait() will block waiting for the last AddBatch rpc response.
     // 2. just cancel()
-    Status mark_close();
+    void mark_close();
 
     bool is_pending_finish() const;
 
@@ -485,7 +487,7 @@ public:
     Status open(RuntimeState* state) override;
 
     void try_close(RuntimeState* state, Status exec_status) override;
-    bool is_pending_finish() override;
+    bool is_pending_finish() override { return _pending_finish; }
     Status close(RuntimeState* state, Status close_status) override;
     Status send(RuntimeState* state, vectorized::Block* block, bool eos = false) override;
 
@@ -646,8 +648,6 @@ private:
     Status _close_status;
     // Use in pipeline, if false, all node channels are done or canceled, can start close().
     bool _pending_finish = true;
-    // Use in pipeline, try_close may be called multiple times.
-    bool _try_closed = false;
 
     // User can change this config at runtime, avoid it being modified during query or loading process.
     bool _transfer_large_data_by_brpc = false;

--- a/be/src/vec/sink/vtablet_sink.h
+++ b/be/src/vec/sink/vtablet_sink.h
@@ -250,8 +250,7 @@ public:
     // 2. just cancel()
     void mark_close();
 
-    bool is_pending_rpc_done() const;
-    void try_pending_rpc_done();
+    bool is_rpc_done() const;
 
     bool is_closed() const { return _is_closed; }
     bool is_cancelled() const { return _cancelled; }
@@ -339,8 +338,6 @@ protected:
 
     // add batches finished means the last rpc has be response, used to check whether this channel can be closed
     std::atomic<bool> _add_batches_finished {false}; // reuse for vectorized
-
-    std::atomic<bool> _pending_rpc {false};
 
     bool _eos_is_produced {false}; // only for restricting producer behaviors
 
@@ -489,7 +486,8 @@ public:
     Status open(RuntimeState* state) override;
 
     void try_close(RuntimeState* state, Status exec_status) override;
-    bool is_close_done() override { return _running_channels_num == 0; }
+    // if true, all node channels rpc done, can start close().
+    bool is_close_done() override;
     Status close(RuntimeState* state, Status close_status) override;
     Status send(RuntimeState* state, vectorized::Block* block, bool eos = false) override;
 
@@ -648,8 +646,6 @@ private:
     int32_t _send_batch_parallelism = 1;
     // Save the status of try_close() and close() method
     Status _close_status;
-    // Use in pipeline, if 0, all node channels are done or canceled, can start close().
-    std::atomic<int32_t> _running_channels_num {0};
     bool _try_close = false;
 
     // User can change this config at runtime, avoid it being modified during query or loading process.


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

1. For pipeline, olap table sink close is divided into three stages, try_close() --> pending_finish() --> close()
only after all node channels are done or canceled, pending_finish() will return false, close() will start.
this will avoid block pipeline on close().

2. In close, check the index channel intolerable failure status after each node channel failure,
if intolerable failure is true, the close will be terminated in advance, and all node channels will be canceled to avoid meaningless blocking.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

