### PR TITLE
[chore](workflow) Improve the cache hit ratio in BE UT (Clang)

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -162,6 +162,7 @@ else
     exit 1
 fi
 
+export CCACHE_COMPILERCHECK=content
 if [[ "${ENABLE_PCH}" == "ON" ]]; then
     export CCACHE_PCH_EXTSUM=true
     export CCACHE_SLOPPINESS="pch_defines,time_macros"


### PR DESCRIPTION
## Proposed changes

In workflow `BE UT (Clang)`, we set up the `ldb_toolchain` before we build the UT. During generating the toolchain tools, the script modifies the `RPATH` and `dynamic linker` of the executables which making the `mtime` of compilers change in every build.

By default, Ccache computes the hash of the compilers' `mtime` and `size` to check the compilers whether they are consistent with the ones which were used to generate the caches. If the compilers change, the caches can not be hit. We should change the default behavior of Ccache by setting the configuration `compiler_check (CCACHE_COMPILERCHECK)` to increase the cache hit ratio in the workflow.

Reference: [https://ccache.dev/manual/latest.html#_configuration_options](https://ccache.dev/manual/latest.html#_configuration_options)

> compiler_check (CCACHE_COMPILERCHECK)
By default, ccache includes the modification time (“mtime”) and size of the compiler in the hash to ensure that results retrieved from the cache are accurate. If compiler plugins are used, these plugins will also be added to the hash. This option can be used to select another strategy. Possible values are:
>>
>> content
>> Hash the content of the compiler binary. This makes ccache very slightly slower compared to mtime, but makes it cope better with compiler upgrades during a build bootstrapping process.
>>
>> mtime
>> Hash the compiler’s mtime and size, which is fast. This is the default.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

