### PR TITLE
[Fix](inverted index) remove IndexReader::indexExists, use fs interface

### DIFF
--- a/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
@@ -141,11 +141,13 @@ public:
             return st;
         }
         if (exists) {
-            st = _fs->delete_directory(index_path.c_str());
-            if (!st.ok()) {
-                LOG(ERROR) << "delete directory:" << index_path << " error:" << st;
-                return st;
-            }
+            LOG(ERROR) << "try to init a directory:" << index_path << " already exists";
+            return Status::InternalError("init_fulltext_index a directory already exists");
+            //st = _fs->delete_directory(index_path.c_str());
+            //if (!st.ok()) {
+            //    LOG(ERROR) << "delete directory:" << index_path << " error:" << st;
+            //    return st;
+            //}
         }
 
         _char_string_reader = std::make_unique<lucene::util::SStringReader<char>>();

--- a/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
@@ -133,12 +133,18 @@ public:
                 _directory + "/" + _segment_file_name, _index_meta->index_id());
 
         // LOG(INFO) << "inverted index path: " << index_path;
-
-        if (lucene::index::IndexReader::indexExists(index_path.c_str())) {
-            create = false;
-            if (lucene::index::IndexReader::isLocked(index_path.c_str())) {
-                LOG(WARNING) << ("Lucene Index was locked... unlocking it.\n");
-                lucene::index::IndexReader::unlock(index_path.c_str());
+        bool exists = false;
+        auto st = _fs->exists(index_path.c_str(), &exists);
+        if (!st.ok()) {
+            LOG(ERROR) << "index_path:"
+                       << " exists error:" << st;
+            return st;
+        }
+        if (exists) {
+            st = _fs->delete_directory(index_path.c_str());
+            if (!st.ok()) {
+                LOG(ERROR) << "delete directory:" << index_path << " error:" << st;
+                return st;
             }
         }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

IndexReader::indexExists in CLucene will use system fs interface to find out whether a directory is exists, which is dangerous when writing files into S3, use fs->exists instead.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

