### PR TITLE
[cleanup](load) remove dynamic schema support from memtable

### DIFF
--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -212,13 +212,6 @@ private:
     void _aggregate_two_row_in_block(vectorized::MutableBlock& mutable_block, RowInBlock* new_row,
                                      RowInBlock* row_in_skiplist);
 
-    // Unfold variant column to Block
-    // Eg. [A | B | C | (D, E, F)]
-    // After unfold block structure changed to -> [A | B | C | D | E | F]
-    // The expanded D, E, F is dynamic part of the block
-    // The flushed Block columns should match exactly from the same type of frontend meta
-    Status unfold_variant_column(vectorized::Block& block, FlushContext* ctx);
-
 private:
     int64_t _tablet_id;
     bool _enable_unique_key_mow = false;

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -38,7 +38,6 @@ class MemTable;
 // Context for single memtable flush
 struct FlushContext {
     ENABLE_FACTORY_CREATOR(FlushContext);
-    TabletSchemaSPtr flush_schema = nullptr;
     const vectorized::Block* block = nullptr;
     std::optional<int32_t> segment_id = std::nullopt;
 };

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -121,9 +121,6 @@ void SegmentWriter::init_column_meta(ColumnMetaPB* meta, uint32_t column_id,
 Status SegmentWriter::init(const FlushContext* flush_ctx) {
     std::vector<uint32_t> column_ids;
     int column_cnt = _tablet_schema->num_columns();
-    if (flush_ctx && flush_ctx->flush_schema) {
-        column_cnt = flush_ctx->flush_schema->num_columns();
-    }
     for (uint32_t i = 0; i < column_cnt; ++i) {
         column_ids.emplace_back(i);
     }
@@ -242,11 +239,7 @@ Status SegmentWriter::init(const std::vector<uint32_t>& col_ids, bool has_key,
         return Status::OK();
     };
 
-    if (flush_ctx && flush_ctx->flush_schema) {
-        RETURN_IF_ERROR(_create_writers(*flush_ctx->flush_schema, col_ids, create_column_writer));
-    } else {
-        RETURN_IF_ERROR(_create_writers(*_tablet_schema, col_ids, create_column_writer));
-    }
+    RETURN_IF_ERROR(_create_writers(*_tablet_schema, col_ids, create_column_writer));
 
     // we don't need the short key index for unique key merge on write table.
     if (_has_key) {


### PR DESCRIPTION
## Proposed changes

Dynamic schema is no longer used, remove it from memtable.
So we can get rid of dependency on rowset writer in memtable. 

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

