### PR TITLE
[improvement](planner) Enable preagg when count distinct key

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -748,7 +748,10 @@ public class SingleNodePlanner {
 
                     if (col.isKey()) {
                         if ((!functionName.equalsIgnoreCase("MAX"))
-                                && (!aggExpr.getFnName().getFunction().equalsIgnoreCase("MIN"))) {
+                                && (!functionName.equalsIgnoreCase("MIN"))
+                                && !functionName.equalsIgnoreCase("NDV")
+                                && !functionName.equalsIgnoreCase(FunctionSet.BITMAP_UNION_INT)
+                                && !functionName.equalsIgnoreCase("multi_distinct_count")) {
                             returnColumnValidate = false;
                             turnOffReason = "the type of agg on StorageEngine's Key column should only be MAX or MIN."
                                     + "agg expr: " + aggExpr.toSql();


### PR DESCRIPTION
## Proposed changes
A table like this:
```
create table xxx (key1, key2, key3)  AGGREGATE KEY(key, key1, key2, key3)
with rollup r_test (key1, key2,key3)

```
Now, ```select key1, count(distinct key2), count(disinct key3) from table xxx group by key1``` can not use rollup `r_test`.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments


