### PR TITLE
[Fix](Nereids) fix cast compare of varchar with double

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
@@ -321,7 +321,7 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule {
             }
             return castResult;
         } catch (Throwable t) {
-            return cast;
+            return new NullLiteral(cast.getDataType());
         }
     }
 

--- a/regression-test/suites/nereids_p0/fold_constant/fold_constant_by_fe.groovy
+++ b/regression-test/suites/nereids_p0/fold_constant/fold_constant_by_fe.groovy
@@ -144,4 +144,16 @@ suite("test_fold_constant_by_fe") {
         res = res.split('VUNION')[1]
         assertFalse(res.contains("unix"))
     }
+
+    res = sql "explain select case 'a' when 1 then 'a' when 'a' then 'b' else 'other' end as col212"
+    res = res.split('VUNION')[1]
+    assertFalse(res.contains("case") || res.contains("else"))
+
+    res = sql "explain select case '1' when 1 then 'a' when 'a' then 'b' else 'other' end as col212"
+    res = res.split('VUNION')[1]
+    assertFalse(res.contains("case") || res.contains("else"))
+
+    res = sql "explain select case '2' when 1 then 'a' when 'a' then 'b' else 'other' end as col212"
+    res = res.split('VUNION')[1]
+    assertFalse(res.contains("case") || res.contains("else"))
 }


### PR DESCRIPTION
## Proposed changes

Problem: when using nereids planner, some constant folding does not work. like: 
explain select case 'a' when 1 then 'a' when 'a' then 'b' else 'other' end as col212;
which will add cast to 'a' to double, but Cast is not treated as constant, so this folding can not be done

Solve: Treat Cast(varchar as double) as NullLiteral if can not cast, which cast condition will return false


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

