### PR TITLE
[Bug](excution) remove dcheck of addrows input block's column name

### DIFF
--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -904,12 +904,12 @@ void MutableBlock::add_row(const Block* block, int row) {
 }
 
 void MutableBlock::add_rows(const Block* block, const int* row_begin, const int* row_end) {
-    DCHECK_EQ(columns(), block->columns());
+    DCHECK_EQ(columns(), block->columns()) << fmt::format(
+            "input block is invalid, self={}, input={}", dump_names(), block->dump_names());
     auto& block_data = block->get_columns_with_type_and_name();
     for (size_t i = 0; i < _columns.size(); ++i) {
-        // DCHECK(_columns[i]->get_data_type() == block_data[i].column->get_data_type());
-        DCHECK_EQ(_data_types[i]->get_name(), block_data[i].type->get_name());
-        DCHECK_EQ(_names[i], block_data[i].name);
+        DCHECK_EQ(_data_types[i]->get_name(), block_data[i].type->get_name()) << fmt::format(
+                "input block is invalid, self={}, input={}", dump_names(), block->dump_names());
         auto& dst = _columns[i];
         auto& src = *block_data[i].column.get();
         dst->insert_indices_from(src, row_begin, row_end);
@@ -917,12 +917,12 @@ void MutableBlock::add_rows(const Block* block, const int* row_begin, const int*
 }
 
 void MutableBlock::add_rows(const Block* block, size_t row_begin, size_t length) {
-    DCHECK_EQ(columns(), block->columns());
+    DCHECK_EQ(columns(), block->columns()) << fmt::format(
+            "input block is invalid, self={}, input={}", dump_names(), block->dump_names());
     auto& block_data = block->get_columns_with_type_and_name();
     for (size_t i = 0; i < _columns.size(); ++i) {
-        // DCHECK(_columns[i]->get_data_type() == block_data[i].column->get_data_type());
-        DCHECK_EQ(_data_types[i]->get_name(), block_data[i].type->get_name());
-        DCHECK_EQ(_names[i], block_data[i].name);
+        DCHECK_EQ(_data_types[i]->get_name(), block_data[i].type->get_name()) << fmt::format(
+                "input block is invalid, self={}, input={}", dump_names(), block->dump_names());
         auto& dst = _columns[i];
         auto& src = *block_data[i].column.get();
         dst->insert_range_from(src, row_begin, length);


### PR DESCRIPTION
## Proposed changes
Sometimes we will meet block without column name, then BE will dcheck failed on addrows. 
```
2be+1fe

tpcds q54

F0625 14:50:51.759466 1254406 block.cpp:912] Check failed: _names[i] == block_data[i].name (cs_sold_date_sk vs. ) 
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

