### PR TITLE
[fix](nereids) fix rf info missing for set op

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -147,6 +147,7 @@ import org.apache.doris.planner.PlanFragment;
 import org.apache.doris.planner.PlanNode;
 import org.apache.doris.planner.RepeatNode;
 import org.apache.doris.planner.ResultSink;
+import org.apache.doris.planner.RuntimeFilterId;
 import org.apache.doris.planner.ScanNode;
 import org.apache.doris.planner.SchemaScanNode;
 import org.apache.doris.planner.SelectNode;
@@ -1556,6 +1557,17 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         } else {
             int childrenSize = childrenFragments.size();
             setOperationFragment = childrenFragments.get(childrenSize - 1);
+            for (PlanFragment fragment : childrenFragments) {
+                // merge rf infos from children
+                Set<RuntimeFilterId> builderRF = fragment.getBuilderRuntimeFilterIds();
+                Set<RuntimeFilterId> targetRF = fragment.getTargetRuntimeFilterIds();
+                for (RuntimeFilterId id : builderRF) {
+                    setOperationFragment.setBuilderRuntimeFilterIds(id);
+                }
+                for (RuntimeFilterId id : targetRF) {
+                    setOperationFragment.setTargetRuntimeFilterIds(id);
+                }
+            }
             for (int i = childrenSize - 2; i >= 0; i--) {
                 context.removePlanFragment(childrenFragments.get(i));
                 for (PlanFragment child : childrenFragments.get(i).getChildren()) {


### PR DESCRIPTION
## Proposed changes

During physical set operation translation, we forget to inherit rf related info from set op children, which will lead the merge filter error and get a long waittime.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

