### PR TITLE
[fix](nereids) fix runtime filter expr order

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
@@ -111,8 +111,8 @@ public class Statistics {
             ColumnStatistic columnStatistic = entry.getValue();
             ColumnStatisticBuilder columnStatisticBuilder = new ColumnStatisticBuilder(columnStatistic);
             columnStatisticBuilder.setNdv(Math.min(columnStatistic.ndv, rowCount));
-            double numNulls = Math.min(columnStatistic.numNulls, rowCount - columnStatistic.ndv);
-            columnStatisticBuilder.setNumNulls(numNulls);
+            double nullFactor = (rowCount - columnStatistic.numNulls) / rowCount;
+            columnStatisticBuilder.setNumNulls(nullFactor * rowCount);
             columnStatisticBuilder.setCount(rowCount);
             statistics.addColumnStats(entry.getKey(), columnStatisticBuilder.build());
         }

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query95.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query95.out
@@ -14,14 +14,14 @@ CteAnchor[cteId= ( CTEId#3=] )
 ----PhysicalTopN
 ------PhysicalProject
 --------hashAgg[GLOBAL]
-----------PhysicalDistribute
-------------hashAgg[LOCAL]
+----------hashAgg[LOCAL]
+------------PhysicalDistribute
 --------------PhysicalProject
 ----------------hashJoin[INNER_JOIN](ws1.ws_ship_date_sk = date_dim.d_date_sk)
-------------------hashJoin[RIGHT_SEMI_JOIN](ws1.ws_order_number = ws_wh.ws_order_number)
---------------------PhysicalDistribute
-----------------------PhysicalProject
-------------------------CteConsumer[cteId= ( CTEId#3=] )
+------------------PhysicalProject
+--------------------filter((date_dim.d_date >= 1999-02-01)(cast(d_date as DATETIMEV2(0)) <= cast(days_add(cast('1999-2-01' as DATEV2), INTERVAL 60 DAY) as DATETIMEV2(0))))
+----------------------PhysicalOlapScan[date_dim]
+------------------PhysicalDistribute
 --------------------hashJoin[RIGHT_SEMI_JOIN](ws1.ws_order_number = web_returns.wr_order_number)
 ----------------------PhysicalProject
 ------------------------hashJoin[INNER_JOIN](web_returns.wr_order_number = ws_wh.ws_order_number)
@@ -32,20 +32,21 @@ CteAnchor[cteId= ( CTEId#3=] )
 ----------------------------PhysicalProject
 ------------------------------PhysicalOlapScan[web_returns]
 ----------------------PhysicalDistribute
-------------------------hashJoin[INNER_JOIN](ws1.ws_web_site_sk = web_site.web_site_sk)
---------------------------hashJoin[INNER_JOIN](ws1.ws_ship_addr_sk = customer_address.ca_address_sk)
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[web_sales]
-----------------------------PhysicalDistribute
-------------------------------PhysicalProject
---------------------------------filter((cast(ca_state as VARCHAR(*)) = 'NC'))
-----------------------------------PhysicalOlapScan[customer_address]
+------------------------hashJoin[RIGHT_SEMI_JOIN](ws1.ws_order_number = ws_wh.ws_order_number)
 --------------------------PhysicalDistribute
 ----------------------------PhysicalProject
-------------------------------filter((cast(web_company_name as VARCHAR(*)) = 'pri'))
---------------------------------PhysicalOlapScan[web_site]
-------------------PhysicalDistribute
---------------------PhysicalProject
-----------------------filter((date_dim.d_date >= 1999-02-01)(cast(d_date as DATETIMEV2(0)) <= cast(days_add(cast('1999-2-01' as DATEV2), INTERVAL 60 DAY) as DATETIMEV2(0))))
-------------------------PhysicalOlapScan[date_dim]
+------------------------------CteConsumer[cteId= ( CTEId#3=] )
+--------------------------PhysicalDistribute
+----------------------------hashJoin[INNER_JOIN](ws1.ws_web_site_sk = web_site.web_site_sk)
+------------------------------hashJoin[INNER_JOIN](ws1.ws_ship_addr_sk = customer_address.ca_address_sk)
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[web_sales]
+--------------------------------PhysicalDistribute
+----------------------------------PhysicalProject
+------------------------------------filter((cast(ca_state as VARCHAR(*)) = 'NC'))
+--------------------------------------PhysicalOlapScan[customer_address]
+------------------------------PhysicalDistribute
+--------------------------------PhysicalProject
+----------------------------------filter((cast(web_company_name as VARCHAR(*)) = 'pri'))
+------------------------------------PhysicalOlapScan[web_site]
 


### PR DESCRIPTION
## Proposed changes

Current runtime filter pushing down to cte internal, we construct the runtime filter expr_order with incremental number, which is not correct. For cte internal rf pushing down, the join node will be always different, the expr_order should be fixed as 0 without incrementation, otherwise, it will lead the checking for expr_order and probe_expr_size illegal or wrong query result.

This pr will revert 2827bc1a3968f3c9bcda3ebd485a90e0d0a17e31 temporarily, it will break the cte rf pushing down plan pattern.


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

