### PR TITLE
[Feature](Compaction)configurable compaction_policy 

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -980,13 +980,6 @@ DEFINE_Int32(num_broadcast_buffer, "32");
 // semi-structure configs
 DEFINE_Bool(enable_parse_multi_dimession_array, "false");
 
-// Currently, two compaction strategies are implemented, SIZE_BASED and TIME_SERIES.
-// In the case of time series compaction, the execution of compaction is adjusted
-// using parameters that have the prefix time_series_compaction.
-DEFINE_mString(compaction_policy, "size_based");
-DEFINE_Validator(compaction_policy, [](const std::string config) -> bool {
-    return config == "size_based" || config == "time_series";
-});
 // the size of input files for each compaction
 DEFINE_mInt64(time_series_compaction_goal_size_mbytes, "512");
 // the minimum number of input files for each compaction if time_series_compaction_goal_size_mbytes not meets

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1003,10 +1003,6 @@ DECLARE_Int32(num_broadcast_buffer);
 // semi-structure configs
 DECLARE_Bool(enable_parse_multi_dimession_array);
 
-// Currently, two compaction strategies are implemented, SIZE_BASED and TIME_SERIES.
-// In the case of time series compaction, the execution of compaction is adjusted
-// using parameters that have the prefix time_series_compaction.
-DECLARE_mString(compaction_policy);
 // the size of input files for each compaction
 DECLARE_mInt64(time_series_compaction_goal_size_mbytes);
 // the minimum number of input files for each compaction if time_series_compaction_goal_size_mbytes not meets

