### PR TITLE
[Fix](planner)fix ctas incorrect string types of the target table.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -1778,14 +1778,14 @@ public class FunctionCallExpr extends Expr {
         // cast(xx as char(N)/varchar(N)) will be handled as substr(cast(xx as char, varchar), 1, N),
         // but type is varchar(*), we change it to varchar(N);
         if (fn.getFunctionName().getFunction().equals("substr")
+                && children.size() == 3
                 && children.get(1) instanceof IntLiteral
                 && children.get(2) instanceof IntLiteral) {
-            long begin = ((IntLiteral) children.get(1)).getValue();
             long len = ((IntLiteral) children.get(2)).getValue();
             if (type.isWildcardChar()) {
-                this.type = ScalarType.createCharType(((int) (begin + len)));
+                this.type = ScalarType.createCharType(((int) (len)));
             } else if (type.isWildcardVarchar()) {
-                this.type = ScalarType.createVarchar(((int) (begin + len)));
+                this.type = ScalarType.createVarchar(((int) (len)));
             }
         }
         // rewrite return type if is nested type function

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -1774,7 +1774,7 @@ public class FunctionCallExpr extends Expr {
             this.type = PRECISION_INFER_RULE.getOrDefault(fnName.getFunction(), DEFAULT_PRECISION_INFER_RULE)
                     .apply(children, this.type);
         }
-        
+
         // cast(xx as char(N)/varchar(N)) will be handled as substr(cast(xx as char, varchar), 1, N),
         // but type is varchar(*), we change it to varchar(N);
         if (fn.getFunctionName().getFunction().equals("substr")

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -1774,6 +1774,20 @@ public class FunctionCallExpr extends Expr {
             this.type = PRECISION_INFER_RULE.getOrDefault(fnName.getFunction(), DEFAULT_PRECISION_INFER_RULE)
                     .apply(children, this.type);
         }
+        
+        // cast(xx as char(N)/varchar(N)) will be handled as substr(cast(xx as char, varchar), 1, N),
+        // but type is varchar(*), we change it to varchar(N);
+        if (fn.getFunctionName().getFunction().equals("substr")
+                && children.get(1) instanceof IntLiteral
+                && children.get(2) instanceof IntLiteral) {
+            long begin = ((IntLiteral) children.get(1)).getValue();
+            long len = ((IntLiteral) children.get(2)).getValue();
+            if (type.isWildcardChar()) {
+                this.type = ScalarType.createCharType(((int) (begin + len)));
+            } else if (type.isWildcardVarchar()) {
+                this.type = ScalarType.createVarchar(((int) (begin + len)));
+            }
+        }
         // rewrite return type if is nested type function
         analyzeNestedFunction();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -1193,8 +1193,9 @@ public class InternalCatalog implements CatalogIf<Database> {
                 Expr resultExpr = resultExprs.get(i);
                 Type resultType = resultExpr.getType();
                 if (resultExpr instanceof FunctionCallExpr
-                        && resultExpr.getType().getPrimitiveType().equals(PrimitiveType.VARCHAR)) {
-                    resultType = ScalarType.createVarchar(65533);
+                        && resultExpr.getType().getPrimitiveType().equals(PrimitiveType.VARCHAR)
+                        && resultExpr.getType().getLength() == -1) {
+                    resultType = ScalarType.createVarchar(ScalarType.MAX_VARCHAR_LENGTH);
                 }
                 if (resultType.isStringType() && (keysDesc == null || !keysDesc.containsCol(name))) {
                     switch (resultType.getPrimitiveType()) {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableAsSelectStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableAsSelectStmtTest.java
@@ -83,7 +83,7 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                 + "as select * from `test`.`decimal_table`";
         createTableAsSelect(selectFromDecimal);
         Assertions.assertEquals("CREATE TABLE `select_decimal_table` (\n"
-                        + "  `userId` varchar(65533) NOT NULL,\n"
+                        + "  `userId` varchar(255) NOT NULL,\n"
                         + "  `amount_decimal` "
                         + "DECIMAL" + "(10, 2) NOT NULL\n"
                         + ") ENGINE=OLAP\n"
@@ -154,8 +154,8 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
         createTableAsSelect(selectFromVarchar);
         ShowResultSet showResultSet = showCreateTableByName("select_varchar");
         Assertions.assertEquals("CREATE TABLE `select_varchar` (\n"
-                        + "  `userId` varchar(65533) NOT NULL,\n"
-                        + "  `username` text NOT NULL\n"
+                        + "  `userId` varchar(255) NOT NULL,\n"
+                        + "  `username` varchar(255) NOT NULL\n"
                         + ") ENGINE=OLAP\n"
                         + "DUPLICATE KEY(`userId`)\n"
                         + "COMMENT 'OLAP'\n"
@@ -242,8 +242,8 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
         createTableAsSelect(selectAlias2);
         ShowResultSet showResultSet2 = showCreateTableByName("select_alias_2");
         Assertions.assertEquals("CREATE TABLE `select_alias_2` (\n"
-                        + "  `alias_name` varchar(65533) NOT NULL,\n"
-                        + "  `username` text NOT NULL\n"
+                        + "  `alias_name` varchar(255) NOT NULL,\n"
+                        + "  `username` varchar(255) NOT NULL\n"
                         + ") ENGINE=OLAP\n"
                         + "DUPLICATE KEY(`alias_name`)\n"
                         + "COMMENT 'OLAP'\n"
@@ -266,8 +266,8 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
         createTableAsSelect(selectFromJoin);
         ShowResultSet showResultSet = showCreateTableByName("select_join");
         Assertions.assertEquals("CREATE TABLE `select_join` (\n"
-                        + "  `userId` varchar(65533) NOT NULL,\n"
-                        + "  `username` text NOT NULL,\n"
+                        + "  `userId` varchar(255) NOT NULL,\n"
+                        + "  `username` varchar(255) NOT NULL,\n"
                         + "  `status` int(11) NOT NULL\n"
                         + ") ENGINE=OLAP\n"
                         + "DUPLICATE KEY(`userId`)\n"
@@ -287,9 +287,9 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
         createTableAsSelect(selectFromJoin1);
         ShowResultSet showResultSet1 = showCreateTableByName("select_join1");
         Assertions.assertEquals("CREATE TABLE `select_join1` (\n"
-                        + "  `userId1` varchar(65533) NOT NULL,\n"
-                        + "  `userId2` text NOT NULL,\n"
-                        + "  `username` text NOT NULL,\n"
+                        + "  `userId1` varchar(255) NOT NULL,\n"
+                        + "  `userId2` varchar(255) NOT NULL,\n"
+                        + "  `username` varchar(255) NOT NULL,\n"
                         + "  `status` int(11) NOT NULL\n"
                         + ") ENGINE=OLAP\n"
                         + "DUPLICATE KEY(`userId1`)\n"
@@ -314,8 +314,8 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
         createTableAsSelect(selectFromName);
         ShowResultSet showResultSet = showCreateTableByName("select_name");
         Assertions.assertEquals("CREATE TABLE `select_name` (\n"
-                        + "  `user` varchar(65533) NOT NULL,\n"
-                        + "  `testname` text NOT NULL,\n"
+                        + "  `user` varchar(255) NOT NULL,\n"
+                        + "  `testname` varchar(255) NOT NULL,\n"
                         + "  `userstatus` int(11) NOT NULL\n"
                         + ") ENGINE=OLAP\n"
                         + "DUPLICATE KEY(`user`)\n"
@@ -339,7 +339,7 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
         ShowResultSet showResultSet = showCreateTableByName("select_union");
         Assertions.assertEquals(
                 "CREATE TABLE `select_union` (\n"
-                        + "  `userId` varchar(65533) NULL\n"
+                        + "  `userId` varchar(255) NULL\n"
                         + ") ENGINE=OLAP\n"
                         + "DUPLICATE KEY(`userId`)\n"
                         + "COMMENT 'OLAP'\n"
@@ -361,7 +361,7 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
         ShowResultSet showResultSet = showCreateTableByName("select_cte");
         Assertions.assertEquals(
                 "CREATE TABLE `select_cte` (\n"
-                        + "  `userId` varchar(65533) NOT NULL\n"
+                        + "  `userId` varchar(255) NOT NULL\n"
                         + ") ENGINE=OLAP\n"
                         + "DUPLICATE KEY(`userId`)\n"
                         + "COMMENT 'OLAP'\n"
@@ -401,8 +401,8 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
         createTableAsSelect(selectFromPartition);
         ShowResultSet showResultSet = showCreateTableByName("selectPartition");
         Assertions.assertEquals("CREATE TABLE `selectPartition` (\n"
-                        + "  `userId` varchar(65533) NOT NULL,\n"
-                        + "  `username` text NOT NULL\n"
+                        + "  `userId` varchar(255) NOT NULL,\n"
+                        + "  `username` varchar(255) NOT NULL\n"
                         + ") ENGINE=OLAP\n"
                         + "DUPLICATE KEY(`userId`)\n"
                         + "COMMENT 'OLAP'\n"
@@ -426,7 +426,7 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
         createTableAsSelect(createSql);
         ShowResultSet showResultSet = showCreateTableByName("test_default_timestamp");
         Assertions.assertEquals("CREATE TABLE `test_default_timestamp` (\n"
-                        + "  `userId` varchar(65533) NOT NULL,\n"
+                        + "  `userId` varchar(255) NOT NULL,\n"
                         + "  `date` datetime"
                         + " NULL DEFAULT CURRENT_TIMESTAMP\n"
                         + ") ENGINE=OLAP\n"
@@ -451,7 +451,7 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
         ShowResultSet showResultSet = showCreateTableByName("test_agg_value");
         Assertions.assertEquals(
                 "CREATE TABLE `test_agg_value` (\n"
-                        + "  `username` varchar(65533) NOT NULL\n"
+                        + "  `username` varchar(255) NOT NULL\n"
                         + ") ENGINE=OLAP\n"
                         + "DUPLICATE KEY(`username`)\n"
                         + "COMMENT 'OLAP'\n"
@@ -475,7 +475,7 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
         Assertions.assertEquals(
                 "CREATE TABLE `test_use_key_type` (\n"
                         + "  `userId` varchar(255) NOT NULL,\n"
-                        + "  `username` text NOT NULL\n"
+                        + "  `username` varchar(255) NOT NULL\n"
                         + ") ENGINE=OLAP\n"
                         + "UNIQUE KEY(`userId`)\n"
                         + "COMMENT 'OLAP'\n"


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

string types from src table will be replaced to text type in ctas table, we change it to be corresponding to the src table.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

