### PR TITLE
[fix](hudi) use hudi api to split the COW table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveScanNode.java
@@ -215,8 +215,9 @@ public class HiveScanNode extends FileQueryScanNode {
 
     @Override
     public List<String> getPathPartitionKeys() {
-        return hmsTable.getRemoteTable().getPartitionKeys()
-                .stream().map(FieldSchema::getName).map(String::toLowerCase).collect(Collectors.toList());
+        return hmsTable.getRemoteTable().getPartitionKeys().stream()
+                .map(FieldSchema::getName).filter(partitionKey -> !"".equals(partitionKey))
+                .map(String::toLowerCase).collect(Collectors.toList());
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes
Fix tow bugs:
1. COW & Read Optimized table will use hive splitter to split files, but it can't recognize some specific files.
```
ERROR 1105 (HY000): errCode = 2, detailMessage =
(172.21.0.101)[CORRUPTION]Invalid magic number in parquet file, bytes read: 3035, file size: 3035,
path: /usr/hive/warehouse/hudi.db/test/.hoodie/metadata/.hoodie/00000000000000.deltacommit.inflight, read magic:
```
2. The read optimized table created by spark will add empty partition even if the table has no partition, so we have to filter these empty partition keys in hive client.
```
| test_ro | CREATE TABLE `test_ro`(
  `_hoodie_commit_time` string COMMENT '',
  ...
  `ts` bigint COMMENT '')
PARTITIONED BY (
 `` string)
ROW FORMAT SERDE
```


