### PR TITLE
[fix](nereids)use "analyze table XXX with sync" in regression cases

### DIFF
--- a/regression-test/suites/nereids_p0/join/bucket_shuffle_join.groovy
+++ b/regression-test/suites/nereids_p0/join/bucket_shuffle_join.groovy
@@ -56,10 +56,8 @@ suite("bucket-shuffle-join") {
     sql """insert into shuffle_join_t2 values("1","1","1");"""
     sql """insert into shuffle_join_t2 values("1","1","1");"""
 
-    sql """analyze table shuffle_join_t1;"""
-    sql """analyze table shuffle_join_t2;"""
-
-    Thread.sleep(2000)
+    sql """analyze table shuffle_join_t1 with sync;"""
+    sql """analyze table shuffle_join_t2 with sync;"""
 
     explain {
         sql("select * from shuffle_join_t1 t1 left join shuffle_join_t2 t2 on t1.a = t2.a;")

--- a/regression-test/suites/nereids_syntax_p0/join.groovy
+++ b/regression-test/suites/nereids_syntax_p0/join.groovy
@@ -69,11 +69,11 @@ suite("join") {
 
     // must analyze before explain, because empty table may generate different plan
     sql """
-        analyze table test_table_b;
+        analyze table test_table_b with sync;
     """
 
     sql """
-        analyze table test_table_a;
+        analyze table test_table_a with sync;
     """
 
     order_qt_inner_join_1 """


### PR DESCRIPTION
## Proposed changes
replace `analyze table XXX` by `analyze table XXX with sync` in regression test cases

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

