### PR TITLE
[chore](third-party) temporary rollback brpc to 1.4

### DIFF
--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -401,7 +401,7 @@ if [[ "${SIMDJSON_SOURCE}" = "simdjson-3.0.1" ]]; then
 fi
 echo "Finished patching ${SIMDJSON_SOURCE}"
 
-if [[ "${BRPC_SOURCE}" == 'brpc-1.5.0' ]]; then
+if [[ "${BRPC_SOURCE}" == 'brpc-1.4.0' ]]; then
     cd "${TP_SOURCE_DIR}/${BRPC_SOURCE}"
     if [[ ! -f "${PATCHED_MARK}" ]]; then
         for patch_file in "${TP_PATCH_DIR}"/brpc-*; do

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -197,10 +197,10 @@ LEVELDB_SOURCE=leveldb-1.23
 LEVELDB_MD5SUM="afbde776fb8760312009963f09a586c7"
 
 # brpc
-BRPC_DOWNLOAD="https://github.com/apache/brpc/archive/refs/tags/1.5.0.tar.gz"
-BRPC_NAME="brpc-1.5.0.tar.gz"
-BRPC_SOURCE="brpc-1.5.0"
-BRPC_MD5SUM="d1b6d9b615292dfa5cefa227822c5996"
+BRPC_DOWNLOAD="https://github.com/apache/brpc/archive/refs/tags/1.4.0.tar.gz"
+BRPC_NAME="brpc-1.4.0.tar.gz"
+BRPC_SOURCE="brpc-1.4.0"
+BRPC_MD5SUM="6af9d50822c33a3abc56a1ec0af0e0bc"
 
 # rocksdb
 ROCKSDB_DOWNLOAD="https://github.com/facebook/rocksdb/archive/v5.14.2.tar.gz"


### PR DESCRIPTION
## Proposed changes

The `bthread_setspecific` method of brpc 1.5 seems to have a bug. So far, two core dumps have appeared, as follows:

Although I have bypassed the error for these two core dumps, in #20450 #20999 , but I don't know the real cause of the error. And errors are very sporadic.

Temporarily rollback to brpc 1.4 before the release of Doris 2.0, and try to return to brpc 1.5 for long-term observation after 2.0 is released

upgrade before: #19610

```
F0618 13:36:54.697724 2114080 key.cpp:197] Check failed: false bthread_setspecific is called on invalid bthread_key_t{index=0 version=1}F0618 13:36:54.697827 2114082 key.cpp:197] Check failed: false bthread_setspecific is called on invalid bthread_key_t{index=0 version=1}
Check failure stack trace: ***
    @     0x55676a1f464d  google::LogMessage::Fail()
    @     0x55676a1f464d  google::LogMessage::Fail()
    @     0x55676a1f464d  google::LogMessage::Fail()
    @     0x55676a1f6b89  google::LogMessage::SendToLog()
    @     0x55676a1f6b89  google::LogMessage::SendToLog()
    @     0x55676a1f6b89  google::LogMessage::SendToLog()
    @     0x55676a1f41b6  google::LogMessage::Flush()
    @     0x55676a1f71f9  google::LogMessageFatal::~LogMessageFatal()
    @     0x55676a1f41b6  google::LogMessage::Flush()
    @     0x55676a1f41b6  google::LogMessage::Flush()
 
0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at doris_master/doris/be/src/common/signal_handler.h:413
1# 0x00007FF01F480090 in /lib/x86_64-linux-gnu/libc.so.6
2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
4# 0x000055676A1FF039 in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
5# 0x000055676A1F464D in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
6# google::LogMessage::SendToLog() in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
7# google::LogMessage::Flush() in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
8# google::LogMessageFatal::~LogMessageFatal() in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
9# bthread_setspecific in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
10# doris::SwitchBthreadLocal::switch_to_bthread_local() at doris_master/doris/be/src/runtime/thread_context.h:226
11# doris::SwitchThreadMemTrackerLimiter::SwitchThreadMemTrackerLimiter(std::shared_ptr<doris::MemTrackerLimiter> const&) at doris_master/doris/be/src/runtime/thread_context.h:299
12# doris::RefCountClosure<doris::PTabletWriterCancelResult>::Run() at doris_master/doris/be/src/util/ref_count_closure.h:42
13# brpc::Controller::EndRPC(brpc::Controller::CompletionInfo const&) in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
14# brpc::Controller::RunEndRPC(void*) in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
15# bthread::TaskGroup::task_runner(long) in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
16# bthread_make_fcontext in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

