### PR TITLE
[fix](memory) fix `bthread_setspecific` error in rpc done.run()

### DIFF
--- a/be/src/io/fs/stream_load_pipe.cpp
+++ b/be/src/io/fs/stream_load_pipe.cpp
@@ -43,7 +43,7 @@ StreamLoadPipe::StreamLoadPipe(size_t max_buffered_bytes, size_t min_chunk_size,
           _use_proto(use_proto) {}
 
 StreamLoadPipe::~StreamLoadPipe() {
-    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->orphan_mem_tracker());
+    SCOPED_TRACK_MEMORY_TO_UNKNOWN();
     while (!_buf_queue.empty()) {
         _buf_queue.pop_front();
     }
@@ -51,7 +51,7 @@ StreamLoadPipe::~StreamLoadPipe() {
 
 Status StreamLoadPipe::read_at_impl(size_t /*offset*/, Slice result, size_t* bytes_read,
                                     const IOContext* /*io_ctx*/) {
-    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->orphan_mem_tracker());
+    SCOPED_TRACK_MEMORY_TO_UNKNOWN();
     *bytes_read = 0;
     size_t bytes_req = result.size;
     char* to = result.data;

--- a/be/src/pipeline/exec/exchange_sink_buffer.cpp
+++ b/be/src/pipeline/exec/exchange_sink_buffer.cpp
@@ -204,7 +204,7 @@ Status ExchangeSinkBuffer::_send_rpc(InstanceLoId id) {
             }
         });
         {
-            SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->orphan_mem_tracker());
+            SCOPED_TRACK_MEMORY_TO_UNKNOWN();
             if (enable_http_send_block(*brpc_request)) {
                 RETURN_IF_ERROR(transmit_block_http(_context->get_runtime_state(), closure,
                                                     *brpc_request,
@@ -251,7 +251,7 @@ Status ExchangeSinkBuffer::_send_rpc(InstanceLoId id) {
             }
         });
         {
-            SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->orphan_mem_tracker());
+            SCOPED_TRACK_MEMORY_TO_UNKNOWN();
             if (enable_http_send_block(*brpc_request)) {
                 RETURN_IF_ERROR(transmit_block_http(_context->get_runtime_state(), closure,
                                                     *brpc_request,

--- a/be/src/runtime/buffer_control_block.cpp
+++ b/be/src/runtime/buffer_control_block.cpp
@@ -40,7 +40,7 @@ void GetResultBatchCtx::on_failure(const Status& status) {
     status.to_protobuf(result->mutable_status());
     {
         // call by result sink
-        SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->orphan_mem_tracker());
+        SCOPED_TRACK_MEMORY_TO_UNKNOWN();
         done->Run();
     }
     delete this;
@@ -55,7 +55,7 @@ void GetResultBatchCtx::on_close(int64_t packet_seq, QueryStatistics* statistics
     result->set_packet_seq(packet_seq);
     result->set_eos(true);
     {
-        SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->orphan_mem_tracker());
+        SCOPED_TRACK_MEMORY_TO_UNKNOWN();
         done->Run();
     }
     delete this;
@@ -83,7 +83,7 @@ void GetResultBatchCtx::on_data(const std::unique_ptr<TFetchDataResult>& t_resul
     }
     st.to_protobuf(result->mutable_status());
     {
-        SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->orphan_mem_tracker());
+        SCOPED_TRACK_MEMORY_TO_UNKNOWN();
         done->Run();
     }
     delete this;

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -206,6 +206,13 @@ private:
     TUniqueId _fragment_instance_id;
 };
 
+#if defined(UNDEFINED_BEHAVIOR_SANITIZER)
+class SwitchBthreadLocal {
+public:
+    static void switch_to_bthread_local() {}
+    static void switch_back_pthread_local() {}
+};
+#else
 // Switch thread context from pthread local to bthread local context.
 // Cache the pointer of bthread local in pthead local,
 // Avoid calling bthread_getspecific frequently to get bthread local, which has performance problems.
@@ -253,6 +260,7 @@ public:
         }
     }
 };
