### PR TITLE
[Fix](MoW) Fix bug about caculating all committed rowsets delete bitmaps when do comapction

### DIFF
--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -614,7 +614,7 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
 
             // Step2: calculate all rowsets' delete bitmaps which are published during compaction.
             for (auto& it : commit_tablet_txn_info_vec) {
-                if (check_if_includes_input_rowsets(it.rowset_ids)) {
+                if (_check_if_includes_input_rowsets(it.rowset_ids)) {
                     DeleteBitmap output_delete_bitmap(_tablet->tablet_id());
                     _tablet->calc_compaction_output_rowset_delete_bitmap(
                             _input_rowsets, _rowid_conversion, 0, UINT64_MAX, &missed_rows,
@@ -672,7 +672,7 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
     return Status::OK();
 }
 
-bool Compaction::check_if_includes_input_rowsets(
+bool Compaction::_check_if_includes_input_rowsets(
         const RowsetIdUnorderedSet& commit_rowset_ids_set) const {
     std::vector<RowsetId> commit_rowset_ids {};
     commit_rowset_ids.insert(commit_rowset_ids.end(), commit_rowset_ids_set.begin(),

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -615,6 +615,11 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
             // Step2: calculate all rowsets' delete bitmaps which are published during compaction.
             for (auto& it : commit_tablet_txn_info_vec) {
                 if (!_check_if_includes_input_rowsets(it.rowset_ids)) {
+                    // When calculating the delete bitmap of all committed rowsets relative to the compaction,
+                    // there may be cases where the compacted rowsets are newer than the committed rowsets.
+                    // At this time, row number conversion cannot be performed, otherwise data will be missing.
+                    // Therefore, we need to check if every committed rowset has calculated delete bitmap for
+                    // all compaction input rowsets.
                     continue;
                 } else {
                     DeleteBitmap output_delete_bitmap(_tablet->tablet_id());

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -614,7 +614,9 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
 
             // Step2: calculate all rowsets' delete bitmaps which are published during compaction.
             for (auto& it : commit_tablet_txn_info_vec) {
-                if (_check_if_includes_input_rowsets(it.rowset_ids)) {
+                if (!_check_if_includes_input_rowsets(it.rowset_ids)) {
+                    continue;
+                } else {
                     DeleteBitmap output_delete_bitmap(_tablet->tablet_id());
                     _tablet->calc_compaction_output_rowset_delete_bitmap(
                             _input_rowsets, _rowid_conversion, 0, UINT64_MAX, &missed_rows,
@@ -626,8 +628,6 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
                             it.partition_id, it.transaction_id, _tablet->tablet_id(),
                             _tablet->schema_hash(), _tablet->tablet_uid(), true, it.delete_bitmap,
                             it.rowset_ids);
-                } else {
-                    continue;
                 }
             }
 

--- a/be/src/olap/compaction.h
+++ b/be/src/olap/compaction.h
@@ -93,7 +93,9 @@ protected:
     void build_basic_info();
 
     void init_profile(const std::string& label);
-    bool check_if_includes_input_rowsets(const RowsetIdUnorderedSet& commit_rowset_ids_set) const;
+
+private:
+    bool _check_if_includes_input_rowsets(const RowsetIdUnorderedSet& commit_rowset_ids_set) const;
 
 protected:
     // the root tracker for this compaction

--- a/be/src/olap/compaction.h
+++ b/be/src/olap/compaction.h
@@ -93,6 +93,7 @@ protected:
     void build_basic_info();
 
     void init_profile(const std::string& label);
+    bool check_if_includes_input_rowsets(const RowsetIdUnorderedSet& commit_rowset_ids_set) const;
 
 protected:
     // the root tracker for this compaction


### PR DESCRIPTION
## Proposed changes

Relative PR Number:  #20907

<!--Describe your changes.-->

When calculating the delete bitmap of all committed rowsets relative to the compaction, there may be cases where the compacted rowsets are newer than the committed rowsets. At this time, row number conversion cannot be performed, otherwise data will be missing.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

