### PR TITLE
[improvement](catalog) return the root cause of error when forwarding init request to master FE

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/Util.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/Util.java
@@ -41,6 +41,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
@@ -615,5 +617,21 @@ public class Util {
             p = p.getCause();
         }
         return rootCause;
+    }
+
+    // Return the stack of the root cause
+    public static String getRootCauseStack(Throwable t) {
+        String rootStack = "unknown";
+        if (t == null) {
+            return rootStack;
+        }
+        Throwable p = t;
+        while (p.getCause() != null) {
+            p = p.getCause();
+        }
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        p.printStackTrace(pw);
+        return sw.toString();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -57,6 +57,7 @@ import org.apache.doris.common.ThriftServerEventProcessor;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.Version;
 import org.apache.doris.common.annotation.LogException;
+import org.apache.doris.common.util.Util;
 import org.apache.doris.cooldown.CooldownDelete;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.datasource.ExternalCatalog;
@@ -69,6 +70,7 @@ import org.apache.doris.planner.StreamLoadPlanner;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ConnectProcessor;
 import org.apache.doris.qe.DdlExecutor;
+import org.apache.doris.qe.MasterCatalogExecutor;
 import org.apache.doris.qe.QeProcessorImpl;
 import org.apache.doris.qe.QueryState;
 import org.apache.doris.qe.VariableMgr;
@@ -1987,10 +1989,15 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         if (!(catalog instanceof ExternalCatalog)) {
             throw new TException("Only support forward ExternalCatalog init operation.");
         }
-        ((ExternalCatalog) catalog).makeSureInitialized();
         TInitExternalCtlMetaResult result = new TInitExternalCtlMetaResult();
-        result.setMaxJournalId(Env.getCurrentEnv().getMaxJournalId());
-        result.setStatus("OK");
+        try {
+            ((ExternalCatalog) catalog).makeSureInitialized();
+            result.setMaxJournalId(Env.getCurrentEnv().getMaxJournalId());
+            result.setStatus(MasterCatalogExecutor.STATUS_OK);
+        } catch (Throwable t) {
+            LOG.warn("init catalog failed. catalog: {}", catalog.getName(), t);
+            result.setStatus(Util.getRootCauseStack(t));
+        }
         return result;
     }
 
@@ -2006,10 +2013,16 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         if (!(db instanceof ExternalDatabase)) {
             throw new TException("Only support forward ExternalDatabase init operation.");
         }
-        ((ExternalDatabase) db).makeSureInitialized();
+
         TInitExternalCtlMetaResult result = new TInitExternalCtlMetaResult();
-        result.setMaxJournalId(Env.getCurrentEnv().getMaxJournalId());
-        result.setStatus("OK");
+        try {
+            ((ExternalDatabase) db).makeSureInitialized();
+            result.setMaxJournalId(Env.getCurrentEnv().getMaxJournalId());
+            result.setStatus(MasterCatalogExecutor.STATUS_OK);
+        } catch (Throwable t) {
+            LOG.warn("init database failed. catalog.database: {}", catalog.getName(), db.getFullName(), t);
+            result.setStatus(Util.getRootCauseStack(t));
+        }
         return result;
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/DebugUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/DebugUtilTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.common.util;
 
+import org.apache.doris.common.DdlException;
 import org.apache.doris.common.Pair;
 
 import org.junit.Assert;
@@ -80,5 +81,20 @@ public class DebugUtilTest {
         result = DebugUtil.getByteUint(1234567890L);  // G
         Assert.assertEquals(result.first, Double.valueOf(1.1497809458523989));
         Assert.assertEquals(result.second, "GB");
+    }
+
+    @Test
+    public void testUtilGetStackTrace() {
+        Exception e1 = new Exception("exception1");
+        DdlException e2 = new DdlException("exception2", e1);
+        e2.printStackTrace();
+        System.out.println(Util.getRootCauseStack(e2));
+        Assert.assertTrue(Util.getRootCauseStack(e2).contains("java.lang.Exception: exception1"));
+
+        DdlException e3 = new DdlException("only one exception");
+        System.out.println(Util.getRootCauseStack(e3));
+        Assert.assertTrue(Util.getRootCauseStack(e3)
+                .contains("org.apache.doris.common.DdlException: errCode = 2, detailMessage = only one exception"));
+        Assert.assertEquals("unknown", Util.getRootCauseStack(null));
     }
 }


### PR DESCRIPTION
## Proposed changes

When init an external catalog/database, non-master FE will forward the init request to master FE,
master FE will to the init operation(connecting to external data source, etc.).
If there are some error happen in init operation, master FE will return error message to non master FE.

But previously, the error message is unclear such as `Interna error processing initExtemnalCtlMeta`,
we have to see the fe.log of master FE to see the root cause.

This PR, I return the root cause to non-master FE directly, to make debug easier:

```
mysql> show databases;
--------------
show databases
--------------

ERROR 1105 (HY000): RuntimeException, msg: org.apache.doris.common.UserException: errCode = 2, detailMessage = MetaException(message:Could not connect to meta store using any of the URIs provided. Most recent failure: shade.doris.hive.org.apache.thrift.transport.TTransportException: java.net.ConnectException: Connection refused (Connection refused)
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

