### PR TITLE
[enhancement](merge-on-write) add more version and txn information for mow publish

### DIFF
--- a/be/src/olap/task/engine_publish_version_task.cpp
+++ b/be/src/olap/task/engine_publish_version_task.cpp
@@ -118,13 +118,6 @@ Status EnginePublishVersionTask::finish() {
         // each tablet
         for (auto& tablet_rs : tablet_related_rs) {
             TabletInfo tablet_info = tablet_rs.first;
-            bool first_time_update = false;
-            if (StorageEngine::instance()->txn_manager()->get_txn_by_tablet_version(
-                        tablet_info.tablet_id, version.second) < 0) {
-                first_time_update = true;
-                StorageEngine::instance()->txn_manager()->update_tablet_version_txn(
-                        tablet_info.tablet_id, version.second, transaction_id);
-            }
             RowsetSharedPtr rowset = tablet_rs.second;
             VLOG_CRITICAL << "begin to publish version on tablet. "
                           << "tablet_id=" << tablet_info.tablet_id
@@ -154,6 +147,13 @@ Status EnginePublishVersionTask::finish() {
             // here and wait pre version publish or lock timeout
             if (tablet->keys_type() == KeysType::UNIQUE_KEYS &&
                 tablet->enable_unique_key_merge_on_write()) {
+                bool first_time_update = false;
+                if (StorageEngine::instance()->txn_manager()->get_txn_by_tablet_version(
+                            tablet_info.tablet_id, version.second) < 0) {
+                    first_time_update = true;
+                    StorageEngine::instance()->txn_manager()->update_tablet_version_txn(
+                            tablet_info.tablet_id, version.second, transaction_id);
+                }
                 Version max_version;
                 TabletState tablet_state;
                 {

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -82,6 +82,9 @@ TxnManager::TxnManager(int32_t txn_map_shard_size, int32_t txn_shard_size)
     _txn_mutex = new std::shared_mutex[_txn_shard_size];
     _txn_tablet_delta_writer_map = new txn_tablet_delta_writer_map_t[_txn_map_shard_size];
     _txn_tablet_delta_writer_map_locks = new std::shared_mutex[_txn_map_shard_size];
+    // For debugging
+    _tablet_version_cache = new ShardedLRUCache("TabletVersionCache", 100000,
+                                                LRUCacheType::NUMBER, 32);
 }
 
 // prepare txn should always be allowed because ingest task will be retried

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -83,8 +83,8 @@ TxnManager::TxnManager(int32_t txn_map_shard_size, int32_t txn_shard_size)
     _txn_tablet_delta_writer_map = new txn_tablet_delta_writer_map_t[_txn_map_shard_size];
     _txn_tablet_delta_writer_map_locks = new std::shared_mutex[_txn_map_shard_size];
     // For debugging
-    _tablet_version_cache = new ShardedLRUCache("TabletVersionCache", 100000,
-                                                LRUCacheType::NUMBER, 32);
+    _tablet_version_cache =
+            new ShardedLRUCache("TabletVersionCache", 100000, LRUCacheType::NUMBER, 32);
 }
 
 // prepare txn should always be allowed because ingest task will be retried

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -781,5 +781,4 @@ void TxnManager::update_tablet_version_txn(int64_t tablet_id, int64_t version, i
     _tablet_version_cache->release(handle);
 }
 
-
 } // namespace doris

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -173,36 +173,8 @@ public:
                                        DeleteBitmapPtr delete_bitmap,
                                        const RowsetIdUnorderedSet& rowset_ids);
 
-    int64_t get_txn_by_tablet_version(int64_t tablet_id, int64_t version) {
-        char key[16];
-        memcpy(key, &tablet_id, sizeof(int64_t));
-        memcpy(key + sizeof(int64_t), &version, sizeof(int64_t));
-        CacheKey cache_key((const char*)&key, sizeof(key));
-
-        auto handle = _tablet_version_cache->lookup(cache_key);
-        if (handle == nullptr) {
-            return -1;
-        }
-        int64_t res = *(int64_t*)_tablet_version_cache->value(handle);
-        return res;
-    }
-
-    void update_tablet_version_txn(int64_t tablet_id, int64_t version, int64_t txn_id) {
-        char key[16];
-        memcpy(key, &tablet_id, sizeof(int64_t));
-        memcpy(key + sizeof(int64_t), &version, sizeof(int64_t));
-        CacheKey cache_key((const char*)&key, sizeof(key));
-
-        int64_t* value = new int64_t;
-        *value = txn_id;
-        auto deleter = [](const doris::CacheKey& key, void* value) {
-            int64_t* cache_value = (int64_t*)value;
-            delete cache_value;
-        };
-
-        _tablet_version_cache->insert(cache_key, value, sizeof(txn_id), deleter,
-                                      CachePriority::NORMAL, sizeof(txn_id));
-    }
+    int64_t get_txn_by_tablet_version(int64_t tablet_id, int64_t version);
+    void update_tablet_version_txn(int64_t tablet_id, int64_t version, int64_t txn_id);
 
 private:
     using TxnKey = std::pair<int64_t, int64_t>; // partition_id, transaction_id;

--- a/be/test/olap/txn_manager_test.cpp
+++ b/be/test/olap/txn_manager_test.cpp
@@ -332,4 +332,23 @@ TEST_F(TxnManagerTest, DeleteCommittedTxn) {
     EXPECT_TRUE(status != Status::OK());
 }
 
+TEST_F(TxnManagerTest, TabletVersionCache) {
+    _txn_mgr->update_tablet_version_txn(123, 100, 456);
+    _txn_mgr->update_tablet_version_txn(124, 100, 567);
+    int64_t tx1 = _txn_mgr->get_txn_by_tablet_version(123, 100);
+    EXPECT_EQ(tx1, 456);
+    int64_t tx2 = _txn_mgr->get_txn_by_tablet_version(124, 100);
+    EXPECT_EQ(tx2, 567);
+    int64_t tx3 = _txn_mgr->get_txn_by_tablet_version(124, 101);
+    EXPECT_EQ(tx3, -1);
+    _txn_mgr->update_tablet_version_txn(123, 101, 888);
+    _txn_mgr->update_tablet_version_txn(124, 101, 890);
+    int64_t tx4 = _txn_mgr->get_txn_by_tablet_version(123, 100);
+    EXPECT_EQ(tx4, 456);
+    int64_t tx5 = _txn_mgr->get_txn_by_tablet_version(123, 101);
+    EXPECT_EQ(tx5, 888);
+    int64_t tx6 = _txn_mgr->get_txn_by_tablet_version(124, 101);
+    EXPECT_EQ(tx6, 890);
+}
+
 } // namespace doris

