### PR TITLE
[typo](docs) add the 'hive.version' property to the example

### DIFF
--- a/docs/en/docs/lakehouse/multi-catalog/multi-catalog.md
+++ b/docs/en/docs/lakehouse/multi-catalog/multi-catalog.md
@@ -89,7 +89,8 @@ For more information about Hive, please see [Hive](./hive.md).
 	```sql
 	CREATE CATALOG hive PROPERTIES (
 	    'type'='hms',
-	    'hive.metastore.uris' = 'thrift://172.21.0.1:7004'
+	    'hive.metastore.uris' = 'thrift://172.21.0.1:7004',
+	    'hive.version' = 'your hive version'
 	);
 	```
 	


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Many people encounter various errors because they have not added the ‘hive.version’。

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

