### PR TITLE
[refactor](load) move find_tablet() out of VOlapTableSink

### DIFF
--- a/be/src/vec/sink/vtablet_finder.cpp
+++ b/be/src/vec/sink/vtablet_finder.cpp
@@ -1,0 +1,89 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/sink/vtablet_finder.h"
+
+#include <fmt/format.h>
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+// IWYU pragma: no_include <opentelemetry/common/threadlocal.h>
+#include "common/compiler_util.h" // IWYU pragma: keep
+#include "common/status.h"
+#include "exec/tablet_info.h"
+#include "runtime/descriptors.h"
+#include "runtime/runtime_state.h"
+#include "vec/core/block.h"
+
+namespace doris {
+namespace stream_load {
+
+Status OlapTabletFinder::find_tablet(RuntimeState* state, vectorized::Block* block, int row_index,
+                                     const VOlapTablePartition** partition, uint32_t& tablet_index,
+                                     bool& stop_processing, bool& is_continue) {
+    Status status = Status::OK();
+    *partition = nullptr;
+    tablet_index = 0;
+    BlockRow block_row;
+    block_row = {block, row_index};
+    if (!_vpartition->find_partition(&block_row, partition)) {
+        RETURN_IF_ERROR(state->append_error_msg_to_file(
+                []() -> std::string { return ""; },
+                [&]() -> std::string {
+                    fmt::memory_buffer buf;
+                    fmt::format_to(buf, "no partition for this tuple. tuple={}",
+                                   block->dump_data(row_index, 1));
+                    return fmt::to_string(buf);
+                },
+                &stop_processing));
+        _num_filtered_rows++;
+        if (stop_processing) {
+            return Status::EndOfFile("Encountered unqualified data, stop processing");
+        }
+        is_continue = true;
+        return status;
+    }
+    if (!(*partition)->is_mutable) {
+        _num_immutable_partition_filtered_rows++;
+        is_continue = true;
+        return status;
+    }
+    if ((*partition)->num_buckets <= 0) {
+        std::stringstream ss;
+        ss << "num_buckets must be greater than 0, num_buckets=" << (*partition)->num_buckets;
+        return Status::InternalError(ss.str());
+    }
+    _partition_ids.emplace((*partition)->id);
+    if (_find_tablet_mode != FindTabletMode::FIND_TABLET_EVERY_ROW) {
+        if (_partition_to_tablet_map.find((*partition)->id) == _partition_to_tablet_map.end()) {
+            tablet_index = _vpartition->find_tablet(&block_row, **partition);
+            _partition_to_tablet_map.emplace((*partition)->id, tablet_index);
+        } else {
+            tablet_index = _partition_to_tablet_map[(*partition)->id];
+        }
+    } else {
+        tablet_index = _vpartition->find_tablet(&block_row, **partition);
+    }
+
+    return status;
+}
+
+} // namespace stream_load
+} // namespace doris

--- a/be/src/vec/sink/vtablet_finder.h
+++ b/be/src/vec/sink/vtablet_finder.h
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <map>
+
+#include "common/status.h"
+#include "exec/tablet_info.h"
+#include "vec/core/block.h"
+
+namespace doris {
+namespace stream_load {
+
+class OlapTabletFinder {
+public:
+    // FIND_TABLET_EVERY_ROW is used for both hash and random distribution info, which indicates that we
+    // should compute tablet index for every row
+    // FIND_TABLET_EVERY_BATCH is only used for random distribution info, which indicates that we should
+    // compute tablet index for every row batch
+    // FIND_TABLET_EVERY_SINK is only used for random distribution info, which indicates that we should
+    // only compute tablet index in the corresponding partition once for the whole time in olap table sink
+    enum FindTabletMode { FIND_TABLET_EVERY_ROW, FIND_TABLET_EVERY_BATCH, FIND_TABLET_EVERY_SINK };
+
+    OlapTabletFinder(VOlapTablePartitionParam* vpartition, FindTabletMode mode)
+            : _vpartition(vpartition), _find_tablet_mode(mode) {};
+
+    Status find_tablet(RuntimeState* state, vectorized::Block* block, int row_index,
+                       const VOlapTablePartition** partition, uint32_t& tablet_index,
+                       bool& filtered, bool& is_continue);
+
+    bool is_find_tablet_every_sink() {
+        return _find_tablet_mode == FindTabletMode::FIND_TABLET_EVERY_SINK;
+    }
+
+    void clear_for_new_batch() {
+        if (_find_tablet_mode == FindTabletMode::FIND_TABLET_EVERY_BATCH) {
+            _partition_to_tablet_map.clear();
+        }
+    }
+
+    bool is_single_tablet() { return _partition_to_tablet_map.size() == 1; }
+
+    const std::set<int64_t>& partition_ids() { return _partition_ids; }
+
+    int64_t num_filtered_rows() const { return _num_filtered_rows; }
+
+    int64_t num_immutable_partition_filtered_rows() const {
+        return _num_immutable_partition_filtered_rows;
+    }
+
+private:
+    VOlapTablePartitionParam* _vpartition;
+    FindTabletMode _find_tablet_mode;
+    std::map<int64_t, int64_t> _partition_to_tablet_map;
+    std::set<int64_t> _partition_ids;
+
+    int64_t _num_filtered_rows = 0;
+    int64_t _num_immutable_partition_filtered_rows = 0;
+};
+
+} // namespace stream_load
+} // namespace doris


### PR DESCRIPTION
## Proposed changes

Move tablet finder out of VOlapTableSink, to improve abstraction and future code reuse.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