+#endif
 
 static ThreadContext* thread_context() {
     if (bthread_self() != 0) {

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -83,6 +83,7 @@
 #define SCOPED_ATTACH_TASK(arg1, ...) (void)0
 #define SCOPED_ATTACH_TASK_WITH_ID(arg1, arg2, arg3) (void)0
 #define SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(mem_tracker_limiter) (void)0
+#define SCOPED_TRACK_MEMORY_TO_UNKNOWN() (void)0
 #endif
 
 #define SKIP_MEMORY_CHECK(...)                  \

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -151,7 +151,6 @@ public:
     NewHttpClosure(T* request, google::protobuf::Closure* done) : _request(request), _done(done) {}
 
     void Run() override {
-        SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->orphan_mem_tracker());
         if (_request != nullptr) {
             delete _request;
             _request = nullptr;

--- a/be/src/util/ref_count_closure.h
+++ b/be/src/util/ref_count_closure.h
@@ -39,7 +39,7 @@ public:
     bool unref() { return _refs.fetch_sub(1) == 1; }
 
     void Run() override {
-        SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->orphan_mem_tracker());
+        SCOPED_TRACK_MEMORY_TO_UNKNOWN();
         if (unref()) {
             delete this;
         }

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -158,7 +158,7 @@ Status Channel::send_block(PBlock* block, bool eos) {
         _closure->ref();
     } else {
         RETURN_IF_ERROR(_wait_last_brpc());
-        SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->orphan_mem_tracker());
+        SCOPED_TRACK_MEMORY_TO_UNKNOWN();
         _closure->cntl.Reset();
     }
     VLOG_ROW << "Channel::send_batch() instance_id=" << _fragment_instance_id
@@ -179,7 +179,7 @@ Status Channel::send_block(PBlock* block, bool eos) {
     _closure->cntl.set_timeout_ms(_brpc_timeout_ms);
 
     {
-        SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->orphan_mem_tracker());
+        SCOPED_TRACK_MEMORY_TO_UNKNOWN();
         if (enable_http_send_block(_brpc_request, _parent->_transfer_large_data_by_brpc)) {
             RETURN_IF_ERROR(transmit_block_http(_state, _closure, _brpc_request, _brpc_dest_addr));
         } else {

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -104,7 +104,7 @@ public:
     ~OpenPartitionClosure() override = default;
 
     void Run() override {
-        SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->orphan_mem_tracker());
+        SCOPED_TRACK_MEMORY_TO_UNKNOWN();
         if (cntl.Failed()) {
             std::stringstream ss;
             ss << "failed to open partition, error=" << berror(this->cntl.ErrorCode())
@@ -837,7 +837,7 @@ void VNodeChannel::try_send_block(RuntimeState* state) {
         _add_block_closure->cntl.http_request().set_content_type("application/json");
 
         {
-            SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->orphan_mem_tracker());
+            SCOPED_TRACK_MEMORY_TO_UNKNOWN();
             _brpc_http_stub->tablet_writer_add_block_by_http(&_add_block_closure->cntl, nullptr,
                                                              &_add_block_closure->result,
                                                              _add_block_closure);
@@ -845,7 +845,7 @@ void VNodeChannel::try_send_block(RuntimeState* state) {
     } else {
         _add_block_closure->cntl.http_request().Clear();
         {
-            SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->orphan_mem_tracker());
+            SCOPED_TRACK_MEMORY_TO_UNKNOWN();
             _stub->tablet_writer_add_block(&_add_block_closure->cntl, &request,
                                            &_add_block_closure->result, _add_block_closure);
         }

--- a/be/src/vec/sink/vtablet_sink.h
+++ b/be/src/vec/sink/vtablet_sink.h
@@ -119,7 +119,7 @@ public:
     ~ReusableClosure() override {
         // shouldn't delete when Run() is calling or going to be called, wait for current Run() done.
         join();
-        SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->orphan_mem_tracker());
+        SCOPED_TRACK_MEMORY_TO_UNKNOWN();
         cntl.Reset();
     }
 
@@ -147,7 +147,7 @@ public:
 
     // plz follow this order: reset() -> set_in_flight() -> send brpc batch
     void reset() {
-        SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->orphan_mem_tracker());
+        SCOPED_TRACK_MEMORY_TO_UNKNOWN();
         cntl.Reset();
         cid = cntl.call_id();
     }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

1. not use `bthread_setspecific` in rpc done.run(), 
2. not use bthread local when UBSAN compiles, may have errors.
```
F0618 13:36:54.697724 2114080 key.cpp:197] Check failed: false bthread_setspecific is called on invalid bthread_key_t{index=0 version=1}F0618 13:36:54.697827 2114082 key.cpp:197] Check failed: false bthread_setspecific is called on invalid bthread_key_t{index=0 version=1}
Check failure stack trace: ***
    @     0x55676a1f464d  google::LogMessage::Fail()
    @     0x55676a1f464d  google::LogMessage::Fail()
    @     0x55676a1f464d  google::LogMessage::Fail()
    @     0x55676a1f6b89  google::LogMessage::SendToLog()
    @     0x55676a1f6b89  google::LogMessage::SendToLog()
    @     0x55676a1f6b89  google::LogMessage::SendToLog()
    @     0x55676a1f41b6  google::LogMessage::Flush()
    @     0x55676a1f71f9  google::LogMessageFatal::~LogMessageFatal()
    @     0x55676a1f41b6  google::LogMessage::Flush()
    @     0x55676a1f41b6  google::LogMessage::Flush()
 
0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at doris_master/doris/be/src/common/signal_handler.h:413
1# 0x00007FF01F480090 in /lib/x86_64-linux-gnu/libc.so.6
2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
4# 0x000055676A1FF039 in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
5# 0x000055676A1F464D in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
6# google::LogMessage::SendToLog() in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
7# google::LogMessage::Flush() in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
8# google::LogMessageFatal::~LogMessageFatal() in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
9# bthread_setspecific in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
10# doris::SwitchBthreadLocal::switch_to_bthread_local() at doris_master/doris/be/src/runtime/thread_context.h:226
11# doris::SwitchThreadMemTrackerLimiter::SwitchThreadMemTrackerLimiter(std::shared_ptr<doris::MemTrackerLimiter> const&) at doris_master/doris/be/src/runtime/thread_context.h:299
12# doris::RefCountClosure<doris::PTabletWriterCancelResult>::Run() at doris_master/doris/be/src/util/ref_count_closure.h:42
13# brpc::Controller::EndRPC(brpc::Controller::CompletionInfo const&) in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
14# brpc::Controller::RunEndRPC(void*) in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
15# bthread::TaskGroup::task_runner(long) in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
16# bthread_make_fcontext in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_b
```


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

