### PR TITLE
[fix](log) fix the too large warning log of BE

### DIFF
--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -154,9 +154,12 @@ void PipelineFragmentContext::cancel(const PPlanFragmentCancelReason& reason,
         _runtime_state->set_is_cancelled(true);
 
         LOG(WARNING) << "PipelineFragmentContext Canceled. reason=" << msg;
-        for (auto& task : _tasks) {
-            LOG(WARNING) << task->debug_string();
-        }
+
+        // Print detail informations below when you debugging here.
+        //
+        // for (auto& task : _tasks) {
+        //     LOG(WARNING) << task->debug_string();
+        // }
 
         _runtime_state->set_process_status(_exec_status);
         // Get pipe from new load stream manager and send cancel to it or the fragment may hang to wait read from pipe

--- a/be/src/pipeline/task_scheduler.cpp
+++ b/be/src/pipeline/task_scheduler.cpp
@@ -278,8 +278,11 @@ void TaskScheduler::_do_work(size_t index) {
 
         task->set_previous_core_id(index);
         if (!status.ok()) {
-            LOG(WARNING) << fmt::format("Pipeline task failed. reason: {}, task: \n{}",
-                                        status.to_string(), task->debug_string());
+            LOG(WARNING) << fmt::format("Pipeline task failed. reason: {}", status.to_string());
+            // Print detail informations below when you debugging here.
+            //
+            // LOG(WARNING)<< "task:\n"<<task->debug_string();
+
             // exec failed，cancel all fragment instance
             fragment_ctx->cancel(PPlanFragmentCancelReason::INTERNAL_ERROR, status.to_string());
             fragment_ctx->send_report(true);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

the be.WARNING log file is too large because of the profile informations when PipelineTask canceled. Now add a switch to control it.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

