### PR TITLE
[Chore](status) avoid empty error msg on status

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1230,7 +1230,7 @@ void CreateTableTaskPool::_create_tablet_worker_thread_callback() {
         Status status = _env->storage_engine()->create_tablet(create_tablet_req);
         if (!status.ok()) {
             DorisMetrics::instance()->create_tablet_requests_failed->increment(1);
-            LOG_WARNING("failed to create tablet")
+            LOG_WARNING("failed to create tablet, reason={}", status.to_string())
                     .tag("signature", agent_task_req.signature)
                     .tag("tablet_id", create_tablet_req.tablet_id)
                     .error(status);

--- a/be/src/common/status.cpp
+++ b/be/src/common/status.cpp
@@ -18,40 +18,6 @@
 
 namespace doris {
 
-Status::Status(const TStatus& s) {
-    _code = static_cast<int>(s.status_code);
-    if (_code != ErrorCode::OK) {
-        if (!s.error_msgs.empty()) {
-            if (_err_msg == nullptr) {
-                _err_msg = std::make_unique<ErrMsg>();
-            }
-            _err_msg->_msg = s.error_msgs[0];
-#ifdef ENABLE_STACKTRACE
-            _err_msg->_stack = "";
-#endif
-        }
-    } else {
-        _err_msg.reset();
-    }
-}
-
-Status::Status(const PStatus& s) {
-    _code = s.status_code();
-    if (_code != ErrorCode::OK) {
-        if (s.error_msgs_size() > 0) {
-            if (_err_msg == nullptr) {
-                _err_msg = std::make_unique<ErrMsg>();
-            }
-            _err_msg->_msg = s.error_msgs(0);
-#ifdef ENABLE_STACKTRACE
-            _err_msg->_stack = "";
-#endif
-        }
-    } else {
-        _err_msg.reset();
-    }
-}
-
 void Status::to_thrift(TStatus* s) const {
     s->error_msgs.clear();
     if (ok()) {

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -353,19 +353,6 @@ public:
         return status;
     }
 
-    template <int code, bool stacktrace = true>
-    Status static Error() {
-        Status status;
-        status._code = code;
-#ifdef ENABLE_STACKTRACE
-        if constexpr (stacktrace && capture_stacktrace<code>()) {
-            status._err_msg = std::make_unique<ErrMsg>();
-            status._err_msg->_stack = get_stack_trace();
-        }
-#endif
-        return status;
-    }
-
     template <typename... Args>
     Status static Error(int code, std::string_view msg, Args&&... args) {
         Status status;
@@ -376,12 +363,6 @@ public:
         } else {
             status._err_msg->_msg = fmt::format(msg, std::forward<Args>(args)...);
         }
-        return status;
-    }
-
-    Status static Error(int code) {
-        Status status;
-        status._code = code;
         return status;
     }
 

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -357,8 +357,8 @@ public:
         }
 #ifdef ENABLE_STACKTRACE
         if (stacktrace && capture_stacktrace(code)) {
-            LOG(WARNING) << "meet error status: " << status;
             status._err_msg->_stack = get_stack_trace();
+            LOG(WARNING) << "meet error status: " << status;
         }
 #endif
         return status;

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -336,7 +336,7 @@ public:
 
     template <int code, bool stacktrace = true, typename... Args>
     Status static Error(std::string_view msg, Args&&... args) {
-        return Error(code, msg, std::forward<Args>(args)...);
+        return Error<stacktrace>(code, msg, std::forward<Args>(args)...);
     }
 
     template <bool stacktrace = true, typename... Args>

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -331,11 +331,13 @@ public:
     Status& operator=(Status&& rhs) noexcept = default;
 
     Status static create(const TStatus& status) {
-        return Error<true>(status.status_code, status.error_msgs[0]);
+        return Error<true>(status.status_code,
+                           status.error_msgs.empty() ? "" : status.error_msgs[0]);
     }
 
     Status static create(const PStatus& pstatus) {
-        return Error<true>(pstatus.status_code(), pstatus.error_msgs(0));
+        return Error<true>(pstatus.status_code(),
+                           pstatus.error_msgs_size() == 0 ? "" : pstatus.error_msgs(0));
     }
 
     template <int code, bool stacktrace = true, typename... Args>

--- a/be/src/exec/rowid_fetcher.cpp
+++ b/be/src/exec/rowid_fetcher.cpp
@@ -131,7 +131,7 @@ Status RowIDFetcher::_merge_rpc_results(const PMultiGetRequest& request,
     vectorized::DataTypeSerDeSPtrs serdes;
     std::unordered_map<uint32_t, uint32_t> col_uid_to_idx;
     auto merge_function = [&](const PMultiGetResponse& resp) {
-        Status st(resp.status());
+        Status st(Status::create(resp.status()));
         if (!st.ok()) {
             LOG(WARNING) << "Failed to fetch " << st.to_string();
             return st;

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -613,7 +613,7 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req,
 #else
     ctx->put_result = k_stream_load_put_result;
 #endif
-    Status plan_status(ctx->put_result.status);
+    Status plan_status(Status::create(ctx->put_result.status));
     if (!plan_status.ok()) {
         LOG(WARNING) << "plan streaming load failed. errmsg=" << plan_status << ctx->brief();
         return plan_status;

--- a/be/src/http/http_handler_with_auth.cpp
+++ b/be/src/http/http_handler_with_auth.cpp
@@ -74,7 +74,7 @@ int HttpHandlerWithAuth::on_header(HttpRequest* req) {
 #else
     CHECK(_exec_env == nullptr);
 #endif
-    Status status(auth_result.status);
+    Status status(Status::create(auth_result.status));
     if (!status.ok()) {
         LOG(WARNING) << "permission verification failed, request: " << auth_request;
         HttpChannel::send_error(req, HttpStatus::FORBIDDEN);

--- a/be/src/io/cache/file_cache.cpp
+++ b/be/src/io/cache/file_cache.cpp
@@ -70,10 +70,9 @@ Status FileCache::download_cache_to_local(const Path& cache_file, const Path& ca
                                 remote_file_reader->path().native(), offset + count_bytes_read,
                                 need_req_size));
             if (bytes_read != need_req_size) {
-                LOG(ERROR) << "read remote file failed: " << remote_file_reader->path().native()
-                           << ", bytes read: " << bytes_read
-                           << " vs need read size: " << need_req_size;
-                return Status::Error<OS_ERROR>();
+                return Status::Error<OS_ERROR>(
+                        "read remote file failed: {}, bytes read: {} vs need read size: {}",
+                        remote_file_reader->path().native(), bytes_read, need_req_size);
             }
             count_bytes_read += bytes_read;
             RETURN_NOT_OK_STATUS_WITH_WARN(

--- a/be/src/io/cache/sub_file_cache.cpp
+++ b/be/src/io/cache/sub_file_cache.cpp
@@ -53,7 +53,7 @@ SubFileCache::SubFileCache(const Path& cache_dir, int64_t alive_time_sec,
           _alive_time_sec(alive_time_sec),
           _remote_file_reader(remote_file_reader) {}
 
-SubFileCache::~SubFileCache() {}
+SubFileCache::~SubFileCache() = default;
 
 Status SubFileCache::read_at_impl(size_t offset, Slice result, size_t* bytes_read,
                                   const IOContext* io_ctx) {
@@ -106,9 +106,8 @@ Status SubFileCache::read_at_impl(size_t offset, Slice result, size_t* bytes_rea
              iter != need_cache_offsets.cend(); ++iter) {
             size_t offset_begin = *iter;
             if (_cache_file_readers.find(*iter) == _cache_file_readers.end()) {
-                LOG(ERROR) << "Local cache file reader can't be found: " << offset_begin << ", "
-                           << offset_begin;
-                return Status::Error<OS_ERROR>();
+                return Status::Error<OS_ERROR>("Local cache file reader can't be found: {}",
+                                               offset_begin);
             }
             if (offset_begin < offset) {
                 offset_begin = offset;
@@ -125,10 +124,9 @@ Status SubFileCache::read_at_impl(size_t offset, Slice result, size_t* bytes_rea
                     fmt::format("Read local cache file failed: {}",
                                 _cache_file_readers[*iter]->path().native()));
             if (sub_bytes_read != read_slice.size) {
-                LOG(ERROR) << "read local cache file failed: "
-                           << _cache_file_readers[*iter]->path().native()
-                           << ", bytes read: " << sub_bytes_read << " vs req size: " << req_size;
-                return Status::Error<OS_ERROR>();
+                return Status::Error<OS_ERROR>(
+                        "read local cache file failed: {} , bytes read: {} vs req size: {}",
+                        _cache_file_readers[*iter]->path().native(), sub_bytes_read, req_size);
             }
             *bytes_read += sub_bytes_read;
             _last_match_times[*iter] = time(nullptr);

--- a/be/src/io/cache/whole_file_cache.cpp
+++ b/be/src/io/cache/whole_file_cache.cpp
@@ -59,9 +59,9 @@ Status WholeFileCache::read_at_impl(size_t offset, Slice result, size_t* bytes_r
             _cache_file_reader->read_at(offset, result, bytes_read, io_ctx),
             fmt::format("Read local cache file failed: {}", _cache_file_reader->path().native()));
     if (*bytes_read != result.size) {
-        LOG(ERROR) << "read cache file failed: " << _cache_file_reader->path().native()
-                   << ", bytes read: " << bytes_read << " vs required size: " << result.size;
-        return Status::Error<OS_ERROR>();
+        return Status::Error<OS_ERROR>(
+                "read cache file failed: {}, bytes read: {} vs required size: {}",
+                _cache_file_reader->path().native(), *bytes_read, result.size);
     }
     update_last_match_time();
     return Status::OK();

--- a/be/src/io/fs/benchmark/benchmark_factory.hpp
+++ b/be/src/io/fs/benchmark/benchmark_factory.hpp
@@ -99,7 +99,7 @@ public:
         std::string conffile = std::string(getenv("DORIS_HOME")) + "/conf/be.conf";
         if (!doris::config::init(conffile.c_str(), true, true, true)) {
             fprintf(stderr, "error read config file. \n");
-            return Status::Error<INTERNAL_ERROR>();
+            return Status::Error<INTERNAL_ERROR>("error read config file.");
         }
         doris::CpuInfo::init();
         Status status = Status::OK();

--- a/be/src/io/fs/multi_table_pipe.cpp
+++ b/be/src/io/fs/multi_table_pipe.cpp
@@ -169,7 +169,7 @@ Status MultiTablePipe::request_and_exec_plans() {
             }));
     _ctx->stream_load_put_cost_nanos = MonotonicNanos() - stream_load_put_start_time;
 
-    Status plan_status(_ctx->multi_table_put_result.status);
+    Status plan_status(Status::create(_ctx->multi_table_put_result.status));
     if (!plan_status.ok()) {
         LOG(WARNING) << "plan streaming load failed. errmsg=" << plan_status << _ctx->brief();
         return plan_status;

--- a/be/src/olap/base_compaction.cpp
+++ b/be/src/olap/base_compaction.cpp
@@ -40,17 +40,17 @@ using namespace ErrorCode;
 BaseCompaction::BaseCompaction(const TabletSharedPtr& tablet)
         : Compaction(tablet, "BaseCompaction:" + std::to_string(tablet->tablet_id())) {}
 
-BaseCompaction::~BaseCompaction() {}
+BaseCompaction::~BaseCompaction() = default;
 
 Status BaseCompaction::prepare_compact() {
     if (!_tablet->init_succeeded()) {
-        return Status::Error<INVALID_ARGUMENT>();
+        return Status::Error<INVALID_ARGUMENT>("_tablet init failed");
     }
 
     std::unique_lock<std::mutex> lock(_tablet->get_base_compaction_lock(), std::try_to_lock);
     if (!lock.owns_lock()) {
-        LOG(WARNING) << "another base compaction is running. tablet=" << _tablet->full_name();
-        return Status::Error<TRY_LOCK_FAILED>();
+        return Status::Error<TRY_LOCK_FAILED>("another base compaction is running. tablet={}",
+                                              _tablet->full_name());
     }
 
     // 1. pick rowsets to compact
@@ -69,15 +69,15 @@ Status BaseCompaction::execute_compact_impl() {
 #endif
     std::unique_lock<std::mutex> lock(_tablet->get_base_compaction_lock(), std::try_to_lock);
     if (!lock.owns_lock()) {
-        LOG(WARNING) << "another base compaction is running. tablet=" << _tablet->full_name();
-        return Status::Error<TRY_LOCK_FAILED>();
+        return Status::Error<TRY_LOCK_FAILED>("another base compaction is running. tablet={}",
+                                              _tablet->full_name());
     }
 
     // Clone task may happen after compaction task is submitted to thread pool, and rowsets picked
     // for compaction may change. In this case, current compaction task should not be executed.
     if (_tablet->get_clone_occurred()) {
         _tablet->set_clone_occurred(false);
-        return Status::Error<BE_CLONE_OCCURRED>();
+        return Status::Error<BE_CLONE_OCCURRED>("get_clone_occurred failed");
     }
 
     SCOPED_ATTACH_TASK(_mem_tracker);
@@ -125,7 +125,7 @@ Status BaseCompaction::pick_rowsets_to_compact() {
     RETURN_IF_ERROR(_check_rowset_overlapping(_input_rowsets));
     _filter_input_rowset();
     if (_input_rowsets.size() <= 1) {
-        return Status::Error<BE_NO_SUITABLE_VERSION>();
+        return Status::Error<BE_NO_SUITABLE_VERSION>("_input_rowsets.size() is 1");
     }
 
     // If there are delete predicate rowsets in tablet, start_version > 0 implies some rowsets before
@@ -141,17 +141,16 @@ Status BaseCompaction::pick_rowsets_to_compact() {
             }
         }
         if (has_delete_predicate) {
-            LOG(WARNING)
-                    << "Some rowsets cannot apply delete predicates in base compaction. tablet_id="
-                    << _tablet->tablet_id();
-            return Status::Error<BE_NO_SUITABLE_VERSION>();
+            return Status::Error<BE_NO_SUITABLE_VERSION>(
+                    "Some rowsets cannot apply delete predicates in base compaction. tablet_id={}",
+                    _tablet->tablet_id());
         }
     }
 
     if (_input_rowsets.size() == 2 && _input_rowsets[0]->end_version() == 1) {
-        // the tablet is with rowset: [0-1], [2-y]
-        // and [0-1] has no data. in this situation, no need to do base compaction.
-        return Status::Error<BE_NO_SUITABLE_VERSION>();
+        return Status::Error<BE_NO_SUITABLE_VERSION>(
+                "the tablet is with rowset: [0-1], [2-y], and [0-1] has no data. in this "
+                "situation, no need to do base compaction.");
     }
 
     // 1. cumulative rowset must reach base_compaction_num_cumulative_deltas threshold
@@ -200,21 +199,21 @@ Status BaseCompaction::pick_rowsets_to_compact() {
         return Status::OK();
     }
 
-    VLOG_NOTICE << "don't satisfy the base compaction policy. tablet=" << _tablet->full_name()
-                << ", num_cumulative_rowsets=" << _input_rowsets.size() - 1
-                << ", cumulative_base_ratio=" << cumulative_base_ratio
-                << ", interval_since_last_base_compaction=" << interval_since_last_base_compaction;
-    return Status::Error<BE_NO_SUITABLE_VERSION>();
+    return Status::Error<BE_NO_SUITABLE_VERSION>(
+            "don't satisfy the base compaction policy. tablet={}, num_cumulative_rowsets={}, "
+            "cumulative_base_ratio={}, interval_since_last_base_compaction={}",
+            _tablet->full_name(), _input_rowsets.size() - 1, cumulative_base_ratio,
+            interval_since_last_base_compaction);
 }
 
 Status BaseCompaction::_check_rowset_overlapping(const std::vector<RowsetSharedPtr>& rowsets) {
     for (auto& rs : rowsets) {
         if (rs->rowset_meta()->is_segments_overlapping()) {
-            LOG(WARNING) << "There is overlapping rowset before cumulative point, "
-                         << "rowset version=" << rs->start_version() << "-" << rs->end_version()
-                         << ", cumulative point=" << _tablet->cumulative_layer_point()
-                         << ", tablet=" << _tablet->full_name();
-            return Status::Error<BE_SEGMENTS_OVERLAPPING>();
+            return Status::Error<BE_SEGMENTS_OVERLAPPING>(
+                    "There is overlapping rowset before cumulative point, rowset version={}-{}, "
+                    "cumulative point={}, tablet={}",
+                    rs->start_version(), rs->end_version(), _tablet->cumulative_layer_point(),
+                    _tablet->full_name());
         }
     }
     return Status::OK();

--- a/be/src/olap/base_tablet.cpp
+++ b/be/src/olap/base_tablet.cpp
@@ -61,8 +61,8 @@ BaseTablet::~BaseTablet() {
 
 Status BaseTablet::set_tablet_state(TabletState state) {
     if (_tablet_meta->tablet_state() == TABLET_SHUTDOWN && state != TABLET_SHUTDOWN) {
-        LOG(WARNING) << "could not change tablet state from shutdown to " << state;
-        return Status::Error<META_INVALID_ARGUMENT>();
+        return Status::Error<META_INVALID_ARGUMENT>(
+                "could not change tablet state from shutdown to {}", state);
     }
     _tablet_meta->set_tablet_state(state);
     _state = state;

--- a/be/src/olap/cold_data_compaction.cpp
+++ b/be/src/olap/cold_data_compaction.cpp
@@ -48,7 +48,7 @@ ColdDataCompaction::~ColdDataCompaction() = default;
 
 Status ColdDataCompaction::prepare_compact() {
     if (UNLIKELY(!_tablet->init_succeeded())) {
-        return Status::Error<INVALID_ARGUMENT>();
+        return Status::Error<INVALID_ARGUMENT>("_tablet init failed");
     }
     return pick_rowsets_to_compact();
 }

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -358,9 +358,8 @@ Status Compaction::do_compaction_impl(int64_t permits) {
 
     _output_rowset = _output_rs_writer->build();
     if (_output_rowset == nullptr) {
-        LOG(WARNING) << "rowset writer build failed. writer version:"
-                     << ", output_version=" << _output_version;
-        return Status::Error<ROWSET_BUILDER_INIT>();
+        return Status::Error<ROWSET_BUILDER_INIT>("rowset writer build failed. output_version: {}",
+                                                  _output_version.to_string());
     }
 
     COUNTER_UPDATE(_output_rowset_data_size_counter, _output_rowset->data_disk_size());
@@ -705,12 +704,11 @@ Status Compaction::check_version_continuity(const std::vector<RowsetSharedPtr>& 
     for (size_t i = 1; i < rowsets.size(); ++i) {
         RowsetSharedPtr rowset = rowsets[i];
         if (rowset->start_version() != prev_rowset->end_version() + 1) {
-            LOG(WARNING) << "There are missed versions among rowsets. "
-                         << "prev_rowset version=" << prev_rowset->start_version() << "-"
-                         << prev_rowset->end_version()
-                         << ", rowset version=" << rowset->start_version() << "-"
-                         << rowset->end_version();
-            return Status::Error<CUMULATIVE_MISS_VERSION>();
+            return Status::Error<CUMULATIVE_MISS_VERSION>(
+                    "There are missed versions among rowsets. prev_rowset version={}-{}, rowset "
+                    "version={}-{}",
+                    prev_rowset->start_version(), prev_rowset->end_version(),
+                    rowset->start_version(), rowset->end_version());
         }
         prev_rowset = rowset;
     }
@@ -721,12 +719,11 @@ Status Compaction::check_version_continuity(const std::vector<RowsetSharedPtr>& 
 Status Compaction::check_correctness(const Merger::Statistics& stats) {
     // 1. check row number
     if (_input_row_num != _output_rowset->num_rows() + stats.merged_rows + stats.filtered_rows) {
-        LOG(WARNING) << "row_num does not match between cumulative input and output! "
-                     << "tablet=" << _tablet->full_name() << ", input_row_num=" << _input_row_num
-                     << ", merged_row_num=" << stats.merged_rows
-                     << ", filtered_row_num=" << stats.filtered_rows
-                     << ", output_row_num=" << _output_rowset->num_rows();
-        return Status::Error<CHECK_LINES_ERROR>();
+        return Status::Error<CHECK_LINES_ERROR>(
+                "row_num does not match between cumulative input and output! tablet={}, "
+                "input_row_num={}, merged_row_num={}, filtered_row_num={}, output_row_num={}",
+                _tablet->full_name(), _input_row_num, stats.merged_rows, stats.filtered_rows,
+                _output_rowset->num_rows());
     }
     return Status::OK();
 }

--- a/be/src/olap/cumulative_compaction.cpp
+++ b/be/src/olap/cumulative_compaction.cpp
@@ -40,17 +40,17 @@ using namespace ErrorCode;
 CumulativeCompaction::CumulativeCompaction(const TabletSharedPtr& tablet)
         : Compaction(tablet, "CumulativeCompaction:" + std::to_string(tablet->tablet_id())) {}
 
-CumulativeCompaction::~CumulativeCompaction() {}
+CumulativeCompaction::~CumulativeCompaction() = default;
 
 Status CumulativeCompaction::prepare_compact() {
     if (!_tablet->init_succeeded()) {
-        return Status::Error<CUMULATIVE_INVALID_PARAMETERS>();
+        return Status::Error<CUMULATIVE_INVALID_PARAMETERS>("_tablet init failed");
     }
 
     std::unique_lock<std::mutex> lock(_tablet->get_cumulative_compaction_lock(), std::try_to_lock);
     if (!lock.owns_lock()) {
-        LOG(INFO) << "The tablet is under cumulative compaction. tablet=" << _tablet->full_name();
-        return Status::Error<TRY_LOCK_FAILED>();
+        return Status::Error<TRY_LOCK_FAILED>(
+                "The tablet is under cumulative compaction. tablet={}", _tablet->full_name());
     }
 
     // 1. calculate cumulative point
@@ -69,15 +69,15 @@ Status CumulativeCompaction::prepare_compact() {
 Status CumulativeCompaction::execute_compact_impl() {
     std::unique_lock<std::mutex> lock(_tablet->get_cumulative_compaction_lock(), std::try_to_lock);
     if (!lock.owns_lock()) {
-        LOG(INFO) << "The tablet is under cumulative compaction. tablet=" << _tablet->full_name();
-        return Status::Error<TRY_LOCK_FAILED>();
+        return Status::Error<TRY_LOCK_FAILED>(
+                "The tablet is under cumulative compaction. tablet={}", _tablet->full_name());
     }
 
     // Clone task may happen after compaction task is submitted to thread pool, and rowsets picked
     // for compaction may change. In this case, current compaction task should not be executed.
     if (_tablet->get_clone_occurred()) {
         _tablet->set_clone_occurred(false);
-        return Status::Error<CUMULATIVE_CLONE_OCCURRED>();
+        return Status::Error<CUMULATIVE_CLONE_OCCURRED>("get_clone_occurred failed");
     }
 
     SCOPED_ATTACH_TASK(_mem_tracker);
@@ -105,7 +105,7 @@ Status CumulativeCompaction::execute_compact_impl() {
 Status CumulativeCompaction::pick_rowsets_to_compact() {
     auto candidate_rowsets = _tablet->pick_candidate_rowsets_to_cumulative_compaction();
     if (candidate_rowsets.empty()) {
-        return Status::Error<CUMULATIVE_NO_SUITABLE_VERSION>();
+        return Status::Error<CUMULATIVE_NO_SUITABLE_VERSION>("candidate_rowsets is empty");
     }
 
     // candidate_rowsets may not be continuous
@@ -134,7 +134,8 @@ Status CumulativeCompaction::pick_rowsets_to_compact() {
             // plus 1 to skip the delete version.
             // NOTICE: after that, the cumulative point may be larger than max version of this tablet, but it doesn't matter.
             _tablet->set_cumulative_layer_point(_last_delete_version.first + 1);
-            return Status::Error<CUMULATIVE_NO_SUITABLE_VERSION>();
+            return Status::Error<CUMULATIVE_NO_SUITABLE_VERSION>(
+                    "_last_delete_version.first not equal to -1");
         }
 
         // we did not meet any delete version. which means compaction_score is not enough to do cumulative compaction.
@@ -174,7 +175,7 @@ Status CumulativeCompaction::pick_rowsets_to_compact() {
             }
         }
 
-        return Status::Error<CUMULATIVE_NO_SUITABLE_VERSION>();
+        return Status::Error<CUMULATIVE_NO_SUITABLE_VERSION>("_input_rowsets is empty");
     }
 
     return Status::OK();

--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -834,9 +834,8 @@ Status DataDir::move_to_trash(const std::string& tablet_path) {
     // 4. move tablet to trash
     VLOG_NOTICE << "move file to trash. " << tablet_path << " -> " << trash_tablet_path;
     if (rename(tablet_path.c_str(), trash_tablet_path.c_str()) < 0) {
-        LOG(WARNING) << "move file to trash failed. [file=" << tablet_path << " target='"
-                     << trash_tablet_path << "' err='" << Errno::str() << "']";
-        return Status::Error<OS_ERROR>();
+        return Status::Error<OS_ERROR>("move file to trash failed. file={}, target={}, err={}",
+                                       tablet_path, trash_tablet_path.native(), Errno::str());
     }
 
     // 5. check parent dir of source file, delete it when empty

--- a/be/src/olap/decimal12.h
+++ b/be/src/olap/decimal12.h
@@ -97,7 +97,8 @@ struct decimal12_t {
 
         if (sign != nullptr) {
             if (sign != value_string) {
-                return Status::Error<ErrorCode::INVALID_ARGUMENT>();
+                return Status::Error<ErrorCode::INVALID_ARGUMENT>(
+                        "decimal12_t::from_string meet invalid sign");
             } else {
                 ++value_string;
             }

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -146,9 +146,8 @@ Status DeltaWriter::init() {
     TabletManager* tablet_mgr = _storage_engine->tablet_manager();
     _tablet = tablet_mgr->get_tablet(_req.tablet_id);
     if (_tablet == nullptr) {
-        LOG(WARNING) << "fail to find tablet. tablet_id=" << _req.tablet_id
-                     << ", schema_hash=" << _req.schema_hash;
-        return Status::Error<TABLE_NOT_FOUND>();
+        return Status::Error<TABLE_NOT_FOUND>("fail to find tablet. tablet_id={}, schema_hash={}",
+                                              _req.tablet_id, _req.schema_hash);
     }
 
     // get rowset ids snapshot
@@ -166,18 +165,16 @@ Status DeltaWriter::init() {
         StorageEngine::instance()->submit_compaction_task(
                 _tablet, CompactionType::CUMULATIVE_COMPACTION, true);
         if (_tablet->version_count() > config::max_tablet_version_num) {
-            LOG(WARNING) << "failed to init delta writer. version count: "
-                         << _tablet->version_count()
-                         << ", exceed limit: " << config::max_tablet_version_num
-                         << ". tablet: " << _tablet->full_name();
-            return Status::Error<TOO_MANY_VERSION>();
+            return Status::Error<TOO_MANY_VERSION>(
+                    "failed to init delta writer. version count: {}, exceed limit: {}, tablet: {}",
+                    _tablet->version_count(), config::max_tablet_version_num, _tablet->full_name());
         }
     }
 
     {
         std::shared_lock base_migration_rlock(_tablet->get_migration_lock(), std::try_to_lock);
         if (!base_migration_rlock.owns_lock()) {
-            return Status::Error<TRY_LOCK_FAILED>();
+            return Status::Error<TRY_LOCK_FAILED>("get lock failed");
         }
         std::lock_guard<std::mutex> push_lock(_tablet->get_push_lock());
         RETURN_IF_ERROR(_storage_engine->txn_manager()->prepare_txn(_req.partition_id, _tablet,
@@ -236,9 +233,9 @@ Status DeltaWriter::write(const vectorized::Block* block, const std::vector<int>
     }
 
     if (_is_closed) {
-        LOG(WARNING) << "write block after closed tablet_id=" << _req.tablet_id
-                     << " load_id=" << _req.load_id << " txn_id=" << _req.txn_id;
-        return Status::Error<ALREADY_CLOSED>();
+        return Status::Error<ALREADY_CLOSED>(
+                "write block after closed tablet_id={}, load_id={}-{}, txn_id={}", _req.tablet_id,
+                _req.load_id.hi(), _req.load_id.lo(), _req.txn_id);
     }
 
     if (is_append) {
@@ -412,8 +409,7 @@ Status DeltaWriter::close_wait(const PSlaveTabletNodes& slave_tablet_nodes,
     // use rowset meta manager to save meta
     _cur_rowset = _rowset_writer->build();
     if (_cur_rowset == nullptr) {
-        LOG(WARNING) << "fail to build rowset";
-        return Status::Error<MEM_ALLOC_FAILED>();
+        return Status::Error<MEM_ALLOC_FAILED>("fail to build rowset");
     }
 
     if (_tablet->enable_unique_key_merge_on_write()) {

--- a/be/src/olap/file_header.h
+++ b/be/src/olap/file_header.h
@@ -35,7 +35,7 @@
 
 namespace doris {
 
-typedef struct _FixedFileHeader {
+using FixedFileHeader = struct _FixedFileHeader {
     // the length of the entire file
     uint32_t file_length;
     // Checksum of the file's contents except the FileHeader
@@ -44,9 +44,9 @@ typedef struct _FixedFileHeader {
     uint32_t protobuf_length;
     // Checksum of Protobuf part
     uint32_t protobuf_checksum;
-} __attribute__((packed)) FixedFileHeader;
+};
 
-typedef struct _FixedFileHeaderV2 {
+using FixedFileHeaderV2 = struct _FixedFileHeaderV2 {
     uint64_t magic_number;
     uint32_t version;
     // the length of the entire file
@@ -57,7 +57,7 @@ typedef struct _FixedFileHeaderV2 {
     uint64_t protobuf_length;
     // Checksum of Protobuf part
     uint32_t protobuf_checksum;
-} __attribute__((packed)) FixedFileHeaderV2;
+};
 
 template <typename MessageType, typename ExtraType = uint32_t>
 class FileHeader {
@@ -67,7 +67,7 @@ public:
         memset(&_extra_fixed_header, 0, sizeof(_extra_fixed_header));
         _fixed_file_header_size = sizeof(_fixed_file_header);
     }
-    ~FileHeader() {}
+    ~FileHeader() = default;
 
     // To calculate the length of the proto part, it needs to be called after the proto is operated,
     // and prepare must be called before calling serialize
@@ -114,12 +114,12 @@ template <typename MessageType, typename ExtraType>
 Status FileHeader<MessageType, ExtraType>::prepare() {
     try {
         if (!_proto.SerializeToString(&_proto_string)) {
-            LOG(WARNING) << "serialize file header to string error. [path='" << _file_path << "']";
-            return Status::Error<ErrorCode::SERIALIZE_PROTOBUF_ERROR>();
+            return Status::Error<ErrorCode::SERIALIZE_PROTOBUF_ERROR>(
+                    "serialize file header to string error. [path={}]", _file_path);
         }
     } catch (...) {
-        LOG(WARNING) << "serialize file header to string error. [path='" << _file_path << "']";
-        return Status::Error<ErrorCode::SERIALIZE_PROTOBUF_ERROR>();
+        return Status::Error<ErrorCode::SERIALIZE_PROTOBUF_ERROR>(
+                "serialize file header to string error. [path={}]", _file_path);
     }
 
     _fixed_file_header.protobuf_checksum =
@@ -187,11 +187,11 @@ Status FileHeader<MessageType, ExtraType>::deserialize() {
             {(const uint8_t*)&_extra_fixed_header, sizeof(_extra_fixed_header)}, &bytes_read));
 
     std::unique_ptr<char[]> buf(new (std::nothrow) char[_fixed_file_header.protobuf_length]);
-    if (nullptr == buf.get()) {
+    if (nullptr == buf) {
         char errmsg[64];
-        LOG(WARNING) << "malloc protobuf buf error. file=" << file_reader->path().native()
-                     << ", error=" << strerror_r(errno, errmsg, 64);
-        return Status::Error<ErrorCode::MEM_ALLOC_FAILED>();
+        return Status::Error<ErrorCode::MEM_ALLOC_FAILED>(
+                "malloc protobuf buf error. file={}, error={}", file_reader->path().native(),
+                strerror_r(errno, errmsg, 64));
     }
     RETURN_IF_ERROR(file_reader->read_at(_fixed_file_header_size + sizeof(_extra_fixed_header),
                                          {buf.get(), _fixed_file_header.protobuf_length},
@@ -199,10 +199,9 @@ Status FileHeader<MessageType, ExtraType>::deserialize() {
     real_file_length = file_reader->size();
 
     if (file_length() != static_cast<uint64_t>(real_file_length)) {
-        LOG(WARNING) << "file length is not match. file=" << file_reader->path().native()
-                     << ", file_length=" << file_length()
-                     << ", real_file_length=" << real_file_length;
-        return Status::Error<ErrorCode::FILE_DATA_ERROR>();
+        return Status::Error<ErrorCode::FILE_DATA_ERROR>(
+                "file length is not match. file={}, file_length=, real_file_length={}",
+                file_reader->path().native(), file_length(), real_file_length);
     }
 
     // check proto checksum
@@ -210,23 +209,24 @@ Status FileHeader<MessageType, ExtraType>::deserialize() {
             olap_adler32(olap_adler32_init(), buf.get(), _fixed_file_header.protobuf_length);
 
     if (real_protobuf_checksum != _fixed_file_header.protobuf_checksum) {
-        LOG(WARNING) << "checksum is not match. file=" << file_reader->path().native()
-                     << ", expect=" << _fixed_file_header.protobuf_checksum
-                     << ", actual=" << real_protobuf_checksum;
-        return Status::Error<ErrorCode::CHECKSUM_ERROR>();
+        return Status::Error<ErrorCode::CHECKSUM_ERROR>(
+                "checksum is not match. file={}, expect={}, actual={}",
+                file_reader->path().native(), _fixed_file_header.protobuf_checksum,
+                real_protobuf_checksum);
     }
 
     try {
         std::string protobuf_str(buf.get(), _fixed_file_header.protobuf_length);
 
         if (!_proto.ParseFromString(protobuf_str)) {
-            LOG(WARNING) << "fail to parse file content to protobuf object. file="
-                         << file_reader->path().native();
-            return Status::Error<ErrorCode::PARSE_PROTOBUF_ERROR>();
+            return Status::Error<ErrorCode::PARSE_PROTOBUF_ERROR>(
+                    "fail to parse file content to protobuf object. file={}",
+                    file_reader->path().native());
         }
     } catch (...) {
         LOG(WARNING) << "fail to load protobuf. file='" << file_reader->path().native();
-        return Status::Error<ErrorCode::PARSE_PROTOBUF_ERROR>();
+        return Status::Error<ErrorCode::PARSE_PROTOBUF_ERROR>("fail to load protobuf. file={}",
+                                                              file_reader->path().native());
     }
 
     return Status::OK();

--- a/be/src/olap/match_predicate.cpp
+++ b/be/src/olap/match_predicate.cpp
@@ -45,8 +45,8 @@ Status MatchPredicate::evaluate(const Schema& schema, InvertedIndexIterator* ite
         return Status::OK();
     }
     if (_skip_evaluate(iterator)) {
-        LOG(INFO) << "match predicate evaluate skipped.";
-        return Status::Error<ErrorCode::INVERTED_INDEX_EVALUATE_SKIPPED>();
+        return Status::Error<ErrorCode::INVERTED_INDEX_EVALUATE_SKIPPED>(
+                "match predicate evaluate skipped.");
     }
     auto column_desc = schema.column(_column_id);
     roaring::Roaring roaring;

--- a/be/src/olap/memtable_flush_executor.cpp
+++ b/be/src/olap/memtable_flush_executor.cpp
@@ -70,7 +70,7 @@ std::ostream& operator<<(std::ostream& os, const FlushStatistic& stat) {
 Status FlushToken::submit(std::unique_ptr<MemTable> mem_table) {
     auto s = _flush_status.load();
     if (s != OK) {
-        return Status::Error(s);
+        return Status::Error(s, "FlushToken meet error");
     }
     if (mem_table->empty()) {
         return Status::OK();
@@ -89,7 +89,7 @@ void FlushToken::cancel() {
 Status FlushToken::wait() {
     _flush_token->wait();
     auto s = _flush_status.load();
-    return s == OK ? Status::OK() : Status::Error(s);
+    return s == OK ? Status::OK() : Status::Error(s, "FlushToken meet error");
 }
 
 Status FlushToken::_do_flush_memtable(MemTable* memtable, int32_t segment_id, int64_t* flush_size) {

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -122,8 +122,8 @@ Status Merger::vmerge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
         block.clear_column_data();
     }
     if (StorageEngine::instance()->stopped()) {
-        LOG(INFO) << "tablet " << tablet->full_name() << "failed to do compaction, engine stopped";
-        return Status::Error<INTERNAL_ERROR>();
+        return Status::Error<INTERNAL_ERROR>("tablet {} failed to do compaction, engine stopped",
+                                             tablet->full_name());
     }
 
     if (stats_output != nullptr) {
@@ -254,8 +254,8 @@ Status Merger::vertical_compact_one_group(
         block.clear_column_data();
     }
     if (StorageEngine::instance()->stopped()) {
-        LOG(INFO) << "tablet " << tablet->full_name() << "failed to do compaction, engine stopped";
-        return Status::Error<INTERNAL_ERROR>();
+        return Status::Error<INTERNAL_ERROR>("tablet {} failed to do compaction, engine stopped",
+                                             tablet->full_name());
     }
 
     if (is_key && stats_output != nullptr) {
@@ -299,8 +299,8 @@ Status Merger::vertical_compact_one_group(TabletSharedPtr tablet, ReaderType rea
         block.clear_column_data();
     }
     if (StorageEngine::instance()->stopped()) {
-        LOG(INFO) << "tablet " << tablet->full_name() << "failed to do compaction, engine stopped";
-        return Status::Error<INTERNAL_ERROR>();
+        return Status::Error<INTERNAL_ERROR>("tablet {} failed to do compaction, engine stopped",
+                                             tablet->full_name());
     }
 
     if (is_key && stats_output != nullptr) {

--- a/be/src/olap/olap_meta.cpp
+++ b/be/src/olap/olap_meta.cpp
@@ -45,13 +45,10 @@
 using rocksdb::DB;
 using rocksdb::DBOptions;
 using rocksdb::ColumnFamilyDescriptor;
-using rocksdb::ColumnFamilyHandle;
 using rocksdb::ColumnFamilyOptions;
 using rocksdb::ReadOptions;
 using rocksdb::WriteOptions;
-using rocksdb::Slice;
 using rocksdb::Iterator;
-using rocksdb::kDefaultColumnFamilyName;
 using rocksdb::NewFixedPrefixTransform;
 
 namespace doris {
@@ -114,8 +111,7 @@ Status OlapMeta::init() {
         _handles.emplace_back(handle);
     }
     if (!s.ok() || _db == nullptr) {
-        LOG(WARNING) << "rocks db open failed, reason:" << s.ToString();
-        return Status::Error<META_OPEN_DB_ERROR>();
+        return Status::Error<META_OPEN_DB_ERROR>("rocks db open failed, reason: {}", s.ToString());
     }
     return Status::OK();
 }
@@ -131,10 +127,10 @@ Status OlapMeta::get(const int column_family_index, const std::string& key, std:
     }
     DorisMetrics::instance()->meta_read_request_duration_us->increment(duration_ns / 1000);
     if (s.IsNotFound()) {
-        return Status::Error<META_KEY_NOT_FOUND>();
+        return Status::Error<META_KEY_NOT_FOUND>("OlapMeta::get meet not found key");
     } else if (!s.ok()) {
-        LOG(WARNING) << "rocks db get key:" << key << " failed, reason:" << s.ToString();
-        return Status::Error<META_GET_ERROR>();
+        return Status::Error<META_GET_ERROR>("rocks db get failed, key: {}, reason: {}", key,
+                                             s.ToString());
     }
     return Status::OK();
 }
@@ -177,8 +173,8 @@ Status OlapMeta::put(const int column_family_index, const std::string& key,
     }
 
     if (!s.ok()) {
-        LOG(WARNING) << "rocks db put key:" << key << " failed, reason:" << s.ToString();
-        return Status::Error<META_PUT_ERROR>();
+        return Status::Error<META_PUT_ERROR>("rocks db put failed, key: {}, reason: {}", key,
+                                             s.ToString());
     }
     return Status::OK();
 }
@@ -210,8 +206,7 @@ Status OlapMeta::put(const int column_family_index, const std::vector<BatchEntry
     }
 
     if (!s.ok()) {
-        // LOG(WARNING) << "rocks db put key:" << key << " failed, reason:" << s.ToString();
-        return Status::Error<META_PUT_ERROR>();
+        return Status::Error<META_PUT_ERROR>("rocks db put failed, reason: {}", s.ToString());
     }
     return Status::OK();
 }
@@ -229,8 +224,8 @@ Status OlapMeta::remove(const int column_family_index, const std::string& key) {
     }
     DorisMetrics::instance()->meta_write_request_duration_us->increment(duration_ns / 1000);
     if (!s.ok()) {
-        LOG(WARNING) << "rocks db delete key:" << key << " failed, reason:" << s.ToString();
-        return Status::Error<META_DELETE_ERROR>();
+        return Status::Error<META_DELETE_ERROR>("rocks db delete key: {}, failed, reason: {}", key,
+                                                s.ToString());
     }
     return Status::OK();
 }
@@ -252,9 +247,8 @@ Status OlapMeta::remove(const int column_family_index, const std::vector<std::st
     }
     DorisMetrics::instance()->meta_write_request_duration_us->increment(duration_ns / 1000);
     if (!s.ok()) {
-        LOG(WARNING) << fmt::format("rocks db delete keys:{} failed, reason:{}", keys,
-                                    s.ToString());
-        return Status::Error<META_DELETE_ERROR>();
+        return Status::Error<META_DELETE_ERROR>("rocks db delete keys:{} failed, reason:{}", keys,
+                                                s.ToString());
     }
     return Status::OK();
 }
@@ -270,8 +264,8 @@ Status OlapMeta::iterate(const int column_family_index, const std::string& prefi
     }
     rocksdb::Status status = it->status();
     if (!status.ok()) {
-        LOG(WARNING) << "rocksdb seek failed. reason:" << status.ToString();
-        return Status::Error<META_ITERATOR_ERROR>();
+        return Status::Error<META_ITERATOR_ERROR>("rocksdb seek failed. reason: {}",
+                                                  status.ToString());
     }
 
     for (; it->Valid(); it->Next()) {
@@ -288,8 +282,8 @@ Status OlapMeta::iterate(const int column_family_index, const std::string& prefi
         }
     }
     if (!it->status().ok()) {
-        LOG(WARNING) << "rocksdb iterator failed. reason:" << status.ToString();
-        return Status::Error<META_ITERATOR_ERROR>();
+        return Status::Error<META_ITERATOR_ERROR>("rocksdb iterator failed. reason: {}",
+                                                  status.ToString());
     }
 
     return Status::OK();

--- a/be/src/olap/options.cpp
+++ b/be/src/olap/options.cpp
@@ -71,10 +71,9 @@ Status parse_root_path(const string& root_path, StorePath* path) {
 
     // parse root path name
     StripWhiteSpace(&tmp_vec[0]);
-    tmp_vec[0].erase(tmp_vec[0].find_last_not_of("/") + 1);
+    tmp_vec[0].erase(tmp_vec[0].find_last_not_of('/') + 1);
     if (tmp_vec[0].empty() || tmp_vec[0][0] != '/') {
-        LOG(WARNING) << "invalid store path. path=" << tmp_vec[0];
-        return Status::Error<INVALID_ARGUMENT>();
+        return Status::Error<INVALID_ARGUMENT>("invalid store path. path={}", tmp_vec[0]);
     }
 
     string canonicalized_path;
@@ -115,8 +114,8 @@ Status parse_root_path(const string& root_path, StorePath* path) {
             // path, so it can override medium_str
             medium_str = to_upper(value);
         } else {
-            LOG(WARNING) << "invalid property of store path, " << tmp_vec[i];
-            return Status::Error<INVALID_ARGUMENT>();
+            return Status::Error<INVALID_ARGUMENT>("invalid property of store path, {}",
+                                                   tmp_vec[i]);
         }
     }
 
@@ -125,7 +124,8 @@ Status parse_root_path(const string& root_path, StorePath* path) {
         if (!valid_signed_number<int64_t>(capacity_str) ||
             strtol(capacity_str.c_str(), nullptr, 10) < 0) {
             LOG(WARNING) << "invalid capacity of store path, capacity=" << capacity_str;
-            return Status::Error<INVALID_ARGUMENT>();
+            return Status::Error<INVALID_ARGUMENT>("invalid capacity of store path, capacity={}",
+                                                   capacity_str);
         }
         path->capacity_bytes = strtol(capacity_str.c_str(), nullptr, 10) * GB_EXCHANGE_BYTE;
     }
@@ -139,8 +139,7 @@ Status parse_root_path(const string& root_path, StorePath* path) {
         } else if (medium_str == REMOTE_CACHE_UC) {
             path->storage_medium = TStorageMedium::REMOTE_CACHE;
         } else {
-            LOG(WARNING) << "invalid storage medium. medium=" << medium_str;
-            return Status::Error<INVALID_ARGUMENT>();
+            return Status::Error<INVALID_ARGUMENT>("invalid storage medium. medium={}", medium_str);
         }
     }
 
@@ -159,8 +158,8 @@ Status parse_conf_store_paths(const string& config_path, std::vector<StorePath>*
         }
     }
     if (paths->empty() || (path_vec.size() != paths->size() && !config::ignore_broken_disk)) {
-        LOG(WARNING) << "fail to parse storage_root_path config. value=[" << config_path << "]";
-        return Status::Error<INVALID_ARGUMENT>();
+        return Status::Error<INVALID_ARGUMENT>("fail to parse storage_root_path config. value={}",
+                                               config_path);
     }
     return Status::OK();
 }

--- a/be/src/olap/push_handler.cpp
+++ b/be/src/olap/push_handler.cpp
@@ -110,12 +110,14 @@ Status PushHandler::_do_streaming_ingestion(TabletSharedPtr tablet, const TPushR
     // add transaction in engine, then check sc status
     // lock, prevent sc handler checking transaction concurrently
     if (tablet == nullptr) {
-        return Status::Error<TABLE_NOT_FOUND>();
+        return Status::Error<TABLE_NOT_FOUND>(
+                "PushHandler::_do_streaming_ingestion input tablet is nullptr");
     }
 
     std::shared_lock base_migration_rlock(tablet->get_migration_lock(), std::try_to_lock);
     if (!base_migration_rlock.owns_lock()) {
-        return Status::Error<TRY_LOCK_FAILED>();
+        return Status::Error<TRY_LOCK_FAILED>(
+                "PushHandler::_do_streaming_ingestion get lock failed");
     }
     PUniqueId load_id;
     load_id.set_hi(0);
@@ -154,10 +156,9 @@ Status PushHandler::_do_streaming_ingestion(TabletSharedPtr tablet, const TPushR
 
     // check if version number exceed limit
     if (tablet->exceed_version_limit(config::max_tablet_version_num)) {
-        LOG(WARNING) << "failed to push data. version count: " << tablet->version_count()
-                     << ", exceed limit: " << config::max_tablet_version_num
-                     << ". tablet: " << tablet->full_name();
-        return Status::Status::Error<TOO_MANY_VERSION>();
+        return Status::Status::Error<TOO_MANY_VERSION>(
+                "failed to push data. version count: {}, exceed limit: {}, tablet: {}",
+                tablet->version_count(), config::max_tablet_version_num, tablet->full_name());
     }
     auto tablet_schema = std::make_shared<TabletSchema>();
     tablet_schema->copy_from(*tablet->tablet_schema());
@@ -245,8 +246,8 @@ Status PushHandler::_convert_v2(TabletSharedPtr cur_tablet, RowsetSharedPtr* cur
             // init schema
             std::unique_ptr<Schema> schema(new (std::nothrow) Schema(tablet_schema));
             if (schema == nullptr) {
-                LOG(WARNING) << "fail to create schema. tablet=" << cur_tablet->full_name();
-                res = Status::Error<MEM_ALLOC_FAILED>();
+                res = Status::Error<MEM_ALLOC_FAILED>("fail to create schema. tablet={}",
+                                                      cur_tablet->full_name());
                 break;
             }
 
@@ -255,9 +256,8 @@ Status PushHandler::_convert_v2(TabletSharedPtr cur_tablet, RowsetSharedPtr* cur
                     schema.get(), _request.broker_scan_range, _request.desc_tbl);
             res = reader->init();
             if (reader == nullptr || !res.ok()) {
-                LOG(WARNING) << "fail to init reader. res=" << res
-                             << ", tablet=" << cur_tablet->full_name();
-                res = Status::Error<PUSH_INIT_ERROR>();
+                res = Status::Error<PUSH_INIT_ERROR>("fail to init reader. res={}, tablet={}", res,
+                                                     cur_tablet->full_name());
                 break;
             }
 
@@ -296,8 +296,7 @@ Status PushHandler::_convert_v2(TabletSharedPtr cur_tablet, RowsetSharedPtr* cur
         }
         *cur_rowset = rowset_writer->build();
         if (*cur_rowset == nullptr) {
-            LOG(WARNING) << "fail to build rowset";
-            res = Status::Error<MEM_ALLOC_FAILED>();
+            res = Status::Error<MEM_ALLOC_FAILED>("fail to build rowset");
             break;
         }
 
@@ -367,8 +366,7 @@ Status PushBrokerReader::init() {
     DescriptorTbl* desc_tbl = nullptr;
     Status status = DescriptorTbl::create(_runtime_state->obj_pool(), _t_desc_tbl, &desc_tbl);
     if (UNLIKELY(!status.ok())) {
-        LOG(WARNING) << "Failed to create descriptor table, msg: " << status;
-        return Status::Error<PUSH_INIT_ERROR>();
+        return Status::Error<PUSH_INIT_ERROR>("Failed to create descriptor table, msg: {}", status);
     }
     _runtime_state->set_desc_tbl(desc_tbl);
     _runtime_state->init_mem_trackers(dummy_id, "PushBrokerReader");
@@ -393,7 +391,7 @@ Status PushBrokerReader::init() {
 
 Status PushBrokerReader::next(vectorized::Block* block) {
     if (!_ready || block == nullptr) {
-        return Status::Error<INVALID_ARGUMENT>();
+        return Status::Error<INVALID_ARGUMENT>("PushBrokerReader not ready or block is nullptr");
     }
     if (_cur_reader == nullptr || _cur_reader_eof) {
         RETURN_IF_ERROR(_get_next_reader());
@@ -641,8 +639,8 @@ Status PushBrokerReader::_get_next_reader() {
         break;
     }
     default:
-        LOG(WARNING) << "Unsupported file format type: " << _file_params.format_type;
-        return Status::Error<PUSH_INIT_ERROR>();
+        return Status::Error<PUSH_INIT_ERROR>("Unsupported file format type: {}",
+                                              _file_params.format_type);
     }
     _cur_reader_eof = false;
 

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -346,9 +346,9 @@ Status TabletReader::_init_return_columns(const ReaderParams& read_params) {
             }
         }
     } else {
-        LOG(WARNING) << "fail to init return columns. [reader_type=" << int(read_params.reader_type)
-                     << " return_columns_size=" << read_params.return_columns.size() << "]";
-        return Status::Error<INVALID_ARGUMENT>();
+        return Status::Error<INVALID_ARGUMENT>(
+                "fail to init return columns. reader_type={}, return_columns_size={}",
+                int(read_params.reader_type), read_params.return_columns.size());
     }
 
     std::sort(_key_cids.begin(), _key_cids.end(), std::greater<uint32_t>());
@@ -370,11 +370,10 @@ Status TabletReader::_init_keys_param(const ReaderParams& read_params) {
 
     size_t scan_key_size = read_params.start_key.front().size();
     if (scan_key_size > _tablet_schema->num_columns()) {
-        LOG(WARNING)
-                << "Input param are invalid. Column count is bigger than num_columns of schema. "
-                << "column_count=" << scan_key_size
-                << ", schema.num_columns=" << _tablet_schema->num_columns();
-        return Status::Error<INVALID_ARGUMENT>();
+        return Status::Error<INVALID_ARGUMENT>(
+                "Input param are invalid. Column count is bigger than num_columns of schema. "
+                "column_count={}, schema.num_columns={}",
+                scan_key_size, _tablet_schema->num_columns());
     }
 
     std::vector<uint32_t> columns(scan_key_size);
@@ -384,10 +383,9 @@ Status TabletReader::_init_keys_param(const ReaderParams& read_params) {
 
     for (size_t i = 0; i < start_key_size; ++i) {
         if (read_params.start_key[i].size() != scan_key_size) {
-            LOG(WARNING) << "The start_key.at(" << i
-                         << ").size == " << read_params.start_key[i].size() << ", not equals the "
-                         << scan_key_size;
-            return Status::Error<INVALID_ARGUMENT>();
+            return Status::Error<INVALID_ARGUMENT>(
+                    "The start_key.at({}).size={}, not equals the scan_key_size={}", i,
+                    read_params.start_key[i].size(), scan_key_size);
         }
 
         Status res = _keys_param.start_keys[i].init_scan_key(
@@ -408,9 +406,9 @@ Status TabletReader::_init_keys_param(const ReaderParams& read_params) {
     std::vector<RowCursor>(end_key_size).swap(_keys_param.end_keys);
     for (size_t i = 0; i < end_key_size; ++i) {
         if (read_params.end_key[i].size() != scan_key_size) {
-            LOG(WARNING) << "The end_key.at(" << i << ").size == " << read_params.end_key[i].size()
-                         << ", not equals the " << scan_key_size;
-            return Status::Error<INVALID_ARGUMENT>();
+            return Status::Error<INVALID_ARGUMENT>(
+                    "The end_key.at({}).size={}, not equals the scan_key_size={}", i,
+                    read_params.end_key[i].size(), scan_key_size);
         }
 
         Status res = _keys_param.end_keys[i].init_scan_key(_tablet_schema,
@@ -450,7 +448,11 @@ Status TabletReader::_init_orderby_keys_param(const ReaderParams& read_params) {
             LOG(WARNING) << "read_orderby_key_num_prefix_columns != _orderby_key_columns.size "
                          << read_params.read_orderby_key_num_prefix_columns << " vs. "
                          << _orderby_key_columns.size();
-            return Status::Error<ErrorCode::INTERNAL_ERROR>();
+            return Status::Error<ErrorCode::INTERNAL_ERROR>(
+                    "read_orderby_key_num_prefix_columns != _orderby_key_columns.size, "
+                    "read_params.read_orderby_key_num_prefix_columns={}, "
+                    "_orderby_key_columns.size()={}",
+                    read_params.read_orderby_key_num_prefix_columns, _orderby_key_columns.size());
         }
     }
 

--- a/be/src/olap/reader.h
+++ b/be/src/olap/reader.h
@@ -183,7 +183,8 @@ public:
     // Return OK and set `*eof` to true when no more rows can be read.
     // Return others when unexpected error happens.
     virtual Status next_block_with_aggregation(vectorized::Block* block, bool* eof) {
-        return Status::Error<ErrorCode::READER_INITIALIZE_ERROR>();
+        return Status::Error<ErrorCode::READER_INITIALIZE_ERROR>(
+                "TabletReader not support next_block_with_aggregation");
     }
 
     virtual uint64_t merged_rows() const { return _merged_rows; }

--- a/be/src/olap/row_cursor.cpp
+++ b/be/src/olap/row_cursor.cpp
@@ -54,8 +54,7 @@ Status RowCursor::_init(const std::vector<uint32_t>& columns) {
     _variable_len = 0;
     for (auto cid : columns) {
         if (_schema->column(cid) == nullptr) {
-            LOG(WARNING) << "Fail to create field.";
-            return Status::Error<INIT_FAILED>();
+            return Status::Error<INIT_FAILED>("Fail to malloc _fixed_buf.");
         }
         _variable_len += column_schema(cid)->get_variable_len();
         if (_schema->column(cid)->type() == FieldType::OLAP_FIELD_TYPE_STRING) {
@@ -66,8 +65,7 @@ Status RowCursor::_init(const std::vector<uint32_t>& columns) {
     _fixed_len = _schema->schema_size();
     _fixed_buf = new (nothrow) char[_fixed_len]();
     if (_fixed_buf == nullptr) {
-        LOG(WARNING) << "Fail to malloc _fixed_buf.";
-        return Status::Error<MEM_ALLOC_FAILED>();
+        return Status::Error<MEM_ALLOC_FAILED>("Fail to malloc _fixed_buf.");
     }
     _owned_fixed_buf = _fixed_buf;
 
@@ -145,11 +143,10 @@ Status RowCursor::init(const std::vector<TabletColumn>& schema) {
 
 Status RowCursor::init(TabletSchemaSPtr schema, size_t column_count) {
     if (column_count > schema->num_columns()) {
-        LOG(WARNING)
-                << "Input param are invalid. Column count is bigger than num_columns of schema. "
-                << "column_count=" << column_count
-                << ", schema.num_columns=" << schema->num_columns();
-        return Status::Error<INVALID_ARGUMENT>();
+        return Status::Error<INVALID_ARGUMENT>(
+                "Input param are invalid. Column count is bigger than num_columns of schema. "
+                "column_count={}, schema.num_columns={}",
+                column_count, schema->num_columns());
     }
 
     std::vector<uint32_t> columns;
@@ -162,10 +159,10 @@ Status RowCursor::init(TabletSchemaSPtr schema, size_t column_count) {
 
 Status RowCursor::init(const std::vector<TabletColumn>& schema, size_t column_count) {
     if (column_count > schema.size()) {
-        LOG(WARNING)
-                << "Input param are invalid. Column count is bigger than num_columns of schema. "
-                << "column_count=" << column_count << ", schema.num_columns=" << schema.size();
-        return Status::Error<INVALID_ARGUMENT>();
+        return Status::Error<INVALID_ARGUMENT>(
+                "Input param are invalid. Column count is bigger than num_columns of schema. "
+                "column_count={}, schema.num_columns={}",
+                column_count, schema.size());
     }
 
     std::vector<uint32_t> columns;
@@ -185,11 +182,10 @@ Status RowCursor::init_scan_key(TabletSchemaSPtr schema,
                                 const std::vector<std::string>& scan_keys) {
     size_t scan_key_size = scan_keys.size();
     if (scan_key_size > schema->num_columns()) {
-        LOG(WARNING)
-                << "Input param are invalid. Column count is bigger than num_columns of schema. "
-                << "column_count=" << scan_key_size
-                << ", schema.num_columns=" << schema->num_columns();
-        return Status::Error<INVALID_ARGUMENT>();
+        return Status::Error<INVALID_ARGUMENT>(
+                "Input param are invalid. Column count is bigger than num_columns of schema. "
+                "column_count={}, schema.num_columns={}",
+                scan_key_size, schema->num_columns());
     }
 
     std::vector<uint32_t> columns(scan_key_size);
@@ -265,9 +261,9 @@ Status RowCursor::build_min_key() {
 
 Status RowCursor::from_tuple(const OlapTuple& tuple) {
     if (tuple.size() != _schema->num_column_ids()) {
-        LOG(WARNING) << "column count does not match. tuple_size=" << tuple.size()
-                     << ", field_count=" << _schema->num_column_ids();
-        return Status::Error<INVALID_ARGUMENT>();
+        return Status::Error<INVALID_ARGUMENT>(
+                "column count does not match. tuple_size={}, field_count={}", tuple.size(),
+                _schema->num_column_ids());
     }
 
     for (size_t i = 0; i < tuple.size(); ++i) {
@@ -336,20 +332,17 @@ Status RowCursor::_alloc_buf() {
     // variable_len for null bytes
     _variable_buf = new (nothrow) char[_variable_len]();
     if (_variable_buf == nullptr) {
-        LOG(WARNING) << "Fail to malloc _variable_buf.";
-        return Status::Error<MEM_ALLOC_FAILED>();
+        return Status::Error<MEM_ALLOC_FAILED>("Fail to malloc _variable_buf.");
     }
     if (_string_field_count > 0) {
         _long_text_buf = (char**)malloc(_string_field_count * sizeof(char*));
         if (_long_text_buf == nullptr) {
-            LOG(WARNING) << "Fail to malloc _long_text_buf.";
-            return Status::Error<MEM_ALLOC_FAILED>();
+            return Status::Error<MEM_ALLOC_FAILED>("Fail to malloc _long_text_buf.");
         }
         for (int i = 0; i < _string_field_count; ++i) {
             _long_text_buf[i] = (char*)malloc(DEFAULT_TEXT_LENGTH * sizeof(char));
             if (_long_text_buf[i] == nullptr) {
-                LOG(WARNING) << "Fail to malloc _long_text_buf.";
-                return Status::Error<MEM_ALLOC_FAILED>();
+                return Status::Error<MEM_ALLOC_FAILED>("Fail to malloc _long_text_buf.");
             }
         }
     }

--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -122,7 +122,7 @@ Status BetaRowset::do_load(bool /*use_cache*/) {
 Status BetaRowset::get_segments_size(std::vector<size_t>* segments_size) {
     auto fs = _rowset_meta->fs();
     if (!fs || _schema == nullptr) {
-        return Status::Error<INIT_FAILED>();
+        return Status::Error<INIT_FAILED>("get fs failed");
     }
     for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
         auto seg_path = segment_file_path(seg_id);
@@ -140,7 +140,7 @@ Status BetaRowset::load_segments(int64_t seg_id_begin, int64_t seg_id_end,
                                  std::vector<segment_v2::SegmentSharedPtr>* segments) {
     auto fs = _rowset_meta->fs();
     if (!fs || _schema == nullptr) {
-        return Status::Error<INIT_FAILED>();
+        return Status::Error<INIT_FAILED>("get fs failed");
     }
     int64_t seg_id = seg_id_begin;
     while (seg_id < seg_id_end) {
@@ -177,7 +177,7 @@ Status BetaRowset::remove() {
                 << ", tabletid:" << _rowset_meta->tablet_id();
     auto fs = _rowset_meta->fs();
     if (!fs) {
-        return Status::Error<INIT_FAILED>();
+        return Status::Error<INIT_FAILED>("get fs failed");
     }
     bool success = true;
     Status st;
@@ -209,8 +209,8 @@ Status BetaRowset::remove() {
         }
     }
     if (!success) {
-        LOG(WARNING) << "failed to remove files in rowset " << unique_id();
-        return Status::Error<ROWSET_DELETE_FILE_FAILED>();
+        return Status::Error<ROWSET_DELETE_FILE_FAILED>("failed to remove files in rowset {}",
+                                                        unique_id());
     }
     return Status::OK();
 }
@@ -225,7 +225,7 @@ Status BetaRowset::link_files_to(const std::string& dir, RowsetId new_rowset_id,
     DCHECK(is_local());
     auto fs = _rowset_meta->fs();
     if (!fs) {
-        return Status::Error<INIT_FAILED>();
+        return Status::Error<INIT_FAILED>("get fs failed");
     }
     if (fs->type() != io::FileSystemType::LOCAL) {
         return Status::InternalError("should be local file system");
@@ -235,16 +235,15 @@ Status BetaRowset::link_files_to(const std::string& dir, RowsetId new_rowset_id,
         auto dst_path = segment_file_path(dir, new_rowset_id, i + new_rowset_start_seg_id);
         bool dst_path_exist = false;
         if (!fs->exists(dst_path, &dst_path_exist).ok() || dst_path_exist) {
-            LOG(WARNING) << "failed to create hard link, file already exist: " << dst_path;
-            return Status::Error<FILE_ALREADY_EXIST>();
+            return Status::Error<FILE_ALREADY_EXIST>(
+                    "failed to create hard link, file already exist: {}", dst_path);
         }
         auto src_path = segment_file_path(i);
         // TODO(lingbin): how external storage support link?
         //     use copy? or keep refcount to avoid being delete?
         if (!local_fs->link_file(src_path, dst_path).ok()) {
-            LOG(WARNING) << "fail to create hard link. from=" << src_path << ", "
-                         << "to=" << dst_path << ", errno=" << Errno::no();
-            return Status::Error<OS_ERROR>();
+            return Status::Error<OS_ERROR>("fail to create hard link. from={}, to={}, errno={}",
+                                           src_path, dst_path);
         }
         for (auto& index : _schema->indexes()) {
             if (index.index_type() != IndexType::INVERTED) {
@@ -255,7 +254,6 @@ Status BetaRowset::link_files_to(const std::string& dir, RowsetId new_rowset_id,
             if (without_index_uids != nullptr && without_index_uids->count(index_id)) {
                 continue;
             }
-
             std::string inverted_index_src_file_path =
                     InvertedIndexDescriptor::get_index_file_name(src_path, index_id);
             std::string inverted_index_dst_file_path =
@@ -271,11 +269,10 @@ Status BetaRowset::link_files_to(const std::string& dir, RowsetId new_rowset_id,
             if (need_to_link) {
                 if (!local_fs->link_file(inverted_index_src_file_path, inverted_index_dst_file_path)
                              .ok()) {
-                    LOG(WARNING) << "fail to create hard link. from="
-                                 << inverted_index_src_file_path << ", "
-                                 << "to=" << inverted_index_dst_file_path
-                                 << ", errno=" << Errno::no();
-                    return Status::Error<OS_ERROR>();
+                    return Status::Error<OS_ERROR>(
+                            "fail to create hard link. from={}, to={}, errno={}",
+                            inverted_index_src_file_path, inverted_index_dst_file_path,
+                            Errno::no());
                 }
                 LOG(INFO) << "success to create hard link. from=" << inverted_index_src_file_path
                           << ", "
@@ -293,8 +290,7 @@ Status BetaRowset::copy_files_to(const std::string& dir, const RowsetId& new_row
         auto dst_path = segment_file_path(dir, new_rowset_id, i);
         RETURN_IF_ERROR(io::global_local_filesystem()->exists(dst_path, &exists));
         if (exists) {
-            LOG(WARNING) << "file already exist: " << dst_path;
-            return Status::Error<FILE_ALREADY_EXIST>();
+            return Status::Error<FILE_ALREADY_EXIST>("file already exist: {}", dst_path);
         }
         auto src_path = segment_file_path(i);
         RETURN_IF_ERROR(io::global_local_filesystem()->copy_dirs(src_path, dst_path));
@@ -412,7 +408,7 @@ Status BetaRowset::add_to_binlog() {
     DCHECK(is_local());
     auto fs = _rowset_meta->fs();
     if (!fs) {
-        return Status::Error<INIT_FAILED>();
+        return Status::Error<INIT_FAILED>("get fs failed");
     }
     if (fs->type() != io::FileSystemType::LOCAL) {
         return Status::InternalError("should be local file system");
@@ -443,9 +439,8 @@ Status BetaRowset::add_to_binlog() {
                         .string();
         VLOG_DEBUG << "link " << seg_file << " to " << binlog_file;
         if (!local_fs->link_file(seg_file, binlog_file).ok()) {
-            LOG(WARNING) << "fail to create hard link. from=" << seg_file << ", "
-                         << "to=" << binlog_file << ", errno=" << Errno::no();
-            return Status::Error<OS_ERROR>();
+            return Status::Error<OS_ERROR>("fail to create hard link. from={}, to={}, errno={}",
+                                           seg_file, binlog_file, Errno::no());
         }
     }
 

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -282,7 +282,7 @@ Status BetaRowsetReader::init(RowsetReaderContext* read_context,
 Status BetaRowsetReader::next_block(vectorized::Block* block) {
     SCOPED_RAW_TIMER(&_stats->block_fetch_ns);
     if (_empty) {
-        return Status::Error<END_OF_FILE>();
+        return Status::Error<END_OF_FILE>("BetaRowsetReader is empty");
     }
 
     do {

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -180,7 +180,8 @@ Status BetaRowsetWriter::_load_noncompacted_segments(
         std::vector<segment_v2::SegmentSharedPtr>* segments, size_t num) {
     auto fs = _rowset_meta->fs();
     if (!fs) {
-        return Status::Error<INIT_FAILED>();
+        return Status::Error<INIT_FAILED>(
+                "BetaRowsetWriter::_load_noncompacted_segments _rowset_meta->fs get failed");
     }
     for (int seg_id = _segcompacted_point; seg_id < num; ++seg_id) {
         auto seg_path =
@@ -271,9 +272,9 @@ Status BetaRowsetWriter::_rename_compacted_segments(int64_t begin, int64_t end) 
                                                       _num_segcompacted);
     ret = rename(src_seg_path.c_str(), dst_seg_path.c_str());
     if (ret) {
-        LOG(WARNING) << "failed to rename " << src_seg_path << " to " << dst_seg_path
-                     << ". ret:" << ret << " errno:" << errno;
-        return Status::Error<ROWSET_RENAME_FILE_FAILED>();
+        return Status::Error<ROWSET_RENAME_FILE_FAILED>(
+                "failed to rename {} to {}. ret:{}, errno:{}", src_seg_path, dst_seg_path, ret,
+                errno);
     }
 
     // rename inverted index files
@@ -315,9 +316,9 @@ Status BetaRowsetWriter::_rename_compacted_segment_plain(uint64_t seg_id) {
     }
     ret = rename(src_seg_path.c_str(), dst_seg_path.c_str());
     if (ret) {
-        LOG(WARNING) << "failed to rename " << src_seg_path << " to " << dst_seg_path
-                     << ". ret:" << ret << " errno:" << errno;
-        return Status::Error<ROWSET_RENAME_FILE_FAILED>();
+        return Status::Error<ROWSET_RENAME_FILE_FAILED>(
+                "failed to rename {} to {}. ret:{}, errno:{}", src_seg_path, dst_seg_path, ret,
+                errno);
     }
     // rename remaining inverted index files
     RETURN_IF_ERROR(_rename_compacted_indices(-1, -1, seg_id));
@@ -345,9 +346,9 @@ Status BetaRowsetWriter::_rename_compacted_indices(int64_t begin, int64_t end, u
                        << dst_idx_path;
             ret = rename(src_idx_path.c_str(), dst_idx_path.c_str());
             if (ret) {
-                LOG(WARNING) << "failed to rename " << src_idx_path << " to " << dst_idx_path
-                             << ". ret:" << ret << " errno:" << errno;
-                return Status::Error<INVERTED_INDEX_RENAME_FILE_FAILED>();
+                return Status::Error<INVERTED_INDEX_RENAME_FILE_FAILED>(
+                        "failed to rename {} to {}. ret:{}, errno:{}", src_idx_path, dst_idx_path,
+                        ret, errno);
             }
             // Erase the origin index file cache
             InvertedIndexSearcherCache::instance()->erase(src_idx_path);
@@ -391,7 +392,8 @@ Status BetaRowsetWriter::_segcompaction_if_necessary() {
         return status;
     }
     if (_segcompaction_status.load() != OK) {
-        status = Status::Error<SEGCOMPACTION_FAILED>();
+        status = Status::Error<SEGCOMPACTION_FAILED>(
+                "BetaRowsetWriter::_segcompaction_if_necessary meet invalid state");
     } else if ((_num_segment - _segcompacted_point) >=
                config::segcompaction_threshold_segment_num) {
         SegCompactionCandidatesSharedPtr segments = std::make_shared<SegCompactionCandidates>();
@@ -421,7 +423,8 @@ Status BetaRowsetWriter::_segcompaction_ramaining_if_necessary() {
         return Status::OK();
     }
     if (_segcompaction_status.load() != OK) {
-        return Status::Error<SEGCOMPACTION_FAILED>();
+        return Status::Error<SEGCOMPACTION_FAILED>(
+                "BetaRowsetWriter::_segcompaction_ramaining_if_necessary meet invalid state");
     }
     if (!_is_segcompacted() || _segcompacted_point == _num_segment) {
         // no need if never segcompact before or all segcompacted
@@ -448,8 +451,7 @@ Status BetaRowsetWriter::_do_add_block(const vectorized::Block* block,
                                        size_t row_offset, size_t input_row_num) {
     auto s = (*segment_writer)->append_block(block, row_offset, input_row_num);
     if (UNLIKELY(!s.ok())) {
-        LOG(WARNING) << "failed to append block: " << s.to_string();
-        return Status::Error<WRITER_DATA_WRITE_ERROR>();
+        return Status::Error<WRITER_DATA_WRITE_ERROR>("failed to append block: {}", s.to_string());
     }
     return Status::OK();
 }
@@ -570,7 +572,7 @@ Status BetaRowsetWriter::wait_flying_segcompaction() {
         LOG(INFO) << "wait flying segcompaction finish time:" << elapsed << "us";
     }
     if (_segcompaction_status.load() != OK) {
-        return Status::Error<SEGCOMPACTION_FAILED>();
+        return Status::Error<SEGCOMPACTION_FAILED>("BetaRowsetWriter meet invalid state.");
     }
     return Status::OK();
 }
@@ -752,7 +754,7 @@ RowsetSharedPtr BetaRowsetWriter::_build_tmp() {
 Status BetaRowsetWriter::_create_file_writer(std::string path, io::FileWriterPtr* file_writer) {
     auto fs = _rowset_meta->fs();
     if (!fs) {
-        return Status::Error<INIT_FAILED>();
+        return Status::Error<INIT_FAILED>("get fs failed");
     }
     Status st = fs->create_file(path, file_writer);
     if (!st.ok()) {
@@ -795,7 +797,6 @@ Status BetaRowsetWriter::_do_create_segment_writer(
         segment_id = segid_offset + _segment_start_id;
         st = create_file_writer(segment_id, &file_writer);
     }
-
     if (!st.ok()) {
         return st;
     }
@@ -846,13 +847,12 @@ Status BetaRowsetWriter::_create_segment_writer(std::unique_ptr<segment_v2::Segm
                                                 const FlushContext* flush_ctx) {
     size_t total_segment_num = _num_segment - _segcompacted_point + 1 + _num_segcompacted;
     if (UNLIKELY(total_segment_num > config::max_segment_num_per_rowset)) {
-        LOG(WARNING) << "too many segments in rowset."
-                     << " tablet_id:" << _context.tablet_id << " rowset_id:" << _context.rowset_id
-                     << " max:" << config::max_segment_num_per_rowset
-                     << " _num_segment:" << _num_segment
-                     << " _segcompacted_point:" << _segcompacted_point
-                     << " _num_segcompacted:" << _num_segcompacted;
-        return Status::Error<TOO_MANY_SEGMENTS>();
+        return Status::Error<TOO_MANY_SEGMENTS>(
+                "too many segments in rowset. tablet_id:{}, rowset_id:{}, max:{}, _num_segment:{}, "
+                "_segcompacted_point:{}, _num_segcompacted:{}",
+                _context.tablet_id, _context.rowset_id.to_string(),
+                config::max_segment_num_per_rowset, _num_segment, _segcompacted_point,
+                _num_segcompacted);
     } else {
         return _do_create_segment_writer(writer, false, -1, -1, flush_ctx);
     }
@@ -870,8 +870,7 @@ Status BetaRowsetWriter::_flush_segment_writer(std::unique_ptr<segment_v2::Segme
     uint64_t index_size;
     Status s = (*writer)->finalize(&segment_size, &index_size);
     if (!s.ok()) {
-        LOG(WARNING) << "failed to finalize segment: " << s.to_string();
-        return Status::Error(s.code());
+        return Status::Error(s.code(), "failed to finalize segment: {}", s.to_string());
     }
     VLOG_DEBUG << "tablet_id:" << _context.tablet_id
                << " flushing filename: " << (*writer)->get_data_dir()->path()
@@ -930,8 +929,8 @@ Status BetaRowsetWriter::flush_segment_writer_for_segcompaction(
 
     auto s = (*writer)->finalize_footer(&segment_size);
     if (!s.ok()) {
-        LOG(WARNING) << "failed to finalize segment: " << s.to_string();
-        return Status::Error<WRITER_DATA_WRITE_ERROR>();
+        return Status::Error<WRITER_DATA_WRITE_ERROR>("failed to finalize segment: {}",
+                                                      s.to_string());
     }
 
     SegmentStatistics segstat;

--- a/be/src/olap/rowset/rowset.h
+++ b/be/src/olap/rowset/rowset.h
@@ -75,7 +75,8 @@ public:
             break;
 
         default:
-            return Status::Error<ErrorCode::ROWSET_INVALID_STATE_TRANSITION>();
+            return Status::Error<ErrorCode::ROWSET_INVALID_STATE_TRANSITION>(
+                    "RowsetStateMachine meet invalid state");
         }
         return Status::OK();
     }
@@ -91,7 +92,8 @@ public:
             break;
 
         default:
-            return Status::Error<ErrorCode::ROWSET_INVALID_STATE_TRANSITION>();
+            return Status::Error<ErrorCode::ROWSET_INVALID_STATE_TRANSITION>(
+                    "RowsetStateMachine meet invalid state");
         }
         return Status::OK();
     }
@@ -103,7 +105,8 @@ public:
             break;
 
         default:
-            return Status::Error<ErrorCode::ROWSET_INVALID_STATE_TRANSITION>();
+            return Status::Error<ErrorCode::ROWSET_INVALID_STATE_TRANSITION>(
+                    "RowsetStateMachine meet invalid state");
         }
         return Status::OK();
     }

--- a/be/src/olap/rowset/rowset_factory.cpp
+++ b/be/src/olap/rowset/rowset_factory.cpp
@@ -35,19 +35,19 @@ Status RowsetFactory::create_rowset(const TabletSchemaSPtr& schema, const std::s
                                     const RowsetMetaSharedPtr& rowset_meta,
                                     RowsetSharedPtr* rowset) {
     if (rowset_meta->rowset_type() == ALPHA_ROWSET) {
-        return Status::Error<ROWSET_INVALID>();
+        return Status::Error<ROWSET_INVALID>("invalid rowset_type");
     }
     if (rowset_meta->rowset_type() == BETA_ROWSET) {
         rowset->reset(new BetaRowset(schema, tablet_path, rowset_meta));
         return (*rowset)->init();
     }
-    return Status::Error<ROWSET_TYPE_NOT_FOUND>(); // should never happen
+    return Status::Error<ROWSET_TYPE_NOT_FOUND>("invalid rowset_type"); // should never happen
 }
 
 Status RowsetFactory::create_rowset_writer(const RowsetWriterContext& context, bool is_vertical,
                                            std::unique_ptr<RowsetWriter>* output) {
     if (context.rowset_type == ALPHA_ROWSET) {
-        return Status::Error<ROWSET_INVALID>();
+        return Status::Error<ROWSET_INVALID>("invalid rowset_type");
     }
     if (context.rowset_type == BETA_ROWSET) {
         if (is_vertical) {
@@ -57,7 +57,7 @@ Status RowsetFactory::create_rowset_writer(const RowsetWriterContext& context, b
         output->reset(new BetaRowsetWriter);
         return (*output)->init(context);
     }
-    return Status::Error<ROWSET_TYPE_NOT_FOUND>();
+    return Status::Error<ROWSET_TYPE_NOT_FOUND>("invalid rowset_type");
 }
 
 } // namespace doris

--- a/be/src/olap/rowset/rowset_meta_manager.cpp
+++ b/be/src/olap/rowset/rowset_meta_manager.cpp
@@ -62,18 +62,14 @@ Status RowsetMetaManager::get_rowset_meta(OlapMeta* meta, TabletUid tablet_uid,
     std::string value;
     Status s = meta->get(META_COLUMN_FAMILY_INDEX, key, &value);
     if (s.is<META_KEY_NOT_FOUND>()) {
-        std::string error_msg = "rowset id:" + key + " not found.";
-        LOG(WARNING) << error_msg;
-        return Status::Error<META_KEY_NOT_FOUND>();
+        return Status::Error<META_KEY_NOT_FOUND>("rowset id: {} not found.", key);
     } else if (!s.ok()) {
-        std::string error_msg = "load rowset id:" + key + " failed.";
-        LOG(WARNING) << error_msg;
-        return Status::Error<IO_ERROR>();
+        return Status::Error<IO_ERROR>("load rowset id: {} failed.", key);
     }
     bool ret = rowset_meta->init(value);
     if (!ret) {
-        std::string error_msg = "parse rowset meta failed. rowset id:" + key;
-        return Status::Error<SERIALIZE_PROTOBUF_ERROR>();
+        return Status::Error<SERIALIZE_PROTOBUF_ERROR>("parse rowset meta failed. rowset id: {}",
+                                                       key);
     }
     return Status::OK();
 }
@@ -88,8 +84,8 @@ Status RowsetMetaManager::get_json_rowset_meta(OlapMeta* meta, TabletUid tablet_
     }
     bool ret = rowset_meta_ptr->json_rowset_meta(json_rowset_meta);
     if (!ret) {
-        std::string error_msg = "get json rowset meta failed. rowset id:" + rowset_id.to_string();
-        return Status::Error<SERIALIZE_PROTOBUF_ERROR>();
+        return Status::Error<SERIALIZE_PROTOBUF_ERROR>("get json rowset meta failed. rowset id:{}",
+                                                       rowset_id.to_string());
     }
     return Status::OK();
 }
@@ -108,8 +104,8 @@ Status RowsetMetaManager::save(OlapMeta* meta, TabletUid tablet_uid, const Rowse
             fmt::format("{}{}_{}", ROWSET_PREFIX, tablet_uid.to_string(), rowset_id.to_string());
     std::string value;
     if (!rowset_meta_pb.SerializeToString(&value)) {
-        LOG(WARNING) << "serialize rowset pb failed. rowset id:" << key;
-        return Status::Error<SERIALIZE_PROTOBUF_ERROR>();
+        return Status::Error<SERIALIZE_PROTOBUF_ERROR>("serialize rowset pb failed. rowset id:{}",
+                                                       key);
     }
 
     return meta->put(META_COLUMN_FAMILY_INDEX, key, value);
@@ -123,8 +119,8 @@ Status RowsetMetaManager::_save_with_binlog(OlapMeta* meta, TabletUid tablet_uid
             fmt::format("{}{}_{}", ROWSET_PREFIX, tablet_uid.to_string(), rowset_id.to_string());
     std::string rowset_value;
     if (!rowset_meta_pb.SerializeToString(&rowset_value)) {
-        LOG(WARNING) << "serialize rowset pb failed. rowset id:" << rowset_key;
-        return Status::Error<SERIALIZE_PROTOBUF_ERROR>();
+        return Status::Error<SERIALIZE_PROTOBUF_ERROR>("serialize rowset pb failed. rowset id:{}",
+                                                       rowset_key);
     }
 
     // create binlog write data
@@ -133,9 +129,8 @@ Status RowsetMetaManager::_save_with_binlog(OlapMeta* meta, TabletUid tablet_uid
     // version is formatted to 20 bytes to avoid the problem of sorting, version is lower, timestamp is lower
     // binlog key is not supported for cumulative rowset
     if (rowset_meta_pb.start_version() != rowset_meta_pb.end_version()) {
-        LOG(WARNING) << "binlog key is not supported for cumulative rowset. rowset id:"
-                     << rowset_key;
-        return Status::Error<ROWSET_BINLOG_NOT_ONLY_ONE_VERSION>();
+        return Status::Error<ROWSET_BINLOG_NOT_ONLY_ONE_VERSION>(
+                "binlog key is not supported for cumulative rowset. rowset id:{}", rowset_key);
     }
     auto version = rowset_meta_pb.start_version();
     std::string binlog_meta_key = make_binlog_meta_key(tablet_uid, version, rowset_id);
@@ -149,8 +144,8 @@ Status RowsetMetaManager::_save_with_binlog(OlapMeta* meta, TabletUid tablet_uid
     binlog_meta_entry_pb.set_rowset_id_v2(rowset_meta_pb.rowset_id_v2());
     std::string binlog_meta_value;
     if (!binlog_meta_entry_pb.SerializeToString(&binlog_meta_value)) {
-        LOG(WARNING) << "serialize binlog pb failed. rowset id:" << binlog_meta_key;
-        return Status::Error<SERIALIZE_PROTOBUF_ERROR>();
+        return Status::Error<SERIALIZE_PROTOBUF_ERROR>("serialize binlog pb failed. rowset id:{}",
+                                                       binlog_meta_key);
     }
 
     // create batch entries
@@ -181,7 +176,7 @@ std::vector<std::string> RowsetMetaManager::get_binlog_filenames(OlapMeta* meta,
             LOG(WARNING) << fmt::format("invalid binlog meta key:{}", key);
             return false;
         }
-        if (auto pos = key.rfind("_"); pos == std::string::npos) {
+        if (auto pos = key.rfind('_'); pos == std::string::npos) {
             LOG(WARNING) << fmt::format("invalid binlog meta key:{}", key);
             return false;
         } else {
@@ -235,7 +230,7 @@ std::pair<std::string, int64_t> RowsetMetaManager::get_binlog_info(
                                                      const std::string& value) -> bool {
         VLOG_DEBUG << fmt::format("key:{}, value:{}", key, value);
         // key is 'binglog_meta_6943f1585fe834b5-e542c2b83a21d0b7_00000000000000000069_020000000000000135449d7cd7eadfe672aa0f928fa99593', extract last part '020000000000000135449d7cd7eadfe672aa0f928fa99593'
-        auto pos = key.rfind("_");
+        auto pos = key.rfind('_');
         if (pos == std::string::npos) {
             LOG(WARNING) << fmt::format("invalid binlog meta key:{}", key);
             return false;
@@ -325,9 +320,7 @@ Status RowsetMetaManager::load_json_rowset_meta(OlapMeta* meta,
     RowsetMeta rowset_meta;
     bool ret = rowset_meta.init_from_json(json_rowset_meta);
     if (!ret) {
-        std::string error_msg = "parse json rowset meta failed.";
-        LOG(WARNING) << error_msg;
-        return Status::Error<SERIALIZE_PROTOBUF_ERROR>();
+        return Status::Error<SERIALIZE_PROTOBUF_ERROR>("parse json rowset meta failed.");
     }
     RowsetId rowset_id = rowset_meta.rowset_id();
     TabletUid tablet_uid = rowset_meta.tablet_uid();

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -51,11 +51,13 @@ public:
     virtual Status init(const RowsetWriterContext& rowset_writer_context) = 0;
 
     virtual Status add_block(const vectorized::Block* block) {
-        return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>();
+        return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>(
+                "RowsetWriter not support add_block");
     }
     virtual Status add_columns(const vectorized::Block* block, const std::vector<uint32_t>& col_ids,
                                bool is_key, uint32_t max_rows_per_segment) {
-        return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>();
+        return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>(
+                "RowsetWriter not support add_columns");
     }
 
     // Precondition: the input `rowset` should have the same type of the rowset we're building
@@ -68,19 +70,25 @@ public:
     // note that `add_row` could also trigger flush when certain conditions are met
     virtual Status flush() = 0;
     virtual Status flush_columns(bool is_key) {
-        return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>();
+        return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>(
+                "RowsetWriter not support flush_columns");
     }
-    virtual Status final_flush() { return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>(); }
+    virtual Status final_flush() {
+        return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>(
+                "RowsetWriter not support final_flush");
+    }
 
     virtual Status unfold_variant_column_and_flush_block(
             vectorized::Block* block, int32_t segment_id,
             const std::shared_ptr<MemTracker>& flush_mem_tracker, int64_t* flush_size) {
-        return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>();
+        return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>(
+                "RowsetWriter not support unfold_variant_column_and_flush_block");
     }
 
     virtual Status flush_single_block(const vectorized::Block* block, int64_t* flush_size,
                                       const FlushContext* ctx = nullptr) {
-        return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>();
+        return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>(
+                "RowsetWriter not support flush_single_block");
     }
 
     // finish building and return pointer to the built rowset (guaranteed to be inited).

--- a/be/src/olap/rowset/segcompaction.cpp
+++ b/be/src/olap/rowset/segcompaction.cpp
@@ -81,8 +81,8 @@ Status SegcompactionWorker::_get_segcompaction_reader(
         std::unique_ptr<RowwiseIterator> iter;
         auto s = seg_ptr->new_iterator(schema, read_options, &iter);
         if (!s.ok()) {
-            LOG(WARNING) << "failed to create iterator[" << seg_ptr->id() << "]: " << s.to_string();
-            return Status::Error<INIT_FAILED>();
+            return Status::Error<INIT_FAILED>("failed to create iterator[{}]: {}", seg_ptr->id(),
+                                              s.to_string());
         }
         seg_iterators.push_back(std::move(iter));
     }
@@ -120,7 +120,8 @@ Status SegcompactionWorker::_delete_original_segments(uint32_t begin, uint32_t e
     auto ctx = _writer->_context;
     auto schema = ctx.tablet_schema;
     if (!fs) {
-        return Status::Error<INIT_FAILED>();
+        return Status::Error<INIT_FAILED>(
+                "SegcompactionWorker::_delete_original_segments get fs failed");
     }
     for (uint32_t i = begin; i <= end; ++i) {
         auto seg_path = BetaRowset::segment_file_path(ctx.rowset_dir, ctx.rowset_id, i);
@@ -164,21 +165,22 @@ Status SegcompactionWorker::_check_correctness(OlapReaderStatistics& reader_stat
     }
 
     if (raw_rows_read != sum_src_row) {
-        LOG(WARNING) << "segcompaction read row num does not match source. expect read row:"
-                     << sum_src_row << " actual read row:" << raw_rows_read;
-        return Status::Error<CHECK_LINES_ERROR>();
+        return Status::Error<CHECK_LINES_ERROR>(
+                "segcompaction read row num does not match source. expect read row:{}, actual read "
+                "row:{}",
+                sum_src_row, raw_rows_read);
     }
 
     if ((output_rows + merged_rows) != raw_rows_read) {
-        LOG(WARNING) << "segcompaction total row num does not match after merge. expect total row:"
-                     << raw_rows_read << " actual total row:" << output_rows + merged_rows
-                     << " (output_rows:" << output_rows << ", merged_rows:" << merged_rows << ")";
-        return Status::Error<CHECK_LINES_ERROR>();
+        return Status::Error<CHECK_LINES_ERROR>(
+                "segcompaction total row num does not match after merge. expect total row:{},  "
+                "actual total row:{}, (output_rows:{},merged_rows:{})",
+                raw_rows_read, output_rows + merged_rows, output_rows, merged_rows);
     }
     if (filtered_rows != 0) {
-        LOG(WARNING) << "segcompaction should not have filtered rows but"
-                     << " actual filtered rows:" << filtered_rows;
-        return Status::Error<CHECK_LINES_ERROR>();
+        return Status::Error<CHECK_LINES_ERROR>(
+                "segcompaction should not have filtered rows but actual filtered rows:{}",
+                filtered_rows);
     }
     return Status::OK();
 }
@@ -192,8 +194,7 @@ Status SegcompactionWorker::_do_compact_segments(SegCompactionCandidatesSharedPt
     SCOPED_CONSUME_MEM_TRACKER(StorageEngine::instance()->segcompaction_mem_tracker());
     /* throttle segcompaction task if memory depleted */
     if (MemInfo::is_exceed_soft_mem_limit(GB_EXCHANGE_BYTE)) {
-        LOG(WARNING) << "skip segcompaction due to memory shortage";
-        return Status::Error<FETCH_MEMORY_EXCEEDED>();
+        return Status::Error<FETCH_MEMORY_EXCEEDED>("skip segcompaction due to memory shortage");
     }
 
     uint32_t begin = (*(segments->begin()))->id();
@@ -205,8 +206,7 @@ Status SegcompactionWorker::_do_compact_segments(SegCompactionCandidatesSharedPt
 
     auto writer = _create_segcompaction_writer(begin, end);
     if (UNLIKELY(writer == nullptr)) {
-        LOG(WARNING) << "failed to get segcompaction writer";
-        return Status::Error<SEGCOMPACTION_INIT_WRITER>();
+        return Status::Error<SEGCOMPACTION_INIT_WRITER>("failed to get segcompaction writer");
     }
 
     DCHECK(ctx.tablet);
@@ -234,8 +234,7 @@ Status SegcompactionWorker::_do_compact_segments(SegCompactionCandidatesSharedPt
         auto s = _get_segcompaction_reader(segments, tablet, schema, &reader_stats, row_sources_buf,
                                            is_key, column_ids, &reader);
         if (UNLIKELY(reader == nullptr || !s.ok())) {
-            LOG(WARNING) << "failed to get segcompaction reader";
-            return Status::Error<SEGCOMPACTION_INIT_READER>();
+            return Status::Error<SEGCOMPACTION_INIT_READER>("failed to get segcompaction reader.");
         }
 
         Merger::Statistics merger_stats;

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.h
@@ -125,7 +125,8 @@ public:
     Status try_query(OlapReaderStatistics* stats, const std::string& column_name,
                      const void* query_value, InvertedIndexQueryType query_type,
                      uint32_t* count) override {
-        return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>();
+        return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>(
+                "FullTextIndexReader not support try_query");
     }
 
     InvertedIndexReaderType type() override;
@@ -148,7 +149,8 @@ public:
     Status try_query(OlapReaderStatistics* stats, const std::string& column_name,
                      const void* query_value, InvertedIndexQueryType query_type,
                      uint32_t* count) override {
-        return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>();
+        return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>(
+                "StringTypeInvertedIndexReader not support try_query");
     }
     InvertedIndexReaderType type() override;
 };
@@ -168,7 +170,7 @@ public:
 public:
     InvertedIndexVisitor(roaring::Roaring* hits, InvertedIndexQueryType query_type,
                          bool only_count = false);
-    virtual ~InvertedIndexVisitor() = default;
+    ~InvertedIndexVisitor() override = default;
 
     void set_reader(lucene::util::bkd::bkd_reader* r) { _reader = r; }
     lucene::util::bkd::bkd_reader* get_reader() { return _reader; }

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -753,7 +753,7 @@ Status SegmentIterator::_apply_index_except_leafnode_of_andnode() {
             }
             LOG(WARNING) << "failed to evaluate index"
                          << ", column predicate type: " << pred->pred_type_string(pred->type())
-                         << ", error msg: " << res;
+                         << ", error msg: " << res.to_string();
             return res;
         }
 

--- a/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
@@ -165,7 +165,7 @@ Status VerticalBetaRowsetWriter::_create_segment_writer(
             BetaRowset::segment_file_path(_context.rowset_dir, _context.rowset_id, _num_segment++);
     auto fs = _rowset_meta->fs();
     if (!fs) {
-        return Status::Error<INIT_FAILED>();
+        return Status::Error<INIT_FAILED>("get fs failed");
     }
     io::FileWriterPtr file_writer;
     Status st = fs->create_file(path, &file_writer);

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -488,7 +488,7 @@ Status VSchemaChangeDirectly::_inner_process(RowsetReaderSharedPtr rowset_reader
     } while (true);
 
     if (!rowset_writer->flush()) {
-        return Status::Error<ALTER_STATUS_ERR>();
+        return Status::Error<ALTER_STATUS_ERR>("rowset_writer flush failed");
     }
 
     return Status::OK();
@@ -561,11 +561,11 @@ Status VSchemaChangeWithSorting::_inner_process(RowsetReaderSharedPtr rowset_rea
             RETURN_IF_ERROR(create_rowset());
 
             if (_mem_tracker->consumption() + new_block->allocated_bytes() > _memory_limitation) {
-                LOG(WARNING) << "Memory limitation is too small for Schema Change."
-                             << " _memory_limitation=" << _memory_limitation
-                             << ", new_block->allocated_bytes()=" << new_block->allocated_bytes()
-                             << ", consumption=" << _mem_tracker->consumption();
-                return Status::Error<INVALID_ARGUMENT>();
+                return Status::Error<INVALID_ARGUMENT>(
+                        "Memory limitation is too small for Schema Change. _memory_limitation={}, "
+                        "new_block->allocated_bytes()={}, consumption={}",
+                        _memory_limitation, new_block->allocated_bytes(),
+                        _mem_tracker->consumption());
             }
         }
         _mem_tracker->consume(new_block->allocated_bytes());
@@ -638,7 +638,7 @@ Status VSchemaChangeWithSorting::_external_sorting(vector<RowsetSharedPtr>& src_
 
 Status SchemaChangeHandler::process_alter_tablet_v2(const TAlterTabletReqV2& request) {
     if (!request.__isset.desc_tbl) {
-        return Status::Error<INVALID_ARGUMENT>().append(
+        return Status::Error<INVALID_ARGUMENT>(
                 "desc_tbl is not set. Maybe the FE version is not equal to the BE "
                 "version.");
     }
@@ -650,16 +650,15 @@ Status SchemaChangeHandler::process_alter_tablet_v2(const TAlterTabletReqV2& req
     TabletSharedPtr base_tablet =
             StorageEngine::instance()->tablet_manager()->get_tablet(request.base_tablet_id);
     if (base_tablet == nullptr) {
-        LOG(WARNING) << "fail to find base tablet. base_tablet=" << request.base_tablet_id;
-        return Status::Error<TABLE_NOT_FOUND>();
+        return Status::Error<TABLE_NOT_FOUND>("fail to find base tablet. base_tablet={}",
+                                              request.base_tablet_id);
     }
     // Lock schema_change_lock util schema change info is stored in tablet header
     std::unique_lock<std::mutex> schema_change_lock(base_tablet->get_schema_change_lock(),
                                                     std::try_to_lock);
     if (!schema_change_lock.owns_lock()) {
-        LOG(WARNING) << "failed to obtain schema change lock. "
-                     << "base_tablet=" << request.base_tablet_id;
-        return Status::Error<TRY_LOCK_FAILED>();
+        return Status::Error<TRY_LOCK_FAILED>("failed to obtain schema change lock. base_tablet={}",
+                                              request.base_tablet_id);
     }
 
     Status res = _do_process_alter_tablet_v2(request);
@@ -680,17 +679,16 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletReqV2&
     TabletSharedPtr base_tablet =
             StorageEngine::instance()->tablet_manager()->get_tablet(request.base_tablet_id);
     if (base_tablet == nullptr) {
-        LOG(WARNING) << "fail to find base tablet. base_tablet=" << request.base_tablet_id;
-        return Status::Error<TABLE_NOT_FOUND>();
+        return Status::Error<TABLE_NOT_FOUND>("fail to find base tablet. base_tablet={}",
+                                              request.base_tablet_id);
     }
 
     // new tablet has to exist
     TabletSharedPtr new_tablet =
             StorageEngine::instance()->tablet_manager()->get_tablet(request.new_tablet_id);
     if (new_tablet == nullptr) {
-        LOG(WARNING) << "fail to find new tablet."
-                     << " new_tablet=" << request.new_tablet_id;
-        return Status::Error<TABLE_NOT_FOUND>();
+        return Status::Error<TABLE_NOT_FOUND>("fail to find new tablet. new_tablet={}",
+                                              request.new_tablet_id);
     }
 
     // check if tablet's state is not_ready, if it is ready, it means the tablet already finished
@@ -710,11 +708,13 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletReqV2&
 
     std::shared_lock base_migration_rlock(base_tablet->get_migration_lock(), std::try_to_lock);
     if (!base_migration_rlock.owns_lock()) {
-        return Status::Error<TRY_LOCK_FAILED>();
+        return Status::Error<TRY_LOCK_FAILED>(
+                "SchemaChangeHandler::_do_process_alter_tablet_v2 get lock failed");
     }
     std::shared_lock new_migration_rlock(new_tablet->get_migration_lock(), std::try_to_lock);
     if (!new_migration_rlock.owns_lock()) {
-        return Status::Error<TRY_LOCK_FAILED>();
+        return Status::Error<TRY_LOCK_FAILED>(
+                "SchemaChangeHandler::_do_process_alter_tablet_v2 get lock failed");
     }
 
     std::vector<Version> versions_to_be_changed;
@@ -791,10 +791,9 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletReqV2&
                     // we only can remove [7-9] from new tablet. If we add [X-10] to new tablet, it will has version
                     // cross: [X-10] [10-12].
                     // So, we should return OLAP_ERR_VERSION_ALREADY_MERGED for fast fail.
-                    LOG(WARNING) << "New tablet has a version " << pair.first
-                                 << " crossing base tablet's max_version="
-                                 << max_rowset->end_version();
-                    return Status::Error<VERSION_ALREADY_MERGED>();
+                    return Status::Error<VERSION_ALREADY_MERGED>(
+                            "New tablet has a version {} crossing base tablet's max_version={}",
+                            pair.first.to_string(), max_rowset->end_version());
                 }
             }
             std::vector<RowsetSharedPtr> empty_vec;
@@ -817,10 +816,9 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletReqV2&
             // acquire data sources correspond to history versions
             base_tablet->capture_rs_readers(versions_to_be_changed, &rs_readers);
             if (rs_readers.empty()) {
-                LOG(WARNING) << "fail to acquire all data sources. "
-                             << "version_num=" << versions_to_be_changed.size()
-                             << ", data_source_num=" << rs_readers.size();
-                res = Status::Error<ALTER_DELTA_DOES_NOT_EXISTS>();
+                res = Status::Error<ALTER_DELTA_DOES_NOT_EXISTS>(
+                        "fail to acquire all data sources. version_num={}, data_source_num={}",
+                        versions_to_be_changed.size(), rs_readers.size());
                 break;
             }
             auto& all_del_preds = base_tablet->delete_predicates();
@@ -1019,8 +1017,8 @@ Status SchemaChangeHandler::_get_versions_to_be_changed(
         RowsetSharedPtr* max_rowset) {
     RowsetSharedPtr rowset = base_tablet->rowset_with_max_version();
     if (rowset == nullptr) {
-        LOG(WARNING) << "Tablet has no version. base_tablet=" << base_tablet->full_name();
-        return Status::Error<ALTER_DELTA_DOES_NOT_EXISTS>();
+        return Status::Error<ALTER_DELTA_DOES_NOT_EXISTS>("Tablet has no version. base_tablet={}",
+                                                          base_tablet->full_name());
     }
     *max_rowset = rowset;
 
@@ -1111,7 +1109,8 @@ Status SchemaChangeHandler::_convert_historical_rowsets(const SchemaChangeParams
         context.write_type = DataWriteType::TYPE_SCHEMA_CHANGE;
         Status status = new_tablet->create_rowset_writer(context, &rowset_writer);
         if (!status.ok()) {
-            res = Status::Error<ROWSET_BUILDER_INIT>();
+            res = Status::Error<ROWSET_BUILDER_INIT>("create_rowset_writer failed, reason={}",
+                                                     status.to_string());
             return process_alter_exit();
         }
 
@@ -1194,10 +1193,9 @@ Status SchemaChangeHandler::_parse_request(const SchemaChangeParams& sc_params,
                 column_mapping->ref_column = column_index;
                 continue;
             } else if (sc_params.alter_tablet_type != ROLLUP) {
-                LOG(WARNING) << fmt::format(
+                return Status::Error<CE_CMD_PARAMS_ERROR>(
                         "referenced column was missing. [column={} ,origin_column={}]", column_name,
                         mvParam.origin_column_name);
-                return Status::Error<CE_CMD_PARAMS_ERROR>();
             }
         }
 
@@ -1332,7 +1330,7 @@ Status SchemaChangeHandler::_init_column_mapping(ColumnMapping* column_mapping,
     column_mapping->default_value = WrapperField::create(column_schema);
 
     if (column_mapping->default_value == nullptr) {
-        return Status::Error<MEM_ALLOC_FAILED>();
+        return Status::Error<MEM_ALLOC_FAILED>("column_mapping->default_value is nullptr");
     }
 
     if (column_schema.is_nullable() && value.length() == 0) {
@@ -1365,7 +1363,8 @@ Status SchemaChangeHandler::_validate_alter_result(TabletSharedPtr new_tablet,
     for (auto& pair : version_rowsets) {
         RowsetSharedPtr rowset = pair.second;
         if (!rowset->check_file_exist()) {
-            return Status::Error<FILE_NOT_EXIST>();
+            return Status::Error<FILE_NOT_EXIST>(
+                    "SchemaChangeHandler::_validate_alter_result meet invalid rowset");
         }
     }
     return Status::OK();

--- a/be/src/olap/schema_change.h
+++ b/be/src/olap/schema_change.h
@@ -108,7 +108,7 @@ public:
                            TabletSchemaSPtr base_tablet_schema) {
         if (rowset_reader->rowset()->empty() || rowset_reader->rowset()->num_rows() == 0) {
             RETURN_WITH_WARN_IF_ERROR(
-                    rowset_writer->flush(), Status::Error<ErrorCode::INVALID_ARGUMENT>(),
+                    rowset_writer->flush(), Status::Error<ErrorCode::INVALID_ARGUMENT>(""),
                     fmt::format("create empty version for schema change failed. version= {}-{}",
                                 rowset_writer->version().first, rowset_writer->version().second));
 
@@ -124,7 +124,7 @@ public:
 
         // Check row num changes
         if (!_check_row_nums(rowset_reader, *rowset_writer)) {
-            return Status::Error<ErrorCode::ALTER_STATUS_ERR>();
+            return Status::Error<ErrorCode::ALTER_STATUS_ERR>("SchemaChange check row nums failed");
         }
 
         LOG(INFO) << "all row nums. source_rows=" << rowset_reader->rowset()->num_rows()

--- a/be/src/olap/single_replica_compaction.cpp
+++ b/be/src/olap/single_replica_compaction.cpp
@@ -384,7 +384,7 @@ Status SingleReplicaCompaction::_make_snapshot(const std::string& ip, int port, 
                 client->make_snapshot(result, request);
             }));
     if (result.status.status_code != TStatusCode::OK) {
-        return Status(result.status);
+        return Status::create(result.status);
     }
 
     if (result.__isset.snapshot_path) {
@@ -510,7 +510,7 @@ Status SingleReplicaCompaction::_release_snapshot(const std::string& ip, int por
             ip, port, [&snapshot_path, &result](BackendServiceConnection& client) {
                 client->release_snapshot(result, snapshot_path);
             }));
-    return Status(result.status);
+    return Status::create(result.status);
 }
 
 Status SingleReplicaCompaction::_finish_clone(const string& clone_dir,

--- a/be/src/olap/single_replica_compaction.cpp
+++ b/be/src/olap/single_replica_compaction.cpp
@@ -53,26 +53,28 @@ SingleReplicaCompaction::~SingleReplicaCompaction() = default;
 Status SingleReplicaCompaction::prepare_compact() {
     VLOG_CRITICAL << _tablet->tablet_id() << " prepare single replcia compaction and pick rowsets!";
     if (!_tablet->init_succeeded()) {
-        return Status::Error<CUMULATIVE_INVALID_PARAMETERS>();
+        return Status::Error<CUMULATIVE_INVALID_PARAMETERS>("_tablet init failed");
     }
 
     std::unique_lock<std::mutex> lock_cumu(_tablet->get_cumulative_compaction_lock(),
                                            std::try_to_lock);
     if (!lock_cumu.owns_lock()) {
         LOG(INFO) << "The tablet is under cumulative compaction. tablet=" << _tablet->full_name();
-        return Status::Error<TRY_LOCK_FAILED>();
+        return Status::Error<TRY_LOCK_FAILED>(
+                "The tablet is under cumulative compaction. tablet={}", _tablet->full_name());
     }
     std::unique_lock<std::mutex> lock_base(_tablet->get_base_compaction_lock(), std::try_to_lock);
     if (!lock_base.owns_lock()) {
         LOG(WARNING) << "another base compaction is running. tablet=" << _tablet->full_name();
-        return Status::Error<TRY_LOCK_FAILED>();
+        return Status::Error<TRY_LOCK_FAILED>("another base compaction is running. tablet={}",
+                                              _tablet->full_name());
     }
 
     // 1. pick rowsets to compact
     RETURN_IF_ERROR(pick_rowsets_to_compact());
     _tablet->set_clone_occurred(false);
     if (_input_rowsets.size() == 1) {
-        return Status::Error<CUMULATIVE_NO_SUITABLE_VERSION>();
+        return Status::Error<CUMULATIVE_NO_SUITABLE_VERSION>("_input_rowsets.size() is 1");
     }
 
     return Status::OK();
@@ -81,7 +83,7 @@ Status SingleReplicaCompaction::prepare_compact() {
 Status SingleReplicaCompaction::pick_rowsets_to_compact() {
     auto candidate_rowsets = _tablet->pick_candidate_rowsets_to_single_replica_compaction();
     if (candidate_rowsets.empty()) {
-        return Status::Error<CUMULATIVE_NO_SUITABLE_VERSION>();
+        return Status::Error<CUMULATIVE_NO_SUITABLE_VERSION>("candidate_rowsets is empty");
     }
     _input_rowsets.clear();
     for (const auto& rowset : candidate_rowsets) {
@@ -96,20 +98,21 @@ Status SingleReplicaCompaction::execute_compact_impl() {
                                            std::try_to_lock);
     if (!lock_cumu.owns_lock()) {
         LOG(INFO) << "The tablet is under cumulative compaction. tablet=" << _tablet->full_name();
-        return Status::Error<TRY_LOCK_FAILED>();
+        return Status::Error<TRY_LOCK_FAILED>(
+                "The tablet is under cumulative compaction. tablet={}", _tablet->full_name());
     }
 
     std::unique_lock<std::mutex> lock_base(_tablet->get_base_compaction_lock(), std::try_to_lock);
     if (!lock_base.owns_lock()) {
-        LOG(WARNING) << "another base compaction is running. tablet=" << _tablet->full_name();
-        return Status::Error<TRY_LOCK_FAILED>();
+        return Status::Error<TRY_LOCK_FAILED>("another base compaction is running. tablet={}",
+                                              _tablet->full_name());
     }
 
     // Clone task may happen after compaction task is submitted to thread pool, and rowsets picked
     // for compaction may change. In this case, current compaction task should not be executed.
     if (_tablet->get_clone_occurred()) {
         _tablet->set_clone_occurred(false);
-        return Status::Error<BE_CLONE_OCCURRED>();
+        return Status::Error<BE_CLONE_OCCURRED>("get_clone_occurred failed");
     }
 
     SCOPED_ATTACH_TASK(_mem_tracker);
@@ -296,8 +299,8 @@ Status SingleReplicaCompaction::_fetch_rowset(const TReplicaInfo& addr, const st
               << ", addr=" << addr.host << ", version=" << rowset_version;
     std::shared_lock migration_rlock(_tablet->get_migration_lock(), std::try_to_lock);
     if (!migration_rlock.owns_lock()) {
-        LOG(WARNING) << "got migration_rlock failed. tablet=" << _tablet->full_name();
-        return Status::Error<TRY_LOCK_FAILED>();
+        return Status::Error<TRY_LOCK_FAILED>("got migration_rlock failed. tablet={}",
+                                              _tablet->full_name());
     }
 
     std::string local_data_path = _tablet->tablet_path() + CLONE_PREFIX;
@@ -585,7 +588,7 @@ Status SingleReplicaCompaction::_finish_clone(const string& clone_dir,
             if (!res.ok()) {
                 break;
             }
-        } while (0);
+        } while (false);
 
         // clear linked files if errors happen
         if (!res.ok()) {

--- a/be/src/olap/snapshot_manager.cpp
+++ b/be/src/olap/snapshot_manager.cpp
@@ -56,14 +56,10 @@
 #include "runtime/thread_context.h"
 #include "util/uid_util.h"
 
-using std::filesystem::path;
-using std::map;
 using std::nothrow;
-using std::set;
 using std::string;
 using std::stringstream;
 using std::vector;
-using std::list;
 
 namespace doris {
 using namespace ErrorCode;
@@ -86,15 +82,13 @@ Status SnapshotManager::make_snapshot(const TSnapshotRequest& request, string* s
     SCOPED_CONSUME_MEM_TRACKER(_mem_tracker);
     Status res = Status::OK();
     if (snapshot_path == nullptr) {
-        LOG(WARNING) << "output parameter cannot be null";
-        return Status::Error<INVALID_ARGUMENT>();
+        return Status::Error<INVALID_ARGUMENT>("output parameter cannot be null");
     }
 
     TabletSharedPtr ref_tablet =
             StorageEngine::instance()->tablet_manager()->get_tablet(request.tablet_id);
     if (ref_tablet == nullptr) {
-        LOG(WARNING) << "failed to get tablet. tablet=" << request.tablet_id;
-        return Status::Error<TABLE_NOT_FOUND>();
+        return Status::Error<TABLE_NOT_FOUND>("failed to get tablet. tablet={}", request.tablet_id);
     }
 
     res = _create_snapshot_files(ref_tablet, request, snapshot_path, allow_incremental_clone);
@@ -125,8 +119,8 @@ Status SnapshotManager::release_snapshot(const string& snapshot_path) {
         }
     }
 
-    LOG(WARNING) << "released snapshot path illegal. [path='" << snapshot_path << "']";
-    return Status::Error<CE_CMD_PARAMS_ERROR>();
+    return Status::Error<CE_CMD_PARAMS_ERROR>("released snapshot path illegal. [path='{}']",
+                                              snapshot_path);
 }
 
 Status SnapshotManager::convert_rowset_ids(const std::string& clone_dir, int64_t tablet_id,
@@ -137,8 +131,8 @@ Status SnapshotManager::convert_rowset_ids(const std::string& clone_dir, int64_t
     bool exists = true;
     RETURN_IF_ERROR(io::global_local_filesystem()->exists(clone_dir, &exists));
     if (!exists) {
-        res = Status::Error<DIR_NOT_EXIST>();
-        LOG(WARNING) << "clone dir not existed when convert rowsetids. clone_dir=" << clone_dir;
+        res = Status::Error<DIR_NOT_EXIST>(
+                "clone dir not existed when convert rowsetids. clone_dir={}", clone_dir);
         return res;
     }
 
@@ -286,8 +280,7 @@ Status SnapshotManager::_rename_rowset_id(const RowsetMetaPB& rs_meta_pb,
     }
     RowsetSharedPtr new_rowset = rs_writer->build();
     if (new_rowset == nullptr) {
-        LOG(WARNING) << "failed to build rowset when rename rowset id";
-        return Status::Error<MEM_ALLOC_FAILED>();
+        return Status::Error<MEM_ALLOC_FAILED>("failed to build rowset when rename rowset id");
     }
     RETURN_IF_ERROR(new_rowset->load(false));
     new_rowset->rowset_meta()->to_rowset_pb(new_rs_meta_pb);
@@ -301,8 +294,7 @@ Status SnapshotManager::_calc_snapshot_id_path(const TabletSharedPtr& tablet, in
                                                std::string* out_path) {
     Status res = Status::OK();
     if (out_path == nullptr) {
-        LOG(WARNING) << "output parameter cannot be null";
-        return Status::Error<INVALID_ARGUMENT>();
+        return Status::Error<INVALID_ARGUMENT>("output parameter cannot be null");
     }
 
     // get current timestamp string
@@ -374,8 +366,7 @@ Status SnapshotManager::_create_snapshot_files(const TabletSharedPtr& ref_tablet
               << ", snapshot_version is " << snapshot_version;
     Status res = Status::OK();
     if (snapshot_path == nullptr) {
-        LOG(WARNING) << "output parameter cannot be null";
-        return Status::Error<INVALID_ARGUMENT>();
+        return Status::Error<INVALID_ARGUMENT>("output parameter cannot be null");
     }
 
     // snapshot_id_path:
@@ -414,8 +405,7 @@ Status SnapshotManager::_create_snapshot_files(const TabletSharedPtr& ref_tablet
     do {
         TabletMetaSharedPtr new_tablet_meta(new (nothrow) TabletMeta());
         if (new_tablet_meta == nullptr) {
-            LOG(WARNING) << "fail to malloc TabletMeta.";
-            res = Status::Error<MEM_ALLOC_FAILED>();
+            res = Status::Error<MEM_ALLOC_FAILED>("fail to malloc TabletMeta.");
             break;
         }
         std::vector<RowsetSharedPtr> consistent_rowsets;
@@ -458,10 +448,10 @@ Status SnapshotManager::_create_snapshot_files(const TabletSharedPtr& ref_tablet
                     if (rowset != nullptr) {
                         if (!rowset->is_local()) {
                             // MUST make full snapshot to ensure `cooldown_meta_id` is consistent with the cooldowned rowsets after clone.
-                            LOG(INFO) << "missed version is a cooldowned rowset, must make full "
-                                         "snapshot. missed_version="
-                                      << missed_version << " tablet_id=" << ref_tablet->tablet_id();
-                            res = Status::Error<ErrorCode::INTERNAL_ERROR>();
+                            res = Status::Error<ErrorCode::INTERNAL_ERROR>(
+                                    "missed version is a cooldowned rowset, must make full "
+                                    "snapshot. missed_version={}, tablet_id={}",
+                                    missed_version, ref_tablet->tablet_id());
                             break;
                         }
                         consistent_rowsets.push_back(rowset);
@@ -502,10 +492,9 @@ Status SnapshotManager::_create_snapshot_files(const TabletSharedPtr& ref_tablet
                 version = last_version->end_version();
                 if (request.__isset.version) {
                     if (last_version->end_version() < request.version) {
-                        LOG(WARNING) << "invalid make snapshot request. "
-                                     << " version=" << last_version->end_version()
-                                     << " req_version=" << request.version;
-                        res = Status::Error<INVALID_ARGUMENT>();
+                        res = Status::Error<INVALID_ARGUMENT>(
+                                "invalid make snapshot request. version={}, req_version={}",
+                                last_version->version().to_string(), request.version);
                         break;
                     }
                     version = request.version;
@@ -515,7 +504,9 @@ Status SnapshotManager::_create_snapshot_files(const TabletSharedPtr& ref_tablet
                     // Get max cooldowned version
                     int64_t max_cooldowned_version = -1;
                     for (auto& [v, rs] : ref_tablet->rowset_map()) {
-                        if (rs->is_local()) continue;
+                        if (rs->is_local()) {
+                            continue;
+                        }
                         consistent_rowsets.push_back(rs);
                         max_cooldowned_version = std::max(max_cooldowned_version, v.second);
                     }
@@ -591,7 +582,8 @@ Status SnapshotManager::_create_snapshot_files(const TabletSharedPtr& ref_tablet
                 res = new_tablet_meta->save_as_json(json_header_path, ref_tablet->data_dir());
             }
         } else {
-            res = Status::Error<INVALID_SNAPSHOT_VERSION>();
+            res = Status::Error<INVALID_SNAPSHOT_VERSION>(
+                    "snapshot_version not equal to g_Types_constants.TSNAPSHOT_REQ_VERSION2");
         }
 
         if (!res.ok()) {

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -78,23 +78,13 @@
 #include "util/trace.h"
 #include "util/uid_util.h"
 
-using apache::thrift::ThriftDebugString;
-using std::filesystem::canonical;
 using std::filesystem::directory_iterator;
 using std::filesystem::path;
-using std::filesystem::recursive_directory_iterator;
-using std::back_inserter;
-using std::copy;
-using std::inserter;
-using std::list;
 using std::map;
-using std::nothrow;
-using std::pair;
 using std::set;
 using std::string;
 using std::stringstream;
 using std::vector;
-using strings::Substitute;
 
 namespace doris {
 using namespace ErrorCode;
@@ -655,8 +645,7 @@ Status StorageEngine::start_trash_sweep(double* usage, bool ignore_guard) {
     tm local_tm_now;
     local_tm_now.tm_isdst = 0;
     if (localtime_r(&now, &local_tm_now) == nullptr) {
-        LOG(WARNING) << "fail to localtime_r time. time=" << now;
-        return Status::Error<OS_ERROR>();
+        return Status::Error<OS_ERROR>("fail to localtime_r time. time={}", now);
     }
     const time_t local_now = mktime(&local_tm_now); //得到当地日历时间
 
@@ -831,8 +820,7 @@ Status StorageEngine::_do_sweep(const std::string& scan_root, const time_t& loca
             tm local_tm_create;
             local_tm_create.tm_isdst = 0;
             if (strptime(str_time.c_str(), "%Y%m%d%H%M%S", &local_tm_create) == nullptr) {
-                LOG(WARNING) << "fail to strptime time. [time=" << str_time << "]";
-                res = Status::Error<OS_ERROR>();
+                res = Status::Error<OS_ERROR>("fail to strptime time. time={}", str_time);
                 continue;
             }
 
@@ -857,8 +845,8 @@ Status StorageEngine::_do_sweep(const std::string& scan_root, const time_t& loca
             }
         }
     } catch (...) {
-        LOG(WARNING) << "Exception occur when scan directory. path_desc=" << scan_root;
-        res = Status::Error<IO_ERROR>();
+        res = Status::Error<IO_ERROR>("Exception occur when scan directory. path_desc={}",
+                                      scan_root);
     }
 
     return res;
@@ -933,8 +921,8 @@ Status StorageEngine::create_tablet(const TCreateTabletReq& request) {
     std::vector<DataDir*> stores;
     stores = get_stores_for_create_tablet(request.storage_medium);
     if (stores.empty()) {
-        LOG(WARNING) << "there is no available disk that can be used to create tablet.";
-        return Status::Error<CE_CMD_PARAMS_ERROR>();
+        return Status::Error<CE_CMD_PARAMS_ERROR>(
+                "there is no available disk that can be used to create tablet.");
     }
     return _tablet_manager->create_tablet(request, stores);
 }
@@ -944,14 +932,14 @@ Status StorageEngine::obtain_shard_path(TStorageMedium::type storage_medium,
     LOG(INFO) << "begin to process obtain root path. storage_medium=" << storage_medium;
 
     if (shard_path == nullptr) {
-        LOG(WARNING) << "invalid output parameter which is null pointer.";
-        return Status::Error<CE_CMD_PARAMS_ERROR>();
+        return Status::Error<CE_CMD_PARAMS_ERROR>(
+                "invalid output parameter which is null pointer.");
     }
 
     auto stores = get_stores_for_create_tablet(storage_medium);
     if (stores.empty()) {
-        LOG(WARNING) << "no available disk can be used to create tablet.";
-        return Status::Error<NO_AVAILABLE_ROOT_PATH>();
+        return Status::Error<NO_AVAILABLE_ROOT_PATH>(
+                "no available disk can be used to create tablet.");
     }
 
     Status res = Status::OK();
@@ -985,12 +973,10 @@ Status StorageEngine::load_header(const string& shard_path, const TCloneReq& req
                     std::filesystem::path(shard_path).parent_path().parent_path().string();
             store = get_store(store_path);
             if (store == nullptr) {
-                LOG(WARNING) << "invalid shard path, path=" << shard_path;
-                return Status::Error<INVALID_ROOT_PATH>();
+                return Status::Error<INVALID_ROOT_PATH>("invalid shard path, path={}", shard_path);
             }
         } catch (...) {
-            LOG(WARNING) << "invalid shard path, path=" << shard_path;
-            return Status::Error<INVALID_ROOT_PATH>();
+            return Status::Error<INVALID_ROOT_PATH>("invalid shard path, path={}", shard_path);
         }
     }
 

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -479,14 +479,15 @@ Status Tablet::modify_rowsets(std::vector<RowsetSharedPtr>& to_add,
         for (auto& rs : to_delete) {
             auto find_rs = _rs_version_map.find(rs->version());
             if (find_rs == _rs_version_map.end()) {
-                LOG(WARNING) << "try to delete not exist version " << rs->version() << " from "
-                             << full_name();
-                return Status::Error<DELETE_VERSION_ERROR>();
+                return Status::Error<DELETE_VERSION_ERROR>(
+                        "try to delete not exist version {} from {}", rs->version().to_string(),
+                        full_name());
             } else if (find_rs->second->rowset_id() != rs->rowset_id()) {
-                LOG(WARNING) << "try to delete version " << rs->version() << " from " << full_name()
-                             << ", but rowset id changed, delete rowset id is " << rs->rowset_id()
-                             << ", exists rowsetid is" << find_rs->second->rowset_id();
-                return Status::Error<DELETE_VERSION_ERROR>();
+                return Status::Error<DELETE_VERSION_ERROR>(
+                        "try to delete version {} from {}, but rowset id changed, delete rowset id "
+                        "is {}, exists rowsetid is {}",
+                        rs->version().to_string(), full_name(), rs->rowset_id().to_string(),
+                        find_rs->second->rowset_id().to_string());
             }
         }
     }
@@ -840,7 +841,7 @@ Status Tablet::capture_consistent_versions(const Version& spec_version,
                 LOG(WARNING) << "tablet:" << full_name()
                              << ", version already has been merged. spec_version: " << spec_version;
             }
-            status = Status::Error<VERSION_ALREADY_MERGED>();
+            status = Status::Error<VERSION_ALREADY_MERGED>("missed_versions is empty");
         } else {
             if (version_path != nullptr) {
                 LOG(WARNING) << "status:" << status << ", tablet:" << full_name()
@@ -914,9 +915,9 @@ Status Tablet::_capture_consistent_rowsets_unlocked(const std::vector<Version>& 
         } while (false);
 
         if (!is_find) {
-            LOG(WARNING) << "fail to find Rowset for version. tablet=" << full_name()
-                         << ", version='" << version;
-            return Status::Error<CAPTURE_ROWSET_ERROR>();
+            return Status::Error<CAPTURE_ROWSET_ERROR>(
+                    "fail to find Rowset for version. tablet={}, version={}", full_name(),
+                    version.to_string());
         }
     }
     return Status::OK();
@@ -941,17 +942,17 @@ Status Tablet::capture_rs_readers(const std::vector<Version>& version_path,
 
             it = _stale_rs_version_map.find(version);
             if (it == _stale_rs_version_map.end()) {
-                LOG(WARNING) << "fail to find Rowset in stale_rs_version for version. tablet="
-                             << full_name() << ", version='" << version.first << "-"
-                             << version.second;
-                return Status::Error<CAPTURE_ROWSET_READER_ERROR>();
+                return Status::Error<CAPTURE_ROWSET_READER_ERROR>(
+                        "fail to find Rowset in stale_rs_version for version. tablet={}, "
+                        "version={}-{}",
+                        full_name(), version.first, version.second);
             }
         }
         RowsetReaderSharedPtr rs_reader;
         auto res = it->second->create_reader(&rs_reader);
         if (!res.ok()) {
-            LOG(WARNING) << "failed to create reader for rowset:" << it->second->rowset_id();
-            return Status::Error<CAPTURE_ROWSET_READER_ERROR>();
+            return Status::Error<CAPTURE_ROWSET_READER_ERROR>(
+                    "failed to create reader for rowset:{}", it->second->rowset_id().to_string());
         }
         rs_readers->push_back(std::move(rs_reader));
     }
@@ -1258,7 +1259,8 @@ Status Tablet::_contains_version(const Version& version) {
             CHECK(it.second != nullptr) << "there exist a version=" << it.first
                                         << " contains the input rs with version=" << version
                                         << ", but the related rs is null";
-            return Status::Error<PUSH_VERSION_ALREADY_EXIST>();
+            return Status::Error<PUSH_VERSION_ALREADY_EXIST>("Tablet push duplicate version {}",
+                                                             version.to_string());
         }
     }
 
@@ -1849,8 +1851,8 @@ void Tablet::reset_compaction(CompactionType compaction_type) {
 Status Tablet::create_initial_rowset(const int64_t req_version) {
     Status res = Status::OK();
     if (req_version < 1) {
-        LOG(WARNING) << "init version of tablet should at least 1. req.ver=" << req_version;
-        return Status::Error<CE_CMD_PARAMS_ERROR>();
+        return Status::Error<CE_CMD_PARAMS_ERROR>(
+                "init version of tablet should at least 1. req.ver={}", req_version);
     }
     Version version(0, req_version);
     RowsetSharedPtr new_rowset;
@@ -2114,7 +2116,9 @@ bool Tablet::update_cooldown_conf(int64_t cooldown_term, int64_t cooldown_replic
         LOG(INFO) << "try cooldown_conf_lock failed, tablet_id=" << tablet_id();
         return false;
     }
-    if (cooldown_term <= _cooldown_term) return false;
+    if (cooldown_term <= _cooldown_term) {
+        return false;
+    }
     LOG(INFO) << "update cooldown conf. tablet_id=" << tablet_id()
               << " cooldown_replica_id: " << _cooldown_replica_id << " -> " << cooldown_replica_id
               << ", cooldown_term: " << _cooldown_term << " -> " << cooldown_term;
@@ -3005,7 +3009,7 @@ Status Tablet::calc_delete_bitmap(RowsetSharedPtr rowset,
     token->wait();
     auto code = calc_status.load();
     if (code != ErrorCode::OK) {
-        return Status::Error(code);
+        return Status::Error(code, "Tablet::calc_delete_bitmap meet error");
     }
     for (auto seg_delete_bitmap : seg_delete_bitmaps) {
         delete_bitmap->merge(*seg_delete_bitmap);
@@ -3497,7 +3501,7 @@ bool Tablet::is_enable_binlog() {
 }
 
 void Tablet::set_binlog_config(BinlogConfig binlog_config) {
-    tablet_meta()->set_binlog_config(std::move(binlog_config));
+    tablet_meta()->set_binlog_config(binlog_config);
 }
 
 void Tablet::gc_binlogs(int64_t version) {
@@ -3544,7 +3548,7 @@ void Tablet::gc_binlogs(int64_t version) {
             rowset_id = binlog_meta_entry_pb.rowset_id_v2();
         } else {
             // key is 'binglog_meta_6943f1585fe834b5-e542c2b83a21d0b7_00000000000000000069_020000000000000135449d7cd7eadfe672aa0f928fa99593', extract last part '020000000000000135449d7cd7eadfe672aa0f928fa99593'
-            auto pos = key.rfind("_");
+            auto pos = key.rfind('_');
             if (pos == std::string::npos) {
                 LOG(WARNING) << fmt::format("invalid binlog meta key:{}", key);
                 return false;

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -67,12 +67,10 @@ namespace doris {
 class CumulativeCompactionPolicy;
 } // namespace doris
 
-using std::list;
 using std::map;
 using std::set;
 using std::string;
 using std::vector;
-using strings::Substitute;
 
 namespace doris {
 using namespace ErrorCode;
@@ -119,13 +117,13 @@ Status TabletManager::_add_tablet_unlocked(TTabletId tablet_id, const TabletShar
     // and then reload the tablet, the tablet's path will the same
     if (!force) {
         if (existed_tablet->tablet_path() == tablet->tablet_path()) {
-            LOG(WARNING) << "add the same tablet twice! tablet_id=" << tablet_id
-                         << ", tablet_path=" << tablet->tablet_path();
-            return Status::Error<ENGINE_INSERT_EXISTS_TABLE>();
+            return Status::Error<ENGINE_INSERT_EXISTS_TABLE>(
+                    "add the same tablet twice! tablet_id={}, tablet_path={}", tablet_id,
+                    tablet->tablet_path());
         }
         if (existed_tablet->data_dir() == tablet->data_dir()) {
-            LOG(WARNING) << "add tablet with same data dir twice! tablet_id=" << tablet_id;
-            return Status::Error<ENGINE_INSERT_EXISTS_TABLE>();
+            return Status::Error<ENGINE_INSERT_EXISTS_TABLE>(
+                    "add tablet with same data dir twice! tablet_id={}", tablet_id);
         }
     }
 
@@ -143,9 +141,9 @@ Status TabletManager::_add_tablet_unlocked(TTabletId tablet_id, const TabletShar
         if (new_rowset == nullptr) {
             // it seems useless to call unlock and return here.
             // it could prevent error when log level is changed in the future.
-            LOG(FATAL) << "new tablet is empty and old tablet exists. it should not happen."
-                       << " tablet_id=" << tablet_id;
-            return Status::Error<ENGINE_INSERT_EXISTS_TABLE>();
+            return Status::Error<ENGINE_INSERT_EXISTS_TABLE>(
+                    "new tablet is empty and old tablet exists. it should not happen. tablet_id={}",
+                    tablet_id);
         }
         old_time = old_rowset == nullptr ? -1 : old_rowset->creation_time();
         new_time = new_rowset->creation_time();
@@ -176,11 +174,10 @@ Status TabletManager::_add_tablet_unlocked(TTabletId tablet_id, const TabletShar
             std::lock_guard<std::shared_mutex> shutdown_tablets_wrlock(_shutdown_tablets_lock);
             _shutdown_tablets.push_back(tablet);
         }
-        LOG(INFO) << "set tablet to shutdown state."
-                  << "tablet_id=" << tablet->tablet_id()
-                  << ", tablet_path=" << tablet->tablet_path();
 
-        res = Status::Error<ENGINE_INSERT_OLD_TABLET>();
+        res = Status::Error<ENGINE_INSERT_OLD_TABLET>(
+                "set tablet to shutdown state. tablet_id={}, tablet_path={}", tablet->tablet_id(),
+                tablet->tablet_path());
     }
     LOG(WARNING) << "add duplicated tablet. force=" << force << ", res=" << res
                  << ", tablet_id=" << tablet_id << ", old_version=" << old_version
@@ -266,11 +263,11 @@ Status TabletManager::create_tablet(const TCreateTabletReq& request, std::vector
         is_schema_change = true;
         base_tablet = _get_tablet_unlocked(request.base_tablet_id);
         if (base_tablet == nullptr) {
-            LOG(WARNING) << "fail to create tablet(change schema), base tablet does not exist. "
-                         << "new_tablet_id=" << tablet_id
-                         << ", base_tablet_id=" << request.base_tablet_id;
             DorisMetrics::instance()->create_tablet_requests_failed->increment(1);
-            return Status::Error<TABLE_CREATE_META_ERROR>();
+            return Status::Error<TABLE_CREATE_META_ERROR>(
+                    "fail to create tablet(change schema), base tablet does not exist. "
+                    "new_tablet_id={}, base_tablet_id={}",
+                    tablet_id, request.base_tablet_id);
         }
         // If we are doing schema-change, we should use the same data dir
         // TODO(lingbin): A litter trick here, the directory should be determined before
@@ -285,9 +282,9 @@ Status TabletManager::create_tablet(const TCreateTabletReq& request, std::vector
     TabletSharedPtr tablet =
             _internal_create_tablet_unlocked(request, is_schema_change, base_tablet.get(), stores);
     if (tablet == nullptr) {
-        LOG(WARNING) << "fail to create tablet. tablet_id=" << request.tablet_id;
         DorisMetrics::instance()->create_tablet_requests_failed->increment(1);
-        return Status::Error<CE_CMD_PARAMS_ERROR>();
+        return Status::Error<CE_CMD_PARAMS_ERROR>("fail to create tablet. tablet_id={}",
+                                                  request.tablet_id);
     }
 
     LOG(INFO) << "success to create tablet. tablet_id=" << tablet_id;
@@ -358,11 +355,10 @@ TabletSharedPtr TabletManager::_internal_create_tablet_unlocked(
         // Because if _add_tablet_unlocked() return OK, we must can get it from map.
         TabletSharedPtr tablet_ptr = _get_tablet_unlocked(new_tablet_id);
         if (tablet_ptr == nullptr) {
-            res = Status::Error<TABLE_NOT_FOUND>();
-            LOG(WARNING) << "fail to get tablet. res=" << res;
+            res = Status::Error<TABLE_NOT_FOUND>("fail to get tablet. res={}", res);
             break;
         }
-    } while (0);
+    } while (false);
 
     if (res.ok()) {
         return tablet;
@@ -751,26 +747,24 @@ Status TabletManager::load_tablet_from_meta(DataDir* data_dir, TTabletId tablet_
     TabletMetaSharedPtr tablet_meta(new TabletMeta());
     Status status = tablet_meta->deserialize(meta_binary);
     if (!status.ok()) {
-        LOG(WARNING) << "fail to load tablet because can not parse meta_binary string. "
-                     << "tablet_id=" << tablet_id << ", schema_hash=" << schema_hash
-                     << ", path=" << data_dir->path() << ", status: " << status;
-        return Status::Error<HEADER_PB_PARSE_FAILED>();
+        return Status::Error<HEADER_PB_PARSE_FAILED>(
+                "fail to load tablet because can not parse meta_binary string. tablet_id={}, "
+                "schema_hash={}, path={}, status={}",
+                tablet_id, schema_hash, data_dir->path(), status);
     }
     tablet_meta->init_rs_metas_fs(data_dir->fs());
 
     // check if tablet meta is valid
     if (tablet_meta->tablet_id() != tablet_id || tablet_meta->schema_hash() != schema_hash) {
-        LOG(WARNING) << "fail to load tablet because meet invalid tablet meta. "
-                     << "trying to load tablet(tablet_id=" << tablet_id
-                     << ", schema_hash=" << schema_hash << ")"
-                     << ", but meet tablet=" << tablet_meta->full_name()
-                     << ", path=" << data_dir->path();
-        return Status::Error<HEADER_PB_PARSE_FAILED>();
+        return Status::Error<HEADER_PB_PARSE_FAILED>(
+                "fail to load tablet because meet invalid tablet meta. trying to load "
+                "tablet(tablet_id={}, schema_hash={}), but meet tablet={}, path={}",
+                tablet_id, schema_hash, tablet_meta->full_name(), data_dir->path());
     }
     if (tablet_meta->tablet_uid().hi == 0 && tablet_meta->tablet_uid().lo == 0) {
-        LOG(WARNING) << "fail to load tablet because its uid == 0. "
-                     << "tablet=" << tablet_meta->full_name() << ", path=" << data_dir->path();
-        return Status::Error<HEADER_PB_PARSE_FAILED>();
+        return Status::Error<HEADER_PB_PARSE_FAILED>(
+                "fail to load tablet because its uid == 0. tablet={}, path={}",
+                tablet_meta->full_name(), data_dir->path());
     }
 
     if (restore) {
@@ -780,9 +774,8 @@ Status TabletManager::load_tablet_from_meta(DataDir* data_dir, TTabletId tablet_
 
     TabletSharedPtr tablet = Tablet::create_tablet_from_meta(tablet_meta, data_dir);
     if (tablet == nullptr) {
-        LOG(WARNING) << "fail to load tablet. tablet_id=" << tablet_id
-                     << ", schema_hash:" << schema_hash;
-        return Status::Error<TABLE_CREATE_FROM_HEADER_ERROR>();
+        return Status::Error<TABLE_CREATE_FROM_HEADER_ERROR>(
+                "fail to load tablet. tablet_id={}, schema_hash={}", tablet_id, schema_hash);
     }
 
     // NOTE: method load_tablet_from_meta could be called by two cases as below
@@ -797,28 +790,28 @@ Status TabletManager::load_tablet_from_meta(DataDir* data_dir, TTabletId tablet_
         bool exists = true;
         RETURN_IF_ERROR(io::global_local_filesystem()->exists(tablet->tablet_path(), &exists));
         if (!exists) {
-            LOG(WARNING) << "tablet path not exists, create tablet failed, path="
-                         << tablet->tablet_path();
-            return Status::Error<TABLE_ALREADY_DELETED_ERROR>();
+            return Status::Error<TABLE_ALREADY_DELETED_ERROR>(
+                    "tablet path not exists, create tablet failed, path={}", tablet->tablet_path());
         }
     }
 
     if (tablet_meta->tablet_state() == TABLET_SHUTDOWN) {
-        LOG(INFO) << "fail to load tablet because it is to be deleted. tablet_id=" << tablet_id
-                  << " schema_hash=" << schema_hash << ", path=" << data_dir->path();
         {
             std::lock_guard<std::shared_mutex> shutdown_tablets_wrlock(_shutdown_tablets_lock);
             _shutdown_tablets.push_back(tablet);
         }
-        return Status::Error<TABLE_ALREADY_DELETED_ERROR>();
+        return Status::Error<TABLE_ALREADY_DELETED_ERROR>(
+                "fail to load tablet because it is to be deleted. tablet_id={}, schema_hash={}, "
+                "path={}",
+                tablet_id, schema_hash, data_dir->path());
     }
     // NOTE: We do not check tablet's initial version here, because if BE restarts when
     // one tablet is doing schema-change, we may meet empty tablet.
     if (tablet->max_version().first == -1 && tablet->tablet_state() == TABLET_RUNNING) {
-        LOG(WARNING) << "fail to load tablet. it is in running state but without delta. "
-                     << "tablet=" << tablet->full_name() << ", path=" << data_dir->path();
         // tablet state is invalid, drop tablet
-        return Status::Error<TABLE_INDEX_VALIDATE_ERROR>();
+        return Status::Error<TABLE_INDEX_VALIDATE_ERROR>(
+                "fail to load tablet. it is in running state but without delta. tablet={}, path={}",
+                tablet->full_name(), data_dir->path());
     }
 
     RETURN_NOT_OK_STATUS_WITH_WARN(
@@ -851,14 +844,14 @@ Status TabletManager::load_tablet_from_dir(DataDir* store, TTabletId tablet_id,
     bool exists = false;
     RETURN_IF_ERROR(io::global_local_filesystem()->exists(header_path, &exists));
     if (!exists) {
-        LOG(WARNING) << "fail to find header file. [header_path=" << header_path << "]";
-        return Status::Error<FILE_NOT_EXIST>();
+        return Status::Error<FILE_NOT_EXIST>("fail to find header file. [header_path={}]",
+                                             header_path);
     }
 
     TabletMetaSharedPtr tablet_meta(new TabletMeta());
     if (!tablet_meta->create_from_file(header_path).ok()) {
-        LOG(WARNING) << "fail to load tablet_meta. file_path=" << header_path;
-        return Status::Error<ENGINE_LOAD_INDEX_TABLE_ERROR>();
+        return Status::Error<ENGINE_LOAD_INDEX_TABLE_ERROR>(
+                "fail to load tablet_meta. file_path={}", header_path);
     }
     // has to change shard id here, because meta file maybe copied from other source
     // its shard is different from local shard
@@ -885,8 +878,7 @@ Status TabletManager::report_tablet_info(TTabletInfo* tablet_info) {
 
     TabletSharedPtr tablet = get_tablet(tablet_info->tablet_id);
     if (tablet == nullptr) {
-        LOG(WARNING) << "can't find tablet=" << tablet_info->tablet_id;
-        return Status::Error<TABLE_NOT_FOUND>();
+        return Status::Error<TABLE_NOT_FOUND>("can't find tablet={}", tablet_info->tablet_id);
     }
 
     tablet->build_tablet_report_info(tablet_info);
@@ -1098,7 +1090,6 @@ void TabletManager::try_delete_unused_tablet_path(DataDir* data_dir, TTabletId t
             LOG(INFO) << "move path " << schema_hash_path << " to trash successfully";
         }
     }
-    return;
 }
 
 void TabletManager::update_root_path_info(std::map<string, DataDirInfo>* path_map,
@@ -1209,8 +1200,8 @@ Status TabletManager::_create_tablet_meta_unlocked(const TCreateTabletReq& reque
         } else if (request.storage_format == TStorageFormat::V2) {
             (*tablet_meta)->set_preferred_rowset_type(BETA_ROWSET);
         } else {
-            LOG(FATAL) << "invalid TStorageFormat: " << request.storage_format;
-            return Status::Error<CE_CMD_PARAMS_ERROR>();
+            return Status::Error<CE_CMD_PARAMS_ERROR>("invalid TStorageFormat: {}",
+                                                      request.storage_format);
         }
     }
     return res;

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -362,8 +362,8 @@ Status TabletMeta::create_from_file(const string& file_path) {
     try {
         tablet_meta_pb.CopyFrom(file_header.message());
     } catch (...) {
-        LOG(WARNING) << "fail to copy protocol buffer object. file='" << file_path;
-        return Status::Error<PARSE_PROTOBUF_ERROR>();
+        return Status::Error<PARSE_PROTOBUF_ERROR>("fail to copy protocol buffer object. file={}",
+                                                   file_path);
     }
 
     init_from_pb(tablet_meta_pb);
@@ -404,7 +404,8 @@ Status TabletMeta::save(const string& file_path, const TabletMetaPB& tablet_meta
         file_header.mutable_message()->CopyFrom(tablet_meta_pb);
     } catch (...) {
         LOG(WARNING) << "fail to copy protocol buffer object. file='" << file_path;
-        return Status::Error<ErrorCode::INTERNAL_ERROR>();
+        return Status::Error<ErrorCode::INTERNAL_ERROR>(
+                "fail to copy protocol buffer object. file={}", file_path);
     }
     RETURN_IF_ERROR(file_header.prepare());
     RETURN_IF_ERROR(file_header.serialize());
@@ -446,8 +447,7 @@ Status TabletMeta::deserialize(const string& meta_binary) {
     TabletMetaPB tablet_meta_pb;
     bool parsed = tablet_meta_pb.ParseFromString(meta_binary);
     if (!parsed) {
-        LOG(WARNING) << "parse tablet meta failed";
-        return Status::Error<INIT_FAILED>();
+        return Status::Error<INIT_FAILED>("parse tablet meta failed");
     }
     init_from_pb(tablet_meta_pb);
     return Status::OK();
@@ -673,9 +673,9 @@ Status TabletMeta::add_rs_meta(const RowsetMetaSharedPtr& rs_meta) {
     for (auto& rs : _rs_metas) {
         if (rs->version() == rs_meta->version()) {
             if (rs->rowset_id() != rs_meta->rowset_id()) {
-                LOG(WARNING) << "version already exist. rowset_id=" << rs->rowset_id()
-                             << " version=" << rs->version() << ", tablet=" << full_name();
-                return Status::Error<PUSH_VERSION_ALREADY_EXIST>();
+                return Status::Error<PUSH_VERSION_ALREADY_EXIST>(
+                        "version already exist. rowset_id={}, version={}, tablet={}",
+                        rs->rowset_id().to_string(), rs->version().to_string(), full_name());
             } else {
                 // rowsetid,version is equal, it is a duplicate req, skip it
                 return Status::OK();

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -373,7 +373,7 @@ Status EngineCloneTask::_make_snapshot(const std::string& ip, int port, TTableId
                 client->make_snapshot(result, request);
             }));
     if (result.status.status_code != TStatusCode::OK) {
-        return Status(result.status);
+        return Status::create(result.status);
     }
 
     if (!result.__isset.snapshot_path) {
@@ -400,7 +400,7 @@ Status EngineCloneTask::_release_snapshot(const std::string& ip, int port,
             ip, port, [&snapshot_path, &result](BackendServiceConnection& client) {
                 client->release_snapshot(result, snapshot_path);
             }));
-    return Status(result.status);
+    return Status::create(result.status);
 }
 
 Status EngineCloneTask::_download_files(DataDir* data_dir, const std::string& remote_url_prefix,

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -117,7 +117,8 @@ Status EngineCloneTask::_do_clone() {
     if (tablet != nullptr) {
         std::shared_lock migration_rlock(tablet->get_migration_lock(), std::try_to_lock);
         if (!migration_rlock.owns_lock()) {
-            return Status::Error<TRY_LOCK_FAILED>();
+            return Status::Error<TRY_LOCK_FAILED>(
+                    "EngineCloneTask::_do_clone meet try lock failed");
         }
         if (tablet->replica_id() < _clone_req.replica_id) {
             // `tablet` may be a dropped replica in FE, e.g:

--- a/be/src/olap/task/engine_publish_version_task.cpp
+++ b/be/src/olap/task/engine_publish_version_task.cpp
@@ -127,19 +127,19 @@ Status EnginePublishVersionTask::finish() {
             // and receive fe's publish version task
             // this be must return as an error tablet
             if (rowset == nullptr) {
-                LOG(WARNING) << "could not find related rowset for tablet " << tablet_info.tablet_id
-                             << " txn id " << transaction_id;
                 _error_tablet_ids->push_back(tablet_info.tablet_id);
-                res = Status::Error<PUSH_ROWSET_NOT_FOUND>();
+                res = Status::Error<PUSH_ROWSET_NOT_FOUND>(
+                        "could not find related rowset for tablet {}, txn id {}",
+                        tablet_info.tablet_id, transaction_id);
                 continue;
             }
             TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(
                     tablet_info.tablet_id, tablet_info.tablet_uid);
             if (tablet == nullptr) {
-                LOG(WARNING) << "can't get tablet when publish version. tablet_id="
-                             << tablet_info.tablet_id << " schema_hash=" << tablet_info.schema_hash;
                 _error_tablet_ids->push_back(tablet_info.tablet_id);
-                res = Status::Error<PUSH_TABLE_NOT_EXIST>();
+                res = Status::Error<PUSH_TABLE_NOT_EXIST>(
+                        "can't get tablet when publish version. tablet_id={}, schema_hash={}",
+                        tablet_info.tablet_id, tablet_info.schema_hash);
                 continue;
             }
             // in uniq key model with merge-on-write, we should see all
@@ -171,7 +171,8 @@ Status EnginePublishVersionTask::finish() {
                         add_error_tablet_id(tablet_info.tablet_id);
                         _discontinuous_version_tablets->emplace_back(
                                 partition_id, tablet_info.tablet_id, version.first);
-                        res = Status::Error<PUBLISH_VERSION_NOT_CONTINUOUS>();
+                        res = Status::Error<PUBLISH_VERSION_NOT_CONTINUOUS>(
+                                "check_version_exist failed");
                         int64_t missed_version = max_version.second + 1;
                         int64_t missed_txn_id =
                                 StorageEngine::instance()->txn_manager()->get_txn_by_tablet_version(

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -49,19 +49,8 @@ namespace doris {
 class OlapMeta;
 } // namespace doris
 
-using apache::thrift::ThriftDebugString;
-using std::filesystem::canonical;
-using std::filesystem::directory_iterator;
-using std::filesystem::path;
-using std::filesystem::recursive_directory_iterator;
-using std::back_inserter;
-using std::copy;
-using std::inserter;
-using std::list;
 using std::map;
-using std::nothrow;
 using std::pair;
-using std::priority_queue;
 using std::set;
 using std::string;
 using std::stringstream;
@@ -142,9 +131,9 @@ Status TxnManager::prepare_txn(TPartitionId partition_id, TTransactionId transac
     // if yes, reject the request.
     txn_partition_map_t& txn_partition_map = _get_txn_partition_map(transaction_id);
     if (txn_partition_map.size() > config::max_runnings_transactions_per_txn_map) {
-        LOG(WARNING) << "too many transactions: " << txn_tablet_map.size()
-                     << ", limit: " << config::max_runnings_transactions_per_txn_map;
-        return Status::Error<TOO_MANY_TRANSACTIONS>();
+        return Status::Error<TOO_MANY_TRANSACTIONS>("too many transactions: {}, limit: {}",
+                                                    txn_tablet_map.size(),
+                                                    config::max_runnings_transactions_per_txn_map);
     }
 
     /// Step 3: Add transaction to engine
@@ -236,10 +225,10 @@ Status TxnManager::commit_txn(OlapMeta* meta, TPartitionId partition_id,
     pair<int64_t, int64_t> key(partition_id, transaction_id);
     TabletInfo tablet_info(tablet_id, schema_hash, tablet_uid);
     if (rowset_ptr == nullptr) {
-        LOG(WARNING) << "could not commit txn because rowset ptr is null. "
-                     << "partition_id: " << key.first << ", transaction_id: " << key.second
-                     << ", tablet: " << tablet_info.to_string();
-        return Status::Error<ROWSET_INVALID>();
+        return Status::Error<ROWSET_INVALID>(
+                "could not commit txn because rowset ptr is null. partition_id: {}, "
+                "transaction_id: {}, tablet: {}",
+                key.first, key.second, tablet_info.to_string());
     }
 
     std::lock_guard<std::shared_mutex> txn_lock(_get_txn_lock(transaction_id));
@@ -275,14 +264,12 @@ Status TxnManager::commit_txn(OlapMeta* meta, TPartitionId partition_id,
                    load_info.load_id.lo() == load_id.lo() && load_info.rowset != nullptr &&
                    load_info.rowset->rowset_id() != rowset_ptr->rowset_id()) {
             // find a rowset with different rowset id, then it should not happen, just return errors
-            LOG(WARNING) << "find rowset exists when commit transaction to engine. but "
-                            "rowset ids "
-                            "are not same."
-                         << "partition_id: " << key.first << ", transaction_id: " << key.second
-                         << ", tablet: " << tablet_info.to_string()
-                         << ", exist rowset_id: " << load_info.rowset->rowset_id()
-                         << ", new rowset_id: " << rowset_ptr->rowset_id();
-            return Status::Error<PUSH_TRANSACTION_ALREADY_EXIST>();
+            return Status::Error<PUSH_TRANSACTION_ALREADY_EXIST>(
+                    "find rowset exists when commit transaction to engine. but rowset ids are not "
+                    "same. partition_id: {}, transaction_id: {}, tablet: {}, exist rowset_id: {}, "
+                    "new rowset_id: {}",
+                    key.first, key.second, tablet_info.to_string(),
+                    load_info.rowset->rowset_id().to_string(), rowset_ptr->rowset_id().to_string());
         } else {
             break;
         }
@@ -295,10 +282,10 @@ Status TxnManager::commit_txn(OlapMeta* meta, TPartitionId partition_id,
         Status save_status = RowsetMetaManager::save(meta, tablet_uid, rowset_ptr->rowset_id(),
                                                      rowset_ptr->rowset_meta()->get_rowset_pb());
         if (save_status != Status::OK()) {
-            LOG(WARNING) << "save committed rowset failed. when commit txn rowset_id:"
-                         << rowset_ptr->rowset_id() << "tablet id: " << tablet_id
-                         << "txn id:" << transaction_id;
-            return Status::Error<ROWSET_SAVE_FAILED>();
+            return Status::Error<ROWSET_SAVE_FAILED>(
+                    "save committed rowset failed. when commit txn rowset_id: {}, tablet id: {}, "
+                    "txn id: {}",
+                    rowset_ptr->rowset_id().to_string(), tablet_id, transaction_id);
         }
     }
 
@@ -360,10 +347,10 @@ Status TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id,
         }
     }
     if (rowset == nullptr) {
-        LOG(WARNING) << "publish txn failed, rowset not found. partition_id: " << partition_id
-                     << ", transaction_id: " << transaction_id
-                     << ", tablet: " << tablet_info.to_string();
-        return Status::Error<TRANSACTION_NOT_EXIST>();
+        return Status::Error<TRANSACTION_NOT_EXIST>(
+                "publish txn failed, rowset not found. partition_id={}, transaction_id={}, "
+                "tablet={}",
+                partition_id, transaction_id, tablet_info.to_string());
     }
 
     /// Step 2: make rowset visible
@@ -404,10 +391,10 @@ Status TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id,
     if (enable_binlog) {
         auto status = rowset->add_to_binlog();
         if (!status.ok()) {
-            LOG(WARNING) << "add rowset to binlog failed. when publish txn rowset_id:"
-                         << rowset->rowset_id() << ", tablet id: " << tablet_id
-                         << ", txn id:" << transaction_id;
-            return Status::Error<ROWSET_ADD_TO_BINLOG_FAILED>();
+            return Status::Error<ROWSET_ADD_TO_BINLOG_FAILED>(
+                    "add rowset to binlog failed. when publish txn rowset_id: {}, tablet id: {}, "
+                    "txn id: {}",
+                    rowset->rowset_id().to_string(), tablet_id, transaction_id);
         }
     }
 
@@ -417,10 +404,10 @@ Status TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id,
                                           rowset->rowset_meta()->get_rowset_pb(), enable_binlog);
     stats->save_meta_time_us += MonotonicMicros() - t5;
     if (!status.ok()) {
-        LOG(WARNING) << "save committed rowset failed. when publish txn rowset_id:"
-                     << rowset->rowset_id() << ", tablet id: " << tablet_id
-                     << ", txn id:" << transaction_id;
-        return Status::Error<ROWSET_SAVE_FAILED>();
+        return Status::Error<ROWSET_SAVE_FAILED>(
+                "save committed rowset failed. when publish txn rowset_id: {}, tablet id: {}, txn "
+                "id: {}",
+                rowset->rowset_id().to_string(), tablet_id, transaction_id);
     }
 
     // TODO(Drogon): remove these test codes
@@ -471,9 +458,9 @@ Status TxnManager::rollback_txn(TPartitionId partition_id, TTransactionId transa
             // case 1: user commit rowset, then the load id must be equal
             TabletTxnInfo& load_info = load_itr->second;
             if (load_info.rowset != nullptr) {
-                // if rowset is not null, it means other thread may commit the rowset
-                // should not delete txn any more
-                return Status::Error<TRANSACTION_ALREADY_COMMITTED>();
+                return Status::Error<TRANSACTION_ALREADY_COMMITTED>(
+                        "if rowset is not null, it means other thread may commit the rowset should "
+                        "not delete txn any more");
             }
         }
         it->second.erase(tablet_info);
@@ -499,7 +486,7 @@ Status TxnManager::delete_txn(OlapMeta* meta, TPartitionId partition_id,
     txn_tablet_map_t& txn_tablet_map = _get_txn_tablet_map(transaction_id);
     auto it = txn_tablet_map.find(key);
     if (it == txn_tablet_map.end()) {
-        return Status::Error<TRANSACTION_NOT_EXIST>();
+        return Status::Error<TRANSACTION_NOT_EXIST>("key not founded from txn_tablet_map");
     }
     auto load_itr = it->second.find(tablet_info);
     if (load_itr != it->second.end()) {
@@ -508,14 +495,13 @@ Status TxnManager::delete_txn(OlapMeta* meta, TPartitionId partition_id,
         TabletTxnInfo& load_info = load_itr->second;
         if (load_info.rowset != nullptr && meta != nullptr) {
             if (load_info.rowset->version().first > 0) {
-                LOG(WARNING) << "could not delete transaction from engine, "
-                             << "just remove it from memory not delete from disk"
-                             << " because related rowset already published."
-                             << ",partition_id: " << key.first << ", transaction_id: " << key.second
-                             << ", tablet: " << tablet_info.to_string()
-                             << ", rowset id: " << load_info.rowset->rowset_id()
-                             << ", version: " << load_info.rowset->version().first;
-                return Status::Error<TRANSACTION_ALREADY_COMMITTED>();
+                return Status::Error<TRANSACTION_ALREADY_COMMITTED>(
+                        "could not delete transaction from engine, just remove it from memory not "
+                        "delete from disk, because related rowset already published. partition_id: "
+                        "{}, transaction_id: {}, tablet: {}, rowset id: {}, version:{}",
+                        key.first, key.second, tablet_info.to_string(),
+                        load_info.rowset->rowset_id().to_string(),
+                        load_info.rowset->version().to_string());
             } else {
                 RowsetMetaManager::remove(meta, tablet_uid, load_info.rowset->rowset_id());
 #ifndef BE_TEST

--- a/be/src/olap/types.h
+++ b/be/src/olap/types.h
@@ -296,7 +296,7 @@ public:
 
     Status from_string(void* buf, const std::string& scan_key, const int precision = 0,
                        const int scale = 0) const override {
-        return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>();
+        return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>("ArrayTypeInfo not support from_string");
     }
 
     std::string to_string(const void* src) const override {
@@ -378,7 +378,8 @@ public:
 
     Status from_string(void* buf, const std::string& scan_key, const int precision = 0,
                        const int scale = 0) const override {
-        return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>();
+        return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>(
+                "MapTypeInfo not support from_string");
     }
 
     std::string to_string(const void* src) const override {
@@ -564,7 +565,8 @@ public:
 
     Status from_string(void* buf, const std::string& scan_key, const int precision = 0,
                        const int scale = 0) const override {
-        return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>();
+        return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>(
+                "StructTypeInfo not support from_string");
     }
 
     std::string to_string(const void* src) const override {
@@ -1028,7 +1030,8 @@ struct FieldTypeTraits<FieldType::OLAP_FIELD_TYPE_DECIMAL32>
                                                                  9, scale, &result);
 
         if (result == StringParser::PARSE_FAILURE) {
-            return Status::Error<ErrorCode::INVALID_ARGUMENT>();
+            return Status::Error<ErrorCode::INVALID_ARGUMENT>(
+                    "FieldTypeTraits<OLAP_FIELD_TYPE_DECIMAL32>::from_string meet PARSE_FAILURE");
         }
         *reinterpret_cast<int32_t*>(buf) = (int32_t)value;
         return Status::OK();
@@ -1052,7 +1055,8 @@ struct FieldTypeTraits<FieldType::OLAP_FIELD_TYPE_DECIMAL64>
         int64_t value = StringParser::string_to_decimal<int64_t>(scan_key.c_str(), scan_key.size(),
                                                                  18, scale, &result);
         if (result == StringParser::PARSE_FAILURE) {
-            return Status::Error<ErrorCode::INVALID_ARGUMENT>();
+            return Status::Error<ErrorCode::INVALID_ARGUMENT>(
+                    "FieldTypeTraits<OLAP_FIELD_TYPE_DECIMAL64>::from_string meet PARSE_FAILURE");
         }
         *reinterpret_cast<int64_t*>(buf) = (int64_t)value;
         return Status::OK();
@@ -1076,7 +1080,8 @@ struct FieldTypeTraits<FieldType::OLAP_FIELD_TYPE_DECIMAL128I>
         int128_t value = StringParser::string_to_decimal<int128_t>(
                 scan_key.c_str(), scan_key.size(), 38, scale, &result);
         if (result == StringParser::PARSE_FAILURE) {
-            return Status::Error<ErrorCode::INVALID_ARGUMENT>();
+            return Status::Error<ErrorCode::INVALID_ARGUMENT>(
+                    "FieldTypeTraits<OLAP_FIELD_TYPE_DECIMAL128I>::from_string meet PARSE_FAILURE");
         }
         *reinterpret_cast<PackedInt128*>(buf) = value;
         return Status::OK();
@@ -1272,9 +1277,9 @@ struct FieldTypeTraits<FieldType::OLAP_FIELD_TYPE_CHAR>
                               const int scale) {
         size_t value_len = scan_key.length();
         if (value_len > OLAP_VARCHAR_MAX_LENGTH) {
-            LOG(WARNING) << "the len of value string is too long, len=" << value_len
-                         << ", max_len=" << OLAP_VARCHAR_MAX_LENGTH;
-            return Status::Error<ErrorCode::INVALID_ARGUMENT>();
+            return Status::Error<ErrorCode::INVALID_ARGUMENT>(
+                    "the len of value string is too long, len={}, max_len={}", value_len,
+                    OLAP_VARCHAR_MAX_LENGTH);
         }
 
         auto slice = reinterpret_cast<Slice*>(buf);
@@ -1338,9 +1343,9 @@ struct FieldTypeTraits<FieldType::OLAP_FIELD_TYPE_VARCHAR>
                               const int scale) {
         size_t value_len = scan_key.length();
         if (value_len > OLAP_VARCHAR_MAX_LENGTH) {
-            LOG(WARNING) << "the len of value string is too long, len=" << value_len
-                         << ", max_len=" << OLAP_VARCHAR_MAX_LENGTH;
-            return Status::Error<ErrorCode::INVALID_ARGUMENT>();
+            return Status::Error<ErrorCode::INVALID_ARGUMENT>(
+                    "the len of value string is too long, len={}, max_len={}", value_len,
+                    OLAP_VARCHAR_MAX_LENGTH);
         }
 
         auto slice = reinterpret_cast<Slice*>(buf);
@@ -1362,9 +1367,9 @@ struct FieldTypeTraits<FieldType::OLAP_FIELD_TYPE_STRING>
                               const int scale) {
         size_t value_len = scan_key.length();
         if (value_len > config::string_type_length_soft_limit_bytes) {
-            LOG(WARNING) << "the len of value string is too long, len=" << value_len
-                         << ", max_len=" << config::string_type_length_soft_limit_bytes;
-            return Status::Error<ErrorCode::INVALID_ARGUMENT>();
+            return Status::Error<ErrorCode::INVALID_ARGUMENT>(
+                    "the len of value string is too long, len={}, max_len={}", value_len,
+                    config::string_type_length_soft_limit_bytes);
         }
 
         auto slice = reinterpret_cast<Slice*>(buf);
@@ -1390,7 +1395,8 @@ struct FieldTypeTraits<FieldType::OLAP_FIELD_TYPE_JSONB>
     static Status from_string(void* buf, const std::string& scan_key, const int precision,
                               const int scale) {
         // TODO support schema change
-        return Status::Error<ErrorCode::INVALID_SCHEMA>();
+        return Status::Error<ErrorCode::INVALID_SCHEMA>(
+                "FieldTypeTraits<OLAP_FIELD_TYPE_JSONB> not support from_string");
     }
 
     static void set_to_min(void* buf) {

--- a/be/src/olap/types.h
+++ b/be/src/olap/types.h
@@ -296,7 +296,8 @@ public:
 
     Status from_string(void* buf, const std::string& scan_key, const int precision = 0,
                        const int scale = 0) const override {
-        return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>("ArrayTypeInfo not support from_string");
+        return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>(
+                "ArrayTypeInfo not support from_string");
     }
 
     std::string to_string(const void* src) const override {

--- a/be/src/olap/utils.cpp
+++ b/be/src/olap/utils.cpp
@@ -51,10 +51,6 @@
 #include "olap/olap_common.h"
 #include "util/string_parser.hpp"
 
-using std::string;
-using std::set;
-using std::vector;
-
 namespace doris {
 using namespace ErrorCode;
 
@@ -408,18 +404,16 @@ unsigned int crc32c_lut(char const* b, unsigned int off, unsigned int len, unsig
     return localCrc;
 }
 
-Status gen_timestamp_string(string* out_string) {
+Status gen_timestamp_string(std::string* out_string) {
     time_t now = time(nullptr);
     tm local_tm;
 
     if (localtime_r(&now, &local_tm) == nullptr) {
-        LOG(WARNING) << "fail to localtime_r time. [time=" << now << "]";
-        return Status::Error<OS_ERROR>();
+        return Status::Error<OS_ERROR>("fail to localtime_r time. time={}", now);
     }
     char time_suffix[16] = {0}; // Example: 20150706111404, 长度是15个字符
     if (strftime(time_suffix, sizeof(time_suffix), "%Y%m%d%H%M%S", &local_tm) == 0) {
-        LOG(WARNING) << "fail to strftime time. [time=" << now << "]";
-        return Status::Error<OS_ERROR>();
+        return Status::Error<OS_ERROR>("fail to strftime time. time={}", now);
     }
 
     *out_string = time_suffix;
@@ -430,22 +424,18 @@ int operator-(const BinarySearchIterator& left, const BinarySearchIterator& righ
     return *left - *right;
 }
 
-Status read_write_test_file(const string& test_file_path) {
+Status read_write_test_file(const std::string& test_file_path) {
     if (access(test_file_path.c_str(), F_OK) == 0) {
         if (remove(test_file_path.c_str()) != 0) {
             char errmsg[64];
-            LOG(WARNING) << "fail to delete test file. "
-                         << "path=" << test_file_path << ", errno=" << errno
-                         << ", err=" << strerror_r(errno, errmsg, 64);
-            return Status::Error<IO_ERROR>();
+            return Status::Error<IO_ERROR>("fail to access test file. path={}, errno={}, err={}",
+                                           test_file_path, errno, strerror_r(errno, errmsg, 64));
         }
     } else {
         if (errno != ENOENT) {
             char errmsg[64];
-            LOG(WARNING) << "fail to access test file. "
-                         << "path=" << test_file_path << ", errno=" << errno
-                         << ", err=" << strerror_r(errno, errmsg, 64);
-            return Status::Error<IO_ERROR>();
+            return Status::Error<IO_ERROR>("fail to access test file. path={}, errno={}, err={}",
+                                           test_file_path, errno, strerror_r(errno, errmsg, 64));
         }
     }
 
@@ -454,13 +444,13 @@ Status read_write_test_file(const string& test_file_path) {
     char* write_test_buff = nullptr;
     char* read_test_buff = nullptr;
     if (posix_memalign((void**)&write_test_buff, DIRECT_IO_ALIGNMENT, TEST_FILE_BUF_SIZE) != 0) {
-        LOG(WARNING) << "fail to allocate write buffer memory. size=" << TEST_FILE_BUF_SIZE;
-        return Status::Error<MEM_ALLOC_FAILED>();
+        return Status::Error<MEM_ALLOC_FAILED>("fail to allocate write buffer memory. size={}",
+                                               TEST_FILE_BUF_SIZE);
     }
     std::unique_ptr<char, decltype(&std::free)> write_buff(write_test_buff, &std::free);
     if (posix_memalign((void**)&read_test_buff, DIRECT_IO_ALIGNMENT, TEST_FILE_BUF_SIZE) != 0) {
-        LOG(WARNING) << "fail to allocate read buffer memory. size=" << TEST_FILE_BUF_SIZE;
-        return Status::Error<MEM_ALLOC_FAILED>();
+        return Status::Error<MEM_ALLOC_FAILED>("fail to allocate read buffer memory. size={}",
+                                               TEST_FILE_BUF_SIZE);
     }
     std::unique_ptr<char, decltype(&std::free)> read_buff(read_test_buff, &std::free);
     // generate random numbers
@@ -481,21 +471,20 @@ Status read_write_test_file(const string& test_file_path) {
     size_t bytes_read = 0;
     RETURN_IF_ERROR(file_reader->read_at(0, {read_buff.get(), TEST_FILE_BUF_SIZE}, &bytes_read));
     if (memcmp(write_buff.get(), read_buff.get(), TEST_FILE_BUF_SIZE) != 0) {
-        LOG(WARNING) << "the test file write_buf and read_buf not equal, [file_name = "
-                     << test_file_path << "]";
-        return Status::Error<TEST_FILE_ERROR>();
+        return Status::Error<TEST_FILE_ERROR>(
+                "the test file write_buf and read_buf not equal, file_name={}.", test_file_path);
     }
     // delete file
     return io::global_local_filesystem()->delete_file(test_file_path);
 }
 
-Status check_datapath_rw(const string& path) {
+Status check_datapath_rw(const std::string& path) {
     bool exists = true;
     RETURN_IF_ERROR(io::global_local_filesystem()->exists(path, &exists));
     if (!exists) {
         return Status::IOError("path does not exist: {}", path);
     }
-    string file_path = path + "/.read_write_test_file";
+    std::string file_path = path + "/.read_write_test_file";
     return read_write_test_file(file_path);
 }
 
@@ -506,7 +495,7 @@ const char* Errno::str() {
 }
 
 const char* Errno::str(int no) {
-    if (0 != strerror_r(no, _buf, BUF_SIZE)) {
+    if (nullptr != strerror_r(no, _buf, BUF_SIZE)) {
         LOG(WARNING) << "fail to get errno string. [no='" << no << "', errno='" << errno << "']";
         snprintf(_buf, BUF_SIZE, "unknown errno");
     }
@@ -553,7 +542,7 @@ bool valid_signed_number<int128_t>(const std::string& value_str) {
     }
 }
 
-bool valid_decimal(const string& value_str, const uint32_t precision, const uint32_t frac) {
+bool valid_decimal(const std::string& value_str, const uint32_t precision, const uint32_t frac) {
     const char* decimal_pattern = "-?\\d+(.\\d+)?";
     std::regex e(decimal_pattern);
     std::smatch what;
@@ -570,7 +559,7 @@ bool valid_decimal(const string& value_str, const uint32_t precision, const uint
     size_t integer_len = 0;
     size_t fractional_len = 0;
     size_t point_pos = value_str.find('.');
-    if (point_pos == string::npos) {
+    if (point_pos == std::string::npos) {
         integer_len = number_length;
         fractional_len = 0;
     } else {
@@ -585,7 +574,7 @@ bool valid_decimal(const string& value_str, const uint32_t precision, const uint
     }
 }
 
-bool valid_datetime(const string& value_str, const uint32_t scale) {
+bool valid_datetime(const std::string& value_str, const uint32_t scale) {
     const char* datetime_pattern =
             "((?:\\d){4})-((?:\\d){2})-((?:\\d){2})[ ]*"
             "(((?:\\d){2}):((?:\\d){2}):((?:\\d){2})([.]*((?:\\d){0,6})))?";

--- a/be/src/olap/utils.cpp
+++ b/be/src/olap/utils.cpp
@@ -495,7 +495,7 @@ const char* Errno::str() {
 }
 
 const char* Errno::str(int no) {
-    if (nullptr != strerror_r(no, _buf, BUF_SIZE)) {
+    if (0 != strerror_r(no, _buf, BUF_SIZE)) {
         LOG(WARNING) << "fail to get errno string. [no='" << no << "', errno='" << errno << "']";
         snprintf(_buf, BUF_SIZE, "unknown errno");
     }

--- a/be/src/olap/utils.h
+++ b/be/src/olap/utils.h
@@ -70,7 +70,7 @@ private:
 template <typename T>
 Status split_string(const std::string& base, const T separator, std::vector<std::string>* result) {
     if (!result) {
-        return Status::Error<ErrorCode::INVALID_ARGUMENT>();
+        return Status::Error<ErrorCode::INVALID_ARGUMENT>("split_string meet nullptr result input");
     }
 
     // 处理base为空的情况

--- a/be/src/olap/version_graph.cpp
+++ b/be/src/olap/version_graph.cpp
@@ -521,9 +521,8 @@ Status VersionGraph::delete_version_from_graph(const Version& version) {
 
     if (_vertex_index_map.find(start_vertex_value) == _vertex_index_map.end() ||
         _vertex_index_map.find(end_vertex_value) == _vertex_index_map.end()) {
-        LOG(WARNING) << "vertex for version does not exists. "
-                     << "version=" << version.first << "-" << version.second;
-        return Status::Error<HEADER_DELETE_VERSION>();
+        return Status::Error<HEADER_DELETE_VERSION>(
+                "vertex for version does not exists. version={}-{}", version.first, version.second);
     }
 
     int64_t start_vertex_index = _vertex_index_map[start_vertex_value];
@@ -567,9 +566,8 @@ void VersionGraph::_add_vertex_to_graph(int64_t vertex_value) {
 Status VersionGraph::capture_consistent_versions(const Version& spec_version,
                                                  std::vector<Version>* version_path) const {
     if (spec_version.first > spec_version.second) {
-        LOG(WARNING) << "invalid specified version. "
-                     << "spec_version=" << spec_version.first << "-" << spec_version.second;
-        return Status::Error<INVALID_ARGUMENT>();
+        return Status::Error<INVALID_ARGUMENT>("invalid specified version. spec_version={}-{}",
+                                               spec_version.first, spec_version.second);
     }
 
     int64_t cur_idx = -1;

--- a/be/src/pipeline/exec/exchange_sink_buffer.cpp
+++ b/be/src/pipeline/exec/exchange_sink_buffer.cpp
@@ -185,7 +185,7 @@ Status ExchangeSinkBuffer::_send_rpc(InstanceLoId id) {
                                        const PTransmitDataResult& result,
                                        const int64_t& start_rpc_time) {
             set_rpc_time(id, start_rpc_time, result.receive_time());
-            Status s = Status(result.status());
+            Status s(Status::create(result.status()));
             if (s.is<ErrorCode::END_OF_FILE>()) {
                 _set_receiver_eof(id);
             } else if (!s.ok()) {
@@ -229,7 +229,7 @@ Status ExchangeSinkBuffer::_send_rpc(InstanceLoId id) {
                                        const PTransmitDataResult& result,
                                        const int64_t& start_rpc_time) {
             set_rpc_time(id, start_rpc_time, result.receive_time());
-            Status s = Status(result.status());
+            Status s(Status::create(result.status()));
             if (s.is<ErrorCode::END_OF_FILE>()) {
                 _set_receiver_eof(id);
             } else if (!s.ok()) {

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -494,7 +494,7 @@ void FragmentMgr::coordinator_callback(const ReportStatusRequest& req) {
             coord->reportExecStatus(res, params);
         }
 
-        rpc_status = Status(res.status);
+        rpc_status = Status(Status::create(res.status));
     } catch (TException& e) {
         std::stringstream msg;
         msg << "ReportExecStatus() to " << req.coord_addr << " failed:\n" << e.what();

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -161,7 +161,7 @@ public:
         _is_cancelled.store(v);
         // Create a error status, so that we could print error stack, and
         // we could know which path call cancel.
-        LOG(INFO) << "task is cancelled, st = " << Status::Error<ErrorCode::CANCELLED>();
+        LOG(INFO) << "task is cancelled, st = " << Status::Error<ErrorCode::CANCELLED>("");
     }
 
     void set_backend_id(int64_t backend_id) { _backend_id = backend_id; }

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -260,7 +260,7 @@ Status StreamLoadExecutor::begin_txn(StreamLoadContext* ctx) {
 #else
         result = k_stream_load_begin_result;
 #endif
-        status = Status(result.status);
+        status = Status::create(result.status);
     }
     g_stream_load_begin_txn_latency << duration_ns / 1000;
     if (!status.ok()) {
@@ -303,7 +303,7 @@ Status StreamLoadExecutor::pre_commit_txn(StreamLoadContext* ctx) {
     // Return if this transaction is precommitted successful; otherwise, we need try
     // to
     // rollback this transaction
-    Status status(result.status);
+    Status status(Status::create(result.status));
     if (!status.ok()) {
         LOG(WARNING) << "precommit transaction failed, errmsg=" << status << ctx->brief();
         if (status.is<PUBLISH_TIMEOUT>()) {
@@ -338,7 +338,7 @@ Status StreamLoadExecutor::operate_txn_2pc(StreamLoadContext* ctx) {
                 config::txn_commit_rpc_timeout_ms));
     }
     g_stream_load_commit_txn_latency << duration_ns / 1000;
-    Status status(result.status);
+    Status status(Status::create(result.status));
     if (!status.ok()) {
         LOG(WARNING) << "2PC commit transaction failed, errmsg=" << status;
         return status;
@@ -394,7 +394,7 @@ Status StreamLoadExecutor::commit_txn(StreamLoadContext* ctx) {
     // Return if this transaction is committed successful; otherwise, we need try
     // to
     // rollback this transaction
-    Status status(result.status);
+    Status status(Status::create(result.status));
     if (!status.ok()) {
         LOG(WARNING) << "commit transaction failed, errmsg=" << status << ", " << ctx->brief();
         if (status.is<PUBLISH_TIMEOUT>()) {

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -303,7 +303,8 @@ void PInternalServiceImpl::_exec_plan_fragment_in_pthread(
     } catch (const Exception& e) {
         st = e.to_status();
     } catch (...) {
-        st = Status::Error(ErrorCode::INTERNAL_ERROR);
+        st = Status::Error(ErrorCode::INTERNAL_ERROR,
+                           "_exec_plan_fragment_impl meet unknown error");
     }
     if (!st.ok()) {
         LOG(WARNING) << "exec plan fragment failed, errmsg=" << st;

--- a/be/src/vec/data_types/data_type_factory.cpp
+++ b/be/src/vec/data_types/data_type_factory.cpp
@@ -34,6 +34,8 @@
 #include <ostream>
 
 #include "common/consts.h"
+#include "common/exception.h"
+#include "common/status.h"
 #include "data_type_time.h"
 #include "olap/field.h"
 #include "olap/olap_common.h"
@@ -225,7 +227,7 @@ DataTypePtr DataTypeFactory::create_data_type(const TypeDescriptor& col_desc, bo
         return std::make_shared<vectorized::DataTypeObject>("json", true);
     case INVALID_TYPE:
     default:
-        DCHECK(false) << "invalid PrimitiveType:" << (int)col_desc.type;
+        throw Exception(ErrorCode::INTERNAL_ERROR, "invalid PrimitiveType: {}", (int)col_desc.type);
         break;
     }
 

--- a/be/src/vec/exec/scan/vmeta_scanner.cpp
+++ b/be/src/vec/exec/scan/vmeta_scanner.cpp
@@ -239,7 +239,7 @@ Status VMetaScanner::_fetch_metadata(const TMetaScanRange& meta_scan_range) {
             },
             time_out));
 
-    Status status(result.status);
+    Status status(Status::create(result.status));
     if (!status.ok()) {
         LOG(WARNING) << "fetch schema table data from master failed, errmsg=" << status;
         return status;

--- a/be/src/vec/exprs/vexpr.cpp
+++ b/be/src/vec/exprs/vexpr.cpp
@@ -212,7 +212,8 @@ Status VExpr::create_expr(const TExprNode& expr_node, VExprSPtr& expr) {
             return Status::InternalError("Unknown expr node type: {}", expr_node.node_type);
         }
     } catch (const Exception& e) {
-        return e.to_status();
+        return Status::InternalError("create expr failed, TExprNode={}, reason={}",
+                                     apache::thrift::ThriftDebugString(expr_node), e.what());
     }
     if (!expr->data_type()) {
         return Status::InvalidArgument("Unknown expr type: {}", expr_node.node_type);

--- a/be/src/vec/functions/match.cpp
+++ b/be/src/vec/functions/match.cpp
@@ -137,9 +137,8 @@ Status FunctionMatchAny::execute_match(const std::string& column_name,
                     column_name, match_query_str,
                     doris::segment_v2::InvertedIndexQueryType::MATCH_ANY_QUERY, inverted_index_ctx);
     if (query_tokens.empty()) {
-        LOG(WARNING) << "invalid input query_str: " << match_query_str
-                     << ", please check your query sql";
-        return Status::Error<ErrorCode::INVERTED_INDEX_NO_TERMS>();
+        return Status::Error<ErrorCode::INVERTED_INDEX_NO_TERMS>(
+                "invalid input query_str: {}, please check your query sql", match_query_str);
     }
 
     auto current_src_array_offset = 0;
@@ -178,9 +177,8 @@ Status FunctionMatchAll::execute_match(const std::string& column_name,
                     column_name, match_query_str,
                     doris::segment_v2::InvertedIndexQueryType::MATCH_ALL_QUERY, inverted_index_ctx);
     if (query_tokens.empty()) {
-        LOG(WARNING) << "invalid input query_str: " << match_query_str
-                     << ", please check your query sql";
-        return Status::Error<ErrorCode::INVERTED_INDEX_NO_TERMS>();
+        return Status::Error<ErrorCode::INVERTED_INDEX_NO_TERMS>(
+                "invalid input query_str: {}, please check your query sql", match_query_str);
     }
 
     auto current_src_array_offset = 0;
@@ -226,9 +224,8 @@ Status FunctionMatchPhrase::execute_match(const std::string& column_name,
                     doris::segment_v2::InvertedIndexQueryType::MATCH_PHRASE_QUERY,
                     inverted_index_ctx);
     if (query_tokens.empty()) {
-        LOG(WARNING) << "invalid input query_str: " << match_query_str
-                     << ", please check your query sql";
-        return Status::Error<ErrorCode::INVERTED_INDEX_NO_TERMS>();
+        return Status::Error<ErrorCode::INVERTED_INDEX_NO_TERMS>(
+                "invalid input query_str: {}, please check your query sql", match_query_str);
     }
 
     auto current_src_array_offset = 0;

--- a/be/src/vec/functions/match.h
+++ b/be/src/vec/functions/match.h
@@ -91,11 +91,11 @@ public:
 
     String get_name() const override { return name; }
 
-    virtual Status execute_match(const std::string& column_name, const std::string& match_query_str,
-                                 size_t input_rows_count, const ColumnString* string_col,
-                                 InvertedIndexCtx* inverted_index_ctx,
-                                 const ColumnArray::Offsets64* array_offsets,
-                                 ColumnUInt8::Container& result) override;
+    Status execute_match(const std::string& column_name, const std::string& match_query_str,
+                         size_t input_rows_count, const ColumnString* string_col,
+                         InvertedIndexCtx* inverted_index_ctx,
+                         const ColumnArray::Offsets64* array_offsets,
+                         ColumnUInt8::Container& result) override;
 };
 
 class FunctionMatchAll : public FunctionMatchBase {
@@ -105,11 +105,11 @@ public:
 
     String get_name() const override { return name; }
 
-    virtual Status execute_match(const std::string& column_name, const std::string& match_query_str,
-                                 size_t input_rows_count, const ColumnString* string_col,
-                                 InvertedIndexCtx* inverted_index_ctx,
-                                 const ColumnArray::Offsets64* array_offsets,
-                                 ColumnUInt8::Container& result) override;
+    Status execute_match(const std::string& column_name, const std::string& match_query_str,
+                         size_t input_rows_count, const ColumnString* string_col,
+                         InvertedIndexCtx* inverted_index_ctx,
+                         const ColumnArray::Offsets64* array_offsets,
+                         ColumnUInt8::Container& result) override;
 };
 
 class FunctionMatchPhrase : public FunctionMatchBase {
@@ -119,11 +119,11 @@ public:
 
     String get_name() const override { return name; }
 
-    virtual Status execute_match(const std::string& column_name, const std::string& match_query_str,
-                                 size_t input_rows_count, const ColumnString* string_col,
-                                 InvertedIndexCtx* inverted_index_ctx,
-                                 const ColumnArray::Offsets64* array_offsets,
-                                 ColumnUInt8::Container& result) override;
+    Status execute_match(const std::string& column_name, const std::string& match_query_str,
+                         size_t input_rows_count, const ColumnString* string_col,
+                         InvertedIndexCtx* inverted_index_ctx,
+                         const ColumnArray::Offsets64* array_offsets,
+                         ColumnUInt8::Container& result) override;
 };
 
 class FunctionMatchElementEQ : public FunctionMatchBase {
@@ -133,12 +133,13 @@ public:
 
     String get_name() const override { return name; }
 
-    virtual Status execute_match(const std::string& column_name, const std::string& match_query_str,
-                                 size_t input_rows_count, const ColumnString* string_col,
-                                 InvertedIndexCtx* inverted_index_ctx,
-                                 const ColumnArray::Offsets64* array_offsets,
-                                 ColumnUInt8::Container& result) override {
-        return Status::Error<ErrorCode::INVERTED_INDEX_NOT_SUPPORTED>();
+    Status execute_match(const std::string& column_name, const std::string& match_query_str,
+                         size_t input_rows_count, const ColumnString* string_col,
+                         InvertedIndexCtx* inverted_index_ctx,
+                         const ColumnArray::Offsets64* array_offsets,
+                         ColumnUInt8::Container& result) override {
+        return Status::Error<ErrorCode::INVERTED_INDEX_NOT_SUPPORTED>(
+                "FunctionMatchElementEQ not support execute_match");
     }
 };
 
@@ -149,12 +150,13 @@ public:
 
     String get_name() const override { return name; }
 
-    virtual Status execute_match(const std::string& column_name, const std::string& match_query_str,
-                                 size_t input_rows_count, const ColumnString* string_col,
-                                 InvertedIndexCtx* inverted_index_ctx,
-                                 const ColumnArray::Offsets64* array_offsets,
-                                 ColumnUInt8::Container& result) override {
-        return Status::Error<ErrorCode::INVERTED_INDEX_NOT_SUPPORTED>();
+    Status execute_match(const std::string& column_name, const std::string& match_query_str,
+                         size_t input_rows_count, const ColumnString* string_col,
+                         InvertedIndexCtx* inverted_index_ctx,
+                         const ColumnArray::Offsets64* array_offsets,
+                         ColumnUInt8::Container& result) override {
+        return Status::Error<ErrorCode::INVERTED_INDEX_NOT_SUPPORTED>(
+                "FunctionMatchElementLT not support execute_match");
     }
 };
 
@@ -165,12 +167,13 @@ public:
 
     String get_name() const override { return name; }
 
-    virtual Status execute_match(const std::string& column_name, const std::string& match_query_str,
-                                 size_t input_rows_count, const ColumnString* string_col,
-                                 InvertedIndexCtx* inverted_index_ctx,
-                                 const ColumnArray::Offsets64* array_offsets,
-                                 ColumnUInt8::Container& result) override {
-        return Status::Error<ErrorCode::INVERTED_INDEX_NOT_SUPPORTED>();
+    Status execute_match(const std::string& column_name, const std::string& match_query_str,
+                         size_t input_rows_count, const ColumnString* string_col,
+                         InvertedIndexCtx* inverted_index_ctx,
+                         const ColumnArray::Offsets64* array_offsets,
+                         ColumnUInt8::Container& result) override {
+        return Status::Error<ErrorCode::INVERTED_INDEX_NOT_SUPPORTED>(
+                "FunctionMatchElementGT not support execute_match");
     }
 };
 
@@ -181,12 +184,13 @@ public:
 
     String get_name() const override { return name; }
 
-    virtual Status execute_match(const std::string& column_name, const std::string& match_query_str,
-                                 size_t input_rows_count, const ColumnString* string_col,
-                                 InvertedIndexCtx* inverted_index_ctx,
-                                 const ColumnArray::Offsets64* array_offsets,
-                                 ColumnUInt8::Container& result) override {
-        return Status::Error<ErrorCode::INVERTED_INDEX_NOT_SUPPORTED>();
+    Status execute_match(const std::string& column_name, const std::string& match_query_str,
+                         size_t input_rows_count, const ColumnString* string_col,
+                         InvertedIndexCtx* inverted_index_ctx,
+                         const ColumnArray::Offsets64* array_offsets,
+                         ColumnUInt8::Container& result) override {
+        return Status::Error<ErrorCode::INVERTED_INDEX_NOT_SUPPORTED>(
+                "FunctionMatchElementLE not support execute_match");
     }
 };
 
@@ -197,12 +201,13 @@ public:
 
     String get_name() const override { return name; }
 
-    virtual Status execute_match(const std::string& column_name, const std::string& match_query_str,
-                                 size_t input_rows_count, const ColumnString* string_col,
-                                 InvertedIndexCtx* inverted_index_ctx,
-                                 const ColumnArray::Offsets64* array_offsets,
-                                 ColumnUInt8::Container& result) override {
-        return Status::Error<ErrorCode::INVERTED_INDEX_NOT_SUPPORTED>();
+    Status execute_match(const std::string& column_name, const std::string& match_query_str,
+                         size_t input_rows_count, const ColumnString* string_col,
+                         InvertedIndexCtx* inverted_index_ctx,
+                         const ColumnArray::Offsets64* array_offsets,
+                         ColumnUInt8::Container& result) override {
+        return Status::Error<ErrorCode::INVERTED_INDEX_NOT_SUPPORTED>(
+                "FunctionMatchElementGE not support execute_match");
     }
 };
 

--- a/be/src/vec/olap/block_reader.cpp
+++ b/be/src/vec/olap/block_reader.cpp
@@ -240,7 +240,7 @@ Status BlockReader::_direct_next_block(Block* block, bool* eof) {
     _eof = *eof;
     if (UNLIKELY(_reader_context.record_rowids)) {
         res = _vcollect_iter.current_block_row_locations(&_block_row_locations);
-        if (UNLIKELY(!res.ok() && res != Status::Error<END_OF_FILE>())) {
+        if (UNLIKELY(!res.ok() && res != Status::Error<END_OF_FILE>(""))) {
             return res;
         }
         DCHECK_EQ(_block_row_locations.size(), block->rows());

--- a/be/src/vec/olap/vcollect_iterator.h
+++ b/be/src/vec/olap/vcollect_iterator.h
@@ -65,7 +65,7 @@ public:
     // Read nest order row in Block.
     // Returns
     //      OK when read successfully.
-    //      Status::Error<END_OF_FILE>() and set *row to nullptr when EOF is reached.
+    //      Status::Error<END_OF_FILE>("") and set *row to nullptr when EOF is reached.
     //      Others when error happens
     Status next(IteratorRowRef* ref);
 

--- a/be/src/vec/olap/vertical_block_reader.cpp
+++ b/be/src/vec/olap/vertical_block_reader.cpp
@@ -240,7 +240,7 @@ Status VerticalBlockReader::_direct_next_block(Block* block, bool* eof) {
     _eof = *eof;
     if (_reader_context.is_key_column_group && UNLIKELY(_reader_context.record_rowids)) {
         res = _vcollect_iter->current_block_row_locations(&_block_row_locations);
-        if (UNLIKELY(!res.ok() && res != Status::Error<END_OF_FILE>())) {
+        if (UNLIKELY(!res.ok() && res != Status::Error<END_OF_FILE>(""))) {
             return res;
         }
         DCHECK_EQ(_block_row_locations.size(), block->rows());

--- a/be/src/vec/sink/vdata_stream_sender.h
+++ b/be/src/vec/sink/vdata_stream_sender.h
@@ -315,7 +315,7 @@ protected:
         auto cntl = &_closure->cntl;
         auto call_id = _closure->cntl.call_id();
         brpc::Join(call_id);
-        receiver_status_ = _closure->result.status();
+        receiver_status_ = Status::create(_closure->result.status());
         if (cntl->Failed()) {
             std::string err = fmt::format(
                     "failed to send brpc batch, error={}, error_text={}, client: {}, "

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -124,7 +124,7 @@ public:
         if (cntl.Failed()) {
             open_partition_failed();
         } else {
-            Status status(result.status());
+            Status status(Status::create(result.status()));
             if (!status.ok()) {
                 open_partition_failed();
             }
@@ -410,7 +410,7 @@ Status VNodeChannel::open_wait() {
         return Status::InternalError("failed to open tablet writer, error={}, error_text={}",
                                      berror(error_code), error_text);
     }
-    Status status(_open_closure->result.status());
+    Status status(Status::create(_open_closure->result.status()));
     if (_open_closure->unref()) {
         delete _open_closure;
     }
@@ -456,7 +456,7 @@ Status VNodeChannel::open_wait() {
             return;
         }
         SCOPED_ATTACH_TASK(_state);
-        Status status(result.status());
+        Status status(Status::create(result.status()));
         if (status.ok()) {
             // if has error tablet, handle them first
             for (auto& error : result.tablet_errors()) {

--- a/be/test/olap/delete_handler_test.cpp
+++ b/be/test/olap/delete_handler_test.cpp
@@ -387,7 +387,7 @@ TEST_F(TestDeleteConditionHandler, StoreCondInvalidParameters) {
     Status failed_res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(),
                                                                  conditions, &del_pred);
     ;
-    EXPECT_EQ(Status::Error<DELETE_INVALID_PARAMETERS>(), failed_res);
+    EXPECT_EQ(Status::Error<DELETE_INVALID_PARAMETERS>(""), failed_res);
 }
 
 // 检测过滤条件中指定的列不存在,或者列不符合要求
@@ -404,7 +404,7 @@ TEST_F(TestDeleteConditionHandler, StoreCondNonexistentColumn) {
     Status failed_res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(),
                                                                  conditions, &del_pred);
     ;
-    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(), failed_res);
+    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(""), failed_res);
 
     // 'v'是value列
     conditions.clear();
@@ -417,7 +417,7 @@ TEST_F(TestDeleteConditionHandler, StoreCondNonexistentColumn) {
     failed_res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                           &del_pred);
     ;
-    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(), failed_res);
+    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(""), failed_res);
 
     // value column in duplicate model can be deleted;
     conditions.clear();
@@ -611,7 +611,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     DeletePredicatePB del_pred_1;
     res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_1);
-    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(), res);
+    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(""), res);
 
     // 测试k1的值越下界，k1类型为int8
     conditions[0].condition_values.clear();
@@ -619,7 +619,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     DeletePredicatePB del_pred_2;
     res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_2);
-    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(), res);
+    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(""), res);
 
     // 测试k2的值越上界，k2类型为int16
     conditions[0].condition_values.clear();
@@ -628,7 +628,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     DeletePredicatePB del_pred_3;
     res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_3);
-    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(), res);
+    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(""), res);
 
     // 测试k2的值越下界，k2类型为int16
     conditions[0].condition_values.clear();
@@ -636,7 +636,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     DeletePredicatePB del_pred_4;
     res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_4);
-    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(), res);
+    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(""), res);
 
     // 测试k3的值越上界，k3类型为int32
     conditions[0].condition_values.clear();
@@ -645,7 +645,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     DeletePredicatePB del_pred_5;
     res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_5);
-    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(), res);
+    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(""), res);
 
     // 测试k3的值越下界，k3类型为int32
     conditions[0].condition_values.clear();
@@ -653,7 +653,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     DeletePredicatePB del_pred_6;
     res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_6);
-    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(), res);
+    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(""), res);
 
     // 测试k4的值越上界，k2类型为int64
     conditions[0].condition_values.clear();
@@ -662,7 +662,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     DeletePredicatePB del_pred_7;
     res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_7);
-    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(), res);
+    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(""), res);
 
     // 测试k4的值越下界，k1类型为int64
     conditions[0].condition_values.clear();
@@ -670,7 +670,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     DeletePredicatePB del_pred_8;
     res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_8);
-    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(), res);
+    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(""), res);
 
     // 测试k5的值越上界，k5类型为int128
     conditions[0].condition_values.clear();
@@ -679,7 +679,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     DeletePredicatePB del_pred_9;
     res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_9);
-    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(), res);
+    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(""), res);
 
     // 测试k5的值越下界，k5类型为int128
     conditions[0].condition_values.clear();
@@ -687,7 +687,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     DeletePredicatePB del_pred_10;
     res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_10);
-    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(), res);
+    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(""), res);
 
     // 测试k9整数部分长度过长，k9类型为decimal, precision=6, frac=3
     conditions[0].condition_values.clear();
@@ -696,7 +696,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     DeletePredicatePB del_pred_11;
     res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_11);
-    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(), res);
+    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(""), res);
 
     // 测试k9小数部分长度过长，k9类型为decimal, precision=6, frac=3
     conditions[0].condition_values.clear();
@@ -704,7 +704,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     DeletePredicatePB del_pred_12;
     res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_12);
-    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(), res);
+    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(""), res);
 
     // 测试k9没有小数部分，但包含小数点
     conditions[0].condition_values.clear();
@@ -712,7 +712,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     DeletePredicatePB del_pred_13;
     res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_13);
-    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(), res);
+    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(""), res);
 
     // 测试k10类型的过滤值不符合对应格式，k10为date
     conditions[0].condition_values.clear();
@@ -721,21 +721,21 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     DeletePredicatePB del_pred_14;
     res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_14);
-    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(), res);
+    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(""), res);
 
     conditions[0].condition_values.clear();
     conditions[0].condition_values.push_back("2013-64-01");
     DeletePredicatePB del_pred_15;
     res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_15);
-    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(), res);
+    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(""), res);
 
     conditions[0].condition_values.clear();
     conditions[0].condition_values.push_back("2013-01-40");
     DeletePredicatePB del_pred_16;
     res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_16);
-    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(), res);
+    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(""), res);
 
     // 测试k11类型的过滤值不符合对应格式，k11为datetime
     conditions[0].condition_values.clear();
@@ -744,42 +744,42 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     DeletePredicatePB del_pred_17;
     res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_17);
-    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(), res);
+    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(""), res);
 
     conditions[0].condition_values.clear();
     conditions[0].condition_values.push_back("2013-64-01 00:00:00");
     DeletePredicatePB del_pred_18;
     res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_18);
-    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(), res);
+    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(""), res);
 
     conditions[0].condition_values.clear();
     conditions[0].condition_values.push_back("2013-01-40 00:00:00");
     DeletePredicatePB del_pred_19;
     res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_19);
-    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(), res);
+    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(""), res);
 
     conditions[0].condition_values.clear();
     conditions[0].condition_values.push_back("2013-01-01 24:00:00");
     DeletePredicatePB del_pred_20;
     res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_20);
-    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(), res);
+    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(""), res);
 
     conditions[0].condition_values.clear();
     conditions[0].condition_values.push_back("2013-01-01 00:60:00");
     DeletePredicatePB del_pred_21;
     res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_21);
-    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(), res);
+    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(""), res);
 
     conditions[0].condition_values.clear();
     conditions[0].condition_values.push_back("2013-01-01 00:00:60");
     DeletePredicatePB del_pred_22;
     res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_22);
-    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(), res);
+    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(""), res);
 
     // 测试k12和k13类型的过滤值过长，k12,k13类型分别为string(64), varchar(64)
     conditions[0].condition_values.clear();
@@ -791,7 +791,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     DeletePredicatePB del_pred_23;
     res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_23);
-    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(), res);
+    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(""), res);
 
     conditions[0].condition_values.clear();
     conditions[0].column_name = "k13";
@@ -802,7 +802,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     DeletePredicatePB del_pred_24;
     res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_24);
-    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(), res);
+    EXPECT_EQ(Status::Error<DELETE_INVALID_CONDITION>(""), res);
 }
 
 class TestDeleteHandler : public testing::Test {

--- a/be/test/olap/olap_meta_test.cpp
+++ b/be/test/olap/olap_meta_test.cpp
@@ -75,7 +75,7 @@ TEST_F(OlapMetaTest, TestPutAndGet) {
 
     // abnormal cases
     s = _meta->get(META_COLUMN_FAMILY_INDEX, "key_not_exist", &value_get);
-    EXPECT_EQ(Status::Error<META_KEY_NOT_FOUND>(), s);
+    EXPECT_EQ(Status::Error<META_KEY_NOT_FOUND>(""), s);
 }
 
 TEST_F(OlapMetaTest, TestRemove) {

--- a/be/test/olap/ordered_data_compaction_test.cpp
+++ b/be/test/olap/ordered_data_compaction_test.cpp
@@ -462,7 +462,7 @@ TEST_F(OrderedDataCompactionTest, test_01) {
             output_data.emplace_back(columns[0].column->get_int(i), columns[1].column->get_int(i));
         }
     } while (s == Status::OK());
-    EXPECT_EQ(Status::Error<END_OF_FILE>(), s);
+    EXPECT_EQ(Status::Error<END_OF_FILE>(""), s);
     EXPECT_EQ(out_rowset->rowset_meta()->num_rows(), output_data.size());
     EXPECT_EQ(output_data.size(), num_input_rowset * num_segments * rows_per_segment);
     std::vector<uint32_t> segment_num_rows;

--- a/be/test/olap/rowid_conversion_test.cpp
+++ b/be/test/olap/rowid_conversion_test.cpp
@@ -391,7 +391,7 @@ protected:
                                          columns[1].column->get_int(i));
             }
         } while (s == Status::OK());
-        EXPECT_EQ(Status::Error<END_OF_FILE>(), s);
+        EXPECT_EQ(Status::Error<END_OF_FILE>(""), s);
         EXPECT_EQ(out_rowset->rowset_meta()->num_rows(), output_data.size());
         std::vector<uint32_t> segment_num_rows;
         EXPECT_TRUE(output_rs_reader->get_segment_num_rows(&segment_num_rows).ok());

--- a/be/test/olap/segcompaction_test.cpp
+++ b/be/test/olap/segcompaction_test.cpp
@@ -321,7 +321,7 @@ TEST_F(SegCompactionTest, SegCompactionThenRead) {
                 }
                 output_block->clear();
             }
-            EXPECT_EQ(Status::Error<END_OF_FILE>(), s);
+            EXPECT_EQ(Status::Error<END_OF_FILE>(""), s);
             EXPECT_EQ(rowset->rowset_meta()->num_rows(), num_rows_read);
             EXPECT_TRUE(rowset_reader->get_segment_num_rows(&segment_num_rows).ok());
             size_t total_num_rows = 0;
@@ -820,7 +820,7 @@ TEST_F(SegCompactionTest, SegCompactionThenReadUniqueTableSmall) {
                 }
                 output_block->clear();
             }
-            EXPECT_EQ(Status::Error<END_OF_FILE>(), s);
+            EXPECT_EQ(Status::Error<END_OF_FILE>(""), s);
             // duplicated keys between segments are counted duplicately
             // so actual read by rowset reader is less or equal to it
             EXPECT_GE(rowset->rowset_meta()->num_rows(), num_rows_read);
@@ -1055,7 +1055,7 @@ TEST_F(SegCompactionTest, SegCompactionThenReadAggTableSmall) {
                 }
                 output_block->clear();
             }
-            EXPECT_EQ(Status::Error<END_OF_FILE>(), s);
+            EXPECT_EQ(Status::Error<END_OF_FILE>(""), s);
             // duplicated keys between segments are counted duplicately
             // so actual read by rowset reader is less or equal to it
             EXPECT_GE(rowset->rowset_meta()->num_rows(), num_rows_read);

--- a/be/test/olap/tablet_meta_manager_test.cpp
+++ b/be/test/olap/tablet_meta_manager_test.cpp
@@ -93,7 +93,7 @@ TEST_F(TabletMetaManagerTest, TestSaveAndGetAndRemove) {
     EXPECT_EQ(Status::OK(), s);
     TabletMetaSharedPtr meta_read(new TabletMeta());
     s = TabletMetaManager::get_meta(_data_dir, tablet_id, schema_hash, meta_read);
-    EXPECT_EQ(Status::Error<META_KEY_NOT_FOUND>(), s);
+    EXPECT_EQ(Status::Error<META_KEY_NOT_FOUND>(""), s);
 }
 
 TEST_F(TabletMetaManagerTest, TestLoad) {

--- a/be/test/vec/olap/vertical_compaction_test.cpp
+++ b/be/test/vec/olap/vertical_compaction_test.cpp
@@ -531,7 +531,7 @@ TEST_F(VerticalCompactionTest, TestDupKeyVerticalMerge) {
             output_data.emplace_back(columns[0].column->get_int(i), columns[1].column->get_int(i));
         }
     } while (s == Status::OK());
-    EXPECT_EQ(Status::Error<END_OF_FILE>(), s);
+    EXPECT_EQ(Status::Error<END_OF_FILE>(""), s);
     EXPECT_EQ(out_rowset->rowset_meta()->num_rows(), output_data.size());
     EXPECT_EQ(output_data.size(), num_input_rowset * num_segments * rows_per_segment);
     std::vector<uint32_t> segment_num_rows;
@@ -638,7 +638,7 @@ TEST_F(VerticalCompactionTest, TestDupWithoutKeyVerticalMerge) {
             output_data.emplace_back(columns[0].column->get_int(i), columns[1].column->get_int(i));
         }
     } while (s == Status::OK());
-    EXPECT_EQ(Status::Error<END_OF_FILE>(), s);
+    EXPECT_EQ(Status::Error<END_OF_FILE>(""), s);
     EXPECT_EQ(out_rowset->rowset_meta()->num_rows(), output_data.size());
     EXPECT_EQ(output_data.size(), num_input_rowset * num_segments * rows_per_segment);
     std::vector<uint32_t> segment_num_rows;
@@ -746,7 +746,7 @@ TEST_F(VerticalCompactionTest, TestUniqueKeyVerticalMerge) {
             output_data.emplace_back(columns[0].column->get_int(i), columns[1].column->get_int(i));
         }
     } while (s == Status::OK());
-    EXPECT_EQ(Status::Error<END_OF_FILE>(), s);
+    EXPECT_EQ(Status::Error<END_OF_FILE>(""), s);
     EXPECT_EQ(out_rowset->rowset_meta()->num_rows(), output_data.size());
     EXPECT_EQ(output_data.size(), num_segments * rows_per_segment);
     std::vector<uint32_t> segment_num_rows;
@@ -846,7 +846,7 @@ TEST_F(VerticalCompactionTest, TestDupKeyVerticalMergeWithDelete) {
             output_data.emplace_back(columns[0].column->get_int(i), columns[1].column->get_int(i));
         }
     } while (s == Status::OK());
-    EXPECT_EQ(Status::Error<END_OF_FILE>(), s);
+    EXPECT_EQ(Status::Error<END_OF_FILE>(""), s);
     EXPECT_EQ(out_rowset->rowset_meta()->num_rows(), output_data.size());
     EXPECT_EQ(output_data.size(),
               num_input_rowset * num_segments * rows_per_segment - num_input_rowset * 100);
@@ -940,7 +940,7 @@ TEST_F(VerticalCompactionTest, TestDupWithoutKeyVerticalMergeWithDelete) {
             output_data.emplace_back(columns[0].column->get_int(i), columns[1].column->get_int(i));
         }
     } while (s == Status::OK());
-    EXPECT_EQ(Status::Error<END_OF_FILE>(), s);
+    EXPECT_EQ(Status::Error<END_OF_FILE>(""), s);
     EXPECT_EQ(out_rowset->rowset_meta()->num_rows(), output_data.size());
     EXPECT_EQ(output_data.size(),
               num_input_rowset * num_segments * rows_per_segment - num_input_rowset * 100);
@@ -1034,7 +1034,7 @@ TEST_F(VerticalCompactionTest, TestAggKeyVerticalMerge) {
             output_data.emplace_back(columns[0].column->get_int(i), columns[1].column->get_int(i));
         }
     } while (s == Status::OK());
-    EXPECT_EQ(Status::Error<END_OF_FILE>(), s);
+    EXPECT_EQ(Status::Error<END_OF_FILE>(""), s);
     EXPECT_EQ(out_rowset->rowset_meta()->num_rows(), output_data.size());
     EXPECT_EQ(output_data.size(), num_segments * rows_per_segment);
     std::vector<uint32_t> segment_num_rows;


### PR DESCRIPTION
## Proposed changes

Sometime we will meet error status with empty error msg. 
This is because sometimes developers forget to pass specific content.
So I removed the state's constructor for the empty message, and modify the relevant code.

```
errCode = 2, detailMessage = Create rollup replicas failed. Error: 10003: [(172.16.0.60)[E-405]], null, 2592000]
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

