### PR TITLE
[Enhancement](multi-catalog) try to reuse existed ugi.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsResource.java
@@ -48,6 +48,7 @@ public class HdfsResource extends Resource {
     public static String HADOOP_USER_NAME = "hadoop.username";
     public static String HADOOP_SECURITY_AUTHENTICATION = "hadoop.security.authentication";
     public static String HADOOP_KERBEROS_PRINCIPAL = "hadoop.kerberos.principal";
+    public static String HADOOP_KERBEROS_AUTHORIZATION = "hadoop.security.authorization";
     public static String HADOOP_KERBEROS_KEYTAB = "hadoop.kerberos.keytab";
     public static String HADOOP_SHORT_CIRCUIT = "dfs.client.read.shortcircuit";
     public static String HADOOP_SOCKET_PATH = "dfs.domain.socket.path";

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/RemoteFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/RemoteFileSystem.java
@@ -31,7 +31,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public abstract class RemoteFileSystem extends PersistentFileSystem {
-    protected org.apache.hadoop.fs.FileSystem dfsFileSystem = null;
+    // this field will be visited by multi-threads, better use volatile qualifier
+    protected volatile org.apache.hadoop.fs.FileSystem dfsFileSystem = null;
 
     public RemoteFileSystem(String name, StorageBackend.StorageType type) {
         super(name, type);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Try to reuse an existed ugi at DFSFileSystem, otherwise if we query a more then ten-thousands partitons hms table, we will do more than ten-thousands login operations, each login operation will cost hundreds of ms from my test.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

