### PR TITLE
 [opt](Nereids) always fallback when parse failed

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -421,17 +421,6 @@ public class ConnectProcessor {
             }
 
             StatementBase parsedStmt = stmts.get(i);
-            if (parsedStmt instanceof SelectStmt && nereidsParseException != null
-                    && ctx.getSessionVariable().isEnableNereidsPlanner()
-                    && !ctx.getSessionVariable().enableFallbackToOriginalPlanner) {
-                Exception exception = new Exception(
-                        String.format("Nereids cannot parse the SQL, and fallback disabled. caused by: \n\n%s",
-                                nereidsParseException.getMessage()), nereidsParseException);
-                // audit it and break
-                handleQueryException(exception, auditStmt, null, null);
-                break;
-            }
-
             parsedStmt.setOrigStmt(new OriginStatement(originStmt, i));
             parsedStmt.setUserInfo(ctx.getCurrentUserIdentity());
             executor = new StmtExecutor(ctx, parsedStmt);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -24,7 +24,6 @@ import org.apache.doris.analysis.LiteralExpr;
 import org.apache.doris.analysis.NullLiteral;
 import org.apache.doris.analysis.Queriable;
 import org.apache.doris.analysis.QueryStmt;
-import org.apache.doris.analysis.SelectStmt;
 import org.apache.doris.analysis.SqlParser;
 import org.apache.doris.analysis.SqlScanner;
 import org.apache.doris.analysis.StatementBase;
@@ -368,7 +367,6 @@ public class ConnectProcessor {
                 .setUser(ClusterNamespace.getNameFromFullName(ctx.getQualifiedUser()))
                 .setSqlHash(ctx.getSqlHash());
 
-        Exception nereidsParseException = null;
         List<StatementBase> stmts = null;
 
         if (ctx.getSessionVariable().isEnableNereidsPlanner()) {
@@ -384,7 +382,6 @@ public class ConnectProcessor {
                 }
             } catch (Exception e) {
                 // TODO: We should catch all exception here until we support all query syntax.
-                nereidsParseException = e;
                 LOG.debug("Nereids parse sql failed. Reason: {}. Statement: \"{}\".",
                         e.getMessage(), originStmt);
             }


### PR DESCRIPTION
## Proposed changes

always fallback to legacy planner when parse failed even if enable_fallback_to_original_planner is set to false

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

