### PR TITLE
[minor](broker) fix name in broker's pom.xml

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -114,58 +114,40 @@ if [[ -z "${DORIS_TOOLCHAIN}" ]]; then
     fi
 fi
 
-if [[ -z "${NEED_CPP_COMPILER}" ]]; then
-    NEED_CPP_COMPILER=1
-fi
-
-if [[ "${NEED_CPP_COMPILER}" -eq 1 ]]; then
-    if [[ "${DORIS_TOOLCHAIN}" == "gcc" ]]; then
-        # set GCC HOME
-        if [[ -z "${DORIS_GCC_HOME}" ]]; then
-            DORIS_GCC_HOME="$(dirname "$(command -v gcc)")"/..
-            export DORIS_GCC_HOME
-        fi
-
-        gcc_ver="$("${DORIS_GCC_HOME}/bin/gcc" -dumpfullversion -dumpversion)"
-        required_ver="11.0.0"
-        if [[ ! "$(printf '%s\n' "${required_ver}" "${gcc_ver}" | sort -V | head -n1)" = "${required_ver}" ]]; then
-            echo "Error: GCC version (${gcc_ver}) must be greater than or equal to ${required_ver}"
-            exit 1
-        fi
-        export CC="${DORIS_GCC_HOME}/bin/gcc"
-        export CXX="${DORIS_GCC_HOME}/bin/g++"
-        if test -x "${DORIS_GCC_HOME}/bin/ld"; then
-            export DORIS_BIN_UTILS="${DORIS_GCC_HOME}/bin/"
-        fi
-        ENABLE_PCH='OFF'
-    elif [[ "${DORIS_TOOLCHAIN}" == "clang" ]]; then
-        # set CLANG HOME
-        if [[ -z "${DORIS_CLANG_HOME}" ]]; then
-            DORIS_CLANG_HOME="$(dirname "$(command -v clang)")"/..
-            export DORIS_CLANG_HOME
-        fi
-
-        clang_ver="$("${DORIS_CLANG_HOME}/bin/clang" -dumpfullversion -dumpversion)"
-        required_ver="16.0.0"
-        if [[ ! "$(printf '%s\n' "${required_ver}" "${clang_ver}" | sort -V | head -n1)" = "${required_ver}" ]]; then
-            echo "Error: CLANG version (${clang_ver}) must be greater than or equal to ${required_ver}"
-            exit 1
-        fi
-        export CC="${DORIS_CLANG_HOME}/bin/clang"
-        export CXX="${DORIS_CLANG_HOME}/bin/clang++"
-        if test -x "${DORIS_CLANG_HOME}/bin/ld.lld"; then
-            export DORIS_BIN_UTILS="${DORIS_CLANG_HOME}/bin/"
-        fi
-        if [[ -f "${DORIS_CLANG_HOME}/bin/llvm-symbolizer" ]]; then
-            export ASAN_SYMBOLIZER_PATH="${DORIS_CLANG_HOME}/bin/llvm-symbolizer"
-        fi
-        if [[ -z "${ENABLE_PCH}" ]]; then
-            ENABLE_PCH='ON'
-        fi
-    else
-        echo "Error: unknown DORIS_TOOLCHAIN=${DORIS_TOOLCHAIN}, currently only 'gcc' and 'clang' are supported"
-        exit 1
+if [[ "${DORIS_TOOLCHAIN}" == "gcc" ]]; then
+    # set GCC HOME
+    if [[ -z "${DORIS_GCC_HOME}" ]]; then
+        DORIS_GCC_HOME="$(dirname "$(command -v gcc)")"/..
+        export DORIS_GCC_HOME
     fi
+
+    export CC="${DORIS_GCC_HOME}/bin/gcc"
+    export CXX="${DORIS_GCC_HOME}/bin/g++"
+    if test -x "${DORIS_GCC_HOME}/bin/ld"; then
+        export DORIS_BIN_UTILS="${DORIS_GCC_HOME}/bin/"
+    fi
+    ENABLE_PCH='OFF'
+elif [[ "${DORIS_TOOLCHAIN}" == "clang" ]]; then
+    # set CLANG HOME
+    if [[ -z "${DORIS_CLANG_HOME}" ]]; then
+        DORIS_CLANG_HOME="$(dirname "$(command -v clang)")"/..
+        export DORIS_CLANG_HOME
+    fi
+
+    export CC="${DORIS_CLANG_HOME}/bin/clang"
+    export CXX="${DORIS_CLANG_HOME}/bin/clang++"
+    if test -x "${DORIS_CLANG_HOME}/bin/ld.lld"; then
+        export DORIS_BIN_UTILS="${DORIS_CLANG_HOME}/bin/"
+    fi
+    if [[ -f "${DORIS_CLANG_HOME}/bin/llvm-symbolizer" ]]; then
+        export ASAN_SYMBOLIZER_PATH="${DORIS_CLANG_HOME}/bin/llvm-symbolizer"
+    fi
+    if [[ -z "${ENABLE_PCH}" ]]; then
+        ENABLE_PCH='ON'
+    fi
+else
+    echo "Error: unknown DORIS_TOOLCHAIN=${DORIS_TOOLCHAIN}, currently only 'gcc' and 'clang' are supported"
+    exit 1
 fi
 
 export CCACHE_COMPILERCHECK=content

