### PR TITLE
[improvement](nererids) Don't break stats cache load loop when meeting unknown stats 

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/cascades/DeriveStatsJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/cascades/DeriveStatsJobTest.java
@@ -17,11 +17,14 @@
 
 package org.apache.doris.nereids.jobs.cascades;
 
+import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.jobs.JobContext;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Alias;
+import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateFunction;
@@ -74,7 +77,8 @@ public class DeriveStatsJobTest {
         long tableId1 = 0;
 
         List<String> qualifier = ImmutableList.of("test", "t");
-        slot1 = new SlotReference("c1", IntegerType.INSTANCE, true, qualifier);
+        slot1 = new SlotReference(ExprId.createGenerator().getNextId(), "c1",
+                IntegerType.INSTANCE, true, qualifier, new Column("c1", PrimitiveType.INT));
         new Expectations() {{
                 ConnectContext.get();
                 result = context;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/StatsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/StatsCalculatorTest.java
@@ -17,12 +17,15 @@
 
 package org.apache.doris.nereids.stats;
 
+import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.nereids.memo.Group;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.And;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
+import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Or;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
@@ -249,7 +252,8 @@ public class StatsCalculatorTest {
     public void testOlapScan(@Mocked ConnectContext context) {
         long tableId1 = 0;
         List<String> qualifier = ImmutableList.of("test", "t");
-        SlotReference slot1 = new SlotReference("c1", IntegerType.INSTANCE, true, qualifier);
+        SlotReference slot1 = new SlotReference(ExprId.createGenerator().getNextId(), "c1",
+                IntegerType.INSTANCE, true, qualifier, new Column("c1", PrimitiveType.INT));
 
         OlapTable table1 = PlanConstructor.newOlapTable(tableId1, "t1", 0);
         LogicalOlapScan logicalOlapScan1 = (LogicalOlapScan) new LogicalOlapScan(RelationUtil.newRelationId(), table1,


### PR DESCRIPTION
## Proposed changes

 Analyze may got executed on master, and query may got submitted to follower, throw exception directly would break the loading for other columns.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

