### PR TITLE
[fix](test) fix json test cases by using def keyword to define local variable

### DIFF
--- a/regression-test/suites/json_p0/test_json_load_and_function.groovy
+++ b/regression-test/suites/json_p0/test_json_load_and_function.groovy
@@ -106,7 +106,7 @@ suite("test_json_load_and_function", "p0") {
     // insert into invalid json rows with enable_insert_strict=true
     // expect excepiton and no rows not changed
     sql """ set enable_insert_strict = true """
-    success = true
+    def success = true
     try {
         sql """INSERT INTO ${testTable} VALUES(26, '')"""
     } catch(Exception ex) {

--- a/regression-test/suites/json_p0/test_json_load_unique_key_and_function.groovy
+++ b/regression-test/suites/json_p0/test_json_load_unique_key_and_function.groovy
@@ -97,7 +97,7 @@ suite("test_json_unique_load_and_function", "p0") {
     // insert into invalid json rows with enable_insert_strict=true
     // expect excepiton and no rows not changed
     sql """ set enable_insert_strict = true """
-    success = true
+    def success = true
     try {
         sql """INSERT INTO ${testTable} VALUES(26, '')"""
     } catch(Exception ex) {

--- a/regression-test/suites/jsonb_p0/test_jsonb_load_and_function.groovy
+++ b/regression-test/suites/jsonb_p0/test_jsonb_load_and_function.groovy
@@ -104,7 +104,7 @@ suite("test_jsonb_load_and_function", "p0") {
     // insert into invalid json rows with enable_insert_strict=true
     // expect excepiton and no rows not changed
     sql """ set enable_insert_strict = true """
-    success = true
+    def success = true
     try {
         sql """INSERT INTO ${testTable} VALUES(26, '')"""
     } catch(Exception ex) {

--- a/regression-test/suites/jsonb_p0/test_jsonb_load_unique_key_and_function.groovy
+++ b/regression-test/suites/jsonb_p0/test_jsonb_load_unique_key_and_function.groovy
@@ -97,7 +97,7 @@ suite("test_jsonb_unique_load_and_function", "p0") {
     // insert into invalid json rows with enable_insert_strict=true
     // expect excepiton and no rows not changed
     sql """ set enable_insert_strict = true """
-    success = true
+    def success = true
     try {
         sql """INSERT INTO ${testTable} VALUES(26, '')"""
     } catch(Exception ex) {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

using `def success = true` instead of `success = true` to avoid global variable conflict.

 regression-test/suites/json_p0/test_json_load_and_function.groovy
 regression-test/suites/json_p0/test_json_load_unique_key_and_function.groovy
 regression-test/suites/jsonb_p0/test_jsonb_load_and_function.groovy
 regression-test/suites/jsonb_p0/test_jsonb_load_unique_key_and_function.groovy

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

