### PR TITLE
[fix](memory) arena support memory reuse after clear()

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -129,6 +129,8 @@ DEFINE_mBool(enable_query_memory_overcommit, "true");
 // The maximum time a thread waits for a full GC. Currently only query will wait for full gc.
 DEFINE_mInt32(thread_wait_gc_max_milliseconds, "1000");
 
+DEFINE_mInt64(pre_serialize_keys_limit_bytes, "16777216");
+
 // the port heartbeat service used
 DEFINE_Int32(heartbeat_service_port, "9050");
 // the count of heart beat service

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -169,6 +169,9 @@ DECLARE_mBool(enable_query_memory_overcommit);
 // The maximum time a thread waits for a full GC. Currently only query will wait for full gc.
 DECLARE_mInt32(thread_wait_gc_max_milliseconds);
 
+// reach mem limit, don't serialize in batch
+DECLARE_mInt64(pre_serialize_keys_limit_bytes);
+
 // the port heartbeat service used
 DECLARE_Int32(heartbeat_service_port);
 // the count of heart beat service

--- a/be/src/vec/columns/predicate_column.h
+++ b/be/src/vec/columns/predicate_column.h
@@ -343,7 +343,7 @@ public:
     void clear() override {
         data.clear();
         if (_arena != nullptr) {
-            _arena.reset(new Arena());
+            _arena->clear();
         }
     }
 

