### PR TITLE
[enhancement](merge-on-write) split delete bitmap from tablet meta

### DIFF
--- a/be/src/olap/olap_meta.h
+++ b/be/src/olap/olap_meta.h
@@ -27,6 +27,7 @@
 namespace rocksdb {
 class ColumnFamilyHandle;
 class DB;
+class WriteBatch;
 } // namespace rocksdb
 
 namespace doris {
@@ -41,7 +42,6 @@ public:
                 : key(key_arg), value(value_arg) {}
     };
 
-public:
     OlapMeta(const std::string& root_path);
     ~OlapMeta();
 
@@ -53,6 +53,7 @@ public:
 
     Status put(const int column_family_index, const std::string& key, const std::string& value);
     Status put(const int column_family_index, const std::vector<BatchEntry>& entries);
+    Status put(rocksdb::WriteBatch* batch);
 
     Status remove(const int column_family_index, const std::string& key);
     Status remove(const int column_family_index, const std::vector<std::string>& keys);
@@ -61,6 +62,10 @@ public:
                    std::function<bool(const std::string&, const std::string&)> const& func);
 
     std::string get_root_path() const { return _root_path; }
+
+    rocksdb::ColumnFamilyHandle* get_handle(const int column_family_index) {
+        return _handles[column_family_index].get();
+    }
 
 private:
     std::string _root_path;

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -778,8 +778,7 @@ void StorageEngine::_clean_unused_rowset_metas() {
 
 void StorageEngine::_clean_unused_delete_bitmap() {
     std::unordered_set<int64_t> removed_tablets;
-    auto clean_delete_bitmap_func = [this, &removed_tablets](int64_t tablet_id, RowsetId rowset_id,
-                                                             int64_t segment_id, int64_t version,
+    auto clean_delete_bitmap_func = [this, &removed_tablets](int64_t tablet_id, int64_t version,
                                                              const std::string& val) -> bool {
         TabletSharedPtr tablet = _tablet_manager->get_tablet(tablet_id);
         if (tablet == nullptr) {

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -793,7 +793,7 @@ void StorageEngine::_clean_unused_delete_bitmap() {
     for (auto data_dir : data_dirs) {
         TabletMetaManager::traverse_delete_bitmap(data_dir->get_meta(), clean_delete_bitmap_func);
         for (auto id : removed_tablets) {
-            TabletMetaManager::remove_delete_bitmap_by_tablet_id(data_dir, id);
+            TabletMetaManager::remove_old_version_delete_bitmap(data_dir, id, INT64_MAX);
         }
         LOG(INFO) << "removed invalid delete bitmap from dir: " << data_dir->path()
                   << ", deleted tablets size: " << removed_tablets.size();

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -247,6 +247,8 @@ private:
 
     void _clean_unused_rowset_metas();
 
+    void _clean_unused_delete_bitmap();
+
     Status _do_sweep(const std::string& scan_root, const time_t& local_tm_now,
                      const int32_t expire);
 

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -101,6 +101,7 @@
 #include "olap/storage_policy.h"
 #include "olap/tablet_manager.h"
 #include "olap/tablet_meta.h"
+#include "olap/tablet_meta_manager.h"
 #include "olap/tablet_schema.h"
 #include "olap/txn_manager.h"
 #include "olap/types.h"
@@ -1513,6 +1514,9 @@ bool Tablet::do_tablet_meta_checkpoint() {
         }
         rs_meta->set_remove_from_rowset_meta();
     }
+
+    TabletMetaManager::remove_old_version_delete_bitmap(_data_dir, tablet_id(),
+                                                        max_version_unlocked().second);
 
     _newly_created_rowset_num = 0;
     _last_checkpoint_time = UnixMillis();

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1515,8 +1515,10 @@ bool Tablet::do_tablet_meta_checkpoint() {
         rs_meta->set_remove_from_rowset_meta();
     }
 
-    TabletMetaManager::remove_old_version_delete_bitmap(_data_dir, tablet_id(),
-                                                        max_version_unlocked().second);
+    if (keys_type() == UNIQUE_KEYS && enable_unique_key_merge_on_write()) {
+        TabletMetaManager::remove_old_version_delete_bitmap(_data_dir, tablet_id(),
+                                                            max_version_unlocked().second);
+    }
 
     _newly_created_rowset_num = 0;
     _last_checkpoint_time = UnixMillis();

--- a/be/src/olap/tablet_meta_manager.h
+++ b/be/src/olap/tablet_meta_manager.h
@@ -36,6 +36,8 @@ const std::string HEADER_PREFIX = "tabletmeta_";
 
 const std::string PENDING_PUBLISH_INFO = "ppi_";
 
+const std::string DELETE_BITMAP = "dlb_";
+
 // Helper Class for managing tablet headers of one root path.
 class TabletMetaManager {
 public:
@@ -69,6 +71,24 @@ public:
 
     static Status traverse_pending_publish(
             OlapMeta* meta, std::function<bool(int64_t, int64_t, const std::string&)> const& func);
+
+    static Status save_delete_bitmap(DataDir* store, TTabletId tablet_id,
+                                     DeleteBitmapPtr delete_bimap, int64_t version);
+
+    static Status traverse_delete_bitmap(OlapMeta* meta,
+                                         std::function<bool(int64_t, RowsetId, int64_t, int64_t,
+                                                            const std::string&)> const& func);
+
+    static std::string encode_delete_bitmap_key(TTabletId tablet_id, int64_t version,
+                                                const RowsetId& rowset_id, int64_t segment_id);
+
+    static void decode_delete_bitmap_key(const string& enc_key, TTabletId* tablet_id,
+                                         int64_t* version, RowsetId* rowset_id,
+                                         int64_t* segment_id);
+    static Status remove_old_version_delete_bitmap(DataDir* store, TTabletId tablet_id,
+                                                   int64_t version);
+
+    static Status remove_delete_bitmap_by_tablet_id(DataDir* store, TTabletId tablet_id);
 };
 
 } // namespace doris

--- a/be/src/olap/tablet_meta_manager.h
+++ b/be/src/olap/tablet_meta_manager.h
@@ -79,13 +79,12 @@ public:
             OlapMeta* meta, std::function<bool(int64_t, int64_t, const std::string&)> const& func);
 
     static std::string encode_delete_bitmap_key(TTabletId tablet_id, int64_t version);
+    static std::string encode_delete_bitmap_key(TTabletId tablet_id);
 
     static void decode_delete_bitmap_key(const string& enc_key, TTabletId* tablet_id,
                                          int64_t* version);
     static Status remove_old_version_delete_bitmap(DataDir* store, TTabletId tablet_id,
                                                    int64_t version);
-
-    static Status remove_delete_bitmap_by_tablet_id(DataDir* store, TTabletId tablet_id);
 };
 
 } // namespace doris

--- a/be/src/olap/tablet_meta_manager.h
+++ b/be/src/olap/tablet_meta_manager.h
@@ -75,16 +75,13 @@ public:
     static Status save_delete_bitmap(DataDir* store, TTabletId tablet_id,
                                      DeleteBitmapPtr delete_bimap, int64_t version);
 
-    static Status traverse_delete_bitmap(OlapMeta* meta,
-                                         std::function<bool(int64_t, RowsetId, int64_t, int64_t,
-                                                            const std::string&)> const& func);
+    static Status traverse_delete_bitmap(
+            OlapMeta* meta, std::function<bool(int64_t, int64_t, const std::string&)> const& func);
 
-    static std::string encode_delete_bitmap_key(TTabletId tablet_id, int64_t version,
-                                                const RowsetId& rowset_id, int64_t segment_id);
+    static std::string encode_delete_bitmap_key(TTabletId tablet_id, int64_t version);
 
     static void decode_delete_bitmap_key(const string& enc_key, TTabletId* tablet_id,
-                                         int64_t* version, RowsetId* rowset_id,
-                                         int64_t* segment_id);
+                                         int64_t* version);
     static Status remove_old_version_delete_bitmap(DataDir* store, TTabletId tablet_id,
                                                    int64_t version);
 

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -42,6 +42,7 @@
 #include "olap/storage_engine.h"
 #include "olap/tablet_manager.h"
 #include "olap/tablet_meta.h"
+#include "olap/tablet_meta_manager.h"
 #include "olap/task/engine_publish_version_task.h"
 #include "util/time.h"
 
@@ -391,8 +392,9 @@ Status TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id,
         }
         stats->partial_update_write_segment_us = MonotonicMicros() - t3;
         int64_t t4 = MonotonicMicros();
