### PR TITLE
[opt](Nereids): Join use List<Plan> as children

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/receiver/PlanReceiver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/receiver/PlanReceiver.java
@@ -321,7 +321,7 @@ public class PlanReceiver implements AbstractReceiver {
                 AbstractPhysicalJoin physicalJoin = (AbstractPhysicalJoin) physicalPlan;
                 logicalPlan = new LogicalJoin<>(physicalJoin.getJoinType(), physicalJoin.getHashJoinConjuncts(),
                         physicalJoin.getOtherJoinConjuncts(), JoinHint.NONE, physicalJoin.getMarkJoinSlotReference(),
-                        physicalJoin.child(0), physicalJoin.child(1));
+                        physicalJoin.children());
             } else {
                 throw new RuntimeException("DPhyp can only handle join and project operator");
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/pattern/GroupMatching.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/pattern/GroupMatching.java
@@ -50,7 +50,6 @@ public class GroupMatching implements Iterable<Plan> {
      * Iterator to get all subtrees from a group.
      */
     public static class GroupIterator implements Iterator<Plan> {
-        private final Pattern pattern;
         private final List<Iterator<Plan>> iterator;
         private int iteratorIndex = 0;
 
@@ -61,7 +60,6 @@ public class GroupMatching implements Iterable<Plan> {
          * @param group group to be matched
          */
         public GroupIterator(Pattern<? extends Plan> pattern, Group group) {
-            this.pattern = pattern;
             this.iterator = Lists.newArrayList();
 
             if (pattern.isGroup() || pattern.isMultiGroup()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/LogicalProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/LogicalProperties.java
@@ -95,10 +95,6 @@ public class LogicalProperties {
         return outputExprIdsSupplier.get();
     }
 
-    public LogicalProperties withOutput(List<Slot> output) {
-        return new LogicalProperties(Suppliers.ofInstance(output));
-    }
-
     @Override
     public String toString() {
         return "LogicalProperties{"

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindExpression.java
@@ -160,7 +160,7 @@ public class BindExpression implements AnalysisRuleFactory {
                             ? JoinType.INNER_JOIN : using.getJoinType(),
                             using.getHashJoinConjuncts(),
                             using.getOtherJoinConjuncts(), using.getHint(), using.getMarkJoinSlotReference(),
-                            using.left(), using.right());
+                            using.children());
                     List<Expression> unboundSlots = lj.getHashJoinConjuncts();
                     Set<String> slotNames = new HashSet<>();
                     List<Slot> leftOutput = new ArrayList<>(lj.left().getOutput());
@@ -208,7 +208,7 @@ public class BindExpression implements AnalysisRuleFactory {
                             .collect(Collectors.toList());
                     return new LogicalJoin<>(join.getJoinType(),
                             hashJoinConjuncts, cond, join.getHint(), join.getMarkJoinSlotReference(),
-                            join.left(), join.right());
+                            join.children());
                 })
             ),
             RuleType.BINDING_AGGREGATE_SLOT.build(

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/InnerJoinLAsscomProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/InnerJoinLAsscomProject.java
@@ -28,7 +28,8 @@ import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.util.Utils;
 
-import java.util.ArrayList;
+import com.google.common.collect.ImmutableList;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -98,7 +99,7 @@ public class InnerJoinLAsscomProject extends OneExplorationRuleFactory {
                     newTopJoin.getJoinReorderContext().copyFrom(topJoin.getJoinReorderContext());
                     newTopJoin.getJoinReorderContext().setHasLAsscom(true);
 
-                    return CBOUtils.projectOrSelf(new ArrayList<>(topJoin.getOutput()), newTopJoin);
+                    return CBOUtils.projectOrSelf(ImmutableList.copyOf(topJoin.getOutput()), newTopJoin);
                 }).toRule(RuleType.LOGICAL_INNER_JOIN_LASSCOM_PROJECT);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/InnerJoinLeftAssociateProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/InnerJoinLeftAssociateProject.java
@@ -27,7 +27,8 @@ import org.apache.doris.nereids.trees.plans.GroupPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 
-import java.util.ArrayList;
+import com.google.common.collect.ImmutableList;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -90,7 +91,7 @@ public class InnerJoinLeftAssociateProject extends OneExplorationRuleFactory {
                     InnerJoinLeftAssociate.setNewBottomJoinReorder(newBottomJoin, bottomJoin);
                     InnerJoinLeftAssociate.setNewTopJoinReorder(newTopJoin, topJoin);
 
-                    return CBOUtils.projectOrSelf(new ArrayList<>(topJoin.getOutput()), newTopJoin);
+                    return CBOUtils.projectOrSelf(ImmutableList.copyOf(topJoin.getOutput()), newTopJoin);
                 }).toRule(RuleType.LOGICAL_INNER_JOIN_LEFT_ASSOCIATIVE);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/InnerJoinRightAssociateProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/InnerJoinRightAssociateProject.java
@@ -27,7 +27,8 @@ import org.apache.doris.nereids.trees.plans.GroupPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 
-import java.util.ArrayList;
+import com.google.common.collect.ImmutableList;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -87,7 +88,7 @@ public class InnerJoinRightAssociateProject extends OneExplorationRuleFactory {
                     setNewBottomJoinReorder(newBottomJoin, bottomJoin);
                     setNewTopJoinReorder(newTopJoin, topJoin);
 
-                    return CBOUtils.projectOrSelf(new ArrayList<>(topJoin.getOutput()), newTopJoin);
+                    return CBOUtils.projectOrSelf(ImmutableList.copyOf(topJoin.getOutput()), newTopJoin);
                 }).toRule(RuleType.LOGICAL_INNER_JOIN_RIGHT_ASSOCIATIVE);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/JoinExchangeBothProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/JoinExchangeBothProject.java
@@ -30,6 +30,7 @@ import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.util.JoinUtils;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
@@ -104,7 +105,7 @@ public class JoinExchangeBothProject extends OneExplorationRuleFactory {
                     JoinExchange.setNewRightJoinReorder(newRightJoin, leftJoin);
                     JoinExchange.setNewTopJoinReorder(newTopJoin, topJoin);
 
-                    return CBOUtils.projectOrSelf(new ArrayList<>(topJoin.getOutput()), newTopJoin);
+                    return CBOUtils.projectOrSelf(ImmutableList.copyOf(topJoin.getOutput()), newTopJoin);
                 }).toRule(RuleType.LOGICAL_JOIN_EXCHANGE);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/JoinExchangeLeftProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/JoinExchangeLeftProject.java