--- a/be/src/http/action/compaction_action.cpp
+++ b/be/src/http/action/compaction_action.cpp
@@ -197,11 +197,6 @@ Status CompactionAction::_execute_compaction_callback(TabletSharedPtr tablet,
     MonotonicStopWatch timer;
     timer.start();
 
-    std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy =
-            CumulativeCompactionPolicyFactory::create_cumulative_compaction_policy();
-    if (tablet->get_cumulative_compaction_policy() == nullptr) {
-        tablet->set_cumulative_compaction_policy(cumulative_compaction_policy);
-    }
     Status res = Status::OK();
     if (compaction_type == PARAM_COMPACTION_BASE) {
         BaseCompaction base_compaction(tablet);

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -148,7 +148,7 @@ int64_t Compaction::get_avg_segment_rows() {
     // input_rowsets_size is total disk_size of input_rowset, this size is the
     // final size after codec and compress, so expect dest segment file size
     // in disk is config::vertical_compaction_max_segment_size
-    if (config::compaction_policy == CUMULATIVE_TIME_SERIES_POLICY) {
+    if (_tablet->tablet_meta()->cumulative_compaction_policy() == CompactionPolicyPB::TIME_SERIES) {
         return (config::time_series_compaction_goal_size_mbytes * 1024 * 1024 * 2) /
                (_input_rowsets_size / (_input_row_num + 1) + 1);
     }

--- a/be/src/olap/cumulative_compaction_policy.cpp
+++ b/be/src/olap/cumulative_compaction_policy.cpp
@@ -343,13 +343,4 @@ int64_t SizeBasedCumulativeCompactionPolicy::_level_size(const int64_t size) {
     if (size >= max_level) return max_level;
     return (int64_t)1 << (sizeof(size) * 8 - 1 - __builtin_clzl(size));
 }
-
-std::shared_ptr<CumulativeCompactionPolicy>
-CumulativeCompactionPolicyFactory::create_cumulative_compaction_policy() {
-    if (config::compaction_policy == CUMULATIVE_TIME_SERIES_POLICY) {
-        return std::make_shared<TimeSeriesCumulativeCompactionPolicy>();
-    }
-    return std::make_shared<SizeBasedCumulativeCompactionPolicy>();
-}
-
 } // namespace doris

--- a/be/src/olap/cumulative_compaction_policy.h
+++ b/be/src/olap/cumulative_compaction_policy.h
@@ -170,13 +170,4 @@ private:
     /// lower bound size to do compaction compaction.
     int64_t _compaction_min_size;
 };
-
-/// The factory of CumulativeCompactionPolicy, it can product different policy according to the `policy` parameter.
-class CumulativeCompactionPolicyFactory {
-public:
-    /// Static factory function. It can product different policy according to the `policy` parameter and use tablet ptr
-    /// to construct the policy. Now it can product size based and num based policies.
-    static std::shared_ptr<CumulativeCompactionPolicy> create_cumulative_compaction_policy();
-};
-
 } // namespace doris

--- a/be/src/olap/cumulative_compaction_policy.h
+++ b/be/src/olap/cumulative_compaction_policy.h
@@ -46,10 +46,10 @@ public:
     /// Constructor function of CumulativeCompactionPolicy,
     /// it needs tablet pointer to access tablet method.
     /// param tablet, the shared pointer of tablet
-    CumulativeCompactionPolicy() {}
+    CumulativeCompactionPolicy() = default;
 
     /// Destructor function of CumulativeCompactionPolicy.
-    virtual ~CumulativeCompactionPolicy() {}
+    virtual ~CumulativeCompactionPolicy() = default;
 
     /// Calculate the cumulative compaction score of the tablet. This function uses rowsets meta and current
     /// cumulative point to calculative the score of tablet. The score depends on the concrete algorithm of policy.

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -302,8 +302,6 @@ private:
     std::vector<TabletSharedPtr> _generate_compaction_tasks(CompactionType compaction_type,
                                                             std::vector<DataDir*>& data_dirs,
                                                             bool check_score);
-    void _update_cumulative_compaction_policy();
-
     bool _push_tablet_into_submitted_compaction(TabletSharedPtr tablet,
                                                 CompactionType compaction_type);
     void _pop_tablet_from_submitted_compaction(TabletSharedPtr tablet,
@@ -460,8 +458,6 @@ private:
     std::condition_variable _compaction_producer_sleep_cv;
 
     std::shared_ptr<StreamLoadRecorder> _stream_load_recorder;
-
-    std::shared_ptr<CumulativeCompactionPolicy> _cumulative_compaction_policy;
 
     scoped_refptr<Thread> _cooldown_tasks_producer_thread;
     scoped_refptr<Thread> _remove_unused_remote_files_thread;

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -238,8 +238,7 @@ TabletSharedPtr Tablet::create_tablet_from_meta(TabletMetaSharedPtr tablet_meta,
     return std::make_shared<Tablet>(tablet_meta, data_dir);
 }
 
-Tablet::Tablet(TabletMetaSharedPtr tablet_meta, DataDir* data_dir,
-               const std::string_view& cumulative_compaction_type)
+Tablet::Tablet(TabletMetaSharedPtr tablet_meta, DataDir* data_dir)
         : BaseTablet(tablet_meta, data_dir),
           _is_bad(false),
           _last_cumu_compaction_failure_millis(0),
@@ -251,7 +250,6 @@ Tablet::Tablet(TabletMetaSharedPtr tablet_meta, DataDir* data_dir,
           _cumulative_point(K_INVALID_CUMULATIVE_POINT),
           _newly_created_rowset_num(0),
           _last_checkpoint_time(0),
-          _cumulative_compaction_type(cumulative_compaction_type),
           _is_clone_occurred(false),
           _is_tablet_path_exists(true),
           _last_missed_version(-1),

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <butil/macros.h>
+#include <gen_cpp/olap_file.pb.h>
 #include <glog/logging.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -209,9 +210,7 @@ public:
 
     // operation for compaction
     bool can_do_compaction(size_t path_hash, CompactionType compaction_type);
-    uint32_t calc_compaction_score(
-            CompactionType compaction_type,
-            std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy);
+    uint32_t calc_compaction_score(CompactionType compaction_type);
 
     // operation for clone
     void calc_missed_versions(int64_t spec_version, std::vector<Version>* missed_versions);
@@ -314,15 +313,6 @@ public:
 
     void set_clone_occurred(bool clone_occurred) { _is_clone_occurred = clone_occurred; }
     bool get_clone_occurred() { return _is_clone_occurred; }
-
-    void set_cumulative_compaction_policy(
-            std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy) {
-        _cumulative_compaction_policy = cumulative_compaction_policy;
-    }
-
-    std::shared_ptr<CumulativeCompactionPolicy> get_cumulative_compaction_policy() {
-        return _cumulative_compaction_policy;
-    }
 
     inline bool all_beta() const {
         std::shared_lock rdlock(_meta_lock);
@@ -561,8 +551,7 @@ private:
     Status _capture_consistent_rowsets_unlocked(const std::vector<Version>& version_path,
                                                 std::vector<RowsetSharedPtr>* rowsets) const;
 
-    uint32_t _calc_cumulative_compaction_score(
-            std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy);
+    uint32_t _calc_cumulative_compaction_score();
     uint32_t _calc_base_compaction_score() const;
 
     // When the proportion of empty edges in the adjacency matrix used to represent the version graph
@@ -645,7 +634,7 @@ private:
     std::atomic<int64_t> _last_checkpoint_time;
 
     // cumulative compaction policy
-    std::shared_ptr<CumulativeCompactionPolicy> _cumulative_compaction_policy;
+    std::unique_ptr<CumulativeCompactionPolicy> _cumulative_compaction_policy;
     std::string_view _cumulative_compaction_type;
 
     std::shared_ptr<CumulativeCompaction> _cumulative_compaction;

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -45,6 +45,7 @@
 #include "olap/binlog_config.h"
 #include "olap/data_dir.h"
 #include "olap/olap_common.h"
+#include "olap/cumulative_compaction_policy.h"
 #include "olap/rowset/rowset.h"
 #include "olap/rowset/rowset_meta.h"
 #include "olap/rowset/rowset_reader.h"
@@ -60,7 +61,6 @@
 namespace doris {
 
 class Tablet;
-class CumulativeCompactionPolicy;
 class CumulativeCompaction;
 class BaseCompaction;
 class SingleReplicaCompaction;
@@ -94,8 +94,7 @@ public:
     static TabletSharedPtr create_tablet_from_meta(TabletMetaSharedPtr tablet_meta,
                                                    DataDir* data_dir = nullptr);
 
-    Tablet(TabletMetaSharedPtr tablet_meta, DataDir* data_dir,
-           const std::string_view& cumulative_compaction_type = "");
+    Tablet(TabletMetaSharedPtr tablet_meta, DataDir* data_dir);
 
     Status init();
     bool init_succeeded();
@@ -635,7 +634,6 @@ private:
 
     // cumulative compaction policy
     std::unique_ptr<CumulativeCompactionPolicy> _cumulative_compaction_policy;
-    std::string_view _cumulative_compaction_type;
 
     std::shared_ptr<CumulativeCompaction> _cumulative_compaction;
     std::shared_ptr<BaseCompaction> _base_compaction;

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -668,8 +668,7 @@ void TabletManager::get_tablet_stat(TTabletStatResult* result) {
 
 TabletSharedPtr TabletManager::find_best_tablet_to_compaction(
         CompactionType compaction_type, DataDir* data_dir,
-        const std::unordered_set<TTabletId>& tablet_submitted_compaction, uint32_t* score,
-        std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy) {
+        const std::unordered_set<TTabletId>& tablet_submitted_compaction, uint32_t* score) {
     int64_t now_ms = UnixMillis();
     const string& compaction_type_str =
             compaction_type == CompactionType::BASE_COMPACTION ? "base" : "cumulative";
@@ -721,8 +720,7 @@ TabletSharedPtr TabletManager::find_best_tablet_to_compaction(
                 }
             }
 
-            uint32_t current_compaction_score = tablet_ptr->calc_compaction_score(
-                    compaction_type, cumulative_compaction_policy);
+            uint32_t current_compaction_score = tablet_ptr->calc_compaction_score(compaction_type);
             if (current_compaction_score < 5) {
                 tablet_ptr->set_skip_compaction(true, compaction_type, UnixSeconds());
             }

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -76,8 +76,7 @@ public:
 
     TabletSharedPtr find_best_tablet_to_compaction(
             CompactionType compaction_type, DataDir* data_dir,
-            const std::unordered_set<TTabletId>& tablet_submitted_compaction, uint32_t* score,
-            std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy);
+            const std::unordered_set<TTabletId>& tablet_submitted_compaction, uint32_t* score);
 
     TabletSharedPtr get_tablet(TTabletId tablet_id, bool include_deleted = false,
                                std::string* err = nullptr);

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -106,7 +106,8 @@ public:
                TabletUid tablet_uid, TTabletType::type tabletType,
                TCompressionType::type compression_type, int64_t storage_policy_id = 0,
                bool enable_unique_key_merge_on_write = false,
-               std::optional<TBinlogConfig> binlog_config = {});
+               std::optional<TBinlogConfig> binlog_config = {},
+               TCompactionPolicy::type compaction_policy = TCompactionPolicy::type::SIZE_BASED);
     // If need add a filed in TableMeta, filed init copy in copy construct function
     TabletMeta(const TabletMeta& tablet_meta);
     TabletMeta(TabletMeta&& tablet_meta) = delete;
@@ -228,6 +229,7 @@ public:
         _binlog_config = std::move(binlog_config);
     }
 
+    CompactionPolicyPB cumulative_compaction_policy() { return _compaction_policy; }
 private:
     Status _save_meta(DataDir* data_dir);
 
@@ -273,6 +275,8 @@ private:
 
     // binlog config
     BinlogConfig _binlog_config {};
+
+    CompactionPolicyPB _compaction_policy = CompactionPolicyPB::SIZE_BASED;
 
     mutable std::shared_mutex _meta_lock;
 };

--- a/be/test/olap/cumulative_compaction_policy_test.cpp
+++ b/be/test/olap/cumulative_compaction_policy_test.cpp
@@ -335,14 +335,11 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, calc_cumulative_compaction_score
         _tablet_meta->add_rs_meta(rowset);
     }
 
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
     _tablet->calculate_cumulative_point();
 
