### PR TITLE
[refactor](load) move memtable flush logic to flush token and rowset writer

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -345,18 +345,6 @@ void DeltaWriter::_reset_mem_table() {
                                   mem_table_insert_tracker, mem_table_flush_tracker));
 
     COUNTER_UPDATE(_segment_num, 1);
-    _mem_table->set_callback([this](MemTableStat& stat) {
-        _memtable_stat += stat;
-        COUNTER_SET(_sort_timer, _memtable_stat.sort_ns);
-        COUNTER_SET(_agg_timer, _memtable_stat.agg_ns);
-        COUNTER_SET(_memtable_duration_timer, _memtable_stat.duration_ns);
-        COUNTER_SET(_segment_writer_timer, _memtable_stat.segment_writer_ns);
-        COUNTER_SET(_put_into_output_timer, _memtable_stat.put_into_output_ns);
-        COUNTER_SET(_sort_times, _memtable_stat.sort_times);
-        COUNTER_SET(_agg_times, _memtable_stat.agg_times);
-        COUNTER_SET(_raw_rows_num, _memtable_stat.raw_rows);
-        COUNTER_SET(_merged_rows_num, _memtable_stat.merged_rows);
-    });
 }
 
 Status DeltaWriter::close() {
@@ -416,10 +404,11 @@ Status DeltaWriter::close_wait(const PSlaveTabletNodes& slave_tablet_nodes,
 
     _mem_table.reset();
 
-    if (_rowset_writer->num_rows() + _memtable_stat.merged_rows != _total_received_rows) {
+    if (_rowset_writer->num_rows() + _rowset_writer->memtable_stat().merged_rows !=
+        _total_received_rows) {
         LOG(WARNING) << "the rows number written doesn't match, rowset num rows written to file: "
                      << _rowset_writer->num_rows()
-                     << ", merged_rows: " << _memtable_stat.merged_rows
+                     << ", merged_rows: " << _rowset_writer->memtable_stat().merged_rows
                      << ", total received rows: " << _total_received_rows;
         return Status::InternalError("rows number written by delta writer dosen't match");
     }
@@ -494,6 +483,16 @@ Status DeltaWriter::close_wait(const PSlaveTabletNodes& slave_tablet_nodes,
     }
     COUNTER_UPDATE(_lock_timer, _lock_watch.elapsed_time() / 1000);
     COUNTER_SET(_delete_bitmap_timer, _rowset_writer->delete_bitmap_ns());
+    const auto& memtable_stat = _rowset_writer->memtable_stat();
+    COUNTER_SET(_sort_timer, memtable_stat.sort_ns);
+    COUNTER_SET(_agg_timer, memtable_stat.agg_ns);
+    COUNTER_SET(_memtable_duration_timer, memtable_stat.duration_ns);
+    COUNTER_SET(_segment_writer_timer, memtable_stat.segment_writer_ns);
+    COUNTER_SET(_put_into_output_timer, memtable_stat.put_into_output_ns);
+    COUNTER_SET(_sort_times, memtable_stat.sort_times);
+    COUNTER_SET(_agg_times, memtable_stat.agg_times);
+    COUNTER_SET(_raw_rows_num, memtable_stat.raw_rows);
+    COUNTER_SET(_merged_rows_num, memtable_stat.merged_rows);
     return Status::OK();
 }
 

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -482,12 +482,12 @@ Status DeltaWriter::close_wait(const PSlaveTabletNodes& slave_tablet_nodes,
         }
     }
     COUNTER_UPDATE(_lock_timer, _lock_watch.elapsed_time() / 1000);
+    COUNTER_SET(_delete_bitmap_timer, _rowset_writer->delete_bitmap_ns());
     const auto& memtable_stat = _rowset_writer->memtable_stat();
     COUNTER_SET(_sort_timer, memtable_stat.sort_ns);
     COUNTER_SET(_agg_timer, memtable_stat.agg_ns);
     COUNTER_SET(_memtable_duration_timer, memtable_stat.duration_ns);
     COUNTER_SET(_segment_writer_timer, memtable_stat.segment_writer_ns);
-    COUNTER_SET(_delete_bitmap_timer, memtable_stat.delete_bitmap_ns);
     COUNTER_SET(_put_into_output_timer, memtable_stat.put_into_output_ns);
     COUNTER_SET(_sort_times, memtable_stat.sort_times);
     COUNTER_SET(_agg_times, memtable_stat.agg_times);

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -263,9 +263,6 @@ Status DeltaWriter::write(const vectorized::Block* block, const std::vector<int>
 }
 
 Status DeltaWriter::_flush_memtable_async() {
-    if (_mem_table->empty()) {
-        return Status::OK();
-    }
     return _flush_token->submit(std::move(_mem_table));
 }
 

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -404,11 +404,11 @@ Status DeltaWriter::close_wait(const PSlaveTabletNodes& slave_tablet_nodes,
 
     _mem_table.reset();
 
-    if (_rowset_writer->num_rows() + _rowset_writer->memtable_stat().merged_rows !=
+    if (_rowset_writer->num_rows() + _flush_token->memtable_stat().merged_rows !=
         _total_received_rows) {
         LOG(WARNING) << "the rows number written doesn't match, rowset num rows written to file: "
                      << _rowset_writer->num_rows()
-                     << ", merged_rows: " << _rowset_writer->memtable_stat().merged_rows
+                     << ", merged_rows: " << _flush_token->memtable_stat().merged_rows
                      << ", total received rows: " << _total_received_rows;
         return Status::InternalError("rows number written by delta writer dosen't match");
     }
@@ -483,11 +483,11 @@ Status DeltaWriter::close_wait(const PSlaveTabletNodes& slave_tablet_nodes,
     }
     COUNTER_UPDATE(_lock_timer, _lock_watch.elapsed_time() / 1000);
     COUNTER_SET(_delete_bitmap_timer, _rowset_writer->delete_bitmap_ns());
-    const auto& memtable_stat = _rowset_writer->memtable_stat();
+    COUNTER_SET(_segment_writer_timer, _rowset_writer->segment_writer_ns());
+    const auto& memtable_stat = _flush_token->memtable_stat();
     COUNTER_SET(_sort_timer, memtable_stat.sort_ns);
     COUNTER_SET(_agg_timer, memtable_stat.agg_ns);
     COUNTER_SET(_memtable_duration_timer, memtable_stat.duration_ns);
-    COUNTER_SET(_segment_writer_timer, memtable_stat.segment_writer_ns);
     COUNTER_SET(_put_into_output_timer, memtable_stat.put_into_output_ns);
     COUNTER_SET(_sort_times, memtable_stat.sort_times);
     COUNTER_SET(_agg_times, memtable_stat.agg_times);

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -209,7 +209,7 @@ Status DeltaWriter::init() {
     // we can make sure same keys sort in the same order in all replicas.
     bool should_serial = false;
     RETURN_IF_ERROR(_storage_engine->memtable_flush_executor()->create_flush_token(
-            &_flush_token, _rowset_writer->type(), should_serial, _req.is_high_priority));
+            _flush_token, _rowset_writer.get(), should_serial, _req.is_high_priority));
 
     _is_init = true;
     return Status::OK();

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -482,12 +482,12 @@ Status DeltaWriter::close_wait(const PSlaveTabletNodes& slave_tablet_nodes,
         }
     }
     COUNTER_UPDATE(_lock_timer, _lock_watch.elapsed_time() / 1000);
-    COUNTER_SET(_delete_bitmap_timer, _rowset_writer->delete_bitmap_ns());
     const auto& memtable_stat = _rowset_writer->memtable_stat();
     COUNTER_SET(_sort_timer, memtable_stat.sort_ns);
     COUNTER_SET(_agg_timer, memtable_stat.agg_ns);
     COUNTER_SET(_memtable_duration_timer, memtable_stat.duration_ns);
     COUNTER_SET(_segment_writer_timer, memtable_stat.segment_writer_ns);
+    COUNTER_SET(_delete_bitmap_timer, memtable_stat.delete_bitmap_ns);
     COUNTER_SET(_put_into_output_timer, memtable_stat.put_into_output_ns);
     COUNTER_SET(_sort_times, memtable_stat.sort_times);
     COUNTER_SET(_agg_times, memtable_stat.agg_times);

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -266,7 +266,6 @@ Status DeltaWriter::_flush_memtable_async() {
     if (_mem_table->empty()) {
         return Status::OK();
     }
-    _mem_table->assign_segment_id();
     return _flush_token->submit(std::move(_mem_table));
 }
 

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -341,7 +341,7 @@ void DeltaWriter::_reset_mem_table() {
         _mem_table_flush_trackers.push_back(mem_table_flush_tracker);
     }
     _mem_table.reset(new MemTable(_req.tablet_id, _tablet_schema.get(), _req.slots, _req.tuple_desc,
-                                  _rowset_writer.get(), _tablet->enable_unique_key_merge_on_write(),
+                                  _tablet->enable_unique_key_merge_on_write(),
                                   mem_table_insert_tracker, mem_table_flush_tracker));
 
     COUNTER_UPDATE(_segment_num, 1);

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -200,8 +200,6 @@ private:
     RuntimeProfile::Counter* _merged_rows_num = nullptr;
 
     MonotonicStopWatch _lock_watch;
-
-    MemTableStat _memtable_stat;
 };
 
 } // namespace doris

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -484,10 +484,6 @@ void MemTable::assign_segment_id() {
     _segment_id = std::optional<int32_t> {_rowset_writer->allocate_segment_id()};
 }
 
