### PR TITLE
[fix](s3) fix s3 fs benchmark tool

### DIFF
--- a/be/src/io/file_factory.cpp
+++ b/be/src/io/file_factory.cpp
@@ -108,8 +108,7 @@ Status FileFactory::create_file_writer(TFileType::type type, ExecEnv* env,
     return Status::OK();
 }
 
-Status FileFactory::create_file_reader(RuntimeProfile* profile,
-                                       const FileSystemProperties& system_properties,
+Status FileFactory::create_file_reader(const FileSystemProperties& system_properties,
                                        const FileDescription& file_description,
                                        std::shared_ptr<io::FileSystem>* file_system,
                                        io::FileReaderSPtr* file_reader,

--- a/be/src/io/file_factory.h
+++ b/be/src/io/file_factory.h
@@ -70,9 +70,8 @@ public:
 
     /// Create FileReader
     static Status create_file_reader(
-            RuntimeProfile* profile, const FileSystemProperties& system_properties,
-            const FileDescription& file_description, std::shared_ptr<io::FileSystem>* file_system,
-            io::FileReaderSPtr* file_reader,
+            const FileSystemProperties& system_properties, const FileDescription& file_description,
+            std::shared_ptr<io::FileSystem>* file_system, io::FileReaderSPtr* file_reader,
             io::FileReaderOptions reader_options = NO_CACHE_READER_OPTIONS);
 
     // Create FileReader for stream load pipe

--- a/be/src/io/fs/benchmark/base_benchmark.h
+++ b/be/src/io/fs/benchmark/base_benchmark.h
@@ -106,7 +106,7 @@ public:
     }
 
     Status read(benchmark::State& state, FileReaderSPtr reader) {
-        bm_log("begin to read {}", _name);
+        bm_log("begin to read {}, thread: {}", _name, state.thread_index());
         size_t buffer_size =
                 _conf_map.contains("buffer_size") ? std::stol(_conf_map["buffer_size"]) : 1000000L;
         std::vector<char> buffer;
@@ -150,13 +150,13 @@ public:
         if (status.ok() && reader != nullptr) {
             status = reader->close();
         }
-        bm_log("finish to read {}, size {}, seconds: {}, status: {}", _name, read_size,
-               elapsed_seconds.count(), status);
+        bm_log("finish to read {}, thread: {}, size {}, seconds: {}, status: {}", _name,
+               state.thread_index(), read_size, elapsed_seconds.count(), status);
         return status;
     }
 
     Status write(benchmark::State& state, FileWriter* writer) {
-        bm_log("begin to write {}, size: {}", _name, _file_size);
+        bm_log("begin to write {}, thread: {}, size: {}", _name, state.thread_index(), _file_size);
         size_t write_size = _file_size;
         size_t buffer_size =
                 _conf_map.contains("buffer_size") ? std::stol(_conf_map["buffer_size"]) : 1000000L;
@@ -190,8 +190,8 @@ public:
         state.counters["WriteTotal(B)"] = write_size;
         state.counters["WriteTime(S)"] = elapsed_seconds.count();
 
-        bm_log("finish to write {}, size: {}, seconds: {}, status: {}", _name, write_size,
-               elapsed_seconds.count(), status);
+        bm_log("finish to write {}, thread: {}, size: {}, seconds: {}, status: {}", _name,
+               state.thread_index(), write_size, elapsed_seconds.count(), status);
         return status;
     }
 

--- a/be/src/io/fs/benchmark/benchmark_factory.hpp
+++ b/be/src/io/fs/benchmark/benchmark_factory.hpp
@@ -44,6 +44,8 @@ Status BenchmarkFactory::getBm(const std::string fs_type, const std::string op_t
             *bm = new S3OpenReadBenchmark(threads, iterations, file_size, conf_map);
         } else if (op_type == "single_read") {
             *bm = new S3SingleReadBenchmark(threads, iterations, file_size, conf_map);
+        } else if (op_type == "prefetch_read") {
+            *bm = new S3PrefetchReadBenchmark(threads, iterations, file_size, conf_map);
         } else if (op_type == "rename") {
             *bm = new S3RenameBenchmark(threads, iterations, file_size, conf_map);
         } else if (op_type == "exists") {

--- a/be/src/io/fs/benchmark/fs_benchmark_tool.cpp
+++ b/be/src/io/fs/benchmark/fs_benchmark_tool.cpp
@@ -21,6 +21,7 @@
 
 #include "io/fs/benchmark/benchmark_factory.hpp"
 #include "io/fs/s3_file_write_bufferpool.h"
+#include "util/cpu_info.h"
 #include "util/threadpool.h"
 
 DEFINE_string(fs_type, "hdfs", "Supported File System: s3, hdfs");
@@ -109,11 +110,14 @@ int main(int argc, char** argv) {
         return 1;
     }
 
+    doris::CpuInfo::init();
+    int num_cores = doris::CpuInfo::num_cores();
+
     // init s3 write buffer pool
     std::unique_ptr<doris::ThreadPool> buffered_reader_prefetch_thread_pool;
     doris::ThreadPoolBuilder("BufferedReaderPrefetchThreadPool")
-            .set_min_threads(16)
-            .set_max_threads(64)
+            .set_min_threads(num_cores)
+            .set_max_threads(num_cores)
             .build(&buffered_reader_prefetch_thread_pool);
     doris::io::S3FileBufferPool* s3_buffer_pool = doris::io::S3FileBufferPool::GetInstance();
     s3_buffer_pool->init(524288000, 5242880, buffered_reader_prefetch_thread_pool.get());

--- a/be/src/io/fs/benchmark/s3_benchmark.hpp
+++ b/be/src/io/fs/benchmark/s3_benchmark.hpp
@@ -19,6 +19,7 @@
 
 #include "io/file_factory.h"
 #include "io/fs/benchmark/base_benchmark.h"
+#include "io/fs/buffered_reader.h"
 #include "io/fs/file_writer.h"
 #include "io/fs/s3_file_reader.h"
 #include "io/fs/s3_file_system.h"
@@ -35,17 +36,14 @@ public:
             : BaseBenchmark(name, threads, iterations, file_size, conf_map) {}
     virtual ~S3Benchmark() = default;
 
-    Status get_fs(const std::string& path) {
+    Status get_fs(const std::string& path, std::shared_ptr<io::S3FileSystem>* fs) {
         S3URI s3_uri(path);
         RETURN_IF_ERROR(s3_uri.parse());
+        S3Conf s3_conf;
         RETURN_IF_ERROR(
-                S3ClientFactory::convert_properties_to_s3_conf(_conf_map, s3_uri, &_s3_conf));
-        return io::S3FileSystem::create(std::move(_s3_conf), "", &_fs);
+                S3ClientFactory::convert_properties_to_s3_conf(_conf_map, s3_uri, &s3_conf));
+        return io::S3FileSystem::create(std::move(s3_conf), "", fs);
     }
-
-protected:
-    doris::S3Conf _s3_conf;
-    std::shared_ptr<io::S3FileSystem> _fs;
 };
 
 class S3OpenReadBenchmark : public S3Benchmark {
@@ -63,14 +61,14 @@ public:
 
     Status run(benchmark::State& state) override {
         auto file_path = get_file_path(state);
-        RETURN_IF_ERROR(get_fs(file_path));
+        std::shared_ptr<io::S3FileSystem> fs;
+        RETURN_IF_ERROR(get_fs(file_path, &fs));
 
         io::FileReaderSPtr reader;
         io::FileReaderOptions reader_opts = FileFactory::get_reader_options(nullptr);
         RETURN_IF_ERROR(FileFactory::create_s3_reader(
-                _conf_map, file_path, reinterpret_cast<std::shared_ptr<io::FileSystem>*>(&_fs),
+                _conf_map, file_path, reinterpret_cast<std::shared_ptr<io::FileSystem>*>(&fs),
                 &reader, reader_opts));
-
         return read(state, reader);
     }
 };
@@ -92,6 +90,40 @@ public:
     }
 };
 
