### PR TITLE
[enhancement](rocksdb) increasing the max_write_buffer_number parameter to improve save meta performance

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1043,6 +1043,9 @@ DEFINE_Bool(enable_set_in_bitmap_value, "false");
 DEFINE_Int64(max_hdfs_file_handle_cache_num, "20000");
 DEFINE_Int64(max_external_file_meta_cache_num, "20000");
 
+// max_write_buffer_number for rocksdb
+DEFINE_Int32(rocksdb_max_write_buffer_number, "5");
+
 #ifdef BE_TEST
 // test s3
 DEFINE_String(test_s3_resource, "resource");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1059,6 +1059,9 @@ DECLARE_Int64(max_hdfs_file_handle_cache_num);
 // max number of meta info of external files, such as parquet footer
 DECLARE_Int64(max_external_file_meta_cache_num);
 
+// max_write_buffer_number for rocksdb
+DECLARE_Int32(rocksdb_max_write_buffer_number);
+
 #ifdef BE_TEST
 // test s3
 DECLARE_String(test_s3_resource);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->


I0627 17:05:46.669010 339643 olap_meta.cpp:71] [Rocksdb] [WARN] [db/[column_family.cc:738](http://column_family.cc:738/)] [meta] Stopping writes because we have 2 immutable memtables (waiting for flush), max_write_buffer_number is set to 2

 increasing the max_write_buffer_number parameter of rocksdb to improve save meta performance.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

