### PR TITLE
[Enhancement](inverted index) make InvertedIndexReader shared_from_this

### DIFF
--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -505,16 +505,16 @@ Status ColumnReader::_load_inverted_index_index(const TabletIndex* index_meta) {
 
     if (is_string_type(type)) {
         if (parser_type != InvertedIndexParserType::PARSER_NONE) {
-            _inverted_index.reset(new FullTextIndexReader(
-                    _file_reader->fs(), _file_reader->path().native(), index_meta));
+            _inverted_index = FullTextIndexReader::create_unique(
+                    _file_reader->fs(), _file_reader->path().native(), index_meta);
             return Status::OK();
         } else {
-            _inverted_index.reset(new StringTypeInvertedIndexReader(
-                    _file_reader->fs(), _file_reader->path().native(), index_meta));
+            _inverted_index = StringTypeInvertedIndexReader::create_unique(
+                    _file_reader->fs(), _file_reader->path().native(), index_meta);
         }
     } else if (is_numeric_type(type)) {
-        _inverted_index.reset(
-                new BkdIndexReader(_file_reader->fs(), _file_reader->path().native(), index_meta));
+        _inverted_index = BkdIndexReader::create_unique(
+                _file_reader->fs(), _file_reader->path().native(), index_meta);
     } else {
         _inverted_index.reset();
     }

--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -233,7 +233,7 @@ Status ColumnReader::new_bitmap_index_iterator(BitmapIndexIterator** iterator) {
 
 Status ColumnReader::new_inverted_index_iterator(const TabletIndex* index_meta,
                                                  OlapReaderStatistics* stats,
-                                                 InvertedIndexIterator** iterator) {
+                                                 std::unique_ptr<InvertedIndexIterator>* iterator) {
     RETURN_IF_ERROR(_ensure_inverted_index_loaded(index_meta));
     if (_inverted_index) {
         RETURN_IF_ERROR(_inverted_index->new_iterator(stats, iterator));

--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -513,8 +513,8 @@ Status ColumnReader::_load_inverted_index_index(const TabletIndex* index_meta) {
                     _file_reader->fs(), _file_reader->path().native(), index_meta);
         }
     } else if (is_numeric_type(type)) {
-        _inverted_index = BkdIndexReader::create_shared(
-                _file_reader->fs(), _file_reader->path().native(), index_meta);
+        _inverted_index = BkdIndexReader::create_shared(_file_reader->fs(),
+                                                        _file_reader->path().native(), index_meta);
     } else {
         _inverted_index.reset();
     }

--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -505,15 +505,15 @@ Status ColumnReader::_load_inverted_index_index(const TabletIndex* index_meta) {
 
     if (is_string_type(type)) {
         if (parser_type != InvertedIndexParserType::PARSER_NONE) {
-            _inverted_index = FullTextIndexReader::create_unique(
+            _inverted_index = FullTextIndexReader::create_shared(
                     _file_reader->fs(), _file_reader->path().native(), index_meta);
             return Status::OK();
         } else {
-            _inverted_index = StringTypeInvertedIndexReader::create_unique(
+            _inverted_index = StringTypeInvertedIndexReader::create_shared(
                     _file_reader->fs(), _file_reader->path().native(), index_meta);
         }
     } else if (is_numeric_type(type)) {
-        _inverted_index = BkdIndexReader::create_unique(
+        _inverted_index = BkdIndexReader::create_shared(
                 _file_reader->fs(), _file_reader->path().native(), index_meta);
     } else {
         _inverted_index.reset();

--- a/be/src/olap/rowset/segment_v2/column_reader.h
+++ b/be/src/olap/rowset/segment_v2/column_reader.h
@@ -120,7 +120,7 @@ public:
     Status new_bitmap_index_iterator(BitmapIndexIterator** iterator);
 
     Status new_inverted_index_iterator(const TabletIndex* index_meta, OlapReaderStatistics* stats,
-                                       InvertedIndexIterator** iterator);
+                                       std::unique_ptr<InvertedIndexIterator>* iterator);
 
     // Seek to the first entry in the column.
     Status seek_to_first(OrdinalPageIndexIterator* iter);

--- a/be/src/olap/rowset/segment_v2/column_reader.h
+++ b/be/src/olap/rowset/segment_v2/column_reader.h
@@ -237,7 +237,7 @@ private:
     std::unique_ptr<ZoneMapIndexReader> _zone_map_index;
     std::unique_ptr<OrdinalIndexReader> _ordinal_index;
     std::unique_ptr<BitmapIndexReader> _bitmap_index;
-    std::unique_ptr<InvertedIndexReader> _inverted_index;
+    std::shared_ptr<InvertedIndexReader> _inverted_index;
     std::unique_ptr<BloomFilterIndexReader> _bloom_filter_index;
     DorisCallOnce<Status> _load_zone_map_index_once;
     DorisCallOnce<Status> _load_ordinal_index_once;

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
@@ -213,8 +213,8 @@ Status InvertedIndexReader::read_null_bitmap(InvertedIndexQueryCacheHandle* cach
 }
 
 Status FullTextIndexReader::new_iterator(OlapReaderStatistics* stats,
-                                         InvertedIndexIterator** iterator) {
-    *iterator = new InvertedIndexIterator(stats, shared_from_this());
+                                         std::unique_ptr<InvertedIndexIterator>* iterator) {
+    *iterator = InvertedIndexIterator::create_unique(stats, shared_from_this());
     return Status::OK();
 }
 
@@ -405,8 +405,8 @@ InvertedIndexReaderType FullTextIndexReader::type() {
 }
 
 Status StringTypeInvertedIndexReader::new_iterator(OlapReaderStatistics* stats,
-                                                   InvertedIndexIterator** iterator) {
-    *iterator = new InvertedIndexIterator(stats, shared_from_this());
+                                                   std::unique_ptr<InvertedIndexIterator>* iterator) {
+    *iterator = InvertedIndexIterator::create_unique(stats, shared_from_this());
     return Status::OK();
 }
 
@@ -548,8 +548,8 @@ BkdIndexReader::BkdIndexReader(io::FileSystemSPtr fs, const std::string& path,
             config::inverted_index_read_buffer_size);
 }
 
-Status BkdIndexReader::new_iterator(OlapReaderStatistics* stats, InvertedIndexIterator** iterator) {
-    *iterator = new InvertedIndexIterator(stats, shared_from_this());
+Status BkdIndexReader::new_iterator(OlapReaderStatistics* stats, std::unique_ptr<InvertedIndexIterator>* iterator) {
+    *iterator = InvertedIndexIterator::create_unique(stats, shared_from_this());
     return Status::OK();
 }
 

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
@@ -543,7 +543,7 @@ BkdIndexReader::BkdIndexReader(io::FileSystemSPtr fs, const std::string& path,
         LOG(WARNING) << "bkd index: " << index_file.string() << " not exist.";
         return;
     }
-    _compoundReader = new DorisCompoundReader(
+    _compoundReader = std::make_unique<DorisCompoundReader>(
             DorisCompoundDirectory::getDirectory(fs, index_dir.c_str()), index_file_name.c_str(),
             config::inverted_index_read_buffer_size);
 }

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
@@ -214,7 +214,7 @@ Status InvertedIndexReader::read_null_bitmap(InvertedIndexQueryCacheHandle* cach
 
 Status FullTextIndexReader::new_iterator(OlapReaderStatistics* stats,
                                          InvertedIndexIterator** iterator) {
-    *iterator = new InvertedIndexIterator(stats, this);
+    *iterator = new InvertedIndexIterator(stats, shared_from_this());
     return Status::OK();
 }
 
@@ -406,7 +406,7 @@ InvertedIndexReaderType FullTextIndexReader::type() {
 
 Status StringTypeInvertedIndexReader::new_iterator(OlapReaderStatistics* stats,
                                                    InvertedIndexIterator** iterator) {
-    *iterator = new InvertedIndexIterator(stats, this);
+    *iterator = new InvertedIndexIterator(stats, shared_from_this());
     return Status::OK();
 }
 
@@ -549,7 +549,7 @@ BkdIndexReader::BkdIndexReader(io::FileSystemSPtr fs, const std::string& path,
 }
 
 Status BkdIndexReader::new_iterator(OlapReaderStatistics* stats, InvertedIndexIterator** iterator) {
-    *iterator = new InvertedIndexIterator(stats, this);
+    *iterator = new InvertedIndexIterator(stats, shared_from_this());
     return Status::OK();
 }
 

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
@@ -404,8 +404,8 @@ InvertedIndexReaderType FullTextIndexReader::type() {
     return InvertedIndexReaderType::FULLTEXT;
 }
 
-Status StringTypeInvertedIndexReader::new_iterator(OlapReaderStatistics* stats,
-                                                   std::unique_ptr<InvertedIndexIterator>* iterator) {
+Status StringTypeInvertedIndexReader::new_iterator(
+        OlapReaderStatistics* stats, std::unique_ptr<InvertedIndexIterator>* iterator) {
     *iterator = InvertedIndexIterator::create_unique(stats, shared_from_this());
     return Status::OK();
 }
@@ -548,7 +548,8 @@ BkdIndexReader::BkdIndexReader(io::FileSystemSPtr fs, const std::string& path,
             config::inverted_index_read_buffer_size);
 }
 
-Status BkdIndexReader::new_iterator(OlapReaderStatistics* stats, std::unique_ptr<InvertedIndexIterator>* iterator) {
+Status BkdIndexReader::new_iterator(OlapReaderStatistics* stats,
+                                    std::unique_ptr<InvertedIndexIterator>* iterator) {
     *iterator = InvertedIndexIterator::create_unique(stats, shared_from_this());
     return Status::OK();
 }

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.h
@@ -109,6 +109,7 @@ protected:
 
 class FullTextIndexReader : public InvertedIndexReader {
     ENABLE_FACTORY_CREATOR(FullTextIndexReader);
+
 public:
     explicit FullTextIndexReader(io::FileSystemSPtr fs, const std::string& path,
                                  const TabletIndex* index_meta)
@@ -130,6 +131,7 @@ public:
 
 class StringTypeInvertedIndexReader : public InvertedIndexReader {
     ENABLE_FACTORY_CREATOR(StringTypeInvertedIndexReader);
+
 public:
     explicit StringTypeInvertedIndexReader(io::FileSystemSPtr fs, const std::string& path,
                                            const TabletIndex* index_meta)
@@ -184,6 +186,7 @@ public:
 
 class BkdIndexReader : public InvertedIndexReader {
     ENABLE_FACTORY_CREATOR(BkdIndexReader);
+
 public:
     explicit BkdIndexReader(io::FileSystemSPtr fs, const std::string& path,
                             const TabletIndex* index_meta);
@@ -193,7 +196,8 @@ public:
                 _compoundReader->close();
             } catch (const CLuceneError& e) {
                 // Handle exception, e.g., log it, but don't rethrow.
-                LOG(ERROR) << "Exception caught in BkdIndexReader destructor: " << e.what() << std::endl;
+                LOG(ERROR) << "Exception caught in BkdIndexReader destructor: " << e.what()
+                           << std::endl;
             } catch (...) {
                 // Handle all other exceptions, but don't rethrow.
                 LOG(ERROR) << "Unknown exception caught in BkdIndexReader destructor." << std::endl;

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.h
@@ -108,6 +108,7 @@ protected:
 };
 
 class FullTextIndexReader : public InvertedIndexReader {
+    ENABLE_FACTORY_CREATOR(FullTextIndexReader);
 public:
     explicit FullTextIndexReader(io::FileSystemSPtr fs, const std::string& path,
                                  const TabletIndex* index_meta)
@@ -128,6 +129,7 @@ public:
 };
 
 class StringTypeInvertedIndexReader : public InvertedIndexReader {
+    ENABLE_FACTORY_CREATOR(StringTypeInvertedIndexReader);
 public:
     explicit StringTypeInvertedIndexReader(io::FileSystemSPtr fs, const std::string& path,
                                            const TabletIndex* index_meta)
@@ -181,6 +183,7 @@ public:
 };
 
 class BkdIndexReader : public InvertedIndexReader {
+    ENABLE_FACTORY_CREATOR(BkdIndexReader);
 public:
     explicit BkdIndexReader(io::FileSystemSPtr fs, const std::string& path,
                             const TabletIndex* index_meta);

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.h
@@ -64,7 +64,7 @@ enum class InvertedIndexReaderType {
     BKD = 2,
 };
 
-class InvertedIndexReader {
+class InvertedIndexReader : public std::enable_shared_from_this<InvertedIndexReader> {
 public:
     explicit InvertedIndexReader(io::FileSystemSPtr fs, const std::string& path,
                                  const TabletIndex* index_meta)
@@ -216,7 +216,7 @@ private:
 
 class InvertedIndexIterator {
 public:
-    InvertedIndexIterator(OlapReaderStatistics* stats, InvertedIndexReader* reader)
+    InvertedIndexIterator(OlapReaderStatistics* stats, std::shared_ptr<InvertedIndexReader> reader)
             : _stats(stats), _reader(reader) {}
 
     Status read_from_inverted_index(const std::string& column_name, const void* query_value,
@@ -235,7 +235,7 @@ public:
 
 private:
     OlapReaderStatistics* _stats;
-    InvertedIndexReader* _reader;
+    std::shared_ptr<InvertedIndexReader> _reader;
 };
 
 } // namespace segment_v2

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.h
@@ -72,7 +72,8 @@ public:
     virtual ~InvertedIndexReader() = default;
 
     // create a new column iterator. Client should delete returned iterator
-    virtual Status new_iterator(OlapReaderStatistics* stats, std::unique_ptr<InvertedIndexIterator>* iterator) = 0;
+    virtual Status new_iterator(OlapReaderStatistics* stats,
+                                std::unique_ptr<InvertedIndexIterator>* iterator) = 0;
     virtual Status query(OlapReaderStatistics* stats, const std::string& column_name,
                          const void* query_value, InvertedIndexQueryType query_type,
                          roaring::Roaring* bit_map) = 0;
@@ -116,7 +117,8 @@ public:
             : InvertedIndexReader(fs, path, index_meta) {}
     ~FullTextIndexReader() override = default;
 
-    Status new_iterator(OlapReaderStatistics* stats, std::unique_ptr<InvertedIndexIterator>* iterator) override;
+    Status new_iterator(OlapReaderStatistics* stats,
+                        std::unique_ptr<InvertedIndexIterator>* iterator) override;
     Status query(OlapReaderStatistics* stats, const std::string& column_name,
                  const void* query_value, InvertedIndexQueryType query_type,
                  roaring::Roaring* bit_map) override;
@@ -138,7 +140,8 @@ public:
             : InvertedIndexReader(fs, path, index_meta) {}
     ~StringTypeInvertedIndexReader() override = default;
 
-    Status new_iterator(OlapReaderStatistics* stats, std::unique_ptr<InvertedIndexIterator>* iterator) override;
+    Status new_iterator(OlapReaderStatistics* stats,
+                        std::unique_ptr<InvertedIndexIterator>* iterator) override;
     Status query(OlapReaderStatistics* stats, const std::string& column_name,
                  const void* query_value, InvertedIndexQueryType query_type,
                  roaring::Roaring* bit_map) override;
@@ -205,7 +208,8 @@ public:
         }
     }
 
-    Status new_iterator(OlapReaderStatistics* stats, std::unique_ptr<InvertedIndexIterator>* iterator) override;
+    Status new_iterator(OlapReaderStatistics* stats,
+                        std::unique_ptr<InvertedIndexIterator>* iterator) override;
 
     Status query(OlapReaderStatistics* stats, const std::string& column_name,
                  const void* query_value, InvertedIndexQueryType query_type,

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.h
@@ -72,7 +72,7 @@ public:
     virtual ~InvertedIndexReader() = default;
 
     // create a new column iterator. Client should delete returned iterator
-    virtual Status new_iterator(OlapReaderStatistics* stats, InvertedIndexIterator** iterator) = 0;
+    virtual Status new_iterator(OlapReaderStatistics* stats, std::unique_ptr<InvertedIndexIterator>* iterator) = 0;
     virtual Status query(OlapReaderStatistics* stats, const std::string& column_name,
                          const void* query_value, InvertedIndexQueryType query_type,
                          roaring::Roaring* bit_map) = 0;
@@ -116,7 +116,7 @@ public:
             : InvertedIndexReader(fs, path, index_meta) {}
     ~FullTextIndexReader() override = default;
 
-    Status new_iterator(OlapReaderStatistics* stats, InvertedIndexIterator** iterator) override;
+    Status new_iterator(OlapReaderStatistics* stats, std::unique_ptr<InvertedIndexIterator>* iterator) override;
     Status query(OlapReaderStatistics* stats, const std::string& column_name,
                  const void* query_value, InvertedIndexQueryType query_type,
                  roaring::Roaring* bit_map) override;
@@ -138,7 +138,7 @@ public:
             : InvertedIndexReader(fs, path, index_meta) {}
     ~StringTypeInvertedIndexReader() override = default;
 
-    Status new_iterator(OlapReaderStatistics* stats, InvertedIndexIterator** iterator) override;
+    Status new_iterator(OlapReaderStatistics* stats, std::unique_ptr<InvertedIndexIterator>* iterator) override;
     Status query(OlapReaderStatistics* stats, const std::string& column_name,
                  const void* query_value, InvertedIndexQueryType query_type,
                  roaring::Roaring* bit_map) override;
@@ -205,7 +205,7 @@ public:
         }
     }
 
-    Status new_iterator(OlapReaderStatistics* stats, InvertedIndexIterator** iterator) override;
+    Status new_iterator(OlapReaderStatistics* stats, std::unique_ptr<InvertedIndexIterator>* iterator) override;
 
     Status query(OlapReaderStatistics* stats, const std::string& column_name,
                  const void* query_value, InvertedIndexQueryType query_type,
@@ -228,6 +228,8 @@ private:
 };
 
 class InvertedIndexIterator {
+    ENABLE_FACTORY_CREATOR(InvertedIndexIterator);
+
 public:
     InvertedIndexIterator(OlapReaderStatistics* stats, std::shared_ptr<InvertedIndexReader> reader)
             : _stats(stats), _reader(reader) {}

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -346,10 +346,8 @@ Status Segment::new_inverted_index_iterator(const TabletColumn& tablet_column,
                                             std::unique_ptr<InvertedIndexIterator>* iter) {
     auto col_unique_id = tablet_column.unique_id();
     if (_column_readers.count(col_unique_id) > 0 && index_meta) {
-        InvertedIndexIterator* it;
         RETURN_IF_ERROR(_column_readers.at(col_unique_id)
-                                ->new_inverted_index_iterator(index_meta, stats, &it));
-        iter->reset(it);
+                                ->new_inverted_index_iterator(index_meta, stats, iter));
         return Status::OK();
     }
     return Status::OK();

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -820,7 +820,7 @@ std::string SegmentIterator::_gen_predicate_result_sign(ColumnPredicateInfo* pre
 
 bool SegmentIterator::_column_has_fulltext_index(int32_t unique_id) {
     bool has_fulltext_index =
-            _inverted_index_iterators[unique_id] != nullptr &&
+            _inverted_index_iterators.count(unique_id) > 0 &&
             _inverted_index_iterators[unique_id]->get_inverted_index_reader_type() ==
                     InvertedIndexReaderType::FULLTEXT;
 

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -821,6 +821,7 @@ std::string SegmentIterator::_gen_predicate_result_sign(ColumnPredicateInfo* pre
 bool SegmentIterator::_column_has_fulltext_index(int32_t unique_id) {
     bool has_fulltext_index =
             _inverted_index_iterators.count(unique_id) > 0 &&
+            _inverted_index_iterators[unique_id] != nullptr &&
             _inverted_index_iterators[unique_id]->get_inverted_index_reader_type() ==
                     InvertedIndexReaderType::FULLTEXT;
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

This PR proposes several changes to improve code safety and readability by replacing raw pointers with smart pointers in several places.
1. use enable_factory_creator in InvertedIndexIterator and InvertedIndexReader, remove explicit new constructor.
2. make InvertedIndexReader shared_from_this, it may desctruct when InvertedIndexIterator use it.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

