### PR TITLE
[Fix](Planner) Fix group concat with multi distinct and segs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AggregateInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AggregateInfo.java
@@ -283,7 +283,9 @@ public final class AggregateInfo extends AggregateInfoBase {
         }
 
         ArrayList<Expr> expr0Children = Lists.newArrayList();
-        if (distinctAggExprs.get(0).getFnName().getFunction().equalsIgnoreCase("group_concat")) {
+        if (distinctAggExprs.get(0).getFnName().getFunction().equalsIgnoreCase("group_concat")
+                || distinctAggExprs.get(0).getFnName().getFunction()
+                        .equalsIgnoreCase("multi_distinct_group_concat")) {
             // Ignore separator parameter, otherwise the same would have to be present for all
             // other distinct aggregates as well.
             // TODO: Deal with constant exprs more generally, instead of special-casing
@@ -297,7 +299,9 @@ public final class AggregateInfo extends AggregateInfoBase {
         boolean hasMultiDistinct = false;
         for (int i = 1; i < distinctAggExprs.size(); ++i) {
             ArrayList<Expr> exprIChildren = Lists.newArrayList();
-            if (distinctAggExprs.get(i).getFnName().getFunction().equalsIgnoreCase("group_concat")) {
+            if (distinctAggExprs.get(i).getFnName().getFunction().equalsIgnoreCase("group_concat")
+                    || distinctAggExprs.get(i).getFnName().getFunction()
+                            .equalsIgnoreCase("multi_distinct_group_concat")) {
                 exprIChildren.add(distinctAggExprs.get(i).getChild(0).ignoreImplicitCast());
             } else {
                 for (Expr expr : distinctAggExprs.get(i).getChildren()) {

--- a/regression-test/data/query_p0/group_concat/test_group_concat.out
+++ b/regression-test/data/query_p0/group_concat/test_group_concat.out
@@ -35,6 +35,10 @@ false
 1	2
 1	2
 
+-- !select_12 --
+1	2
+1	2
+
 -- !select_group_concat_order_by_all_data --
 1	1	1
 1	1	11

--- a/regression-test/suites/query_p0/group_concat/test_group_concat.groovy
+++ b/regression-test/suites/query_p0/group_concat/test_group_concat.groovy
@@ -81,6 +81,15 @@ suite("test_group_concat") {
                 b2;
               """
 
+    qt_select_12 """
+                select
+                group_concat( distinct b1, '?'), group_concat( distinct b3, '?')
+                from
+                table_group_concat
+                group by 
+                b2;
+              """
+
     sql """ drop table table_group_concat """
     sql """create table table_group_concat ( b1 varchar(10) not null, b2 int not null, b3 varchar(10) not null )
             ENGINE=OLAP


### PR DESCRIPTION
## Proposed changes

Problem: when use select group_concat(distinct a, 'seg1'), group_concat(distinct b, 'seg2') ... Error would rised
Reason: Group_concat function regard 'seg' as arguments also, so multi distinct column error would rised
Solved: let Multi Distinct group_concat function only get first argument as real argument

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

