### PR TITLE
[Improve](tools)Add IssueNavigationLink to make IDEA support hyperlink on GitHub PR on Git plugin.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ package-lock.json
 .cache
 .settings/
 **/.idea/
+!.idea/vcs.xml
 **/.vscode/
 **/.fleet/
 

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+  
+      http://www.apache.org/licenses/LICENSE-2.0
+  
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+  -->
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+  <component name="IssueNavigationConfiguration">
+    <option name="links">
+      <list>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="#(\d+)" />
+          <option name="linkRegexp" value="https://github.com/apache/doris/pull/$1" />
+        </IssueNavigationLink>
+      </list>
+    </option>
+  </component>
+</project>


### PR DESCRIPTION

<img width="1280" alt="image" src="https://github.com/apache/doris/assets/16631152/6ef6663f-06c6-4caa-a509-b8ae101e6328">
Now we can directly click the link to the pr corresponding to GitHub, without going through the boring steps of copying, opening the browser, and pasting

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

