### PR TITLE
[improvement](spark-load) support load into mow table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkLoadPendingTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkLoadPendingTask.java
@@ -299,7 +299,7 @@ public class SparkLoadPendingTask extends LoadTask {
         if (column.getAggregationType() != null) {
             if (enableMergeOnWrite && !isKey
                     && AggregateType.NONE.equals(column.getAggregationType())) {
-                aggregationType = AggregateType.NONE.toString();
+                aggregationType = AggregateType.REPLACE.toString();
             } else {
                 aggregationType = column.getAggregationType().toString();
             }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

support load into mow table.

For the table of the unique model, after enabling the merge on write feature, the aggregate type is none, which causes spark load to fail to preprocess.

Therefore, when generating the configuration, process the table with merge on write enabled, and set the aggregate type of the non-key column to replace.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

