### PR TITLE
[fix](regression) fix p1 test_backup_restore fail caused by http download 401 invalid token error

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -766,16 +766,17 @@ void TaskWorkerPool::_download_worker_thread_callback() {
         }
         LOG(INFO) << "get download task. signature=" << agent_task_req.signature
                   << ", job_id=" << download_request.job_id
-                  << "task detail: " << apache::thrift::ThriftDebugString(download_request);
+                  << ", task detail: " << apache::thrift::ThriftDebugString(download_request);
 
         // TODO: download
         std::vector<int64_t> downloaded_tablet_ids;
 
         auto status = Status::OK();
         if (download_request.__isset.remote_tablet_snapshots) {
-            SnapshotLoader loader(_env, download_request.job_id, agent_task_req.signature);
-            loader.remote_http_download(download_request.remote_tablet_snapshots,
-                                        &downloaded_tablet_ids);
+            std::unique_ptr<SnapshotLoader> loader = std::make_unique<SnapshotLoader>(
+                    _env, download_request.job_id, agent_task_req.signature);
+            status = loader->remote_http_download(download_request.remote_tablet_snapshots,
+                                                  &downloaded_tablet_ids);
         } else {
             std::unique_ptr<SnapshotLoader> loader = std::make_unique<SnapshotLoader>(
                     _env, download_request.job_id, agent_task_req.signature,

--- a/regression-test/pipeline/p1/conf/fe.conf
+++ b/regression-test/pipeline/p1/conf/fe.conf
@@ -85,3 +85,5 @@ auto_check_statistics_in_sec=60
 dynamic_partition_check_interval_seconds=3
 
 enable_feature_binlog=true
+
+auth_token = 5ff161c3-2c08-4079-b108-26c8850b6598


### PR DESCRIPTION
## Proposed changes
fix p1 test_backup_restore fail caused by http download 401 invalid token error
(1)  set fe auth token,  becouse regression cannot get the cluster token, so not auto generate it in test env.
(2)  fix remote_http_download result code problem.

# problem :
<img width="921" alt="image" src="https://github.com/apache/doris/assets/67053339/793f0394-a7b4-4742-81e9-048eb8346c58">


Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

