### PR TITLE
[Fix](pipeline) fix ExchangeSinkBuffer request id memory alloc problem

### DIFF
--- a/be/src/pipeline/exec/exchange_sink_buffer.cpp
+++ b/be/src/pipeline/exec/exchange_sink_buffer.cpp
@@ -58,10 +58,6 @@ ExchangeSinkBuffer::ExchangeSinkBuffer(PUniqueId query_id, PlanNodeId dest_node_
 ExchangeSinkBuffer::~ExchangeSinkBuffer() = default;
 
 void ExchangeSinkBuffer::close() {
-    for (const auto& pair : _instance_to_request) {
-        pair.second->release_finst_id();
-        pair.second->release_query_id();
-    }
     _instance_to_broadcast_package_queue.clear();
     _instance_to_package_queue.clear();
     _instance_to_request.clear();
@@ -269,7 +265,7 @@ Status ExchangeSinkBuffer::_send_rpc(InstanceLoId id) {
 void ExchangeSinkBuffer::_construct_request(InstanceLoId id, PUniqueId finst_id) {
     _instance_to_request[id] = std::make_unique<PTransmitDataParams>();
     _instance_to_request[id]->mutable_finst_id()->CopyFrom(finst_id);
-    _instance_to_request[id]->set_allocated_query_id(&_query_id);
+    _instance_to_request[id]->mutable_query_id()->CopyFrom(_query_id);
 
     _instance_to_request[id]->set_node_id(_dest_node_id);
     _instance_to_request[id]->set_sender_id(_sender_id);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

1. pair.second->release_finst_id() makes finst_id memory leaked.
2. _instance_to_request[id]->set_allocated_query_id(&_query_id) makes buffer double free.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

