### PR TITLE
[fix](nereids) fix cte as bc right side hang bug

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -1418,10 +1418,12 @@ public class Coordinator {
                             params.instanceExecParams.size() + destParams.perExchNumSenders.get(exchId.asInt()));
                 }
 
+                List<TPlanFragmentDestination> destinations = multiSink.getDestinations().get(i);
                 if (enablePipelineEngine && enableShareHashTableForBroadcastJoin
                         && params.fragment.isRightChildOfBroadcastHashJoin()) {
                     // here choose the first instance to build hash table.
                     Map<TNetworkAddress, FInstanceExecParam> destHosts = new HashMap<>();
+
                     destParams.instanceExecParams.forEach(param -> {
                         if (destHosts.containsKey(param.host)) {
                             destHosts.get(param.host).instancesSharingHashTable.add(param.instanceId);
@@ -1436,7 +1438,7 @@ public class Coordinator {
                             } catch (Exception e) {
                                 throw new RuntimeException(e);
                             }
-                            params.destinations.add(dest);
+                            destinations.add(dest);
                         }
                     });
                 } else {
@@ -1445,7 +1447,7 @@ public class Coordinator {
                         dest.fragment_instance_id = destParams.instanceExecParams.get(j).instanceId;
                         dest.server = toRpcHost(destParams.instanceExecParams.get(j).host);
                         dest.brpc_server = toBrpcHost(destParams.instanceExecParams.get(j).host);
-                        multiSink.getDestinations().get(i).add(dest);
+                        destinations.add(dest);
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -1418,12 +1418,35 @@ public class Coordinator {
                             params.instanceExecParams.size() + destParams.perExchNumSenders.get(exchId.asInt()));
                 }
 
-                for (int j = 0; j < destParams.instanceExecParams.size(); ++j) {
-                    TPlanFragmentDestination dest = new TPlanFragmentDestination();
-                    dest.fragment_instance_id = destParams.instanceExecParams.get(j).instanceId;
-                    dest.server = toRpcHost(destParams.instanceExecParams.get(j).host);
-                    dest.brpc_server = toBrpcHost(destParams.instanceExecParams.get(j).host);
-                    multiSink.getDestinations().get(i).add(dest);
+                if (enablePipelineEngine && enableShareHashTableForBroadcastJoin
+                        && params.fragment.isRightChildOfBroadcastHashJoin()) {
+                    // here choose the first instance to build hash table.
+                    Map<TNetworkAddress, FInstanceExecParam> destHosts = new HashMap<>();
+                    destParams.instanceExecParams.forEach(param -> {
+                        if (destHosts.containsKey(param.host)) {
+                            destHosts.get(param.host).instancesSharingHashTable.add(param.instanceId);
+                        } else {
+                            destHosts.put(param.host, param);
+                            param.buildHashTableForBroadcastJoin = true;
+                            TPlanFragmentDestination dest = new TPlanFragmentDestination();
+                            dest.fragment_instance_id = param.instanceId;
+                            try {
+                                dest.server = toRpcHost(param.host);
+                                dest.setBrpcServer(toBrpcHost(param.host));
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            }
+                            params.destinations.add(dest);
+                        }
+                    });
+                } else {
+                    for (int j = 0; j < destParams.instanceExecParams.size(); ++j) {
+                        TPlanFragmentDestination dest = new TPlanFragmentDestination();
+                        dest.fragment_instance_id = destParams.instanceExecParams.get(j).instanceId;
+                        dest.server = toRpcHost(destParams.instanceExecParams.get(j).host);
+                        dest.brpc_server = toBrpcHost(destParams.instanceExecParams.get(j).host);
+                        multiSink.getDestinations().get(i).add(dest);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Proposed changes

During original computeMultiCastFragmentParams process, we don't handle the scenario the cte as the broadcast right side, which will lead the missing setting of the buildHashTableForBroadcastJoin flag true and finally the sql hang.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

