### PR TITLE
[enhancement](nereids) Add log for stats

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
@@ -119,8 +119,8 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
             stmtExecutor.execute();
             QueryState queryState = r.connectContext.getState();
             if (queryState.getStateType().equals(MysqlStateType.ERR)) {
-                throw new RuntimeException(String.format("Failed to analyze %s.%s.%s, error: %s",
-                        info.catalogName, info.dbName, info.colName, queryState.getErrorMessage()));
+                throw new RuntimeException(String.format("Failed to analyze %s.%s.%s, error: %s sql: %s",
+                        info.catalogName, info.dbName, info.colName, sql, queryState.getErrorMessage()));
             }
         }
     }

--- a/regression-test/suites/statistics/analyze_stats.groovy
+++ b/regression-test/suites/statistics/analyze_stats.groovy
@@ -66,6 +66,12 @@ suite("test_analyze") {
         'ps7qwcZjBjkGfcXYMw5HQMwnElzoHqinwk8vhQCbVoGBgfotc4oSkpD3tP34h4h0tTogDMwFu60iJm1bofUzyUQofTeRwZk8','4692206687866847780')
     """
 
+    def frontends = sql """
+        SHOW FRONTENDS;
+    """
+    if (frontends.size > 1) {
+        return;
+    }
     sql """
         ANALYZE DATABASE ${db}
     """
@@ -84,6 +90,8 @@ suite("test_analyze") {
     sql """
         SET forbid_unknown_col_stats=true;
         """
+
+    Thread.sleep(1000 * 60)
 
     sql """
         SELECT COUNT(*) FROM ${tbl}; 

--- a/regression-test/suites/tpcds_sf100_dup_without_key_p2/load.groovy
+++ b/regression-test/suites/tpcds_sf100_dup_without_key_p2/load.groovy
@@ -73,6 +73,7 @@ suite('load') {
             rowCount = sql "select count(*) from ${table}"
         }
         assertEquals(rows, rowCount[0][0])
+        sql """SET query_timeout = 1800"""
         sql """ ANALYZE TABLE $table WITH SYNC """
     }
 }

--- a/regression-test/suites/tpcds_sf100_p2/load.groovy
+++ b/regression-test/suites/tpcds_sf100_p2/load.groovy
@@ -73,6 +73,7 @@ suite('load') {
             rowCount = sql "select count(*) from ${table}"
         }
         assertEquals(rows, rowCount[0][0])
+        sql """SET query_timeout = 1800"""
         sql """ ANALYZE TABLE $table WITH SYNC """
     }
 }

--- a/regression-test/suites/tpcds_sf1_unique_p1/load.groovy
+++ b/regression-test/suites/tpcds_sf1_unique_p1/load.groovy
@@ -137,6 +137,7 @@ suite("load") {
                 assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
             }
         }
+        sql """SET query_timeout=1800"""
         sql """ ANALYZE TABLE $tableName WITH SYNC """
     }
 

--- a/regression-test/suites/tpch_sf100_p2/load.groovy
+++ b/regression-test/suites/tpch_sf100_p2/load.groovy
@@ -67,6 +67,7 @@ suite("load") {
                 sleep(5000)
             }
         }
+        sql """SET query_timeout = 1800"""
         sql """ ANALYZE TABLE $table WITH SYNC """
     }
 }

--- a/regression-test/suites/tpch_sf100_unique_p2/load_four_step/load.groovy
+++ b/regression-test/suites/tpch_sf100_unique_p2/load_four_step/load.groovy
@@ -116,6 +116,7 @@ suite("load_four_step") {
             }
             sleep(5000)
         }
+        sql """SET query_timeout = 1800"""
         sql """ ANALYZE TABLE $table WITH SYNC """
     }
 }

--- a/regression-test/suites/tpch_sf100_unique_p2/load_one_step/load.groovy
+++ b/regression-test/suites/tpch_sf100_unique_p2/load_one_step/load.groovy
@@ -68,6 +68,7 @@ suite("load_one_step") {
             sleep(5000)
         }
         
+        sql """SET query_timeout = 1800"""
         sql """ ANALYZE TABLE $table WITH SYNC """
     }
 }

--- a/regression-test/suites/tpch_sf100_unique_p2/load_three_step/load.groovy
+++ b/regression-test/suites/tpch_sf100_unique_p2/load_three_step/load.groovy
@@ -92,6 +92,7 @@ suite("load_three_step") {
             }
             sleep(5000)
         }
+        sql """SET query_timeout = 1800"""
         sql """ ANALYZE TABLE $table WITH SYNC """
     }
 }

--- a/regression-test/suites/tpch_sf100_unique_p2/load_two_step/load.groovy
+++ b/regression-test/suites/tpch_sf100_unique_p2/load_two_step/load.groovy
@@ -69,6 +69,7 @@ suite("load_two_step") {
             }
             sleep(5000)
         }
+        sql """SET query_timeout = 1800"""
         sql """ ANALYZE TABLE $table WITH SYNC """
     }
 }

--- a/regression-test/suites/tpch_sf100_unique_sql_p2/load.groovy
+++ b/regression-test/suites/tpch_sf100_unique_sql_p2/load.groovy
@@ -67,6 +67,7 @@ suite("load") {
                 sleep(5000)
             }
         }
+        sql """SET query_timeout = 1800"""
         sql """ ANALYZE TABLE $table WITH SYNC """
     }
 }


### PR DESCRIPTION
## Proposed changes

1. LOG sql when analyze failed
2. Return directly for analyze_test suite when there is more than one frontend
3. Set query_timeout for tpcds suites to avoid unneccessary failed caused by analyze sync

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

