### PR TITLE
[fix](Nereids): reject infer distinct when children exist NLJ

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/InferSetOperatorDistinct.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/InferSetOperatorDistinct.java
@@ -22,6 +22,8 @@ import org.apache.doris.nereids.rules.RuleType;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.algebra.SetOperation.Qualifier;
 import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
+import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
+import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 
 import com.google.common.collect.ImmutableList;
 
@@ -41,7 +43,12 @@ public class InferSetOperatorDistinct extends OneRewriteRuleFactory {
     public Rule build() {
         return logicalSetOperation()
                 .when(operation -> operation.getQualifier() == Qualifier.DISTINCT)
+                .when(operation -> operation.children().stream().allMatch(this::rejectNLJ))
                 .then(setOperation -> {
+                    if (setOperation.children().stream().anyMatch(child -> child instanceof LogicalAggregate)) {
+                        return null;
+                    }
+
                     List<Plan> newChildren = setOperation.children().stream()
                             .map(child -> new LogicalAggregate<>(ImmutableList.copyOf(child.getOutput()), child))
                             .collect(ImmutableList.toImmutableList());
@@ -50,5 +57,17 @@ public class InferSetOperatorDistinct extends OneRewriteRuleFactory {
                     }
                     return setOperation.withChildren(newChildren);
                 }).toRule(RuleType.INFER_SET_OPERATOR_DISTINCT);
+    }
+
+    // if children exist NLJ, we can't infer distinct
+    private boolean rejectNLJ(Plan plan) {
+        if (plan instanceof LogicalProject) {
+            plan = plan.child(0);
+        }
+        if (plan instanceof LogicalJoin) {
+            LogicalJoin<?, ?> join = (LogicalJoin<?, ?>) plan;
+            return join.getOtherJoinConjuncts().isEmpty();
+        }
+        return true;
     }
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

distinct will influent NLJ runtime filter bitmap

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

