### PR TITLE
[fix](partial-update) fix a coredump in commit_phase_update_delete_bitmap

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -330,7 +330,10 @@ void SegmentWriter::_serialize_block_to_row_column(vectorized::Block& block) {
 Status SegmentWriter::append_block_with_partial_content(const vectorized::Block* block,
                                                         size_t row_pos, size_t num_rows) {
     CHECK(block->columns() > _tablet_schema->num_key_columns() &&
-          block->columns() < _tablet_schema->num_columns());
+          block->columns() < _tablet_schema->num_columns())
+            << "block columns: " << block->columns()
+            << ", num key columns: " << _tablet_schema->num_key_columns()
+            << ", total schema columns: " << _tablet_schema->num_columns();
     CHECK(_tablet_schema->keys_type() == UNIQUE_KEYS && _opts.enable_unique_key_merge_on_write);
 
     // find missing column cids

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -328,6 +328,9 @@ public:
 
     Status create_rowset_writer(RowsetWriterContext& context,
                                 std::unique_ptr<RowsetWriter>* rowset_writer);
+
+    Status create_transient_rowset_writer(RowsetSharedPtr rowset_ptr,
+                                          std::unique_ptr<RowsetWriter>* rowset_writer);
     Status create_transient_rowset_writer(RowsetWriterContext& context, const RowsetId& rowset_id,
                                           std::unique_ptr<RowsetWriter>* rowset_writer);
 

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -214,10 +214,6 @@ private:
     void _insert_txn_partition_map_unlocked(int64_t transaction_id, int64_t partition_id);
     void _clear_txn_partition_map_unlocked(int64_t transaction_id, int64_t partition_id);
 
-    Status _create_transient_rowset_writer(std::shared_ptr<Tablet> tablet,
-                                           RowsetSharedPtr rowset_ptr,
-                                           std::unique_ptr<RowsetWriter>* rowset_writer);
-
 private:
     const int32_t _txn_map_shard_size;
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

```
SLF4J: Actual binding is of type [org.slf4j.impl.Reload4jLoggerFactory]
F0627 14:53:59.750797 504076 segment_writer.cpp:333] Check failed: block->columns() > _tablet_schema->num_key_columns() && block->columns() < _tablet_schema->num_columns() block columns: 203, num key columns: 1,
total schema columns: 203
*** Check failure stack trace: ***
    @     0x55e7c081b83d  google::LogMessage::Fail()
    @     0x55e7c081dd79  google::LogMessage::SendToLog()
    @     0x55e7c081b3a6  google::LogMessage::Flush()
    @     0x55e7c081e3e9  google::LogMessageFatal::~LogMessageFatal()
    @     0x55e7b9a03478  doris::segment_v2::SegmentWriter::append_block_with_partial_content()
    @     0x55e7b9a0518e  doris::segment_v2::SegmentWriter::append_block()
    @     0x55e7b9932720  doris::BetaRowsetWriter::_do_add_block()
    @     0x55e7b992f7ed  doris::BetaRowsetWriter::_add_block()
    @     0x55e7b9933544  doris::BetaRowsetWriter::flush_single_memtable()
    @     0x55e7b9b4a810  doris::Tablet::calc_segment_delete_bitmap()
    @     0x55e7b9b4ca43  doris::Tablet::calc_delete_bitmap()
    @     0x55e7b9b4ee65  doris::Tablet::commit_phase_update_delete_bitmap()
    @     0x55e7b9be705d  doris::DeltaWriter::close_wait()
    @     0x55e7b9d3a95a  doris::TabletsChannel::_close_wait()
    @     0x55e7b9d3a423  doris::TabletsChannel::close()
    @     0x55e7b9c9076d  doris::LoadChannel::_handle_eos()
    @     0x55e7b9c8fb6e  doris::LoadChannel::add_batch()
    @     0x55e7b9c87765  doris::LoadChannelMgr::add_batch()
    @     0x55e7b9d80776  std::_Function_handler<>::_M_invoke()
    @     0x55e7b9324f62  doris::PriorityThreadPool::work_thread()
    @     0x55e7c3573890  execute_native_thread_routine
    @     0x7f1b176ed609  start_thread
    @     0x7f1b1797c133  clone
    @              (nil)  (unknown)
*** Query id: 0-0 ***
```
commit_phase_update_delete_bitmap can't use the original rowset writer directly, it should use a rowset writer with full schema.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

