### PR TITLE
[Bug](case function) do not crash if prepare failed (#15113)

### DIFF
--- a/be/src/vec/exprs/vcase_expr.cpp
+++ b/be/src/vec/exprs/vcase_expr.cpp
@@ -69,23 +69,11 @@ Status VCaseExpr::open(RuntimeState* state, VExprContext* context,
                        FunctionContext::FunctionStateScope scope) {
     RETURN_IF_ERROR(VExpr::open(state, context, scope));
     RETURN_IF_ERROR(VExpr::init_function_context(context, scope, _function));
-    if (scope == doris_udf::FunctionContext::FRAGMENT_LOCAL) {
-        auto* case_state = new CaseState {_data_type};
-        context->fn_context(_fn_context_index)
-                ->set_function_state(FunctionContext::FRAGMENT_LOCAL, case_state);
-    }
     return Status::OK();
 }
 
 void VCaseExpr::close(RuntimeState* state, VExprContext* context,
                       FunctionContext::FunctionStateScope scope) {
-    if (scope == doris_udf::FunctionContext::FRAGMENT_LOCAL) {
-        auto* case_state = reinterpret_cast<CaseState*>(
-                context->fn_context(_fn_context_index)
-                        ->get_function_state(FunctionContext::FRAGMENT_LOCAL));
-        delete case_state;
-    }
-
     VExpr::close_function_context(context, scope, _function);
     VExpr::close(state, context, scope);
 }

--- a/be/src/vec/functions/function_case.h
+++ b/be/src/vec/functions/function_case.h
@@ -27,10 +27,6 @@
 
 namespace doris::vectorized {
 
-struct CaseState {
-    DataTypePtr result_type = nullptr;
-};
-
 template <bool has_case, bool has_else>
 struct FunctionCaseName;
 
@@ -378,10 +374,7 @@ public:
 
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         size_t result, size_t input_rows_count) override {
-        auto* case_state = reinterpret_cast<CaseState*>(
-                context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
-
-        return execute_get_type(case_state->result_type, block, arguments, result,
+        return execute_get_type(block.get_by_position(result).type, block, arguments, result,
                                 input_rows_count);
     }
 };


### PR DESCRIPTION
(cherry picked from commit b2438b076dd9e3705e446c9839c67a735134b909)

reproduce case:
- DDL:
create table if not exists test
(
    stat_date varchar(4096) null comment ''
    ,all_charge_num int(11) null comment ''
    ,station_id varchar(255) NULL COMMENT ''
    ,station_type_desc varchar(4096) NULL COMMENT ''
)ENGINE = OLAP
DUPLICATE KEY(`stat_date`)
COMMENT ""
DISTRIBUTED BY HASH(`stat_date`) BUCKETS 1
PROPERTIES (
	"replication_allocation" = "tag.location.default: 1",
	"in_memory" = "false",
	"storage_format" = "V2"
);

- SQL:
select
	count(DISTINCT CASE WHEN max(all_charge_num) = 0 THEN station_id END)
from
	test
where
	CASE
		WHEN station_type_desc LIKE '%集1%' THEN '小区集站'
		WHEN station_type_desc LIKE '%集2%' THEN '超充集站'
		ELSE station_type_desc
	END = '小区集享站'
GROUP BY
	stat_date
;

The be node will crash when execute this sql
<img width="1707" alt="image" src="https://github.com/apache/doris/assets/9734567/64e41e38-cb72-4d77-b5b3-6fe474abb0df">