-    std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy =
-            CumulativeCompactionPolicyFactory::create_cumulative_compaction_policy();
-    const uint32_t score = _tablet->calc_compaction_score(CompactionType::CUMULATIVE_COMPACTION,
-                                                          cumulative_compaction_policy);
+    const uint32_t score = _tablet->calc_compaction_score(CompactionType::CUMULATIVE_COMPACTION);
 
     EXPECT_EQ(15, score);
 }
@@ -355,13 +352,10 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, calc_cumulative_compaction_score
         _tablet_meta->add_rs_meta(rowset);
     }
 
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
     _tablet->calculate_cumulative_point();
-    std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy =
-            CumulativeCompactionPolicyFactory::create_cumulative_compaction_policy();
-    const uint32_t score = _tablet->calc_compaction_score(CompactionType::CUMULATIVE_COMPACTION,
-                                                          cumulative_compaction_policy);
+    const uint32_t score = _tablet->calc_compaction_score(CompactionType::CUMULATIVE_COMPACTION);
 
     EXPECT_EQ(7, score);
 }
@@ -374,7 +368,7 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, calculate_cumulative_point_big_b
         _tablet_meta->add_rs_meta(rowset);
     }
 
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
     _tablet->calculate_cumulative_point();
 
@@ -389,7 +383,7 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, calculate_cumulative_point_overl
         _tablet_meta->add_rs_meta(rowset);
     }
 
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
     _tablet->calculate_cumulative_point();
 
