### PR TITLE
[fix](load) fix dead loop in _handle_mem_exceed_limit function when reduce memory for load

### DIFF
--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -371,10 +371,11 @@ void LoadChannelMgr::_handle_mem_exceed_limit() {
                     continue;
                 }
                 all_writers_mem.emplace_back(kv.second, item.first, std::move(item.second));
-                size_t pos = all_writers_mem.size() - 1;
-                tablets_mem_heap.emplace(std::get<2>(all_writers_mem[pos]).begin(),
-                                         std::get<2>(all_writers_mem[pos]).end(), pos);
             }
+        }
+        for (size_t i = 0; i < all_writers_mem.size(); i++) {
+            tablets_mem_heap.emplace(std::get<2>(all_writers_mem[i]).begin(),
+                                     std::get<2>(all_writers_mem[i]).end(), i);
         }
 
         // reduce 1/10 memory every time


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

* Problem
W0712 03:25:36.371089 3393743 thread_mem_tracker_mgr.h:178] MemHook alloc large memory: 85899345920, stacktrace:
        0x5607a64e0b04  malloc
        0x5607afb6c3d8  operator new()
        0x5607a64d7f0a  std::vector<>::_M_realloc_insert<>()
        0x5607a64d2421  doris::LoadChannelMgr::_handle_mem_exceed_limit()
        0x5607a64d1b86  doris::LoadChannelMgr::add_batch()
        0x5607a65cff16  std::_Function_handler<>::_M_invoke()
        0x5607a5b54422  doris::PriorityThreadPool::work_thread()
        0x5607afbedde0  execute_native_thread_routine
        0x7fbee6f96609  start_thread
        0x7fbee7225133  clone

* Why
```
        // tuple<LoadChannel, index_id, multimap<mem size, tablet_id>>
        using WritersMem = std::tuple<std::shared_ptr<LoadChannel>, int64_t,
                                      std::multimap<int64_t, int64_t, std::greater<int64_t>>>;
        std::vector<WritersMem> all_writers_mem;
        ...
        for (auto item : writers_mem_snap) {
                // multimap is empty
                if (item.second.empty()) {
                    continue;
                }
                all_writers_mem.emplace_back(kv.second, item.first, std::move(item.second));
                size_t pos = all_writers_mem.size() - 1;
                tablets_mem_heap.emplace(std::get<2>(all_writers_mem[pos]).begin(),
                                         std::get<2>(all_writers_mem[pos]).end(), pos);
        }
```
The Iterator of `std::get<2>(all_writers_mem[pos]).begin()` or  `std::get<2>(all_writers_mem[pos]).end()` may lose effectiveness when `all_writers_mem` is expanded.  An invalid Iterator is used, which causes an endless loop in some scenarios.






## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

