### PR TITLE
[Fix](Planner) fix limit execute before sort in show export job

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/ExportMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/ExportMgr.java
@@ -307,7 +307,7 @@ public class ExportMgr extends MasterDaemon {
                     exportJobInfos.add(composeExportJobInfo(job));
                 }
 
-                if (++counter >= resultNum) {
+                if (++counter >= resultNum && orderByPairs == null) {
                     break;
                 }
             }
@@ -327,8 +327,12 @@ public class ExportMgr extends MasterDaemon {
         Collections.sort(exportJobInfos, comparator);
 
         List<List<String>> results = Lists.newArrayList();
+        int counter = 0;
         for (List<Comparable> list : exportJobInfos) {
             results.add(list.stream().map(e -> e.toString()).collect(Collectors.toList()));
+            if (++counter >= resultNum) {
+                break;
+            }
         }
 
         return results;


### PR DESCRIPTION
## Proposed changes

Problem: 
When doing show export jobs, limit would execute before sort before changed. So the result would not be expected because limit always cut results first and we can not get what we want.
Example:
we having export job1 and job2 with JobId1 > JobId2. We want to get job with JobId1
show export from db order by JobId desc limit 1;
We do limit 1 first, so we would probably get Job2 because JobId assigned from small to large
Solve: 
We can not cut results first if we have order by clause. And cut result set after sorting

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

