### PR TITLE
[Bug](RuntimeFiter) Fix bf error change the murmurhash to crc32 in regression test p2

### DIFF
--- a/be/src/agent/be_exec_version_manager.h
+++ b/be/src/agent/be_exec_version_manager.h
@@ -55,6 +55,7 @@ private:
  * 2: start from doris 2.0
  *    a. function month/day/hour/minute/second's return type is changed to smaller type.
  *    b. in order to solve agg of sum/count is not compatibility during the upgrade process
+ *    c. change the string hash method in runtime filter
  *
 */
 inline const int BeExecVersionManager::max_be_exec_version = 2;


### PR DESCRIPTION
## Proposed changes

[Bug](RuntimeFiter) Fix bf error change the murmurhash to crc32 in regression test p2 cause join result with string type result error.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