--- a/be/src/vec/exec/join/process_hash_table_probe_impl.h
+++ b/be/src/vec/exec/join/process_hash_table_probe_impl.h
@@ -181,7 +181,7 @@ Status ProcessHashTableProbe<JoinOpType>::do_process(HashTableType& hash_table_c
         if (_arena) {
             old_probe_keys_memory_usage = _arena->size();
         }
-        _arena.reset(new Arena());
+        _arena.reset(new Arena()); // TODO arena reuse by clear()?
         if constexpr (ColumnsHashing::IsPreSerializedKeysHashMethodTraits<KeyGetter>::value) {
             if (_probe_keys.size() < probe_rows) {
                 _probe_keys.resize(probe_rows);

--- a/be/src/vec/exec/join/vhash_join_node.h
+++ b/be/src/vec/exec/join/vhash_join_node.h
@@ -72,6 +72,8 @@ struct SerializedHashTableContext {
             ColumnsHashing::HashMethodSerialized<typename HashTable::value_type, Mapped, true>;
     using Iter = typename HashTable::iterator;
 
+    SerializedHashTableContext() { _arena.reset(new Arena()); }
+
     HashTable hash_table;
     Iter iter;
     bool inited = false;
@@ -83,7 +85,7 @@ struct SerializedHashTableContext {
             keys.resize(num_rows);
         }
 
-        _arena.reset(new Arena());
+        _arena->clear();
         keys_memory_usage = 0;
         size_t keys_size = key_columns.size();
         for (size_t i = 0; i < num_rows; ++i) {

--- a/be/src/vec/exec/vaggregation_node.h
+++ b/be/src/vec/exec/vaggregation_node.h
@@ -102,7 +102,10 @@ struct AggregationMethodSerialized {
     std::vector<StringRef> keys;
     size_t keys_memory_usage = 0;
     AggregationMethodSerialized()
-            : _serialized_key_buffer_size(0), _serialized_key_buffer(nullptr) {}
+            : _serialized_key_buffer_size(0), _serialized_key_buffer(nullptr) {
+        _arena.reset(new Arena());
+        _serialize_key_arena.reset(new Arena());
+    }
 
     using State = ColumnsHashing::HashMethodSerialized<typename Data::value_type, Mapped, true>;
 
@@ -120,20 +123,19 @@ struct AggregationMethodSerialized {
         }
         size_t total_bytes = max_one_row_byte_size * num_rows;
 
-        if (total_bytes > SERIALIZE_KEYS_MEM_LIMIT_IN_BYTES) {
+        if (total_bytes > config::pre_serialize_keys_limit_bytes) {
             // reach mem limit, don't serialize in batch
-            // for simplicity, we just create a new arena here.
-            _arena.reset(new Arena());
+            _arena->clear();
             size_t keys_size = key_columns.size();
             for (size_t i = 0; i < num_rows; ++i) {
                 keys[i] = serialize_keys_to_pool_contiguous(i, keys_size, key_columns, *_arena);
             }
             keys_memory_usage = _arena->size();
         } else {
-            _arena.reset();
+            _arena->clear();
             if (total_bytes > _serialized_key_buffer_size) {
                 _serialized_key_buffer_size = total_bytes;
-                _serialize_key_arena.reset(new Arena());
+                _serialize_key_arena->clear();
                 _serialized_key_buffer = reinterpret_cast<uint8_t*>(
                         _serialize_key_arena->alloc(_serialized_key_buffer_size));
             }
@@ -175,7 +177,7 @@ struct AggregationMethodSerialized {
     }
 
     void reset() {
-        _arena.reset();
+        _arena.reset(new Arena());
         keys_memory_usage = 0;
         _serialized_key_buffer_size = 0;
     }
@@ -185,7 +187,6 @@ private:
     uint8_t* _serialized_key_buffer;
     std::unique_ptr<Arena> _serialize_key_arena;
     std::unique_ptr<Arena> _arena;
-    static constexpr size_t SERIALIZE_KEYS_MEM_LIMIT_IN_BYTES = 16 * 1024 * 1024; // 16M
 };
 
 using AggregatedDataWithoutKey = AggregateDataPtr;

--- a/be/src/vec/exec/vpartition_sort_node.h
+++ b/be/src/vec/exec/vpartition_sort_node.h
@@ -102,7 +102,10 @@ struct PartitionMethodSerialized {
     using State = ColumnsHashing::HashMethodSerialized<typename Data::value_type, Mapped, true>;
 
     template <typename Other>
-    explicit PartitionMethodSerialized(const Other& other) : data(other.data) {}
+    explicit PartitionMethodSerialized(const Other& other) : data(other.data) {
+        _arena.reset(new Arena());
+        _serialize_key_arena.reset(new Arena());
+    }
 
     size_t serialize_keys(const ColumnRawPtrs& key_columns, size_t num_rows) {
         if (keys.size() < num_rows) {
@@ -115,20 +118,20 @@ struct PartitionMethodSerialized {
         }
         size_t total_bytes = max_one_row_byte_size * num_rows;
 
-        if (total_bytes > SERIALIZE_KEYS_MEM_LIMIT_IN_BYTES) {
+        if (total_bytes > config::pre_serialize_keys_limit_bytes) {
             // reach mem limit, don't serialize in batch
             // for simplicity, we just create a new arena here.
-            _arena.reset(new Arena());
+            _arena->clear();
             size_t keys_size = key_columns.size();
             for (size_t i = 0; i < num_rows; ++i) {
                 keys[i] = serialize_keys_to_pool_contiguous(i, keys_size, key_columns, *_arena);
             }
             keys_memory_usage = _arena->size();
         } else {
-            _arena.reset();
+            _arena->clear();
             if (total_bytes > _serialized_key_buffer_size) {
                 _serialized_key_buffer_size = total_bytes;
-                _serialize_key_arena.reset(new Arena());
+                _serialize_key_arena->clear();
                 _serialized_key_buffer = reinterpret_cast<uint8_t*>(
                         _serialize_key_arena->alloc(_serialized_key_buffer_size));
             }
@@ -152,7 +155,6 @@ private:
     uint8_t* _serialized_key_buffer;
     std::unique_ptr<Arena> _serialize_key_arena;
     std::unique_ptr<Arena> _arena;
-    static constexpr size_t SERIALIZE_KEYS_MEM_LIMIT_IN_BYTES = 16 * 1024 * 1024; // 16M
 };
 
 //for string


### PR DESCRIPTION
## Proposed changes

In the past, MemPool also used clear() to reuse memory. after replacing it with Arena, the performance of predicate column and agg is low. 

After Arena also support clear(), the performance was the same as MemPool

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

