### PR TITLE
[Enhancement](heartbeat) make heartbeat ok when config repeated host-ip pairs

### DIFF
--- a/be/src/util/network_util.cpp
+++ b/be/src/util/network_util.cpp
@@ -97,7 +97,7 @@ Status hostname_to_ip_addrs(const std::string& name, std::vector<std::string>* a
         }
 
         // add address if not exists
-        std::vector<string> address = std::string(addr_buf);
+        std::string address = std::string(addr_buf);
         if (std::find(addresses.begin(), addresses.end(), address) != addresses.end()) {
             LOG(WARNING)
                     << "Repeated ip addresses has been found for host: " << name

--- a/be/src/util/network_util.cpp
+++ b/be/src/util/network_util.cpp
@@ -98,7 +98,7 @@ Status hostname_to_ip_addrs(const std::string& name, std::vector<std::string>* a
 
         // add address if not exists
         std::string address = std::string(addr_buf);
-        if (std::find(addresses.begin(), addresses.end(), address) != addresses.end()) {
+        if (std::find(addresses->begin(), addresses->end(), address) != addresses->end()) {
             LOG(WARNING)
                     << "Repeated ip addresses has been found for host: " << name
                     << ", ip address:" << address

--- a/be/src/util/network_util.cpp
+++ b/be/src/util/network_util.cpp
@@ -99,10 +99,9 @@ Status hostname_to_ip_addrs(const std::string& name, std::vector<std::string>* a
         // add address if not exists
         std::string address = std::string(addr_buf);
         if (std::find(addresses->begin(), addresses->end(), address) != addresses->end()) {
-            LOG(WARNING)
-                    << "Repeated ip addresses has been found for host: " << name
-                    << ", ip address:" << address
-                    << ", please check your network configuration";
+            LOG(WARNING) << "Repeated ip addresses has been found for host: " << name
+                         << ", ip address:" << address
+                         << ", please check your network configuration";
         } else {
             addresses->push_back(address);
         }

--- a/be/src/util/network_util.cpp
+++ b/be/src/util/network_util.cpp
@@ -98,7 +98,12 @@ Status hostname_to_ip_addrs(const std::string& name, std::vector<std::string>* a
 
         // add address if not exists
         std::vector<string> address = std::string(addr_buf);
-        if (std::find(addresses.begin(), addresses.end(), address) == addresses.end()) {
+        if (std::find(addresses.begin(), addresses.end(), address) != addresses.end()) {
+            LOG(WARNING)
+                    << "Repeated ip addresses has been found for host: " << name
+                    << ", ip address:" << address
+                    << ", please check your network configuration";
+        } else {
             addresses->push_back(address);
         }
         it = it->ai_next;

--- a/be/src/util/network_util.cpp
+++ b/be/src/util/network_util.cpp
@@ -96,7 +96,11 @@ Status hostname_to_ip_addrs(const std::string& name, std::vector<std::string>* a
             return Status::InternalError("Could not convert IPv4 address for: {}", name);
         }
 
-        addresses->push_back(std::string(addr_buf));
+        // add address if not exists
+        std::vector<string> address = std::string(addr_buf);
+        if (std::find(addresses.begin(), addresses.end(), address) == addresses.end()) {
+            addresses->push_back(address);
+        }
         it = it->ai_next;
     }
 


### PR DESCRIPTION
## Proposed changes

Add some deduplication code when analysing BE's hostname.

Our dev ops did an operation which produced some repeated hostname-ip pairs in `/etc/hosts` and then all the querys failed and the error messages were like this : 

**Error message at client side:**

![err](https://github.com/apache/doris/assets/5926365/4b30f987-35a7-4017-b9fa-75ad7a6dcbf9)

**Error message at server side:**

![err2](https://github.com/apache/doris/assets/5926365/e61936ab-fc60-43aa-8f3f-76ca62d1a508)

I think we can add a deduplication process at `network_util.cpp` to avoid such errors.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

