### PR TITLE
[fix](cooldown) Fix potential deadlock while calling `handleCooldownConf`

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
@@ -129,6 +129,7 @@ public class TabletInvertedIndex {
                              List<TTabletMetaInfo> tabletToUpdate,
                              List<CooldownConf> cooldownConfToPush,
                              List<CooldownConf> cooldownConfToUpdate) {
+        List<Pair<TabletMeta, TTabletInfo>> cooldownTablets = new ArrayList<>();
         long stamp = readLock();
         long start = System.currentTimeMillis();
         try {
@@ -198,8 +199,11 @@ public class TabletInvertedIndex {
                             }
 
                             if (Config.enable_storage_policy && backendTabletInfo.isSetCooldownTerm()) {
-                                handleCooldownConf(tabletMeta, backendTabletInfo, cooldownConfToPush,
-                                        cooldownConfToUpdate);
+                                // Place tablet info in a container and process it outside of read lock to avoid
+                                // deadlock with OlapTable lock
+                                synchronized (cooldownTablets) {
+                                    cooldownTablets.add(Pair.of(tabletMeta, backendTabletInfo));
+                                }
                                 replica.setCooldownMetaId(backendTabletInfo.getCooldownMetaId());
                                 replica.setCooldownTerm(backendTabletInfo.getCooldownTerm());
                             }
@@ -326,6 +330,7 @@ public class TabletInvertedIndex {
         } finally {
             readUnlock(stamp);
         }
+        cooldownTablets.forEach(p -> handleCooldownConf(p.first, p.second, cooldownConfToPush, cooldownConfToUpdate));
 
         long end = System.currentTimeMillis();
         LOG.info("finished to do tablet diff with backend[{}]. sync: {}."
@@ -422,9 +427,7 @@ public class TabletInvertedIndex {
         if (cooldownConf.first <= 0) { // invalid cooldownReplicaId
             CooldownConf conf = new CooldownConf(tabletMeta.getDbId(), tabletMeta.getTableId(),
                     tabletMeta.getPartitionId(), tabletMeta.getIndexId(), beTabletInfo.tablet_id, cooldownConf.second);
-            synchronized (cooldownConfToUpdate) {
-                cooldownConfToUpdate.add(conf);
-            }
+            cooldownConfToUpdate.add(conf);
             return;
         }
 
@@ -445,17 +448,13 @@ public class TabletInvertedIndex {
         if (!replicaAlive) {
             CooldownConf conf = new CooldownConf(tabletMeta.getDbId(), tabletMeta.getTableId(),
                     tabletMeta.getPartitionId(), tabletMeta.getIndexId(), beTabletInfo.tablet_id, cooldownConf.second);
-            synchronized (cooldownConfToUpdate) {
-                cooldownConfToUpdate.add(conf);
-            }
+            cooldownConfToUpdate.add(conf);
             return;
         }
 
         if (beTabletInfo.getCooldownTerm() < cooldownConf.second) {
             CooldownConf conf = new CooldownConf(beTabletInfo.tablet_id, cooldownConf.first, cooldownConf.second);
-            synchronized (cooldownConfToPush) {
-                cooldownConfToPush.add(conf);
-            }
+            cooldownConfToPush.add(conf);
             return;
         }
     }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

`TableScheduler` took the write lock on the table and then went to the write lock on the inverted index, while `tabletReport`  takes the read lock for the inverted index, and then goes to the read lock for the table, which cause a deadlock.
To solve this problem, place tablet info in a container and process it (call `handleCooldownConf`) outside of inverted index's read lock.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

