### PR TITLE
[fix](unique-key) fix query results show duplicate key for unique key table after upgrading

### DIFF
--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -722,7 +722,10 @@ void BetaRowsetWriter::_build_rowset_meta(std::shared_ptr<RowsetMeta> rowset_met
          ++itr) {
         segments_encoded_key_bounds.push_back(*itr);
     }
-    if (!_is_segment_overlapping(segments_encoded_key_bounds)) {
+    // segment key bounds are empty in old version(before version 1.2.x). So we should not modify
+    // the overlap property when key bounds are empty.
+    if (!segments_encoded_key_bounds.empty() &&
+        !_is_segment_overlapping(segments_encoded_key_bounds)) {
         rowset_meta->set_segments_overlap(NONOVERLAPPING);
     }
 


### PR DESCRIPTION

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
problem: 
After upgrading from version 1.1.5 to 1.2.4.1,   the query results show duplicate key for unique key table.

why:
we add segment key bounds in rowset to accelerate compaction and queries in version 1.2.x. when after upgading from 1.1.x, the rowset cloned from other node will rebuild rowset meta. Because the key bounds is empty, then NONOVERLAPPING was set. 


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

