### PR TITLE
[fix](nereids)the microseconds value is wrong when create datatimev2 literal from LocalDateTime

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeV2Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeV2Literal.java
@@ -62,27 +62,9 @@ public class DateTimeV2Literal extends DateTimeLiteral {
         return visitor.visitDateTimeV2Literal(this, context);
     }
 
-    private long formatMicroSecond(long microSecond) {
-        if (microSecond == 0) {
-            return microSecond;
-        }
-        while (10 * microSecond <= 999999) {
-            microSecond = 10 * microSecond;
-        }
-        return microSecond;
-    }
-
-    /*
-     * Legacy and Nereids have different approaches to handling accuracy in scale.
-     * For example, with a scale of 5, Legacy would store 123450, while Nereids
-     * would store it as 12345.
-     * Therefore, we need to perform a conversion.
-     * Alternatively, can we standardize the format?
-     */
     @Override
     public LiteralExpr toLegacyLiteral() {
-        return new org.apache.doris.analysis.DateLiteral(year, month, day, hour, minute, second,
-                formatMicroSecond(microSecond),
+        return new org.apache.doris.analysis.DateLiteral(year, month, day, hour, minute, second, microSecond,
                 getDataType().toCatalogDataType());
     }
 
@@ -93,15 +75,10 @@ public class DateTimeV2Literal extends DateTimeLiteral {
 
     @Override
     public String getStringValue() {
-        int scale = getDataType().getScale();
-        if (scale == 0) {
-            return String.format("%04d-%02d-%02d %02d:%02d:%02d", year, month, day, hour, minute, second);
-        } else {
-            int microsecond = (int) (microSecond / Math.pow(10, DateTimeV2Type.MAX_SCALE - scale));
-            return String.format("%04d-%02d-%02d %02d:%02d:%02d"
-                    + ".%0" + scale + "d",
-                    year, month, day, hour, minute, second, microsecond);
-        }
+        return String.format("%04d-%02d-%02d %02d:%02d:%02d"
+                + (getDataType().getScale() > 0 ? ".%0" + getDataType().getScale() + "d" : ""),
+                year, month, day, hour, minute, second,
+                (int) (microSecond / Math.pow(10, DateTimeV2Type.MAX_SCALE - getDataType().getScale())));
     }
 
     @Override
@@ -153,11 +130,12 @@ public class DateTimeV2Literal extends DateTimeLiteral {
      * convert java LocalDateTime object to DateTimeV2Literal object.
      */
     public static Expression fromJavaDateType(LocalDateTime dateTime, int precision) {
-        return isDateOutOfRange(dateTime)
+        long value = (long) Math.pow(10, DateTimeV2Type.MAX_SCALE - precision);
+        return isDateOutOfRange(dateTime) 
                 ? new NullLiteral(DateTimeV2Type.of(precision))
-                : new DateTimeV2Literal(DateTimeV2Type.of(precision),
-                        dateTime.getYear(), dateTime.getMonthValue(), dateTime.getDayOfMonth(),
-                        dateTime.getHour(), dateTime.getMinute(), dateTime.getSecond(),
-                        dateTime.getNano() / (long) Math.pow(10, 9 - precision));
+                : new DateTimeV2Literal(DateTimeV2Type.of(precision), dateTime.getYear(),
+                        dateTime.getMonthValue(), dateTime.getDayOfMonth(), dateTime.getHour(),
+                        dateTime.getMinute(), dateTime.getSecond(),
+                        (dateTime.getNano() / 1000) / value * value);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeV2Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeV2Literal.java
@@ -131,7 +131,7 @@ public class DateTimeV2Literal extends DateTimeLiteral {
      */
     public static Expression fromJavaDateType(LocalDateTime dateTime, int precision) {
         long value = (long) Math.pow(10, DateTimeV2Type.MAX_SCALE - precision);
-        return isDateOutOfRange(dateTime) 
+        return isDateOutOfRange(dateTime)
                 ? new NullLiteral(DateTimeV2Type.of(precision))
                 : new DateTimeV2Literal(DateTimeV2Type.of(precision), dateTime.getYear(),
                         dateTime.getMonthValue(), dateTime.getDayOfMonth(), dateTime.getHour(),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/DateUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/DateUtils.java
@@ -158,7 +158,7 @@ public class DateUtils {
                 getOrDefault(accessor, ChronoField.HOUR_OF_DAY),
                 getOrDefault(accessor, ChronoField.MINUTE_OF_HOUR),
                 getOrDefault(accessor, ChronoField.SECOND_OF_MINUTE),
-                1000 * getOrDefault(accessor, ChronoField.MICRO_OF_SECOND));
+                getOrDefault(accessor, ChronoField.NANO_OF_SECOND));
     }
 
     public static int getOrDefault(final TemporalAccessor accessor, final ChronoField field) {


### PR DESCRIPTION


## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

