### PR TITLE
[Bug](lazyopen) delete lazy open DCheck when unkown load id

### DIFF
--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -149,7 +149,6 @@ Status LoadChannelMgr::open_partition(const OpenPartitionRequest& params) {
         if (it != _load_channels.end()) {
             channel = it->second;
         } else {
-            DCHECK(false);
             return Status::InternalError("unknown load id, load id=" + load_id.to_string());
         }
     }


### PR DESCRIPTION
## Proposed changes

When lazy open, the load_id may not be found due to it was deleted because cancel, so there is no need for DCheck.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

