### PR TITLE
[feature](TVF) support path partition keys for external file TVF

### DIFF
--- a/docs/en/docs/sql-manual/sql-functions/table-functions/hdfs.md
+++ b/docs/en/docs/sql-manual/sql-functions/table-functions/hdfs.md
@@ -88,6 +88,10 @@ File format parameters:
 - `trim_double_quotes`: Boolean type (optional), the default value is `false`. True means that the outermost double quotes of each field in the csv file are trimmed.
 - `skip_lines`: Integer type (optional), the default value is 0. It will skip some lines in the head of csv file. It will be disabled when the format is `csv_with_names` or `csv_with_names_and_types`.
 
+other kinds of parameters:
+
+- `path_partition_keys`: (optional) Specifies the column names carried in the file path. For example, if the file path is /path/to/city=beijing/date="2023-07-09", you should fill in `path_partition_keys="city,date"`. It will automatically read the corresponding column names and values from the path during load process.
+
 ### Examples
 
 Read and access csv format files on hdfs storage.

--- a/docs/en/docs/sql-manual/sql-functions/table-functions/s3.md
+++ b/docs/en/docs/sql-manual/sql-functions/table-functions/s3.md
@@ -85,6 +85,10 @@ file format parameter:
 - `trim_double_quotes`: Boolean type (optional), the default value is `false`. True means that the outermost double quotes of each field in the csv file are trimmed.
 - `skip_lines`: Integer type (optional), the default value is 0. It will skip some lines in the head of csv file. It will be disabled when the format is `csv_with_names` or `csv_with_names_and_types`.
 
+other parameter:
+
+- `path_partition_keys`: (optional) Specifies the column names carried in the file path. For example, if the file path is /path/to/city=beijing/date="2023-07-09", you should fill in `path_partition_keys="city,date"`. It will automatically read the corresponding column names and values from the path during load process.
+
 ### Example
 
 Read and access csv format files on S3-compatible object storage.

--- a/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/hdfs.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/hdfs.md
@@ -87,7 +87,10 @@ hdfs(
     <version since="dev">下面2个参数是用于csv格式的导入</version>
 
 - `trim_double_quotes`： 布尔类型，选填，默认值为 `false`，为 `true` 时表示裁剪掉 csv 文件每个字段最外层的双引号
-- `skip_lines`： 整数类型，选填，默认值为0，含义为跳过csv文件的前几行。当设置format设置为 `csv_with_names` 或 `csv_with_names_and_types` 时，该参数会失效 
+- `skip_lines`： 整数类型，选填，默认值为0，含义为跳过csv文件的前几行。当设置format设置为 `csv_with_names` 或 `csv_with_names_and_types` 时，该参数会失效
+
+其他参数：
+- `path_partition_keys`：（选填）指定文件路径中携带的分区列名，例如/path/to/city=beijing/date="2023-07-09", 则填写`path_partition_keys="city,date"`，将会自动从路径中读取相应列名和列值进行导入。
 
 ### Examples
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/s3.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/s3.md
@@ -87,6 +87,9 @@ S3 tvf中的每一个参数都是一个 `"key"="value"` 对。
 - `trim_double_quotes`： 布尔类型，选填，默认值为 `false`，为 `true` 时表示裁剪掉 csv 文件每个字段最外层的双引号
 - `skip_lines`： 整数类型，选填，默认值为0，含义为跳过csv文件的前几行。当设置format设置为 `csv_with_names` 或 `csv_with_names_and_types` 时，该参数会失效
 
+其他参数：
+- `path_partition_keys`：（选填）指定文件路径中携带的分区列名，例如/path/to/city=beijing/date="2023-07-09", 则填写`path_partition_keys="city,date"`，将会自动从路径中读取相应列名和列值进行导入。
+
 ### Example
 
 读取并访问 S3 兼容的对象存储上的csv格式文件

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/S3TvfLoadStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/S3TvfLoadStmt.java
@@ -166,6 +166,12 @@ public class S3TvfLoadStmt extends NativeInsertStmt {
             }
         }
 
