### PR TITLE
[improvement](Jsonb) optimization Jsonb path parse

### DIFF
--- a/be/src/util/jsonb_document.h
+++ b/be/src/util/jsonb_document.h
@@ -351,7 +351,9 @@ public:
     //return true if json path valid else return false
     bool seek(const char* string, size_t length);
 
-    void add_leg_to_leg_vector(std::unique_ptr<leg_info> leg) { leg_vector.emplace_back(leg.release()); }
+    void add_leg_to_leg_vector(std::unique_ptr<leg_info> leg) {
+        leg_vector.emplace_back(leg.release());
+    }
 
     size_t get_leg_vector_size() { return leg_vector.size(); }
 
@@ -1314,7 +1316,8 @@ inline bool JsonbPath::parse_array(Stream* stream, JsonbPath* path) {
         stream->add_leg_len();
         stream->skip(1);
         if (stream->peek() == END_ARRAY) {
-            std::unique_ptr<leg_info> leg(new leg_info(stream->get_leg_ptr(), stream->get_leg_len(), 0, ARRAY_CODE));
+            std::unique_ptr<leg_info> leg(
+                    new leg_info(stream->get_leg_ptr(), stream->get_leg_len(), 0, ARRAY_CODE));
             path->add_leg_to_leg_vector(std::move(leg));
             stream->skip(1);
             return true;
@@ -1388,7 +1391,8 @@ inline bool JsonbPath::parse_member(Stream* stream, JsonbPath* path) {
         stream->set_leg_ptr(const_cast<char*>(stream->position()));
         stream->add_leg_len();
         stream->skip(1);
-        std::unique_ptr<leg_info> leg(new leg_info(stream->get_leg_ptr(), stream->get_leg_len(), 0, MEMBER_CODE));
+        std::unique_ptr<leg_info> leg(
+                new leg_info(stream->get_leg_ptr(), stream->get_leg_len(), 0, MEMBER_CODE));
         path->add_leg_to_leg_vector(std::move(leg));
         return true;
     }
@@ -1433,7 +1437,8 @@ inline bool JsonbPath::parse_member(Stream* stream, JsonbPath* path) {
         stream->remove_escapes();
     }
 
-    std::unique_ptr<leg_info> leg(new leg_info(stream->get_leg_ptr(), stream->get_leg_len(), 0, MEMBER_CODE));
+    std::unique_ptr<leg_info> leg(
+            new leg_info(stream->get_leg_ptr(), stream->get_leg_len(), 0, MEMBER_CODE));
     path->add_leg_to_leg_vector(std::move(leg));
 
     return true;

--- a/be/src/util/jsonb_document.h
+++ b/be/src/util/jsonb_document.h
@@ -309,14 +309,6 @@ public:
 
     bool get_has_escapes() const { return has_escapes; }
 
-    void set_is_invalid_json_path(bool has) { is_invalid_json_path = has; }
-
-    bool get_is_invalid_json_path() const { return is_invalid_json_path; }
-
-    void set_type(unsigned int code) { type = code; }
-
-    bool get_type() const { return type; }
-
 private:
     /// The current position in the stream.
     const char* m_position;
@@ -332,20 +324,17 @@ private:
 
     ///Whether to contain escape characters
     bool has_escapes = false;
-
-    ///Is the json path valid
-    bool is_invalid_json_path = false;
-
-    ///type: 0 is member 1 is array
-    unsigned int type;
 };
 
-struct leg_info{
+struct leg_info {
     ///path leg ptr
     char* leg_ptr;
 
     ///path leg len
     unsigned int leg_len;
+
+    ///array_index
+    int array_index;
 
     ///type: 0 is member 1 is array
     unsigned int type;
@@ -354,25 +343,19 @@ struct leg_info{
 class JsonbPath {
 public:
     // parse json path
-    static bool parsePath(Stream* stream);
+    static bool parsePath(Stream* stream, JsonbPath* path);
 
-    static bool parse_array(Stream* stream);
-    static bool parse_member(Stream* stream);
+    static bool parse_array(Stream* stream, JsonbPath* path);
+    static bool parse_member(Stream* stream, JsonbPath* path);
 
-    bool parsePath_tmp(const char* string, size_t length);
+    //return true if json path valid else return false
+    bool seek(const char* string, size_t length);
 
-    void add_leg_to_leg_vector(leg_info* leg){
-        leg_vector.emplace_back(leg);
-    }
+    void add_leg_to_leg_vector(leg_info* leg) { leg_vector.emplace_back(leg); }
 
-    size_t get_leg_vector_size() {
-        return leg_vector.size();
-    }
+    size_t get_leg_vector_size() { return leg_vector.size(); }
 
-    leg_info* get_leg_from_leg_vector(size_t i){
-        return leg_vector[i];
-    }
-
+    leg_info* get_leg_from_leg_vector(size_t i) { return leg_vector[i]; }
 
 private:
     std::vector<leg_info*> leg_vector;
@@ -557,16 +540,6 @@ public:
 
     // get the raw byte array of the value
     const char* getValuePtr() const;
-
-    // find the JSONB value by a key path string (null terminated)
-    JsonbValue* findPath(const char* key_path, bool& is_invalid_json_path,
-                         hDictFind handler = nullptr) {
-        return findPath(key_path, (unsigned int)strlen(key_path), is_invalid_json_path, handler);
-    }
-
-    // find the JSONB value by a key path string (with length)
-    JsonbValue* findPath(const char* key_path, unsigned int len, bool& is_invalid_json_path,
-                         hDictFind handler);
 
     // find the JSONB value by JsonbPath
     JsonbValue* findValue(JsonbPath& path, hDictFind handler);
@@ -1239,9 +1212,9 @@ inline const char* JsonbValue::getValuePtr() const {
     }
 }
 
-inline bool JsonbPath::parsePath_tmp(const char* key_path, size_t kp_len){
+inline bool JsonbPath::seek(const char* key_path, size_t kp_len) {
     //path invalid
-    if (!key_path ||  kp_len == 0) return false;
+    if (!key_path || kp_len == 0) return false;
     Stream stream(key_path, kp_len);
     stream.skip_whitespace();
     if (stream.exhausted() || stream.read() != SCOPE) {
@@ -1253,210 +1226,99 @@ inline bool JsonbPath::parsePath_tmp(const char* key_path, size_t kp_len){
         stream.skip_whitespace();
         stream.clear_leg_ptr();
         stream.clear_leg_len();
-        if (!JsonbPath::parsePath(&stream)) {
+
+        if (!JsonbPath::parsePath(&stream, this)) {
             //path invalid
             return false;
         }
-
-        if (stream.get_leg_ptr() == nullptr || stream.get_leg_len() == 0) {
-            return false;
-        }
-
-        leg_info* leg = new leg_info(stream.get_leg_ptr(),stream.get_leg_len(),stream.get_type());
-
-        add_leg_to_leg_vector(leg);
-
     }
-
     return true;
-
 }
 
-inline JsonbValue* JsonbValue::findValue(JsonbPath& path, hDictFind handler){
+inline JsonbValue* JsonbValue::findValue(JsonbPath& path, hDictFind handler) {
     JsonbValue* pval = this;
     for (size_t i = 0; i < path.get_leg_vector_size(); ++i) {
-        if (path.get_leg_from_leg_vector(i)->type == MEMBER_CODE) {
+        switch (path.get_leg_from_leg_vector(i)->type) {
+        case MEMBER_CODE: {
             if (LIKELY(pval->type_ == JsonbType::T_Object)) {
-                if (path.get_leg_from_leg_vector(i)->leg_len == 1 && *path.get_leg_from_leg_vector(i)->leg_ptr == WILDCARD) {
-                    return pval;
+                if (path.get_leg_from_leg_vector(i)->leg_len == 1 &&
+                    *path.get_leg_from_leg_vector(i)->leg_ptr == WILDCARD) {
+                    continue;
                 }
 
                 pval = ((ObjectVal*)pval)
-                        ->find(path.get_leg_from_leg_vector(i)->leg_ptr, path.get_leg_from_leg_vector(i)->leg_len, handler);
+                               ->find(path.get_leg_from_leg_vector(i)->leg_ptr,
+                                      path.get_leg_from_leg_vector(i)->leg_len, handler);
 
                 if (!pval) return nullptr;
+                continue;
             } else {
                 return nullptr;
             }
-        } else {
-            return nullptr;
         }
-    }
-    return pval;
-}
-
-
-
-inline JsonbValue* JsonbValue::findPath(const char* key_path, unsigned int kp_len,
-                                        bool& is_invalid_json_path, hDictFind handler = nullptr) {
-    if (!key_path) return nullptr;
-    if (kp_len == 0) {
-        is_invalid_json_path = true;
-        return nullptr;
-    }
-    Stream stream(key_path, kp_len);
-    stream.skip_whitespace();
-    if (stream.exhausted() || stream.read() != SCOPE) {
-        is_invalid_json_path = true;
-        return nullptr;
-    }
-
-    JsonbValue* pval = this;
-
-    while (pval && !stream.exhausted()) {
-        stream.skip_whitespace();
-        stream.clear_leg_ptr();
-        stream.clear_leg_len();
-
-        if (!JsonbPath::parsePath(&stream)) {
-            is_invalid_json_path = stream.get_is_invalid_json_path();
-            return nullptr;
-        }
-
-        if (stream.get_leg_len() == 0) {
-            return nullptr;
-        }
-
-        if (stream.get_type() == MEMBER_CODE) {
-            if (LIKELY(pval->type_ == JsonbType::T_Object)) {
-                if (stream.get_leg_len() == 1 && *stream.get_leg_ptr() == WILDCARD) {
-                    return pval;
-                } else if (stream.get_has_escapes()) {
-                    stream.remove_escapes();
-                }
-
-                pval = ((ObjectVal*)pval)
-                               ->find(stream.get_leg_ptr(), stream.get_leg_len(), handler);
-
-                if (!pval) return nullptr;
-            } else {
-                return nullptr;
-            }
-        } else if (stream.get_type() == ARRAY_CODE) {
-            int index = 0;
-            std::string_view idx_string(stream.get_leg_ptr(), stream.get_leg_len());
-
-            if (stream.get_leg_len() == 1 && *stream.get_leg_ptr() == WILDCARD) {
+        case ARRAY_CODE: {
+            if (path.get_leg_from_leg_vector(i)->leg_len == 1 &&
+                *path.get_leg_from_leg_vector(i)->leg_ptr == WILDCARD) {
                 if (LIKELY(pval->type_ == JsonbType::T_Array)) {
-                    stream.skip(1);
-                    stream.skip_whitespace();
                     continue;
                 } else {
                     return nullptr;
                 }
-            } else if (std::equal(LAST, LAST + 4, stream.get_leg_ptr(),
-                                  [](char c1, char c2) {
-                                      return std::tolower(c1) == std::tolower(c2);
-                                  }) &&
-                       stream.get_leg_len() >= 4) {
-                auto pos = idx_string.find(MINUS);
-
-                if (pos != std::string::npos) {
-                    idx_string = idx_string.substr(pos + 1);
-
-                    auto result = std::from_chars(idx_string.data(),
-                                                  idx_string.data() + idx_string.size(), index);
-                    if (result.ec != std::errc()) {
-                        is_invalid_json_path = true;
-                        return nullptr;
-                    }
-
-                    if (pval->type_ == JsonbType::T_Object) {
-                        if (index == 0) {
-                            continue;
-                        } else {
-                            return nullptr;
-                        }
-                    } else if (LIKELY(pval->type_ == JsonbType::T_Array)) {
-                        size_t num = ((ArrayVal*)pval)->numElem();
-                        if (index > num) return nullptr;
-                        index = num - 1 - index;
-                    } else {
-                        return nullptr;
-                    }
-                } else if (stream.get_leg_len() == 4) {
-                    if (pval->type_ == JsonbType::T_Object) {
-                        continue;
-                    } else if (LIKELY(pval->type_ == JsonbType::T_Array)) {
-                        index = ((ArrayVal*)pval)->numElem() - 1;
-                    } else {
-                        return nullptr;
-                    }
-
-                } else {
-                    is_invalid_json_path = true;
-                    return nullptr;
-                }
-            } else {
-                auto result = std::from_chars(idx_string.data(),
-                                              idx_string.data() + idx_string.size(), index);
-                if (result.ec != std::errc()) {
-                    is_invalid_json_path = true;
-                    return nullptr;
-                }
-
-                if (pval->type_ == JsonbType::T_Object) {
-                    if (index == 0) {
-                        continue;
-                    } else {
-                        return nullptr;
-                    }
-                } else if (LIKELY(pval->type_ == JsonbType::T_Array)) {
-                    if (std::abs(index) >= ((ArrayVal*)pval)->numElem()) return nullptr;
-                } else {
-                    return nullptr;
-                }
             }
 
-            if (index >= 0) {
-                pval = ((ArrayVal*)pval)->get(index);
-            } else {
-                pval = ((ArrayVal*)pval)->get(((ArrayVal*)pval)->numElem() + index);
+            if (pval->type_ == JsonbType::T_Object &&
+                path.get_leg_from_leg_vector(i)->array_index == 0) {
+                continue;
             }
+
+            if (pval->type_ != JsonbType::T_Array ||
+                path.get_leg_from_leg_vector(i)->leg_ptr != nullptr ||
+                path.get_leg_from_leg_vector(i)->leg_len != 0)
+                return nullptr;
+
+            if (path.get_leg_from_leg_vector(i)->array_index >= 0) {
+                pval = ((ArrayVal*)pval)->get(path.get_leg_from_leg_vector(i)->array_index);
+            } else {
+                pval = ((ArrayVal*)pval)
+                               ->get(((ArrayVal*)pval)->numElem() +
+                                     path.get_leg_from_leg_vector(i)->array_index);
+            }
+
+            if (!pval) return nullptr;
+            continue;
+        }
         }
     }
-
     return pval;
 }
 
-inline bool JsonbPath::parsePath(Stream* stream) {
+inline bool JsonbPath::parsePath(Stream* stream, JsonbPath* path) {
     if (stream->peek() == BEGIN_ARRAY) {
-        return parse_array(stream);
+        return parse_array(stream, path);
     } else if (stream->peek() == BEGIN_MEMBER) {
-        return parse_member(stream);
+        return parse_member(stream, path);
     } else {
-        stream->set_is_invalid_json_path(true);
         return false; //invalid json path
     }
 }
 
-inline bool JsonbPath::parse_array(Stream* stream) {
+inline bool JsonbPath::parse_array(Stream* stream, JsonbPath* path) {
     assert(stream->peek() == BEGIN_ARRAY);
     stream->skip(1);
     if (stream->exhausted()) {
-        stream->set_is_invalid_json_path(true);
         return false;
     }
 
     if (stream->peek() == WILDCARD) {
         stream->set_leg_ptr(const_cast<char*>(stream->position()));
         stream->add_leg_len();
-        stream->skip(1);
+        stream->skip(2);
         if (stream->peek() == END_ARRAY) {
-            stream->set_type(ARRAY_CODE);
+            leg_info* leg =
+                    new leg_info(stream->get_leg_ptr(), stream->get_leg_len(), 0, ARRAY_CODE);
+            path->add_leg_to_leg_vector(leg);
             return true;
         } else {
-            stream->set_is_invalid_json_path(true);
             return false;
         }
     }
@@ -1467,22 +1329,57 @@ inline bool JsonbPath::parse_array(Stream* stream) {
         stream->add_leg_len();
     }
 
-    if (!stream->exhausted() && stream->peek() == END_ARRAY) {
-        stream->skip(1);
-        stream->set_type(ARRAY_CODE);
-        return true;
+    if (stream->exhausted() || stream->peek() != END_ARRAY) {
+        return false;
     } else {
-        stream->set_is_invalid_json_path(true);
+        stream->skip(1);
+    }
+
+    //parse array index to int
+
+    std::string_view idx_string(stream->get_leg_ptr(), stream->get_leg_len());
+    int index = 0;
+
+    if (stream->get_leg_len() >= 4 &&
+        std::equal(LAST, LAST + 4, stream->get_leg_ptr(),
+                   [](char c1, char c2) { return std::tolower(c1) == std::tolower(c2); })) {
+        auto pos = idx_string.find(MINUS);
+
+        if (pos != std::string::npos) {
+            idx_string = idx_string.substr(pos + 1);
+
+            auto result = std::from_chars(idx_string.data(), idx_string.data() + idx_string.size(),
+                                          index);
+            if (result.ec != std::errc()) {
+                return false;
+            }
+
+        } else if (stream->get_leg_len() > 4) {
+            return false;
+        }
+
+        leg_info* leg = new leg_info(nullptr, 0, -index - 1, ARRAY_CODE);
+        path->add_leg_to_leg_vector(leg);
+        return true;
+    }
+
+    auto result = std::from_chars(idx_string.data(), idx_string.data() + idx_string.size(), index);
+
+    if (result.ec != std::errc()) {
         return false;
     }
+
+    leg_info* leg = new leg_info(nullptr, 0, index, ARRAY_CODE);
+    path->add_leg_to_leg_vector(leg);
+
+    return true;
 }
 
-inline bool JsonbPath::parse_member(Stream* stream) {
+inline bool JsonbPath::parse_member(Stream* stream, JsonbPath* path) {
     // advance past the .
     assert(stream->peek() == BEGIN_MEMBER);
     stream->skip(1);
     if (stream->exhausted()) {
-        stream->set_is_invalid_json_path(true);
         return false;
     }
 
@@ -1490,7 +1387,8 @@ inline bool JsonbPath::parse_member(Stream* stream) {
         stream->set_leg_ptr(const_cast<char*>(stream->position()));
         stream->add_leg_len();
         stream->skip(1);
-        stream->set_type(MEMBER_CODE);
+        leg_info* leg = new leg_info(stream->get_leg_ptr(), stream->get_leg_len(), 0, MEMBER_CODE);
+        path->add_leg_to_leg_vector(leg);
         return true;
     }
 
@@ -1525,12 +1423,17 @@ inline bool JsonbPath::parse_member(Stream* stream) {
         stream->add_leg_len();
     }
 
-    if (left_quotation_marks != nullptr && right_quotation_marks == nullptr) {
-        stream->set_is_invalid_json_path(true);
+    if ((left_quotation_marks != nullptr && right_quotation_marks == nullptr) ||
+        stream->get_leg_ptr() == nullptr || stream->get_leg_len() == 0) {
         return false; //invalid json path
     }
 
-    stream->set_type(MEMBER_CODE);
+    if (stream->get_has_escapes()) {
+        stream->remove_escapes();
+    }
+
+    leg_info* leg = new leg_info(stream->get_leg_ptr(), stream->get_leg_len(), 0, MEMBER_CODE);
+    path->add_leg_to_leg_vector(leg);
 
     return true;
 }

--- a/be/src/vec/functions/function_jsonb.cpp
+++ b/be/src/vec/functions/function_jsonb.cpp
@@ -542,7 +542,8 @@ public:
                                              rdata.size()));
                 }
 
-                inner_loop_impl(i, res_data, res_offsets, null_map, writer, formater, l_raw, l_size, path);
+                inner_loop_impl(i, res_data, res_offsets, null_map, writer, formater, l_raw, l_size,
+                                path);
             } else { // will make array string to user
                 writer->reset();
                 writer->writeStartArray();
@@ -579,8 +580,7 @@ public:
                     }
 
                     // value is NOT necessary to be deleted since JsonbValue will not allocate memory
-                    JsonbValue* value =
-                            doc->getValue()->findValue(path, nullptr);
+                    JsonbValue* value = doc->getValue()->findValue(path, nullptr);
 
                     if (UNLIKELY(!value)) {
                         writer->writeNull();

--- a/be/src/vec/functions/function_jsonb.cpp
+++ b/be/src/vec/functions/function_jsonb.cpp
@@ -436,82 +436,7 @@ private:
                                               ColumnString::Offsets& res_offsets, NullMap& null_map,
                                               const std::unique_ptr<JsonbWriter>& writer,
                                               std::unique_ptr<JsonbToJson>& formater,
-                                              const char* l_raw, int l_size, const char* r_raw,
-                                              int r_size, bool& is_invalid_json_path) {
-        String path(r_raw, r_size);
-
-        if (null_map[i]) {
-            StringOP::push_null_string(i, res_data, res_offsets, null_map);
-            return;
-        }
-
-        // doc is NOT necessary to be deleted since JsonbDocument will not allocate memory
-        JsonbDocument* doc = JsonbDocument::createDocument(l_raw, l_size);
-        if (UNLIKELY(!doc || !doc->getValue())) {
-            StringOP::push_null_string(i, res_data, res_offsets, null_map);
-            return;
-        }
-
-        // value is NOT necessary to be deleted since JsonbValue will not allocate memory
-        JsonbValue* value = doc->getValue()->findPath(r_raw, r_size, is_invalid_json_path, nullptr);
-
-        if (UNLIKELY(!value) || is_invalid_json_path) {
-            StringOP::push_null_string(i, res_data, res_offsets, null_map);
-            return;
-        }
-
-        if constexpr (ValueType::only_get_type) {
-            StringOP::push_value_string(std::string_view(value->typeName()), i, res_data,
-                                        res_offsets);
-            return;
-        }
-
-        if constexpr (std::is_same_v<DataTypeJsonb, ReturnType>) {
-            writer->reset();
-            writer->writeValue(value);
-            StringOP::push_value_string(std::string_view(writer->getOutput()->getBuffer(),
-                                                         writer->getOutput()->getSize()),
-                                        i, res_data, res_offsets);
-        } else {
-            if (LIKELY(value->isString())) {
-                auto str_value = (JsonbStringVal*)value;
-                StringOP::push_value_string(
-                        std::string_view(str_value->getBlob(), str_value->length()), i, res_data,
-                        res_offsets);
-            } else if (value->isNull()) {
-                StringOP::push_value_string("null", i, res_data, res_offsets);
-            } else if (value->isTrue()) {
-                StringOP::push_value_string("true", i, res_data, res_offsets);
-            } else if (value->isFalse()) {
-                StringOP::push_value_string("false", i, res_data, res_offsets);
-            } else if (value->isInt8()) {
-                StringOP::push_value_string(std::to_string(((const JsonbInt8Val*)value)->val()), i,
-                                            res_data, res_offsets);
-            } else if (value->isInt16()) {
-                StringOP::push_value_string(std::to_string(((const JsonbInt16Val*)value)->val()), i,
-                                            res_data, res_offsets);
-            } else if (value->isInt32()) {
-                StringOP::push_value_string(std::to_string(((const JsonbInt32Val*)value)->val()), i,
-                                            res_data, res_offsets);
-            } else if (value->isInt64()) {
-                StringOP::push_value_string(std::to_string(((const JsonbInt64Val*)value)->val()), i,
-                                            res_data, res_offsets);
-            } else {
-                if (!formater) {
-                    formater.reset(new JsonbToJson());
-                }
-                StringOP::push_value_string(formater->to_json_string(value), i, res_data,
-                                            res_offsets);
-            }
-        }
-    }
-
-    static ALWAYS_INLINE void inner_loop_impl_tmp(size_t i, ColumnString::Chars& res_data,
-                                              ColumnString::Offsets& res_offsets, NullMap& null_map,
-                                              const std::unique_ptr<JsonbWriter>& writer,
-                                              std::unique_ptr<JsonbToJson>& formater,
-                                              const char* l_raw, int l_size, JsonbPath& path, bool& is_invalid_json_path) {
-
+                                              const char* l_raw, int l_size, JsonbPath& path) {
         if (null_map[i]) {
             StringOP::push_null_string(i, res_data, res_offsets, null_map);
             return;
@@ -527,7 +452,7 @@ private:
         // value is NOT necessary to be deleted since JsonbValue will not allocate memory
         JsonbValue* value = doc->getValue()->findValue(path, nullptr);
 
-        if (UNLIKELY(!value) || is_invalid_json_path) {
+        if (UNLIKELY(!value)) {
             StringOP::push_null_string(i, res_data, res_offsets, null_map);
             return;
         }
@@ -674,8 +599,13 @@ public:
             int r_size = roffsets[i] - roffsets[i - 1];
             const char* r_raw = reinterpret_cast<const char*>(&rdata[roffsets[i - 1]]);
 
+            JsonbPath path;
+            if (!path.seek(r_raw, r_size)) {
+                is_invalid_json_path = true;
+            }
+
             inner_loop_impl(i, res_data, res_offsets, null_map, writer, formater, l_raw, l_size,
-                            r_raw, r_size, is_invalid_json_path);
+                            path);
         } //for
     }     //function
     static void vector_scalar(FunctionContext* context, const ColumnString::Chars& ldata,
@@ -693,14 +623,16 @@ public:
         std::unique_ptr<JsonbToJson> formater;
 
         JsonbPath path;
-        path.parsePath_tmp(rdata.data, rdata.size);
+        if (!path.seek(rdata.data, rdata.size)) {
+            is_invalid_json_path = true;
+        }
 
         for (size_t i = 0; i < input_rows_count; ++i) {
             int l_size = loffsets[i] - loffsets[i - 1];
             const char* l_raw = reinterpret_cast<const char*>(&ldata[loffsets[i - 1]]);
 
-            inner_loop_impl_tmp(i, res_data, res_offsets, null_map, writer, formater, l_raw, l_size,
-                                path, is_invalid_json_path);
+            inner_loop_impl(i, res_data, res_offsets, null_map, writer, formater, l_raw, l_size,
+                            path);
         } //for
     }     //function
     static void scalar_vector(FunctionContext* context, const StringRef& ldata,
@@ -722,8 +654,13 @@ public:
             int r_size = roffsets[i] - roffsets[i - 1];
             const char* r_raw = reinterpret_cast<const char*>(&rdata[roffsets[i - 1]]);
 
+            JsonbPath path;
+            if (!path.seek(r_raw, r_size)) {
+                is_invalid_json_path = true;
+            }
+
             inner_loop_impl(i, res_data, res_offsets, null_map, writer, formater, ldata.data,
-                            ldata.size, r_raw, r_size, is_invalid_json_path);
+                            ldata.size, path);
         } //for
     }     //function
 };
@@ -738,8 +675,7 @@ struct JsonbExtractImpl {
 private:
     static ALWAYS_INLINE void inner_loop_impl(size_t i, Container& res, NullMap& null_map,
                                               const char* l_raw_str, int l_str_size,
-                                              const char* r_raw_str, int r_str_size,
-                                              bool& is_invalid_json_path) {
+                                              JsonbPath& path) {
         if (null_map[i]) {
             res[i] = 0;
             return;
@@ -754,10 +690,9 @@ private:
         }
 
         // value is NOT necessary to be deleted since JsonbValue will not allocate memory
-        JsonbValue* value =
-                doc->getValue()->findPath(r_raw_str, r_str_size, is_invalid_json_path, nullptr);
+        JsonbValue* value = doc->getValue()->findValue(path, nullptr);
 
-        if (UNLIKELY(!value) || is_invalid_json_path) {
+        if (UNLIKELY(!value)) {
             if constexpr (!only_check_exists) {
                 null_map[i] = 1;
             }
@@ -815,87 +750,6 @@ private:
         }
     }
 
-static ALWAYS_INLINE void inner_loop_impl_tmp(size_t i, Container& res, NullMap& null_map,
-                                              const char* l_raw_str, int l_str_size,
-                                              JsonbPath& path,
-                                              bool& is_invalid_json_path) {
-    if (null_map[i]) {
-        res[i] = 0;
-        return;
-    }
-
-    // doc is NOT necessary to be deleted since JsonbDocument will not allocate memory
-    JsonbDocument* doc = JsonbDocument::createDocument(l_raw_str, l_str_size);
-    if (UNLIKELY(!doc || !doc->getValue())) {
-        null_map[i] = 1;
-        res[i] = 0;
-        return;
-    }
-
-    // value is NOT necessary to be deleted since JsonbValue will not allocate memory
-    JsonbValue* value =
-            doc->getValue()->findValue(path, nullptr);
-
-    if (UNLIKELY(!value) || is_invalid_json_path) {
-        if constexpr (!only_check_exists) {
-            null_map[i] = 1;
-        }
-        res[i] = 0;
-        return;
-    }
-
-    // if only check path exists, it's true here and skip check value
-    if constexpr (only_check_exists) {
-        res[i] = 1;
-        return;
-    }
-
-    if constexpr (std::is_same_v<void, typename ValueType::T>) {
-        if (value->isNull()) {
-            res[i] = 1;
-        } else {
-            res[i] = 0;
-        }
-    } else if constexpr (std::is_same_v<bool, typename ValueType::T>) {
-        if (value->isTrue()) {
-            res[i] = 1;
-        } else if (value->isFalse()) {
-            res[i] = 0;
-        } else {
-            null_map[i] = 1;
-            res[i] = 0;
-        }
-    } else if constexpr (std::is_same_v<int32_t, typename ValueType::T>) {
-        if (value->isInt8() || value->isInt16() || value->isInt32()) {
-            res[i] = (int32_t)((const JsonbIntVal*)value)->val();
-        } else {
-            null_map[i] = 1;
-            res[i] = 0;
-        }
-    } else if constexpr (std::is_same_v<int64_t, typename ValueType::T>) {
-        if (value->isInt8() || value->isInt16() || value->isInt32() || value->isInt64()) {
-            res[i] = ((const JsonbIntVal*)value)->val();
-        } else {
-            null_map[i] = 1;
-            res[i] = 0;
-        }
-    } else if constexpr (std::is_same_v<double, typename ValueType::T>) {
-        if (value->isDouble()) {
-            res[i] = ((const JsonbDoubleVal*)value)->val();
-        } else if (value->isInt8() || value->isInt16() || value->isInt32() ||
-                   value->isInt64()) {
-            res[i] = ((const JsonbIntVal*)value)->val();
-        } else {
-            null_map[i] = 1;
-            res[i] = 0;
-        }
-    } else {
-        LOG(FATAL) << "unexpected type ";
-    }
-
-    }
-
-
 public:
     // for jsonb_extract_int/int64/double
     static void vector_vector(FunctionContext* context, const ColumnString::Chars& ldata,
@@ -917,8 +771,12 @@ public:
             const char* r_raw_str = reinterpret_cast<const char*>(&rdata[roffsets[i - 1]]);
             int r_str_size = roffsets[i] - roffsets[i - 1];
 
-            inner_loop_impl(i, res, null_map, l_raw_str, l_str_size, r_raw_str, r_str_size,
-                            is_invalid_json_path);
+            JsonbPath path;
+            if (!path.seek(r_raw_str, r_str_size)) {
+                is_invalid_json_path = true;
+            }
+
+            inner_loop_impl(i, res, null_map, l_raw_str, l_str_size, path);
         } //for
     }     //function
     static void scalar_vector(FunctionContext* context, const StringRef& ldata,
@@ -936,8 +794,12 @@ public:
             const char* r_raw_str = reinterpret_cast<const char*>(&rdata[roffsets[i - 1]]);
             int r_str_size = roffsets[i] - roffsets[i - 1];
 
-            inner_loop_impl(i, res, null_map, ldata.data, ldata.size, r_raw_str, r_str_size,
-                            is_invalid_json_path);
+            JsonbPath path;
+            if (!path.seek(r_raw_str, r_str_size)) {
+                is_invalid_json_path = true;
+            }
+
+            inner_loop_impl(i, res, null_map, ldata.data, ldata.size, path);
         } //for
     }     //function
     static void vector_scalar(FunctionContext* context, const ColumnString::Chars& ldata,
@@ -947,7 +809,9 @@ public:
         res.resize(size);
 
         JsonbPath path;
-        path.parsePath_tmp(rdata.data, rdata.size);
+        if (!path.seek(rdata.data, rdata.size)) {
+            is_invalid_json_path = true;
+        }
 
         for (size_t i = 0; i < loffsets.size(); i++) {
             if constexpr (only_check_exists) {
@@ -957,8 +821,7 @@ public:
             const char* l_raw_str = reinterpret_cast<const char*>(&ldata[loffsets[i - 1]]);
             int l_str_size = loffsets[i] - loffsets[i - 1];
 
-            inner_loop_impl_tmp(i, res, null_map, l_raw_str, l_str_size, path,
-                            is_invalid_json_path);
+            inner_loop_impl(i, res, null_map, l_raw_str, l_str_size, path);
         } //for
     }     //function
 };


### PR DESCRIPTION
The previous logic was to read jsonbvalue while parsing the json path. For complex json paths, there will be a lot of repeated parsing work. The optimization idea is to separate the analysis and value of jsonpath