### PR TITLE
[fix](stats) Update analyze task execute time 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
@@ -399,6 +399,7 @@ public class AnalysisManager extends Daemon implements Writable {
         taskInfoBuilder.setSamplingPartition(isSamplingPartition);
         taskInfoBuilder.setJobType(JobType.MANUAL);
         taskInfoBuilder.setState(AnalysisState.PENDING);
+        taskInfoBuilder.setLastExecTimeInMs(System.currentTimeMillis());
         taskInfoBuilder.setAnalysisType(analysisType);
         taskInfoBuilder.setAnalysisMode(analysisMode);
         taskInfoBuilder.setAnalysisMethod(analysisMethod);
@@ -437,6 +438,7 @@ public class AnalysisManager extends Daemon implements Writable {
         taskInfoBuilder.setTblName(jobInfo.tblName);
         taskInfoBuilder.setJobType(JobType.SYSTEM);
         taskInfoBuilder.setState(AnalysisState.PENDING);
+        taskInfoBuilder.setLastExecTimeInMs(System.currentTimeMillis());
         taskInfoBuilder.setAnalysisType(jobInfo.analysisType);
         taskInfoBuilder.setAnalysisMode(jobInfo.analysisMode);
         taskInfoBuilder.setAnalysisMethod(jobInfo.analysisMethod);

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisTaskWrapper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisTaskWrapper.java
@@ -65,7 +65,7 @@ public class AnalysisTaskWrapper extends FutureTask<Void> {
                     LOG.warn("Failed to execute task", except);
                     Env.getCurrentEnv().getAnalysisManager()
                             .updateTaskStatus(task.info,
-                                    AnalysisState.FAILED, except.getMessage(), -1);
+                                    AnalysisState.FAILED, except.getMessage(), System.currentTimeMillis());
                 } else {
                     Env.getCurrentEnv().getAnalysisManager()
                             .updateTaskStatus(task.info,


### PR DESCRIPTION
## Proposed changes

Before this PR `last_execute_time` of pending analyze jobs would be 1970-01-01, you can reproduce it by run `show analyze`

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

