### PR TITLE
[fix](executor)Fix incorrect priority queue refactor

### DIFF
--- a/be/src/pipeline/task_queue.cpp
+++ b/be/src/pipeline/task_queue.cpp
@@ -42,7 +42,7 @@ PipelineTask* SubTaskQueue::try_take(bool is_steal) {
 
 PriorityTaskQueue::PriorityTaskQueue() : _closed(false) {
     double factor = 1;
-    for (int i = 0; i < SUB_QUEUE_LEVEL; ++i) {
+    for (int i = SUB_QUEUE_LEVEL - 1; i >= 0; i--) {
         _sub_queues[i].set_level_factor(factor);
         factor *= LEVEL_QUEUE_TIME_FACTOR;
     }


### PR DESCRIPTION
## Proposed changes
For PriorityTaskQueue, 0 level queue should has the highest priority which means its factor should be the bigest.
But currently 0 level queue has the smallest factor, thie may cause small query has the lowest priority, need fix it.
