### PR TITLE
[enhancement](repeat) add filter in repeat node in BE

### DIFF
--- a/be/src/vec/exec/vrepeat_node.cpp
+++ b/be/src/vec/exec/vrepeat_node.cpp
@@ -209,7 +209,7 @@ Status VRepeatNode::pull(doris::RuntimeState* state, vectorized::Block* output_b
             _repeat_id_idx = 0;
         }
     }
-
+    RETURN_IF_ERROR(VExprContext::filter_block(_conjuncts, output_block, output_block->columns()));
     *eos = _child_eos && _child_block.rows() == 0;
     reached_limit(output_block, eos);
     COUNTER_SET(_rows_returned_counter, _num_rows_returned);


### PR DESCRIPTION
## Proposed changes

This SQL will have a filter on repeat node with nereids plan.

```sql
 WITH dt AS
    (select 'test' as name,1 as score
    UNION
    all
    SELECT 'test' AS name,1 AS score
    UNION
    all SELECT 'test2' AS name,12 AS score
    UNION
    all SELECT 'test2' AS name,12 AS score ) ,
result_data AS
    (SELECT name,
        sum(score) AS score
    FROM dt
    GROUP BY  CUBE(name))
SELECT *
FROM result_data
WHERE name = 'test';
```


Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

