### PR TITLE
[fix](memory) memory management thread exits gracefully

### DIFF
--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -187,7 +187,8 @@ void Daemon::memory_maintenance_thread() {
     int32_t interval_milliseconds = config::memory_maintenance_sleep_time_ms;
     int64_t last_print_proc_mem = PerfCounters::get_vm_rss();
     while (!_stop_background_threads_latch.wait_for(
-            std::chrono::milliseconds(interval_milliseconds))) {
+                   std::chrono::milliseconds(interval_milliseconds)) &&
+           !k_doris_exit) {
         if (!MemInfo::initialized() || !ExecEnv::GetInstance()->initialized()) {
             continue;
         }
@@ -225,7 +226,8 @@ void Daemon::memory_gc_thread() {
     int32_t memory_minor_gc_sleep_time_ms = 0;
     int32_t memory_full_gc_sleep_time_ms = 0;
     while (!_stop_background_threads_latch.wait_for(
-            std::chrono::milliseconds(interval_milliseconds))) {
+                   std::chrono::milliseconds(interval_milliseconds)) &&
+           !k_doris_exit) {
         if (!MemInfo::initialized() || !ExecEnv::GetInstance()->initialized()) {
             continue;
         }
@@ -272,7 +274,8 @@ void Daemon::load_channel_tracker_refresh_thread() {
     // Refresh the memory statistics of the load channel tracker more frequently,
     // which helps to accurately control the memory of LoadChannelMgr.
     while (!_stop_background_threads_latch.wait_for(
-            std::chrono::milliseconds(config::load_channel_memory_refresh_sleep_time_ms))) {
+                   std::chrono::milliseconds(config::load_channel_memory_refresh_sleep_time_ms)) &&
+           !k_doris_exit) {
         if (ExecEnv::GetInstance()->initialized()) {
             doris::ExecEnv::GetInstance()->load_channel_mgr()->refresh_mem_tracker();
         }
@@ -280,7 +283,8 @@ void Daemon::load_channel_tracker_refresh_thread() {
 }
 
 void Daemon::memory_tracker_profile_refresh_thread() {
-    while (!_stop_background_threads_latch.wait_for(std::chrono::milliseconds(50))) {
+    while (!_stop_background_threads_latch.wait_for(std::chrono::milliseconds(100)) &&
+           !k_doris_exit) {
         MemTracker::refresh_all_tracker_profile();
         MemTrackerLimiter::refresh_all_tracker_profile();
     }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

```
==2606023==ERROR: AddressSanitizer: heap-use-after-free on address 0x60e000043670 at pc 0x55bb56449d60 bp 0x7f58725a9330 sp 0x7f58725a9328
READ of size 8 at 0x60e000043670 thread T34 (memory_tracker_)
    #0 0x55bb56449d5f in std::_shared_ptr<doris::RuntimeProfile::HighWaterMarkCounter, (_gnu_cxx::_Lock_policy)2>::operator bool() const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-
linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1295:16
    #1 0x55bb5644671e in doris::MemTracker::refresh_profile_counter() repo_center/doris_master/doris/be/src/runtime/memory/mem_tracker.h:123:13
    #2 0x55bb56433b27 in doris::MemTrackerLimiter::refresh_all_tracker_profile() repo_center/doris_master/doris/be/src/runtime/memory/mem_tracker_limiter.cpp:120:22
    #3 0x55bb5380299a in doris::Daemon::memory_tracker_profile_refresh_thread() repo_center/doris_master/doris/be/src/common/daemon.cpp:280:9
    #4 0x55bb5380bc5b in doris::Daemon::start()::$_4::operator()() const repo_center/doris_master/doris/be/src/common/daemon.cpp:458:30
    #5 0x55bb5380bc06 in void std::_invoke_impl<void, doris::Daemon::start()::$_4&>(std::_invoke_other, doris::Daemon::start()::$_4&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-lin
ux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #6 0x55bb5380bb88 in std::enable_if<is_invocable_r_v<void, doris::Daemon::start()::$4&>, void>::type std::_invoke_r<void, doris::Daemon::start()::$_4&>(doris::Daemon::start()::$_4&
) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #7 0x55bb5380b9be in std::_Function_handler<void (), doris::Daemon::start()::$_4>::_M_invoke(std::_Any_data const&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../
../../include/c++/11/bits/std_function.h:291:9
    #8 0x55bb538ca7c6 in std::function<void ()>::operator()() const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #9 0x55bb569661f4 in doris::Thread::supervise_thread(void*) repo_center/doris_master/doris/be/src/util/thread.cpp:453:5
    #10 0x7f5938aae608 in start_thread /build/glibc-sMfBJT/glibc-2.31/nptl/pthread_create.c:477:8
    #11 0x7f5938d3d162 in __clone /build/glibc-sMfBJT/glibc-2.31/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95

0x60e000043670 is located 48 bytes inside of 160-byte region [0x60e000043640,0x60e0000436e0)
freed by thread T0 here:
    #0 0x55bb5379064d in operator delete(void*) (/mnt/ssd01/doris-master/VEC_ASAN/be/lib/doris_be+0x149f464d) (BuildId: bb27ad362e41964d)
    #1 0x55bb5559f725 in std::default_delete<doris::MemTrackerLimiter>::operator()(doris::MemTrackerLimiter*) const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../.
./include/c++/11/bits/unique_ptr.h:85:2
    #2 0x55bb5559d2bf in std::unique_ptr<doris::MemTrackerLimiter, std::default_delete<doris::MemTrackerLimiter> >::~unique_ptr() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu
/11/../../../../include/c++/11/bits/unique_ptr.h:361:4
    #3 0x55bb555940c1 in doris::ShardedLRUCache::~ShardedLRUCache() repo_center/doris_master/doris/be/src/olap/lru_cache.cpp:577:1
    #4 0x55bb55594118 in doris::ShardedLRUCache::~ShardedLRUCache() repo_center/doris_master/doris/be/src/olap/lru_cache.cpp:568:37
    #5 0x55bb55786b94 in std::default_delete<doris::Cache>::operator()(doris::Cache*) const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/un
ique_ptr.h:85:2
    #6 0x55bb55785d1f in std::unique_ptr<doris::Cache, std::default_delete<doris::Cache> >::~unique_ptr() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/
c++/11/bits/unique_ptr.h:361:4
    #7 0x55bb559de529 in doris::StoragePageCache::~StoragePageCache() repo_center/doris_master/doris/be/src/olap/page_cache.h:36:7
    #8 0x7f5938c648d6 in __run_exit_handlers /build/glibc-sMfBJT/glibc-2.31/stdlib/exit.
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

