### PR TITLE
fix(compaction) release the block and segment iterator after reading to the end of the segment file

### DIFF
--- a/be/src/vec/olap/vertical_merge_iterator.cpp
+++ b/be/src/vec/olap/vertical_merge_iterator.cpp
@@ -356,6 +356,7 @@ Status VerticalMergeIteratorContext::_load_next_block() {
         if (!st.ok()) {
             _valid = false;
             if (st.is<END_OF_FILE>()) {
+                _block.reset();
                 return Status::OK();
             } else {
                 return st;
@@ -601,7 +602,9 @@ Status VerticalFifoMergeIterator::init(const StorageReadOptions& opts) {
 Status VerticalMaskMergeIterator::check_all_iter_finished() {
     for (auto iter : _origin_iter_ctx) {
         if (iter->inited()) {
-            RETURN_IF_ERROR(iter->advance());
+            if (iter->valid()) {
+                RETURN_IF_ERROR(iter->advance());
+            }
             DCHECK(!iter->valid());
         }
     }

--- a/be/src/vec/olap/vertical_merge_iterator.cpp
+++ b/be/src/vec/olap/vertical_merge_iterator.cpp
@@ -356,7 +356,12 @@ Status VerticalMergeIteratorContext::_load_next_block() {
         if (!st.ok()) {
             _valid = false;
             if (st.is<END_OF_FILE>()) {
+                // When reading to the end of the segment file, clearing the block did not release the memory.
+                // Directly releasing the block to free up memory.
                 _block.reset();
+                // When reading through segment file for columns that are dictionary encoded,
+                // the column iterator in the segment iterator will hold the dictionary.
+                // Release the segment iterator to free up the dictionary.
                 _iter.reset();
                 return Status::OK();
             } else {

--- a/be/src/vec/olap/vertical_merge_iterator.cpp
+++ b/be/src/vec/olap/vertical_merge_iterator.cpp
@@ -357,6 +357,7 @@ Status VerticalMergeIteratorContext::_load_next_block() {
             _valid = false;
             if (st.is<END_OF_FILE>()) {
                 _block.reset();
+                _iter.reset();
                 return Status::OK();
             } else {
                 return st;


### PR DESCRIPTION
## Proposed changes

When reading to the end of the segment file, clearing the block did not release the memory, leading to high memory usage during compaction.

When reading through segment file for columns that are dictionary encoded, the column iterator in the segment iterator will hold the dictionary. Release the segment iterator to free up the dictionary.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