+        List<String> columnsFromPath = dataDescription.getColumnsFromPath();
+        if (columnsFromPath != null) {
+            params.put(ExternalFileTableValuedFunction.PATH_PARTITION_KEYS,
+                    String.join(",", columnsFromPath));
+        }
+
         Preconditions.checkState(!brokerDesc.isMultiLoadBroker(), "do not support multi broker load currently");
         Preconditions.checkState(brokerDesc.getStorageType() == StorageType.S3, "only support S3 load");
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -2177,7 +2177,7 @@ public class SingleNodePlanner {
 
     /**
      * Create a tree of PlanNodes for the given tblRef, which can be a BaseTableRef,
-     * CollectionTableRef or an InlineViewRef.
+     * TableValuedFunctionRef, CollectionTableRef or an InlineViewRef.
      * <p>
      * 'fastPartitionKeyScans' indicates whether to try to produce the slots with
      * metadata instead of table scans. Only applicable to BaseTableRef which is also

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/TVFScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/TVFScanNode.java
@@ -99,7 +99,7 @@ public class TVFScanNode extends FileQueryScanNode {
 
     @Override
     public List<String> getPathPartitionKeys() {
-        return Lists.newArrayList();
+        return tableValuedFunction.getPathPartitionKeys();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/ExternalFileTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/ExternalFileTableValuedFunction.java
@@ -71,12 +71,15 @@ import org.apache.thrift.TException;
 import org.apache.thrift.TSerializer;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * ExternalFileTableValuedFunction is used for S3/HDFS/LOCAL table-valued-function
@@ -98,6 +101,7 @@ public abstract class ExternalFileTableValuedFunction extends TableValuedFunctio
     protected static final String SKIP_LINES = "skip_lines";
     protected static final String CSV_SCHEMA = "csv_schema";
     protected static final String COMPRESS_TYPE = "compress_type";
+    public static final String PATH_PARTITION_KEYS = "path_partition_keys";
     // decimal(p,s)
     private static final Pattern DECIMAL_TYPE_PATTERN = Pattern.compile("decimal\\((\\d+),(\\d+)\\)");
     // datetime(p)
@@ -118,10 +122,13 @@ public abstract class ExternalFileTableValuedFunction extends TableValuedFunctio
             .add(CSV_SCHEMA)
             .build();
 
-    // Columns got from file
+    // Columns got from file and path(if has)
     protected List<Column> columns = null;
     // User specified csv columns, it will override columns got from file
-    private List<Column> csvSchema = Lists.newArrayList();
+    private final List<Column> csvSchema = Lists.newArrayList();
+
+    // Partition columns from path, e.g. /path/to/columnName=columnValue.
+    private List<String> pathPartitionKeys;
 
     protected List<TBrokerFileStatus> fileStatuses = Lists.newArrayList();
     protected Map<String, String> locationProperties;
@@ -171,6 +178,10 @@ public abstract class ExternalFileTableValuedFunction extends TableValuedFunctio
             return locationProperties.get(S3Properties.ENDPOINT);
         }
         return "";
+    }
+
+    public List<String> getPathPartitionKeys() {
+        return pathPartitionKeys;
     }
 
     protected void parseFile() throws AnalysisException {
@@ -232,6 +243,12 @@ public abstract class ExternalFileTableValuedFunction extends TableValuedFunctio
                 || formatString.equals("csv_with_names_and_types")) {
             parseCsvSchema(csvSchema, validParams);
         }
+        pathPartitionKeys = Optional.ofNullable(validParams.get(PATH_PARTITION_KEYS))
+                .map(str ->
+                        Arrays.stream(str.split(","))
+                                .map(String::trim)
+                                .collect(Collectors.toList()))
+                .orElse(Lists.newArrayList());
     }
 
     // public for unit test
@@ -371,8 +388,8 @@ public abstract class ExternalFileTableValuedFunction extends TableValuedFunctio
                 if (!result.getStatus().getErrorMsgsList().isEmpty()) {
                     errMsg = result.getStatus().getErrorMsgsList().get(0);
                 } else {
-                    errMsg =  "fetchTableStructureAsync failed. backend address: "
-                                + address.getHostname() + ":" + address.getPort();
+                    errMsg = "fetchTableStructureAsync failed. backend address: "
+                            + address.getHostname() + ":" + address.getPort();
                 }
                 throw new AnalysisException(errMsg);
             }
@@ -392,6 +409,7 @@ public abstract class ExternalFileTableValuedFunction extends TableValuedFunctio
 
     /**
      * Convert PTypeDesc into doris column type
+     *
      * @param typeNodes list PTypeNodes in PTypeDesc
      * @param start the start index of typeNode to parse
      * @return column type and the number of parsed PTypeNodes
@@ -403,7 +421,7 @@ public abstract class ExternalFileTableValuedFunction extends TableValuedFunctio
         int parsedNodes;
         if (tPrimitiveType == TPrimitiveType.ARRAY) {
             Pair<Type, Integer> itemType = getColumnType(typeNodes, start + 1);
-            type =  ArrayType.create(itemType.key(), true);
+            type = ArrayType.create(itemType.key(), true);
             parsedNodes = 1 + itemType.value();
         } else if (tPrimitiveType == TPrimitiveType.MAP) {
             Pair<Type, Integer> keyType = getColumnType(typeNodes, start + 1);
@@ -428,14 +446,21 @@ public abstract class ExternalFileTableValuedFunction extends TableValuedFunctio
     }
 
     private void fillColumns(InternalService.PFetchTableSchemaResult result)
-                            throws AnalysisException {
+            throws AnalysisException {
         if (result.getColumnNums() == 0) {
             throw new AnalysisException("The amount of column is 0");
         }
+        // add fetched file columns
         for (int idx = 0; idx < result.getColumnNums(); ++idx) {
             PTypeDesc type = result.getColumnTypes(idx);
             String colName = result.getColumnNames(idx);
             columns.add(new Column(colName, getColumnType(type.getTypesList(), 0).key(), true));
+        }
+        // add path columns
+        // HACK(tsy): path columns are all treated as STRING type now, after BE supports reading all columns
+        //  types by all format readers from file meta, maybe reading path columns types from BE then.
+        for (String colName : pathPartitionKeys) {
+            columns.add(new Column(colName, Type.STRING, false));
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/HdfsTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/HdfsTableValuedFunction.java
@@ -59,11 +59,11 @@ public class HdfsTableValuedFunction extends ExternalFileTableValuedFunction {
     private String filePath;
 
     public HdfsTableValuedFunction(Map<String, String> params) throws AnalysisException {
-        Map<String, String> fileFormatParams = new CaseInsensitiveMap();
+        Map<String, String> fileParams = new CaseInsensitiveMap();
         locationProperties = Maps.newHashMap();
         for (String key : params.keySet()) {
             if (FILE_FORMAT_PROPERTIES.contains(key.toLowerCase())) {
-                fileFormatParams.put(key, params.get(key));
+                fileParams.put(key, params.get(key));
             } else {
                 // because HADOOP_FS_NAME contains upper and lower case
                 if (HdfsResource.HADOOP_FS_NAME.equalsIgnoreCase(key)) {
@@ -73,6 +73,9 @@ public class HdfsTableValuedFunction extends ExternalFileTableValuedFunction {
                 }
             }
         }
+        if (params.containsKey(PATH_PARTITION_KEYS)) {
+            fileParams.put(PATH_PARTITION_KEYS, params.get(PATH_PARTITION_KEYS));
+        }
 
         if (!locationProperties.containsKey(HDFS_URI)) {
             throw new AnalysisException(String.format("Configuration '%s' is required.", HDFS_URI));
@@ -81,7 +84,7 @@ public class HdfsTableValuedFunction extends ExternalFileTableValuedFunction {
         hdfsUri = URI.create(locationProperties.get(HDFS_URI));
         filePath = locationProperties.get(HdfsResource.HADOOP_FS_NAME) + hdfsUri.getPath();
 
-        parseProperties(fileFormatParams);
+        parseProperties(fileParams);
         parseFile();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/S3TableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/S3TableValuedFunction.java
@@ -54,7 +54,8 @@ public class S3TableValuedFunction extends ExternalFileTableValuedFunction {
             ImmutableSet.of("access_key", "secret_key", "session_token", "region");
 
     private static final ImmutableSet<String> OPTIONAL_KEYS =
-            ImmutableSet.of(S3Properties.SESSION_TOKEN, PropertyConverter.USE_PATH_STYLE, S3Properties.REGION);
+            ImmutableSet.of(S3Properties.SESSION_TOKEN, PropertyConverter.USE_PATH_STYLE, S3Properties.REGION,
+                    PATH_PARTITION_KEYS);
 
     private static final ImmutableSet<String> PROPERTIES_SET = ImmutableSet.<String>builder()
             .add(S3_URI)

--- a/regression-test/suites/load_p2/broker_load/test_tvf_based_broker_load.groovy
+++ b/regression-test/suites/load_p2/broker_load/test_tvf_based_broker_load.groovy
@@ -29,7 +29,7 @@ suite("test_tvf_based_broker_load_p2", "p2") {
                   "set7",
                   "null_default",
                   "filter",
-                  //  "path_column",
+                  "path_column",
                   "parquet_s3_case1", // col1 not in file but in table, will load default value for it.
                   "parquet_s3_case2", // x1 not in file, not in table, will throw "col not found" error.
                   "parquet_s3_case3", // p_comment not in table but in file, load normally.
@@ -61,7 +61,7 @@ suite("test_tvf_based_broker_load_p2", "p2") {
                  "s3://doris-build-1308700295/regression/load/data/part*",
                  "s3://doris-build-1308700295/regression/load/data/part*",
                  "s3://doris-build-1308700295/regression/load/data/part*",
-                 //  "s3://doris-build-1308700295/regression/load/data/path/*/part*",
+                 "s3://doris-build-1308700295/regression/load/data/path/*/part*",
                  "s3://doris-build-1308700295/regression/load/data/part*",
                  "s3://doris-build-1308700295/regression/load/data/part*",
                  "s3://doris-build-1308700295/regression/load/data/part*",
@@ -93,7 +93,7 @@ suite("test_tvf_based_broker_load_p2", "p2") {
                         """p_partkey,  p_size""",
                         """p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment""",
                         """p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment""",
-                        //  """p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment""",
+                        """p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment""",
                         """p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment, col1""",
                         """p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment, x1""",
                         """p_partkey, p_name, p_mfgr, p_brand, p_type, p_size, p_container, p_retailprice, p_comment""",
@@ -123,8 +123,8 @@ suite("test_tvf_based_broker_load_p2", "p2") {
                         //    """WATCHID,JAVAENABLE,TITLE,GOODEVENT,EVENTTIME,EVENTDATE,COUNTERID,CLIENTIP,REGIONID,USERID,COUNTERCLASS,OS,USERAGENT,URL,REFERER,ISREFRESH,REFERERCATEGORYID,REFERERREGIONID,URLCATEGORYID,URLREGIONID,RESOLUTIONWIDTH,RESOLUTIONHEIGHT,RESOLUTIONDEPTH,FLASHMAJOR,FLASHMINOR,FLASHMINOR2,NETMAJOR,NETMINOR,USERAGENTMAJOR,USERAGENTMINOR,COOKIEENABLE,JAVASCRIPTENABLE,ISMOBILE,MOBILEPHONE,MOBILEPHONEMODEL,PARAMS,IPNETWORKID,TRAFICSOURCEID,SEARCHENGINEID,SEARCHPHRASE,ADVENGINEID,ISARTIFICAL,WINDOWCLIENTWIDTH,WINDOWCLIENTHEIGHT,CLIENTTIMEZONE,CLIENTEVENTTIME,SILVERLIGHTVERSION1,SILVERLIGHTVERSION2,SILVERLIGHTVERSION3,SILVERLIGHTVERSION4,PAGECHARSET,CODEVERSION,ISLINK,ISDOWNLOAD,ISNOTBOUNCE,FUNIQID,ORIGINALURL,HID,ISOLDCOUNTER,ISEVENT,ISPARAMETER,DONTCOUNTHITS,WITHHASH,HITCOLOR,LOCALEVENTTIME,AGE,SEX,INCOME,INTERESTS,ROBOTNESS,REMOTEIP,WINDOWNAME,OPENERNAME,HISTORYLENGTH,BROWSERLANGUAGE,BROWSERCOUNTRY,SOCIALNETWORK,SOCIALACTION,HTTPERROR,SENDTIMING,DNSTIMING,CONNECTTIMING,RESPONSESTARTTIMING,RESPONSEENDTIMING,FETCHTIMING,SOCIALSOURCENETWORKID,SOCIALSOURCEPAGE,PARAMPRICE,PARAMORDERID,PARAMCURRENCY,PARAMCURRENCYID,OPENSTATSERVICENAME,OPENSTATCAMPAIGNID,OPENSTATADID,OPENSTATSOURCEID,UTMSOURCE,UTMMEDIUM,UTMCAMPAIGN,UTMCONTENT,UTMTERM,FROMTAG,HASGCLID,REFERERHASH,URLHASH,CLID""",
                         //    """watchid,javaenable,title,goodevent,eventtime,eventdate,counterid,clientip,regionid,userid,counterclass,os,useragent,url,referer,isrefresh,referercategoryid,refererregionid,urlcategoryid,urlregionid,resolutionwidth,resolutionheight,resolutiondepth,flashmajor,flashminor,flashminor2,netmajor,netminor,useragentmajor,useragentminor,cookieenable,javascriptenable,ismobile,mobilephone,mobilephonemodel,params,ipnetworkid,traficsourceid,searchengineid,searchphrase,advengineid,isartifical,windowclientwidth,windowclientheight,clienttimezone,clienteventtime,silverlightversion1,silverlightversion2,silverlightversion3,silverlightversion4,pagecharset,codeversion,islink,isdownload,isnotbounce,funiqid,originalurl,hid,isoldcounter,isevent,isparameter,dontcounthits,withhash,hitcolor,localeventtime,age,sex,income,interests,robotness,remoteip,windowname,openername,historylength,browserlanguage,browsercountry,socialnetwork,socialaction,httperror,sendtiming,dnstiming,connecttiming,responsestarttiming,responseendtiming,fetchtiming,socialsourcenetworkid,socialsourcepage,paramprice,paramorderid,paramcurrency,paramcurrencyid,openstatservicename,openstatcampaignid,openstatadid,openstatsourceid,utmsource,utmmedium,utmcampaign,utmcontent,utmterm,fromtag,hasgclid,refererhash,urlhash,clid""",
     ]
-    def column_in_paths = ["", "", "", "", "", "", "", "", "", "", "", ""/*, "COLUMNS FROM PATH AS (city)"*/, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""]
-    def preceding_filters = ["", "", "", "", "", "", "", "", "", "", "", "preceding filter p_size < 10"/*, ""*/, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""]
+    def column_in_paths = ["", "", "", "", "", "", "", "", "", "", "", "", "COLUMNS FROM PATH AS (city)", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""]
+    def preceding_filters = ["", "", "", "", "", "", "", "", "", "", "", "preceding filter p_size < 10", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""]
     def set_values = ["",
                       "",
                       "SET(comment=p_comment, retailprice=p_retailprice, container=p_container, size=p_size, type=p_type, brand=p_brand, mfgr=p_mfgr, name=p_name, partkey=p_partkey)",
@@ -137,7 +137,7 @@ suite("test_tvf_based_broker_load_p2", "p2") {
                       "set(partsize = p_partkey + p_size)",
                       "",
                       "",
-                      // "",
+                      "",
                       "",
                       "",
                       "",
@@ -157,7 +157,7 @@ suite("test_tvf_based_broker_load_p2", "p2") {
                       "",
                       ""
     ]
-    def where_exprs = ["", "", "", "", "", "", "", "", "", "", "", "where p_partkey>10"/*, ""*/, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""]
+    def where_exprs = ["", "", "", "", "", "", "", "", "", "", "", "where p_partkey>10", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""]
 
     def etl_info = ["unselected.rows=0; dpp.abnorm.ALL=0; dpp.norm.ALL=200000",
                     "unselected.rows=0; dpp.abnorm.ALL=0; dpp.norm.ALL=200000",


### PR DESCRIPTION
## Proposed changes

For partition columns from file path, e.g. /path/to/columnName=columnValue, support them in external file TVF.

Usage:

TVF(..., path_partition_keys="k1,k2,k3");

The corresponding keys will be split by "," and parsed as partition keys from path.

## Further comments

Tests and docs will be added later.

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

