### PR TITLE
[fix](kerberos) should renew the kerberos ticket each half of ticket lifetime

### DIFF
--- a/be/src/io/fs/hdfs_file_system.h
+++ b/be/src/io/fs/hdfs_file_system.h
@@ -78,7 +78,7 @@ public:
     bool invalid() {
         return _invalid ||
                (_is_kerberos &&
-                _now() - _create_time.load() > config::kerberos_expiration_time_seconds * 1000);
+                _now() - _create_time.load() > config::kerberos_expiration_time_seconds * 1000 / 2);
     }
 
     void set_invalid() { _invalid = true; }


### PR DESCRIPTION
## Proposed changes

Follow #21265, the renew interval of kerberos ticket should be half of `config::kerberos_expiration_time_seconds`

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