@@ -30,6 +30,7 @@ import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.util.JoinUtils;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
@@ -104,7 +105,7 @@ public class JoinExchangeLeftProject extends OneExplorationRuleFactory {
                     JoinExchange.setNewRightJoinReorder(newRightJoin, leftJoin);
                     JoinExchange.setNewTopJoinReorder(newTopJoin, topJoin);
 
-                    return CBOUtils.projectOrSelf(new ArrayList<>(topJoin.getOutput()), newTopJoin);
+                    return CBOUtils.projectOrSelf(ImmutableList.copyOf(topJoin.getOutput()), newTopJoin);
                 }).toRule(RuleType.LOGICAL_JOIN_EXCHANGE);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/JoinExchangeRightProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/JoinExchangeRightProject.java
@@ -30,6 +30,7 @@ import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.util.JoinUtils;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
@@ -104,7 +105,7 @@ public class JoinExchangeRightProject extends OneExplorationRuleFactory {
                     JoinExchange.setNewRightJoinReorder(newRightJoin, rightJoin);
                     JoinExchange.setNewTopJoinReorder(newTopJoin, topJoin);
 
-                    return CBOUtils.projectOrSelf(new ArrayList<>(topJoin.getOutput()), newTopJoin);
+                    return CBOUtils.projectOrSelf(ImmutableList.copyOf(topJoin.getOutput()), newTopJoin);
                 }).toRule(RuleType.LOGICAL_JOIN_EXCHANGE);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/LogicalJoinSemiJoinTransposeProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/LogicalJoinSemiJoinTransposeProject.java
@@ -27,7 +27,6 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 
 import com.google.common.collect.ImmutableList;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -56,7 +55,7 @@ public class LogicalJoinSemiJoinTransposeProject implements ExplorationRuleFacto
                             // Discard this project, because it is useless.
                             Plan newBottomJoin = topJoin.withChildrenNoContext(a, c);
                             Plan newTopJoin = bottomJoin.withChildrenNoContext(newBottomJoin, b);
-                            return CBOUtils.projectOrSelf(new ArrayList<>(topJoin.getOutput()),
+                            return CBOUtils.projectOrSelf(ImmutableList.copyOf(topJoin.getOutput()),
                                     newTopJoin);
                         }).toRule(RuleType.LOGICAL_JOIN_LOGICAL_SEMI_JOIN_TRANSPOSE_PROJECT),
 
