### PR TITLE
[branch-1.2](revert) revert 21282

### DIFF
--- a/be/src/http/action/metrics_action.cpp
+++ b/be/src/http/action/metrics_action.cpp
@@ -29,7 +29,6 @@
 #include "http/http_request.h"
 #include "http/http_response.h"
 #include "runtime/exec_env.h"
-#include "util/mem_info.h"
 #include "util/metrics.h"
 
 namespace doris {
@@ -38,9 +37,7 @@ void MetricsAction::handle(HttpRequest* req) {
     const std::string& type = req->param("type");
     const std::string& with_tablet = req->param("with_tablet");
     std::string str;
-    if (MemInfo::is_exceed_soft_mem_limit(GB_EXCHANGE_BYTE)) {
-        str = "";
-    } else if (type == "core") {
+    if (type == "core") {
         str = _metric_registry->to_core_string();
     } else if (type == "json") {
         str = _metric_registry->to_json(with_tablet == "true");


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Should find out why metrics to promethues use more memory, not prohibit

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

