### PR TITLE
[Opt](orc-reader) Optimize orc reader by dict filtering.

### DIFF
--- a/be/src/vec/exec/format/orc/vorc_reader.h
+++ b/be/src/vec/exec/format/orc/vorc_reader.h
@@ -143,7 +143,10 @@ public:
     Status init_reader(
             const std::vector<std::string>* column_names,
             std::unordered_map<std::string, ColumnValueRangeType>* colname_to_value_range,
-            const VExprContextSPtrs& conjuncts, bool is_acid);
+            const VExprContextSPtrs& conjuncts, bool is_acid,
+            const TupleDescriptor* tuple_descriptor, const RowDescriptor* row_descriptor,
+            const VExprContextSPtrs* not_single_slot_filter_conjuncts,
+            const std::unordered_map<int, VExprContextSPtrs>* slot_id_to_filter_conjuncts);
 
     Status set_fill_columns(
             const std::unordered_map<std::string, std::tuple<std::string, const SlotDescriptor*>>&
@@ -167,8 +170,6 @@ public:
 
     void _build_delete_row_filter(const Block* block, size_t rows);
 
-    void close();
-
     int64_t size() const;
 
     std::unordered_map<std::string, TypeDescriptor> get_name_to_type() override;
@@ -178,11 +179,19 @@ public:
     Status get_parsed_schema(std::vector<std::string>* col_names,
                              std::vector<TypeDescriptor>* col_types) override;
 
-    Status filter(orc::ColumnVectorBatch& data, uint16_t* sel, uint16_t size, void* arg);
-
     void set_delete_rows(const TransactionalHiveReader::AcidRowIDSet* delete_rows) {
         _delete_rows = delete_rows;
     }
+
+    Status filter(orc::ColumnVectorBatch& data, uint16_t* sel, uint16_t size, void* arg);
+
+    Status fill_dict_filter_column_names(
+            std::unique_ptr<orc::StripeInformation> current_strip_information,
+            std::list<std::string>& column_names);
+
+    Status on_string_dicts_loaded(
+            std::unordered_map<std::string, orc::StringDictionary*>& column_name_to_dict_map,
+            bool* is_stripe_filtered);
 
 private:
     struct OrcProfile {
@@ -207,6 +216,27 @@ private:
 
     private:
         OrcReader* orcReader;
+    };
+
+    class StringDictFilterImpl : public orc::StringDictFilter {
+    public:
+        StringDictFilterImpl(OrcReader* orc_reader) : _orc_reader(orc_reader) {}
+        ~StringDictFilterImpl() override = default;
+
+        virtual void fillDictFilterColumnNames(
+                std::unique_ptr<orc::StripeInformation> current_strip_information,
+                std::list<std::string>& column_names) const override {
+            _orc_reader->fill_dict_filter_column_names(std::move(current_strip_information),
+                                                       column_names);
+        }
+        virtual void onStringDictsLoaded(
+                std::unordered_map<std::string, orc::StringDictionary*>& column_name_to_dict_map,
+                bool* is_stripe_filtered) const override {
+            _orc_reader->on_string_dicts_loaded(column_name_to_dict_map, is_stripe_filtered);
+        }
+
+    private:
+        OrcReader* _orc_reader;
     };
 
     // Create inner orc file,
@@ -344,6 +374,10 @@ private:
         return Status::OK();
     }
 
+    template <bool is_filter>
+    Status _decode_int32_column(const std::string& col_name, const MutableColumnPtr& data_column,
+                                orc::ColumnVectorBatch* cvb, size_t num_values);
+
     template <typename DecimalPrimitiveType, bool is_filter>
     Status _decode_decimal_column(const std::string& col_name, const MutableColumnPtr& data_column,
                                   const DataTypePtr& data_type, orc::ColumnVectorBatch* cvb,
@@ -410,6 +444,20 @@ private:
                                  const orc::TypeKind& type_kind, orc::ColumnVectorBatch* cvb,
                                  size_t num_values);
 
