### PR TITLE
[improvement](multi catalog)Use getPartitionsByNames to retrieve hive partitions.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/PooledHiveMetaStoreClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/PooledHiveMetaStoreClient.java
@@ -152,6 +152,20 @@ public class PooledHiveMetaStoreClient {
         }
     }
 
+    public List<Partition> getPartitions(String dbName, String tblName, List<String> partitionNames) {
+        try (CachedClient client = getClient()) {
+            try {
+                return client.client.getPartitionsByNames(dbName, tblName, partitionNames);
+            } catch (Exception e) {
+                client.setThrowable(e);
+                throw e;
+            }
+        } catch (Exception e) {
+            throw new HMSClientException("failed to get partition for table %s in db %s with value %s", e, tblName,
+                dbName, partitionNames);
+        }
+    }
+
     public List<Partition> getPartitionsByFilter(String dbName, String tblName, String filter) {
         try (CachedClient client = getClient()) {
             try {

--- a/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -1739,13 +1739,17 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
     return getPartitionsByNames(getDefaultCatalog(conf), db_name, tbl_name, part_names);
   }
 
-  @Override
-  public List<Partition> getPartitionsByNames(String catName, String db_name, String tbl_name,
-                                              List<String> part_names) throws TException {
-    List<Partition> parts =
-        client.get_partitions_by_names(prependCatalogToDbName(catName, db_name, conf), tbl_name, part_names);
-    return deepCopyPartitions(filterHook.filterPartitions(parts));
-  }
+    @Override
+    public List<Partition> getPartitionsByNames(String catName, String db_name, String tbl_name,
+                                                List<String> part_names) throws TException {
+        if (hiveVersion == HiveVersion.V1_0 || hiveVersion == HiveVersion.V2_0 || hiveVersion == HiveVersion.V2_3) {
+            return deepCopyPartitions(
+                filterHook.filterPartitions(client.get_partitions_by_names(db_name, tbl_name, part_names)));
+        } else {
+            return deepCopyPartitions(filterHook.filterPartitions(
+                client.get_partitions_by_names(prependCatalogToDbName(catName, db_name, conf), tbl_name, part_names)));
+        }
+    }
 
   @Override
   public PartitionValuesResponse listPartitionValues(PartitionValuesRequest request)


### PR DESCRIPTION
<!--Describe your changes.-->
Before, we get hive partition using HMS getPartition api. In this case, each partition need to call the api once. The performance is very poor when partition number is large. This pr use getPartitionsByNames to get multiple partitions in one api call.
To get 90000 partitions, the time costing is reduced to 14s from 108s.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

