### PR TITLE
[Bug](table-function) return InvalidArgument when explode_split meet empty delimiter

### DIFF
--- a/be/src/vec/data_types/data_type_time_v2.cpp
+++ b/be/src/vec/data_types/data_type_time_v2.cpp
@@ -202,7 +202,7 @@ void DataTypeDateTimeV2::cast_to_date_v2(const UInt64 from, UInt32& to) {
 
 DataTypePtr create_datetimev2(UInt64 scale_value) {
     if (scale_value > 6) {
-        throw doris::Exception(doris::ErrorCode::NOT_IMPLEMENTED_ERROR, "scale_value > 6 {}",
+        throw doris::Exception(doris::ErrorCode::NOT_IMPLEMENTED_ERROR, "scale_value {} > 6",
                                scale_value);
     }
     return std::make_shared<DataTypeDateTimeV2>(scale_value);

--- a/be/src/vec/exprs/table_function/vexplode_split.cpp
+++ b/be/src/vec/exprs/table_function/vexplode_split.cpp
@@ -71,6 +71,10 @@ Status VExplodeSplitTableFunction::process_init(Block* block) {
     auto& delimiter_const_column = block->get_by_position(delimiter_column_idx).column;
     if (is_column_const(*delimiter_const_column)) {
         _delimiter = delimiter_const_column->get_data_at(0);
+        if (_delimiter.empty()) {
+            return Status::InvalidArgument(
+                    "explode_split(test, delimiter) delimiter column must be not empty");
+        }
     } else {
         return Status::NotSupported(
                 "explode_split(test, delimiter) delimiter column must be const");

--- a/be/test/vec/function/table_function_test.cpp
+++ b/be/test/vec/function/table_function_test.cpp
@@ -195,14 +195,12 @@ TEST_F(TableFunctionTest, vexplode_split) {
         // Case 3: explode_split("a,b,c", "a,")) --> ["", "b,c"]
         // Case 4: explode_split("", ",")) --> [""]
         InputTypeSet input_types = {TypeIndex::String, Consted {TypeIndex::String}};
-        InputDataSet input_sets = {{Null(), Null()},
-                                   {std::string("a,b,c"), std::string(",")},
+        InputDataSet input_sets = {{std::string("a,b,c"), std::string(",")},
                                    {std::string("a,b,c"), std::string("a,")},
                                    {std::string(""), std::string(",")}};
 
         InputTypeSet output_types = {TypeIndex::String};
-        InputDataSet output_sets = {{},
-                                    {std::string("a"), std::string("b"), std::string("c")},
+        InputDataSet output_sets = {{std::string("a"), std::string("b"), std::string("c")},
                                     {std::string(""), std::string("b,c")},
                                     {std::string("")}};
 

--- a/regression-test/suites/nereids_p0/sql_functions/table_function/explode_split.groovy
+++ b/regression-test/suites/nereids_p0/sql_functions/table_function/explode_split.groovy
@@ -42,4 +42,8 @@ suite("explode_split") {
                          lateral view explode_split(k2, ',') tmp as  e1 """
 
     qt_explode_split """ select e1 from (select 1 k1) as t lateral view explode_split("啊，啊，额，啊","，") tmp1 as e1; """
+    test {
+        sql """ select e1 from (select 1 k1) as t lateral view explode_split("aaa","") tmp1 as e1; """
+        exception "INVALID_ARGUMENT"
+    }
 }


### PR DESCRIPTION
## Proposed changes

return InvalidArgument when explode_split meet empty delimiter
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

