### PR TITLE
[Fix](Nereids)fix insert into default value exception

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/PrimitiveType.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/PrimitiveType.java
@@ -507,6 +507,26 @@ public enum PrimitiveType {
         builder.put(TIMEV2, TIMEV2);
         builder.put(TIMEV2, DOUBLE);
 
+        builder.put(BOOLEAN, CHAR);
+        builder.put(TINYINT, CHAR);
+        builder.put(SMALLINT, CHAR);
+        builder.put(CHAR, CHAR);
+        builder.put(INT, CHAR);
+        builder.put(BIGINT, CHAR);
+        builder.put(LARGEINT, CHAR);
+        builder.put(FLOAT, CHAR);
+        builder.put(DOUBLE, CHAR);
+        builder.put(DATE, CHAR);
+        builder.put(DATETIME, CHAR);
+        builder.put(DATEV2, CHAR);
+        builder.put(DATETIMEV2, CHAR);
+        builder.put(DECIMALV2, CHAR);
+        builder.put(DECIMAL32, CHAR);
+        builder.put(DECIMAL64, CHAR);
+        builder.put(DECIMAL128, CHAR);
+        builder.put(VARCHAR, CHAR);
+        builder.put(STRING, CHAR);
+
         implicitCastMap = builder.build();
     }
 

