### PR TITLE
[enhancement](Nereids): prune unuse plan in optimized group

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/CostAndEnforcerJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/CostAndEnforcerJob.java
@@ -192,6 +192,15 @@ public class CostAndEnforcerJob extends Job implements Cloneable {
                 if (curTotalCost.getValue() > context.getCostUpperBound()) {
                     curTotalCost = Cost.infinite();
                 }
+
+                // Prune when there are a plan has less cost when this plan is not property passer.
+                // Because the best plan of request property = plan with the lowest cost + enforcer
+                Optional<Pair<Cost, GroupExpression>> bestExprPair = groupExpression.getOwnerGroup().getLowestCostPlan(PhysicalProperties.ANY);
+                if (bestExprPair.isPresent() && bestExprPair.get().first.getValue() < curTotalCost.getValue()
+                        && requestChildrenProperties.stream().allMatch(p -> p.equals(PhysicalProperties.ANY))) {
+                    curTotalCost = Cost.infinite();
+                }
+
                 // the request child properties will be covered by the output properties
                 // that corresponding to the request properties. so if we run a costAndEnforceJob of the same
                 // group expression, that request child properties will be different of this.


### PR DESCRIPTION
## Proposed changes
For those plan that the required property can not pass to its child
 The cost of distributed plan is equal to the sum of enforcer cost and its cost
 The enforcer cost is always constant. Therefore, we only need to choose the best plan to optimized.
    
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

