### PR TITLE
[fix](memory) fix mem tracker in NodeChannel rpc callback

### DIFF
--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -413,13 +413,13 @@ Status VNodeChannel::open_wait() {
     // add block closure
     _add_block_closure = ReusableClosure<PTabletWriterAddBlockResult>::create();
     _add_block_closure->addFailedHandler([this](bool is_last_rpc) {
-        SCOPED_ATTACH_TASK(_state);
         std::lock_guard<std::mutex> l(this->_closed_lock);
         if (this->_is_closed) {
             // if the node channel is closed, no need to call `mark_as_failed`,
             // and notice that _index_channel may already be destroyed.
             return;
         }
+        SCOPED_ATTACH_TASK(_state);
         // If rpc failed, mark all tablets on this node channel as failed
         _index_channel->mark_as_failed(this->node_id(), this->host(),
                                        fmt::format("rpc failed, error coed:{}, error text:{}",
@@ -438,13 +438,13 @@ Status VNodeChannel::open_wait() {
 
     _add_block_closure->addSuccessHandler([this](const PTabletWriterAddBlockResult& result,
                                                  bool is_last_rpc) {
-        SCOPED_ATTACH_TASK(_state);
         std::lock_guard<std::mutex> l(this->_closed_lock);
         if (this->_is_closed) {
             // if the node channel is closed, no need to call the following logic,
             // and notice that _index_channel may already be destroyed.
             return;
         }
+        SCOPED_ATTACH_TASK(_state);
         Status status(result.status());
         if (status.ok()) {
             // if has error tablet, handle them first


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

```
#0  0x0000564dcdf85bcc in doris::RuntimeState::query_mem_tracker (this=0x7fd8d07a9c00) at doris/be/src/runtime/runtime_state.cpp:254
#1  0x0000564dcdfbb60e in doris::AttachTask::AttachTask (this=<optimized out>, runtime_state=0x7fd8d07a9c00) at doris/be/src/runtime/thread_context.cpp:44
#2  0x0000564dd44a084f in doris::stream_load::VNodeChannel::open_wait()::$_1::operator()(doris::PTabletWriterAddBlockResult const&, bool) const (this=<optimized out>, result=..., is_last_rpc=<optimized out>)
    at doris/be/src/vec/sink/vtablet_sink.cpp:441
#3  std::__invoke_impl<void, doris::stream_load::VNodeChannel::open_wait()::$_1&, doris::PTabletWriterAddBlockResult const&, bool>(std::__invoke_other, doris::stream_load::VNodeChannel::open_wait()::$_1&, doris::PTabletWriterAddBlockResult const&, bool&&) (__f=..., __args=<optimized out>, __args=<optimized out>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
#4  std::__invoke_r<void, doris::stream_load::VNodeChannel::open_wait()::$_1&, doris::PTabletWriterAddBlockResult const&, bool>(doris::stream_load::VNodeChannel::open_wait()::$_1&, doris::PTabletWriterAddBlockResult const&, bool&&) (__fn=..., __args=<optimized out>, __args=<optimized out>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111
#5  std::_Function_handler<void (doris::PTabletWriterAddBlockResult const&, bool), doris::stream_load::VNodeChannel::open_wait()::$_1>::_M_invoke(std::_Any_data const&, doris::PTabletWriterAddBlockResult const&, bool&&) (__functor=..., __args=<error reading variable>, __args=<error reading variable>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
#6  0x0000564dd44a7a78 in std::function<void (doris::PTabletWriterAddBlockResult const&, bool)>::operator()(doris::PTabletWriterAddBlockResult const&, bool) const (this=0x7fd4d71ffb08, __args=false, 
    __args=false) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
#7  doris::stream_load::ReusableClosure<doris::PTabletWriterAddBlockResult>::Run (this=0x7fdb2d84d800) at doris/be/src/vec/sink/vtablet_sink.h:176
#8  0x0000564dd530840b in brpc::Controller::EndRPC(brpc::Controller::CompletionInfo const&) ()
#9  0x0000564dd53332df in brpc::policy::ProcessRpcResponse(brpc::InputMessageBase*) ()
#10 0x0000564dd532a737 in brpc::ProcessInputMessage(void*) ()
#11 0x0000564dd532b0e1 in brpc::InputMessenger::InputMessageClosure::~InputMessageClosure() ()
#12 0x0000564dd532ba74 in brpc::InputMessenger::OnNewMessages(brpc::Socket*) ()
#13 0x0000564dd5457a3e in brpc::Socket::ProcessEvent(void*) ()
#14 0x0000564dd52be5af in bthread::TaskGroup::task_runner(long) ()
#15 0x0000564dd52a9be1 in bthread_make_fcontext ()
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

