### PR TITLE
[improvement](limit) check exec node limit against invalid value

### DIFF
--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -152,6 +152,9 @@ ExecNode::ExecNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl
           _memory_used_counter(nullptr),
           _get_next_span(),
           _is_closed(false) {
+    if (_limit < -1) {
+        _limit = -1;
+    }
     if (tnode.__isset.output_tuple_id) {
         _output_row_descriptor.reset(new RowDescriptor(descs, {tnode.output_tuple_id}, {true}));
     }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

To improve BE robustness, set ExecNode::_limit to -1 if FE set it to an invalid value.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

