### PR TITLE
[enhancement](Nereids) Avoid frequent variable retrieval from connect context when calculating cost

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/Cost.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/Cost.java
@@ -17,8 +17,6 @@
 
 package org.apache.doris.nereids.cost;
 
-import org.apache.doris.qe.ConnectContext;
-
 /**
  * Cost encapsulate the real cost with double type.
  * We do this because we want to customize the operation of adding child cost
@@ -31,7 +29,7 @@ public interface Cost {
      * This is for calculating the cost in simplifier
      */
     static Cost withRowCount(double rowCount) {
-        if (ConnectContext.get().getSessionVariable().getEnableNewCostModel()) {
+        if (CostCalculator.ENABLE_COST_V2) {
             return new CostV2(0, rowCount, 0);
         }
         return new CostV1(rowCount);
@@ -41,14 +39,14 @@ public interface Cost {
      * return zero cost
      */
     static Cost zero() {
-        if (ConnectContext.get().getSessionVariable().getEnableNewCostModel()) {
+        if (CostCalculator.ENABLE_COST_V2) {
             return CostV2.zero();
         }
         return CostV1.zero();
     }
 
     static Cost infinite() {
-        if (ConnectContext.get().getSessionVariable().getEnableNewCostModel()) {
+        if (CostCalculator.ENABLE_COST_V2) {
             return CostV2.infinite();
         }
         return CostV1.infinite();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
@@ -184,10 +184,10 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
         // replicate
         if (spec instanceof DistributionSpecReplicated) {
             double dataSize = childStatistics.computeSize();
-            double memLimit = ConnectContext.get().getSessionVariable().getMaxExecMemByte();
+            double memLimit = CostCalculator.MEM_LIMIT;
             //if build side is big, avoid use broadcast join
-            double rowsLimit = ConnectContext.get().getSessionVariable().getBroadcastRowCountLimit();
-            double brMemlimit = ConnectContext.get().getSessionVariable().getBroadcastHashtableMemLimitPercentage();
+            double rowsLimit = CostCalculator.ROWS_LIMIT;
+            double brMemlimit = CostCalculator.BROADCAST_MEM_LIMIT;
             if (dataSize > memLimit * brMemlimit
                     || childStatistics.getRowCount() > rowsLimit) {
                 return CostV1.of(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostWeight.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostWeight.java
@@ -17,8 +17,6 @@
 
 package org.apache.doris.nereids.cost;
 
-import org.apache.doris.qe.ConnectContext;
-
 import com.google.common.base.Preconditions;
 
 /**
@@ -66,11 +64,11 @@ public class CostWeight {
     }
 
     public static CostWeight get() {
-        double cpuWeight = ConnectContext.get().getSessionVariable().getCboCpuWeight();
-        double memWeight = ConnectContext.get().getSessionVariable().getCboMemWeight();
-        double netWeight = ConnectContext.get().getSessionVariable().getCboNetWeight();
+        double cpuWeight = CostCalculator.DEFAULT_CPU_WEIGHT;
+        double memWeight = CostCalculator.DEFAULT_MEM_WEIGHT;
+        double netWeight = CostCalculator.DEFAULT_NET_WEIGHT;
         return new CostWeight(cpuWeight, memWeight, netWeight,
-                ConnectContext.get().getSessionVariable().getNereidsCboPenaltyFactor());
+                CostCalculator.PENAL_FACTOR);
     }
 
     //TODO: add it in session variable

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Optimizer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Optimizer.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids.jobs.executor;
 
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.StatementContext;
+import org.apache.doris.nereids.cost.CostCalculator;
 import org.apache.doris.nereids.jobs.cascades.DeriveStatsJob;
 import org.apache.doris.nereids.jobs.cascades.OptimizeGroupJob;
 import org.apache.doris.nereids.jobs.joinorder.JoinOrderJob;
@@ -51,6 +52,7 @@ public class Optimizer {
     public void execute() {
         // init memo
         cascadesContext.toMemo();
+        CostCalculator.init();
         // stats derive
         cascadesContext.pushJob(new DeriveStatsJob(cascadesContext.getMemo().getRoot().getLogicalExpression(),
                 cascadesContext.getCurrentJobContext()));


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Avoid frequent variable retrieval from connect context when calculating cost

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