@@ -74,7 +73,7 @@ public class LogicalJoinSemiJoinTransposeProject implements ExplorationRuleFacto
                             // Discard this project, because it is useless.
                             Plan newBottomJoin = topJoin.withChildrenNoContext(a, b);
                             Plan newTopJoin = bottomJoin.withChildrenNoContext(newBottomJoin, c);
-                            return CBOUtils.projectOrSelf(new ArrayList<>(topJoin.getOutput()),
+                            return CBOUtils.projectOrSelf(ImmutableList.copyOf(topJoin.getOutput()),
                                     newTopJoin);
                         }).toRule(RuleType.LOGICAL_JOIN_LOGICAL_SEMI_JOIN_TRANSPOSE_PROJECT)
         );

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/OuterJoinAssocProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/OuterJoinAssocProject.java
@@ -31,9 +31,9 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.nereids.util.ExpressionUtils;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -99,7 +99,7 @@ public class OuterJoinAssocProject extends OneExplorationRuleFactory {
                     newTopJoin.getJoinReorderContext().copyFrom(topJoin.getJoinReorderContext());
                     OuterJoinAssoc.setReorderContext(newTopJoin, newBottomJoin);
 
-                    return CBOUtils.projectOrSelf(new ArrayList<>(topJoin.getOutput()), newTopJoin);
+                    return CBOUtils.projectOrSelf(ImmutableList.copyOf(topJoin.getOutput()), newTopJoin);
                 }).toRule(RuleType.LOGICAL_OUTER_JOIN_ASSOC_PROJECT);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/OuterJoinLAsscomProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/OuterJoinLAsscomProject.java
@@ -27,7 +27,8 @@ import org.apache.doris.nereids.trees.plans.GroupPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 
-import java.util.ArrayList;
+import com.google.common.collect.ImmutableList;
+
 import java.util.HashSet;
 import java.util.Set;
 
@@ -80,7 +81,7 @@ public class OuterJoinLAsscomProject extends OneExplorationRuleFactory {
                     newTopJoin.getJoinReorderContext().copyFrom(topJoin.getJoinReorderContext());
                     newTopJoin.getJoinReorderContext().setHasLAsscom(true);
 
-                    return CBOUtils.projectOrSelf(new ArrayList<>(topJoin.getOutput()), newTopJoin);
+                    return CBOUtils.projectOrSelf(ImmutableList.copyOf(topJoin.getOutput()), newTopJoin);
                 }).toRule(RuleType.LOGICAL_OUTER_JOIN_LASSCOM_PROJECT);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/PushdownProjectThroughInnerJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/PushdownProjectThroughInnerJoin.java
@@ -122,7 +122,7 @@ public class PushdownProjectThroughInnerJoin implements ExplorationRuleFactory {
 
         if (!rightContains) {
             Plan newJoin = join.withChildren(newLeft, join.right());
-            return CBOUtils.projectOrSelf(new ArrayList<>(project.getOutput()), newJoin);
+            return CBOUtils.projectOrSelf(ImmutableList.copyOf(project.getOutput()), newJoin);
         }
 
         Builder<NamedExpression> newBProject = ImmutableList.<NamedExpression>builder().addAll(bProjects);
@@ -133,7 +133,7 @@ public class PushdownProjectThroughInnerJoin implements ExplorationRuleFactory {
         Plan newRight = CBOUtils.projectOrSelf(newBProject.build(), join.right());
 
         Plan newJoin = join.withChildren(newLeft, newRight);
-        return CBOUtils.projectOrSelf(new ArrayList<>(project.getOutput()), newJoin);
+        return CBOUtils.projectOrSelf(ImmutableList.copyOf(project.getOutput()), newJoin);
     }
 
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/PushdownProjectThroughSemiJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/PushdownProjectThroughSemiJoin.java
@@ -90,6 +90,6 @@ public class PushdownProjectThroughSemiJoin implements ExplorationRuleFactory {
         Plan newLeft = CBOUtils.projectOrSelf(newProject, join.left());
 
         Plan newJoin = join.withChildren(newLeft, join.right());
-        return CBOUtils.projectOrSelf(new ArrayList<>(project.getOutput()), newJoin);
+        return CBOUtils.projectOrSelf(ImmutableList.copyOf(project.getOutput()), newJoin);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/SemiJoinSemiJoinTransposeProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/SemiJoinSemiJoinTransposeProject.java
@@ -28,9 +28,9 @@ import org.apache.doris.nereids.trees.plans.GroupPlan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -81,7 +81,7 @@ public class SemiJoinSemiJoinTransposeProject extends OneExplorationRuleFactory 
                     LogicalJoin newTopSemi = bottomSemi.withChildrenNoContext(acProject, b);
                     newTopSemi.getJoinReorderContext().copyFrom(topSemi.getJoinReorderContext());
                     newTopSemi.getJoinReorderContext().setHasLAsscom(true);
-                    return CBOUtils.projectOrSelf(new ArrayList<>(topSemi.getOutput()), newTopSemi);
+                    return CBOUtils.projectOrSelf(ImmutableList.copyOf(topSemi.getOutput()), newTopSemi);
                 }).toRule(RuleType.LOGICAL_SEMI_JOIN_SEMI_JOIN_TRANSPOSE_PROJECT);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/ExpressionRewrite.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/ExpressionRewrite.java
