### PR TITLE
[fix](merge-on-write) fix that delete bitmap is not calculated correctly when has sequence column

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2924,6 +2924,8 @@ Status Tablet::calc_segment_delete_bitmap(RowsetSharedPtr rowset,
         }
         remaining -= num_read;
     }
+    DCHECK_EQ(total, row_id) << "segment total rows: " << total << " row_id:" << row_id;
+
     if (pos > 0) {
         RETURN_IF_ERROR(generate_new_block_for_partial_update(
                 rowset_schema, read_plan_ori, read_plan_update, rsid_to_rowset, &block));

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2871,7 +2871,7 @@ Status Tablet::calc_segment_delete_bitmap(RowsetSharedPtr rowset,
         if (num_read == batch_size && num_read != remaining) {
             num_read -= 1;
         }
-        for (size_t i = 0; i < num_read; i++) {
+        for (size_t i = 0; i < num_read; i++, row_id++) {
             Slice key = Slice(index_column->get_data_at(i).data, index_column->get_data_at(i).size);
             RowLocation loc;
             // same row in segments should be filtered
@@ -2888,7 +2888,6 @@ Status Tablet::calc_segment_delete_bitmap(RowsetSharedPtr rowset,
                 return st;
             }
             if (st.is<NOT_FOUND>()) {
-                ++row_id;
                 continue;
             }
 
@@ -2922,7 +2921,6 @@ Status Tablet::calc_segment_delete_bitmap(RowsetSharedPtr rowset,
             }
             // when st = ok
             delete_bitmap->add({loc.rowset_id, loc.segment_id, 0}, loc.row_id);
-            ++row_id;
         }
         remaining -= num_read;
     }


### PR DESCRIPTION

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
This problem was introduced by: #17542
`row_id` does not add 1 when there is a continue statement.
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

