### PR TITLE
[Enhancement](multi-catalog) Support sql cache for hms table.

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Pair.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Pair.java
@@ -34,9 +34,9 @@ public class Pair<F, S> {
     public static PairComparator<Pair<?, Comparable>> PAIR_VALUE_COMPARATOR = new PairComparator<>();
 
     @SerializedName(value = "first")
-    public F first;
+    public final F first;
     @SerializedName(value = "second")
-    public S second;
+    public final S second;
 
     private Pair(F first, S second) {
         this.first = first;

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Pair.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Pair.java
@@ -34,9 +34,9 @@ public class Pair<F, S> {
     public static PairComparator<Pair<?, Comparable>> PAIR_VALUE_COMPARATOR = new PairComparator<>();
 
     @SerializedName(value = "first")
-    public final F first;
+    public F first;
     @SerializedName(value = "second")
-    public final S second;
+    public S second;
 
     private Pair(F first, S second) {
         this.first = first;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/EsExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/EsExternalTable.java
@@ -47,12 +47,9 @@ public class EsExternalTable extends ExternalTable {
         super(id, name, catalog, dbName, TableType.ES_EXTERNAL_TABLE);
     }
 
-    protected synchronized void makeSureInitialized() {
-        super.makeSureInitialized();
-        if (!objectCreated) {
-            esTable = toEsTable();
-            objectCreated = true;
-        }
+    @Override
+    protected void doInitialize() {
+        esTable = toEsTable();
     }
 
     public EsTable getEsTable() {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
@@ -79,6 +79,8 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
     protected ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock(true);
 
     /**
+     * versionInfo: Pair(version, versionTime)
+     *
      * version:
      *  -1: table has not been initialized
      *  0: table has just been initialized

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
@@ -371,6 +371,13 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
         return Optional.empty();
     }
 
+    /**
+     * Should only be called in ExternalCatalog's getSchema(),
+     * which is called from schema cache.
+     * If you want to get schema of this table, use getFullSchema()
+     *
+     * @return
+     */
     public List<Column> initSchemaAndUpdateTime() {
         lastUpdateTime = System.currentTimeMillis();
         return initSchema();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
@@ -31,7 +31,6 @@ import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.ExternalSchemaCache;
-import org.apache.doris.datasource.HMSExternalCatalog;
 import org.apache.doris.persist.gson.GsonPostProcessable;
 import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.statistics.AnalysisInfo;
@@ -67,8 +66,7 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
     protected String name;
     @SerializedName(value = "type")
     protected TableType type = null;
-    // TODO(dutyu): can we delete this field?
-    //  I do not find any place which use this field
+    // TODO(dutyu): can we delete this field? I do not find any place which use this field
     @SerializedName(value = "timestamp")
     protected long timestamp;
     @SerializedName(value = "dbName")
@@ -122,7 +120,7 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
         return false;
     }
 
-    protected synchronized void makeSureInitialized() {
+    public synchronized void makeSureInitialized() {
         try {
             // getDbOrAnalysisException will call makeSureInitialized in ExternalCatalog.
             ExternalDatabase db = catalog.getDbOrAnalysisException(dbName);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
@@ -65,6 +65,8 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
     protected String name;
     @SerializedName(value = "type")
     protected TableType type = null;
+    // TODO(dutyu): can we delete this field?
+    //  I do not find any place which use this field
     @SerializedName(value = "timestamp")
     protected long timestamp;
     @SerializedName(value = "dbName")
@@ -75,6 +77,16 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
     protected boolean objectCreated;
     protected ExternalCatalog catalog;
     protected ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock(true);
+
+    // -1: table has not been initialized
+    // 0: table has been initialized
+    // >0: event id of hms event
+    protected volatile long version = -1L;
+
+    // -1: table has not been initialized
+    // 0: table has been initialized
+    // >0: event time of hms event
+    protected volatile long versionTime = -1L;
 
     /**
      * No args constructor for persist.
@@ -291,6 +303,21 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
     @Override
     public long getUpdateTime() {
         return 0;
+    }
+
+    public long getVersionTime() {
+        return versionTime;
+    }
+
+    public long getVersion() {
+        return version;
+    }
+
+    public void refreshVersion(long version, long versionTime) {
+        if (version != -1L) {
+            this.version = version;
+            this.versionTime = versionTime;
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
@@ -84,8 +84,7 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
     protected volatile long version = -1L;
 
     // -1: table has not been initialized
-    // 0: table has been initialized
-    // >0: event time of hms event
+    // >0: event time of update time (milliseconds)
     protected volatile long versionTime = -1L;
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
@@ -101,6 +101,7 @@ public class HMSExternalTable extends ExternalTable {
     }
 
     private volatile org.apache.hadoop.hive.metastore.api.Table remoteTable = null;
+
     private List<Column> partitionColumns;
 
     private DLAType dlaType = DLAType.UNKNOWN;
@@ -143,6 +144,9 @@ public class HMSExternalTable extends ExternalTable {
                     dlaType = DLAType.UNKNOWN;
                 }
             }
+            // set version to 0L if table has been initialized
+            version = 0L;
+            versionTime = System.nanoTime();
             objectCreated = true;
         }
     }
@@ -247,21 +251,6 @@ public class HMSExternalTable extends ExternalTable {
             default:
                 return null;
         }
-    }
-
-    @Override
-    public String getComment() {
-        return "";
-    }
-
-    @Override
-    public long getCreateTime() {
-        return 0;
-    }
-
-    @Override
-    public long getUpdateTime() {
-        return 0;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
@@ -146,7 +146,8 @@ public class HMSExternalTable extends ExternalTable {
             }
             // set version to 0L if table has been initialized
             version = 0L;
-            versionTime = System.nanoTime();
+            // set versionTime to current ts so cache will miss
+            versionTime = System.currentTimeMillis();
             objectCreated = true;
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/IcebergExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/IcebergExternalTable.java
@@ -51,13 +51,6 @@ public class IcebergExternalTable extends ExternalTable {
         return ((IcebergExternalCatalog) catalog).getIcebergCatalogType();
     }
 
-    protected synchronized void makeSureInitialized() {
-        super.makeSureInitialized();
-        if (!objectCreated) {
-            objectCreated = true;
-        }
-    }
-
     @Override
     public List<Column> initSchema() {
         Schema schema = ((IcebergExternalCatalog) catalog).getIcebergTable(dbName, name).schema();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/JdbcExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/JdbcExternalTable.java
@@ -48,12 +48,8 @@ public class JdbcExternalTable extends ExternalTable {
     }
 
     @Override
-    protected synchronized void makeSureInitialized() {
-        super.makeSureInitialized();
-        if (!objectCreated) {
-            jdbcTable = toJdbcTable();
-            objectCreated = true;
-        }
+    protected void doInitialize() {
+        jdbcTable = toJdbcTable();
     }
 
     public JdbcTable getJdbcTable() {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/MaxComputeExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/MaxComputeExternalTable.java
@@ -55,12 +55,8 @@ public class MaxComputeExternalTable extends ExternalTable {
     }
 
     @Override
-    protected synchronized void makeSureInitialized() {
-        super.makeSureInitialized();
-        if (!objectCreated) {
-            odpsTable = ((MaxComputeExternalCatalog) catalog).getClient().tables().get(name);
-            objectCreated = true;
-        }
+    protected void doInitialize() {
+        odpsTable = ((MaxComputeExternalCatalog) catalog).getClient().tables().get(name);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/PaimonExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/PaimonExternalTable.java
@@ -52,13 +52,6 @@ public class PaimonExternalTable extends ExternalTable {
         return ((PaimonExternalCatalog) catalog).getPaimonCatalogType();
     }
 
-    protected synchronized void makeSureInitialized() {
-        super.makeSureInitialized();
-        if (!objectCreated) {
-            objectCreated = true;
-        }
-    }
-
     public Table getOriginTable() {
         if (originTable == null) {
             originTable = ((PaimonExternalCatalog) catalog).getPaimonTable(dbName, name);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/TestExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/TestExternalTable.java
@@ -38,12 +38,6 @@ public class TestExternalTable extends ExternalTable {
     }
 
     @Override
-    public synchronized void makeSureInitialized() {
-        super.makeSureInitialized();
-        this.objectCreated = true;
-    }
-
-    @Override
     public String getMysqlType() {
         return type.name();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
@@ -59,7 +59,6 @@ import com.google.gson.annotations.SerializedName;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import javax.annotation.Nullable;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -72,6 +71,7 @@ import java.util.TreeMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 /**
  * CatalogMgr will load all catalogs at FE startup,

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
@@ -645,12 +645,13 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
     public void replayRefreshExternalTable(ExternalObjectLog log) {
         Pair<ExternalDatabase, ExternalTable> dbTablePair = getExternalDbTblPair(log);
         if (dbTablePair != null) {
+            ExternalDatabase db = dbTablePair.first;
+            ExternalTable table = dbTablePair.second;
             // no need to refresh table version
             // because `objectCreated` of this table will set to false
-            dbTablePair.second.unsetObjectCreated();
+            table.unsetObjectCreated();
             Env.getCurrentEnv().getExtMetaCacheMgr()
-                    .invalidateTableCache(log.getCatalogId(), dbTablePair.first.getFullName(),
-                                dbTablePair.second.getName());
+                    .invalidateTableCache(log.getCatalogId(), db.getFullName(), table.getName());
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
@@ -149,7 +149,7 @@ public class ExternalMetaCacheMgr {
 
     public void addPartitionsCache(long catalogId, ExternalTable table, List<String> partitionNames) {
         if (!(table instanceof HMSExternalTable)) {
-            LOG.warn("only support HMSTable");
+            LOG.warn("add PartitionsCache only support HMSTable");
             return;
         }
         String dbName = ClusterNamespace.getNameFromFullName(table.getDbName());
@@ -163,7 +163,7 @@ public class ExternalMetaCacheMgr {
 
     public void dropPartitionsCache(long catalogId, ExternalTable table, List<String> partitionNames) {
         if (!(table instanceof HMSExternalTable)) {
-            LOG.warn("only support HMSTable");
+            LOG.warn("drop PartitionsCache only support HMSTable");
             return;
         }
         String dbName = ClusterNamespace.getNameFromFullName(table.getDbName());
@@ -174,16 +174,19 @@ public class ExternalMetaCacheMgr {
         LOG.debug("drop partition cache for {}.{} in catalog {}", dbName, table.getName(), catalogId);
     }
 
-    public void invalidatePartitionsCache(long catalogId, String dbName, String tableName,
+    public void invalidatePartitionsCache(long catalogId, String dbName, ExternalTable table,
             List<String> partitionNames) {
+        if (!(table instanceof HMSExternalTable)) {
+            LOG.warn("invalidate PartitionsCache only support HMSTable");
+            return;
+        }
         HiveMetaStoreCache metaCache = cacheMap.get(catalogId);
         if (metaCache != null) {
             dbName = ClusterNamespace.getNameFromFullName(dbName);
             for (String partitionName : partitionNames) {
-                metaCache.invalidatePartitionCache(dbName, tableName, partitionName);
+                metaCache.invalidatePartitionCache(dbName, table.getName(), partitionName);
             }
-
         }
-        LOG.debug("invalidate partition cache for {}.{} in catalog {}", dbName, tableName, catalogId);
+        LOG.debug("invalidate partition cache for {}.{} in catalog {}", dbName, table.getName(), catalogId);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalObjectLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalObjectLog.java
@@ -31,6 +31,8 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.List;
 
+
+
 @NoArgsConstructor
 @Getter
 @Data
@@ -58,6 +60,12 @@ public class ExternalObjectLog implements Writable {
 
     @SerializedName(value = "lastUpdateTime")
     private long lastUpdateTime;
+
+    @SerializedName(value = "tableVersion")
+    private long tableVersion = -1L;
+
+    @SerializedName(value = "tableVersionTime")
+    private long tableVersionTime = -1L;
 
     @Override
     public void write(DataOutput out) throws IOException {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AddPartitionEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AddPartitionEvent.java
@@ -88,7 +88,7 @@ public class AddPartitionEvent extends MetastorePartitionEvent {
             }
             Env.getCurrentEnv().getCatalogMgr()
                     .addExternalPartitions(catalogName, dbName, hmsTbl.getTableName(), partitionNames,
-                                this.getEventId(), (long) this.event.getEventTime(), true);
+                                this.getEventId(), this.event.getEventTime(), true);
         } catch (DdlException e) {
             throw new MetastoreNotificationException(
                     debugString("Failed to process event"), e);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AddPartitionEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AddPartitionEvent.java
@@ -50,7 +50,7 @@ public class AddPartitionEvent extends MetastorePartitionEvent {
     }
 
     private AddPartitionEvent(NotificationEvent event,
-            String catalogName) {
+                              String catalogName) {
         super(event, catalogName);
         Preconditions.checkArgument(getEventType().equals(MetastoreEventType.ADD_PARTITION));
         Preconditions
@@ -72,7 +72,7 @@ public class AddPartitionEvent extends MetastorePartitionEvent {
     }
 
     protected static List<MetastoreEvent> getEvents(NotificationEvent event,
-            String catalogName) {
+                                                    String catalogName) {
         return Lists.newArrayList(new AddPartitionEvent(event, catalogName));
     }
 
@@ -87,7 +87,8 @@ public class AddPartitionEvent extends MetastorePartitionEvent {
                 return;
             }
             Env.getCurrentEnv().getCatalogMgr()
-                    .addExternalPartitions(catalogName, dbName, hmsTbl.getTableName(), partitionNames, true);
+                    .addExternalPartitions(catalogName, dbName, hmsTbl.getTableName(), partitionNames,
+                                this.getEventId(), (long) this.event.getEventTime(), true);
         } catch (DdlException e) {
             throw new MetastoreNotificationException(
                     debugString("Failed to process event"), e);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AddPartitionEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AddPartitionEvent.java
@@ -87,8 +87,8 @@ public class AddPartitionEvent extends MetastorePartitionEvent {
                 return;
             }
             Env.getCurrentEnv().getCatalogMgr()
-                    .addExternalPartitions(catalogName, dbName, hmsTbl.getTableName(), partitionNames,
-                                this.getEventId(), this.event.getEventTime() * 1000, true);
+                    .addExternalPartitions(catalogName, dbName, hmsTbl.getTableName(),
+                                partitionNames, this.getEventId(), true);
         } catch (DdlException e) {
             throw new MetastoreNotificationException(
                     debugString("Failed to process event"), e);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AddPartitionEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AddPartitionEvent.java
@@ -88,7 +88,7 @@ public class AddPartitionEvent extends MetastorePartitionEvent {
             }
             Env.getCurrentEnv().getCatalogMgr()
                     .addExternalPartitions(catalogName, dbName, hmsTbl.getTableName(), partitionNames,
-                                this.getEventId(), this.event.getEventTime(), true);
+                                this.getEventId(), this.event.getEventTime() * 1000, true);
         } catch (DdlException e) {
             throw new MetastoreNotificationException(
                     debugString("Failed to process event"), e);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterPartitionEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterPartitionEvent.java
@@ -93,17 +93,14 @@ public class AlterPartitionEvent extends MetastorePartitionEvent {
             if (isRename) {
                 Env.getCurrentEnv().getCatalogMgr()
                         .dropExternalPartitions(catalogName, dbName, tblName,
-                                Lists.newArrayList(partitionNameBefore),
-                                this.getEventId(), this.event.getEventTime() * 1000, true);
+                                Lists.newArrayList(partitionNameBefore), this.getEventId(), true);
                 Env.getCurrentEnv().getCatalogMgr()
                         .addExternalPartitions(catalogName, dbName, tblName,
-                                Lists.newArrayList(partitionNameAfter),
-                                this.getEventId(), this.event.getEventTime() * 1000, true);
+                                Lists.newArrayList(partitionNameAfter), this.getEventId(), true);
             } else {
                 Env.getCurrentEnv().getCatalogMgr()
                         .refreshExternalPartitions(catalogName, dbName, hmsTbl.getTableName(),
-                                Lists.newArrayList(partitionNameAfter),
-                                this.getEventId(), this.event.getEventTime() * 1000, true);
+                                Lists.newArrayList(partitionNameAfter), this.getEventId(), true);
             }
         } catch (DdlException e) {
             throw new MetastoreNotificationException(

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterPartitionEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterPartitionEvent.java
@@ -94,16 +94,16 @@ public class AlterPartitionEvent extends MetastorePartitionEvent {
                 Env.getCurrentEnv().getCatalogMgr()
                         .dropExternalPartitions(catalogName, dbName, tblName,
                                 Lists.newArrayList(partitionNameBefore),
-                                this.getEventId(), this.event.getEventTime(), true);
+                                this.getEventId(), this.event.getEventTime() * 1000, true);
                 Env.getCurrentEnv().getCatalogMgr()
                         .addExternalPartitions(catalogName, dbName, tblName,
                                 Lists.newArrayList(partitionNameAfter),
-                                this.getEventId(), this.event.getEventTime(), true);
+                                this.getEventId(), this.event.getEventTime() * 1000, true);
             } else {
                 Env.getCurrentEnv().getCatalogMgr()
                         .refreshExternalPartitions(catalogName, dbName, hmsTbl.getTableName(),
                                 Lists.newArrayList(partitionNameAfter),
-                                this.getEventId(), this.event.getEventTime(), true);
+                                this.getEventId(), this.event.getEventTime() * 1000, true);
             }
         } catch (DdlException e) {
             throw new MetastoreNotificationException(

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterPartitionEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterPartitionEvent.java
@@ -93,14 +93,17 @@ public class AlterPartitionEvent extends MetastorePartitionEvent {
             if (isRename) {
                 Env.getCurrentEnv().getCatalogMgr()
                         .dropExternalPartitions(catalogName, dbName, tblName,
-                                Lists.newArrayList(partitionNameBefore), true);
+                                Lists.newArrayList(partitionNameBefore),
+                                this.getEventId(), this.event.getEventTime(), true);
                 Env.getCurrentEnv().getCatalogMgr()
                         .addExternalPartitions(catalogName, dbName, tblName,
-                                Lists.newArrayList(partitionNameAfter), true);
+                                Lists.newArrayList(partitionNameAfter),
+                                this.getEventId(), this.event.getEventTime(), true);
             } else {
                 Env.getCurrentEnv().getCatalogMgr()
                         .refreshExternalPartitions(catalogName, dbName, hmsTbl.getTableName(),
-                                Lists.newArrayList(partitionNameAfter), true);
+                                Lists.newArrayList(partitionNameAfter),
+                                this.getEventId(), this.event.getEventTime(), true);
             }
         } catch (DdlException e) {
             throw new MetastoreNotificationException(

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/DropPartitionEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/DropPartitionEvent.java
@@ -80,7 +80,7 @@ public class DropPartitionEvent extends MetastorePartitionEvent {
             }
             Env.getCurrentEnv().getCatalogMgr()
                     .dropExternalPartitions(catalogName, dbName, hmsTbl.getTableName(), partitionNames,
-                                this.getEventId(), this.event.getEventTime(), true);
+                                this.getEventId(), this.event.getEventTime() * 1000, true);
         } catch (DdlException e) {
             throw new MetastoreNotificationException(
                     debugString("Failed to process event"), e);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/DropPartitionEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/DropPartitionEvent.java
@@ -79,7 +79,8 @@ public class DropPartitionEvent extends MetastorePartitionEvent {
                 return;
             }
             Env.getCurrentEnv().getCatalogMgr()
-                    .dropExternalPartitions(catalogName, dbName, hmsTbl.getTableName(), partitionNames, true);
+                    .dropExternalPartitions(catalogName, dbName, hmsTbl.getTableName(), partitionNames,
+                                this.getEventId(), this.event.getEventTime(), true);
         } catch (DdlException e) {
             throw new MetastoreNotificationException(
                     debugString("Failed to process event"), e);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/DropPartitionEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/DropPartitionEvent.java
@@ -79,8 +79,8 @@ public class DropPartitionEvent extends MetastorePartitionEvent {
                 return;
             }
             Env.getCurrentEnv().getCatalogMgr()
-                    .dropExternalPartitions(catalogName, dbName, hmsTbl.getTableName(), partitionNames,
-                                this.getEventId(), this.event.getEventTime() * 1000, true);
+                    .dropExternalPartitions(catalogName, dbName, hmsTbl.getTableName(),
+                                partitionNames, this.getEventId(), true);
         } catch (DdlException e) {
             throw new MetastoreNotificationException(
                     debugString("Failed to process event"), e);

--- a/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
@@ -71,6 +71,7 @@ public final class MetricRepo {
     public static LongCounterMetric COUNTER_QUERY_ERR;
     public static LongCounterMetric COUNTER_QUERY_TABLE;
     public static LongCounterMetric COUNTER_QUERY_OLAP_TABLE;
+    public static LongCounterMetric COUNTER_QUERY_HMS_TABLE;
     public static Histogram HISTO_QUERY_LATENCY;
     public static AutoMappedMetric<Histogram> USER_HISTO_QUERY_LATENCY;
     public static AutoMappedMetric<GaugeMetricImpl<Long>> USER_GAUGE_QUERY_INSTANCE_NUM;
@@ -285,6 +286,9 @@ public final class MetricRepo {
         COUNTER_QUERY_OLAP_TABLE = new LongCounterMetric("query_olap_table", MetricUnit.REQUESTS,
                 "total query from olap table");
         DORIS_METRIC_REGISTER.addMetrics(COUNTER_QUERY_OLAP_TABLE);
+        COUNTER_QUERY_HMS_TABLE = new LongCounterMetric("query_hms_table", MetricUnit.REQUESTS,
+                "total query from hms table");
+        DORIS_METRIC_REGISTER.addMetrics(COUNTER_QUERY_HMS_TABLE);
         HISTO_QUERY_LATENCY = METRIC_REGISTER.histogram(
                 MetricRegistry.name("query", "latency", "ms"));
         USER_HISTO_QUERY_LATENCY = new AutoMappedMetric<>(name -> {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveScanNode.java
@@ -75,6 +75,8 @@ public class HiveScanNode extends FileQueryScanNode {
     public static final String PROP_ARRAY_DELIMITER_HIVE3 = "collection.delim";
     public static final String DEFAULT_ARRAY_DELIMITER = "\2";
     protected final HMSExternalTable hmsTable;
+    private volatile long tableVersion = -1L;
+    private volatile long tableVersionTime = -1L;
     private HiveTransaction hiveTransaction = null;
 
     /**
@@ -116,6 +118,10 @@ public class HiveScanNode extends FileQueryScanNode {
                     ConnectContext.get().getQualifiedUser(), hmsTable, hmsTable.isFullAcidTable());
             Env.getCurrentHiveTransactionMgr().register(hiveTransaction);
         }
+
+        // record version and version time at the end of init phase
+        tableVersion = hmsTable.getVersion();
+        tableVersionTime = hmsTable.getVersionTime();
     }
 
     protected List<HivePartition> getPartitions() throws AnalysisException {
@@ -189,6 +195,14 @@ public class HiveScanNode extends FileQueryScanNode {
                 "get file split failed for table: " + hmsTable.getName() + ", err: " + Util.getRootCauseMessage(t),
                 t);
         }
+    }
+
+    public long getTableVersion() {
+        return tableVersion;
+    }
+
+    public long getTableVersionTime() {
+        return tableVersionTime;
     }
 
     private void getFileSplitByPartitions(HiveMetaStoreCache cache, List<HivePartition> partitions,

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveScanNode.java
@@ -29,6 +29,7 @@ import org.apache.doris.catalog.Type;
 import org.apache.doris.catalog.external.HMSExternalTable;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
+import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.common.util.Util;
@@ -120,8 +121,9 @@ public class HiveScanNode extends FileQueryScanNode {
         }
 
         // record version and version time at the end of init phase
-        tableVersion = hmsTable.getVersion();
-        tableVersionTime = hmsTable.getVersionTime();
+        Pair<Long, Long> versionInfo = hmsTable.getVersionInfo();
+        tableVersion = versionInfo.first;
+        tableVersionTime = versionInfo.second;
     }
 
     protected List<HivePartition> getPartitions() throws AnalysisException {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
@@ -237,7 +237,7 @@ public class CacheAnalyzer {
         }
         if (enableSqlCache()
                 && (now - latestTable.latestTime) >= Config.cache_last_version_interval_second * 1000L) {
-            LOG.debug("TIME:{},{},{}", now, latestTable.latestTime,
+            LOG.debug("sql cache time: {},{},{}", now, latestTable.latestTime,
                     Config.cache_last_version_interval_second * 1000);
             cache = new SqlCache(this.queryId, this.selectStmt);
             ((SqlCache) cache).setCacheInfo(this.latestTable, allViewExpandStmtListStr);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
@@ -217,7 +217,7 @@ public class CacheAnalyzer {
 
         for (int i = 0; i < scanNodes.size(); i++) {
             ScanNode node = scanNodes.get(i);
-            if (enablePartitionCache() && (node instanceof HiveScanNode)
+            if (enablePartitionCache() && (node instanceof OlapScanNode)
                         && ((OlapScanNode) node).getSelectedPartitionNum() > 1 && selectStmt.hasGroupByClause()) {
                 LOG.debug("more than one partition scanned when query has agg, partition cache cannot use, queryid {}",
                         DebugUtil.printId(queryId));

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
@@ -210,7 +210,7 @@ public class CacheAnalyzer {
         long olapScanNodeSize = scanNodes.stream().filter(node -> node instanceof OlapScanNode).count();
         long hiveScanNodeSize = scanNodes.stream().filter(node -> node instanceof HiveScanNode).count();
         if (!(olapScanNodeSize == scanNodes.size() || hiveScanNodeSize == scanNodes.size())) {
-            LOG.debug("only support olap/hive table or federated query, other types are not supported now, "
+            LOG.debug("only support olap/hive table with non-federated query, other types are not supported now, "
                         + "queryId {}", DebugUtil.printId(queryId));
             return CacheMode.None;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/PartitionCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/PartitionCache.java
@@ -72,7 +72,7 @@ public class PartitionCache extends Cache {
     public void setCacheInfo(CacheAnalyzer.CacheTable latestTable, RangePartitionInfo partitionInfo, Column partColumn,
                              CompoundPredicate partitionPredicate, String allViewExpandStmtListStr) {
         this.latestTable = latestTable;
-        this.olapTable = latestTable.olapTable;
+        this.olapTable = (OlapTable) latestTable.table;
         this.partitionInfo = partitionInfo;
         this.partColumn = partColumn;
         this.partitionPredicate = partitionPredicate;
@@ -108,7 +108,7 @@ public class PartitionCache extends Cache {
             MetricRepo.COUNTER_CACHE_HIT_PARTITION.increase(1L);
         }
 
-        range.setTooNewByID(latestTable.latestPartitionId);
+        range.setTooNewByID(latestTable.latestId);
         //build rewrite sql
         this.hitRange = range.buildDiskPartitionRange(newRangeList);
         if (newRangeList != null && newRangeList.size() > 0) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/SqlCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/SqlCache.java
@@ -48,7 +48,7 @@ public class SqlCache extends Cache {
         InternalService.PFetchCacheRequest request = InternalService.PFetchCacheRequest.newBuilder()
                 .setSqlKey(CacheProxy.getMd5(getSqlWithViewStmt()))
                 .addParams(InternalService.PCacheParam.newBuilder()
-                        .setPartitionKey(latestTable.latestPartitionId)
+                        .setPartitionKey(latestTable.latestId)
                         .setLastVersion(latestTable.latestVersion)
                         .setLastVersionTime(latestTable.latestTime))
                 .build();
@@ -79,7 +79,7 @@ public class SqlCache extends Cache {
         }
 
         InternalService.PUpdateCacheRequest updateRequest =
-                rowBatchBuilder.buildSqlUpdateRequest(getSqlWithViewStmt(), latestTable.latestPartitionId,
+                rowBatchBuilder.buildSqlUpdateRequest(getSqlWithViewStmt(), latestTable.latestId,
                         latestTable.latestVersion, latestTable.latestTime);
         if (updateRequest.getValuesCount() > 0) {
             CacheBeProxy proxy = new CacheBeProxy();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/SqlCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/SqlCache.java
@@ -48,9 +48,11 @@ public class SqlCache extends Cache {
         InternalService.PFetchCacheRequest request = InternalService.PFetchCacheRequest.newBuilder()
                 .setSqlKey(CacheProxy.getMd5(getSqlWithViewStmt()))
                 .addParams(InternalService.PCacheParam.newBuilder()
+                        // the name `partitionKey` fails to express the meaning for hms table
+                        // but it's ok, just reserve the name here
                         .setPartitionKey(latestTable.latestId)
                         .setLastVersion(latestTable.latestVersion)
-                        .setLastVersionTime(latestTable.latestTime))
+                        .setLastVersionTime(latestTable.latestVersionTime))
                 .build();
 
         InternalService.PFetchCacheResult cacheResult = proxy.fetchCache(request, 10000, status);
@@ -80,7 +82,7 @@ public class SqlCache extends Cache {
 
         InternalService.PUpdateCacheRequest updateRequest =
                 rowBatchBuilder.buildSqlUpdateRequest(getSqlWithViewStmt(), latestTable.latestId,
-                        latestTable.latestVersion, latestTable.latestTime);
+                        latestTable.latestVersion, latestTable.latestVersionTime);
         if (updateRequest.getValuesCount() > 0) {
             CacheBeProxy proxy = new CacheBeProxy();
             Status status = new Status();

--- a/fe/fe-core/src/test/java/org/apache/doris/external/hms/HmsSqlCacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/external/hms/HmsSqlCacheTest.java
@@ -1,0 +1,251 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.external.hms;
+
+import org.apache.doris.analysis.CreateCatalogStmt;
+import org.apache.doris.analysis.CreateDbStmt;
+import org.apache.doris.analysis.CreateTableStmt;
+import org.apache.doris.analysis.StatementBase;
+import org.apache.doris.analysis.TupleDescriptor;
+import org.apache.doris.analysis.TupleId;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.catalog.TableIf;
+import org.apache.doris.catalog.external.HMSExternalDatabase;
+import org.apache.doris.catalog.external.HMSExternalTable;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.datasource.CatalogMgr;
+import org.apache.doris.datasource.HMSExternalCatalog;
+import org.apache.doris.nereids.datasets.tpch.AnalyzeCheckTestBase;
+import org.apache.doris.planner.OlapScanNode;
+import org.apache.doris.planner.PlanNodeId;
+import org.apache.doris.planner.ScanNode;
+import org.apache.doris.planner.external.HiveScanNode;
+import org.apache.doris.qe.cache.CacheAnalyzer;
+
+import com.google.common.collect.Lists;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class HmsSqlCacheTest extends AnalyzeCheckTestBase {
+    private static final String HMS_CATALOG = "hms_ctl";
+    private static final long NOW = System.currentTimeMillis();
+    private Env env;
+    private CatalogMgr mgr;
+    private OlapScanNode olapScanNode;
+
+    @Mocked
+    private HMSExternalTable tbl;
+    @Mocked
+    private HMSExternalTable view1;
+    @Mocked
+    private HiveScanNode hiveScanNode;
+
+    @Override
+    protected void runBeforeAll() throws Exception {
+        FeConstants.runningUnitTest = true;
+        Config.enable_query_hive_views = true;
+        Config.cache_enable_sql_mode = true;
+        Config.cache_enable_partition_mode = true;
+        connectContext.getSessionVariable().setEnableSqlCache(true);
+
+        env = Env.getCurrentEnv();
+        connectContext.setEnv(env);
+        mgr = env.getCatalogMgr();
+
+        // create hms catalog
+        CreateCatalogStmt hmsCatalogStmt = (CreateCatalogStmt) parseAndAnalyzeStmt(
+                "create catalog hms_ctl properties('type' = 'hms', 'hive.metastore.uris' = 'thrift://192.168.0.1:9083');",
+                connectContext);
+        mgr.createCatalog(hmsCatalogStmt);
+
+        // create inner db and tbl for test
+        CreateDbStmt createDbStmt = (CreateDbStmt) parseAndAnalyzeStmt("create database test", connectContext);
+        mgr.getInternalCatalog().createDb(createDbStmt);
+
+        CreateTableStmt createTableStmt = (CreateTableStmt) parseAndAnalyzeStmt("create table test.tbl1(\n"
+                + "k1 int comment 'test column k1', "
+                + "k2 int comment 'test column k2')  comment 'test table1' "
+                + "distributed by hash(k1) buckets 1\n"
+                + "properties(\"replication_num\" = \"1\");");
+        mgr.getInternalCatalog().createTable(createTableStmt);
+    }
+
+    private void init(HMSExternalCatalog hmsCatalog) {
+        Deencapsulation.setField(hmsCatalog, "initialized", true);
+        Deencapsulation.setField(hmsCatalog, "objectCreated", true);
+
+        List<Column> schema = Lists.newArrayList();
+        schema.add(new Column("k1", PrimitiveType.INT));
+
+        HMSExternalDatabase db = new HMSExternalDatabase(hmsCatalog, 10000, "hms_db");
+        Deencapsulation.setField(db, "initialized", true);
+
+        Deencapsulation.setField(tbl, "objectCreated", true);
+        new Expectations(tbl) {
+            {
+                tbl.getId();
+                minTimes = 0;
+                result = 10001;
+
+                tbl.getName();
+                minTimes = 0;
+                result = "hms_tbl";
+
+                tbl.getDbName();
+                minTimes = 0;
+                result = "hms_db";
+
+                tbl.getFullSchema();
+                minTimes = 0;
+                result = schema;
+
+                tbl.isSupportedHmsTable();
+                minTimes = 0;
+                result = true;
+
+                tbl.isView();
+                minTimes = 0;
+                result = false;
+
+                tbl.getType();
+                minTimes = 0;
+                result = TableIf.TableType.HMS_EXTERNAL_TABLE;
+            }
+        };
+
+        Deencapsulation.setField(view1, "objectCreated", true);
+
+        new Expectations(view1) {
+            {
+                view1.getId();
+                minTimes = 0;
+                result = 10002;
+
+                view1.getName();
+                minTimes = 0;
+                result = "hms_view1";
+
+                view1.getDbName();
+                minTimes = 0;
+                result = "hms_db";
+
+                view1.isView();
+                minTimes = 0;
+                result = true;
+
+                view1.getCatalog();
+                minTimes = 0;
+                result = hmsCatalog;
+
+                view1.getType();
+                minTimes = 0;
+                result = TableIf.TableType.HMS_EXTERNAL_TABLE;
+
+                view1.getFullSchema();
+                minTimes = 0;
+                result = schema;
+
+                view1.getViewText();
+                minTimes = 0;
+                result = "SELECT * FROM hms_db.hms_tbl";
+
+                view1.isSupportedHmsTable();
+                minTimes = 0;
+                result = true;
+            }
+        };
+
+
+        db.addTableForTest(tbl);
+        db.addTableForTest(view1);
+        hmsCatalog.addDatabaseForTest(db);
+
+        new Expectations(hiveScanNode) {
+            {
+                hiveScanNode.getTargetTable();
+                minTimes = 0;
+                result = tbl;
+
+                hiveScanNode.getTableVersion();
+                minTimes = 0;
+                result = 0L;
+
+                hiveScanNode.getTableVersionTime();
+                minTimes = 0;
+                result = NOW;
+            }
+        };
+
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(1));
+        desc.setTable(mgr.getInternalCatalog().getDbNullable("default_cluster:test").getTableNullable("tbl1"));
+        olapScanNode = new OlapScanNode(new PlanNodeId(1), desc, "tb1ScanNode");
+    }
+
+    @Test
+    public void testHitSqlCache1() throws Exception {
+        init((HMSExternalCatalog) mgr.getCatalog(HMS_CATALOG));
+        StatementBase parseStmt = parseAndAnalyzeStmt("select * from hms_ctl.hms_db.hms_tbl", connectContext);
+        List<ScanNode> scanNodes = Arrays.asList(hiveScanNode);
+        CacheAnalyzer ca = new CacheAnalyzer(connectContext, parseStmt, scanNodes);
+        ca.checkCacheMode(NOW + Config.cache_last_version_interval_second * 1000L * 2);
+        Assert.assertEquals(ca.getCacheMode(), CacheAnalyzer.CacheMode.Sql);
+    }
+
+    @Test
+    public void testHitSqlCache2() throws Exception {
+        init((HMSExternalCatalog) mgr.getCatalog(HMS_CATALOG));
+        StatementBase parseStmt = parseAndAnalyzeStmt("select * from hms_ctl.hms_db.hms_view1", connectContext);
+        List<ScanNode> scanNodes = Arrays.asList(hiveScanNode);
+        CacheAnalyzer ca = new CacheAnalyzer(connectContext, parseStmt, scanNodes);
+        ca.checkCacheMode(NOW + Config.cache_last_version_interval_second * 1000L * 2);
+        Assert.assertEquals(ca.getCacheMode(), CacheAnalyzer.CacheMode.Sql);
+    }
+
+    @Test
+    public void testNotHitSqlCache1() throws Exception {
+        init((HMSExternalCatalog) mgr.getCatalog(HMS_CATALOG));
+        StatementBase parseStmt = parseAndAnalyzeStmt("select * from hms_ctl.hms_db.hms_tbl", connectContext);
+        List<ScanNode> scanNodes = Arrays.asList(hiveScanNode);
+        CacheAnalyzer ca = new CacheAnalyzer(connectContext, parseStmt, scanNodes);
+        assert Config.cache_last_version_interval_second > 0;
+        ca.checkCacheMode(NOW);
+        Assert.assertEquals(ca.getCacheMode(), CacheAnalyzer.CacheMode.None);
+    }
+
+    @Test
+    public void testNotHitSqlCache2() throws Exception {
+        init((HMSExternalCatalog) mgr.getCatalog(HMS_CATALOG));
+        // cache mode is None if this query is a federated query
+        StatementBase parseStmt = parseAndAnalyzeStmt("select * from hms_ctl.hms_db.hms_tbl "
+                    + "inner join internal.test.tbl1", connectContext);
+        List<ScanNode> scanNodes = Arrays.asList(hiveScanNode, olapScanNode);
+        CacheAnalyzer ca = new CacheAnalyzer(connectContext, parseStmt, scanNodes);
+        assert Config.cache_last_version_interval_second > 0;
+        ca.checkCacheMode(NOW + Config.cache_last_version_interval_second * 1000L * 2);
+        Assert.assertEquals(ca.getCacheMode(), CacheAnalyzer.CacheMode.None);
+    }
+}


### PR DESCRIPTION
## Proposed changes

This pr is mainly to support sql cache for hms table with following changes:

- Support sql cache when scan nodes are all `HiveScanNode` at `CacheAnalyzer`.
- Add `version` and `versionTime` at `ExternalTable`, -1 means a external table is not initialized, 0 means this table has just been initialized, and `version` and `versionTime` will be refreshed when processing some hms events (`MetastorePartitionEvent`). If user refresh a hms table by `RrefreshCatalogStmt` or `RefreshTableStmt` manualy or refresh table is invoked by hms events, `version` will be set to 0 and `versionTime` will be set to current timestamp after table initialization later so the next query will meet a cache miss. 
- Remove some duplicated code blocks in `CatalogMgr`.

Additional Information:

- Partition cache is not supported for hms tables.
- Not support sql cache for a federated query mixed with olap tables and hms tables.
- Not support sql cache when using nereids planner.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

