### PR TITLE
[fix](stats) support utf-8 string range compare

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/StringLikeLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/StringLikeLiteral.java
@@ -36,9 +36,9 @@ public abstract class StringLikeLiteral extends Literal {
     public double getDouble() {
         long v = 0;
         int pos = 0;
-        int len = Math.min(value.length(), 8);
+        int len = Math.min(value.length(), 7);
         while (pos < len) {
-            v += ((long) value.charAt(pos)) << ((7 - pos) * 8);
+            v += Byte.toUnsignedLong(value.getBytes()[pos]) << ((6 - pos) * 8);
             pos++;
         }
         return (double) v;


### PR DESCRIPTION
## Proposed changes
in previous version, some utf-8 string literal are mapped to negative double. this issue makes our range check misfunction.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

