### PR TITLE
[fix](nereids) Fix clean expired stats failed.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DropStatsStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DropStatsStmt.java
@@ -64,7 +64,9 @@ public class DropStatsStmt extends DdlStmt {
     public DropStatsStmt(TableName tableName,
             List<String> columnNames) {
         this.tableName = tableName;
-        this.columnNames = new HashSet<>(columnNames);
+        if (columnNames != null) {
+            this.columnNames = new HashSet<>(columnNames);
+        }
         dropExpired = false;
     }
 


### PR DESCRIPTION
## Proposed changes

1. Fix clean expired stats failed.Expired jobs would be cleaned in the AnalysisManager now, remoe useless code in StatsCleaner
2. Fix analyze drop stats

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

