### PR TITLE
[fix](time_zone) be compatible with doris old version for CST time_zone when load orc file in broker load

### DIFF
--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -744,7 +744,7 @@ Status OrcReader::set_fill_columns(
 
     // create orc row reader
     _row_reader_options.range(_range_start_offset, _range_size);
-    _row_reader_options.setTimezoneName(_ctz);
+    _row_reader_options.setTimezoneName(_ctz == "CST" ? "Asia/Shanghai" : _ctz);
     _row_reader_options.include(_read_cols);
     if (_lazy_read_ctx.can_lazy_read) {
         _row_reader_options.filter(_lazy_read_ctx.predicate_orc_columns);


### PR DESCRIPTION
## Proposed changes

Fix error for broker load with orc file when time_zone is CST of which message is "Failed to create orc row reader. reason = Can't open /usr/share/zoneinfo/CST"


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

