### PR TITLE
[improvement](memory) improve inserting sparse rows into string column

### DIFF
--- a/be/src/vec/columns/column_decimal.h
+++ b/be/src/vec/columns/column_decimal.h
@@ -129,9 +129,6 @@ public:
         const T* src_data = reinterpret_cast<const T*>(src.get_raw_data().data);
 
         for (int i = 0; i < new_size; ++i) {
-            if (i + IColumn::PREFETCH_STEP < new_size) {
-                __builtin_prefetch(&src_data[indices_begin[i + IColumn::PREFETCH_STEP]], 0, 1);
-            }
             data[origin_size + i] = src_data[indices_begin[i]];
         }
     }

--- a/be/src/vec/columns/column_string.cpp
+++ b/be/src/vec/columns/column_string.cpp
@@ -110,42 +110,36 @@ void ColumnString::insert_range_from(const IColumn& src, size_t start, size_t le
 void ColumnString::insert_indices_from(const IColumn& src, const int* indices_begin,
                                        const int* indices_end) {
     const ColumnString& src_str = assert_cast<const ColumnString&>(src);
-    size_t total_delta_chars_size = 0;
     auto src_offset_data = src_str.offsets.data();
-    for (auto x = indices_begin; x != indices_end; ++x) {
-        if (*x != -1) {
-            total_delta_chars_size += src_offset_data[*x] - src_offset_data[*x - 1];
-        }
-    }
+
     auto old_char_size = chars.size();
-    check_chars_length(old_char_size + total_delta_chars_size, offsets.size());
+    size_t total_chars_size = old_char_size;
 
     auto dst_offsets_pos = offsets.size();
-    chars.resize(old_char_size + total_delta_chars_size);
     offsets.resize(offsets.size() + indices_end - indices_begin);
+    auto* dst_offsets_data = offsets.data();
+
+    for (auto x = indices_begin; x != indices_end; ++x) {
+        if (*x != -1) {
+            total_chars_size += src_offset_data[*x] - src_offset_data[*x - 1];
+        }
+        dst_offsets_data[dst_offsets_pos++] = total_chars_size;
+    }
+    check_chars_length(total_chars_size, offsets.size());
+
+    chars.resize(total_chars_size);
 
     auto* src_data_ptr = src_str.chars.data();
     auto* dst_data_ptr = chars.data();
-    auto* dst_offsets_data = offsets.data();
 
     size_t dst_chars_pos = old_char_size;
     for (auto x = indices_begin; x != indices_end; ++x) {
-        if (*x == -1) {
-            dst_offsets_data[dst_offsets_pos++] = dst_chars_pos;
-        } else {
+        if (*x != -1) {
             const size_t size_to_append = src_offset_data[*x] - src_offset_data[*x - 1];
-
-            if (!size_to_append) {
-                /// shortcut for empty string
-                dst_offsets_data[dst_offsets_pos++] = dst_chars_pos;
-            } else {
-                const size_t offset = src_offset_data[*x - 1];
-
-                memcpy_small_allow_read_write_overflow15(dst_data_ptr + dst_chars_pos,
-                                                         src_data_ptr + offset, size_to_append);
-                dst_chars_pos += size_to_append;
-                dst_offsets_data[dst_offsets_pos++] = dst_chars_pos;
-            }
+            const size_t offset = src_offset_data[*x - 1];
+            memcpy_small_allow_read_write_overflow15(dst_data_ptr + dst_chars_pos,
+                                                     src_data_ptr + offset, size_to_append);
+            dst_chars_pos += size_to_append;
         }
     }
 }

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -150,11 +150,6 @@ public:
         offsets.push_back(new_size);
     }
 
-    void prefetch(const IColumn& src_, size_t n) {
-        const ColumnString& src = assert_cast<const ColumnString&>(src_);
-        __builtin_prefetch(&src.chars[src.offsets[n - 1]], 0, 1);
-    }
-
     void insert_from(const IColumn& src_, size_t n) override {
         const ColumnString& src = assert_cast<const ColumnString&>(src_);
         const size_t size_to_append =

--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -376,18 +376,12 @@ void ColumnVector<T>::insert_indices_from(const IColumn& src, const int* indices
     if constexpr (std::is_same_v<T, UInt8>) {
         // nullmap : indices_begin[i] == -1 means is null at the here, set true here
         for (int i = 0; i < new_size; ++i) {
-            if (i + IColumn::PREFETCH_STEP < new_size) {
-                __builtin_prefetch(&src_data[indices_begin[i + IColumn::PREFETCH_STEP]], 0, 1);
-            }
             data[origin_size + i] = (indices_begin[i] == -1) +
                                     (indices_begin[i] != -1) * src_data[indices_begin[i]];
         }
     } else {
         // real data : indices_begin[i] == -1 what at is meaningless
         for (int i = 0; i < new_size; ++i) {
-            if (i + IColumn::PREFETCH_STEP < new_size) {
-                __builtin_prefetch(&src_data[indices_begin[i + IColumn::PREFETCH_STEP]], 0, 1);
-            }
             data[origin_size + i] = src_data[indices_begin[i]];
         }
     }


### PR DESCRIPTION
and remove prefetch when insert data into columns, because it's effect is not stable in production env.

## Proposed changes

Issue Number: close #xxx

For the following test, which simulate hash join outputing 435699854 rows from 5131 buiding rows:
```
    {
        auto col = doris::vectorized::ColumnString::create();
        constexpr int build_rows = 5131;
        constexpr int output_rows = 435699854;
        std::string str("01234567");
        for (int i = 0; i < build_rows; ++i) {
            col->insert_data(str.data(), str.size());
        }
        int indices[output_rows];
        for (int i = 0; i < output_rows; ++i) {
            indices[i] = i % build_rows;
        }
        auto col2 = doris::vectorized::ColumnString::create();
        doris::MonotonicStopWatch watch;
        watch.start();
        col2->insert_indices_from(*col, indices, indices + output_rows);
        watch.stop();
        LOG(WARNING) << "string column insert_indices_from, rows: " << output_rows << ", time: " << doris::PrettyPrinter::print(watch.elapsed_time(), doris::TUnit::TIME_NS);
    }
```
The ColumnString::insert_indices_from inserting time improve from 6s665ms to 3s158ms:
```
W0702 23:08:39.672044 1277989 doris_main.cpp:545] string column insert_indices_from, rows: 435699854, time: 3s153ms
W0702 23:09:36.368853 1282061 doris_main.cpp:545] string column insert_indices_from, rows: 435699854, time: 3s158ms


W0703 00:30:26.093307 1468640 doris_main.cpp:545] string column insert_indices_from, rows: 435699854, time: 6s761ms
W0703 00:31:21.043638 1472937 doris_main.cpp:545] string column insert_indices_from, rows: 435699854, time: 6s665ms
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

