### PR TITLE
[opt](hudi) using native reader to read the base file with no log file

### DIFF
--- a/fe/be-java-extensions/hudi-scanner/pom.xml
+++ b/fe/be-java-extensions/hudi-scanner/pom.xml
@@ -37,6 +37,12 @@ under the License.
             <groupId>org.apache.doris</groupId>
             <artifactId>java-common</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>fe-common</artifactId>
+                    <groupId>org.apache.doris</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -63,6 +69,10 @@ under the License.
                 <exclusion>
                     <groupId>org.apache.avro</groupId>
                     <artifactId>avro</artifactId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>hudi-hadoop-mr</artifactId>
+                    <groupId>org.apache.hudi</groupId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -92,7 +102,6 @@ under the License.
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
-        <!-- conflict with hudi-*-bundle -->
     </dependencies>
     <build>
         <finalName>hudi-scanner</finalName>

--- a/fe/be-java-extensions/hudi-scanner/src/main/java/org/apache/doris/hudi/HudiColumnValue.java
+++ b/fe/be-java-extensions/hudi-scanner/src/main/java/org/apache/doris/hudi/HudiColumnValue.java
@@ -25,10 +25,13 @@ import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.DateObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.HiveDecimalObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampObjectInspector;
+import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -60,6 +63,11 @@ public class HudiColumnValue implements ColumnValue {
 
     private Object inspectObject() {
         return ((PrimitiveObjectInspector) fieldInspector).getPrimitiveJavaObject(fieldData);
+    }
+
+    @Override
+    public boolean canGetStringAsBytes() {
+        return true;
     }
 
     @Override
@@ -143,6 +151,16 @@ public class HudiColumnValue implements ColumnValue {
 
     @Override
     public byte[] getBytes() {
+        // Get bytes directly if fieldData is BytesWritable or Text to avoid decoding&encoding
+        if (fieldData instanceof BytesWritable) {
+            return ((BytesWritable) fieldData).getBytes();
+        }
+        if (fieldData instanceof Text) {
+            return ((Text) fieldData).getBytes();
+        }
+        if (fieldData instanceof String) {
+            return ((String) fieldData).getBytes(StandardCharsets.UTF_8);
+        }
         return (byte[]) inspectObject();
     }
 

--- a/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/MockJniScanner.java
+++ b/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/MockJniScanner.java
@@ -51,6 +51,11 @@ public class MockJniScanner extends JniScanner {
         }
 
         @Override
+        public boolean canGetStringAsBytes() {
+            return false;
+        }
+
+        @Override
         public boolean isNull() {
             return false;
         }

--- a/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/vec/ColumnValue.java
+++ b/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/vec/ColumnValue.java
@@ -27,6 +27,9 @@ import java.util.List;
  * Column value in vector column
  */
 public interface ColumnValue {
+    // Get bytes directly when reading string value to avoid decoding&encoding
+    boolean canGetStringAsBytes();
+
     boolean isNull();
 
     boolean getBoolean();

--- a/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/vec/ScanPredicate.java
+++ b/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/vec/ScanPredicate.java
@@ -119,6 +119,11 @@ public class ScanPredicate {
         }
 
         @Override
+        public boolean canGetStringAsBytes() {
+            return false;
+        }
+
+        @Override
         public String toString() {
             return inspectObject().toString();
         }

--- a/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/vec/VectorColumn.java
+++ b/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/vec/VectorColumn.java
@@ -597,7 +597,11 @@ public class VectorColumn {
             case CHAR:
             case VARCHAR:
             case STRING:
-                appendStringAndOffset(o.getString());
+                if (o.canGetStringAsBytes()) {
+                    appendBytesAndOffset(o.getBytes());
+                } else {
+                    appendStringAndOffset(o.getString());
+                }
                 break;
             case BINARY:
                 appendBytesAndOffset(o.getBytes());

--- a/fe/be-java-extensions/max-compute-scanner/src/main/java/org/apache/doris/maxcompute/MaxComputeColumnValue.java
+++ b/fe/be-java-extensions/max-compute-scanner/src/main/java/org/apache/doris/maxcompute/MaxComputeColumnValue.java
@@ -58,6 +58,11 @@ public class MaxComputeColumnValue implements ColumnValue {
     }
 
     @Override
+    public boolean canGetStringAsBytes() {
+        return false;
+    }
+
+    @Override
     public boolean isNull() {
         return column.isNull(idx);
     }

--- a/fe/be-java-extensions/paimon-scanner/src/main/java/org/apache/doris/paimon/PaimonColumnValue.java
+++ b/fe/be-java-extensions/paimon-scanner/src/main/java/org/apache/doris/paimon/PaimonColumnValue.java
@@ -45,6 +45,11 @@ public class PaimonColumnValue implements ColumnValue {
     }
 
     @Override
+    public boolean canGetStringAsBytes() {
+        return false;
+    }
+
+    @Override
     public boolean getBoolean() {
         return record.getBoolean(idx);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileQueryScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileQueryScanNode.java
@@ -244,9 +244,10 @@ public abstract class FileQueryScanNode extends FileScanNode {
 
         // set hdfs params for hdfs file type.
         Map<String, String> locationProperties = getLocationProperties();
-        if (fileFormatType == TFileFormatType.FORMAT_JNI) {
+        if (fileFormatType == TFileFormatType.FORMAT_JNI || locationType == TFileType.FILE_S3) {
             params.setProperties(locationProperties);
-        } else if (locationType == TFileType.FILE_HDFS || locationType == TFileType.FILE_BROKER) {
+        }
+        if (locationType == TFileType.FILE_HDFS || locationType == TFileType.FILE_BROKER) {
             String fsName = getFsName(inputSplit);
             THdfsParams tHdfsParams = HdfsResource.generateHdfsParam(locationProperties);
             tHdfsParams.setFsName(fsName);
@@ -259,8 +260,6 @@ public abstract class FileQueryScanNode extends FileScanNode {
                 }
                 params.addToBrokerAddresses(new TNetworkAddress(broker.host, broker.port));
             }
-        } else if (locationType == TFileType.FILE_S3) {
-            params.setProperties(locationProperties);
         }
 
         List<String> pathPartitionKeys = getPathPartitionKeys();


### PR DESCRIPTION
## Proposed changes

Two optimizations:
1. Insert string bytes directly to remove decoding&encoding process.
2. Use native reader to read the hudi base file if it has no log file. Use `explain` to show how many splits are read natively.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

