### PR TITLE
[Fix](ScannerScheduler) fix dead lock when shutdown group_local_scan_thread_pool

### DIFF
--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -66,22 +66,23 @@ ScannerScheduler::~ScannerScheduler() {
 
     _is_closed = true;
 
+    _task_group_local_scan_queue->close();
     _scheduler_pool->shutdown();
     _local_scan_thread_pool->shutdown();
     _remote_scan_thread_pool->shutdown();
     _limited_scan_thread_pool->shutdown();
+    _group_local_scan_thread_pool->shutdown();
 
     _scheduler_pool->wait();
     _local_scan_thread_pool->join();
+    _remote_scan_thread_pool->wait();
+    _limited_scan_thread_pool->wait();
+    _group_local_scan_thread_pool->wait();
 
     for (int i = 0; i < QUEUE_NUM; i++) {
         delete _pending_queues[i];
     }
     delete[] _pending_queues;
-
-    _task_group_local_scan_queue->close();
-    _group_local_scan_thread_pool->shutdown();
-    _group_local_scan_thread_pool->wait();
 }
 
 Status ScannerScheduler::init(ExecEnv* env) {

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -70,7 +70,6 @@ ScannerScheduler::~ScannerScheduler() {
     _local_scan_thread_pool->shutdown();
     _remote_scan_thread_pool->shutdown();
     _limited_scan_thread_pool->shutdown();
-    _group_local_scan_thread_pool->shutdown();
 
     _scheduler_pool->wait();
     _local_scan_thread_pool->join();
@@ -81,6 +80,7 @@ ScannerScheduler::~ScannerScheduler() {
     delete[] _pending_queues;
 
     _task_group_local_scan_queue->close();
+    _group_local_scan_thread_pool->shutdown();
     _group_local_scan_thread_pool->wait();
 }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

1. `_group_local_scan_thread_pool->shutdown();` is called before `_task_group_local_scan_queue->close();`. This could cause problems as threads in the thread pool might still be trying to fetch tasks from the queue. When you shut down the thread pool, these threads might get interrupted while there are still unprocessed tasks in the queue. To avoid this, we should first close the queue and then shut down the thread pool. This way, threads in the thread pool will not try to fetch new tasks after the queue is closed, but instead finish their current tasks and then exit.

2. `_scheduler_pool->wait();` and `_local_scan_thread_pool->join();` are called, but for the other thread pools (`_remote_scan_thread_pool`, `_limited_scan_thread_pool`, `_group_local_scan_thread_pool`), no corresponding `wait` or `join` methods are called. This could result in threads in these thread pools still running after the `ScannerScheduler` object has been destroyed, which could lead to undefined behavior. We should ensure that all threads have exited before destroying the `ScannerScheduler` object.


This PR first closes the task queue, then shuts down all the thread pools, and finally waits for all threads in the thread pools to exit. This ensures that all tasks are properly handled, all threads are properly exited, and avoids resource leaks and undefined behavior.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

