### PR TITLE
[fix](show-stmt) fix show create table missing storage_medium info

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/DataProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/DataProperty.java
@@ -55,6 +55,22 @@ public class DataProperty implements Writable, GsonPostProcessable {
         // for persist
     }
 
+    public String getStorageMediumString() {
+        int val = storageMedium.getValue();
+        switch (val) {
+            case 0:
+                return "hdd";
+            case 1:
+                return "ssd";
+            case 2:
+                return "s3";
+            case 3:
+                return "remote_cache";
+            default:
+                return "unknown";
+        }
+    }
+
     public DataProperty(TStorageMedium medium) {
         this.storageMedium = medium;
         this.cooldownTimeMs = MAX_COOLDOWN_TIME_MS;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -3140,6 +3140,10 @@ public class Env {
             sb.append(",\n\"").append(PropertyAnalyzer.PROPERTIES_ENABLE_SINGLE_REPLICA_COMPACTION).append("\" = \"");
             sb.append(olapTable.enableSingleReplicaCompaction()).append("\"");
 
+            // storage medium
+            sb.append(",\n\"").append(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM).append("\" = \"");
+            sb.append(olapTable.getStorageMedium()).append("\"");
+
             // enable duplicate without keys by default
             if (olapTable.isDuplicateWithoutKey()) {
                 sb.append(",\n\"")

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -170,6 +170,8 @@ public class OlapTable extends Table {
 
     private AutoIncrementGenerator autoIncrementGenerator;
 
+    private String storageMedium;
+
     public OlapTable() {
         // for persist
         super(TableType.OLAP);
@@ -1293,6 +1295,13 @@ public class OlapTable extends Table {
         }
 
         tempPartitions.write(out);
+
+        if (storageMedium == null || storageMedium.length() == 0) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            Text.writeString(out, storageMedium);
+        }
     }
 
     @Override
@@ -1397,6 +1406,10 @@ public class OlapTable extends Table {
             }
         }
         tempPartitions.unsetPartitionInfo();
+
+        if (in.readBoolean()) {
+            storageMedium = Text.readString(in);
+        }
 
         // In the present, the fullSchema could be rebuilt by schema change while the properties is changed by MV.
         // After that, some properties of fullSchema and nameToColumn may be not same as properties of base columns.
@@ -1819,6 +1832,15 @@ public class OlapTable extends Table {
             return tableProperty.enableSingleReplicaCompaction();
         }
         return false;
+    }
+
+
+    public void setStorageMedium(String medium) {
+        storageMedium = medium;
+    }
+
+    public String getStorageMedium() {
+        return storageMedium;
     }
 
     public void setStoreRowColumn(boolean storeRowColumn) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -2137,6 +2137,7 @@ public class InternalCatalog implements CatalogIf<Database> {
             try {
                 dataProperty = PropertyAnalyzer.analyzeDataProperty(stmt.getProperties(),
                         new DataProperty(DataProperty.DEFAULT_STORAGE_MEDIUM));
+                olapTable.setStorageMedium(dataProperty.getStorageMediumString());
             } catch (AnalysisException e) {
                 throw new DdlException(e.getMessage());
             }
@@ -2303,10 +2304,12 @@ public class InternalCatalog implements CatalogIf<Database> {
             } else if (partitionInfo.getType() == PartitionType.RANGE
                     || partitionInfo.getType() == PartitionType.LIST) {
                 try {
+                    DataProperty dataProperty = null;
                     // just for remove entries in stmt.getProperties(),
                     // and then check if there still has unknown properties
-                    PropertyAnalyzer.analyzeDataProperty(stmt.getProperties(),
+                    dataProperty = PropertyAnalyzer.analyzeDataProperty(stmt.getProperties(),
                             new DataProperty(DataProperty.DEFAULT_STORAGE_MEDIUM));
+                    olapTable.setStorageMedium(dataProperty.getStorageMediumString());
                     if (partitionInfo.getType() == PartitionType.RANGE) {
                         DynamicPartitionUtil.checkAndSetDynamicPartitionProperty(olapTable, properties, db);
                     } else if (partitionInfo.getType() == PartitionType.LIST) {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableAsSelectStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableAsSelectStmtTest.java
@@ -95,7 +95,8 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                         + "\"storage_format\" = \"V2\",\n"
                         + "\"light_schema_change\" = \"true\",\n"
                         + "\"disable_auto_compaction\" = \"false\",\n"
-                        + "\"enable_single_replica_compaction\" = \"false\"\n"
+                        + "\"enable_single_replica_compaction\" = \"false\",\n"
+                        + "\"storage_medium\" = \"hdd\"\n"
                         + ");",
                 showCreateTableByName("select_decimal_table").getResultRows().get(0).get(1));
         String selectFromDecimal1 =
@@ -115,7 +116,8 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                             + "\"storage_format\" = \"V2\",\n"
                             + "\"light_schema_change\" = \"true\",\n"
                             + "\"disable_auto_compaction\" = \"false\",\n"
-                            + "\"enable_single_replica_compaction\" = \"false\"\n"
+                            + "\"enable_single_replica_compaction\" = \"false\",\n"
+                            + "\"storage_medium\" = \"hdd\"\n"
                             + ");",
                     showCreateTableByName("select_decimal_table_1").getResultRows().get(0).get(1));
         } else {
@@ -131,7 +133,8 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                             + "\"storage_format\" = \"V2\",\n"
                             + "\"light_schema_change\" = \"true\",\n"
                             + "\"disable_auto_compaction\" = \"false\",\n"
-                            + "\"enable_single_replica_compaction\" = \"false\"\n"
+                            + "\"enable_single_replica_compaction\" = \"false\",\n"
+                            + "\"storage_medium\" = \"hdd\"\n"
                             + ");",
                     showCreateTableByName("select_decimal_table_1").getResultRows().get(0).get(1));
         }
@@ -165,7 +168,8 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                         + "\"storage_format\" = \"V2\",\n"
                         + "\"light_schema_change\" = \"true\",\n"
                         + "\"disable_auto_compaction\" = \"false\",\n"
-                        + "\"enable_single_replica_compaction\" = \"false\"\n"
+                        + "\"enable_single_replica_compaction\" = \"false\",\n"
+                        + "\"storage_medium\" = \"hdd\"\n"
                         + ");",
                 showResultSet.getResultRows().get(0).get(1));
     }
