### PR TITLE
[fix](tvf) To fix the bug that requires adding backticks on "frontends()" in order to query the frontends TVF.

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -7581,6 +7581,8 @@ keyword ::=
     {: RESULT = id; :}
     | KW_FEATURE:id
     {: RESULT = id; :}
+    | KW_FRONTENDS:id
+    {: RESULT = id; :}
     | KW_MAP:id
     {: RESULT = id; :}
     | KW_VARCHAR:id

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/FrontendsTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/FrontendsTableValuedFunction.java
@@ -32,14 +32,14 @@ import java.util.Map;
 
 /**
  * The Implement of table valued function
- * backends().
+ * frontends().
  */
 public class FrontendsTableValuedFunction extends MetadataTableValuedFunction {
     public static final String NAME = "frontends";
 
     private static final ImmutableList<Column> SCHEMA = ImmutableList.of(
             new Column("Name", ScalarType.createStringType()),
-            new Column("HOST", ScalarType.createStringType()),
+            new Column("Host", ScalarType.createStringType()),
             new Column("EditLogPort", ScalarType.createStringType()),
             new Column("HttpPort", ScalarType.createStringType()),
             new Column("QueryPort", ScalarType.createStringType()),

--- a/regression-test/suites/correctness_p0/table_valued_function/test_frontends_tvf.groovy
+++ b/regression-test/suites/correctness_p0/table_valued_function/test_frontends_tvf.groovy
@@ -25,4 +25,26 @@ suite("test_frontends_tvf") {
     table = sql """ select Name from `frontends`();"""
     assertTrue(table.size() > 0)
     assertTrue(table[0].size == 1)
+
+    // case insensitive
+    table = sql """ select name, host, editlogport, httpport, alive from frontends();"""
+    assertTrue(table.size() > 0)
+    assertTrue(table[0].size == 5)
+    assertEquals("true", table[0][4])
+
+    // test aliase columns
+    table = sql """ select name as n, host as h, alive as a, editlogport as e from frontends(); """
+    assertTrue(table.size() > 0)
+    assertTrue(table[0].size == 4)
+    assertEquals("true", table[0][2])
+
+    // test changing position of columns
+    def res = sql """ select count(*) from frontends() where alive = 'true'; """
+    assertTrue(res[0][0] > 0)
+
+    sql """ select Name, Host, EditLogPort
+            HttpPort, QueryPort, RpcPort, `Role`, IsMaster, ClusterId
+            `Join`, Alive, ReplayedJournalId, LastHeartbeat
+            IsHelper, ErrMsg, Version, CurrentConnected from frontends();
+    """
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

1. Backquotes must be used before, like
```sql
select * from `frontends()`;
```
But if you remove the back quote, there will be a problem, like
![image](https://github.com/apache/doris/assets/25766626/0d70981f-79e7-4842-a79d-be86ba74122d)

2. Added test cases


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

