### PR TITLE
[bugfix](workloadgroup) could not upgrade from 2.0 alpha

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroup.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroup.java
@@ -287,6 +287,7 @@ public class WorkloadGroup implements Writable, GsonPostProcessable {
                     memoryLimitString.length() - 1));
         } else {
             this.memoryLimitPercent = 100;
+            this.properties.put(MEMORY_LIMIT, "100");
         }
         this.initQueryQueue();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroup.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroup.java
@@ -281,8 +281,13 @@ public class WorkloadGroup implements Writable, GsonPostProcessable {
 
     @Override
     public void gsonPostProcess() throws IOException {
-        String memoryLimitString = properties.get(MEMORY_LIMIT);
-        this.memoryLimitPercent = Double.parseDouble(memoryLimitString.substring(0, memoryLimitString.length() - 1));
+        if (properties.containsKey(MEMORY_LIMIT)) {
+            String memoryLimitString = properties.get(MEMORY_LIMIT);
+            this.memoryLimitPercent = Double.parseDouble(memoryLimitString.substring(0,
+                    memoryLimitString.length() - 1));
+        } else {
+            this.memoryLimitPercent = 100;
+        }
         this.initQueryQueue();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroup.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadgroup/WorkloadGroup.java
@@ -287,7 +287,7 @@ public class WorkloadGroup implements Writable, GsonPostProcessable {
                     memoryLimitString.length() - 1));
         } else {
             this.memoryLimitPercent = 100;
-            this.properties.put(MEMORY_LIMIT, "100");
+            this.properties.put(MEMORY_LIMIT, "100%");
         }
         this.initQueryQueue();
     }


### PR DESCRIPTION
## Proposed changes

2.0 alpha the workload group does not have property mem_limit, but it is a required propery in 2.0 beta, so the check will failed.

Skip the check and allow upgrade successfully.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