@@ -204,7 +204,7 @@ public class ExpressionRewrite implements RewriteRuleFactory {
                 }
                 return new LogicalJoin<>(join.getJoinType(), rewriteHashJoinConjuncts,
                         rewriteOtherJoinConjuncts, join.getHint(), join.getMarkJoinSlotReference(),
-                        join.left(), join.right());
+                        join.children());
             }).toRule(RuleType.REWRITE_JOIN_EXPRESSION);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ExistsApplyToJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ExistsApplyToJoin.java
@@ -107,7 +107,7 @@ public class ExistsApplyToJoin extends OneRewriteRuleFactory {
                         : ExpressionUtils.EMPTY_CONDITION,
                     JoinHint.NONE,
                     apply.getMarkJoinSlotReference(),
-                    (LogicalPlan) apply.left(), (LogicalPlan) apply.right());
+                    apply.children());
         } else {
             return new LogicalJoin<>(JoinType.LEFT_SEMI_JOIN, ExpressionUtils.EMPTY_CONDITION,
                     predicate != null
@@ -115,7 +115,7 @@ public class ExistsApplyToJoin extends OneRewriteRuleFactory {
                         : ExpressionUtils.EMPTY_CONDITION,
                     JoinHint.NONE,
                     apply.getMarkJoinSlotReference(),
-                    (LogicalPlan) apply.left(), (LogicalPlan) apply.right());
+                    apply.children());
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ExtractFilterFromCrossJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ExtractFilterFromCrossJoin.java
@@ -41,7 +41,7 @@ public class ExtractFilterFromCrossJoin extends OneRewriteRuleFactory {
                 .then(join -> {
                     LogicalJoin<Plan, Plan> newJoin = new LogicalJoin<>(JoinType.CROSS_JOIN,
                             ExpressionUtils.EMPTY_CONDITION, ExpressionUtils.EMPTY_CONDITION, join.getHint(),
-                            join.getMarkJoinSlotReference(), join.left(), join.right());
+                            join.getMarkJoinSlotReference(), join.children());
                     Set<Expression> predicates = Stream.concat(join.getHashJoinConjuncts().stream(),
                                     join.getOtherJoinConjuncts().stream())
                             .collect(ImmutableSet.toImmutableSet());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/FindHashConditionForJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/FindHashConditionForJoin.java
@@ -74,7 +74,7 @@ public class FindHashConditionForJoin extends OneRewriteRuleFactory {
                     remainedNonHashJoinConjuncts,
                     join.getHint(),
                     join.getMarkJoinSlotReference(),
-                    join.left(), join.right());
+                    join.children());
         }).toRule(RuleType.FIND_HASH_CONDITION_FOR_JOIN);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/InApplyToJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/InApplyToJoin.java
@@ -111,12 +111,12 @@ public class InApplyToJoin extends OneRewriteRuleFactory {
                         Lists.newArrayList(),
                         conjuncts,
                         JoinHint.NONE, apply.getMarkJoinSlotReference(),
-                        apply.left(), apply.right());
+                        apply.children());
             } else {
                 return new LogicalJoin<>(JoinType.LEFT_SEMI_JOIN, Lists.newArrayList(),
                         conjuncts,
                         JoinHint.NONE, apply.getMarkJoinSlotReference(),
-                        apply.left(), apply.right());
+                        apply.children());
             }
         }).toRule(RuleType.IN_APPLY_TO_JOIN);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushFilterInsideJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushFilterInsideJoin.java
