### PR TITLE
[fix](Nereids): when child is Aggregate, don't infer Distinct for it

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/InferSetOperatorDistinct.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/InferSetOperatorDistinct.java
@@ -50,13 +50,19 @@ public class InferSetOperatorDistinct extends OneRewriteRuleFactory {
                     }
 
                     List<Plan> newChildren = setOperation.children().stream()
-                            .map(child -> new LogicalAggregate<>(ImmutableList.copyOf(child.getOutput()), true, child))
+                            .map(child -> isAgg(child) ? child
+                                    : new LogicalAggregate<>(ImmutableList.copyOf(child.getOutput()), true, child))
                             .collect(ImmutableList.toImmutableList());
                     if (newChildren.equals(setOperation.children())) {
                         return null;
                     }
                     return setOperation.withChildren(newChildren);
                 }).toRule(RuleType.INFER_SET_OPERATOR_DISTINCT);
+    }
+
+    private boolean isAgg(Plan plan) {
+        return plan instanceof LogicalAggregate || (plan instanceof LogicalProject && plan.child(
+                0) instanceof LogicalAggregate);
     }
 
     // if children exist NLJ, we can't infer distinct


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

when child is Aggregate, don't infer Distinct for it

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