@@ -404,7 +398,7 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, pick_candidate_rowsets) {
         _tablet_meta->add_rs_meta(rowset);
     }
 
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
     _tablet->calculate_cumulative_point();
 
@@ -420,7 +414,7 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, pick_candidate_rowsets_big_base)
         _tablet_meta->add_rs_meta(rowset);
     }
 
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
     _tablet->calculate_cumulative_point();
 
@@ -436,7 +430,7 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, pick_input_rowsets_normal) {
         _tablet_meta->add_rs_meta(rowset);
     }
 
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
     _tablet->calculate_cumulative_point();
 
@@ -463,7 +457,7 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, pick_input_rowsets_big_base) {
         _tablet_meta->add_rs_meta(rowset);
     }
 
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
     _tablet->calculate_cumulative_point();
 
@@ -490,7 +484,7 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, pick_input_rowsets_promotion) {
         _tablet_meta->add_rs_meta(rowset);
     }
 
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
     _tablet->calculate_cumulative_point();
 
@@ -517,7 +511,7 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, pick_input_rowsets_not_same_leve
         _tablet_meta->add_rs_meta(rowset);
     }
 
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
     _tablet->calculate_cumulative_point();
 
@@ -544,7 +538,7 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, pick_input_rowsets_empty) {
         _tablet_meta->add_rs_meta(rowset);
     }
 
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
     _tablet->calculate_cumulative_point();
 
@@ -571,7 +565,7 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, pick_input_rowsets_not_reach_min
         _tablet_meta->add_rs_meta(rowset);
     }
 
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
     _tablet->calculate_cumulative_point();
 
@@ -598,7 +592,7 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, pick_input_rowsets_delete) {
         _tablet_meta->add_rs_meta(rowset);
     }
 
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
     _tablet->calculate_cumulative_point();
 
@@ -626,7 +620,7 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, _calc_promotion_size_big) {
         _tablet_meta->add_rs_meta(rowset);
     }
 
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
     _tablet->calculate_cumulative_point();
 
@@ -641,7 +635,7 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, _calc_promotion_size_small) {
         _tablet_meta->add_rs_meta(rowset);
     }
 
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
     _tablet->calculate_cumulative_point();
 
@@ -656,7 +650,7 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, _level_size) {
         _tablet_meta->add_rs_meta(rowset);
     }
     config::compaction_promotion_size_mbytes = 1024;
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
 
     SizeBasedCumulativeCompactionPolicy* policy =
@@ -677,7 +671,7 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, _pick_missing_version_cumulative
         _tablet_meta->add_rs_meta(rowset);
     }
 
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
 
     // has miss version

