### PR TITLE
[Fix](multi-catalog) fix NPE for FileCacheValue.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -909,9 +909,9 @@ public class HiveMetaStoreCache {
     @Data
     public static class FileCacheValue {
         // File Cache for self splitter.
-        private List<HiveFileStatus> files;
+        private final List<HiveFileStatus> files = Lists.newArrayList();
         // File split cache for old splitter. This is a temp variable.
-        private List<Split> splits;
+        private final List<Split> splits = Lists.newArrayList();
         private boolean isSplittable;
         // The values of partitions.
         // e.g for file : hdfs://path/to/table/part1=a/part2=b/datafile
@@ -921,9 +921,6 @@ public class HiveMetaStoreCache {
         private AcidInfo acidInfo;
 
         public void addFile(RemoteFile file) {
-            if (files == null) {
-                files = Lists.newArrayList();
-            }
             HiveFileStatus status = new HiveFileStatus();
             status.setBlockLocations(file.getBlockLocations());
             status.setPath(file.getPath());
@@ -934,9 +931,6 @@ public class HiveMetaStoreCache {
         }
 
         public void addSplit(Split split) {
-            if (splits == null) {
-                splits = Lists.newArrayList();
-            }
             splits.add(split);
         }
 


### PR DESCRIPTION
## Proposed changes

`FileCacheValue.files` may be null if there is not any files exists for some partitions.

![npe](https://github.com/apache/doris/assets/5926365/dd8f3a53-1407-4271-9a3b-632e9a08ebf4)


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

