### PR TITLE
[minor](fe) remove several unnecessary codes

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/EsExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/EsExternalDatabase.java
@@ -20,12 +20,11 @@ package org.apache.doris.catalog.external;
 import org.apache.doris.datasource.EsExternalCatalog;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.InitDatabaseLog;
-import org.apache.doris.persist.gson.GsonPostProcessable;
 
 /**
  * Elasticsearch metastore external database.
  */
-public class EsExternalDatabase extends ExternalDatabase<EsExternalTable> implements GsonPostProcessable {
+public class EsExternalDatabase extends ExternalDatabase<EsExternalTable> {
 
     /**
      * Create Elasticsearch external database.

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalDatabase.java
@@ -21,7 +21,6 @@ import org.apache.doris.catalog.TableIf;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.HMSExternalCatalog;
 import org.apache.doris.datasource.InitDatabaseLog;
-import org.apache.doris.persist.gson.GsonPostProcessable;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -33,7 +32,7 @@ import java.util.stream.Collectors;
 /**
  * Hive metastore external database.
  */
-public class HMSExternalDatabase extends ExternalDatabase<HMSExternalTable> implements GsonPostProcessable {
+public class HMSExternalDatabase extends ExternalDatabase<HMSExternalTable> {
     private static final Logger LOG = LogManager.getLogger(HMSExternalDatabase.class);
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/IcebergExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/IcebergExternalDatabase.java
@@ -21,7 +21,6 @@ import org.apache.doris.catalog.TableIf;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.InitDatabaseLog;
 import org.apache.doris.datasource.iceberg.IcebergExternalCatalog;
-import org.apache.doris.persist.gson.GsonPostProcessable;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -30,7 +29,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class IcebergExternalDatabase extends ExternalDatabase<IcebergExternalTable> implements GsonPostProcessable {
+public class IcebergExternalDatabase extends ExternalDatabase<IcebergExternalTable> {
 
     private static final Logger LOG = LogManager.getLogger(IcebergExternalDatabase.class);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/JdbcExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/JdbcExternalDatabase.java
@@ -20,9 +20,8 @@ package org.apache.doris.catalog.external;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.InitDatabaseLog;
 import org.apache.doris.datasource.JdbcExternalCatalog;
-import org.apache.doris.persist.gson.GsonPostProcessable;
 
-public class JdbcExternalDatabase extends ExternalDatabase<JdbcExternalTable> implements GsonPostProcessable {
+public class JdbcExternalDatabase extends ExternalDatabase<JdbcExternalTable> {
 
     /**
      * Create Jdbc external database.

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/MaxComputeExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/MaxComputeExternalDatabase.java
@@ -20,13 +20,11 @@ package org.apache.doris.catalog.external;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.InitDatabaseLog;
 import org.apache.doris.datasource.MaxComputeExternalCatalog;
-import org.apache.doris.persist.gson.GsonPostProcessable;
 
 /**
  * MaxCompute external database.
  */
-public class MaxComputeExternalDatabase extends ExternalDatabase<MaxComputeExternalTable>
-            implements GsonPostProcessable {
+public class MaxComputeExternalDatabase extends ExternalDatabase<MaxComputeExternalTable> {
     /**
      * Create MaxCompute external database.
      *

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/PaimonExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/PaimonExternalDatabase.java
@@ -21,7 +21,6 @@ import org.apache.doris.catalog.TableIf;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.InitDatabaseLog;
 import org.apache.doris.datasource.paimon.PaimonExternalCatalog;
-import org.apache.doris.persist.gson.GsonPostProcessable;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -30,7 +29,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class PaimonExternalDatabase extends ExternalDatabase<PaimonExternalTable> implements GsonPostProcessable {
+public class PaimonExternalDatabase extends ExternalDatabase<PaimonExternalTable> {
 
     private static final Logger LOG = LogManager.getLogger(PaimonExternalDatabase.class);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/TestExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/TestExternalDatabase.java
@@ -20,9 +20,8 @@ package org.apache.doris.catalog.external;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.InitDatabaseLog;
 import org.apache.doris.datasource.test.TestExternalCatalog;
-import org.apache.doris.persist.gson.GsonPostProcessable;
 
-public class TestExternalDatabase extends ExternalDatabase<TestExternalTable> implements GsonPostProcessable {
+public class TestExternalDatabase extends ExternalDatabase<TestExternalTable> {
 
     public TestExternalDatabase(ExternalCatalog extCatalog, long id, String name) {
         super(extCatalog, id, name, InitDatabaseLog.Type.TEST);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/JdbcExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/JdbcExternalCatalog.java
@@ -28,16 +28,12 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Map;
 
 @Getter
 public class JdbcExternalCatalog extends ExternalCatalog {
-    private static final Logger LOG = LogManager.getLogger(JdbcExternalCatalog.class);
-
     private static final List<String> REQUIRED_PROPERTIES = Lists.newArrayList(
             JdbcResource.JDBC_URL,
             JdbcResource.DRIVER_URL,


### PR DESCRIPTION
1. The class 'ExternalDatabase' has implemented the 'GsonPostProcessable' interface, so there is redundant codes in some subclass of 'ExternalDatabase'.
2. A LOG object is not used in this file.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

