### PR TITLE
[Bug](pipeline) fix hang on union_source_operator when child sink_operator all finished

### DIFF
--- a/be/src/pipeline/exec/union_source_operator.cpp
+++ b/be/src/pipeline/exec/union_source_operator.cpp
@@ -49,7 +49,7 @@ UnionSourceOperator::UnionSourceOperator(OperatorBuilderBase* operator_builder, 
 // we assumed it can read to process const expr， Although we don't know whether there is
 // ,and queue have data, could read also
 bool UnionSourceOperator::can_read() {
-    return _need_read_for_const_expr || _data_queue->remaining_has_data();
+    return _need_read_for_const_expr || _data_queue->has_data_or_finished();
 }
 
 Status UnionSourceOperator::pull_data(RuntimeState* state, vectorized::Block* block, bool* eos) {

--- a/be/src/pipeline/exec/union_source_operator.cpp
+++ b/be/src/pipeline/exec/union_source_operator.cpp
@@ -46,10 +46,14 @@ UnionSourceOperator::UnionSourceOperator(OperatorBuilderBase* operator_builder, 
           _data_queue(queue),
           _need_read_for_const_expr(true) {};
 
+bool UnionSourceOperator::_has_data() {
+    return _need_read_for_const_expr || _data_queue->remaining_has_data();
+}
+
 // we assumed it can read to process const expr， Although we don't know whether there is
 // ,and queue have data, could read also
 bool UnionSourceOperator::can_read() {
-    return _need_read_for_const_expr || _data_queue->has_data_or_finished();
+    return _has_data() || _data_queue->is_all_finish();
 }
 
 Status UnionSourceOperator::pull_data(RuntimeState* state, vectorized::Block* block, bool* eos) {
@@ -83,9 +87,9 @@ Status UnionSourceOperator::get_block(RuntimeState* state, vectorized::Block* bl
             std::bind(&UnionSourceOperator::pull_data, this, std::placeholders::_1,
                       std::placeholders::_2, std::placeholders::_3)));
     //have exectue const expr, queue have no data any more, and child could be colsed
-    if (eos || (!can_read() && _data_queue->is_all_finish())) {
+    if (eos || (!_has_data() && _data_queue->is_all_finish())) {
         source_state = SourceState::FINISHED;
-    } else if (can_read()) {
+    } else if (_has_data()) {
         source_state = SourceState::MORE_DATA;
     } else {
         source_state = SourceState::DEPEND_ON_SOURCE;

--- a/be/src/pipeline/exec/union_source_operator.h
+++ b/be/src/pipeline/exec/union_source_operator.h
@@ -59,6 +59,8 @@ public:
     Status pull_data(RuntimeState* state, vectorized::Block* output_block, bool* eos);
 
 private:
+    bool _has_data();
+
     std::shared_ptr<DataQueue> _data_queue;
     bool _need_read_for_const_expr;
 };


### PR DESCRIPTION
## Proposed changes
When `union_source_operator`'s child `sink_operator` all finished, `union_source_operator.can_read()` is false, then is operator will not be schedured.

<img width="692" alt="图片" src="https://github.com/apache/doris/assets/7939630/58a70528-41ac-4cfb-8660-10178151bd00">


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

