### PR TITLE
[typo](docs)Correct the fe-config markdown comments

### DIFF
--- a/docs/en/docs/admin-manual/config/fe-config.md
+++ b/docs/en/docs/admin-manual/config/fe-config.md
@@ -1563,7 +1563,7 @@ Whether it is a configuration item unique to the Master FE node: true
 
 The maximum number of threads in the data synchronization job thread pool. There is only one thread pool in the entire FE, which is used to process all data synchronization tasks in the FE that send data to the BE. The implementation of the thread pool is in the `SyncTaskPool` class.
 
-Default: 10
+Default: `64*1024*1024` (64M)
 
 Is it possible to dynamically configure: false
 


### PR DESCRIPTION
Correcting fe-config.md comments: max_bytes_sync_commit = 64*1024*1024 (64MB)

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