--- a/be/test/olap/cumulative_compaction_time_series_policy_test.cpp
+++ b/be/test/olap/cumulative_compaction_time_series_policy_test.cpp
@@ -37,14 +37,14 @@ class TestTimeSeriesCumulativeCompactionPolicy : public testing::Test {
 public:
     TestTimeSeriesCumulativeCompactionPolicy() {}
     void SetUp() {
-        config::compaction_policy = "time_series";
         config::time_series_compaction_goal_size_mbytes = 1024;
         config::time_series_compaction_file_count_threshold = 10;
         config::time_series_compaction_time_threshold_seconds = 3600;
 
-        _tablet_meta = static_cast<TabletMetaSharedPtr>(new TabletMeta(
-                1, 2, 15673, 15674, 4, 5, TTabletSchema(), 6, {{7, 8}}, UniqueId(9, 10),
-                TTabletType::TABLET_TYPE_DISK, TCompressionType::LZ4F));
+        _tablet_meta = static_cast<TabletMetaSharedPtr>(
+                new TabletMeta(1, 2, 15673, 15674, 4, 5, TTabletSchema(), 6, {{7, 8}},
+                               UniqueId(9, 10), TTabletType::TABLET_TYPE_DISK,
+                               TCompressionType::LZ4F, TCompactionPolicy::type::TIME_SERIES));
 
         _json_rowset_meta = R"({
             "rowset_id": 540081,

--- a/be/test/olap/cumulative_compaction_time_series_policy_test.cpp
+++ b/be/test/olap/cumulative_compaction_time_series_policy_test.cpp
@@ -41,10 +41,10 @@ public:
         config::time_series_compaction_file_count_threshold = 10;
         config::time_series_compaction_time_threshold_seconds = 3600;
 
-        _tablet_meta = static_cast<TabletMetaSharedPtr>(
-                new TabletMeta(1, 2, 15673, 15674, 4, 5, TTabletSchema(), 6, {{7, 8}},
-                               UniqueId(9, 10), TTabletType::TABLET_TYPE_DISK,
-                               TCompressionType::LZ4F, TCompactionPolicy::type::TIME_SERIES));
+        _tablet_meta = static_cast<TabletMetaSharedPtr>(new TabletMeta(
+                1, 2, 15673, 15674, 4, 5, TTabletSchema(), 6, {{7, 8}}, UniqueId(9, 10),
+                TTabletType::TABLET_TYPE_DISK, TCompressionType::LZ4F, 0, false, {},
+                TCompactionPolicy::TIME_SERIES));
 
         _json_rowset_meta = R"({
             "rowset_id": 540081,

--- a/be/test/olap/cumulative_compaction_time_series_policy_test.cpp
+++ b/be/test/olap/cumulative_compaction_time_series_policy_test.cpp
@@ -301,7 +301,7 @@ TEST_F(TestTimeSeriesCumulativeCompactionPolicy, calculate_cumulative_point_over
         _tablet_meta->add_rs_meta(rowset);
     }
 
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_TIME_SERIES_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
     _tablet->calculate_cumulative_point();
 
@@ -316,7 +316,7 @@ TEST_F(TestTimeSeriesCumulativeCompactionPolicy, calculate_cumulative_point_big_
         _tablet_meta->add_rs_meta(rowset);
     }
 
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_TIME_SERIES_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
     _tablet->calculate_cumulative_point();
 
@@ -331,14 +331,11 @@ TEST_F(TestTimeSeriesCumulativeCompactionPolicy, calc_cumulative_compaction_scor
         _tablet_meta->add_rs_meta(rowset);
     }
 
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_TIME_SERIES_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
     _tablet->calculate_cumulative_point();
 
-    std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy =
-            CumulativeCompactionPolicyFactory::create_cumulative_compaction_policy();
-    const uint32_t score = _tablet->calc_compaction_score(CompactionType::CUMULATIVE_COMPACTION,
-                                                          cumulative_compaction_policy);
+    const uint32_t score = _tablet->calc_compaction_score(CompactionType::CUMULATIVE_COMPACTION);
 
     EXPECT_EQ(0, score);
 }
@@ -351,13 +348,10 @@ TEST_F(TestTimeSeriesCumulativeCompactionPolicy, calc_cumulative_compaction_scor
         _tablet_meta->add_rs_meta(rowset);
     }
 
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_TIME_SERIES_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
     _tablet->calculate_cumulative_point();
-    std::shared_ptr<CumulativeCompactionPolicy> cumulative_compaction_policy =
-            CumulativeCompactionPolicyFactory::create_cumulative_compaction_policy();
-    const uint32_t score = _tablet->calc_compaction_score(CompactionType::CUMULATIVE_COMPACTION,
-                                                          cumulative_compaction_policy);
+    const uint32_t score = _tablet->calc_compaction_score(CompactionType::CUMULATIVE_COMPACTION);
 
     EXPECT_EQ(5, score);
 }
@@ -370,7 +364,7 @@ TEST_F(TestTimeSeriesCumulativeCompactionPolicy, pick_candidate_rowsets) {
         _tablet_meta->add_rs_meta(rowset);
     }
 
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_TIME_SERIES_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
     _tablet->calculate_cumulative_point();
 
@@ -386,7 +380,7 @@ TEST_F(TestTimeSeriesCumulativeCompactionPolicy, pick_candidate_rowsets_big_rows
         _tablet_meta->add_rs_meta(rowset);
     }
 
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_TIME_SERIES_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
     _tablet->calculate_cumulative_point();
 
@@ -402,7 +396,7 @@ TEST_F(TestTimeSeriesCumulativeCompactionPolicy, pick_input_rowsets_goal_size) {
         _tablet_meta->add_rs_meta(rowset);
     }
 
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_TIME_SERIES_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
     _tablet->calculate_cumulative_point();
 
