### PR TITLE
[fix](partial-update) disable partial update when undergoing a schema changing process

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -162,19 +162,16 @@ Status DeltaWriter::init() {
         // tablet is under alter process. The delete bitmap will be calculated after conversion.
         if (_tablet->tablet_state() == TABLET_NOTREADY &&
             SchemaChangeHandler::tablet_in_converting(_tablet->tablet_id())) {
+            // Disable 'partial_update' when the tablet is undergoing a 'schema changing process'
+            if (_req.table_schema_param->is_partial_update()) {
+                return Status::InternalError(
+                        "Unable to do 'partial_update' when "
+                        "the tablet is undergoing a 'schema changing process'");
+            }
             _rowset_ids.clear();
         } else {
             _rowset_ids = _tablet->all_rs_id(_cur_max_version);
         }
-    }
-
-    // Disable 'partial_update' when the tablet is undergoing a 'schema changing process'
-    if (_tablet->enable_unique_key_merge_on_write() && _tablet->tablet_state() == TABLET_NOTREADY &&
-        SchemaChangeHandler::tablet_in_converting(_tablet->tablet_id()) &&
-        _req.table_schema_param->is_partial_update()) {
-        return Status::InternalError(
-                "Unable to do 'partial_update' when "
-                "the tablet is undergoing a 'schema changing process'");
     }
 
     // check tablet version number

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -48,6 +48,7 @@
 #include "olap/schema_change.h"
 #include "olap/storage_engine.h"
 #include "olap/tablet_manager.h"
+#include "olap/tablet_meta.h"
 #include "olap/txn_manager.h"
 #include "runtime/exec_env.h"
 #include "runtime/load_channel_mgr.h"
@@ -165,6 +166,15 @@ Status DeltaWriter::init() {
         } else {
             _rowset_ids = _tablet->all_rs_id(_cur_max_version);
         }
+    }
+
+    // Disable 'partial_update' when the tablet is undergoing a 'schema changing process'
+    if (_tablet->enable_unique_key_merge_on_write() && _tablet->tablet_state() == TABLET_NOTREADY &&
+        SchemaChangeHandler::tablet_in_converting(_tablet->tablet_id()) &&
+        _req.table_schema_param->is_partial_update()) {
+        return Status::InternalError(
+                "Unable to do 'partial_update' when "
+                "the tablet is undergoing a 'schema changing process'");
     }
 
     // check tablet version number


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

For now, when a tablet is undergoing a direct schema change task, it should be unreadable for other taskes, such load.

So, performing partial column updates (which requires to read missing columns) during a direct schema change on the unique key table leads to undefined behavior in the stream load process. 

Therefore, the use of partial column updates during schema change is prohibited for now by immediately returning internal error.

For example:

Initially, we create a table `tbl` as follows:
```sql
CREATE TABLE tbl (
    a int,
    b int,
    c int,
    d int,
    e int,
    f int,
    g int
)ENGINE=OLAP
UNIQUE KEY(`a`, `b`, `c`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`a`) BUCKETS 1
PROPERTIES (
    "replication_num" = "1"
);
```

Then, we load some data, say 50M rows, into it.

After that, we apply a **direct** schema change to the table, such as `alter table tbl modify column d varchar(1024);`.

In the meantime, we will immediately get **INTERNAL_ERROR** if we do a partial update using stream load on columns `a,b,c,g` before the dispatched schema change task finished, like:

```xml
{
    . . . 
    "Status": "Fail",
    "Message": "[INTERNAL_ERROR]cancelled: INTERNAL_ERROR",
    "NumberTotalRows": 0,
    "NumberLoadedRows": 0,
    "NumberFilteredRows": 0,
    "NumberUnselectedRows": 0,
    . . . 
}
```


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

