### PR TITLE
[bugfix](scanner) when scanner init failed during get tablet, not need call update counters

### DIFF
--- a/be/src/vec/exec/scan/vscanner.h
+++ b/be/src/vec/exec/scan/vscanner.h
@@ -126,7 +126,13 @@ public:
     bool need_to_close() { return _need_to_close; }
 
     void mark_to_need_to_close() {
-        _update_counters_before_close();
+        // If the scanner is failed during init or open, then not need update counters
+        // because the query is fail and the counter is useless. And it may core during
+        // update counters. For example, update counters depend on scanner's tablet, but
+        // the tablet == null when init failed.
+        if (_is_open) {
+            _update_counters_before_close();
+        }
         _need_to_close = true;
     }
 


### PR DESCRIPTION
## Proposed changes

If the scanner is failed during init or open, then not need update counters because the query is fail and the counter is useless. 
And it may core during update counters. For example, update counters depend on scanner's tablet, but the tablet == null when init failed.
![image](https://github.com/apache/doris/assets/9208457/33d791ac-131b-4abd-9d8f-24e773095fdc)


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

