### PR TITLE
[fix](memory) Fix hash table buf initialize null pointer

### DIFF
--- a/be/src/vec/common/hash_table/hash_table.h
+++ b/be/src/vec/common/hash_table/hash_table.h
@@ -445,8 +445,8 @@ protected:
     using Self = HashTable;
     using cell_type = Cell;
 
-    size_t m_size = 0; /// Amount of elements
-    Cell* buf;         /// A piece of memory for all elements except the element with zero key.
+    size_t m_size = 0;   /// Amount of elements
+    Cell* buf {nullptr}; /// A piece of memory for all elements except the element with zero key.
     Grower grower;
     int64_t _resize_timer_ns;
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

When compiling `FunctionArrayEnumerateUniq::_execute_by_hash`, `AllocatorWithStackMemory::free(buf)`
will be called when `delete HashMapContainer`. the gcc compiler will think that `size > N` and `buf` is not heap memory,
and report an error `' void free(void*)' called on unallocated object 'hash_map'`

This only fails on doris docker + gcc 11.1, no problem on doris docker + clang 16.0.1,
no problem on ldb_toolchanin gcc 11.1 and clang 16.0.1.

But for this compilation problem, I still don’t understand why gcc in docker will report an error. If the hash map is not initialized and buf is not alloc, it should not go to allocator::free. If you are familiar with the principle of compilation, hope you can guide me, thxs!~

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

