### PR TITLE
[typo](docs) 修正一个错别字,将"不再分区范围内的数据" 改成 "不在分区范围内的数据"

### DIFF
--- a/docs/zh-CN/docs/sql-manual/sql-reference/Data-Manipulation-Statements/Load/BROKER-LOAD.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Data-Manipulation-Statements/Load/BROKER-LOAD.md
@@ -90,7 +90,7 @@ WITH BROKER broker_name
 
   - `PARTITION(p1, p2, ...)`
 
-    可以指定仅导入表的某些分区。不再分区范围内的数据将被忽略。
+    可以指定仅导入表的某些分区。不在分区范围内的数据将被忽略。
 
   - `COLUMNS TERMINATED BY`
 


### PR DESCRIPTION
## [typo](docs) 修正一个错别字,将"不再分区范围内的数据" 改成 "不在分区范围内的数据"
Issue Number: close #xxx

修正一个错别字,将"不再分区范围内的数据" 改成 "不在分区范围内的数据"

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

