### PR TITLE
[Fix](be)fix be core no print queryid

### DIFF
--- a/be/src/common/signal_handler.h
+++ b/be/src/common/signal_handler.h
@@ -48,10 +48,10 @@
 
 namespace doris::signal {
 
-namespace {
-
 inline thread_local uint64 query_id_hi;
 inline thread_local uint64 query_id_lo;
+
+namespace {
 
 // We'll install the failure signal handler for these signals.  We could
 // use strsignal() to get signal names, but we don't use it to avoid


### PR DESCRIPTION
## Proposed changes

fix signal_handler no print query_id when be core

Issue Number: #14656

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

