### PR TITLE
[fix](catalog) wrong required slot info causing BE crash

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -389,7 +389,7 @@ public class HiveMetaStoreCache {
                 throw e;
             }
         }
-        result.setPartitionValues(partitionValues);
+        result.setPartitionValues(Lists.newArrayList(partitionValues));
         return result;
     }
 
@@ -924,7 +924,7 @@ public class HiveMetaStoreCache {
                 return dummyKey.equals(((FileCacheKey) obj).dummyKey);
             }
             return location.equals(((FileCacheKey) obj).location)
-                && partitionValues.equals(((FileCacheKey) obj).partitionValues);
+                && Objects.equals(partitionValues, ((FileCacheKey) obj).partitionValues);
         }
 
         @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -389,6 +389,7 @@ public class HiveMetaStoreCache {
                 throw e;
             }
         }
+        // Must copy the partitionValues to avoid concurrent modification of key and value
         result.setPartitionValues(Lists.newArrayList(partitionValues));
         return result;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileQueryScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileQueryScanNode.java
@@ -81,7 +81,7 @@ import java.util.Set;
 
 /**
  * FileQueryScanNode for querying the file access type of catalog, now only support
- * hive,hudi, iceberg and TVF.
+ * hive, hudi, iceberg and TVF.
  */
 public abstract class FileQueryScanNode extends FileScanNode {
     private static final Logger LOG = LogManager.getLogger(FileQueryScanNode.class);
@@ -163,6 +163,10 @@ public abstract class FileQueryScanNode extends FileScanNode {
     @Override
     public void updateRequiredSlots(PlanTranslatorContext planTranslatorContext,
             Set<SlotId> requiredByProjectSlotIdSet) throws UserException {
+        updateRequiredSlots();
+    }
+
+    private void updateRequiredSlots() throws UserException {
         params.unsetRequiredSlots();
         for (SlotDescriptor slot : desc.getSlots()) {
             if (!slot.isMaterialized()) {
@@ -196,6 +200,7 @@ public abstract class FileQueryScanNode extends FileScanNode {
     // Create scan range locations and the statistics.
     protected void doFinalize() throws UserException {
         createScanRangeLocations();
+        updateRequiredSlots();
     }
 
     private void setColumnPositionMapping()
@@ -415,3 +420,4 @@ public abstract class FileQueryScanNode extends FileScanNode {
         return Optional.empty();
     }
 }
+

--- a/regression-test/data/external_table_emr_p2/hive/test_external_catalog_hive.out
+++ b/regression-test/data/external_table_emr_p2/hive/test_external_catalog_hive.out
@@ -93,3 +93,6 @@ moccasin steel bisque cornsilk lace
 -- !q25 --
 Z6n2t4XA2n7CXTECJ,PE,iBbsCh0RE1Dd2A,z48
 
+-- !pr21598 --
+5
+

--- a/regression-test/suites/external_table_emr_p2/hive/test_external_catalog_hive.groovy
+++ b/regression-test/suites/external_table_emr_p2/hive/test_external_catalog_hive.groovy
@@ -86,6 +86,8 @@ suite("test_external_catalog_hive", "p2") {
         sql """ use tpch_1000_orc; """
         q03()
 
+        // test #21598
+        qt_pr21598 """select count(*) from( (SELECT r_regionkey AS key1, r_name AS name, pday AS pday FROM (SELECT r_regionkey, r_name, replace(r_comment, ' ', 'aaaa') AS pday FROM ${catalog_name}.tpch_1000_parquet.region) t2))x;"""
 
         // test remember last used database after switch / rename catalog
         sql """switch ${catalog_name};"""


### PR DESCRIPTION
## Proposed changes

For file scan node, this is a special field `requiredSlot`, this field is set depends on the `isMaterialized` info of slot.
But `isMaterialized` info can be changed during the plan process, so we must update the `requiredSlot`
in `finalize` phase of scan node, otherwise, it may causing BE crash due to mismatching slot info.


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

