### PR TITLE
[deps](benchmark) bump benchmakr from 1.5.6 -> 1.8.0

### DIFF
--- a/dist/LICENSE-dist.txt
+++ b/dist/LICENSE-dist.txt
@@ -1484,7 +1484,7 @@ The Apache Software License, Version 2.0
     * orc: 1.7.2
     * cctz: 2.3
     * aws sdk: 1.9.211
-    * benchmark: 1.5.6
+    * benchmark: 1.8.0
     * simdjson: 3.0.1
     * libhdfs3: 2.3.8
     * opentelemetry-proto: 0.18.0

--- a/thirdparty/CHANGELOG.md
+++ b/thirdparty/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file contains version of the third-party dependency libraries in the build-env image. The docker build-env image is apache/doris, and the tag is `build-env-${version}`
 
+## v20230625
+
+- Modified benchmark 1.5.6 -> 1.8.0
+
 ## v20230531
 
 - Modified hadoop libhdfs 3.3.4.2 -> 3.3.4.3

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1452,7 +1452,7 @@ build_benchmark() {
     cmake --build "build" --config Release
 
     mkdir -p "${TP_INCLUDE_DIR}/benchmark"
-    cp "${TP_SOURCE_DIR}/${BENCHMARK_SOURCE}/include/benchmark/benchmark.h" "${TP_INCLUDE_DIR}/benchmark/"
+    cp "${TP_SOURCE_DIR}/${BENCHMARK_SOURCE}/include/benchmark/*" "${TP_INCLUDE_DIR}/benchmark/"
     cp "${TP_SOURCE_DIR}/${BENCHMARK_SOURCE}/build/src/libbenchmark.a" "${TP_LIB_DIR}"
 }
 

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1452,7 +1452,8 @@ build_benchmark() {
     cmake --build "build" --config Release
 
     mkdir -p "${TP_INCLUDE_DIR}/benchmark"
-    cp "${TP_SOURCE_DIR}/${BENCHMARK_SOURCE}/include/benchmark/*" "${TP_INCLUDE_DIR}/benchmark/"
+    cp "${TP_SOURCE_DIR}/${BENCHMARK_SOURCE}/include/benchmark/benchmark.h" "${TP_INCLUDE_DIR}/benchmark/"
+    cp "${TP_SOURCE_DIR}/${BENCHMARK_SOURCE}/include/benchmark/export.h" "${TP_INCLUDE_DIR}/benchmark/"
     cp "${TP_SOURCE_DIR}/${BENCHMARK_SOURCE}/build/src/libbenchmark.a" "${TP_LIB_DIR}"
 }
 

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -386,10 +386,10 @@ PDQSORT_FILE="pdqsort.h"
 PDQSORT_MD5SUM="af28f79d5d7d7a5486f54d9f1244c2b5"
 
 # benchmark
-BENCHMARK_DOWNLOAD="https://github.com/google/benchmark/archive/v1.5.6.tar.gz"
-BENCHMARK_NAME=benchmark-1.5.6.tar.gz
-BENCHMARK_SOURCE=benchmark-1.5.6
-BENCHMARK_MD5SUM="668b9e10d8b0795e5d461894db18db3c"
+BENCHMARK_DOWNLOAD="https://github.com/google/benchmark/archive/refs/tags/v1.8.0.tar.gz"
+BENCHMARK_NAME=v1.8.0.tar.gz
+BENCHMARK_SOURCE=benchmark-1.8.0
+BENCHMARK_MD5SUM="8ddf8571d3f6198d37852bcbd964f817"
 
 # xsimd
 # for arrow-7.0.0, if arrow upgrade, this version may also need to be changed


### PR DESCRIPTION
## Proposed changes

To support some new methods used in #21074

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

