### PR TITLE
[fix](memory) Fix metrics to promethues check memory exceed

### DIFF
--- a/be/src/http/action/metrics_action.cpp
+++ b/be/src/http/action/metrics_action.cpp
@@ -22,6 +22,7 @@
 #include "http/http_channel.h"
 #include "http/http_headers.h"
 #include "http/http_request.h"
+#include "util/mem_info.h"
 #include "util/metrics.h"
 
 namespace doris {
@@ -30,7 +31,9 @@ void MetricsAction::handle(HttpRequest* req) {
     const std::string& type = req->param("type");
     const std::string& with_tablet = req->param("with_tablet");
     std::string str;
-    if (type == "core") {
+    if (MemInfo::is_exceed_soft_mem_limit(GB_EXCHANGE_BYTE)) {
+        str = "";
+    } else if (type == "core") {
         str = _metric_registry->to_core_string();
     } else if (type == "json") {
         str = _metric_registry->to_json(with_tablet == "true");


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

metrics to promethues may use a few G of memory

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

