### PR TITLE
[chore](block) temporarily disable DCHECK for column name equality in MutableBlock

### DIFF
--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -904,7 +904,7 @@ void MutableBlock::add_row(const Block* block, int row) {
 }
 
 void MutableBlock::add_rows(const Block* block, const int* row_begin, const int* row_end) {
-    DCHECK_EQ(columns(), block->columns());
+    DCHECK_LE(columns(), block->columns());
     auto& block_data = block->get_columns_with_type_and_name();
     for (size_t i = 0; i < _columns.size(); ++i) {
         DCHECK_EQ(_data_types[i]->get_name(), block_data[i].type->get_name());
@@ -915,7 +915,7 @@ void MutableBlock::add_rows(const Block* block, const int* row_begin, const int*
 }
 
 void MutableBlock::add_rows(const Block* block, size_t row_begin, size_t length) {
-    DCHECK_EQ(columns(), block->columns());
+    DCHECK_LE(columns(), block->columns());
     auto& block_data = block->get_columns_with_type_and_name();
     for (size_t i = 0; i < _columns.size(); ++i) {
         DCHECK_EQ(_data_types[i]->get_name(), block_data[i].type->get_name());

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -907,9 +907,7 @@ void MutableBlock::add_rows(const Block* block, const int* row_begin, const int*
     DCHECK_EQ(columns(), block->columns());
     auto& block_data = block->get_columns_with_type_and_name();
     for (size_t i = 0; i < _columns.size(); ++i) {
-        // DCHECK(_columns[i]->get_data_type() == block_data[i].column->get_data_type());
         DCHECK_EQ(_data_types[i]->get_name(), block_data[i].type->get_name());
-        DCHECK_EQ(_names[i], block_data[i].name);
         auto& dst = _columns[i];
         auto& src = *block_data[i].column.get();
         dst->insert_indices_from(src, row_begin, row_end);
@@ -920,9 +918,7 @@ void MutableBlock::add_rows(const Block* block, size_t row_begin, size_t length)
     DCHECK_EQ(columns(), block->columns());
     auto& block_data = block->get_columns_with_type_and_name();
     for (size_t i = 0; i < _columns.size(); ++i) {
-        // DCHECK(_columns[i]->get_data_type() == block_data[i].column->get_data_type());
         DCHECK_EQ(_data_types[i]->get_name(), block_data[i].type->get_name());
-        DCHECK_EQ(_names[i], block_data[i].name);
         auto& dst = _columns[i];
         auto& src = *block_data[i].column.get();
         dst->insert_range_from(src, row_begin, length);


### PR DESCRIPTION

## Proposed changes

Issue Number: close #xxx

temporarily disable DCHECK for column name equality in MutableBlock::add_rows to avoid UBSAN core as follows:

```
F0624 10:10:16.796823 2779385 block.cpp:912] Check failed: _names[i] == block_data[i].name ( vs. cs_sold_date_sk)

 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handle
r.h:413
 1# 0x00007FBB7B5C30C0 in /lib/x86_64-linux-gnu/libc.so.6
 2# raise in /lib/x86_64-linux-gnu/libc.so.6
 3# abort in /lib/x86_64-linux-gnu/libc.so.6
 4# 0x0000560BF09C9659 in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
 5# 0x0000560BF09BEC6D in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
 6# google::LogMessage::SendToLog() in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
 7# google::LogMessage::Flush() in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
 8# google::LogMessageFatal::~LogMessageFatal() in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
 9# doris::vectorized::MutableBlock::add_rows(doris::vectorized::Block const*, int const*, int const*) at /home/zcp/repo_center/doris_master/doris/be/src/vec/
core/block.cpp:912
10# doris::vectorized::Channel::add_rows(doris::vectorized::Block*, std::vector<int, std::allocator<int> > const&) at /home/zcp/repo_center/doris_master/doris
/be/src/vec/sink/vdata_stream_sender.cpp:222
11# doris::Status doris::vectorized::VDataStreamSender::channel_add_rows<std::vector<doris::vectorized::Channel*, std::allocator<doris::vectorized::Channel*>
> >(doris::RuntimeState*, std::vector<doris::vectorized::Channel*, std::allocator<doris::vectorized::Channel*> >&, int, unsigned long const*, int, doris::vect
orized::Block*) at /home/zcp/repo_center/doris_master/doris/be/src/vec/sink/vdata_stream_sender.h:401
12# doris::vectorized::VDataStreamSender::send(doris::RuntimeState*, doris::vectorized::Block*, bool) at /home/zcp/repo_center/doris_master/doris/be/src/vec/s
ink/vdata_stream_sender.cpp:654
13# doris::pipeline::DataSinkOperator<doris::pipeline::ExchangeSinkOperatorBuilder>::sink(doris::RuntimeState*, doris::vectorized::Block*, doris::pipeline::So
urceState) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/exec/operator.h:277
14# doris::pipeline::PipelineTask::execute(bool*) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/pipeline_task.cpp:224
15# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/task_scheduler.cpp:274
16# void std::__invoke_impl<void, void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&>(std::__invoke_me
mfun_deref, void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&) at /var/local/ldb_toolchain/bin/../lib
/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
17# std::__invoke_result<void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&>::type std::__invoke<void
(doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&>(void (doris::pipeline::TaskScheduler::*&)(unsigned long
), doris::pipeline::TaskScheduler*&, unsigned long&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:9
6
18# void std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>::__call<void, , 0ul, 1ul>(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420
19# void std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>::operator()<, void>() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503
20# void std::__invoke_impl<void, std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>&>(std::_
_invoke_other, std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>&) at /var/local/ldb_toolcha
in/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
21# std::enable_if<is_invocable_r_v<void, std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>&
>, void>::type std::__invoke_r<void, std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>&>(std
::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>&) at /var/local/ldb_toolchain/bin/../lib/gcc/
x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
22# std::_Function_handler<void (), std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)> >::_M_
invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
23# std::function<void ()>::operator()() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:5
60
24# doris::FunctionRunnable::run() at /home/zcp/repo_center/doris_master/doris/be/src/util/threadpool.cpp:48
25# doris::ThreadPool::dispatch_thread() at /home/zcp/repo_center/doris_master/doris/be/src/util/threadpool.cpp:531
26# void std::__invoke_impl<void, void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::Thre
adPool*&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
27# std::__invoke_result<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>::type std::__invoke<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(void (d
oris::ThreadPool::*&)(), doris::ThreadPool*&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
28# void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) at /var/local/ldb_toolchai
n/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420
29# void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::operator()<, void>() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/..
/../../../include/c++/11/functional:503
30# void std::__invoke_impl<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (doris::ThreadPool::*(d
oris::ThreadPool*))()>&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
31# std::enable_if<is_invocable_r_v<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (
doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_
64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
32# std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolch
ain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
33# std::function<void ()>::operator()() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:5
60
34# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_master/doris/be/src/util/thread.cpp:465
35# start_thread at /build/glibc-sMfBJT/glibc-2.31/nptl/pthread_create.c:478
36# __clone in /lib/x86_64-linux-gnu/libc.so.6

```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