@@ -49,7 +49,7 @@ public class PushFilterInsideJoin extends OneRewriteRuleFactory {
                     otherConditions.addAll(join.getOtherJoinConjuncts());
                     return new LogicalJoin<>(join.getJoinType(), join.getHashJoinConjuncts(),
                             otherConditions, join.getHint(), join.getMarkJoinSlotReference(),
-                            join.left(), join.right());
+                            join.children());
                 }).toRule(RuleType.PUSH_FILTER_INSIDE_JOIN);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ScalarApplyToJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ScalarApplyToJoin.java
@@ -93,7 +93,6 @@ public class ScalarApplyToJoin extends OneRewriteRuleFactory {
                         : correlationFilter.get()),
                 JoinHint.NONE,
                 apply.getMarkJoinSlotReference(),
-                (LogicalPlan) apply.left(),
-                (LogicalPlan) apply.right());
+                apply.children());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/AbstractPlan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/AbstractPlan.java
@@ -19,13 +19,6 @@ package org.apache.doris.nereids.trees.plans;
 
 import org.apache.doris.nereids.analyzer.Unbound;
 import org.apache.doris.nereids.memo.GroupExpression;
-import org.apache.doris.nereids.memo.Memo;
-import org.apache.doris.nereids.metrics.CounterType;
-import org.apache.doris.nereids.metrics.EventChannel;
-import org.apache.doris.nereids.metrics.EventProducer;
-import org.apache.doris.nereids.metrics.consumer.LogConsumer;
-import org.apache.doris.nereids.metrics.enhancer.AddCounterEventEnhancer;
-import org.apache.doris.nereids.metrics.event.CounterEvent;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.UnboundLogicalProperties;
 import org.apache.doris.nereids.trees.AbstractTreeNode;
