### PR TITLE
[imporve](bloomfilter) refactor runtime_filter_mgr with bloomfilter

### DIFF
--- a/be/src/runtime/runtime_filter_mgr.cpp
+++ b/be/src/runtime/runtime_filter_mgr.cpp
@@ -26,6 +26,8 @@
 #include <gen_cpp/types.pb.h>
 #include <stddef.h>
 
+#include <memory>
+#include <mutex>
 #include <ostream>
 #include <string>
 #include <utility>
@@ -39,6 +41,7 @@
 #include "runtime/runtime_state.h"
 #include "runtime/thread_context.h"
 #include "util/brpc_client_cache.h"
+#include "util/spinlock.h"
 
 namespace doris {
 
@@ -208,10 +211,11 @@ Status RuntimeFilterMergeControllerEntity::_init_with_desc(
         const TRuntimeFilterDesc* runtime_filter_desc, const TQueryOptions* query_options,
         const std::vector<doris::TRuntimeFilterTargetParams>* target_info,
         const int producer_size) {
-    std::lock_guard<std::mutex> guard(_filter_map_mutex);
+    std::unique_lock<std::shared_mutex> guard(_filter_map_mutex);
     std::shared_ptr<RuntimeFilterCntlVal> cntVal = std::make_shared<RuntimeFilterCntlVal>();
     // runtime_filter_desc and target will be released,
     // so we need to copy to cntVal
+    cntVal->arrive_count = 0;
     cntVal->producer_size = producer_size;
     cntVal->runtime_filter_desc = *runtime_filter_desc;
     cntVal->target_info = *target_info;
@@ -219,10 +223,10 @@ Status RuntimeFilterMergeControllerEntity::_init_with_desc(
     cntVal->filter =
             cntVal->pool->add(new IRuntimeFilter(_state, &_state->get_query_ctx()->obj_pool));
 
-    std::string filter_id = std::to_string(runtime_filter_desc->filter_id);
+    auto filter_id = runtime_filter_desc->filter_id;
     // LOG(INFO) << "entity filter id:" << filter_id;
     cntVal->filter->init_with_desc(&cntVal->runtime_filter_desc, query_options, -1, false);
-    _filter_map.emplace(filter_id, cntVal);
+    _filter_map.emplace(filter_id, CntlValwithLock {cntVal, std::make_unique<SpinLock>()});
     return Status::OK();
 }
 
@@ -230,10 +234,11 @@ Status RuntimeFilterMergeControllerEntity::_init_with_desc(
         const TRuntimeFilterDesc* runtime_filter_desc, const TQueryOptions* query_options,
         const std::vector<doris::TRuntimeFilterTargetParamsV2>* targetv2_info,
         const int producer_size) {
-    std::lock_guard<std::mutex> guard(_filter_map_mutex);
+    std::unique_lock<std::shared_mutex> guard(_filter_map_mutex);
     std::shared_ptr<RuntimeFilterCntlVal> cntVal = std::make_shared<RuntimeFilterCntlVal>();
     // runtime_filter_desc and target will be released,
     // so we need to copy to cntVal
+    cntVal->arrive_count = 0;
     cntVal->producer_size = producer_size;
     cntVal->runtime_filter_desc = *runtime_filter_desc;
     cntVal->targetv2_info = *targetv2_info;
@@ -241,10 +246,10 @@ Status RuntimeFilterMergeControllerEntity::_init_with_desc(
     cntVal->filter =
             cntVal->pool->add(new IRuntimeFilter(_state, &_state->get_query_ctx()->obj_pool));
 
-    std::string filter_id = std::to_string(runtime_filter_desc->filter_id);
+    auto filter_id = runtime_filter_desc->filter_id;
     // LOG(INFO) << "entity filter id:" << filter_id;
     cntVal->filter->init_with_desc(&cntVal->runtime_filter_desc, query_options);
-    _filter_map.emplace(filter_id, cntVal);
+    _filter_map.emplace(filter_id, CntlValwithLock {cntVal, std::make_unique<SpinLock>()});
     return Status::OK();
 }
 
@@ -312,34 +317,43 @@ Status RuntimeFilterMergeControllerEntity::merge(const PMergeFilterRequest* requ
     std::shared_ptr<RuntimeFilterCntlVal> cntVal;
     int merged_size = 0;
     int64_t merge_time = 0;
+    int64_t start_merge = MonotonicMillis();
+    auto filter_id = request->filter_id();
+    std::map<int, CntlValwithLock>::iterator iter;
     {
-        int64_t start_merge = MonotonicMillis();
-        std::lock_guard<std::mutex> guard(_filter_map_mutex);
-        auto iter = _filter_map.find(std::to_string(request->filter_id()));
+        std::shared_lock<std::shared_mutex> guard(_filter_map_mutex);
+        iter = _filter_map.find(filter_id);
         VLOG_ROW << "recv filter id:" << request->filter_id() << " " << request->ShortDebugString();
         if (iter == _filter_map.end()) {
             return Status::InvalidArgument("unknown filter id {}",
                                            std::to_string(request->filter_id()));
         }
-        cntVal = iter->second;
+    }
+    // iter->second = pair{CntlVal,SpinLock}
+    cntVal = iter->second.first;
+    {
+        std::lock_guard<SpinLock> l(*iter->second.second);
         if (auto bf = cntVal->filter->get_bloomfilter()) {
-            RETURN_IF_ERROR(bf->init_with_fixed_length());
+            if (cntVal->arrive_count > 0) {
+                RETURN_IF_ERROR(bf->init_with_fixed_length());
+            }
         }
         MergeRuntimeFilterParams params(request, attach_data);
-        ObjectPool* pool = iter->second->pool.get();
+        ObjectPool* pool = cntVal->pool.get();
         RuntimeFilterWrapperHolder holder;
         RETURN_IF_ERROR(IRuntimeFilter::create_wrapper(_state, &params, pool, holder.getHandle()));
         RETURN_IF_ERROR(cntVal->filter->merge_from(holder.getHandle()->get()));
-        cntVal->arrive_id.insert(UniqueId(request->fragment_id()).to_string());
+        cntVal->arrive_id.insert(UniqueId(request->fragment_id()));
+        cntVal->arrive_count++;
         merged_size = cntVal->arrive_id.size();
         // TODO: avoid log when we had acquired a lock
         VLOG_ROW << "merge size:" << merged_size << ":" << cntVal->producer_size;
         DCHECK_LE(merged_size, cntVal->producer_size);
-        iter->second->merge_time += (MonotonicMillis() - start_merge);
+        cntVal->merge_time += (MonotonicMillis() - start_merge);
         if (merged_size < cntVal->producer_size) {
             return Status::OK();
         } else {
-            merge_time = iter->second->merge_time;
+            merge_time = cntVal->merge_time;
         }
     }
 

--- a/be/src/runtime/runtime_filter_mgr.cpp
+++ b/be/src/runtime/runtime_filter_mgr.cpp
@@ -26,8 +26,6 @@
 #include <gen_cpp/types.pb.h>
 #include <stddef.h>
 
-#include <memory>
-#include <mutex>
 #include <ostream>
 #include <string>
 #include <utility>

--- a/be/src/runtime/runtime_filter_mgr.h
+++ b/be/src/runtime/runtime_filter_mgr.h
@@ -145,12 +145,13 @@ public:
         std::vector<doris::TRuntimeFilterTargetParams> target_info;
         std::vector<doris::TRuntimeFilterTargetParamsV2> targetv2_info;
         IRuntimeFilter* filter;
-        std::unordered_set<std::string> arrive_id; // fragment_instance_id ?
+        std::unordered_set<UniqueId> arrive_id; // fragment_instance_id ?
         std::shared_ptr<ObjectPool> pool;
+        int arrive_count;
     };
 
 public:
-    RuntimeFilterCntlVal* get_filter(int id) { return _filter_map[std::to_string(id)].get(); }
+    RuntimeFilterCntlVal* get_filter(int id) { return _filter_map[id].first.get(); }
 
 private:
     Status _init_with_desc(const TRuntimeFilterDesc* runtime_filter_desc,
@@ -166,11 +167,11 @@ private:
     UniqueId _query_id;
     UniqueId _fragment_instance_id;
     // protect _filter_map
-    std::mutex _filter_map_mutex;
+    std::shared_mutex _filter_map_mutex;
     std::shared_ptr<MemTracker> _mem_tracker;
-    // TODO: convert filter id to i32
-    // filter-id -> val
-    std::map<std::string, std::shared_ptr<RuntimeFilterCntlVal>> _filter_map;
+    using CntlValwithLock =
+            std::pair<std::shared_ptr<RuntimeFilterCntlVal>, std::unique_ptr<SpinLock>>;
+    std::map<int, CntlValwithLock> _filter_map;
     RuntimeState* _state;
     bool _opt_remote_rf = true;
 };

--- a/be/src/runtime/runtime_filter_mgr.h
+++ b/be/src/runtime/runtime_filter_mgr.h
@@ -26,6 +26,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>

--- a/be/src/runtime/runtime_filter_mgr.h
+++ b/be/src/runtime/runtime_filter_mgr.h
@@ -147,7 +147,6 @@ public:
         IRuntimeFilter* filter;
         std::unordered_set<UniqueId> arrive_id; // fragment_instance_id ?
         std::shared_ptr<ObjectPool> pool;
-        int arrive_count;
     };
 
 public:


### PR DESCRIPTION
## Proposed changes

1. Reduced the granularity of the lock. In the past, the entire map was locked
2. map(string)  --> map(int)
3. The bf does not need to init_with_fixed_length
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

