### PR TITLE
[fix](runtime_filter) remove incorrect DCHECK

### DIFF
--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -1199,7 +1199,6 @@ bool IRuntimeFilter::await() {
                                 ? RuntimeFilterState::TIME_OUT
                                 : RuntimeFilterState::NOT_READY,
                         std::memory_order_acq_rel)) {
-                DCHECK(expected == RuntimeFilterState::READY);
                 return true;
             }
             return false;
@@ -1272,7 +1271,6 @@ bool IRuntimeFilter::is_ready_or_timeout() {
         }
         if (!_rf_state_atomic.compare_exchange_strong(expected, RuntimeFilterState::NOT_READY,
                                                       std::memory_order_acq_rel)) {
-            DCHECK(expected == RuntimeFilterState::READY);
             return true;
         }
         return false;


### PR DESCRIPTION
## Proposed changes

When `runtime_filter_wait_time_ms` was set to 0, the runtime filter's state maybe was TIMEOUT because runtime filters were shared in different fragment instances.
So this patch remove two` DCHECK(expected == RuntimeFilterState::READY)`

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

