### PR TITLE
[FIX](serde)Fix decimal for arrow serde

### DIFF
--- a/be/src/vec/data_types/serde/data_type_decimal_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_decimal_serde.cpp
@@ -80,10 +80,8 @@ void DataTypeDecimalSerDe<T>::write_column_to_arrow(const IColumn& column, const
                                  array_builder->type()->name());
                 continue;
             }
-            const auto& data_ref = col.get_data_at(i);
-            const int32_t* p_value = reinterpret_cast<const int32_t*>(data_ref.data);
-            int64_t high = *p_value > 0 ? 0 : 1UL << 63;
-            arrow::Decimal128 value(high, *p_value > 0 ? *p_value : -*p_value);
+            Int128 p_value = Int128(col.get_element(i));
+            arrow::Decimal128 value(reinterpret_cast<const uint8_t*>(&p_value));
             checkArrowStatus(builder.Append(value), column.get_name(),
                              array_builder->type()->name());
         }
@@ -96,10 +94,8 @@ void DataTypeDecimalSerDe<T>::write_column_to_arrow(const IColumn& column, const
                                  array_builder->type()->name());
                 continue;
             }
-            const auto& data_ref = col.get_data_at(i);
-            const int64_t* p_value = reinterpret_cast<const int64_t*>(data_ref.data);
-            int64_t high = *p_value > 0 ? 0 : 1UL << 63;
-            arrow::Decimal128 value(high, *p_value > 0 ? *p_value : -*p_value);
+            Int128 p_value = Int128(col.get_element(i));
+            arrow::Decimal128 value(reinterpret_cast<const uint8_t*>(&p_value));
             checkArrowStatus(builder.Append(value), column.get_name(),
                              array_builder->type()->name());
         }
