### PR TITLE
[decimalv2](compatibility) add config to allow invalid decimalv2 literal

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1027,6 +1027,8 @@ DEFINE_Int64(max_external_file_meta_cache_num, "20000");
 // max_write_buffer_number for rocksdb
 DEFINE_Int32(rocksdb_max_write_buffer_number, "5");
 
+DEFINE_Bool(allow_invalid_decimalv2_literal, "false");
+
 #ifdef BE_TEST
 // test s3
 DEFINE_String(test_s3_resource, "resource");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1043,6 +1043,9 @@ DECLARE_Int64(max_external_file_meta_cache_num);
 // max_write_buffer_number for rocksdb
 DECLARE_Int32(rocksdb_max_write_buffer_number);
 
+// Allow invalid decimalv2 literal for compatible with old version. Recommend set it false strongly.
+DECLARE_mBool(allow_invalid_decimalv2_literal);
+
 #ifdef BE_TEST
 // test s3
 DECLARE_String(test_s3_resource);

--- a/be/src/runtime/decimalv2_value.cpp
+++ b/be/src/runtime/decimalv2_value.cpp
@@ -358,7 +358,9 @@ int DecimalV2Value::parse_from_str(const char* decimal_str, int32_t length) {
 
     _value = StringParser::string_to_decimal<__int128>(decimal_str, length, PRECISION, SCALE,
                                                        &result);
-    if (result != StringParser::PARSE_SUCCESS) {
+    if (!config::allow_invalid_decimalv2_literal && result != StringParser::PARSE_SUCCESS) {
+        error = E_DEC_BAD_NUM;
+    } else if (config::allow_invalid_decimalv2_literal && result == StringParser::PARSE_FAILURE) {
         error = E_DEC_BAD_NUM;
     }
     return error;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

