### PR TITLE
[fix](planner)scan node's smap should use materiazlied slots and project list as left and right expr list

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/ScanNode.java
@@ -533,8 +533,11 @@ public abstract class ScanNode extends PlanNode {
             // this happens if the olap table is in the most inner sub-query block in the cascades sub-queries
             // create a tmpSmap for the later setOutputSmap call
             ExprSubstitutionMap tmpSmap = new ExprSubstitutionMap(
-                    Lists.newArrayList(outputTupleDesc.getSlots().stream().map(slot -> new SlotRef(slot)).collect(
-                    Collectors.toList())), Lists.newArrayList(projectList));
+                    Lists.newArrayList(outputTupleDesc.getSlots().stream()
+                            .filter(slot -> slot.isMaterialized())
+                            .map(slot -> new SlotRef(slot))
+                            .collect(Collectors.toList())),
+                    Lists.newArrayList(projectList));
             Set<SlotId> allOutputSlotIds = outputTupleDesc.getSlots().stream().map(slot -> slot.getId())
                     .collect(Collectors.toSet());
             List<Expr> newRhs = Lists.newArrayList();


### PR DESCRIPTION
## Proposed changes

Creating an ExprSubstitutionMap using project list and materialized slots. The project list and slots size must be the same. The bug is caused by use all slots from tuple descriptor as right expr list of ExprSubstitutionMap. This pr changes to only use materialized slots which has the same size of project list.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

