### PR TITLE
[Bug](pipeline) adjust scanner scheduler.submit and _num_scheduling_ctx maintain

### DIFF
--- a/be/src/olap/tablet_schema_cache.cpp
+++ b/be/src/olap/tablet_schema_cache.cpp
@@ -42,7 +42,6 @@ void TabletSchemaCache::stop() {
     while (!_is_stopped) {
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }
-    LOG(INFO) << "xxx stopped";
 }
 
 /**

--- a/be/src/vec/exec/scan/pip_scanner_context.h
+++ b/be/src/vec/exec/scan/pip_scanner_context.h
@@ -45,7 +45,7 @@ public:
         {
             std::unique_lock l(_transfer_lock);
             if (state->is_cancelled()) {
-                _process_status = Status::Cancelled("cancelled");
+                set_status_on_error(Status::Cancelled("cancelled"), false);
             }
 
             if (!_process_status.ok()) {

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -28,6 +28,7 @@
 #include <utility>
 
 #include "common/config.h"
+#include "common/status.h"
 #include "runtime/descriptors.h"
 #include "runtime/exec_env.h"
 #include "runtime/query_context.h"
@@ -192,7 +193,7 @@ Status ScannerContext::get_block_from_queue(RuntimeState* state, vectorized::Blo
         if (state.ok()) {
             _num_scheduling_ctx++;
         } else {
-            _process_status = state;
+            set_status_on_error(state, false);
         }
     }
     // Wait for block from queue
@@ -205,11 +206,11 @@ Status ScannerContext::get_block_from_queue(RuntimeState* state, vectorized::Blo
     }
 
     if (state->is_cancelled()) {
-        _process_status = Status::Cancelled("cancelled");
+        set_status_on_error(Status::Cancelled("cancelled"), false);
     }
 
-    if (!_process_status.ok()) {
-        return _process_status;
+    if (!status().ok()) {
+        return status();
     }
 
     if (!_blocks_queue.empty()) {
@@ -225,12 +226,16 @@ Status ScannerContext::get_block_from_queue(RuntimeState* state, vectorized::Blo
     return Status::OK();
 }
 
-bool ScannerContext::set_status_on_error(const Status& status) {
-    std::lock_guard l(_transfer_lock);
+bool ScannerContext::set_status_on_error(const Status& status, bool need_lock) {
+    std::unique_lock l(_transfer_lock, std::defer_lock);
+    if (need_lock) {
+        l.lock();
+    }
     if (_process_status.ok()) {
         _process_status = status;
         _status_error = true;
         _blocks_queue_added_cv.notify_one();
+        _should_stop = true;
         return true;
     }
     return false;
@@ -330,10 +335,12 @@ std::string ScannerContext::debug_string() {
 
 void ScannerContext::reschedule_scanner_ctx() {
     std::lock_guard l(_transfer_lock);
-    auto submit_st = _scanner_scheduler->submit(this);
+    auto state = _scanner_scheduler->submit(this);
     //todo(wb) rethinking is it better to mark current scan_context failed when submit failed many times?
-    if (submit_st.ok()) {
+    if (state.ok()) {
         _num_scheduling_ctx++;
+    } else {
+        set_status_on_error(state, false);
     }
 }
 
@@ -344,9 +351,11 @@ void ScannerContext::push_back_scanner_and_reschedule(VScannerSPtr scanner) {
     }
     std::lock_guard l(_transfer_lock);
     if (has_enough_space_in_blocks_queue()) {
-        auto submit_st = _scanner_scheduler->submit(this);
-        if (submit_st.ok()) {
+        auto state = _scanner_scheduler->submit(this);
+        if (state.ok()) {
             _num_scheduling_ctx++;
+        } else {
+            set_status_on_error(state, false);
         }
     }
 

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -53,7 +53,7 @@
 
 namespace doris::vectorized {
 
-ScannerScheduler::ScannerScheduler() {}
+ScannerScheduler::ScannerScheduler() = default;
 
 ScannerScheduler::~ScannerScheduler() {
     if (!_is_init) {
@@ -135,6 +135,9 @@ Status ScannerScheduler::init(ExecEnv* env) {
 }
 
 Status ScannerScheduler::submit(ScannerContext* ctx) {
+    if (ctx->done()) {
+        return Status::EndOfFile("ScannerContext is done");
+    }
     if (ctx->queue_idx == -1) {
         ctx->queue_idx = (_queue_idx++ % QUEUE_NUM);
     }
@@ -163,7 +166,6 @@ void ScannerScheduler::_schedule_thread(int queue_id) {
         // If ctx is done, no need to schedule it again.
         // But should notice that there may still scanners running in scanner pool.
     }
-    return;
 }
 
 [[maybe_unused]] static void* run_scanner_bthread(void* arg) {

--- a/be/src/vec/exec/scan/scanner_scheduler.h
+++ b/be/src/vec/exec/scan/scanner_scheduler.h
@@ -67,7 +67,7 @@ public:
 
     Status init(ExecEnv* env);
 
-    Status submit(ScannerContext* ctx);
+    [[nodiscard]] Status submit(ScannerContext* ctx);
 
     std::unique_ptr<ThreadPoolToken> new_limited_scan_pool_token(ThreadPool::ExecutionMode mode,
                                                                  int max_concurrency);
@@ -86,7 +86,6 @@ private:
     void _task_group_scanner_scan(ScannerScheduler* scheduler,
                                   taskgroup::ScanTaskTaskGroupQueue* scan_queue);
 
-private:
     // Scheduling queue number.
     // TODO: make it configurable.
     static const int QUEUE_NUM = 4;


### PR DESCRIPTION
## Proposed changes

F0714 09:50:52.553777  9149 task_scheduler.cpp:249] Check failed: !task->is_pending_finish() must not pending close QueryId: 36e0dd2fc7104db2-bc2c1b434b3e9edd
InstanceId: 36e0dd2fc7104db2-bc2c1b434b3e9ef1

num_running_scanners = 0, num_scheduling_ctx = 1 

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

