### PR TITLE
[feature](function) support time_to_sec

### DIFF
--- a/be/src/vec/functions/function_date_or_datetime_computation.cpp
+++ b/be/src/vec/functions/function_date_or_datetime_computation.cpp
@@ -123,6 +123,7 @@ using FunctionCurTime = FunctionCurrentDateOrDateTime<CurrentTimeImpl<CurTimeFun
 using FunctionCurrentTime = FunctionCurrentDateOrDateTime<CurrentTimeImpl<CurrentTimeFunctionName>>;
 using FunctionUtcTimeStamp = FunctionCurrentDateOrDateTime<UtcTimestampImpl>;
 using FunctionTimeToSec = FunctionCurrentDateOrDateTime<TimeToSecImpl>;
+using FunctionSecToTime = FunctionCurrentDateOrDateTime<SecToTimeImpl>;
 
 /// @TEMPORARY: for be_exec_version=2
 using FunctionToWeekTwoArgsOld =
@@ -177,6 +178,7 @@ void register_function_date_time_computation(SimpleFunctionFactory& factory) {
     factory.register_function<FunctionCurrentTime>();
     factory.register_function<FunctionUtcTimeStamp>();
     factory.register_function<FunctionTimeToSec>();
+    factory.register_function<FunctionSecToTime>();
 
     // alias
     factory.register_alias("days_add", "date_add");

--- a/be/src/vec/functions/function_date_or_datetime_computation.h
+++ b/be/src/vec/functions/function_date_or_datetime_computation.h
@@ -1071,24 +1071,16 @@ struct TimeToSecImpl {
     static constexpr auto name = "time_to_sec";
     static Status execute(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                           size_t result, size_t input_rows_count) {
-        auto res_col = ColumnInt32::create();
-        const auto& [argument_column, arg_is_const] =
-                unpack_if_const(block.get_by_position(arguments[0]).column);
-        const auto& column_data = assert_cast<const ColumnFloat64&>(*argument_column);
-        if (arg_is_const) {
-            double time = column_data.get_element(0);
-            res_col->insert_value(static_cast<int>(time));
-            block.replace_by_position(result,
-                                      ColumnConst::create(std::move(res_col), input_rows_count));
-        } else {
-            auto& res_data = res_col->get_data();
-            res_data.resize(input_rows_count);
-            for (int i = 0; i < input_rows_count; ++i) {
-                double time = column_data.get_element(i);
-                res_data[i] = static_cast<int>(time);
-            }
-            block.replace_by_position(result, std::move(res_col));
+        auto res_col = ColumnInt32::create(input_rows_count);
+        const auto& arg_col = block.get_by_position(arguments[0]).column;
+        const auto& column_data = assert_cast<const ColumnFloat64&>(*arg_col);
+
+        auto& res_data = res_col->get_data();
+        for (int i = 0; i < input_rows_count; ++i) {
+            res_data[i] = static_cast<int>(column_data.get_element(i));
         }
+        block.replace_by_position(result, std::move(res_col));
+
         return Status::OK();
     }
 };
@@ -1098,14 +1090,12 @@ struct SecToTimeImpl {
     static constexpr auto name = "sec_to_time";
     static Status execute(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                           size_t result, size_t input_rows_count) {
-        auto res_col = ColumnFloat64::create();
-        const auto& [argument_column, arg_const] =
-                unpack_if_const(block.get_by_position(arguments[0]).column);
-        const auto& column_data = assert_cast<const ColumnInt32&>(*argument_column);
-        const size_t rows = arg_const ? 1 : input_rows_count;
+        const auto& arg_col = block.get_by_position(arguments[0]).column;
+        const auto& column_data = assert_cast<const ColumnInt32&>(*arg_col);
+
+        auto res_col = ColumnFloat64::create(input_rows_count);
         auto& res_data = res_col->get_data();
-        res_data.resize(rows);
-        for (int i = 0; i < rows; ++i) {
+        for (int i = 0; i < input_rows_count; ++i) {
             res_data[i] = static_cast<double>(column_data.get_element(i));
         }
 

--- a/be/src/vec/functions/function_date_or_datetime_computation.h
+++ b/be/src/vec/functions/function_date_or_datetime_computation.h
@@ -1071,7 +1071,7 @@ struct TimeToSecImpl {
     static constexpr auto name = "time_to_sec";
     static Status execute(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                           size_t result, size_t input_rows_count) {
-        auto res_col = ColumnVector<Int32>::create();
+        auto res_col = ColumnInt32::create();
         const auto& [argument_column, arg_is_const] =
                 unpack_if_const(block.get_by_position(arguments[0]).column);
         const auto& column_data = assert_cast<const ColumnFloat64&>(*argument_column);
@@ -1089,6 +1089,27 @@ struct TimeToSecImpl {
             }
             block.replace_by_position(result, std::move(res_col));
         }
+        return Status::OK();
+    }
+};
+
+struct SecToTimeImpl {
+    using ReturnType = DataTypeTime;
+    static constexpr auto name = "sec_to_time";
+    static Status execute(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
+                          size_t result, size_t input_rows_count) {
+        auto res_col = ColumnFloat64::create();
+        const auto& [argument_column, arg_const] =
+                unpack_if_const(block.get_by_position(arguments[0]).column);
+        const auto& column_data = assert_cast<const ColumnInt32&>(*argument_column);
+        const size_t rows = arg_const ? 1 : input_rows_count;
+        auto& res_data = res_col->get_data();
+        res_data.resize(rows);
+        for (int i = 0; i < rows; ++i) {
+            res_data[i] = static_cast<double>(column_data.get_element(i));
+        }
+
+        block.replace_by_position(result, std::move(res_col));
         return Status::OK();
     }
 };

--- a/docs/en/docs/sql-manual/sql-functions/date-time-functions/sec_to_time.md
+++ b/docs/en/docs/sql-manual/sql-functions/date-time-functions/sec_to_time.md
@@ -1,0 +1,48 @@
+---
+{
+    "title": "sec_to_time",
+    "language": "en"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+## sec_to_time
+### description
+#### Syntax
+
+`TIME sec_to_time(INT timestamp)`
+
+The parameter is a timestamp of type INT, and the function returns a time of type TIME.
+
+### example
+
+```
+mysql >select sec_to_time(time_to_sec(cast('16:32:18' as time)));
++----------------------------------------------------+
+| sec_to_time(time_to_sec(CAST('16:32:18' AS TIME))) |
++----------------------------------------------------+
+| 16:32:18                                           |
++----------------------------------------------------+
+1 row in set (0.53 sec)
+```
+
+### keywords
+    SEC_TO_TIME

--- a/docs/sidebars.json
+++ b/docs/sidebars.json
@@ -345,6 +345,7 @@
                                 "sql-manual/sql-functions/date-time-functions/to_date",
                                 "sql-manual/sql-functions/date-time-functions/to_days",
                                 "sql-manual/sql-functions/date-time-functions/time_to_sec",
+                                "sql-manual/sql-functions/date-time-functions/sec_to_time",
                                 "sql-manual/sql-functions/date-time-functions/extract",
                                 "sql-manual/sql-functions/date-time-functions/makedate",
                                 "sql-manual/sql-functions/date-time-functions/str_to_date",

--- a/docs/zh-CN/docs/sql-manual/sql-functions/date-time-functions/sec_to_time.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/date-time-functions/sec_to_time.md
@@ -1,0 +1,48 @@
+---
+{
+    "title": "sec_to_time",
+    "language": "zh-CN"
+}
+---
+
+<!-- 
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+## sec_to_time
+### description
+#### Syntax
+
+`TIME sec_to_time(INT timestamp)`
+
+参数为INT类型时间戳，函数返回TIME类型时间。
+
+### example
+
+```
+mysql >select sec_to_time(time_to_sec(cast('16:32:18' as time)));
++----------------------------------------------------+
+| sec_to_time(time_to_sec(CAST('16:32:18' AS TIME))) |
++----------------------------------------------------+
+| 16:32:18                                           |
++----------------------------------------------------+
+1 row in set (0.53 sec)
+```
+
+### keywords
+    SEC_TO_TIME

--- a/gensrc/script/doris_builtins_functions.py
+++ b/gensrc/script/doris_builtins_functions.py
@@ -996,6 +996,7 @@ visible_functions = {
 
         [['to_days'], 'INT', ['DATEV2'], ''],
         [['time_to_sec'], 'INT', ['TIME'], ''],
+        [['sec_to_time'], 'TIME', ['INT'], ''],
 
         [['year'], 'SMALLINT', ['DATETIMEV2'], ''],
         [['month'], 'TINYINT', ['DATETIMEV2'], ''],


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

```
mysql >select sec_to_time(time_to_sec(cast('16:32:18' as time)));
+----------------------------------------------------+
| sec_to_time(time_to_sec(CAST('16:32:18' AS TIME))) |
+----------------------------------------------------+
| 16:32:18                                           |
+----------------------------------------------------+
1 row in set (0.53 sec)

mysql [test]>select sec_to_time(59538);
+--------------------+
| sec_to_time(59538) |
+--------------------+
| 16:32:18           |
+--------------------+
1 row in set (0.03 sec)
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