@@ -429,7 +423,7 @@ TEST_F(TestTimeSeriesCumulativeCompactionPolicy, pick_input_rowsets_file_count) 
         _tablet_meta->add_rs_meta(rowset);
     }
 
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_TIME_SERIES_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
     _tablet->calculate_cumulative_point();
 
@@ -456,7 +450,7 @@ TEST_F(TestTimeSeriesCumulativeCompactionPolicy, pick_input_rowsets_time_interva
         _tablet_meta->add_rs_meta(rowset);
     }
 
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_TIME_SERIES_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
     _tablet->calculate_cumulative_point();
     int64_t now = UnixMillis();
@@ -485,7 +479,7 @@ TEST_F(TestTimeSeriesCumulativeCompactionPolicy, pick_input_rowsets_empty) {
         _tablet_meta->add_rs_meta(rowset);
     }
 
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_TIME_SERIES_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
     _tablet->calculate_cumulative_point();
     int64_t now = UnixMillis();
@@ -514,7 +508,7 @@ TEST_F(TestTimeSeriesCumulativeCompactionPolicy, pick_input_rowsets_delete) {
         _tablet_meta->add_rs_meta(rowset);
     }
 
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_TIME_SERIES_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
     _tablet->calculate_cumulative_point();
 
@@ -542,7 +536,7 @@ TEST_F(TestTimeSeriesCumulativeCompactionPolicy, _pick_missing_version_cumulativ
         _tablet_meta->add_rs_meta(rowset);
     }
 
-    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr, CUMULATIVE_TIME_SERIES_POLICY));
+    TabletSharedPtr _tablet(new Tablet(_tablet_meta, nullptr));
     _tablet->init();
 
     // has miss version

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
@@ -279,6 +279,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                                 tbl.isInMemory(),
                                 tabletType,
                                 null,
+                                tbl.getCompactionPolicy(),
                                 tbl.getCompressionType(),
                                 tbl.getEnableUniqueKeyMergeOnWrite(), tbl.getStoragePolicy(),
                                 tbl.disableAutoCompaction(),

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
@@ -274,6 +274,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                                     tbl.isInMemory(),
                                     tbl.getPartitionInfo().getTabletType(partitionId),
                                     null,
+                                    tbl.getCompactionPolicy(),
                                     tbl.getCompressionType(),
                                     tbl.getEnableUniqueKeyMergeOnWrite(), tbl.getStoragePolicy(),
                                     tbl.disableAutoCompaction(),

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -1027,6 +1027,7 @@ public class RestoreJob extends AbstractJob {
                             localTbl.isInMemory(),
                             localTbl.getPartitionInfo().getTabletType(restorePart.getId()),
                             null,
+                            localTbl.getCompactionPolicy(),
                             localTbl.getCompressionType(),
                             localTbl.getEnableUniqueKeyMergeOnWrite(), localTbl.getStoragePolicy(),
                             localTbl.disableAutoCompaction(),

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -57,6 +57,7 @@ import org.apache.doris.statistics.MVAnalysisTask;
 import org.apache.doris.statistics.OlapAnalysisTask;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
+import org.apache.doris.thrift.TCompactionPolicy;
 import org.apache.doris.thrift.TCompressionType;
 import org.apache.doris.thrift.TOlapTable;
 import org.apache.doris.thrift.TSortType;
@@ -1993,6 +1994,12 @@ public class OlapTable extends Table {
         return !tempPartitions.isEmpty();
     }
 
+    public void setCompactionPolicy(TCompactionPolicy compactionPolicy) {
+        TableProperty tableProperty = getOrCreatTableProperty();
+        tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_COMPACTION_POLICY, compactionPolicy.name());
+        tableProperty.buildCompactionPolicy();
+    }
+
     public void setCompressionType(TCompressionType compressionType) {
         TableProperty tableProperty = getOrCreatTableProperty();
         tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_COMPRESSION, compressionType.name());
@@ -2010,6 +2017,13 @@ public class OlapTable extends Table {
             return TStorageFormat.DEFAULT;
         }
         return tableProperty.getStorageFormat();
