### PR TITLE
[fix](truncate) it will directly return and avoid throwing IllegalStateException caused by bufferSize equals zero when table has no partition

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -1871,7 +1871,7 @@ public class InternalCatalog implements CatalogIf<Database> {
         // create columns
         List<Column> baseSchema = stmt.getColumns();
         validateColumns(baseSchema, isKeysRequired);
-        checkAutoIncColummns(baseSchema, keysType);
+        checkAutoIncColumns(baseSchema, keysType);
 
         // analyze replica allocation
         ReplicaAllocation replicaAlloc = PropertyAnalyzer.analyzeReplicaAllocation(stmt.getProperties(), "");
@@ -2643,7 +2643,7 @@ public class InternalCatalog implements CatalogIf<Database> {
     /*
      * check column's auto increment property
      */
-    private void checkAutoIncColummns(List<Column> columns, KeysType type) throws DdlException {
+    private void checkAutoIncColumns(List<Column> columns, KeysType type) throws DdlException {
         boolean encounterAutoIncColumn = false;
         for (Column column : columns) {
             if (column.isAutoInc()) {
@@ -2709,6 +2709,11 @@ public class InternalCatalog implements CatalogIf<Database> {
                     origPartitions.put(partition.getName(), partition.getId());
                     partitionsDistributionInfo.put(partition.getId(), partition.getDistributionInfo());
                 }
+            }
+            // if table currently has no partitions, this sql like empty command and do nothing, should return directly
+            // at the same time, it will avoid throwing IllegalStateException when `bufferSize` equals zero
+            if (origPartitions.isEmpty()) {
+                return;
             }
             copiedTbl = olapTable.selectiveCopy(origPartitions.keySet(), IndexExtState.VISIBLE, false);
         } finally {

--- a/regression-test/suites/ddl_p0/test_truncate_table1.groovy
+++ b/regression-test/suites/ddl_p0/test_truncate_table1.groovy
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+suite("test_truncate_table1") {
+    // test truncate partition table which has no partition
+    def testTable = "test_truncate_no_partition_table"
+    sql "DROP TABLE IF EXISTS ${testTable}"
+    sql """
+        CREATE TABLE ${testTable}
+		(
+			k1 DATE,
+			k2 DECIMAL(10, 2) DEFAULT "10.5",
+			k3 CHAR(10) COMMENT "string column",
+			k4 INT NOT NULL DEFAULT "1" COMMENT "int column"
+		)
+		PARTITION BY RANGE(k1)
+		()
+		DISTRIBUTED BY HASH(k2) BUCKETS 1
+		PROPERTIES (
+			"replication_num" = "1"
+		);
+		"""
+    List<List<Object>> result = sql "show partitions from ${testTable}"
+    logger.info("${result}")
+    assertEquals(result.size(), 0)
+
+    sql """truncate table ${testTable};"""
+    result = sql "show partitions from ${testTable}"
+    logger.info("${result}")
+    assertEquals(result.size(), 0)
+	
+    sql "DROP TABLE IF EXISTS ${testTable}"
+
+
+
+    // test truncate non partition table
+    def testNonPartitionTable = "test_truncate_non_partition_table"
+    sql "DROP TABLE IF EXISTS ${testNonPartitionTable}"
+    sql """
+        CREATE TABLE ${testNonPartitionTable}
+		(
+			k1 DATE,
+			k2 DECIMAL(10, 2) DEFAULT "10.5",
+			k3 CHAR(10) COMMENT "string column",
+			k4 INT NOT NULL DEFAULT "1" COMMENT "int column"
+		)
+		DISTRIBUTED BY HASH(k2) BUCKETS 1
+		PROPERTIES (
+			"replication_num" = "1"
+		);
+		"""
+    List<List<Object>> result1 = sql "show partitions from ${testNonPartitionTable}"
+    logger.info("${result1}")
+    assertEquals(result1.size(), 1)
+
+    sql """truncate table ${testNonPartitionTable};"""
+    result1 = sql "show partitions from ${testNonPartitionTable}"
+    logger.info("${result1}")
+    assertEquals(result1.size(), 1)
+	
+    sql "DROP TABLE IF EXISTS ${testNonPartitionTable}"
+}
+


### PR DESCRIPTION
## Proposed changes

if table currently has no partition, the truncate SQL will be a empty command, it should directly return and avoid throwing IllegalStateException caused by `bufferSize` equals zero

Issue Number: close https://github.com/apache/doris/issues/21316
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

