### PR TITLE
[community](github) required at least 2 approval

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -63,6 +63,7 @@ github:
           - Build Third Party Libraries (Linux)
           - Build Third Party Libraries (macOS)
           - COMPILE (DORIS_COMPILE)
+          - Need_2_Approval
 
       required_pull_request_reviews:
         dismiss_stale_reviews: true


### PR DESCRIPTION
## Proposed changes

Make `Need_2_Approval` check as required.
After this PR merged, all PRs need at least 2 approvals to merge.

One must be committer, the other can be anyone.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

