### PR TITLE
[tools](tpcds) Update README.md, use default gcc

### DIFF
--- a/tools/tpcds-tools/README.md
+++ b/tools/tpcds-tools/README.md
@@ -24,6 +24,7 @@ follow the steps below:
 
 ### 1. build tpc-ds dsdgen dsqgen tool.
 
+    export PATH=/usr/bin/:$PATH
     ./bin/build-tpcds-tools.sh
 
 ### 2. generate tpc-ds data. use -h for more infomations.


### PR DESCRIPTION
compile with gcc-11 is not ok,
```
ld.lld: error: duplicate symbol: nItemIndex
>>> defined at s_catalog_order.c:56
>>>            s_catalog_order.o:(nItemIndex)
>>> defined at s_purchase.c:55
>>>            s_purchase.o:(.bss+0x5A0)

ld.lld: error: duplicate symbol: g_s_web_order_lineitem
>>> defined at s_web_order.c:54
>>>            s_web_order.o:(g_s_web_order_lineitem)
>>> defined at s_web_order_lineitem.c:54
>>>            s_web_order_lineitem.o:(.bss+0x0)

ld.lld: error: duplicate symbol: nItemIndex
>>> defined at s_catalog_order.c:56
>>>            s_catalog_order.o:(nItemIndex)
>>> defined at s_web_order.c:56
>>>            s_web_order.o:(.data+0x0)

ld.lld: error: duplicate symbol: g_w_catalog_page
>>> defined at s_catalog_page.c:51
>>>            s_catalog_page.o:(g_w_catalog_page)
>>> defined at w_catalog_page.c:52
>>>            w_catalog_page.o:(.bss+0x0)

ld.lld: error: duplicate symbol: g_w_warehouse
>>> defined at s_warehouse.c:51
>>>            s_warehouse.o:(g_w_warehouse)
>>> defined at w_warehouse.c:53
>>>            w_warehouse.o:(.bss+0x0)

ld.lld: error: duplicate symbol: g_w_web_site
>>> defined at s_web_site.c:51
>>>            s_web_site.o:(g_w_web_site)
>>> defined at w_web_site.c:59
>>>            w_web_site.o:(.bss+0x0)
collect2: error: ld returned 1 exit status
make: *** [makefile:233: dsdgen] Error 1
```
compile with gcc 9.40 or below is ok,
default gcc often meet requirements.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

