### PR TITLE
 [Fix](multi-catalog) Filter invisible files for hive table.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -51,7 +51,6 @@ import org.apache.doris.planner.ColumnBound;
 import org.apache.doris.planner.ListPartitionPrunerV2;
 import org.apache.doris.planner.PartitionPrunerV2Base.UniqueId;
 import org.apache.doris.planner.external.FileSplit;
-import org.apache.doris.spi.Split;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -66,8 +65,8 @@ import com.google.common.collect.RangeMap;
 import com.google.common.collect.Streams;
 import com.google.common.collect.TreeRangeMap;
 import lombok.Data;
-import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.Path;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -67,6 +67,7 @@ import com.google.common.collect.Streams;
 import com.google.common.collect.TreeRangeMap;
 import lombok.Data;
 import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.Path;
@@ -955,7 +956,7 @@ public class HiveMetaStoreCache {
         // File Cache for self splitter.
         private final List<HiveFileStatus> files = Lists.newArrayList();
         // File split cache for old splitter. This is a temp variable.
-        private final List<Split> splits = Lists.newArrayList();
+        private final List<FileSplit> splits = Lists.newArrayList();
         private boolean isSplittable;
         // The values of partitions.
         // e.g for file : hdfs://path/to/table/part1=a/part2=b/datafile
@@ -965,17 +966,21 @@ public class HiveMetaStoreCache {
         private AcidInfo acidInfo;
 
         public void addFile(RemoteFile file) {
-            HiveFileStatus status = new HiveFileStatus();
-            status.setBlockLocations(file.getBlockLocations());
-            status.setPath(file.getPath());
-            status.length = file.getSize();
-            status.blockSize = file.getBlockSize();
-            status.modificationTime = file.getModificationTime();
-            files.add(status);
+            if (isFileVisible(file.getName())) {
+                HiveFileStatus status = new HiveFileStatus();
+                status.setBlockLocations(file.getBlockLocations());
+                status.setPath(file.getPath());
+                status.length = file.getSize();
+                status.blockSize = file.getBlockSize();
+                status.modificationTime = file.getModificationTime();
+                files.add(status);
+            }
         }
 
-        public void addSplit(Split split) {
-            splits.add(split);
+        public void addSplit(FileSplit split) {
+            if (isFileVisible(split.getPath().getName())) {
+                splits.add(split);
+            }
         }
 
         public int getValuesSize() {
@@ -989,6 +994,12 @@ public class HiveMetaStoreCache {
 
         public void setAcidInfo(AcidInfo acidInfo) {
             this.acidInfo = acidInfo;
+        }
+
+        private boolean isFileVisible(String filename) {
+            return StringUtils.isNotEmpty(filename)
+                        && !filename.startsWith(".")
+                        && !filename.startsWith("_");
         }
     }
 


### PR DESCRIPTION
## Proposed changes

![image](https://github.com/apache/doris/assets/5926365/ddbd0bb7-3e6a-43de-87c5-713ddb3c531c)

```java
errCode = 2, detailMessage = (xxx)[INTERNAL_ERROR]failed to init reader for file /user/hive/warehouse/xxx.db/xxx/pday=20230717/rule_set_no=xxx/.part-11a8fa15-9c2d-4860-994e-f47f23c2563e-5-829310.inprogress.c0dc4be1-1073-47f3-a3ac-02cdbb262db5, err: [INTERNAL_ERROR]Init OrcReader failed. reason = File size too small
```

In fact, hive can not read files which startswith "." or "_", so we need filter these files.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

