### PR TITLE
[Bug](alter table) return error status to avoid core dump on schema change meet invalid …

### DIFF
--- a/regression-test/suites/cold_heat_separation_p2/table_modify_resouce_and_policy.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/table_modify_resouce_and_policy.groovy
@@ -196,12 +196,16 @@ suite("table_modify_resouce") {
     log.info( "test tablets not empty")
     assertTrue(tablets.size() > 0)
     fetchDataSize(sizes, tablets[0])
+
+    def try_times = 100
     while (sizes[0] != 0) {
         log.info( "test local size is not zero, sleep 10s")
         sleep(10000)
         tablets = sql """
         SHOW TABLETS FROM ${tableName}
         """
+        try_times -= 1
+        assertTrue(try_times > 0)
     }
     // 所有的local data size为0
     log.info( "test all local size is zero")


### PR DESCRIPTION
## Proposed changes

return error status to avoid core dump on schema change meet invalid input

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

