### PR TITLE
[feature](profile) add process hashtable time in join node 

### DIFF
--- a/be/src/vec/exec/join/process_hash_table_probe.h
+++ b/be/src/vec/exec/join/process_hash_table_probe.h
@@ -105,7 +105,7 @@ struct ProcessHashTableProbe {
     RuntimeProfile::Counter* _search_hashtable_timer;
     RuntimeProfile::Counter* _build_side_output_timer;
     RuntimeProfile::Counter* _probe_side_output_timer;
-
+    RuntimeProfile::Counter* _probe_process_hashtable_timer;
     static constexpr int PROBE_SIDE_EXPLODE_RATE = 3;
 };
 

--- a/be/src/vec/exec/join/process_hash_table_probe_impl.h
+++ b/be/src/vec/exec/join/process_hash_table_probe_impl.h
@@ -47,7 +47,8 @@ ProcessHashTableProbe<JoinOpType>::ProcessHashTableProbe(HashJoinNode* join_node
           _rows_returned_counter(join_node->_rows_returned_counter),
           _search_hashtable_timer(join_node->_search_hashtable_timer),
           _build_side_output_timer(join_node->_build_side_output_timer),
-          _probe_side_output_timer(join_node->_probe_side_output_timer) {}
+          _probe_side_output_timer(join_node->_probe_side_output_timer),
+          _probe_process_hashtable_timer(join_node->_probe_process_hashtable_timer) {}
 
 template <int JoinOpType>
 template <bool have_other_join_conjunct>
@@ -1070,6 +1071,7 @@ Status ProcessHashTableProbe<JoinOpType>::process_data_in_hashtable(HashTableTyp
                                                                     Block* output_block,
                                                                     bool* eos) {
     using Mapped = typename HashTableType::Mapped;
+    SCOPED_TIMER(_probe_process_hashtable_timer);
     if constexpr (std::is_same_v<Mapped, RowRefListWithFlag> ||
                   std::is_same_v<Mapped, RowRefListWithFlags>) {
         hash_table_ctx.init_once();

--- a/be/src/vec/exec/join/vhash_join_node.cpp
+++ b/be/src/vec/exec/join/vhash_join_node.cpp
@@ -471,6 +471,8 @@ Status HashJoinNode::prepare(RuntimeState* state) {
             ADD_CHILD_TIMER(probe_phase_profile, "ProbeWhenBuildSideOutputTime", "ProbeTime");
     _probe_side_output_timer =
             ADD_CHILD_TIMER(probe_phase_profile, "ProbeWhenProbeSideOutputTime", "ProbeTime");
+    _probe_process_hashtable_timer =
+            ADD_CHILD_TIMER(probe_phase_profile, "ProbeWhenProcessHashTableTime", "ProbeTime");
     _open_timer = ADD_TIMER(runtime_profile(), "OpenTime");
     _allocate_resource_timer = ADD_TIMER(runtime_profile(), "AllocateResourceTime");
     _process_other_join_conjunct_timer = ADD_TIMER(runtime_profile(), "OtherJoinConjunctTime");

--- a/be/src/vec/exec/join/vhash_join_node.h
+++ b/be/src/vec/exec/join/vhash_join_node.h
@@ -304,6 +304,7 @@ private:
     RuntimeProfile::Counter* _search_hashtable_timer;
     RuntimeProfile::Counter* _build_side_output_timer;
     RuntimeProfile::Counter* _probe_side_output_timer;
+    RuntimeProfile::Counter* _probe_process_hashtable_timer;
     RuntimeProfile::Counter* _build_side_compute_hash_timer;
     RuntimeProfile::Counter* _build_side_merge_block_timer;
     RuntimeProfile::Counter* _build_runtime_filter_timer;


### PR DESCRIPTION
## Proposed changes

before 
 - ProbeTime: 311.720ms
                   - BuildOutputBlock: 3.74ms
                   - JoinFilterTimer: 86.258us
                   - ProbeWhenBuildSideOutputTime: 24.449ms
                   - ProbeWhenProbeSideOutputTime: 2.370ms
                   - ProbeWhenSearchHashTableTime: 126.929ms

after

 - ProbeTime: 320.504ms
                   - BuildOutputBlock: 3.602ms
                   - JoinFilterTimer: 150.432us
                   - ProbeWhenBuildSideOutputTime: 29.376ms
                   - ProbeWhenProbeSideOutputTime: 3.328ms
                   - ProbeWhenProcessHashTableTime: 134.202ms
                   - ProbeWhenSearchHashTableTime: 136.798ms
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

