### PR TITLE
[Fix](planner)fix rewritten alias function's original function is not analyzed again

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -1983,7 +1983,7 @@ public class FunctionCallExpr extends Expr {
         retExpr.fnParams = new FunctionParams(oriExpr.fnParams.isDistinct(), oriParamsExprs);
 
         // retExpr changed to original function, should be analyzed again.
-        retExpr.analyze(analyzer);
+        // retExpr.analyze(analyzer);
 
         // reset children
         retExpr.children.clear();

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -1983,12 +1983,13 @@ public class FunctionCallExpr extends Expr {
         retExpr.fnParams = new FunctionParams(oriExpr.fnParams.isDistinct(), oriParamsExprs);
 
         // retExpr changed to original function, should be analyzed again.
-        // retExpr.analyze(analyzer);
+        retExpr.fn = null;
 
         // reset children
         retExpr.children.clear();
         retExpr.children.addAll(oriExpr.getChildren());
         retExpr.isRewrote = true;
+        retExpr.analyze(analyzer);
         return retExpr;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -1953,7 +1953,7 @@ public class FunctionCallExpr extends Expr {
      * @return
      * @throws AnalysisException
      */
-    public Expr rewriteExpr() throws AnalysisException {
+    public Expr rewriteExpr(Analyzer analyzer) throws AnalysisException {
         if (isRewrote) {
             return this;
         }
@@ -1982,8 +1982,8 @@ public class FunctionCallExpr extends Expr {
 
         retExpr.fnParams = new FunctionParams(oriExpr.fnParams.isDistinct(), oriParamsExprs);
 
-        // retExpr changed to original function, so the fn should be null.
-        retExpr.fn = null;
+        // retExpr changed to original function, should be analyzed again.
+        retExpr.analyze(analyzer);
 
         // reset children
         retExpr.children.clear();

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/RewriteAliasFunctionRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/RewriteAliasFunctionRule.java
@@ -38,7 +38,7 @@ public class RewriteAliasFunctionRule implements ExprRewriteRule {
             if (fn instanceof AliasFunction) {
                 Expr originFn = ((AliasFunction) fn).getOriginFunction();
                 if (originFn instanceof FunctionCallExpr) {
-                    return ((FunctionCallExpr) expr).rewriteExpr();
+                    return ((FunctionCallExpr) expr).rewriteExpr(analyzer);
                 } else if (originFn instanceof CastExpr) {
                     return ((CastExpr) originFn).rewriteExpr(((AliasFunction) fn).getParameters(),
                             ((FunctionCallExpr) expr).getParams().exprs());


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

fn is null because the alias function's original function is analyzed again, we fix it by add an analysis phase.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

