### PR TITLE
[fix](nereids)miss group id in explain plan

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupId.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupId.java
@@ -44,6 +44,6 @@ public class GroupId extends Id<GroupId> {
 
     @Override
     public String toString() {
-        return "GroupId#" + id;
+        return "@" + id;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -751,7 +751,7 @@ public class Memo {
                         if (costAndGroupExpression.isPresent()) {
                             Cost cost = costAndGroupExpression.get().first;
                             GroupExpression child = costAndGroupExpression.get().second;
-                            builder.append("\n    " + cost.getValue() + " " + prop)
+                            builder.append("\n\n    " + cost.getValue() + " " + prop)
                                     .append("\n     ").append(child)
                                     .append("\n     " + child.getInputPropertiesListOrEmpty(prop));
                         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/AbstractPlan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/AbstractPlan.java
@@ -203,9 +203,14 @@ public abstract class AbstractPlan extends AbstractTreeNode<Plan> implements Pla
      * @return "" if groupExpression is empty, o.w. string format of group id
      */
     public String getGroupIdAsString() {
-        String groupId = getGroupExpression().isPresent()
-                ? "#" + getGroupExpression().get().getOwnerGroup().getGroupId().asInt()
-                : "";
+        String groupId;
+        if (getGroupExpression().isPresent()) {
+            groupId = "@" + groupExpression.get().getOwnerGroup().getGroupId().asInt();
+        } else if (getMutableState("group").isPresent()) {
+            groupId = "@" + getMutableState("group").get();
+        } else {
+            groupId = "";
+        }
         return groupId;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
@@ -158,9 +158,14 @@ public class PhysicalHashJoin<
     @Override
     public PhysicalHashJoin<Plan, Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 2);
-        return new PhysicalHashJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, hint, markJoinSlotReference,
+        PhysicalHashJoin newJoin = new PhysicalHashJoin<>(joinType, hashJoinConjuncts,
+                otherJoinConjuncts, hint, markJoinSlotReference,
                 Optional.empty(), getLogicalProperties(), physicalProperties, statistics,
                 children.get(0), children.get(1));
+        if (groupExpression.isPresent()) {
+            newJoin.setMutableState("group", groupExpression.get().getOwnerGroup().getGroupId().asInt());
+        }
+        return newJoin;
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes
after we introduce "PushdownFilterThroughProject" post processor, some plan node missed their groupExpression (withChildren function will remove groupExpression). 
this is not good for debug, since it takes more time to find the owner group of a plan node
This pr record the missing owner group id in plan node mutableState.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

