### PR TITLE
[fix](profile) Fix wrong instance number in query profile

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -478,7 +478,8 @@ public class Coordinator {
         Map<String, Integer> result = Maps.newTreeMap();
         if (enablePipelineEngine) {
             for (PipelineExecContexts ctxs : beToPipelineExecCtxs.values()) {
-                result.put(ctxs.brpcAddr.hostname.concat(":").concat("" + ctxs.brpcAddr.port), ctxs.ctxs.size());
+                result.put(ctxs.brpcAddr.hostname.concat(":").concat("" + ctxs.brpcAddr.port),
+                        ctxs.getInstanceNumber());
             }
         } else {
             for (BackendExecStates states : beToExecStates.values()) {
@@ -846,6 +847,7 @@ public class Coordinator {
                         beToPipelineExecCtxs.putIfAbsent(pipelineExecContext.backend.getId(), ctxs);
                     }
                     ctxs.addContext(pipelineExecContext);
+                    ctxs.setInstanceNumber(entry.getValue().getFragmentNumOnHost());
 
                     ++backendIdx;
                 }
@@ -2971,6 +2973,7 @@ public class Coordinator {
         List<PipelineExecContext> ctxs = Lists.newArrayList();
         boolean twoPhaseExecution = false;
         ScopedSpan scopedSpan = new ScopedSpan();
+        int instanceNumber;
 
         public PipelineExecContexts(long beId, TNetworkAddress brpcAddr, boolean twoPhaseExecution) {
             this.beId = beId;
@@ -2980,6 +2983,14 @@ public class Coordinator {
 
         public void addContext(PipelineExecContext ctx) {
             this.ctxs.add(ctx);
+        }
+
+        public void setInstanceNumber(int instanceNumber) {
+            this.instanceNumber = instanceNumber;
+        }
+
+        public int getInstanceNumber() {
+            return instanceNumber;
         }
 
         /**

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -843,11 +843,11 @@ public class Coordinator {
                     PipelineExecContexts ctxs = beToPipelineExecCtxs.get(pipelineExecContext.backend.getId());
                     if (ctxs == null) {
                         ctxs = new PipelineExecContexts(pipelineExecContext.backend.getId(),
-                                pipelineExecContext.brpcAddress, twoPhaseExecution);
+                                pipelineExecContext.brpcAddress, twoPhaseExecution,
+                                entry.getValue().getFragmentNumOnHost());
                         beToPipelineExecCtxs.putIfAbsent(pipelineExecContext.backend.getId(), ctxs);
                     }
                     ctxs.addContext(pipelineExecContext);
-                    ctxs.setInstanceNumber(entry.getValue().getFragmentNumOnHost());
 
                     ++backendIdx;
                 }
@@ -2975,18 +2975,16 @@ public class Coordinator {
         ScopedSpan scopedSpan = new ScopedSpan();
         int instanceNumber;
 
-        public PipelineExecContexts(long beId, TNetworkAddress brpcAddr, boolean twoPhaseExecution) {
+        public PipelineExecContexts(long beId, TNetworkAddress brpcAddr, boolean twoPhaseExecution,
+                int instanceNumber) {
             this.beId = beId;
             this.brpcAddr = brpcAddr;
             this.twoPhaseExecution = twoPhaseExecution;
+            this.instanceNumber = instanceNumber;
         }
 
         public void addContext(PipelineExecContext ctx) {
             this.ctxs.add(ctx);
-        }
-
-        public void setInstanceNumber(int instanceNumber) {
-            this.instanceNumber = instanceNumber;
         }
 
         public int getInstanceNumber() {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

when PipelineEngine = true

before:
```
          -  Total  Instances  Num:  2
          -  Instances  Num  Per  BE:  xxx:2
          -  Parallel  Fragment  Exec  Instance  Num:  48
```
after:
```
          -  Total  Instances  Num:  49
          -  Instances  Num  Per  BE:  xxx:49
          -  Parallel  Fragment  Exec  Instance  Num:  48
```
(the more 1 is for Fragment0-exchange)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