-Status MemTable::close() {
-    return flush();
-}
-
 Status MemTable::unfold_variant_column(vectorized::Block& block, FlushContext* ctx) {
     if (block.rows() == 0) {
         return Status::OK();

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -54,7 +54,7 @@ using namespace ErrorCode;
 
 MemTable::MemTable(int64_t tablet_id, const TabletSchema* tablet_schema,
                    const std::vector<SlotDescriptor*>* slot_descs, TupleDescriptor* tuple_desc,
-                   RowsetWriter* rowset_writer, bool enable_unique_key_mow,
+                   bool enable_unique_key_mow,
                    const std::shared_ptr<MemTracker>& insert_mem_tracker,
                    const std::shared_ptr<MemTracker>& flush_mem_tracker)
         : _tablet_id(tablet_id),
@@ -63,7 +63,6 @@ MemTable::MemTable(int64_t tablet_id, const TabletSchema* tablet_schema,
           _tablet_schema(tablet_schema),
           _insert_mem_tracker(insert_mem_tracker),
           _flush_mem_tracker(flush_mem_tracker),
-          _rowset_writer(rowset_writer),
           _is_first_insertion(true),
           _agg_functions(tablet_schema->num_columns()),
           _offsets_of_aggregate_states(tablet_schema->num_columns()),

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -449,37 +449,4 @@ std::unique_ptr<vectorized::Block> MemTable::to_block() {
     return vectorized::Block::create_unique(_output_mutable_block.to_block());
 }
 
-/*
-Status MemTable::flush() {
-    VLOG_CRITICAL << "begin to flush memtable for tablet: " << tablet_id()
-                  << ", memsize: " << memory_usage() << ", rows: " << _stat.raw_rows;
-    int64_t duration_ns;
-    SCOPED_RAW_TIMER(&duration_ns);
-    SKIP_MEMORY_CHECK(RETURN_IF_ERROR(_do_flush()));
-    _delta_writer_callback(_stat);
-    DorisMetrics::instance()->memtable_flush_total->increment(1);
-    DorisMetrics::instance()->memtable_flush_duration_us->increment(duration_ns / 1000);
-    VLOG_CRITICAL << "after flush memtable for tablet: " << tablet_id()
-                  << ", flushsize: " << _flush_size;
-
-    return Status::OK();
-}
-
-Status MemTable::_do_flush() {
-    SCOPED_CONSUME_MEM_TRACKER(_flush_mem_tracker);
-    std::unique_ptr<vectorized::Block> block = to_block();
-
-    FlushContext ctx;
-    ctx.block = block.get();
-    if (_tablet_schema->is_dynamic_schema()) {
-        // Unfold variant column
-        RETURN_IF_ERROR(_rowset_writer->unfold_variant_column(*block, &ctx));
-    }
-    //ctx.segment_id = _segment_id;
-    SCOPED_RAW_TIMER(&_stat.segment_writer_ns);
-    RETURN_IF_ERROR(_rowset_writer->flush_single_memtable(block.get(), &_flush_size, &ctx));
-    return Status::OK();
-}
-*/
-
 } // namespace doris

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -450,6 +450,7 @@ std::unique_ptr<vectorized::Block> MemTable::to_block() {
     return vectorized::Block::create_unique(_output_mutable_block.to_block());
 }
 
+/*
 Status MemTable::flush() {
     VLOG_CRITICAL << "begin to flush memtable for tablet: " << tablet_id()
                   << ", memsize: " << memory_usage() << ", rows: " << _stat.raw_rows;
@@ -480,5 +481,6 @@ Status MemTable::_do_flush() {
     RETURN_IF_ERROR(_rowset_writer->flush_single_memtable(block.get(), &_flush_size, &ctx));
     return Status::OK();
 }
+*/
 
 } // namespace doris

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -453,10 +453,6 @@ std::unique_ptr<vectorized::Block> MemTable::to_block() {
 Status MemTable::flush() {
     VLOG_CRITICAL << "begin to flush memtable for tablet: " << tablet_id()
                   << ", memsize: " << memory_usage() << ", rows: " << _stat.raw_rows;
-    // For merge_on_write table, it must get all segments in this flush.
-    // The id of new segment is set by the _num_segment of beta_rowset_writer,
-    // and new segment ids is between [atomic_num_segments_before_flush, atomic_num_segments_after_flush),
-    // and use the ids to load segment data file for calc delete bitmap.
     int64_t duration_ns;
     SCOPED_RAW_TIMER(&duration_ns);
     SKIP_MEMORY_CHECK(RETURN_IF_ERROR(_do_flush()));

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -473,7 +473,7 @@ Status MemTable::_do_flush() {
     ctx.block = block.get();
     if (_tablet_schema->is_dynamic_schema()) {
         // Unfold variant column
-        RETURN_IF_ERROR(unfold_variant_column(*block, &ctx));
+        RETURN_IF_ERROR(_rowset_writer->unfold_variant_column(*block, &ctx));
     }
     ctx.segment_id = _segment_id;
     SCOPED_RAW_TIMER(&_stat.segment_writer_ns);
@@ -483,79 +483,6 @@ Status MemTable::_do_flush() {
 
 void MemTable::assign_segment_id() {
     _segment_id = std::optional<int32_t> {_rowset_writer->allocate_segment_id()};
-}
-
-Status MemTable::unfold_variant_column(vectorized::Block& block, FlushContext* ctx) {
-    if (block.rows() == 0) {
-        return Status::OK();
-    }
-
-    // Sanitize block to match exactly from the same type of frontend meta
-    vectorized::schema_util::FullBaseSchemaView schema_view;
-    schema_view.table_id = _tablet_schema->table_id();
-    vectorized::ColumnWithTypeAndName* variant_column =
-            block.try_get_by_name(BeConsts::DYNAMIC_COLUMN_NAME);
-    if (!variant_column) {
-        return Status::OK();
-    }
-    auto base_column = variant_column->column;
-    vectorized::ColumnObject& object_column =
-            assert_cast<vectorized::ColumnObject&>(base_column->assume_mutable_ref());
-    if (object_column.empty()) {
-        block.erase(BeConsts::DYNAMIC_COLUMN_NAME);
-        return Status::OK();
-    }
-    object_column.finalize();
-    // Has extended columns
-    RETURN_IF_ERROR(vectorized::schema_util::send_fetch_full_base_schema_view_rpc(&schema_view));
-    // Dynamic Block consists of two parts, dynamic part of columns and static part of columns
-    //  static   dynamic
-    // | ----- | ------- |
-    // The static ones are original _tablet_schame columns
-    TabletSchemaSPtr flush_schema = std::make_shared<TabletSchema>(*_tablet_schema);
-    vectorized::Block flush_block(std::move(block));
-    // The dynamic ones are auto generated and extended, append them the the orig_block
-    for (auto& entry : object_column.get_subcolumns()) {
-        const std::string& column_name = entry->path.get_path();
-        auto column_iter = schema_view.column_name_to_column.find(column_name);
-        if (UNLIKELY(column_iter == schema_view.column_name_to_column.end())) {
-            // Column maybe dropped by light weight schema change DDL
-            continue;
-        }
-        TabletColumn column(column_iter->second);
-        auto data_type = vectorized::DataTypeFactory::instance().create_data_type(
-                column, column.is_nullable());
-        // Dynamic generated columns does not appear in original tablet schema
-        if (_tablet_schema->field_index(column.name()) < 0) {
-            flush_schema->append_column(column);
-            flush_block.insert({data_type->create_column(), data_type, column.name()});
-        }
-    }
-
-    // Ensure column are all present at this schema version.Otherwise there will be some senario:
-    //  Load1 -> version(10) with schema [a, b, c, d, e], d & e is new added columns and schema version became 10
-    //  Load2 -> version(10) with schema [a, b, c] and has no extended columns and fetched the schema at version 10
-    //  Load2 will persist meta with [a, b, c] but Load1 will persist meta with [a, b, c, d, e]
-    // So we should make sure that rowset at the same schema version alawys contain the same size of columns.
-    // so that all columns at schema_version is in either _tablet_schema or schema_change_recorder
-    for (const auto& [name, column] : schema_view.column_name_to_column) {
-        if (_tablet_schema->field_index(name) == -1) {
-            const auto& tcolumn = schema_view.column_name_to_column[name];
-            TabletColumn new_column(tcolumn);
-            _rowset_writer->mutable_schema_change_recorder()->add_extended_columns(
-                    column, schema_view.schema_version);
-        }
-    }
-
-    // Last schema alignment before flush to disk, due to the schema maybe variant before this procedure
-    // Eg. add columnA(INT) -> drop ColumnA -> add ColumnA(Double), then columnA could be type of `Double`,
-    // unfold will cast to Double type
-    RETURN_IF_ERROR(vectorized::schema_util::unfold_object(
-            flush_block.get_position_by_name(BeConsts::DYNAMIC_COLUMN_NAME), flush_block, true));
-    flush_block.erase(BeConsts::DYNAMIC_COLUMN_NAME);
-    ctx->flush_schema = flush_schema;
-    block.swap(flush_block);
-    return Status::OK();
 }
 
 } // namespace doris

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -475,14 +475,10 @@ Status MemTable::_do_flush() {
         // Unfold variant column
         RETURN_IF_ERROR(_rowset_writer->unfold_variant_column(*block, &ctx));
     }
-    ctx.segment_id = _segment_id;
+    //ctx.segment_id = _segment_id;
     SCOPED_RAW_TIMER(&_stat.segment_writer_ns);
     RETURN_IF_ERROR(_rowset_writer->flush_single_memtable(block.get(), &_flush_size, &ctx));
     return Status::OK();
-}
-
-void MemTable::assign_segment_id() {
-    _segment_id = std::optional<int32_t> {_rowset_writer->allocate_segment_id()};
 }
 
 } // namespace doris

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -24,30 +24,19 @@
 #include <algorithm>
 #include <limits>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include "common/config.h"
-#include "common/consts.h"
-#include "common/logging.h"
 #include "olap/olap_define.h"
-#include "olap/rowset/rowset_writer.h"
 #include "olap/tablet_schema.h"
 #include "runtime/descriptors.h"
 #include "runtime/exec_env.h"
 #include "runtime/load_channel_mgr.h"
-#include "runtime/thread_context.h"
-#include "util/doris_metrics.h"
 #include "util/runtime_profile.h"
 #include "util/stopwatch.hpp"
 #include "vec/aggregate_functions/aggregate_function_reader.h"
 #include "vec/aggregate_functions/aggregate_function_simple_factory.h"
 #include "vec/columns/column.h"
-#include "vec/columns/column_object.h"
-#include "vec/common/assert_cast.h"
-#include "vec/common/schema_util.h"
-#include "vec/core/column_with_type_and_name.h"
-#include "vec/data_types/data_type_factory.hpp"
 
 namespace doris {
 using namespace ErrorCode;

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -215,13 +215,6 @@ private:
     void _aggregate_two_row_in_block(vectorized::MutableBlock& mutable_block, RowInBlock* new_row,
                                      RowInBlock* row_in_skiplist);
 
-    // Unfold variant column to Block
-    // Eg. [A | B | C | (D, E, F)]
-    // After unfold block structure changed to -> [A | B | C | D | E | F]
-    // The expanded D, E, F is dynamic part of the block
-    // The flushed Block columns should match exactly from the same type of frontend meta
-    Status unfold_variant_column(vectorized::Block& block, FlushContext* ctx);
-
 private:
     int64_t _tablet_id;
     bool _enable_unique_key_mow = false;

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -147,7 +147,6 @@ public:
         sort_ns += stat.sort_ns;
         agg_ns += stat.agg_ns;
         put_into_output_ns += stat.put_into_output_ns;
-        delete_bitmap_ns += stat.delete_bitmap_ns;
         segment_writer_ns += stat.segment_writer_ns;
         duration_ns += stat.duration_ns;
         sort_times += stat.sort_times;
@@ -161,7 +160,6 @@ public:
     int64_t sort_ns = 0;
     int64_t agg_ns = 0;
     int64_t put_into_output_ns = 0;
-    int64_t delete_bitmap_ns = 0;
     int64_t segment_writer_ns = 0;
     int64_t duration_ns = 0;
     int64_t sort_times = 0;

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -197,6 +197,7 @@ public:
     std::unique_ptr<vectorized::Block> to_block();
 
     int64_t flush_size() const { return _flush_size; }
+    void set_flush_size(int64_t flush_size) { _flush_size = flush_size; }
 
     void set_callback(std::function<void(MemTableStat&)> callback) {
         _delta_writer_callback = callback;
@@ -204,6 +205,7 @@ public:
 
     bool empty() const { return _input_mutable_block.rows() == 0; }
     void assign_segment_id();
+    std::optional<int32_t> segment_id() const { return _segment_id; }
 
 private:
     Status _do_flush();

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -191,12 +191,6 @@ public:
 
     std::unique_ptr<vectorized::Block> to_block();
 
-    void set_callback(std::function<void(MemTableStat&)> callback) {
-        _delta_writer_callback = callback;
-    }
-
-    void callback() { _delta_writer_callback(_stat); }
-
     bool empty() const { return _input_mutable_block.rows() == 0; }
 
     MemTableStat& stat() { return _stat; }
@@ -258,7 +252,6 @@ private:
     void _aggregate();
     void _put_into_output(vectorized::Block& in_block);
     bool _is_first_insertion;
-    std::function<void(MemTableStat&)> _delta_writer_callback;
 
     void _init_agg_functions(const vectorized::Block* block);
     std::vector<vectorized::AggregateFunctionPtr> _agg_functions;

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -204,8 +204,6 @@ public:
     }
 
     bool empty() const { return _input_mutable_block.rows() == 0; }
-    void assign_segment_id();
-    std::optional<int32_t> segment_id() const { return _segment_id; }
 
 private:
     Status _do_flush();
@@ -270,7 +268,6 @@ private:
     void _put_into_output(vectorized::Block& in_block);
     bool _is_first_insertion;
     std::function<void(MemTableStat&)> _delta_writer_callback;
-    std::optional<int32_t> _segment_id = std::nullopt;
 
     void _init_agg_functions(const vectorized::Block* block);
     std::vector<vectorized::AggregateFunctionPtr> _agg_functions;

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -197,6 +197,10 @@ public:
 
     bool empty() const { return _input_mutable_block.rows() == 0; }
 
+    MemTableStat& stat() { return _stat; }
+
+    std::shared_ptr<MemTracker> flush_mem_tracker() { return _flush_mem_tracker; }
+
 private:
     // for vectorized
     void _aggregate_two_row_in_block(vectorized::MutableBlock& mutable_block, RowInBlock* new_row,

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -147,7 +147,6 @@ public:
         sort_ns += stat.sort_ns;
         agg_ns += stat.agg_ns;
         put_into_output_ns += stat.put_into_output_ns;
-        segment_writer_ns += stat.segment_writer_ns;
         duration_ns += stat.duration_ns;
         sort_times += stat.sort_times;
         agg_times += stat.agg_times;
@@ -160,7 +159,6 @@ public:
     int64_t sort_ns = 0;
     int64_t agg_ns = 0;
     int64_t put_into_output_ns = 0;
-    int64_t segment_writer_ns = 0;
     int64_t duration_ns = 0;
     int64_t sort_times = 0;
     int64_t agg_times = 0;

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -195,6 +195,8 @@ public:
         _delta_writer_callback = callback;
     }
 
+    void callback() { _delta_writer_callback(_stat); }
+
     bool empty() const { return _input_mutable_block.rows() == 0; }
 
     MemTableStat& stat() { return _stat; }

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -193,7 +193,6 @@ public:
 
     /// Flush
     Status flush();
-    Status close();
 
     int64_t flush_size() const { return _flush_size; }
 

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -196,9 +196,6 @@ public:
 
     std::unique_ptr<vectorized::Block> to_block();
 
-    int64_t flush_size() const { return _flush_size; }
-    void set_flush_size(int64_t flush_size) { _flush_size = flush_size; }
-
     void set_callback(std::function<void(MemTableStat&)> callback) {
         _delta_writer_callback = callback;
     }
@@ -244,8 +241,6 @@ private:
 
     RowsetWriter* _rowset_writer;
 
-    // the data size flushed on disk of this memtable
-    int64_t _flush_size = 0;
     // Number of rows inserted to this memtable.
     // This is not the rows in this memtable, because rows may be merged
     // in unique or aggregate key model.

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -191,9 +191,6 @@ public:
 
     bool need_agg() const;
 
-    /// Flush
-    Status flush();
-
     std::unique_ptr<vectorized::Block> to_block();
 
     void set_callback(std::function<void(MemTableStat&)> callback) {
@@ -201,9 +198,6 @@ public:
     }
 
     bool empty() const { return _input_mutable_block.rows() == 0; }
-
-private:
-    Status _do_flush();
 
 private:
     // for vectorized

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -38,7 +38,6 @@
 
 namespace doris {
 
-class RowsetWriter;
 class Schema;
 class SlotDescriptor;
 class TabletSchema;
@@ -171,8 +170,7 @@ class MemTable {
 public:
     MemTable(int64_t tablet_id, const TabletSchema* tablet_schema,
              const std::vector<SlotDescriptor*>* slot_descs, TupleDescriptor* tuple_desc,
-             RowsetWriter* rowset_writer, bool enable_unique_key_mow,
-             const std::shared_ptr<MemTracker>& insert_mem_tracker,
+             bool enable_unique_key_mow, const std::shared_ptr<MemTracker>& insert_mem_tracker,
              const std::shared_ptr<MemTracker>& flush_mem_tracker);
     ~MemTable();
 
@@ -232,8 +230,6 @@ private:
     void _init_columns_offset_by_slot_descs(const std::vector<SlotDescriptor*>* slot_descs,
                                             const TupleDescriptor* tuple_desc);
     std::vector<int> _column_offset;
-
-    RowsetWriter* _rowset_writer;
 
     // Number of rows inserted to this memtable.
     // This is not the rows in this memtable, because rows may be merged

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -43,7 +43,6 @@ class SlotDescriptor;
 class TabletSchema;
 class TupleDescriptor;
 enum KeysType : int;
-struct FlushContext;
 
 // row pos in _input_mutable_block
 struct RowInBlock {
@@ -259,7 +258,6 @@ private:
     // Memory usage without _arena.
     size_t _mem_usage;
 
-    std::shared_ptr<MowContext> _mow_context;
     size_t _num_columns;
 }; // class MemTable
 

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -147,6 +147,7 @@ public:
         sort_ns += stat.sort_ns;
         agg_ns += stat.agg_ns;
         put_into_output_ns += stat.put_into_output_ns;
+        delete_bitmap_ns += stat.delete_bitmap_ns;
         segment_writer_ns += stat.segment_writer_ns;
         duration_ns += stat.duration_ns;
         sort_times += stat.sort_times;
@@ -160,6 +161,7 @@ public:
     int64_t sort_ns = 0;
     int64_t agg_ns = 0;
     int64_t put_into_output_ns = 0;
+    int64_t delete_bitmap_ns = 0;
     int64_t segment_writer_ns = 0;
     int64_t duration_ns = 0;
     int64_t sort_times = 0;

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -141,7 +141,7 @@ private:
 
 class MemTableStat {
 public:
-    MemTableStat& operator+=(MemTableStat& stat) {
+    MemTableStat& operator+=(const MemTableStat& stat) {
         raw_rows += stat.raw_rows;
         merged_rows += stat.merged_rows;
         sort_ns += stat.sort_ns;
@@ -195,7 +195,7 @@ public:
 
     bool empty() const { return _input_mutable_block.rows() == 0; }
 
-    MemTableStat& stat() { return _stat; }
+    const MemTableStat& stat() { return _stat; }
 
     std::shared_ptr<MemTracker> flush_mem_tracker() { return _flush_mem_tracker; }
 

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -194,6 +194,8 @@ public:
     /// Flush
     Status flush();
 
+    std::unique_ptr<vectorized::Block> to_block();
+
     int64_t flush_size() const { return _flush_size; }
 
     void set_callback(std::function<void(MemTableStat&)> callback) {

--- a/be/src/olap/memtable_flush_executor.cpp
+++ b/be/src/olap/memtable_flush_executor.cpp
@@ -97,8 +97,8 @@ Status FlushToken::_do_flush_memtable(MemTable* memtable, int32_t segment_id, in
     SCOPED_RAW_TIMER(&duration_ns);
     std::unique_ptr<vectorized::Block> block = memtable->to_block();
     SKIP_MEMORY_CHECK(RETURN_IF_ERROR(_rowset_writer->flush_memtable(
-            block.get(), segment_id, memtable->flush_mem_tracker(), memtable->stat(),
-            flush_size)));
+            block.get(), segment_id, memtable->flush_mem_tracker(), flush_size)));
+    _memtable_stat += memtable->stat();
     DorisMetrics::instance()->memtable_flush_total->increment(1);
     DorisMetrics::instance()->memtable_flush_duration_us->increment(duration_ns / 1000);
     VLOG_CRITICAL << "after flush memtable for tablet: " << memtable->tablet_id()

--- a/be/src/olap/memtable_flush_executor.cpp
+++ b/be/src/olap/memtable_flush_executor.cpp
@@ -72,6 +72,9 @@ Status FlushToken::submit(std::unique_ptr<MemTable> mem_table) {
     if (s != OK) {
         return Status::Error(s);
     }
+    if (mem_table->empty()) {
+        return Status::OK();
+    }
     int64_t submit_task_time = MonotonicNanos();
     auto task = std::make_shared<MemtableFlushTask>(
             this, std::move(mem_table), _rowset_writer->allocate_segment_id(), submit_task_time);

--- a/be/src/olap/memtable_flush_executor.cpp
+++ b/be/src/olap/memtable_flush_executor.cpp
@@ -96,7 +96,7 @@ Status FlushToken::_do_flush_memtable(MemTable* memtable, int32_t segment_id, in
     int64_t duration_ns;
     SCOPED_RAW_TIMER(&duration_ns);
     std::unique_ptr<vectorized::Block> block = memtable->to_block();
-    SKIP_MEMORY_CHECK(RETURN_IF_ERROR(_rowset_writer->flush_memtable(
+    SKIP_MEMORY_CHECK(RETURN_IF_ERROR(_rowset_writer->unfold_variant_column_and_flush_block(
             block.get(), segment_id, memtable->flush_mem_tracker(), flush_size)));
     _memtable_stat += memtable->stat();
     DorisMetrics::instance()->memtable_flush_total->increment(1);

--- a/be/src/olap/memtable_flush_executor.h
+++ b/be/src/olap/memtable_flush_executor.h
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "common/status.h"
+#include "olap/memtable.h"
 #include "util/threadpool.h"
 
 namespace doris {
@@ -73,6 +74,8 @@ public:
 
     void set_rowset_writer(RowsetWriter* rowset_writer) { _rowset_writer = rowset_writer; }
 
+    const MemTableStat& memtable_stat() { return _memtable_stat; }
+
 private:
     friend class MemtableFlushTask;
 
@@ -89,6 +92,8 @@ private:
     FlushStatistic _stats;
 
     RowsetWriter* _rowset_writer;
+
+    MemTableStat _memtable_stat;
 };
 
 // MemTableFlushExecutor is responsible for flushing memtables to disk.

--- a/be/src/olap/memtable_flush_executor.h
+++ b/be/src/olap/memtable_flush_executor.h
@@ -78,7 +78,7 @@ private:
 
     void _flush_memtable(MemTable* mem_table, int32_t segment_id, int64_t submit_task_time);
 
-    Status _do_flush_memtable(MemTable* memtable, int32_t segment_id, int64_t& flush_size);
+    Status _do_flush_memtable(MemTable* memtable, int32_t segment_id, int64_t* flush_size);
 
     std::unique_ptr<ThreadPoolToken> _flush_token;
 

--- a/be/src/olap/memtable_flush_executor.h
+++ b/be/src/olap/memtable_flush_executor.h
@@ -76,9 +76,9 @@ public:
 private:
     friend class MemtableFlushTask;
 
-    void _flush_memtable(MemTable* mem_table, int64_t submit_task_time);
+    void _flush_memtable(MemTable* mem_table, int32_t segment_id, int64_t submit_task_time);
 
-    Status _do_flush_memtable(MemTable* memtable);
+    Status _do_flush_memtable(MemTable* memtable, int32_t segment_id);
 
     std::unique_ptr<ThreadPoolToken> _flush_token;
 

--- a/be/src/olap/memtable_flush_executor.h
+++ b/be/src/olap/memtable_flush_executor.h
@@ -78,7 +78,7 @@ private:
 
     void _flush_memtable(MemTable* mem_table, int32_t segment_id, int64_t submit_task_time);
 
-    Status _do_flush_memtable(MemTable* memtable, int32_t segment_id);
+    Status _do_flush_memtable(MemTable* memtable, int32_t segment_id, int64_t& flush_size);
 
     std::unique_ptr<ThreadPoolToken> _flush_token;
 

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -142,7 +142,7 @@ Status BetaRowsetWriter::add_block(const vectorized::Block* block) {
 }
 
 Status BetaRowsetWriter::_generate_delete_bitmap(int32_t segment_id) {
-    SCOPED_RAW_TIMER(&_memtable_stat.delete_bitmap_ns);
+    SCOPED_RAW_TIMER(&_delete_bitmap_ns);
     if (!_context.tablet->enable_unique_key_merge_on_write() ||
         _context.tablet_schema->is_partial_update()) {
         return Status::OK();

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -990,7 +990,7 @@ Status BetaRowsetWriter::_unfold_variant_column(vectorized::Block& block, FlushC
     //  static   dynamic
     // | ----- | ------- |
     // The static ones are original _tablet_schame columns
-    TabletSchemaSPtr flush_schema = std::make_shared<TabletSchema>(_context.tablet_schema);
+    TabletSchemaSPtr flush_schema = std::make_shared<TabletSchema>(*_context.tablet_schema);
     vectorized::Block flush_block(std::move(block));
     // The dynamic ones are auto generated and extended, append them the the orig_block
     for (auto& entry : object_column.get_subcolumns()) {

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -142,7 +142,7 @@ Status BetaRowsetWriter::add_block(const vectorized::Block* block) {
 }
 
 Status BetaRowsetWriter::_generate_delete_bitmap(int32_t segment_id) {
-    SCOPED_RAW_TIMER(&_delete_bitmap_ns);
+    SCOPED_RAW_TIMER(&_memtable_stat.delete_bitmap_ns);
     if (!_context.tablet->enable_unique_key_merge_on_write() ||
         _context.tablet_schema->is_partial_update()) {
         return Status::OK();

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -544,7 +544,7 @@ Status BetaRowsetWriter::_do_flush_memtable(MemTable* memtable, int32_t segment_
         RETURN_IF_ERROR(unfold_variant_column(*block, &ctx));
     }
     ctx.segment_id = std::optional<int32_t> {segment_id};
-    SCOPED_RAW_TIMER(&memtable->stat().segment_writer_ns);
+    SCOPED_RAW_TIMER(&_memtable_stat.segment_writer_ns);
     RETURN_IF_ERROR(flush_single_memtable(block.get(), flush_size, &ctx));
     return Status::OK();
 }

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -520,7 +520,7 @@ Status BetaRowsetWriter::flush() {
 
 Status BetaRowsetWriter::flush_memtable(vectorized::Block* block, int32_t segment_id,
                                         const std::shared_ptr<MemTracker>& flush_mem_tracker,
-                                        const MemTableStat& stat, int64_t* flush_size) {
+                                        int64_t* flush_size) {
     SCOPED_CONSUME_MEM_TRACKER(flush_mem_tracker);
 
     FlushContext ctx;
@@ -530,9 +530,8 @@ Status BetaRowsetWriter::flush_memtable(vectorized::Block* block, int32_t segmen
         RETURN_IF_ERROR(_unfold_variant_column(*block, &ctx));
     }
     ctx.segment_id = std::optional<int32_t> {segment_id};
-    SCOPED_RAW_TIMER(&_memtable_stat.segment_writer_ns);
+    SCOPED_RAW_TIMER(&_segment_writer_ns);
     RETURN_IF_ERROR(flush_single_memtable(block, flush_size, &ctx));
-    _memtable_stat += stat;
     return Status::OK();
 }
 

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -35,7 +35,6 @@
 #include "io/fs/file_reader_options.h"
 #include "io/fs/file_system.h"
 #include "io/fs/file_writer.h"
-#include "olap/memtable.h"
 #include "olap/olap_define.h"
 #include "olap/rowset/beta_rowset.h"
 #include "olap/rowset/rowset_factory.h"
@@ -526,7 +525,7 @@ Status BetaRowsetWriter::flush_memtable(MemTable* memtable, int32_t segment_id, 
     int64_t duration_ns;
     SCOPED_RAW_TIMER(&duration_ns);
     SKIP_MEMORY_CHECK(RETURN_IF_ERROR(_do_flush_memtable(memtable, segment_id, flush_size)));
-    memtable->callback();
+    _memtable_stat += memtable->stat();
     DorisMetrics::instance()->memtable_flush_total->increment(1);
     DorisMetrics::instance()->memtable_flush_duration_us->increment(duration_ns / 1000);
     VLOG_CRITICAL << "after flush memtable for tablet: " << memtable->tablet_id()

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -48,8 +48,11 @@
 #include "olap/tablet_schema.h"
 #include "util/slice.h"
 #include "util/time.h"
+#include "vec/columns/column.h"
+#include "vec/columns/column_object.h"
 #include "vec/common/schema_util.h" // LocalSchemaChangeRecorder
 #include "vec/core/block.h"
+#include "vec/data_types/data_type_factory.hpp"
 
 namespace doris {
 using namespace ErrorCode;
@@ -923,6 +926,79 @@ Status BetaRowsetWriter::flush_segment_writer_for_segcompaction(
 
     writer->reset();
 
+    return Status::OK();
+}
+
+Status BetaRowsetWriter::unfold_variant_column(vectorized::Block& block, FlushContext* ctx) {
+    if (block.rows() == 0) {
+        return Status::OK();
+    }
+
+    // Sanitize block to match exactly from the same type of frontend meta
+    vectorized::schema_util::FullBaseSchemaView schema_view;
+    schema_view.table_id = _rowset_meta->tablet_schema()->table_id();
+    vectorized::ColumnWithTypeAndName* variant_column =
+            block.try_get_by_name(BeConsts::DYNAMIC_COLUMN_NAME);
+    if (!variant_column) {
+        return Status::OK();
+    }
+    auto base_column = variant_column->column;
+    vectorized::ColumnObject& object_column =
+            assert_cast<vectorized::ColumnObject&>(base_column->assume_mutable_ref());
+    if (object_column.empty()) {
+        block.erase(BeConsts::DYNAMIC_COLUMN_NAME);
+        return Status::OK();
+    }
+    object_column.finalize();
+    // Has extended columns
+    RETURN_IF_ERROR(vectorized::schema_util::send_fetch_full_base_schema_view_rpc(&schema_view));
+    // Dynamic Block consists of two parts, dynamic part of columns and static part of columns
+    //  static   dynamic
+    // | ----- | ------- |
+    // The static ones are original _tablet_schame columns
+    TabletSchemaSPtr flush_schema = _rowset_meta->tablet_schema();
+    vectorized::Block flush_block(std::move(block));
+    // The dynamic ones are auto generated and extended, append them the the orig_block
+    for (auto& entry : object_column.get_subcolumns()) {
+        const std::string& column_name = entry->path.get_path();
+        auto column_iter = schema_view.column_name_to_column.find(column_name);
+        if (UNLIKELY(column_iter == schema_view.column_name_to_column.end())) {
+            // Column maybe dropped by light weight schema change DDL
+            continue;
+        }
+        TabletColumn column(column_iter->second);
+        auto data_type = vectorized::DataTypeFactory::instance().create_data_type(
+                column, column.is_nullable());
+        // Dynamic generated columns does not appear in original tablet schema
+        if (_rowset_meta->tablet_schema()->field_index(column.name()) < 0) {
+            flush_schema->append_column(column);
+            flush_block.insert({data_type->create_column(), data_type, column.name()});
+        }
+    }
+
+    // Ensure column are all present at this schema version.Otherwise there will be some senario:
+    //  Load1 -> version(10) with schema [a, b, c, d, e], d & e is new added columns and schema version became 10
+    //  Load2 -> version(10) with schema [a, b, c] and has no extended columns and fetched the schema at version 10
+    //  Load2 will persist meta with [a, b, c] but Load1 will persist meta with [a, b, c, d, e]
+    // So we should make sure that rowset at the same schema version alawys contain the same size of columns.
+    // so that all columns at schema_version is in either _rowset_meta->tablet_schema() or schema_change_recorder
+    for (const auto& [name, column] : schema_view.column_name_to_column) {
+        if (_rowset_meta->tablet_schema()->field_index(name) == -1) {
+            const auto& tcolumn = schema_view.column_name_to_column[name];
+            TabletColumn new_column(tcolumn);
+            mutable_schema_change_recorder()->add_extended_columns(
+                    column, schema_view.schema_version);
+        }
+    }
+
+    // Last schema alignment before flush to disk, due to the schema maybe variant before this procedure
+    // Eg. add columnA(INT) -> drop ColumnA -> add ColumnA(Double), then columnA could be type of `Double`,
+    // unfold will cast to Double type
+    RETURN_IF_ERROR(vectorized::schema_util::unfold_object(
+            flush_block.get_position_by_name(BeConsts::DYNAMIC_COLUMN_NAME), flush_block, true));
+    flush_block.erase(BeConsts::DYNAMIC_COLUMN_NAME);
+    ctx->flush_schema = flush_schema;
+    block.swap(flush_block);
     return Status::OK();
 }
 

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -526,7 +526,7 @@ Status BetaRowsetWriter::flush_memtable(MemTable* memtable, int32_t segment_id, 
     int64_t duration_ns;
     SCOPED_RAW_TIMER(&duration_ns);
     SKIP_MEMORY_CHECK(RETURN_IF_ERROR(_do_flush_memtable(memtable, segment_id, flush_size)));
-    // TODO: _delta_writer_callback(_stat);
+    memtable->callback();
     DorisMetrics::instance()->memtable_flush_total->increment(1);
     DorisMetrics::instance()->memtable_flush_duration_us->increment(duration_ns / 1000);
     VLOG_CRITICAL << "after flush memtable for tablet: " << memtable->tablet_id()

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -990,7 +990,7 @@ Status BetaRowsetWriter::_unfold_variant_column(vectorized::Block& block, FlushC
     //  static   dynamic
     // | ----- | ------- |
     // The static ones are original _tablet_schame columns
-    TabletSchemaSPtr flush_schema = _context.tablet_schema;
+    TabletSchemaSPtr flush_schema = std::make_shared<TabletSchema>(_context.tablet_schema);
     vectorized::Block flush_block(std::move(block));
     // The dynamic ones are auto generated and extended, append them the the orig_block
     for (auto& entry : object_column.get_subcolumns()) {

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -518,7 +518,8 @@ Status BetaRowsetWriter::flush() {
     return Status::OK();
 }
 
-Status BetaRowsetWriter::flush_memtable(MemTable* memtable, int32_t segment_id, int64_t* flush_size) {
+Status BetaRowsetWriter::flush_memtable(MemTable* memtable, int32_t segment_id,
+                                        int64_t* flush_size) {
     VLOG_CRITICAL << "begin to flush memtable for tablet: " << memtable->tablet_id()
                   << ", memsize: " << memtable->memory_usage()
                   << ", rows: " << memtable->stat().raw_rows;
@@ -533,7 +534,8 @@ Status BetaRowsetWriter::flush_memtable(MemTable* memtable, int32_t segment_id, 
     return Status::OK();
 }
 
-Status BetaRowsetWriter::_do_flush_memtable(MemTable* memtable, int32_t segment_id, int64_t* flush_size) {
+Status BetaRowsetWriter::_do_flush_memtable(MemTable* memtable, int32_t segment_id,
+                                            int64_t* flush_size) {
     SCOPED_CONSUME_MEM_TRACKER(memtable->flush_mem_tracker());
     std::unique_ptr<vectorized::Block> block = memtable->to_block();
 
@@ -1018,8 +1020,8 @@ Status BetaRowsetWriter::unfold_variant_column(vectorized::Block& block, FlushCo
         if (_rowset_meta->tablet_schema()->field_index(name) == -1) {
             const auto& tcolumn = schema_view.column_name_to_column[name];
             TabletColumn new_column(tcolumn);
-            mutable_schema_change_recorder()->add_extended_columns(
-                    column, schema_view.schema_version);
+            mutable_schema_change_recorder()->add_extended_columns(column,
+                                                                   schema_view.schema_version);
         }
     }
 

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -518,9 +518,9 @@ Status BetaRowsetWriter::flush() {
     return Status::OK();
 }
 
-Status BetaRowsetWriter::flush_memtable(vectorized::Block* block, int32_t segment_id,
-                                        const std::shared_ptr<MemTracker>& flush_mem_tracker,
-                                        int64_t* flush_size) {
+Status BetaRowsetWriter::unfold_variant_column_and_flush_block(
+        vectorized::Block* block, int32_t segment_id,
+        const std::shared_ptr<MemTracker>& flush_mem_tracker, int64_t* flush_size) {
     SCOPED_CONSUME_MEM_TRACKER(flush_mem_tracker);
 
     FlushContext ctx;
@@ -531,12 +531,12 @@ Status BetaRowsetWriter::flush_memtable(vectorized::Block* block, int32_t segmen
     }
     ctx.segment_id = std::optional<int32_t> {segment_id};
     SCOPED_RAW_TIMER(&_segment_writer_ns);
-    RETURN_IF_ERROR(flush_single_memtable(block, flush_size, &ctx));
+    RETURN_IF_ERROR(flush_single_block(block, flush_size, &ctx));
     return Status::OK();
 }
 
-Status BetaRowsetWriter::flush_single_memtable(const vectorized::Block* block, int64* flush_size,
-                                               const FlushContext* ctx) {
+Status BetaRowsetWriter::flush_single_block(const vectorized::Block* block, int64* flush_size,
+                                            const FlushContext* ctx) {
     if (block->rows() == 0) {
         return Status::OK();
     }

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -947,7 +947,8 @@ Status BetaRowsetWriter::flush_segment_writer_for_segcompaction(
     return Status::OK();
 }
 
-Status BetaRowsetWriter::_unfold_variant_column(vectorized::Block& block, TabletSchemaSPtr& flush_schema) {
+Status BetaRowsetWriter::_unfold_variant_column(vectorized::Block& block,
+                                                TabletSchemaSPtr& flush_schema) {
     if (block.rows() == 0) {
         return Status::OK();
     }

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -160,6 +160,7 @@ private:
                                   const FlushContext* ctx = nullptr);
     Status _flush_segment_writer(std::unique_ptr<segment_v2::SegmentWriter>* writer,
                                  int64_t* flush_size = nullptr);
+    Status _do_flush_memtable(MemTable* memtable, int32_t segment_id, int64_t* flush_size);
     Status _generate_delete_bitmap(int32_t segment_id);
     void _build_rowset_meta(std::shared_ptr<RowsetMeta> rowset_meta);
     Status _segcompaction_if_necessary();

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -118,18 +118,6 @@ public:
 
     int32_t allocate_segment_id() override { return _next_segment_id.fetch_add(1); };
 
-    // Maybe modified by local schema change
-    vectorized::schema_util::LocalSchemaChangeRecorder* mutable_schema_change_recorder() override {
-        return _context.schema_change_recorder.get();
-    }
-
-    // Unfold variant column to Block
-    // Eg. [A | B | C | (D, E, F)]
-    // After unfold block structure changed to -> [A | B | C | D | E | F]
-    // The expanded D, E, F is dynamic part of the block
-    // The flushed Block columns should match exactly from the same type of frontend meta
-    Status unfold_variant_column(vectorized::Block& block, FlushContext* ctx) override;
-
     SegcompactionWorker& get_segcompaction_worker() { return _segcompaction_worker; }
 
     Status flush_segment_writer_for_segcompaction(
@@ -181,6 +169,13 @@ private:
     Status _rename_compacted_segments(int64_t begin, int64_t end);
     Status _rename_compacted_segment_plain(uint64_t seg_id);
     Status _rename_compacted_indices(int64_t begin, int64_t end, uint64_t seg_id);
+
+    // Unfold variant column to Block
+    // Eg. [A | B | C | (D, E, F)]
+    // After unfold block structure changed to -> [A | B | C | D | E | F]
+    // The expanded D, E, F is dynamic part of the block
+    // The flushed Block columns should match exactly from the same type of frontend meta
+    Status _unfold_variant_column(vectorized::Block& block, FlushContext* ctx);
 
     // build a tmp rowset for load segment to calc delete_bitmap
     // for this segment

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -90,6 +90,8 @@ public:
 
     Status flush() override;
 
+    Status flush_memtable(MemTable* memtable, int32_t segment_id, int64_t* flush_size) override;
+
     // Return the file size flushed to disk in "flush_size"
     // This method is thread-safe.
     Status flush_single_memtable(const vectorized::Block* block, int64_t* flush_size,

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -132,6 +132,8 @@ public:
 
     void set_segment_start_id(int32_t start_id) override { _segment_start_id = start_id; }
 
+    int64_t delete_bitmap_ns() override { return _delete_bitmap_ns; }
+
     const MemTableStat& memtable_stat() override { return _memtable_stat; }
 
 private:
@@ -236,6 +238,8 @@ protected:
     fmt::memory_buffer vlog_buffer;
 
     std::shared_ptr<MowContext> _mow_context;
+
+    int64_t _delete_bitmap_ns = 0;
 
     MemTableStat _memtable_stat;
 };

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -91,7 +91,9 @@ public:
 
     Status flush() override;
 
-    Status flush_memtable(MemTable* memtable, int32_t segment_id, int64_t* flush_size) override;
+    Status flush_memtable(vectorized::Block* block, int32_t segment_id,
+                          const std::shared_ptr<MemTracker>& flush_mem_tracker,
+                          const MemTableStat& stat, int64_t* flush_size) override;
 
     // Return the file size flushed to disk in "flush_size"
     // This method is thread-safe.
@@ -149,7 +151,6 @@ private:
                                   const FlushContext* ctx = nullptr);
     Status _flush_segment_writer(std::unique_ptr<segment_v2::SegmentWriter>* writer,
                                  int64_t* flush_size = nullptr);
-    Status _do_flush_memtable(MemTable* memtable, int32_t segment_id, int64_t* flush_size);
     Status _generate_delete_bitmap(int32_t segment_id);
     void _build_rowset_meta(std::shared_ptr<RowsetMeta> rowset_meta);
     Status _segcompaction_if_necessary();

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -36,6 +36,7 @@
 
 #include "common/status.h"
 #include "io/fs/file_reader_writer_fwd.h"
+#include "olap/memtable.h"
 #include "olap/olap_common.h"
 #include "olap/rowset/rowset.h"
 #include "olap/rowset/rowset_meta.h"
@@ -143,6 +144,8 @@ public:
 
     int64_t delete_bitmap_ns() override { return _delete_bitmap_ns; }
 
+    const MemTableStat& memtable_stat() override { return _memtable_stat; }
+
 private:
     Status _do_add_block(const vectorized::Block* block,
                          std::unique_ptr<segment_v2::SegmentWriter>* segment_writer,
@@ -241,6 +244,8 @@ protected:
     std::shared_ptr<MowContext> _mow_context;
 
     int64_t _delete_bitmap_ns = 0;
+
+    MemTableStat _memtable_stat;
 };
 
 } // namespace doris

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -90,14 +90,14 @@ public:
 
     Status flush() override;
 
-    Status flush_memtable(vectorized::Block* block, int32_t segment_id,
-                          const std::shared_ptr<MemTracker>& flush_mem_tracker,
-                          int64_t* flush_size) override;
+    Status unfold_variant_column_and_flush_block(
+            vectorized::Block* block, int32_t segment_id,
+            const std::shared_ptr<MemTracker>& flush_mem_tracker, int64_t* flush_size) override;
 
     // Return the file size flushed to disk in "flush_size"
     // This method is thread-safe.
-    Status flush_single_memtable(const vectorized::Block* block, int64_t* flush_size,
-                                 const FlushContext* ctx = nullptr) override;
+    Status flush_single_block(const vectorized::Block* block, int64_t* flush_size,
+                              const FlushContext* ctx = nullptr) override;
 
     RowsetSharedPtr build() override;
 

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -142,8 +142,6 @@ public:
 
     void set_segment_start_id(int32_t start_id) override { _segment_start_id = start_id; }
 
-    int64_t delete_bitmap_ns() override { return _delete_bitmap_ns; }
-
     const MemTableStat& memtable_stat() override { return _memtable_stat; }
 
 private:
@@ -242,8 +240,6 @@ protected:
     fmt::memory_buffer vlog_buffer;
 
     std::shared_ptr<MowContext> _mow_context;
-
-    int64_t _delete_bitmap_ns = 0;
 
     MemTableStat _memtable_stat;
 };

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -120,6 +120,13 @@ public:
         return _context.schema_change_recorder.get();
     }
 
+    // Unfold variant column to Block
+    // Eg. [A | B | C | (D, E, F)]
+    // After unfold block structure changed to -> [A | B | C | D | E | F]
+    // The expanded D, E, F is dynamic part of the block
+    // The flushed Block columns should match exactly from the same type of frontend meta
+    Status unfold_variant_column(vectorized::Block& block, FlushContext* ctx) override;
+
     SegcompactionWorker& get_segcompaction_worker() { return _segcompaction_worker; }
 
     Status flush_segment_writer_for_segcompaction(

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -36,7 +36,6 @@
 
 #include "common/status.h"
 #include "io/fs/file_reader_writer_fwd.h"
-#include "olap/memtable.h"
 #include "olap/olap_common.h"
 #include "olap/rowset/rowset.h"
 #include "olap/rowset/rowset_meta.h"
@@ -93,7 +92,7 @@ public:
 
     Status flush_memtable(vectorized::Block* block, int32_t segment_id,
                           const std::shared_ptr<MemTracker>& flush_mem_tracker,
-                          const MemTableStat& stat, int64_t* flush_size) override;
+                          int64_t* flush_size) override;
 
     // Return the file size flushed to disk in "flush_size"
     // This method is thread-safe.
@@ -134,7 +133,7 @@ public:
 
     int64_t delete_bitmap_ns() override { return _delete_bitmap_ns; }
 
-    const MemTableStat& memtable_stat() override { return _memtable_stat; }
+    int64_t segment_writer_ns() override { return _segment_writer_ns; }
 
 private:
     Status _do_add_block(const vectorized::Block* block,
@@ -240,8 +239,7 @@ protected:
     std::shared_ptr<MowContext> _mow_context;
 
     int64_t _delete_bitmap_ns = 0;
-
-    MemTableStat _memtable_stat;
+    int64_t _segment_writer_ns = 0;
 };
 
 } // namespace doris

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -177,7 +177,7 @@ private:
     // After unfold block structure changed to -> [A | B | C | D | E | F]
     // The expanded D, E, F is dynamic part of the block
     // The flushed Block columns should match exactly from the same type of frontend meta
-    Status _unfold_variant_column(vectorized::Block& block, FlushContext* ctx);
+    Status _unfold_variant_column(vectorized::Block& block, TabletSchemaSPtr& flush_schema);
 
     // build a tmp rowset for load segment to calc delete_bitmap
     // for this segment

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -107,6 +107,8 @@ public:
     virtual vectorized::schema_util::LocalSchemaChangeRecorder*
     mutable_schema_change_recorder() = 0;
 
+    virtual Status unfold_variant_column(vectorized::Block& block, FlushContext* ctx) = 0;
+
     virtual int64_t delete_bitmap_ns() { return 0; }
 
 private:

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -72,6 +72,10 @@ public:
     }
     virtual Status final_flush() { return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>(); }
 
+    virtual Status flush_memtable(MemTable* memtable, int32_t segment_id, int64_t* flush_size) {
+        return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>();
+    }
+
     virtual Status flush_single_memtable(const vectorized::Block* block, int64_t* flush_size,
                                          const FlushContext* ctx = nullptr) {
         return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>();

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -73,7 +73,9 @@ public:
     }
     virtual Status final_flush() { return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>(); }
 
-    virtual Status flush_memtable(MemTable* memtable, int32_t segment_id, int64_t* flush_size) {
+    virtual Status flush_memtable(vectorized::Block* block, int32_t segment_id,
+                                  const std::shared_ptr<MemTracker>& flush_mem_tracker,
+                                  const MemTableStat& stat, int64_t* flush_size) {
         return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>();
     }
 

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -34,7 +34,6 @@
 namespace doris {
 
 class MemTable;
-class MemTableStat;
 
 // Context for single memtable flush
 struct FlushContext {
@@ -75,7 +74,7 @@ public:
 
     virtual Status flush_memtable(vectorized::Block* block, int32_t segment_id,
                                   const std::shared_ptr<MemTracker>& flush_mem_tracker,
-                                  const MemTableStat& stat, int64_t* flush_size) {
+                                  int64_t* flush_size) {
         return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>();
     }
 
@@ -113,7 +112,7 @@ public:
 
     virtual int64_t delete_bitmap_ns() { return 0; }
 
-    virtual const MemTableStat& memtable_stat() = 0;
+    virtual int64_t segment_writer_ns() { return 0; }
 
 private:
     DISALLOW_COPY_AND_ASSIGN(RowsetWriter);

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -114,8 +114,6 @@ public:
 
     virtual Status unfold_variant_column(vectorized::Block& block, FlushContext* ctx) = 0;
 
-    virtual int64_t delete_bitmap_ns() { return 0; }
-
     virtual const MemTableStat& memtable_stat() = 0;
 
 private:

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -34,6 +34,7 @@
 namespace doris {
 
 class MemTable;
+class MemTableStat;
 
 // Context for single memtable flush
 struct FlushContext {
@@ -114,6 +115,8 @@ public:
     virtual Status unfold_variant_column(vectorized::Block& block, FlushContext* ctx) = 0;
 
     virtual int64_t delete_bitmap_ns() { return 0; }
+
+    virtual const MemTableStat& memtable_stat() = 0;
 
 private:
     DISALLOW_COPY_AND_ASSIGN(RowsetWriter);

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -111,6 +111,8 @@ public:
 
     virtual void set_segment_start_id(int num_segment) { LOG(FATAL) << "not supported!"; }
 
+    virtual int64_t delete_bitmap_ns() { return 0; }
+
     virtual const MemTableStat& memtable_stat() = 0;
 
 private:

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -72,14 +72,14 @@ public:
     }
     virtual Status final_flush() { return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>(); }
 
-    virtual Status flush_memtable(vectorized::Block* block, int32_t segment_id,
-                                  const std::shared_ptr<MemTracker>& flush_mem_tracker,
-                                  int64_t* flush_size) {
+    virtual Status unfold_variant_column_and_flush_block(
+            vectorized::Block* block, int32_t segment_id,
+            const std::shared_ptr<MemTracker>& flush_mem_tracker, int64_t* flush_size) {
         return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>();
     }
 
-    virtual Status flush_single_memtable(const vectorized::Block* block, int64_t* flush_size,
-                                         const FlushContext* ctx = nullptr) {
+    virtual Status flush_single_block(const vectorized::Block* block, int64_t* flush_size,
+                                      const FlushContext* ctx = nullptr) {
         return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>();
     }
 

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -109,11 +109,6 @@ public:
 
     virtual void set_segment_start_id(int num_segment) { LOG(FATAL) << "not supported!"; }
 
-    virtual vectorized::schema_util::LocalSchemaChangeRecorder*
-    mutable_schema_change_recorder() = 0;
-
-    virtual Status unfold_variant_column(vectorized::Block& block, FlushContext* ctx) = 0;
-
     virtual const MemTableStat& memtable_stat() = 0;
 
 private:

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2955,7 +2955,7 @@ Status Tablet::calc_segment_delete_bitmap(RowsetSharedPtr rowset,
                 rowset_schema, read_plan_ori, read_plan_update, rsid_to_rowset, &block));
         sort_block(block, ordered_block);
         int64_t size;
-        RETURN_IF_ERROR(rowset_writer->flush_single_memtable(&ordered_block, &size));
+        RETURN_IF_ERROR(rowset_writer->flush_single_block(&ordered_block, &size));
     }
     LOG(INFO) << "calc segment delete bitmap, tablet: " << tablet_id() << " rowset: " << rowset_id
               << " seg_id: " << seg->id() << " dummy_version: " << end_version + 1


### PR DESCRIPTION
## Proposed changes

1. move memtable flush logic from `Memtable::flush()` to `BetaRowsetWriter::flush_memtable()`
2. move segment id assignment from `DeltaWriter::_flush_memtable_async()` to `FlushToken::submit()`.
3. cleanup `MemTable` class, removed dependency on `RowsetWriter` in `Memtable`.
4. avoid delta writer callback by moving `DeltaWriter::_memtable_stat` to `DeltaWriter::_memtable_stat`.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

