### PR TITLE
[fix](stats) fix when some stat is NULL, causing an exception during display stat

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
@@ -154,13 +154,13 @@ public class ColumnStatistic {
             }
             String min = resultRow.getColumnValue("min");
             String max = resultRow.getColumnValue("max");
-            if (min != null) {
+            if (min != null && !min.equalsIgnoreCase("NULL")) {
                 columnStatisticBuilder.setMinValue(StatisticsUtil.convertToDouble(col.getType(), min));
                 columnStatisticBuilder.setMinExpr(StatisticsUtil.readableValue(col.getType(), min));
             } else {
                 columnStatisticBuilder.setMinValue(Double.MIN_VALUE);
             }
-            if (max != null) {
+            if (max != null && !max.equalsIgnoreCase("NULL")) {
                 columnStatisticBuilder.setMaxValue(StatisticsUtil.convertToDouble(col.getType(), max));
                 columnStatisticBuilder.setMaxExpr(StatisticsUtil.readableValue(col.getType(), max));
             } else {


### PR DESCRIPTION
## Proposed changes

During manual statistics injection, some statistics may be`NULL`, causing an exception during display.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

