### PR TITLE
[chore](Nereids) fix typo in some plan visitor

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AddDefaultLimit.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AddDefaultLimit.java
@@ -23,6 +23,8 @@ import org.apache.doris.nereids.trees.plans.LimitPhase;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalCTEAnchor;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFileSink;
+import org.apache.doris.nereids.trees.plans.logical.LogicalCTE;
+import org.apache.doris.nereids.trees.plans.logical.LogicalFileSink;
 import org.apache.doris.nereids.trees.plans.logical.LogicalLimit;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapTableSink;
 import org.apache.doris.nereids.trees.plans.logical.LogicalSort;
@@ -67,6 +69,12 @@ public class AddDefaultLimit extends DefaultPlanRewriter<StatementContext> imple
             StatementContext context) {
         Plan child = olapTableSink.child().accept(this, context);
         return olapTableSink.withChildren(child);
+    }
+
+    @Override
+    public LogicalPlan visitLogicalFileSink(LogicalFileSink<? extends Plan> sink, StatementContext context) {
+        Plan child = sink.child().accept(this, context);
+        return ((LogicalPlan) sink.withChildren(child));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AddDefaultLimit.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AddDefaultLimit.java
@@ -23,8 +23,6 @@ import org.apache.doris.nereids.trees.plans.LimitPhase;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalCTEAnchor;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFileSink;
-import org.apache.doris.nereids.trees.plans.logical.LogicalCTE;
-import org.apache.doris.nereids.trees.plans.logical.LogicalFileSink;
 import org.apache.doris.nereids.trees.plans.logical.LogicalLimit;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapTableSink;
 import org.apache.doris.nereids.trees.plans.logical.LogicalSort;
@@ -69,12 +67,6 @@ public class AddDefaultLimit extends DefaultPlanRewriter<StatementContext> imple
             StatementContext context) {
         Plan child = olapTableSink.child().accept(this, context);
         return olapTableSink.withChildren(child);
-    }
-
-    @Override
-    public LogicalPlan visitLogicalFileSink(LogicalFileSink<? extends Plan> sink, StatementContext context) {
-        Plan child = sink.child().accept(this, context);
-        return ((LogicalPlan) sink.withChildren(child));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -246,7 +246,7 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
     }
 
     @Override
-    public Statistics visitLogicalFileSink(LogicalFileSink<? extends Plan> olapTableSink, Void context) {
+    public Statistics visitLogicalFileSink(LogicalFileSink<? extends Plan> fileSink, Void context) {
         return groupExpression.childStatistics(0);
     }
 
@@ -383,7 +383,7 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
     }
 
     @Override
-    public Statistics visitPhysicalFileSink(PhysicalFileSink<? extends Plan> olapTableSink, Void context) {
+    public Statistics visitPhysicalFileSink(PhysicalFileSink<? extends Plan> fileSink, Void context) {
         return groupExpression.childStatistics(0);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalFileSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalFileSink.java
@@ -87,7 +87,7 @@ public class LogicalFileSink<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), filePath, format, properties);
+        return Objects.hash(filePath, format, properties);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalFileSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalFileSink.java
@@ -109,7 +109,7 @@ public class PhysicalFileSink<CHILD_TYPE extends Plan> extends PhysicalUnary<CHI
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), filePath, format, properties);
+        return Objects.hash(filePath, format, properties);
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

FileSink should be always the top of a plan tree, we should override the visitor in add default limit rule.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