+    template <bool is_filter>
+    Status _decode_string_non_dict_encoded_column(const std::string& col_name,
+                                                  const MutableColumnPtr& data_column,
+                                                  const orc::TypeKind& type_kind,
+                                                  orc::EncodedStringVectorBatch* cvb,
+                                                  size_t num_values);
+
+    template <bool is_filter>
+    Status _decode_string_dict_encoded_column(const std::string& col_name,
+                                              const MutableColumnPtr& data_column,
+                                              const orc::TypeKind& type_kind,
+                                              orc::EncodedStringVectorBatch* cvb,
+                                              size_t num_values);
+
     Status _fill_doris_array_offsets(const std::string& col_name,
                                      ColumnArray::Offsets64& doris_offsets,
                                      orc::DataBuffer<int64_t>& orc_offsets, size_t num_values,
@@ -418,6 +466,17 @@ private:
     std::string _get_field_name_lower_case(const orc::Type* orc_type, int pos);
 
     void _collect_profile_on_close();
+
+    bool _can_filter_by_dict(int slot_id);
+
+    Status _rewrite_dict_conjuncts(std::vector<int32_t>& dict_codes, int slot_id, bool is_nullable);
+
+    Status _convert_dict_cols_to_string_cols(Block* block,
+                                             const std::vector<orc::ColumnVectorBatch*>* batch_vec);
+
+    MutableColumnPtr _convert_dict_column_to_string_column(const ColumnInt32* dict_column,
+                                                           orc::ColumnVectorBatch* cvb,
+                                                           const orc::Type* orc_column_typ);
 
 private:
     RuntimeProfile* _profile = nullptr;
@@ -449,7 +508,6 @@ private:
     std::unique_ptr<ORCFileInputStream> _file_input_stream;
     Statistics _statistics;
     OrcProfile _orc_profile;
-    bool _closed = false;
 
     std::unique_ptr<orc::ColumnVectorBatch> _batch;
     std::unique_ptr<orc::Reader> _reader;
@@ -473,6 +531,17 @@ private:
     std::unique_ptr<TextConverter> _text_converter = nullptr;
     const TransactionalHiveReader::AcidRowIDSet* _delete_rows = nullptr;
     std::unique_ptr<IColumn::Filter> _delete_rows_filter_ptr = nullptr;
+
+    const TupleDescriptor* _tuple_descriptor;
+    const RowDescriptor* _row_descriptor;
+    const std::unordered_map<int, VExprContextSPtrs>* _slot_id_to_filter_conjuncts;
+    VExprContextSPtrs _dict_filter_conjuncts;
+    VExprContextSPtrs _non_dict_filter_conjuncts;
+    VExprContextSPtrs _filter_conjuncts;
+    // std::pair<col_name, slot_id>
+    std::vector<std::pair<std::string, int>> _dict_filter_cols;
+    std::shared_ptr<ObjectPool> _obj_pool;
+    std::unique_ptr<orc::StringDictFilter> _string_dict_filter;
 };
 
 class ORCFileInputStream : public orc::InputStream {

--- a/be/src/vec/exec/format/table/transactional_hive_reader.cpp
+++ b/be/src/vec/exec/format/table/transactional_hive_reader.cpp
@@ -57,12 +57,17 @@ TransactionalHiveReader::TransactionalHiveReader(std::unique_ptr<GenericReader> 
 Status TransactionalHiveReader::init_reader(
         const std::vector<std::string>& column_names,
         std::unordered_map<std::string, ColumnValueRangeType>* colname_to_value_range,
-        const VExprContextSPtrs& conjuncts) {
+        const VExprContextSPtrs& conjuncts, const TupleDescriptor* tuple_descriptor,
+        const RowDescriptor* row_descriptor,
+        const VExprContextSPtrs* not_single_slot_filter_conjuncts,
+        const std::unordered_map<int, VExprContextSPtrs>* slot_id_to_filter_conjuncts) {
     OrcReader* orc_reader = static_cast<OrcReader*>(_file_format_reader.get());
     _col_names.insert(_col_names.end(), column_names.begin(), column_names.end());
     _col_names.insert(_col_names.end(), TransactionalHive::READ_ROW_COLUMN_NAMES_LOWER_CASE.begin(),
                       TransactionalHive::READ_ROW_COLUMN_NAMES_LOWER_CASE.end());
-    Status status = orc_reader->init_reader(&_col_names, colname_to_value_range, conjuncts, true);
+    Status status = orc_reader->init_reader(
+            &_col_names, colname_to_value_range, conjuncts, true, tuple_descriptor, row_descriptor,
+            not_single_slot_filter_conjuncts, slot_id_to_filter_conjuncts);
     return status;
 }
 
@@ -132,8 +137,9 @@ Status TransactionalHiveReader::init_row_filters(const TFileRangeDesc& range) {
         OrcReader delete_reader(_profile, _state, _params, delete_range, _MIN_BATCH_SIZE,
                                 _state->timezone(), _io_ctx, false);
 
-        RETURN_IF_ERROR(delete_reader.init_reader(
-                &TransactionalHive::DELETE_ROW_COLUMN_NAMES_LOWER_CASE, nullptr, {}, false));
+        RETURN_IF_ERROR(
+                delete_reader.init_reader(&TransactionalHive::DELETE_ROW_COLUMN_NAMES_LOWER_CASE,
+                                          nullptr, {}, false, nullptr, nullptr, nullptr, nullptr));
 
         std::unordered_map<std::string, std::tuple<std::string, const SlotDescriptor*>>
                 partition_columns;

--- a/be/src/vec/exec/format/table/transactional_hive_reader.h
+++ b/be/src/vec/exec/format/table/transactional_hive_reader.h
@@ -106,7 +106,10 @@ public:
     Status init_reader(
             const std::vector<std::string>& column_names,
             std::unordered_map<std::string, ColumnValueRangeType>* colname_to_value_range,
-            const VExprContextSPtrs& conjuncts);
+            const VExprContextSPtrs& conjuncts, const TupleDescriptor* tuple_descriptor,
+            const RowDescriptor* row_descriptor,
+            const VExprContextSPtrs* not_single_slot_filter_conjuncts,
+            const std::unordered_map<int, VExprContextSPtrs>* slot_id_to_filter_conjuncts);
 
 private:
     struct TransactionalHiveProfile {

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -673,13 +673,17 @@ Status VFileScanner::_get_next_reader() {
                         TransactionalHiveReader::create_unique(std::move(orc_reader), _profile,
                                                                _state, _params, range,
                                                                _io_ctx.get());
-                init_status = tran_orc_reader->init_reader(_file_col_names, _colname_to_value_range,
-                                                           _push_down_conjuncts);
+                init_status = tran_orc_reader->init_reader(
+                        _file_col_names, _colname_to_value_range, _push_down_conjuncts,
+                        _real_tuple_desc, _default_val_row_desc.get(),
+                        &_not_single_slot_filter_conjuncts, &_slot_id_to_filter_conjuncts);
                 RETURN_IF_ERROR(tran_orc_reader->init_row_filters(range));
                 _cur_reader = std::move(tran_orc_reader);
             } else {
-                init_status = orc_reader->init_reader(&_file_col_names, _colname_to_value_range,
-                                                      _push_down_conjuncts, false);
+                init_status = orc_reader->init_reader(
+                        &_file_col_names, _colname_to_value_range, _push_down_conjuncts, false,
+                        _real_tuple_desc, _default_val_row_desc.get(),
+                        &_not_single_slot_filter_conjuncts, &_slot_id_to_filter_conjuncts);
                 _cur_reader = std::move(orc_reader);
             }
             break;


### PR DESCRIPTION
## Proposed changes

- Optimize orc reader by dict filtering.  It is similar with #17594.
### Test result

**ssb-flat-100**: (3 nodes)
| Query        | before opt           | after opt  |
| ------------- |:-------------:| ---------:|
Q1.1 | 1.239 | 1.145
Q1.2 | 1.254 | 1.128
Q1.3 | 1.931 | 1.644
Q2.1 | 1.359 | 1.006
Q2.2 | 1.229 | 0.674
Q2.3 | 0.934 | 0.427
Q3.1 | 2.226 | 1.712
Q3.2 | 2.042 | 1.562
Q3.3 | 1.631 | 1.021
Q3.4 | 1.618 | 0.732
Q4.1 | 2.294 | 1.858
Q4.2 | 2.511 | 1.961
Q4.3 | 1.736 | 1.446
total | 22.004 | 16.316


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

