### PR TITLE
[Fix](s3FileWriter) fix bytes_appended bug for s3_file_writer

### DIFF
--- a/be/src/io/fs/s3_file_writer.h
+++ b/be/src/io/fs/s3_file_writer.h
@@ -113,7 +113,6 @@ private:
 
     std::shared_ptr<Aws::S3::S3Client> _client;
     std::string _upload_id;
-    size_t _bytes_appended {0};
 
     // Current Part Num for CompletedPart
     int _cur_part_num = 1;

--- a/be/src/io/fs/s3_file_writer.h
+++ b/be/src/io/fs/s3_file_writer.h
@@ -57,8 +57,6 @@ public:
         return Status::NotSupported("not support");
     }
 
-    size_t bytes_appended() const { return _bytes_appended; }
-
     int64_t upload_cost_ms() const { return *_upload_cost_ms; }
 
 private:


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

S3FileWriter inherits from FileWriter, but bytes_appended is not made virtual. 
So delete the function and member.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

