### PR TITLE
[fix](compaction) fix time series compaction policy to adjust vertical compaction max segment size

### DIFF
--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -126,6 +126,10 @@ int64_t Compaction::get_avg_segment_rows() {
     // input_rowsets_size is total disk_size of input_rowset, this size is the
     // final size after codec and compress, so expect dest segment file size
     // in disk is config::vertical_compaction_max_segment_size
+    if (config::compaction_policy == "time_series") {
+        return (config::time_series_compaction_goal_size_mbytes * 1024 * 1024 * 2) /
+               (_input_rowsets_size / (_input_row_num + 1) + 1);
+    }
     return config::vertical_compaction_max_segment_size /
            (_input_rowsets_size / (_input_row_num + 1) + 1);
 }

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -36,6 +36,7 @@
 #include "io/fs/file_system.h"
 #include "io/fs/remote_file_system.h"
 #include "olap/cumulative_compaction_policy.h"
+#include "olap/cumulative_compaction_time_series_policy.h"
 #include "olap/data_dir.h"
 #include "olap/olap_define.h"
 #include "olap/rowset/beta_rowset.h"
@@ -126,7 +127,7 @@ int64_t Compaction::get_avg_segment_rows() {
     // input_rowsets_size is total disk_size of input_rowset, this size is the
     // final size after codec and compress, so expect dest segment file size
     // in disk is config::vertical_compaction_max_segment_size
-    if (config::compaction_policy == "time_series") {
+    if (config::compaction_policy == CUMULATIVE_TIME_SERIES_POLICY) {
         return (config::time_series_compaction_goal_size_mbytes * 1024 * 1024 * 2) /
                (_input_rowsets_size / (_input_row_num + 1) + 1);
     }

--- a/be/src/olap/cumulative_compaction_policy.cpp
+++ b/be/src/olap/cumulative_compaction_policy.cpp
@@ -346,7 +346,7 @@ int64_t SizeBasedCumulativeCompactionPolicy::_level_size(const int64_t size) {
 
 std::shared_ptr<CumulativeCompactionPolicy>
 CumulativeCompactionPolicyFactory::create_cumulative_compaction_policy() {
-    if (config::compaction_policy == "time_series") {
+    if (config::compaction_policy == CUMULATIVE_TIME_SERIES_POLICY) {
         return std::make_shared<TimeSeriesCumulativeCompactionPolicy>();
     }
     return std::make_shared<SizeBasedCumulativeCompactionPolicy>();

--- a/be/src/olap/cumulative_compaction_policy.h
+++ b/be/src/olap/cumulative_compaction_policy.h
@@ -33,7 +33,7 @@ namespace doris {
 class Tablet;
 struct Version;
 
-inline std::string_view CUMULATIVE_SIZE_BASED_POLICY = "SIZE_BASED";
+inline std::string_view CUMULATIVE_SIZE_BASED_POLICY = "size_based";
 
 /// This class CumulativeCompactionPolicy is the base class of cumulative compaction policy.
 /// It defines the policy to do cumulative compaction. It has different derived classes, which implements

--- a/be/src/olap/cumulative_compaction_time_series_policy.h
+++ b/be/src/olap/cumulative_compaction_time_series_policy.h
@@ -21,7 +21,7 @@
 
 namespace doris {
 
-inline std::string_view CUMULATIVE_TIME_SERIES_POLICY = "TIME_SERIES";
+inline std::string_view CUMULATIVE_TIME_SERIES_POLICY = "time_series";
 
 /// TimeSeries cumulative compaction policy implementation.
 /// The following three conditions will be considered when calculating compaction scores and selecting input rowsets in this policy:

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -77,6 +77,7 @@
 #include "olap/binlog.h"
 #include "olap/cumulative_compaction.h"
 #include "olap/cumulative_compaction_policy.h"
+#include "olap/cumulative_compaction_time_series_policy.h"
 #include "olap/delete_bitmap_calculator.h"
 #include "olap/memtable.h"
 #include "olap/olap_common.h"

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1078,7 +1078,7 @@ uint32_t Tablet::_calc_base_compaction_score() const {
 
     // In the time series compaction policy, we want the base compaction to be triggered
     // when there are delete versions present.
-    if (config::compaction_policy == "time_series") {
+    if (config::compaction_policy == CUMULATIVE_TIME_SERIES_POLICY) {
         return (base_rowset_exist && has_delete) ? score : 0;
     }
 


### PR DESCRIPTION
## Proposed changes

In the time series compaction policy, the vertical compaction max segment size should be adjusted to be the time series compaction goal size multiplied by 2.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

