### PR TITLE
[Fix](cache) fix lru cache handle field order

### DIFF
--- a/be/src/olap/lru_cache.h
+++ b/be/src/olap/lru_cache.h
@@ -254,8 +254,8 @@ struct LRUHandle {
     uint32_t hash; // Hash of key(); used for fast sharding and comparisons
     CachePriority priority = CachePriority::NORMAL;
     MemTrackerLimiter* mem_tracker;
-    char key_data[1]; // Beginning of key
     LRUCacheType type;
+    char key_data[1]; // Beginning of key
 
     CacheKey key() const {
         // For cheaper lookups, we allow a temporary Handle object


### PR DESCRIPTION
## Proposed changes

For LRUHandle, all fields should be put ahead of key_data.
The LRUHandle is allocated using malloc and starting from field key_data is for key data.

    size_t handle_size = sizeof(LRUHandle) - 1 + key.size();
    LRUHandle* e = reinterpret_cast<LRUHandle*>(malloc(handle_size));
    e->value = value;
    e->deleter = deleter;
    e->charge = charge;
    e->key_length = key.size();
    e->total_size = (_type == LRUCacheType::SIZE ? handle_size + charge : 1);
    DCHECK(_type == LRUCacheType::SIZE || bytes != -1) << " _type " << _type;
    e->bytes = (_type == LRUCacheType::SIZE ? handle_size + charge : handle_size + bytes);
    e->hash = hash;
    e->refs = 2; // one for the returned handle, one for LRUCache.
    e->next = e->prev = nullptr;
    e->in_cache = true;
    e->priority = priority;
    e->mem_tracker = tracker;
    e->type = _type;
    memcpy(e->key_data, key.data(), key.size());
<!--Describe your changes.-->


