### PR TITLE
[typo](doc) Fix struct_element and  coalesce functions syntax format 

### DIFF
--- a/docs/en/docs/sql-manual/sql-functions/encrypt-digest-functions/md5sum.md
+++ b/docs/en/docs/sql-manual/sql-functions/encrypt-digest-functions/md5sum.md
@@ -28,7 +28,7 @@ under the License.
 Calculates an MD5 128-bit checksum for the strings
 #### Syntax
 
-`MD5SUM(str[,str])`
+`STRING MD5SUM(STRING str, ...)`
 
 ### example
 
@@ -53,4 +53,4 @@ MySQL > select md5sum("ab","cd");
 
 ### keywords
 
-    MD5SUM
+    MD5SUM,MD5

--- a/docs/en/docs/sql-manual/sql-functions/encrypt-digest-functions/sm3sum.md
+++ b/docs/en/docs/sql-manual/sql-functions/encrypt-digest-functions/sm3sum.md
@@ -28,7 +28,7 @@ under the License.
 Calculates an SM3 128-bit checksum for the strings
 #### Syntax
 
-`SM3SUM(str[,str])`
+`STRING SM3SUM(STRING str, ...)`
 
 ### example
 

--- a/docs/en/docs/sql-manual/sql-functions/struct-functions/struct_element.md
+++ b/docs/en/docs/sql-manual/sql-functions/struct-functions/struct_element.md
@@ -37,15 +37,16 @@ Function allows getting a field from a struct.
 #### Syntax
 
 ```
-struct_element(struct, n/s)
+Tn struct_element(STRUCT<T1, T2, ..., Tn, ...> struct, Integer-type field_n)
+Tn struct_element(STRUCT<T1, T2, ..., Tn, ...> struct, VARCHAR field_n_name)
 ```
 
 #### Arguments
 
 ```
 struct - The input struct column. If null, null will be returned.
-n - The position of field，starting from 1，only supports constants.
-s - The name of field，only supports constants.
+field_n - The position of field，starting from 1，only supports constants.
+field_n_name - The name of field，only supports constants.
 ```
 
 #### Returned value

--- a/docs/zh-CN/docs/sql-manual/sql-functions/conditional-functions/coalesce.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/conditional-functions/coalesce.md
@@ -28,7 +28,7 @@ under the License.
 ### description
 #### Syntax
 
-`coalesce(expr1, expr2, ...., expr_n))`
+`coalesce(expr1, expr2, ...., expr_n)`
 
 返回参数中的第一个非空表达式（从左向右）
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/struct-functions/struct_element.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/struct-functions/struct_element.md
@@ -37,15 +37,16 @@ struct_element
 #### Syntax
 
 ```
-struct_element(struct, n/s)
+Tn struct_element(STRUCT<T1, T2, ..., Tn, ...> struct, Integer-type field_n)
+Tn struct_element(STRUCT<T1, T2, ..., Tn, ...> struct, VARCHAR field_n_name)
 ```
 
 #### Arguments
 
 ```
 struct - 输入的struct列，如果是null，则返回null
-n - field的位置，起始位置从1开始，仅支持常量
-s - field的名字，仅支持常量
+field_n - field的位置，起始位置从1开始，仅支持常量
+field_n_name - field的名字，仅支持常量
 ```
 
 #### Returned value


### PR DESCRIPTION
## Proposed changes

Fix struct_element and  coalesce functions syntax format 


Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

