### PR TITLE
[fix](bitmap) fix bug: incorrect orthogonal bitmap results in some cases

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_orthogonal_bitmap.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_orthogonal_bitmap.h
@@ -252,7 +252,10 @@ public:
 
     void get(IColumn& to) const {
         auto& column = assert_cast<ColumnBitmap&>(to);
-        column.get_data().emplace_back(result);
+        column.get_data().emplace_back(!result.empty()
+                                               ? result
+                                               : const_cast<AggOrthBitMapExprCal*>(this)
+                                                         ->bitmap_expr_cal.bitmap_calculate());
     }
 
 private:
@@ -286,7 +289,9 @@ public:
 
     void get(IColumn& to) const {
         auto& column = assert_cast<ColumnVector<Int64>&>(to);
-        column.get_data().emplace_back(result);
+        column.get_data().emplace_back(result ? result
+                                              : const_cast<AggOrthBitMapExprCalCount*>(this)
+                                                        ->bitmap_expr_cal.bitmap_calculate_count());
     }
 
 private:


### PR DESCRIPTION
## Proposed changes

Issue Number: close #20819

If there is only one aggregation (update finalize) phase, `result` field will not be updated.

This pr is aim to resolve it.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

