### PR TITLE
[enhancement](merge-on-write) some misc optimizations

### DIFF
--- a/be/src/olap/primary_key_index.cpp
+++ b/be/src/olap/primary_key_index.cpp
@@ -41,13 +41,15 @@ Status PrimaryKeyIndexBuilder::init() {
     options.data_page_size = config::primary_key_data_page_size;
     options.encoding = segment_v2::EncodingInfo::get_default_encoding(type_info, true);
     // TODO(liaoxin) test to confirm whether it needs to be compressed
-    options.compression = segment_v2::NO_COMPRESSION; // currently not compressed
+    options.compression = segment_v2::ZSTD; // currently not compressed
     _primary_key_index_builder.reset(
             new segment_v2::IndexedColumnWriter(options, type_info, _file_writer));
     RETURN_IF_ERROR(_primary_key_index_builder->init());
 
-    _bloom_filter_index_builder.reset(new segment_v2::PrimaryKeyBloomFilterIndexWriterImpl(
-            segment_v2::BloomFilterOptions(), type_info));
+    auto opt = segment_v2::BloomFilterOptions();
+    opt.fpp = 0.01;
+    _bloom_filter_index_builder.reset(
+            new segment_v2::PrimaryKeyBloomFilterIndexWriterImpl(opt, type_info));
     return Status::OK();
 }
 

--- a/be/src/olap/primary_key_index.cpp
+++ b/be/src/olap/primary_key_index.cpp
@@ -40,8 +40,7 @@ Status PrimaryKeyIndexBuilder::init() {
     options.write_value_index = true;
     options.data_page_size = config::primary_key_data_page_size;
     options.encoding = segment_v2::EncodingInfo::get_default_encoding(type_info, true);
-    // TODO(liaoxin) test to confirm whether it needs to be compressed
-    options.compression = segment_v2::ZSTD; // currently not compressed
+    options.compression = segment_v2::ZSTD;
     _primary_key_index_builder.reset(
             new segment_v2::IndexedColumnWriter(options, type_info, _file_writer));
     RETURN_IF_ERROR(_primary_key_index_builder->init());

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -73,8 +73,6 @@ class InvertedIndexIterator;
 
 using io::FileCacheManager;
 
-static bvar::LatencyRecorder g_segment_lookup_rowkey_latency("doris_pk", "segment_lookup_rowkey");
-
 Status Segment::open(io::FileSystemSPtr fs, const std::string& path, uint32_t segment_id,
                      RowsetId rowset_id, TabletSchemaSPtr tablet_schema,
                      const io::FileReaderOptions& reader_options,
@@ -358,7 +356,6 @@ Status Segment::new_inverted_index_iterator(const TabletColumn& tablet_column,
 }
 
 Status Segment::lookup_row_key(const Slice& key, bool with_seq_col, RowLocation* row_location) {
-    SCOPED_BVAR_LATENCY(g_segment_lookup_rowkey_latency);
     RETURN_IF_ERROR(load_pk_index_and_bf());
     bool has_seq_col = _tablet_schema->has_sequence_col();
     size_t seq_col_length = 0;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

1. use ZSTD for pk index data page
2. change bf fp rate from 0.05 to 0.01
3. remove g_segment_lookup_rowkey_latency which cost lots of cpu on high qps

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

