### PR TITLE
[improvement](config) update Be config max_runnings_transactions_per_txn_map default value

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -666,7 +666,7 @@ DEFINE_mBool(transfer_large_data_by_brpc, "false");
 
 // max number of txns for every txn_partition_map in txn manager
 // this is a self protection to avoid too many txns saving in manager
-DEFINE_mInt64(max_runnings_transactions_per_txn_map, "100");
+DEFINE_mInt64(max_runnings_transactions_per_txn_map, "500");
 
 // tablet_map_lock shard size, the value is 2^n, n=0,1,2,3,4
 // this is a an enhancement for better performance to manage tablet

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -666,7 +666,7 @@ DEFINE_mBool(transfer_large_data_by_brpc, "false");
 
 // max number of txns for every txn_partition_map in txn manager
 // this is a self protection to avoid too many txns saving in manager
-DEFINE_mInt64(max_runnings_transactions_per_txn_map, "500");
+DEFINE_mInt64(max_runnings_transactions_per_txn_map, "2000");
 
 // tablet_map_lock shard size, the value is 2^n, n=0,1,2,3,4
 // this is a an enhancement for better performance to manage tablet

--- a/docs/en/docs/admin-manual/config/be-config.md
+++ b/docs/en/docs/admin-manual/config/be-config.md
@@ -1410,7 +1410,7 @@ Indicates how many tablets failed to load in the data directory. At the same tim
 #### `max_runnings_transactions_per_txn_map`
 
 * Description: Max number of txns for every txn_partition_map in txn manager, this is a self protection to avoid too many txns saving in manager
-* Default value: 100
+* Default value: 500
 
 #### `max_download_speed_kbps`
 

--- a/docs/en/docs/admin-manual/config/be-config.md
+++ b/docs/en/docs/admin-manual/config/be-config.md
@@ -1410,7 +1410,7 @@ Indicates how many tablets failed to load in the data directory. At the same tim
 #### `max_runnings_transactions_per_txn_map`
 
 * Description: Max number of txns for every txn_partition_map in txn manager, this is a self protection to avoid too many txns saving in manager
-* Default value: 500
+* Default value: 2000
 
 #### `max_download_speed_kbps`
 

--- a/docs/zh-CN/docs/admin-manual/config/be-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/be-config.md
@@ -1427,7 +1427,7 @@ load tablets from header failed, failed tablets size: xxx, path=xxx
 #### `max_runnings_transactions_per_txn_map`
 
 * 描述: txn 管理器中每个 txn_partition_map 的最大 txns 数，这是一种自我保护，以避免在管理器中保存过多的 txns
-* 默认值: 100
+* 默认值: 500
 
 #### `max_download_speed_kbps`
 

--- a/docs/zh-CN/docs/admin-manual/config/be-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/be-config.md
@@ -1427,7 +1427,7 @@ load tablets from header failed, failed tablets size: xxx, path=xxx
 #### `max_runnings_transactions_per_txn_map`
 
 * 描述: txn 管理器中每个 txn_partition_map 的最大 txns 数，这是一种自我保护，以避免在管理器中保存过多的 txns
-* 默认值: 500
+* 默认值: 2000
 
 #### `max_download_speed_kbps`
 


### PR DESCRIPTION
## Proposed changes
The be config `max_runnings_transactions_per_txn_map` old value is 100, and increase the value to 2000 to avoid too many accumulated transactions, causing E-233 problems

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

