### PR TITLE
[chore](docker) add downloading doris source code for build centos7 dev image

### DIFF
--- a/docker/compilation/Dockerfile
+++ b/docker/compilation/Dockerfile
@@ -70,7 +70,9 @@ RUN rm -f /etc/profile.d/ccache.* \
     && cp /etc/pki/tls/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt
 
 # clone lastest source code, download and build third party
-COPY doris ${DEFAULT_DIR}/doris
+WORKDIR ${DEFAULT_DIR}
+RUN git clone --recurse-submodules https://github.com/apache/doris.git
+
 RUN cd ${DEFAULT_DIR}/doris && /bin/bash thirdparty/build-thirdparty.sh \
     && rm -rf ${DEFAULT_DIR}/doris/thirdparty/src \
     && rm -rf ${DEFAULT_DIR}/doris-thirdparty.tar.gz \


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

There is no doris directory when execute 'docker build --no-cache -f Dockerfile -t doris_dev:latest'.
According to the comments, I think it should download the source code.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

