### PR TITLE
[Fix](nereids) Fix Olap table qualifier only contains db name bug.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
@@ -170,10 +170,10 @@ public class BindRelation extends OneAnalysisRuleFactory {
         List<Long> partIds = getPartitionIds(table, unboundRelation);
         if (!CollectionUtils.isEmpty(partIds)) {
             scan = new LogicalOlapScan(unboundRelation.getRelationId(),
-                    (OlapTable) table, ImmutableList.of(tableQualifier.get(1)), partIds, unboundRelation.getHints());
+                    (OlapTable) table, tableQualifier, partIds, unboundRelation.getHints());
         } else {
             scan = new LogicalOlapScan(unboundRelation.getRelationId(),
-                    (OlapTable) table, ImmutableList.of(tableQualifier.get(1)), unboundRelation.getHints());
+                    (OlapTable) table, tableQualifier, unboundRelation.getHints());
         }
         if (!Util.showHiddenColumns() && scan.getTable().hasDeleteSign()
                 && !ConnectContext.get().getSessionVariable()

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/SlotBinder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/SlotBinder.java
@@ -143,6 +143,7 @@ class SlotBinder extends SubExprAnalyzer {
                 return new BoundStar(slots);
             case 1: // select table.*
             case 2: // select db.table.*
+            case 3: // select catalog.db.table.*
                 return bindQualifiedStar(qualifier, slots);
             default:
                 throw new AnalysisException("Not supported qualifier: "
@@ -166,6 +167,8 @@ class SlotBinder extends SubExprAnalyzer {
                             return qualifierStar.get(0).equalsIgnoreCase(boundSlotQualifier.get(0));
                         case 2:// bound slot is `db`.`table`.`column`
                             return qualifierStar.get(0).equalsIgnoreCase(boundSlotQualifier.get(1));
+                        case 3:// bound slot is `catalog`.`db`.`table`.`column`
+                            return qualifierStar.get(0).equalsIgnoreCase(boundSlotQualifier.get(2));
                         default:
                             throw new AnalysisException("Not supported qualifier: "
                                     + StringUtils.join(qualifierStar, "."));
@@ -180,9 +183,28 @@ class SlotBinder extends SubExprAnalyzer {
                         case 2:// bound slot is `db`.`table`.`column`
                             return qualifierStar.get(0).equalsIgnoreCase(boundSlotQualifier.get(0))
                                     && qualifierStar.get(1).equalsIgnoreCase(boundSlotQualifier.get(1));
+                        case 3:// bound slot is `catalog`.`db`.`table`.`column`
+                            return qualifierStar.get(0).equalsIgnoreCase(boundSlotQualifier.get(1))
+                                && qualifierStar.get(1).equalsIgnoreCase(boundSlotQualifier.get(2));
                         default:
                             throw new AnalysisException("Not supported qualifier: "
                                     + StringUtils.join(qualifierStar, ".") + ".*");
+                    }
+                case 3: // catalog.db.table.*
+                    boundSlotQualifier = boundSlot.getQualifier();
+                    switch (boundSlotQualifier.size()) {
+                        // bound slot is `column` and no qualified
+                        case 0:
+                        case 1: // bound slot is `table`.`column`
+                        case 2:// bound slot is `db`.`table`.`column`
+                            return false;
+                        case 3:// bound slot is `catalog`.`db`.`table`.`column`
+                            return qualifierStar.get(0).equalsIgnoreCase(boundSlotQualifier.get(0))
+                                && qualifierStar.get(1).equalsIgnoreCase(boundSlotQualifier.get(1))
+                                && qualifierStar.get(2).equalsIgnoreCase(boundSlotQualifier.get(2));
+                        default:
+                            throw new AnalysisException("Not supported qualifier: "
+                                + StringUtils.join(qualifierStar, ".") + ".*");
                     }
                 default:
                     throw new AnalysisException("Not supported name: "

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCatalogRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCatalogRelation.java
@@ -33,6 +33,7 @@ import org.apache.doris.nereids.util.Utils;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 import java.util.Objects;
@@ -97,13 +98,23 @@ public abstract class LogicalCatalogRelation extends LogicalRelation implements 
      * Full qualified name parts, i.e., concat qualifier and name into a list.
      */
     public List<String> qualified() {
-        return Utils.qualifiedNameParts(qualifier, table.getName());
+        // Usually, qualifier already include the whole qualifier (catalog, database and table).
+        if (qualifier.size() == 3) {
+            return new ImmutableList.Builder<String>().addAll(qualifier).build();
+        } else {
+            return Utils.qualifiedNameParts(qualifier, table.getName());
+        }
     }
 
     /**
      * Full qualified table name, concat qualifier and name with `.` as separator.
      */
     public String qualifiedName() {
-        return Utils.qualifiedName(qualifier, table.getName());
+        // Usually, qualifier already include the whole qualifier (catalog, database and table).
+        if (qualifier.size() == 3) {
+            return StringUtils.join(qualifier, ".");
+        } else {
+            return Utils.qualifiedName(qualifier, table.getName());
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalCatalogRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalCatalogRelation.java
@@ -35,6 +35,7 @@ import org.apache.doris.statistics.Statistics;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 import java.util.Objects;
@@ -113,14 +114,24 @@ public abstract class PhysicalCatalogRelation extends PhysicalRelation implement
      * Full qualified name parts, i.e., concat qualifier and name into a list.
      */
     public List<String> qualified() {
-        return Utils.qualifiedNameParts(qualifier, table.getName());
+        // Usually, qualifier already include the whole qualifier (catalog, database and table).
+        if (qualifier.size() == 3) {
+            return new ImmutableList.Builder<String>().addAll(qualifier).build();
+        } else {
+            return Utils.qualifiedNameParts(qualifier, table.getName());
+        }
     }
 
     /**
      * Full qualified table name, concat qualifier and name with `.` as separator.
      */
     public String qualifiedName() {
-        return Utils.qualifiedName(qualifier, table.getName());
+        // Usually, qualifier already include the whole qualifier (catalog, database and table).
+        if (qualifier.size() == 3) {
+            return StringUtils.join(qualifier, ".");
+        } else {
+            return Utils.qualifiedName(qualifier, table.getName());
+        }
     }
 
 }


### PR DESCRIPTION
While creating LogicalOlapScan, the qualifier only includes database name (without catalog name). This will cause getDatabase function in LogicalCatalogRelation fail to find the correct database, because without catalog name, it only search current catalog. This will cause an error because current catalog may be an external catalog, and Olap database only exist in internal catalog.
This pr pass the whole qualifier to LogicalOlapScan, including catalog name, db name and table name.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

