### PR TITLE
[fix](test) should not create and read internal table when use mock cluster in UT

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchemaInitializer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchemaInitializer.java
@@ -55,7 +55,7 @@ public class InternalSchemaInitializer extends Thread {
     private static final Logger LOG = LogManager.getLogger(InternalSchemaInitializer.class);
 
     public void run() {
-        if (FeConstants.disableInternalSchemaDb) {
+        if (!FeConstants.enableInternalSchemaDb) {
             return;
         }
         while (!created()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeConstants.java
@@ -50,8 +50,8 @@ public class FeConstants {
     // set to true to skip some step when running FE unit test
     public static boolean runningUnitTest = false;
 
-    // set to true to disable internal schema db
-    public static boolean disableInternalSchemaDb = false;
+    // set to false to disable internal schema db
+    public static boolean enableInternalSchemaDb = true;
 
     // default scheduler interval is 10 seconds
     public static int default_scheduler_interval_millisecond = 10000;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -23,6 +23,7 @@ import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.SchemaTable;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.Config;
+import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.exceptions.AnalysisException;
@@ -596,7 +597,8 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
             if (colName == null) {
                 throw new RuntimeException(String.format("Invalid slot: %s", slotReference.getExprId()));
             }
-            ColumnStatistic cache = Config.enable_stats ? getColumnStatistic(table, colName) : ColumnStatistic.UNKNOWN;
+            ColumnStatistic cache = Config.enable_stats && FeConstants.enableInternalSchemaDb
+                    ? getColumnStatistic(table, colName) : ColumnStatistic.UNKNOWN;
             if (cache.avgSizeByte <= 0) {
                 cache = new ColumnStatisticBuilder(cache)
                         .setAvgSizeByte(slotReference.getColumn().get().getType().getSlotSize())

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/datasets/tpch/TPCHTestBase.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/datasets/tpch/TPCHTestBase.java
@@ -17,18 +17,9 @@
 
 package org.apache.doris.nereids.datasets.tpch;
 
-import org.apache.doris.catalog.InternalSchemaInitializer;
-import org.apache.doris.common.FeConstants;
-
 public abstract class TPCHTestBase extends AnalyzeCheckTestBase {
     @Override
     protected void runBeforeAll() throws Exception {
-        // The internal table for TPCHTestBase is constructed in order to facilitate
-        // the execution of certain tests that require the invocation of a deriveStats job.
-        // This deriveStats job is responsible for retrieving statistics from the aforementioned
-        // internal table.
-        FeConstants.disableInternalSchemaDb = false;
-        new InternalSchemaInitializer().start();
         createDatabase("tpch");
         connectContext.setDatabase("default_cluster:tpch");
         TPCHUtils.createTables(this);

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
@@ -45,7 +45,6 @@ import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.DiskInfo;
 import org.apache.doris.catalog.Env;
-import org.apache.doris.catalog.InternalSchemaInitializer;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.Table;
@@ -129,12 +128,11 @@ public abstract class TestWithFeService {
 
     @BeforeAll
     public final void beforeAll() throws Exception {
-        FeConstants.disableInternalSchemaDb = true;
+        FeConstants.enableInternalSchemaDb = false;
         beforeCreatingConnectContext();
         connectContext = createDefaultCtx();
         beforeCluster();
         createDorisCluster();
-        new InternalSchemaInitializer().start();
         runBeforeAll();
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/UtFrameUtils.java
@@ -210,7 +210,7 @@ public class UtFrameUtils {
 
     public static void createDorisCluster(String runningDir, int backendNum) throws EnvVarNotSetException, IOException,
             FeStartException, NotInitException, DdlException, InterruptedException {
-        FeConstants.disableInternalSchemaDb = true;
+        FeConstants.enableInternalSchemaDb = false;
         int feRpcPort = startFEServer(runningDir);
         List<Backend> bes = Lists.newArrayList();
         for (int i = 0; i < backendNum; i++) {
@@ -245,7 +245,7 @@ public class UtFrameUtils {
         // set runningUnitTest to true, so that for ut,
         // the agent task will be sent to "127.0.0.1" to make cluster running well.
         FeConstants.runningUnitTest = true;
-        FeConstants.disableInternalSchemaDb = true;
+        FeConstants.enableInternalSchemaDb = false;
         int feRpcPort = startFEServer(runningDir);
         for (int i = 0; i < backendNum; i++) {
             String host = "127.0.0." + (i + 1);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

build internal table in fe service

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

