### PR TITLE
[Fix](load) add error message when load unsupport compression code

### DIFF
--- a/be/src/util/block_compression.cpp
+++ b/be/src/util/block_compression.cpp
@@ -918,7 +918,7 @@ Status get_block_compression_codec(segment_v2::CompressionTypePB type,
         *codec = ZstdBlockCompression::instance();
         break;
     default:
-        return Status::NotFound("unknown compression type({})", type);
+        return Status::InternalError("unknown compression type({})", type);
     }
 
     return Status::OK();
@@ -943,7 +943,7 @@ Status get_block_compression_codec(tparquet::CompressionCodec::type parquet_code
         *codec = GzipBlockCompression::instance();
         break;
     default:
-        return Status::NotFound("unknown compression type({})", parquet_codec);
+        return Status::InternalError("unknown compression type({})", parquet_codec);
     }
 
     return Status::OK();


### PR DESCRIPTION
## Proposed changes

When load unsupport compression code, the result is:
![image](https://github.com/apache/doris/assets/77738092/e8e3c146-28af-4337-b36d-dd4d9b71b9e6)
But it is uncorrect, it should fail.
Expect result: 
![image](https://github.com/apache/doris/assets/77738092/719d52bc-ada6-4199-9960-86f36849974a)


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

