### PR TITLE
[Fix](executor)fix incorrect status transfer

### DIFF
--- a/be/src/pipeline/task_scheduler.cpp
+++ b/be/src/pipeline/task_scheduler.cpp
@@ -115,8 +115,7 @@ void BlockedTaskScheduler::_schedule() {
                     VLOG_DEBUG << "Task pending" << task->debug_string();
                     iter++;
                 } else {
-                    _make_task_run(local_blocked_tasks, iter, ready_tasks,
-                                   PipelineTaskState::PENDING_FINISH);
+                    _make_task_run(local_blocked_tasks, iter, ready_tasks);
                 }
             } else if (task->fragment_context()->is_canceled()) {
                 if (task->is_pending_finish()) {


### PR DESCRIPTION
## Proposed changes

When a task status=PENDING_FINISH, and its  status changed from ```is_pending_finish =true``` changed to ```is_pending_finish =false```, it should be changed to runable and finish the task.
But currently even a task' status changed to ``` is_pending_finish=false```, it's still marked pending finish.
Then the task can never go into acitve task queue.
