### PR TITLE
[fix](config) disable cold data compaction by config temporarily on branch-2.0

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -881,7 +881,7 @@ DEFINE_mInt64(generate_cooldown_task_interval_sec, "20");
 DEFINE_mInt32(remove_unused_remote_files_interval_sec, "21600"); // 6h
 DEFINE_mInt32(confirm_unused_remote_files_interval_sec, "60");
 DEFINE_Int32(cold_data_compaction_thread_num, "2");
-DEFINE_mInt32(cold_data_compaction_interval_sec, "1800");
+DEFINE_mInt32(cold_data_compaction_interval_sec, "200000000");
 DEFINE_mInt64(generate_cache_cleaner_task_interval_sec, "43200"); // 12 h
 DEFINE_Int32(concurrency_per_dir, "2");
 DEFINE_mInt64(cooldown_lag_time_sec, "10800");       // 3h


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

change cold_data_compaction_interval_sec to 2314 days to disable cold data compaction.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

