### PR TITLE
[Enhancement](Compaction) Caculate all committed rowsets delete bitmaps when do comapction

### DIFF
--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -625,12 +625,12 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
         // delete all delete bitmaps in rowset_to_delete
         // every commited rowset should add new version delete bitmap to rowset_to_add
 
-        for (;;) {
-            auto beta_rowset = reinterpret_cast<BetaRowset*>(_rowset.get());
+        for (const auto &it:tablet_txn_infos) {
+            auto beta_rowset = reinterpret_cast<BetaRowset*>(it.rowset.get());
             std::vector<segment_v2::SegmentSharedPtr> segments;
             RETURN_IF_ERROR(beta_rowset->load_segments(&segments));
             RETURN_IF_ERROR(_tablet->commit_phase_update_delete_bitmap(
-                    _cur_rowset, _rowset_ids, _delete_bitmap, _tablet->max_version().second,
+                    it.rowset, it.rowset_ids, it.delete_bitmap, _tablet->max_version().second,
                     segments, _rowset_writer.get()));
         }
 

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -615,10 +615,9 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
             // Step2: calculate all rowsets' delete bitmaps which are published during compaction.
             for (auto& it : commit_tablet_txn_info_vec) {
                 DeleteBitmap output_delete_bitmap(_tablet->tablet_id());
-                    _tablet->calc_compaction_output_rowset_delete_bitmap(
-                            _input_rowsets, _rowid_conversion, 0, UINT64_MAX,
-                            &missed_rows, &location_map, *it.delete_bitmap.get(),
-                            &output_delete_bitmap);
+                _tablet->calc_compaction_output_rowset_delete_bitmap(
+                        _input_rowsets, _rowid_conversion, 0, UINT64_MAX, &missed_rows,
+                        &location_map, *it.delete_bitmap.get(), &output_delete_bitmap);
                 it.delete_bitmap->merge(output_delete_bitmap);
                 // Step3: write back updated delete bitmap and tablet info.
                 it.rowset_ids.insert(_output_rowset->rowset_id());

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -633,6 +633,7 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
                         tablet_txn_info.rowset, tablet_txn_info.rowset_ids,
                         tablet_txn_info.delete_bitmap, cur_max_version, segments,
                         delta_writer->get_rowset_writer().get()));
