### PR TITLE
[Bug](runtime-filter) fix runtime filter not register on vdata_gen_scan_node

### DIFF
--- a/be/src/exprs/runtime_filter_slots.h
+++ b/be/src/exprs/runtime_filter_slots.h
@@ -137,16 +137,12 @@ public:
                     continue;
                 }
             } else if (is_in_filter && over_max_in_num) {
-#ifdef VLOG_DEBUG_IS_ON
                 std::string msg = fmt::format(
                         "fragment instance {} ignore runtime filter(in filter id {}) because: "
                         "in_num({}) >= max_in_num({})",
                         print_id(state->fragment_instance_id()), filter_desc.filter_id,
                         hash_table_size, max_in_num);
                 RETURN_IF_ERROR(ignore_remote_filter(runtime_filter, msg));
-#else
-                RETURN_IF_ERROR(ignore_remote_filter(runtime_filter, "ignored"));
-#endif
                 continue;
             }
 
@@ -220,11 +216,7 @@ public:
     Status publish() {
         for (auto& pair : _runtime_filters) {
             for (auto filter : pair.second) {
-                auto state = filter->publish();
-                if (!state) {
-                    // TODO: solve publish failed when scan not schedured
-                    LOG(WARNING) << "filter publish failed, reason=" << state.to_string();
-                }
+                RETURN_IF_ERROR(filter->publish());
             }
         }
         return Status::OK();

--- a/be/src/runtime/runtime_filter_mgr.cpp
+++ b/be/src/runtime/runtime_filter_mgr.cpp
@@ -73,16 +73,13 @@ Status RuntimeFilterMgr::get_filter_by_role(const int filter_id, const RuntimeFi
     } else {
         filter_map = &_producer_map;
     }
-    auto state = Status::OK();
+
     auto iter = filter_map->find(key);
     if (iter == filter_map->end()) {
-        state = Status::InvalidArgument("unknown filter");
-        LOG_WARNING("get filter failed, key={}, role={}, reason={}", key, (int)role,
-                    state.to_string());
-    } else {
-        *target = iter->second.filter;
+        return Status::InternalError("get filter failed, key={}, role={}", key, (int)role);
     }
-    return state;
+    *target = iter->second.filter;
+    return Status::OK();
 }
 
 Status RuntimeFilterMgr::get_consume_filter(const int filter_id, IRuntimeFilter** consumer_filter) {
@@ -98,8 +95,7 @@ Status RuntimeFilterMgr::register_filter(const RuntimeFilterRole role,
                                          const TRuntimeFilterDesc& desc,
                                          const TQueryOptions& options, int node_id,
                                          bool build_bf_exactly) {
-    DCHECK((role == RuntimeFilterRole::CONSUMER && node_id >= 0) ||
-           role != RuntimeFilterRole::CONSUMER);
+    DCHECK(role != RuntimeFilterRole::CONSUMER || node_id >= 0);
     SCOPED_CONSUME_MEM_TRACKER(_tracker.get());
     int32_t key = desc.filter_id;
 

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -64,7 +64,6 @@ RuntimeState::RuntimeState(const TUniqueId& fragment_instance_id,
           _load_job_id(-1),
           _normal_row_number(0),
           _error_row_number(0),
-          _error_log_file_path(""),
           _error_log_file(nullptr) {
     Status status = init(fragment_instance_id, query_options, query_globals, exec_env);
     DCHECK(status.ok());
@@ -90,7 +89,6 @@ RuntimeState::RuntimeState(const TPlanFragmentExecParams& fragment_exec_params,
           _num_finished_scan_range(0),
           _normal_row_number(0),
           _error_row_number(0),
-          _error_log_file_path(""),
           _error_log_file(nullptr) {
     if (fragment_exec_params.__isset.runtime_filter_params) {
         _runtime_filter_mgr->set_runtime_filter_params(fragment_exec_params.runtime_filter_params);

--- a/be/src/vec/exec/data_gen_functions/vnumbers_tvf.h
+++ b/be/src/vec/exec/data_gen_functions/vnumbers_tvf.h
@@ -37,7 +37,7 @@ class Block;
 class VNumbersTVF : public VDataGenFunctionInf {
 public:
     VNumbersTVF(TupleId tuple_id, const TupleDescriptor* tuple_desc);
-    ~VNumbersTVF() = default;
+    ~VNumbersTVF() override = default;
 
     Status get_next(RuntimeState* state, vectorized::Block* block, bool* eos) override;
 

--- a/be/src/vec/exec/scan/vscan_node.h
+++ b/be/src/vec/exec/scan/vscan_node.h
@@ -98,7 +98,7 @@ public:
             }
         }
     }
-    virtual ~VScanNode() = default;
+    ~VScanNode() override = default;
 
     friend class VScanner;
     friend class NewOlapScanner;
@@ -242,7 +242,6 @@ protected:
 
     Status _prepare_scanners();
 
-protected:
     RuntimeState* _state;
     bool _is_pipeline_scan = false;
     bool _shared_scan_opt = false;
@@ -329,7 +328,6 @@ protected:
     // If sort info is set, push limit to each scanner;
     int64_t _limit_per_scanner = -1;
 
-protected:
     std::shared_ptr<vectorized::SharedScannerController> _shared_scanner_controller;
     bool _should_create_scanner = false;
     int _context_queue_id = -1;

--- a/be/src/vec/exec/vdata_gen_scan_node.cpp
+++ b/be/src/vec/exec/vdata_gen_scan_node.cpp
@@ -24,7 +24,9 @@
 #include "common/logging.h"
 #include "common/status.h"
 #include "exec/exec_node.h"
+#include "exprs/runtime_filter.h"
 #include "runtime/descriptors.h"
+#include "runtime/query_context.h"
 #include "runtime/runtime_state.h"
 #include "util/runtime_profile.h"
 #include "vec/core/block.h"
@@ -44,7 +46,8 @@ VDataGenFunctionScanNode::VDataGenFunctionScanNode(ObjectPool* pool, const TPlan
         : ScanNode(pool, tnode, descs),
           _is_init(false),
           _tuple_id(tnode.data_gen_scan_node.tuple_id),
-          _tuple_desc(nullptr) {
+          _tuple_desc(nullptr),
+          _runtime_filter_descs(tnode.runtime_filters) {
     // set _table_func here
     switch (tnode.data_gen_scan_node.func_name) {
     case TDataGenFunctionName::NUMBERS:
@@ -73,6 +76,16 @@ Status VDataGenFunctionScanNode::prepare(RuntimeState* state) {
 
     if (nullptr == _tuple_desc) {
         return Status::InternalError("Failed to get tuple descriptor.");
+    }
+
+    for (const auto& filter_desc : _runtime_filter_descs) {
+        if (filter_desc.__isset.opt_remote_rf && filter_desc.opt_remote_rf) {
+            RETURN_IF_ERROR(state->get_query_ctx()->runtime_filter_mgr()->register_filter(
+                    RuntimeFilterRole::CONSUMER, filter_desc, state->query_options(), id(), false));
+        } else {
+            RETURN_IF_ERROR(state->runtime_filter_mgr()->register_filter(
+                    RuntimeFilterRole::CONSUMER, filter_desc, state->query_options(), id(), false));
+        }
     }
 
     _is_init = true;

--- a/be/src/vec/exec/vdata_gen_scan_node.cpp
+++ b/be/src/vec/exec/vdata_gen_scan_node.cpp
@@ -78,6 +78,7 @@ Status VDataGenFunctionScanNode::prepare(RuntimeState* state) {
         return Status::InternalError("Failed to get tuple descriptor.");
     }
 
+    // TODO: use runtime filter to filte result block, maybe this node need derive from vscan_node.
     for (const auto& filter_desc : _runtime_filter_descs) {
         if (filter_desc.__isset.opt_remote_rf && filter_desc.opt_remote_rf) {
             RETURN_IF_ERROR(state->get_query_ctx()->runtime_filter_mgr()->register_filter(

--- a/be/src/vec/exec/vdata_gen_scan_node.cpp
+++ b/be/src/vec/exec/vdata_gen_scan_node.cpp
@@ -80,13 +80,19 @@ Status VDataGenFunctionScanNode::prepare(RuntimeState* state) {
 
     // TODO: use runtime filter to filte result block, maybe this node need derive from vscan_node.
     for (const auto& filter_desc : _runtime_filter_descs) {
+        IRuntimeFilter* runtime_filter = nullptr;
         if (filter_desc.__isset.opt_remote_rf && filter_desc.opt_remote_rf) {
             RETURN_IF_ERROR(state->get_query_ctx()->runtime_filter_mgr()->register_filter(
                     RuntimeFilterRole::CONSUMER, filter_desc, state->query_options(), id(), false));
+            RETURN_IF_ERROR(state->get_query_ctx()->runtime_filter_mgr()->get_consume_filter(
+                    filter_desc.filter_id, &runtime_filter));
         } else {
             RETURN_IF_ERROR(state->runtime_filter_mgr()->register_filter(
                     RuntimeFilterRole::CONSUMER, filter_desc, state->query_options(), id(), false));
+            RETURN_IF_ERROR(state->runtime_filter_mgr()->get_consume_filter(filter_desc.filter_id,
+                                                                            &runtime_filter));
         }
+        runtime_filter->init_profile(_runtime_profile.get());
     }
 
     _is_init = true;

--- a/be/src/vec/exec/vdata_gen_scan_node.h
+++ b/be/src/vec/exec/vdata_gen_scan_node.h
@@ -42,15 +42,12 @@ public:
     VDataGenFunctionScanNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs);
     ~VDataGenFunctionScanNode() override = default;
 
-    // initialize _mysql_scanner, and create _text_converter.
     Status prepare(RuntimeState* state) override;
 
-    // Start MySQL scan using _mysql_scanner.
     Status open(RuntimeState* state) override;
 
     Status get_next(RuntimeState* state, vectorized::Block* block, bool* eos) override;
 
-    // Close the _mysql_scanner, and report errors.
     Status close(RuntimeState* state) override;
 
     // No use
@@ -64,6 +61,8 @@ protected:
 
     // Descriptor of tuples generated
     const TupleDescriptor* _tuple_desc;
+
+    std::vector<TRuntimeFilterDesc> _runtime_filter_descs;
 };
 
 } // namespace vectorized

--- a/be/src/vec/exec/vschema_scan_node.h
+++ b/be/src/vec/exec/vschema_scan_node.h
@@ -42,7 +42,7 @@ class Block;
 class VSchemaScanNode : public ScanNode {
 public:
     VSchemaScanNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs);
-    ~VSchemaScanNode();
+    ~VSchemaScanNode() override;
     Status prepare(RuntimeState* state) override;
     Status get_next(RuntimeState* state, vectorized::Block* block, bool* eos) override;
 


### PR DESCRIPTION
## Proposed changes
fix runtime filter not register on vdata_gen_scan_node

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