+// Read a single specified file by prefetch reader
+class S3PrefetchReadBenchmark : public S3Benchmark {
+public:
+    S3PrefetchReadBenchmark(int threads, int iterations, size_t file_size,
+                            const std::map<std::string, std::string>& conf_map)
+            : S3Benchmark("S3PrefetchReadBenchmark", threads, iterations, file_size, conf_map) {}
+    virtual ~S3PrefetchReadBenchmark() = default;
+
+    virtual std::string get_file_path(benchmark::State& state) override {
+        std::string file_path = _conf_map["file_path"];
+        bm_log("file_path: {}", file_path);
+        return file_path;
+    }
+
+    Status run(benchmark::State& state) override {
+        FileSystemProperties fs_props;
+        fs_props.system_type = TFileType::FILE_S3;
+        fs_props.properties = _conf_map;
+
+        FileDescription fd;
+        fd.path = get_file_path(state);
+        fd.start_offset = 0;
+        fd.file_size = _file_size;
+        std::shared_ptr<io::FileSystem> fs;
+        io::FileReaderSPtr reader;
+        io::FileReaderOptions reader_options = FileFactory::get_reader_options(nullptr);
+        IOContext io_ctx;
+        RETURN_IF_ERROR(io::DelegateReader::create_file_reader(
+                nullptr, fs_props, fd, &fs, &reader, io::DelegateReader::AccessMode::SEQUENTIAL,
+                reader_options, &io_ctx));
+        return read(state, reader);
+    }
+};
+
 class S3CreateWriteBenchmark : public S3Benchmark {
 public:
     S3CreateWriteBenchmark(int threads, int iterations, size_t file_size,
@@ -104,10 +136,11 @@ public:
         if (_file_size <= 0) {
             _file_size = 10 * 1024 * 1024; // default 10MB
         }
-        RETURN_IF_ERROR(get_fs(file_path));
+        std::shared_ptr<io::S3FileSystem> fs;
+        RETURN_IF_ERROR(get_fs(file_path, &fs));
 
         io::FileWriterPtr writer;
-        RETURN_IF_ERROR(_fs->create_file(file_path, &writer));
+        RETURN_IF_ERROR(fs->create_file(file_path, &writer));
         return write(state, writer.get());
     }
 };
