### PR TITLE
[fix](docs) some document errors of spark load on yarn ha model.

### DIFF
--- a/docs/en/docs/data-operate/import/import-way/spark-load-manual.md
+++ b/docs/en/docs/data-operate/import/import-way/spark-load-manual.md
@@ -201,7 +201,7 @@ REVOKE USAGE_PRIV ON RESOURCE resource_name FROM ROLE role_name
     - `spark.hadoop.dfs.ha.namenodes.nameservices01` , unique identifier for each NameNode in the nameservice.
     - `spark.hadoop.dfs.namenode.rpc-address.nameservices01.mynamenode1`, fully qualified RPC address for each NameNode.
     - `spark.hadoop.dfs.namenode.rpc-address.nameservices01.mynamenode2`, fully qualified RPC address for each NameNode.
-    - `spark.hadoop.dfs.client.failover.proxy.provider` = `org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider`, set the implementation class.
+    - `spark.hadoop.dfs.client.failover.proxy.provider.nameservices01` = `org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider`, set the implementation class.
 -`working_dir`: directory used by ETL. Spark is required when used as an ETL resource. For example: `hdfs://host :port/tmp/doris`.
 - `broker.hadoop.security.authentication`: Specify the authentication method as kerberos.
 - `broker.kerberos_principal`: Specify the principal of kerberos.
@@ -264,7 +264,7 @@ PROPERTIES
   "spark.hadoop.dfs.ha.namenodes.nameservices01" = "mynamenode1,mynamenode2",
   "spark.hadoop.dfs.namenode.rpc-address.nameservices01.mynamenode1" = "xxxx:8020",
   "spark.hadoop.dfs.namenode.rpc-address.nameservices01.mynamenode2" = "xxxx:8020",
-  "spark.hadoop.dfs.client.failover.proxy.provider" = "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider",
+  "spark.hadoop.dfs.client.failover.proxy.provider.nameservices01" = "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider",
   "working_dir" = "hdfs://nameservices01/doris_prd_data/sinan/spark_load/",
   "broker" = "broker_name",
   "broker.username" = "username",
@@ -273,7 +273,7 @@ PROPERTIES
   "broker.dfs.ha.namenodes.nameservices01" = "mynamenode1, mynamenode2",
   "broker.dfs.namenode.rpc-address.nameservices01.mynamenode1" = "xxxx:8020",
   "broker.dfs.namenode.rpc-address.nameservices01.mynamenode2" = "xxxx:8020",
-  "broker.dfs.client.failover.proxy.provider" = "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider"
+  "broker.dfs.client.failover.proxy.provider.nameservices01" = "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider"
 );
 ```
 
@@ -731,6 +731,8 @@ The following configuration belongs to the system level configuration of spark l
 + `enable_spark_load`
 
 Open spark load and create resource. The default value is false. This feature is turned off.
+
+**Note:** This parameter has been deleted in version 1.2, spark_load is enabled by default.
 
 + `spark_load_default_timeout_second`
 

--- a/docs/zh-CN/docs/data-operate/import/import-way/spark-load-manual.md
+++ b/docs/zh-CN/docs/data-operate/import/import-way/spark-load-manual.md
@@ -173,7 +173,7 @@ REVOKE USAGE_PRIV ON RESOURCE resource_name FROM ROLE role_name
   - `spark.hadoop.dfs.ha.namenodes.nameservices01` , nameservice 中每个 NameNode 的唯一标识符
   - `spark.hadoop.dfs.namenode.rpc-address.nameservices01.mynamenode1`, 每个 NameNode 的完全限定的 RPC 地址
   - `spark.hadoop.dfs.namenode.rpc-address.nameservices01.mynamenode2`, 每个 NameNode 的完全限定的 RPC 地址
-  - `spark.hadoop.dfs.client.failover.proxy.provider` = `org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider`, 设置实现类
+  - `spark.hadoop.dfs.client.failover.proxy.provider.nameservices01` = `org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider`, 设置实现类
 - `working_dir`: ETL 使用的目录。Spark 作为 ETL 资源使用时必填。例如：hdfs://host:port/tmp/doris。
   - 其他参数为可选，参考 http://spark.apache.org/docs/latest/configuration.html
 - `working_dir`: ETL 使用的目录。Spark 作为 ETL 资源使用时必填。例如：hdfs://host:port/tmp/doris。
@@ -238,7 +238,7 @@ PROPERTIES
   "spark.hadoop.dfs.ha.namenodes.nameservices01" = "mynamenode1,mynamenode2",
   "spark.hadoop.dfs.namenode.rpc-address.nameservices01.mynamenode1" = "xxxx:8020",
   "spark.hadoop.dfs.namenode.rpc-address.nameservices01.mynamenode2" = "xxxx:8020",
-  "spark.hadoop.dfs.client.failover.proxy.provider" = "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider",
+  "spark.hadoop.dfs.client.failover.proxy.provider.nameservices01" = "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider",
   "working_dir" = "hdfs://nameservices01/doris_prd_data/sinan/spark_load/",
   "broker" = "broker_name",
   "broker.username" = "username",
@@ -247,7 +247,7 @@ PROPERTIES
   "broker.dfs.ha.namenodes.nameservices01" = "mynamenode1, mynamenode2",
   "broker.dfs.namenode.rpc-address.nameservices01.mynamenode1" = "xxxx:8020",
   "broker.dfs.namenode.rpc-address.nameservices01.mynamenode2" = "xxxx:8020",
-  "broker.dfs.client.failover.proxy.provider" = "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider"
+  "broker.dfs.client.failover.proxy.provider.nameservices01" = "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider"
 );
 
 ```
@@ -694,6 +694,8 @@ LoadFinishTime: 2019-07-27 11:50:16
 - `enable_spark_load`
 
   开启 Spark Load 和创建 Resource 功能。默认为 False，关闭此功能。
+
+  **注意：** 这个参数在1.2版本中已经删除，默认开启spark_load。
 
 - `spark_load_default_timeout_second`
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
spark.hadoop.dfs.client.failover.proxy.provider and broker.dfs.client.failover.proxy.provider is the wrong description, the correct one is spark.hadoop.dfs.client.failover.proxy.provider.nameservices01 and broker .dfs.client.failover.proxy.provider.nameservices01. According to the current document use case location, an error will be reported indicating that nameservices01 cannot be recognized.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

