### PR TITLE
[fix](planner)fix bug of pushing conjuncts into inlineview

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -1881,7 +1881,9 @@ public class Analyzer {
                     // aliases and having it analyzed is needed for the following EvalPredicate() call
                     conjunct.analyze(this);
                 }
-                Expr newConjunct = conjunct.getResultValue(true);
+                // getResultValue will modify the conjunct internally
+                // we have to use a clone to keep conjunct unchanged
+                Expr newConjunct = conjunct.clone().getResultValue(true);
                 newConjunct = FoldConstantsRule.INSTANCE.apply(newConjunct, this, null);
                 if (newConjunct instanceof BoolLiteral || newConjunct instanceof NullLiteral) {
                     boolean evalResult = true;

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -2799,7 +2799,8 @@ public class SingleNodePlanner {
                 }
                 GroupByClause groupByClause = stmt.getGroupByClause();
                 List<Expr> exprs = groupByClause.getGroupingExprs();
-                if (!exprs.contains(sourceExpr)) {
+                final Expr srcExpr = sourceExpr;
+                if (!exprs.stream().anyMatch(expr -> expr.comeFrom(srcExpr))) {
                     isAllSlotReferToGroupBys = false;
                     break;
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -1860,15 +1860,21 @@ public class SingleNodePlanner {
             return;
         }
 
-        List<Expr> newConjuncts = cloneExprs(conjuncts);
         final QueryStmt stmt = inlineViewRef.getViewStmt();
         final Analyzer viewAnalyzer = inlineViewRef.getAnalyzer();
         viewAnalyzer.markConjunctsAssigned(conjuncts);
+        // even if the conjuncts are constant, they may contains slotRef
+        // for example: case when slotRef is null then 0 else 1
+        // we need substitute the conjuncts using inlineViewRef's analyzer
+        // otherwise, when analyzing the conjunct in the inline view
+        // the analyzer is not able to find the column because it comes from outside
+        List<Expr> newConjuncts =
+                Expr.substituteList(conjuncts, inlineViewRef.getSmap(), viewAnalyzer, false);
         if (stmt instanceof SelectStmt) {
             final SelectStmt select = (SelectStmt) stmt;
             if (select.getAggInfo() != null) {
                 viewAnalyzer.registerConjuncts(newConjuncts, select.getAggInfo().getOutputTupleId().asList());
-            } else if (select.getTableRefs().size() > 1) {
+            } else if (select.getTableRefs().size() > 0) {
                 for (int i = select.getTableRefs().size() - 1; i >= 0; i--) {
                     viewAnalyzer.registerConjuncts(newConjuncts,
                             select.getTableRefs().get(i).getDesc().getId().asList());
@@ -2801,6 +2807,7 @@ public class SingleNodePlanner {
                 List<Expr> exprs = groupByClause.getGroupingExprs();
                 final Expr srcExpr = sourceExpr;
                 if (!exprs.stream().anyMatch(expr -> expr.comeFrom(srcExpr))) {
+                    // the sourceExpr doesn't come from any of the group by exprs
                     isAllSlotReferToGroupBys = false;
                     break;
                 }

--- a/regression-test/suites/correctness_p0/test_push_conjuncts_inlineview.groovy
+++ b/regression-test/suites/correctness_p0/test_push_conjuncts_inlineview.groovy
@@ -76,42 +76,42 @@ explain {
     }
 
 sql """
-    WITH V_GAIA_SD_RECHARGE_CARD AS
-    (SELECT client,
-         gsrc_account_id,
-         gsrc_status,
-         GSRC_AMT,
-         gsrc_member_card_id,
-         last_update_time,
-         rk
+    WITH ttt AS
+    (SELECT c1,
+         c2,
+         c3,
+         c4,
+         c5,
+         c6,
+         c7
     FROM 
-        (SELECT '10000003' client, '0816ffk' gsrc_account_id, '1' gsrc_status, 1416.0800 GSRC_AMT, '0816ffk' gsrc_member_card_id, '2023-07-03 15:36:36' last_update_time, 1 rk ) a
-        WHERE rk = 1 )
-    SELECT dd.CLIENT,
-            dd.recharge_card
+        (SELECT '10000003' c1, '0816ffk' c2, '1' c3, 1416.0800 c4, '0816ffk' c5, '2023-07-03 15:36:36' c6, 1 c7 ) a
+        WHERE c7 = 1 )
+    SELECT dd.c1,
+            dd.d1
     FROM 
-        (SELECT src.CLIENT,
+        (SELECT src.c1,
             
             CASE
-            WHEN IFNULL(src.GSRC_STATUS,'') = ''
-                OR src.GSRC_STATUS = '3' THEN
+            WHEN IFNULL(src.c3,'') = ''
+                OR src.c3 = '3' THEN
             '-1'
-            WHEN src.GSRC_AMT = 0 THEN
+            WHEN src.c4 = 0 THEN
             '0'
-            WHEN src.GSRC_AMT <= 200 THEN
+            WHEN src.c4 <= 200 THEN
             '1'
-            WHEN src.GSRC_AMT > 200
-                AND src.GSRC_AMT <= 500 THEN
+            WHEN src.c4 > 200
+                AND src.c4 <= 500 THEN
             '2'
-            WHEN src.GSRC_AMT > 500
-                AND src.GSRC_AMT <= 1000 THEN
+            WHEN src.c4 > 500
+                AND src.c4 <= 1000 THEN
             '3'
             ELSE '4'
-            END AS recharge_card
-        FROM V_GAIA_SD_RECHARGE_CARD src
-        WHERE src.CLIENT = '10000003'
-        GROUP BY  src.CLIENT, recharge_card ) dd
-    WHERE dd.recharge_card IN ('-1');
+            END AS d1
+        FROM ttt src
+        WHERE src.c1 = '10000003'
+        GROUP BY  src.c1, d1 ) dd
+    WHERE dd.d1 IN ('-1');
 """
 
  sql """ DROP TABLE IF EXISTS `push_conjunct_table` """

--- a/regression-test/suites/correctness_p0/test_push_conjuncts_inlineview.groovy
+++ b/regression-test/suites/correctness_p0/test_push_conjuncts_inlineview.groovy
@@ -75,6 +75,45 @@ explain {
         contains "= '123'"
     }
 
+sql """
+    WITH V_GAIA_SD_RECHARGE_CARD AS
+    (SELECT client,
+         gsrc_account_id,
+         gsrc_status,
+         GSRC_AMT,
+         gsrc_member_card_id,
+         last_update_time,
+         rk
+    FROM 
+        (SELECT '10000003' client, '0816ffk' gsrc_account_id, '1' gsrc_status, 1416.0800 GSRC_AMT, '0816ffk' gsrc_member_card_id, '2023-07-03 15:36:36' last_update_time, 1 rk ) a
+        WHERE rk = 1 )
+    SELECT dd.CLIENT,
+            dd.recharge_card
+    FROM 
+        (SELECT src.CLIENT,
+            
+            CASE
+            WHEN IFNULL(src.GSRC_STATUS,'') = ''
+                OR src.GSRC_STATUS = '3' THEN
+            '-1'
+            WHEN src.GSRC_AMT = 0 THEN
+            '0'
+            WHEN src.GSRC_AMT <= 200 THEN
+            '1'
+            WHEN src.GSRC_AMT > 200
+                AND src.GSRC_AMT <= 500 THEN
+            '2'
+            WHEN src.GSRC_AMT > 500
+                AND src.GSRC_AMT <= 1000 THEN
+            '3'
+            ELSE '4'
+            END AS recharge_card
+        FROM V_GAIA_SD_RECHARGE_CARD src
+        WHERE src.CLIENT = '10000003'
+        GROUP BY  src.CLIENT, recharge_card ) dd
+    WHERE dd.recharge_card IN ('-1');
+"""
+
  sql """ DROP TABLE IF EXISTS `push_conjunct_table` """
 }
 

--- a/regression-test/suites/correctness_p0/test_push_conjuncts_inlineview.groovy
+++ b/regression-test/suites/correctness_p0/test_push_conjuncts_inlineview.groovy
@@ -60,6 +60,21 @@ suite("test_push_conjuncts_inlineview") {
         contains "4:VSELECT"
     }
 
+explain {
+        sql("""SELECT *
+                FROM 
+                    (SELECT `a_key` AS `a_key`
+                    FROM 
+                        (SELECT `b`.`a_key` AS `a_key`
+                        FROM 
+                            (SELECT `a`.`a_key` AS `a_key`
+                            FROM `push_conjunct_table` a) b
+                            GROUP BY  1 ) t2 ) t1
+                        WHERE a_key = '123';""")
+        notContains "having"
+        contains "= '123'"
+    }
+
  sql """ DROP TABLE IF EXISTS `push_conjunct_table` """
 }
 


### PR DESCRIPTION
## Proposed changes

1. markConstantConjunct method shouldn't change the input conjunct
2. Use Expr's comeFrom method to check if the pushed expr is one of the group by exprs, this is the correct way to check if the conjunct can be pushed down through the agg node.
3. migrateConstantConjuncts should substitute the conjuncts using inlineViewRef's analyzer to make the analyzer recognize the column in the conjuncts in the following analyze phase

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

