### PR TITLE
[decimalv2](compatibility) add config to allow invalid decimalv2 literal

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -921,6 +921,9 @@ CONF_mBool(enable_stack_trace, "true");
 // enable shrink memory, default is false
 CONF_Bool(enable_shrink_memory, "false");
 
+// Allow invalid decimalv2 literal for compatible with old version. Recommend set it false strongly.
+CONF_Bool(allow_invalid_decimalv2_literal, "false");
+
 #ifdef BE_TEST
 // test s3
 CONF_String(test_s3_resource, "resource");

--- a/be/src/runtime/decimalv2_value.cpp
+++ b/be/src/runtime/decimalv2_value.cpp
@@ -353,7 +353,9 @@ int DecimalV2Value::parse_from_str(const char* decimal_str, int32_t length) {
 
     _value = StringParser::string_to_decimal<__int128>(decimal_str, length, PRECISION, SCALE,
                                                        &result);
-    if (result != StringParser::PARSE_SUCCESS) {
+    if (!config::allow_invalid_decimalv2_literal && result != StringParser::PARSE_SUCCESS) {
+        error = E_DEC_BAD_NUM;
+    } else if (config::allow_invalid_decimalv2_literal && result == StringParser::PARSE_FAILURE) {
         error = E_DEC_BAD_NUM;
     }
     return error;


### PR DESCRIPTION
## Proposed changes

pick #21327

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

