### PR TITLE
[fix](profile) avoid unnecessary refresh profile of TabletsChannel

### DIFF
--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -189,6 +189,13 @@ void LoadChannel::_report_profile(PTabletWriterAddBlockResult* response) {
     // and ensures to update the latest LoadChannel profile according to the timestamp.
     _self_profile->set_timestamp(_last_updated_time);
 
+    {
+        std::lock_guard<SpinLock> l(_tablets_channels_lock);
+        for (auto& it : _tablets_channels) {
+            it.second->refresh_profile();
+        }
+    }
+
     TRuntimeProfileTree tprofile;
     _profile->to_thrift(&tprofile);
     ThriftSerializer ser(false, 4096);

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -253,6 +253,18 @@ void TabletsChannel::_close_wait(DeltaWriter* writer,
 }
 
 int64_t TabletsChannel::mem_consumption() {
+    int64_t mem_usage = 0;
+    {
+        std::lock_guard<SpinLock> l(_tablet_writers_lock);
+        for (auto& it : _tablet_writers) {
+            int64_t writer_mem = it.second->mem_consumption(MemType::ALL);
+            mem_usage += writer_mem;
+        }
+    }
+    return mem_usage;
+}
+
+void TabletsChannel::refresh_profile() {
     int64_t write_mem_usage = 0;
     int64_t flush_mem_usage = 0;
     int64_t max_tablet_mem_usage = 0;
@@ -260,7 +272,6 @@ int64_t TabletsChannel::mem_consumption() {
     int64_t max_tablet_flush_mem_usage = 0;
     {
         std::lock_guard<SpinLock> l(_tablet_writers_lock);
-        _mem_consumptions.clear();
         for (auto& it : _tablet_writers) {
             int64_t write_mem = it.second->mem_consumption(MemType::WRITE);
             write_mem_usage += write_mem;
@@ -270,7 +281,6 @@ int64_t TabletsChannel::mem_consumption() {
             if (flush_mem > max_tablet_flush_mem_usage) max_tablet_flush_mem_usage = flush_mem;
             if (write_mem + flush_mem > max_tablet_mem_usage)
                 max_tablet_mem_usage = write_mem + flush_mem;
-            _mem_consumptions.emplace(write_mem + flush_mem, it.first);
         }
     }
     COUNTER_SET(_memory_usage_counter, write_mem_usage + flush_mem_usage);
@@ -279,7 +289,6 @@ int64_t TabletsChannel::mem_consumption() {
     COUNTER_SET(_max_tablet_memory_usage_counter, max_tablet_mem_usage);
     COUNTER_SET(_max_tablet_write_memory_usage_counter, max_tablet_write_mem_usage);
     COUNTER_SET(_max_tablet_flush_memory_usage_counter, max_tablet_flush_mem_usage);
-    return write_mem_usage + flush_mem_usage;
 }
 
 void TabletsChannel::get_active_memtable_mem_consumption(

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -115,6 +115,8 @@ public:
 
     int64_t mem_consumption();
 
+    void refresh_profile();
+
     void get_active_memtable_mem_consumption(
             std::multimap<int64_t, int64_t, std::greater<int64_t>>* mem_consumptions);
 
@@ -194,10 +196,6 @@ private:
     bool _is_high_priority = false;
 
     bool _write_single_replica = false;
-
-    // mem -> tablet_id
-    // sort by memory size
-    std::multimap<int64_t, int64_t, std::greater<int64_t>> _mem_consumptions;
 
     RuntimeProfile* _profile;
     RuntimeProfile::Counter* _add_batch_number_counter = nullptr;


### PR DESCRIPTION
## Proposed changes

Before, refresh the TabletsChannel profile in the LoadChannelMgr refresh memory statistics thread

This means that `enable_profile=false` will refresh and have performance loss in stress test
![img_v2_a99689ae-a705-42b7-910a-b3634d8c7b7g](https://github.com/apache/doris/assets/13197424/818ce16b-3418-42dc-b0aa-dcfd78bf65ec)



## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

