### PR TITLE
[bug](proc) fix NumberFormatException in show proc '/current_queries'

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/CurrentQueryStatementsProcNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/CurrentQueryStatementsProcNode.java
@@ -63,7 +63,7 @@ public class CurrentQueryStatementsProcNode implements ProcNodeInterface {
         sortedRowData.sort((l1, l2) -> {
             final long execTime1 = Long.parseLong(l1.get(EXEC_TIME_INDEX));
             final long execTime2 = Long.parseLong(l2.get(EXEC_TIME_INDEX));
-            return Long.compare(execTime1, execTime2);
+            return Long.compare(execTime2, execTime1);
         });
         result.setRows(sortedRowData);
         return result;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/CurrentQueryStatementsProcNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/CurrentQueryStatementsProcNode.java
@@ -61,9 +61,9 @@ public class CurrentQueryStatementsProcNode implements ProcNodeInterface {
 
         // sort according to ExecTime
         sortedRowData.sort((l1, l2) -> {
-            final int execTime1 = Integer.parseInt(l1.get(EXEC_TIME_INDEX));
-            final int execTime2 = Integer.parseInt(l2.get(EXEC_TIME_INDEX));
-            return execTime2 - execTime1;
+            final long execTime1 = Long.parseLong(l1.get(EXEC_TIME_INDEX));
+            final long execTime2 = Long.parseLong(l2.get(EXEC_TIME_INDEX));
+            return Long.compare(execTime1, execTime2);
         });
         result.setRows(sortedRowData);
         return result;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/CurrentQueryStatisticsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/CurrentQueryStatisticsProcDir.java
@@ -92,9 +92,9 @@ public class CurrentQueryStatisticsProcDir implements ProcDirInterface {
         }
         // sort according to ExecTime
         sortedRowData.sort((l1, l2) -> {
-            final int execTime1 = Integer.parseInt(l1.get(EXEC_TIME_INDEX));
-            final int execTime2 = Integer.parseInt(l2.get(EXEC_TIME_INDEX));
-            return execTime2 - execTime1;
+            final long execTime1 = Long.parseLong(l1.get(EXEC_TIME_INDEX));
+            final long execTime2 = Long.parseLong(l2.get(EXEC_TIME_INDEX));
+            return Long.compare(execTime1, execTime2);
         });
         result.setRows(sortedRowData);
         return result;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/CurrentQueryStatisticsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/CurrentQueryStatisticsProcDir.java
@@ -94,7 +94,7 @@ public class CurrentQueryStatisticsProcDir implements ProcDirInterface {
         sortedRowData.sort((l1, l2) -> {
             final long execTime1 = Long.parseLong(l1.get(EXEC_TIME_INDEX));
             final long execTime2 = Long.parseLong(l2.get(EXEC_TIME_INDEX));
-            return Long.compare(execTime1, execTime2);
+            return Long.compare(execTime2, execTime1);
         });
         result.setRows(sortedRowData);
         return result;


### PR DESCRIPTION
## Proposed changes

If the current query is running for a very long time, the ExecTime of this query may larger than the MAX_INT value, then a NumberFormatException will be thrown when execute "show proc '/current_queries'."
The query's ExecTime is long type, we should not use 'Integer.parseInt' to parse it.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