--- a/env.sh
+++ b/env.sh
@@ -125,7 +125,7 @@ if [[ "${NEED_CPP_COMPILER}" -eq 1 ]]; then
             DORIS_GCC_HOME="$(dirname "$(command -v gcc)")"/..
             export DORIS_GCC_HOME
         fi
-    
+
         gcc_ver="$("${DORIS_GCC_HOME}/bin/gcc" -dumpfullversion -dumpversion)"
         required_ver="11.0.0"
         if [[ ! "$(printf '%s\n' "${required_ver}" "${gcc_ver}" | sort -V | head -n1)" = "${required_ver}" ]]; then

--- a/env.sh
+++ b/env.sh
@@ -114,52 +114,58 @@ if [[ -z "${DORIS_TOOLCHAIN}" ]]; then
     fi
 fi
 
-if [[ "${DORIS_TOOLCHAIN}" == "gcc" ]]; then
-    # set GCC HOME
-    if [[ -z "${DORIS_GCC_HOME}" ]]; then
-        DORIS_GCC_HOME="$(dirname "$(command -v gcc)")"/..
-        export DORIS_GCC_HOME
-    fi
+if [[ -z "${NEED_CPP_COMPILER}" ]]; then
+    NEED_CPP_COMPILER=1
+fi
 
-    gcc_ver="$("${DORIS_GCC_HOME}/bin/gcc" -dumpfullversion -dumpversion)"
-    required_ver="11.0.0"
-    if [[ ! "$(printf '%s\n' "${required_ver}" "${gcc_ver}" | sort -V | head -n1)" = "${required_ver}" ]]; then
-        echo "Error: GCC version (${gcc_ver}) must be greater than or equal to ${required_ver}"
+if [[ "${NEED_CPP_COMPILER}" -eq 1 ]]; then
+    if [[ "${DORIS_TOOLCHAIN}" == "gcc" ]]; then
+        # set GCC HOME
+        if [[ -z "${DORIS_GCC_HOME}" ]]; then
+            DORIS_GCC_HOME="$(dirname "$(command -v gcc)")"/..
+            export DORIS_GCC_HOME
+        fi
+    
+        gcc_ver="$("${DORIS_GCC_HOME}/bin/gcc" -dumpfullversion -dumpversion)"
+        required_ver="11.0.0"
+        if [[ ! "$(printf '%s\n' "${required_ver}" "${gcc_ver}" | sort -V | head -n1)" = "${required_ver}" ]]; then
+            echo "Error: GCC version (${gcc_ver}) must be greater than or equal to ${required_ver}"
+            exit 1
+        fi
+        export CC="${DORIS_GCC_HOME}/bin/gcc"
+        export CXX="${DORIS_GCC_HOME}/bin/g++"
+        if test -x "${DORIS_GCC_HOME}/bin/ld"; then
+            export DORIS_BIN_UTILS="${DORIS_GCC_HOME}/bin/"
+        fi
+        ENABLE_PCH='OFF'
+    elif [[ "${DORIS_TOOLCHAIN}" == "clang" ]]; then
+        # set CLANG HOME
+        if [[ -z "${DORIS_CLANG_HOME}" ]]; then
+            DORIS_CLANG_HOME="$(dirname "$(command -v clang)")"/..
+            export DORIS_CLANG_HOME
+        fi
+
+        clang_ver="$("${DORIS_CLANG_HOME}/bin/clang" -dumpfullversion -dumpversion)"
+        required_ver="16.0.0"
+        if [[ ! "$(printf '%s\n' "${required_ver}" "${clang_ver}" | sort -V | head -n1)" = "${required_ver}" ]]; then
+            echo "Error: CLANG version (${clang_ver}) must be greater than or equal to ${required_ver}"
+            exit 1
+        fi
+        export CC="${DORIS_CLANG_HOME}/bin/clang"
+        export CXX="${DORIS_CLANG_HOME}/bin/clang++"
+        if test -x "${DORIS_CLANG_HOME}/bin/ld.lld"; then
+            export DORIS_BIN_UTILS="${DORIS_CLANG_HOME}/bin/"
+        fi
+        if [[ -f "${DORIS_CLANG_HOME}/bin/llvm-symbolizer" ]]; then
+            export ASAN_SYMBOLIZER_PATH="${DORIS_CLANG_HOME}/bin/llvm-symbolizer"
+        fi
+        if [[ -z "${ENABLE_PCH}" ]]; then
+            ENABLE_PCH='ON'
+        fi
+    else
+        echo "Error: unknown DORIS_TOOLCHAIN=${DORIS_TOOLCHAIN}, currently only 'gcc' and 'clang' are supported"
         exit 1
     fi
