### PR TITLE
[Fix](multi-catalog) Invalidate cache when enable auto refresh catalog.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/RefreshCatalogStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/RefreshCatalogStmt.java
@@ -38,7 +38,7 @@ public class RefreshCatalogStmt extends DdlStmt {
 
     private final String catalogName;
     private Map<String, String> properties;
-    private boolean invalidCache = false;
+    private boolean invalidCache = true;
 
     public RefreshCatalogStmt(String catalogName, Map<String, String> properties) {
         this.catalogName = catalogName;
@@ -66,9 +66,12 @@ public class RefreshCatalogStmt extends DdlStmt {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_CATALOG_ACCESS_DENIED,
                     analyzer.getQualifiedUser(), catalogName);
         }
-        String invalidConfig = properties == null ? null : properties.get(INVALID_CACHE);
-        // Default is to invalid cache.
-        invalidCache = invalidConfig == null ? true : invalidConfig.equalsIgnoreCase("true");
+
+        boolean notInvalidCache = properties != null && properties.get(INVALID_CACHE).equalsIgnoreCase("false");
+        // set default value of invalidCache to true
+        // otherwise RefreshManager will lost the default value of invalidCache
+        // set invalidCache to false only if user set the property "invalid_cache"="false"
+        invalidCache = invalidCache && !notInvalidCache;
     }
 
     @Override
@@ -77,4 +80,5 @@ public class RefreshCatalogStmt extends DdlStmt {
         stringBuilder.append("REFRESH CATALOG ").append("`").append(catalogName).append("`");
         return stringBuilder.toString();
     }
+
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/RefreshCatalogStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/RefreshCatalogStmt.java
@@ -38,6 +38,11 @@ public class RefreshCatalogStmt extends DdlStmt {
 
     private final String catalogName;
     private Map<String, String> properties;
+
+    /**
+     * Set default value to true, otherwise
+     * {@link org.apache.doris.catalog.RefreshManager.RefreshTask} will lost the default value
+     */
     private boolean invalidCache = true;
 
     public RefreshCatalogStmt(String catalogName, Map<String, String> properties) {
@@ -67,11 +72,8 @@ public class RefreshCatalogStmt extends DdlStmt {
                     analyzer.getQualifiedUser(), catalogName);
         }
 
-        boolean notInvalidCache = properties != null && properties.get(INVALID_CACHE).equalsIgnoreCase("false");
-        // set default value of invalidCache to true
-        // otherwise RefreshManager will lost the default value of invalidCache
-        // set invalidCache to false only if user set the property "invalid_cache"="false"
-        invalidCache = invalidCache && !notInvalidCache;
+        // Set to false only if user set the property "invalid_cache"="false"
+        invalidCache = !(properties != null && properties.get(INVALID_CACHE).equalsIgnoreCase("false"));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
@@ -17,7 +17,12 @@
 
 package org.apache.doris.catalog;
 
-import org.apache.doris.analysis.*;
+import org.apache.doris.analysis.CreateTableStmt;
+import org.apache.doris.analysis.DropTableStmt;
+import org.apache.doris.analysis.RefreshCatalogStmt;
+import org.apache.doris.analysis.RefreshDbStmt;
+import org.apache.doris.analysis.RefreshTableStmt;
+import org.apache.doris.analysis.TableName;
 import org.apache.doris.catalog.external.ExternalDatabase;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ThreadPoolManager;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
@@ -17,12 +17,7 @@
 
 package org.apache.doris.catalog;
 
-import org.apache.doris.analysis.CreateTableStmt;
-import org.apache.doris.analysis.DropTableStmt;
-import org.apache.doris.analysis.RefreshCatalogStmt;
-import org.apache.doris.analysis.RefreshDbStmt;
-import org.apache.doris.analysis.RefreshTableStmt;
-import org.apache.doris.analysis.TableName;
+import org.apache.doris.analysis.*;
 import org.apache.doris.catalog.external.ExternalDatabase;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ThreadPoolManager;
@@ -189,6 +184,11 @@ public class RefreshManager {
                     CatalogIf catalog = Env.getCurrentEnv().getCatalogMgr().getCatalog(catalogId);
                     if (catalog != null) {
                         String catalogName = catalog.getName();
+                        /**
+                         * Now do not invoke
+                         * {@link org.apache.doris.analysis.RefreshCatalogStmt#analyze(Analyzer)} is ok,
+                         * because the default value of invalidCache is true.
+                         * */
                         RefreshCatalogStmt refreshCatalogStmt = new RefreshCatalogStmt(catalogName, null);
                         try {
                             DdlExecutor.execute(Env.getCurrentEnv(), refreshCatalogStmt);

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/RefreshTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/RefreshTableTest.java
@@ -76,6 +76,7 @@ public class RefreshTableTest extends TestWithFeService {
         table.makeSureInitialized();
         Assertions.assertTrue(table.isObjectCreated());
         RefreshCatalogStmt refreshCatalogStmt = new RefreshCatalogStmt("test1", null);
+        Assertions.assertTrue(refreshCatalogStmt.isInvalidCache());
         try {
             DdlExecutor.execute(Env.getCurrentEnv(), refreshCatalogStmt);
         } catch (Exception e) {
@@ -97,6 +98,7 @@ public class RefreshTableTest extends TestWithFeService {
         } catch (Exception e) {
             // Do nothing
         }
+        Assertions.assertFalse(((ExternalCatalog) test1).isInitialized());
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

The default value of `RefreshCatalogStmt.invalidCache` is false now, but the `RefreshManager.RefreshTask` does not invoke `RefreshCatalogStmt.analyze()` so it will not invalidate the cache. This pr mainly fix this problem

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