--- a/be/test/olap/txn_manager_test.cpp
+++ b/be/test/olap/txn_manager_test.cpp
@@ -333,21 +333,22 @@ TEST_F(TxnManagerTest, DeleteCommittedTxn) {
 }
 
 TEST_F(TxnManagerTest, TabletVersionCache) {
-    _txn_mgr->update_tablet_version_txn(123, 100, 456);
-    _txn_mgr->update_tablet_version_txn(124, 100, 567);
-    int64_t tx1 = _txn_mgr->get_txn_by_tablet_version(123, 100);
+    std::unique_ptr<TxnManager> txn_mgr = std::make_unique<TxnManager>(64, 1024);
+    txn_mgr->update_tablet_version_txn(123, 100, 456);
+    txn_mgr->update_tablet_version_txn(124, 100, 567);
+    int64_t tx1 = txn_mgr->get_txn_by_tablet_version(123, 100);
     EXPECT_EQ(tx1, 456);
-    int64_t tx2 = _txn_mgr->get_txn_by_tablet_version(124, 100);
+    int64_t tx2 = txn_mgr->get_txn_by_tablet_version(124, 100);
     EXPECT_EQ(tx2, 567);
-    int64_t tx3 = _txn_mgr->get_txn_by_tablet_version(124, 101);
+    int64_t tx3 = txn_mgr->get_txn_by_tablet_version(124, 101);
     EXPECT_EQ(tx3, -1);
-    _txn_mgr->update_tablet_version_txn(123, 101, 888);
-    _txn_mgr->update_tablet_version_txn(124, 101, 890);
-    int64_t tx4 = _txn_mgr->get_txn_by_tablet_version(123, 100);
+    txn_mgr->update_tablet_version_txn(123, 101, 888);
+    txn_mgr->update_tablet_version_txn(124, 101, 890);
+    int64_t tx4 = txn_mgr->get_txn_by_tablet_version(123, 100);
     EXPECT_EQ(tx4, 456);
-    int64_t tx5 = _txn_mgr->get_txn_by_tablet_version(123, 101);
+    int64_t tx5 = txn_mgr->get_txn_by_tablet_version(123, 101);
     EXPECT_EQ(tx5, 888);
-    int64_t tx6 = _txn_mgr->get_txn_by_tablet_version(124, 101);
+    int64_t tx6 = txn_mgr->get_txn_by_tablet_version(124, 101);
     EXPECT_EQ(tx6, 890);
 }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

In Doris, when a unique key MoW table encounters a publish timeout issue, the most common root cause is often a missing version. We need a way to quickly identify which version is missing, leading to the publish timeout problem, and be able to locate all logs associated with the transaction ID related to that version

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

