### PR TITLE
[fix](regression) Add get master token into regression framework

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Syncer.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Syncer.groovy
@@ -28,6 +28,7 @@ import org.apache.doris.regression.json.BinlogData
 import org.apache.doris.thrift.TBinlogType
 import org.apache.doris.thrift.TCommitTxnResult
 import org.apache.doris.thrift.TGetBinlogResult
+import org.apache.doris.thrift.TGetMasterTokenResult
 import org.apache.doris.thrift.TGetSnapshotResult
 import org.apache.doris.thrift.TIngestBinlogRequest
 import org.apache.doris.thrift.TIngestBinlogResult
@@ -306,6 +307,37 @@ class Syncer {
         return isCheckedOK
     }
 
+    Boolean checkGetMasterToken(TGetMasterTokenResult result) {
+        Boolean isCheckedOK = false
+
+        // step 1: check status
+        if (result != null && result.isSetStatus()) {
+            TStatus status = result.getStatus()
+            if (status.isSetStatusCode()) {
+                TStatusCode code = status.getStatusCode()
+                switch (code) {
+                    case TStatusCode.OK:
+                        isCheckedOK = result.isSetToken()
+                        break
+                    default:
+                        logger.error("Get Master token result code is: ${code}")
+                        break
+                }
+            } else {
+                logger.error("Invalid TStatus! StatusCode is unset.")
+            }
+        } else {
+            logger.error("Invalid TGetMasterTokenResult! result: ${result}")
+        }
+
+        if (isCheckedOK) {
+            context.token = result.getToken()
+            logger.info("Token is ${context.token}.")
+        }
+
+        return isCheckedOK
+    }
+
     Boolean checkSnapshotFinish() {
         String checkSQL = "SHOW BACKUP FROM " + context.db
         List<Object> row = suite.sql(checkSQL)[0]
@@ -446,9 +478,23 @@ class Syncer {
         context.closeBackendClients()
     }
 
+    Boolean getMasterToken() {
+        logger.info("Get master token.")
+        FrontendClientImpl clientImpl = context.getSourceFrontClient()
+        TGetMasterTokenResult result = SyncerUtils.getMasterToken(clientImpl, context)
+
+        return checkGetMasterToken(result)
+    }
+
     Boolean restoreSnapshot() {
         logger.info("Restore snapshot ${context.labelName}")
         FrontendClientImpl clientImpl = context.getSourceFrontClient()
+
+        // step 1: get master token
+        if (!getMasterToken()) {
+            logger.error("Get Master error!")
+            return false
+        }
 
         // step 1: recode job info
         Gson gson = new Gson()

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/SyncerContext.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/SyncerContext.groovy
@@ -110,6 +110,7 @@ class SyncerContext {
     public String labelName
     public String tableName
     public TGetSnapshotResult getSnapshotResult
+    public String token
 
     public Config config
     public String user
@@ -127,7 +128,7 @@ class SyncerContext {
     }
 
     ExtraInfo genExtraInfo() {
-        ExtraInfo info = new ExtraInfo("5ff161c3-2c08-4079-b108-26c8850b6598")
+        ExtraInfo info = new ExtraInfo(token)
         sourceBackendClients.forEach((id, client) -> {
             info.addBackendNetaddr(id, client.address.hostname, client.httpPort)
         })

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/util/SyncerUtils.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/util/SyncerUtils.groovy
@@ -25,6 +25,8 @@ import org.apache.doris.thrift.TBeginTxnRequest
 import org.apache.doris.thrift.TBeginTxnResult
 import org.apache.doris.thrift.TCommitTxnRequest
 import org.apache.doris.thrift.TCommitTxnResult
+import org.apache.doris.thrift.TGetMasterTokenRequest
+import org.apache.doris.thrift.TGetMasterTokenResult
 import org.apache.doris.thrift.TGetSnapshotRequest
 import org.apache.doris.thrift.TGetSnapshotResult
 import org.apache.doris.thrift.TIngestBinlogRequest
@@ -110,5 +112,12 @@ class SyncerUtils {
         request.setMeta(context.getSnapshotResult.getMeta())
         request.setJobInfo(context.getSnapshotResult.getJobInfo())
         return clientImpl.client.restoreSnapshot(request)
+    }
+
+    static TGetMasterTokenResult getMasterToken(FrontendClientImpl clientImpl, SyncerContext context) throws TException {
+        TGetMasterTokenRequest request = new TGetMasterTokenRequest()
+        request.setUser(context.user)
+        request.setPassword(context.passwd)
+        return clientImpl.client.getMasterToken(request)
     }
 }


### PR DESCRIPTION
Bug: 
Because the old version does not support getMasterToken, the token is fixed in the old version of the test, which causes the P1 regression test_backup_restore case to fail.

Bug fix:
Add get master token into regression framework.
