### PR TITLE
[feature](dbt) materialization table skip the process of backup

### DIFF
--- a/extension/dbt-doris/dbt/include/doris/macros/adapters/relation.sql
+++ b/extension/dbt-doris/dbt/include/doris/macros/adapters/relation.sql
@@ -120,13 +120,16 @@
 {%- endmacro%}
 
 {% macro doris__drop_relation(relation) -%}
+  {% if relation is not none %}
     {% set relation_type = relation.type %}
-    {% if relation_type is none %}
+    {% if not relation_type or relation_type is none %}
         {% set relation_type = 'table' %}
     {% endif %}
     {% call statement('drop_relation', auto_begin=False) %}
-    drop {{ relation_type }} if exists {{ relation }}
+      drop {{ relation_type }} if exists {{ relation }}
     {% endcall %}
+  {% endif %}
+
 {%- endmacro %}
 
 {% macro doris__truncate_relation(relation) -%}
@@ -142,7 +145,7 @@
   {% call statement('rename_relation') %}
     {% if to_relation.is_view %}
     {% set results = run_query('show create view ' + from_relation.render() ) %}
-    create view {{ to_relation }} as {{ results[0]['Create View'].replace(from_relation.table, to_relation.table).split('AS',1)[1] }}
+    create view {{ to_relation }} as {{ results[0]['Create View'].split('AS',1)[1] }}
     {% else %}
     alter table {{ from_relation }} rename {{ to_relation.table }}
     {% endif %}


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

1.  materialization table skip the process of backup
2. materialization table to full refresh mode atomically
3. Handle the case where the `rename table` is null


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

