### PR TITLE
[fix](merge-on-write) fix be core and delete unused pending publish info for async publish when tablet dropped

### DIFF
--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -1216,6 +1216,11 @@ void StorageEngine::add_async_publish_task(int64_t partition_id, int64_t tablet_
                                            bool is_recovery) {
     if (!is_recovery) {
         TabletSharedPtr tablet = tablet_manager()->get_tablet(tablet_id);
+        if (tablet == nullptr) {
+            LOG(INFO) << "tablet may be dropped when add async publish task, tablet_id: "
+                      << tablet_id;
+            return;
+        }
         PendingPublishInfoPB pending_publish_info_pb;
         pending_publish_info_pb.set_partition_id(partition_id);
         pending_publish_info_pb.set_transaction_id(transaction_id);
@@ -1259,7 +1264,6 @@ void StorageEngine::_async_publish_callback() {
                 if (!tablet) {
                     LOG(WARNING) << "tablet does not exist when async publush, tablet_id: "
                                  << tablet_id;
-                    // TODO(liaoxin) remove pending publish info from db
                     tablet_iter = _async_publish_tasks.erase(tablet_iter);
                     continue;
                 }

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -255,6 +255,8 @@ private:
 
     void _clean_unused_delete_bitmap();
 
+    void _clean_unused_pending_publish_info();
+
     Status _do_sweep(const std::string& scan_root, const time_t& local_tm_now,
                      const int32_t expire);
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk2/zhangchen/doris-dev/be/src/common/signal_handler.h:413
 1# os::Linux::chained_handler(int, siginfo*, void*) in /root/jdk1.8.0_331/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /root/jdk1.8.0_331/jre/lib/amd64/server/libjvm.so
 3# signalHandler(int, siginfo*, void*) in /root/jdk1.8.0_331/jre/lib/amd64/server/libjvm.so
 4# 0x00007FCD1B593400 in /lib64/libc.so.6
 5# doris::StorageEngine::add_async_publish_task(long, long, long, long, bool) at /mnt/disk2/zhangchen/doris-dev/be/src/olap/olap_server.cpp:1222
 6# doris::PublishVersionTaskPool::_publish_version_worker_thread_callback() at /mnt/disk2/zhangchen/doris-dev/be/src/agent/task_worker_pool.cpp:1492
 7# doris::ThreadPool::dispatch_thread() in /mnt/datadisk0/output/be/lib/doris_be
 8# doris::Thread::supervise_thread(void*) at /mnt/disk2/zhangchen/doris-dev/be/src/util/thread.cpp:466
 9# start_thread in /lib64/libpthre

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

