### PR TITLE
[fix](Materialized) fix return error when create mv as select * from

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
@@ -208,7 +208,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
             if (!(selectListItemExpr instanceof SlotRef) && !(selectListItemExpr instanceof FunctionCallExpr)
                     && !(selectListItemExpr instanceof ArithmeticExpr)) {
                 throw new AnalysisException("The materialized view only support the single column or function expr. "
-                        + "Error column: " + selectListItemExpr.toSql());
+                        + "Error column: " + (selectListItemExpr == null ? "" : selectListItemExpr.toSql()));
             }
             List<SlotRef> slots = new ArrayList<>();
             selectListItemExpr.collect(SlotRef.class, slots);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

when create mv as select * from tbl, will return error like : `ERROR 1105 (HY000): errCode = 2, detailMessage = Unexpected exception: null`, and it is not good for user.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

