### PR TITLE
[fix](cup) add keywords KW_PERCENT

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -7658,6 +7658,8 @@ keyword ::=
     {: RESULT = id; :}
     | KW_PERIOD:id
     {: RESULT = id; :}
+    | KW_PERCENT:id
+    {: RESULT = id; :}
     ;
 
 // Identifier that contain keyword


### PR DESCRIPTION
## Proposed changes

Or it may cause some edit log replay error, like parsing `create routine load` stmt, which contains this keyword as
a column name

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

