### PR TITLE
[improvement](compaction) Support for configuring the compaction policy during table creation

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -445,7 +445,8 @@ void TaskWorkerPool::_update_tablet_meta_worker_thread_callback() {
                         tablet_meta_info.compaction_policy);
                 need_to_save = true;
             }
-            if (tablet_meta_info.__isset.time_series_compaction_goal_size_mbytes && tablet_meta_info.time_series_compaction_goal_size_mbytes != -1) {
+            if (tablet_meta_info.__isset.time_series_compaction_goal_size_mbytes &&
+                tablet_meta_info.time_series_compaction_goal_size_mbytes != -1) {
                 tablet->tablet_meta()
                         ->mutable_tablet_schema()
                         ->set_time_series_compaction_goal_size_mbytes(
@@ -459,7 +460,8 @@ void TaskWorkerPool::_update_tablet_meta_worker_thread_callback() {
                         tablet_meta_info.time_series_compaction_goal_size_mbytes);
                 need_to_save = true;
             }
-            if (tablet_meta_info.__isset.time_series_compaction_file_count_threshold && tablet_meta_info.time_series_compaction_file_count_threshold != -1) {
+            if (tablet_meta_info.__isset.time_series_compaction_file_count_threshold &&
+                tablet_meta_info.time_series_compaction_file_count_threshold != -1) {
                 tablet->tablet_meta()
                         ->mutable_tablet_schema()
                         ->set_time_series_compaction_file_count_threshold(
@@ -473,7 +475,8 @@ void TaskWorkerPool::_update_tablet_meta_worker_thread_callback() {
                         tablet_meta_info.time_series_compaction_file_count_threshold);
                 need_to_save = true;
             }
-            if (tablet_meta_info.__isset.time_series_compaction_time_threshold_seconds && tablet_meta_info.time_series_compaction_time_threshold_seconds != -1) {
+            if (tablet_meta_info.__isset.time_series_compaction_time_threshold_seconds &&
+                tablet_meta_info.time_series_compaction_time_threshold_seconds != -1) {
                 tablet->tablet_meta()
                         ->mutable_tablet_schema()
                         ->set_time_series_compaction_time_threshold_seconds(

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -433,6 +433,60 @@ void TaskWorkerPool::_update_tablet_meta_worker_thread_callback() {
                 tablet->tablet_schema_unlocked()->set_is_in_memory(tablet_meta_info.is_in_memory);
                 need_to_save = true;
             }
+            if (tablet_meta_info.__isset.compaction_policy) {
+                tablet->tablet_meta()->mutable_tablet_schema()->set_compaction_policy(
+                        tablet_meta_info.compaction_policy);
+                std::shared_lock rlock(tablet->get_header_lock());
+                for (auto& rowset_meta : tablet->tablet_meta()->all_mutable_rs_metas()) {
+                    rowset_meta->tablet_schema()->set_compaction_policy(
+                            tablet_meta_info.compaction_policy);
+                }
+                tablet->tablet_schema_unlocked()->set_compaction_policy(
+                        tablet_meta_info.compaction_policy);
+                need_to_save = true;
+            }
+            if (tablet_meta_info.__isset.time_series_compaction_goal_size_mbytes && tablet_meta_info.time_series_compaction_goal_size_mbytes != -1) {
+                tablet->tablet_meta()
+                        ->mutable_tablet_schema()
+                        ->set_time_series_compaction_goal_size_mbytes(
+                                tablet_meta_info.time_series_compaction_goal_size_mbytes);
+                std::shared_lock rlock(tablet->get_header_lock());
+                for (auto& rowset_meta : tablet->tablet_meta()->all_mutable_rs_metas()) {
+                    rowset_meta->tablet_schema()->set_time_series_compaction_goal_size_mbytes(
+                            tablet_meta_info.time_series_compaction_goal_size_mbytes);
+                }
+                tablet->tablet_schema_unlocked()->set_time_series_compaction_goal_size_mbytes(
+                        tablet_meta_info.time_series_compaction_goal_size_mbytes);
+                need_to_save = true;
+            }
+            if (tablet_meta_info.__isset.time_series_compaction_file_count_threshold && tablet_meta_info.time_series_compaction_file_count_threshold != -1) {
+                tablet->tablet_meta()
+                        ->mutable_tablet_schema()
+                        ->set_time_series_compaction_file_count_threshold(
+                                tablet_meta_info.time_series_compaction_file_count_threshold);
+                std::shared_lock rlock(tablet->get_header_lock());
+                for (auto& rowset_meta : tablet->tablet_meta()->all_mutable_rs_metas()) {
+                    rowset_meta->tablet_schema()->set_time_series_compaction_file_count_threshold(
+                            tablet_meta_info.time_series_compaction_file_count_threshold);
+                }
+                tablet->tablet_schema_unlocked()->set_time_series_compaction_file_count_threshold(
+                        tablet_meta_info.time_series_compaction_file_count_threshold);
+                need_to_save = true;
+            }
+            if (tablet_meta_info.__isset.time_series_compaction_time_threshold_seconds && tablet_meta_info.time_series_compaction_time_threshold_seconds != -1) {
+                tablet->tablet_meta()
+                        ->mutable_tablet_schema()
+                        ->set_time_series_compaction_time_threshold_seconds(
+                                tablet_meta_info.time_series_compaction_time_threshold_seconds);
+                std::shared_lock rlock(tablet->get_header_lock());
+                for (auto& rowset_meta : tablet->tablet_meta()->all_mutable_rs_metas()) {
+                    rowset_meta->tablet_schema()->set_time_series_compaction_time_threshold_seconds(
+                            tablet_meta_info.time_series_compaction_time_threshold_seconds);
+                }
+                tablet->tablet_schema_unlocked()->set_time_series_compaction_time_threshold_seconds(
+                        tablet_meta_info.time_series_compaction_time_threshold_seconds);
+                need_to_save = true;
+            }
             if (tablet_meta_info.__isset.replica_id) {
                 tablet->tablet_meta()->set_replica_id(tablet_meta_info.replica_id);
             }

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -980,20 +980,6 @@ DEFINE_Int32(num_broadcast_buffer, "32");
 // semi-structure configs
 DEFINE_Bool(enable_parse_multi_dimession_array, "false");
 
-// Currently, two compaction strategies are implemented, SIZE_BASED and TIME_SERIES.
-// In the case of time series compaction, the execution of compaction is adjusted
-// using parameters that have the prefix time_series_compaction.
-DEFINE_mString(compaction_policy, "size_based");
-DEFINE_Validator(compaction_policy, [](const std::string config) -> bool {
-    return config == "size_based" || config == "time_series";
-});
-// the size of input files for each compaction
-DEFINE_mInt64(time_series_compaction_goal_size_mbytes, "512");
-// the minimum number of input files for each compaction if time_series_compaction_goal_size_mbytes not meets
-DEFINE_mInt64(time_series_compaction_file_count_threshold, "2000");
-// if compaction has not been performed within 3600 seconds, a compaction will be triggered
-DEFINE_mInt64(time_series_compaction_time_threshold_seconds, "3600");
-
 // max depth of expression tree allowed.
 DEFINE_Int32(max_depth_of_expr_tree, "600");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1003,17 +1003,6 @@ DECLARE_Int32(num_broadcast_buffer);
 // semi-structure configs
 DECLARE_Bool(enable_parse_multi_dimession_array);
 
-// Currently, two compaction strategies are implemented, SIZE_BASED and TIME_SERIES.
-// In the case of time series compaction, the execution of compaction is adjusted
-// using parameters that have the prefix time_series_compaction.
-DECLARE_mString(compaction_policy);
-// the size of input files for each compaction
-DECLARE_mInt64(time_series_compaction_goal_size_mbytes);
-// the minimum number of input files for each compaction if time_series_compaction_goal_size_mbytes not meets
-DECLARE_mInt64(time_series_compaction_file_count_threshold);
-// if compaction has not been performed within 3600 seconds, a compaction will be triggered
-DECLARE_mInt64(time_series_compaction_time_threshold_seconds);
-
 // max depth of expression tree allowed.
 DECLARE_Int32(max_depth_of_expr_tree);
 

--- a/be/src/http/action/compaction_action.cpp
+++ b/be/src/http/action/compaction_action.cpp
@@ -37,6 +37,7 @@
 #include "olap/base_compaction.h"
 #include "olap/cumulative_compaction.h"
 #include "olap/cumulative_compaction_policy.h"
+#include "olap/cumulative_compaction_time_series_policy.h"
 #include "olap/full_compaction.h"
 #include "olap/olap_define.h"
 #include "olap/storage_engine.h"
@@ -198,7 +199,12 @@ Status CompactionAction::_execute_compaction_callback(TabletSharedPtr tablet,
     timer.start();
 
     std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy =
-            CumulativeCompactionPolicyFactory::create_cumulative_compaction_policy();
+            tablet->tablet_meta()->tablet_schema()->compaction_policy() ==
+                            CUMULATIVE_TIME_SERIES_POLICY
+                    ? CumulativeCompactionPolicyFactory::
+                              create_time_series_cumulative_compaction_policy()
+                    : CumulativeCompactionPolicyFactory::
+                              create_size_based_cumulative_compaction_policy();
     if (tablet->get_cumulative_compaction_policy() == nullptr) {
         tablet->set_cumulative_compaction_policy(cumulative_compaction_policy);
     }

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -148,8 +148,10 @@ int64_t Compaction::get_avg_segment_rows() {
     // input_rowsets_size is total disk_size of input_rowset, this size is the
     // final size after codec and compress, so expect dest segment file size
     // in disk is config::vertical_compaction_max_segment_size
-    if (config::compaction_policy == CUMULATIVE_TIME_SERIES_POLICY) {
-        return (config::time_series_compaction_goal_size_mbytes * 1024 * 1024 * 2) /
+    if (_tablet->tablet_meta()->tablet_schema()->compaction_policy() ==
+        CUMULATIVE_TIME_SERIES_POLICY) {
+        return (_tablet->tablet_meta()->tablet_schema()->time_series_compaction_goal_size_mbytes() *
+                1024 * 1024 * 2) /
                (_input_rowsets_size / (_input_row_num + 1) + 1);
     }
     return config::vertical_compaction_max_segment_size /

--- a/be/src/olap/cumulative_compaction.cpp
+++ b/be/src/olap/cumulative_compaction.cpp
@@ -90,8 +90,8 @@ Status CumulativeCompaction::execute_compact_impl() {
     _state = CompactionState::SUCCESS;
 
     // 5. set cumulative point
-    _tablet->cumulative_compaction_policy()->update_cumulative_point(
-            _tablet.get(), _input_rowsets, _output_rowset, _last_delete_version);
+    _tablet->cumulative_compaction_policy()->update_cumulative_point(_tablet.get(), _output_rowset,
+                                                                     _last_delete_version);
     VLOG_CRITICAL << "after cumulative compaction, current cumulative point is "
                   << _tablet->cumulative_layer_point() << ", tablet=" << _tablet->full_name();
 
@@ -120,11 +120,8 @@ Status CumulativeCompaction::pick_rowsets_to_compact() {
                      << ", tablet=" << _tablet->full_name();
     }
 
-    size_t compaction_score = 0;
     _tablet->cumulative_compaction_policy()->pick_input_rowsets(
-            _tablet.get(), candidate_rowsets, config::cumulative_compaction_max_deltas,
-            config::cumulative_compaction_min_deltas, &_input_rowsets, &_last_delete_version,
-            &compaction_score);
+            _tablet.get(), candidate_rowsets, &_input_rowsets, &_last_delete_version);
 
     // Cumulative compaction will process with at least 1 rowset.
     // So when there is no rowset being chosen, we should return Status::Error<CUMULATIVE_NO_SUITABLE_VERSION>():

--- a/be/src/olap/cumulative_compaction_policy.h
+++ b/be/src/olap/cumulative_compaction_policy.h
@@ -33,7 +33,7 @@ namespace doris {
 class Tablet;
 struct Version;
 
-inline std::string_view CUMULATIVE_SIZE_BASED_POLICY = "size_based";
+inline constexpr std::string_view CUMULATIVE_SIZE_BASED_POLICY = "size_based";
 
 /// This class CumulativeCompactionPolicy is the base class of cumulative compaction policy.
 /// It defines the policy to do cumulative compaction. It has different derived classes, which implements

--- a/be/src/olap/cumulative_compaction_time_series_policy.h
+++ b/be/src/olap/cumulative_compaction_time_series_policy.h
@@ -25,9 +25,9 @@ inline std::string_view CUMULATIVE_TIME_SERIES_POLICY = "time_series";
 
 /// TimeSeries cumulative compaction policy implementation.
 /// The following three conditions will be considered when calculating compaction scores and selecting input rowsets in this policy:
-/// Condition 1: the size of input files for compaction meets the requirement of parameter _compaction_goal_size
-/// Condition 2: the number of input files reaches the threshold specified by parameter _compaction_file_count_threshold
-/// Condition 3: the time interval between compactions exceeds the value specified by parameter _compaction_time_threshold_seconds
+/// Condition 1: the size of input files for compaction meets the requirement of time_series_compaction_goal_size_mbytes
+/// Condition 2: the number of input files reaches the threshold specified by time_series_compaction_file_count_threshold
+/// Condition 3: the time interval between compactions exceeds the value specified by  time_series_compaction_time_threshold_seconds
 /// The conditions are evaluated sequentially, starting with Condition 1.
 /// If any condition is met, the compaction score calculation or selection of input rowsets will be successful.
 class TimeSeriesCumulativeCompactionPolicy final : public CumulativeCompactionPolicy {
@@ -42,22 +42,17 @@ public:
     /// When the first time the tablet does compact, this calculation is executed. Its main policy is to find first rowset
     /// which does not satisfied the _compaction_goal_size * 0.8.
     /// The result of compaction may be slightly smaller than the _compaction_goal_size.
-    void calculate_cumulative_point(Tablet* tablet,
-                                    const std::vector<RowsetMetaSharedPtr>& all_rowsets,
-                                    int64_t current_cumulative_point,
-                                    int64_t* cumulative_point) override;
+    int64_t calculate_cumulative_point(Tablet* tablet) override;
 
     /// Its main policy is picking rowsets from candidate rowsets by Condition 1, 2, 3.
-    int pick_input_rowsets(Tablet* tablet, const std::vector<RowsetSharedPtr>& candidate_rowsets,
-                           const int64_t max_compaction_score, const int64_t min_compaction_score,
-                           std::vector<RowsetSharedPtr>* input_rowsets,
-                           Version* last_delete_version, size_t* compaction_score) override;
+    void pick_input_rowsets(Tablet* tablet, const std::vector<RowsetSharedPtr>& candidate_rowsets,
+                            std::vector<RowsetSharedPtr>* input_rowset,
+                            Version* last_delete_version) override;
 
     /// The point must be updated after each cumulative compaction is completed.
     /// We want each rowset to do cumulative compaction once.
-    void update_cumulative_point(Tablet* tablet, const std::vector<RowsetSharedPtr>& input_rowsets,
-                                 RowsetSharedPtr _output_rowset,
-                                 Version& last_delete_version) override;
+    void update_cumulative_point(Tablet* tablet, const RowsetSharedPtr& output_rowset,
+                                 const Version& last_delete_version) override;
     std::string_view name() override { return CUMULATIVE_TIME_SERIES_POLICY; }
 };
 

--- a/be/src/olap/cumulative_compaction_time_series_policy.h
+++ b/be/src/olap/cumulative_compaction_time_series_policy.h
@@ -21,7 +21,7 @@
 
 namespace doris {
 
-inline std::string_view CUMULATIVE_TIME_SERIES_POLICY = "time_series";
+inline constexpr std::string_view CUMULATIVE_TIME_SERIES_POLICY = "time_series";
 
 /// TimeSeries cumulative compaction policy implementation.
 /// The following three conditions will be considered when calculating compaction scores and selecting input rowsets in this policy:

--- a/be/src/olap/full_compaction.cpp
+++ b/be/src/olap/full_compaction.cpp
@@ -85,8 +85,8 @@ Status FullCompaction::execute_compact_impl() {
 
     // 4. set cumulative point
     Version last_version = _input_rowsets.back()->version();
-    _tablet->cumulative_compaction_policy()->update_cumulative_point(_tablet.get(), _input_rowsets,
-                                                                     _output_rowset, last_version);
+    _tablet->cumulative_compaction_policy()->update_cumulative_point(_tablet.get(), _output_rowset,
+                                                                     last_version);
     VLOG_CRITICAL << "after cumulative compaction, current cumulative point is "
                   << _tablet->cumulative_layer_point() << ", tablet=" << _tablet->full_name();
 

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -52,6 +52,7 @@
 #include "olap/cold_data_compaction.h"
 #include "olap/compaction_permit_limiter.h"
 #include "olap/cumulative_compaction_policy.h"
+#include "olap/cumulative_compaction_time_series_policy.h"
 #include "olap/data_dir.h"
 #include "olap/olap_common.h"
 #include "olap/rowset/beta_rowset_writer.h"
@@ -851,7 +852,7 @@ std::vector<TabletSharedPtr> StorageEngine::_generate_compaction_tasks(
                     compaction_type == CompactionType::CUMULATIVE_COMPACTION
                             ? copied_cumu_map[data_dir]
                             : copied_base_map[data_dir],
-                    &disk_max_score, _cumulative_compaction_policy);
+                    &disk_max_score, _all_cumulative_compaction_policy);
             if (tablet != nullptr) {
                 if (!tablet->tablet_meta()->tablet_schema()->disable_auto_compaction()) {
                     if (need_pick_tablet) {
@@ -881,9 +882,12 @@ std::vector<TabletSharedPtr> StorageEngine::_generate_compaction_tasks(
 }
 
 void StorageEngine::_update_cumulative_compaction_policy() {
-    if (_cumulative_compaction_policy == nullptr) {
-        _cumulative_compaction_policy =
-                CumulativeCompactionPolicyFactory::create_cumulative_compaction_policy();
+    if (_all_cumulative_compaction_policy.size() < 2) {
+        _all_cumulative_compaction_policy[CUMULATIVE_SIZE_BASED_POLICY] =
+                CumulativeCompactionPolicyFactory::create_size_based_cumulative_compaction_policy();
+        _all_cumulative_compaction_policy[CUMULATIVE_TIME_SERIES_POLICY] =
+                CumulativeCompactionPolicyFactory::
+                        create_time_series_cumulative_compaction_policy();
     }
 }
 
@@ -994,7 +998,14 @@ Status StorageEngine::submit_compaction_task(TabletSharedPtr tablet, CompactionT
                                              bool force) {
     _update_cumulative_compaction_policy();
     if (tablet->get_cumulative_compaction_policy() == nullptr) {
-        tablet->set_cumulative_compaction_policy(_cumulative_compaction_policy);
+        if (tablet->tablet_meta()->tablet_schema()->compaction_policy() ==
+            CUMULATIVE_TIME_SERIES_POLICY) {
+            tablet->set_cumulative_compaction_policy(
+                    _all_cumulative_compaction_policy[CUMULATIVE_TIME_SERIES_POLICY]);
+        } else {
+            tablet->set_cumulative_compaction_policy(
+                    _all_cumulative_compaction_policy[CUMULATIVE_SIZE_BASED_POLICY]);
+        }
     }
     tablet->set_skip_compaction(false);
     return _submit_compaction_task(tablet, compaction_type, force);

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -461,7 +461,8 @@ private:
 
     std::shared_ptr<StreamLoadRecorder> _stream_load_recorder;
 
-    std::shared_ptr<CumulativeCompactionPolicy> _cumulative_compaction_policy;
+    std::unordered_map<std::string_view, std::shared_ptr<CumulativeCompactionPolicy>>
+            _all_cumulative_compaction_policy;
 
     scoped_refptr<Thread> _cooldown_tasks_producer_thread;
     scoped_refptr<Thread> _remove_unused_remote_files_thread;

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -39,6 +39,7 @@
 #include "gutil/strings/strcat.h"
 #include "gutil/strings/substitute.h"
 #include "io/fs/local_file_system.h"
+#include "olap/cumulative_compaction_time_series_policy.h"
 #include "olap/data_dir.h"
 #include "olap/olap_common.h"
 #include "olap/olap_define.h"
@@ -663,7 +664,8 @@ void TabletManager::get_tablet_stat(TTabletStatResult* result) {
 TabletSharedPtr TabletManager::find_best_tablet_to_compaction(
         CompactionType compaction_type, DataDir* data_dir,
         const std::unordered_set<TTabletId>& tablet_submitted_compaction, uint32_t* score,
-        std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy) {
+        const std::unordered_map<std::string_view, std::shared_ptr<CumulativeCompactionPolicy>>&
+                all_cumulative_compaction_policy) {
     int64_t now_ms = UnixMillis();
     const string& compaction_type_str =
             compaction_type == CompactionType::BASE_COMPACTION ? "base" : "cumulative";
@@ -715,6 +717,11 @@ TabletSharedPtr TabletManager::find_best_tablet_to_compaction(
                 }
             }
 
+            auto cumulative_compaction_policy =
+                    tablet_ptr->tablet_meta()->tablet_schema()->compaction_policy() ==
+                                    CUMULATIVE_TIME_SERIES_POLICY
+                            ? all_cumulative_compaction_policy.at(CUMULATIVE_TIME_SERIES_POLICY)
+                            : all_cumulative_compaction_policy.at(CUMULATIVE_SIZE_BASED_POLICY);
             uint32_t current_compaction_score = tablet_ptr->calc_compaction_score(
                     compaction_type, cumulative_compaction_policy);
             if (current_compaction_score < 5) {

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -77,7 +77,8 @@ public:
     TabletSharedPtr find_best_tablet_to_compaction(
             CompactionType compaction_type, DataDir* data_dir,
             const std::unordered_set<TTabletId>& tablet_submitted_compaction, uint32_t* score,
-            std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy);
+            const std::unordered_map<std::string_view, std::shared_ptr<CumulativeCompactionPolicy>>&
+                    all_cumulative_compaction_policy);
 
     TabletSharedPtr get_tablet(TTabletId tablet_id, bool include_deleted = false,
                                std::string* err = nullptr);

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -266,6 +266,21 @@ TabletMeta::TabletMeta(int64_t table_id, int64_t partition_id, int64_t tablet_id
     if (tablet_schema.__isset.skip_write_index_on_load) {
         schema->set_skip_write_index_on_load(tablet_schema.skip_write_index_on_load);
     }
+    if (tablet_schema.__isset.compaction_policy) {
+        schema->set_compaction_policy(tablet_schema.compaction_policy);
+    }
+    if (tablet_schema.__isset.time_series_compaction_goal_size_mbytes) {
+        schema->set_time_series_compaction_goal_size_mbytes(
+                tablet_schema.time_series_compaction_goal_size_mbytes);
+    }
+    if (tablet_schema.__isset.time_series_compaction_file_count_threshold) {
+        schema->set_time_series_compaction_file_count_threshold(
+                tablet_schema.time_series_compaction_file_count_threshold);
+    }
+    if (tablet_schema.__isset.time_series_compaction_time_threshold_seconds) {
+        schema->set_time_series_compaction_time_threshold_seconds(
+                tablet_schema.time_series_compaction_time_threshold_seconds);
+    }
 
     if (binlog_config.has_value()) {
         BinlogConfig tmp_binlog_config;

--- a/be/src/olap/tablet_schema.cpp
+++ b/be/src/olap/tablet_schema.cpp
@@ -710,6 +710,12 @@ void TabletSchema::init_from_pb(const TabletSchemaPB& schema) {
     _enable_single_replica_compaction = schema.enable_single_replica_compaction();
     _store_row_column = schema.store_row_column();
     _skip_write_index_on_load = schema.skip_write_index_on_load();
+    _compaction_policy = schema.compaction_policy();
+    _time_series_compaction_goal_size_mbytes = schema.time_series_compaction_goal_size_mbytes();
+    _time_series_compaction_file_count_threshold =
+            schema.time_series_compaction_file_count_threshold();
+    _time_series_compaction_time_threshold_seconds =
+            schema.time_series_compaction_time_threshold_seconds();
     _is_dynamic_schema = schema.is_dynamic_schema();
     _delete_sign_idx = schema.delete_sign_idx();
     _sequence_col_idx = schema.sequence_col_idx();
@@ -765,6 +771,13 @@ void TabletSchema::build_current_tablet_schema(int64_t index_id, int32_t version
     _enable_single_replica_compaction = ori_tablet_schema.enable_single_replica_compaction();
     _store_row_column = ori_tablet_schema.store_row_column();
     _skip_write_index_on_load = ori_tablet_schema.skip_write_index_on_load();
+    _compaction_policy = ori_tablet_schema.compaction_policy();
+    _time_series_compaction_goal_size_mbytes =
+            ori_tablet_schema.time_series_compaction_goal_size_mbytes();
+    _time_series_compaction_file_count_threshold =
+            ori_tablet_schema.time_series_compaction_file_count_threshold();
+    _time_series_compaction_time_threshold_seconds =
+            ori_tablet_schema.time_series_compaction_time_threshold_seconds();
     _sort_type = ori_tablet_schema.sort_type();
     _sort_col_num = ori_tablet_schema.sort_col_num();
 
@@ -865,6 +878,13 @@ void TabletSchema::to_schema_pb(TabletSchemaPB* tablet_schema_pb) const {
     tablet_schema_pb->set_enable_single_replica_compaction(_enable_single_replica_compaction);
     tablet_schema_pb->set_store_row_column(_store_row_column);
     tablet_schema_pb->set_skip_write_index_on_load(_skip_write_index_on_load);
+    tablet_schema_pb->set_compaction_policy(_compaction_policy);
+    tablet_schema_pb->set_time_series_compaction_goal_size_mbytes(
+            _time_series_compaction_goal_size_mbytes);
+    tablet_schema_pb->set_time_series_compaction_file_count_threshold(
+            _time_series_compaction_file_count_threshold);
+    tablet_schema_pb->set_time_series_compaction_time_threshold_seconds(
+            _time_series_compaction_time_threshold_seconds);
     tablet_schema_pb->set_delete_sign_idx(_delete_sign_idx);
     tablet_schema_pb->set_sequence_col_idx(_sequence_col_idx);
     tablet_schema_pb->set_sort_type(_sort_type);
@@ -1151,6 +1171,15 @@ bool operator==(const TabletSchema& a, const TabletSchema& b) {
     if (a._enable_single_replica_compaction != b._enable_single_replica_compaction) return false;
     if (a._store_row_column != b._store_row_column) return false;
     if (a._skip_write_index_on_load != b._skip_write_index_on_load) return false;
+    if (a._compaction_policy != b._compaction_policy) return false;
+    if (a._time_series_compaction_goal_size_mbytes != b._time_series_compaction_goal_size_mbytes)
+        return false;
+    if (a._time_series_compaction_file_count_threshold !=
+        b._time_series_compaction_file_count_threshold)
+        return false;
+    if (a._time_series_compaction_time_threshold_seconds !=
+        b._time_series_compaction_time_threshold_seconds)
+        return false;
     return true;
 }
 

--- a/be/src/olap/tablet_schema.h
+++ b/be/src/olap/tablet_schema.h
@@ -248,6 +248,28 @@ public:
     bool store_row_column() const { return _store_row_column; }
     void set_skip_write_index_on_load(bool skip) { _skip_write_index_on_load = skip; }
     bool skip_write_index_on_load() const { return _skip_write_index_on_load; }
+    void set_compaction_policy(std::string compaction_policy) {
+        _compaction_policy = compaction_policy;
+    }
+    std::string compaction_policy() const { return _compaction_policy; }
+    void set_time_series_compaction_goal_size_mbytes(int64_t goal_size_mbytes) {
+        _time_series_compaction_goal_size_mbytes = goal_size_mbytes;
+    }
+    int64_t time_series_compaction_goal_size_mbytes() const {
+        return _time_series_compaction_goal_size_mbytes;
+    }
+    void set_time_series_compaction_file_count_threshold(int64_t file_count_threshold) {
+        _time_series_compaction_file_count_threshold = file_count_threshold;
+    }
+    int64_t time_series_compaction_file_count_threshold() const {
+        return _time_series_compaction_file_count_threshold;
+    }
+    void set_time_series_compaction_time_threshold_seconds(int64_t time_threshold) {
+        _time_series_compaction_time_threshold_seconds = time_threshold;
+    }
+    int64_t time_series_compaction_time_threshold_seconds() const {
+        return _time_series_compaction_time_threshold_seconds;
+    }
     bool is_dynamic_schema() const { return _is_dynamic_schema; }
     int32_t delete_sign_idx() const { return _delete_sign_idx; }
     void set_delete_sign_idx(int32_t delete_sign_idx) { _delete_sign_idx = delete_sign_idx; }
@@ -355,6 +377,10 @@ private:
     int64_t _mem_size = 0;
     bool _store_row_column = false;
     bool _skip_write_index_on_load = false;
+    std::string _compaction_policy;
+    int64_t _time_series_compaction_goal_size_mbytes = 1024;
+    int64_t _time_series_compaction_file_count_threshold = 10000;
+    int64_t _time_series_compaction_time_threshold_seconds = 3600;
 
     bool _is_partial_update;
     std::set<std::string> _partial_update_input_columns;

--- a/be/src/olap/tablet_schema.h
+++ b/be/src/olap/tablet_schema.h
@@ -378,8 +378,8 @@ private:
     bool _store_row_column = false;
     bool _skip_write_index_on_load = false;
     std::string _compaction_policy;
-    int64_t _time_series_compaction_goal_size_mbytes = 1024;
-    int64_t _time_series_compaction_file_count_threshold = 10000;
+    int64_t _time_series_compaction_goal_size_mbytes = 512;
+    int64_t _time_series_compaction_file_count_threshold = 2000;
     int64_t _time_series_compaction_time_threshold_seconds = 3600;
 
     bool _is_partial_update;

--- a/be/test/olap/cumulative_compaction_time_series_policy_test.cpp
+++ b/be/test/olap/cumulative_compaction_time_series_policy_test.cpp
@@ -37,14 +37,15 @@ class TestTimeSeriesCumulativeCompactionPolicy : public testing::Test {
 public:
     TestTimeSeriesCumulativeCompactionPolicy() {}
     void SetUp() {
-        config::compaction_policy = "time_series";
-        config::time_series_compaction_goal_size_mbytes = 1024;
-        config::time_series_compaction_file_count_threshold = 10;
-        config::time_series_compaction_time_threshold_seconds = 3600;
-
         _tablet_meta = static_cast<TabletMetaSharedPtr>(new TabletMeta(
                 1, 2, 15673, 15674, 4, 5, TTabletSchema(), 6, {{7, 8}}, UniqueId(9, 10),
                 TTabletType::TABLET_TYPE_DISK, TCompressionType::LZ4F));
+
+        _tablet_meta->tablet_schema()->set_compaction_policy(
+                std::string(CUMULATIVE_TIME_SERIES_POLICY));
+        _tablet_meta->tablet_schema()->set_time_series_compaction_goal_size_mbytes(100);
+        _tablet_meta->tablet_schema()->set_time_series_compaction_file_count_threshold(10);
+        _tablet_meta->tablet_schema()->set_time_series_compaction_time_threshold_seconds(3600);
 
         _json_rowset_meta = R"({
             "rowset_id": 540081,
@@ -106,28 +107,28 @@ public:
     void init_rs_meta_big_rowset(std::vector<RowsetMetaSharedPtr>* rs_metas) {
         RowsetMetaSharedPtr ptr1(new RowsetMeta());
         init_rs_meta(ptr1, 0, 1);
-        ptr1->set_total_disk_size(1024 * 1024 * 1024);
+        ptr1->set_total_disk_size(100 * 1024 * 1024);
         rs_metas->push_back(ptr1);
 
         RowsetMetaSharedPtr ptr2(new RowsetMeta());
         init_rs_meta(ptr2, 2, 3);
-        ptr2->set_total_disk_size(1024 * 1024 * 1024);
+        ptr2->set_total_disk_size(100 * 1024 * 1024);
         rs_metas->push_back(ptr2);
 
         RowsetMetaSharedPtr ptr3(new RowsetMeta());
         init_rs_meta(ptr3, 4, 4);
-        ptr3->set_total_disk_size(512 * 1024 * 1024);
+        ptr3->set_total_disk_size(51 * 1024 * 1024);
         rs_metas->push_back(ptr3);
 
         RowsetMetaSharedPtr ptr4(new RowsetMeta());
         init_rs_meta(ptr4, 5, 5);
         ptr4->set_segments_overlap(OVERLAPPING);
-        ptr4->set_total_disk_size(512 * 1024 * 1024);
+        ptr4->set_total_disk_size(51 * 1024 * 1024);
         rs_metas->push_back(ptr4);
 
         RowsetMetaSharedPtr ptr5(new RowsetMeta());
         init_rs_meta(ptr5, 6, 6);
-        ptr5->set_total_disk_size(512 * 1024 * 1024);
+        ptr5->set_total_disk_size(51 * 1024 * 1024);
         rs_metas->push_back(ptr5);
     }
 
@@ -336,7 +337,7 @@ TEST_F(TestTimeSeriesCumulativeCompactionPolicy, calc_cumulative_compaction_scor
     _tablet->calculate_cumulative_point();
 
     std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy =
-            CumulativeCompactionPolicyFactory::create_cumulative_compaction_policy();
+            CumulativeCompactionPolicyFactory::create_time_series_cumulative_compaction_policy();
     const uint32_t score = _tablet->calc_compaction_score(CompactionType::CUMULATIVE_COMPACTION,
                                                           cumulative_compaction_policy);
 
@@ -355,7 +356,7 @@ TEST_F(TestTimeSeriesCumulativeCompactionPolicy, calc_cumulative_compaction_scor
     _tablet->init();
     _tablet->calculate_cumulative_point();
     std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy =
-            CumulativeCompactionPolicyFactory::create_cumulative_compaction_policy();
+            CumulativeCompactionPolicyFactory::create_time_series_cumulative_compaction_policy();
     const uint32_t score = _tablet->calc_compaction_score(CompactionType::CUMULATIVE_COMPACTION,
                                                           cumulative_compaction_policy);
 
@@ -410,13 +411,10 @@ TEST_F(TestTimeSeriesCumulativeCompactionPolicy, pick_input_rowsets_goal_size) {
 
     std::vector<RowsetSharedPtr> input_rowsets;
     Version last_delete_version {-1, -1};
-    size_t compaction_score = 0;
     _tablet->_cumulative_compaction_policy->pick_input_rowsets(
-            _tablet.get(), candidate_rowsets, 10, 5, &input_rowsets, &last_delete_version,
-            &compaction_score);
+            _tablet.get(), candidate_rowsets, &input_rowsets, &last_delete_version);
 
     EXPECT_EQ(2, input_rowsets.size());
-    EXPECT_EQ(4, compaction_score);
     EXPECT_EQ(-1, last_delete_version.first);
     EXPECT_EQ(-1, last_delete_version.second);
 }
@@ -437,13 +435,10 @@ TEST_F(TestTimeSeriesCumulativeCompactionPolicy, pick_input_rowsets_file_count) 
 
     std::vector<RowsetSharedPtr> input_rowsets;
     Version last_delete_version {-1, -1};
-    size_t compaction_score = 0;
     _tablet->_cumulative_compaction_policy->pick_input_rowsets(
-            _tablet.get(), candidate_rowsets, 10, 5, &input_rowsets, &last_delete_version,
-            &compaction_score);
+            _tablet.get(), candidate_rowsets, &input_rowsets, &last_delete_version);
 
     EXPECT_EQ(4, input_rowsets.size());
-    EXPECT_EQ(10, compaction_score);
     EXPECT_EQ(-1, last_delete_version.first);
     EXPECT_EQ(-1, last_delete_version.second);
 }
@@ -466,13 +461,10 @@ TEST_F(TestTimeSeriesCumulativeCompactionPolicy, pick_input_rowsets_time_interva
 
     std::vector<RowsetSharedPtr> input_rowsets;
     Version last_delete_version {-1, -1};
-    size_t compaction_score = 0;
     _tablet->_cumulative_compaction_policy->pick_input_rowsets(
-            _tablet.get(), candidate_rowsets, 10, 5, &input_rowsets, &last_delete_version,
-            &compaction_score);
+            _tablet.get(), candidate_rowsets, &input_rowsets, &last_delete_version);
 
     EXPECT_EQ(4, input_rowsets.size());
-    EXPECT_EQ(4, compaction_score);
     EXPECT_EQ(-1, last_delete_version.first);
     EXPECT_EQ(-1, last_delete_version.second);
 }
@@ -495,13 +487,10 @@ TEST_F(TestTimeSeriesCumulativeCompactionPolicy, pick_input_rowsets_empty) {
 
     std::vector<RowsetSharedPtr> input_rowsets;
     Version last_delete_version {-1, -1};
-    size_t compaction_score = 0;
     _tablet->_cumulative_compaction_policy->pick_input_rowsets(
-            _tablet.get(), candidate_rowsets, 10, 5, &input_rowsets, &last_delete_version,
-            &compaction_score);
+            _tablet.get(), candidate_rowsets, &input_rowsets, &last_delete_version);
 
     EXPECT_EQ(0, input_rowsets.size());
-    EXPECT_EQ(0, compaction_score);
     EXPECT_EQ(-1, last_delete_version.first);
     EXPECT_EQ(-1, last_delete_version.second);
 }
@@ -522,14 +511,10 @@ TEST_F(TestTimeSeriesCumulativeCompactionPolicy, pick_input_rowsets_delete) {
 
     std::vector<RowsetSharedPtr> input_rowsets;
     Version last_delete_version {-1, -1};
-    size_t compaction_score = 0;
-
     _tablet->_cumulative_compaction_policy->pick_input_rowsets(
-            _tablet.get(), candidate_rowsets, 10, 5, &input_rowsets, &last_delete_version,
-            &compaction_score);
+            _tablet.get(), candidate_rowsets, &input_rowsets, &last_delete_version);
 
     EXPECT_EQ(2, input_rowsets.size());
-    EXPECT_EQ(4, compaction_score);
     EXPECT_EQ(5, last_delete_version.first);
     EXPECT_EQ(5, last_delete_version.second);
 }

--- a/docs/en/docs/admin-manual/config/be-config.md
+++ b/docs/en/docs/admin-manual/config/be-config.md
@@ -665,33 +665,6 @@ BaseCompaction:546859:
 * Description: Minimal interval (s) to update peer replica infos
 * Default value: 60 (s)
 
-#### `compaction_policy`
-
-* Type: string
-* Description: Configure the compaction strategy in the compression phase. Currently, two compaction strategies are implemented, size_based and time_series.
-  - size_based: Version merging can only be performed when the disk volume of the rowset is the same order of magnitude. After merging, qualified rowsets are promoted to the base compaction stage. In the case of a large number of small batch imports, it can reduce the write magnification of base compact, balance the read magnification and space magnification, and reduce the data of file versions.
-  - time_series: When the disk size of a rowset accumulates to a certain threshold, version merging takes place. The merged rowset is directly promoted to the base compaction stage. This approach effectively reduces the write amplification rate of compaction, especially in scenarios with continuous imports in a time series context.
-* Default value: size_based
-
-#### `time_series_compaction_goal_size_mbytes`
-
-* Type: int64
-* Description: Enabling time series compaction will utilize this parameter to adjust the size of input files for each compaction. The output file size will be approximately equal to the input file size.
-* Default value: 512
-
-#### `time_series_compaction_file_count_threshold`
-
-* Type: int64
-* Description: Enabling time series compaction will utilize this parameter to adjust the minimum number of input files for each compaction. It comes into effect only when the condition specified by time_series_compaction_goal_size_mbytes is not met.
-  - If the number of files in a tablet exceeds the configured threshold, it will trigger a compaction process.
-* Default value: 2000
-
-#### `time_series_compaction_time_threshold_seconds`
-
-* Type: int64
-* Description: When time series compaction is enabled, a significant duration passes without a compaction being executed, a compaction will be triggered.
-* Default value: 3600 (s)
-
 
 ### Load
 

--- a/docs/en/docs/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE.md
+++ b/docs/en/docs/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE.md
@@ -399,6 +399,35 @@ Set table properties. The following attributes are currently supported:
 
    `"skip_write_index_on_load" = "false"`
 
+* `compaction_policy`
+
+    Configure the compaction strategy in the compression phase. Only support configuring the compaction policy as "time_series".
+
+    time_series: When the disk size of a rowset accumulates to a certain threshold, version merging takes place. The merged rowset is directly promoted to the base compaction stage. This approach effectively reduces the write amplification rate of compaction, especially in scenarios with continuous imports in a time series context.
+    In the case of time series compaction, the execution of compaction is adjusted using parameters that have the prefix time_series_compaction.
+
+    `"compaction_policy" = ""`
+
+* `time_series_compaction_goal_size_mbytes`
+
+    Time series compaction policy will utilize this parameter to adjust the size of input files for each compaction. The output file size will be approximately equal to the input file size.
+
+    `"time_series_compaction_goal_size_mbytes" = "1024"`
+
+* `time_series_compaction_file_count_threshold`
+
+    Time series compaction policy will utilize this parameter to adjust the minimum number of input files for each compaction.
+
+    If the number of files in a tablet exceeds the configured threshold, it will trigger a compaction process.
+
+    `"time_series_compaction_file_count_threshold" = "10000"`
+
+* `time_series_compaction_time_threshold_seconds`
+
+     When time series compaction policy is applied, a significant duration passes without a compaction being executed, a compaction will be triggered.
+
+    `"time_series_compaction_time_threshold_seconds" = "3600"`
+
 * Dynamic partition related
 
    The relevant parameters of dynamic partition are as follows:

--- a/docs/en/docs/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE.md
+++ b/docs/en/docs/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE.md
@@ -412,7 +412,7 @@ Set table properties. The following attributes are currently supported:
 
     Time series compaction policy will utilize this parameter to adjust the size of input files for each compaction. The output file size will be approximately equal to the input file size.
 
-    `"time_series_compaction_goal_size_mbytes" = "1024"`
+    `"time_series_compaction_goal_size_mbytes" = "512"`
 
 * `time_series_compaction_file_count_threshold`
 
@@ -420,7 +420,7 @@ Set table properties. The following attributes are currently supported:
 
     If the number of files in a tablet exceeds the configured threshold, it will trigger a compaction process.
 
-    `"time_series_compaction_file_count_threshold" = "10000"`
+    `"time_series_compaction_file_count_threshold" = "2000"`
 
 * `time_series_compaction_time_threshold_seconds`
 

--- a/docs/zh-CN/docs/admin-manual/config/be-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/be-config.md
@@ -679,33 +679,6 @@ BaseCompaction:546859:
 * 描述：更新 peer replica infos 的最小间隔时间
 * 默认值：60（s）
 
-#### `compaction_policy`
-
-* 类型：string
-* 描述：配置 compaction 的合并策略，目前实现了两种合并策略，size_based 和 time_series
-  - size_based: 仅当 rowset 的磁盘体积在相同数量级时才进行版本合并。合并之后满足条件的 rowset 进行晋升到 base compaction阶段。能够做到在大量小批量导入的情况下：降低base compact的写入放大率，并在读取放大率和空间放大率之间进行权衡，同时减少了文件版本的数据。
-  - time_series: 当 rowset 的磁盘体积积攒到一定大小时进行版本合并。合并后的 rowset 直接晋升到 base compaction 阶段。在时序场景持续导入的情况下有效降低 compact 的写入放大率。
-* 默认值：size_based
-
-#### `time_series_compaction_goal_size_mbytes`
-
-* 类型：int64
-* 描述：开启 time series compaction 时，将使用此参数来调整每次 compaction 输入的文件的大小，输出的文件大小和输入相当
-* 默认值：512
-
-#### `time_series_compaction_file_count_threshold`
-
-* 类型：int64
-* 描述：开启 time series compaction 时，将使用此参数来调整每次 compaction 输入的文件数量的最小值，只有当 time_series_compaction_goal_size_mbytes 条件不满足时，该参数才会发挥作用
-  - 一个 tablet 中文件数超过该配置，会触发 compaction
-* 默认值：2000
-
-#### `time_series_compaction_time_threshold_seconds`
-
-* 类型：int64
-* 描述：开启 time series compaction 时，将使用此参数来调整 compaction 的最长时间间隔，即长时间未执行过 compaction 时，就会触发一次 compaction，单位为秒
-* 默认值：3600
-
 
 ### 导入
 

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE.md
@@ -383,6 +383,35 @@ UNIQUE KEY(k1, k2)
 
     `"skip_write_index_on_load" = "false"`
 
+* `compaction_policy`
+
+    配置这个表的 compaction 的合并策略，仅支持配置为 time_series。
+
+    time_series: 当 rowset 的磁盘体积积攒到一定大小时进行版本合并。合并后的 rowset 直接晋升到 base compaction 阶段。在时序场景持续导入的情况下有效降低 compact 的写入放大率。
+    此策略将使用 time_series_compaction 为前缀的参数调整 compaction 的执行。
+
+    `"compaction_policy" = ""`
+
+* `time_series_compaction_goal_size_mbytes`
+
+    compaction 的合并策略为 time_series 时，将使用此参数来调整每次 compaction 输入的文件的大小，输出的文件大小和输入相当。
+
+    `"time_series_compaction_goal_size_mbytes" = "1024"`
+
+* `time_series_compaction_file_count_threshold`
+
+    compaction 的合并策略为 time_series 时，将使用此参数来调整每次 compaction 输入的文件数量的最小值。
+
+    一个 tablet 中，文件数超过该配置，就会触发 compaction。
+
+    `"time_series_compaction_file_count_threshold" = "10000"`
+
+* `time_series_compaction_time_threshold_seconds`
+
+    compaction 的合并策略为 time_series 时，将使用此参数来调整 compaction 的最长时间间隔，即长时间未执行过 compaction 时，就会触发一次 compaction，单位为秒。
+
+    `"time_series_compaction_time_threshold_seconds" = "3600"`
+
 * 动态分区相关
 
     动态分区相关参数如下：

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE.md
@@ -396,7 +396,7 @@ UNIQUE KEY(k1, k2)
 
     compaction 的合并策略为 time_series 时，将使用此参数来调整每次 compaction 输入的文件的大小，输出的文件大小和输入相当。
 
-    `"time_series_compaction_goal_size_mbytes" = "1024"`
+    `"time_series_compaction_goal_size_mbytes" = "512"`
 
 * `time_series_compaction_file_count_threshold`
 
@@ -404,7 +404,7 @@ UNIQUE KEY(k1, k2)
 
     一个 tablet 中，文件数超过该配置，就会触发 compaction。
 
-    `"time_series_compaction_file_count_threshold" = "10000"`
+    `"time_series_compaction_file_count_threshold" = "2000"`
 
 * `time_series_compaction_time_threshold_seconds`
 

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
@@ -211,6 +211,21 @@ public class Alter {
         } else if (currentAlterOps.checkCcrEnable(alterClauses)) {
             olapTable.setCcrEnable(currentAlterOps.isCcrEnable(alterClauses));
             needProcessOutsideTableLock = true;
+        } else if (currentAlterOps.checkCompactionPolicy(alterClauses)) {
+            olapTable.setCompactionPolicy(currentAlterOps.getCompactionPolicy(alterClauses));
+            needProcessOutsideTableLock = true;
+        } else if (currentAlterOps.checkTimeSeriesCompactionGoalSizeMbytes(alterClauses)) {
+            olapTable.setTimeSeriesCompactionGoalSizeMbytes(currentAlterOps
+                                            .getTimeSeriesCompactionGoalSizeMbytes(alterClauses));
+            needProcessOutsideTableLock = true;
+        } else if (currentAlterOps.checkTimeSeriesCompactionFileCountThreshold(alterClauses)) {
+            olapTable.setTimeSeriesCompactionFileCountThreshold(currentAlterOps
+                                            .getTimeSeriesCompactionFileCountThreshold(alterClauses));
+            needProcessOutsideTableLock = true;
+        } else if (currentAlterOps.checkTimeSeriesCompactionTimeThresholdSeconds(alterClauses)) {
+            olapTable.setTimeSeriesCompactionTimeThresholdSeconds(currentAlterOps
+                                            .getTimeSeriesCompactionTimeThresholdSeconds(alterClauses));
+            needProcessOutsideTableLock = true;
         } else if (currentAlterOps.checkBinlogConfigChange(alterClauses)) {
             if (!Config.enable_feature_binlog) {
                 throw new DdlException("Binlog feature is not enabled");
@@ -514,7 +529,13 @@ public class Alter {
                 // currently, only in memory and storage policy property could reach here
                 Preconditions.checkState(properties.containsKey(PropertyAnalyzer.PROPERTIES_INMEMORY)
                         || properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_POLICY)
-                        || properties.containsKey(PropertyAnalyzer.PROPERTIES_CCR_ENABLE));
+                        || properties.containsKey(PropertyAnalyzer.PROPERTIES_CCR_ENABLE)
+                        || properties.containsKey(PropertyAnalyzer.PROPERTIES_COMPACTION_POLICY)
+                        || properties.containsKey(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_GOAL_SIZE_MBYTES)
+                        || properties
+                            .containsKey(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_FILE_COUNT_THRESHOLD)
+                        || properties
+                            .containsKey(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_TIME_THRESHOLD_SECONDS));
                 ((SchemaChangeHandler) schemaChangeHandler).updateTableProperties(db, tableName, properties);
             } else {
                 throw new DdlException("Invalid alter operation: " + alterClause.getOpType());

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/AlterOperations.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/AlterOperations.java
@@ -99,6 +99,60 @@ public class AlterOperations {
         ).map(c -> ((ModifyTablePropertiesClause) c).isCcrEnable()).findFirst().orElse(false);
     }
 
+    public boolean checkCompactionPolicy(List<AlterClause> alterClauses) {
+        return alterClauses.stream().filter(clause ->
+            clause instanceof ModifyTablePropertiesClause
+        ).anyMatch(clause -> clause.getProperties().containsKey(PropertyAnalyzer.PROPERTIES_COMPACTION_POLICY));
+    }
+
+    public String getCompactionPolicy(List<AlterClause> alterClauses) {
+        return alterClauses.stream().filter(clause ->
+            clause instanceof ModifyTablePropertiesClause
+        ).map(c -> ((ModifyTablePropertiesClause) c).compactionPolicy()).findFirst().orElse("");
+    }
+
+    public boolean checkTimeSeriesCompactionGoalSizeMbytes(List<AlterClause> alterClauses) {
+        return alterClauses.stream().filter(clause ->
+            clause instanceof ModifyTablePropertiesClause
+        ).anyMatch(clause -> clause.getProperties()
+                    .containsKey(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_GOAL_SIZE_MBYTES));
+    }
+
+    public long getTimeSeriesCompactionGoalSizeMbytes(List<AlterClause> alterClauses) {
+        return alterClauses.stream().filter(clause ->
+            clause instanceof ModifyTablePropertiesClause
+        ).map(c -> ((ModifyTablePropertiesClause) c)
+        .timeSeriesCompactionGoalSizeMbytes()).findFirst().orElse((long) -1);
+    }
+
+    public boolean checkTimeSeriesCompactionFileCountThreshold(List<AlterClause> alterClauses) {
+        return alterClauses.stream().filter(clause ->
+            clause instanceof ModifyTablePropertiesClause
+        ).anyMatch(clause -> clause.getProperties()
+                    .containsKey(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_FILE_COUNT_THRESHOLD));
+    }
+
+    public long getTimeSeriesCompactionFileCountThreshold(List<AlterClause> alterClauses) {
+        return alterClauses.stream().filter(clause ->
+            clause instanceof ModifyTablePropertiesClause
+        ).map(c -> ((ModifyTablePropertiesClause) c)
+        .timeSeriesCompactionFileCountThreshold()).findFirst().orElse((long) -1);
+    }
+
+    public boolean checkTimeSeriesCompactionTimeThresholdSeconds(List<AlterClause> alterClauses) {
+        return alterClauses.stream().filter(clause ->
+            clause instanceof ModifyTablePropertiesClause
+        ).anyMatch(clause -> clause.getProperties()
+                    .containsKey(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_TIME_THRESHOLD_SECONDS));
+    }
+
+    public long getTimeSeriesCompactionTimeThresholdSeconds(List<AlterClause> alterClauses) {
+        return alterClauses.stream().filter(clause ->
+            clause instanceof ModifyTablePropertiesClause
+        ).map(c -> ((ModifyTablePropertiesClause) c)
+        .timeSeriesCompactionTimeThresholdSeconds()).findFirst().orElse((long) -1);
+    }
+
     // MODIFY_TABLE_PROPERTY is also processed by SchemaChangeHandler
     public boolean hasSchemaChangeOp() {
         return currentOps.contains(AlterOpType.SCHEMA_CHANGE) || currentOps.contains(AlterOpType.MODIFY_TABLE_PROPERTY);

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
@@ -284,6 +284,10 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                                 tbl.disableAutoCompaction(),
                                 tbl.enableSingleReplicaCompaction(),
                                 tbl.skipWriteIndexOnLoad(),
+                                tbl.compactionPolicy(),
+                                tbl.timeSeriesCompactionGoalSizeMbytes(),
+                                tbl.timeSeriesCompactionFileCountThreshold(),
+                                tbl.timeSeriesCompactionTimeThresholdSeconds(),
                                 tbl.storeRowColumn(),
                                 tbl.isDynamicSchema(),
                                 binlogConfig);

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -2138,8 +2138,9 @@ public class SchemaChangeHandler extends AlterHandler {
         long storagePolicyId = storagePolicyNameToId(storagePolicy);
 
         String compactionPolicy = properties.get(PropertyAnalyzer.PROPERTIES_COMPACTION_POLICY);
-        if (!Strings.isNullOrEmpty(compactionPolicy) && !compactionPolicy.equals("time_series")) {
-            throw new UserException("Table compaction Policy only support for time series");
+        if (!Strings.isNullOrEmpty(compactionPolicy) && !compactionPolicy.equals("time_series")
+                                                            && !compactionPolicy.equals("size_based")) {
+            throw new UserException("Table compaction Policy only support for time series or size_based");
         }
 
         // if (isInMemory < 0 && storagePolicyId < 0) {

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -2137,13 +2137,39 @@ public class SchemaChangeHandler extends AlterHandler {
         }
         long storagePolicyId = storagePolicyNameToId(storagePolicy);
 
-        if (isInMemory < 0 && storagePolicyId < 0) {
-            LOG.info("Properties already up-to-date");
-            return;
+        String compactionPolicy = properties.get(PropertyAnalyzer.PROPERTIES_COMPACTION_POLICY);
+        if (!Strings.isNullOrEmpty(compactionPolicy) && !compactionPolicy.equals("time_series")) {
+            throw new UserException("Table compaction Policy only support for time series");
+        }
+
+        // if (isInMemory < 0 && storagePolicyId < 0) {
+        //     LOG.info("Properties already up-to-date");
+        //     return;
+        // }
+
+        Map<String, Long> timeSeriesCompactionConfig = new HashMap<>();
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_GOAL_SIZE_MBYTES)) {
+            timeSeriesCompactionConfig
+                        .put(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_GOAL_SIZE_MBYTES,
+                        Long.parseLong(properties
+                        .get(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_GOAL_SIZE_MBYTES)));
+        }
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_FILE_COUNT_THRESHOLD)) {
+            timeSeriesCompactionConfig
+                        .put(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_FILE_COUNT_THRESHOLD,
+                        Long.parseLong(properties
+                        .get(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_FILE_COUNT_THRESHOLD)));
+        }
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_TIME_THRESHOLD_SECONDS)) {
+            timeSeriesCompactionConfig
+                        .put(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_TIME_THRESHOLD_SECONDS,
+                        Long.parseLong(properties
+                        .get(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_TIME_THRESHOLD_SECONDS)));
         }
 
         for (Partition partition : partitions) {
-            updatePartitionProperties(db, olapTable.getName(), partition.getName(), storagePolicyId, isInMemory, null);
+            updatePartitionProperties(db, olapTable.getName(), partition.getName(), storagePolicyId, isInMemory,
+                                        null, compactionPolicy, timeSeriesCompactionConfig);
         }
 
         olapTable.writeLockOrDdlException();
@@ -2232,6 +2258,87 @@ public class SchemaChangeHandler extends AlterHandler {
             countDownLatch.addMark(kv.getKey(), kv.getValue());
             UpdateTabletMetaInfoTask task = new UpdateTabletMetaInfoTask(kv.getKey(), kv.getValue(), isInMemory,
                     storagePolicyId, binlogConfig, countDownLatch);
+            batchTask.addTask(task);
+        }
+        if (!FeConstants.runningUnitTest) {
+            // send all tasks and wait them finished
+            AgentTaskQueue.addBatchTask(batchTask);
+            AgentTaskExecutor.submit(batchTask);
+            LOG.info("send update tablet meta task for table {}, partitions {}, number: {}", tableName, partitionName,
+                    batchTask.getTaskNum());
+
+            // estimate timeout
+            long timeout = Config.tablet_create_timeout_second * 1000L * totalTaskNum;
+            timeout = Math.min(timeout, Config.max_create_table_timeout_second * 1000);
+            boolean ok = false;
+            try {
+                ok = countDownLatch.await(timeout, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                LOG.warn("InterruptedException: ", e);
+            }
+
+            if (!ok || !countDownLatch.getStatus().ok()) {
+                String errMsg = "Failed to update partition[" + partitionName + "]. tablet meta.";
+                // clear tasks
+                AgentTaskQueue.removeBatchTask(batchTask, TTaskType.UPDATE_TABLET_META_INFO);
+
+                if (!countDownLatch.getStatus().ok()) {
+                    errMsg += " Error: " + countDownLatch.getStatus().getErrorMsg();
+                } else {
+                    List<Map.Entry<Long, Set<Pair<Long, Integer>>>> unfinishedMarks = countDownLatch.getLeftMarks();
+                    // only show at most 3 results
+                    List<Map.Entry<Long, Set<Pair<Long, Integer>>>> subList = unfinishedMarks.subList(0,
+                            Math.min(unfinishedMarks.size(), 3));
+                    if (!subList.isEmpty()) {
+                        errMsg += " Unfinished mark: " + Joiner.on(", ").join(subList);
+                    }
+                }
+                errMsg += ". This operation maybe partial successfully, You should retry until success.";
+                LOG.warn(errMsg);
+                throw new DdlException(errMsg);
+            }
+        }
+    }
+
+    /**
+     * Update one specified partition's properties by partition name of table
+     * This operation may return partial successfully, with an exception to inform user to retry
+     */
+    public void updatePartitionProperties(Database db, String tableName, String partitionName, long storagePolicyId,
+                                          int isInMemory, BinlogConfig binlogConfig, String compactionPolicy,
+                                          Map<String, Long> timeSeriesCompactionConfig) throws UserException {
+        // be id -> <tablet id,schemaHash>
+        Map<Long, Set<Pair<Long, Integer>>> beIdToTabletIdWithHash = Maps.newHashMap();
+        OlapTable olapTable = (OlapTable) db.getTableOrMetaException(tableName, Table.TableType.OLAP);
+        olapTable.readLock();
+        try {
+            Partition partition = olapTable.getPartition(partitionName);
+            if (partition == null) {
+                throw new DdlException(
+                        "Partition[" + partitionName + "] does not exist in table[" + olapTable.getName() + "]");
+            }
+
+            for (MaterializedIndex index : partition.getMaterializedIndices(IndexExtState.VISIBLE)) {
+                int schemaHash = olapTable.getSchemaHashByIndexId(index.getId());
+                for (Tablet tablet : index.getTablets()) {
+                    for (Replica replica : tablet.getReplicas()) {
+                        Set<Pair<Long, Integer>> tabletIdWithHash = beIdToTabletIdWithHash.computeIfAbsent(
+                                replica.getBackendId(), k -> Sets.newHashSet());
+                        tabletIdWithHash.add(Pair.of(tablet.getId(), schemaHash));
+                    }
+                }
+            }
+        } finally {
+            olapTable.readUnlock();
+        }
+
+        int totalTaskNum = beIdToTabletIdWithHash.keySet().size();
+        MarkedCountDownLatch<Long, Set<Pair<Long, Integer>>> countDownLatch = new MarkedCountDownLatch<>(totalTaskNum);
+        AgentBatchTask batchTask = new AgentBatchTask();
+        for (Map.Entry<Long, Set<Pair<Long, Integer>>> kv : beIdToTabletIdWithHash.entrySet()) {
+            countDownLatch.addMark(kv.getKey(), kv.getValue());
+            UpdateTabletMetaInfoTask task = new UpdateTabletMetaInfoTask(kv.getKey(), kv.getValue(), isInMemory,
+                    storagePolicyId, binlogConfig, countDownLatch, compactionPolicy, timeSeriesCompactionConfig);
             batchTask.addTask(task);
         }
         if (!FeConstants.runningUnitTest) {

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
@@ -279,6 +279,10 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                                     tbl.disableAutoCompaction(),
                                     tbl.enableSingleReplicaCompaction(),
                                     tbl.skipWriteIndexOnLoad(),
+                                    tbl.compactionPolicy(),
+                                    tbl.timeSeriesCompactionGoalSizeMbytes(),
+                                    tbl.timeSeriesCompactionFileCountThreshold(),
+                                    tbl.timeSeriesCompactionTimeThresholdSeconds(),
                                     tbl.storeRowColumn(),
                                     tbl.isDynamicSchema(),
                                     binlogConfig);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyTablePropertiesClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyTablePropertiesClause.java
@@ -183,9 +183,9 @@ public class ModifyTablePropertiesClause extends AlterTableClause {
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_COMPACTION_POLICY)) {
             String compactionPolicy = properties.getOrDefault(PropertyAnalyzer.PROPERTIES_COMPACTION_POLICY, "");
             if (!Strings.isNullOrEmpty(compactionPolicy)
-                    && !compactionPolicy.equals("time_series")) {
+                    && !compactionPolicy.equals("time_series") && !compactionPolicy.equals("size_based")) {
                 throw new AnalysisException(
-                        "Table compaction policy only support for time_series");
+                        "Table compaction policy only support for time_series or size_based");
             }
             this.needTableStable = false;
             setCompactionPolicy(compactionPolicy);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyTablePropertiesClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyTablePropertiesClause.java
@@ -46,12 +46,52 @@ public class ModifyTablePropertiesClause extends AlterTableClause {
 
     private boolean ccrEnable = false;
 
+    private String compactionPolicy;
+
+    private long timeSeriesCompactionGoalSizeMbytes;
+
+    private long timeSeriesCompactionFileCountThreshold;
+
+    private long timeSeriesCompactionTimeThresholdSeconds;
+
     public void setCcrEnable(boolean ccrEnable) {
         this.ccrEnable = ccrEnable;
     }
 
     public boolean isCcrEnable() {
         return ccrEnable;
+    }
+
+    public void setCompactionPolicy(String compactionPolicy) {
+        this.compactionPolicy = compactionPolicy;
+    }
+
+    public String compactionPolicy() {
+        return compactionPolicy;
+    }
+
+    public void setTimeSeriesCompactionGoalSizeMbytes(long timeSeriesCompactionGoalSizeMbytes) {
+        this.timeSeriesCompactionGoalSizeMbytes = timeSeriesCompactionGoalSizeMbytes;
+    }
+
+    public long timeSeriesCompactionGoalSizeMbytes() {
+        return timeSeriesCompactionGoalSizeMbytes;
+    }
+
+    public void setTimeSeriesCompactionFileCountThreshold(long timeSeriesCompactionFileCountThreshold) {
+        this.timeSeriesCompactionFileCountThreshold = timeSeriesCompactionFileCountThreshold;
+    }
+
+    public Long timeSeriesCompactionFileCountThreshold() {
+        return timeSeriesCompactionFileCountThreshold;
+    }
+
+    public void setTimeSeriesCompactionTimeThresholdSeconds(long timeSeriesCompactionTimeThresholdSeconds) {
+        this.timeSeriesCompactionTimeThresholdSeconds = timeSeriesCompactionTimeThresholdSeconds;
+    }
+
+    public Long timeSeriesCompactionTimeThresholdSeconds() {
+        return timeSeriesCompactionTimeThresholdSeconds;
     }
 
     public ModifyTablePropertiesClause(Map<String, String> properties) {
@@ -140,6 +180,49 @@ public class ModifyTablePropertiesClause extends AlterTableClause {
                 || properties.containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_MAX_BYTES)
                 || properties.containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_MAX_HISTORY_NUMS)) {
             // do nothing, will be alter in SchemaChangeHandler.updateBinlogConfig
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_COMPACTION_POLICY)) {
+            String compactionPolicy = properties.getOrDefault(PropertyAnalyzer.PROPERTIES_COMPACTION_POLICY, "");
+            if (!Strings.isNullOrEmpty(compactionPolicy)
+                    && !compactionPolicy.equals("time_series")) {
+                throw new AnalysisException(
+                        "Table compaction policy only support for time_series");
+            }
+            this.needTableStable = false;
+            setCompactionPolicy(compactionPolicy);
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_GOAL_SIZE_MBYTES)) {
+            long goalSizeMbytes;
+            String goalSizeMbytesStr = properties
+                                        .get(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_GOAL_SIZE_MBYTES);
+            try {
+                goalSizeMbytes = Long.parseLong(goalSizeMbytesStr);
+            } catch (NumberFormatException e) {
+                throw new AnalysisException("Invalid time_series_compaction_goal_size_mbytes format: "
+                        + goalSizeMbytesStr);
+            }
+            this.needTableStable = false;
+            setTimeSeriesCompactionGoalSizeMbytes(goalSizeMbytes);
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_FILE_COUNT_THRESHOLD)) {
+            long fileCountThreshold;
+            String fileCountThresholdStr = properties
+                                        .get(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_FILE_COUNT_THRESHOLD);
+            try {
+                fileCountThreshold = Long.parseLong(fileCountThresholdStr);
+            } catch (NumberFormatException e) {
+                throw new AnalysisException("Invalid time_series_compaction_file_count_threshold format: "
+                                                                                + fileCountThresholdStr);
+            }
+            this.needTableStable = false;
+            setTimeSeriesCompactionFileCountThreshold(fileCountThreshold);
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_TIME_THRESHOLD_SECONDS)) {
+            long timeThresholdSeconds;
+            try {
+                timeThresholdSeconds = Long.parseLong(properties
+                                    .get(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_TIME_THRESHOLD_SECONDS));
+            } catch (NumberFormatException e) {
+                throw new AnalysisException("Invalid time_series_compaction_time_threshold_seconds format");
+            }
+            this.needTableStable = false;
+            setTimeSeriesCompactionTimeThresholdSeconds(timeThresholdSeconds);
         } else {
             throw new AnalysisException("Unknown table property: " + properties.keySet());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -1032,6 +1032,10 @@ public class RestoreJob extends AbstractJob {
                             localTbl.disableAutoCompaction(),
                             localTbl.enableSingleReplicaCompaction(),
                             localTbl.skipWriteIndexOnLoad(),
+                            localTbl.compactionPolicy(),
+                            localTbl.timeSeriesCompactionGoalSizeMbytes(),
+                            localTbl.timeSeriesCompactionFileCountThreshold(),
+                            localTbl.timeSeriesCompactionTimeThresholdSeconds(),
                             localTbl.storeRowColumn(),
                             localTbl.isDynamicSchema(),
                             binlogConfig);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -3108,6 +3108,25 @@ public class Env {
                 sb.append(olapTable.skipWriteIndexOnLoad()).append("\"");
             }
 
+            // compaction policy
+            sb.append(",\n\"").append(PropertyAnalyzer.PROPERTIES_COMPACTION_POLICY).append("\" = \"");
+            sb.append(olapTable.compactionPolicy()).append("\"");
+
+            // time series compaction goal size
+            sb.append(",\n\"").append(PropertyAnalyzer
+                                    .PROPERTIES_TIME_SERIES_COMPACTION_GOAL_SIZE_MBYTES).append("\" = \"");
+            sb.append(olapTable.timeSeriesCompactionGoalSizeMbytes()).append("\"");
+
+            // time series compaction file count threshold
+            sb.append(",\n\"").append(PropertyAnalyzer
+                                    .PROPERTIES_TIME_SERIES_COMPACTION_FILE_COUNT_THRESHOLD).append("\" = \"");
+            sb.append(olapTable.timeSeriesCompactionFileCountThreshold()).append("\"");
+
+            // time series compaction time threshold
+            sb.append(",\n\"").append(PropertyAnalyzer
+                                    .PROPERTIES_TIME_SERIES_COMPACTION_TIME_THRESHOLD_SECONDS).append("\" = \"");
+            sb.append(olapTable.timeSeriesCompactionTimeThresholdSeconds()).append("\"");
+
             // dynamic schema
             if (olapTable.isDynamicSchema()) {
                 sb.append(",\n\"").append(PropertyAnalyzer.PROPERTIES_DYNAMIC_SCHEMA).append("\" = \"");

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -1813,6 +1813,62 @@ public class OlapTable extends Table {
         return false;
     }
 
+    public void setCompactionPolicy(String compactionPolicy) {
+        TableProperty tableProperty = getOrCreatTableProperty();
+        tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_COMPACTION_POLICY, compactionPolicy);
+        tableProperty.buildCompactionPolicy();
+    }
+
+    public String compactionPolicy() {
+        if (tableProperty != null) {
+            return tableProperty.compactionPolicy();
+        }
+        return "";
+    }
+
+    public void setTimeSeriesCompactionGoalSizeMbytes(long timeSeriesCompactionGoalSizeMbytes) {
+        TableProperty tableProperty = getOrCreatTableProperty();
+        tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_GOAL_SIZE_MBYTES,
+                                                        Long.valueOf(timeSeriesCompactionGoalSizeMbytes).toString());
+        tableProperty.buildTimeSeriesCompactionGoalSizeMbytes();
+    }
+
+    public Long timeSeriesCompactionGoalSizeMbytes() {
+        if (tableProperty != null) {
+            return tableProperty.timeSeriesCompactionGoalSizeMbytes();
+        }
+        return null;
+    }
+
+    public void setTimeSeriesCompactionFileCountThreshold(long timeSeriesCompactionFileCountThreshold) {
+        TableProperty tableProperty = getOrCreatTableProperty();
+        tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_FILE_COUNT_THRESHOLD,
+                                                    Long.valueOf(timeSeriesCompactionFileCountThreshold).toString());
+        tableProperty.buildTimeSeriesCompactionFileCountThreshold();
+    }
+
+    public Long timeSeriesCompactionFileCountThreshold() {
+        if (tableProperty != null) {
+            return tableProperty.timeSeriesCompactionFileCountThreshold();
+        }
+        return null;
+    }
+
+    public void setTimeSeriesCompactionTimeThresholdSeconds(long timeSeriesCompactionTimeThresholdSeconds) {
+        TableProperty tableProperty = getOrCreatTableProperty();
+        tableProperty.modifyTableProperties(PropertyAnalyzer
+                                                    .PROPERTIES_TIME_SERIES_COMPACTION_TIME_THRESHOLD_SECONDS,
+                                                    Long.valueOf(timeSeriesCompactionTimeThresholdSeconds).toString());
+        tableProperty.buildTimeSeriesCompactionTimeThresholdSeconds();
+    }
+
+    public Long timeSeriesCompactionTimeThresholdSeconds() {
+        if (tableProperty != null) {
+            return tableProperty.timeSeriesCompactionTimeThresholdSeconds();
+        }
+        return null;
+    }
+
     public Boolean isDynamicSchema() {
         if (tableProperty != null) {
             return tableProperty.isDynamicSchema();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
@@ -86,6 +86,14 @@ public class TableProperty implements Writable {
 
     private boolean skipWriteIndexOnLoad = false;
 
+    private String compactionPolicy = "";
+
+    private long timeSeriesCompactionGoalSizeMbytes = 1024;
+
+    private long timeSeriesCompactionFileCountThreshold = 10000;
+
+    private long timeSeriesCompactionTimeThresholdSeconds = 3600;
+
     private DataSortInfo dataSortInfo = new DataSortInfo();
 
     public TableProperty(Map<String, String> properties) {
@@ -212,6 +220,45 @@ public class TableProperty implements Writable {
 
     public boolean skipWriteIndexOnLoad() {
         return skipWriteIndexOnLoad;
+    }
+
+    public TableProperty buildCompactionPolicy() {
+        compactionPolicy = properties.getOrDefault(PropertyAnalyzer.PROPERTIES_COMPACTION_POLICY, "");
+        return this;
+    }
+
+    public String compactionPolicy() {
+        return compactionPolicy;
+    }
+
+    public TableProperty buildTimeSeriesCompactionGoalSizeMbytes() {
+        timeSeriesCompactionGoalSizeMbytes = Long.parseLong(properties
+                    .getOrDefault(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_GOAL_SIZE_MBYTES, "1024"));
+        return this;
+    }
+
+    public long timeSeriesCompactionGoalSizeMbytes() {
+        return timeSeriesCompactionGoalSizeMbytes;
+    }
+
+    public TableProperty buildTimeSeriesCompactionFileCountThreshold() {
+        timeSeriesCompactionFileCountThreshold = Long.parseLong(properties
+                    .getOrDefault(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_FILE_COUNT_THRESHOLD, "10000"));
+        return this;
+    }
+
+    public long timeSeriesCompactionFileCountThreshold() {
+        return timeSeriesCompactionFileCountThreshold;
+    }
+
+    public TableProperty buildTimeSeriesCompactionTimeThresholdSeconds() {
+        timeSeriesCompactionTimeThresholdSeconds = Long.parseLong(properties
+                    .getOrDefault(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_TIME_THRESHOLD_SECONDS, "3600"));
+        return this;
+    }
+
+    public long timeSeriesCompactionTimeThresholdSeconds() {
+        return timeSeriesCompactionTimeThresholdSeconds;
     }
 
     public TableProperty buildStoragePolicy() {
@@ -434,6 +481,10 @@ public class TableProperty implements Writable {
                 .buildEnableLightSchemaChange()
                 .buildStoreRowColumn()
                 .buildSkipWriteIndexOnLoad()
+                .buildCompactionPolicy()
+                .buildTimeSeriesCompactionGoalSizeMbytes()
+                .buildTimeSeriesCompactionFileCountThreshold()
+                .buildTimeSeriesCompactionTimeThresholdSeconds()
                 .buildDisableAutoCompaction()
                 .buildEnableSingleReplicaCompaction();
         if (Env.getCurrentEnvJournalVersion() < FeMetaVersion.VERSION_105) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
@@ -88,9 +88,9 @@ public class TableProperty implements Writable {
 
     private String compactionPolicy = "";
 
-    private long timeSeriesCompactionGoalSizeMbytes = 1024;
+    private long timeSeriesCompactionGoalSizeMbytes = 512;
 
-    private long timeSeriesCompactionFileCountThreshold = 10000;
+    private long timeSeriesCompactionFileCountThreshold = 2000;
 
     private long timeSeriesCompactionTimeThresholdSeconds = 3600;
 
@@ -233,7 +233,7 @@ public class TableProperty implements Writable {
 
     public TableProperty buildTimeSeriesCompactionGoalSizeMbytes() {
         timeSeriesCompactionGoalSizeMbytes = Long.parseLong(properties
-                    .getOrDefault(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_GOAL_SIZE_MBYTES, "1024"));
+                    .getOrDefault(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_GOAL_SIZE_MBYTES, "512"));
         return this;
     }
 
@@ -243,7 +243,7 @@ public class TableProperty implements Writable {
 
     public TableProperty buildTimeSeriesCompactionFileCountThreshold() {
         timeSeriesCompactionFileCountThreshold = Long.parseLong(properties
-                    .getOrDefault(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_FILE_COUNT_THRESHOLD, "10000"));
+                    .getOrDefault(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_FILE_COUNT_THRESHOLD, "2000"));
         return this;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -608,9 +608,9 @@ public class PropertyAnalyzer {
         if (properties.containsKey(PROPERTIES_COMPACTION_POLICY)) {
             compactionPolicy = properties.get(PROPERTIES_COMPACTION_POLICY);
             properties.remove(PROPERTIES_COMPACTION_POLICY);
-            if (!compactionPolicy.equals("time_series")) {
+            if (!compactionPolicy.equals("time_series") && !compactionPolicy.equals("size_based")) {
                 throw new AnalysisException(PROPERTIES_COMPACTION_POLICY
-                        + " must be `time_series`");
+                        + " must be time_series or size_based");
             }
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -127,6 +127,17 @@ public class PropertyAnalyzer {
 
     public static final String PROPERTIES_SKIP_WRITE_INDEX_ON_LOAD = "skip_write_index_on_load";
 
+    public static final String PROPERTIES_COMPACTION_POLICY = "compaction_policy";
+
+    public static final String PROPERTIES_TIME_SERIES_COMPACTION_GOAL_SIZE_MBYTES =
+                                                        "time_series_compaction_goal_size_mbytes";
+
+    public static final String PROPERTIES_TIME_SERIES_COMPACTION_FILE_COUNT_THRESHOLD =
+                                                        "time_series_compaction_file_count_threshold";
+
+    public static final String PROPERTIES_TIME_SERIES_COMPACTION_TIME_THRESHOLD_SECONDS =
+                                                        "time_series_compaction_time_threshold_seconds";
+
     public static final String PROPERTIES_MUTABLE = "mutable";
 
     public static final String PROPERTIES_CCR_ENABLE = "ccr_enable";
@@ -587,6 +598,81 @@ public class PropertyAnalyzer {
         }
         throw new AnalysisException(PROPERTIES_SKIP_WRITE_INDEX_ON_LOAD
                 + " must be `true` or `false`");
+    }
+
+    public static String analyzeCompactionPolicy(Map<String, String> properties) throws AnalysisException {
+        if (properties == null || properties.isEmpty()) {
+            return "";
+        }
+        String compactionPolicy = "";
+        if (properties.containsKey(PROPERTIES_COMPACTION_POLICY)) {
+            compactionPolicy = properties.get(PROPERTIES_COMPACTION_POLICY);
+            properties.remove(PROPERTIES_COMPACTION_POLICY);
+            if (!compactionPolicy.equals("time_series")) {
+                throw new AnalysisException(PROPERTIES_COMPACTION_POLICY
+                        + " must be `time_series`");
+            }
+        }
+
+        return compactionPolicy;
+    }
+
+    public static long analyzeTimeSeriesCompactionGoalSizeMbytes(Map<String, String> properties,
+                                            long defaultGoalSizeMbytes) throws AnalysisException {
+        long goalSizeMbytes = defaultGoalSizeMbytes;
+        if (properties == null || properties.isEmpty()) {
+            return goalSizeMbytes;
+        }
+        if (properties.containsKey(PROPERTIES_TIME_SERIES_COMPACTION_GOAL_SIZE_MBYTES)) {
+            String goalSizeMbytesStr = properties.get(PROPERTIES_TIME_SERIES_COMPACTION_GOAL_SIZE_MBYTES);
+            properties.remove(PROPERTIES_TIME_SERIES_COMPACTION_GOAL_SIZE_MBYTES);
+            try {
+                goalSizeMbytes = Long.parseLong(goalSizeMbytesStr);
+            } catch (NumberFormatException e) {
+                throw new AnalysisException("Invalid time_series_compaction_goal_size_mbytes format: "
+                        + goalSizeMbytesStr);
+            }
+        }
+        return goalSizeMbytes;
+    }
+
+    public static long analyzeTimeSeriesCompactionFileCountThreshold(Map<String, String> properties,
+                                            long defaultFileCountThreshold) throws AnalysisException {
+        long fileCountThreshold = defaultFileCountThreshold;
+        if (properties == null || properties.isEmpty()) {
+            return fileCountThreshold;
+        }
+        if (properties.containsKey(PROPERTIES_TIME_SERIES_COMPACTION_FILE_COUNT_THRESHOLD)) {
+            String fileCountThresholdStr = properties
+                                            .get(PROPERTIES_TIME_SERIES_COMPACTION_FILE_COUNT_THRESHOLD);
+            properties.remove(PROPERTIES_TIME_SERIES_COMPACTION_FILE_COUNT_THRESHOLD);
+            try {
+                fileCountThreshold = Long.parseLong(fileCountThresholdStr);
+            } catch (NumberFormatException e) {
+                throw new AnalysisException("Invalid time_series_compaction_file_count_threshold format: "
+                                                                                + fileCountThresholdStr);
+            }
+        }
+        return fileCountThreshold;
+    }
+
+    public static long analyzeTimeSeriesCompactionTimeThresholdSeconds(Map<String, String> properties,
+                                                long defaultTimeThresholdSeconds) throws AnalysisException {
+        long timeThresholdSeconds = defaultTimeThresholdSeconds;
+        if (properties == null || properties.isEmpty()) {
+            return timeThresholdSeconds;
+        }
+        if (properties.containsKey(PROPERTIES_TIME_SERIES_COMPACTION_TIME_THRESHOLD_SECONDS)) {
+            String timeThresholdSecondsStr = properties.get(PROPERTIES_TIME_SERIES_COMPACTION_TIME_THRESHOLD_SECONDS);
+            properties.remove(PROPERTIES_TIME_SERIES_COMPACTION_TIME_THRESHOLD_SECONDS);
+            try {
+                timeThresholdSeconds = Long.parseLong(timeThresholdSecondsStr);
+            } catch (NumberFormatException e) {
+                throw new AnalysisException("Invalid time_series_compaction_time_threshold_seconds format: "
+                                                                                + timeThresholdSecondsStr);
+            }
+        }
+        return timeThresholdSeconds;
     }
 
     // analyzeCompressionType will parse the compression type from properties

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -2014,20 +2014,20 @@ public class InternalCatalog implements CatalogIf<Database> {
         olapTable.setCompactionPolicy(compactionPolicy);
 
         // set time series compaction goal size
-        long timeSeriesCompactionGoalSizeMbytes = 1024;
+        long timeSeriesCompactionGoalSizeMbytes = 512;
         try {
             timeSeriesCompactionGoalSizeMbytes = PropertyAnalyzer
-                                        .analyzeTimeSeriesCompactionGoalSizeMbytes(properties, 1024);
+                                        .analyzeTimeSeriesCompactionGoalSizeMbytes(properties, 512);
         } catch (AnalysisException e) {
             throw new DdlException(e.getMessage());
         }
         olapTable.setTimeSeriesCompactionGoalSizeMbytes(timeSeriesCompactionGoalSizeMbytes);
 
         // set time series compaction file count threshold
-        long timeSeriesCompactionFileCountThreshold = 10000;
+        long timeSeriesCompactionFileCountThreshold = 2000;
         try {
             timeSeriesCompactionFileCountThreshold = PropertyAnalyzer
-                                    .analyzeTimeSeriesCompactionFileCountThreshold(properties, 10000);
+                                    .analyzeTimeSeriesCompactionFileCountThreshold(properties, 2000);
         } catch (AnalysisException e) {
             throw new DdlException(e.getMessage());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -1762,13 +1762,9 @@ public class InternalCatalog implements CatalogIf<Database> {
             DataSortInfo dataSortInfo, boolean enableUniqueKeyMergeOnWrite, String storagePolicy,
             IdGeneratorBuffer idGeneratorBuffer, boolean disableAutoCompaction,
             boolean enableSingleReplicaCompaction, boolean skipWriteIndexOnLoad,
-<<<<<<< HEAD
-            boolean storeRowColumn, boolean isDynamicSchema, BinlogConfig binlogConfig) throws DdlException {
-=======
             String compactionPolicy, Long timeSeriesCompactionGoalSizeMbytes,
             Long timeSeriesCompactionFileCountThreshold, Long timeSeriesCompactionTimeThresholdSeconds,
-            boolean storeRowColumn, boolean isDynamicSchema) throws DdlException {
->>>>>>> 02130ea787 ([improvement](compaction) Support for configuring the compaction policy during table creation)
+            boolean storeRowColumn, boolean isDynamicSchema, BinlogConfig binlogConfig) throws DdlException {
         // create base index first.
         Preconditions.checkArgument(baseIndexId != -1);
         MaterializedIndex baseIndex = new MaterializedIndex(baseIndexId, IndexState.NORMAL);
@@ -1831,13 +1827,9 @@ public class InternalCatalog implements CatalogIf<Database> {
                             storageMedium, schema, bfColumns, bfFpp, countDownLatch, indexes, isInMemory, tabletType,
                             dataSortInfo, compressionType, enableUniqueKeyMergeOnWrite, storagePolicy,
                             disableAutoCompaction, enableSingleReplicaCompaction, skipWriteIndexOnLoad,
-<<<<<<< HEAD
-                            storeRowColumn, isDynamicSchema, binlogConfig);
-=======
                             compactionPolicy, timeSeriesCompactionGoalSizeMbytes,
                             timeSeriesCompactionFileCountThreshold, timeSeriesCompactionTimeThresholdSeconds,
-                            storeRowColumn, isDynamicSchema);
->>>>>>> 02130ea787 ([improvement](compaction) Support for configuring the compaction policy during table creation)
+                            storeRowColumn, isDynamicSchema, binlogConfig);
 
                     task.setStorageFormat(storageFormat);
                     batchTask.addTask(task);
@@ -2346,14 +2338,10 @@ public class InternalCatalog implements CatalogIf<Database> {
                         olapTable.getDataSortInfo(), olapTable.getEnableUniqueKeyMergeOnWrite(), storagePolicy,
                         idGeneratorBuffer, olapTable.disableAutoCompaction(),
                         olapTable.enableSingleReplicaCompaction(), skipWriteIndexOnLoad,
-<<<<<<< HEAD
-                        storeRowColumn, isDynamicSchema, binlogConfigForTask);
-=======
                         olapTable.compactionPolicy(), olapTable.timeSeriesCompactionGoalSizeMbytes(),
                         olapTable.timeSeriesCompactionFileCountThreshold(),
                         olapTable.timeSeriesCompactionTimeThresholdSeconds(),
-                        storeRowColumn, isDynamicSchema);
->>>>>>> 02130ea787 ([improvement](compaction) Support for configuring the compaction policy during table creation)
+                        storeRowColumn, isDynamicSchema, binlogConfigForTask);
                 olapTable.addPartition(partition);
             } else if (partitionInfo.getType() == PartitionType.RANGE
                     || partitionInfo.getType() == PartitionType.LIST) {
@@ -2419,14 +2407,10 @@ public class InternalCatalog implements CatalogIf<Database> {
                             olapTable.getDataSortInfo(), olapTable.getEnableUniqueKeyMergeOnWrite(), storagePolicy,
                             idGeneratorBuffer, olapTable.disableAutoCompaction(),
                             olapTable.enableSingleReplicaCompaction(), skipWriteIndexOnLoad,
-<<<<<<< HEAD
-                            storeRowColumn, isDynamicSchema, binlogConfigForTask);
-=======
                             olapTable.compactionPolicy(), olapTable.timeSeriesCompactionGoalSizeMbytes(),
                             olapTable.timeSeriesCompactionFileCountThreshold(),
                             olapTable.timeSeriesCompactionTimeThresholdSeconds(),
-                            storeRowColumn, isDynamicSchema);
->>>>>>> 02130ea787 ([improvement](compaction) Support for configuring the compaction policy during table creation)
+                            storeRowColumn, isDynamicSchema, binlogConfigForTask);
                     olapTable.addPartition(partition);
                 }
             } else {
@@ -2846,14 +2830,10 @@ public class InternalCatalog implements CatalogIf<Database> {
                         olapTable.getPartitionInfo().getDataProperty(oldPartitionId).getStoragePolicy(),
                         idGeneratorBuffer, olapTable.disableAutoCompaction(),
                         olapTable.enableSingleReplicaCompaction(), olapTable.skipWriteIndexOnLoad(),
-<<<<<<< HEAD
-                        olapTable.storeRowColumn(), olapTable.isDynamicSchema(), binlogConfig);
-=======
                         olapTable.compactionPolicy(), olapTable.timeSeriesCompactionGoalSizeMbytes(),
                         olapTable.timeSeriesCompactionFileCountThreshold(),
                         olapTable.timeSeriesCompactionTimeThresholdSeconds(),
-                        olapTable.storeRowColumn(), olapTable.isDynamicSchema());
->>>>>>> 02130ea787 ([improvement](compaction) Support for configuring the compaction policy during table creation)
+                        olapTable.storeRowColumn(), olapTable.isDynamicSchema(), binlogConfig);
                 newPartitions.add(newPartition);
             }
         } catch (DdlException e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
@@ -809,7 +809,10 @@ public class ReportHandler extends Daemon {
                                             olapTable.getEnableUniqueKeyMergeOnWrite(), olapTable.getStoragePolicy(),
                                             olapTable.disableAutoCompaction(),
                                             olapTable.enableSingleReplicaCompaction(),
-                                            olapTable.skipWriteIndexOnLoad(),
+                                            olapTable.skipWriteIndexOnLoad(), olapTable.compactionPolicy(),
+                                            olapTable.timeSeriesCompactionGoalSizeMbytes(),
+                                            olapTable.timeSeriesCompactionFileCountThreshold(),
+                                            olapTable.timeSeriesCompactionTimeThresholdSeconds(),
                                             olapTable.storeRowColumn(), olapTable.isDynamicSchema(),
                                             binlogConfig);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/task/CreateReplicaTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/CreateReplicaTask.java
@@ -105,6 +105,14 @@ public class CreateReplicaTask extends AgentTask {
 
     private boolean skipWriteIndexOnLoad;
 
+    private String compactionPolicy;
+
+    private long timeSeriesCompactionGoalSizeMbytes;
+
+    private long timeSeriesCompactionFileCountThreshold;
+
+    private long timeSeriesCompactionTimeThresholdSeconds;
+
     private boolean storeRowColumn;
 
     private BinlogConfig binlogConfig;
@@ -123,6 +131,10 @@ public class CreateReplicaTask extends AgentTask {
                              String storagePolicy, boolean disableAutoCompaction,
                              boolean enableSingleReplicaCompaction,
                              boolean skipWriteIndexOnLoad,
+                             String compactionPolicy,
+                             long timeSeriesCompactionGoalSizeMbytes,
+                             long timeSeriesCompactionFileCountThreshold,
+                             long timeSeriesCompactionTimeThresholdSeconds,
                              boolean storeRowColumn,
                              boolean isDynamicSchema,
                              BinlogConfig binlogConfig) {
@@ -162,6 +174,10 @@ public class CreateReplicaTask extends AgentTask {
         this.disableAutoCompaction = disableAutoCompaction;
         this.enableSingleReplicaCompaction = enableSingleReplicaCompaction;
         this.skipWriteIndexOnLoad = skipWriteIndexOnLoad;
+        this.compactionPolicy = compactionPolicy;
+        this.timeSeriesCompactionGoalSizeMbytes = timeSeriesCompactionGoalSizeMbytes;
+        this.timeSeriesCompactionFileCountThreshold = timeSeriesCompactionFileCountThreshold;
+        this.timeSeriesCompactionTimeThresholdSeconds = timeSeriesCompactionTimeThresholdSeconds;
         this.storeRowColumn = storeRowColumn;
         this.binlogConfig = binlogConfig;
     }
@@ -270,7 +286,10 @@ public class CreateReplicaTask extends AgentTask {
         tSchema.setDisableAutoCompaction(disableAutoCompaction);
         tSchema.setEnableSingleReplicaCompaction(enableSingleReplicaCompaction);
         tSchema.setSkipWriteIndexOnLoad(skipWriteIndexOnLoad);
-        tSchema.setSkipWriteIndexOnLoad(skipWriteIndexOnLoad);
+        tSchema.setCompactionPolicy(compactionPolicy);
+        tSchema.setTimeSeriesCompactionGoalSizeMbytes(timeSeriesCompactionGoalSizeMbytes);
+        tSchema.setTimeSeriesCompactionFileCountThreshold(timeSeriesCompactionFileCountThreshold);
+        tSchema.setTimeSeriesCompactionTimeThresholdSeconds(timeSeriesCompactionTimeThresholdSeconds);
         tSchema.setStoreRowColumn(storeRowColumn);
         tSchema.setIsDynamicSchema(isDynamicSchema);
         createTabletReq.setTabletSchema(tSchema);

--- a/fe/fe-core/src/main/java/org/apache/doris/task/UpdateTabletMetaInfoTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/UpdateTabletMetaInfoTask.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.BinlogConfig;
 import org.apache.doris.common.MarkedCountDownLatch;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.Status;
+import org.apache.doris.common.util.PropertyAnalyzer;
 import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.thrift.TTabletMetaInfo;
 import org.apache.doris.thrift.TTaskType;
@@ -30,6 +31,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
@@ -44,6 +46,8 @@ public class UpdateTabletMetaInfoTask extends AgentTask {
     private int inMemory = -1; // < 0 means not to update inMemory property, > 0 means true, == 0 means false
     private long storagePolicyId = -1; // < 0 means not to update storage policy, == 0 means to reset storage policy
     private BinlogConfig binlogConfig = null; // null means not to update binlog config
+    private String compactionPolicy = null; // null means not to update compaction policy
+    private Map<String, Long> timeSeriesCompactionConfig = null; // null means not to update compaction policy config
     // For ReportHandler
     private List<TTabletMetaInfo> tabletMetaInfos;
 
@@ -63,6 +67,22 @@ public class UpdateTabletMetaInfoTask extends AgentTask {
         this.inMemory = inMemory;
         this.binlogConfig = binlogConfig;
         this.latch = latch;
+    }
+
+    public UpdateTabletMetaInfoTask(long backendId,
+                                    Set<Pair<Long, Integer>> tableIdWithSchemaHash,
+                                    int inMemory, long storagePolicyId,
+                                    BinlogConfig binlogConfig,
+                                    MarkedCountDownLatch<Long, Set<Pair<Long, Integer>>> latch,
+                                    String compactionPolicy,
+                                    Map<String, Long> timeSeriesCompactionConfig) {
+        this(backendId, tableIdWithSchemaHash);
+        this.storagePolicyId = storagePolicyId;
+        this.inMemory = inMemory;
+        this.binlogConfig = binlogConfig;
+        this.latch = latch;
+        this.compactionPolicy = compactionPolicy;
+        this.timeSeriesCompactionConfig = timeSeriesCompactionConfig;
     }
 
     public UpdateTabletMetaInfoTask(long backendId, List<TTabletMetaInfo> tabletMetaInfos) {
@@ -109,6 +129,26 @@ public class UpdateTabletMetaInfoTask extends AgentTask {
                 }
                 if (binlogConfig != null) {
                     metaInfo.setBinlogConfig(binlogConfig.toThrift());
+                }
+                if (compactionPolicy != null) {
+                    metaInfo.setCompactionPolicy(compactionPolicy);
+                }
+                if (!timeSeriesCompactionConfig.isEmpty()) {
+                    if (timeSeriesCompactionConfig
+                            .containsKey(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_GOAL_SIZE_MBYTES)) {
+                        metaInfo.setTimeSeriesCompactionGoalSizeMbytes(timeSeriesCompactionConfig
+                                    .get(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_GOAL_SIZE_MBYTES));
+                    }
+                    if (timeSeriesCompactionConfig
+                            .containsKey(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_FILE_COUNT_THRESHOLD)) {
+                        metaInfo.setTimeSeriesCompactionFileCountThreshold(timeSeriesCompactionConfig
+                                        .get(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_FILE_COUNT_THRESHOLD));
+                    }
+                    if (timeSeriesCompactionConfig
+                            .containsKey(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_TIME_THRESHOLD_SECONDS)) {
+                        metaInfo.setTimeSeriesCompactionTimeThresholdSeconds(timeSeriesCompactionConfig
+                                    .get(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_TIME_THRESHOLD_SECONDS));
+                    }
                 }
                 updateTabletMetaInfoReq.addToTabletMetaInfos(metaInfo);
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/task/AgentTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/task/AgentTaskTest.java
@@ -107,7 +107,7 @@ public class AgentTaskTest {
         createReplicaTask = new CreateReplicaTask(backendId1, dbId, tableId, partitionId,
                 indexId1, tabletId1, replicaId1, shortKeyNum, schemaHash1, version, KeysType.AGG_KEYS, storageType,
                 TStorageMedium.SSD, columns, null, 0, latch, null, false, TTabletType.TABLET_TYPE_DISK, null,
-                TCompressionType.LZ4F, false, "", false, false, false, false, false, null);
+                TCompressionType.LZ4F, false, "", false, false, false, "", 0, 0, 0, false, false, null);
 
         // drop
         dropTask = new DropReplicaTask(backendId1, tabletId1, replicaId1, schemaHash1, false);

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -236,6 +236,10 @@ message TabletSchemaPB {
     repeated string partial_update_input_columns = 21;
     optional bool enable_single_replica_compaction = 22 [default=false];
     optional bool skip_write_index_on_load = 23 [default=false];
+    optional string compaction_policy = 24;
+    optional int64 time_series_compaction_goal_size_mbytes = 25 [default=1024];
+    optional int64 time_series_compaction_file_count_threshold = 26 [default=10000];
+    optional int64 time_series_compaction_time_threshold_seconds = 27 [default=3600];
 }
 
 enum TabletStatePB {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -44,6 +44,10 @@ struct TTabletSchema {
     16: optional bool store_row_column = false
     17: optional bool enable_single_replica_compaction = false
     18: optional bool skip_write_index_on_load = false
+    19: optional string compaction_policy
+    20: optional i64 time_series_compaction_goal_size_mbytes = 1024
+    21: optional i64 time_series_compaction_file_count_threshold = 10000
+    22: optional i64 time_series_compaction_time_threshold_seconds = 3600
 }
 
 // this enum stands for different storage format in src_backends

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -405,6 +405,10 @@ struct TTabletMetaInfo {
     7: optional i64 storage_policy_id
     8: optional Types.TReplicaId replica_id
     9: optional TBinlogConfig binlog_config
+    10: optional string compaction_policy
+    11: optional i64 time_series_compaction_goal_size_mbytes = -1
+    12: optional i64 time_series_compaction_file_count_threshold = -1
+    13: optional i64 time_series_compaction_time_threshold_seconds = -1
 }
 
 struct TUpdateTabletMetaInfoReq {


### PR DESCRIPTION
## Proposed changes

There were two global compaction policies available: "size_based" and "time_series". Now, the "time_series" compaction policy only can be specified during table creation. 

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