@@ -188,7 +192,8 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                         + "\"storage_format\" = \"V2\",\n"
                         + "\"light_schema_change\" = \"true\",\n"
                         + "\"disable_auto_compaction\" = \"false\",\n"
-                        + "\"enable_single_replica_compaction\" = \"false\"\n"
+                        + "\"enable_single_replica_compaction\" = \"false\",\n"
+                        + "\"storage_medium\" = \"hdd\"\n"
                         + ");",
                 showResultSet1.getResultRows().get(0).get(1));
 
@@ -213,7 +218,8 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                         + "\"storage_format\" = \"V2\",\n"
                         + "\"light_schema_change\" = \"true\",\n"
                         + "\"disable_auto_compaction\" = \"false\",\n"
-                        + "\"enable_single_replica_compaction\" = \"false\"\n"
+                        + "\"enable_single_replica_compaction\" = \"false\",\n"
+                        + "\"storage_medium\" = \"hdd\"\n"
                         + ");",
                 showResultSet2.getResultRows().get(0).get(1));
     }
@@ -235,7 +241,8 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                 + "\"storage_format\" = \"V2\",\n"
                 + "\"light_schema_change\" = \"true\",\n"
                 + "\"disable_auto_compaction\" = \"false\",\n"
-                + "\"enable_single_replica_compaction\" = \"false\"\n"
+                + "\"enable_single_replica_compaction\" = \"false\",\n"
+                + "\"storage_medium\" = \"hdd\"\n"
                 + ");", showResultSet1.getResultRows().get(0).get(1));
         String selectAlias2 = "create table `test`.`select_alias_2` PROPERTIES(\"replication_num\" = \"1\") "
                 + "as select userId as alias_name, username from `test`.`varchar_table`";
@@ -253,7 +260,8 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                         + "\"storage_format\" = \"V2\",\n"
                         + "\"light_schema_change\" = \"true\",\n"
                         + "\"disable_auto_compaction\" = \"false\",\n"
-                        + "\"enable_single_replica_compaction\" = \"false\"\n"
+                        + "\"enable_single_replica_compaction\" = \"false\",\n"
+                        + "\"storage_medium\" = \"hdd\"\n"
                         + ");",
                 showResultSet2.getResultRows().get(0).get(1));
     }
@@ -278,7 +286,8 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                         + "\"storage_format\" = \"V2\",\n"
                         + "\"light_schema_change\" = \"true\",\n"
                         + "\"disable_auto_compaction\" = \"false\",\n"
-                        + "\"enable_single_replica_compaction\" = \"false\"\n"
+                        + "\"enable_single_replica_compaction\" = \"false\",\n"
+                        + "\"storage_medium\" = \"hdd\"\n"
                         + ");",
                 showResultSet.getResultRows().get(0).get(1));
         String selectFromJoin1 = "create table `test`.`select_join1` PROPERTIES(\"replication_num\" = \"1\") "
