### PR TITLE
[Agg](exec) support aggregation_node limit short circuit

### DIFF
--- a/be/src/vec/exec/vaggregation_node.cpp
+++ b/be/src/vec/exec/vaggregation_node.cpp
@@ -151,6 +151,10 @@ Status AggregationNode::init(const TPlanNode& tnode, RuntimeState* state) {
 
     // init aggregate functions
     _aggregate_evaluators.reserve(tnode.agg_node.aggregate_functions.size());
+    // In case of : `select * from (select GoodEvent from hits union select CounterID from hits) as h limit 10;`
+    // only union with limit: we can short circuit query the pipeline exec engine.
+    _can_short_circuit =
+            tnode.agg_node.aggregate_functions.empty() && state->enable_pipeline_exec();
 
     TSortInfo dummy;
     for (int i = 0; i < tnode.agg_node.aggregate_functions.size(); ++i) {

--- a/be/src/vec/exec/vaggregation_node.h
+++ b/be/src/vec/exec/vaggregation_node.h
@@ -897,6 +897,7 @@ private:
     std::vector<size_t> _probe_key_sz;
 
     std::vector<AggFnEvaluator*> _aggregate_evaluators;
+    bool _can_short_circuit = false;
 
     // may be we don't have to know the tuple id
     TupleId _intermediate_tuple_id;
@@ -1060,6 +1061,10 @@ private:
 
             if (_should_limit_output) {
                 _reach_limit = _get_hash_table_size() >= _limit;
+                if (_reach_limit && _can_short_circuit) {
+                    _can_read = true;
+                    return Status::Error<ErrorCode::END_OF_FILE>("");
+                }
             }
         }
 


### PR DESCRIPTION
## Proposed changes

opt the aggregate node limit in union

after:
![img_v2_4eb38628-aa5b-4a0f-a641-014ff5e4aacg](https://github.com/apache/doris/assets/10553413/7186f0b2-ca4f-4f64-9b6b-b94aa1b4f4f1)

before:
![img_v2_a70fea44-7cef-442e-bcd5-e8a2cb5d92bg](https://github.com/apache/doris/assets/10553413/5875f71a-96e9-4ca4-8d8c-07cf168d4222)



<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

