### PR TITLE
[bugfix](build script) fix noavx2 package name branch condition

### DIFF
--- a/build-for-release.sh
+++ b/build-for-release.sh
@@ -128,7 +128,7 @@ BE="be"
 EXT="extensions"
 PACKAGE="apache-doris-${VERSION}-bin-${ARCH}"
 
-if [[ "${_USE_AVX2}" == "0" && "${ARCH}" == "x86_64" ]]; then
+if [[ "${_USE_AVX2}" == "0" ]]; then
     PACKAGE="${PACKAGE}-noavx2"
 fi
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

ARCH changed from x86_64 to x64, but the check condition for noavx2 remains x86_64. Just remove check for ARCH.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

