### PR TITLE
[fix](MTMV) Disable partition specification temporarily

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -1919,12 +1919,11 @@ create_stmt ::=
     | KW_CREATE KW_MATERIALIZED KW_VIEW ident:mvName build_mv:buildMethod
          opt_mv_refersh_info:refreshInfo
          opt_mv_keys:keyDesc
-         opt_mv_partition:partitionDesc
          opt_distribution:distributionDesc
          opt_properties:properties
          KW_AS query_stmt:query
     {:
-        RESULT = new CreateMultiTableMaterializedViewStmt(mvName, buildMethod, refreshInfo, keyDesc, partitionDesc, distributionDesc, properties, query);
+        RESULT = new CreateMultiTableMaterializedViewStmt(mvName, buildMethod, refreshInfo, keyDesc, null, distributionDesc, properties, query);
     :}
     | KW_CREATE KW_INDEX opt_if_not_exists:ifNotExists ident:indexName KW_ON table_name:tableName LPAREN ident_list:cols RPAREN opt_index_type:indexType opt_properties:properties opt_comment:comment
     {:

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/MultiTableMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/MultiTableMaterializedViewTest.java
@@ -41,6 +41,7 @@ import org.apache.doris.utframe.TestWithFeService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -243,6 +244,7 @@ public class MultiTableMaterializedViewTest extends TestWithFeService {
 
     @ParameterizedTest
     @ValueSource(strings = {"AGGREGATE", "UNIQUE", "DUPLICATE"})
+    @Disabled
     public void testCreateWithPartition(String keyType) throws Exception {
         String aggregation = keyType.equals("AGGREGATE") ? "SUM" : "";
         createTable("CREATE TABLE test.t1 ("


### PR DESCRIPTION
## Proposed changes

Issue Number: close #20773 

The syntax for supporting partition updates in the future has not been researched yet, and there are issues with partition syntax. Therefore, the partition syntax has been temporarily removed in the current version and will be added after future research

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

