### PR TITLE
[improvement](nereids) prune hash join output slot ids list

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -1067,6 +1067,10 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
                     sd = context.getDescTable().copySlotDescriptor(intermediateDescriptor, leftSlotDescriptor);
                 } else {
                     sd = context.createSlotDesc(intermediateDescriptor, sf);
+                    if (hashOutputSlotReferenceMap.get(sf.getExprId()) != null) {
+                        hashJoinNode.addSlotIdToHashOutputSlotIds(leftSlotDescriptor.getId());
+                        hashJoinNode.getHashOutputExprSlotIdMap().put(sf.getExprId(), leftSlotDescriptor.getId());
+                    }
                 }
                 leftIntermediateSlotDescriptor.add(sd);
             }
@@ -1083,6 +1087,10 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
                     sd = context.getDescTable().copySlotDescriptor(intermediateDescriptor, rightSlotDescriptor);
                 } else {
                     sd = context.createSlotDesc(intermediateDescriptor, sf);
+                    if (hashOutputSlotReferenceMap.get(sf.getExprId()) != null) {
+                        hashJoinNode.addSlotIdToHashOutputSlotIds(rightSlotDescriptor.getId());
+                        hashJoinNode.getHashOutputExprSlotIdMap().put(sf.getExprId(), rightSlotDescriptor.getId());
+                    }
                 }
                 rightIntermediateSlotDescriptor.add(sd);
             }
@@ -1413,6 +1421,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
                 requiredOtherConjunctsSlotIdSet.forEach(e -> requiredExprIds.add(context.findExprId(e)));
                 for (ExprId exprId : requiredExprIds) {
                     SlotId slotId = ((HashJoinNode) hashJoinNode).getHashOutputExprSlotIdMap().get(exprId);
+                    Preconditions.checkState(slotId != null);
                     ((HashJoinNode) hashJoinNode).addSlotIdToHashOutputSlotIds(slotId);
                 }
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -1134,8 +1134,15 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         }
 
         if (hashJoin.getMarkJoinSlotReference().isPresent()) {
-            outputSlotReferences.add(hashJoin.getMarkJoinSlotReference().get());
-            context.createSlotDesc(intermediateDescriptor, hashJoin.getMarkJoinSlotReference().get());
+            SlotReference sf = hashJoin.getMarkJoinSlotReference().get();
+            outputSlotReferences.add(sf);
+            context.createSlotDesc(intermediateDescriptor, sf);
+            if (hashOutputSlotReferenceMap.get(sf.getExprId()) != null) {
+                SlotRef markJoinSlotId = context.findSlotRef(sf.getExprId());
+                Preconditions.checkState(markJoinSlotId != null);
+                hashJoinNode.addSlotIdToHashOutputSlotIds(markJoinSlotId.getSlotId());
+                hashJoinNode.getHashOutputExprSlotIdMap().put(sf.getExprId(), markJoinSlotId.getSlotId());
+            }
         }
 
         // set slots as nullable for outer join

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -1434,7 +1434,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
                     extractExecSlot(expr, requiredOtherConjunctsSlotIdSet);
                 }
                 requiredOtherConjunctsSlotIdSet.forEach(e -> requiredExprIds.add(context.findExprId(e)));
-                requiredByProjectSlotIdSet.forEach(e -> requiredExprIds.add(context.findExprId(e)));
+                requiredSlotIdSet.forEach(e -> requiredExprIds.add(context.findExprId(e)));
                 for (ExprId exprId : requiredExprIds) {
                     SlotId slotId = ((HashJoinNode) hashJoinNode).getHashOutputExprSlotIdMap().get(exprId);
                     Preconditions.checkState(slotId != null);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
@@ -56,6 +56,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -213,18 +214,18 @@ public class HashJoinNode extends JoinNodeBase {
      * @param slotIdList
      */
     private void initHashOutputSlotIds(List<SlotId> slotIdList, Analyzer analyzer) {
-        hashOutputSlotIds.clear();
+        Set<SlotId> hashOutputSlotIdSet = Sets.newHashSet();
         // step1: change output slot id to src slot id
         if (vSrcToOutputSMap != null) {
             for (SlotId slotId : slotIdList) {
                 SlotRef slotRef = new SlotRef(analyzer.getDescTbl().getSlotDesc(slotId));
                 Expr srcExpr = vSrcToOutputSMap.mappingForRhsExpr(slotRef);
                 if (srcExpr == null) {
-                    hashOutputSlotIds.add(slotId);
+                    hashOutputSlotIdSet.add(slotId);
                 } else {
                     List<SlotRef> srcSlotRefList = Lists.newArrayList();
                     srcExpr.collect(SlotRef.class, srcSlotRefList);
-                    hashOutputSlotIds
+                    hashOutputSlotIdSet
                             .addAll(srcSlotRefList.stream().map(e -> e.getSlotId()).collect(Collectors.toList()));
                 }
             }
@@ -234,8 +235,8 @@ public class HashJoinNode extends JoinNodeBase {
         List<SlotId> otherAndConjunctSlotIds = Lists.newArrayList();
         Expr.getIds(otherJoinConjuncts, null, otherAndConjunctSlotIds);
         Expr.getIds(conjuncts, null, otherAndConjunctSlotIds);
-        hashOutputSlotIds.addAll(otherAndConjunctSlotIds);
-        hashOutputExprSlotIdMap.clear();
+        hashOutputSlotIdSet.addAll(otherAndConjunctSlotIds);
+        hashOutputSlotIds = new HashSet<>(hashOutputSlotIdSet);
     }
 
     public Map<ExprId, SlotId> getHashOutputExprSlotIdMap() {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
@@ -37,7 +37,6 @@ import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.CheckedMath;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
-import org.apache.doris.common.util.VectorizedUtil;
 import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.statistics.StatisticalType;
 import org.apache.doris.thrift.TEqJoinCondition;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

1. prune hash join output slot ids list based on slot ids in required project and other conjunctions, to reduce the be side effort. 
2. support pruning for semi/anti also

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

