### PR TITLE
[Fix](multi-catalog) Fix hive transaction table regression test by adding hive-docker missing configurations.

### DIFF
--- a/docker/thirdparties/docker-compose/hive/hadoop-hive.env.tpl.tpl
+++ b/docker/thirdparties/docker-compose/hive/hadoop-hive.env.tpl.tpl
@@ -24,6 +24,8 @@ HIVE_SITE_CONF_hive_metastore_uris=thrift://doris--hive-metastore:9083
 HDFS_CONF_dfs_namenode_datanode_registration_ip___hostname___check=false
 HIVE_SITE_CONF_hive_server2_thrift_bind_host=0.0.0.0
 HIVE_SITE_CONF_hive_server2_thrift_port=10000
+HIVE_SITE_CONF_hive_compactor_initiator_on=true
+HIVE_SITE_CONF_hive_compactor_worker_threads=2
 
 CORE_CONF_hadoop_http_staticuser_user=root
 CORE_CONF_hadoop_proxyuser_hue_hosts=*


### PR DESCRIPTION
## Proposed changes

Fix hive transaction table regression test `test_transactional_hive` by adding hive-docker missing configurations of #20679. Hive need to be set these configurations to do compaction.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

