### PR TITLE
[enhance](multi-catalog) support multi name service when config hive catalog

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
@@ -100,24 +100,28 @@ public class HMSExternalCatalog extends ExternalCatalog {
         if (Strings.isNullOrEmpty(dfsNameservices)) {
             return;
         }
-        String namenodes = catalogProperty.getOrDefault("dfs.ha.namenodes." + dfsNameservices, "");
-        if (Strings.isNullOrEmpty(namenodes)) {
-            throw new DdlException("Missing dfs.ha.namenodes." + dfsNameservices + " property");
-        }
-        String[] names = namenodes.split(",");
-        for (String name : names) {
-            String address = catalogProperty.getOrDefault("dfs.namenode.rpc-address." + dfsNameservices + "." + name,
-                    "");
-            if (Strings.isNullOrEmpty(address)) {
-                throw new DdlException(
-                        "Missing dfs.namenode.rpc-address." + dfsNameservices + "." + name + " property");
+
+        String[] nameservices = dfsNameservices.split(",");
+        for (String dfsservice : nameservices) {
+            String namenodes = catalogProperty.getOrDefault("dfs.ha.namenodes." + dfsservice, "");
+            if (Strings.isNullOrEmpty(namenodes)) {
+                throw new DdlException("Missing dfs.ha.namenodes." + dfsservice + " property");
             }
-        }
-        String failoverProvider = catalogProperty.getOrDefault("dfs.client.failover.proxy.provider." + dfsNameservices,
-                "");
-        if (Strings.isNullOrEmpty(failoverProvider)) {
-            throw new DdlException(
-                    "Missing dfs.client.failover.proxy.provider." + dfsNameservices + " property");
+            String[] names = namenodes.split(",");
+            for (String name : names) {
+                String address = catalogProperty.getOrDefault("dfs.namenode.rpc-address." + dfsservice + "." + name,
+                        "");
+                if (Strings.isNullOrEmpty(address)) {
+                    throw new DdlException(
+                            "Missing dfs.namenode.rpc-address." + dfsservice + "." + name + " property");
+                }
+            }
+            String failoverProvider = catalogProperty.getOrDefault("dfs.client.failover.proxy.provider." + dfsservice,
+                    "");
+            if (Strings.isNullOrEmpty(failoverProvider)) {
+                throw new DdlException(
+                        "Missing dfs.client.failover.proxy.provider." + dfsservice + " property");
+            }
         }
     }
 


### PR DESCRIPTION
fix code style

when create catalog with multi-servicename like below:
REATE CATALOG hive_prod_t1 PROPERTIES (
    'type'='hms',
    'hive.metastore.uris' = 'thrift://10.198.xxx:9011,thrift://11.11.xxx:9001,thrift://10.198.xxx:9011',
    'hadoop.username' = 'user',
    'dfs.nameservices'='ns1007,ns1017',
    'dfs.ha.namenodes.ns1007'='nn1,nn2',
    'dfs.namenode.rpc-address.ns1007.nn1'='10.198.xxxx:8120',
    'dfs.namenode.rpc-address.ns1007.nn2'='10.198.xxx:8120',
    'dfs.client.failover.proxy.provider.ns1007'='org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider',
    'dfs.ha.namenodes.ns1017'='nn1,nn2',
    'dfs.namenode.rpc-address.ns1017.nn1'='10.198.xxxx:8120',
    'dfs.namenode.rpc-address.ns1017.nn2'='10.198.xxxx:8120',
    'dfs.client.failover.proxy.provider.ns1017'='org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider'
);

the result will be: ERROR 1105 (HY000): errCode = 2, detailMessage = Missing dfs.ha.namenodes.ns1007,ns1017 property


Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

