### PR TITLE
[enhancement](merge-on-write) add primary key data page size config

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -307,7 +307,7 @@ DEFINE_Bool(disable_storage_row_cache, "true");
 // Cache for mow primary key storage page size
 DEFINE_String(pk_storage_page_cache_limit, "10%");
 // data page size for primary key index
-DEFINE_Int32(primary_key_data_page_size, "65536");
+DEFINE_Int32(primary_key_data_page_size, "32768");
 
 DEFINE_Bool(enable_low_cardinality_optimize, "true");
 DEFINE_Bool(enable_low_cardinality_cache_code, "true");

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -306,6 +306,8 @@ DEFINE_Bool(disable_storage_row_cache, "true");
 
 // Cache for mow primary key storage page size
 DEFINE_String(pk_storage_page_cache_limit, "10%");
+// data page size for primary key index
+DEFINE_Int32(primary_key_data_page_size, "65536");
 
 DEFINE_Bool(enable_low_cardinality_optimize, "true");
 DEFINE_Bool(enable_low_cardinality_cache_code, "true");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -347,6 +347,8 @@ DECLARE_Bool(disable_storage_row_cache);
 // Cache for mow primary key storage page size, it's seperated from
 // storage_page_cache_limit
 DECLARE_String(pk_storage_page_cache_limit);
+// data page size for primary key index
+DECLARE_Int32(primary_key_data_page_size);
 
 DECLARE_Bool(enable_low_cardinality_optimize);
 DECLARE_Bool(enable_low_cardinality_cache_code);

--- a/be/src/olap/primary_key_index.cpp
+++ b/be/src/olap/primary_key_index.cpp
@@ -38,6 +38,7 @@ Status PrimaryKeyIndexBuilder::init() {
     segment_v2::IndexedColumnWriterOptions options;
     options.write_ordinal_index = true;
     options.write_value_index = true;
+    options.data_page_size = config::primary_key_data_page_size;
     options.encoding = segment_v2::EncodingInfo::get_default_encoding(type_info, true);
     // TODO(liaoxin) test to confirm whether it needs to be compressed
     options.compression = segment_v2::NO_COMPRESSION; // currently not compressed

--- a/be/src/olap/rowset/segment_v2/indexed_column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/indexed_column_reader.cpp
@@ -37,6 +37,8 @@ using namespace ErrorCode;
 namespace segment_v2 {
 
 static bvar::Adder<uint64_t> g_index_reader_bytes("doris_pk", "index_reader_bytes");
+static bvar::Adder<uint64_t> g_index_reader_compressed_bytes("doris_pk",
+                                                             "index_reader_compressed_bytes");
 static bvar::PerSecond<bvar::Adder<uint64_t>> g_index_reader_bytes_per_second(
         "doris_pk", "index_reader_bytes_per_second", &g_index_reader_bytes, 60);
 static bvar::Adder<uint64_t> g_index_reader_pages("doris_pk", "index_reader_pages");
@@ -119,6 +121,7 @@ Status IndexedColumnReader::read_page(const PagePointer& pp, PageHandle* handle,
     opts.pre_decode = pre_decode;
 
     auto st = PageIO::read_and_decompress_page(opts, handle, body, footer);
+    g_index_reader_compressed_bytes << pp.size;
     g_index_reader_bytes << footer->uncompressed_size();
     g_index_reader_pages << 1;
     return st;

--- a/be/src/olap/rowset/segment_v2/indexed_column_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/indexed_column_writer.cpp
@@ -63,6 +63,7 @@ Status IndexedColumnWriter::init() {
     PageBuilder* data_page_builder = nullptr;
     PageBuilderOptions builder_option;
     builder_option.need_check_bitmap = false;
+    builder_option.data_page_size = _options.data_page_size;
     RETURN_IF_ERROR(encoding_info->create_page_builder(builder_option, &data_page_builder));
     _data_page_builder.reset(data_page_builder);
 

--- a/be/src/olap/rowset/segment_v2/indexed_column_writer.h
+++ b/be/src/olap/rowset/segment_v2/indexed_column_writer.h
@@ -47,6 +47,7 @@ class PageBuilder;
 
 struct IndexedColumnWriterOptions {
     size_t index_page_size = 64 * 1024;
+    size_t data_page_size = 1024 * 1024;
     bool write_ordinal_index = false;
     bool write_value_index = false;
     EncodingTypePB encoding = DEFAULT_ENCODING;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
The default data page size is 1MB  for primary key index, it may cause significant read amplification. So I add a `primary_key_data_page_size` config.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

