### PR TITLE
[enhance](S3) add s3 bvar metrics for all s3 operation

### DIFF
--- a/be/src/io/fs/s3_file_reader.cpp
+++ b/be/src/io/fs/s3_file_reader.cpp
@@ -33,6 +33,7 @@
 #include "common/compiler_util.h" // IWYU pragma: keep
 #include "io/fs/s3_common.h"
 #include "util/doris_metrics.h"
+#include "util/s3_util.h"
 
 namespace doris {
 namespace io {
@@ -95,6 +96,7 @@ Status S3FileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_rea
         return Status::InternalError("init s3 client error");
     }
     auto outcome = client->GetObject(request);
+    s3_bvar::s3_get_total << 1;
     if (!outcome.IsSuccess()) {
         return Status::IOError("failed to read from {}: {}", _path.native(),
                                outcome.GetError().GetMessage());

--- a/be/src/io/fs/s3_file_writer.cpp
+++ b/be/src/io/fs/s3_file_writer.cpp
@@ -50,6 +50,7 @@
 #include "util/defer_op.h"
 #include "util/doris_metrics.h"
 #include "util/runtime_profile.h"
+#include "util/s3_util.h"
 
 namespace Aws {
 namespace S3 {
@@ -112,6 +113,7 @@ Status S3FileWriter::_create_multi_upload_request() {
     create_request.SetContentType("application/octet-stream");
 
     auto outcome = _client->CreateMultipartUpload(create_request);
+    s3_bvar::s3_multi_part_upload_total << 1;
 
     if (outcome.IsSuccess()) {
         _upload_id = outcome.GetResult().GetUploadId();
@@ -151,6 +153,7 @@ Status S3FileWriter::abort() {
     AbortMultipartUploadRequest request;
     request.WithBucket(_bucket).WithKey(_key).WithUploadId(_upload_id);
     auto outcome = _client->AbortMultipartUpload(request);
+    s3_bvar::s3_multi_part_upload_total << 1;
     if (outcome.IsSuccess() ||
         outcome.GetError().GetErrorType() == Aws::S3::S3Errors::NO_SUCH_UPLOAD ||
         outcome.GetError().GetResponseCode() == Aws::Http::HttpResponseCode::NOT_FOUND) {
@@ -267,6 +270,7 @@ void S3FileWriter::_upload_one_part(int64_t part_num, S3FileBuffer& buf) {
     upload_request.SetContentType("application/octet-stream");
 
     auto upload_part_callable = _client->UploadPartCallable(upload_request);
+    s3_bvar::s3_multi_part_upload_total << 1;
 
     UploadPartOutcome upload_part_outcome = upload_part_callable.get();
     if (!upload_part_outcome.IsSuccess()) {
@@ -317,6 +321,7 @@ Status S3FileWriter::_complete() {
     complete_request.WithMultipartUpload(completed_upload);
 
     auto compute_outcome = _client->CompleteMultipartUpload(complete_request);
+    s3_bvar::s3_multi_part_upload_total << 1;
 
     if (!compute_outcome.IsSuccess()) {
         auto s = Status::IOError(
@@ -356,6 +361,7 @@ void S3FileWriter::_put_object(S3FileBuffer& buf) {
     request.SetContentLength(buf.get_size());
     request.SetContentType("application/octet-stream");
     auto response = _client->PutObject(request);
+    s3_bvar::s3_put_total << 1;
     if (!response.IsSuccess()) {
         _st = Status::InternalError("Error: [{}:{}, responseCode:{}]",
                                     response.GetError().GetExceptionName(),

--- a/be/src/util/s3_util.cpp
+++ b/be/src/util/s3_util.cpp
@@ -23,6 +23,7 @@
 #include <aws/core/utils/logging/LogSystemInterface.h>
 #include <aws/core/utils/memory/stl/AWSStringStream.h>
 #include <aws/s3/S3Client.h>
+#include <bvar/reducer.h>
 #include <util/string_util.h>
 
 #include <atomic>

--- a/be/src/util/s3_util.cpp
+++ b/be/src/util/s3_util.cpp
@@ -37,6 +37,18 @@
 
 namespace doris {
 
+namespace s3_bvar {
+bvar::Adder<uint64_t> s3_get_total("s3_get", "total_num");
+bvar::Adder<uint64_t> s3_put_total("s3_put", "total_num");
+bvar::Adder<uint64_t> s3_delete_total("s3_delete", "total_num");
+bvar::Adder<uint64_t> s3_head_total("s3_head", "total_num");
+bvar::Adder<uint64_t> s3_multi_part_upload_total("s3_multi_part_upload", "total_num");
+bvar::Adder<uint64_t> s3_list_total("s3_list", "total_num");
+bvar::Adder<uint64_t> s3_list_object_versions_total("s3_list_object_versions", "total_num");
+bvar::Adder<uint64_t> s3_get_bucket_version_total("s3_get_bucket_version", "total_num");
+bvar::Adder<uint64_t> s3_copy_object_total("s3_copy_object", "total_num");
+}; // namespace s3_bvar
+
 class DorisAWSLogger final : public Aws::Utils::Logging::LogSystemInterface {
 public:
     DorisAWSLogger() : _log_level(Aws::Utils::Logging::LogLevel::Info) {}

--- a/be/src/util/s3_util.h
+++ b/be/src/util/s3_util.h
@@ -41,16 +41,16 @@ class S3Client;
 namespace doris {
 
 namespace s3_bvar {
-    extern bvar::Adder<uint64_t> s3_get_total;
-    extern bvar::Adder<uint64_t> s3_put_total;
-    extern bvar::Adder<uint64_t> s3_delete_total;
-    extern bvar::Adder<uint64_t> s3_head_total;
-    extern bvar::Adder<uint64_t> s3_multi_part_upload_total;
-    extern bvar::Adder<uint64_t> s3_list_total;
-    extern bvar::Adder<uint64_t> s3_list_object_versions_total;
-    extern bvar::Adder<uint64_t> s3_get_bucket_version_total;
-    extern bvar::Adder<uint64_t> s3_copy_object_total;
-};
+extern bvar::Adder<uint64_t> s3_get_total;
+extern bvar::Adder<uint64_t> s3_put_total;
+extern bvar::Adder<uint64_t> s3_delete_total;
+extern bvar::Adder<uint64_t> s3_head_total;
+extern bvar::Adder<uint64_t> s3_multi_part_upload_total;
+extern bvar::Adder<uint64_t> s3_list_total;
+extern bvar::Adder<uint64_t> s3_list_object_versions_total;
+extern bvar::Adder<uint64_t> s3_get_bucket_version_total;
+extern bvar::Adder<uint64_t> s3_copy_object_total;
+}; // namespace s3_bvar
 
 class S3URI;
 

--- a/be/src/util/s3_util.h
+++ b/be/src/util/s3_util.h
@@ -19,6 +19,7 @@
 
 #include <aws/core/Aws.h>
 #include <aws/core/client/ClientConfiguration.h>
+#include <bvar/reducer.h>
 #include <fmt/format.h>
 #include <stdint.h>
 
@@ -38,6 +39,18 @@ class S3Client;
 } // namespace Aws
 
 namespace doris {
+
+namespace s3_bvar {
+    extern bvar::Adder<uint64_t> s3_get_total;
+    extern bvar::Adder<uint64_t> s3_put_total;
+    extern bvar::Adder<uint64_t> s3_delete_total;
+    extern bvar::Adder<uint64_t> s3_head_total;
+    extern bvar::Adder<uint64_t> s3_multi_part_upload_total;
+    extern bvar::Adder<uint64_t> s3_list_total;
+    extern bvar::Adder<uint64_t> s3_list_object_versions_total;
+    extern bvar::Adder<uint64_t> s3_get_bucket_version_total;
+    extern bvar::Adder<uint64_t> s3_copy_object_total;
+};
 
 class S3URI;
 

--- a/be/src/util/s3_util.h
+++ b/be/src/util/s3_util.h
@@ -19,7 +19,6 @@
 
 #include <aws/core/Aws.h>
 #include <aws/core/client/ClientConfiguration.h>
-#include <bvar/reducer.h>
 #include <fmt/format.h>
 #include <stdint.h>
 
@@ -37,6 +36,10 @@ namespace S3 {
 class S3Client;
 } // namespace S3
 } // namespace Aws
+namespace bvar {
+template <typename T>
+class Adder;
+}
 
 namespace doris {
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
Formerly there is no observability for each s3 operation, this pr mainly adds kinds of bvar for us to have a glance at the s3 operation's num when running BE.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