@@ -53,10 +46,6 @@ import javax.annotation.Nullable;
  */
 public abstract class AbstractPlan extends AbstractTreeNode<Plan> implements Plan {
     public static final String FRAGMENT_ID = "fragment";
-    private static final EventProducer PLAN_CONSTRUCT_TRACER = new EventProducer(CounterEvent.class,
-            EventChannel.getDefaultChannel()
-                    .addEnhancers(new AddCounterEventEnhancer())
-                    .addConsumers(new LogConsumer(CounterEvent.class, EventChannel.LOG)));
 
     protected final Statistics statistics;
     protected final PlanType type;
@@ -87,7 +76,6 @@ public abstract class AbstractPlan extends AbstractTreeNode<Plan> implements Pla
         this.logicalPropertiesSupplier = Suppliers.memoize(() -> optLogicalProperties.orElseGet(
                 this::computeLogicalProperties));
         this.statistics = statistics;
-        PLAN_CONSTRUCT_TRACER.log(CounterEvent.of(Memo.getStateId(), CounterType.PLAN_CONSTRUCTOR, null, null, null));
     }
 
     /**
@@ -103,7 +91,6 @@ public abstract class AbstractPlan extends AbstractTreeNode<Plan> implements Pla
         this.logicalPropertiesSupplier = Suppliers.memoize(() -> optLogicalProperties.orElseGet(
                 this::computeLogicalProperties));
         this.statistics = statistics;
-        PLAN_CONSTRUCT_TRACER.log(CounterEvent.of(Memo.getStateId(), CounterType.PLAN_CONSTRUCTOR, null, null, null));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/Command.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/Command.java
@@ -43,17 +43,6 @@ public abstract class Command extends AbstractPlan implements LogicalPlan {
         super(type, children);
     }
 
-    public Command(PlanType type, Optional<LogicalProperties> optLogicalProperties, Plan... children) {
-        super(type, optLogicalProperties, children);
-    }
-
-    public Command(PlanType type, Optional<GroupExpression> groupExpression,
-            Optional<LogicalProperties> optLogicalProperties,
-            @Nullable Statistics statistics,
-            Plan... children) {
-        super(type, groupExpression, optLogicalProperties, statistics, children);
-    }
-
     public void run(ConnectContext ctx, StmtExecutor executor) throws Exception {
         // all command should impl this interface.
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/Command.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/Command.java
@@ -27,9 +27,6 @@ import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.StmtExecutor;
-import org.apache.doris.statistics.Statistics;
-
-import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Optional;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/AbstractLogicalPlan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/AbstractLogicalPlan.java
@@ -26,6 +26,7 @@ import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.qe.ConnectContext;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -40,12 +41,13 @@ public abstract class AbstractLogicalPlan extends AbstractPlan implements Logica
         super(type, children);
     }
 
-    public AbstractLogicalPlan(PlanType type, Optional<LogicalProperties> logicalProperties, Plan... children) {
-        super(type, logicalProperties, children);
+    public AbstractLogicalPlan(PlanType type, Optional<GroupExpression> groupExpression,
+            Optional<LogicalProperties> logicalProperties, Plan... children) {
+        super(type, groupExpression, logicalProperties, null, children);
     }
 
     public AbstractLogicalPlan(PlanType type, Optional<GroupExpression> groupExpression,
-                               Optional<LogicalProperties> logicalProperties, Plan... children) {
+            Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         super(type, groupExpression, logicalProperties, null, children);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalBinary.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalBinary.java
@@ -42,5 +42,10 @@ public abstract class LogicalBinary<
         super(type, groupExpression, logicalProperties, leftChild, rightChild);
     }
 
+    public LogicalBinary(PlanType type, Optional<GroupExpression> groupExpression,
+            Optional<LogicalProperties> logicalProperties, List<Plan> children) {
+        super(type, groupExpression, logicalProperties, children);
+    }
+
     public abstract List<Slot> computeOutput();
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJoin.java
@@ -94,14 +94,26 @@ public class LogicalJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends 
                 Optional.empty(), Optional.empty(), leftChild, rightChild);
     }
 
+    public LogicalJoin(
+            JoinType joinType,
+            List<Expression> hashJoinConjuncts,
+            List<Expression> otherJoinConjuncts,
+            JoinHint hint,
+            Optional<MarkJoinSlotReference> markJoinSlotReference,
+            List<Plan> children) {
+        this(joinType, hashJoinConjuncts,
+                otherJoinConjuncts, hint, markJoinSlotReference,
+                Optional.empty(), Optional.empty(), children);
+    }
+
     /**
      * Just use in withXXX method.
      */
     private LogicalJoin(JoinType joinType, List<Expression> hashJoinConjuncts, List<Expression> otherJoinConjuncts,
             JoinHint hint, Optional<MarkJoinSlotReference> markJoinSlotReference,
             Optional<GroupExpression> groupExpression, Optional<LogicalProperties> logicalProperties,
-            LEFT_CHILD_TYPE leftChild, RIGHT_CHILD_TYPE rightChild, JoinReorderContext joinReorderContext) {
-        super(PlanType.LOGICAL_JOIN, groupExpression, logicalProperties, leftChild, rightChild);
+            List<Plan> children, JoinReorderContext joinReorderContext) {
+        super(PlanType.LOGICAL_JOIN, groupExpression, logicalProperties, children);
         this.joinType = Objects.requireNonNull(joinType, "joinType can not be null");
         this.hashJoinConjuncts = ImmutableList.copyOf(hashJoinConjuncts);
         this.otherJoinConjuncts = ImmutableList.copyOf(otherJoinConjuncts);
@@ -121,6 +133,23 @@ public class LogicalJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends 
             LEFT_CHILD_TYPE leftChild,
             RIGHT_CHILD_TYPE rightChild) {
         super(PlanType.LOGICAL_JOIN, groupExpression, logicalProperties, leftChild, rightChild);
+        this.joinType = Objects.requireNonNull(joinType, "joinType can not be null");
+        this.hashJoinConjuncts = ImmutableList.copyOf(hashJoinConjuncts);
+        this.otherJoinConjuncts = ImmutableList.copyOf(otherJoinConjuncts);
+        this.hint = Objects.requireNonNull(hint, "hint can not be null");
+        this.markJoinSlotReference = markJoinSlotReference;
+    }
+
+    private LogicalJoin(
+            JoinType joinType,
+            List<Expression> hashJoinConjuncts,
+            List<Expression> otherJoinConjuncts,
+            JoinHint hint,
+            Optional<MarkJoinSlotReference> markJoinSlotReference,
+            Optional<GroupExpression> groupExpression,
+            Optional<LogicalProperties> logicalProperties,
+            List<Plan> children) {
+        super(PlanType.LOGICAL_JOIN, groupExpression, logicalProperties, children);
         this.joinType = Objects.requireNonNull(joinType, "joinType can not be null");
         this.hashJoinConjuncts = ImmutableList.copyOf(hashJoinConjuncts);
         this.otherJoinConjuncts = ImmutableList.copyOf(otherJoinConjuncts);
@@ -252,13 +281,13 @@ public class LogicalJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends 
     public LogicalJoin<Plan, Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 2);
         return new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, hint, markJoinSlotReference,
