### PR TITLE
[fix](inverted index) update output rowset index meta with input rowset when drop inverted index

### DIFF
--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -1021,9 +1021,8 @@ Status StorageEngine::process_index_change_task(const TAlterInvertedIndexReq& re
         return Status::InternalError("tablet not exist, tablet_id={}.", tablet_id);
     }
 
-    IndexBuilderSharedPtr index_builder =
-            std::make_shared<IndexBuilder>(tablet, request.columns, request.indexes_desc,
-                                           request.alter_inverted_indexes, request.is_drop_op);
+    IndexBuilderSharedPtr index_builder = std::make_shared<IndexBuilder>(
+            tablet, request.columns, request.alter_inverted_indexes, request.is_drop_op);
     RETURN_IF_ERROR(_handle_index_change(index_builder));
     return Status::OK();
 }

--- a/be/src/olap/tablet_schema.cpp
+++ b/be/src/olap/tablet_schema.cpp
@@ -637,6 +637,17 @@ void TabletSchema::append_index(TabletIndex index) {
     _indexes.push_back(std::move(index));
 }
 
+void TabletSchema::remove_index(int64_t index_id) {
+    std::vector<TabletIndex> indexes;
+    for (auto index : _indexes) {
+        if (index.index_id() == index_id) {
+            continue;
+        }
+        indexes.emplace_back(std::move(index));
+    }
+    _indexes = std::move(indexes);
+}
+
 void TabletSchema::clear_columns() {
     _field_name_to_index.clear();
     _field_id_to_index.clear();

--- a/be/src/olap/tablet_schema.h
+++ b/be/src/olap/tablet_schema.h
@@ -207,6 +207,7 @@ public:
     void to_schema_pb(TabletSchemaPB* tablet_meta_pb) const;
     void append_column(TabletColumn column, bool is_dropped_column = false);
     void append_index(TabletIndex index);
+    void remove_index(int64_t index_id);
     // Must make sure the row column is always the last column
     void add_row_column();
     void copy_from(const TabletSchema& tablet_schema);

--- a/be/src/olap/task/index_builder.cpp
+++ b/be/src/olap/task/index_builder.cpp
@@ -61,10 +61,16 @@ Status IndexBuilder::update_inverted_index_info() {
         auto input_rs_tablet_schema = input_rowset->tablet_schema();
         output_rs_tablet_schema->copy_from(*input_rs_tablet_schema);
         if (_is_drop_op) {
+            // base on input rowset's tablet_schema to build
+            // output rowset's tablet_schema which only remove
+            // the indexes specified in this drop index request
             for (auto t_inverted_index : _alter_inverted_indexes) {
                 output_rs_tablet_schema->remove_index(t_inverted_index.index_id);
             }
         } else {
+            // base on input rowset's tablet_schema to build
+            // output rowset's tablet_schema which only add
+            // the indexes specified in this build index request
             for (auto t_inverted_index : _alter_inverted_indexes) {
                 TabletIndex index;
                 index.init_from_thrift(t_inverted_index, *input_rs_tablet_schema);
@@ -427,6 +433,13 @@ Status IndexBuilder::do_build_inverted_index() {
 }
 
 Status IndexBuilder::modify_rowsets(const Merger::Statistics* stats) {
+    for (auto rowset_ptr : _output_rowsets) {
+        auto rowset_id = rowset_ptr->rowset_id();
+        if (StorageEngine::instance()->check_rowset_id_in_unused_rowsets(rowset_id)) {
+            DCHECK(false) << "output rowset: " << rowset_id.to_string() << " in unused rowsets";
+        }
+    }
+
     if (_tablet->keys_type() == KeysType::UNIQUE_KEYS &&
         _tablet->enable_unique_key_merge_on_write()) {
         std::lock_guard<std::mutex> rwlock(_tablet->get_rowset_update_lock());

--- a/be/src/olap/task/index_builder.h
+++ b/be/src/olap/task/index_builder.h
@@ -36,7 +36,6 @@ using RowsetWriterUniquePtr = std::unique_ptr<RowsetWriter>;
 class IndexBuilder {
 public:
     IndexBuilder(const TabletSharedPtr& tablet, const std::vector<TColumn>& columns,
-                 const std::vector<TOlapTableIndex> exist_indexes,
                  const std::vector<doris::TOlapTableIndex>& alter_inverted_indexes,
                  bool is_drop_op = false);
     ~IndexBuilder();
@@ -65,7 +64,6 @@ private:
 private:
     TabletSharedPtr _tablet;
     std::vector<TColumn> _columns;
-    std::vector<TOlapTableIndex> _exist_indexes;
     std::vector<doris::TOlapTableIndex> _alter_inverted_indexes;
     bool _is_drop_op;
     std::unordered_map<std::string, std::set<int32_t>> _rowset_alter_index_column_ids;

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/IndexChangeJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/IndexChangeJob.java
@@ -290,7 +290,7 @@ public class IndexChangeJob implements Writable {
                             partitionId, originIndexId, originTabletId,
                             originSchemaHash, olapTable.getIndexes(),
                             alterInvertedIndexes, originSchemaColumns,
-                            isDropOp, taskSignature);
+                            isDropOp, taskSignature, jobId);
                     invertedIndexBatchTask.addTask(alterInvertedIndexTask);
                 }
             } // end for tablet

--- a/fe/fe-core/src/main/java/org/apache/doris/task/AlterInvertedIndexTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/AlterInvertedIndexTask.java
@@ -97,6 +97,7 @@ public class AlterInvertedIndexTask extends AgentTask {
         req.setTabletId(tabletId);
         req.setSchemaHash(schemaHash);
         req.setIsDropOp(isDropOp);
+        // set jonId for debugging in BE
         req.setJobId(jobId);
 
         if (!alterInvertedIndexes.isEmpty()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/task/AlterInvertedIndexTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/AlterInvertedIndexTask.java
@@ -44,11 +44,13 @@ public class AlterInvertedIndexTask extends AgentTask {
     private List<Column> schemaColumns;
     private List<Index> existIndexes;
     private boolean isDropOp = false;
+    private long jobId;
 
     public AlterInvertedIndexTask(long backendId, long dbId, long tableId,
             long partitionId, long indexId, long tabletId, int schemaHash,
             List<Index> existIndexes, List<Index> alterInvertedIndexes,
-            List<Column> schemaColumns, boolean isDropOp, long taskSignature) {
+            List<Column> schemaColumns, boolean isDropOp, long taskSignature,
+            long jobId) {
         super(null, backendId, TTaskType.ALTER_INVERTED_INDEX, dbId, tableId,
                 partitionId, indexId, tabletId, taskSignature);
         this.tabletId = tabletId;
@@ -57,6 +59,7 @@ public class AlterInvertedIndexTask extends AgentTask {
         this.alterInvertedIndexes = alterInvertedIndexes;
         this.schemaColumns = schemaColumns;
         this.isDropOp = isDropOp;
+        this.jobId = jobId;
     }
 
     public long getTabletId() {
@@ -94,6 +97,7 @@ public class AlterInvertedIndexTask extends AgentTask {
         req.setTabletId(tabletId);
         req.setSchemaHash(schemaHash);
         req.setIsDropOp(isDropOp);
+        req.setJobId(jobId);
 
         if (!alterInvertedIndexes.isEmpty()) {
             List<TOlapTableIndex> tIndexes = new ArrayList<>();


### PR DESCRIPTION
## Proposed changes

fix problem, example:
if there are two inverted index in table: index_A, index_B
1.  add index_C, the FE's latest index meta is (index_A, index_B, index_C), but now, the stock rowset's index meta in tablet_chema is (index_A, index_B), if no new load or build index, the stock rowset will not create index file for index_C
2. drop index_A, and then update output rowset's tablet_schema with the FE's lasted index meta( index_B, indx_C), and modify output rowsets into meta to instead of input rowsets, the rowset's index meta is changed to (index_B, index_C)
3. drop index_B, the picked input rowset's index meta is (index_B, index_C), but due to index file for index_C is not created, then link file will fail.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

