### PR TITLE
[fix](compaction) fix time series compaction policy

### DIFF
--- a/be/src/olap/cumulative_compaction_time_series_policy.cpp
+++ b/be/src/olap/cumulative_compaction_time_series_policy.cpp
@@ -179,6 +179,7 @@ int TimeSeriesCumulativeCompactionPolicy::pick_input_rowsets(
                 input_rowsets->clear();
                 *compaction_score = 0;
                 transient_size = 0;
+                total_size = 0;
                 continue;
             }
         }
@@ -196,6 +197,7 @@ int TimeSeriesCumulativeCompactionPolicy::pick_input_rowsets(
                 // Only 1 non-overlapping rowset, skip it
                 input_rowsets->clear();
                 *compaction_score = 0;
+                total_size = 0;
                 continue;
             }
             return transient_size;


### PR DESCRIPTION
## Proposed changes

While clearing the input rowsets, the total size was not cleared, which caused the subsequent total size to continuously meet the condition and block the compaction.


Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

