### PR TITLE
[fix](type system) fix write column to arrow with null date

### DIFF
--- a/be/src/vec/data_types/serde/data_type_array_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_array_serde.cpp
@@ -58,9 +58,14 @@ void DataTypeArraySerDe::write_column_to_arrow(const IColumn& column, const UInt
     auto& builder = assert_cast<arrow::ListBuilder&>(*array_builder);
     auto nested_builder = builder.value_builder();
     for (size_t array_idx = start; array_idx < end; ++array_idx) {
-        checkArrowStatus(builder.Append(), column.get_name(), array_builder->type()->name());
-        nested_serde->write_column_to_arrow(nested_data, null_map, nested_builder,
-                                            offsets[array_idx - 1], offsets[array_idx]);
+        if (null_map && !null_map[array_idx]) {
+            checkArrowStatus(builder.AppendNull(), column.get_name(),
+                             array_builder->type()->name());
+        } else {
+            checkArrowStatus(builder.Append(), column.get_name(), array_builder->type()->name());
+            nested_serde->write_column_to_arrow(nested_data, null_map, nested_builder,
+                                                offsets[array_idx - 1], offsets[array_idx]);
+        }
     }
 }
 

--- a/be/src/vec/data_types/serde/data_type_date64_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_date64_serde.cpp
@@ -37,7 +37,7 @@ void DataTypeDate64SerDe::write_column_to_arrow(const IColumn& column, const UIn
         const vectorized::VecDateTimeValue* time_val =
                 (const vectorized::VecDateTimeValue*)(&col_data[i]);
         int len = time_val->to_buffer(buf);
-        if (null_map && null_map[i]) {
+        if (null_map && !null_map[i]) {
             checkArrowStatus(string_builder.AppendNull(), column.get_name(),
                              array_builder->type()->name());
         } else {

--- a/be/src/vec/data_types/serde/data_type_datetimev2_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_datetimev2_serde.cpp
@@ -37,7 +37,7 @@ void DataTypeDateTimeV2SerDe::write_column_to_arrow(const IColumn& column, const
         const vectorized::DateV2Value<vectorized::DateTimeV2ValueType>* time_val =
                 (const vectorized::DateV2Value<vectorized::DateTimeV2ValueType>*)(&col_data[i]);
         int len = time_val->to_buffer(buf);
-        if (null_map && null_map[i]) {
+        if (null_map && !null_map[i]) {
             checkArrowStatus(string_builder.AppendNull(), column.get_name(),
                              array_builder->type()->name());
         } else {

--- a/be/src/vec/data_types/serde/data_type_datev2_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_datev2_serde.cpp
@@ -37,7 +37,9 @@ void DataTypeDateV2SerDe::write_column_to_arrow(const IColumn& column, const UIn
         const vectorized::DateV2Value<vectorized::DateV2ValueType>* time_val =
                 (const vectorized::DateV2Value<vectorized::DateV2ValueType>*)(&col_data[i]);
         int len = time_val->to_buffer(buf);
-        if (null_map && null_map[i]) {
+        // null_map is true if a column has an empty value
+        // null_map[i] true if it gets data, false if it doesn't
+        if (null_map && !null_map[i]) {
             checkArrowStatus(string_builder.AppendNull(), column.get_name(),
                              array_builder->type()->name());
         } else {

--- a/be/src/vec/data_types/serde/data_type_decimal_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_decimal_serde.cpp
@@ -41,7 +41,7 @@ void DataTypeDecimalSerDe<T>::write_column_to_arrow(const IColumn& column, const
         std::shared_ptr<arrow::DataType> s_decimal_ptr =
                 std::make_shared<arrow::Decimal128Type>(27, 9);
         for (size_t i = start; i < end; ++i) {
-            if (null_map && null_map[i]) {
+            if (null_map && !null_map[i]) {
                 checkArrowStatus(builder.AppendNull(), column.get_name(),
                                  array_builder->type()->name());
                 continue;
@@ -58,7 +58,7 @@ void DataTypeDecimalSerDe<T>::write_column_to_arrow(const IColumn& column, const
         std::shared_ptr<arrow::DataType> s_decimal_ptr =
                 std::make_shared<arrow::Decimal128Type>(38, col.get_scale());
         for (size_t i = start; i < end; ++i) {
-            if (null_map && null_map[i]) {
+            if (null_map && !null_map[i]) {
                 checkArrowStatus(builder.AppendNull(), column.get_name(),
                                  array_builder->type()->name());
                 continue;
@@ -75,7 +75,7 @@ void DataTypeDecimalSerDe<T>::write_column_to_arrow(const IColumn& column, const
         std::shared_ptr<arrow::DataType> s_decimal_ptr =
                 std::make_shared<arrow::Decimal128Type>(8, col.get_scale());
         for (size_t i = start; i < end; ++i) {
-            if (null_map && null_map[i]) {
+            if (null_map && !null_map[i]) {
                 checkArrowStatus(builder.AppendNull(), column.get_name(),
                                  array_builder->type()->name());
                 continue;
@@ -91,7 +91,7 @@ void DataTypeDecimalSerDe<T>::write_column_to_arrow(const IColumn& column, const
         std::shared_ptr<arrow::DataType> s_decimal_ptr =
                 std::make_shared<arrow::Decimal128Type>(18, col.get_scale());
         for (size_t i = start; i < end; ++i) {
-            if (null_map && null_map[i]) {
+            if (null_map && !null_map[i]) {
                 checkArrowStatus(builder.AppendNull(), column.get_name(),
                                  array_builder->type()->name());
                 continue;

--- a/be/src/vec/data_types/serde/data_type_hll_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_hll_serde.cpp
@@ -87,7 +87,7 @@ void DataTypeHLLSerDe::write_column_to_arrow(const IColumn& column, const UInt8*
     const auto& col = assert_cast<const ColumnHLL&>(column);
     auto& builder = assert_cast<arrow::StringBuilder&>(*array_builder);
     for (size_t string_i = start; string_i < end; ++string_i) {
-        if (null_map && null_map[string_i]) {
+        if (null_map && !null_map[string_i]) {
             checkArrowStatus(builder.AppendNull(), column.get_name(),
                              array_builder->type()->name());
         } else {

--- a/be/src/vec/data_types/serde/data_type_string_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_string_serde.cpp
@@ -74,7 +74,7 @@ void DataTypeStringSerDe::write_column_to_arrow(const IColumn& column, const UIn
     const auto& string_column = assert_cast<const ColumnString&>(column);
     auto& builder = assert_cast<arrow::StringBuilder&>(*array_builder);
     for (size_t string_i = start; string_i < end; ++string_i) {
-        if (null_map && null_map[string_i]) {
+        if (null_map && !null_map[string_i]) {
             checkArrowStatus(builder.AppendNull(), column.get_name(),
                              array_builder->type()->name());
             continue;


### PR DESCRIPTION
## Proposed changes

`null_map` is defined by `res.empty()? nullptr: res.data()` generation, the original logic is incorrect for `null_map[i]`, which represents whether a value is available, not whether it is empty

```
        // null_map is true if a column has an empty value
        // null_map[i] true if it gets data, false if it doesn't
        if (null_map && !null_map[i]) {
            checkArrowStatus(string_builder.AppendNull(), column.get_name(),
                             array_builder->type()->name());
        } else {
            checkArrowStatus(string_builder.Append(buf, len), column.get_name(),
                             array_builder->type()->name());
        }
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

