### PR TITLE
[Bug](excution) avoid core dump on filter_block_internal and add debug information

### DIFF
--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -701,6 +701,12 @@ void Block::filter_block_internal(Block* block, const std::vector<uint32_t>& col
             if (column->size() != count) {
                 if (column->is_exclusive()) {
                     const auto result_size = column->assume_mutable()->filter(filter);
+                    if (result_size != count) {
+                        throw Exception(ErrorCode::INTERNAL_ERROR,
+                                        "result_size not euqal with filter_size, result_size={}, "
+                                        "filter_size={}",
+                                        result_size, count);
+                    }
                     CHECK_EQ(result_size, count);
                 } else {
                     column = column->filter(filter, count);


### PR DESCRIPTION
## Proposed changes
```sql
SELECT   l_orderkey,   sum(l_extendedprice * (1 - l_discount)) AS revenue,   o_orderdate,   o_shippriority FROM   customer,   orders,   lineitem WHERE   c_mktsegment = 'BUILDING'   AND c_custkey = o_custkey   AND l_orderkey = o_orderkey   AND o_orderdate < DATE '1995-03-15'   AND l_shipdate > DATE '1995-03-15' GROUP BY   l_orderkey,   o_orderdate,   o_shippriority ORDER BY   revenue DESC,   o_orderdate LIMIT 10;
```
```cpp
    @     0x55f62049c619  google::LogMessageFatal::~LogMessageFatal()

    @     0x55f61b6bc587  doris::vectorized::Block::filter_block_internal()

    @     0x55f61cd579ab  doris::vectorized::VExprContext::execute_conjuncts_and_filter_block()

    @     0x55f61cd57607  doris::vectorized::VExprContext::filter_block()

    @     0x55f61cb4d57f  doris::vectorized::VScanner::get_block()

    @     0x55f61ca97ab5  doris::vectorized::ScannerScheduler::_scanner_scan()

    @     0x55f61ca98ad1  _ZNSt17_Function_handlerIFvvEZZN5doris10vectorized16ScannerScheduler18_schedule_scannersEPNS2_14ScannerContextEENK3$_0clEvEUlvE0_E9_M_invokeERKSt9_Any_data

    @     0x55f61ca9ae0d  doris::PriorityWorkStealingThreadPool::work_thread()

    @     0x55f622f26e00  execute_native_thread_routine

    @     0x7f0011884450  start_thread

    @     0x7f0011b09d53  clone
```
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

