### PR TITLE
[feature](properties) Erase dynamic properties when table is synced

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
@@ -208,8 +208,8 @@ public class Alter {
 
             olapTable.setStoragePolicy(currentStoragePolicy);
             needProcessOutsideTableLock = true;
-        } else if (currentAlterOps.checkCcrEnable(alterClauses)) {
-            olapTable.setCcrEnable(currentAlterOps.isCcrEnable(alterClauses));
+        } else if (currentAlterOps.checkIsBeingSynced(alterClauses)) {
+            olapTable.setIsBeingSynced(currentAlterOps.isBeingSynced(alterClauses));
             needProcessOutsideTableLock = true;
         } else if (currentAlterOps.checkBinlogConfigChange(alterClauses)) {
             if (!Config.enable_feature_binlog) {
@@ -514,7 +514,7 @@ public class Alter {
                 // currently, only in memory and storage policy property could reach here
                 Preconditions.checkState(properties.containsKey(PropertyAnalyzer.PROPERTIES_INMEMORY)
                         || properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_POLICY)
-                        || properties.containsKey(PropertyAnalyzer.PROPERTIES_CCR_ENABLE));
+                        || properties.containsKey(PropertyAnalyzer.PROPERTIES_IS_BEING_SYNCED));
                 ((SchemaChangeHandler) schemaChangeHandler).updateTableProperties(db, tableName, properties);
             } else {
                 throw new DdlException("Invalid alter operation: " + alterClause.getOpType());

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/AlterOperations.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/AlterOperations.java
@@ -78,10 +78,10 @@ public class AlterOperations {
         ).map(c -> ((ModifyTablePropertiesClause) c).getStoragePolicy()).findFirst().orElse("");
     }
 
-    public boolean checkCcrEnable(List<AlterClause> alterClauses) {
+    public boolean checkIsBeingSynced(List<AlterClause> alterClauses) {
         return alterClauses.stream().filter(clause ->
             clause instanceof ModifyTablePropertiesClause
-        ).anyMatch(clause -> clause.getProperties().containsKey(PropertyAnalyzer.PROPERTIES_CCR_ENABLE));
+        ).anyMatch(clause -> clause.getProperties().containsKey(PropertyAnalyzer.PROPERTIES_IS_BEING_SYNCED));
     }
 
     public boolean checkBinlogConfigChange(List<AlterClause> alterClauses) {
@@ -93,10 +93,10 @@ public class AlterOperations {
             || clause.getProperties().containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_MAX_HISTORY_NUMS));
     }
 
-    public boolean isCcrEnable(List<AlterClause> alterClauses) {
+    public boolean isBeingSynced(List<AlterClause> alterClauses) {
         return alterClauses.stream().filter(clause ->
             clause instanceof ModifyTablePropertiesClause
-        ).map(c -> ((ModifyTablePropertiesClause) c).isCcrEnable()).findFirst().orElse(false);
+        ).map(c -> ((ModifyTablePropertiesClause) c).isBeingSynced()).findFirst().orElse(false);
     }
 
     // MODIFY_TABLE_PROPERTY is also processed by SchemaChangeHandler

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BackupStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BackupStmt.java
@@ -22,6 +22,7 @@ import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.PrintableMap;
+import org.apache.doris.common.util.PropertyAnalyzer;
 
 import com.google.common.collect.Maps;
 
