### PR TITLE
[Bug](materialized-veiw) fix error happens when parsing create materialized view stmt

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -355,8 +355,8 @@ public class OlapTable extends Table {
             Preconditions.checkState(storageType == TStorageType.COLUMN);
         }
 
-        MaterializedIndexMeta indexMeta = new MaterializedIndexMeta(indexId, schema, schemaVersion,
-                schemaHash, shortKeyColumnCount, storageType, keysType, origStmt, indexes);
+        MaterializedIndexMeta indexMeta = new MaterializedIndexMeta(indexId, schema, schemaVersion, schemaHash,
+                shortKeyColumnCount, storageType, keysType, origStmt, indexes, getQualifiedDbName());
         try {
             indexMeta.parseStmt(analyzer);
         } catch (Exception e) {


### PR DESCRIPTION
## Proposed changes

```java
2023-06-22 04:32:08,263 ERROR (leaderCheckpointer|77) [Checkpoint.doCheckpoint():156] Exception when generate new image file
java.io.IOException: java.lang.reflect.InvocationTargetException
	at org.apache.doris.persist.meta.MetaReader.read(MetaReader.java:119) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.catalog.Env.loadImage(Env.java:1723) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.master.Checkpoint.doCheckpoint(Checkpoint.java:149) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.master.Checkpoint.runAfterCatalogReady(Checkpoint.java:77) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.common.util.MasterDaemon.runOneCycle(MasterDaemon.java:58) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.common.util.Daemon.run(Daemon.java:116) ~[doris-fe.jar:1.2-SNAPSHOT]
Caused by: java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_131]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_131]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_131]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_131]
	at org.apache.doris.persist.meta.MetaReader.read(MetaReader.java:116) ~[doris-fe.jar:1.2-SNAPSHOT]
	... 5 more
Caused by: com.google.gson.JsonSyntaxException: java.io.IOException: error happens when parsing create materialized view stmt: org.apache.doris.qe.OriginStatement@4f099e4a
	at com.google.gson.Gson.fromJson(Gson.java:978) ~[gson-2.8.9.jar:?]
	at com.google.gson.Gson.fromJson(Gson.java:928) ~[gson-2.8.9.jar:?]
	at com.google.gson.Gson.fromJson(Gson.java:877) ~[gson-2.8.9.jar:?]
	at com.google.gson.Gson.fromJson(Gson.java:848) ~[gson-2.8.9.jar:?]
	at org.apache.doris.catalog.MaterializedIndexMeta.read(MaterializedIndexMeta.java:279) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.catalog.OlapTable.readFields(OlapTable.java:1297) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.catalog.Table.read(Table.java:382) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.catalog.Database.readFields(Database.java:624) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.datasource.InternalCatalog.loadDb(InternalCatalog.java:2911) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.catalog.Env.loadDb(Env.java:1786) ~[doris-fe.jar:1.2-SNAPSHOT]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_131]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_131]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_131]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_131]
	at org.apache.doris.persist.meta.MetaReader.read(MetaReader.java:116) ~[doris-fe.jar:1.2-SNAPSHOT]
	... 5 more
Caused by: java.io.IOException: error happens when parsing create materialized view stmt: org.apache.doris.qe.OriginStatement@4f099e4a
	at org.apache.doris.catalog.MaterializedIndexMeta.parseStmt(MaterializedIndexMeta.java:310) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.catalog.MaterializedIndexMeta.gsonPostProcess(MaterializedIndexMeta.java:285) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.persist.gson.GsonUtils$PostProcessTypeAdapterFactory$1.read(GsonUtils.java:510) ~[doris-fe.jar:1.2-SNAPSHOT]
	at com.google.gson.Gson.fromJson(Gson.java:963) ~[gson-2.8.9.jar:?]
	at com.google.gson.Gson.fromJson(Gson.java:928) ~[gson-2.8.9.jar:?]
	at com.google.gson.Gson.fromJson(Gson.java:877) ~[gson-2.8.9.jar:?]
	at com.google.gson.Gson.fromJson(Gson.java:848) ~[gson-2.8.9.jar:?]
	at org.apache.doris.catalog.MaterializedIndexMeta.read(MaterializedIndexMeta.java:279) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.catalog.OlapTable.readFields(OlapTable.java:1297) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.catalog.Table.read(Table.java:382) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.catalog.Database.readFields(Database.java:624) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.datasource.InternalCatalog.loadDb(InternalCatalog.java:2911) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.catalog.Env.loadDb(Env.java:1786) ~[doris-fe.jar:1.2-SNAPSHOT]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_131]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_131]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_131]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_131]
	at org.apache.doris.persist.meta.MetaReader.read(MetaReader.java:116) ~[doris-fe.jar:1.2-SNAPSHOT]
	... 5 more
Caused by: java.lang.NullPointerException
	at org.apache.doris.catalog.Function.convertToStateCombinator(Function.java:843) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.analysis.CreateMaterializedViewStmt.buildMVColumnItem(CreateMaterializedViewStmt.java:456) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.analysis.CreateMaterializedViewStmt.parseDefineExpr(CreateMaterializedViewStmt.java:506) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.catalog.MaterializedIndexMeta.parseStmt(MaterializedIndexMeta.java:306) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.catalog.MaterializedIndexMeta.gsonPostProcess(MaterializedIndexMeta.java:285) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.persist.gson.GsonUtils$PostProcessTypeAdapterFactory$1.read(GsonUtils.java:510) ~[doris-fe.jar:1.2-SNAPSHOT]
	at com.google.gson.Gson.fromJson(Gson.java:963) ~[gson-2.8.9.jar:?]
	at com.google.gson.Gson.fromJson(Gson.java:928) ~[gson-2.8.9.jar:?]
	at com.google.gson.Gson.fromJson(Gson.java:877) ~[gson-2.8.9.jar:?]
	at com.google.gson.Gson.fromJson(Gson.java:848) ~[gson-2.8.9.jar:?]
	at org.apache.doris.catalog.MaterializedIndexMeta.read(MaterializedIndexMeta.java:279) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.catalog.OlapTable.readFields(OlapTable.java:1297) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.catalog.Table.read(Table.java:382) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.catalog.Database.readFields(Database.java:624) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.datasource.InternalCatalog.loadDb(InternalCatalog.java:2911) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.catalog.Env.loadDb(Env.java:1786) ~[doris-fe.jar:1.2-SNAPSHOT]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_131]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_131]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_131]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_131]
	at org.apache.doris.persist.meta.MetaReader.read(MetaReader.java:116) ~[doris-fe.jar:1.2-SNAPSHOT]
	... 5 more
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

