### PR TITLE
[bugfix](deserialize ) pack struct to avoid parse wrong content for file header

### DIFF
--- a/be/src/olap/file_header.h
+++ b/be/src/olap/file_header.h
@@ -44,7 +44,7 @@ using FixedFileHeader = struct _FixedFileHeader {
     uint32_t protobuf_length;
     // Checksum of Protobuf part
     uint32_t protobuf_checksum;
-};
+} __attribute__((packed));
 
 using FixedFileHeaderV2 = struct _FixedFileHeaderV2 {
     uint64_t magic_number;
@@ -57,7 +57,7 @@ using FixedFileHeaderV2 = struct _FixedFileHeaderV2 {
     uint64_t protobuf_length;
     // Checksum of Protobuf part
     uint32_t protobuf_checksum;
-};
+} __attribute__((packed));
 
 template <typename MessageType, typename ExtraType = uint32_t>
 class FileHeader {

--- a/be/src/olap/file_header.h
+++ b/be/src/olap/file_header.h
@@ -158,6 +158,9 @@ Status FileHeader<MessageType, ExtraType>::deserialize() {
     size_t bytes_read = 0;
     RETURN_IF_ERROR(file_reader->read_at(
             0, {(const uint8_t*)&_fixed_file_header, _fixed_file_header_size}, &bytes_read));
+    DCHECK(_fixed_file_header_size == bytes_read)
+            << " deserialize read bytes dismatch, request bytes " << _fixed_file_header_size
+            << " actual read " << bytes_read;
 
     //Status read_at(size_t offset, Slice result, size_t* bytes_read,
     //             const IOContext* io_ctx = nullptr);
@@ -167,6 +170,9 @@ Status FileHeader<MessageType, ExtraType>::deserialize() {
         FixedFileHeader tmp_header;
         RETURN_IF_ERROR(file_reader->read_at(0, {(const uint8_t*)&tmp_header, sizeof(tmp_header)},
                                              &bytes_read));
+        DCHECK(sizeof(tmp_header) == bytes_read)
+                << " deserialize read bytes dismatch, request bytes " << sizeof(tmp_header)
+                << " actual read " << bytes_read;
         _fixed_file_header.file_length = tmp_header.file_length;
         _fixed_file_header.checksum = tmp_header.checksum;
         _fixed_file_header.protobuf_length = tmp_header.protobuf_length;
@@ -200,7 +206,7 @@ Status FileHeader<MessageType, ExtraType>::deserialize() {
 
     if (file_length() != static_cast<uint64_t>(real_file_length)) {
         return Status::Error<ErrorCode::FILE_DATA_ERROR>(
-                "file length is not match. file={}, file_length=, real_file_length={}",
+                "file length is not match. file={}, file_length={}, real_file_length={}",
                 file_reader->path().native(), file_length(), real_file_length);
     }
 

--- a/be/src/olap/file_header.h
+++ b/be/src/olap/file_header.h
@@ -215,9 +215,13 @@ Status FileHeader<MessageType, ExtraType>::deserialize() {
             olap_adler32(olap_adler32_init(), buf.get(), _fixed_file_header.protobuf_length);
 
     if (real_protobuf_checksum != _fixed_file_header.protobuf_checksum) {
+        // When compiling using gcc there woule be error like:
+        // Cannot bind packed field '_FixedFileHeaderV2::protobuf_checksum' to 'unsigned int&'
+        // so we need to using unary operator+ to evaluate one value to pass
+        // to status to successfully compile.
         return Status::Error<ErrorCode::CHECKSUM_ERROR>(
                 "checksum is not match. file={}, expect={}, actual={}",
-                file_reader->path().native(), _fixed_file_header.protobuf_checksum,
+                file_reader->path().native(), +_fixed_file_header.protobuf_checksum,
                 real_protobuf_checksum);
     }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
Recently we encountered one strange bug where the log is `file length is not match. file=/mnt/hdd01/master/NO_AVX2/doris.HDD/snapshot/20230713122303.26.72000/45832/536215111/45832.hdr, file_length=, real_file_length=0` when running restore P2 case, after checking the file on the remote storage we doubt it's the local file deserialize who caused this situation.
Then we analyzed the layout for the struct and the content of the hdr file then we found out that it must be the wrong layout which cause reading wrong content.
![image](https://github.com/apache/doris/assets/43750022/8f3086a7-e2b5-4a20-9c10-d9b4db139fec)

Before #21454, the struct file header is packed so there were no such bug, while the `__attribute__((packed))` is removed in #21454, this pr mainly adds it back.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

