### PR TITLE
[Fix](core) Get tablet version should hold meta lock

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -453,6 +453,7 @@ Status DeltaWriter::close_wait(const PSlaveTabletNodes& slave_tablet_nodes,
             RETURN_IF_ERROR(_tablet->calc_delete_bitmap_between_segments(_cur_rowset, segments,
                                                                          _delete_bitmap));
         }
+        std::shared_lock meta_rlock(_tablet->get_header_lock());
         RETURN_IF_ERROR(_tablet->commit_phase_update_delete_bitmap(
                 _cur_rowset, _rowset_ids, _delete_bitmap, _tablet->max_version().second, segments,
                 _rowset_writer.get()));

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -3153,7 +3153,6 @@ Status Tablet::commit_phase_update_delete_bitmap(
     RowsetIdUnorderedSet rowset_ids_to_add;
     RowsetIdUnorderedSet rowset_ids_to_del;
 
-    std::shared_lock meta_rlock(_meta_lock);
     cur_rowset_ids = all_rs_id(cur_version);
     _rowset_ids_difference(cur_rowset_ids, pre_rowset_ids, &rowset_ids_to_add, &rowset_ids_to_del);
     if (!rowset_ids_to_add.empty() || !rowset_ids_to_del.empty()) {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

Fix be core.

Info:

SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.Reload4jLoggerFactory]
*** Query id: 0-0 ***
*** Aborted at 1686881815 (unix time) try "date -d @1686881815" if you are using GNU date ***
*** Current BE git commitID: 8b2a2dd871 ***
*** SIGSEGV address not mapped to object (@0xb0) received by PID 2962482 (TID 2964647 OR 0x7fc9ce282700) from PID 176; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk2/zhangchen/doris-dev/be/src/common/signal_handler.h:413
 1# 0x00007FCD15D29BF9 in /usr/lib/jvm/java-1.11.0-openjdk-amd64/lib/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-1.11.0-openjdk-amd64/lib/server/libjvm.so
 3# 0x00007FCD15D2293C in /usr/lib/jvm/java-1.11.0-openjdk-amd64/lib/server/libjvm.so
 4# 0x00007FCD1A8660C0 in /lib/x86_64-linux-gnu/libc.so.6
 5# doris::TabletMeta::max_version() const at /mnt/disk2/zhangchen/doris-dev/be/src/olap/tablet_meta.cpp:651
 6# doris::DeltaWriter::close_wait(doris::PSlaveTabletNodes const&, bool) at /mnt/disk2/zhangchen/doris-dev/be/src/olap/delta_writer.cpp:457
 7# doris::TabletsChannel::_close_wait(doris::DeltaWriter*, google::protobuf::RepeatedPtrField<doris::PTabletInfo>*, google::protobuf::RepeatedPtrField<doris::PTabletError>*, doris::PSlaveTabletNodes, bool) at /mnt/disk2/zhangchen/doris-dev/be/src/runtime/tablets_channel.cpp:241
 8# doris::TabletsChannel::close(doris::LoadChannel*, int, long, bool*, google::protobuf::RepeatedField<long> const&, google::protobuf::RepeatedPtrField<doris::PTabletInfo>*, google::protobuf::RepeatedPtrField<doris::PTabletError>*, google::protobuf::Map<long, doris::PSlaveTabletNodes> const&, google::protobuf::Map<long, doris::PSuccessSlaveTabletNodeIds>*, bool) at /mnt/disk2/zhangchen/doris-dev/be/src/runtime/tablets_channel.cpp:204
 9# doris::LoadChannel::_handle_eos(std::shared_ptr<doris::TabletsChannel>&, doris::PTabletWriterAddBlockRequest const&, doris::PTabletWriterAddBlockResult*) at /mnt/disk2/zhangchen/doris-dev/be/src/runtime/load_channel.h:134
10# doris::LoadChannel::add_batch(doris::PTabletWriterAddBlockRequest const&, doris::PTabletWriterAddBlockResult*) at /mnt/disk2/zhangchen/doris-dev/be/src/runtime/load_channel.cpp:166
11# doris::LoadChannelMgr::add_batch(doris::PTabletWriterAddBlockRequest const&, doris::PTabletWriterAddBlockResult*) at /mnt/disk2/zhangchen/doris-dev/be/src/runtime/load_channel_mgr.cpp:209
12# std::_Function_handler<void (), doris::PInternalServiceImpl::_tablet_writer_add_block(google::protobuf::RpcController*, doris::PTabletWriterAddBlockRequest const*, doris::PTabletWriterAddBlockResult*, google::protobuf::Closure*)::$_0>::_M_invoke(std::_Any_data const&) at /mnt/disk2/zhangchen/env/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
13# doris::PriorityThreadPool::work_thread(int) at /mnt/disk2/zhangchen/doris-dev/be/src/util/priority_thread_pool.hpp:147
14# execute_native_thread_routine at ../../../../../libstdc++-v3/src/c++11/thread.cc:84
15# start_thread at /build/glibc-sMfBJT/glibc-2.31/nptl/pthread_create.c:478
16# __clone in /lib/x86_64-linux-gnu/libc.so.6
 

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

