### PR TITLE
[Fix](storage engine) shutdown cooldown and cold data compaction thread when engine stop

### DIFF
--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -165,6 +165,9 @@ StorageEngine::~StorageEngine() {
     if (_calc_delete_bitmap_thread_pool) {
         _calc_delete_bitmap_thread_pool->shutdown();
     }
+    if (_cold_data_compaction_thread_pool) {
+        _cold_data_compaction_thread_pool->shutdown();
+    }
     _clear();
     _s_instance = nullptr;
 }
@@ -560,6 +563,8 @@ void StorageEngine::stop() {
     THREAD_JOIN(_fd_cache_clean_thread);
     THREAD_JOIN(_tablet_checkpoint_tasks_producer_thread);
     THREAD_JOIN(_async_publish_thread);
+    THREAD_JOIN(_cold_data_compaction_producer_thread);
+    THREAD_JOIN(_cooldown_tasks_producer_thread);
 #undef THREAD_JOIN
 
 #define THREADS_JOIN(threads)            \


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

when stop be gracefully, storage engine did not shut down cooldown and cold data compaction thread correctly.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

