### PR TITLE
[fix](sink) fix OlapTableSink early close causes load failure

### DIFF
--- a/be/src/vec/sink/vtablet_sink.h
+++ b/be/src/vec/sink/vtablet_sink.h
@@ -251,7 +251,7 @@ public:
     // 2. just cancel()
     void mark_close();
 
-    bool is_rpc_done() const;
+    bool is_send_data_rpc_done() const;
 
     bool is_closed() const { return _is_closed; }
     bool is_cancelled() const { return _cancelled; }
@@ -606,6 +606,9 @@ private:
     // Save the status of try_close() and close() method
     Status _close_status;
     bool _try_close = false;
+    bool _prepare = false;
+
+    std::atomic<bool> _open_partition_done {false};
 
     // User can change this config at runtime, avoid it being modified during query or loading process.
     bool _transfer_large_data_by_brpc = false;


### PR DESCRIPTION
## Proposed changes

open_partition_finished must be before mark_close
```
Failed to commit txn [121422]. Tablet [1931632] success replica num is 0 < quorum replica num 1 while error backends 10084 error replica info  replica [1931633] commitBackends null or tabletBackend [10084] does not in commitBackends commitBackends null
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

