### PR TITLE
[Performance](Nereids): speedup analyze by removing sort()/addAll() in OptimizeGroupExpressionJob

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/OptimizeGroupExpressionJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/OptimizeGroupExpressionJob.java
@@ -23,9 +23,7 @@ import org.apache.doris.nereids.jobs.JobType;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.rules.Rule;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -42,15 +40,14 @@ public class OptimizeGroupExpressionJob extends Job {
     @Override
     public void execute() {
         countJobExecutionTimesOfGroupExpressions(groupExpression);
-        List<Rule> validRules = new ArrayList<>();
         List<Rule> implementationRules = getRuleSet().getImplementationRules();
         List<Rule> explorationRules = getExplorationRules();
 
-        validRules.addAll(getValidRules(groupExpression, implementationRules));
-        validRules.addAll(getValidRules(groupExpression, explorationRules));
-        validRules.sort(Comparator.comparingInt(o -> o.getRulePromise().promise()));
+        for (Rule rule : getValidRules(groupExpression, explorationRules)) {
+            pushJob(new ApplyRuleJob(groupExpression, rule, context));
+        }
 
-        for (Rule rule : validRules) {
+        for (Rule rule : getValidRules(groupExpression, implementationRules)) {
             pushJob(new ApplyRuleJob(groupExpression, rule, context));
         }
     }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

`sort()` and `allAll()` all rules will cost much time and it's useless action, remove them to speed up.

explain tpcds q72: 1.72s -> 1.46s

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

