### PR TITLE
[fix](pipeline) fix MultiCoreTaskQueue steal take core_id assgin error

### DIFF
--- a/be/src/pipeline/task_queue.cpp
+++ b/be/src/pipeline/task_queue.cpp
@@ -182,7 +182,7 @@ PipelineTask* MultiCoreTaskQueue::_steal_take(size_t core_id) {
         DCHECK(next_id < _core_size);
         auto task = _prio_task_queue_list[next_id].try_take(true);
         if (task) {
-            task->set_core_id(next_id);
+            task->set_core_id(core_id);
             return task;
         }
     }


### PR DESCRIPTION
## Proposed changes
1.  fix MultiCoreTaskQueue steal take core_id assgin error
stealed pipeline_task will run on core_id thread not previous next_id thread, so the pipeline_task will use core_id queue runtime  and should be assginned core_id. 


Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

