### PR TITLE
[1.2][fix](jdbc) Handling Zero DateTime Values in Non-nullable Columns for JDBC Catalog Reading MySQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ tools/**/tpch-data/
 
 # be-ut
 data_test
+/ui/dist


### PR DESCRIPTION
## Proposed changes

cherry-pick from #21296

This pull request addresses the issue encountered when JDBC Catalog reads zero datetime values (0000-00-00 00:00:00) from non-nullable columns in MySQL. JDBC has difficulty handling such datetime format, which leads to read errors.

The proposed solution introduces the parameter zeroDateTimeBehavior=convertToNull in the jdbc_url. In this manner, when JDBC encounters 0000-00-00 00:00:00, it will convert these zero datetime values to null. Consequently, Doris will treat the DateTime column as a nullable type, allowing the read operation to proceed successfully. This change ensures data integrity and enhances read reliability when working with MySQL data sources.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

