### PR TITLE
[Fix](planner)fix to_monday() in fold constant bug.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ExpressionFunctions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ExpressionFunctions.java
@@ -144,9 +144,7 @@ public enum ExpressionFunctions {
             }
             boolean match = true;
             for (int i = 0; i < argTypes1.length; i++) {
-                if (!(argTypes1[i].isDate() && argTypes2[i].isDateV2())
-                        && !(argTypes1[i].isDatetime() && argTypes2[i].isDatetimeV2())
-                        && !(argTypes1[i].isDecimalV2() && argTypes2[i].isDecimalV3())
+                if (!(argTypes1[i].isDecimalV2() && argTypes2[i].isDecimalV3())
                         && !(argTypes1[i].isDecimalV2() && argTypes2[i].isDecimalV2())
                         && !argTypes1[i].equals(argTypes2[i])) {
                     match = false;

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/FEFunctions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/FEFunctions.java
@@ -364,13 +364,14 @@ public class FEFunctions {
 
     @FEFunction(name = "to_monday", argTypes = {"DATETIME"}, returnType = "DATE")
     public static DateLiteral toMonday(LiteralExpr arg) {
-        if (arg instanceof DateLiteral && (arg.getType().isDate() || arg.getType().isDatetime())) {
+        if (arg instanceof DateLiteral && (arg.getType().isDateLike())) {
             DateLiteral dateLiteral = ((DateLiteral) arg);
             LocalDateTime dateTime = LocalDateTime.of(
                     ((int) dateLiteral.getYear()), ((int) dateLiteral.getMonth()), ((int) dateLiteral.getDay()),
                     0, 0, 0);
             dateTime = toMonday(dateTime);
-            return new DateLiteral(dateTime.getYear(), dateTime.getMonthValue(), dateTime.getDayOfMonth(), Type.DATE);
+            return new DateLiteral(dateTime.getYear(), dateTime.getMonthValue(), dateTime.getDayOfMonth(),
+                    (arg.getType().isDateType() || arg.getType().isDatetime()) ? Type.DATE : Type.DATEV2);
         }
         return null;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/FEFunctions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/FEFunctions.java
@@ -364,14 +364,13 @@ public class FEFunctions {
 
     @FEFunction(name = "to_monday", argTypes = {"DATETIME"}, returnType = "DATE")
     public static DateLiteral toMonday(LiteralExpr arg) {
-        if (arg instanceof DateLiteral && (arg.getType().isDateLike())) {
+        if (arg instanceof DateLiteral && (arg.getType().isDate() || arg.getType().isDatetime())) {
             DateLiteral dateLiteral = ((DateLiteral) arg);
             LocalDateTime dateTime = LocalDateTime.of(
                     ((int) dateLiteral.getYear()), ((int) dateLiteral.getMonth()), ((int) dateLiteral.getDay()),
                     0, 0, 0);
             dateTime = toMonday(dateTime);
-            return new DateLiteral(dateTime.getYear(), dateTime.getMonthValue(), dateTime.getDayOfMonth(),
-                    (arg.getType().isDateType() || arg.getType().isDatetime()) ? Type.DATE : Type.DATEV2);
+            return new DateLiteral(dateTime.getYear(), dateTime.getMonthValue(), dateTime.getDayOfMonth(), Type.DATE);
         }
         return null;
     }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

two to_monday() function will be selected because the function whose args are date types accepts datev2 types. So the datev2 types will be replaced to the date types. We fix it by disable function that accepts date types accepts datev2 types.

for example:
```sql
select to_monday('2021-02-01')
```
the function returns datetime type not datetimev2 type because the to_monday(date) is selected. because function to_monday(date) accepts datev2 type. After being disabled, to_monday(datev2) will be selected.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

