### PR TITLE
[Enhancement](regression) let test case fail fast when job cancelled

### DIFF
--- a/regression-test/suites/index_p0/test_bitmap_index.groovy
+++ b/regression-test/suites/index_p0/test_bitmap_index.groovy
@@ -64,7 +64,8 @@ suite("test_bitmap_index") {
     int max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -85,7 +86,8 @@ suite("test_bitmap_index") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -145,7 +147,8 @@ suite("test_bitmap_index") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName2)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -170,7 +173,8 @@ suite("test_bitmap_index") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName2)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -230,7 +234,8 @@ suite("test_bitmap_index") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName3)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -251,7 +256,8 @@ suite("test_bitmap_index") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName3)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {

--- a/regression-test/suites/inverted_index_p0/test_bitmap_index.groovy
+++ b/regression-test/suites/inverted_index_p0/test_bitmap_index.groovy
@@ -56,7 +56,8 @@ suite("test_bitmap_index", "inverted_index") {
     int max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -77,7 +78,8 @@ suite("test_bitmap_index", "inverted_index") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -129,7 +131,8 @@ suite("test_bitmap_index", "inverted_index") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName2)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -154,7 +157,8 @@ suite("test_bitmap_index", "inverted_index") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName2)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -206,7 +210,8 @@ suite("test_bitmap_index", "inverted_index") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName3)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -227,7 +232,8 @@ suite("test_bitmap_index", "inverted_index") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName3)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {

--- a/regression-test/suites/inverted_index_p0/test_inverted_index.groovy
+++ b/regression-test/suites/inverted_index_p0/test_inverted_index.groovy
@@ -64,7 +64,8 @@ suite("test_inverted_index", "inverted_index") {
     int max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -85,7 +86,8 @@ suite("test_inverted_index", "inverted_index") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -145,7 +147,8 @@ suite("test_inverted_index", "inverted_index") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName2)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -170,7 +173,8 @@ suite("test_inverted_index", "inverted_index") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName2)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -234,7 +238,8 @@ suite("test_inverted_index", "inverted_index") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName3)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -255,7 +260,8 @@ suite("test_inverted_index", "inverted_index") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName3)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {

--- a/regression-test/suites/nereids_syntax_p0/advance_mv.groovy
+++ b/regression-test/suites/nereids_syntax_p0/advance_mv.groovy
@@ -92,7 +92,8 @@ suite("advance_mv") {
     int max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -113,7 +114,8 @@ suite("advance_mv") {
     int max_try_secs1 = 60
     while (max_try_secs1--) {
         String res = getJobState(tbName2)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -134,7 +136,8 @@ suite("advance_mv") {
     int max_try_secs2 = 60
     while (max_try_secs2--) {
         String res = getJobState(tbName2)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -156,7 +159,8 @@ suite("advance_mv") {
     int max_try_secs3 = 60
     while (max_try_secs3--) {
         String res = getJobState(tbName3)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {

--- a/regression-test/suites/nereids_syntax_p0/rollup.groovy
+++ b/regression-test/suites/nereids_syntax_p0/rollup.groovy
@@ -49,7 +49,8 @@ suite("rollup") {
     int max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobRollupState("rollup_t1")
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {

--- a/regression-test/suites/nereids_syntax_p0/rollup/agg.groovy
+++ b/regression-test/suites/nereids_syntax_p0/rollup/agg.groovy
@@ -45,7 +45,8 @@ suite("agg") {
     int max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobRollupState(tbName)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -61,7 +62,8 @@ suite("agg") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobColumnState(tbName)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {

--- a/regression-test/suites/nereids_syntax_p0/rollup/agg_date.groovy
+++ b/regression-test/suites/nereids_syntax_p0/rollup/agg_date.groovy
@@ -48,7 +48,8 @@ suite("agg_date", "rollup") {
     int max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobRollupState(tbName)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -64,7 +65,8 @@ suite("agg_date", "rollup") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobColumnState(tbName)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {

--- a/regression-test/suites/nereids_syntax_p0/rollup/bitmap.groovy
+++ b/regression-test/suites/nereids_syntax_p0/rollup/bitmap.groovy
@@ -39,7 +39,8 @@ suite("bitmap", "rollup") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {

--- a/regression-test/suites/nereids_syntax_p0/rollup/date.groovy
+++ b/regression-test/suites/nereids_syntax_p0/rollup/date.groovy
@@ -45,7 +45,8 @@ suite("date", "rollup") {
     sql "CREATE materialized VIEW amt_max1 AS SELECT store_id, max(sale_date1) FROM ${tbName1} GROUP BY store_id;"
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -61,7 +62,8 @@ suite("date", "rollup") {
     sql "CREATE materialized VIEW amt_max2 AS SELECT store_id, max(sale_datetime1) FROM ${tbName1} GROUP BY store_id;"
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -77,7 +79,8 @@ suite("date", "rollup") {
     sql "CREATE materialized VIEW amt_max3 AS SELECT store_id, max(sale_datetime2) FROM ${tbName1} GROUP BY store_id;"
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -93,7 +96,8 @@ suite("date", "rollup") {
     sql "CREATE materialized VIEW amt_max4 AS SELECT store_id, max(sale_datetime3) FROM ${tbName1} GROUP BY store_id;"
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {

--- a/regression-test/suites/nereids_syntax_p0/rollup/hll.groovy
+++ b/regression-test/suites/nereids_syntax_p0/rollup/hll.groovy
@@ -41,7 +41,8 @@ suite("hll", "rollup") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {

--- a/regression-test/suites/nereids_syntax_p0/rollup/hll_with_light_sc.groovy
+++ b/regression-test/suites/nereids_syntax_p0/rollup/hll_with_light_sc.groovy
@@ -40,7 +40,8 @@ suite("hll_with_light_sc", "rollup") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {

--- a/regression-test/suites/nereids_syntax_p0/test_materialized_view_nereids.groovy
+++ b/regression-test/suites/nereids_syntax_p0/test_materialized_view_nereids.groovy
@@ -49,7 +49,8 @@ suite("test_materialized_view_nereids") {
     int max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -64,7 +65,8 @@ suite("test_materialized_view_nereids") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName2)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -101,7 +103,8 @@ suite("test_materialized_view_nereids") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {

--- a/regression-test/suites/rollup/test_materialized_view_bitmap.groovy
+++ b/regression-test/suites/rollup/test_materialized_view_bitmap.groovy
@@ -39,7 +39,8 @@ suite("test_materialized_view_bitmap", "rollup") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {

--- a/regression-test/suites/rollup/test_materialized_view_date.groovy
+++ b/regression-test/suites/rollup/test_materialized_view_date.groovy
@@ -45,7 +45,8 @@ suite("test_materialized_view_date", "rollup") {
     sql "CREATE materialized VIEW amt_max1 AS SELECT store_id, max(sale_date1) FROM ${tbName1} GROUP BY store_id;"
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -61,7 +62,8 @@ suite("test_materialized_view_date", "rollup") {
     sql "CREATE materialized VIEW amt_max2 AS SELECT store_id, max(sale_datetime1) FROM ${tbName1} GROUP BY store_id;"
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -77,7 +79,8 @@ suite("test_materialized_view_date", "rollup") {
     sql "CREATE materialized VIEW amt_max3 AS SELECT store_id, max(sale_datetime2) FROM ${tbName1} GROUP BY store_id;"
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -93,7 +96,8 @@ suite("test_materialized_view_date", "rollup") {
     sql "CREATE materialized VIEW amt_max4 AS SELECT store_id, max(sale_datetime3) FROM ${tbName1} GROUP BY store_id;"
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {

--- a/regression-test/suites/rollup/test_materialized_view_hll.groovy
+++ b/regression-test/suites/rollup/test_materialized_view_hll.groovy
@@ -41,7 +41,8 @@ suite("test_materialized_view_hll", "rollup") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {

--- a/regression-test/suites/rollup/test_materialized_view_hll_with_light_sc.groovy
+++ b/regression-test/suites/rollup/test_materialized_view_hll_with_light_sc.groovy
@@ -41,7 +41,8 @@ suite("test_materialized_view_hll_with_light_sc", "rollup") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {

--- a/regression-test/suites/rollup_p0/test_materialized_view.groovy
+++ b/regression-test/suites/rollup_p0/test_materialized_view.groovy
@@ -52,7 +52,8 @@ suite("test_materialized_view") {
     int max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -67,7 +68,8 @@ suite("test_materialized_view") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName2)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -100,7 +102,8 @@ suite("test_materialized_view") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {

--- a/regression-test/suites/rollup_p0/test_materialized_view_lazy_open.groovy
+++ b/regression-test/suites/rollup_p0/test_materialized_view_lazy_open.groovy
@@ -135,7 +135,8 @@ suite("test_materialized_view_lazy_open", "rollup") {
     int max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -151,7 +152,8 @@ suite("test_materialized_view_lazy_open", "rollup") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName2)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -167,7 +169,8 @@ suite("test_materialized_view_lazy_open", "rollup") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName3)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -183,7 +186,8 @@ suite("test_materialized_view_lazy_open", "rollup") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName4)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {

--- a/regression-test/suites/rollup_p0/test_rollup_add_column.groovy
+++ b/regression-test/suites/rollup_p0/test_rollup_add_column.groovy
@@ -44,7 +44,8 @@ suite("test_rollup_add_column") {
     int max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobRollupState(tbName)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -61,7 +62,8 @@ suite("test_rollup_add_column") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobColumnState(tbName)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {

--- a/regression-test/suites/rollup_p0/test_rollup_agg.groovy
+++ b/regression-test/suites/rollup_p0/test_rollup_agg.groovy
@@ -45,7 +45,8 @@ suite("test_rollup_agg") {
     int max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobRollupState(tbName)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -61,7 +62,8 @@ suite("test_rollup_agg") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobColumnState(tbName)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {

--- a/regression-test/suites/rollup_p0/test_rollup_agg_date.groovy
+++ b/regression-test/suites/rollup_p0/test_rollup_agg_date.groovy
@@ -44,7 +44,8 @@ suite("test_rollup_agg_date", "rollup") {
     int max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobRollupState(tbName)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -60,7 +61,8 @@ suite("test_rollup_agg_date", "rollup") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobColumnState(tbName)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {

--- a/regression-test/suites/schema_change/test_alter_table_column_with_delete_drop_column_dup_key.groovy
+++ b/regression-test/suites/schema_change/test_alter_table_column_with_delete_drop_column_dup_key.groovy
@@ -50,7 +50,8 @@ suite("test_alter_table_column_with_delete_drop_column_dup_key", "schema_change"
     int max_try_secs = 1200
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -71,7 +72,8 @@ suite("test_alter_table_column_with_delete_drop_column_dup_key", "schema_change"
     max_try_secs = 1200
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -122,7 +124,8 @@ suite("test_alter_table_column_with_delete_drop_column_dup_key", "schema_change"
     max_try_secs = 1200
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -143,7 +146,8 @@ suite("test_alter_table_column_with_delete_drop_column_dup_key", "schema_change"
     max_try_secs = 1200
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -167,7 +171,8 @@ suite("test_alter_table_column_with_delete_drop_column_dup_key", "schema_change"
     max_try_secs = 1200
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -215,7 +220,8 @@ suite("test_alter_table_column_with_delete_drop_column_dup_key", "schema_change"
     max_try_secs = 1200
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -236,7 +242,8 @@ suite("test_alter_table_column_with_delete_drop_column_dup_key", "schema_change"
     max_try_secs = 1200
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {

--- a/regression-test/suites/schema_change/test_alter_table_column_with_delete_drop_column_unique_key.groovy
+++ b/regression-test/suites/schema_change/test_alter_table_column_with_delete_drop_column_unique_key.groovy
@@ -51,7 +51,8 @@ suite("test_alter_table_column_with_delete_drop_column_unique_key", "schema_chan
     int max_try_secs = 1200
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -72,7 +73,8 @@ suite("test_alter_table_column_with_delete_drop_column_unique_key", "schema_chan
     max_try_secs = 1200
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -123,7 +125,8 @@ suite("test_alter_table_column_with_delete_drop_column_unique_key", "schema_chan
     max_try_secs = 1200
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -144,7 +147,8 @@ suite("test_alter_table_column_with_delete_drop_column_unique_key", "schema_chan
     max_try_secs = 1200
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -168,7 +172,8 @@ suite("test_alter_table_column_with_delete_drop_column_unique_key", "schema_chan
     max_try_secs = 1200
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {

--- a/regression-test/suites/schema_change_p0/test_alter_table_column.groovy
+++ b/regression-test/suites/schema_change_p0/test_alter_table_column.groovy
@@ -45,7 +45,8 @@ suite("test_alter_table_column") {
     int max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -65,7 +66,8 @@ suite("test_alter_table_column") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -102,7 +104,8 @@ suite("test_alter_table_column") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName2)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -146,7 +149,8 @@ suite("test_alter_table_column") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbNameAddArray)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             break
         } else {
             Thread.sleep(2000)
@@ -209,7 +213,8 @@ suite("test_alter_table_column") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName3)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {

--- a/regression-test/suites/schema_change_p0/test_alter_table_column_nullable.groovy
+++ b/regression-test/suites/schema_change_p0/test_alter_table_column_nullable.groovy
@@ -49,7 +49,8 @@ suite("test_alter_table_column_nullable") {
     int max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -86,7 +87,8 @@ suite("test_alter_table_column_nullable") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {
@@ -155,7 +157,8 @@ suite("test_alter_table_column_nullable") {
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {

--- a/regression-test/suites/schema_change_p0/test_alter_table_column_with_delete.groovy
+++ b/regression-test/suites/schema_change_p0/test_alter_table_column_with_delete.groovy
@@ -46,7 +46,8 @@ suite("test_alter_table_column_with_delete") {
     int max_try_secs = 120
     while (max_try_secs--) {
         String res = getJobState(tbName1)
-        if (res == "FINISHED") {
+        if (res == "FINISHED" || res == "CANCELLED") {
+            assertEquals("FINISHED", res)
             sleep(3000)
             break
         } else {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #20578 

In doris regression-test/suites, a lot of test cases quit immediately only if "FINISHED", otherwise they will wait till timeout. For example:

```groovy
while (max_try_secs--) {
        String res = getJobState(tbName1)
        if (res == "FINISHED") {
            sleep(3000)
            break
        } else {
            Thread.sleep(1000)
            if (max_try_secs < 1) {
                println "test timeout," + "state:" + res
                assertEquals("FINISHED", res)
            }
        }
   }
```

This PR added checks so that these test cases can quit immediately also if "CANCELLED", which is the only unchanging status other than "FINISHED".

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

