### PR TITLE
[fix](compile) fix ColumnArray::update_crcs_with_value

### DIFF
--- a/be/src/vec/columns/column_array.cpp
+++ b/be/src/vec/columns/column_array.cpp
@@ -315,12 +315,12 @@ void ColumnArray::update_crcs_with_value(std::vector<uint64_t>& hash, PrimitiveT
         for (size_t i = 0; i < s; ++i) {
             // every row
             if (null_data[i] == 0) {
-                update_crc_with_value(i, hash[i]);
+                update_crc_with_value(i, i + 1, hash[i], nullptr);
             }
         }
     } else {
         for (size_t i = 0; i < s; ++i) {
-            update_crc_with_value(i, hash[i]);
+            update_crc_with_value(i, i + 1, hash[i], nullptr);
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

Fix compile error, the fix is backported from master:

```
/mnt/disk1/chenkaijie/doris-1.2/be/src/vec/columns/column_array.cpp:319:17: error: use of undeclared identifier 'decimalv2_do_crc'
                decimalv2_do_crc(i, hash[i]);
                ^
/mnt/disk1/chenkaijie/doris-1.2/be/src/vec/columns/column_array.cpp:324:13: error: use of undeclared identifier 'decimalv2_do_crc'
            decimalv2_do_crc(i, hash[i]);
            ^
2 errors generated.
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