-        std::shared_lock rlock(tablet->get_header_lock());
-        tablet->save_meta();
+        RETURN_IF_ERROR(TabletMetaManager::save_delete_bitmap(
+                tablet->data_dir(), tablet->tablet_id(), tablet_txn_info.delete_bitmap,
+                version.second));
         stats->save_meta_time_us = MonotonicMicros() - t4;
     }
 

--- a/be/src/service/backend_service.cpp
+++ b/be/src/service/backend_service.cpp
@@ -384,7 +384,7 @@ void BackendService::check_storage_format(TCheckStorageFormatResult& result) {
 
 void BackendService::ingest_binlog(TIngestBinlogResult& result,
                                    const TIngestBinlogRequest& request) {
-    constexpr uint64_t kMaxTimeoutMs = 10000;
+    constexpr uint64_t kMaxTimeoutMs = 1000;
     TStatus tstatus;
     Defer defer {[&result, &tstatus]() { result.__set_status(tstatus); }};
 

--- a/be/src/service/backend_service.cpp
+++ b/be/src/service/backend_service.cpp
@@ -384,7 +384,7 @@ void BackendService::check_storage_format(TCheckStorageFormatResult& result) {
 
 void BackendService::ingest_binlog(TIngestBinlogResult& result,
                                    const TIngestBinlogRequest& request) {
-    constexpr uint64_t kMaxTimeoutMs = 1000;
+    constexpr uint64_t kMaxTimeoutMs = 5000;
     TStatus tstatus;
     Defer defer {[&result, &tstatus]() { result.__set_status(tstatus); }};
 

--- a/be/src/service/backend_service.cpp
+++ b/be/src/service/backend_service.cpp
@@ -384,7 +384,7 @@ void BackendService::check_storage_format(TCheckStorageFormatResult& result) {
 
 void BackendService::ingest_binlog(TIngestBinlogResult& result,
                                    const TIngestBinlogRequest& request) {
-    constexpr uint64_t kMaxTimeoutMs = 5000;
+    constexpr uint64_t kMaxTimeoutMs = 10000;
     TStatus tstatus;
     Defer defer {[&result, &tstatus]() { result.__set_status(tstatus); }};
 

--- a/be/test/olap/tablet_meta_manager_test.cpp
+++ b/be/test/olap/tablet_meta_manager_test.cpp
@@ -174,7 +174,7 @@ TEST_F(TabletMetaManagerTest, TestSaveDeleteBimap) {
     EXPECT_EQ(num_keys, max_version - 201);
 
     num_keys = 0;
-    TabletMetaManager::remove_delete_bitmap_by_tablet_id(_data_dir, test_tablet_id);
+    TabletMetaManager::remove_old_version_delete_bitmap(_data_dir, test_tablet_id, INT64_MAX);
     TabletMetaManager::traverse_delete_bitmap(_data_dir->get_meta(), load_delete_bitmap_func);
     EXPECT_EQ(num_keys, 0);
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

In MoW table，save meta will be called when publish. It will serialize rowset meta, delete bitmap and other tablet meta info. The size of the tablet meta is relatively large, and persistence will cause performance overhead to Rocksdb. 
So I split delete bitmap form tablet meta, only save delete bitmap when publish. Regularly perform checkpoint to save delete bitmap to tablet meta.



## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

