### PR TITLE
[fix](planner)only forbid literal value in AnalyticExpr's order by list

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AnalyticExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AnalyticExpr.java
@@ -478,7 +478,7 @@ public class AnalyticExpr extends Expr {
         type = getFnCall().getType();
 
         for (Expr e : partitionExprs) {
-            if (e.isConstant()) {
+            if (e.isLiteral()) {
                 throw new AnalysisException(
                     "Expressions in the PARTITION BY clause must not be constant: "
                     + e.toSql() + " (in " + toSql() + ")");
@@ -486,7 +486,7 @@ public class AnalyticExpr extends Expr {
         }
 
         for (OrderByElement e : orderByElements) {
-            if (e.getExpr().isConstant()) {
+            if (e.getExpr().isLiteral()) {
                 throw new AnalysisException(
                     "Expressions in the ORDER BY clause must not be constant: "
                             + e.getExpr().toSql() + " (in " + toSql() + ")");


### PR DESCRIPTION
## Proposed changes

pick from master https://github.com/apache/doris/pull/21819

The original error is the window function's order by clause doesn't support a literal value. But we use Expr's isConstant method to check if it's an literal, this is wrong. So the pr uses the correct method( isLiteral ) to check if an expr is literal to solve this problem

```sql
select
    sortNum,
    BITMAP_UNION_COUNT (c.pv) over (ORDER BY **sortNum** ) totalNum
from(
select 
    ifnull(a.sortNum, b.sortNum) sortNum,
    BITMAP_UNION (ifnull(a.c_pv, b.c_pv)) pv
from
    (select **_1 sortNum_**, c_pv from ${tableName2} t where t.c_int = 1) a
full join
    (select **_2 sortNum_**, c_pv from ${tableName2} t where t.c_int = 2) b
    on a.sortNum = b.sortNum
GROUP BY
    sortNum
ORDER BY
    sortNum
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