--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/PrimitiveType.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/PrimitiveType.java
@@ -507,26 +507,6 @@ public enum PrimitiveType {
         builder.put(TIMEV2, TIMEV2);
         builder.put(TIMEV2, DOUBLE);
 
-        builder.put(BOOLEAN, CHAR);
-        builder.put(TINYINT, CHAR);
-        builder.put(SMALLINT, CHAR);
-        builder.put(CHAR, CHAR);
-        builder.put(INT, CHAR);
-        builder.put(BIGINT, CHAR);
-        builder.put(LARGEINT, CHAR);
-        builder.put(FLOAT, CHAR);
-        builder.put(DOUBLE, CHAR);
-        builder.put(DATE, CHAR);
-        builder.put(DATETIME, CHAR);
-        builder.put(DATEV2, CHAR);
-        builder.put(DATETIMEV2, CHAR);
-        builder.put(DECIMALV2, CHAR);
-        builder.put(DECIMAL32, CHAR);
-        builder.put(DECIMAL64, CHAR);
-        builder.put(DECIMAL128, CHAR);
-        builder.put(VARCHAR, CHAR);
-        builder.put(STRING, CHAR);
-
         implicitCastMap = builder.build();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/NativeInsertStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/NativeInsertStmt.java
@@ -524,7 +524,7 @@ public class NativeInsertStmt extends InsertStmt {
                 final List<Expr> resultExprs = queryStmt.getResultExprs();
                 Preconditions.checkState(resultExprs.isEmpty(), "result exprs should be empty.");
                 for (int i = 0; i < rowSize; i++) {
-                    resultExprs.add(new IntLiteral(1));
+                    resultExprs.add(new StringLiteral(SelectStmt.DEFAULT_VALUE));
                     final DefaultValueExpr defaultValueExpr = new DefaultValueExpr();
                     valueList.getFirstRow().add(defaultValueExpr);
                     colLabels.add(defaultValueExpr.toColumnLabel());
@@ -544,7 +544,8 @@ public class NativeInsertStmt extends InsertStmt {
         Map<String, Expr> slotToIndex = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
         for (int i = 0; i < queryStmt.getResultExprs().size(); i++) {
             Expr expr = queryStmt.getResultExprs().get(i);
-            if (!(expr instanceof IntLiteral && ((IntLiteral) expr).getValue() == 1)) {
+            if (!(expr instanceof StringLiteral && ((StringLiteral) expr).getValue()
+                    .equals(SelectStmt.DEFAULT_VALUE))) {
                 slotToIndex.put(realTargetColumnNames.get(i), queryStmt.getResultExprs().get(i)
                         .checkTypeCompatibility(targetTable.getColumn(realTargetColumnNames.get(i)).getType()));
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/NativeInsertStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/NativeInsertStmt.java
@@ -524,7 +524,7 @@ public class NativeInsertStmt extends InsertStmt {
                 final List<Expr> resultExprs = queryStmt.getResultExprs();
                 Preconditions.checkState(resultExprs.isEmpty(), "result exprs should be empty.");
                 for (int i = 0; i < rowSize; i++) {
-                    resultExprs.add(new DefaultValueExpr());
+                    resultExprs.add(new IntLiteral(1));
                     final DefaultValueExpr defaultValueExpr = new DefaultValueExpr();
                     valueList.getFirstRow().add(defaultValueExpr);
                     colLabels.add(defaultValueExpr.toColumnLabel());
@@ -543,7 +543,8 @@ public class NativeInsertStmt extends InsertStmt {
         realTargetColumnNames = targetColumns.stream().map(Column::getName).collect(Collectors.toList());
         Map<String, Expr> slotToIndex = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
         for (int i = 0; i < queryStmt.getResultExprs().size(); i++) {
-            if (!(queryStmt.getResultExprs().get(i) instanceof DefaultValueExpr)) {
+            Expr expr = queryStmt.getResultExprs().get(i);
+            if (!(expr instanceof IntLiteral && ((IntLiteral) expr).getValue() == 1)) {
                 slotToIndex.put(realTargetColumnNames.get(i), queryStmt.getResultExprs().get(i)
                         .checkTypeCompatibility(targetTable.getColumn(realTargetColumnNames.get(i)).getType()));
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -80,6 +80,7 @@ import java.util.stream.Collectors;
  */
 public class SelectStmt extends QueryStmt {
     private static final Logger LOG = LogManager.getLogger(SelectStmt.class);
+    public static final String DEFAULT_VALUE = "__DEFAULT_VALUE__";
     private UUID id = UUID.randomUUID();
 
     // ///////////////////////////////////////
@@ -575,7 +576,7 @@ public class SelectStmt extends QueryStmt {
             }
             for (Expr expr : valueList.getFirstRow()) {
                 if (expr instanceof DefaultValueExpr) {
-                    resultExprs.add(new IntLiteral(1));
+                    resultExprs.add(new StringLiteral(DEFAULT_VALUE));
                 } else {
                     resultExprs.add(rewriteQueryExprByMvColumnExpr(expr, analyzer));
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -575,7 +575,7 @@ public class SelectStmt extends QueryStmt {
             }
             for (Expr expr : valueList.getFirstRow()) {
                 if (expr instanceof DefaultValueExpr) {
-                    resultExprs.add(new IntLiteral(1));
+                    resultExprs.add(new DefaultValueExpr());
                 } else {
                     resultExprs.add(rewriteQueryExprByMvColumnExpr(expr, analyzer));
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -575,7 +575,7 @@ public class SelectStmt extends QueryStmt {
             }
             for (Expr expr : valueList.getFirstRow()) {
                 if (expr instanceof DefaultValueExpr) {
-                    resultExprs.add(new DefaultValueExpr());
+                    resultExprs.add(new IntLiteral(1));
                 } else {
                     resultExprs.add(rewriteQueryExprByMvColumnExpr(expr, analyzer));
                 }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/InsertStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/InsertStmtTest.java
@@ -161,9 +161,9 @@ public class InsertStmtTest {
         ConnectContext ctx = UtFrameUtils.createDefaultCtx();
         String sql = "values(1,'a',2,'b')";
 
-        SqlScanner input = new SqlScanner(new StringReader(sql),
+        org.apache.doris.analysis.SqlScanner input = new org.apache.doris.analysis.SqlScanner(new StringReader(sql),
                 ctx.getSessionVariable().getSqlMode());
-        SqlParser parser = new SqlParser(input);
+        org.apache.doris.analysis.SqlParser parser = new org.apache.doris.analysis.SqlParser(input);
         Analyzer analyzer = new Analyzer(ctx.getEnv(), ctx);
         StatementBase statementBase = null;
         try {
@@ -215,7 +215,7 @@ public class InsertStmtTest {
         Assert.assertEquals(expr4.getFnName().getFunction(), "to_bitmap");
         List<Expr> slots = Lists.newArrayList();
         expr4.collect(IntLiteral.class, slots);
-        Assert.assertEquals(expr4.toSql(), 1, slots.size());
+        Assert.assertEquals(expr4.toSql(), 0, slots.size());
         Assert.assertEquals(queryStmtSubstitute.getResultExprs().get(0).getStringValue(),
                 slots.get(0).getStringValue());
 
@@ -233,9 +233,9 @@ public class InsertStmtTest {
         ConnectContext ctx = UtFrameUtils.createDefaultCtx();
         String sql = "select kk1, kk2, kk3, kk4 from db.tbl";
 
-        SqlScanner input = new SqlScanner(new StringReader(sql),
+        org.apache.doris.analysis.SqlScanner input = new org.apache.doris.analysis.SqlScanner(new StringReader(sql),
                 ctx.getSessionVariable().getSqlMode());
-        SqlParser parser = new SqlParser(input);
+        org.apache.doris.analysis.SqlParser parser = new org.apache.doris.analysis.SqlParser(input);
         Analyzer analyzer = new Analyzer(ctx.getEnv(), ctx);
         StatementBase statementBase = null;
         try {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/InsertStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/InsertStmtTest.java
@@ -161,9 +161,9 @@ public class InsertStmtTest {
         ConnectContext ctx = UtFrameUtils.createDefaultCtx();
         String sql = "values(1,'a',2,'b')";
 
-        SqlScanner input = new SqlScanner(new StringReader(sql),
+        org.apache.doris.analysis.SqlScanner input = new org.apache.doris.analysis.SqlScanner(new StringReader(sql),
                 ctx.getSessionVariable().getSqlMode());
-        SqlParser parser = new SqlParser(input);
+        org.apache.doris.analysis.SqlParser parser = new org.apache.doris.analysis.SqlParser(input);
         Analyzer analyzer = new Analyzer(ctx.getEnv(), ctx);
         StatementBase statementBase = null;
         try {
@@ -215,7 +215,7 @@ public class InsertStmtTest {
         Assert.assertEquals(expr4.getFnName().getFunction(), "to_bitmap");
         List<Expr> slots = Lists.newArrayList();
         expr4.collect(IntLiteral.class, slots);
-        Assert.assertEquals(expr4.toSql(), 0, slots.size());
+        Assert.assertEquals(expr4.toSql(), 1, slots.size());
         Assert.assertEquals(queryStmtSubstitute.getResultExprs().get(0).getStringValue(),
                 slots.get(0).getStringValue());
 
@@ -233,9 +233,9 @@ public class InsertStmtTest {
         ConnectContext ctx = UtFrameUtils.createDefaultCtx();
         String sql = "select kk1, kk2, kk3, kk4 from db.tbl";
 
-        SqlScanner input = new SqlScanner(new StringReader(sql),
+        org.apache.doris.analysis.SqlScanner input = new org.apache.doris.analysis.SqlScanner(new StringReader(sql),
                 ctx.getSessionVariable().getSqlMode());
-        SqlParser parser = new SqlParser(input);
+        org.apache.doris.analysis.SqlParser parser = new org.apache.doris.analysis.SqlParser(input);
         Analyzer analyzer = new Analyzer(ctx.getEnv(), ctx);
         StatementBase statementBase = null;
         try {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/InsertStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/InsertStmtTest.java
@@ -161,9 +161,9 @@ public class InsertStmtTest {
         ConnectContext ctx = UtFrameUtils.createDefaultCtx();
         String sql = "values(1,'a',2,'b')";
 
-        org.apache.doris.analysis.SqlScanner input = new org.apache.doris.analysis.SqlScanner(new StringReader(sql),
+        SqlScanner input = new SqlScanner(new StringReader(sql),
                 ctx.getSessionVariable().getSqlMode());
-        org.apache.doris.analysis.SqlParser parser = new org.apache.doris.analysis.SqlParser(input);
+        SqlParser parser = new SqlParser(input);
         Analyzer analyzer = new Analyzer(ctx.getEnv(), ctx);
         StatementBase statementBase = null;
         try {
@@ -233,9 +233,9 @@ public class InsertStmtTest {
         ConnectContext ctx = UtFrameUtils.createDefaultCtx();
         String sql = "select kk1, kk2, kk3, kk4 from db.tbl";
 
-        org.apache.doris.analysis.SqlScanner input = new org.apache.doris.analysis.SqlScanner(new StringReader(sql),
+        SqlScanner input = new SqlScanner(new StringReader(sql),
                 ctx.getSessionVariable().getSqlMode());
-        org.apache.doris.analysis.SqlParser parser = new org.apache.doris.analysis.SqlParser(input);
+        SqlParser parser = new SqlParser(input);
         Analyzer analyzer = new Analyzer(ctx.getEnv(), ctx);
         StatementBase statementBase = null;
         try {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

default value in the first cell of values when rise a cast exception, we filter it when check the types of values in insert, when the literal is string and value is the specific default value string, we skip type check.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

