### PR TITLE
[Enhancement](inverted index) reset global instance for InvertedIndexSearcherCache when destroy

### DIFF
--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.h
@@ -77,6 +77,18 @@ public:
     // "capacity" is the capacity of lru cache.
     static void create_global_instance(size_t capacity, uint32_t num_shards = 16);
 
+    void reset() {
+        _cache.reset();
+        _mem_tracker.reset();
+        // Reset or clear the state of the object.
+    }
+
+    static void reset_global_instance() {
+        if (_s_instance != nullptr) {
+            _s_instance->reset();
+        }
+    }
+
     // Return global instance.
     // Client should call create_global_cache before.
     static InvertedIndexSearcherCache* instance() { return _s_instance; }

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -410,6 +410,7 @@ void ExecEnv::_destroy() {
     _experimental_mem_tracker.reset();
     _page_no_cache_mem_tracker.reset();
     _brpc_iobuf_block_memory_tracker.reset();
+    InvertedIndexSearcherCache::reset_global_instance();
 
     _is_init = false;
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

This PR aims to address the need for resetting the InvertedIndexSearcherCache during the destroy of doris_be. Given that InvertedIndexSearcherCache is a global instance, it is necessary to explicitly reset its members.

Implementing this change will effectively eliminate the memory leak information that currently appears when doris_be is stopped gracefully. This contributes to a cleaner and more efficient shutdown process.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

