### PR TITLE
[fix](load) segcompaction does not signal waiters when an error hanppens

### DIFF
--- a/be/src/olap/rowset/segcompaction.cpp
+++ b/be/src/olap/rowset/segcompaction.cpp
@@ -302,7 +302,7 @@ void SegcompactionWorker::compact_segments(SegCompactionCandidatesSharedPtr segm
         case SEGCOMPACTION_INIT_READER:
         case SEGCOMPACTION_INIT_WRITER:
             LOG(WARNING) << "segcompaction failed, try next time:" << status;
-            return;
+            break;
         default:
             auto ctx = _writer->_context;
             LOG(WARNING) << "segcompaction fatal, terminating the write job."


### PR DESCRIPTION
This leads to a deadlock.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

