### PR TITLE
[fix](segment-iterator) fix query result error caused by not handling error codes

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -1204,8 +1204,8 @@ Status SegmentIterator::next_batch(vectorized::Block* block) {
         // read 100 rows to estimate average row size
         nrows_read_limit = 100;
     }
-    _read_columns_by_index(nrows_read_limit, _current_batch_rows_read,
-                           _lazy_materialization_read || _opts.record_rowids);
+    RETURN_IF_ERROR(_read_columns_by_index(nrows_read_limit, _current_batch_rows_read,
+                                           _lazy_materialization_read || _opts.record_rowids));
 
     _opts.stats->blocks_load += 1;
     _opts.stats->raw_rows_read += _current_batch_rows_read;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

 W0714 12:16:19.794226 61816 compaction.cpp:557] row_num does not match between cumulative input and output! tablet=1126068.1373953763.0f47c30d117f086c-35984adcf0055c8e, input_row_num=553187, merged_row_num=0, filtered_row_num=0, output_row_num=525727 

after fix：
W0718 09:20:46.012212 1065202 beta_rowset_reader.cpp:317] failed to read next block: [INVALID_ARGUMENT]ZSTD_decompressStream error: Corrupted block detected
W0718 09:20:46.012256 1065202 vcollect_iterator.cpp:485] failed to get next from child, res=[E-3111]
W0718 09:20:46.012262 1065202 block_reader.cpp:300] next failed: [E-3111]
W0718 09:20:46.012269 1065202 merger.cpp:169] failed to read next block when merging rowsets of tablet 10015.419513808.0f47c30d117f086c-35984adcf0055c8e[res=[E-3111]]

SegmentIterator didn't not handling error codes when get next block，resulting in only obtaining partial results and returning them.

branch-2.0  has refactored the code here and fixed the issue.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