+    }
+
+    public TCompactionPolicy getCompactionPolicy() {
+        if (tableProperty == null) {
+            return TCompactionPolicy.SIZE_BASED;
+        }
+        return tableProperty.getCompactionPolicy();
     }
 
     public TCompressionType getCompressionType() {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
@@ -25,6 +25,7 @@ import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.PropertyAnalyzer;
 import org.apache.doris.persist.OperationType;
 import org.apache.doris.persist.gson.GsonUtils;
+import org.apache.doris.thrift.TCompactionPolicy;
 import org.apache.doris.thrift.TCompressionType;
 import org.apache.doris.thrift.TStorageFormat;
 
@@ -75,6 +76,8 @@ public class TableProperty implements Writable {
     private TStorageFormat storageFormat = TStorageFormat.DEFAULT;
 
     private TCompressionType compressionType = TCompressionType.LZ4F;
+
+    private TCompactionPolicy compactionPolicy = TCompactionPolicy.SIZE_BASED;
 
     private boolean enableLightSchemaChange = false;
 
@@ -292,6 +295,13 @@ public class TableProperty implements Writable {
         return this;
     }
 
+    public TableProperty buildCompactionPolicy() {
+        compactionPolicy = TCompactionPolicy
+                .valueOf(properties.getOrDefault(PropertyAnalyzer.PROPERTIES_COMPACTION_POLICY,
+                        TCompactionPolicy.SIZE_BASED.name()));
+        return this;
+    }
+
     public TableProperty buildCompressionType() {
         compressionType = TCompressionType.valueOf(properties.getOrDefault(PropertyAnalyzer.PROPERTIES_COMPRESSION,
                 TCompressionType.LZ4F.name()));
@@ -373,6 +383,10 @@ public class TableProperty implements Writable {
 
     public DataSortInfo getDataSortInfo() {
         return dataSortInfo;
+    }
+
+    public TCompactionPolicy getCompactionPolicy() {
+        return compactionPolicy;
     }
 
     public TCompressionType getCompressionType() {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -35,6 +35,7 @@ import org.apache.doris.datasource.CatalogMgr;
 import org.apache.doris.policy.Policy;
 import org.apache.doris.policy.StoragePolicy;
 import org.apache.doris.resource.Tag;
+import org.apache.doris.thrift.TCompactionPolicy;
 import org.apache.doris.thrift.TCompressionType;
 import org.apache.doris.thrift.TSortType;
 import org.apache.doris.thrift.TStorageFormat;
@@ -78,6 +79,7 @@ public class PropertyAnalyzer {
     public static final String PROPERTIES_COLOCATE_WITH = "colocate_with";
 
     public static final String PROPERTIES_TIMEOUT = "timeout";
+    public static final String PROPERTIES_COMPACTION_POLICY = "compaction_policy";
     public static final String PROPERTIES_COMPRESSION = "compression";
 
     public static final String PROPERTIES_ENABLE_LIGHT_SCHEMA_CHANGE = "light_schema_change";
@@ -593,6 +595,22 @@ public class PropertyAnalyzer {
         }
         throw new AnalysisException(PROPERTIES_SKIP_WRITE_INDEX_ON_LOAD
                 + " must be `true` or `false`");
+    }
+
+    public static TCompactionPolicy analyzeCompactionPolicy(Map<String, String> properties) throws AnalysisException {
+        String compactionPolicy = "";
+        if (properties != null && properties.containsKey(PROPERTIES_COMPACTION_POLICY)) {
+            compactionPolicy = properties.get(PROPERTIES_COMPACTION_POLICY);
+            properties.remove(PROPERTIES_COMPACTION_POLICY);
+        } else {
+            return TCompactionPolicy.SIZE_BASED;
+        }
+
+        if (compactionPolicy.equalsIgnoreCase("TIME_SERIES")) {
+            return TCompactionPolicy.TIME_SERIES;
+        } else {
+            return TCompactionPolicy.SIZE_BASED;
+        }
     }
 
     // analyzeCompressionType will parse the compression type from properties

--- a/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
@@ -805,6 +805,7 @@ public class ReportHandler extends Daemon {
                                             olapTable.isInMemory(),
                                             olapTable.getPartitionInfo().getTabletType(partitionId),
                                             null,
+                                            olapTable.getCompactionPolicy(),
                                             olapTable.getCompressionType(),
                                             olapTable.getEnableUniqueKeyMergeOnWrite(), olapTable.getStoragePolicy(),
                                             olapTable.disableAutoCompaction(),

--- a/fe/fe-core/src/main/java/org/apache/doris/task/CreateReplicaTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/CreateReplicaTask.java
@@ -29,6 +29,7 @@ import org.apache.doris.common.Status;
 import org.apache.doris.policy.Policy;
 import org.apache.doris.policy.PolicyTypeEnum;
 import org.apache.doris.thrift.TColumn;
+import org.apache.doris.thrift.TCompactionPolicy;
 import org.apache.doris.thrift.TCompressionType;
 import org.apache.doris.thrift.TCreateTabletReq;
 import org.apache.doris.thrift.TOlapTableIndex;
@@ -62,6 +63,7 @@ public class CreateReplicaTask extends AgentTask {
     private TStorageType storageType;
     private TStorageMedium storageMedium;
     private TCompressionType compressionType;
+    private TCompactionPolicy compactionPolicy;
 
     private List<Column> columns;
 
@@ -118,6 +120,7 @@ public class CreateReplicaTask extends AgentTask {
                              boolean isInMemory,
                              TTabletType tabletType,
                              DataSortInfo dataSortInfo,
+                             TCompactionPolicy compactionPolicy,
                              TCompressionType compressionType,
                              boolean enableUniqueKeyMergeOnWrite,
                              String storagePolicy, boolean disableAutoCompaction,
@@ -137,6 +140,7 @@ public class CreateReplicaTask extends AgentTask {
         this.keysType = keysType;
         this.storageType = storageType;
         this.storageMedium = storageMedium;
+        this.compactionPolicy = compactionPolicy;
         this.compressionType = compressionType;
 
         this.columns = columns;
@@ -298,6 +302,7 @@ public class CreateReplicaTask extends AgentTask {
         }
 
         createTabletReq.setTabletType(tabletType);
+        createTabletReq.setCompactionPolicy(compactionPolicy);
         createTabletReq.setCompressionType(compressionType);
         createTabletReq.setEnableUniqueKeyMergeOnWrite(enableUniqueKeyMergeOnWrite);
 

--- a/fe/fe-core/src/test/java/org/apache/doris/task/AgentTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/task/AgentTaskTest.java
@@ -28,6 +28,7 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.MarkedCountDownLatch;
 import org.apache.doris.thrift.TAgentTaskRequest;
 import org.apache.doris.thrift.TBackend;
+import org.apache.doris.thrift.TCompactionPolicy;
 import org.apache.doris.thrift.TCompressionType;
 import org.apache.doris.thrift.TStorageMedium;
 import org.apache.doris.thrift.TStorageType;
@@ -107,7 +108,7 @@ public class AgentTaskTest {
         createReplicaTask = new CreateReplicaTask(backendId1, dbId, tableId, partitionId,
                 indexId1, tabletId1, replicaId1, shortKeyNum, schemaHash1, version, KeysType.AGG_KEYS, storageType,
                 TStorageMedium.SSD, columns, null, 0, latch, null, false, TTabletType.TABLET_TYPE_DISK, null,
-                TCompressionType.LZ4F, false, "", false, false, false, false, false, null);
+                TCompactionPolicy.SIZE_BASED, TCompressionType.LZ4F, false, "", false, false, false, false, false, null);
 
         // drop
         dropTask = new DropReplicaTask(backendId1, tabletId1, replicaId1, schemaHash1, false);

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -276,6 +276,11 @@ message BinlogConfigPB {
     optional int64 max_history_nums = 4;
 }
 
+enum CompactionPolicyPB {
+    SIZE_BASED = 0;
+    TIME_SERIES = 1;
+}
+
 message TabletMetaPB {
     optional int64 table_id = 1;    // ?
     optional int64 partition_id = 2;    // ?
@@ -311,6 +316,7 @@ message TabletMetaPB {
     optional int64 storage_policy_id = 25;
     optional PUniqueId cooldown_meta_id = 26;
     optional BinlogConfigPB binlog_config = 27;
+    optional CompactionPolicyPB compaction_policy = 28;
 }
 
 message OLAPRawDeltaHeaderMessage {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -114,6 +114,11 @@ struct TBinlogConfig {
     4: optional i64 max_history_nums;
 }
 
+enum TCompactionPolicy {
+    SIZE_BASED = 0,
+    TIME_SERIES = 1
+}
+
 struct TCreateTabletReq {
     1: required Types.TTabletId tablet_id
     2: required TTabletSchema tablet_schema
@@ -141,6 +146,7 @@ struct TCreateTabletReq {
     19: optional bool enable_unique_key_merge_on_write = false
     20: optional i64 storage_policy_id
     21: optional TBinlogConfig binlog_config
+    22: optional TCompactionPolicy compaction_policy
 }
 
 struct TDropTabletReq {


### PR DESCRIPTION
## Proposed changes

configure `compaction_policy` at table level better than doris-cluser level。like this:

```sql
CREATE TABLE example_db.table_hash
(
    k1 DATE,
    k2 DECIMAL(10, 2) DEFAULT "10.5",
    k3 CHAR(10) COMMENT "string column",
    k4 INT NOT NULL DEFAULT "1" COMMENT "int column"
)
DUPLICATE KEY(k1, k2)
COMMENT "my first table"
PARTITION BY RANGE(k1)
(
    PARTITION p1 VALUES LESS THAN ("2020-02-01"),
    PARTITION p2 VALUES LESS THAN ("2020-03-01"),
    PARTITION p3 VALUES LESS THAN ("2020-04-01")
)
DISTRIBUTED BY HASH(k1) BUCKETS 32
PROPERTIES (
    "compaction_policy" = "TIME_SERIES"
);
```


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

