### PR TITLE
[fix](memory) fix mem tracker grace exit

### DIFF
--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -217,8 +217,8 @@ private:
     MemTrackerLimiter* _orphan_mem_tracker_raw;
     std::shared_ptr<MemTrackerLimiter> _experimental_mem_tracker;
     // page size not in cache, data page/index page/etc.
-    std::shared_ptr<MemTracker> _page_no_cache_mem_tracker;
-    std::shared_ptr<MemTracker> _brpc_iobuf_block_memory_tracker;
+    std::unique_ptr<MemTracker> _page_no_cache_mem_tracker;
+    std::unique_ptr<MemTracker> _brpc_iobuf_block_memory_tracker;
 
     std::unique_ptr<ThreadPool> _send_batch_thread_pool;
 

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -217,8 +217,8 @@ private:
     MemTrackerLimiter* _orphan_mem_tracker_raw;
     std::shared_ptr<MemTrackerLimiter> _experimental_mem_tracker;
     // page size not in cache, data page/index page/etc.
-    std::unique_ptr<MemTracker> _page_no_cache_mem_tracker;
-    std::unique_ptr<MemTracker> _brpc_iobuf_block_memory_tracker;
+    std::shared_ptr<MemTracker> _page_no_cache_mem_tracker;
+    std::shared_ptr<MemTracker> _brpc_iobuf_block_memory_tracker;
 
     std::unique_ptr<ThreadPool> _send_batch_thread_pool;
 

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -341,9 +341,9 @@ void ExecEnv::init_mem_tracker() {
     _experimental_mem_tracker = std::make_shared<MemTrackerLimiter>(
             MemTrackerLimiter::Type::EXPERIMENTAL, "ExperimentalSet");
     _page_no_cache_mem_tracker =
-            std::make_unique<MemTracker>("PageNoCache", _orphan_mem_tracker_raw);
+            std::make_shared<MemTracker>("PageNoCache", _orphan_mem_tracker_raw);
     _brpc_iobuf_block_memory_tracker =
-            std::make_unique<MemTracker>("IOBufBlockMemory", _orphan_mem_tracker_raw);
+            std::make_shared<MemTracker>("IOBufBlockMemory", _orphan_mem_tracker_raw);
 }
 
 void ExecEnv::init_download_cache_buf() {
@@ -426,8 +426,8 @@ void ExecEnv::_destroy() {
     _download_cache_thread_pool.reset(nullptr);
     _orphan_mem_tracker.reset();
     _experimental_mem_tracker.reset();
-    _page_no_cache_mem_tracker.reset(nullptr);
-    _brpc_iobuf_block_memory_tracker.reset(nullptr);
+    _page_no_cache_mem_tracker.reset();
+    _brpc_iobuf_block_memory_tracker.reset();
 
     _is_init = false;
 }

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -341,9 +341,9 @@ void ExecEnv::init_mem_tracker() {
     _experimental_mem_tracker = std::make_shared<MemTrackerLimiter>(
             MemTrackerLimiter::Type::EXPERIMENTAL, "ExperimentalSet");
     _page_no_cache_mem_tracker =
-            std::make_shared<MemTracker>("PageNoCache", _orphan_mem_tracker_raw);
+            std::make_unique<MemTracker>("PageNoCache", _orphan_mem_tracker_raw);
     _brpc_iobuf_block_memory_tracker =
-            std::make_shared<MemTracker>("IOBufBlockMemory", _orphan_mem_tracker_raw);
+            std::make_unique<MemTracker>("IOBufBlockMemory", _orphan_mem_tracker_raw);
 }
 
 void ExecEnv::init_download_cache_buf() {
@@ -424,6 +424,10 @@ void ExecEnv::_destroy() {
     _join_node_thread_pool.reset(nullptr);
     _serial_download_cache_thread_token.reset(nullptr);
     _download_cache_thread_pool.reset(nullptr);
+    _orphan_mem_tracker.reset();
+    _experimental_mem_tracker.reset();
+    _page_no_cache_mem_tracker.reset(nullptr);
+    _brpc_iobuf_block_memory_tracker.reset(nullptr);
 
     _is_init = false;
 }

--- a/be/src/runtime/memory/mem_tracker.cpp
+++ b/be/src/runtime/memory/mem_tracker.cpp
@@ -24,6 +24,7 @@
 
 #include <mutex>
 
+#include "common/daemon.h"
 #include "runtime/memory/mem_tracker_limiter.h"
 #include "runtime/thread_context.h"
 
@@ -81,7 +82,7 @@ void MemTracker::bind_parent(MemTrackerLimiter* parent) {
 }
 
 MemTracker::~MemTracker() {
-    if (_parent_group_num != -1) {
+    if (_parent_group_num != -1 && !k_doris_exit) {
         std::lock_guard<std::mutex> l(mem_tracker_pool[_parent_group_num].group_lock);
         if (_tracker_group_it != mem_tracker_pool[_parent_group_num].trackers.end()) {
             mem_tracker_pool[_parent_group_num].trackers.erase(_tracker_group_it);

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -26,6 +26,7 @@
 #include <queue>
 #include <utility>
 
+#include "common/daemon.h"
 #include "runtime/exec_env.h"
 #include "runtime/fragment_mgr.h"
 #include "runtime/load_channel_mgr.h"
@@ -79,7 +80,7 @@ MemTrackerLimiter::~MemTrackerLimiter() {
     // in real time. Merge its consumption into orphan when parent is process, to avoid repetition.
     ExecEnv::GetInstance()->orphan_mem_tracker()->consume(_consumption->current_value());
     _consumption->set(0);
-    {
+    if (!k_doris_exit) {
         std::lock_guard<std::mutex> l(mem_tracker_limiter_pool[_group_num].group_lock);
         if (_tracker_limiter_group_it != mem_tracker_limiter_pool[_group_num].trackers.end()) {
             mem_tracker_limiter_pool[_group_num].trackers.erase(_tracker_limiter_group_it);

--- a/be/src/vec/exprs/vexpr_context.cpp
+++ b/be/src/vec/exprs/vexpr_context.cpp
@@ -21,8 +21,6 @@
 #include <ostream>
 #include <string>
 
-#include "common/daemon.h"
-
 // IWYU pragma: no_include <opentelemetry/common/threadlocal.h>
 #include "common/compiler_util.h" // IWYU pragma: keep
 #include "common/object_pool.h"


### PR DESCRIPTION
## Proposed changes

```
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007fea68c45859 in __GI_abort () at abort.c:79
#2  0x00007fea68c45729 in __assert_fail_base (
    fmt=0x7fea68ddb588 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n",
    assertion=0x7fea68ac3120 "new_prio == -1 || (new_prio >= fifo_min_prio && new_prio <= fifo_max_prio)", file=0x7fea68ac3114 "tpp.c", line=82,
    function=<optimized out>) at assert.c:92
#3  0x00007fea68c56fd6 in {}GI{}_assert_fail (
    assertion=assertion@entry=0x7fea68ac3120 "new_prio == -1 || (new_prio >= fifo_min_prio && new_prio <= fifo_max_prio)",
    file=file@entry=0x7fea68ac3114 "tpp.c", line=line@entry=82,
    function=function@entry=0x7fea68ac31d0 <{}PRETTY_FUNCTION{}.7875> "{_}_pthread_tpp_change_priority") at assert.c:101
#4  0x00007fea68ac01d9 in __pthread_tpp_change_priority (
    previous_prio=previous_prio@entry=-1, new_prio=new_prio@entry=1436)
    at tpp.c:82
#5  0x00007fea68ab5b09 in __pthread_mutex_lock_full (mutex=0x7fea6810d258)
    at ../nptl/pthread_mutex_lock.c:545
#6  0x0000558f03fc34ab in {}gthread_mutex_lock ({_}_mutex=0x7fea6810d258)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/x86_64-linux-gnu/c++/11/bits/gthr-default.h:749
#7  0x0000558f03fc758b in std::mutex::lock (this=0x7fea6810d258)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../i-TyT-------------{}Type <RET> for more, q to quit, c to continue without paging{}
nclude/c++/11/bits/std_mutex.h:100
#8  0x0000558f03fc60ef in std::lock_guard<std::mutex>::lock_guard (this=0x7ffeadbd7780, __m=...)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_mutex.h:229
#9  0x0000558f078b4fac in doris::MemTracker::~MemTracker (this=0x7fea30cfbcb0)
    at /home/zcp/repo_center/doris_master/doris/be/src/runtime/memory/mem_tracker.cpp:85
#10 0x0000558f06e127e1 in std::destroy_at<doris::MemTracker> (__location=0x7fea30cfbcb0)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:88
#11 0x0000558f06e12601 in std::allocator_traits<std::allocator<doris::MemTracker> >::destroy<doris::MemTracker> (__a=..., __p=0x7fea30cfbcb0)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:533
#12 0x0000558f06e12014 in std::Sp_counted_ptr_inplace<doris::MemTracker, std::allocator<doris::MemTracker>, (_gnu_cxx::_Lock_policy)2>::_M_dispose (this=0x7fea30cfbca0)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:528
#13 0x0000558f03f86132 in std::Sp_counted_base<(_gnu_cxx::_Lock_policy)2>::_M_release (
    this=0x7fea30cfbca0)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:168
#14 0x0000558f03f85e1e in std::{}shared_count<({}gnu_cxx::Lock_policy)2>::~_shared_count (
    this=0x558f46ff07f0 <doris::ExecEnv::GetInstance()::s_exec_env+200>)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:702
#15 0x0000558f06961dad in std::{}shared_ptr<doris::MemTracker, ({}gnu_cxx::Lock_policy)2>::~_shared_ptr (this=0x558f46ff07e8 <doris::ExecEnv::GetInstance()::s_exec_env+192>)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1149
#16 0x0000558f0695c699 in std::shared_ptr<doris::MemTracker>::~shared_ptr (
    this=0x558f46ff07e8 <doris::ExecEnv::GetInstance()::s_exec_env+192>)
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

