### PR TITLE
[fix](rpc) shutdown removed backend client without wait

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceClient.java
@@ -143,28 +143,7 @@ public class BackendServiceClient {
     }
 
     public void shutdown() {
-        if (!channel.isShutdown()) {
-            channel.shutdown();
-            try {
-                if (!channel.awaitTermination(5, TimeUnit.SECONDS)) {
-                    LOG.warn("Timed out gracefully shutting down connection: {}. ", channel);
-                }
-            } catch (InterruptedException e) {
-                return;
-            }
-        }
-
-        if (!channel.isTerminated()) {
-            channel.shutdownNow();
-            try {
-                if (!channel.awaitTermination(5, TimeUnit.SECONDS)) {
-                    LOG.warn("Timed out forcefully shutting down connection: {}. ", channel);
-                }
-            } catch (InterruptedException e) {
-                return;
-            }
-        }
-
+        channel.shutdown();
         LOG.warn("shut down backend service client: {}", address);
     }
 


### PR DESCRIPTION
1. `ManagedChannel` needs to shutdown manually, otherwise, the channel will leak.
2. If a connection reset occurs, then `removeProxy` will be called, and shutdown will be called further. But the original implementation of `shutdown` will wait until the channel becomes terminated, this process may consume some time, but it is not necessary.