-                Optional.empty(), Optional.empty(), children.get(0), children.get(1), joinReorderContext);
+                Optional.empty(), Optional.empty(), children, joinReorderContext);
     }
 
     @Override
     public LogicalJoin<Plan, Plan> withGroupExpression(Optional<GroupExpression> groupExpression) {
         return new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, hint, markJoinSlotReference,
-                groupExpression, Optional.of(getLogicalProperties()), left(), right(), joinReorderContext);
+                groupExpression, Optional.of(getLogicalProperties()), children, joinReorderContext);
     }
 
     @Override
@@ -266,7 +295,7 @@ public class LogicalJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends 
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 2);
         return new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, hint, markJoinSlotReference,
-                groupExpression, logicalProperties, children.get(0), children.get(1), joinReorderContext);
+                groupExpression, logicalProperties, children, joinReorderContext);
     }
 
     public LogicalJoin<Plan, Plan> withChildrenNoContext(Plan left, Plan right) {
@@ -277,7 +306,7 @@ public class LogicalJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends 
     public LogicalJoin<Plan, Plan> withJoinConjuncts(
             List<Expression> hashJoinConjuncts, List<Expression> otherJoinConjuncts) {
         return new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts,
-                hint, markJoinSlotReference, left(), right());
+                hint, markJoinSlotReference, children);
     }
 
     public LogicalJoin<Plan, Plan> withHashJoinConjunctsAndChildren(
@@ -295,7 +324,7 @@ public class LogicalJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends 
 
     public LogicalJoin<Plan, Plan> withJoinType(JoinType joinType) {
         return new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, hint,
-                markJoinSlotReference, left(), right());
+                markJoinSlotReference, children);
     }
 
     public LogicalJoin<Plan, Plan> withTypeChildren(JoinType joinType, Plan left, Plan right) {
@@ -305,7 +334,7 @@ public class LogicalJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends 
 
     public LogicalJoin<Plan, Plan> withOtherJoinConjuncts(List<Expression> otherJoinConjuncts) {
         return new LogicalJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, hint,
-                markJoinSlotReference, left(), right());
+                markJoinSlotReference, children);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalUnary.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalUnary.java
@@ -38,10 +38,6 @@ public abstract class LogicalUnary<CHILD_TYPE extends Plan>
         super(type, child);
     }
 
-    public LogicalUnary(PlanType type, Optional<LogicalProperties> logicalProperties, CHILD_TYPE child) {
-        super(type, logicalProperties, child);
-    }
-
     public LogicalUnary(PlanType type, Optional<GroupExpression> groupExpression,
                             Optional<LogicalProperties> logicalProperties, CHILD_TYPE child) {
         super(type, groupExpression, logicalProperties, child);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/HyperGraphBuilder.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/HyperGraphBuilder.java
@@ -130,7 +130,7 @@ public class HyperGraphBuilder {
                     rightBitmap);
             Plan leftPlan = plans.get(leftKey.get());
             Plan rightPlan = plans.get(rightKey.get());
-            LogicalJoin join = new LogicalJoin<>(joinType, new ArrayList<>(), leftPlan, rightPlan);
+            LogicalJoin join = new LogicalJoin<>(joinType, leftPlan, rightPlan);
 
             BitSet key = new BitSet();
             key.or(leftKey.get());

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/LogicalPlanBuilder.java
@@ -121,7 +121,7 @@ public class LogicalPlanBuilder {
     }
 
     public LogicalPlanBuilder joinEmptyOn(LogicalPlan right, JoinType joinType) {
-        LogicalJoin<LogicalPlan, LogicalPlan> join = new LogicalJoin<>(joinType, new ArrayList<>(), this.plan, right);
+        LogicalJoin<LogicalPlan, LogicalPlan> join = new LogicalJoin<>(joinType, this.plan, right);
         return from(join);
     }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Join use List<Plan> as children can avoid to construct extra `ImmutableList`

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

