### PR TITLE
[doc]Fix parameter name `storage_root_path`

### DIFF
--- a/docs/en/docs/get-starting/get-starting.md
+++ b/docs/en/docs/get-starting/get-starting.md
@@ -197,7 +197,7 @@ Go to the `apache-doris-x.x.x/be` directory
 cd apache-doris-x.x.x/be
 ```
 
-Modify the BE configuration file `conf/be.conf`, here we mainly modify two parameters: `priority_networks'` and `storage_root`, if you need more optimized configuration, please refer to [BE parameter configuration](../admin-manual/config/be-config.md) instructions to make adjustments.
+Modify the BE configuration file `conf/be.conf`, here we mainly modify two parameters: `priority_networks'` and `storage_root_path`, if you need more optimized configuration, please refer to [BE parameter configuration](../admin-manual/config/be-config.md) instructions to make adjustments.
 
 1. Add priority_networks parameter
 

--- a/docs/zh-CN/docs/get-starting/get-starting.md
+++ b/docs/zh-CN/docs/get-starting/get-starting.md
@@ -202,7 +202,7 @@ Doris FE 的停止可以通过下面的命令完成
 cd apache-doris-x.x.x/be
 ```
 
-修改 BE 配置文件 `conf/be.conf` ，这里我们主要修改两个参数：`priority_networks` 及 `storage_root` ，如果你需要更多优化配置，请参考 [BE 参数配置](../admin-manual/config/be-config.md)说明，进行调整。
+修改 BE 配置文件 `conf/be.conf` ，这里我们主要修改两个参数：`priority_networks` 及 `storage_root_path` ，如果你需要更多优化配置，请参考 [BE 参数配置](../admin-manual/config/be-config.md)说明，进行调整。
 
 1. 添加 priority_networks 参数
 


### PR DESCRIPTION
Inconsistent parameter names in the documentation