+                // Step3: write back updated delete bitmap and tablet info.
                 StorageEngine::instance()->txn_manager()->set_txn_related_delete_bitmap(
                         it.first.first, it.first.second, _tablet->tablet_id(),
                         _tablet->schema_hash(), _tablet->tablet_uid(), true,

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -580,7 +580,7 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
         // of incremental data later.
         _tablet->calc_compaction_output_rowset_delete_bitmap(
                 _input_rowsets, _rowid_conversion, 0, version.second + 1, &missed_rows,
-                &location_map, &output_rowset_delete_bitmap);
+                &location_map, {}, &output_rowset_delete_bitmap);
         std::size_t missed_rows_size = missed_rows.size();
         if (compaction_type() == ReaderType::READER_CUMULATIVE_COMPACTION) {
             if (stats != nullptr && stats->merged_rows != missed_rows_size) {
@@ -606,39 +606,36 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
             // of publish phase.
             // All rowsets which need to recalculate have been published so we don't need to acquire lock.
             // Step1: collect this tablet's all committed rowsets' delete bitmaps
-            TxnManager::txn_tablet_map_t txn_tablet_map {};
+            CommitTabletTxnInfoVec commit_tablet_txn_info_vec {};
             StorageEngine::instance()->txn_manager()->get_all_commit_tablet_txn_info_by_tablet(
-                    _tablet, txn_tablet_map);
+                    _tablet, commit_tablet_txn_info_vec);
 
             // Step2: calculate all rowsets' delete bitmaps which are published during compaction.
             int64_t cur_max_version = _tablet->max_version().second;
             RowsetIdUnorderedSet rowset_ids = _tablet->all_rs_id(cur_max_version);
             rowset_ids.insert(_output_rowset->rowset_id());
-            for (const auto& it : txn_tablet_map) {
-                for (const auto& tablet_load_it : it.second) {
-                    const TabletTxnInfo& tablet_txn_info = tablet_load_it.second;
-                    DeleteBitmap output_delete_bitmap(_tablet->tablet_id());
-                    std::shared_ptr<Rowset> rowset = tablet_txn_info.rowset;
-                    for (uint32_t seg_id = 0; seg_id < rowset->num_segments(); ++seg_id) {
-                        _tablet->calc_compaction_output_rowset_delete_bitmap(
-                                std::vector<std::shared_ptr<Rowset>>(1, rowset), _rowid_conversion,
-                                version.second, UINT64_MAX, &missed_rows, &location_map,
-                                &output_delete_bitmap);
-                    }
-                    tablet_txn_info.delete_bitmap->merge(output_delete_bitmap);
-                    // Step3: write back updated delete bitmap and tablet info.
-                    StorageEngine::instance()->txn_manager()->set_txn_related_delete_bitmap(
-                            it.first.first, it.first.second, _tablet->tablet_id(),
-                            _tablet->schema_hash(), _tablet->tablet_uid(), true,
-                            tablet_txn_info.delete_bitmap, rowset_ids);
+            for (const auto& it : commit_tablet_txn_info_vec) {
+                DeleteBitmap output_delete_bitmap(_tablet->tablet_id());
+                std::shared_ptr<Rowset> rowset = it.rowset;
+                for (uint32_t seg_id = 0; seg_id < rowset->num_segments(); ++seg_id) {
+                    _tablet->calc_compaction_output_rowset_delete_bitmap(
+                            std::vector<std::shared_ptr<Rowset>>(1, rowset), _rowid_conversion,
+                            version.second, UINT64_MAX, &missed_rows, &location_map,
+                            it.delete_bitmap, &output_delete_bitmap);
                 }
+                it.delete_bitmap->merge(output_delete_bitmap);
+                // Step3: write back updated delete bitmap and tablet info.
+                StorageEngine::instance()->txn_manager()->set_txn_related_delete_bitmap(
+                        it.partition_id, it.transaction_id, _tablet->tablet_id(),
+                        _tablet->schema_hash(), _tablet->tablet_uid(), true, it.delete_bitmap,
+                        rowset_ids);
             }
 
             // Convert the delete bitmap of the input rowsets to output rowset for
             // incremental data.
             _tablet->calc_compaction_output_rowset_delete_bitmap(
                     _input_rowsets, _rowid_conversion, version.second, UINT64_MAX, &missed_rows,
-                    &location_map, &output_rowset_delete_bitmap);
+                    &location_map, {}, &output_rowset_delete_bitmap);
             if (compaction_type() == ReaderType::READER_CUMULATIVE_COMPACTION) {
                 DCHECK_EQ(missed_rows.size(), missed_rows_size);
                 if (missed_rows.size() != missed_rows_size) {

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -628,11 +628,11 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
 
         RETURN_IF_ERROR(_tablet->check_rowid_conversion(_output_rowset, location_map));
         location_map.clear();
-        SCOPED_SIMPLE_TRACE_IF_TIMEOUT(TRACE_TABLET_LOCK_THRESHOLD);
 
         {
             std::lock_guard<std::mutex> wrlock_(_tablet->get_rowset_update_lock());
             std::lock_guard<std::shared_mutex> wrlock(_tablet->get_header_lock());
+            SCOPED_SIMPLE_TRACE_IF_TIMEOUT(TRACE_TABLET_LOCK_THRESHOLD);
 
             // Convert the delete bitmap of the input rowsets to output rowset for
             // incremental data.

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -618,7 +618,7 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
             rowset_ids.insert(_output_rowset->rowset_id());
             for (const auto& it : commit_tablet_txn_info_vec) {
                 DeleteBitmap output_delete_bitmap(_tablet->tablet_id());
-                std::shared_ptr<Rowset> rowset = it.rowset;
+                const std::shared_ptr<Rowset>& rowset = it.rowset;
                 for (uint32_t seg_id = 0; seg_id < rowset->num_segments(); ++seg_id) {
                     _tablet->calc_compaction_output_rowset_delete_bitmap(
                             std::vector<std::shared_ptr<Rowset>>(1, rowset), _rowid_conversion,

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -599,9 +599,9 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
         // of publish phase.
         // All rowsets which need to recalculate have been published so we don't need to acquire lock.
         // Step1: collect this tablet's all committed rowsets' delete bitmaps
-        std::map<TabletInfo,TabletTxnInfo> tablet_info_map {};
+        TxnManager::txn_tablet_map_t txn_tablet_map{};
         StorageEngine::instance()->txn_manager()->get_all_tablet_txn_infos_by_tablet(
-                _tablet, tablet_info_map);
+                _tablet, txn_tablet_map);
 
         // Step2: calculate all rowsets' delete bitmaps which are published during compaction.
         // e.g. before compaction:
@@ -619,18 +619,20 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
         // This part is to calculate 7-7's delete bitmap.
 
         int64_t cur_max_version = _tablet->max_version().second;
-        for (const auto &it:tablet_info_map) {
-            const TabletInfo& tablet_info = it.first;
-            const TabletTxnInfo& tablet_txn_info = it.second;
-            auto beta_rowset = reinterpret_cast<BetaRowset*>(tablet_txn_info.rowset.get());
-            std::vector<segment_v2::SegmentSharedPtr> segments;
-            RETURN_IF_ERROR(beta_rowset->load_segments(&segments));
-            RETURN_IF_ERROR(_tablet->commit_phase_update_delete_bitmap(
-                    tablet_txn_info.rowset, tablet_txn_info.rowset_ids, tablet_txn_info.delete_bitmap, cur_max_version,
-                    segments, _rowset_writer.get()));
-            StorageEngine::instance()->txn_manager()->set_txn_related_delete_bitmap(
-                    tablet_info.partition_id, _req.txn_id, _tablet->tablet_id(), _tablet->schema_hash(),
-                    _tablet->tablet_uid(), true, it.delete_bitmap, _tablet->all_rs_id(cur_max_version));
+        for (const auto &it:txn_tablet_map) {
+            for(const auto &tablet_load_it:it.second){
+                const TabletInfo& tablet_info = tablet_load_it.first;
+                const TabletTxnInfo& tablet_txn_info = tablet_load_it.second;
+                auto beta_rowset = reinterpret_cast<BetaRowset*>(tablet_txn_info.rowset.get());
+                std::vector<segment_v2::SegmentSharedPtr> segments;
+                RETURN_IF_ERROR(beta_rowset->load_segments(&segments));
+                RETURN_IF_ERROR(_tablet->commit_phase_update_delete_bitmap(
+                        tablet_txn_info.rowset, tablet_txn_info.rowset_ids, tablet_txn_info.delete_bitmap, cur_max_version,
+                        segments, _rowset_writer.get()));
+                StorageEngine::instance()->txn_manager()->set_txn_related_delete_bitmap(
+                        it.first.first, it.first.second, _tablet->tablet_id(), _tablet->schema_hash(),
+                        _tablet->tablet_uid(), true, tablet_txn_info.delete_bitmap, _tablet->all_rs_id(cur_max_version));
+            }
         }
 
         RETURN_IF_ERROR(_tablet->check_rowid_conversion(_output_rowset, location_map));

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -616,8 +616,8 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
         // 7-7 doesn't have delete bitmap.
         // 8-8 has committed, so we want 7-7 delete bitmap version is 8(dummy).
         // This part is to calculate 7-7's delete bitmap.
-        const ;
         // get pre_rowset_ids
+        const uint64_t pre_version = 0;
         // get cur_rowset_ids
         const uint64_t cur_version = version.second;
         // get rowset_to_add and rowset_to_delete

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -25,6 +25,7 @@
 #include <cstdlib>
 #include <list>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <ostream>
 #include <set>
@@ -580,7 +581,8 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
         // of incremental data later.
         _tablet->calc_compaction_output_rowset_delete_bitmap(
                 _input_rowsets, _rowid_conversion, 0, version.second + 1, &missed_rows,
-                &location_map, {}, &output_rowset_delete_bitmap);
+                &location_map, std::make_shared<DeleteBitmap>(_tablet->tablet_id()),
+                &output_rowset_delete_bitmap);
         std::size_t missed_rows_size = missed_rows.size();
         if (compaction_type() == ReaderType::READER_CUMULATIVE_COMPACTION) {
             if (stats != nullptr && stats->merged_rows != missed_rows_size) {
@@ -635,7 +637,8 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
             // incremental data.
             _tablet->calc_compaction_output_rowset_delete_bitmap(
                     _input_rowsets, _rowid_conversion, version.second, UINT64_MAX, &missed_rows,
-                    &location_map, {}, &output_rowset_delete_bitmap);
+                    &location_map, std::make_shared<DeleteBitmap>(_tablet->tablet_id()),
+                    &output_rowset_delete_bitmap);
             if (compaction_type() == ReaderType::READER_CUMULATIVE_COMPACTION) {
                 DCHECK_EQ(missed_rows.size(), missed_rows_size);
                 if (missed_rows.size() != missed_rows_size) {

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -618,15 +618,12 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
                 for (const auto& tablet_load_it : it.second) {
                     const TabletTxnInfo& tablet_txn_info = tablet_load_it.second;
                     DeleteBitmap output_delete_bitmap(_tablet->tablet_id());
-                    RowLocation src;
                     std::shared_ptr<Rowset> rowset = tablet_txn_info.rowset;
-                    src.rowset_id = rowset->rowset_id();
                     for (uint32_t seg_id = 0; seg_id < rowset->num_segments(); ++seg_id) {
-                        src.segment_id = seg_id;
-                        _tablet->convert_rowid(rowset, *tablet_txn_info.delete_bitmap, src,
-                                               _rowid_conversion, version.second, UINT64_MAX,
-                                               &missed_rows, &location_map,
-                                               &output_rowset_delete_bitmap);
+                        _tablet->calc_compaction_output_rowset_delete_bitmap(
+                                std::vector<std::shared_ptr<Rowset>>(1, rowset), _rowid_conversion,
+                                version.second, UINT64_MAX, &missed_rows, &location_map,
+                                &output_delete_bitmap);
                     }
                     tablet_txn_info.delete_bitmap->merge(output_delete_bitmap);
                     // Step3: write back updated delete bitmap and tablet info.

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -592,12 +592,17 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
                 LOG(WARNING) << err_msg;
             }
         }
-
-        RETURN_IF_ERROR(_tablet->check_rowid_conversion(_output_rowset, location_map));
-        location_map.clear();
+        // here we will calculate all the rowsets delete bitmaps which are committed but not published to reduce the calculation pressure
+        // of publish phase.
+        // publish phase maybe calculate the same segment delete bitmap so we need to acquire lock.
         {
             std::lock_guard<std::mutex> wrlock_(_tablet->get_rowset_update_lock());
             std::lock_guard<std::shared_mutex> wrlock(_tablet->get_header_lock());
+
+
+
+            RETURN_IF_ERROR(_tablet->check_rowid_conversion(_output_rowset, location_map));
+            location_map.clear();
             SCOPED_SIMPLE_TRACE_IF_TIMEOUT(TRACE_TABLET_LOCK_THRESHOLD);
 
             // Convert the delete bitmap of the input rowsets to output rowset for

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -616,10 +616,12 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
         // 7-7 doesn't have delete bitmap.
         // 8-8 has committed, so we want 7-7 delete bitmap version is 8(dummy).
         // This part is to calculate 7-7's delete bitmap.
-
+        const ;
         // get pre_rowset_ids
         // get cur_rowset_ids
+        const uint64_t cur_version = _tablet->max_version().second;
         // get rowset_to_add and rowset_to_delete
+
         // delete all delete bitmaps in rowset_to_delete
         // every commited rowset should add new version delete bitmap to rowset_to_add
 

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -632,7 +632,7 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
                 RETURN_IF_ERROR(_tablet->commit_phase_update_delete_bitmap(
                         tablet_txn_info.rowset, tablet_txn_info.rowset_ids,
                         tablet_txn_info.delete_bitmap, cur_max_version, segments,
-                        delta_writer->get_rowset_writer().get()));
+                        delta_writer->get_rowset_writer()));
                 // Step3: write back updated delete bitmap and tablet info.
                 StorageEngine::instance()->txn_manager()->set_txn_related_delete_bitmap(
                         it.first.first, it.first.second, _tablet->tablet_id(),

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -615,13 +615,10 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
             // Step2: calculate all rowsets' delete bitmaps which are published during compaction.
             for (auto& it : commit_tablet_txn_info_vec) {
                 DeleteBitmap output_delete_bitmap(_tablet->tablet_id());
-                const std::shared_ptr<Rowset>& rowset = it.rowset;
-                for (uint32_t seg_id = 0; seg_id < rowset->num_segments(); ++seg_id) {
                     _tablet->calc_compaction_output_rowset_delete_bitmap(
-                            _input_rowsets, _rowid_conversion, version.second, UINT64_MAX,
+                            _input_rowsets, _rowid_conversion, 0, UINT64_MAX,
                             &missed_rows, &location_map, *it.delete_bitmap.get(),
                             &output_delete_bitmap);
-                }
                 it.delete_bitmap->merge(output_delete_bitmap);
                 // Step3: write back updated delete bitmap and tablet info.
                 it.rowset_ids.insert(_output_rowset->rowset_id());

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -644,6 +644,7 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
             }
         }
 
+        // Step4: calculate all commited and published version for this compacted rowset's delete bitmap.
         RETURN_IF_ERROR(_tablet->check_rowid_conversion(_output_rowset, location_map));
         location_map.clear();
 

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -568,7 +568,6 @@ Status Compaction::construct_input_rowset_readers() {
 Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
     std::vector<RowsetSharedPtr> output_rowsets;
     output_rowsets.push_back(_output_rowset);
-    std::shared_lock meta_rlock(_tablet->get_header_lock());
 
     if (_tablet->keys_type() == KeysType::UNIQUE_KEYS &&
         _tablet->enable_unique_key_merge_on_write()) {

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -47,6 +47,7 @@
 #include "olap/rowset/segment_v2/inverted_index_compaction.h"
 #include "olap/storage_engine.h"
 #include "olap/storage_policy.h"
+#include "olap/txn_manager.h"
 #include "olap/tablet.h"
 #include "olap/tablet_meta.h"
 #include "olap/task/engine_checksum_task.h"
@@ -598,6 +599,33 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
         {
             std::lock_guard<std::mutex> wrlock_(_tablet->get_rowset_update_lock());
             std::lock_guard<std::shared_mutex> wrlock(_tablet->get_header_lock());
+
+            // step1: collect this tablet's all committed rowsets' delete bitmaps
+            std::vector<TabletTxnInfo> tablet_txn_infos{};
+            StorageEngine::instance()->txn_manager()->get_all_tablet_txn_infos_by_tablet(_tablet, tablet_txn_infos);
+
+            // step2: calculate all rowsets' delete bitmaps which are not published committed and now published.
+            // e.g. before compaction:
+            //       5-5 6-6 published
+            //       7-7 8-8 committed not published
+            // then 5-5 delete bitmap versions are 6, 7(dummy), 8(dummy).
+            // 6-6 delete bitmap versions are 7(dummy), 8(dummy).
+            //       when compaction:
+            //       5-5 6-6 7-7 published
+            //       8-8 committed not published
+            // then 5-5 delete bitmap versions are 6, 7, 8(dummy).
+            // 6-6 delete bitmap versions are 7, 8(dummy).
+            // 7-7 doesn't have delete bitmap.
+            // 8-8 has committed, so we want 7-7 delete bitmap version is 8(dummy).
+            // This part is to calculate 7-7's delete bitmap.
+
+            auto beta_rowset = reinterpret_cast<BetaRowset*>(_rowset.get());
+            std::vector<segment_v2::SegmentSharedPtr> segments;
+            RETURN_IF_ERROR(beta_rowset->load_segments(&segments));
+            RETURN_IF_ERROR(_tablet->commit_phase_update_delete_bitmap(
+                    _cur_rowset, _rowset_ids, _delete_bitmap, _tablet->max_version().second, segments,
+                    _rowset_writer.get()));
+
 
 
 

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -594,15 +594,15 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
             }
         }
 
-        // here we will calculate all the rowsets delete bitmaps which are committed but not published to reduce the calculation pressure
+        // Here we will calculate all the rowsets delete bitmaps which are committed but not published to reduce the calculation pressure
         // of publish phase.
-        // all rowsets which need to recalculate have been published so we don't need to acquire lock.
-        // step1: collect this tablet's all committed rowsets' delete bitmaps
+        // All rowsets which need to recalculate have been published so we don't need to acquire lock.
+        // Step1: collect this tablet's all committed rowsets' delete bitmaps
         std::vector<TabletTxnInfo> tablet_txn_infos {};
         StorageEngine::instance()->txn_manager()->get_all_tablet_txn_infos_by_tablet(
                 _tablet, tablet_txn_infos);
 
-        // step2: calculate all rowsets' delete bitmaps which are published during compaction.
+        // Step2: calculate all rowsets' delete bitmaps which are published during compaction.
         // e.g. before compaction:
         //       5-5 6-6 published
         //       7-7 8-8 committed not published
@@ -616,6 +616,12 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
         // 7-7 doesn't have delete bitmap.
         // 8-8 has committed, so we want 7-7 delete bitmap version is 8(dummy).
         // This part is to calculate 7-7's delete bitmap.
+
+        // get pre_rowset_ids
+        // get cur_rowset_ids
+        // get rowset_to_add and rowset_to_delete
+        // delete all delete bitmaps in rowset_to_delete
+        // every commited rowset should add new version delete bitmap to rowset_to_add
 
         for (;;) {
             auto beta_rowset = reinterpret_cast<BetaRowset*>(_rowset.get());

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -619,15 +619,14 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
             // 8-8 has committed, so we want 7-7 delete bitmap version is 8(dummy).
             // This part is to calculate 7-7's delete bitmap.
 
-            auto beta_rowset = reinterpret_cast<BetaRowset*>(_rowset.get());
-            std::vector<segment_v2::SegmentSharedPtr> segments;
-            RETURN_IF_ERROR(beta_rowset->load_segments(&segments));
-            RETURN_IF_ERROR(_tablet->commit_phase_update_delete_bitmap(
-                    _cur_rowset, _rowset_ids, _delete_bitmap, _tablet->max_version().second, segments,
-                    _rowset_writer.get()));
-
-
-
+            for(;;){
+                auto beta_rowset = reinterpret_cast<BetaRowset*>(_rowset.get());
+                std::vector<segment_v2::SegmentSharedPtr> segments;
+                RETURN_IF_ERROR(beta_rowset->load_segments(&segments));
+                RETURN_IF_ERROR(_tablet->commit_phase_update_delete_bitmap(
+                        _cur_rowset, _rowset_ids, _delete_bitmap, _tablet->max_version().second, segments,
+                        _rowset_writer.get()));
+            }
 
             RETURN_IF_ERROR(_tablet->check_rowid_conversion(_output_rowset, location_map));
             location_map.clear();

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -623,6 +623,9 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
                 DeltaWriter* delta_writer =
                         StorageEngine::instance()->txn_manager()->get_txn_tablet_delta_writer(
                                 it.first.second, _tablet->tablet_id());
+                if (!delta_writer) {
+                    continue;
+                }
                 const TabletTxnInfo& tablet_txn_info = tablet_load_it.second;
                 auto beta_rowset = reinterpret_cast<BetaRowset*>(tablet_txn_info.rowset.get());
                 std::vector<segment_v2::SegmentSharedPtr> segments;

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -602,7 +602,7 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
         StorageEngine::instance()->txn_manager()->get_all_tablet_txn_infos_by_tablet(
                 _tablet, tablet_txn_infos);
 
-        // step2: calculate all rowsets' delete bitmaps which are not published committed and now published.
+        // step2: calculate all rowsets' delete bitmaps which are published during compaction.
         // e.g. before compaction:
         //       5-5 6-6 published
         //       7-7 8-8 committed not published

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -619,7 +619,7 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
         const ;
         // get pre_rowset_ids
         // get cur_rowset_ids
-        const uint64_t cur_version = _tablet->max_version().second;
+        const uint64_t cur_version = version.second;
         // get rowset_to_add and rowset_to_delete
 
         // delete all delete bitmaps in rowset_to_delete

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -634,7 +634,7 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
                 RETURN_IF_ERROR(beta_rowset->load_segments(&segments));
                 RETURN_IF_ERROR(_tablet->commit_phase_update_delete_bitmap(
                         tablet_txn_info.rowset, tablet_txn_info.rowset_ids,
-                        tablet_txn_info.delete_bitmap, cur_max_version, segments,
+                        tablet_txn_info.delete_bitmap, cur_max_version, segments, it.first.second,
                         delta_writer->get_rowset_writer()));
                 // Step3: write back updated delete bitmap and tablet info.
                 StorageEngine::instance()->txn_manager()->set_txn_related_delete_bitmap(

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -624,7 +624,6 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
                 DeltaWriter* delta_writer =
                         StorageEngine::instance()->txn_manager()->get_txn_tablet_delta_writer(
                                 it.first.second, _tablet->tablet_id());
-                const TabletInfo& tablet_info = tablet_load_it.first;
                 const TabletTxnInfo& tablet_txn_info = tablet_load_it.second;
                 auto beta_rowset = reinterpret_cast<BetaRowset*>(tablet_txn_info.rowset.get());
                 std::vector<segment_v2::SegmentSharedPtr> segments;

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -128,7 +128,7 @@ public:
 
     int64_t total_received_rows() const { return _total_received_rows; }
 
-    std::shared_ptr<RowsetWriter>& get_rowset_writer() { return _rowset_writer; }
+    RowsetWriter* get_rowset_writer() { return _rowset_writer.get(); }
 
 private:
     DeltaWriter(WriteRequest* req, StorageEngine* storage_engine, RuntimeProfile* profile,
@@ -156,7 +156,7 @@ private:
     WriteRequest _req;
     TabletSharedPtr _tablet;
     RowsetSharedPtr _cur_rowset;
-    std::shared_ptr<RowsetWriter> _rowset_writer;
+    std::unique_ptr<RowsetWriter> _rowset_writer;
     // TODO: Recheck the lifetime of _mem_table, Look should use unique_ptr
     std::unique_ptr<MemTable> _mem_table;
     //const TabletSchema* _tablet_schema;

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -128,6 +128,8 @@ public:
 
     int64_t total_received_rows() const { return _total_received_rows; }
 
+    std::shared_ptr<RowsetWriter>& get_rowset_writer() {return _rowset_writer;}
+
 private:
     DeltaWriter(WriteRequest* req, StorageEngine* storage_engine, RuntimeProfile* profile,
                 const UniqueId& load_id);
@@ -154,7 +156,7 @@ private:
     WriteRequest _req;
     TabletSharedPtr _tablet;
     RowsetSharedPtr _cur_rowset;
-    std::unique_ptr<RowsetWriter> _rowset_writer;
+    std::shared_ptr<RowsetWriter> _rowset_writer;
     // TODO: Recheck the lifetime of _mem_table, Look should use unique_ptr
     std::unique_ptr<MemTable> _mem_table;
     //const TabletSchema* _tablet_schema;

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -128,7 +128,7 @@ public:
 
     int64_t total_received_rows() const { return _total_received_rows; }
 
-    std::shared_ptr<RowsetWriter>& get_rowset_writer() {return _rowset_writer;}
+    std::shared_ptr<RowsetWriter>& get_rowset_writer() { return _rowset_writer; }
 
 private:
     DeltaWriter(WriteRequest* req, StorageEngine* storage_engine, RuntimeProfile* profile,

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -128,8 +128,6 @@ public:
 
     int64_t total_received_rows() const { return _total_received_rows; }
 
-    RowsetWriter* get_rowset_writer() { return _rowset_writer.get(); }
-
 private:
     DeltaWriter(WriteRequest* req, StorageEngine* storage_engine, RuntimeProfile* profile,
                 const UniqueId& load_id);

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -3308,7 +3308,8 @@ void Tablet::calc_compaction_output_rowset_delete_bitmap(
         const std::vector<RowsetSharedPtr>& input_rowsets, const RowIdConversion& rowid_conversion,
         uint64_t start_version, uint64_t end_version, std::set<RowLocation>* missed_rows,
         std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>>* location_map,
-        DeleteBitmap* output_rowset_delete_bitmap) {
+        DeleteBitmap* output_rowset_delete_bitmap,
+        const DeleteBitmap& commit_rowset_delete_bitmap) {
     RowLocation src;
     RowLocation dst;
     for (auto& rowset : input_rowsets) {
@@ -3319,6 +3320,9 @@ void Tablet::calc_compaction_output_rowset_delete_bitmap(
             _tablet_meta->delete_bitmap().subset({rowset->rowset_id(), seg_id, start_version},
                                                  {rowset->rowset_id(), seg_id, end_version},
                                                  &subset_map);
+            if (!commit_rowset_delete_bitmap.empty()) {
+                subset_map.merge(commit_rowset_delete_bitmap);
+            }
             // traverse all versions and convert rowid
             for (auto iter = subset_map.delete_bitmap.begin();
                  iter != subset_map.delete_bitmap.end(); ++iter) {

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -3319,9 +3319,6 @@ void Tablet::calc_compaction_output_rowset_delete_bitmap(
             _tablet_meta->delete_bitmap().subset({rowset->rowset_id(), seg_id, start_version},
                                                  {rowset->rowset_id(), seg_id, end_version},
                                                  &subset_map);
-            if (!commit_rowset_delete_bitmap.empty()) {
-                subset_map.merge(commit_rowset_delete_bitmap);
-            }
             // traverse all versions and convert rowid
             for (auto iter = subset_map.delete_bitmap.begin();
                  iter != subset_map.delete_bitmap.end(); ++iter) {

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -3240,6 +3240,13 @@ Status Tablet::commit_phase_update_delete_bitmap(
               << ", rowset_ids to del: " << rowset_ids_to_del.size()
               << ", cur max_version: " << cur_version << ", transaction_id: " << txn_id
               << ", cost: " << watch.get_elapse_time_us() << "(us), total rows: " << total_rows;
+
+    for (auto iter = delete_bitmap->delete_bitmap.begin();
+         iter != delete_bitmap->delete_bitmap.end(); ++iter) {
+        delete_bitmap->merge({std::get<0>(iter->first), std::get<1>(iter->first), cur_version},
+                             iter->second);
+        delete_bitmap->delete_bitmap.erase({std::get<0>(iter->first), std::get<1>(iter->first), 0});
+    }
     pre_rowset_ids = cur_rowset_ids;
     return Status::OK();
 }

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -3308,20 +3308,16 @@ void Tablet::calc_compaction_output_rowset_delete_bitmap(
         const std::vector<RowsetSharedPtr>& input_rowsets, const RowIdConversion& rowid_conversion,
         uint64_t start_version, uint64_t end_version, std::set<RowLocation>* missed_rows,
         std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>>* location_map,
-        const DeleteBitmapPtr commit_delete_bitmap, DeleteBitmap* output_rowset_delete_bitmap) {
+        const DeleteBitmap& input_delete_bitmap, DeleteBitmap* output_rowset_delete_bitmap) {
     RowLocation src;
     RowLocation dst;
-    DeleteBitmapPtr delete_bitmap;
     for (auto& rowset : input_rowsets) {
         src.rowset_id = rowset->rowset_id();
         for (uint32_t seg_id = 0; seg_id < rowset->num_segments(); ++seg_id) {
             src.segment_id = seg_id;
             DeleteBitmap subset_map(tablet_id());
-            delete_bitmap = commit_delete_bitmap->empty()
-                                    ? std::make_shared<DeleteBitmap>(_tablet_meta->delete_bitmap())
-                                    : commit_delete_bitmap;
-            delete_bitmap->subset({rowset->rowset_id(), seg_id, start_version},
-                                  {rowset->rowset_id(), seg_id, end_version}, &subset_map);
+            input_delete_bitmap.subset({rowset->rowset_id(), seg_id, start_version},
+                                       {rowset->rowset_id(), seg_id, end_version}, &subset_map);
             // traverse all versions and convert rowid
             for (auto iter = subset_map.delete_bitmap.begin();
                  iter != subset_map.delete_bitmap.end(); ++iter) {

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -3308,17 +3308,20 @@ void Tablet::calc_compaction_output_rowset_delete_bitmap(
         const std::vector<RowsetSharedPtr>& input_rowsets, const RowIdConversion& rowid_conversion,
         uint64_t start_version, uint64_t end_version, std::set<RowLocation>* missed_rows,
         std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>>* location_map,
-        DeleteBitmap* output_rowset_delete_bitmap) {
+        const DeleteBitmapPtr commit_delete_bitmap, DeleteBitmap* output_rowset_delete_bitmap) {
     RowLocation src;
     RowLocation dst;
+    DeleteBitmapPtr delete_bitmap;
     for (auto& rowset : input_rowsets) {
         src.rowset_id = rowset->rowset_id();
         for (uint32_t seg_id = 0; seg_id < rowset->num_segments(); ++seg_id) {
             src.segment_id = seg_id;
             DeleteBitmap subset_map(tablet_id());
-            _tablet_meta->delete_bitmap().subset({rowset->rowset_id(), seg_id, start_version},
-                                                 {rowset->rowset_id(), seg_id, end_version},
-                                                 &subset_map);
+            delete_bitmap = commit_delete_bitmap->empty()
+                                    ? std::make_shared<DeleteBitmap>(_tablet_meta->delete_bitmap())
+                                    : commit_delete_bitmap;
+            delete_bitmap->subset({rowset->rowset_id(), seg_id, start_version},
+                                  {rowset->rowset_id(), seg_id, end_version}, &subset_map);
             // traverse all versions and convert rowid
             for (auto iter = subset_map.delete_bitmap.begin();
                  iter != subset_map.delete_bitmap.end(); ++iter) {

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -3308,8 +3308,7 @@ void Tablet::calc_compaction_output_rowset_delete_bitmap(
         const std::vector<RowsetSharedPtr>& input_rowsets, const RowIdConversion& rowid_conversion,
         uint64_t start_version, uint64_t end_version, std::set<RowLocation>* missed_rows,
         std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>>* location_map,
-        DeleteBitmap* output_rowset_delete_bitmap,
-        const DeleteBitmap& commit_rowset_delete_bitmap) {
+        DeleteBitmap* output_rowset_delete_bitmap) {
     RowLocation src;
     RowLocation dst;
     for (auto& rowset : input_rowsets) {

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -3326,7 +3326,7 @@ void Tablet::calc_compaction_output_rowset_delete_bitmap(
 }
 
 void Tablet::convert_rowid(
-        const shared_ptr<Rowset>& rowset, const DeleteBitmap& subset_map, RowLocation& src,
+        const std::shared_ptr<Rowset>& rowset, const DeleteBitmap& subset_map, RowLocation& src,
         const RowIdConversion& rowid_conversion, const uint64_t& start_version,
         const uint64_t& end_version, std::set<RowLocation>* missed_rows,
         std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>>* location_map,

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -3310,6 +3310,7 @@ void Tablet::calc_compaction_output_rowset_delete_bitmap(
         std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>>* location_map,
         DeleteBitmap* output_rowset_delete_bitmap) {
     RowLocation src;
+    RowLocation dst;
     for (auto& rowset : input_rowsets) {
         src.rowset_id = rowset->rowset_id();
         for (uint32_t seg_id = 0; seg_id < rowset->num_segments(); ++seg_id) {
@@ -3319,306 +3320,299 @@ void Tablet::calc_compaction_output_rowset_delete_bitmap(
                                                  {rowset->rowset_id(), seg_id, end_version},
                                                  &subset_map);
             // traverse all versions and convert rowid
-            convert_rowid(rowset, subset_map, src, rowid_conversion, start_version, end_version,
-                          missed_rows, location_map, output_rowset_delete_bitmap);
-        }
-    }
-}
-
-void Tablet::convert_rowid(
-        const std::shared_ptr<Rowset>& rowset, const DeleteBitmap& subset_map, RowLocation& src,
-        const RowIdConversion& rowid_conversion, const uint64_t& start_version,
-        const uint64_t& end_version, std::set<RowLocation>* missed_rows,
-        std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>>* location_map,
-        DeleteBitmap* output_rowset_delete_bitmap) {
-    RowLocation dst;
-    for (auto iter = subset_map.delete_bitmap.begin(); iter != subset_map.delete_bitmap.end();
-         ++iter) {
-        auto cur_version = std::get<2>(iter->first);
-        for (auto index = iter->second.begin(); index != iter->second.end(); ++index) {
-            src.row_id = *index;
-            if (rowid_conversion.get(src, &dst) != 0) {
-                VLOG_CRITICAL << "Can't find rowid, may be deleted by the delete_handler, "
-                              << " src loaction: |" << src.rowset_id << "|" << src.segment_id << "|"
-                              << src.row_id << " version: " << cur_version;
-                missed_rows->insert(src);
-                continue;
+            for (auto iter = subset_map.delete_bitmap.begin();
+                 iter != subset_map.delete_bitmap.end(); ++iter) {
+                auto cur_version = std::get<2>(iter->first);
+                for (auto index = iter->second.begin(); index != iter->second.end(); ++index) {
+                    src.row_id = *index;
+                    if (rowid_conversion.get(src, &dst) != 0) {
+                        VLOG_CRITICAL << "Can't find rowid, may be deleted by the delete_handler, "
+                                      << " src loaction: |" << src.rowset_id << "|"
+                                      << src.segment_id << "|" << src.row_id
+                                      << " version: " << cur_version;
+                        missed_rows->insert(src);
+                        continue;
+                    }
+                    VLOG_DEBUG << "calc_compaction_output_rowset_delete_bitmap dst location: |"
+                               << dst.rowset_id << "|" << dst.segment_id << "|" << dst.row_id
+                               << " src location: |" << src.rowset_id << "|" << src.segment_id
+                               << "|" << src.row_id << " start version: " << start_version
+                               << "end version" << end_version;
+                    (*location_map)[rowset].emplace_back(src, dst);
+                    output_rowset_delete_bitmap->add({dst.rowset_id, dst.segment_id, cur_version},
+                                                     dst.row_id);
+                }
             }
-            VLOG_DEBUG << "calc_compaction_output_rowset_delete_bitmap dst location: |"
-                       << dst.rowset_id << "|" << dst.segment_id << "|" << dst.row_id
-                       << " src location: |" << src.rowset_id << "|" << src.segment_id << "|"
-                       << src.row_id << " start version: " << start_version << "end version"
-                       << end_version;
-            (*location_map)[rowset].emplace_back(src, dst);
-            output_rowset_delete_bitmap->add({dst.rowset_id, dst.segment_id, cur_version},
-                                             dst.row_id);
         }
     }
-}
 
-void Tablet::merge_delete_bitmap(const DeleteBitmap& delete_bitmap) {
-    _tablet_meta->delete_bitmap().merge(delete_bitmap);
-}
+    void Tablet::merge_delete_bitmap(const DeleteBitmap& delete_bitmap) {
+        _tablet_meta->delete_bitmap().merge(delete_bitmap);
+    }
 
-Status Tablet::check_rowid_conversion(
-        RowsetSharedPtr dst_rowset,
-        const std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>>&
-                location_map) {
-    if (location_map.empty()) {
-        VLOG_DEBUG << "check_rowid_conversion, location_map is empty";
+    Status Tablet::check_rowid_conversion(
+            RowsetSharedPtr dst_rowset,
+            const std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>>&
+                    location_map) {
+        if (location_map.empty()) {
+            VLOG_DEBUG << "check_rowid_conversion, location_map is empty";
+            return Status::OK();
+        }
+        std::vector<segment_v2::SegmentSharedPtr> dst_segments;
+        _load_rowset_segments(dst_rowset, &dst_segments);
+        std::unordered_map<RowsetId, std::vector<segment_v2::SegmentSharedPtr>, HashOfRowsetId>
+                input_rowsets_segment;
+
+        VLOG_DEBUG << "check_rowid_conversion, dst_segments size: " << dst_segments.size();
+        for (auto [src_rowset, locations] : location_map) {
+            std::vector<segment_v2::SegmentSharedPtr>& segments =
+                    input_rowsets_segment[src_rowset->rowset_id()];
+            if (segments.empty()) {
+                _load_rowset_segments(src_rowset, &segments);
+            }
+            for (auto& [src, dst] : locations) {
+                std::string src_key;
+                std::string dst_key;
+                Status s = segments[src.segment_id]->read_key_by_rowid(src.row_id, &src_key);
+                if (UNLIKELY(s.is<NOT_IMPLEMENTED_ERROR>())) {
+                    LOG(INFO) << "primary key index of old version does not "
+                                 "support reading key by rowid";
+                    break;
+                }
+                if (UNLIKELY(!s)) {
+                    LOG(WARNING) << "failed to get src key: |" << src.rowset_id << "|"
+                                 << src.segment_id << "|" << src.row_id << " status: " << s;
+                    DCHECK(false);
+                    return s;
+                }
+
+                s = dst_segments[dst.segment_id]->read_key_by_rowid(dst.row_id, &dst_key);
+                if (UNLIKELY(!s)) {
+                    LOG(WARNING) << "failed to get dst key: |" << dst.rowset_id << "|"
+                                 << dst.segment_id << "|" << dst.row_id << " status: " << s;
+                    DCHECK(false);
+                    return s;
+                }
+
+                VLOG_DEBUG << "check_rowid_conversion, src: |" << src.rowset_id << "|"
+                           << src.segment_id << "|" << src.row_id << "|" << src_key << " dst: |"
+                           << dst.rowset_id << "|" << dst.segment_id << "|" << dst.row_id << "|"
+                           << dst_key;
+                if (UNLIKELY(src_key.compare(dst_key) != 0)) {
+                    LOG(WARNING) << "failed to check key, src key: |" << src.rowset_id << "|"
+                                 << src.segment_id << "|" << src.row_id << "|" << src_key
+                                 << " dst key: |" << dst.rowset_id << "|" << dst.segment_id << "|"
+                                 << dst.row_id << "|" << dst_key;
+                    DCHECK(false);
+                    return Status::InternalError("failed to check rowid conversion");
+                }
+            }
+        }
         return Status::OK();
     }
-    std::vector<segment_v2::SegmentSharedPtr> dst_segments;
-    _load_rowset_segments(dst_rowset, &dst_segments);
-    std::unordered_map<RowsetId, std::vector<segment_v2::SegmentSharedPtr>, HashOfRowsetId>
-            input_rowsets_segment;
 
-    VLOG_DEBUG << "check_rowid_conversion, dst_segments size: " << dst_segments.size();
-    for (auto [src_rowset, locations] : location_map) {
-        std::vector<segment_v2::SegmentSharedPtr>& segments =
-                input_rowsets_segment[src_rowset->rowset_id()];
-        if (segments.empty()) {
-            _load_rowset_segments(src_rowset, &segments);
-        }
-        for (auto& [src, dst] : locations) {
-            std::string src_key;
-            std::string dst_key;
-            Status s = segments[src.segment_id]->read_key_by_rowid(src.row_id, &src_key);
-            if (UNLIKELY(s.is<NOT_IMPLEMENTED_ERROR>())) {
-                LOG(INFO) << "primary key index of old version does not "
-                             "support reading key by rowid";
-                break;
+    RowsetIdUnorderedSet Tablet::all_rs_id(int64_t max_version) const {
+        RowsetIdUnorderedSet rowset_ids;
+        for (const auto& rs_it : _rs_version_map) {
+            if (rs_it.first.second == 1) {
+                // [0-1] rowset is empty for each tablet, skip it
+                continue;
             }
-            if (UNLIKELY(!s)) {
-                LOG(WARNING) << "failed to get src key: |" << src.rowset_id << "|" << src.segment_id
-                             << "|" << src.row_id << " status: " << s;
-                DCHECK(false);
-                return s;
-            }
-
-            s = dst_segments[dst.segment_id]->read_key_by_rowid(dst.row_id, &dst_key);
-            if (UNLIKELY(!s)) {
-                LOG(WARNING) << "failed to get dst key: |" << dst.rowset_id << "|" << dst.segment_id
-                             << "|" << dst.row_id << " status: " << s;
-                DCHECK(false);
-                return s;
-            }
-
-            VLOG_DEBUG << "check_rowid_conversion, src: |" << src.rowset_id << "|" << src.segment_id
-                       << "|" << src.row_id << "|" << src_key << " dst: |" << dst.rowset_id << "|"
-                       << dst.segment_id << "|" << dst.row_id << "|" << dst_key;
-            if (UNLIKELY(src_key.compare(dst_key) != 0)) {
-                LOG(WARNING) << "failed to check key, src key: |" << src.rowset_id << "|"
-                             << src.segment_id << "|" << src.row_id << "|" << src_key
-                             << " dst key: |" << dst.rowset_id << "|" << dst.segment_id << "|"
-                             << dst.row_id << "|" << dst_key;
-                DCHECK(false);
-                return Status::InternalError("failed to check rowid conversion");
+            if (rs_it.first.second <= max_version) {
+                rowset_ids.insert(rs_it.second->rowset_id());
             }
         }
+        return rowset_ids;
     }
-    return Status::OK();
-}
 
-RowsetIdUnorderedSet Tablet::all_rs_id(int64_t max_version) const {
-    RowsetIdUnorderedSet rowset_ids;
-    for (const auto& rs_it : _rs_version_map) {
-        if (rs_it.first.second == 1) {
-            // [0-1] rowset is empty for each tablet, skip it
-            continue;
-        }
-        if (rs_it.first.second <= max_version) {
-            rowset_ids.insert(rs_it.second->rowset_id());
-        }
-    }
-    return rowset_ids;
-}
-
-bool Tablet::check_all_rowset_segment() {
-    for (auto& version_rowset : _rs_version_map) {
-        RowsetSharedPtr rowset = version_rowset.second;
-        if (!rowset->check_rowset_segment()) {
-            LOG(WARNING) << "Tablet Segment Check. find a bad tablet, tablet_id=" << tablet_id();
-            return false;
-        }
-    }
-    return true;
-}
-
-void Tablet::set_skip_compaction(bool skip, CompactionType compaction_type, int64_t start) {
-    if (!skip) {
-        _skip_cumu_compaction = false;
-        _skip_base_compaction = false;
-        return;
-    }
-    if (compaction_type == CompactionType::CUMULATIVE_COMPACTION) {
-        _skip_cumu_compaction = true;
-        _skip_cumu_compaction_ts = start;
-    } else {
-        DCHECK(compaction_type == CompactionType::BASE_COMPACTION);
-        _skip_base_compaction = true;
-        _skip_base_compaction_ts = start;
-    }
-}
-
-bool Tablet::should_skip_compaction(CompactionType compaction_type, int64_t now) {
-    if (compaction_type == CompactionType::CUMULATIVE_COMPACTION && _skip_cumu_compaction &&
-        now < _skip_cumu_compaction_ts + 120) {
-        return true;
-    } else if (compaction_type == CompactionType::BASE_COMPACTION && _skip_base_compaction &&
-               now < _skip_base_compaction_ts + 120) {
-        return true;
-    }
-    return false;
-}
-
-std::pair<std::string, int64_t> Tablet::get_binlog_info(std::string_view binlog_version) const {
-    return RowsetMetaManager::get_binlog_info(_data_dir->get_meta(), tablet_uid(), binlog_version);
-}
-
-std::string Tablet::get_binlog_rowset_meta(std::string_view binlog_version,
-                                           std::string_view rowset_id) const {
-    return RowsetMetaManager::get_binlog_rowset_meta(_data_dir->get_meta(), tablet_uid(),
-                                                     binlog_version, rowset_id);
-}
-
-std::string Tablet::get_segment_filepath(std::string_view rowset_id,
-                                         std::string_view segment_index) const {
-    return fmt::format("{}/_binlog/{}_{}.dat", _tablet_path, rowset_id, segment_index);
-}
-
-std::vector<std::string> Tablet::get_binlog_filepath(std::string_view binlog_version) const {
-    const auto& [rowset_id, num_segments] = get_binlog_info(binlog_version);
-    std::vector<std::string> binlog_filepath;
-    for (int i = 0; i < num_segments; ++i) {
-        // TODO(Drogon): rewrite by filesystem path
-        auto segment_file = fmt::format("{}_{}.dat", rowset_id, i);
-        binlog_filepath.emplace_back(fmt::format("{}/_binlog/{}", _tablet_path, segment_file));
-    }
-    return binlog_filepath;
-}
-
-bool Tablet::can_add_binlog(uint64_t total_binlog_size) const {
-    return !_data_dir->reach_capacity_limit(total_binlog_size);
-}
-
-bool Tablet::is_enable_binlog() {
-    return config::enable_feature_binlog && tablet_meta()->binlog_config().is_enable();
-}
-
-void Tablet::set_binlog_config(BinlogConfig binlog_config) {
-    tablet_meta()->set_binlog_config(std::move(binlog_config));
-}
-
-void Tablet::gc_binlogs(int64_t version) {
-    auto meta = _data_dir->get_meta();
-    DCHECK(meta != nullptr);
-
-    const auto& tablet_uid = this->tablet_uid();
-    const auto tablet_id = this->tablet_id();
-    const auto& tablet_path = this->tablet_path();
-    std::string begin_key = make_binlog_meta_key_prefix(tablet_uid);
-    std::string end_key = make_binlog_meta_key_prefix(tablet_uid, version + 1);
-    LOG(INFO) << fmt::format("gc binlog meta, tablet_id:{}, begin_key:{}, end_key:{}", tablet_id,
-                             begin_key, end_key);
-
-    std::vector<std::string> wait_for_deleted_binlog_keys;
-    std::vector<std::string> wait_for_deleted_binlog_files;
-    auto add_to_wait_for_deleted = [&](std::string_view key, std::string_view rowset_id,
-                                       int64_t num_segments) {
-        // add binlog meta key and binlog data key
-        wait_for_deleted_binlog_keys.emplace_back(key);
-        wait_for_deleted_binlog_keys.push_back(get_binlog_data_key_from_meta_key(key));
-
-        for (int64_t i = 0; i < num_segments; ++i) {
-            auto segment_file = fmt::format("{}_{}.dat", rowset_id, i);
-            wait_for_deleted_binlog_files.emplace_back(
-                    fmt::format("{}/_binlog/{}", tablet_path, segment_file));
-        }
-    };
-
-    auto check_binlog_ttl = [&](const std::string& key, const std::string& value) mutable -> bool {
-        if (key >= end_key) {
-            return false;
-        }
-
-        BinlogMetaEntryPB binlog_meta_entry_pb;
-        if (!binlog_meta_entry_pb.ParseFromString(value)) {
-            LOG(WARNING) << "failed to parse binlog meta entry, key:" << key;
-            return true;
-        }
-
-        auto num_segments = binlog_meta_entry_pb.num_segments();
-        std::string rowset_id;
-        if (binlog_meta_entry_pb.has_rowset_id_v2()) {
-            rowset_id = binlog_meta_entry_pb.rowset_id_v2();
-        } else {
-            // key is 'binglog_meta_6943f1585fe834b5-e542c2b83a21d0b7_00000000000000000069_020000000000000135449d7cd7eadfe672aa0f928fa99593', extract last part '020000000000000135449d7cd7eadfe672aa0f928fa99593'
-            auto pos = key.rfind("_");
-            if (pos == std::string::npos) {
-                LOG(WARNING) << fmt::format("invalid binlog meta key:{}", key);
+    bool Tablet::check_all_rowset_segment() {
+        for (auto& version_rowset : _rs_version_map) {
+            RowsetSharedPtr rowset = version_rowset.second;
+            if (!rowset->check_rowset_segment()) {
+                LOG(WARNING) << "Tablet Segment Check. find a bad tablet, tablet_id="
+                             << tablet_id();
                 return false;
             }
-            rowset_id = key.substr(pos + 1);
         }
-        add_to_wait_for_deleted(key, rowset_id, num_segments);
-
         return true;
-    };
-
-    auto status = meta->iterate(META_COLUMN_FAMILY_INDEX, begin_key, check_binlog_ttl);
-    if (!status.ok()) {
-        LOG(WARNING) << "failed to iterate binlog meta, status:" << status;
-        return;
     }
 
-    // first remove binlog files, if failed, just break, then retry next time
-    // this keep binlog meta in meta store, so that binlog can be removed next time
-    bool remove_binlog_files_failed = false;
-    for (auto& file : wait_for_deleted_binlog_files) {
-        if (unlink(file.c_str()) != 0) {
-            // file not exist, continue
-            if (errno == ENOENT) {
-                continue;
+    void Tablet::set_skip_compaction(bool skip, CompactionType compaction_type, int64_t start) {
+        if (!skip) {
+            _skip_cumu_compaction = false;
+            _skip_base_compaction = false;
+            return;
+        }
+        if (compaction_type == CompactionType::CUMULATIVE_COMPACTION) {
+            _skip_cumu_compaction = true;
+            _skip_cumu_compaction_ts = start;
+        } else {
+            DCHECK(compaction_type == CompactionType::BASE_COMPACTION);
+            _skip_base_compaction = true;
+            _skip_base_compaction_ts = start;
+        }
+    }
+
+    bool Tablet::should_skip_compaction(CompactionType compaction_type, int64_t now) {
+        if (compaction_type == CompactionType::CUMULATIVE_COMPACTION && _skip_cumu_compaction &&
+            now < _skip_cumu_compaction_ts + 120) {
+            return true;
+        } else if (compaction_type == CompactionType::BASE_COMPACTION && _skip_base_compaction &&
+                   now < _skip_base_compaction_ts + 120) {
+            return true;
+        }
+        return false;
+    }
+
+    std::pair<std::string, int64_t> Tablet::get_binlog_info(std::string_view binlog_version) const {
+        return RowsetMetaManager::get_binlog_info(_data_dir->get_meta(), tablet_uid(),
+                                                  binlog_version);
+    }
+
+    std::string Tablet::get_binlog_rowset_meta(std::string_view binlog_version,
+                                               std::string_view rowset_id) const {
+        return RowsetMetaManager::get_binlog_rowset_meta(_data_dir->get_meta(), tablet_uid(),
+                                                         binlog_version, rowset_id);
+    }
+
+    std::string Tablet::get_segment_filepath(std::string_view rowset_id,
+                                             std::string_view segment_index) const {
+        return fmt::format("{}/_binlog/{}_{}.dat", _tablet_path, rowset_id, segment_index);
+    }
+
+    std::vector<std::string> Tablet::get_binlog_filepath(std::string_view binlog_version) const {
+        const auto& [rowset_id, num_segments] = get_binlog_info(binlog_version);
+        std::vector<std::string> binlog_filepath;
+        for (int i = 0; i < num_segments; ++i) {
+            // TODO(Drogon): rewrite by filesystem path
+            auto segment_file = fmt::format("{}_{}.dat", rowset_id, i);
+            binlog_filepath.emplace_back(fmt::format("{}/_binlog/{}", _tablet_path, segment_file));
+        }
+        return binlog_filepath;
+    }
+
+    bool Tablet::can_add_binlog(uint64_t total_binlog_size) const {
+        return !_data_dir->reach_capacity_limit(total_binlog_size);
+    }
+
+    bool Tablet::is_enable_binlog() {
+        return config::enable_feature_binlog && tablet_meta()->binlog_config().is_enable();
+    }
+
+    void Tablet::set_binlog_config(BinlogConfig binlog_config) {
+        tablet_meta()->set_binlog_config(std::move(binlog_config));
+    }
+
+    void Tablet::gc_binlogs(int64_t version) {
+        auto meta = _data_dir->get_meta();
+        DCHECK(meta != nullptr);
+
+        const auto& tablet_uid = this->tablet_uid();
+        const auto tablet_id = this->tablet_id();
+        const auto& tablet_path = this->tablet_path();
+        std::string begin_key = make_binlog_meta_key_prefix(tablet_uid);
+        std::string end_key = make_binlog_meta_key_prefix(tablet_uid, version + 1);
+        LOG(INFO) << fmt::format("gc binlog meta, tablet_id:{}, begin_key:{}, end_key:{}",
+                                 tablet_id, begin_key, end_key);
+
+        std::vector<std::string> wait_for_deleted_binlog_keys;
+        std::vector<std::string> wait_for_deleted_binlog_files;
+        auto add_to_wait_for_deleted = [&](std::string_view key, std::string_view rowset_id,
+                                           int64_t num_segments) {
+            // add binlog meta key and binlog data key
+            wait_for_deleted_binlog_keys.emplace_back(key);
+            wait_for_deleted_binlog_keys.push_back(get_binlog_data_key_from_meta_key(key));
+
+            for (int64_t i = 0; i < num_segments; ++i) {
+                auto segment_file = fmt::format("{}_{}.dat", rowset_id, i);
+                wait_for_deleted_binlog_files.emplace_back(
+                        fmt::format("{}/_binlog/{}", tablet_path, segment_file));
+            }
+        };
+
+        auto check_binlog_ttl = [&](const std::string& key,
+                                    const std::string& value) mutable -> bool {
+            if (key >= end_key) {
+                return false;
             }
 
-            remove_binlog_files_failed = true;
-            LOG(WARNING) << "failed to remove binlog file:" << file << ", errno:" << errno;
-            break;
+            BinlogMetaEntryPB binlog_meta_entry_pb;
+            if (!binlog_meta_entry_pb.ParseFromString(value)) {
+                LOG(WARNING) << "failed to parse binlog meta entry, key:" << key;
+                return true;
+            }
+
+            auto num_segments = binlog_meta_entry_pb.num_segments();
+            std::string rowset_id;
+            if (binlog_meta_entry_pb.has_rowset_id_v2()) {
+                rowset_id = binlog_meta_entry_pb.rowset_id_v2();
+            } else {
+                // key is 'binglog_meta_6943f1585fe834b5-e542c2b83a21d0b7_00000000000000000069_020000000000000135449d7cd7eadfe672aa0f928fa99593', extract last part '020000000000000135449d7cd7eadfe672aa0f928fa99593'
+                auto pos = key.rfind("_");
+                if (pos == std::string::npos) {
+                    LOG(WARNING) << fmt::format("invalid binlog meta key:{}", key);
+                    return false;
+                }
+                rowset_id = key.substr(pos + 1);
+            }
+            add_to_wait_for_deleted(key, rowset_id, num_segments);
+
+            return true;
+        };
+
+        auto status = meta->iterate(META_COLUMN_FAMILY_INDEX, begin_key, check_binlog_ttl);
+        if (!status.ok()) {
+            LOG(WARNING) << "failed to iterate binlog meta, status:" << status;
+            return;
+        }
+
+        // first remove binlog files, if failed, just break, then retry next time
+        // this keep binlog meta in meta store, so that binlog can be removed next time
+        bool remove_binlog_files_failed = false;
+        for (auto& file : wait_for_deleted_binlog_files) {
+            if (unlink(file.c_str()) != 0) {
+                // file not exist, continue
+                if (errno == ENOENT) {
+                    continue;
+                }
+
+                remove_binlog_files_failed = true;
+                LOG(WARNING) << "failed to remove binlog file:" << file << ", errno:" << errno;
+                break;
+            }
+        }
+        if (!remove_binlog_files_failed) {
+            meta->remove(META_COLUMN_FAMILY_INDEX, wait_for_deleted_binlog_keys);
         }
     }
-    if (!remove_binlog_files_failed) {
-        meta->remove(META_COLUMN_FAMILY_INDEX, wait_for_deleted_binlog_keys);
-    }
-}
 
-Status Tablet::calc_delete_bitmap_between_segments(
-        RowsetSharedPtr rowset, const std::vector<segment_v2::SegmentSharedPtr>& segments,
-        DeleteBitmapPtr delete_bitmap) {
-    size_t const num_segments = segments.size();
-    if (num_segments < 2) {
+    Status Tablet::calc_delete_bitmap_between_segments(
+            RowsetSharedPtr rowset, const std::vector<segment_v2::SegmentSharedPtr>& segments,
+            DeleteBitmapPtr delete_bitmap) {
+        size_t const num_segments = segments.size();
+        if (num_segments < 2) {
+            return Status::OK();
+        }
+
+        OlapStopWatch watch;
+        auto const rowset_id = rowset->rowset_id();
+        size_t seq_col_length = 0;
+        if (_schema->has_sequence_col()) {
+            auto seq_col_idx = _schema->sequence_col_idx();
+            seq_col_length = _schema->column(seq_col_idx).length();
+        }
+
+        MergeIndexDeleteBitmapCalculator calculator;
+        RETURN_IF_ERROR(calculator.init(rowset_id, segments, seq_col_length));
+
+        RETURN_IF_ERROR(calculator.calculate_all(delete_bitmap));
+
+        LOG(INFO) << fmt::format(
+                "construct delete bitmap between segments, "
+                "tablet: {}, rowset: {}, number of segments: {}, bitmap size: {}, cost {} (us)",
+                tablet_id(), rowset_id.to_string(), num_segments,
+                delete_bitmap->delete_bitmap.size(), watch.get_elapse_time_us());
         return Status::OK();
     }
-
-    OlapStopWatch watch;
-    auto const rowset_id = rowset->rowset_id();
-    size_t seq_col_length = 0;
-    if (_schema->has_sequence_col()) {
-        auto seq_col_idx = _schema->sequence_col_idx();
-        seq_col_length = _schema->column(seq_col_idx).length();
-    }
-
-    MergeIndexDeleteBitmapCalculator calculator;
-    RETURN_IF_ERROR(calculator.init(rowset_id, segments, seq_col_length));
-
-    RETURN_IF_ERROR(calculator.calculate_all(delete_bitmap));
-
-    LOG(INFO) << fmt::format(
-            "construct delete bitmap between segments, "
-            "tablet: {}, rowset: {}, number of segments: {}, bitmap size: {}, cost {} (us)",
-            tablet_id(), rowset_id.to_string(), num_segments, delete_bitmap->delete_bitmap.size(),
-            watch.get_elapse_time_us());
-    return Status::OK();
-}
 
 } // namespace doris

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -3240,13 +3240,6 @@ Status Tablet::commit_phase_update_delete_bitmap(
               << ", rowset_ids to del: " << rowset_ids_to_del.size()
               << ", cur max_version: " << cur_version << ", transaction_id: " << txn_id
               << ", cost: " << watch.get_elapse_time_us() << "(us), total rows: " << total_rows;
-
-    for (auto iter = delete_bitmap->delete_bitmap.begin();
-         iter != delete_bitmap->delete_bitmap.end(); ++iter) {
-        delete_bitmap->merge({std::get<0>(iter->first), std::get<1>(iter->first), cur_version},
-                             iter->second);
-        delete_bitmap->delete_bitmap.erase({std::get<0>(iter->first), std::get<1>(iter->first), 0});
-    }
     pre_rowset_ids = cur_rowset_ids;
     return Status::OK();
 }

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -477,7 +477,8 @@ public:
             const RowIdConversion& rowid_conversion, uint64_t start_version, uint64_t end_version,
             std::set<RowLocation>* missed_rows,
             std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>>* location_map,
-            DeleteBitmap* output_rowset_delete_bitmap);
+            DeleteBitmap* output_rowset_delete_bitmap,
+            const DeleteBitmap& commit_rowset_delete_bitmap);
     void merge_delete_bitmap(const DeleteBitmap& delete_bitmap);
     Status check_rowid_conversion(
             RowsetSharedPtr dst_rowset,

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -478,12 +478,6 @@ public:
             std::set<RowLocation>* missed_rows,
             std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>>* location_map,
             DeleteBitmap* output_rowset_delete_bitmap);
-    void convert_rowid(
-            const std::shared_ptr<Rowset>& rowset, const DeleteBitmap& subset_map, RowLocation& src,
-            const RowIdConversion& rowid_conversion, const uint64_t& start_version,
-            const uint64_t& end_version, std::set<RowLocation>* missed_rows,
-            std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>>* location_map,
-            DeleteBitmap* output_rowset_delete_bitmap);
     void merge_delete_bitmap(const DeleteBitmap& delete_bitmap);
     Status check_rowid_conversion(
             RowsetSharedPtr dst_rowset,

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -478,6 +478,12 @@ public:
             std::set<RowLocation>* missed_rows,
             std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>>* location_map,
             DeleteBitmap* output_rowset_delete_bitmap);
+    void convert_rowid(
+            const shared_ptr<Rowset>& rowset, const DeleteBitmap& subset_map, RowLocation& src,
+            const RowIdConversion& rowid_conversion, const uint64_t& start_version,
+            const uint64_t& end_version, std::set<RowLocation>* missed_rows,
+            std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>>* location_map,
+            DeleteBitmap* output_rowset_delete_bitmap);
     void merge_delete_bitmap(const DeleteBitmap& delete_bitmap);
     Status check_rowid_conversion(
             RowsetSharedPtr dst_rowset,

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -477,7 +477,7 @@ public:
             const RowIdConversion& rowid_conversion, uint64_t start_version, uint64_t end_version,
             std::set<RowLocation>* missed_rows,
             std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>>* location_map,
-            DeleteBitmapPtr commit_delete_bitmap, DeleteBitmap* output_rowset_delete_bitmap);
+            const DeleteBitmap& input_delete_bitmap, DeleteBitmap* output_rowset_delete_bitmap);
     void merge_delete_bitmap(const DeleteBitmap& delete_bitmap);
     Status check_rowid_conversion(
             RowsetSharedPtr dst_rowset,

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -477,7 +477,7 @@ public:
             const RowIdConversion& rowid_conversion, uint64_t start_version, uint64_t end_version,
             std::set<RowLocation>* missed_rows,
             std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>>* location_map,
-            DeleteBitmap* output_rowset_delete_bitmap);
+            DeleteBitmapPtr commit_delete_bitmap, DeleteBitmap* output_rowset_delete_bitmap);
     void merge_delete_bitmap(const DeleteBitmap& delete_bitmap);
     Status check_rowid_conversion(
             RowsetSharedPtr dst_rowset,

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -479,7 +479,7 @@ public:
             std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>>* location_map,
             DeleteBitmap* output_rowset_delete_bitmap);
     void convert_rowid(
-            const shared_ptr<Rowset>& rowset, const DeleteBitmap& subset_map, RowLocation& src,
+            const std::shared_ptr<Rowset>& rowset, const DeleteBitmap& subset_map, RowLocation& src,
             const RowIdConversion& rowid_conversion, const uint64_t& start_version,
             const uint64_t& end_version, std::set<RowLocation>* missed_rows,
             std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>>* location_map,

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -477,8 +477,7 @@ public:
             const RowIdConversion& rowid_conversion, uint64_t start_version, uint64_t end_version,
             std::set<RowLocation>* missed_rows,
             std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>>* location_map,
-            DeleteBitmap* output_rowset_delete_bitmap,
-            const DeleteBitmap& commit_rowset_delete_bitmap);
+            DeleteBitmap* output_rowset_delete_bitmap);
     void merge_delete_bitmap(const DeleteBitmap& delete_bitmap);
     Status check_rowid_conversion(
             RowsetSharedPtr dst_rowset,

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -941,6 +941,11 @@ bool DeleteBitmap::contains_agg(const BitmapKey& bmk, uint32_t row_id) const {
     return get_agg(bmk)->contains(row_id);
 }
 
+bool DeleteBitmap::empty() const {
+    std::shared_lock l(lock);
+    return delete_bitmap.empty();
+}
+
 bool DeleteBitmap::contains_agg_without_cache(const BitmapKey& bmk, uint32_t row_id) const {
     std::shared_lock l(lock);
     DeleteBitmap::BitmapKey start {std::get<0>(bmk), std::get<1>(bmk), 0};

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -931,11 +931,6 @@ void DeleteBitmap::remove(const BitmapKey& start, const BitmapKey& end) {
     }
 }
 
-bool DeleteBitmap::empty() const {
-    std::shared_lock l(lock);
-    return delete_bitmap.empty();
-}
-
 bool DeleteBitmap::contains(const BitmapKey& bmk, uint32_t row_id) const {
     std::shared_lock l(lock);
     auto it = delete_bitmap.find(bmk);

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -931,6 +931,11 @@ void DeleteBitmap::remove(const BitmapKey& start, const BitmapKey& end) {
     }
 }
 
+bool DeleteBitmap::empty() const {
+    std::shared_lock l(lock);
+    return delete_bitmap.empty();
+}
+
 bool DeleteBitmap::contains(const BitmapKey& bmk, uint32_t row_id) const {
     std::shared_lock l(lock);
     auto it = delete_bitmap.find(bmk);

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -988,7 +988,7 @@ void DeleteBitmap::subset(const BitmapKey& start, const BitmapKey& end,
     roaring::Roaring roaring;
     DCHECK(start < end);
     std::shared_lock l(lock);
-    for (auto it = delete_bitmap.upper_bound(start); it != delete_bitmap.end(); ++it) {
+    for (auto it = delete_bitmap.lower_bound(start); it != delete_bitmap.end(); ++it) {
         auto& [k, bm] = *it;
         if (k >= end) {
             break;

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -357,6 +357,13 @@ public:
     bool contains(const BitmapKey& bmk, uint32_t row_id) const;
 
     /**
+     * Checks if this delete bitmap is empty
+     *
+     * @return true if empty
+     */
+    bool empty() const;
+
+    /**
      * Sets the bitmap of specific segment, it's may be insertion or replacement
      *
      * @return 1 if the insertion took place, 0 if the assignment took place

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -350,11 +350,6 @@ public:
     void remove(const BitmapKey& lower_key, const BitmapKey& upper_key);
 
     /**
-     * checks if delete bimap is empty
-     */
-    bool empty() const;
-
-    /**
      * Checks if the given row is marked deleted
      *
      * @return true if marked deleted

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -350,6 +350,11 @@ public:
     void remove(const BitmapKey& lower_key, const BitmapKey& upper_key);
 
     /**
+     * checks if delete bimap is empty
+     */
+    bool empty() const;
+
+    /**
      * Checks if the given row is marked deleted
      *
      * @return true if marked deleted

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -724,6 +724,20 @@ void TxnManager::add_txn_tablet_delta_writer(int64_t transaction_id, int64_t tab
     txn_tablet_delta_writer_map[transaction_id][tablet_id] = delta_writer;
 }
 
+    DeltaWriter* TxnManager::get_txn_tablet_delta_writer(int64_t transaction_id, int64_t tablet_id) {
+        std::lock_guard<std::shared_mutex> txn_wrlock(
+                _get_txn_tablet_delta_writer_map_lock(transaction_id));
+        txn_tablet_delta_writer_map_t& txn_tablet_delta_writer_map =
+                _get_txn_tablet_delta_writer_map(transaction_id);
+        auto find = txn_tablet_delta_writer_map.find(transaction_id);
+        if (find != txn_tablet_delta_writer_map.end()) {
+            auto it = find->second.find(tablet_id);
+            if(it !=find->second.end()){
+                return it->second;
+            }
+        }
+    }
+
 void TxnManager::finish_slave_tablet_pull_rowset(int64_t transaction_id, int64_t tablet_id,
                                                  int64_t node_id, bool is_succeed) {
     std::lock_guard<std::shared_mutex> txn_wrlock(

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -724,21 +724,6 @@ void TxnManager::add_txn_tablet_delta_writer(int64_t transaction_id, int64_t tab
     txn_tablet_delta_writer_map[transaction_id][tablet_id] = delta_writer;
 }
 
-DeltaWriter* TxnManager::get_txn_tablet_delta_writer(int64_t transaction_id, int64_t tablet_id) {
-    std::lock_guard<std::shared_mutex> txn_wrlock(
-            _get_txn_tablet_delta_writer_map_lock(transaction_id));
-    txn_tablet_delta_writer_map_t& txn_tablet_delta_writer_map =
-            _get_txn_tablet_delta_writer_map(transaction_id);
-    auto find = txn_tablet_delta_writer_map.find(transaction_id);
-    if (find != txn_tablet_delta_writer_map.end()) {
-        auto it = find->second.find(tablet_id);
-        if (it != find->second.end()) {
-            return it->second;
-        }
-    }
-    return nullptr;
-}
-
 void TxnManager::finish_slave_tablet_pull_rowset(int64_t transaction_id, int64_t tablet_id,
                                                  int64_t node_id, bool is_succeed) {
     std::lock_guard<std::shared_mutex> txn_wrlock(

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -632,14 +632,14 @@ void TxnManager::get_all_related_tablets(std::set<TabletInfo>* tablet_infos) {
     }
 }
 
-void TxnManager::get_all_tablet_txn_infos_by_tablet(const TabletSharedPtr tablet,
-                                                    std::map<TabletInfo,TabletTxnInfo>& tablet_info_map) {
+void TxnManager::get_all_tablet_txn_infos_by_tablet(const TabletSharedPtr& tablet,
+                                                    txn_tablet_map_t& txn_tablet_map) {
     for (int32_t i = 0; i < _txn_map_shard_size; i++) {
         std::shared_lock txn_rdlock(_txn_map_locks[i]);
         for (auto& it : _txn_tablet_maps[i]) {
             auto tablet_load_it = it.second.find(tablet->get_tablet_info());
             if(tablet_load_it!=it.second.end()){
-                tablet_info_map[tablet_load_it->first] = tablet_load_it->second;
+                txn_tablet_map.insert(std::make_pair(it.first, it.second));
             }
         }
     }

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -632,8 +632,8 @@ void TxnManager::get_all_related_tablets(std::set<TabletInfo>* tablet_infos) {
     }
 }
 
-
-void TxnManager::get_all_tablet_txn_infos_by_tablet(const TabletSharedPtr tablet, std::vector<TabletTxnInfo>& tablet_txn_infos){
+void TxnManager::get_all_tablet_txn_infos_by_tablet(const TabletSharedPtr tablet,
+                                                    std::vector<TabletTxnInfo>& tablet_txn_infos) {
     for (int32_t i = 0; i < _txn_map_shard_size; i++) {
         std::shared_lock txn_rdlock(_txn_map_locks[i]);
         for (auto& it : _txn_tablet_maps[i]) {

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -632,8 +632,8 @@ void TxnManager::get_all_related_tablets(std::set<TabletInfo>* tablet_infos) {
     }
 }
 
-void TxnManager::get_all_tablet_txn_infos_by_tablet(const TabletSharedPtr& tablet,
-                                                    txn_tablet_map_t& txn_tablet_map) {
+void TxnManager::get_all_commit_tablet_txn_info_by_tablet(const TabletSharedPtr& tablet,
+                                                          txn_tablet_map_t& txn_tablet_map) {
     for (int32_t i = 0; i < _txn_map_shard_size; i++) {
         std::shared_lock txn_rdlock(_txn_map_locks[i]);
         for (auto& it : _txn_tablet_maps[i]) {

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -736,6 +736,7 @@ DeltaWriter* TxnManager::get_txn_tablet_delta_writer(int64_t transaction_id, int
             return it->second;
         }
     }
+    return nullptr;
 }
 
 void TxnManager::finish_slave_tablet_pull_rowset(int64_t transaction_id, int64_t tablet_id,

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -638,7 +638,7 @@ void TxnManager::get_all_tablet_txn_infos_by_tablet(const TabletSharedPtr& table
         std::shared_lock txn_rdlock(_txn_map_locks[i]);
         for (auto& it : _txn_tablet_maps[i]) {
             auto tablet_load_it = it.second.find(tablet->get_tablet_info());
-            if(tablet_load_it!=it.second.end()){
+            if (tablet_load_it != it.second.end()) {
                 txn_tablet_map.insert(std::make_pair(it.first, it.second));
             }
         }
@@ -724,19 +724,19 @@ void TxnManager::add_txn_tablet_delta_writer(int64_t transaction_id, int64_t tab
     txn_tablet_delta_writer_map[transaction_id][tablet_id] = delta_writer;
 }
 
-    DeltaWriter* TxnManager::get_txn_tablet_delta_writer(int64_t transaction_id, int64_t tablet_id) {
-        std::lock_guard<std::shared_mutex> txn_wrlock(
-                _get_txn_tablet_delta_writer_map_lock(transaction_id));
-        txn_tablet_delta_writer_map_t& txn_tablet_delta_writer_map =
-                _get_txn_tablet_delta_writer_map(transaction_id);
-        auto find = txn_tablet_delta_writer_map.find(transaction_id);
-        if (find != txn_tablet_delta_writer_map.end()) {
-            auto it = find->second.find(tablet_id);
-            if(it !=find->second.end()){
-                return it->second;
-            }
+DeltaWriter* TxnManager::get_txn_tablet_delta_writer(int64_t transaction_id, int64_t tablet_id) {
+    std::lock_guard<std::shared_mutex> txn_wrlock(
+            _get_txn_tablet_delta_writer_map_lock(transaction_id));
+    txn_tablet_delta_writer_map_t& txn_tablet_delta_writer_map =
+            _get_txn_tablet_delta_writer_map(transaction_id);
+    auto find = txn_tablet_delta_writer_map.find(transaction_id);
+    if (find != txn_tablet_delta_writer_map.end()) {
+        auto it = find->second.find(tablet_id);
+        if (it != find->second.end()) {
+            return it->second;
         }
     }
+}
 
 void TxnManager::finish_slave_tablet_pull_rowset(int64_t transaction_id, int64_t tablet_id,
                                                  int64_t node_id, bool is_succeed) {

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -636,7 +636,7 @@ void TxnManager::get_all_commit_tablet_txn_info_by_tablet(
         const TabletSharedPtr& tablet, CommitTabletTxnInfoVec& commit_tablet_txn_info_vec) {
     for (int32_t i = 0; i < _txn_map_shard_size; i++) {
         std::shared_lock txn_rdlock(_txn_map_locks[i]);
-        for (auto& it : _txn_tablet_maps[i]) {
+        for (const auto& it : _txn_tablet_maps[i]) {
             auto tablet_load_it = it.second.find(tablet->get_tablet_info());
             if (tablet_load_it != it.second.end()) {
                 TPartitionId partition_id = it.first.first;

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -633,12 +633,14 @@ void TxnManager::get_all_related_tablets(std::set<TabletInfo>* tablet_infos) {
 }
 
 void TxnManager::get_all_tablet_txn_infos_by_tablet(const TabletSharedPtr tablet,
-                                                    std::vector<TabletTxnInfo>& tablet_txn_infos) {
+                                                    std::map<TabletInfo,TabletTxnInfo>& tablet_info_map) {
     for (int32_t i = 0; i < _txn_map_shard_size; i++) {
         std::shared_lock txn_rdlock(_txn_map_locks[i]);
         for (auto& it : _txn_tablet_maps[i]) {
             auto tablet_load_it = it.second.find(tablet->get_tablet_info());
-            tablet_txn_infos.push_back(tablet_load_it->second);
+            if(tablet_load_it!=it.second.end()){
+                tablet_info_map[tablet_load_it->first] = tablet_load_it->second;
+            }
         }
     }
 }

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -632,6 +632,17 @@ void TxnManager::get_all_related_tablets(std::set<TabletInfo>* tablet_infos) {
     }
 }
 
+
+void TxnManager::get_all_tablet_txn_infos_by_tablet(const TabletSharedPtr tablet, std::vector<TabletTxnInfo>& tablet_txn_infos){
+    for (int32_t i = 0; i < _txn_map_shard_size; i++) {
+        std::shared_lock txn_rdlock(_txn_map_locks[i]);
+        for (auto& it : _txn_tablet_maps[i]) {
+            auto tablet_load_it = it.second.find(tablet->get_tablet_info());
+            tablet_txn_infos.push_back(tablet_load_it->second);
+        }
+    }
+}
+
 bool TxnManager::has_txn(TPartitionId partition_id, TTransactionId transaction_id,
                          TTabletId tablet_id, SchemaHash schema_hash, TabletUid tablet_uid) {
     pair<int64_t, int64_t> key(partition_id, transaction_id);

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -185,6 +185,7 @@ public:
 
     void add_txn_tablet_delta_writer(int64_t transaction_id, int64_t tablet_id,
                                      DeltaWriter* delta_writer);
+    DeltaWriter* get_txn_tablet_delta_writer(int64_t transaction_id, int64_t tablet_id);
     void clear_txn_tablet_delta_writer(int64_t transaction_id);
     void finish_slave_tablet_pull_rowset(int64_t transaction_id, int64_t tablet_id, int64_t node_id,
                                          bool is_succeed);

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -194,8 +194,8 @@ public:
                                        TabletUid tablet_uid, bool unique_key_merge_on_write,
                                        DeleteBitmapPtr delete_bitmap,
                                        const RowsetIdUnorderedSet& rowset_ids);
-    void get_all_tablet_txn_infos_by_tablet(const TabletSharedPtr& tablet,
-                                            txn_tablet_map_t& txn_tablet_map);
+    void get_all_commit_tablet_txn_info_by_tablet(const TabletSharedPtr& tablet,
+                                                  txn_tablet_map_t& txn_tablet_map);
 
 private:
     std::shared_mutex& _get_txn_map_lock(TTransactionId transactionId);

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -80,15 +80,18 @@ struct TabletTxnInfo {
 
 struct CommitTabletTxnInfo {
     CommitTabletTxnInfo(TPartitionId partition_id, TTransactionId transaction_id,
-                        RowsetSharedPtr rowset, DeleteBitmapPtr delete_bitmap)
+                        RowsetSharedPtr rowset, DeleteBitmapPtr delete_bitmap,
+                        RowsetIdUnorderedSet rowset_ids)
             : transaction_id(transaction_id),
               partition_id(partition_id),
               rowset(rowset),
-              delete_bitmap(delete_bitmap) {}
+              delete_bitmap(delete_bitmap),
+              rowset_ids(rowset_ids) {}
     TTransactionId transaction_id;
     TPartitionId partition_id;
     RowsetSharedPtr rowset;
     DeleteBitmapPtr delete_bitmap;
+    RowsetIdUnorderedSet rowset_ids;
 };
 
 using CommitTabletTxnInfoVec = std::vector<CommitTabletTxnInfo>;
@@ -187,7 +190,7 @@ public:
                                        DeleteBitmapPtr delete_bitmap,
                                        const RowsetIdUnorderedSet& rowset_ids);
     void get_all_commit_tablet_txn_info_by_tablet(
-            const TabletSharedPtr& tablet, CommitTabletTxnInfoVec& commit_tablet_txn_info_vec);
+            const TabletSharedPtr& tablet, CommitTabletTxnInfoVec* commit_tablet_txn_info_vec);
 
 private:
     using TxnKey = std::pair<int64_t, int64_t>; // partition_id, transaction_id;

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -91,29 +91,6 @@ public:
         delete[] _txn_tablet_delta_writer_map;
         delete[] _txn_tablet_delta_writer_map_locks;
     }
-    using TxnKey = std::pair<int64_t, int64_t>; // partition_id, transaction_id;
-
-    // Implement TxnKey hash function to support TxnKey as a key for `unordered_map`.
-    struct TxnKeyHash {
-        template <typename T, typename U>
-        size_t operator()(const std::pair<T, U>& e) const {
-            return std::hash<T>()(e.first) ^ std::hash<U>()(e.second);
-        }
-    };
-
-    // Implement TxnKey equal function to support TxnKey as a key for `unordered_map`.
-    struct TxnKeyEqual {
-        template <class T, typename U>
-        bool operator()(const std::pair<T, U>& l, const std::pair<T, U>& r) const {
-            return l.first == r.first && l.second == r.second;
-        }
-    };
-
-    typedef std::unordered_map<TxnKey, std::map<TabletInfo, TabletTxnInfo>, TxnKeyHash, TxnKeyEqual>
-            txn_tablet_map_t;
-    typedef std::unordered_map<int64_t, std::unordered_set<int64_t>> txn_partition_map_t;
-    typedef std::unordered_map<int64_t, std::map<int64_t, DeltaWriter*>>
-            txn_tablet_delta_writer_map_t;
 
     // add a txn to manager
     // partition id is useful in publish version stage because version is associated with partition
@@ -198,6 +175,29 @@ public:
                                                   txn_tablet_map_t& txn_tablet_map);
 
 private:
+    using TxnKey = std::pair<int64_t, int64_t>; // partition_id, transaction_id;
+
+    // Implement TxnKey hash function to support TxnKey as a key for `unordered_map`.
+    struct TxnKeyHash {
+        template <typename T, typename U>
+        size_t operator()(const std::pair<T, U>& e) const {
+            return std::hash<T>()(e.first) ^ std::hash<U>()(e.second);
+        }
+    };
+
+    // Implement TxnKey equal function to support TxnKey as a key for `unordered_map`.
+    struct TxnKeyEqual {
+        template <class T, typename U>
+        bool operator()(const std::pair<T, U>& l, const std::pair<T, U>& r) const {
+            return l.first == r.first && l.second == r.second;
+        }
+    };
+
+    typedef std::unordered_map<TxnKey, std::map<TabletInfo, TabletTxnInfo>, TxnKeyHash, TxnKeyEqual>
+            txn_tablet_map_t;
+    typedef std::unordered_map<int64_t, std::unordered_set<int64_t>> txn_partition_map_t;
+    typedef std::unordered_map<int64_t, std::map<int64_t, DeltaWriter*>>
+            txn_tablet_delta_writer_map_t;
     std::shared_mutex& _get_txn_map_lock(TTransactionId transactionId);
 
     txn_tablet_map_t& _get_txn_tablet_map(TTransactionId transactionId);

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -185,7 +185,6 @@ public:
 
     void add_txn_tablet_delta_writer(int64_t transaction_id, int64_t tablet_id,
                                      DeltaWriter* delta_writer);
-    DeltaWriter* get_txn_tablet_delta_writer(int64_t transaction_id, int64_t tablet_id);
     void clear_txn_tablet_delta_writer(int64_t transaction_id);
     void finish_slave_tablet_pull_rowset(int64_t transaction_id, int64_t tablet_id, int64_t node_id,
                                          bool is_succeed);

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -172,6 +172,7 @@ public:
                                        DeleteBitmapPtr delete_bitmap,
                                        const RowsetIdUnorderedSet& rowset_ids);
     void get_all_tablet_txn_infos_by_tablet(const TabletSharedPtr tablet, std::vector<TabletTxnInfo>& delete_bitmaps);
+
 private:
     using TxnKey = std::pair<int64_t, int64_t>; // partition_id, transaction_id;
 

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -78,6 +78,21 @@ struct TabletTxnInfo {
     TabletTxnInfo() {}
 };
 
+struct CommitTabletTxnInfo {
+    CommitTabletTxnInfo(TPartitionId partition_id, TTransactionId transaction_id,
+                        RowsetSharedPtr rowset, DeleteBitmapPtr delete_bitmap)
+            : transaction_id(transaction_id),
+              partition_id(partition_id),
+              rowset(rowset),
+              delete_bitmap(delete_bitmap) {}
+    TTransactionId transaction_id;
+    TPartitionId partition_id;
+    RowsetSharedPtr rowset;
+    DeleteBitmapPtr delete_bitmap;
+};
+
+using CommitTabletTxnInfoVec = std::vector<CommitTabletTxnInfo>;
+
 // txn manager is used to manage mapping between tablet and txns
 class TxnManager {
 public:
@@ -171,8 +186,8 @@ public:
                                        TabletUid tablet_uid, bool unique_key_merge_on_write,
                                        DeleteBitmapPtr delete_bitmap,
                                        const RowsetIdUnorderedSet& rowset_ids);
-    void get_all_commit_tablet_txn_info_by_tablet(const TabletSharedPtr& tablet,
-                                                  txn_tablet_map_t& txn_tablet_map);
+    void get_all_commit_tablet_txn_info_by_tablet(
+            const TabletSharedPtr& tablet, CommitTabletTxnInfoVec& commit_tablet_txn_info_vec);
 
 private:
     using TxnKey = std::pair<int64_t, int64_t>; // partition_id, transaction_id;
@@ -198,6 +213,7 @@ private:
     typedef std::unordered_map<int64_t, std::unordered_set<int64_t>> txn_partition_map_t;
     typedef std::unordered_map<int64_t, std::map<int64_t, DeltaWriter*>>
             txn_tablet_delta_writer_map_t;
+
     std::shared_mutex& _get_txn_map_lock(TTransactionId transactionId);
 
     txn_tablet_map_t& _get_txn_tablet_map(TTransactionId transactionId);

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -171,7 +171,7 @@ public:
                                        TabletUid tablet_uid, bool unique_key_merge_on_write,
                                        DeleteBitmapPtr delete_bitmap,
                                        const RowsetIdUnorderedSet& rowset_ids);
-
+    void get_all_tablet_txn_infos_by_tablet(const TabletSharedPtr tablet, std::vector<TabletTxnInfo>& delete_bitmaps);
 private:
     using TxnKey = std::pair<int64_t, int64_t>; // partition_id, transaction_id;
 

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -211,11 +211,9 @@ private:
         }
     };
 
-    typedef std::unordered_map<TxnKey, std::map<TabletInfo, TabletTxnInfo>, TxnKeyHash, TxnKeyEqual>
-            txn_tablet_map_t;
-    typedef std::unordered_map<int64_t, std::unordered_set<int64_t>> txn_partition_map_t;
-    typedef std::unordered_map<int64_t, std::map<int64_t, DeltaWriter*>>
-            txn_tablet_delta_writer_map_t;
+    using txn_tablet_map_t = std::unordered_map<TxnKey, std::map<TabletInfo, TabletTxnInfo>, TxnKeyHash, TxnKeyEqual>;
+    using txn_partition_map_t = std::unordered_map<int64_t, std::unordered_set<int64_t>>;
+    using txn_tablet_delta_writer_map_t = std::unordered_map<int64_t, std::map<int64_t, DeltaWriter *>>;
 
     std::shared_mutex& _get_txn_map_lock(TTransactionId transactionId);
 

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -172,7 +172,7 @@ public:
                                        DeleteBitmapPtr delete_bitmap,
                                        const RowsetIdUnorderedSet& rowset_ids);
     void get_all_tablet_txn_infos_by_tablet(const TabletSharedPtr tablet,
-                                            std::vector<TabletTxnInfo>& delete_bitmaps);
+                                            std::map<TabletInfo,TabletTxnInfo>& tablet_info_map);
 
 private:
     using TxnKey = std::pair<int64_t, int64_t>; // partition_id, transaction_id;

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -171,7 +171,8 @@ public:
                                        TabletUid tablet_uid, bool unique_key_merge_on_write,
                                        DeleteBitmapPtr delete_bitmap,
                                        const RowsetIdUnorderedSet& rowset_ids);
-    void get_all_tablet_txn_infos_by_tablet(const TabletSharedPtr tablet, std::vector<TabletTxnInfo>& delete_bitmaps);
+    void get_all_tablet_txn_infos_by_tablet(const TabletSharedPtr tablet,
+                                            std::vector<TabletTxnInfo>& delete_bitmaps);
 
 private:
     using TxnKey = std::pair<int64_t, int64_t>; // partition_id, transaction_id;

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -199,7 +199,6 @@ public:
                                             txn_tablet_map_t& txn_tablet_map);
 
 private:
-
     std::shared_mutex& _get_txn_map_lock(TTransactionId transactionId);
 
     txn_tablet_map_t& _get_txn_tablet_map(TTransactionId transactionId);

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -211,9 +211,11 @@ private:
         }
     };
 
-    using txn_tablet_map_t = std::unordered_map<TxnKey, std::map<TabletInfo, TabletTxnInfo>, TxnKeyHash, TxnKeyEqual>;
+    using txn_tablet_map_t = std::unordered_map<TxnKey, std::map<TabletInfo, TabletTxnInfo>,
+                                                TxnKeyHash, TxnKeyEqual>;
     using txn_partition_map_t = std::unordered_map<int64_t, std::unordered_set<int64_t>>;
-    using txn_tablet_delta_writer_map_t = std::unordered_map<int64_t, std::map<int64_t, DeltaWriter *>>;
+    using txn_tablet_delta_writer_map_t =
+            std::unordered_map<int64_t, std::map<int64_t, DeltaWriter*>>;
 
     std::shared_mutex& _get_txn_map_lock(TTransactionId transactionId);
 

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -91,6 +91,29 @@ public:
         delete[] _txn_tablet_delta_writer_map;
         delete[] _txn_tablet_delta_writer_map_locks;
     }
+    using TxnKey = std::pair<int64_t, int64_t>; // partition_id, transaction_id;
+
+    // Implement TxnKey hash function to support TxnKey as a key for `unordered_map`.
+    struct TxnKeyHash {
+        template <typename T, typename U>
+        size_t operator()(const std::pair<T, U>& e) const {
+            return std::hash<T>()(e.first) ^ std::hash<U>()(e.second);
+        }
+    };
+
+    // Implement TxnKey equal function to support TxnKey as a key for `unordered_map`.
+    struct TxnKeyEqual {
+        template <class T, typename U>
+        bool operator()(const std::pair<T, U>& l, const std::pair<T, U>& r) const {
+            return l.first == r.first && l.second == r.second;
+        }
+    };
+
+    typedef std::unordered_map<TxnKey, std::map<TabletInfo, TabletTxnInfo>, TxnKeyHash, TxnKeyEqual>
+            txn_tablet_map_t;
+    typedef std::unordered_map<int64_t, std::unordered_set<int64_t>> txn_partition_map_t;
+    typedef std::unordered_map<int64_t, std::map<int64_t, DeltaWriter*>>
+            txn_tablet_delta_writer_map_t;
 
     // add a txn to manager
     // partition id is useful in publish version stage because version is associated with partition
@@ -171,33 +194,10 @@ public:
                                        TabletUid tablet_uid, bool unique_key_merge_on_write,
                                        DeleteBitmapPtr delete_bitmap,
                                        const RowsetIdUnorderedSet& rowset_ids);
-    void get_all_tablet_txn_infos_by_tablet(const TabletSharedPtr tablet,
-                                            std::map<TabletInfo,TabletTxnInfo>& tablet_info_map);
+    void get_all_tablet_txn_infos_by_tablet(const TabletSharedPtr& tablet,
+                                            txn_tablet_map_t& txn_tablet_map);
 
 private:
-    using TxnKey = std::pair<int64_t, int64_t>; // partition_id, transaction_id;
-
-    // Implement TxnKey hash function to support TxnKey as a key for `unordered_map`.
-    struct TxnKeyHash {
-        template <typename T, typename U>
-        size_t operator()(const std::pair<T, U>& e) const {
-            return std::hash<T>()(e.first) ^ std::hash<U>()(e.second);
-        }
-    };
-
-    // Implement TxnKey equal function to support TxnKey as a key for `unordered_map`.
-    struct TxnKeyEqual {
-        template <class T, typename U>
-        bool operator()(const std::pair<T, U>& l, const std::pair<T, U>& r) const {
-            return l.first == r.first && l.second == r.second;
-        }
-    };
-
-    typedef std::unordered_map<TxnKey, std::map<TabletInfo, TabletTxnInfo>, TxnKeyHash, TxnKeyEqual>
-            txn_tablet_map_t;
-    typedef std::unordered_map<int64_t, std::unordered_set<int64_t>> txn_partition_map_t;
-    typedef std::unordered_map<int64_t, std::map<int64_t, DeltaWriter*>>
-            txn_tablet_delta_writer_map_t;
 
     std::shared_mutex& _get_txn_map_lock(TTransactionId transactionId);
 

--- a/be/test/olap/tablet_meta_test.cpp
+++ b/be/test/olap/tablet_meta_test.cpp
@@ -179,7 +179,7 @@ TEST(TabletMetaTest, TestDeleteBitmap) {
         ASSERT_EQ(d.cardinality(), 4);
         ASSERT_EQ(db_upper.get({RowsetId {2, 0, 1, 1}, 1, 2}, &d), 0);
         ASSERT_EQ(d.cardinality(), 1);
-        ASSERT_EQ(db_upper.delete_bitmap.size(), 20);
+        ASSERT_EQ(db_upper.delete_bitmap.size(), 21);
     }
 
     {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

Here we will calculate all the rowsets delete bitmaps which are committed but not published to reduce the calculation pressure of publish phase.

Step1: collect this tablet's all committed rowsets' delete bitmaps.

Step2: calculate all rowsets' delete bitmaps which are published during compaction.

Step3: write back updated delete bitmap and tablet info.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