@@ -125,12 +158,13 @@ public:
 
     Status run(benchmark::State& state) override {
         auto file_path = get_file_path(state);
-        RETURN_IF_ERROR(get_fs(file_path));
+        std::shared_ptr<io::S3FileSystem> fs;
+        RETURN_IF_ERROR(get_fs(file_path, &fs));
 
         auto start = std::chrono::high_resolution_clock::now();
         std::vector<FileInfo> files;
         bool exists = true;
-        RETURN_IF_ERROR(_fs->list(file_path, true, &files, &exists));
+        RETURN_IF_ERROR(fs->list(file_path, true, &files, &exists));
         auto end = std::chrono::high_resolution_clock::now();
         auto elapsed_seconds =
                 std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
@@ -168,10 +202,11 @@ public:
     Status run(benchmark::State& state) override {
         auto file_path = get_file_path(state);
         auto new_file_path = file_path + "_new";
-        RETURN_IF_ERROR(get_fs(file_path));
+        std::shared_ptr<io::S3FileSystem> fs;
+        RETURN_IF_ERROR(get_fs(file_path, &fs));
 
         auto start = std::chrono::high_resolution_clock::now();
-        RETURN_IF_ERROR(_fs->rename(file_path, new_file_path));
+        RETURN_IF_ERROR(fs->rename(file_path, new_file_path));
         auto end = std::chrono::high_resolution_clock::now();
         auto elapsed_seconds =
                 std::chrono::duration_cast<std::chrono::duration<double>>(end - start);
@@ -192,11 +227,12 @@ public:
 
     Status run(benchmark::State& state) override {
         auto file_path = get_file_path(state);
-        RETURN_IF_ERROR(get_fs(file_path));
+        std::shared_ptr<io::S3FileSystem> fs;
+        RETURN_IF_ERROR(get_fs(file_path, &fs));
 
         auto start = std::chrono::high_resolution_clock::now();
         bool res = false;
-        RETURN_IF_ERROR(_fs->exists(file_path, &res));
+        RETURN_IF_ERROR(fs->exists(file_path, &res));
         auto end = std::chrono::high_resolution_clock::now();
         auto elapsed_seconds =
                 std::chrono::duration_cast<std::chrono::duration<double>>(end - start);

--- a/be/src/io/fs/buffered_reader.cpp
+++ b/be/src/io/fs/buffered_reader.cpp
@@ -780,7 +780,6 @@ Status DelegateReader::create_file_reader(RuntimeProfile* profile,
             }
         }
         if (is_thread_safe) {
-            LOG(INFO) << "xxxx PrefetchBufferedReader";
             // PrefetchBufferedReader needs thread-safe reader to prefetch data concurrently.
             *file_reader = std::make_shared<io::PrefetchBufferedReader>(profile, reader, file_range,
                                                                         io_ctx);

--- a/be/src/io/fs/buffered_reader.cpp
+++ b/be/src/io/fs/buffered_reader.cpp
@@ -765,7 +765,7 @@ Status DelegateReader::create_file_reader(RuntimeProfile* profile,
                                           io::FileReaderOptions reader_options,
                                           const IOContext* io_ctx, const PrefetchRange file_range) {
     io::FileReaderSPtr reader;
-    RETURN_IF_ERROR(FileFactory::create_file_reader(profile, system_properties, file_description,
+    RETURN_IF_ERROR(FileFactory::create_file_reader(system_properties, file_description,
                                                     file_system, &reader, reader_options));
     if (reader->size() < IN_MEMORY_FILE_SIZE) {
         *file_reader = std::make_shared<InMemoryFileReader>(reader);
@@ -780,6 +780,7 @@ Status DelegateReader::create_file_reader(RuntimeProfile* profile,
             }
         }
         if (is_thread_safe) {
+            LOG(INFO) << "xxxx PrefetchBufferedReader";
             // PrefetchBufferedReader needs thread-safe reader to prefetch data concurrently.
             *file_reader = std::make_shared<io::PrefetchBufferedReader>(profile, reader, file_range,
                                                                         io_ctx);

--- a/be/src/util/s3_util.cpp
+++ b/be/src/util/s3_util.cpp
@@ -19,7 +19,6 @@
 
 #include <aws/core/auth/AWSAuthSigner.h>
 #include <aws/core/auth/AWSCredentials.h>
-#include <aws/core/client/ClientConfiguration.h>
 #include <aws/core/utils/logging/LogLevel.h>
 #include <aws/core/utils/logging/LogSystemInterface.h>
 #include <aws/core/utils/memory/stl/AWSStringStream.h>

--- a/be/src/util/s3_util.cpp
+++ b/be/src/util/s3_util.cpp
@@ -141,7 +141,7 @@ std::shared_ptr<Aws::S3::S3Client> S3ClientFactory::create(const S3Conf& s3_conf
     Aws::Auth::AWSCredentials aws_cred(s3_conf.ak, s3_conf.sk);
     DCHECK(!aws_cred.IsExpiredOrEmpty());
 
-    Aws::Client::ClientConfiguration aws_config;
+    Aws::Client::ClientConfiguration aws_config = S3ClientFactory::getClientConfiguration();
     aws_config.endpointOverride = s3_conf.endpoint;
     aws_config.region = s3_conf.region;
     if (s3_conf.max_connections > 0) {

--- a/be/src/util/s3_util.h
+++ b/be/src/util/s3_util.h
@@ -100,6 +100,16 @@ public:
     static Status convert_properties_to_s3_conf(const std::map<std::string, std::string>& prop,
                                                 const S3URI& s3_uri, S3Conf* s3_conf);
 
+    static Aws::Client::ClientConfiguration& getClientConfiguration() {
+        // The default constructor of ClientConfiguration will do some http call
+        // such as Aws::Internal::GetEC2MetadataClient and other init operation,
+        // which is unnecessary.
+        // So here we use a static instance, and deep copy every time
+        // to avoid unnecessary operations.
+        static Aws::Client::ClientConfiguration instance;
+        return instance;
+    }
+
 private:
     S3ClientFactory();
 

--- a/be/src/util/s3_util.h
+++ b/be/src/util/s3_util.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <aws/core/Aws.h>
+#include <aws/core/client/ClientConfiguration.h>
 #include <fmt/format.h>
 #include <stdint.h>
 

--- a/be/src/vec/core/block_spill_reader.cpp
+++ b/be/src/vec/core/block_spill_reader.cpp
@@ -53,7 +53,7 @@ Status BlockSpillReader::open() {
     FileDescription file_description;
     file_description.path = file_path_;
 
-    RETURN_IF_ERROR(FileFactory::create_file_reader(nullptr, system_properties, file_description,
+    RETURN_IF_ERROR(FileFactory::create_file_reader(system_properties, file_description,
                                                     &file_system, &file_reader_));
 
     size_t file_size = file_reader_->size();

--- a/be/src/vec/exec/format/csv/csv_reader.cpp
+++ b/be/src/vec/exec/format/csv/csv_reader.cpp
@@ -661,7 +661,7 @@ Status CsvReader::_prepare_parse(size_t* read_line, bool* is_parse_name) {
     io::FileReaderOptions reader_options = FileFactory::get_reader_options(_state);
     reader_options.modification_time =
             _range.__isset.modification_time ? _range.modification_time : 0;
-    RETURN_IF_ERROR(FileFactory::create_file_reader(_profile, _system_properties, _file_description,
+    RETURN_IF_ERROR(FileFactory::create_file_reader(_system_properties, _file_description,
                                                     &_file_system, &_file_reader, reader_options));
     if (_file_reader->size() == 0 && _params.file_type != TFileType::FILE_STREAM &&
         _params.file_type != TFileType::FILE_BROKER) {

--- a/bin/run-fs-benchmark.sh
+++ b/bin/run-fs-benchmark.sh
@@ -263,6 +263,7 @@ export LIBHDFS_OPTS="${final_java_opt}"
 
 # see https://github.com/apache/doris/blob/master/docs/zh-CN/community/developer-guide/debug-tool.md#jemalloc-heap-profile
 export JEMALLOC_CONF="percpu_arena:percpu,background_thread:true,metadata_thp:auto,muzzy_decay_ms:30000,dirty_decay_ms:30000,oversize_threshold:0,lg_tcache_max:16,prof_prefix:jeprof.out"
+export AWS_EC2_METADATA_DISABLED=true
 
 echo "$@"
 ${LIMIT:+${LIMIT}} "${DORIS_HOME}/lib/fs_benchmark_tool" "$@" 2>&1 | tee "${LOG_DIR}/fs_benchmark_tool.log"

--- a/bin/run-fs-benchmark.sh
+++ b/bin/run-fs-benchmark.sh
@@ -264,6 +264,7 @@ export LIBHDFS_OPTS="${final_java_opt}"
 # see https://github.com/apache/doris/blob/master/docs/zh-CN/community/developer-guide/debug-tool.md#jemalloc-heap-profile
 export JEMALLOC_CONF="percpu_arena:percpu,background_thread:true,metadata_thp:auto,muzzy_decay_ms:30000,dirty_decay_ms:30000,oversize_threshold:0,lg_tcache_max:16,prof_prefix:jeprof.out"
 export AWS_EC2_METADATA_DISABLED=true
+export AWS_MAX_ATTEMPTS=2
 
 echo "$@"
 ${LIMIT:+${LIMIT}} "${DORIS_HOME}/lib/fs_benchmark_tool" "$@" 2>&1 | tee "${LOG_DIR}/fs_benchmark_tool.log"

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -302,6 +302,8 @@ export LIBHDFS_OPTS="${final_java_opt}"
 
 # see https://github.com/apache/doris/blob/master/docs/zh-CN/community/developer-guide/debug-tool.md#jemalloc-heap-profile
 export JEMALLOC_CONF="percpu_arena:percpu,background_thread:true,metadata_thp:auto,muzzy_decay_ms:30000,dirty_decay_ms:30000,oversize_threshold:0,lg_tcache_max:16,prof_prefix:jeprof.out"
+export AWS_EC2_METADATA_DISABLED=true
+export AWS_MAX_ATTEMPTS=2
 
 if [[ "${RUN_DAEMON}" -eq 1 ]]; then
     nohup ${LIMIT:+${LIMIT}} "${DORIS_HOME}/lib/doris_be" "$@" >>"${LOG_DIR}/be.out" 2>&1 </dev/null &

--- a/docs/en/docs/lakehouse/fs_benchmark_tool.md
+++ b/docs/en/docs/lakehouse/fs_benchmark_tool.md
@@ -84,27 +84,29 @@ The type of file system on which the operation is required. Currently supported 
 
 Specifies the type of operation
 
--  `create_write`: Each thread creates a file named `test_${current thread number}`  in the `base_dir(set in conf file)` directory and writes to the file with a write size `file_size` of.
+- `create_write`: Each thread creates a file named `test_${current thread number}`  in the `base_dir(set in conf file)` directory and writes to the file with a write size `file_size` of.
 
--  `open_read`: On `create_write` the basis of the created file, each thread reads the file with the name of `test_${current thread number}`  and the read size of `file_size`.
+- `open_read`: On `create_write` the basis of the created file, each thread reads the file with the name of `test_${current thread number}`  and the read size of `file_size`.
 
--  `exists`: Each thread queries whether a file with  `test_${current thread number}` filename exists.
+- `single_read`: Read `file_path(set in conf file)` file, read size is `file_size`.
 
--  `rename`: On `create_write` the basis of the created file, each thread changes the `test_${current thread number}` filename to `test_${current thread number}_new`.
+- `prefetch_read`：Use prefetch reader to read `file_path(set in conf file)` file, read size is `file_size`. Only for s3 file system.
 
--  `single_read`: Read `file_path(set in conf file)` file, read size is `file_size`.
+- `exists`: Each thread queries whether a file with  `test_${current thread number}` filename exists.
 
--  `list`: Get `base_dir(set in conf file)` the list of files in the directory.
+- `rename`: On `create_write` the basis of the created file, each thread changes the `test_${current thread number}` filename to `test_${current thread number}_new`.
+
+- `list`: Get `base_dir(set in conf file)` the list of files in the directory.
 
 `--file_size` 
 
 The file size of the operation, in bytes.
 
--  `create_write`: Default is 10 MB.
+- `create_write`: Default is 10 MB.
 
--  `open_read`: Default is 10 MB.
+- `open_read`: Default is 10 MB.
 
--  `single_read`: The default is 0, that is, the full file is read.
+- `single_read`: The default is 0, that is, the full file is read.
 
 `--threads`
 

--- a/docs/zh-CN/docs/lakehouse/fs_benchmark_tool.md
+++ b/docs/zh-CN/docs/lakehouse/fs_benchmark_tool.md
@@ -85,11 +85,13 @@ sh run-fs-benchmark.sh \
 
 - `open_read`：在`create_write`创建好文件的基础下，每个线程读取文件名为`test_当前的线程号`的文件，读取大小为`file_size`。
 
+- `single_read`：读取`file_path(conf文件中设置)`文件，读取大小为`file_size`。
+
+- `prefetch_read`：使用 prefetch reader 读取`file_path(conf文件中设置)`文件，读取大小为`file_size`。仅适用于 s3。
+
 - `exists` ：每个线程查询文件名为`test_当前的线程号`的文件是否存在。
 
 - `rename` ：在`create_write`创建好文件的基础下，每个线程将文件名为为`test_当前的线程号`的文件更改为为`test_当前的线程号_new`。
-
-- `single_read`：读取`file_path(conf文件中设置)`文件，读取大小为`file_size`。
 
 - `list`：获取 `base_dir(conf文件中设置)` 目录下的文件列表。
 


### PR DESCRIPTION
## Proposed changes

1. fix concurrency bug of s3 fs benchmark tool, to avoid crash on multi thread.
2. Add `prefetch_read` operation to test prefetch reader.
3. add `AWS_EC2_METADATA_DISABLED` env in `start_be.sh` to avoid call ec2 metadata when creating s3 client.
4. add `AWS_MAX_ATTEMPTS` env in `start_be.sh` to avoid warning log of s3 sdk.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

