### PR TITLE
[chore](mv) when create mv failed show more failed msg

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
@@ -459,9 +459,8 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                             .getReplicaAllocation(task.getPartitionId()).getTotalReplicaNum();
                     int failedTaskCount = failedAgentTasks.get(task.getTabletId()).size();
                     if (expectSucceedTaskNum - failedTaskCount < expectSucceedTaskNum / 2 + 1) {
-                        throw new AlterCancelException(
-                                "rollup tasks failed on same tablet reach threshold "
-                                        + failedAgentTasks.get(task.getTabletId()));
+                        throw new AlterCancelException("rollup tasks failed on same tablet reach threshold "
+                                + failedAgentTasks.get(task.getTabletId()) + ", reason=" + task.getErrorMsg());
                     }
                 }
             }


### PR DESCRIPTION
## Proposed changes
`before:`
`detailMessage = rollup tasks failed on same tablet reach threshold [[ALTER], signature: 15083, backendId: 11001`


`after:`
`detailMessage = rollup tasks failed on same tablet reach threshold [[ALTER], signature: 16060, backendId: 11001, tablet id: 16060], reason=task type: ALTER, status_code: INTERNAL_ERROR, status_message: [(10.16.10.8)[INTERNAL_ERROR]The input: -1 is not valid, to_bitmap only support bigint value from 0 to 18446744073709551615 currently, cannot create MV with to_bitmap on column with negative values or cannot load negative values to column with to_bitmap MV on it.]`

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

