### PR TITLE
[fix](Nereids) subquery not return correct data type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/InSubquery.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/InSubquery.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids.trees.expressions;
 
 import org.apache.doris.nereids.exceptions.UnboundException;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
+import org.apache.doris.nereids.types.BooleanType;
 import org.apache.doris.nereids.types.DataType;
 
 import com.google.common.base.Preconditions;
@@ -40,7 +41,7 @@ public class InSubquery extends SubqueryExpr {
         super(Objects.requireNonNull(listQuery.getQueryPlan(), "subquery can not be null"));
         this.compareExpr = Objects.requireNonNull(compareExpression, "compareExpr can not be null");
         this.listQuery = Objects.requireNonNull(listQuery, "listQuery can not be null");
-        this.isNot = Objects.requireNonNull(isNot, "isNot can not be null");
+        this.isNot = isNot;
     }
 
     public InSubquery(Expression compareExpr, ListQuery listQuery, List<Slot> correlateSlots, boolean isNot) {
@@ -60,12 +61,12 @@ public class InSubquery extends SubqueryExpr {
                 typeCoercionExpr);
         this.compareExpr = Objects.requireNonNull(compareExpr, "compareExpr can not be null");
         this.listQuery = Objects.requireNonNull(listQuery, "listQuery can not be null");
-        this.isNot = Objects.requireNonNull(isNot, "isNot can not be null");
+        this.isNot = isNot;
     }
 
     @Override
     public DataType getDataType() throws UnboundException {
-        return listQuery.getDataType();
+        return BooleanType.INSTANCE;
     }
 
     @Override
@@ -75,7 +76,7 @@ public class InSubquery extends SubqueryExpr {
 
     @Override
     public String toSql() {
-        return this.compareExpr.toSql() + " IN (INSUBQUERY) " + super.toSql();
+        return this.compareExpr.toSql() + " IN (" + super.toSql() + ")";
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/ListQuery.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/ListQuery.java
@@ -33,6 +33,7 @@ import java.util.Optional;
  * just for subquery.
  */
 public class ListQuery extends SubqueryExpr implements LeafExpression {
+
     public ListQuery(LogicalPlan subquery) {
         super(Objects.requireNonNull(subquery, "subquery can not be null"));
     }
@@ -44,7 +45,7 @@ public class ListQuery extends SubqueryExpr implements LeafExpression {
     @Override
     public DataType getDataType() {
         Preconditions.checkArgument(queryPlan.getOutput().size() == 1);
-        return queryPlan.getOutput().get(0).getDataType();
+        return typeCoercionExpr.orElse(queryPlan.getOutput().get(0)).getDataType();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/ScalarSubquery.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/ScalarSubquery.java
@@ -33,6 +33,7 @@ import java.util.Optional;
  * A subquery that will return only one row and one column.
  */
 public class ScalarSubquery extends SubqueryExpr implements LeafExpression {
+
     public ScalarSubquery(LogicalPlan subquery) {
         super(Objects.requireNonNull(subquery, "subquery can not be null"));
     }
@@ -52,7 +53,7 @@ public class ScalarSubquery extends SubqueryExpr implements LeafExpression {
     @Override
     public DataType getDataType() throws UnboundException {
         Preconditions.checkArgument(queryPlan.getOutput().size() == 1);
-        return queryPlan.getOutput().get(0).getDataType();
+        return typeCoercionExpr.orElse(queryPlan.getOutput().get(0)).getDataType();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SubqueryExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SubqueryExpr.java
@@ -33,9 +33,9 @@ import java.util.Optional;
  * Subquery Expression.
  */
 public abstract class SubqueryExpr extends Expression {
+
     protected final LogicalPlan queryPlan;
     protected final List<Slot> correlateSlots;
-
     protected final Optional<Expression> typeCoercionExpr;
 
     public SubqueryExpr(LogicalPlan subquery) {

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/PlannerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/PlannerTest.java
@@ -36,6 +36,9 @@ public class PlannerTest extends TestWithFeService {
 
     @Override
     protected void runBeforeAll() throws Exception {
+
+        connectContext.getSessionVariable().setEnableNereidsPlanner(false);
+
         // Create database `db1`.
         createDatabase("db1");
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

if we do type coercion on subquery, it return datatype after type coercion

error info
```
Both side of binary arithmetic is not numeric. left type is DECIMALV3(2, 1) and right type is DECIMAL(27, 9)')
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

