### PR TITLE
[fix](multicatalog) fix protocol of reading data from cosn for hive/iceberg catalog

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeConstants.java
@@ -75,6 +75,7 @@ public class FeConstants {
     public static String FS_PREFIX_OSS = "oss";
     public static String FS_PREFIX_BOS = "bos";
     public static String FS_PREFIX_COS = "cos";
+    public static String FS_PREFIX_COSN = "cosn";
     public static String FS_PREFIX_OBS = "obs";
     public static String FS_PREFIX_OFS = "ofs";
     public static String FS_PREFIX_GFS = "gfs";

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -311,7 +311,7 @@ public class HiveMetaStoreCache {
     // convert oss:// to s3://
     private String convertToS3IfNecessary(String location) {
         LOG.debug("try convert location to s3 prefix: " + location);
-        if (location.startsWith(FeConstants.FS_PREFIX_COS)
+        if (location.equals(FeConstants.FS_PREFIX_COS)
                 || location.startsWith(FeConstants.FS_PREFIX_BOS)
                 || location.startsWith(FeConstants.FS_PREFIX_BOS)
                 || location.startsWith(FeConstants.FS_PREFIX_OSS)

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -311,12 +311,12 @@ public class HiveMetaStoreCache {
     // convert oss:// to s3://
     private String convertToS3IfNecessary(String location) {
         LOG.debug("try convert location to s3 prefix: " + location);
-        if (location.equals(FeConstants.FS_PREFIX_COS)
-                || location.startsWith(FeConstants.FS_PREFIX_BOS)
-                || location.startsWith(FeConstants.FS_PREFIX_BOS)
-                || location.startsWith(FeConstants.FS_PREFIX_OSS)
-                || location.startsWith(FeConstants.FS_PREFIX_S3A)
-                || location.startsWith(FeConstants.FS_PREFIX_S3N)) {
+        if ((location.startsWith(FeConstants.FS_PREFIX_COS)) && !(location.startsWith(FeConstants.FS_PREFIX_COSN))
+            || location.startsWith(FeConstants.FS_PREFIX_BOS)
+            || location.startsWith(FeConstants.FS_PREFIX_BOS)
+            || location.startsWith(FeConstants.FS_PREFIX_OSS)
+            || location.startsWith(FeConstants.FS_PREFIX_S3A)
+            || location.startsWith(FeConstants.FS_PREFIX_S3N)) {
             int pos = location.indexOf("://");
             if (pos == -1) {
                 throw new RuntimeException("No '://' found in location: " + location);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveScanProvider.java
@@ -112,16 +112,17 @@ public class HiveScanProvider extends HMSTableScanProvider {
     public TFileType getLocationType() throws DdlException, MetaNotFoundException {
         String location = hmsTable.getRemoteTable().getSd().getLocation();
         if (location != null && !location.isEmpty()) {
-            if (location.startsWith(FeConstants.FS_PREFIX_S3)
-                    || location.startsWith(FeConstants.FS_PREFIX_S3A)
-                    || location.startsWith(FeConstants.FS_PREFIX_S3N)
-                    || location.startsWith(FeConstants.FS_PREFIX_BOS)
-                    || location.startsWith(FeConstants.FS_PREFIX_COS)
-                    || location.startsWith(FeConstants.FS_PREFIX_OSS)
-                    || location.startsWith(FeConstants.FS_PREFIX_OBS)) {
-                return TFileType.FILE_S3;
-            } else if (location.startsWith(FeConstants.FS_PREFIX_HDFS)) {
+            if (location.startsWith(FeConstants.FS_PREFIX_HDFS)
+                || location.startsWith(FeConstants.FS_PREFIX_COSN)) {
                 return TFileType.FILE_HDFS;
+            } else if (location.startsWith(FeConstants.FS_PREFIX_S3)
+                || location.startsWith(FeConstants.FS_PREFIX_S3A)
+                || location.startsWith(FeConstants.FS_PREFIX_S3N)
+                || location.startsWith(FeConstants.FS_PREFIX_BOS)
+                || location.startsWith(FeConstants.FS_PREFIX_COS)
+                || location.startsWith(FeConstants.FS_PREFIX_OSS)
+                || location.startsWith(FeConstants.FS_PREFIX_OBS)) {
+                return TFileType.FILE_S3;
             } else if (location.startsWith(FeConstants.FS_PREFIX_FILE)) {
                 return TFileType.FILE_LOCAL;
             } else if (location.startsWith(FeConstants.FS_PREFIX_OFS)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/iceberg/IcebergScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/iceberg/IcebergScanProvider.java
@@ -117,16 +117,17 @@ public class IcebergScanProvider extends QueryScanProvider {
     public TFileType getLocationType() throws DdlException, MetaNotFoundException {
         String location = icebergSource.getIcebergTable().location();
         if (location != null && !location.isEmpty()) {
-            if (location.startsWith(FeConstants.FS_PREFIX_S3)
-                    || location.startsWith(FeConstants.FS_PREFIX_S3A)
-                    || location.startsWith(FeConstants.FS_PREFIX_S3N)
-                    || location.startsWith(FeConstants.FS_PREFIX_BOS)
-                    || location.startsWith(FeConstants.FS_PREFIX_COS)
-                    || location.startsWith(FeConstants.FS_PREFIX_OSS)
-                    || location.startsWith(FeConstants.FS_PREFIX_OBS)) {
-                return TFileType.FILE_S3;
-            } else if (location.startsWith(FeConstants.FS_PREFIX_HDFS)) {
+            if (location.startsWith(FeConstants.FS_PREFIX_HDFS)
+                || location.startsWith(FeConstants.FS_PREFIX_COSN)) {
                 return TFileType.FILE_HDFS;
+            } else if (location.startsWith(FeConstants.FS_PREFIX_S3)
+                || location.startsWith(FeConstants.FS_PREFIX_S3A)
+                || location.startsWith(FeConstants.FS_PREFIX_S3N)
+                || location.startsWith(FeConstants.FS_PREFIX_BOS)
+                || location.startsWith(FeConstants.FS_PREFIX_COS)
+                || location.startsWith(FeConstants.FS_PREFIX_OSS)
+                || location.startsWith(FeConstants.FS_PREFIX_OBS)) {
+                return TFileType.FILE_S3;
             } else if (location.startsWith(FeConstants.FS_PREFIX_FILE)) {
                 return TFileType.FILE_LOCAL;
             } else if (location.startsWith(FeConstants.FS_PREFIX_OFS)) {


### PR DESCRIPTION
Error msg:
ERROR 1105 (HY000): errCode = 2, detailMessage = get file split failed for table: xxxx, err: org.apache.hadoop.fs.s3a.RemoteFileChangedException: open `s3a://xxx-bucket/xxx.db/xxx_table/dt=20230704/000000_0': Change reported by S3 during open at position 198924776. ETag e42667ea1cbdfcfacb46fa1627356bce was unavailable

Reason: tencent cloud cosn(CHDFS) is not applicable accessed by s3 protocol, it's more like a hdfs system.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

