### PR TITLE
[Enhancement](http) Unify http auth config

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -421,7 +421,7 @@ DEFINE_String(ssl_certificate_path, "");
 // Path of private key
 DEFINE_String(ssl_private_key_path, "");
 // Whether to check authorization
-DEFINE_Bool(enable_http_auth, "false");
+DEFINE_Bool(enable_all_http_auth, "false");
 // Number of webserver workers
 DEFINE_Int32(webserver_num_workers, "48");
 // Period to update rate counters and sampling counters in ms.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -457,7 +457,7 @@ DECLARE_String(ssl_certificate_path);
 // Path of private key
 DECLARE_String(ssl_private_key_path);
 // Whether to check authorization
-DECLARE_Bool(enable_http_auth);
+DECLARE_Bool(enable_all_http_auth);
 // Number of webserver workers
 DECLARE_Int32(webserver_num_workers);
 // Period to update rate counters and sampling counters in ms.

--- a/be/src/http/http_handler_with_auth.cpp
+++ b/be/src/http/http_handler_with_auth.cpp
@@ -39,7 +39,7 @@ int HttpHandlerWithAuth::on_header(HttpRequest* req) {
     TCheckAuthResult auth_result;
     AuthInfo auth_info;
 
-    if (!config::enable_http_auth) {
+    if (!config::enable_all_http_auth) {
         return 0;
     }
 

--- a/be/test/http/http_auth_test.cpp
+++ b/be/test/http/http_auth_test.cpp
@@ -49,7 +49,7 @@ static HttpAuthTestHandler s_auth_handler =
 class HttpAuthTest : public testing::Test {};
 
 TEST_F(HttpAuthTest, disable_auth) {
-    EXPECT_FALSE(config::enable_http_auth);
+    EXPECT_FALSE(config::enable_all_http_auth);
 
     auto evhttp_req = evhttp_request_new(nullptr, nullptr);
     HttpRequest req(evhttp_req);
@@ -57,8 +57,8 @@ TEST_F(HttpAuthTest, disable_auth) {
     evhttp_request_free(evhttp_req);
 }
 
-TEST_F(HttpAuthTest, enable_http_auth) {
-    config::enable_http_auth = true;
+TEST_F(HttpAuthTest, enable_all_http_auth) {
+    config::enable_all_http_auth = true;
 
     // 1. empty auth info
     {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Http interface authentication configuration item of FE and BE IS different. 
The value of FE is 'enable_all_http_auth', and the value of BE is 'enable_http_auth'.
This pr gives it a unified name.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