@@ -30,6 +31,7 @@ import java.util.Map;
 public class BackupStmt extends AbstractBackupStmt {
     private static final String PROP_TYPE = "type";
     public static final String PROP_CONTENT = "content";
+    public static final String PROP_IS_BEING_SYNCED = PropertyAnalyzer.PROPERTIES_IS_BEING_SYNCED;
 
     public enum BackupType {
         INCREMENTAL, FULL
@@ -41,6 +43,7 @@ public class BackupStmt extends AbstractBackupStmt {
 
     private BackupType type = BackupType.FULL;
     private BackupContent content = BackupContent.ALL;
+    private boolean isBeingSynced = false;
 
 
     public BackupStmt(LabelName labelName, String repoName, AbstractBackupTableRefClause abstractBackupTableRefClause,
@@ -58,6 +61,10 @@ public class BackupStmt extends AbstractBackupStmt {
 
     public BackupContent getContent() {
         return content;
+    }
+
+    public boolean isBeingSynced() {
+        return isBeingSynced;
     }
 
     @Override
@@ -101,6 +108,17 @@ public class BackupStmt extends AbstractBackupStmt {
                         "Invalid backup job content:" + contentProp);
             }
             copiedProperties.remove(PROP_CONTENT);
+        }
+        // is_being_synced
+        String isBeingSyncedProp = copiedProperties.get(PROP_IS_BEING_SYNCED);
+        if (isBeingSyncedProp != null) {
+            try {
+                isBeingSynced = Boolean.parseBoolean(isBeingSyncedProp);
+            } catch (Exception e) {
+                ErrorReport.reportAnalysisException(ErrorCode.ERR_COMMON_ERROR,
+                        "Invalid backup job is_being_synced: " + isBeingSyncedProp);
+            }
+            copiedProperties.remove(PROP_IS_BEING_SYNCED);
         }
 
         if (!copiedProperties.isEmpty()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyTablePropertiesClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyTablePropertiesClause.java
@@ -44,14 +44,14 @@ public class ModifyTablePropertiesClause extends AlterTableClause {
 
     private String storagePolicy;
 
-    private boolean ccrEnable = false;
+    private boolean isBeingSynced = false;
 
-    public void setCcrEnable(boolean ccrEnable) {
-        this.ccrEnable = ccrEnable;
+    public void setIsBeingSynced(boolean isBeingSynced) {
+        this.isBeingSynced = isBeingSynced;
     }
 
-    public boolean isCcrEnable() {
-        return ccrEnable;
+    public boolean isBeingSynced() {
+        return isBeingSynced;
     }
 
     public ModifyTablePropertiesClause(Map<String, String> properties) {
@@ -131,10 +131,10 @@ public class ModifyTablePropertiesClause extends AlterTableClause {
             throw new AnalysisException("Can not change enable_duplicate_without_keys_by_default");
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_LIGHT_SCHEMA_CHANGE)) {
             // do nothing, will be alter in SchemaChangeHandler.updateTableProperties
-        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_CCR_ENABLE)) {
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_IS_BEING_SYNCED)) {
             this.needTableStable = false;
-            setCcrEnable(
-                    Boolean.parseBoolean(properties.getOrDefault(PropertyAnalyzer.PROPERTIES_CCR_ENABLE, "false")));
+            setIsBeingSynced(Boolean.parseBoolean(
+                    properties.getOrDefault(PropertyAnalyzer.PROPERTIES_IS_BEING_SYNCED, "false")));
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_ENABLE)
                 || properties.containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_TTL_SECONDS)
                 || properties.containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_MAX_BYTES)

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -395,7 +395,7 @@ public class BackupHandler extends MasterDaemon implements Writable {
         // Create a backup job
         BackupJob backupJob = new BackupJob(stmt.getLabel(), db.getId(),
                 ClusterNamespace.getNameFromFullName(db.getFullName()),
-                tblRefs, stmt.getTimeoutMs(), stmt.getContent(), env, repoId);
+                tblRefs, stmt.getTimeoutMs(), stmt.getContent(), env, repoId, stmt.isBeingSynced());
         // write log
         env.getEditLog().logBackupJob(backupJob);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/CreateTableRecord.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/CreateTableRecord.java
@@ -63,7 +63,7 @@ public class CreateTableRecord {
 
         table.readLock();
         try {
-            Env.getDdlStmt(table, createTableStmt, addPartitionStmt, createRollupStmt, false, false /* show password */,
+            Env.getBeingSyncedDdlStmt(table, createTableStmt, addPartitionStmt, createRollupStmt, false, false /* show password */,
                     -1L);
         } finally {
             table.readUnlock();

--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/CreateTableRecord.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/CreateTableRecord.java
@@ -63,8 +63,8 @@ public class CreateTableRecord {
 
         table.readLock();
         try {
-            Env.getBeingSyncedDdlStmt(table, createTableStmt, addPartitionStmt, createRollupStmt, false, false /* show password */,
-                    -1L);
+            Env.getBeingSyncedDdlStmt(table, createTableStmt, addPartitionStmt, createRollupStmt,
+                    false, false /* show password */, -1L);
         } finally {
             table.readUnlock();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/DistributionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/DistributionInfo.java
@@ -78,6 +78,14 @@ public abstract class DistributionInfo implements Writable {
         throw new NotImplementedException("not implemented");
     }
 
+    public boolean isAutoBucket() {
+        return autoBucket;
+    }
+
+    public void disableAutoBucket() {
+        autoBucket = false;
+    }
+
     public void markAutoBucket() {
         autoBucket = true;
     }
@@ -95,7 +103,11 @@ public abstract class DistributionInfo implements Writable {
         type = DistributionInfoType.valueOf(Text.readString(in));
     }
 
-    public String toSql() {
+    public final String toSql() {
+        return toSql(false);
+    }
+
+    public String toSql(boolean getStatic) {
         return "";
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HashDistributionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HashDistributionInfo.java
@@ -138,7 +138,7 @@ public class HashDistributionInfo extends DistributionInfo {
     }
 
     @Override
-    public String toSql() {
+    public String toSql(boolean getStatic) {
         StringBuilder builder = new StringBuilder();
         builder.append("DISTRIBUTED BY HASH(");
 
@@ -149,7 +149,7 @@ public class HashDistributionInfo extends DistributionInfo {
         String colList = Joiner.on(", ").join(colNames);
         builder.append(colList);
 
-        if (autoBucket) {
+        if (autoBucket && !getStatic) {
             builder.append(") BUCKETS AUTO");
         } else {
             builder.append(") BUCKETS ").append(bucketNum);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -738,6 +738,13 @@ public class OlapTable extends Table {
         }
     }
 
+    public void disableAutoBucket() {
+        if (tableProperty.isAutoBucket()) {
+            defaultDistributionInfo.disableAutoBucket();
+            tableProperty.eraseAutoBucket();
+        }
+    }
+
     public DistributionInfo getDefaultDistributionInfo() {
         return defaultDistributionInfo;
     }
@@ -1764,15 +1771,15 @@ public class OlapTable extends Table {
         return "";
     }
 
-    public void setCcrEnable(boolean ccrEnable) throws UserException {
-        // TODO(Drogon): Config.enable_ccr
+    public void setIsBeingSynced(boolean isBeingSynced) throws UserException {
         TableProperty tableProperty = getOrCreatTableProperty();
-        tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_CCR_ENABLE, Boolean.toString(ccrEnable));
-        tableProperty.buildCcrEnable();
+        tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_IS_BEING_SYNCED,
+                Boolean.toString(isBeingSynced));
+        tableProperty.buildIsBeingSynced();
     }
 
-    public boolean isCcrEnable() {
-        return tableProperty != null && tableProperty.isCcrEnable();
+    public boolean isBeingSynced() {
+        return tableProperty != null && tableProperty.isBeingSynced();
     }
 
     public void setDisableAutoCompaction(boolean disableAutoCompaction) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RandomDistributionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RandomDistributionInfo.java
@@ -53,9 +53,9 @@ public class RandomDistributionInfo extends DistributionInfo {
     }
 
     @Override
-    public String toSql() {
+    public String toSql(boolean getStatic) {
         StringBuilder builder = new StringBuilder();
-        if (autoBucket) {
+        if (autoBucket && !getStatic) {
             builder.append("DISTRIBUTED BY RANDOM BUCKETS AUTO");
         } else {
             builder.append("DISTRIBUTED BY RANDOM BUCKETS ").append(bucketNum);

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -129,7 +129,8 @@ public class PropertyAnalyzer {
 
     public static final String PROPERTIES_MUTABLE = "mutable";
 
-    public static final String PROPERTIES_CCR_ENABLE = "ccr_enable";
+    // is_syncing can only set by syncer and can not be changed
+    public static final String PROPERTIES_IS_BEING_SYNCED = "is_being_synced";
 
     // binlog.enable, binlog.ttl_seconds, binlog.max_bytes, binlog.max_history_nums
     public static final String PROPERTIES_BINLOG_PREFIX = "binlog.";

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -1144,7 +1144,7 @@ public class InternalCatalog implements CatalogIf<Database> {
                 }
 
                 Env.getDdlStmt(stmt, stmt.getDbName(), table, createTableStmt, null, null, false, false, true, -1L,
-                        false);
+                        false, false);
                 if (createTableStmt.isEmpty()) {
                     ErrorReport.reportDdlException(ErrorCode.ERROR_CREATE_TABLE_LIKE_EMPTY, "CREATE");
                 }
@@ -2117,6 +2117,11 @@ public class InternalCatalog implements CatalogIf<Database> {
             throw new DdlException(e.getMessage());
         }
         BinlogConfig binlogConfigForTask = new BinlogConfig(olapTable.getBinlogConfig());
+
+        // set is being synced
+        boolean isBeingSynced = PropertyAnalyzer.analyzeBooleanProp(properties,
+                PropertyAnalyzer.PROPERTIES_IS_BEING_SYNCED, false);
+        olapTable.setIsBeingSynced(isBeingSynced);
 
         if (partitionInfo.getType() == PartitionType.UNPARTITIONED) {
             // if this is an unpartitioned table, we should analyze data property and replication num here.

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -964,7 +964,7 @@ public class ShowExecutor {
             }
             List<String> createTableStmt = Lists.newArrayList();
             Env.getDdlStmt(null, null, table, createTableStmt, null, null, false,
-                    true /* hide password */, false, -1L, showStmt.isNeedBriefDdl());
+                    true /* hide password */, false, -1L, showStmt.isNeedBriefDdl(), false);
             if (createTableStmt.isEmpty()) {
                 resultSet = new ShowResultSet(showStmt.getMetaData(), rows);
                 return;

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
@@ -212,7 +212,7 @@ public class BackupJobTest {
                 new TableName(InternalCatalog.INTERNAL_CATALOG_NAME, UnitTestUtil.DB_NAME, UnitTestUtil.TABLE_NAME),
                 null));
         job = new BackupJob("label", dbId, UnitTestUtil.DB_NAME, tableRefs, 13600 * 1000, BackupStmt.BackupContent.ALL,
-                env, repo.getId());
+                env, repo.getId(), false);
     }
 
     @Test
@@ -348,7 +348,7 @@ public class BackupJobTest {
                 new TableRef(new TableName(InternalCatalog.INTERNAL_CATALOG_NAME, UnitTestUtil.DB_NAME, "unknown_tbl"),
                         null));
         job = new BackupJob("label", dbId, UnitTestUtil.DB_NAME, tableRefs, 13600 * 1000, BackupStmt.BackupContent.ALL,
-                env, repo.getId());
+                env, repo.getId(), false);
         job.run();
         Assert.assertEquals(Status.ErrCode.NOT_FOUND, job.getStatus().getErrCode());
         Assert.assertEquals(BackupJobState.CANCELLED, job.getState());


### PR DESCRIPTION
# Add property "is_being_synced"
The syncer will mark the table in dest cluster as "is being synced" when establishing synchronization, so that it can be distinguished during use.
# Erase properties when table is being synced in dest cluster
- Disable dynamic partition and erase its other properties.  
- Switch auto bucket to static bucket.  (bucket nums depend on its source table)
- Erase property estimate_partition_size
- Erase storage policy
- Erase colocate with