### PR TITLE
[regression-test](agg-state) change set to set global enable_agg_state

### DIFF
--- a/regression-test/suites/datatype_p0/agg_state/group_concat/test_agg_state_group_concat.groovy
+++ b/regression-test/suites/datatype_p0/agg_state/group_concat/test_agg_state_group_concat.groovy
@@ -16,7 +16,7 @@
 // under the License.
 
 suite("test_agg_state_group_concat") {
-    sql "set enable_agg_state=true"
+    sql "set global enable_agg_state=true"
     sql """ DROP TABLE IF EXISTS a_table; """
     sql """
             create table a_table(

--- a/regression-test/suites/datatype_p0/agg_state/max/test_agg_state_max.groovy
+++ b/regression-test/suites/datatype_p0/agg_state/max/test_agg_state_max.groovy
@@ -16,7 +16,7 @@
 // under the License.
 
 suite("test_agg_state_max") {
-    sql "set enable_agg_state=true"
+    sql "set global enable_agg_state=true"
     sql """ DROP TABLE IF EXISTS a_table; """
     sql """
             create table a_table(

--- a/regression-test/suites/datatype_p0/agg_state/nereids/test_agg_state_nereids.groovy
+++ b/regression-test/suites/datatype_p0/agg_state/nereids/test_agg_state_nereids.groovy
@@ -16,7 +16,7 @@
 // under the License.
 
 suite("test_agg_state_nereids") {
-    sql "set enable_agg_state=true"
+    sql "set global enable_agg_state=true"
     sql "set enable_nereids_planner=true;"
     sql "set enable_fallback_to_original_planner=false;"
 

--- a/regression-test/suites/datatype_p0/agg_state/test_agg_state.groovy
+++ b/regression-test/suites/datatype_p0/agg_state/test_agg_state.groovy
@@ -16,7 +16,7 @@
 // under the License.
 
 suite("test_agg_state") {
-    sql "set enable_agg_state=true"
+    sql "set global enable_agg_state=true"
     sql """ DROP TABLE IF EXISTS d_table; """
     sql """
             create table d_table(


### PR DESCRIPTION
## Proposed changes
When there are multiple fe, we need set global to set the session variable of all fe

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

