### PR TITLE
[fix](profile) delete useless profile add_child

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -88,7 +88,6 @@ DeltaWriter::DeltaWriter(WriteRequest* req, StorageEngine* storage_engine, Runti
 
 void DeltaWriter::_init_profile(RuntimeProfile* profile) {
     _profile = profile->create_child(fmt::format("DeltaWriter {}", _req.tablet_id), true, true);
-    profile->add_child(_profile, false, nullptr);
     _lock_timer = ADD_TIMER(_profile, "LockTime");
     _sort_timer = ADD_TIMER(_profile, "MemTableSortTime");
     _agg_timer = ADD_TIMER(_profile, "MemTableAggTime");

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -56,7 +56,6 @@ void LoadChannel::_init_profile() {
             _profile->create_child(fmt::format("LoadChannel load_id={} (host={}, backend_id={})",
                                                _load_id.to_string(), _sender_ip, _backend_id),
                                    true, true);
-    _profile->add_child(_self_profile, false, nullptr);
     _add_batch_number_counter = ADD_COUNTER(_self_profile, "NumberBatchAdded", TUnit::UNIT);
     _peak_memory_usage_counter = ADD_COUNTER(_self_profile, "PeakMemoryUsage", TUnit::BYTES);
     _add_batch_timer = ADD_TIMER(_self_profile, "AddBatchTime");

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -73,11 +73,9 @@ TabletsChannel::~TabletsChannel() {
 void TabletsChannel::_init_profile(RuntimeProfile* profile) {
     _profile =
             profile->create_child(fmt::format("TabletsChannel {}", _key.to_string()), true, true);
-    profile->add_child(_profile, false, nullptr);
     _add_batch_number_counter = ADD_COUNTER(_profile, "NumberBatchAdded", TUnit::UNIT);
 
     auto* memory_usage = _profile->create_child("PeakMemoryUsage", true, true);
-    _profile->add_child(memory_usage, false, nullptr);
     _slave_replica_timer = ADD_TIMER(_profile, "SlaveReplicaTime");
     _memory_usage_counter = memory_usage->AddHighWaterMarkCounter("Total", TUnit::BYTES);
     _write_memory_usage_counter = memory_usage->AddHighWaterMarkCounter("Write", TUnit::BYTES);

--- a/be/src/vec/common/sort/sorter.h
+++ b/be/src/vec/common/sort/sorter.h
@@ -62,8 +62,6 @@ public:
         external_sort_bytes_threshold_ = state->external_sort_bytes_threshold();
         if (profile != nullptr) {
             block_spill_profile_ = profile->create_child("BlockSpill", true, true);
-            profile->add_child(block_spill_profile_, false, nullptr);
-
             spilled_block_count_ = ADD_COUNTER(block_spill_profile_, "BlockCount", TUnit::UNIT);
             spilled_original_block_size_ =
                     ADD_COUNTER(block_spill_profile_, "BlockBytes", TUnit::BYTES);

--- a/be/src/vec/exec/join/vjoin_node_base.cpp
+++ b/be/src/vec/exec/join/vjoin_node_base.cpp
@@ -108,7 +108,6 @@ VJoinNodeBase::VJoinNodeBase(ObjectPool* pool, const TPlanNode& tnode, const Des
 Status VJoinNodeBase::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(ExecNode::prepare(state));
     _build_phase_profile = runtime_profile()->create_child("BuildPhase", true, true);
-    runtime_profile()->add_child(_build_phase_profile, false, nullptr);
     _build_get_next_timer = ADD_TIMER(_build_phase_profile, "BuildGetNextTime");
     _build_timer = ADD_TIMER(_build_phase_profile, "BuildTime");
     _build_rows_counter = ADD_COUNTER(_build_phase_profile, "BuildRows", TUnit::UNIT);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

look forward to fix
```
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50

#1  0x00007efc3b218859 in __GI_abort () at abort.c:79

#2  0x000055e6a4930f2a in _gnu_cxx::_verbose_terminate_handler ()

    at ../../../../libstdc+-v3/libsupc+/vterminate.cc:95

#3  0x000055e6a492f866 in _cxxabiv1::_terminate (handler=<optimized out>)

    at ../../../../libstdc+-v3/libsupc+/eh_terminate.cc:48

#4  0x000055e6a492f8d1 in std::terminate ()

    at ../../../../libstdc+-v3/libsupc+/eh_terminate.cc:58

#5  0x000055e6a492fa24 in _cxxabiv1::_cxa_throw (obj=<optimized out>,

    tinfo=0x55e6a5249be0 <typeinfo for std::length_error>,

    dest=0x55e6a493cf20 <std::length_error::~length_error()>)

    at ../../../../libstdc+-v3/libsupc+/eh_throw.cc:95

#6  0x000055e6a497e5af in std::__throw_length_error (

    __s=0x55e67c54fd40 <str> "vector::reserve")

    at ../../../../../libstdc+-v3/src/c+11/functexcept.cc:82

#7  0x000055e6845ffad9 in std::vector<doris::TRuntimeProfileNode, std::allocator<doris::TRuntimeProfileNode> >::reserve (this=0x7ee3580e4428,

    __n=18446744052231971750)

    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/vector.tcc:70

#8  0x000055e6845f326a in doris::RuntimeProfile::to_thrift (

    this=0x617002bffb00, nodes=0x7ee3580e4428)

    at doris_master/doris/be/src/util/runtime_profile.cpp:-Type <RET> for more, q to quit, c to continue without paging-

627

#9  0x000055e6845f3bd5 in doris::RuntimeProfile::to_thrift (

    this=0x617007f7f800, nodes=0x7ee3580e4428)

    at doris_master/doris/be/src/util/runtime_profile.cpp:668

#10 0x000055e6845f3bd5 in doris::RuntimeProfile::to_thrift (

    this=0x61700308ac80, nodes=0x7ee3580e4428)

    at doris_master/doris/be/src/util/runtime_profile.cpp:668

#11 0x000055e6845f2fc6 in doris::RuntimeProfile::to_thrift (

    this=0x61700308ac80, tree=0x7ee3580e4420)

    at doris_master/doris/be/src/util/runtime_profile.cpp:623

#12 0x000055e683e84d4e in doris::LoadChannel::_report_profile (

    this=0x61300369df80, response=0x611005e95c40)

    at doris_master/doris/be/src/runtime/load_channel.cpp:193

#13 0x000055e683e84547 in doris::LoadChannel::add_batch (this=0x61300369df80,

    request=..., response=0x611005e95c40)

    at doris_master/doris/be/src/runtime/load_channel.cpp:167

#14 0x000055e683e578f4 in doris::LoadChannelMgr::add_batch (

    this=0x612000196840, request=..., response=0x611005e95c40)
```

```
 LoadChannels:
              -  HandleMemLimitTime:  1.485ms
              -  LoadChannelMgrAddBatchTime:  16m24s
            LoadChannel  load_id=60aaed93810049d1-9614e7ef902ecfa5  (host=10.16.10.8,  backend_id=10004):
                  -  EosHost:  10004
                  -  AddBatchTime:  16m24s
                      -  HandleEosTime:  0ns
                  -  AddBatchTimes:  1.515K  (1515)
                  -  NumberBatchAdded:  1.496K  (1496)
                  -  PeakMemoryUsage:  2.53  GB
                TabletsChannel  (load_id=60aaed93810049d1-9614e7ef902ecfa5,  index_id=1281120):
                      -  NumberBatchAdded:  1.497K  (1497)
                      -  SlaveReplicaTime:  0ns
                    DeltaWriter  1281143:
                          -  DeltaWriterCloseWaitTime:  0ns
                          -  LockTime:  0ns
                          -  MemTableAggTime:  0ns
                          -  MemTableAggTimes:  0
                          -  MemTableDeleteBitmapTime:  0ns
                          -  MemTableDurationTime:  0ns
                          -  MemTablePutIntoOutputTime:  0ns
                          -  MemTableSortTime:  0ns
                          -  MemTableSortTimes:  0
                          -  MemTableWaitFlushTime:  0ns
                          -  MergedRowNum:  0
                          -  RawRowNum:  0
                          -  SegmentNum:  2
                          -  SegmentWriterTime:  0ns
                    DeltaWriter  1281141:
                          -  DeltaWriterCloseWaitTime:  0ns
                          -  LockTime:  0ns
                          -  MemTableAggTime:  0ns
                          -  MemTableAggTimes:  0
                          -  MemTableDeleteBitmapTime:  0ns
                          -  MemTableDurationTime:  0ns
                          -  MemTablePutIntoOutputTime:  0ns
                          -  MemTableSortTime:  0ns
                          -  MemTableSortTimes:  0
                          -  MemTableWaitFlushTime:  0ns
                          -  MergedRowNum:  0
                          -  RawRowNum:  0
                          -  SegmentNum:  2
                          -  SegmentWriterTime:  0ns
                    DeltaWriter  1281139:
                          -  DeltaWriterCloseWaitTime:  0ns
                          -  LockTime:  0ns
                          -  MemTableAggTime:  0ns
                          -  MemTableAggTimes:  0
                          -  MemTableDeleteBitmapTime:  0ns
                          -  MemTableDurationTime:  0ns
                          -  MemTablePutIntoOutputTime:  0ns
                          -  MemTableSortTime:  0ns
                          -  MemTableSortTimes:  0
                          -  MemTableWaitFlushTime:  0ns
                          -  MergedRowNum:  0
                          -  RawRowNum:  0
                          -  SegmentNum:  2
                          -  SegmentWriterTime:  0ns
                    DeltaWriter  1281137:
                          -  DeltaWriterCloseWaitTime:  0ns
                          -  LockTime:  0ns
                          -  MemTableAggTime:  0ns
                          -  MemTableAggTimes:  0
                          -  MemTableDeleteBitmapTime:  0ns
                          -  MemTableDurationTime:  0ns
                          -  MemTablePutIntoOutputTime:  0ns
                          -  MemTableSortTime:  0ns
                          -  MemTableSortTimes:  0
                          -  MemTableWaitFlushTime:  0ns
                          -  MergedRowNum:  0
                          -  RawRowNum:  0
                          -  SegmentNum:  2
                          -  SegmentWriterTime:  0ns
                    DeltaWriter  1281135:
                          -  DeltaWriterCloseWaitTime:  0ns
                          -  LockTime:  0ns
                          -  MemTableAggTime:  0ns
                          -  MemTableAggTimes:  0
                          -  MemTableDeleteBitmapTime:  0ns
                          -  MemTableDurationTime:  0ns
                          -  MemTablePutIntoOutputTime:  0ns
                          -  MemTableSortTime:  0ns
                          -  MemTableSortTimes:  0
                          -  MemTableWaitFlushTime:  0ns
                          -  MergedRowNum:  0
                          -  RawRowNum:  0
                          -  SegmentNum:  2
                          -  SegmentWriterTime:  0ns
                    DeltaWriter  1281133:
                          -  DeltaWriterCloseWaitTime:  0ns
                          -  LockTime:  0ns
                          -  MemTableAggTime:  0ns
                          -  MemTableAggTimes:  0
                          -  MemTableDeleteBitmapTime:  0ns
                          -  MemTableDurationTime:  0ns
                          -  MemTablePutIntoOutputTime:  0ns
                          -  MemTableSortTime:  0ns
                          -  MemTableSortTimes:  0
                          -  MemTableWaitFlushTime:  0ns
                          -  MergedRowNum:  0
                          -  RawRowNum:  0
                          -  SegmentNum:  2
                          -  SegmentWriterTime:  0ns
                    DeltaWriter  1281131:
                          -  DeltaWriterCloseWaitTime:  0ns
                          -  LockTime:  0ns
                          -  MemTableAggTime:  0ns
                          -  MemTableAggTimes:  0
                          -  MemTableDeleteBitmapTime:  0ns
                          -  MemTableDurationTime:  0ns
                          -  MemTablePutIntoOutputTime:  0ns
                          -  MemTableSortTime:  0ns
                          -  MemTableSortTimes:  0
                          -  MemTableWaitFlushTime:  0ns
                          -  MergedRowNum:  0
                          -  RawRowNum:  0
                          -  SegmentNum:  2
                          -  SegmentWriterTime:  0ns
                    DeltaWriter  1281129:
                          -  DeltaWriterCloseWaitTime:  0ns
                          -  LockTime:  0ns
                          -  MemTableAggTime:  0ns
                          -  MemTableAggTimes:  0
                          -  MemTableDeleteBitmapTime:  0ns
                          -  MemTableDurationTime:  0ns
                          -  MemTablePutIntoOutputTime:  0ns
                          -  MemTableSortTime:  0ns
                          -  MemTableSortTimes:  0
                          -  MemTableWaitFlushTime:  0ns
                          -  MergedRowNum:  0
                          -  RawRowNum:  0
                          -  SegmentNum:  2
                          -  SegmentWriterTime:  0ns
                    DeltaWriter  1281127:
                          -  DeltaWriterCloseWaitTime:  0ns
                          -  LockTime:  0ns
                          -  MemTableAggTime:  0ns
                          -  MemTableAggTimes:  0
                          -  MemTableDeleteBitmapTime:  0ns
                          -  MemTableDurationTime:  0ns
                          -  MemTablePutIntoOutputTime:  0ns
                          -  MemTableSortTime:  0ns
                          -  MemTableSortTimes:  0
                          -  MemTableWaitFlushTime:  0ns
                          -  MergedRowNum:  0
                          -  RawRowNum:  0
                          -  SegmentNum:  2
                          -  SegmentWriterTime:  0ns
                    DeltaWriter  1281125:
                          -  DeltaWriterCloseWaitTime:  0ns
                          -  LockTime:  0ns
                          -  MemTableAggTime:  0ns
                          -  MemTableAggTimes:  0
                          -  MemTableDeleteBitmapTime:  0ns
                          -  MemTableDurationTime:  0ns
                          -  MemTablePutIntoOutputTime:  0ns
                          -  MemTableSortTime:  0ns
                          -  MemTableSortTimes:  0
                          -  MemTableWaitFlushTime:  0ns
                          -  MergedRowNum:  0
                          -  RawRowNum:  0
                          -  SegmentNum:  2
                          -  SegmentWriterTime:  0ns
                    DeltaWriter  1281123:
                          -  DeltaWriterCloseWaitTime:  0ns
                          -  LockTime:  0ns
                          -  MemTableAggTime:  0ns
                          -  MemTableAggTimes:  0
                          -  MemTableDeleteBitmapTime:  0ns
                          -  MemTableDurationTime:  0ns
                          -  MemTablePutIntoOutputTime:  0ns
                          -  MemTableSortTime:  0ns
                          -  MemTableSortTimes:  0
                          -  MemTableWaitFlushTime:  0ns
                          -  MergedRowNum:  0
                          -  RawRowNum:  0
                          -  SegmentNum:  2
                          -  SegmentWriterTime:  0ns
                    DeltaWriter  1281121:
                          -  DeltaWriterCloseWaitTime:  0ns
                          -  LockTime:  0ns
                          -  MemTableAggTime:  0ns
                          -  MemTableAggTimes:  0
                          -  MemTableDeleteBitmapTime:  0ns
                          -  MemTableDurationTime:  0ns
                          -  MemTablePutIntoOutputTime:  0ns
                          -  MemTableSortTime:  0ns
                          -  MemTableSortTimes:  0
                          -  MemTableWaitFlushTime:  0ns
                          -  MergedRowNum:  0
                          -  RawRowNum:  0
                          -  SegmentNum:  2
                          -  SegmentWriterTime:  0ns
                    PeakMemoryUsage:
                          -  Flush:  9.00  MB
                          -  MaxTablet:  218.53  MB
                          -  MaxTabletFlush:  1.50  MB
                          -  MaxTabletWrite:  217.03  MB
                          -  Total:  2.53  GB
                          -  Write:  2.52  GB
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