@@ -112,13 +108,13 @@ template <typename T>
 void DataTypeDecimalSerDe<T>::read_column_from_arrow(IColumn& column,
                                                      const arrow::Array* arrow_array, int start,
                                                      int end, const cctz::time_zone& ctz) const {
+    auto concrete_array = down_cast<const arrow::DecimalArray*>(arrow_array);
+    const auto* arrow_decimal_type =
+            static_cast<const arrow::DecimalType*>(arrow_array->type().get());
+    const auto arrow_scale = arrow_decimal_type->scale();
+    auto& column_data = static_cast<ColumnDecimal<T>&>(column).get_data();
     if constexpr (std::is_same_v<T, Decimal<Int128>>) {
-        auto& column_data = static_cast<ColumnDecimal<vectorized::Decimal128>&>(column).get_data();
-        auto concrete_array = down_cast<const arrow::DecimalArray*>(arrow_array);
-        const auto* arrow_decimal_type =
-                static_cast<const arrow::DecimalType*>(arrow_array->type().get());
         // TODO check precision
-        const auto arrow_scale = arrow_decimal_type->scale();
         for (size_t value_i = start; value_i < end; ++value_i) {
             auto value = *reinterpret_cast<const vectorized::Decimal128*>(
                     concrete_array->Value(value_i));
@@ -139,6 +135,10 @@ void DataTypeDecimalSerDe<T>::read_column_from_arrow(IColumn& column,
                 value = value / common::exp10_i128(arrow_scale - 9);
             }
             column_data.emplace_back(value);
+        }
+    } else if constexpr (std::is_same_v<T, Decimal64> || std::is_same_v<T, Decimal32>) {
+        for (size_t value_i = start; value_i < end; ++value_i) {
+            column_data.emplace_back(*reinterpret_cast<const T*>(concrete_array->Value(value_i)));
         }
     } else {
         LOG(FATAL) << "Not support read " << column.get_name() << " from arrow";

--- a/be/test/vec/data_types/serde/data_type_serde_arrow_test.cpp
+++ b/be/test/vec/data_types/serde/data_type_serde_arrow_test.cpp
@@ -51,6 +51,7 @@
 #include "util/arrow/row_batch.h"
 #include "util/bitmap_value.h"
 #include "util/quantile_state.h"
+#include "util/string_parser.hpp"
 #include "vec/columns/column.h"
 #include "vec/columns/column_array.h"
 #include "vec/columns/column_complex.h"
@@ -77,7 +78,6 @@
 #include "vec/data_types/data_type_time_v2.h"
 #include "vec/runtime/vdatetime_value.h"
 #include "vec/utils/arrow_column_to_doris_column.h"
-#include "util/string_parser.hpp"
 
 namespace doris::vectorized {
 
@@ -164,9 +164,11 @@ void serialize_and_deserialize_arrow_test() {
             type_desc.scale = 2;
             tslot.__set_slotType(type_desc.to_thrift());
             {
-                vectorized::DataTypePtr decimal_data_type = std::make_shared<DataTypeDecimal<Decimal32 >>(type_desc.precision, type_desc.scale);
+                vectorized::DataTypePtr decimal_data_type =
+                        std::make_shared<DataTypeDecimal<Decimal32>>(type_desc.precision,
+                                                                     type_desc.scale);
                 auto decimal_column = decimal_data_type->create_column();
-                auto& data = ((vectorized::ColumnDecimal<vectorized::Decimal<vectorized::Int32 >>*)
+                auto& data = ((vectorized::ColumnDecimal<vectorized::Decimal<vectorized::Int32>>*)
                                       decimal_column.get())
                                      ->get_data();
                 for (int i = 0; i < row_num; ++i) {
@@ -176,10 +178,12 @@ void serialize_and_deserialize_arrow_test() {
                     }
                     Int32 val;
                     StringParser::ParseResult result = StringParser::PARSE_SUCCESS;
-                    i % 2 == 0 ? val = StringParser::string_to_decimal<__int128>("1234567.56", 11, type_desc.precision, type_desc.scale,
-                                                                              &result)
-                               : val = StringParser::string_to_decimal<__int128>("-1234567.56", 12, type_desc.precision, type_desc.scale,
-                                                                               &result);
+                    i % 2 == 0 ? val = StringParser::string_to_decimal<__int128>(
+                                         "1234567.56", 11, type_desc.precision, type_desc.scale,
+                                         &result)
+                               : val = StringParser::string_to_decimal<__int128>(
+                                         "-1234567.56", 12, type_desc.precision, type_desc.scale,
+                                         &result);
                     EXPECT_TRUE(result == StringParser::PARSE_SUCCESS);
                     data.push_back(val);
                 }
@@ -194,7 +198,9 @@ void serialize_and_deserialize_arrow_test() {
             type_desc.scale = 6;
             tslot.__set_slotType(type_desc.to_thrift());
             {
-                vectorized::DataTypePtr decimal_data_type = std::make_shared<DataTypeDecimal<Decimal64>>(type_desc.precision, type_desc.scale);
+                vectorized::DataTypePtr decimal_data_type =
+                        std::make_shared<DataTypeDecimal<Decimal64>>(type_desc.precision,
+                                                                     type_desc.scale);
                 auto decimal_column = decimal_data_type->create_column();
                 auto& data = ((vectorized::ColumnDecimal<vectorized::Decimal<vectorized::Int64>>*)
                                       decimal_column.get())
@@ -206,9 +212,11 @@ void serialize_and_deserialize_arrow_test() {
                     }
                     Int64 val;
                     StringParser::ParseResult result = StringParser::PARSE_SUCCESS;
-                    std::string decimal_string = i % 2 == 0 ? "-123456789012.123456" : "123456789012.123456";
-                    val = StringParser::string_to_decimal<__int128>(decimal_string.c_str(), decimal_string.size(), type_desc.precision, type_desc.scale,
-                                                                                &result);
+                    std::string decimal_string =
+                            i % 2 == 0 ? "-123456789012.123456" : "123456789012.123456";
+                    val = StringParser::string_to_decimal<__int128>(
+                            decimal_string.c_str(), decimal_string.size(), type_desc.precision,
+                            type_desc.scale, &result);
                     EXPECT_TRUE(result == StringParser::PARSE_SUCCESS);
                     data.push_back(val);
                 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
when read decimal value from arrow serde , got wrong value.
```
 mysql> select f_decimal from doris_source_test_numberic;
+----------------------+
| f_decimal            |
+----------------------+
| -123456789012.123456 |
|             0.000000 |
|  123456789012.123456 |
+----------------------+
3 rows in set (0.01 sec)mysql> desc doris_source_test_numberic
    -> ;
+------------+------------------+------+-------+---------+-------+
| Field      | Type             | Null | Key   | Default | Extra |
+------------+------------------+------+-------+---------+-------+
| f_int      | INT              | Yes  | true  | NULL    |       |
| f_bigint   | BIGINT           | Yes  | false | NULL    | NONE  |
| f_tinyint  | TINYINT          | Yes  | false | NULL    | NONE  |
| f_smallint | SMALLINT         | Yes  | false | NULL    | NONE  |
| f_largeint | LARGEINT         | Yes  | false | NULL    | NONE  |
| f_float    | FLOAT            | Yes  | false | NULL    | NONE  |
| f_double   | DOUBLE           | Yes  | false | NULL    | NONE  |
| f_decimal  | DECIMALV3(18, 6) | Yes  | false | NULL    | NONE  |
+------------+------------------+------+-------+---------+-------+
8 rows in set (0.00 sec) 
```

![image](https://github.com/apache/doris/assets/18551114/9895e76a-d062-4de5-a6e7-b5155bc721bd)


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