-    export CC="${DORIS_GCC_HOME}/bin/gcc"
-    export CXX="${DORIS_GCC_HOME}/bin/g++"
-    if test -x "${DORIS_GCC_HOME}/bin/ld"; then
-        export DORIS_BIN_UTILS="${DORIS_GCC_HOME}/bin/"
-    fi
-    ENABLE_PCH='OFF'
-elif [[ "${DORIS_TOOLCHAIN}" == "clang" ]]; then
-    # set CLANG HOME
-    if [[ -z "${DORIS_CLANG_HOME}" ]]; then
-        DORIS_CLANG_HOME="$(dirname "$(command -v clang)")"/..
-        export DORIS_CLANG_HOME
-    fi
-
-    clang_ver="$("${DORIS_CLANG_HOME}/bin/clang" -dumpfullversion -dumpversion)"
-    required_ver="16.0.0"
-    if [[ ! "$(printf '%s\n' "${required_ver}" "${clang_ver}" | sort -V | head -n1)" = "${required_ver}" ]]; then
-        echo "Error: CLANG version (${clang_ver}) must be greater than or equal to ${required_ver}"
-        exit 1
-    fi
-    export CC="${DORIS_CLANG_HOME}/bin/clang"
-    export CXX="${DORIS_CLANG_HOME}/bin/clang++"
-    if test -x "${DORIS_CLANG_HOME}/bin/ld.lld"; then
-        export DORIS_BIN_UTILS="${DORIS_CLANG_HOME}/bin/"
-    fi
-    if [[ -f "${DORIS_CLANG_HOME}/bin/llvm-symbolizer" ]]; then
-        export ASAN_SYMBOLIZER_PATH="${DORIS_CLANG_HOME}/bin/llvm-symbolizer"
-    fi
-    if [[ -z "${ENABLE_PCH}" ]]; then
-        ENABLE_PCH='ON'
-    fi
-else
-    echo "Error: unknown DORIS_TOOLCHAIN=${DORIS_TOOLCHAIN}, currently only 'gcc' and 'clang' are supported"
-    exit 1
 fi
 
 export CCACHE_COMPILERCHECK=content

--- a/fs_brokers/apache_hdfs_broker/build.sh
+++ b/fs_brokers/apache_hdfs_broker/build.sh
@@ -22,9 +22,6 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
 export DORIS_HOME="${ROOT}/../.."
 
-# build broker doesn't need cpp compiler,
-# set NEED_CPP_COMPILER=0 to skip compiler check in env.sh
-export NEED_CPP_COMPILER=0
 . "${DORIS_HOME}/env.sh"
 
 export BROKER_HOME="${ROOT}"

--- a/fs_brokers/apache_hdfs_broker/build.sh
+++ b/fs_brokers/apache_hdfs_broker/build.sh
@@ -22,6 +22,9 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
 export DORIS_HOME="${ROOT}/../.."
 
+# build broker doesn't need cpp compiler,
+# set NEED_CPP_COMPILER=0 to skip compiler check in env.sh
+export NEED_CPP_COMPILER=0
 . "${DORIS_HOME}/env.sh"
 
 export BROKER_HOME="${ROOT}"

--- a/fs_brokers/apache_hdfs_broker/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/pom.xml
@@ -63,7 +63,7 @@ under the License.
         </mailingList>
     </mailingLists>
     <properties>
-        <palo.home>${basedir}/../../</palo.home>
+        <doris.home>${basedir}/../../</doris.home>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -363,7 +363,7 @@ under the License.
                         <configuration>
                             <executable>cp</executable>
                             <arguments>
-                                <argument>${palo.home}/gensrc/thrift/PaloBrokerService.thrift</argument>
+                                <argument>${doris.home}/gensrc/thrift/PaloBrokerService.thrift</argument>
                                 <argument>${basedir}/src/main/resources/thrift/</argument>
                             </arguments>
                             <skip>${skip.plugin}</skip>


### PR DESCRIPTION
## Proposed changes

1. change palo -> doris
2. do not check compiler's version in`env.sh`, because building broker does not need gcc compiler. And the version is also checked in CMakefile

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

