### PR TITLE
[opt](hudi) get hudi split concurrently by using parallelStream

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/TablePartitionValues.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/TablePartitionValues.java
@@ -171,7 +171,7 @@ public class TablePartitionValues {
         return readWriteLock.writeLock();
     }
 
-    private void cleanPartitions() {
+    public void cleanPartitions() {
         nextPartitionId = 0;
         idToPartitionItem.clear();
         partitionNameToIdMap.clear();

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/hudi/HudiCachedPartitionProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/hudi/HudiCachedPartitionProcessor.java
@@ -93,10 +93,9 @@ public class HudiCachedPartitionProcessor extends HudiPartitionProcessor {
             partitionValues.readLock().lock();
             try {
                 long lastUpdateTimestamp = partitionValues.getLastUpdateTimestamp();
-                if (lastTimestamp == lastUpdateTimestamp) {
+                if (lastTimestamp <= lastUpdateTimestamp) {
                     return partitionValues;
                 }
-                assert (lastTimestamp > lastUpdateTimestamp);
             } finally {
                 partitionValues.readLock().unlock();
             }
@@ -104,10 +103,9 @@ public class HudiCachedPartitionProcessor extends HudiPartitionProcessor {
             partitionValues.writeLock().lock();
             try {
                 long lastUpdateTimestamp = partitionValues.getLastUpdateTimestamp();
-                if (lastTimestamp == lastUpdateTimestamp) {
+                if (lastTimestamp <= lastUpdateTimestamp) {
                     return partitionValues;
                 }
-                assert (lastTimestamp > lastUpdateTimestamp);
                 List<String> partitionNames;
                 if (lastUpdateTimestamp == 0) {
                     partitionNames = getAllPartitionNames(tableMetaClient);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/hudi/HudiPartitionProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/hudi/HudiPartitionProcessor.java
@@ -18,7 +18,6 @@
 package org.apache.doris.planner.external.hudi;
 
 import org.apache.hudi.common.config.HoodieMetadataConfig;
-import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
@@ -47,12 +46,8 @@ public abstract class HudiPartitionProcessor {
     }
 
     public List<String> getAllPartitionNames(HoodieTableMetaClient tableMetaClient) throws IOException {
-        TypedProperties configProperties = new TypedProperties();
         HoodieMetadataConfig metadataConfig = HoodieMetadataConfig.newBuilder()
-                .fromProperties(configProperties)
-                .enable(configProperties.getBoolean(HoodieMetadataConfig.ENABLE.key(),
-                        HoodieMetadataConfig.DEFAULT_METADATA_ENABLE_FOR_READERS)
-                        && HoodieTableMetadataUtil.isFilesPartitionAvailable(tableMetaClient))
+                .enable(HoodieTableMetadataUtil.isFilesPartitionAvailable(tableMetaClient))
                 .build();
 
         HoodieTableMetadata newTableMetadata = HoodieTableMetadata.create(
@@ -60,7 +55,7 @@ public abstract class HudiPartitionProcessor {
                 tableMetaClient.getBasePathV2().toString(),
                 FileSystemViewStorageConfig.SPILLABLE_DIR.defaultValue(), true);
 
-        return newTableMetadata.getPartitionPathWithPathPrefixes(Collections.singletonList(""));
+        return newTableMetadata.getAllPartitionPaths();
     }
 
     public List<String> getPartitionNamesInRange(HoodieTimeline timeline, String startTimestamp, String endTimestamp) {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/hudi/HudiPartitionProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/hudi/HudiPartitionProcessor.java
@@ -58,16 +58,26 @@ public abstract class HudiPartitionProcessor {
         return newTableMetadata.getAllPartitionPaths();
     }
 
+    public List<String> getPartitionNamesBeforeOrEquals(HoodieTimeline timeline, String timestamp) {
+        return new ArrayList<>(HoodieInputFormatUtils.getWritePartitionPaths(
+                timeline.findInstantsBeforeOrEquals(timestamp).getInstants().stream().map(instant -> {
+                    try {
+                        return TimelineUtils.getCommitMetadata(instant, timeline);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e.getMessage(), e);
+                    }
+                }).collect(Collectors.toList())));
+    }
+
     public List<String> getPartitionNamesInRange(HoodieTimeline timeline, String startTimestamp, String endTimestamp) {
         return new ArrayList<>(HoodieInputFormatUtils.getWritePartitionPaths(
-                timeline.findInstantsInRange(startTimestamp, endTimestamp).getInstants().stream()
-                        .map(instant -> {
-                            try {
-                                return TimelineUtils.getCommitMetadata(instant, timeline);
-                            } catch (IOException e) {
-                                throw new RuntimeException(e.getMessage(), e);
-                            }
-                        }).collect(Collectors.toList())));
+                timeline.findInstantsInRange(startTimestamp, endTimestamp).getInstants().stream().map(instant -> {
+                    try {
+                        return TimelineUtils.getCommitMetadata(instant, timeline);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e.getMessage(), e);
+                    }
+                }).collect(Collectors.toList())));
     }
 
     public static List<String> parsePartitionValues(List<String> partitionColumns, String partitionPath) {


### PR DESCRIPTION
## Proposed changes

This PR contains two optimizations:
1. Using parallel stream to get hoodie splits concurrently. It reduce the split time from 1min20s to 12s when splitting 10,000 partitions.
2. Reading hoodie meta table to get table partitions. It reduce the getting partition time from 12min to 3s when reading 10,000 partitions.

