### PR TITLE
[fix](nereids)PredicatePropagation only support integer types for now

### DIFF
--- a/regression-test/suites/nereids_p0/infer_predicate/infer_predicate.groovy
+++ b/regression-test/suites/nereids_p0/infer_predicate/infer_predicate.groovy
@@ -26,6 +26,8 @@ suite("test_infer_predicate") {
 
     sql '''create table infer_tb2 (k1 tinyint, k2 smallint, k3 int, k4 bigint, k5 largeint, k6 date, k7 datetime, k8 float, k9 double) distributed by hash(k1) buckets 3 properties('replication_num' = '1');'''
 
+    sql '''create table infer_tb3 (k1 varchar(100), k2 int) distributed by hash(k1) buckets 3 properties('replication_num' = '1');'''
+
     explain {
         sql "select * from infer_tb1 inner join infer_tb2 where infer_tb2.k1 = infer_tb1.k2  and infer_tb2.k1 = 1;"
         contains "PREDICATES: k2[#20] = 1"
@@ -39,5 +41,10 @@ suite("test_infer_predicate") {
     explain {
         sql "select * from infer_tb1 inner join infer_tb2 where cast(infer_tb2.k4 as int) = infer_tb1.k2  and infer_tb2.k4 = 1;"
         notContains "PREDICATES: k2[#20] = 1"
+    }
+
+    explain {
+        sql "select * from infer_tb1 inner join infer_tb3 where infer_tb3.k1 = infer_tb1.k2  and infer_tb3.k1 = '123';"
+        notContains "PREDICATES: k2[#6] = '123'"
     }
 }


### PR DESCRIPTION
## Proposed changes
Consider sql : select * from infer_tb1 inner join infer_tb3 where infer_tb3.k1 = infer_tb1.k2  and infer_tb3.k1 = '123';
 infer_tb3.k1 is varchar(100),  infer_tb1.k2 is int.

We shouldn't infer infer_tb1.k2 = '123'

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

