### PR TITLE
[fix](Nereids) use groupExpr's children to make logicalPlan

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/receiver/PlanReceiver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/receiver/PlanReceiver.java
@@ -306,7 +306,7 @@ public class PlanReceiver implements AbstractReceiver {
             }
             hasGenerated.add(groupExpression);
 
-            // process child first
+            // process child first, plan's child may be changed due to mergeGroup
             Plan physicalPlan = groupExpression.getPlan();
             for (Group child : groupExpression.children()) {
                 makeLogicalExpression(child);
@@ -316,12 +316,12 @@ public class PlanReceiver implements AbstractReceiver {
             if (physicalPlan instanceof PhysicalProject) {
                 PhysicalProject physicalProject = (PhysicalProject) physicalPlan;
                 logicalPlan = new LogicalProject<>(physicalProject.getProjects(),
-                        physicalProject.child(0));
+                        new GroupPlan(groupExpression.child(0)));
             } else if (physicalPlan instanceof AbstractPhysicalJoin) {
                 AbstractPhysicalJoin physicalJoin = (AbstractPhysicalJoin) physicalPlan;
                 logicalPlan = new LogicalJoin<>(physicalJoin.getJoinType(), physicalJoin.getHashJoinConjuncts(),
                         physicalJoin.getOtherJoinConjuncts(), JoinHint.NONE, physicalJoin.getMarkJoinSlotReference(),
-                        physicalJoin.children());
+                        groupExpression.children().stream().map(g -> new GroupPlan(g)).collect(Collectors.toList()));
             } else {
                 throw new RuntimeException("DPhyp can only handle join and project operator");
             }


### PR DESCRIPTION
## Proposed changes

After mergeGroup, the children of the plan are different from GroupExpr. To avoid optimizing out-dated group, we should construct new plan with groupExpr's children rather than plan's children

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

