### PR TITLE
[fix](s3_writer) init member's value to avoid undefined behavior

### DIFF
--- a/be/src/io/fs/s3_file_write_bufferpool.h
+++ b/be/src/io/fs/s3_file_write_bufferpool.h
@@ -104,8 +104,8 @@ struct S3FileBuffer : public std::enable_shared_from_this<S3FileBuffer> {
     // caller of this buf could use this callback to do syncronization
     Callback _on_finish_upload = nullptr;
     Status _status;
-    size_t _offset;
-    size_t _size;
+    size_t _offset {0};
+    size_t _size {0};
     std::shared_ptr<std::iostream> _stream_ptr;
     // only served as one reserved buffer
     Slice _buf;


### PR DESCRIPTION
## Proposed changes

Must init the value of member, otherwise, the init value is undefined,
may causing undefined behavior, for example, when write data using s3 file writer,
the `appendv` method may be blocked due to invalid offset value.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

