### PR TITLE
[improvement](s3) increase the connection num of s3 client

### DIFF
--- a/be/src/util/s3_util.cpp
+++ b/be/src/util/s3_util.cpp
@@ -145,7 +145,10 @@ std::shared_ptr<Aws::S3::S3Client> S3ClientFactory::create(const S3Conf& s3_conf
     aws_config.region = s3_conf.region;
     if (s3_conf.max_connections > 0) {
         aws_config.maxConnections = s3_conf.max_connections;
+    } else {
+        aws_config.maxConnections = config::doris_remote_scanner_thread_pool_thread_num;
     }
+    
     if (s3_conf.request_timeout_ms > 0) {
         aws_config.requestTimeoutMs = s3_conf.request_timeout_ms;
     }

--- a/be/src/util/s3_util.cpp
+++ b/be/src/util/s3_util.cpp
@@ -148,7 +148,7 @@ std::shared_ptr<Aws::S3::S3Client> S3ClientFactory::create(const S3Conf& s3_conf
     } else {
         aws_config.maxConnections = config::doris_remote_scanner_thread_pool_thread_num;
     }
-    
+
     if (s3_conf.request_timeout_ms > 0) {
         aws_config.requestTimeoutMs = s3_conf.request_timeout_ms;
     }


### PR DESCRIPTION
## Proposed changes

The default maxConnection of s3 client is 25.
It should be increased to improve the query performance.

In my test, a tpch 300 benchmark with data stored on object storage, the total time
can reduce from 430s -> 330s

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