@@ -300,7 +309,8 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                         + "\"storage_format\" = \"V2\",\n"
                         + "\"light_schema_change\" = \"true\",\n"
                         + "\"disable_auto_compaction\" = \"false\",\n"
-                        + "\"enable_single_replica_compaction\" = \"false\"\n"
+                        + "\"enable_single_replica_compaction\" = \"false\",\n"
+                        + "\"storage_medium\" = \"hdd\"\n"
                         + ");",
                 showResultSet1.getResultRows().get(0).get(1));
     }
@@ -326,7 +336,8 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                         + "\"storage_format\" = \"V2\",\n"
                         + "\"light_schema_change\" = \"true\",\n"
                         + "\"disable_auto_compaction\" = \"false\",\n"
-                        + "\"enable_single_replica_compaction\" = \"false\"\n"
+                        + "\"enable_single_replica_compaction\" = \"false\",\n"
+                        + "\"storage_medium\" = \"hdd\"\n"
                         + ");",
                 showResultSet.getResultRows().get(0).get(1));
     }
@@ -349,7 +360,8 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                         + "\"storage_format\" = \"V2\",\n"
                         + "\"light_schema_change\" = \"true\",\n"
                         + "\"disable_auto_compaction\" = \"false\",\n"
-                        + "\"enable_single_replica_compaction\" = \"false\"\n"
+                        + "\"enable_single_replica_compaction\" = \"false\",\n"
+                        + "\"storage_medium\" = \"hdd\"\n"
                         + ");", showResultSet.getResultRows().get(0).get(1));
     }
 
@@ -371,7 +383,8 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                         + "\"storage_format\" = \"V2\",\n"
                         + "\"light_schema_change\" = \"true\",\n"
                         + "\"disable_auto_compaction\" = \"false\",\n"
-                        + "\"enable_single_replica_compaction\" = \"false\"\n"
+                        + "\"enable_single_replica_compaction\" = \"false\",\n"
+                        + "\"storage_medium\" = \"hdd\"\n"
                         + ");",
                 showResultSet.getResultRows().get(0).get(1));
         String selectFromCteAndUnion = "create table `test`.`select_cte_union` PROPERTIES(\"replication_num\" = \"1\")"
@@ -389,7 +402,8 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                 + "\"storage_format\" = \"V2\",\n"
                 + "\"light_schema_change\" = \"true\",\n"
                 + "\"disable_auto_compaction\" = \"false\",\n"
-                + "\"enable_single_replica_compaction\" = \"false\"\n"
+                + "\"enable_single_replica_compaction\" = \"false\",\n"
+                + "\"storage_medium\" = \"hdd\"\n"
                 + ");", showResultSet1.getResultRows().get(0).get(1));
     }
 
@@ -414,7 +428,8 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                         + "\"storage_format\" = \"V2\",\n"
                         + "\"light_schema_change\" = \"true\",\n"
                         + "\"disable_auto_compaction\" = \"false\",\n"
-                        + "\"enable_single_replica_compaction\" = \"false\"\n"
+                        + "\"enable_single_replica_compaction\" = \"false\",\n"
+                        + "\"storage_medium\" = \"hdd\"\n"
                         + ");",
                 showResultSet.getResultRows().get(0).get(1));
     }
@@ -438,7 +453,8 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                         + "\"storage_format\" = \"V2\",\n"
                         + "\"light_schema_change\" = \"true\",\n"
                         + "\"disable_auto_compaction\" = \"false\",\n"
-                        + "\"enable_single_replica_compaction\" = \"false\"\n"
+                        + "\"enable_single_replica_compaction\" = \"false\",\n"
+                        + "\"storage_medium\" = \"hdd\"\n"
                         + ");",
                 showResultSet.getResultRows().get(0).get(1));
     }
@@ -461,7 +477,8 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                         + "\"storage_format\" = \"V2\",\n"
                         + "\"light_schema_change\" = \"true\",\n"
                         + "\"disable_auto_compaction\" = \"false\",\n"
-                        + "\"enable_single_replica_compaction\" = \"false\"\n"
+                        + "\"enable_single_replica_compaction\" = \"false\",\n"
+                        + "\"storage_medium\" = \"hdd\"\n"
                         + ");",
                 showResultSet.getResultRows().get(0).get(1));
     }
@@ -485,7 +502,8 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                         + "\"storage_format\" = \"V2\",\n"
                         + "\"light_schema_change\" = \"true\",\n"
                         + "\"disable_auto_compaction\" = \"false\",\n"
