### PR TITLE
[branch1.2][fix](catalog) disable hdfs fs cache to avoid to many fs c…

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -256,6 +256,9 @@ public class HiveMetaStoreCache {
             // Otherwise, getSplits() may throw exception: "Not a file xxx"
             // https://blog.actorsfit.com/a?ID=00550-ce56ec63-1bff-4b0c-a6f7-447b93efaa31
             jobConf.set("mapreduce.input.fileinputformat.input.dir.recursive", "true");
+            // FileInputFormat.setInputPaths() will call FileSystem.get(), which will create new FileSystem
+            // and save it in FileSystem.Cache. We don't need this cache.
+            jobConf.set("fs.hdfs.impl.disable.cache", "true");
             FileInputFormat.setInputPaths(jobConf, finalLocation);
             try {
                 InputFormat<?, ?> inputFormat = HiveUtil.getInputFormat(jobConf, key.inputFormat, false);


### PR DESCRIPTION
…ache in memory

## Proposed changes

FileInputFormat.setInputPaths() will call FileSystem.get(), which will create new FileSystem
and save it in FileSystem.Cache. We don't need this cache.
And if user call `refresh catalog` frequently, there will be lots of fs cache in it, causing OOM

cherry-pick #21283

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

