### PR TITLE
[Chore](script)Remove redundant Clang checks

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -114,54 +114,6 @@ if [[ -z "${DORIS_TOOLCHAIN}" ]]; then
     fi
 fi
 
-if [[ "${DORIS_TOOLCHAIN}" == "gcc" ]]; then
-    # set GCC HOME
-    if [[ -z "${DORIS_GCC_HOME}" ]]; then
-        DORIS_GCC_HOME="$(dirname "$(command -v gcc)")"/..
-        export DORIS_GCC_HOME
-    fi
-
-    gcc_ver="$("${DORIS_GCC_HOME}/bin/gcc" -dumpfullversion -dumpversion)"
-    required_ver="11.0.0"
-    if [[ ! "$(printf '%s\n' "${required_ver}" "${gcc_ver}" | sort -V | head -n1)" = "${required_ver}" ]]; then
-        echo "Error: GCC version (${gcc_ver}) must be greater than or equal to ${required_ver}"
-        exit 1
-    fi
-    export CC="${DORIS_GCC_HOME}/bin/gcc"
-    export CXX="${DORIS_GCC_HOME}/bin/g++"
-    if test -x "${DORIS_GCC_HOME}/bin/ld"; then
-        export DORIS_BIN_UTILS="${DORIS_GCC_HOME}/bin/"
-    fi
-    ENABLE_PCH='OFF'
-elif [[ "${DORIS_TOOLCHAIN}" == "clang" ]]; then
-    # set CLANG HOME
-    if [[ -z "${DORIS_CLANG_HOME}" ]]; then
-        DORIS_CLANG_HOME="$(dirname "$(command -v clang)")"/..
-        export DORIS_CLANG_HOME
-    fi
-
-    clang_ver="$("${DORIS_CLANG_HOME}/bin/clang" -dumpfullversion -dumpversion)"
-    required_ver="16.0.0"
-    if [[ ! "$(printf '%s\n' "${required_ver}" "${clang_ver}" | sort -V | head -n1)" = "${required_ver}" ]]; then
-        echo "Error: CLANG version (${clang_ver}) must be greater than or equal to ${required_ver}"
-        exit 1
-    fi
-    export CC="${DORIS_CLANG_HOME}/bin/clang"
-    export CXX="${DORIS_CLANG_HOME}/bin/clang++"
-    if test -x "${DORIS_CLANG_HOME}/bin/ld.lld"; then
-        export DORIS_BIN_UTILS="${DORIS_CLANG_HOME}/bin/"
-    fi
-    if [[ -f "${DORIS_CLANG_HOME}/bin/llvm-symbolizer" ]]; then
-        export ASAN_SYMBOLIZER_PATH="${DORIS_CLANG_HOME}/bin/llvm-symbolizer"
-    fi
-    if [[ -z "${ENABLE_PCH}" ]]; then
-        ENABLE_PCH='ON'
-    fi
-else
-    echo "Error: unknown DORIS_TOOLCHAIN=${DORIS_TOOLCHAIN}, currently only 'gcc' and 'clang' are supported"
-    exit 1
-fi
-
 export CCACHE_COMPILERCHECK=content
 if [[ "${ENABLE_PCH}" == "ON" ]]; then
     export CCACHE_PCH_EXTSUM=true


### PR DESCRIPTION
Clang/GCC has already been checked in `CMakeList.txt`, so there is no need to check again in `env.sh`

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

