### PR TITLE
[minor](log) print error msg to fe.out before log is initialized

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/DorisFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/DorisFE.java
@@ -187,6 +187,9 @@ public class DorisFE {
                 Thread.sleep(2000);
             }
         } catch (Throwable e) {
+            // Some exception may thrown before LOG is inited.
+            // So need to print to stdout
+            e.printStackTrace();
             LOG.warn("", e);
         }
     }


### PR DESCRIPTION
## Proposed changes

The exception may be thrown before LOG is initialized.
Such as wrong config value. So we need to print it to fe.out, otherwise
we can't know what's wrong.

After this PR, the error can be found in fe.out, such as:

```
java.lang.NumberFormatException: For input string: "3g"
        at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
        at java.lang.Long.parseLong(Long.java:589)
        at java.lang.Long.parseLong(Long.java:631)
        at org.apache.doris.common.ConfigBase.setConfigField(ConfigBase.java:253)
        at org.apache.doris.common.ConfigBase.setFields(ConfigBase.java:232)
        at org.apache.doris.common.ConfigBase.initConf(ConfigBase.java:146)
        at org.apache.doris.common.ConfigBase.init(ConfigBase.java:112)
        at org.apache.doris.DorisFE.start(DorisFE.java:101)
        at org.apache.doris.DorisFE.main(DorisFE.java:73)
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

