### PR TITLE
[Bugfix](CCR) BinlogTombstone tableId is null when db disable binlog

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogTombstone.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogTombstone.java
@@ -22,6 +22,8 @@ import org.apache.doris.persist.gson.GsonUtils;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -54,6 +56,13 @@ public class BinlogTombstone {
         this.dbBinlogTombstone = false;
         this.dbId = dbId;
         this.tableIds = null;
+        this.commitSeq = commitSeq;
+    }
+
+    public BinlogTombstone(long dbId, Long tableId, long commitSeq) {
+        this.dbBinlogTombstone = false;
+        this.dbId = dbId;
+        this.tableIds = new ArrayList<Long>(Arrays.asList(tableId));
         this.commitSeq = commitSeq;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogTombstone.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogTombstone.java
@@ -59,7 +59,7 @@ public class BinlogTombstone {
         this.commitSeq = commitSeq;
     }
 
-    public BinlogTombstone(long dbId, Long tableId, long commitSeq) {
+    public BinlogTombstone(long dbId, long tableId, long commitSeq) {
         this.dbBinlogTombstone = false;
         this.dbId = dbId;
         this.tableIds = new ArrayList<Long>(Arrays.asList(tableId));

--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogTombstone.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogTombstone.java
@@ -58,12 +58,12 @@ public class BinlogTombstone {
         this.commitSeq = commitSeq;
     }
 
-    // public BinlogTombstone(long dbId, long tableId, long commitSeq) {
-    //     this.dbBinlogTombstone = false;
-    //     this.dbId = dbId;
-    //     this.tableIds = Collections.singletonList(tableId);
-    //     this.commitSeq = commitSeq;
-    // }
+    public BinlogTombstone(long dbId, long tableId, long commitSeq) {
+        this.dbBinlogTombstone = false;
+        this.dbId = dbId;
+        this.tableIds = Collections.singletonList(tableId);
+        this.commitSeq = commitSeq;
+    }
 
     public void addTableRecord(long tableId, UpsertRecord upsertRecord) {
         Map<Long, UpsertRecord.TableRecord> tableRecords = upsertRecord.getTableRecords();

--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogTombstone.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogTombstone.java
@@ -22,8 +22,7 @@ import org.apache.doris.persist.gson.GsonUtils;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -59,12 +58,12 @@ public class BinlogTombstone {
         this.commitSeq = commitSeq;
     }
 
-    public BinlogTombstone(long dbId, long tableId, long commitSeq) {
-        this.dbBinlogTombstone = false;
-        this.dbId = dbId;
-        this.tableIds = new ArrayList<Long>(Arrays.asList(tableId));
-        this.commitSeq = commitSeq;
-    }
+    // public BinlogTombstone(long dbId, long tableId, long commitSeq) {
+    //     this.dbBinlogTombstone = false;
+    //     this.dbId = dbId;
+    //     this.tableIds = Collections.singletonList(tableId);
+    //     this.commitSeq = commitSeq;
+    // }
 
     public void addTableRecord(long tableId, UpsertRecord upsertRecord) {
         Map<Long, UpsertRecord.TableRecord> tableRecords = upsertRecord.getTableRecords();

--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/TableBinlog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/TableBinlog.java
@@ -154,7 +154,7 @@ public class TableBinlog {
             lock.writeLock().unlock();
         }
 
-        BinlogTombstone tombstone = new BinlogTombstone(dbId, largestExpiredCommitSeq);
+        BinlogTombstone tombstone = new BinlogTombstone(dbId, tableId, largestExpiredCommitSeq);
         if (tombstoneUpsert != null) {
             UpsertRecord upsertRecord = UpsertRecord.fromJson(tombstoneUpsert.getData());
             tombstone.addTableRecord(tableId, upsertRecord);

--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/TableBinlog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/TableBinlog.java
@@ -154,8 +154,7 @@ public class TableBinlog {
             lock.writeLock().unlock();
         }
 
-        // Test only
-        BinlogTombstone tombstone = new BinlogTombstone(dbId, largestExpiredCommitSeq);
+        BinlogTombstone tombstone = new BinlogTombstone(dbId, tableId, largestExpiredCommitSeq);
         if (tombstoneUpsert != null) {
             UpsertRecord upsertRecord = UpsertRecord.fromJson(tombstoneUpsert.getData());
             tombstone.addTableRecord(tableId, upsertRecord);

--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/TableBinlog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/TableBinlog.java
@@ -154,7 +154,8 @@ public class TableBinlog {
             lock.writeLock().unlock();
         }
 
-        BinlogTombstone tombstone = new BinlogTombstone(dbId, tableId, largestExpiredCommitSeq);
+        // Test only
+        BinlogTombstone tombstone = new BinlogTombstone(dbId, largestExpiredCommitSeq);
         if (tombstoneUpsert != null) {
             UpsertRecord upsertRecord = UpsertRecord.fromJson(tombstoneUpsert.getData());
             tombstone.addTableRecord(tableId, upsertRecord);


### PR DESCRIPTION
Bug:  
BinlogTombstone tableId is null when db disable binlog.  
  
Bugfix:  
Added a new constructor for BinlogTombstome, which sets BinlogTombstome.tableId to an ArrayList that only contains the current tableId when db binlog is disabled.
