### PR TITLE
[fix](dbt) dbt getconfig array or string

### DIFF
--- a/extension/dbt-doris/dbt/include/doris/macros/adapters/relation.sql
+++ b/extension/dbt-doris/dbt/include/doris/macros/adapters/relation.sql
@@ -22,9 +22,12 @@
 {%- endmacro %}
 
 {% macro doris__partition_by() -%}
-  {% set cols = config.get('partition_by') %}
+  {% set cols = config.get('partition_by', validator=validation.any[list, basestring]) %}
   {% set partition_type = config.get('partition_type', 'RANGE') %}
   {% if cols is not none %}
+      {%- if cols is string -%}
+        {%- set cols = [cols] -%}
+      {%- endif -%}
     PARTITION BY {{ partition_type }} (
       {% for col in cols %}
         {{ col }}{% if not loop.last %},{% endif %}
@@ -41,8 +44,11 @@
 {%- endmacro %}
 
 {% macro doris__duplicate_key() -%}
-  {% set cols = config.get('duplicate_key', validator=validation.any[list]) %}
+  {% set cols = config.get('duplicate_key', validator=validation.any[list, basestring]) %}
   {% if cols is not none %}
+      {%- if cols is string -%}
+        {%- set cols = [cols] -%}
+      {%- endif -%}
     DUPLICATE KEY (
       {% for item in cols %}
         {{ item }}
@@ -53,8 +59,13 @@
 {%- endmacro %}
 
 {% macro doris__unique_key() -%}
-  {% set cols = config.get('unique_key', validator=validation.any[list]) %}
+  {% set cols = config.get('unique_key', validator=validation.any[list, basestring]) %}
+
   {% if cols is not none %}
+    {%- if cols is string -%}
+      {%- set cols = [cols] -%}
+    {%- endif -%}
+
     UNIQUE KEY (
       {% for item in cols %}
         {{ item }}
@@ -67,11 +78,14 @@
 {% macro doris__distributed_by(column_names) -%}
   {% set label = 'DISTRIBUTED BY HASH' %}
   {% set engine = config.get('engine', validator=validation.any[basestring]) %}
-  {% set cols = config.get('distributed_by', validator=validation.any[list]) %}
+  {% set cols = config.get('distributed_by', validator=validation.any[list, basestring]) %}
   {% if cols is none and engine in [none,'OLAP'] %}
     {% set cols = column_names %}
   {% endif %}
-  {% if cols  %}
+  {% if cols is not none %}
+      {%- if cols is string -%}
+        {%- set cols = [cols] -%}
+      {%- endif -%}
     {{ label }} (
       {% for item in cols %}
         {{ item }}{% if not loop.last %},{% endif %}


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

{{ config(unique_key='id') }}
{{ config(unique_key=['id','name']) }}
Follow the dbt habit, use string for a single column name, and use array for multiple columns

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

