### PR TITLE
[fix](clone) fix cannot further repair clone replica which  miss version data

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
@@ -505,10 +505,14 @@ public class Tablet extends MetaObject implements Writable {
             }
             alive++;
 
+            // this replica is alive but version incomplete
             if (replica.getLastFailedVersion() > 0 || replica.getVersion() < visibleVersion) {
-                // this replica is alive but version incomplete
+                if (replica.needFurtherRepair() && backend.isScheduleAvailable()) {
+                    needFurtherRepairReplica = replica;
+                }
                 continue;
             }
+
             aliveAndVersionComplete++;
 
             if (!backend.isScheduleAvailable()) {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

The cloned replica may miss some version data if there are loading data task during the cloning process.

It will cuase this replica's last failed version > 0.

After  finish cloning,  the balance dest  replicas should be repaired even if  their last failed version > 0

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

