### PR TITLE
[Fix](multi-catalog) Fallback to refresh catalog when hms events are missing

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
@@ -30,9 +30,9 @@ import org.apache.doris.datasource.hive.event.MetastoreNotificationFetchExceptio
 import org.apache.doris.datasource.property.PropertyConverter;
 import org.apache.doris.datasource.property.constants.HMSProperties;
 
-import org.apache.commons.lang3.StringUtils;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
@@ -208,7 +208,7 @@ public class HMSExternalCatalog extends ExternalCatalog {
         if (lastSyncedEventId < 0) {
             refreshCatalog(hmsExternalCatalog);
             // invoke getCurrentEventId() and save the event id before refresh catalog to avoid missing events
-            // but set currentEventId to lastSyncedEventId only if there is not any problems when refreshing catalog
+            // but set lastSyncedEventId to currentEventId only if there is not any problems when refreshing catalog
             lastSyncedEventId = currentEventId;
             LOG.info(
                     "First pulling events on catalog [{}],refreshCatalog and init lastSyncedEventId,"
@@ -231,7 +231,7 @@ public class HMSExternalCatalog extends ExternalCatalog {
             if (StringUtils.isNotEmpty(e.getMessage())
                         && e.getMessage().contains(HiveMetaStoreClient.REPL_EVENTS_MISSING_IN_METASTORE)) {
                 refreshCatalog(hmsExternalCatalog);
-                // set currentEventId to lastSyncedEventId after refresh catalog succesfully
+                // set lastSyncedEventId to currentEventId after refresh catalog successfully
                 lastSyncedEventId = currentEventId;
                 LOG.warn("Notification events are missing, maybe an event can not be handled "
                         + "or processing rate is too low, fallback to refresh the catalog");


### PR DESCRIPTION
Fix #20227, the implementation has some problems and can not catch event-missing-exception.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

