### PR TITLE
[Test](Framework) add enable cache data args for test CommandLine

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/Config.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/Config.groovy
@@ -154,6 +154,7 @@ class Config {
         config.dataPath = FileUtils.getCanonicalPath(cmd.getOptionValue(dataOpt, config.dataPath))
         config.realDataPath = FileUtils.getCanonicalPath(cmd.getOptionValue(realDataOpt, config.realDataPath))
         config.cacheDataPath = cmd.getOptionValue(cacheDataOpt, config.cacheDataPath)
+        config.enableCacheData = Boolean.parseBoolean(cmd.getOptionValue(enableCacheDataOpt, "true"))
         config.pluginPath = FileUtils.getCanonicalPath(cmd.getOptionValue(pluginOpt, config.pluginPath))
         config.sslCertificatePath = FileUtils.getCanonicalPath(cmd.getOptionValue(sslCertificateOpt, config.sslCertificatePath))
         config.suiteWildcard = cmd.getOptionValue(suiteOpt, config.testSuites)

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/ConfigOptions.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/ConfigOptions.groovy
@@ -45,6 +45,7 @@ class ConfigOptions {
     static Option dataOpt
     static Option realDataOpt
     static Option cacheDataOpt
+    static Option enableCacheDataOpt
     static Option pluginOpt
     static Option sslCertificateOpt
     static Option suiteOpt
@@ -145,7 +146,14 @@ class ConfigOptions {
                 .longOpt("cacheDataPath")
                 .desc("the cache data path caches data for stream load from s3")
                 .build()
-
+       enableCacheDataOpt = Option.builder("ECD")
+                .argName("enableCacheData")
+                .required(false)
+                .hasArg(true)
+                .type(String.class)
+                .longOpt("enableCacheData")
+                .desc("enable caches data for stream load from s3")
+                .build()
         pluginOpt = Option.builder("plugin")
                 .argName("pluginPath")
                 .required(false)


### PR DESCRIPTION
## Proposed changes

1. add regression cache data args for test CommandLine
Because  enableCacheData  param is not added to command line from this pr  https://github.com/apache/doris/pull/20874,  when use command line to test, it will always download s3 data again and fails many times.  



Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

