### PR TITLE
[typo][docs] Delete the extra characters in the tablet-local-debug Ch…

### DIFF
--- a/docs/zh-CN/docs/admin-manual/maint-monitor/tablet-local-debug.md
+++ b/docs/zh-CN/docs/admin-manual/maint-monitor/tablet-local-debug.md
@@ -34,7 +34,7 @@ Doris线上运行过程中，因为各种原因，可能出现各种各样的bug
 
 可以通过 BE 日志确认 tablet id，然后通过以下命令获取信息（假设 tablet id 为 10020）。
 
-获获取 tablet 所在的 DbId/TableId/PartitionId 等信息。
+获取 tablet 所在的 DbId/TableId/PartitionId 等信息。
 
 ```
 mysql> show tablet 10020\G


### PR DESCRIPTION
…inese document.

Delete the extra characters in the tablet-local-debug Chinese document.  "获获取 tablet ..." has more than one  "获" word.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

