### PR TITLE
[bug](node) fix partiton sort node core dump when eos

### DIFF
--- a/be/src/vec/exec/vpartition_sort_node.cpp
+++ b/be/src/vec/exec/vpartition_sort_node.cpp
@@ -60,9 +60,6 @@ Status VPartitionSortNode::init(const TPlanNode& tnode, RuntimeState* state) {
         _partition_exprs_num = _partition_expr_ctxs.size();
         _partition_columns.resize(_partition_exprs_num);
     }
-    if (_partition_exprs_num == 0) {
-        _value_places.push_back(_pool->add(new PartitionBlocks()));
-    }
 
     _has_global_limit = tnode.partition_sort_node.has_global_limit;
     _top_n_algorithm = tnode.partition_sort_node.top_n_algorithm;
@@ -177,6 +174,9 @@ Status VPartitionSortNode::sink(RuntimeState* state, vectorized::Block* input_bl
     if (current_rows > 0) {
         child_input_rows = child_input_rows + current_rows;
         if (UNLIKELY(_partition_exprs_num == 0)) {
+            if (UNLIKELY(_value_places.empty())) {
+                _value_places.push_back(_pool->add(new PartitionBlocks()));
+            }
             //no partition key
             _value_places[0]->append_whole_block(input_block, child(0)->row_desc());
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -737,7 +737,7 @@ public class SessionVariable implements Serializable, Writable {
     private int maxJoinNumBushyTree = 5;
 
     @VariableMgr.VarAttr(name = ENABLE_PARTITION_TOPN)
-    private boolean enablePartitionTopN = true;
+    private boolean enablePartitionTopN = false;
 
     @VariableMgr.VarAttr(name = ENABLE_INFER_PREDICATE)
     private boolean enableInferPredicate = true;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -737,7 +737,7 @@ public class SessionVariable implements Serializable, Writable {
     private int maxJoinNumBushyTree = 5;
 
     @VariableMgr.VarAttr(name = ENABLE_PARTITION_TOPN)
-    private boolean enablePartitionTopN = false;
+    private boolean enablePartitionTopN = true;
 
     @VariableMgr.VarAttr(name = ENABLE_INFER_PREDICATE)
     private boolean enableInferPredicate = true;


### PR DESCRIPTION
## Proposed changes
Now have a case is at call sink function firstly,
one of thread which input block rows=0, and eos = true,
this will cause _value_places[0] have not append any block.
so it's can not do sorter work.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

