### PR TITLE
[bugfix](RowsetIterator) use valid stats when creating segment iterator

### DIFF
--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -91,8 +91,6 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
     // and in such cases we will try to use the beta rowset reader's own statistics.
     if (_context->stats != nullptr) {
         _stats = _context->stats;
-    } else {
-        _context->stats = _stats;
     }
 
     // convert RowsetReaderContext to StorageReadOptions
@@ -208,7 +206,7 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
     _read_options.read_orderby_key_reverse = read_context->read_orderby_key_reverse;
     _read_options.read_orderby_key_columns = read_context->read_orderby_key_columns;
     _read_options.io_ctx.reader_type = read_context->reader_type;
-    _read_options.io_ctx.file_cache_stats = &read_context->stats->file_cache_stats;
+    _read_options.io_ctx.file_cache_stats = &_stats->file_cache_stats;
     _read_options.runtime_state = read_context->runtime_state;
     _read_options.output_columns = read_context->output_columns;
 


### PR DESCRIPTION
## Proposed changes
The former logic would directly use read_context as segment iterator's _context `_context = read_context;`. But if it's invoked by schema change or compaction, it would pass one read_context whose stats is nullptr like the following picture.
![image](https://github.com/apache/doris/assets/43750022/c754b35f-482f-4894-85ec-02b6d79fefe6)

Thus the following file cache statistics assignation would get one invalid address `_read_options.io_ctx.file_cache_stats = &read_context->stats->file_cache_stats;` which would be the offset for file_cache_stats in stats.

This pr would make the read_context->stats always valid to prevent such coredump.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

