### PR TITLE
[improvement](scripts) change the arch name in build-for-release scripts

### DIFF
--- a/build-for-release.sh
+++ b/build-for-release.sh
@@ -110,6 +110,17 @@ echo "Get params:
 
 ARCH="$(uname -m)"
 
+if [[ "${ARCH}" == "aarch64" ]]; then
+    ARCH="arm64"
+elif [[ "${ARCH}" == "x86_64" ]]; then
+    ARCH="x64"
+else
+    echo "Unknown arch: ${ARCH}"
+    exit 1
+fi
+
+echo "ARCH: ${ARCH}"
+
 ORI_OUTPUT="${ROOT}/output"
 
 FE="fe"


### PR DESCRIPTION
## Proposed changes

Use `uname -m` to get the arch of the machine.
And for `aarch64`, change it to `arm64`
for `x86_64`, change it to `x64`

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

