### PR TITLE
[improvement](regression) add custom_env.sh from regression pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,8 @@ core.*
 .DS_Store
 .classpath
 nohup.out
-custom_env.sh
-custom_env_mac.sh
+/custom_env.sh
+/custom_env_mac.sh
 derby.log
 dependency-reduced-pom.xml
 yarn.lock
@@ -43,6 +43,7 @@ docs/.temp
 
 # output, thirdparty, extension
 output/
+output.bak/
 rpc_data/
 metastore_db/
 thirdparty/src*

--- a/regression-test/pipeline/common/custom_env.sh
+++ b/regression-test/pipeline/common/custom_env.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# shellcheck disable=SC2034
+BUILD_FS_BENCHMARK=ON


### PR DESCRIPTION
## Proposed changes

This file will be used when compiling Doris in regression pipeline.
And we can modify it to control the compile behavior.

I add `BUILD_FS_BENCHMARK=ON`, so that it will build fs_benchmark_tool.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

