### PR TITLE
[fix](tablet clone) fix single replica load failed during migration

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Replica.java
@@ -129,9 +129,16 @@ public class Replica implements Writable {
     private long furtherRepairSetTime = -1;
     private static final long FURTHER_REPAIR_TIMEOUT_MS = 20 * 60 * 1000L; // 20min
 
-    // if this watermarkTxnId is set, which means before deleting a replica,
-    // we should ensure that all txns on this replicas are finished.
-    private long watermarkTxnId = -1;
+
+    /* Decommission a backend B has three steps:
+     * 1. wait peer backends catchup with B;
+     * 2. B change state to DECOMMISSION, set preWatermarkTxnId. B can load data now.
+     * 3. wait txn before preWatermarkTxnId finished, set postWatermarkTxnId. B can't load data now.
+     * 4. wait txn before postWatermarkTxnId finished, delete B.
+     *
+     */
+    private long preWatermarkTxnId = -1;
+    private long postWatermarkTxnId = -1;
 
     public Replica() {
     }
@@ -568,12 +575,20 @@ public class Replica implements Writable {
         }
     }
 
-    public void setWatermarkTxnId(long watermarkTxnId) {
-        this.watermarkTxnId = watermarkTxnId;
+    public void setPreWatermarkTxnId(long preWatermarkTxnId) {
+        this.preWatermarkTxnId = preWatermarkTxnId;
     }
 
-    public long getWatermarkTxnId() {
-        return watermarkTxnId;
+    public long getPreWatermarkTxnId() {
+        return preWatermarkTxnId;
+    }
+
+    public void setPostWatermarkTxnId(long postWatermarkTxnId) {
+        this.postWatermarkTxnId = postWatermarkTxnId;
+    }
+
+    public long getPostWatermarkTxnId() {
+        return postWatermarkTxnId;
     }
 
     public boolean isAlive() {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Replica.java
@@ -130,7 +130,7 @@ public class Replica implements Writable {
     private static final long FURTHER_REPAIR_TIMEOUT_MS = 20 * 60 * 1000L; // 20min
 
 
-    /* Decommission a backend B has three steps:
+    /* Decommission a backend B, steps are as follow:
      * 1. wait peer backends catchup with B;
      * 2. B change state to DECOMMISSION, set preWatermarkTxnId. B can load data now.
      * 3. wait txn before preWatermarkTxnId finished, set postWatermarkTxnId. B can't load data now.

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -1082,7 +1082,7 @@ public class TabletScheduler extends MasterDaemon {
          */
         if (!force && !Config.enable_force_drop_redundant_replica
                 && !FeConstants.runningUnitTest
-                && (!replica.getState().canLoad() || replica.getState() == ReplicaState.DECOMMISSION)) {
+                && (replica.getState().canLoad() || replica.getState() == ReplicaState.DECOMMISSION)) {
             if (replica.getState() != ReplicaState.DECOMMISSION) {
                 replica.setState(ReplicaState.DECOMMISSION);
                 // set priority to normal because it may wait for a long time.

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -1065,7 +1065,7 @@ public class TabletScheduler extends MasterDaemon {
         if (matchupReplicaCount <= 1) {
             LOG.info("can not delete only one replica, tabletId = {} replicaId = {}", tabletCtx.getTabletId(),
                      replica.getId());
-            throw new SchedException(Status.FINISHED, "the only one latest replia can not be dropped, tabletId = "
+            throw new SchedException(Status.UNRECOVERABLE, "the only one latest replia can not be dropped, tabletId = "
                                         + tabletCtx.getTabletId() + ", replicaId = " + replica.getId());
         }
 
@@ -1080,25 +1080,46 @@ public class TabletScheduler extends MasterDaemon {
          *      If all are finished, which means this replica is
          *      safe to be deleted.
          */
-        if (!force && !Config.enable_force_drop_redundant_replica && replica.getState().canLoad()
-                && replica.getWatermarkTxnId() == -1 && !FeConstants.runningUnitTest) {
-            long nextTxnId = Env.getCurrentGlobalTransactionMgr()
-                    .getTransactionIDGenerator().getNextTransactionId();
-            replica.setWatermarkTxnId(nextTxnId);
-            replica.setState(ReplicaState.DECOMMISSION);
-            // set priority to normal because it may wait for a long time. Remain it as VERY_HIGH may block other task.
-            tabletCtx.setPriority(Priority.NORMAL);
-            LOG.info("set replica {} on backend {} of tablet {} state to DECOMMISSION due to reason {}",
-                    replica.getId(), replica.getBackendId(), tabletCtx.getTabletId(), reason);
-            throw new SchedException(Status.SCHEDULE_FAILED, SubCode.WAITING_DECOMMISSION,
-                    "set watermark txn " + nextTxnId);
-        } else if (replica.getState() == ReplicaState.DECOMMISSION && replica.getWatermarkTxnId() != -1) {
-            long watermarkTxnId = replica.getWatermarkTxnId();
+        if (!force && !Config.enable_force_drop_redundant_replica
+                && !FeConstants.runningUnitTest
+                && (!replica.getState().canLoad() || replica.getState() == ReplicaState.DECOMMISSION)) {
+            if (replica.getState() != ReplicaState.DECOMMISSION) {
+                replica.setState(ReplicaState.DECOMMISSION);
+                // set priority to normal because it may wait for a long time.
+                // Remain it as VERY_HIGH may block other task.
+                tabletCtx.setPriority(Priority.NORMAL);
+                LOG.info("set replica {} on backend {} of tablet {} state to DECOMMISSION due to reason {}",
+                        replica.getId(), replica.getBackendId(), tabletCtx.getTabletId(), reason);
+            }
+
+            long preWatermarkTxnId = replica.getPreWatermarkTxnId();
+            if (preWatermarkTxnId == -1) {
+                preWatermarkTxnId = Env.getCurrentGlobalTransactionMgr()
+                        .getTransactionIDGenerator().getNextTransactionId();
+                replica.setPreWatermarkTxnId(preWatermarkTxnId);
+            }
+
+            long postWatermarkTxnId = replica.getPostWatermarkTxnId();
+            if (postWatermarkTxnId == -1) {
+                try {
+                    if (!Env.getCurrentGlobalTransactionMgr().isPreviousTransactionsFinished(preWatermarkTxnId,
+                            tabletCtx.getDbId(), tabletCtx.getTblId(), tabletCtx.getPartitionId())) {
+                        throw new SchedException(Status.SCHEDULE_FAILED, SubCode.WAITING_DECOMMISSION,
+                                "wait txn before pre watermark txn " + preWatermarkTxnId + " to be finished");
+                    }
+                } catch (AnalysisException e) {
+                    throw new SchedException(Status.UNRECOVERABLE, e.getMessage());
+                }
+                postWatermarkTxnId = Env.getCurrentGlobalTransactionMgr()
+                        .getTransactionIDGenerator().getNextTransactionId();
+                replica.setPostWatermarkTxnId(postWatermarkTxnId);
+            }
+
             try {
-                if (!Env.getCurrentGlobalTransactionMgr().isPreviousTransactionsFinished(watermarkTxnId,
-                        tabletCtx.getDbId(), Lists.newArrayList(tabletCtx.getTblId()))) {
+                if (!Env.getCurrentGlobalTransactionMgr().isPreviousTransactionsFinished(postWatermarkTxnId,
+                        tabletCtx.getDbId(), tabletCtx.getTblId(), tabletCtx.getPartitionId())) {
                     throw new SchedException(Status.SCHEDULE_FAILED, SubCode.WAITING_DECOMMISSION,
-                            "wait txn before " + watermarkTxnId + " to be finished");
+                            "wait txn before post watermark txn  " + postWatermarkTxnId + " to be finished");
                 }
             } catch (AnalysisException e) {
                 throw new SchedException(Status.UNRECOVERABLE, e.getMessage());

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
@@ -426,6 +426,19 @@ public class GlobalTransactionMgr implements Writable {
     }
 
     /**
+     * Check whether a load job for a partition already exists before
+     * checking all `TransactionId` related with this load job have finished.
+     * finished
+     *
+     * @throws AnalysisException is database does not exist anymore
+     */
+    public boolean isPreviousTransactionsFinished(long endTransactionId, long dbId, long tableId,
+            long partitionId) throws AnalysisException {
+        DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(dbId);
+        return dbTransactionMgr.isPreviousTransactionsFinished(endTransactionId, tableId, partitionId);
+    }
+
+    /**
      * The txn cleaner will run at a fixed interval and try to delete expired and timeout txns:
      * expired: txn is in VISIBLE or ABORTED, and is expired.
      * timeout: txn is in PREPARE, but timeout

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionState.java
@@ -523,10 +523,6 @@ public class TransactionState implements Writable {
         return this.idToTableCommitInfos.get(tableId);
     }
 
-    public void removeTable(long tableId) {
-        this.idToTableCommitInfos.remove(tableId);
-    }
-
     public void setTxnCommitAttachment(TxnCommitAttachment txnCommitAttachment) {
         this.txnCommitAttachment = txnCommitAttachment;
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/clone/RebalanceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/clone/RebalanceTest.java
@@ -307,8 +307,8 @@ public class RebalanceTest {
             Replica decommissionedReplica = replicas.stream()
                     .filter(r -> r.getState() == Replica.ReplicaState.DECOMMISSION)
                     .collect(MoreCollectors.onlyElement());
-            // expected watermarkTxnId is 111
-            Assert.assertEquals(111, decommissionedReplica.getWatermarkTxnId());
+            Assert.assertEquals(111, decommissionedReplica.getPreWatermarkTxnId());
+            Assert.assertEquals(112, decommissionedReplica.getPostWatermarkTxnId());
         });
 
         // Delete replica should change invertedIndex too


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

Issue: for replica num <= 2,  load data may fail during migration. 

For example, suppose replica num = 1,   current version = 1, the only one replica is on BE A.
1. BE A begin a txn T1;
2. Begin a migration from BE  A to B;
3. End migration, then got:   A [decommission, version=1],    B [normal, version=1];
4. Finish txn T1,  then A [decommission, version=2];  B[normal, version=1, last failed version=2]
5. Begin a txn T2, but now:  A is decommission,  B is version fall behind,  so T2 will fail.

Here is a fix.
To decommission A, the steps are as follow:
1. wait A's peer catchup with A;
2. set A's state to decommission,  generate a txn water mark  M1 for A,   A is still both readable and writeable; 
3. wait txn before M1 to be finished,  generate another txn water mark M2 for A,  A is now readable but not writeable;
4. wait txn before M2 to be finished,  then delete A;

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

