### PR TITLE
[Bug](pipeline) add DCHECK for _instance_to_sending_by_pipeline = false on _send_rpc

### DIFF
--- a/be/src/pipeline/exec/exchange_sink_buffer.cpp
+++ b/be/src/pipeline/exec/exchange_sink_buffer.cpp
@@ -62,6 +62,8 @@ void ExchangeSinkBuffer::close() {
         pair.second->release_finst_id();
         pair.second->release_query_id();
     }
+    _instance_to_broadcast_package_queue.clear();
+    _instance_to_package_queue.clear();
     _instance_to_request.clear();
 }
 
@@ -146,7 +148,7 @@ Status ExchangeSinkBuffer::add_block(BroadcastTransmitInfo&& request) {
             send_now = true;
             _instance_to_sending_by_pipeline[ins_id.lo] = false;
         }
-        _instance_to_broadcast_package_queue[ins_id.lo].emplace(std::move(request));
+        _instance_to_broadcast_package_queue[ins_id.lo].emplace(request);
     }
     if (send_now) {
         RETURN_IF_ERROR(_send_rpc(ins_id.lo));

--- a/be/src/pipeline/exec/exchange_sink_buffer.cpp
+++ b/be/src/pipeline/exec/exchange_sink_buffer.cpp
@@ -160,6 +160,8 @@ Status ExchangeSinkBuffer::add_block(BroadcastTransmitInfo&& request) {
 Status ExchangeSinkBuffer::_send_rpc(InstanceLoId id) {
     std::unique_lock<std::mutex> lock(*_instance_to_package_queue_mutex[id]);
 
+    DCHECK(_instance_to_sending_by_pipeline[id] == false);
+
     std::queue<TransmitInfo, std::list<TransmitInfo>>& q = _instance_to_package_queue[id];
     std::queue<BroadcastTransmitInfo, std::list<BroadcastTransmitInfo>>& broadcast_q =
             _instance_to_broadcast_package_queue[id];
@@ -259,7 +261,6 @@ Status ExchangeSinkBuffer::_send_rpc(InstanceLoId id) {
         broadcast_q.pop();
     } else {
         _instance_to_sending_by_pipeline[id] = true;
-        return Status::OK();
     }
 
     return Status::OK();

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -133,8 +133,6 @@ PipelineFragmentContext::PipelineFragmentContext(
 }
 
 PipelineFragmentContext::~PipelineFragmentContext() {
-    _sink.release();
-    _multi_cast_stream_sink_senders.clear();
     if (_runtime_state != nullptr) {
         // The memory released by the query end is recorded in the query mem tracker, main memory in _runtime_state.
         SCOPED_ATTACH_TASK(_runtime_state.get());

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -133,6 +133,8 @@ PipelineFragmentContext::PipelineFragmentContext(
 }
 
 PipelineFragmentContext::~PipelineFragmentContext() {
+    _sink.release();
+    _multi_cast_stream_sink_senders.clear();
     if (_runtime_state != nullptr) {
         // The memory released by the query end is recorded in the query mem tracker, main memory in _runtime_state.
         SCOPED_ATTACH_TASK(_runtime_state.get());

--- a/be/src/util/ref_count_closure.h
+++ b/be/src/util/ref_count_closure.h
@@ -31,7 +31,7 @@ template <typename T>
 class RefCountClosure : public google::protobuf::Closure {
 public:
     RefCountClosure() : _refs(0) {}
-    ~RefCountClosure() {}
+    ~RefCountClosure() override = default;
 
     void ref() { _refs.fetch_add(1); }
 


### PR DESCRIPTION
## Proposed changes
```cpp
Core was generated by `/mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be'.

Program terminated with signal SIGSEGV, Segmentation fault.

#0  0x0000556fc48ebbb1 in std::__atomic_base<bool>::load (this=0x7d8, __m=std::memory_order::seq_cst)

    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/atomic_base.h:481

481 return __atomic_load_n(&_M_i, int(__m));

[Current thread is 1 (Thread 0x7f6255064700 (LWP 1216124))]

(gdb) bt

#0  0x0000556fc48ebbb1 in std::__atomic_base<bool>::load (this=0x7d8, __m=std::memory_order::seq_cst)

    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/atomic_base.h:481

#1  std::atomic<bool>::load (this=0x7d8, __m=std::memory_order::seq_cst)

    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/atomic:112

#2  0x0000556fc7e9d486 in doris::RuntimeState::is_cancelled (this=0x0)

    at /home/zcp/repo_center/doris_master/doris/be/src/runtime/runtime_state.h:158

#3  0x0000556fefca3e26 in doris::pipeline::PipelineFragmentContext::cancel (this=0x7f6007042410, 

    reason=@0x7f796ebfea24: doris::INTERNAL_ERROR, 

    msg="failed to send brpc when exchange, error=RPC call is timed out, error_text=[E1008]Reached timeout=300000ms @0.0.0.0:0, client: 172.21.0.38, latency = 300000110")

    at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/pipeline_fragment_context.cpp:149

#4  0x0000556fefc9ae65 in doris::pipeline::ExchangeSinkBuffer::_failed (this=0x7f6006f67c00, id=-4840408317930866523, 

    err="failed to send brpc when exchange, error=RPC call is timed out, error_text=[E1008]Reached timeout=300000ms @0.0.0.0:0, client: 172.21.0.38, latency = 300000110")

    at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/exec/exchange_sink_buffer.cpp:283

#5  0x0000556fefc560df in doris::pipeline::ExchangeSinkBuffer::_send_rpc(long)::$_0::operator()(long const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const (this=0x7f7b519e28c0, 

    id=@0x7f7b519e2900: -4840408317930866523, 

    err="failed to send brpc when exchange, error=RPC call is timed out, error_text=[E1008]Reached timeout=300000ms @0.0.0.0:0, client: 172.21.0.38, latency = 300000110")

    at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/exec/exchange_sink_buffer.cpp:182

#6  0x0000556fefc56039 in std::__invoke_impl<void, doris::pipeline::ExchangeSinkBuffer::_send_rpc(long)::$_0&, long const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>(std::__invoke_other, doris::pipeline::ExchangeSinkBuffer::_send_rpc(long)::$_0&, long const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (__f=..., 

    __args="failed to send brpc when exchange, error=RPC call is timed out, error_text=[E1008]Reached timeout=300000ms @0.0.0.0:0, client: 172.21.0.38, latency = 300000110", 

    __args="failed to send brpc when exchange, error=RPC call is timed out, error_text=[E1008]Reached timeout=300000ms @0.0.0.0:0, client: 172.21.0.38, latency = 300000110")

    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61

#7  0x0000556fefc55ed9 in std::__invoke_r<void, doris::pipeline::ExchangeSinkBuffer::_send_rpc(long)::$_0&, long const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>(doris::pipeline::ExchangeSinkBuffer::_send_rpc(long)::$_0&, long const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (__fn=..., 

    __args="failed to send brpc when exchange, error=RPC call is timed out, error_text=[E1008]Reached timeout=300000ms @0.0
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

