### PR TITLE
[fix](multi-table-load) fix memory leak when processing multi-table routine load

### DIFF
--- a/be/src/io/fs/multi_table_pipe.h
+++ b/be/src/io/fs/multi_table_pipe.h
@@ -32,7 +32,7 @@ class MultiTablePipe : public KafkaConsumerPipe {
 public:
     MultiTablePipe(std::shared_ptr<StreamLoadContext> ctx, size_t max_buffered_bytes = 1024 * 1024,
                    size_t min_chunk_size = 64 * 1024)
-            : KafkaConsumerPipe(max_buffered_bytes, min_chunk_size), _ctx(ctx) {}
+            : KafkaConsumerPipe(max_buffered_bytes, min_chunk_size), _ctx(ctx.get()) {}
 
     ~MultiTablePipe() override = default;
 
@@ -74,7 +74,7 @@ private:
     std::atomic<uint64_t> _unplanned_row_cnt {0}; // trigger plan request when exceed threshold
     std::atomic<uint64_t> _inflight_plan_cnt {0}; // how many plan fragment are executing?
     std::atomic<bool> _consume_finished {false};
-    std::shared_ptr<StreamLoadContext> _ctx;
+    StreamLoadContext* _ctx;
     Status _status; // save the first error status of all executing plan fragment
 #ifndef BE_TEST
     std::mutex _tablet_commit_infos_lock;

--- a/be/src/io/fs/multi_table_pipe.h
+++ b/be/src/io/fs/multi_table_pipe.h
@@ -74,6 +74,9 @@ private:
     std::atomic<uint64_t> _unplanned_row_cnt {0}; // trigger plan request when exceed threshold
     std::atomic<uint64_t> _inflight_plan_cnt {0}; // how many plan fragment are executing?
     std::atomic<bool> _consume_finished {false};
+    // note: Use raw pointer here to avoid cycle reference with StreamLoadContext.
+    // Life cycle of MultiTablePipe is under control of StreamLoadContext, which means StreamLoadContext is created
+    // before NultiTablePipe and released after it. It is safe to use raw pointer here.
     StreamLoadContext* _ctx;
     Status _status; // save the first error status of all executing plan fragment
 #ifndef BE_TEST


### PR DESCRIPTION
## Proposed changes

close:#21606
 
### Debug

Using jemalloc prof tool and found there is unreasonable memory overhead within multi_table_put_result obj.
![image](https://github.com/apache/doris/assets/82279870/1eb53a3f-146b-460e-9400-e79f19191af2)

Found that there are cycle refs during processing each single routine load task, i.e. StreamLoadContext holds a shared ptr ref to MultiTablePipe, and MultitablePipe holds shared ptr ref to StreamLoadContext as well.

Furthermore, during related loading process, StreamLoadContext's obj cnt is always growing and do not decrease when load stream stopped.
![image](https://github.com/apache/doris/assets/82279870/aa4db539-297c-4e34-8803-f4293a09da00)

### Resolve

Using a naked ptr rather than shared ptr in MultiTablePipe to hold the StreamLoadContext, so that both the StreamLoadContext and the MultiTablePipe will be released normally. 

Why not use weak_ptr?
1. Cuz introducing weak_ptr is not so elegant and has lower performance.
2. MultiTablePipe's life cycle is under control of the StreamLoadContext, it is reasonable to use raw ptr to provide MultiTablePipe with an access to the current ctx. StreanLoadContext is sure to be released after MultiTablePipe, and will not result in dangling pointer. 

### Fix result

Memory usage during load process:
![image](https://github.com/apache/doris/assets/82279870/e2980411-91aa-4cb4-aecc-db5685ac79e9)


Observing the obj cnt:
![image](https://github.com/apache/doris/assets/82279870/0b0062b6-39b5-42f6-ab02-439762afdb59)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

