### PR TITLE
[Fix](compaction) return internal error to avoid be core when finalize_columns_data

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -757,7 +757,12 @@ Status SegmentWriter::finalize_columns_data() {
     if (_has_key) {
         _row_count = _num_rows_written;
     } else {
-        CHECK_EQ(_row_count, _num_rows_written);
+        if (_row_count != _num_rows_written) {
+            std::stringstream ss;
+            ss << "_row_count != _num_rows_written:" << _row_count << " vs. " << _num_rows_written;
+            LOG(WARNING) << ss.str();
+            return Status::InternalError(ss.str());
+        }
     }
     _num_rows_written = 0;
 

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -757,6 +757,8 @@ Status SegmentWriter::finalize_columns_data() {
     if (_has_key) {
         _row_count = _num_rows_written;
     } else {
+        DCHECK(_row_count == _num_rows_written)
+                << "_row_count != _num_rows_written:" << _row_count << " vs. " << _num_rows_written;
         if (_row_count != _num_rows_written) {
             std::stringstream ss;
             ss << "_row_count != _num_rows_written:" << _row_count << " vs. " << _num_rows_written;


### PR DESCRIPTION
## Proposed changes
return error instead of CHECK_EQ to avoid be core when finalize_columns_data

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

