### PR TITLE
[Fix](Core) Fix core caused by null MowContext ptr

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -437,7 +437,7 @@ Status DeltaWriter::close_wait(const PSlaveTabletNodes& slave_tablet_nodes,
         // transient rowset writer to write the new segments, then merge it back the original
         // rowset.
         std::unique_ptr<RowsetWriter> rowset_writer;
-        std::unique_ptr<MowContext> mow_context_ptr = std::make_unique<MowContext>(
+        std::shared_ptr<MowContext> mow_context_ptr = std::make_shared<MowContext>(
                 _cur_max_version, _req.txn_id, _rowset_ids, _delete_bitmap);
         _tablet->create_transient_rowset_writer(_cur_rowset, mow_context_ptr, &rowset_writer);
         RETURN_IF_ERROR(_tablet->commit_phase_update_delete_bitmap(

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -437,8 +437,8 @@ Status DeltaWriter::close_wait(const PSlaveTabletNodes& slave_tablet_nodes,
         // transient rowset writer to write the new segments, then merge it back the original
         // rowset.
         std::unique_ptr<RowsetWriter> rowset_writer;
-        std::shared_ptr<MowContext> mow_context_ptr(
-                new MowContext(_cur_max_version, _req.txn_id, _rowset_ids, _delete_bitmap));
+        std::unique_ptr<MowContext> mow_context_ptr = std::make_unique<MowContext>(
+                _cur_max_version, _req.txn_id, _rowset_ids, _delete_bitmap);
         _tablet->create_transient_rowset_writer(_cur_rowset, mow_context_ptr, &rowset_writer);
         RETURN_IF_ERROR(_tablet->commit_phase_update_delete_bitmap(
                 _cur_rowset, _rowset_ids, _delete_bitmap, segments, _req.txn_id,

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1910,7 +1910,7 @@ Status Tablet::create_rowset_writer(RowsetWriterContext& context,
 // create a rowset writer with rowset_id and seg_id
 // after writer, merge this transient rowset with original rowset
 Status Tablet::create_transient_rowset_writer(const RowsetSharedPtr& rowset_ptr,
-                                              const std::unique_ptr<MowContext>& mow_context,
+                                              const std::shared_ptr<MowContext>& mow_context,
                                               std::unique_ptr<RowsetWriter>* rowset_writer) {
     RowsetWriterContext context;
     context.rowset_state = PREPARED;

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1910,7 +1910,7 @@ Status Tablet::create_rowset_writer(RowsetWriterContext& context,
 // create a rowset writer with rowset_id and seg_id
 // after writer, merge this transient rowset with original rowset
 Status Tablet::create_transient_rowset_writer(const RowsetSharedPtr& rowset_ptr,
-                                              const std::shared_ptr<MowContext>& mow_context,
+                                              const std::unique_ptr<MowContext>& mow_context,
                                               std::unique_ptr<RowsetWriter>* rowset_writer) {
     RowsetWriterContext context;
     context.rowset_state = PREPARED;

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1909,7 +1909,8 @@ Status Tablet::create_rowset_writer(RowsetWriterContext& context,
 
 // create a rowset writer with rowset_id and seg_id
 // after writer, merge this transient rowset with original rowset
-Status Tablet::create_transient_rowset_writer(RowsetSharedPtr rowset_ptr,
+Status Tablet::create_transient_rowset_writer(const RowsetSharedPtr& rowset_ptr,
+                                              const std::shared_ptr<MowContext>& mow_context,
                                               std::unique_ptr<RowsetWriter>* rowset_writer) {
     RowsetWriterContext context;
     context.rowset_state = PREPARED;
@@ -1919,6 +1920,7 @@ Status Tablet::create_transient_rowset_writer(RowsetSharedPtr rowset_ptr,
     context.tablet_schema->set_partial_update_info(false, std::set<std::string>());
     context.newest_write_timestamp = UnixSeconds();
     context.tablet_id = table_id();
+    context.mow_context = mow_context;
     // ATTN: context.tablet is a shared_ptr, can't simply set it's value to `this`. We should
     // get the shared_ptr from tablet_manager.
     context.tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id());

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -330,7 +330,7 @@ public:
                                 std::unique_ptr<RowsetWriter>* rowset_writer);
 
     Status create_transient_rowset_writer(const RowsetSharedPtr& rowset_ptr,
-                                          const std::shared_ptr<MowContext>& mow_context,
+                                          const std::unique_ptr<MowContext>& mow_context,
                                           std::unique_ptr<RowsetWriter>* rowset_writer);
     Status create_transient_rowset_writer(RowsetWriterContext& context, const RowsetId& rowset_id,
                                           std::unique_ptr<RowsetWriter>* rowset_writer);

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -329,7 +329,8 @@ public:
     Status create_rowset_writer(RowsetWriterContext& context,
                                 std::unique_ptr<RowsetWriter>* rowset_writer);
 
-    Status create_transient_rowset_writer(RowsetSharedPtr rowset_ptr,
+    Status create_transient_rowset_writer(const RowsetSharedPtr& rowset_ptr,
+                                          const std::shared_ptr<MowContext>& mow_context,
                                           std::unique_ptr<RowsetWriter>* rowset_writer);
     Status create_transient_rowset_writer(RowsetWriterContext& context, const RowsetId& rowset_id,
                                           std::unique_ptr<RowsetWriter>* rowset_writer);

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -330,7 +330,7 @@ public:
                                 std::unique_ptr<RowsetWriter>* rowset_writer);
 
     Status create_transient_rowset_writer(const RowsetSharedPtr& rowset_ptr,
-                                          const std::unique_ptr<MowContext>& mow_context,
+                                          const std::shared_ptr<MowContext>& mow_context,
                                           std::unique_ptr<RowsetWriter>* rowset_writer);
     Status create_transient_rowset_writer(RowsetWriterContext& context, const RowsetId& rowset_id,
                                           std::unique_ptr<RowsetWriter>* rowset_writer);

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -25,6 +25,7 @@
 #include <filesystem>
 #include <iterator>
 #include <list>
+#include <memory>
 #include <new>
 #include <ostream>
 #include <queue>
@@ -35,6 +36,7 @@
 #include "common/logging.h"
 #include "olap/data_dir.h"
 #include "olap/delta_writer.h"
+#include "olap/olap_common.h"
 #include "olap/rowset/rowset_meta.h"
 #include "olap/rowset/rowset_meta_manager.h"
 #include "olap/schema_change.h"
@@ -375,7 +377,10 @@ Status TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id,
     // update delete_bitmap
     if (tablet_txn_info.unique_key_merge_on_write) {
         std::unique_ptr<RowsetWriter> rowset_writer;
-        tablet->create_transient_rowset_writer(rowset, &rowset_writer);
+        std::shared_ptr<MowContext> mow_context_ptr(new MowContext(version.second, transaction_id,
+                                                                   tablet_txn_info.rowset_ids,
+                                                                   tablet_txn_info.delete_bitmap));
+        tablet->create_transient_rowset_writer(rowset, mow_context_ptr, &rowset_writer);
 
         int64_t t2 = MonotonicMicros();
         RETURN_IF_ERROR(tablet->update_delete_bitmap(rowset, tablet_txn_info.rowset_ids,

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -377,9 +377,9 @@ Status TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id,
     // update delete_bitmap
     if (tablet_txn_info.unique_key_merge_on_write) {
         std::unique_ptr<RowsetWriter> rowset_writer;
-        std::shared_ptr<MowContext> mow_context_ptr(new MowContext(version.second, transaction_id,
-                                                                   tablet_txn_info.rowset_ids,
-                                                                   tablet_txn_info.delete_bitmap));
+        std::unique_ptr<MowContext> mow_context_ptr = std::make_unique<MowContext>(
+                version.second, transaction_id, tablet_txn_info.rowset_ids,
+                tablet_txn_info.delete_bitmap);
         tablet->create_transient_rowset_writer(rowset, mow_context_ptr, &rowset_writer);
 
         int64_t t2 = MonotonicMicros();

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -377,7 +377,7 @@ Status TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id,
     // update delete_bitmap
     if (tablet_txn_info.unique_key_merge_on_write) {
         std::unique_ptr<RowsetWriter> rowset_writer;
-        std::unique_ptr<MowContext> mow_context_ptr = std::make_unique<MowContext>(
+        std::shared_ptr<MowContext> mow_context_ptr = std::make_shared<MowContext>(
                 version.second, transaction_id, tablet_txn_info.rowset_ids,
                 tablet_txn_info.delete_bitmap);
         tablet->create_transient_rowset_writer(rowset, mow_context_ptr, &rowset_writer);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

Query id: 0-0 ***
Aborted at 1688614857 (unix time) try "date -d @1688614857" if you are using GNU date ***
Current BE git commitID: b3db904847 ***
SIGSEGV address not mapped to object (@0x10) received by PID 1580278 (TID 1581464 OR 0x7efa1ede9700) from PID 16; stack trace: ***
0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:413

1# 0x00007F0BDD7800A7 in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so

2# JVM_handle_linux_signal in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so

3# 0x00007F0BDD77902C in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so

4# 0x00007F0BFF89D090 in /lib/x86_64-linux-gnu/libc.so.6

5# doris::BetaRowsetWriter::_generate_delete_bitmap(int) at /home/zcp/repo_center/doris_master/doris/be/src/olap/rowset/beta_rowset_writer.cpp:158

6# doris::BetaRowsetWriter::flush_single_memtable(doris::vectorized::Block const*, long*, doris::FlushContext const*) at /home/zcp/repo_center/doris_master/doris/be/src/olap/rowset/beta_rowset_writer.cpp:535

7# doris::Tablet::calc_segment_delete_bitmap(std::shared_ptr<doris::Rowset>, std::shared_ptr<doris::segment_v2::Segment> const&, std::vector<std::shared_ptr<doris::Rowset>, std::allocator<std::shared_ptr<doris::Rowset> > > const&, std::shared_ptr<doris::DeleteBitmap>, long, doris::RowsetWriter*) in /mnt/ssd01/doris-master/VEC_ASAN/be/lib/doris_be

8# doris::Tablet::calc_delete_bitmap(std::shared_ptr<doris::Rowset>, std::vector<std::shared_ptr<doris::segment_v2::Segment>, std::allocator<std::shared_ptr<doris::segment_v2::Segment> > > const&, std::vector<std::shared_ptr<doris::Rowset>, std::allocator<std::shared_ptr<doris::Rowset> > > const&, std::shared_ptr<doris::DeleteBitmap>, long, doris::RowsetWriter*) at /home/zcp/repo_center/doris_master/doris/be/src/olap/tablet.cpp:3003

9# doris::Tablet::update_delete_bitmap(std::shared_ptr<doris::Rowset> const&, std::unordered_set<doris::RowsetId, doris::HashOfRowsetId, std::equal_to<doris::RowsetId>, std::allocator<doris::RowsetId> > const&, std::shared_ptr<doris::DeleteBitmap>, long, doris::RowsetWriter*) at /home/zcp/repo_center/doris_master/doris/be/src/olap/tablet.cpp:3284

10# doris::TxnManager::publish_txn(doris::OlapMeta*, long, long, long, int, doris::UniqueId, doris::Version const&, doris::TabletPublishStatistics*) at /home/zcp/repo_center/doris_master/doris/be/src/olap/txn_manager.cpp:378

11# doris::TxnManager::publish_txn(long, std::shared_ptr<doris::Tablet> const&, long, doris::Version const&, doris::TabletPublishStatistics*) at /home/zcp/repo_center/doris_master/doris/be/src/olap/txn_manager.cpp:171

12# doris::TabletPublishTxnTask::handle() at /home/zcp/repo_center/doris_master/doris/be/src/olap/task/engine_publish_version_task.cpp:248

13# doris::ThreadPool::dispatch_thread() in /mnt/ssd01/doris-master/VEC_ASAN/be/lib/doris_be

14# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_master/doris/be/src/util/thread.cpp:466

15# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478

16# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

