### PR TITLE
[improvement](functions) avoid copying of block in create_block_with_nested_columns

### DIFF
--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -128,6 +128,11 @@ Block::Block(const PBlock& pblock) {
     initialize_index_by_name();
 }
 
+void Block::reserve(size_t count) {
+    index_by_name.reserve(count);
+    data.reserve(count);
+}
+
 void Block::initialize_index_by_name() {
     for (size_t i = 0, size = data.size(); i < size; ++i) {
         index_by_name[data[i].name] = i;

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -91,6 +91,8 @@ public:
     Block(const std::vector<SlotDescriptor*>& slots, size_t block_size,
           bool ignore_trivial_slot = false);
 
+    void reserve(size_t count);
+
     /// insert the column at the specified position
     void insert(size_t position, const ColumnWithTypeAndName& elem);
     void insert(size_t position, ColumnWithTypeAndName&& elem);

--- a/be/src/vec/functions/function_helpers.cpp
+++ b/be/src/vec/functions/function_helpers.cpp
@@ -44,6 +44,7 @@ std::tuple<Block, ColumnNumbers> create_block_with_nested_columns(const Block& b
                                                                   const bool need_check_same) {
     Block res;
     ColumnNumbers res_args(args.size());
+    res.reserve(args.size() + 1);
 
     // only build temp block by args column, if args[i] == args[j]
     // just keep one
@@ -100,7 +101,7 @@ std::tuple<Block, ColumnNumbers> create_block_with_nested_columns(const Block& b
         }
     }
 
-    return {res, res_args};
+    return {std::move(res), std::move(res_args)};
 }
 
 std::tuple<Block, ColumnNumbers, size_t> create_block_with_nested_columns(const Block& block,
@@ -109,7 +110,7 @@ std::tuple<Block, ColumnNumbers, size_t> create_block_with_nested_columns(const 
     auto [res, res_args] = create_block_with_nested_columns(block, args, true);
     // insert result column in temp block
     res.insert(block.get_by_position(result));
-    return {res, res_args, res.columns() - 1};
+    return {std::move(res), std::move(res_args), res.columns() - 1};
 }
 
 void validate_argument_type(const IFunction& func, const DataTypes& arguments,


### PR DESCRIPTION
## Proposed changes

The performance cost of copying blocks is not negligible, so unnecessary copying should be avoided.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

