### PR TITLE
[fix](in) fix wrong DCHECK of in expr for not nullable column

### DIFF
--- a/be/src/runtime/primitive_type.cpp
+++ b/be/src/runtime/primitive_type.cpp
@@ -29,36 +29,10 @@ PrimitiveType convert_type_to_primitive(FunctionContext::Type type) {
     switch (type) {
     case FunctionContext::Type::INVALID_TYPE:
         return PrimitiveType::INVALID_TYPE;
-    case FunctionContext::Type::TYPE_DOUBLE:
-        return PrimitiveType::TYPE_DOUBLE;
     case FunctionContext::Type::TYPE_NULL:
         return PrimitiveType::TYPE_NULL;
-    case FunctionContext::Type::TYPE_CHAR:
-        return PrimitiveType::TYPE_CHAR;
-    case FunctionContext::Type::TYPE_VARCHAR:
-        return PrimitiveType::TYPE_VARCHAR;
-    case FunctionContext::Type::TYPE_STRING:
-        return PrimitiveType::TYPE_STRING;
-    case FunctionContext::Type::TYPE_DATETIME:
-        return PrimitiveType::TYPE_DATETIME;
-    case FunctionContext::Type::TYPE_DECIMALV2:
-        return PrimitiveType::TYPE_DECIMALV2;
-    case FunctionContext::Type::TYPE_DECIMAL32:
-        return PrimitiveType::TYPE_DECIMAL32;
-    case FunctionContext::Type::TYPE_DECIMAL64:
-        return PrimitiveType::TYPE_DECIMAL64;
-    case FunctionContext::Type::TYPE_DECIMAL128I:
-        return PrimitiveType::TYPE_DECIMAL128I;
     case FunctionContext::Type::TYPE_BOOLEAN:
         return PrimitiveType::TYPE_BOOLEAN;
-    case FunctionContext::Type::TYPE_ARRAY:
-        return PrimitiveType::TYPE_ARRAY;
-    case FunctionContext::Type::TYPE_OBJECT:
-        return PrimitiveType::TYPE_OBJECT;
-    case FunctionContext::Type::TYPE_HLL:
-        return PrimitiveType::TYPE_HLL;
-    case FunctionContext::Type::TYPE_QUANTILE_STATE:
-        return PrimitiveType::TYPE_QUANTILE_STATE;
     case FunctionContext::Type::TYPE_TINYINT:
         return PrimitiveType::TYPE_TINYINT;
     case FunctionContext::Type::TYPE_SMALLINT:
@@ -69,14 +43,42 @@ PrimitiveType convert_type_to_primitive(FunctionContext::Type type) {
         return PrimitiveType::TYPE_BIGINT;
     case FunctionContext::Type::TYPE_LARGEINT:
         return PrimitiveType::TYPE_LARGEINT;
+    case FunctionContext::Type::TYPE_FLOAT:
+        return PrimitiveType::TYPE_FLOAT;
+    case FunctionContext::Type::TYPE_DOUBLE:
+        return PrimitiveType::TYPE_DOUBLE;
     case FunctionContext::Type::TYPE_DATE:
         return PrimitiveType::TYPE_DATE;
+    case FunctionContext::Type::TYPE_DATETIME:
+        return PrimitiveType::TYPE_DATETIME;
+    case FunctionContext::Type::TYPE_CHAR:
+        return PrimitiveType::TYPE_CHAR;
+    case FunctionContext::Type::TYPE_VARCHAR:
+        return PrimitiveType::TYPE_VARCHAR;
+    case FunctionContext::Type::TYPE_HLL:
+        return PrimitiveType::TYPE_HLL;
+    case FunctionContext::Type::TYPE_STRING:
+        return PrimitiveType::TYPE_STRING;
+    case FunctionContext::Type::TYPE_DECIMALV2:
+        return PrimitiveType::TYPE_DECIMALV2;
+    case FunctionContext::Type::TYPE_OBJECT:
+        return PrimitiveType::TYPE_OBJECT;
+    case FunctionContext::Type::TYPE_ARRAY:
+        return PrimitiveType::TYPE_ARRAY;
+    case FunctionContext::Type::TYPE_QUANTILE_STATE:
+        return PrimitiveType::TYPE_QUANTILE_STATE;
     case FunctionContext::Type::TYPE_DATEV2:
         return PrimitiveType::TYPE_DATEV2;
     case FunctionContext::Type::TYPE_DATETIMEV2:
         return PrimitiveType::TYPE_DATETIMEV2;
     case FunctionContext::Type::TYPE_TIMEV2:
         return PrimitiveType::TYPE_TIMEV2;
+    case FunctionContext::Type::TYPE_DECIMAL32:
+        return PrimitiveType::TYPE_DECIMAL32;
+    case FunctionContext::Type::TYPE_DECIMAL64:
+        return PrimitiveType::TYPE_DECIMAL64;
+    case FunctionContext::Type::TYPE_DECIMAL128I:
+        return PrimitiveType::TYPE_DECIMAL128I;
     case FunctionContext::Type::TYPE_JSONB:
         return PrimitiveType::TYPE_JSONB;
     default:

--- a/be/src/vec/functions/in.h
+++ b/be/src/vec/functions/in.h
@@ -156,7 +156,6 @@ public:
                 }
 
             } else { // non-nullable
-                DCHECK(!in_state->null_in_set);
 
                 auto search_hash_set = [&](auto* col_ptr) {
                     for (size_t i = 0; i < input_rows_count; ++i) {
@@ -176,6 +175,11 @@ public:
                     search_hash_set(column_string_ptr);
                 } else {
                     search_hash_set(materialized_column.get());
+                }
+                if (in_state->null_in_set) {
+                    for (size_t i = 0; i < input_rows_count; ++i) {
+                        vec_null_map_to[i] = negative == vec_res[i];
+                    }
                 }
             }
         } else {

--- a/regression-test/data/query_p0/sql_functions/test_in_expr.out
+++ b/regression-test/data/query_p0/sql_functions/test_in_expr.out
@@ -8,12 +8,60 @@
 -- !select --
 
 -- !select --
-103	4	d
+103	4	d	1.4
 
 -- !select --
-103	4	d
+103	4	d	1.4
 
 -- !select --
+
+-- !select_float_in --
+1.1	\N
+1.2	\N
+1.3	\N
+1.4	\N
+1.5	\N
+\N	\N
+
+-- !select_float_in2 --
+1.1	\N
+1.2	\N
+1.3	\N
+1.4	\N
+1.5	\N
+\N	\N
+
+-- !select_float_in3 --
+1.1	\N
+1.2	\N
+1.3	\N
+1.4	\N
+1.5	\N
+\N	\N
+
+-- !select_float_in4 --
+1.1	\N
+1.2	\N
+1.3	\N
+1.4	\N
+1.5	\N
+\N	\N
+
+-- !select_float_in5 --
+1.1	\N
+1.2	\N
+1.3	\N
+1.4	\N
+1.5	\N
+\N	\N
+
+-- !select_float_in6 --
+1.1	\N
+1.2	\N
+1.3	\N
+1.4	\N
+1.5	\N
+\N	\N
 
 -- !select --
 c
@@ -52,6 +100,90 @@ d
 a
 b
 d
+
+-- !select_not_null_in_null --
+100	true
+101	\N
+102	\N
+103	\N
+
+-- !select_not_null_in_null2 --
+100	\N
+101	\N
+102	\N
+103	\N
+
+-- !select_not_null_in_null3 --
+a	true
+b	\N
+c	\N
+d	\N
+
+-- !select_not_null_in_null4 --
+a	\N
+b	\N
+c	\N
+d	\N
+
+-- !select_not_null_not_in_null --
+100	false
+101	\N
+102	\N
+103	\N
+
+-- !select_not_null_not_in_null2 --
+100	\N
+101	\N
+102	\N
+103	\N
+
+-- !select_not_null_not_in_null3 --
+a	false
+b	\N
+c	\N
+d	\N
+
+-- !select_not_null_not_in_null4 --
+a	\N
+b	\N
+c	\N
+d	\N
+
+-- !select_not_null_float_in --
+1.1	\N
+1.2	\N
+1.3	\N
+1.4	\N
+
+-- !select_not_null_float_in2 --
+1.1	\N
+1.2	\N
+1.3	\N
+1.4	\N
+
+-- !select_not_null_float_in3 --
+1.1	\N
+1.2	\N
+1.3	\N
+1.4	\N
+
+-- !select_not_null_float_in4 --
+1.1	\N
+1.2	\N
+1.3	\N
+1.4	\N
+
+-- !select_not_null_float_in5 --
+1.1	\N
+1.2	\N
+1.3	\N
+1.4	\N
+
+-- !select_not_null_float_in6 --
+1.1	\N
+1.2	\N
+1.3	\N
+1.4	\N
 
 -- !select --
 2


### PR DESCRIPTION
also fix coredump of in expr of float column;
fix wrong result of in expr of not null column in null value

## Proposed changes

Issue Number: close #xxx

`DCHECK(!in_state->null_in_set);` in `FunctionIn::execute_impl` when left column is not nullable is not necessary, remove it;
function `convert_type_to_primitive` in be/src/runtime/primitive_type.cpp forget to handle float type, fix it;
when left column is not nullable, if values in expr list have null value, nullable flags should also be set as when left column is nullable.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

