### PR TITLE
[refactor](load) split flush_segment_writer into two parts

### DIFF
--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -120,8 +120,6 @@ public:
 
     int64_t tablet_id() { return _tablet->tablet_id(); }
 
-    int32_t schema_hash() { return _tablet->schema_hash(); }
-
     void finish_slave_tablet_pull_rowset(int64_t node_id, bool is_succeed);
 
     int64_t total_received_rows() const { return _total_received_rows; }

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -54,13 +54,11 @@ namespace vectorized {
 class Block;
 } // namespace vectorized
 
-enum WriteType { LOAD = 1, LOAD_DELETE = 2, DELETE = 3 };
 enum MemType { WRITE = 1, FLUSH = 2, ALL = 3 };
 
 struct WriteRequest {
     int64_t tablet_id;
     int32_t schema_hash;
-    WriteType write_type;
     int64_t txn_id;
     int64_t partition_id;
     PUniqueId load_id;

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -752,7 +752,6 @@ Status BetaRowsetWriter::create_file_writer(uint32_t segment_id, io::FileWriterP
 Status BetaRowsetWriter::_create_file_writer(uint32_t begin, uint32_t end,
                                              io::FileWriterPtr* file_writer) {
     std::string path;
-    DCHECK(begin >= 0 && end >= 0);
     path = BetaRowset::local_segment_path_segcompacted(_context.rowset_dir, _context.rowset_id,
                                                        begin, end);
     return _create_file_writer(path, file_writer);

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -756,7 +756,7 @@ Status BetaRowsetWriter::_create_file_writer(uint32_t begin, uint32_t end,
     path = BetaRowset::local_segment_path_segcompacted(_context.rowset_dir, _context.rowset_id,
                                                        begin, end);
     return _create_file_writer(path, file_writer);
- }
+}
 
 Status BetaRowsetWriter::_do_create_segment_writer(
         std::unique_ptr<segment_v2::SegmentWriter>* writer, bool is_segcompaction, int64_t begin,

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -749,7 +749,8 @@ Status BetaRowsetWriter::create_file_writer(uint32_t segment_id, io::FileWriterP
     return _create_file_writer(path, file_writer);
 }
 
-Status BetaRowsetWriter::_create_file_writer(uint32_t begin, uint32_t end, io::FileWriterPtr* file_writer) {
+Status BetaRowsetWriter::_create_file_writer(uint32_t begin, uint32_t end,
+                                             io::FileWriterPtr* file_writer) {
     std::string path;
     DCHECK(begin >= 0 && end >= 0);
     path = BetaRowset::local_segment_path_segcompacted(_context.rowset_dir, _context.rowset_id,

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -859,8 +859,9 @@ void BetaRowsetWriter::add_segment(uint32_t segid, SegmentStatistics& segstat) {
         _segment_num_rows.resize(_next_segment_id);
         _segment_num_rows[segid_offset] = segstat.row_num;
     }
-    VLOG_DEBUG << "_segid_statistics_map add new record. segid:" << segid << " row_num:" << segstat.row_num
-               << " data_size:" << segstat.data_size << " index_size:" << segstat.index_size;
+    VLOG_DEBUG << "_segid_statistics_map add new record. segid:" << segid
+               << " row_num:" << segstat.row_num << " data_size:" << segstat.data_size
+               << " index_size:" << segstat.index_size;
 
     {
         std::lock_guard<std::mutex> lock(_segment_set_mutex);

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -84,6 +84,8 @@ public:
 
     Status add_rowset_for_linked_schema_change(RowsetSharedPtr rowset) override;
 
+    Status create_file_writer(uint32_t segment_id, io::FileWriterPtr* writer);
+
     void add_segment(uint32_t segid, SegmentStatistics& segstat);
 
     Status flush() override;
@@ -140,6 +142,8 @@ private:
                       std::unique_ptr<segment_v2::SegmentWriter>* writer,
                       const FlushContext* flush_ctx = nullptr);
 
+    Status _create_file_writer(std::string path, io::FileWriterPtr* file_writer);
+    Status _create_file_writer(uint32_t begin, uint32_t end, io::FileWriterPtr* writer);
     Status _do_create_segment_writer(std::unique_ptr<segment_v2::SegmentWriter>* writer,
                                      bool is_segcompaction, int64_t begin, int64_t end,
                                      const FlushContext* ctx = nullptr);

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -60,6 +60,13 @@ namespace vectorized::schema_util {
 class LocalSchemaChangeRecorder;
 }
 
+struct SegmentStatistics {
+    int64_t row_num;
+    int64_t data_size;
+    int64_t index_size;
+    KeyBoundsPB key_bounds;
+};
+
 class BetaRowsetWriter : public RowsetWriter {
     friend class SegcompactionWorker;
 
@@ -76,6 +83,8 @@ public:
     Status add_rowset(RowsetSharedPtr rowset) override;
 
     Status add_rowset_for_linked_schema_change(RowsetSharedPtr rowset) override;
+
+    void add_segment(uint32_t segid, SegmentStatistics& segstat);
 
     Status flush() override;
 
@@ -197,13 +206,7 @@ protected:
     // written rows by add_block/add_row (not effected by segcompaction)
     std::atomic<int64_t> _raw_num_rows_written;
 
-    struct Statistics {
-        int64_t row_num;
-        int64_t data_size;
-        int64_t index_size;
-        KeyBoundsPB key_bounds;
-    };
-    std::map<uint32_t, Statistics> _segid_statistics_map;
+    std::map<uint32_t, SegmentStatistics> _segid_statistics_map;
     std::mutex _segid_statistics_map_mutex;
 
     bool _is_pending = false;

--- a/be/src/olap/rowset/segcompaction.cpp
+++ b/be/src/olap/rowset/segcompaction.cpp
@@ -102,7 +102,7 @@ Status SegcompactionWorker::_get_segcompaction_reader(
 }
 
 std::unique_ptr<segment_v2::SegmentWriter> SegcompactionWorker::_create_segcompaction_writer(
-        uint64_t begin, uint64_t end) {
+        uint32_t begin, uint32_t end) {
     Status status;
     std::unique_ptr<segment_v2::SegmentWriter> writer = nullptr;
     status = _create_segment_writer_for_segcompaction(&writer, begin, end);
@@ -196,8 +196,8 @@ Status SegcompactionWorker::_do_compact_segments(SegCompactionCandidatesSharedPt
         return Status::Error<FETCH_MEMORY_EXCEEDED>();
     }
 
-    uint64_t begin = (*(segments->begin()))->id();
-    uint64_t end = (*(segments->end() - 1))->id();
+    uint32_t begin = (*(segments->begin()))->id();
+    uint32_t end = (*(segments->end() - 1))->id();
     uint64_t begin_time = GetCurrentTimeMicros();
     uint64_t index_size = 0;
     uint64_t total_index_size = 0;

--- a/be/src/olap/rowset/segcompaction.h
+++ b/be/src/olap/rowset/segcompaction.h
@@ -63,8 +63,8 @@ private:
                                      vectorized::RowSourcesBuffer& row_sources_buf, bool is_key,
                                      std::vector<uint32_t>& return_columns,
                                      std::unique_ptr<vectorized::VerticalBlockReader>* reader);
-    std::unique_ptr<segment_v2::SegmentWriter> _create_segcompaction_writer(uint64_t begin,
-                                                                            uint64_t end);
+    std::unique_ptr<segment_v2::SegmentWriter> _create_segcompaction_writer(uint32_t begin,
+                                                                            uint32_t end);
     Status _delete_original_segments(uint32_t begin, uint32_t end);
     Status _check_correctness(OlapReaderStatistics& reader_stat, Merger::Statistics& merger_stat,
                               uint64_t begin, uint64_t end);

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -239,7 +239,8 @@ void TabletsChannel::_close_wait(DeltaWriter* writer,
     if (st.ok()) {
         PTabletInfo* tablet_info = tablet_vec->Add();
         tablet_info->set_tablet_id(writer->tablet_id());
-        tablet_info->set_schema_hash(writer->schema_hash());
+        // unused required field.
+        tablet_info->set_schema_hash(0);
         tablet_info->set_received_rows(writer->total_received_rows());
     } else {
         PTabletError* tablet_error = tablet_errors->Add();

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -318,7 +318,6 @@ Status TabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& request
         wrequest.index_id = request.index_id();
         wrequest.tablet_id = tablet.tablet_id();
         wrequest.schema_hash = schema_hash;
-        wrequest.write_type = WriteType::LOAD;
         wrequest.txn_id = _txn_id;
         wrequest.partition_id = tablet.partition_id();
         wrequest.load_id = request.id();
@@ -377,7 +376,6 @@ Status TabletsChannel::_open_all_writers_for_partition(const int64_t& tablet_id,
         wrequest.index_id = request.index_id();
         wrequest.tablet_id = tablet;
         wrequest.schema_hash = schema_hash;
-        wrequest.write_type = WriteType::LOAD;
         wrequest.txn_id = _txn_id;
         wrequest.partition_id = partition_id;
         wrequest.load_id = request.id();
@@ -427,7 +425,6 @@ Status TabletsChannel::open_all_writers_for_partition(const OpenPartitionRequest
         wrequest.index_id = request.index_id();
         wrequest.tablet_id = tablet.tablet_id();
         wrequest.schema_hash = schema_hash;
-        wrequest.write_type = WriteType::LOAD;
         wrequest.txn_id = _txn_id;
         wrequest.partition_id = tablet.partition_id();
         wrequest.load_id = request.id();

--- a/be/test/olap/delta_writer_test.cpp
+++ b/be/test/olap/delta_writer_test.cpp
@@ -464,7 +464,7 @@ TEST_F(TestDeltaWriter, open) {
     load_id.set_lo(0);
     WriteRequest write_req = {
             10003, 270068375, 20001, 30001, load_id, tuple_desc, &(tuple_desc->slots()),
-            true, &param};
+            true,  &param};
     DeltaWriter* delta_writer = nullptr;
 
     // test vec delta writer

--- a/be/test/olap/delta_writer_test.cpp
+++ b/be/test/olap/delta_writer_test.cpp
@@ -463,8 +463,8 @@ TEST_F(TestDeltaWriter, open) {
     load_id.set_hi(0);
     load_id.set_lo(0);
     WriteRequest write_req = {
-            10004, 270068376, 20002, 30002, load_id, tuple_desc, &(tuple_desc->slots()),
-            false, &param};
+            10003, 270068375, 20001, 30001, load_id, tuple_desc, &(tuple_desc->slots()),
+            true, &param};
     DeltaWriter* delta_writer = nullptr;
 
     // test vec delta writer

--- a/be/test/olap/delta_writer_test.cpp
+++ b/be/test/olap/delta_writer_test.cpp
@@ -462,8 +462,9 @@ TEST_F(TestDeltaWriter, open) {
     PUniqueId load_id;
     load_id.set_hi(0);
     load_id.set_lo(0);
-    WriteRequest write_req = {10003,   270068375, 20001, 30001, load_id, tuple_desc,
-                              &tuple_desc->slots(), true,  &param};
+    WriteRequest write_req = {
+            10004, 270068376, 20002, 30002, load_id, tuple_desc, &(tuple_desc->slots()),
+            false, &param};
     DeltaWriter* delta_writer = nullptr;
 
     // test vec delta writer
@@ -646,8 +647,9 @@ TEST_F(TestDeltaWriter, vec_sequence_col) {
     PUniqueId load_id;
     load_id.set_hi(0);
     load_id.set_lo(0);
-    WriteRequest write_req = {10005, 270068377, 20003, 30003, load_id, tuple_desc,
-                              &(tuple_desc->slots()), false, &param};
+    WriteRequest write_req = {
+            10005, 270068377, 20003, 30003, load_id, tuple_desc, &(tuple_desc->slots()),
+            false, &param};
     DeltaWriter* delta_writer = nullptr;
     std::unique_ptr<RuntimeProfile> profile;
     profile = std::make_unique<RuntimeProfile>("LoadChannels");

--- a/be/test/olap/delta_writer_test.cpp
+++ b/be/test/olap/delta_writer_test.cpp
@@ -499,8 +499,9 @@ TEST_F(TestDeltaWriter, vec_write) {
     PUniqueId load_id;
     load_id.set_hi(0);
     load_id.set_lo(0);
-    WriteRequest write_req = {10004, 270068376, 20002, 30002, load_id, tuple_desc,
-                              &(tuple_desc->slots()), false, &param};
+    WriteRequest write_req = {
+            10004, 270068376, 20002, 30002, load_id, tuple_desc, &(tuple_desc->slots()),
+            false, &param};
     DeltaWriter* delta_writer = nullptr;
     std::unique_ptr<RuntimeProfile> profile;
     profile = std::make_unique<RuntimeProfile>("LoadChannels");

--- a/be/test/olap/delta_writer_test.cpp
+++ b/be/test/olap/delta_writer_test.cpp
@@ -462,8 +462,8 @@ TEST_F(TestDeltaWriter, open) {
     PUniqueId load_id;
     load_id.set_hi(0);
     load_id.set_lo(0);
-    WriteRequest write_req = {10003,   270068375,  WriteType::LOAD,      20001, 30001,
-                              load_id, tuple_desc, &tuple_desc->slots(), true,  &param};
+    WriteRequest write_req = {10003,   270068375, 20001, 30001, load_id, tuple_desc,
+                              &tuple_desc->slots(), true,  &param};
     DeltaWriter* delta_writer = nullptr;
 
     // test vec delta writer
@@ -498,8 +498,8 @@ TEST_F(TestDeltaWriter, vec_write) {
     PUniqueId load_id;
     load_id.set_hi(0);
     load_id.set_lo(0);
-    WriteRequest write_req = {10004,   270068376,  WriteType::LOAD,        20002, 30002,
-                              load_id, tuple_desc, &(tuple_desc->slots()), false, &param};
+    WriteRequest write_req = {10004, 270068376, 20002, 30002, load_id, tuple_desc,
+                              &(tuple_desc->slots()), false, &param};
     DeltaWriter* delta_writer = nullptr;
     std::unique_ptr<RuntimeProfile> profile;
     profile = std::make_unique<RuntimeProfile>("LoadChannels");
@@ -646,8 +646,8 @@ TEST_F(TestDeltaWriter, vec_sequence_col) {
     PUniqueId load_id;
     load_id.set_hi(0);
     load_id.set_lo(0);
-    WriteRequest write_req = {10005,   270068377,  WriteType::LOAD,        20003, 30003,
-                              load_id, tuple_desc, &(tuple_desc->slots()), false, &param};
+    WriteRequest write_req = {10005, 270068377, 20003, 30003, load_id, tuple_desc,
+                              &(tuple_desc->slots()), false, &param};
     DeltaWriter* delta_writer = nullptr;
     std::unique_ptr<RuntimeProfile> profile;
     profile = std::make_unique<RuntimeProfile>("LoadChannels");

--- a/be/test/olap/engine_storage_migration_task_test.cpp
+++ b/be/test/olap/engine_storage_migration_task_test.cpp
@@ -182,7 +182,7 @@ TEST_F(TestEngineStorageMigrationTask, write_and_migration) {
     PUniqueId load_id;
     load_id.set_hi(0);
     load_id.set_lo(0);
-    WriteRequest write_req = {10005,   270068377,  WriteType::LOAD,        20003, 30003,
+    WriteRequest write_req = {10005,   270068377, 20003, 30003,
                               load_id, tuple_desc, &(tuple_desc->slots()), false, &param};
     DeltaWriter* delta_writer = nullptr;
 

--- a/be/test/olap/engine_storage_migration_task_test.cpp
+++ b/be/test/olap/engine_storage_migration_task_test.cpp
@@ -182,8 +182,9 @@ TEST_F(TestEngineStorageMigrationTask, write_and_migration) {
     PUniqueId load_id;
     load_id.set_hi(0);
     load_id.set_lo(0);
-    WriteRequest write_req = {10005,   270068377, 20003, 30003,
-                              load_id, tuple_desc, &(tuple_desc->slots()), false, &param};
+    WriteRequest write_req = {
+            10005, 270068377, 20003, 30003, load_id, tuple_desc, &(tuple_desc->slots()),
+            false, &param};
     DeltaWriter* delta_writer = nullptr;
 
     std::unique_ptr<RuntimeProfile> profile;

--- a/be/test/olap/remote_rowset_gc_test.cpp
+++ b/be/test/olap/remote_rowset_gc_test.cpp
@@ -188,7 +188,7 @@ TEST_F(RemoteRowsetGcTest, normal) {
     PUniqueId load_id;
     load_id.set_hi(0);
     load_id.set_lo(0);
-    WriteRequest write_req = {10005,   270068377,  WriteType::LOAD,        20003, 30003,
+    WriteRequest write_req = {10005, 270068377, 20003, 30003,
                               load_id, tuple_desc, &(tuple_desc->slots()), false, &param};
     std::unique_ptr<RuntimeProfile> profile;
     profile = std::make_unique<RuntimeProfile>("LoadChannels");

--- a/be/test/olap/remote_rowset_gc_test.cpp
+++ b/be/test/olap/remote_rowset_gc_test.cpp
@@ -188,8 +188,9 @@ TEST_F(RemoteRowsetGcTest, normal) {
     PUniqueId load_id;
     load_id.set_hi(0);
     load_id.set_lo(0);
-    WriteRequest write_req = {10005, 270068377, 20003, 30003,
-                              load_id, tuple_desc, &(tuple_desc->slots()), false, &param};
+    WriteRequest write_req = {
+            10005, 270068377, 20003, 30003, load_id, tuple_desc, &(tuple_desc->slots()),
+            false, &param};
     std::unique_ptr<RuntimeProfile> profile;
     profile = std::make_unique<RuntimeProfile>("LoadChannels");
     DeltaWriter* delta_writer = nullptr;

--- a/be/test/olap/tablet_cooldown_test.cpp
+++ b/be/test/olap/tablet_cooldown_test.cpp
@@ -354,8 +354,16 @@ void createTablet(StorageEngine* engine, TabletSharedPtr* tablet, int64_t replic
     load_id.set_hi(0);
     load_id.set_lo(0);
 
-    WriteRequest write_req = {tablet_id, schema_hash, txn_id, partition_id,
-                              load_id,   tuple_desc,  &(tuple_desc->slots()), false,  &param};
+    WriteRequest write_req = {tablet_id,
+                              schema_hash,
+                              txn_id,
+                              partition_id,
+                              load_id,
+                              tuple_desc,
+                              &(tuple_desc->slots()),
+                              false,
+                              &param};
+
     DeltaWriter* delta_writer = nullptr;
     std::unique_ptr<RuntimeProfile> profile;
     profile = std::make_unique<RuntimeProfile>("LoadChannels");

--- a/be/test/olap/tablet_cooldown_test.cpp
+++ b/be/test/olap/tablet_cooldown_test.cpp
@@ -354,7 +354,7 @@ void createTablet(StorageEngine* engine, TabletSharedPtr* tablet, int64_t replic
     load_id.set_hi(0);
     load_id.set_lo(0);
 
-    WriteRequest write_req = {tablet_id, schema_hash, WriteType::LOAD,        txn_id, partition_id,
+    WriteRequest write_req = {tablet_id, schema_hash, txn_id, partition_id,
                               load_id,   tuple_desc,  &(tuple_desc->slots()), false,  &param};
     DeltaWriter* delta_writer = nullptr;
     std::unique_ptr<RuntimeProfile> profile;


### PR DESCRIPTION
1. split flush_segment_writer into two parts. One for flushing segment while one for adding segment.
2. remove useless WriteType.
3. export a create_file_writer for a segment.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

