### PR TITLE
[improve](error) include detailed  messages in rowset reader init error

### DIFF
--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -224,7 +224,7 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
         auto s = seg_ptr->new_iterator(_input_schema, _read_options, &iter);
         if (!s.ok()) {
             LOG(WARNING) << "failed to create iterator[" << seg_ptr->id() << "]: " << s.to_string();
-            return Status::Error<ROWSET_READER_INIT>();
+            return Status::Error<ROWSET_READER_INIT>(s.to_string());
         }
         if (iter->empty()) {
             continue;
@@ -268,7 +268,7 @@ Status BetaRowsetReader::init(RowsetReaderContext* read_context,
     if (!s.ok()) {
         LOG(WARNING) << "failed to init iterator: " << s.to_string();
         _iterator.reset();
-        return Status::Error<ROWSET_READER_INIT>();
+        return Status::Error<ROWSET_READER_INIT>(s.to_string());
     }
     return Status::OK();
 }

--- a/be/src/olap/task/index_builder.cpp
+++ b/be/src/olap/task/index_builder.cpp
@@ -183,7 +183,7 @@ Status IndexBuilder::handle_single_rowset(RowsetMetaSharedPtr output_rowset_meta
             if (!res.ok()) {
                 LOG(WARNING) << "failed to create iterator[" << seg_ptr->id()
                              << "]: " << res.to_string();
-                return Status::Error<ErrorCode::ROWSET_READER_INIT>();
+                return Status::Error<ErrorCode::ROWSET_READER_INIT>(res.to_string());
             }
 
             std::shared_ptr<vectorized::Block> block = std::make_shared<vectorized::Block>(


### PR DESCRIPTION
## Proposed changes

Print detailed messages in rowset reader init error, for example:
`res=[E-3110][CORRUPTION]Bad page: checksum mismatch (actual=2264761750 vs expect=32607)`


Before:

```
mysql> select count(*) from store_sales;                                                                                           
ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.7)[CANCELLED][INTERNAL_ERROR]
failed to initialize storage reader. tablet=10156.539307473.ff45f287121705c6-1e3c3228d0b5e282, 
res=[E-3110]
    @     0x555d93afb316  doris::BetaRowsetReader::get_segment_iterators()
    @     0x555d93afb96c  doris::BetaRowsetReader::init()
    @     0x555d9a62c7f3  doris::vectorized::BlockReader::_init_collect_iter()
    @     0x555d9a62d859  doris::vectorized::BlockReader::init()
    @     0x555d971a10a3  doris::vectorized::NewOlapScanne
```

After:

```
mysql> select count(*) from store_sales;
ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.7)[CANCELLED][INTERNAL_ERROR]
failed to initialize storage reader. tablet=10156.539307473.ff45f287121705c6-1e3c3228d0b5e282, 
res=[E-3110][CORRUPTION]Bad page: checksum mismatch (actual=2264761750 vs expect=32607)
    @     0x55ad67a3a342  doris::BetaRowsetReader::get_segment_iterators()
    @     0x55ad67a3aa0c  doris::BetaRowsetReader::init()
    @     0x55ad6e56b963  doris::vectorized::BlockReader::_init_collect_iter()
    @     0x55ad6e56c9c9  doris::vectorized::Blo
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

