### PR TITLE
[fix](Nereids) fix 3 plan errors about select mv

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/mv/AbstractSelectMaterializedIndexRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/mv/AbstractSelectMaterializedIndexRule.java
@@ -59,6 +59,7 @@ import org.apache.doris.nereids.util.ExpressionUtils;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Lists;
 import org.apache.commons.collections.CollectionUtils;
 
@@ -340,7 +341,7 @@ public abstract class AbstractSelectMaterializedIndexRule {
             if (equalColNames.contains(column.getName())) {
                 matchCount++;
             } else if (nonEqualColNames.contains(column.getName())) {
-                // Unequivalence predicate's columns can match only first column in index.
+                // un-equivalence predicate's columns can match only first column in index.
                 matchCount++;
                 break;
             } else {
@@ -414,15 +415,15 @@ public abstract class AbstractSelectMaterializedIndexRule {
 
     /** SlotContext */
     protected static class SlotContext {
+
         // base index Slot to selected mv Slot
         public final Map<Slot, Slot> baseSlotToMvSlot;
-
-        // selected mv Slot name to mv Slot
-        public final Map<String, Slot> mvNameToMvSlot;
+        // selected mv Slot name to mv Slot, we must use ImmutableSortedMap because column name could be uppercase
+        public final ImmutableSortedMap<String, Slot> mvNameToMvSlot;
 
         public SlotContext(Map<Slot, Slot> baseSlotToMvSlot, Map<String, Slot> mvNameToMvSlot) {
             this.baseSlotToMvSlot = ImmutableMap.copyOf(baseSlotToMvSlot);
-            this.mvNameToMvSlot = ImmutableMap.copyOf(mvNameToMvSlot);
+            this.mvNameToMvSlot = ImmutableSortedMap.copyOf(mvNameToMvSlot, String.CASE_INSENSITIVE_ORDER);
         }
     }
 
@@ -446,7 +447,7 @@ public abstract class AbstractSelectMaterializedIndexRule {
         }
 
         @Override
-        public LogicalAggregate visitLogicalAggregate(LogicalAggregate agg, Void ctx) {
+        public LogicalAggregate<Plan> visitLogicalAggregate(LogicalAggregate<? extends Plan> agg, Void ctx) {
             Plan child = agg.child(0).accept(this, ctx);
             List<Expression> groupByExprs = agg.getGroupByExpressions();
             List<Expression> newGroupByExprs = groupByExprs.stream()
@@ -462,7 +463,7 @@ public abstract class AbstractSelectMaterializedIndexRule {
         }
 
         @Override
-        public LogicalRepeat visitLogicalRepeat(LogicalRepeat repeat, Void ctx) {
+        public LogicalRepeat<Plan> visitLogicalRepeat(LogicalRepeat<? extends Plan> repeat, Void ctx) {
             Plan child = repeat.child(0).accept(this, ctx);
             List<List<Expression>> groupingSets = repeat.getGroupingSets();
             ImmutableList.Builder<List<Expression>> newGroupingExprs = ImmutableList.builder();
@@ -482,7 +483,7 @@ public abstract class AbstractSelectMaterializedIndexRule {
         }
 
         @Override
-        public LogicalFilter visitLogicalFilter(LogicalFilter filter, Void ctx) {
+        public LogicalFilter<Plan> visitLogicalFilter(LogicalFilter<? extends Plan> filter, Void ctx) {
             Plan child = filter.child(0).accept(this, ctx);
             Set<Expression> newConjuncts = ImmutableSet.copyOf(ExpressionUtils.extractConjunction(
                     new ReplaceExpressionWithMvColumn(slotContext).replace(filter.getPredicate())));
@@ -491,7 +492,7 @@ public abstract class AbstractSelectMaterializedIndexRule {
         }
 
         @Override
-        public LogicalProject visitLogicalProject(LogicalProject project, Void ctx) {
+        public LogicalProject<Plan> visitLogicalProject(LogicalProject<? extends Plan> project, Void ctx) {
             Plan child = project.child(0).accept(this, ctx);
             List<NamedExpression> projects = project.getProjects();
             List<NamedExpression> newProjects = projects.stream()
@@ -511,15 +512,15 @@ public abstract class AbstractSelectMaterializedIndexRule {
      * ReplaceExpressionWithMvColumn
      */
     protected static class ReplaceExpressionWithMvColumn extends DefaultExpressionRewriter<Void> {
+
         // base index Slot to selected mv Slot
         private final Map<Slot, Slot> baseSlotToMvSlot;
-
-        // selected mv Slot name to mv Slot
-        private final Map<String, Slot> mvNameToMvSlot;
+        // selected mv Slot name to mv Slot,  we must use ImmutableSortedMap because column name could be uppercase
+        private final ImmutableSortedMap<String, Slot> mvNameToMvSlot;
 
         public ReplaceExpressionWithMvColumn(SlotContext slotContext) {
             this.baseSlotToMvSlot = ImmutableMap.copyOf(slotContext.baseSlotToMvSlot);
-            this.mvNameToMvSlot = ImmutableMap.copyOf(slotContext.mvNameToMvSlot);
+            this.mvNameToMvSlot = ImmutableSortedMap.copyOf(slotContext.mvNameToMvSlot, String.CASE_INSENSITIVE_ORDER);
         }
 
         public Expression replace(Expression expression) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/mv/SelectMaterializedIndexWithAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/mv/SelectMaterializedIndexWithAggregate.java
@@ -111,7 +111,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                         return new ReplaceExpressions(slotContext)
                             .replace(agg.withChildren(mvPlan), mvPlan);
                     } else {
-                        return new LogicalProject(
+                        return new LogicalProject<>(
                             generateProjectsAlias(agg.getOutput(), slotContext),
                                 new ReplaceExpressions(slotContext).replace(
                                     new LogicalAggregate<>(
@@ -155,12 +155,12 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                             SlotContext slotContext = generateBaseScanExprToMvExpr(mvPlan);
 
                             if (result.exprRewriteMap.isEmpty()) {
-                                return new LogicalProject(
+                                return new LogicalProject<>(
                                     generateProjectsAlias(agg.getOutput(), slotContext),
                                         new ReplaceExpressions(slotContext).replace(
                                         agg.withChildren(filter.withChildren(mvPlan)), mvPlan));
                             } else {
-                                return new LogicalProject(
+                                return new LogicalProject<>(
                                     generateProjectsAlias(agg.getOutput(), slotContext),
                                         new ReplaceExpressions(slotContext).replace(
                                             new LogicalAggregate<>(
@@ -200,7 +200,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                             SlotContext slotContext = generateBaseScanExprToMvExpr(mvPlan);
 
                             if (result.exprRewriteMap.isEmpty()) {
-                                return new LogicalProject(
+                                return new LogicalProject<>(
                                     generateProjectsAlias(agg.getOutput(), slotContext),
                                         new ReplaceExpressions(slotContext).replace(
                                         agg.withChildren(
@@ -213,7 +213,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                                 LogicalProject<LogicalOlapScan> newProject = new LogicalProject<>(
                                         generateNewOutputsWithMvOutputs(mvPlan, newProjectList),
                                         scan.withMaterializedIndexSelected(result.preAggStatus, result.indexId));
-                                return new LogicalProject(
+                                return new LogicalProject<>(
                                     generateProjectsAlias(agg.getOutput(), slotContext),
                                         new ReplaceExpressions(slotContext).replace(
                                             new LogicalAggregate<>(
@@ -258,7 +258,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                             SlotContext slotContext = generateBaseScanExprToMvExpr(mvPlan);
 
                             if (result.exprRewriteMap.isEmpty()) {
-                                return new LogicalProject(
+                                return new LogicalProject<>(
                                     generateProjectsAlias(agg.getOutput(), slotContext),
                                         new ReplaceExpressions(slotContext).replace(
                                         agg.withChildren(
@@ -272,7 +272,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                                         generateNewOutputsWithMvOutputs(mvPlan, newProjectList),
                                         filter.withChildren(mvPlan));
 
-                                return new LogicalProject(
+                                return new LogicalProject<>(
                                     generateProjectsAlias(agg.getOutput(), slotContext),
                                         new ReplaceExpressions(slotContext).replace(
                                             new LogicalAggregate<>(
@@ -315,7 +315,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                             SlotContext slotContext = generateBaseScanExprToMvExpr(mvPlan);
 
                             if (result.exprRewriteMap.isEmpty()) {
-                                return new LogicalProject(
+                                return new LogicalProject<>(
                                     generateProjectsAlias(agg.getOutput(), slotContext),
                                         new ReplaceExpressions(slotContext).replace(
                                         agg.withChildren(
@@ -329,7 +329,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                                 LogicalProject<Plan> newProject = new LogicalProject<>(
                                         generateNewOutputsWithMvOutputs(mvPlan, newProjectList), mvPlan);
 
-                                return new LogicalProject(
+                                return new LogicalProject<>(
                                     generateProjectsAlias(agg.getOutput(), slotContext),
                                         new ReplaceExpressions(slotContext).replace(
                                             new LogicalAggregate<>(
@@ -361,7 +361,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                     SlotContext slotContext = generateBaseScanExprToMvExpr(mvPlan);
 
                     if (result.exprRewriteMap.isEmpty()) {
-                        return new LogicalProject(
+                        return new LogicalProject<>(
                             generateProjectsAlias(agg.getOutput(), slotContext),
                                 new ReplaceExpressions(slotContext).replace(
                                 agg.withChildren(
@@ -369,7 +369,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                                         generateNewOutputsWithMvOutputs(mvPlan, repeat.getOutputs()), mvPlan)
                                 ), mvPlan));
                     } else {
-                        return new LogicalProject(
+                        return new LogicalProject<>(
                             generateProjectsAlias(agg.getOutput(), slotContext),
                                 new ReplaceExpressions(slotContext).replace(
                                     new LogicalAggregate<>(
@@ -415,7 +415,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                             SlotContext slotContext = generateBaseScanExprToMvExpr(mvPlan);
 
                             if (result.exprRewriteMap.isEmpty()) {
-                                return new LogicalProject(
+                                return new LogicalProject<>(
                                     generateProjectsAlias(agg.getOutput(), slotContext),
                                         new ReplaceExpressions(slotContext).replace(
                                         agg.withChildren(
@@ -424,7 +424,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                                                     filter.withChildren(mvPlan)
                                             )), mvPlan));
                             } else {
-                                return new LogicalProject(
+                                return new LogicalProject<>(
                                     generateProjectsAlias(agg.getOutput(), slotContext),
                                         new ReplaceExpressions(slotContext).replace(
                                             new LogicalAggregate<>(
@@ -467,7 +467,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                             SlotContext slotContext = generateBaseScanExprToMvExpr(mvPlan);
 
                             if (result.exprRewriteMap.isEmpty()) {
-                                return new LogicalProject(
+                                return new LogicalProject<>(
                                     generateProjectsAlias(agg.getOutput(), slotContext),
                                         new ReplaceExpressions(slotContext).replace(
                                         agg.withChildren(
@@ -483,7 +483,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                                 LogicalProject<LogicalOlapScan> newProject = new LogicalProject<>(
                                         generateNewOutputsWithMvOutputs(mvPlan, newProjectList),
                                         mvPlan);
-                                return new LogicalProject(
+                                return new LogicalProject<>(
                                     generateProjectsAlias(agg.getOutput(), slotContext),
                                         new ReplaceExpressions(slotContext).replace(
                                             new LogicalAggregate<>(
@@ -532,7 +532,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                             SlotContext slotContext = generateBaseScanExprToMvExpr(mvPlan);
 
                             if (result.exprRewriteMap.isEmpty()) {
-                                return new LogicalProject(
+                                return new LogicalProject<>(
                                     generateProjectsAlias(agg.getOutput(), slotContext),
                                         new ReplaceExpressions(slotContext).replace(
                                         agg.withChildren(
@@ -551,7 +551,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                                         generateNewOutputsWithMvOutputs(mvPlan, newProjectList),
                                         filter.withChildren(mvPlan));
 
-                                return new LogicalProject(
+                                return new LogicalProject<>(
                                     generateProjectsAlias(agg.getOutput(), slotContext),
                                         new ReplaceExpressions(slotContext).replace(
                                             new LogicalAggregate<>(
@@ -598,7 +598,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                             SlotContext slotContext = generateBaseScanExprToMvExpr(mvPlan);
 
                             if (result.exprRewriteMap.isEmpty()) {
-                                return new LogicalProject(
+                                return new LogicalProject<>(
                                     generateProjectsAlias(agg.getOutput(), slotContext),
                                         new ReplaceExpressions(slotContext).replace(
                                         agg.withChildren(
@@ -617,7 +617,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                                         generateNewOutputsWithMvOutputs(mvPlan, newProjectList),
                                         scan.withMaterializedIndexSelected(result.preAggStatus, result.indexId));
 
-                                return new LogicalProject(
+                                return new LogicalProject<>(
                                     generateProjectsAlias(agg.getOutput(), slotContext),
                                         new ReplaceExpressions(slotContext).replace(
                                             new LogicalAggregate<>(
@@ -955,6 +955,10 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
             } else if (ctx.valueNameToColumn.containsKey(childNameWithFuncName)) {
                 AggregateType aggType = ctx.valueNameToColumn.get(childNameWithFuncName).getAggregationType();
                 if (aggType == matchingAggType) {
+                    if (aggFunc.isDistinct()) {
+                        return PreAggStatus.off(
+                                String.format("Aggregate function %s is distinct aggregation", aggFunc.toSql()));
+                    }
                     return PreAggStatus.on();
                 } else {
                     return PreAggStatus.off(String.format("Aggregate operator don't match, aggregate function: %s"
@@ -968,13 +972,11 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
     }
 
     private static class CheckContext {
+
         public final LogicalOlapScan scan;
-
-        public final Map<String, Column> keyNameToColumn;
-
-        public final Map<String, Column> valueNameToColumn;
-
         public final long index;
+        public final Map<String, Column> keyNameToColumn;
+        public final Map<String, Column> valueNameToColumn;
 
         public CheckContext(LogicalOlapScan scan, long indexId) {
             this.scan = scan;
@@ -1073,8 +1075,8 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
             // The query `select c1, count(distinct c2) from t where c2 > 0 group by c1` can't use the materialized
             // index because we have a filter `c2 > 0` for the aggregated column c2.
             Set<Slot> slotsToReplace = slotMap.keySet();
-            if (!isInputSlotsContainsAny(ImmutableList.copyOf(predicates), slotsToReplace)
-                    && !isInputSlotsContainsAny(groupingExprs, slotsToReplace)) {
+            if (isInputSlotsContainsNone(ImmutableList.copyOf(predicates), slotsToReplace)
+                    && isInputSlotsContainsNone(groupingExprs, slotsToReplace)) {
                 ImmutableSet<Slot> newRequiredSlots = requiredScanOutput.stream()
                         .map(slot -> (Slot) ExpressionUtils.replace(slot, slotMap))
                         .collect(ImmutableSet.toImmutableSet());
@@ -1129,9 +1131,9 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
         }
     }
 
-    private boolean isInputSlotsContainsAny(List<Expression> expressions, Set<Slot> slotsToCheck) {
+    private boolean isInputSlotsContainsNone(List<Expression> expressions, Set<Slot> slotsToCheck) {
         Set<Slot> inputSlotSet = ExpressionUtils.getInputSlotSet(expressions);
-        return !Sets.intersection(inputSlotSet, slotsToCheck).isEmpty();
+        return Sets.intersection(inputSlotSet, slotsToCheck).isEmpty();
     }
 
     private static class RewriteContext {
@@ -1147,8 +1149,8 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
     private static class AggFuncRewriter extends DefaultExpressionRewriter<RewriteContext> {
         public static final AggFuncRewriter INSTANCE = new AggFuncRewriter();
 
-        private static Expression rewrite(Expression expr, RewriteContext context) {
-            return expr.accept(INSTANCE, context);
+        private static void rewrite(Expression expr, RewriteContext context) {
+            expr.accept(INSTANCE, context);
         }
 
         /**
@@ -1176,7 +1178,8 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                                 .stream()
                                 .filter(s -> bitmapUnionColumn.equalsIgnoreCase(normalizeName(s.getName())))
                                 .findFirst()
-                                .get();
+                                .orElseThrow(() -> new AnalysisException(
+                                        "cannot find bitmap union slot when select mv"));
 
                         context.exprRewriteMap.slotMap.put(slotOpt.get(), bitmapUnionSlot);
                         context.exprRewriteMap.projectExprMap.put(slotOpt.get(), bitmapUnionSlot);
@@ -1203,7 +1206,8 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                                 .stream()
                                 .filter(s -> countColumn.equalsIgnoreCase(normalizeName(s.getName())))
                                 .findFirst()
-                                .get();
+                                .orElseThrow(() -> new AnalysisException(
+                                        "cannot find count slot when select mv"));
 
                         context.exprRewriteMap.slotMap.put(slotOpt.get(), countSlot);
                         context.exprRewriteMap.projectExprMap.put(slotOpt.get(), countSlot);
@@ -1239,7 +1243,8 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                                 .stream()
                                 .filter(s -> bitmapUnionCountColumn.equalsIgnoreCase(normalizeName(s.getName())))
                                 .findFirst()
-                                .get();
+                                .orElseThrow(() -> new AnalysisException(
+                                        "cannot find bitmap union count slot when select mv"));
 
                         context.exprRewriteMap.slotMap.put(slotOpt.get(), bitmapUnionCountSlot);
                         context.exprRewriteMap.projectExprMap.put(toBitmap, bitmapUnionCountSlot);
@@ -1266,7 +1271,8 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                                 .stream()
                                 .filter(s -> bitmapUnionCountColumn.equalsIgnoreCase(normalizeName(s.getName())))
                                 .findFirst()
-                                .get();
+                                .orElseThrow(() -> new AnalysisException(
+                                        "cannot find bitmap union count slot when select mv"));
 
                         context.exprRewriteMap.slotMap.put(slotOpt.get(), bitmapUnionCountSlot);
                         context.exprRewriteMap.projectExprMap.put(bitmapHash, bitmapUnionCountSlot);
@@ -1301,7 +1307,8 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                                 .stream()
                                 .filter(s -> hllUnionColumn.equalsIgnoreCase(normalizeName(s.getName())))
                                 .findFirst()
-                                .get();
+                                .orElseThrow(() -> new AnalysisException(
+                                        "cannot find hll union slot when select mv"));
 
                         context.exprRewriteMap.slotMap.put(slotOpt.get(), hllUnionSlot);
                         context.exprRewriteMap.projectExprMap.put(hllHash, hllUnionSlot);
@@ -1336,7 +1343,8 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                                 .stream()
                                 .filter(s -> hllUnionColumn.equalsIgnoreCase(normalizeName(s.getName())))
                                 .findFirst()
-                                .get();
+                                .orElseThrow(() -> new AnalysisException(
+                                        "cannot find hll union slot when select mv"));
 
                         context.exprRewriteMap.slotMap.put(slotOpt.get(), hllUnionSlot);
                         context.exprRewriteMap.projectExprMap.put(hllHash, hllUnionSlot);
@@ -1371,7 +1379,8 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                             .stream()
                             .filter(s -> hllUnionColumn.equalsIgnoreCase(normalizeName(s.getName())))
                             .findFirst()
-                            .get();
+                            .orElseThrow(() -> new AnalysisException(
+                                    "cannot find hll union slot when select mv"));
 
                     context.exprRewriteMap.slotMap.put(slotOpt.get(), hllUnionSlot);
                     context.exprRewriteMap.projectExprMap.put(slotOpt.get(), hllUnionSlot);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/MaterializedViewSelector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/MaterializedViewSelector.java
@@ -157,18 +157,15 @@ public class MaterializedViewSelector {
             }
         }
 
-        // Step2: check all columns in compensating predicates are available in the view
-        // output
+        // Step2: check all columns in compensating predicates are available in the view output
         checkCompensatingPredicates(columnNamesInPredicates.get(tableId), candidateIndexIdToMeta, selectBaseIndex,
                 scanNode.getTupleId());
-        // Step3: group by list in query is the subset of group by list in view or view
-        // contains no aggregation
+        // Step3: group by list in query is the subset of group by list in view or view contains no aggregation
         checkGrouping(table, columnNamesInGrouping.get(tableId), candidateIndexIdToMeta, selectBaseIndex,
                 scanNode.getTupleId());
         // Step4: aggregation functions are available in the view output
         checkAggregationFunction(table, aggColumnsInQuery.get(tableId), candidateIndexIdToMeta, scanNode.getTupleId());
-        // Step5: columns required to compute output expr are available in the view
-        // output
+        // Step5: columns required to compute output expr are available in the view output
         checkOutputColumns(columnNamesInQueryOutput.get(tableId), candidateIndexIdToMeta, selectBaseIndex,
                 scanNode.getTupleId());
         // Step6: if table type is aggregate and the candidateIndexIdToSchema is empty,
@@ -654,7 +651,7 @@ public class MaterializedViewSelector {
         }
 
         // Step4: compute the output column
-        // ISSUE-3174: all of columns which belong to top tuple should be considered in
+        // ISSUE-3174: all columns which belong to top tuple should be considered in
         // selector.
         List<TupleId> tupleIds = selectStmt.getTableRefIdsWithoutInlineView();
         for (TupleId tupleId : tupleIds) {
@@ -664,12 +661,7 @@ public class MaterializedViewSelector {
     }
 
     private void addAggColumnInQuery(Long tableId, FunctionCallExpr fnExpr) {
-        Set<FunctionCallExpr> aggColumns = aggColumnsInQuery.get(tableId);
-        if (aggColumns == null) {
-            aggColumns = Sets.newHashSet();
-            aggColumnsInQuery.put(tableId, aggColumns);
-        }
-        aggColumns.add(fnExpr);
+        aggColumnsInQuery.computeIfAbsent(tableId, k -> Sets.newHashSet()).add(fnExpr);
     }
 
     private boolean aggFunctionsMatchAggColumns(Set<FunctionCallExpr> queryExprList,


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

fix 3 issues:
1. in legacy planner, should not consider aux expr when do mv selection
2. in Nereids, should not hit mv when agg function on value column is distinct
3. select mv cannot rewrite agg function in on table with column name in uppercase

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

