### PR TITLE
[fix](fuzzy)nereids and pipeline config  changed by fuzzy in non-pipeline env.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1021,8 +1021,7 @@ public class SessionVariable implements Serializable, Writable {
                 break;
         }
         // pull_request_id default value is 0. When it is 0, use default (global) session variable.
-        if (Config.pull_request_id > 0)
-        {
+        if (Config.pull_request_id > 0) {
             switch (Config.pull_request_id % 4) {
                 case 0:
                     this.enablePipelineEngine = true;
@@ -1049,10 +1048,8 @@ public class SessionVariable implements Serializable, Writable {
             }
         }
         
-
         if (Config.fuzzy_test_type.equals("p0")) {
-            if (Config.pull_request_id > 0)
-            {
+            if (Config.pull_request_id > 0) {
                 if (Config.pull_request_id % 2 == 1) {
                     this.batchSize = 4064;
                 } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1020,37 +1020,44 @@ public class SessionVariable implements Serializable, Writable {
                 this.externalAggPartitionBits = 4;
                 break;
         }
-        // pull_request_id default value is 0
-        switch (Config.pull_request_id % 4) {
-            case 0:
-                this.enablePipelineEngine = true;
-                this.runtimeFilterType |= TRuntimeFilterType.BITMAP.getValue();
-                this.enableNereidsPlanner = true;
-                break;
-            case 1:
-                this.enablePipelineEngine = true;
-                this.runtimeFilterType |= TRuntimeFilterType.BITMAP.getValue();
-                this.enableNereidsPlanner = false;
-                break;
-            case 2:
-                this.enablePipelineEngine = false;
-                this.runtimeFilterType &= ~TRuntimeFilterType.BITMAP.getValue();
-                this.enableNereidsPlanner = true;
-                break;
-            case 3:
-                this.enablePipelineEngine = false;
-                this.runtimeFilterType &= ~TRuntimeFilterType.BITMAP.getValue();
-                this.enableNereidsPlanner = false;
-                break;
-            default:
-                break;
+        // pull_request_id default value is 0. When it is 0, use default (global) session variable.
+        if (Config.pull_request_id > 0)
+        {
+            switch (Config.pull_request_id % 4) {
+                case 0:
+                    this.enablePipelineEngine = true;
+                    this.runtimeFilterType |= TRuntimeFilterType.BITMAP.getValue();
+                    this.enableNereidsPlanner = true;
+                    break;
+                case 1:
+                    this.enablePipelineEngine = true;
+                    this.runtimeFilterType |= TRuntimeFilterType.BITMAP.getValue();
+                    this.enableNereidsPlanner = false;
+                    break;
+                case 2:
+                    this.enablePipelineEngine = false;
+                    this.runtimeFilterType &= ~TRuntimeFilterType.BITMAP.getValue();
+                    this.enableNereidsPlanner = true;
+                    break;
+                case 3:
+                    this.enablePipelineEngine = false;
+                    this.runtimeFilterType &= ~TRuntimeFilterType.BITMAP.getValue();
+                    this.enableNereidsPlanner = false;
+                    break;
+                default:
+                    break;
+            }
         }
+        
 
         if (Config.fuzzy_test_type.equals("p0")) {
-            if (Config.pull_request_id % 2 == 1) {
-                this.batchSize = 4064;
-            } else {
-                this.batchSize = 50;
+            if (Config.pull_request_id > 0)
+            {
+                if (Config.pull_request_id % 2 == 1) {
+                    this.batchSize = 4064;
+                } else {
+                    this.batchSize = 50;
+                }
             }
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1047,7 +1047,7 @@ public class SessionVariable implements Serializable, Writable {
                     break;
             }
         }
-        
+
         if (Config.fuzzy_test_type.equals("p0")) {
             if (Config.pull_request_id > 0) {
                 if (Config.pull_request_id % 2 == 1) {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
In non-pipeline environment, enable_nereids_planner and enable_pipeline must not changed by fuzzy.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

