### PR TITLE
[Fix](multi-catalog) Add hadoop system classpath to CLASSPATH to resolve can not enable hadoop short circuit reading in some environments.

### DIFF
--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -104,7 +104,10 @@ fi
 
 # the CLASSPATH and LIBHDFS_OPTS is used for hadoop libhdfs
 # and conf/ dir so that hadoop libhdfs can read .xml config file in conf/
-export CLASSPATH="${DORIS_HOME}/conf/:${DORIS_CLASSPATH}"
+if command -v hadoop >/dev/null 2>&1; then
+    HADOOP_SYSTEM_CLASSPATH="$(hadoop classpath --glob)"
+fi
+export CLASSPATH="${HADOOP_SYSTEM_CLASSPATH}:${DORIS_HOME}/conf/:${DORIS_CLASSPATH}"
 # DORIS_CLASSPATH is for self-managed jni
 export DORIS_CLASSPATH="-Djava.class.path=${DORIS_CLASSPATH}"
 


### PR DESCRIPTION
## Proposed changes

Add hadoop system classpath to CLASSPATH to resolve can not enable hadoop short circuit reading in some environments.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

