### PR TITLE
[Enhancement](multi-catalog) use a independent thread-pool for hive file-cache loader.

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1703,9 +1703,25 @@ public class Config extends ConfigBase {
     /**
      * Max cache loader thread-pool size.
      * Max thread pool size for loading external meta cache
+     * Deprecated, use max_partition_cache_loader_thread_pool_size instead.
      */
+    @Deprecated
     @ConfField(mutable = false, masterOnly = false)
     public static int max_external_cache_loader_thread_pool_size = 10;
+
+    /**
+     * Max partition cache loader thread-pool size.
+     * Max thread pool size for loading external meta cache
+     */
+    @ConfField(mutable = false, masterOnly = false)
+    public static int max_partition_cache_loader_thread_pool_size = 10;
+
+    /**
+     * Max file cache loader thread-pool size.
+     * Max thread pool size for loading external meta cache
+     */
+    @ConfField(mutable = false, masterOnly = false)
+    public static int max_file_cache_loader_thread_pool_size = 50;
 
     /**
      * Max cache num of external catalog's file

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1694,11 +1694,15 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = false, masterOnly = false, description = {"Hive表到分区名列表缓存的最大数量。",
         "Max cache number of hive table to partition names list."})
-    public static long max_hive_table_catch_num = 1000;
+    public static long max_hive_table_cache_num = 1000;
 
     @ConfField(mutable = false, masterOnly = false, description = {"获取Hive分区值时候的最大返回数量，-1代表没有限制。",
         "Max number of hive partition values to return while list partitions, -1 means no limitation."})
     public static short max_hive_list_partition_num = -1;
+
+    @ConfField(mutable = false, masterOnly = false, description = {"Hive Metastore 池实例数。",
+            "Max number of hive partition values to return while list partitions, -1 means no limitation."})
+    public static short max_hms_client_pool_size = 16;
 
     /**
      * Max cache loader thread-pool size.

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1701,7 +1701,7 @@ public class Config extends ConfigBase {
     public static short max_hive_list_partition_num = -1;
 
     @ConfField(mutable = false, masterOnly = false, description = {"Hive Metastore 池实例数。",
-            "Max number of hive partition values to return while list partitions, -1 means no limitation."})
+            "Max number of hive metastore client pool."})
     public static short max_hms_client_pool_size = 16;
 
     /**

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1703,22 +1703,13 @@ public class Config extends ConfigBase {
     /**
      * Max cache loader thread-pool size.
      * Max thread pool size for loading external meta cache
-     * Deprecated, use max_partition_cache_loader_thread_pool_size instead.
      */
-    @Deprecated
     @ConfField(mutable = false, masterOnly = false)
     public static int max_external_cache_loader_thread_pool_size = 10;
 
     /**
-     * Max partition cache loader thread-pool size.
-     * Max thread pool size for loading external meta cache
-     */
-    @ConfField(mutable = false, masterOnly = false)
-    public static int max_partition_cache_loader_thread_pool_size = 10;
-
-    /**
      * Max file cache loader thread-pool size.
-     * Max thread pool size for loading external meta cache
+     * Max thread pool size for loading external file cache
      */
     @ConfField(mutable = false, masterOnly = false)
     public static int max_file_cache_loader_thread_pool_size = 50;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
@@ -49,7 +49,8 @@ public class ExternalMetaCacheMgr {
     private ThreadPoolExecutor fileCacheLoader;
 
     public ExternalMetaCacheMgr() {
-        partitionCacheLoader = ThreadPoolManager.newDaemonCacheThreadPool(Config.max_partition_cache_loader_thread_pool_size,
+        partitionCacheLoader = ThreadPoolManager.newDaemonCacheThreadPool(
+                    Config.max_partition_cache_loader_thread_pool_size,
                 "PartitionCacheLoader", true);
         fileCacheLoader = ThreadPoolManager.newDaemonCacheThreadPool(Config.max_file_cache_loader_thread_pool_size,
                 "FileCacheLoader", true);
@@ -60,7 +61,8 @@ public class ExternalMetaCacheMgr {
         if (cache == null) {
             synchronized (cacheMap) {
                 if (!cacheMap.containsKey(catalog.getId())) {
-                    cacheMap.put(catalog.getId(), new HiveMetaStoreCache(catalog, partitionCacheLoader, fileCacheLoader));
+                    cacheMap.put(catalog.getId(),
+                                new HiveMetaStoreCache(catalog, partitionCacheLoader, fileCacheLoader));
                 }
                 cache = cacheMap.get(catalog.getId());
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
@@ -49,13 +49,15 @@ public class ExternalMetaCacheMgr {
     private ThreadPoolExecutor fileCacheLoader;
 
     public ExternalMetaCacheMgr() {
+        // Use a bounded queue to avoid OOM
+        // The thread pool will wait at most 60 seconds when queue is full
         cacheLoader = ThreadPoolManager.newDaemonFixedThreadPool(
                     Config.max_external_cache_loader_thread_pool_size,
-                    Integer.MAX_VALUE,
+                Config.max_external_cache_loader_thread_pool_size * 100,
                 "ExternalCacheLoader", true);
         fileCacheLoader = ThreadPoolManager.newDaemonFixedThreadPool(
                     Config.max_file_cache_loader_thread_pool_size,
-                    Integer.MAX_VALUE,
+                Config.max_file_cache_loader_thread_pool_size * 100,
                 "FileCacheLoader", true);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
@@ -52,11 +52,11 @@ public class ExternalMetaCacheMgr {
         // Use a bounded queue to avoid OOM
         // The thread pool will wait at most 60 seconds when queue is full
         cacheLoader = ThreadPoolManager.newDaemonFixedThreadPool(
-                    Config.max_external_cache_loader_thread_pool_size,
+                Config.max_external_cache_loader_thread_pool_size,
                 Config.max_external_cache_loader_thread_pool_size * 100,
                 "ExternalCacheLoader", true);
         fileCacheLoader = ThreadPoolManager.newDaemonFixedThreadPool(
-                    Config.max_file_cache_loader_thread_pool_size,
+                Config.max_file_cache_loader_thread_pool_size,
                 Config.max_file_cache_loader_thread_pool_size * 100,
                 "FileCacheLoader", true);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
@@ -49,11 +49,13 @@ public class ExternalMetaCacheMgr {
     private ThreadPoolExecutor fileCacheLoader;
 
     public ExternalMetaCacheMgr() {
-        cacheLoader = ThreadPoolManager.newDaemonCacheThreadPool(
+        cacheLoader = ThreadPoolManager.newDaemonFixedThreadPool(
                     Config.max_external_cache_loader_thread_pool_size,
+                    Integer.MAX_VALUE,
                 "ExternalCacheLoader", true);
-        fileCacheLoader = ThreadPoolManager.newDaemonCacheThreadPool(
+        fileCacheLoader = ThreadPoolManager.newDaemonFixedThreadPool(
                     Config.max_file_cache_loader_thread_pool_size,
+                    Integer.MAX_VALUE,
                 "FileCacheLoader", true);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
@@ -53,7 +53,6 @@ import java.util.Objects;
 public class HMSExternalCatalog extends ExternalCatalog {
     private static final Logger LOG = LogManager.getLogger(HMSExternalCatalog.class);
 
-    private static final int MAX_CLIENT_POOL_SIZE = 8;
     protected PooledHiveMetaStoreClient client;
     // Record the latest synced event id when processing hive events
     // Must set to -1 otherwise client.getNextNotification will throw exception
@@ -156,7 +155,7 @@ public class HMSExternalCatalog extends ExternalCatalog {
             }
         }
 
-        client = new PooledHiveMetaStoreClient(hiveConf, MAX_CLIENT_POOL_SIZE);
+        client = new PooledHiveMetaStoreClient(hiveConf, Config.max_hms_client_pool_size);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -133,7 +133,7 @@ public class HiveMetaStoreCache {
     }
 
     private void init() {
-        partitionValuesCache = CacheBuilder.newBuilder().maximumSize(Config.max_hive_table_catch_num)
+        partitionValuesCache = CacheBuilder.newBuilder().maximumSize(Config.max_hive_table_cache_num)
                 .expireAfterAccess(Config.external_cache_expire_time_minutes_after_access, TimeUnit.MINUTES)
                 .build(CacheLoader.asyncReloading(
                         new CacheLoader<PartitionValueCacheKey, HivePartitionValues>() {


### PR DESCRIPTION
## Proposed changes

Sometimes it is very slow to query a table which has more then ten thousands partitions and the query time spent mainly in getting file cache of partitions. So we can use an independent thread-pool for hive file-cache-loader.

![file-cache-1](https://github.com/apache/doris/assets/5926365/53a01e79-bc35-4333-a0d4-1dadc3eaf948)
![file-cache-3](https://github.com/apache/doris/assets/5926365/ce47fee7-186f-48d4-8772-7942d7c393e0)




<!--Describe your changes.-->


**This pr mainly does following changes:** 

1. Rename FE config `max_hive_table_catch_num` to `max_hive_table_cache_num`
2. Change the thread pool of `org.apache.doris.datasource.ExternalMetaCacheMgr` from `newDaemonCacheThreadPool` to `newDaemonFixedThreadPool`, the previous thread pool is a bounded cache thread pool and the reject handler just log the error info, the task will be lost and not any exception will be thown if the thread pool is full.
3. Use an independent thread-pool for hive file-cache-loader because it is a potential perf bottleneck.
4. Expose FE config `max_hms_client_pool_size` for hms client pool, the current value 8 is not enough for large-scale hive cluster.

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

