### PR TITLE
[feature](Nereids): DPHyp just output logicalExpression.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
@@ -47,6 +47,7 @@ public class StatementContext {
     private int maxNAryInnerJoin = 0;
 
     private boolean isDpHyp = false;
+    private boolean isOtherJoinReorder = false;
 
     private final IdGenerator<ExprId> exprIdGenerator = ExprId.createGenerator();
 
@@ -106,6 +107,14 @@ public class StatementContext {
 
     public void setDpHyp(boolean dpHyp) {
         isDpHyp = dpHyp;
+    }
+
+    public boolean isOtherJoinReorder() {
+        return isOtherJoinReorder;
+    }
+
+    public void setOtherJoinReorder(boolean otherJoinReorder) {
+        isOtherJoinReorder = otherJoinReorder;
     }
 
     public ExprId getNextExprId() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/OptimizeGroupExpressionJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/OptimizeGroupExpressionJob.java
@@ -61,12 +61,17 @@ public class OptimizeGroupExpressionJob extends Job {
                 || context.getCascadesContext().getMemo().getGroupExpressionsSize() > context.getCascadesContext()
                 .getConnectContext().getSessionVariable().memoMaxGroupExpressionSize;
         boolean isDpHyp = context.getCascadesContext().getStatementContext().isDpHyp();
+        boolean isOtherJoinReorder = context.getCascadesContext().getStatementContext().isOtherJoinReorder();
         boolean isEnableBushyTree = context.getCascadesContext().getConnectContext().getSessionVariable()
                 .isEnableBushyTree();
         if (isDisableJoinReorder) {
             return Collections.emptyList();
         } else if (isDpHyp) {
-            return getRuleSet().getDPHypReorderRules();
+            if (isOtherJoinReorder) {
+                return getRuleSet().getDPHypReorderRules();
+            } else {
+                return Collections.emptyList();
+            }
         } else if (isEnableBushyTree) {
             return getRuleSet().getBushyTreeJoinReorder();
         } else if (context.getCascadesContext().getStatementContext().getMaxNAryInnerJoin() <= 5) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/receiver/PlanReceiver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/receiver/PlanReceiver.java
@@ -29,7 +29,6 @@ import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.memo.Memo;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
-import org.apache.doris.nereids.rules.Rule;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
@@ -326,11 +325,7 @@ public class PlanReceiver implements AbstractReceiver {
             } else {
                 throw new RuntimeException("DPhyp can only handle join and project operator");
             }
-            // shadow all join order rule
-            CopyInResult copyInResult = jobContext.getCascadesContext().getMemo().copyIn(logicalPlan, root, false);
-            for (Rule rule : jobContext.getCascadesContext().getRuleSet().getImplementationRules()) {
-                copyInResult.correspondingExpression.setApplied(rule);
-            }
+            jobContext.getCascadesContext().getMemo().copyIn(logicalPlan, root, false);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
@@ -28,6 +28,7 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalDistribute;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
 import org.apache.doris.nereids.util.TreeStringUtils;
 import org.apache.doris.nereids.util.Utils;
 import org.apache.doris.statistics.Statistics;
@@ -180,6 +181,10 @@ public class Group {
         return move;
     }
 
+    public void clearLowestCostPlans() {
+        lowestCostPlans.clear();
+    }
+
     public double getCostLowerBound() {
         return -1D;
     }
@@ -289,6 +294,10 @@ public class Group {
     public int removeParentExpression(GroupExpression parent) {
         parentExpressions.remove(parent);
         return parentExpressions.size();
+    }
+
+    public void removeParentPhysicalExpressions() {
+        parentExpressions.entrySet().removeIf(entry -> entry.getKey().getPlan() instanceof PhysicalPlan);
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
@@ -168,6 +168,10 @@ public class GroupExpression {
         toGroupExpression.ruleMasks.or(ruleMasks);
     }
 
+    public void clearApplied() {
+        ruleMasks.clear();
+    }
+
     public boolean isStatDerived() {
         return statDerived;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -114,6 +114,23 @@ public class Memo {
         return groupExpressions.size();
     }
 
+    /** just keep LogicalExpression in Memo. */
+    public void removePhysicalExpression() {
+        groupExpressions.entrySet().removeIf(entry -> entry.getValue().getPlan() instanceof PhysicalPlan);
+
+        for (Group group : groups.values()) {
+            group.clearPhysicalExpressions();
+            group.clearLowestCostPlans();
+            group.removeParentPhysicalExpressions();
+            group.setExplored(false);
+        }
+
+        // logical groupExpression reset ruleMask
+        groupExpressions.values().stream()
+                .filter(groupExpression -> groupExpression.getPlan() instanceof LogicalPlan)
+                .forEach(GroupExpression::clearApplied);
+    }
+
     private Plan skipProject(Plan plan, Group targetGroup) {
         // Some top project can't be eliminated
         if (plan instanceof LogicalProject && ((LogicalProject<?>) plan).canEliminate()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleSet.java
@@ -202,7 +202,7 @@ public class RuleSet {
             .build();
 
     public static final List<Rule> DPHYP_REORDER_RULES = ImmutableList.<Rule>builder()
-            .add(JoinCommute.NON_INNER.build())
+            .add(JoinCommute.BUSHY.build())
             .addAll(OTHER_REORDER_RULES)
             .build();
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

After DPHyp, clear all physicalExpression and other, just keep logicalExpression as original plan as input of cascades optimize.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

