### PR TITLE
[fix](tablet clone) sched should wait for slot if has be path

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
@@ -103,7 +103,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
      */
     private static final int RUNNING_FAILED_COUNTER_THRESHOLD = 3;
 
-    public static final int FINISHED_COUNTER_THRESHOLD = 3;
+    public static final int FINISHED_COUNTER_THRESHOLD = 4;
 
     private static VersionCountComparator VERSION_COUNTER_COMPARATOR = new VersionCountComparator();
 

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -1357,6 +1357,8 @@ public class TabletScheduler extends MasterDaemon {
             return rootPathLoadStatistic;
         }
 
+        boolean hasBePath = false;
+
         // no root path with specified media type is found, get arbitrary one.
         for (RootPathLoadStatistic rootPathLoadStatistic : allFitPaths) {
             PathSlot slot = backendsWorkingSlots.get(rootPathLoadStatistic.getBeId());
@@ -1367,6 +1369,7 @@ public class TabletScheduler extends MasterDaemon {
                 continue;
             }
 
+            hasBePath = true;
             long pathHash = slot.takeSlot(rootPathLoadStatistic.getPathHash());
             if (pathHash == -1) {
                 LOG.debug("backend {}'s path {}'s slot is full, skip. tablet: {}",
@@ -1377,7 +1380,13 @@ public class TabletScheduler extends MasterDaemon {
             return rootPathLoadStatistic;
         }
 
-        throw new SchedException(Status.UNRECOVERABLE, "unable to find dest path which can be fit in");
+        if (hasBePath) {
+            throw new SchedException(Status.SCHEDULE_FAILED, SubCode.WAITING_SLOT,
+                    "unable to find dest path which can be fit in");
+        } else {
+            throw new SchedException(Status.UNRECOVERABLE,
+                    "unable to find dest path which can be fit in");
+        }
     }
 
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

when chose a dst path for tablet clone,  it should
1. if no available be path, make the shed ctx failed;
2. if has available be path but not have slot now,  make the sched ctx waiting for slot.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

