### PR TITLE
[fix](nereids)check table privilege when it's needed

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/UserAuthentication.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/UserAuthentication.java
@@ -23,13 +23,23 @@ import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.rules.Rule;
 import org.apache.doris.nereids.rules.RuleType;
 import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalEsScan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalFileScan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalRelation;
+import org.apache.doris.nereids.trees.plans.logical.LogicalSchemaScan;
 import org.apache.doris.qe.ConnectContext;
+
+import com.google.common.collect.Sets;
+
+import java.util.Set;
 
 /**
  * Check whether a user is permitted to scan specific tables.
  */
 public class UserAuthentication extends OneAnalysisRuleFactory {
+    Set<Class<?>> relationsToCheck = Sets.newHashSet(LogicalOlapScan.class, LogicalEsScan.class,
+            LogicalFileScan.class, LogicalSchemaScan.class);
 
     @Override
     public Rule build() {
@@ -43,15 +53,20 @@ public class UserAuthentication extends OneAnalysisRuleFactory {
         if (connectContext.getSessionVariable().isPlayNereidsDump()) {
             return relation;
         }
-        String dbName = !relation.getQualifier().isEmpty() ? relation.getQualifier().get(0) : null;
-        String tableName = relation.getTable().getName();
-        if (!connectContext.getEnv().getAccessManager()
-                .checkTblPriv(connectContext, dbName, tableName, PrivPredicate.SELECT)) {
-            String message = ErrorCode.ERR_TABLEACCESS_DENIED_ERROR.formatErrorMsg("SELECT",
-                    ConnectContext.get().getQualifiedUser(), ConnectContext.get().getRemoteIP(),
-                    dbName + ": " + tableName);
-            throw new AnalysisException(message);
+
+        if (relationsToCheck.contains(relation.getClass())) {
+            String dbName =
+                    !relation.getQualifier().isEmpty() ? relation.getQualifier().get(0) : null;
+            String tableName = relation.getTable().getName();
+            if (!connectContext.getEnv().getAccessManager().checkTblPriv(connectContext, dbName,
+                    tableName, PrivPredicate.SELECT)) {
+                String message = ErrorCode.ERR_TABLEACCESS_DENIED_ERROR.formatErrorMsg("SELECT",
+                        ConnectContext.get().getQualifiedUser(), ConnectContext.get().getRemoteIP(),
+                        dbName + ": " + tableName);
+                throw new AnalysisException(message);
+            }
         }
+
         return relation;
     }
 }


### PR DESCRIPTION
check privilege on LogicalOlapScan, LogicalEsScan, LogicalFileScan and LogicalSchemaScan

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

