### PR TITLE
[Enhancement](multi-catalog) Merge hms events every round to speed up events processing.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AddPartitionEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AddPartitionEvent.java
@@ -41,6 +41,14 @@ public class AddPartitionEvent extends MetastoreTableEvent {
     private final Table hmsTbl;
     private final List<String> partitionNames;
 
+    // for test
+    public AddPartitionEvent(long eventId, String catalogName, String dbName,
+                             String tblName, List<String> partitionNames) {
+        super(eventId, catalogName, dbName, tblName);
+        this.partitionNames = partitionNames;
+        this.hmsTbl = null;
+    }
+
     private AddPartitionEvent(NotificationEvent event,
             String catalogName) {
         super(event, catalogName);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AddPartitionEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AddPartitionEvent.java
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
 /**
  * MetastoreEvent for ADD_PARTITION event type
  */
-public class AddPartitionEvent extends MetastoreTableEvent {
+public class AddPartitionEvent extends MetastorePartitionEvent {
     private final Table hmsTbl;
     private final List<String> partitionNames;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterDatabaseEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterDatabaseEvent.java
@@ -41,6 +41,14 @@ public class AlterDatabaseEvent extends MetastoreEvent {
     // true if this alter event was due to a rename operation
     private final boolean isRename;
 
+    // for test
+    public AlterDatabaseEvent(long eventId, String catalogName, String dbName, boolean isRename) {
+        super(eventId, catalogName, dbName, null);
+        this.isRename = isRename;
+        this.dbBefore = null;
+        this.dbAfter = null;
+    }
+
     private AlterDatabaseEvent(NotificationEvent event,
             String catalogName) {
         super(event, catalogName);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterDatabaseEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterDatabaseEvent.java
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+
 package org.apache.doris.datasource.hive.event;
 
 import org.apache.doris.catalog.Env;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterDatabaseEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterDatabaseEvent.java
@@ -18,21 +18,66 @@
 
 package org.apache.doris.datasource.hive.event;
 
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.DdlException;
+import org.apache.doris.datasource.CatalogIf;
+import org.apache.doris.datasource.ExternalCatalog;
+import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.NotificationEvent;
+import org.apache.hadoop.hive.metastore.messaging.json.JSONAlterDatabaseMessage;
+
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import org.apache.hadoop.hive.metastore.api.NotificationEvent;
 
 import java.util.List;
 
 /**
- * MetastoreEvent for Alter_DATABASE event type
+ * MetastoreEvent for ALTER_DATABASE event type
  */
 public class AlterDatabaseEvent extends MetastoreEvent {
+
+    private final Database dbBefore;
+    private final Database dbAfter;
+
+    // true if this alter event was due to a rename operation
+    private final boolean isRename;
 
     private AlterDatabaseEvent(NotificationEvent event,
             String catalogName) {
         super(event, catalogName);
         Preconditions.checkArgument(getEventType().equals(MetastoreEventType.ALTER_DATABASE));
+
+        try {
+            JSONAlterDatabaseMessage alterDatabaseMessage =
+                    (JSONAlterDatabaseMessage) MetastoreEventsProcessor.getMessageDeserializer(event.getMessageFormat())
+                                .getAlterDatabaseMessage(event.getMessage());
+            dbBefore = Preconditions.checkNotNull(alterDatabaseMessage.getDbObjBefore());
+            dbAfter = Preconditions.checkNotNull(alterDatabaseMessage.getDbObjAfter());
+        } catch (Exception e) {
+            throw new MetastoreNotificationException(
+                    debugString("Unable to parse the alter database message"), e);
+        }
+        // this is a rename event if either dbName of before and after object changed
+        isRename = !dbBefore.getName().equalsIgnoreCase(dbAfter.getName());
+    }
+
+    private void processRename() throws DdlException {
+        CatalogIf catalog = Env.getCurrentEnv().getCatalogMgr().getCatalog(catalogName);
+        if (catalog == null) {
+            throw new DdlException("No catalog found with name: " + catalogName);
+        }
+        if (!(catalog instanceof ExternalCatalog)) {
+            throw new DdlException("Only support ExternalCatalog Databases");
+        }
+        if (catalog.getDbNullable(dbAfter.getName()) != null) {
+            infoLog("AlterExternalDatabase canceled, because dbAfter has exist, "
+                            + "catalogName:[{}],dbName:[{}]",
+                    catalogName, dbAfter.getName());
+            return;
+        }
+        Env.getCurrentEnv().getCatalogMgr().dropExternalDatabase(dbBefore.getName(), catalogName, true);
+        Env.getCurrentEnv().getCatalogMgr().createExternalDatabase(dbAfter.getName(), catalogName, true);
+
     }
 
     protected static List<MetastoreEvent> getEvents(NotificationEvent event,
@@ -40,9 +85,22 @@ public class AlterDatabaseEvent extends MetastoreEvent {
         return Lists.newArrayList(new AlterDatabaseEvent(event, catalogName));
     }
 
+    public boolean isRename() {
+        return isRename;
+    }
+
     @Override
     protected void process() throws MetastoreNotificationException {
-        // only can change properties,we do nothing
-        infoLog("catalogName:[{}],dbName:[{}]", catalogName, dbName);
+        try {
+            if (isRename) {
+                processRename();
+                return;
+            }
+            // only can change properties,we do nothing
+            infoLog("catalogName:[{}],dbName:[{}]", catalogName, dbName);
+        } catch (Exception e) {
+            throw new MetastoreNotificationException(
+                    debugString("Failed to process event"), e);
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterDatabaseEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterDatabaseEvent.java
@@ -15,19 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
-
 package org.apache.doris.datasource.hive.event;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.datasource.ExternalCatalog;
-import org.apache.hadoop.hive.metastore.api.Database;
-import org.apache.hadoop.hive.metastore.api.NotificationEvent;
-import org.apache.hadoop.hive.metastore.messaging.json.JSONAlterDatabaseMessage;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.NotificationEvent;
+import org.apache.hadoop.hive.metastore.messaging.json.JSONAlterDatabaseMessage;
 
 import java.util.List;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterPartitionEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterPartitionEvent.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.messaging.AlterPartitionMessage;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -93,5 +94,13 @@ public class AlterPartitionEvent extends MetastoreTableEvent {
             throw new MetastoreNotificationException(
                     debugString("Failed to process event"), e);
         }
+    }
+
+    @Override
+    protected boolean canBeBatched(MetastoreEvent event) {
+        return event instanceof AlterPartitionEvent
+                    && isSameTable((MetastoreTableEvent) event)
+                    && Objects.equals(partitionBefore, ((AlterPartitionEvent) event).partitionBefore)
+                    && Objects.equals(partitionAfter, ((AlterPartitionEvent) event).partitionAfter);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterPartitionEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterPartitionEvent.java
@@ -45,6 +45,18 @@ public class AlterPartitionEvent extends MetastoreTableEvent {
     // true if this alter event was due to a rename operation
     private final boolean isRename;
 
+    // for test
+    public AlterPartitionEvent(long eventId, String catalogName, String dbName, String tblName,
+                                String partitionNameBefore, String partitionNameAfter) {
+        super(eventId, catalogName, dbName, tblName);
+        this.partitionNameBefore = partitionNameBefore;
+        this.partitionNameAfter = partitionNameAfter;
+        this.hmsTbl = null;
+        this.partitionAfter = null;
+        this.partitionBefore = null;
+        isRename = !partitionNameBefore.equalsIgnoreCase(partitionNameAfter);
+    }
+
     private AlterPartitionEvent(NotificationEvent event,
             String catalogName) {
         super(event, catalogName);
@@ -99,7 +111,7 @@ public class AlterPartitionEvent extends MetastoreTableEvent {
     @Override
     protected boolean canBeBatched(MetastoreEvent event) {
         return event instanceof AlterPartitionEvent
-                    && isSameTable((MetastoreTableEvent) event)
+                    && isSameTable(event)
                     && Objects.equals(partitionBefore, ((AlterPartitionEvent) event).partitionBefore)
                     && Objects.equals(partitionAfter, ((AlterPartitionEvent) event).partitionAfter);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterPartitionEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterPartitionEvent.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
 /**
  * MetastoreEvent for ALTER_PARTITION event type
  */
-public class AlterPartitionEvent extends MetastoreTableEvent {
+public class AlterPartitionEvent extends MetastorePartitionEvent {
     private final Table hmsTbl;
     private final org.apache.hadoop.hive.metastore.api.Partition partitionAfter;
     private final org.apache.hadoop.hive.metastore.api.Partition partitionBefore;
@@ -110,8 +110,8 @@ public class AlterPartitionEvent extends MetastoreTableEvent {
 
     @Override
     protected boolean canBeBatched(MetastoreEvent event) {
-        return event instanceof AlterPartitionEvent
-                    && isSameTable(event)
+        return isSameTable(event)
+                    && event instanceof AlterPartitionEvent
                     && Objects.equals(partitionBefore, ((AlterPartitionEvent) event).partitionBefore)
                     && Objects.equals(partitionAfter, ((AlterPartitionEvent) event).partitionAfter);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterTableEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterTableEvent.java
@@ -124,4 +124,10 @@ public class AlterTableEvent extends MetastoreTableEvent {
                     debugString("Failed to process event"), e);
         }
     }
+
+    @Override
+    protected boolean overrideGroupEvents() {
+        // The processor will recreate/rename/refresh the hms table, so we can skip all the group events earlier
+        return true;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterTableEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterTableEvent.java
@@ -101,6 +101,10 @@ public class AlterTableEvent extends MetastoreTableEvent {
         return isRename;
     }
 
+    public boolean isView() {
+        return isView;
+    }
+
     /**
      * If the ALTER_TABLE event is due a table rename, this method removes the old table
      * and creates a new table with the new name. Else, we just refresh table
@@ -127,5 +131,22 @@ public class AlterTableEvent extends MetastoreTableEvent {
             throw new MetastoreNotificationException(
                     debugString("Failed to process event"), e);
         }
+    }
+
+    @Override
+    protected boolean canBeBatched(MetastoreEvent that) {
+        if (!(that instanceof MetastoreTableEvent) || !isSameTable((MetastoreTableEvent) that)) {
+            return false;
+        }
+        if (that instanceof DropTableEvent) {
+            return false;
+        }
+        if (that instanceof CreateTableEvent) {
+            return false;
+        }
+        if (that instanceof AlterTableEvent) {
+            return !((AlterTableEvent) that).isRename() && !((AlterTableEvent) that).isView();
+        }
+        return true;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterTableEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterTableEvent.java
@@ -97,6 +97,10 @@ public class AlterTableEvent extends MetastoreTableEvent {
 
     }
 
+    public boolean isRename() {
+        return isRename;
+    }
+
     /**
      * If the ALTER_TABLE event is due a table rename, this method removes the old table
      * and creates a new table with the new name. Else, we just refresh table
@@ -123,11 +127,5 @@ public class AlterTableEvent extends MetastoreTableEvent {
             throw new MetastoreNotificationException(
                     debugString("Failed to process event"), e);
         }
-    }
-
-    @Override
-    protected boolean overrideGroupEvents() {
-        // The processor will recreate/rename/refresh the hms table, so we can skip all the group events earlier
-        return true;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterTableEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterTableEvent.java
@@ -42,6 +42,16 @@ public class AlterTableEvent extends MetastoreTableEvent {
     private final boolean isRename;
     private final boolean isView;
 
+    // for test
+    public AlterTableEvent(long eventId, String catalogName, String dbName,
+                             String tblName, boolean isRename, boolean isView) {
+        super(eventId, catalogName, dbName, tblName);
+        this.isRename = isRename;
+        this.isView = isView;
+        this.tableBefore = null;
+        this.tableAfter = null;
+    }
+
     private AlterTableEvent(NotificationEvent event, String catalogName) {
         super(event, catalogName);
         Preconditions.checkArgument(MetastoreEventType.ALTER_TABLE.equals(getEventType()));

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterTableEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterTableEvent.java
@@ -135,7 +135,7 @@ public class AlterTableEvent extends MetastoreTableEvent {
 
     @Override
     protected boolean canBeBatched(MetastoreEvent that) {
-        if (!(that instanceof MetastoreTableEvent) || !isSameTable((MetastoreTableEvent) that)) {
+        if (!(that instanceof MetastoreTableEvent) || !isSameTable(that)) {
             return false;
         }
         if (that instanceof DropTableEvent) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterTableEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterTableEvent.java
@@ -56,25 +56,25 @@ public class AlterTableEvent extends MetastoreTableEvent {
         super(event, catalogName);
         Preconditions.checkArgument(MetastoreEventType.ALTER_TABLE.equals(getEventType()));
         Preconditions
-            .checkNotNull(event.getMessage(), debugString("Event message is null"));
+                .checkNotNull(event.getMessage(), debugString("Event message is null"));
         try {
             JSONAlterTableMessage alterTableMessage =
-                (JSONAlterTableMessage) MetastoreEventsProcessor.getMessageDeserializer(event.getMessageFormat())
-                    .getAlterTableMessage(event.getMessage());
+                    (JSONAlterTableMessage) MetastoreEventsProcessor.getMessageDeserializer(event.getMessageFormat())
+                            .getAlterTableMessage(event.getMessage());
             tableAfter = Preconditions.checkNotNull(alterTableMessage.getTableObjAfter());
             tableBefore = Preconditions.checkNotNull(alterTableMessage.getTableObjBefore());
         } catch (Exception e) {
             throw new MetastoreNotificationException(
-                debugString("Unable to parse the alter table message"), e);
+                    debugString("Unable to parse the alter table message"), e);
         }
         // this is a rename event if either dbName or tblName of before and after object changed
         isRename = !tableBefore.getDbName().equalsIgnoreCase(tableAfter.getDbName())
-            || !tableBefore.getTableName().equalsIgnoreCase(tableAfter.getTableName());
+                || !tableBefore.getTableName().equalsIgnoreCase(tableAfter.getTableName());
         isView = tableBefore.isSetViewExpandedText() || tableBefore.isSetViewOriginalText();
     }
 
     public static List<MetastoreEvent> getEvents(NotificationEvent event,
-                                                 String catalogName) {
+            String catalogName) {
         return Lists.newArrayList(new AlterTableEvent(event, catalogName));
     }
 
@@ -83,9 +83,9 @@ public class AlterTableEvent extends MetastoreTableEvent {
             return;
         }
         Env.getCurrentEnv().getCatalogMgr()
-            .dropExternalTable(tableBefore.getDbName(), tableBefore.getTableName(), catalogName, true);
+                .dropExternalTable(tableBefore.getDbName(), tableBefore.getTableName(), catalogName, true);
         Env.getCurrentEnv().getCatalogMgr()
-            .createExternalTableFromEvent(tableAfter.getDbName(), tableAfter.getTableName(), catalogName, true);
+                .createExternalTableFromEvent(tableAfter.getDbName(), tableAfter.getTableName(), catalogName, true);
     }
 
     private void processRename() throws DdlException {
@@ -93,17 +93,17 @@ public class AlterTableEvent extends MetastoreTableEvent {
             return;
         }
         boolean hasExist = Env.getCurrentEnv().getCatalogMgr()
-            .externalTableExistInLocal(tableAfter.getDbName(), tableAfter.getTableName(), catalogName);
+                .externalTableExistInLocal(tableAfter.getDbName(), tableAfter.getTableName(), catalogName);
         if (hasExist) {
             infoLog("AlterExternalTable canceled,because tableAfter has exist, "
-                    + "catalogName:[{}],dbName:[{}],tableName:[{}]",
-                catalogName, dbName, tableAfter.getTableName());
+                            + "catalogName:[{}],dbName:[{}],tableName:[{}]",
+                    catalogName, dbName, tableAfter.getTableName());
             return;
         }
         Env.getCurrentEnv().getCatalogMgr()
-            .dropExternalTable(tableBefore.getDbName(), tableBefore.getTableName(), catalogName, true);
+                .dropExternalTable(tableBefore.getDbName(), tableBefore.getTableName(), catalogName, true);
         Env.getCurrentEnv().getCatalogMgr()
-            .createExternalTableFromEvent(tableAfter.getDbName(), tableAfter.getTableName(), catalogName, true);
+                .createExternalTableFromEvent(tableAfter.getDbName(), tableAfter.getTableName(), catalogName, true);
 
     }
 
@@ -123,7 +123,7 @@ public class AlterTableEvent extends MetastoreTableEvent {
     protected void process() throws MetastoreNotificationException {
         try {
             infoLog("catalogName:[{}],dbName:[{}],tableBefore:[{}],tableAfter:[{}]", catalogName, dbName,
-                tableBefore.getTableName(), tableAfter.getTableName());
+                    tableBefore.getTableName(), tableAfter.getTableName());
             if (isRename) {
                 processRename();
                 return;
@@ -136,10 +136,10 @@ public class AlterTableEvent extends MetastoreTableEvent {
             }
             //The scope of refresh can be narrowed in the future
             Env.getCurrentEnv().getCatalogMgr()
-                .refreshExternalTable(tableBefore.getDbName(), tableBefore.getTableName(), catalogName, true);
+                    .refreshExternalTable(tableBefore.getDbName(), tableBefore.getTableName(), catalogName, true);
         } catch (Exception e) {
             throw new MetastoreNotificationException(
-                debugString("Failed to process event"), e);
+                    debugString("Failed to process event"), e);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterTableEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterTableEvent.java
@@ -152,8 +152,7 @@ public class AlterTableEvent extends MetastoreTableEvent {
             return true;
         }
         if (that instanceof AlterTableEvent) {
-            // `that` event must not be a rename event
-            return !((AlterTableEvent) that).isView();
+            return !((AlterTableEvent) that).isRename() && !((AlterTableEvent) that).isView();
         }
         return !(that instanceof DropTableEvent) && !(that instanceof CreateTableEvent);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterTableEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterTableEvent.java
@@ -44,7 +44,7 @@ public class AlterTableEvent extends MetastoreTableEvent {
 
     // for test
     public AlterTableEvent(long eventId, String catalogName, String dbName,
-                             String tblName, boolean isRename, boolean isView) {
+                           String tblName, boolean isRename, boolean isView) {
         super(eventId, catalogName, dbName, tblName);
         this.isRename = isRename;
         this.isView = isView;
@@ -56,25 +56,25 @@ public class AlterTableEvent extends MetastoreTableEvent {
         super(event, catalogName);
         Preconditions.checkArgument(MetastoreEventType.ALTER_TABLE.equals(getEventType()));
         Preconditions
-                .checkNotNull(event.getMessage(), debugString("Event message is null"));
+            .checkNotNull(event.getMessage(), debugString("Event message is null"));
         try {
             JSONAlterTableMessage alterTableMessage =
-                    (JSONAlterTableMessage) MetastoreEventsProcessor.getMessageDeserializer(event.getMessageFormat())
-                            .getAlterTableMessage(event.getMessage());
+                (JSONAlterTableMessage) MetastoreEventsProcessor.getMessageDeserializer(event.getMessageFormat())
+                    .getAlterTableMessage(event.getMessage());
             tableAfter = Preconditions.checkNotNull(alterTableMessage.getTableObjAfter());
             tableBefore = Preconditions.checkNotNull(alterTableMessage.getTableObjBefore());
         } catch (Exception e) {
             throw new MetastoreNotificationException(
-                    debugString("Unable to parse the alter table message"), e);
+                debugString("Unable to parse the alter table message"), e);
         }
         // this is a rename event if either dbName or tblName of before and after object changed
         isRename = !tableBefore.getDbName().equalsIgnoreCase(tableAfter.getDbName())
-                || !tableBefore.getTableName().equalsIgnoreCase(tableAfter.getTableName());
+            || !tableBefore.getTableName().equalsIgnoreCase(tableAfter.getTableName());
         isView = tableBefore.isSetViewExpandedText() || tableBefore.isSetViewOriginalText();
     }
 
     public static List<MetastoreEvent> getEvents(NotificationEvent event,
-            String catalogName) {
+                                                 String catalogName) {
         return Lists.newArrayList(new AlterTableEvent(event, catalogName));
     }
 
@@ -83,9 +83,9 @@ public class AlterTableEvent extends MetastoreTableEvent {
             return;
         }
         Env.getCurrentEnv().getCatalogMgr()
-                .dropExternalTable(tableBefore.getDbName(), tableBefore.getTableName(), catalogName, true);
+            .dropExternalTable(tableBefore.getDbName(), tableBefore.getTableName(), catalogName, true);
         Env.getCurrentEnv().getCatalogMgr()
-                .createExternalTableFromEvent(tableAfter.getDbName(), tableAfter.getTableName(), catalogName, true);
+            .createExternalTableFromEvent(tableAfter.getDbName(), tableAfter.getTableName(), catalogName, true);
     }
 
     private void processRename() throws DdlException {
@@ -93,17 +93,17 @@ public class AlterTableEvent extends MetastoreTableEvent {
             return;
         }
         boolean hasExist = Env.getCurrentEnv().getCatalogMgr()
-                .externalTableExistInLocal(tableAfter.getDbName(), tableAfter.getTableName(), catalogName);
+            .externalTableExistInLocal(tableAfter.getDbName(), tableAfter.getTableName(), catalogName);
         if (hasExist) {
             infoLog("AlterExternalTable canceled,because tableAfter has exist, "
-                            + "catalogName:[{}],dbName:[{}],tableName:[{}]",
-                    catalogName, dbName, tableAfter.getTableName());
+                    + "catalogName:[{}],dbName:[{}],tableName:[{}]",
+                catalogName, dbName, tableAfter.getTableName());
             return;
         }
         Env.getCurrentEnv().getCatalogMgr()
-                .dropExternalTable(tableBefore.getDbName(), tableBefore.getTableName(), catalogName, true);
+            .dropExternalTable(tableBefore.getDbName(), tableBefore.getTableName(), catalogName, true);
         Env.getCurrentEnv().getCatalogMgr()
-                .createExternalTableFromEvent(tableAfter.getDbName(), tableAfter.getTableName(), catalogName, true);
+            .createExternalTableFromEvent(tableAfter.getDbName(), tableAfter.getTableName(), catalogName, true);
 
     }
 
@@ -123,7 +123,7 @@ public class AlterTableEvent extends MetastoreTableEvent {
     protected void process() throws MetastoreNotificationException {
         try {
             infoLog("catalogName:[{}],dbName:[{}],tableBefore:[{}],tableAfter:[{}]", catalogName, dbName,
-                    tableBefore.getTableName(), tableAfter.getTableName());
+                tableBefore.getTableName(), tableAfter.getTableName());
             if (isRename) {
                 processRename();
                 return;
@@ -136,27 +136,25 @@ public class AlterTableEvent extends MetastoreTableEvent {
             }
             //The scope of refresh can be narrowed in the future
             Env.getCurrentEnv().getCatalogMgr()
-                    .refreshExternalTable(tableBefore.getDbName(), tableBefore.getTableName(), catalogName, true);
+                .refreshExternalTable(tableBefore.getDbName(), tableBefore.getTableName(), catalogName, true);
         } catch (Exception e) {
             throw new MetastoreNotificationException(
-                    debugString("Failed to process event"), e);
+                debugString("Failed to process event"), e);
         }
     }
 
     @Override
     protected boolean canBeBatched(MetastoreEvent that) {
-        if (!(that instanceof MetastoreTableEvent) || !isSameTable(that)) {
+        if (!isSameTable(that)) {
             return false;
         }
-        if (that instanceof DropTableEvent) {
-            return false;
-        }
-        if (that instanceof CreateTableEvent) {
-            return false;
+        if (isRename() || isView()) {
+            return true;
         }
         if (that instanceof AlterTableEvent) {
-            return !((AlterTableEvent) that).isRename() && !((AlterTableEvent) that).isView();
+            // `that` event must not be a rename event
+            return !((AlterTableEvent) that).isView();
         }
-        return true;
+        return !(that instanceof DropTableEvent) && !(that instanceof CreateTableEvent);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/CreateDatabaseEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/CreateDatabaseEvent.java
@@ -32,6 +32,11 @@ import java.util.List;
  */
 public class CreateDatabaseEvent extends MetastoreEvent {
 
+    // for test
+    public CreateDatabaseEvent(long eventId, String catalogName, String dbName) {
+        super(eventId, catalogName, dbName, null);
+    }
+
     private CreateDatabaseEvent(NotificationEvent event,
             String catalogName) {
         super(event, catalogName);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/CreateTableEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/CreateTableEvent.java
@@ -35,6 +35,12 @@ import java.util.List;
 public class CreateTableEvent extends MetastoreTableEvent {
     private final Table hmsTbl;
 
+    // for test
+    public CreateTableEvent(long eventId, String catalogName, String dbName, String tblName) {
+        super(eventId, catalogName, dbName, tblName);
+        this.hmsTbl = null;
+    }
+
     private CreateTableEvent(NotificationEvent event, String catalogName) throws MetastoreNotificationException {
         super(event, catalogName);
         Preconditions.checkArgument(MetastoreEventType.CREATE_TABLE.equals(getEventType()));

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/CreateTableEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/CreateTableEvent.java
@@ -62,6 +62,11 @@ public class CreateTableEvent extends MetastoreTableEvent {
     }
 
     @Override
+    protected boolean willCreateOrDropTable() {
+        return true;
+    }
+
+    @Override
     protected void process() throws MetastoreNotificationException {
         try {
             infoLog("catalogName:[{}],dbName:[{}],tableName:[{}]", catalogName, dbName, tblName);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/DropPartitionEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/DropPartitionEvent.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
 /**
  * MetastoreEvent for ADD_PARTITION event type
  */
-public class DropPartitionEvent extends MetastoreTableEvent {
+public class DropPartitionEvent extends MetastorePartitionEvent {
     private final Table hmsTbl;
     private final List<String> partitionNames;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/DropTableEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/DropTableEvent.java
@@ -65,4 +65,9 @@ public class DropTableEvent extends MetastoreTableEvent {
                     debugString("Failed to process event"), e);
         }
     }
+
+    @Override
+    protected boolean overrideGroupEvents() {
+        return true;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/DropTableEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/DropTableEvent.java
@@ -34,6 +34,13 @@ import java.util.List;
 public class DropTableEvent extends MetastoreTableEvent {
     private final String tableName;
 
+    // for test
+    public DropTableEvent(long eventId, String catalogName, String dbName,
+                           String tblName) {
+        super(eventId, catalogName, dbName, tblName);
+        this.tableName = tblName;
+    }
+
     private DropTableEvent(NotificationEvent event,
             String catalogName) {
         super(event, catalogName);
@@ -74,8 +81,8 @@ public class DropTableEvent extends MetastoreTableEvent {
         if (that instanceof CreateTableEvent) {
             return false;
         }
-        if (that instanceof AlterTableEvent && ((AlterTableEvent) that).isRename()) {
-            return false;
+        if (that instanceof AlterTableEvent) {
+            return !((AlterTableEvent) that).isRename();
         }
         return true;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/DropTableEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/DropTableEvent.java
@@ -65,9 +65,4 @@ public class DropTableEvent extends MetastoreTableEvent {
                     debugString("Failed to process event"), e);
         }
     }
-
-    @Override
-    protected boolean overrideGroupEvents() {
-        return true;
-    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/DropTableEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/DropTableEvent.java
@@ -65,4 +65,18 @@ public class DropTableEvent extends MetastoreTableEvent {
                     debugString("Failed to process event"), e);
         }
     }
+
+    @Override
+    protected boolean canBeBatched(MetastoreEvent that) {
+        if (!(that instanceof MetastoreTableEvent) || !isSameTable((MetastoreTableEvent) that)) {
+            return false;
+        }
+        if (that instanceof CreateTableEvent) {
+            return false;
+        }
+        if (that instanceof AlterTableEvent && ((AlterTableEvent) that).isRename()) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/DropTableEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/DropTableEvent.java
@@ -68,7 +68,7 @@ public class DropTableEvent extends MetastoreTableEvent {
 
     @Override
     protected boolean canBeBatched(MetastoreEvent that) {
-        if (!(that instanceof MetastoreTableEvent) || !isSameTable((MetastoreTableEvent) that)) {
+        if (!(that instanceof MetastoreTableEvent) || !isSameTable(that)) {
             return false;
         }
         if (that instanceof CreateTableEvent) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/DropTableEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/DropTableEvent.java
@@ -75,8 +75,12 @@ public class DropTableEvent extends MetastoreTableEvent {
 
     @Override
     protected boolean canBeBatched(MetastoreEvent that) {
-        // `that` event must not be a rename event,
-        // so just return true if the event belongs to the same table
-        return isSameTable(that);
+        if (!isSameTable(that)) {
+            return false;
+        }
+        if (that instanceof AlterTableEvent) {
+            return !((AlterTableEvent) that).isRename();
+        }
+        return true;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/DropTableEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/DropTableEvent.java
@@ -63,6 +63,11 @@ public class DropTableEvent extends MetastoreTableEvent {
     }
 
     @Override
+    protected boolean willCreateOrDropTable() {
+        return true;
+    }
+
+    @Override
     protected void process() throws MetastoreNotificationException {
         try {
             infoLog("catalogName:[{}],dbName:[{}],tableName:[{}]", catalogName, dbName, tableName);
@@ -75,12 +80,8 @@ public class DropTableEvent extends MetastoreTableEvent {
 
     @Override
     protected boolean canBeBatched(MetastoreEvent that) {
-        if (!isSameTable(that)) {
-            return false;
-        }
-        if (that instanceof AlterTableEvent) {
-            return !((AlterTableEvent) that).isRename();
-        }
-        return true;
+        // `that` event must not be a rename table event
+        // so merge all events which belong to this table before is ok
+        return isSameTable(that);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/DropTableEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/DropTableEvent.java
@@ -75,15 +75,8 @@ public class DropTableEvent extends MetastoreTableEvent {
 
     @Override
     protected boolean canBeBatched(MetastoreEvent that) {
-        if (!(that instanceof MetastoreTableEvent) || !isSameTable(that)) {
-            return false;
-        }
-        if (that instanceof CreateTableEvent) {
-            return false;
-        }
-        if (that instanceof AlterTableEvent) {
-            return !((AlterTableEvent) that).isRename();
-        }
-        return true;
+        // `that` event must not be a rename event,
+        // so just return true if the event belongs to the same table
+        return isSameTable(that);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/InsertEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/InsertEvent.java
@@ -72,4 +72,10 @@ public class InsertEvent extends MetastoreTableEvent {
                     debugString("Failed to process event"), e);
         }
     }
+
+    @Override
+    protected boolean overrideGroupEvents() {
+        // The processor will refresh the hms table so we can skip all the group events earlier
+        return true;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/InsertEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/InsertEvent.java
@@ -75,7 +75,7 @@ public class InsertEvent extends MetastoreTableEvent {
 
     @Override
     protected boolean canBeBatched(MetastoreEvent that) {
-        if (!(that instanceof MetastoreTableEvent) || !isSameTable((MetastoreTableEvent) that)) {
+        if (!(that instanceof MetastoreTableEvent) || !isSameTable(that)) {
             return false;
         }
         if (that instanceof CreateTableEvent) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/InsertEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/InsertEvent.java
@@ -72,10 +72,4 @@ public class InsertEvent extends MetastoreTableEvent {
                     debugString("Failed to process event"), e);
         }
     }
-
-    @Override
-    protected boolean overrideGroupEvents() {
-        // The processor will refresh the hms table so we can skip all the group events earlier
-        return true;
-    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/InsertEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/InsertEvent.java
@@ -35,6 +35,13 @@ import java.util.List;
 public class InsertEvent extends MetastoreTableEvent {
     private final Table hmsTbl;
 
+    // for test
+    public InsertEvent(long eventId, String catalogName, String dbName,
+                          String tblName) {
+        super(eventId, catalogName, dbName, tblName);
+        this.hmsTbl = null;
+    }
+
     private InsertEvent(NotificationEvent event, String catalogName) {
         super(event, catalogName);
         Preconditions.checkArgument(getEventType().equals(MetastoreEventType.INSERT));

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/InsertEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/InsertEvent.java
@@ -72,4 +72,21 @@ public class InsertEvent extends MetastoreTableEvent {
                     debugString("Failed to process event"), e);
         }
     }
+
+    @Override
+    protected boolean canBeBatched(MetastoreEvent that) {
+        if (!(that instanceof MetastoreTableEvent) || !isSameTable((MetastoreTableEvent) that)) {
+            return false;
+        }
+        if (that instanceof CreateTableEvent) {
+            return false;
+        }
+        if (that instanceof DropTableEvent) {
+            return false;
+        }
+        if (that instanceof AlterTableEvent) {
+            return !((AlterTableEvent) that).isRename() && !((AlterTableEvent) that).isView();
+        }
+        return true;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/InsertEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/InsertEvent.java
@@ -86,8 +86,7 @@ public class InsertEvent extends MetastoreTableEvent {
             return false;
         }
         if (that instanceof AlterTableEvent) {
-            // `that` event must not be a rename event
-            return !((AlterTableEvent) that).isView();
+            return !((AlterTableEvent) that).isRename() && !((AlterTableEvent) that).isView();
         }
         return !(that instanceof DropTableEvent) && !(that instanceof CreateTableEvent);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/InsertEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/InsertEvent.java
@@ -82,18 +82,13 @@ public class InsertEvent extends MetastoreTableEvent {
 
     @Override
     protected boolean canBeBatched(MetastoreEvent that) {
-        if (!(that instanceof MetastoreTableEvent) || !isSameTable(that)) {
-            return false;
-        }
-        if (that instanceof CreateTableEvent) {
-            return false;
-        }
-        if (that instanceof DropTableEvent) {
+        if (!isSameTable(that)) {
             return false;
         }
         if (that instanceof AlterTableEvent) {
-            return !((AlterTableEvent) that).isRename() && !((AlterTableEvent) that).isView();
+            // `that` event must not be a rename event
+            return !((AlterTableEvent) that).isView();
         }
-        return true;
+        return !(that instanceof DropTableEvent) && !(that instanceof CreateTableEvent);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/InsertEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/InsertEvent.java
@@ -37,7 +37,7 @@ public class InsertEvent extends MetastoreTableEvent {
 
     // for test
     public InsertEvent(long eventId, String catalogName, String dbName,
-                          String tblName) {
+                       String tblName) {
         super(eventId, catalogName, dbName, tblName);
         this.hmsTbl = null;
     }
@@ -59,6 +59,11 @@ public class InsertEvent extends MetastoreTableEvent {
 
     protected static List<MetastoreEvent> getEvents(NotificationEvent event, String catalogName) {
         return Lists.newArrayList(new InsertEvent(event, catalogName));
+    }
+
+    @Override
+    protected boolean willCreateOrDropTable() {
+        return false;
     }
 
     @Override
@@ -85,9 +90,9 @@ public class InsertEvent extends MetastoreTableEvent {
         if (!isSameTable(that)) {
             return false;
         }
-        if (that instanceof AlterTableEvent) {
-            return !((AlterTableEvent) that).isRename() && !((AlterTableEvent) that).isView();
-        }
-        return !(that instanceof DropTableEvent) && !(that instanceof CreateTableEvent);
+
+        // that event must be a MetastoreTableEvent event
+        // otherwise `isSameTable` will return false
+        return !((MetastoreTableEvent) that).willCreateOrDropTable();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreEvent.java
@@ -57,6 +57,17 @@ public abstract class MetastoreEvent {
 
     protected final String catalogName;
 
+    // for test
+    protected MetastoreEvent(long eventId, String catalogName, String dbName, String tblName) {
+        this.eventId = eventId;
+        this.catalogName = catalogName;
+        this.dbName = dbName;
+        this.tblName = tblName;
+        this.eventType = null;
+        this.metastoreNotificationEvent = null;
+        this.event = null;
+    }
+
     protected MetastoreEvent(NotificationEvent event, String catalogName) {
         this.event = event;
         this.dbName = event.getDbName();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreEvent.java
@@ -18,14 +18,12 @@
 
 package org.apache.doris.datasource.hive.event;
 
-import lombok.Getter;
 import org.apache.hadoop.hive.metastore.api.NotificationEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * Abstract base class for all MetastoreEvents. A MetastoreEvent is an object used to
@@ -209,45 +207,6 @@ public abstract class MetastoreEvent {
             name.append(part.get(colName));
         }
         return name.toString();
-    }
-
-    // Ture means that we can skip all events which belongs to the same group
-    protected boolean overrideGroupEvents() {
-        return false;
-    }
-
-    protected final GroupKey getGroupKey() {
-        return new GroupKey(this.catalogName, this.dbName, this.tblName);
-    }
-
-    // Use GroupKey to group by events
-    @Getter
-    public static class GroupKey {
-        private final String catalogName;
-        private final String dbName;
-        private final String tblName;
-
-        private GroupKey(String catalogName, String dbName, String tblName) {
-            this.catalogName = catalogName;
-            this.dbName = dbName;
-            this.tblName = tblName;
-        }
-
-        @Override
-        public boolean equals(Object that) {
-            if (!(that instanceof GroupKey)) {
-                return false;
-            }
-            GroupKey thatKey = (GroupKey) that;
-            return Objects.equals(catalogName, thatKey.catalogName)
-                        && Objects.equals(dbName, thatKey.dbName)
-                        && Objects.equals(tblName, thatKey.tblName);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(catalogName, dbName, tblName);
-        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreEvent.java
@@ -18,12 +18,14 @@
 
 package org.apache.doris.datasource.hive.event;
 
+import lombok.Getter;
 import org.apache.hadoop.hive.metastore.api.NotificationEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Abstract base class for all MetastoreEvents. A MetastoreEvent is an object used to
@@ -207,6 +209,45 @@ public abstract class MetastoreEvent {
             name.append(part.get(colName));
         }
         return name.toString();
+    }
+
+    // Ture means that we can skip all events which belongs to the same group
+    protected boolean overrideGroupEvents() {
+        return false;
+    }
+
+    protected final GroupKey getGroupKey() {
+        return new GroupKey(this.catalogName, this.dbName, this.tblName);
+    }
+
+    // Use GroupKey to group by events
+    @Getter
+    public static class GroupKey {
+        private final String catalogName;
+        private final String dbName;
+        private final String tblName;
+
+        private GroupKey(String catalogName, String dbName, String tblName) {
+            this.catalogName = catalogName;
+            this.dbName = dbName;
+            this.tblName = tblName;
+        }
+
+        @Override
+        public boolean equals(Object that) {
+            if (!(that instanceof GroupKey)) {
+                return false;
+            }
+            GroupKey thatKey = (GroupKey) that;
+            return Objects.equals(catalogName, thatKey.catalogName)
+                        && Objects.equals(dbName, thatKey.dbName)
+                        && Objects.equals(tblName, thatKey.tblName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(catalogName, dbName, tblName);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreEventFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreEventFactory.java
@@ -86,7 +86,7 @@ public class MetastoreEventFactory implements EventFactory {
      * */
     List<MetastoreEvent> createBatchEvents(String catalogName, List<MetastoreEvent> events) {
         List<MetastoreEvent> eventsCopy = Lists.newArrayList(events);
-        Map<String, List<Integer>> indexMap = Maps.newLinkedHashMap();
+        Map<MetastoreTableEvent.TableKey, List<Integer>> indexMap = Maps.newLinkedHashMap();
         for (int i = 0; i < events.size(); i++) {
             MetastoreEvent event = events.get(i);
             // Only check MetastoreTableEvent
@@ -95,8 +95,7 @@ public class MetastoreEventFactory implements EventFactory {
             }
 
             // Divide events into multi groups to reduce check count
-            String groupKey = String.format("%s.%s.%s",
-                        event.catalogName, event.dbName, event.tblName);
+            MetastoreTableEvent.TableKey groupKey = ((MetastoreTableEvent) event).getTableKey();
             if (!indexMap.containsKey(groupKey)) {
                 List<Integer> indexList = Lists.newLinkedList();
                 indexList.add(i);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreEventFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreEventFactory.java
@@ -83,6 +83,15 @@ public class MetastoreEventFactory implements EventFactory {
     /**
      * Merge events to reduce the cost time on event processing, currently mainly handles MetastoreTableEvent
      * because merge MetastoreTableEvent is simple and cost-effective.
+     * For example, consider there are some events as following:
+     *
+     *    event1: alter table db1.t1 add partition p1;
+     *    event2: alter table db1.t1 drop partition p2;
+     *    event3: alter table db1.t2 add partition p3;
+     *    event4: alter table db2.t3 rename to t4;
+     *    event5: drop table db1.t1;
+     *
+     * Only `event3 event4 event5` will be reserved and other events will be skipped.
      * */
     public List<MetastoreEvent> createBatchEvents(String catalogName, List<MetastoreEvent> events) {
         List<MetastoreEvent> eventsCopy = Lists.newArrayList(events);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreEventFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreEventFactory.java
@@ -118,6 +118,12 @@ public class MetastoreEventFactory implements EventFactory {
                         .collect(Collectors.toList());
             indexList.add(i);
             indexMap.put(groupKey, indexList);
+
+            // if the event is a rename event, just clear indexMap
+            // to make sure the table references of these events in indexMap will not change
+            if (event instanceof AlterTableEvent && ((AlterTableEvent) event).isRename()) {
+                indexMap.clear();
+            }
         }
 
         List<MetastoreEvent> filteredEvents = eventsCopy.stream().filter(Objects::nonNull)

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreEventFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreEventFactory.java
@@ -89,6 +89,14 @@ public class MetastoreEventFactory implements EventFactory {
         Map<MetastoreTableEvent.TableKey, List<Integer>> indexMap = Maps.newLinkedHashMap();
         for (int i = 0; i < events.size(); i++) {
             MetastoreEvent event = events.get(i);
+
+            // if the event is a rename event, just clear indexMap
+            // to make sure the table references of these events in indexMap will not change
+            if (event instanceof AlterDatabaseEvent && ((AlterDatabaseEvent) event).isRename()) {
+                indexMap.clear();
+                continue;
+            }
+
             // Only check MetastoreTableEvent
             if (!(event instanceof MetastoreTableEvent)) {
                 continue;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastorePartitionEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastorePartitionEvent.java
@@ -1,0 +1,40 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+package org.apache.doris.datasource.hive.event;
+
+import org.apache.hadoop.hive.metastore.api.NotificationEvent;
+
+/**
+ * Base class for all the partition events
+ */
+public abstract class MetastorePartitionEvent extends MetastoreTableEvent {
+
+    // for test
+    protected MetastorePartitionEvent(long eventId, String catalogName, String dbName, String tblName) {
+        super(eventId, catalogName, dbName, tblName);
+    }
+
+    protected MetastorePartitionEvent(NotificationEvent event, String catalogName) {
+        super(event, catalogName);
+    }
+
+    protected boolean willCreateOrDropTable() {
+        return false;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreTableEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreTableEvent.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import org.apache.hadoop.hive.metastore.api.NotificationEvent;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Base class for all the table events
@@ -47,4 +48,11 @@ public abstract class MetastoreTableEvent extends MetastoreEvent {
                     .add("numFiles")
                     .add("comment")
                     .build();
+
+    protected boolean isSameTable(MetastoreTableEvent that) {
+        return that != null
+                    && Objects.equals(catalogName, that.catalogName)
+                    && Objects.equals(dbName, that.dbName)
+                    && Objects.equals(tblName, that.tblName);
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreTableEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreTableEvent.java
@@ -49,10 +49,43 @@ public abstract class MetastoreTableEvent extends MetastoreEvent {
                     .add("comment")
                     .build();
 
-    protected boolean isSameTable(MetastoreTableEvent that) {
-        return that != null
-                    && Objects.equals(catalogName, that.catalogName)
-                    && Objects.equals(dbName, that.dbName)
-                    && Objects.equals(tblName, that.tblName);
+    protected boolean isSameTable(MetastoreEvent that) {
+        if (!(that instanceof MetastoreTableEvent)) {
+            return false;
+        }
+        TableKey thisKey = getTableKey();
+        TableKey thatKey = ((MetastoreTableEvent) that).getTableKey();
+        return thisKey.hashCode() == thatKey.hashCode() && Objects.equals(thisKey, thatKey);
+    }
+
+    public TableKey getTableKey() {
+        return new TableKey(catalogName, dbName, tblName);
+    }
+
+    static class TableKey {
+        private final String catalogName;
+        private final String dbName;
+        private final String tblName;
+
+        private TableKey(String catalogName, String dbName, String tblName) {
+            this.catalogName = catalogName;
+            this.dbName = dbName;
+            this.tblName = tblName;
+        }
+
+        @Override
+        public boolean equals(Object that) {
+            if (!(that instanceof TableKey)) {
+                return false;
+            }
+            return Objects.equals(catalogName, ((TableKey) that).catalogName)
+                        && Objects.equals(dbName, ((TableKey) that).dbName)
+                        && Objects.equals(tblName, ((TableKey) that).tblName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(catalogName, dbName, tblName);
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreTableEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreTableEvent.java
@@ -30,6 +30,10 @@ import java.util.Objects;
  */
 public abstract class MetastoreTableEvent extends MetastoreEvent {
 
+    // for test
+    protected MetastoreTableEvent(long eventId, String catalogName, String dbName, String tblName) {
+        super(eventId, catalogName, dbName, tblName);
+    }
 
     protected MetastoreTableEvent(NotificationEvent event, String catalogName) {
         super(event, catalogName);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreTableEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreTableEvent.java
@@ -59,8 +59,13 @@ public abstract class MetastoreTableEvent extends MetastoreEvent {
         }
         TableKey thisKey = getTableKey();
         TableKey thatKey = ((MetastoreTableEvent) that).getTableKey();
-        return thisKey.hashCode() == thatKey.hashCode() && Objects.equals(thisKey, thatKey);
+        return Objects.equals(thisKey, thatKey);
     }
+
+    /**
+     * Returns if the process of this event will create or drop this table.
+     */
+    abstract protected boolean willCreateOrDropTable();
 
     public TableKey getTableKey() {
         return new TableKey(catalogName, dbName, tblName);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreTableEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreTableEvent.java
@@ -65,7 +65,7 @@ public abstract class MetastoreTableEvent extends MetastoreEvent {
     /**
      * Returns if the process of this event will create or drop this table.
      */
-    abstract protected boolean willCreateOrDropTable();
+    protected abstract boolean willCreateOrDropTable();
 
     public TableKey getTableKey() {
         return new TableKey(catalogName, dbName, tblName);

--- a/fe/fe-core/src/test/java/org/apache/doris/external/hms/MetastoreEventFactoryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/external/hms/MetastoreEventFactoryTest.java
@@ -1,0 +1,21 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.external.hms;
+
+public class MetastoreEventFactoryTest {
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/external/hms/MetastoreEventFactoryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/external/hms/MetastoreEventFactoryTest.java
@@ -27,7 +27,6 @@ import org.apache.doris.datasource.hive.event.InsertEvent;
 import org.apache.doris.datasource.hive.event.MetastoreEvent;
 import org.apache.doris.datasource.hive.event.MetastoreEventFactory;
 
-
 import org.apache.hadoop.util.Lists;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/fe/fe-core/src/test/java/org/apache/doris/external/hms/MetastoreEventFactoryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/external/hms/MetastoreEventFactoryTest.java
@@ -17,5 +17,146 @@
 
 package org.apache.doris.external.hms;
 
+import org.apache.doris.datasource.hive.event.AddPartitionEvent;
+import org.apache.doris.datasource.hive.event.AlterPartitionEvent;
+import org.apache.doris.datasource.hive.event.AlterTableEvent;
+import org.apache.doris.datasource.hive.event.CreateDatabaseEvent;
+import org.apache.doris.datasource.hive.event.CreateTableEvent;
+import org.apache.doris.datasource.hive.event.DropTableEvent;
+import org.apache.doris.datasource.hive.event.InsertEvent;
+import org.apache.doris.datasource.hive.event.MetastoreEvent;
+import org.apache.doris.datasource.hive.event.MetastoreEventFactory;
+
+
+import org.apache.hadoop.util.Lists;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+
 public class MetastoreEventFactoryTest {
+    private static final MetastoreEventFactory factory = new MetastoreEventFactory();
+
+    @Test
+    public void testCreateBatchEvents() {
+        AlterPartitionEvent e1 = new AlterPartitionEvent(1L, "test_ctl", "test_db", "t1", "p1", "p1");
+        AlterPartitionEvent e2 = new AlterPartitionEvent(2L, "test_ctl", "test_db", "t1", "p1", "p1");
+        AddPartitionEvent e3 = new AddPartitionEvent(3L, "test_ctl", "test_db", "t1", Arrays.asList("p1"));
+        AlterTableEvent e4 = new AlterTableEvent(4L, "test_ctl", "test_db", "t1", false, false);
+        AlterTableEvent e5 = new AlterTableEvent(5L, "test_ctl", "test_db", "t1", true, false);
+        AlterTableEvent e6 = new AlterTableEvent(6L, "test_ctl", "test_db", "t1", false, true);
+        DropTableEvent e7 = new DropTableEvent(7L, "test_ctl", "test_db", "t1");
+        InsertEvent e8 = new InsertEvent(8L, "test_ctl", "test_db", "t1");
+        CreateDatabaseEvent e9 = new CreateDatabaseEvent(9L, "test_ctl", "test_db2");
+        AlterPartitionEvent e10 = new AlterPartitionEvent(10L, "test_ctl", "test_db", "t2", "p1", "p1");
+        AlterTableEvent e11 = new AlterTableEvent(11L, "test_ctl", "test_db", "t1", false, false);
+        CreateTableEvent e12 = new CreateTableEvent(12L, "test_ctl", "test_db", "t1");
+
+        List<MetastoreEvent> mergedEvents;
+        List<MetastoreEvent> testEvents = Lists.newLinkedList();
+
+        testEvents.add(e1);
+        testEvents.add(e2);
+        mergedEvents = factory.createBatchEvents("test_ctl", testEvents);
+        Assertions.assertTrue(mergedEvents.size() == 1);
+        Assertions.assertTrue(mergedEvents.get(0).getEventId() == 2L);
+
+        testEvents.clear();
+        testEvents.add(e1);
+        testEvents.add(e2);
+        testEvents.add(e3);
+        testEvents.add(e9);
+        testEvents.add(e10);
+        testEvents.add(e4);
+        mergedEvents = factory.createBatchEvents("test_ctl", testEvents);
+        Assertions.assertTrue(mergedEvents.size() == 3);
+        Assertions.assertTrue(mergedEvents.get(0).getEventId() == 9L);
+        Assertions.assertTrue(mergedEvents.get(1).getEventId() == 10L);
+        Assertions.assertTrue(mergedEvents.get(2).getEventId() == 4L);
+
+        testEvents.clear();
+        testEvents.add(e1);
+        testEvents.add(e2);
+        testEvents.add(e10);
+        testEvents.add(e5);
+        testEvents.add(e4);
+        mergedEvents = factory.createBatchEvents("test_ctl", testEvents);
+        Assertions.assertTrue(mergedEvents.size() == 3);
+        Assertions.assertTrue(mergedEvents.get(0).getEventId() == 10L);
+        Assertions.assertTrue(mergedEvents.get(1).getEventId() == 5L);
+        Assertions.assertTrue(mergedEvents.get(2).getEventId() == 4L);
+
+        testEvents.clear();
+        testEvents.add(e1);
+        testEvents.add(e2);
+        testEvents.add(e10);
+        testEvents.add(e6);
+        testEvents.add(e4);
+        mergedEvents = factory.createBatchEvents("test_ctl", testEvents);
+        Assertions.assertTrue(mergedEvents.size() == 3);
+        Assertions.assertTrue(mergedEvents.get(0).getEventId() == 10L);
+        Assertions.assertTrue(mergedEvents.get(1).getEventId() == 6L);
+        Assertions.assertTrue(mergedEvents.get(2).getEventId() == 4L);
+
+        testEvents.clear();
+        testEvents.add(e1);
+        testEvents.add(e2);
+        testEvents.add(e10);
+        testEvents.add(e4);
+        testEvents.add(e11);
+        mergedEvents = factory.createBatchEvents("test_ctl", testEvents);
+        Assertions.assertTrue(mergedEvents.size() == 2);
+        Assertions.assertTrue(mergedEvents.get(0).getEventId() == 10L);
+        Assertions.assertTrue(mergedEvents.get(1).getEventId() == 11L);
+
+        testEvents.clear();
+        testEvents.add(e1);
+        testEvents.add(e2);
+        testEvents.add(e10);
+        testEvents.add(e4);
+        testEvents.add(e8);
+        mergedEvents = factory.createBatchEvents("test_ctl", testEvents);
+        Assertions.assertTrue(mergedEvents.size() == 2);
+        Assertions.assertTrue(mergedEvents.get(0).getEventId() == 10L);
+        Assertions.assertTrue(mergedEvents.get(1).getEventId() == 8L);
+
+        testEvents.clear();
+        testEvents.add(e1);
+        testEvents.add(e2);
+        testEvents.add(e10);
+        testEvents.add(e5);
+        testEvents.add(e8);
+        mergedEvents = factory.createBatchEvents("test_ctl", testEvents);
+        Assertions.assertTrue(mergedEvents.size() == 3);
+        Assertions.assertTrue(mergedEvents.get(0).getEventId() == 10L);
+        Assertions.assertTrue(mergedEvents.get(1).getEventId() == 5L);
+        Assertions.assertTrue(mergedEvents.get(2).getEventId() == 8L);
+
+        testEvents.clear();
+        testEvents.add(e1);
+        testEvents.add(e2);
+        testEvents.add(e10);
+        testEvents.add(e12);
+        testEvents.add(e4);
+        testEvents.add(e7);
+        mergedEvents = factory.createBatchEvents("test_ctl", testEvents);
+        Assertions.assertTrue(mergedEvents.size() == 3);
+        Assertions.assertTrue(mergedEvents.get(0).getEventId() == 10L);
+        Assertions.assertTrue(mergedEvents.get(1).getEventId() == 12L);
+        Assertions.assertTrue(mergedEvents.get(2).getEventId() == 7L);
+
+        testEvents.clear();
+        testEvents.add(e1);
+        testEvents.add(e2);
+        testEvents.add(e10);
+        testEvents.add(e5);
+        testEvents.add(e7);
+        mergedEvents = factory.createBatchEvents("test_ctl", testEvents);
+        Assertions.assertTrue(mergedEvents.size() == 3);
+        Assertions.assertTrue(mergedEvents.get(0).getEventId() == 10L);
+        Assertions.assertTrue(mergedEvents.get(1).getEventId() == 5L);
+        Assertions.assertTrue(mergedEvents.get(2).getEventId() == 7L);
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/external/hms/MetastoreEventFactoryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/external/hms/MetastoreEventFactoryTest.java
@@ -75,6 +75,7 @@ public class MetastoreEventFactoryTest {
         Assertions.assertTrue(mergedEvents.get(1).getEventId() == 10L);
         Assertions.assertTrue(mergedEvents.get(2).getEventId() == 4L);
 
+        // because e5 is a rename event, it will not be merged
         testEvents.clear();
         testEvents.add(e1);
         testEvents.add(e2);
@@ -121,6 +122,7 @@ public class MetastoreEventFactoryTest {
         Assertions.assertTrue(mergedEvents.get(0).getEventId() == 10L);
         Assertions.assertTrue(mergedEvents.get(1).getEventId() == 8L);
 
+        // because e5 is a rename event, it will not be merged
         testEvents.clear();
         testEvents.add(e1);
         testEvents.add(e2);
@@ -146,6 +148,7 @@ public class MetastoreEventFactoryTest {
         Assertions.assertTrue(mergedEvents.get(1).getEventId() == 12L);
         Assertions.assertTrue(mergedEvents.get(2).getEventId() == 7L);
 
+        // because e5 is a rename event, it will not be merged
         testEvents.clear();
         testEvents.add(e1);
         testEvents.add(e2);

--- a/fe/fe-core/src/test/java/org/apache/doris/external/hms/MetastoreEventFactoryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/external/hms/MetastoreEventFactoryTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.external.hms;
 
 import org.apache.doris.datasource.hive.event.AddPartitionEvent;
+import org.apache.doris.datasource.hive.event.AlterDatabaseEvent;
 import org.apache.doris.datasource.hive.event.AlterPartitionEvent;
 import org.apache.doris.datasource.hive.event.AlterTableEvent;
 import org.apache.doris.datasource.hive.event.CreateDatabaseEvent;
@@ -52,6 +53,8 @@ public class MetastoreEventFactoryTest {
         AlterPartitionEvent e10 = new AlterPartitionEvent(10L, "test_ctl", "test_db", "t2", "p1", "p1");
         AlterTableEvent e11 = new AlterTableEvent(11L, "test_ctl", "test_db", "t1", false, false);
         CreateTableEvent e12 = new CreateTableEvent(12L, "test_ctl", "test_db", "t1");
+        AlterDatabaseEvent e13 = new AlterDatabaseEvent(13L, "test_ctl", "test_db", true);
+        AlterDatabaseEvent e14 = new AlterDatabaseEvent(14L, "test_ctl", "test_db", false);
 
         List<MetastoreEvent> mergedEvents;
         List<MetastoreEvent> testEvents = Lists.newLinkedList();
@@ -158,6 +161,33 @@ public class MetastoreEventFactoryTest {
         Assertions.assertTrue(mergedEvents.size() == 3);
         Assertions.assertTrue(mergedEvents.get(0).getEventId() == 10L);
         Assertions.assertTrue(mergedEvents.get(1).getEventId() == 5L);
+        Assertions.assertTrue(mergedEvents.get(2).getEventId() == 7L);
+
+        testEvents.clear();
+        testEvents.add(e1);
+        testEvents.add(e2);
+        testEvents.add(e10);
+        testEvents.add(e4);
+        testEvents.add(e13);
+        testEvents.add(e7);
+        mergedEvents = factory.createBatchEvents("test_ctl", testEvents);
+        Assertions.assertTrue(mergedEvents.size() == 4);
+        Assertions.assertTrue(mergedEvents.get(0).getEventId() == 10L);
+        Assertions.assertTrue(mergedEvents.get(1).getEventId() == 4L);
+        Assertions.assertTrue(mergedEvents.get(2).getEventId() == 13L);
+        Assertions.assertTrue(mergedEvents.get(3).getEventId() == 7L);
+
+        testEvents.clear();
+        testEvents.add(e1);
+        testEvents.add(e2);
+        testEvents.add(e10);
+        testEvents.add(e4);
+        testEvents.add(e14);
+        testEvents.add(e7);
+        mergedEvents = factory.createBatchEvents("test_ctl", testEvents);
+        Assertions.assertTrue(mergedEvents.size() == 3);
+        Assertions.assertTrue(mergedEvents.get(0).getEventId() == 10L);
+        Assertions.assertTrue(mergedEvents.get(1).getEventId() == 14L);
         Assertions.assertTrue(mergedEvents.get(2).getEventId() == 7L);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/external/hms/MetastoreEventFactoryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/external/hms/MetastoreEventFactoryTest.java
@@ -143,10 +143,9 @@ public class MetastoreEventFactoryTest {
         testEvents.add(e4);
         testEvents.add(e7);
         mergedEvents = factory.createBatchEvents("test_ctl", testEvents);
-        Assertions.assertTrue(mergedEvents.size() == 3);
+        Assertions.assertTrue(mergedEvents.size() == 2);
         Assertions.assertTrue(mergedEvents.get(0).getEventId() == 10L);
-        Assertions.assertTrue(mergedEvents.get(1).getEventId() == 12L);
-        Assertions.assertTrue(mergedEvents.get(2).getEventId() == 7L);
+        Assertions.assertTrue(mergedEvents.get(1).getEventId() == 7L);
 
         // because e5 is a rename event, it will not be merged
         testEvents.clear();


### PR DESCRIPTION
## Proposed changes

Currently we find that `MetastoreEventsProcessor` can not catch up the event producing rate in our cluster, so we need to merge some hms events every round.

It works fine from my test:
![event](https://github.com/apache/doris/assets/5926365/9069ad6d-a88d-4d39-9a44-e2925dbc2e2b)


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

