### PR TITLE
[optimization](heartbeart) Rm startuptime from front heart beart class

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
@@ -113,7 +113,7 @@ public class HeartbeatMgr extends MasterDaemon {
         for (Frontend frontend : frontends) {
             FrontendHeartbeatHandler handler = new FrontendHeartbeatHandler(frontend,
                     Env.getCurrentEnv().getClusterId(),
-                    Env.getCurrentEnv().getToken(), ExecuteEnv.getInstance().getStartupTime());
+                    Env.getCurrentEnv().getToken());
             hbResponses.add(executor.submit(handler));
         }
 
@@ -292,13 +292,6 @@ public class HeartbeatMgr extends MasterDaemon {
             this.token = token;
         }
 
-        public FrontendHeartbeatHandler(Frontend fe, int clusterId, String token, long callerFeStartTime) {
-            this.fe = fe;
-            this.clusterId = clusterId;
-            this.token = token;
-            this.callerFeStartTime = callerFeStartTime;
-        }
-
         @Override
         public HeartbeatResponse call() {
             HostInfo selfNode = Env.getCurrentEnv().getSelfNode();
@@ -307,7 +300,7 @@ public class HeartbeatMgr extends MasterDaemon {
                 if (Env.getCurrentEnv().isReady()) {
                     return new FrontendHbResponse(fe.getNodeName(), Config.query_port, Config.rpc_port,
                             Env.getCurrentEnv().getMaxJournalId(), System.currentTimeMillis(),
-                            Version.DORIS_BUILD_VERSION + "-" + Version.DORIS_BUILD_SHORT_HASH, callerFeStartTime);
+                            Version.DORIS_BUILD_VERSION + "-" + Version.DORIS_BUILD_SHORT_HASH, ExecuteEnv.getInstance().getStartupTime());
                 } else {
                     return new FrontendHbResponse(fe.getNodeName(), "not ready");
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
@@ -300,7 +300,8 @@ public class HeartbeatMgr extends MasterDaemon {
                 if (Env.getCurrentEnv().isReady()) {
                     return new FrontendHbResponse(fe.getNodeName(), Config.query_port, Config.rpc_port,
                             Env.getCurrentEnv().getMaxJournalId(), System.currentTimeMillis(),
-                            Version.DORIS_BUILD_VERSION + "-" + Version.DORIS_BUILD_SHORT_HASH, ExecuteEnv.getInstance().getStartupTime());
+                            Version.DORIS_BUILD_VERSION + "-" + Version.DORIS_BUILD_SHORT_HASH,
+                            ExecuteEnv.getInstance().getStartupTime());
                 } else {
                     return new FrontendHbResponse(fe.getNodeName(), "not ready");
                 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Remove unneeded startruptime field from FrontHeartBeart class, using the singleton ExecuteEnv variables startupTime instead.

## Further comments


