### PR TITLE
[enhancement](stats) Update tbl stats after system job succeeded

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
@@ -259,11 +259,6 @@ public class AnalysisManager extends Daemon implements Writable {
             persistAnalysisJob(jobInfo);
             analysisJobIdToTaskMap.put(jobInfo.jobId, analysisTaskInfos);
         }
-        try {
-            updateTableStats(jobInfo);
-        } catch (Throwable e) {
-            LOG.warn("Failed to update Table statistics in job: {}", info.toString());
-        }
 
         analysisTaskInfos.values().forEach(taskScheduler::schedule);
     }
@@ -622,6 +617,13 @@ public class AnalysisManager extends Daemon implements Writable {
                 logCreateAnalysisJob(job);
             } else {
                 job.state = AnalysisState.FINISHED;
+                if (job.jobType.equals(JobType.SYSTEM)) {
+                    try {
+                        updateTableStats(job);
+                    } catch (Throwable e) {
+                        LOG.warn("Failed to update Table statistics in job: {}", info.toString());
+                    }
+                }
                 logCreateAnalysisJob(job);
             }
             analysisJobIdToTaskMap.remove(job.jobId);


### PR DESCRIPTION
## Proposed changes

So that if FE crushed when system analyze task running, the system task for column could be created and running when FE recovered

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

