### PR TITLE
[improvement](workloadgroup)add check when drop/set workload group

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
@@ -1035,6 +1035,15 @@ public class Auth implements Writable {
         }
     }
 
+    public Pair<Boolean, String> isWorkloadGroupInUse(String groupName) {
+        readLock();
+        try {
+            return propertyMgr.isWorkloadGroupInUse(groupName);
+        } finally {
+            readUnlock();
+        }
+    }
+
     public void getAllDomains(Set<String> allDomains) {
         readLock();
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserProperty.java
@@ -305,6 +305,10 @@ public class UserProperty implements Writable {
                 if (keyArr.length != 1) {
                     throw new DdlException(PROP_WORKLOAD_GROUP + " format error");
                 }
+                boolean ret = Env.getCurrentEnv().getWorkloadGroupMgr().isWorkloadGroupExists(value);
+                if (!ret) {
+                    throw new DdlException("workload group " + value + " not exists");
+                }
                 workloadGroup = value;
             } else {
                 throw new DdlException("Unknown user property(" + key + ")");

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserPropertyMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserPropertyMgr.java
@@ -37,6 +37,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -180,6 +181,15 @@ public class UserPropertyMgr implements Writable {
             return null;
         }
         return existProperty.getWorkloadGroup();
+    }
+
+    public Pair<Boolean, String> isWorkloadGroupInUse(String groupName) {
+        for (Entry<String, UserProperty> entry : propertyMap.entrySet()) {
+            if (entry.getValue().getWorkloadGroup().equals(groupName)) {
+                return Pair.of(true, entry.getKey());
+            }
+        }
+        return Pair.of(false, "");
     }
 
     private UserProperty getLdapPropertyIfNull(String qualifiedUser, UserProperty existProperty) {

--- a/fe/fe-core/src/test/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/resource/workloadgroup/WorkloadGroupMgrTest.java
@@ -23,8 +23,10 @@ import org.apache.doris.analysis.DropWorkloadGroupStmt;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
+import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
+import org.apache.doris.mysql.privilege.Auth;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.persist.EditLog;
 import org.apache.doris.qe.ConnectContext;
@@ -53,6 +55,10 @@ public class WorkloadGroupMgrTest {
 
     @Mocked
     AccessControllerManager accessControllerManager;
+
+    @Mocked
+    private Auth auth;
+
 
     private AtomicLong id = new AtomicLong(10);
 
@@ -86,6 +92,18 @@ public class WorkloadGroupMgrTest {
                 accessControllerManager.checkWorkloadGroupPriv((ConnectContext) any, anyString, (PrivPredicate) any);
                 minTimes = 0;
                 result = true;
+
+                env.getAuth();
+                minTimes = 0;
+                result = auth;
+
+                auth.isWorkloadGroupInUse(anyString);
+                minTimes = 0;
+                result = new Delegate() {
+                    Pair<Boolean, String> list() {
+                        return Pair.of(false, "");
+                    }
+                };
             }
         };
     }


### PR DESCRIPTION
## Proposed changes

1 check group exists when set group for user property;
eg, if g1 not exists, then set op should be failed.
```
mysql [test]>SET PROPERTY FOR 'root' 'default_workload_group' = 'g1';
ERROR 1105 (HY000): errCode = 2, detailMessage = workload group g1 not exists
```

2 check whether group is used for user when drop group;
eg, if a group is set for root, then drop should be failed.
```
mysql [test]>drop workload group test_g1;
ERROR 1105 (HY000): errCode = 2, detailMessage = workload group test_g1 is set for user root
```
