### PR TITLE
[fix](restore) work around, ingest binlog after backup/restore which local_tablet.partition_id is not correct, use req.partition_id

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Syncer.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Syncer.groovy
@@ -680,7 +680,7 @@ class Syncer {
                     }
 
                     tarPartition.value.version = srcPartition.value.version
-                    long partitionId = fakePartitionId == -1 ? srcPartition.key : fakePartitionId
+                    long partitionId = fakePartitionId == -1 ? tarPartition.key : fakePartitionId
                     long version = fakeVersion == -1 ? srcPartition.value.version : fakeVersion
 
                     TIngestBinlogRequest request = new TIngestBinlogRequest()


### PR DESCRIPTION
## Proposed changes

work around, ingest binlog after backup/restore which local_tablet.partition_id is not correct, use req.partition_id
