### PR TITLE
[fix](compile) Remove fs/benchmark/fs_benchmark_tool.cpp in IO_FILES

### DIFF
--- a/be/src/io/CMakeLists.txt
+++ b/be/src/io/CMakeLists.txt
@@ -22,6 +22,7 @@ set(LIBRARY_OUTPUT_PATH "${BUILD_DIR}/src/io")
 set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/src/io")
 
 file(GLOB_RECURSE IO_FILES CONFIGURE_DEPENDS *.cpp)
+list(REMOVE_ITEM IO_FILES "${CMAKE_CURRENT_SOURCE_DIR}/fs/benchmark/fs_benchmark_tool.cpp")
 
 add_library(IO STATIC ${IO_FILES})
 


### PR DESCRIPTION
## Proposed changes

Remove fs/benchmark/fs_benchmark_tool.cpp which contains main function in IO_FILES

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

