### PR TITLE
[Fix](Planner) Add rewrite of return type in where clause when useing case when

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
@@ -1324,7 +1324,7 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
      * The error message only contains this.toSql() if printExpr is true.
      */
     public void checkReturnsBool(String name, boolean printExpr) throws AnalysisException {
-        if (!type.isBoolean() && !type.isNull() && !type.isTinyint()) {
+        if (!type.isBoolean() && !type.isNull()) {
             if (this instanceof BoolLiteral) {
                 return;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -27,6 +27,7 @@ import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.catalog.TableIf.TableType;
 import org.apache.doris.catalog.Type;
@@ -650,6 +651,11 @@ public class SelectStmt extends QueryStmt {
             } else {
                 whereClause = new BoolLiteral(true);
             }
+        } else if (whereClause instanceof CaseExpr
+                && (((CaseExpr) whereClause).getChild(1) instanceof IntLiteral)
+                && (((CaseExpr) whereClause).getChild(2) instanceof IntLiteral)) {
+            whereClause = new CastExpr(TypeDef.create(PrimitiveType.BOOLEAN), whereClause);
+            whereClause.setType(Type.BOOLEAN);
         }
     }
 


### PR DESCRIPTION

## Proposed changes

Rewrite case when (constant literal) else (constant literal) return type to boolean type forcely, or if we pass this to be, it will core at assert_cast when using debug mode to compile.


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

