### PR TITLE
[fix](partial-update) sequence column is not proceeded correctly

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -358,10 +358,12 @@ Status Segment::lookup_row_key(const Slice& key, bool with_seq_col, RowLocation*
     RETURN_IF_ERROR(load_pk_index_and_bf());
     bool has_seq_col = _tablet_schema->has_sequence_col();
     size_t seq_col_length = 0;
-    if (has_seq_col && with_seq_col) {
+    if (has_seq_col) {
         seq_col_length = _tablet_schema->column(_tablet_schema->sequence_col_idx()).length() + 1;
     }
-    Slice key_without_seq = Slice(key.get_data(), key.get_size() - seq_col_length);
+
+    Slice key_without_seq =
+            Slice(key.get_data(), key.get_size() - (with_seq_col ? seq_col_length : 0));
 
     DCHECK(_pk_index_reader != nullptr);
     if (!_pk_index_reader->check_present(key_without_seq)) {
@@ -394,6 +396,10 @@ Status Segment::lookup_row_key(const Slice& key, bool with_seq_col, RowLocation*
         // compare key
         if (key_without_seq.compare(sought_key_without_seq) != 0) {
             return Status::NotFound("Can't find key in the segment");
+        }
+
+        if (!with_seq_col) {
+            return Status::OK();
         }
 
         // compare sequence id


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

When checking the keys in PrimaryKeyIndex, seq_col_length is not set to correct value, then we got a NOT_FOUND result for an existing key.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

