### PR TITLE
[fix](status) fix cmake warning with message 'Manually-specified variables were not used by the project:ENABLE_STACKTRACE'

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -531,6 +531,10 @@ if (USE_JEMALLOC)
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -DUSE_JEMALLOC")
 endif()
 
+if (ENABLE_STACKTRACE)
+    add_compile_options(-DENABLE_STACKTRACE)
+endif()
+
 # STRICT_MEMORY_USE=ON` expects BE to use less memory, and gives priority to ensuring stability
 # when the cluster memory is limited.
 # TODO In the future, expect a dynamic soft memory limit, combined with real-time memory usage of the cluster,

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -470,8 +470,8 @@ inline std::ostream& operator<<(std::ostream& ostr, const Status& status) {
     ostr << '[' << status.code_as_string() << ']';
     ostr << (status._err_msg ? status._err_msg->_msg : "");
 #ifdef ENABLE_STACKTRACE
-    if (status->_err_msg && !status->_err_msg._stack.empty()) {
-        ostr << '\n' << status->_err_msg._stack;
+    if (status._err_msg && !status._err_msg->_stack.empty()) {
+        ostr << '\n' << status._err_msg->_stack;
     }
 #endif
     return ostr;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

