### PR TITLE
[fix](inverted index) make error message more friendly when query token is empty

### DIFF
--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
@@ -244,7 +244,9 @@ Status FullTextIndexReader::query(OlapReaderStatistics* stats, const std::string
 
         if (analyse_result.empty()) {
             return Status::Error<ErrorCode::INVERTED_INDEX_NO_TERMS>(
-                    "invalid input query_str: {}, please check your query sql", search_str);
+                    "token parser result is empty for query, "
+                    "please check your query: '{}' and index parser: '{}'",
+                    search_str, get_parser_string_from_properties(_index_meta.properties()));
         }
 
         std::unique_ptr<lucene::search::Query> query;

--- a/be/src/vec/functions/match.cpp
+++ b/be/src/vec/functions/match.cpp
@@ -138,7 +138,9 @@ Status FunctionMatchAny::execute_match(const std::string& column_name,
                     doris::segment_v2::InvertedIndexQueryType::MATCH_ANY_QUERY, inverted_index_ctx);
     if (query_tokens.empty()) {
         return Status::Error<ErrorCode::INVERTED_INDEX_NO_TERMS>(
-                "invalid input query_str: {}, please check your query sql", match_query_str);
+                "token parser result is empty for query, "
+                "please check your query: '{}' and index parser: '{}'",
+                match_query_str, inverted_index_parser_type_to_string(parser_type));
     }
 
     auto current_src_array_offset = 0;
@@ -178,7 +180,9 @@ Status FunctionMatchAll::execute_match(const std::string& column_name,
                     doris::segment_v2::InvertedIndexQueryType::MATCH_ALL_QUERY, inverted_index_ctx);
     if (query_tokens.empty()) {
         return Status::Error<ErrorCode::INVERTED_INDEX_NO_TERMS>(
-                "invalid input query_str: {}, please check your query sql", match_query_str);
+                "token parser result is empty for query, "
+                "please check your query: '{}' and index parser: '{}'",
+                match_query_str, inverted_index_parser_type_to_string(parser_type));
     }
 
     auto current_src_array_offset = 0;
@@ -225,7 +229,9 @@ Status FunctionMatchPhrase::execute_match(const std::string& column_name,
                     inverted_index_ctx);
     if (query_tokens.empty()) {
         return Status::Error<ErrorCode::INVERTED_INDEX_NO_TERMS>(
-                "invalid input query_str: {}, please check your query sql", match_query_str);
+                "token parser result is empty for query, "
+                "please check your query: '{}' and index parser: '{}'",
+                match_query_str, inverted_index_parser_type_to_string(parser_type));
     }
 
     auto current_src_array_offset = 0;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

old: invalid input query_str: 刘先生, please check your query sql

new: token parser result is empty for query, please check your query: '先生' and index parser: 'english'

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

