### PR TITLE
[Enhancement] add soft link for the compile_commands.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ package-lock.json
 docs/contents/
 docs/.temp
 
+# compile_commands.json
+compile_commands.json
+
 # output, thirdparty, extension
 output/
 output.bak/

--- a/build.sh
+++ b/build.sh
@@ -704,7 +704,7 @@ if [[ -n "${DORIS_POST_BUILD_HOOK}" ]]; then
 fi
 
 if [[ -f "${CMAKE_BUILD_DIR}/compile_commands.json" ]]; then
-    ln -s ${CMAKE_BUILD_DIR}/compile_commands.json ${DORIS_HOME}/compile_commands.json
+    ln -s "${CMAKE_BUILD_DIR}/compile_commands.json" "${DORIS_HOME}/compile_commands.json"
 fi
 
 exit 0

--- a/build.sh
+++ b/build.sh
@@ -703,4 +703,8 @@ if [[ -n "${DORIS_POST_BUILD_HOOK}" ]]; then
     eval "${DORIS_POST_BUILD_HOOK}"
 fi
 
+if [[ -f "${CMAKE_BUILD_DIR}/compile_commands.json" ]]; then
+    ln -s ${CMAKE_BUILD_DIR}/compile_commands.json ${DORIS_HOME}/compile_commands.json
+fi
+
 exit 0


### PR DESCRIPTION
## Proposed changes

Issue Number: close #21657

add soft link for the compile_commands.json

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