-                        + "\"enable_single_replica_compaction\" = \"false\"\n"
+                        + "\"enable_single_replica_compaction\" = \"false\",\n"
+                        + "\"storage_medium\" = \"hdd\"\n"
                         + ");",
                 showResultSet.getResultRows().get(0).get(1));
     }
@@ -533,7 +551,8 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                                 + "\"storage_format\" = \"V2\",\n"
                                 + "\"light_schema_change\" = \"true\",\n"
                                 + "\"disable_auto_compaction\" = \"false\",\n"
-                                + "\"enable_single_replica_compaction\" = \"false\"\n"
+                                + "\"enable_single_replica_compaction\" = \"false\",\n"
+                                + "\"storage_medium\" = \"hdd\"\n"
                                 + ");",
                         createTableStmts.get(0));
             } else {
@@ -549,7 +568,8 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                                 + "\"storage_format\" = \"V2\",\n"
                                 + "\"light_schema_change\" = \"true\",\n"
                                 + "\"disable_auto_compaction\" = \"false\",\n"
-                                + "\"enable_single_replica_compaction\" = \"false\"\n"
+                                + "\"enable_single_replica_compaction\" = \"false\",\n"
+                                + "\"storage_medium\" = \"hdd\"\n"
                                 + ");",
                         createTableStmts.get(0));
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateTableTest.java
@@ -146,6 +146,16 @@ public class CreateTableTest {
                 .expectThrowsNoException(() -> createTable("create table test.tb7(key1 int, key2 varchar(10)) \n"
                         + "distributed by hash(key1) buckets 1 properties('replication_num' = '1', 'storage_medium' = 'ssd');"));
 
+        ConfigBase.setMutableConfig("disable_storage_medium_check", "true");
+        ExceptionChecker
+                .expectThrowsNoException(() -> createTable("create table test.tb7_1(key1 int, key2 varchar(10))\n"
+                                + "PARTITION BY RANGE(`key1`) (\n"
+                                + "    PARTITION `p1` VALUES LESS THAN (\"10\"),\n"
+                                + "    PARTITION `p2` VALUES LESS THAN (\"20\"),\n"
+                                + "    PARTITION `p3` VALUES LESS THAN (\"30\"))\n"
+                                + "distributed by hash(key1)\n"
+                                + "buckets 1 properties('replication_num' = '1', 'storage_medium' = 'ssd');"));
+
         ExceptionChecker
                 .expectThrowsNoException(() -> createTable("create table test.compression1(key1 int, key2 varchar(10)) \n"
                         + "distributed by hash(key1) buckets 1 \n"
@@ -299,6 +309,19 @@ public class CreateTableTest {
                                 + "Create failed replications:\n"
                                 + "replication tag: {\"location\" : \"default\"}, replication num: 1, storage medium: SSD",
                         () -> createTable("create table test.tb7(key1 int, key2 varchar(10)) distributed by hash(key1) \n"
+                                + "buckets 1 properties('replication_num' = '1', 'storage_medium' = 'ssd');"));
+
+        ConfigBase.setMutableConfig("disable_storage_medium_check", "false");
+        ExceptionChecker
+                .expectThrowsWithMsg(DdlException.class, "Failed to find enough backend, please check the replication num,replication tag and storage medium.\n"
+                                + "Create failed replications:\n"
+                                + "replication tag: {\"location\" : \"default\"}, replication num: 1, storage medium: SSD",
+                        () -> createTable("create table test.tb7_1(key1 int, key2 varchar(10))\n"
+                                + "PARTITION BY RANGE(`key1`) (\n"
+                                + "    PARTITION `p1` VALUES LESS THAN (\"10\"),\n"
+                                + "    PARTITION `p2` VALUES LESS THAN (\"20\"),\n"
+                                + "    PARTITION `p3` VALUES LESS THAN (\"30\"))\n"
+                                + "distributed by hash(key1)\n"
                                 + "buckets 1 properties('replication_num' = '1', 'storage_medium' = 'ssd');"));
 
         ExceptionChecker


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

test ddl (reproduce):
```
CREATE TABLE IF NOT EXISTS example_db.example_range_tbl
(
    `user_id` LARGEINT NOT NULL COMMENT "用户id",
    `date` DATE NOT NULL COMMENT "数据灌入日期时间",
    `timestamp` DATETIME NOT NULL COMMENT "数据灌入的时间戳",
    `city` VARCHAR(20) COMMENT "用户所在城市",
    `age` SMALLINT COMMENT "用户年龄",
    `sex` TINYINT COMMENT "用户性别",
    `last_visit_date` DATETIME REPLACE DEFAULT "1970-01-01 00:00:00" COMMENT "用户最后一次访问时间",
    `cost` BIGINT SUM DEFAULT "0" COMMENT "用户总消费",
    `max_dwell_time` INT MAX DEFAULT "0" COMMENT "用户最大停留时间",
    `min_dwell_time` INT MIN DEFAULT "99999" COMMENT "用户最小停留时间"
)
ENGINE=OLAP
AGGREGATE KEY(`user_id`, `date`, `timestamp`, `city`, `age`, `sex`)
PARTITION BY RANGE(`date`)
(
    PARTITION `p201701` VALUES LESS THAN ("2017-02-01"),
    PARTITION `p201702` VALUES LESS THAN ("2017-03-01"),
    PARTITION `p201703` VALUES LESS THAN ("2017-04-01")
)
DISTRIBUTED BY HASH(`user_id`) BUCKETS 16
PROPERTIES
(
    "replication_num" = "1",
    "storage_medium" = "HDD"
);
```


before fix:
show create table example_db.example_range_tbl;
```
| example_range_tbl | CREATE TABLE `example_range_tbl` (
  `user_id` largeint(40) NOT NULL COMMENT '用户id',
  `date` date NOT NULL COMMENT '数据灌入日期时间',
  `timestamp` datetime NOT NULL COMMENT '数据灌入的时间戳',
  `city` varchar(20) NULL COMMENT '用户所在城市',
  `age` smallint(6) NULL COMMENT '用户年龄',
  `sex` tinyint(4) NULL COMMENT '用户性别',
  `last_visit_date` datetime REPLACE NULL DEFAULT "1970-01-01 00:00:00" COMMENT '用户最后一次访问时间',
  `cost` bigint(20) SUM NULL DEFAULT "0" COMMENT '用户总消费',
  `max_dwell_time` int(11) MAX NULL DEFAULT "0" COMMENT '用户最大停留时间',
  `min_dwell_time` int(11) MIN NULL DEFAULT "99999" COMMENT '用户最小停留时间'
) ENGINE=OLAP
AGGREGATE KEY(`user_id`, `date`, `timestamp`, `city`, `age`, `sex`)
COMMENT 'OLAP'
PARTITION BY RANGE(`date`)
(PARTITION p201701 VALUES [('0000-01-01'), ('2017-02-01')),
PARTITION p201702 VALUES [('2017-02-01'), ('2017-03-01')),
PARTITION p201703 VALUES [('2017-03-01'), ('2017-04-01')))
DISTRIBUTED BY HASH(`user_id`) BUCKETS 16
PROPERTIES (
"replication_allocation" = "tag.location.default: 1",
"storage_format" = "V2",
"light_schema_change" = "true",
"disable_auto_compaction" = "false",
"enable_single_replica_compaction" = "false"
); |
```

after fix:
```
| example_range_tbl | CREATE TABLE `example_range_tbl` (
  `user_id` largeint(40) NOT NULL COMMENT '用户id',
  `date` date NOT NULL COMMENT '数据灌入日期时间',
  `timestamp` datetime NOT NULL COMMENT '数据灌入的时间戳',
  `city` varchar(20) NULL COMMENT '用户所在城市',
  `age` smallint(6) NULL COMMENT '用户年龄',
  `sex` tinyint(4) NULL COMMENT '用户性别',
  `last_visit_date` datetime REPLACE NULL DEFAULT "1970-01-01 00:00:00" COMMENT '用户最后一次访问时间',
  `cost` bigint(20) SUM NULL DEFAULT "0" COMMENT '用户总消费',
  `max_dwell_time` int(11) MAX NULL DEFAULT "0" COMMENT '用户最大停留时间',
  `min_dwell_time` int(11) MIN NULL DEFAULT "99999" COMMENT '用户最小停留时间'
) ENGINE=OLAP
AGGREGATE KEY(`user_id`, `date`, `timestamp`, `city`, `age`, `sex`)
COMMENT 'OLAP'
PARTITION BY RANGE(`date`)
(PARTITION p201701 VALUES [('0000-01-01'), ('2017-02-01')),
PARTITION p201702 VALUES [('2017-02-01'), ('2017-03-01')),
PARTITION p201703 VALUES [('2017-03-01'), ('2017-04-01')))
DISTRIBUTED BY HASH(`user_id`) BUCKETS 16
PROPERTIES (
"replication_allocation" = "tag.location.default: 1",
"storage_format" = "V2",
"light_schema_change" = "true",
"disable_auto_compaction" = "false",
"enable_single_replica_compaction" = "false",
"storage_medium" = "hdd"             <==== show storage medium properly
); |
```


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

