### PR TITLE
[fix](nereids) Fix analytic expr

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AnalyticExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AnalyticExpr.java
@@ -700,10 +700,10 @@ public class AnalyticExpr extends Expr {
                                             + getFnCall().getChildren().get(0).getType());
             }
 
-            if (getFnCall().getChildren().get(2) instanceof CastExpr) {
-                throw new AnalysisException("Type = " + type + " can't not convert to "
-                                            + getFnCall().getChildren().get(0).getType());
-            }
+            // if (getFnCall().getChildren().get(2) instanceof CastExpr) {
+            //     throw new AnalysisException("Type = " + type + " can't not convert to "
+            //                                 + getFnCall().getChildren().get(0).getType());
+            // }
 
             // check the value whether out of range
             checkDefaultValue(analyzer);

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -54,10 +54,12 @@ import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TUniqueId;
 
 import com.google.common.base.Preconditions;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.text.StringSubstitutor;
 import org.apache.thrift.TException;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -102,6 +104,9 @@ public class StatisticsUtil {
 
     public static List<ColumnStatistic> deserializeToColumnStatistics(List<ResultRow> resultBatches)
             throws Exception {
+        if (CollectionUtils.isEmpty(resultBatches)) {
+            return Collections.emptyList();
+        }
         return resultBatches.stream().map(ColumnStatistic::fromResultRow).collect(Collectors.toList());
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -54,12 +54,10 @@ import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TUniqueId;
 
 import com.google.common.base.Preconditions;
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.text.StringSubstitutor;
 import org.apache.thrift.TException;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -104,9 +102,6 @@ public class StatisticsUtil {
 
     public static List<ColumnStatistic> deserializeToColumnStatistics(List<ResultRow> resultBatches)
             throws Exception {
-        if (CollectionUtils.isEmpty(resultBatches)) {
-            return Collections.emptyList();
-        }
         return resultBatches.stream().map(ColumnStatistic::fromResultRow).collect(Collectors.toList());
     }
 

--- a/regression-test/suites/query_p0/aggregate/analytic_expr.groovy
+++ b/regression-test/suites/query_p0/aggregate/analytic_expr.groovy
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+suite("analytic_expr_test") {
+    sql """
+        CREATE TABLE `test_load_03` (
+          `id` varchar(10) NULL,
+          `ctime` datetime NULL,
+          `url` text NULL
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`id`)
+        COMMENT 'OLAP'
+        DISTRIBUTED BY HASH(`id`) BUCKETS 10
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1",
+        "storage_format" = "V2",
+        "light_schema_change" = "true",
+        "disable_auto_compaction" = "false"
+        ); 
+    """
+
+    sql """INSERT INTO `test_load_03` (`id`, `ctime`, `url`) VALUES ('Marry', '2015-11-12 03:14:30', 'url5');"""
+    sql """INSERT INTO `test_load_03` (`id`, `ctime`, `url`) VALUES ('Marry', '2015-11-12 02:13:00', 'url4');"""
+    sql """INSERT INTO `test_load_03` (`id`, `ctime`, `url`) VALUES ('Marry', '2015-11-12 01:16:40', 'url3');"""
+    sql """INSERT INTO `test_load_03` (`id`, `ctime`, `url`) VALUES ('Marry', '2015-11-12 01:15:10', 'url2');"""
+    sql """INSERT INTO `test_load_03` (`id`, `ctime`, `url`) VALUES ('Marry', '2015-11-12 01:10:00', 'url1');"""
+    sql """INSERT INTO `test_load_03` (`id`, `ctime`, `url`) VALUES ('Peter', '2015-10-12 03:14:30', 'url5');"""
+    sql """INSERT INTO `test_load_03` (`id`, `ctime`, `url`) VALUES ('Peter', '2015-10-12 02:13:00', 'url4');"""
+    sql """INSERT INTO `test_load_03` (`id`, `ctime`, `url`) VALUES ('Peter', '2015-10-12 01:16:40', 'url3');"""
+    sql """INSERT INTO `test_load_03` (`id`, `ctime`, `url`) VALUES ('Peter', '2015-10-12 01:15:10', 'url2');"""
+    sql """INSERT INTO `test_load_03` (`id`, `ctime`, `url`) VALUES ('Peter', '2015-10-12 01:10:00', 'url1');"""
+
+    sql """select
+         id,url,ctime,
+         first_value(ctime) over(partition by id order by ctime) as first_ctime,
+            lag(ctime,1,0) over(partition by id order by ctime) as lag_ctime,
+            lead(ctime,1,0) over(partition by id order by ctime) as lead_ctime
+        from test_load_03; 
+    """
+}


### PR DESCRIPTION
## Proposed changes

```sql
select
 id,url,ctime,
 first_value(ctime) over(partition by id order by ctime) as first_ctime,
    lag(ctime,1,0) over(partition by id order by ctime) as lag_ctime,
    lead(ctime,1,0) over(partition by id order by ctime) as lead_ctime
from test_load_03; 
```

exception stack

```
2023-07-11 15:23:56,314 WARN (mysql-nio-pool-39|1488) [StmtExecutor.execute():589] execute Exception. stmt[49648, 7e6ce428e4954a15-8935cf5a0a7dfb0f]
org.apache.doris.common.AnalysisException: errCode = 2, detailMessage = Type = DATETIME can't not convert to DATETIME
    at org.apache.doris.analysis.AnalyticExpr.standardize(AnalyticExpr.java:705) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.analysis.AnalyticExpr.analyzeImpl(AnalyticExpr.java:574) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.analysis.Expr.analyze(Expr.java:421) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.analysis.SelectStmt.analyze(SelectStmt.java:455) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.qe.StmtExecutor.analyzeAndGenerateQueryPlan(StmtExecutor.java:808) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.qe.StmtExecutor.analyze(StmtExecutor.java:721) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:446) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:409) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:330) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.qe.ConnectProcessor.dispatch(ConnectProcessor.java:473) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.qe.ConnectProcessor.processOnce(ConnectProcessor.java:700) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52) ~[doris-fe.jar:1.2-SNAPSHOT]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[?:1.8.0_131]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[?:1.8.0_131]
    at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_131]
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

