### PR TITLE
[Fix](inverted index) check inverted index file existence befor data compaction

### DIFF
--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -396,7 +396,7 @@ Status Compaction::do_compaction_impl(int64_t permits) {
                   << ", destination index size=" << dest_segment_num << ".";
         std::for_each(
                 ctx.skip_inverted_index.cbegin(), ctx.skip_inverted_index.cend(),
-                [&ctx, &src_segment_num, &dest_segment_num, &index_writer_path, &src_index_files,
+                [&src_segment_num, &dest_segment_num, &index_writer_path, &src_index_files,
                  &dest_index_files, &fs, &tablet_path, &trans_vec, &dest_segment_num_rows,
                  this](int32_t column_uniq_id) {
                     auto st = compact_column(
@@ -404,7 +404,11 @@ Status Compaction::do_compaction_impl(int64_t permits) {
                             src_segment_num, dest_segment_num, src_index_files, dest_index_files,
                             fs, index_writer_path, tablet_path, trans_vec, dest_segment_num_rows);
                     if (!st.ok()) {
-                        ctx.skip_inverted_index.erase(column_uniq_id);
+                        LOG(ERROR) << "failed to do index compaction"
+                                   << ". tablet=" << _tablet->full_name()
+                                   << ". column uniq id=" << column_uniq_id << ". index_id= "
+                                   << _cur_tablet_schema->get_inverted_index(column_uniq_id)
+                                              ->index_id();
                     }
                 });
 

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -492,7 +492,7 @@ Status Compaction::construct_output_rowset_writer(RowsetWriterContext& ctx, bool
                                             << inverted_index_src_file_path << " fs->exists error";
                                     return false;
                                 }
-                                if (exists) {
+                                if (!exists) {
                                     LOG(WARNING) << inverted_index_src_file_path
                                                  << " is not exists, will skip index compaction";
                                     return false;

--- a/be/src/olap/rowset/segment_v2/inverted_index_compaction.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_compaction.cpp
@@ -41,16 +41,6 @@ Status compact_column(int32_t index_id, int src_segment_num, int dest_segment_nu
         // format: rowsetId_segmentId_indexId.idx
         std::string src_idx_full_name =
                 src_index_files[i] + "_" + std::to_string(index_id) + ".idx";
-        bool exists = false;
-        auto st = fs->exists(src_idx_full_name, &exists);
-        if (!st.ok()) {
-            LOG(ERROR) << src_idx_full_name << " fs->exists error:" << st;
-            return Status::IOError("fs->exists error:", st.to_string());
-        }
-        if (!exists) {
-            LOG(WARNING) << src_idx_full_name << " is not exists, will stop index compaction ";
-            return Status::NotFound("file not found:", src_idx_full_name);
-        }
         DorisCompoundReader* reader = new DorisCompoundReader(
                 DorisCompoundDirectory::getDirectory(fs, tablet_path.c_str()),
                 src_idx_full_name.c_str());

--- a/be/src/olap/rowset/segment_v2/inverted_index_compaction.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_compaction.cpp
@@ -24,12 +24,12 @@
 
 namespace doris {
 namespace segment_v2 {
-void compact_column(int32_t index_id, int src_segment_num, int dest_segment_num,
-                    std::vector<std::string> src_index_files,
-                    std::vector<std::string> dest_index_files, const io::FileSystemSPtr& fs,
-                    std::string index_writer_path, std::string tablet_path,
-                    std::vector<std::vector<std::pair<uint32_t, uint32_t>>> trans_vec,
-                    std::vector<uint32_t> dest_segment_num_rows) {
+Status compact_column(int32_t index_id, int src_segment_num, int dest_segment_num,
+                      std::vector<std::string> src_index_files,
+                      std::vector<std::string> dest_index_files, const io::FileSystemSPtr& fs,
+                      std::string index_writer_path, std::string tablet_path,
+                      std::vector<std::vector<std::pair<uint32_t, uint32_t>>> trans_vec,
+                      std::vector<uint32_t> dest_segment_num_rows) {
     lucene::store::Directory* dir =
             DorisCompoundDirectory::getDirectory(fs, index_writer_path.c_str(), false);
     auto index_writer = _CLNEW lucene::index::IndexWriter(dir, nullptr, true /* create */,
@@ -45,11 +45,11 @@ void compact_column(int32_t index_id, int src_segment_num, int dest_segment_num,
         auto st = fs->exists(src_idx_full_name, &exists);
         if (!st.ok()) {
             LOG(ERROR) << src_idx_full_name << " fs->exists error:" << st;
-            return;
+            return Status::IOError("fs->exists error:", st.to_string());
         }
         if (!exists) {
             LOG(WARNING) << src_idx_full_name << " is not exists, will stop index compaction ";
-            return;
+            return Status::NotFound("file not found:", src_idx_full_name);
         }
         DorisCompoundReader* reader = new DorisCompoundReader(
                 DorisCompoundDirectory::getDirectory(fs, tablet_path.c_str()),
@@ -90,6 +90,7 @@ void compact_column(int32_t index_id, int src_segment_num, int dest_segment_num,
 
     // delete temporary index_writer_path
     fs->delete_directory(index_writer_path.c_str());
+    return Status::OK();
 }
 } // namespace segment_v2
 } // namespace doris

--- a/be/src/olap/rowset/segment_v2/inverted_index_compaction.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_compaction.h
@@ -25,11 +25,11 @@
 namespace doris {
 
 namespace segment_v2 {
-void compact_column(int32_t index_id, int src_segment_num, int dest_segment_num,
-                    std::vector<std::string> src_index_files,
-                    std::vector<std::string> dest_index_files, const io::FileSystemSPtr& fs,
-                    std::string index_writer_path, std::string tablet_path,
-                    std::vector<std::vector<std::pair<uint32_t, uint32_t>>> trans_vec,
-                    std::vector<uint32_t> dest_segment_num_rows);
+Status compact_column(int32_t index_id, int src_segment_num, int dest_segment_num,
+                      std::vector<std::string> src_index_files,
+                      std::vector<std::string> dest_index_files, const io::FileSystemSPtr& fs,
+                      std::string index_writer_path, std::string tablet_path,
+                      std::vector<std::vector<std::pair<uint32_t, uint32_t>>> trans_vec,
+                      std::vector<uint32_t> dest_segment_num_rows);
 } // namespace segment_v2
 } // namespace doris


### PR DESCRIPTION

## Proposed changes

Issue Number: close #xxx

1. inverted index compaction(which means using exists index file to merge into a new index file) may fail due to some reasons.
2. we need to skip index compaction when it fails, then it will rewrite columns data and new index.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

