### PR TITLE
[Fix](multi-catalog) Do not throw exceptions when file not exists for external hive tables.

### DIFF
--- a/be/src/io/fs/file_handle_cache.cpp
+++ b/be/src/io/fs/file_handle_cache.cpp
@@ -42,7 +42,7 @@ Status HdfsFileHandle::init(int64_t file_size) {
     _hdfs_file = hdfsOpenFile(_fs, _fname.c_str(), O_RDONLY, 0, 0, 0);
     if (_hdfs_file == nullptr) {
         std::string _err_msg = hdfs_error();
-        if (_err_msg.find("No such file or directory") != string::npos) {
+        if (_err_msg.find("No such file or directory") != std::string::npos) {
             return Status::NotFound(_err_msg);
         }
         return Status::IOError("failed to open {}: {}", _fname, _err_msg);

--- a/be/src/io/fs/file_handle_cache.cpp
+++ b/be/src/io/fs/file_handle_cache.cpp
@@ -41,7 +41,11 @@ HdfsFileHandle::~HdfsFileHandle() {
 Status HdfsFileHandle::init(int64_t file_size) {
     _hdfs_file = hdfsOpenFile(_fs, _fname.c_str(), O_RDONLY, 0, 0, 0);
     if (_hdfs_file == nullptr) {
-        return Status::IOError("failed to open {}: {}", _fname, hdfs_error());
+        std::string _err_msg = hdfs_error();
+        if (_err_msg.find("No such file or directory") != string::npos) {
+            return Status::NotFound(_err_msg);
+        }
+        return Status::IOError("failed to open {}: {}", _fname, _err_msg);
     }
 
     _file_size = file_size;


### PR DESCRIPTION

## Proposed changes

```
W0724 00:21:15.718437 12363 fragment_mgr.cpp:474] report error status: [INTERNAL_ERROR]failed to init reader for file /xxx/xxx.db/xxx/partitions=xxx/part-00301-85c11a89-36da-4608-8f8f-0aba1c85a798.c000, err: [IO_ERROR]failed to open /xxx/xxx.db/xxx/partitions=xxx/part-00301-85c11a89-36da-4608-8f8f-0aba1c85a798.c000: (2), No such file or directory), reason: RemoteException: File does not exist: /xxx/xxx.db/xxx/partitions=xxx/part-00301-85c11a89-36da-4608-8f8f-0aba1c85a798.c000
        at org.apache.hadoop.hdfs.server.namenode.INodeFile.valueOf(INodeFile.java:86)
        at org.apache.hadoop.hdfs.server.namenode.INodeFile.valueOf(INodeFile.java:76)
        at org.apache.hadoop.hdfs.server.namenode.FSDirStatAndListingOp.getBlockLocations(FSDirStatAndListingOp.java:158)
        at org.apache.hadoop.hdfs.server.namenode.FSNamesystem.getBlockLocations(FSNamesystem.java:1927)
        at org.apache.hadoop.hdfs.server.namenode.NameNodeRpcServer.getBlockLocations(NameNodeRpcServer.java:738)
        at org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolServerSideTranslatorPB.getBlockLocations(ClientNamenodeProtocolServerSideTranslatorPB.java:426)
        at org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos$ClientNamenodeProtocol$2.callBlockingMethod(ClientNamenodeProtocolProtos.java)
        at org.apache.hadoop.ipc.ProtobufRpcEngine$Server$ProtoBufRpcInvoker.call(ProtobufRpcEngine.java:524)
        at org.apache.hadoop.ipc.RPC$Server.call(RPC.java:1025)
        at org.apache.hadoop.ipc.Server$RpcCall.run(Server.java:876)
        at org.apache.hadoop.ipc.Server$RpcCall.run(Server.java:822)
        at java.security.AccessController.doPrivileged(Native Method)
        at javax.security.auth.Subject.doAs(Subject.java:422)
        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1730)
        at org.apache.hadoop.ipc.Server$Handler.run(Server.java:2682)
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

