### PR TITLE
[fix](planner)scan node's smap should use materiazlied slots and project list as left and right expr list

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/ScanNode.java
@@ -496,8 +496,11 @@ public abstract class ScanNode extends PlanNode {
             // this happens if the olap table is in the most inner sub-query block in the cascades sub-queries
             // create a tmpSmap for the later setOutputSmap call
             ExprSubstitutionMap tmpSmap = new ExprSubstitutionMap(
-                    Lists.newArrayList(outputTupleDesc.getSlots().stream().map(slot -> new SlotRef(slot)).collect(
-                    Collectors.toList())), Lists.newArrayList(projectList));
+                    Lists.newArrayList(outputTupleDesc.getSlots().stream()
+                            .filter(slot -> slot.isMaterialized())
+                            .map(slot -> new SlotRef(slot))
+                            .collect(Collectors.toList())),
+                    Lists.newArrayList(projectList));
             Set<SlotId> allOutputSlotIds = outputTupleDesc.getSlots().stream().map(slot -> slot.getId())
                     .collect(Collectors.toSet());
             List<Expr> newRhs = Lists.newArrayList();


### PR DESCRIPTION
pick from master https://github.com/apache/doris/pull/21142

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

