### PR TITLE
[fix](forward) fix MissingFormatArgumentException when failed to forward stmt to Master

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
@@ -117,9 +117,9 @@ public class MasterOpExecutor {
             // may throw NullPointerException. add err msg
             throw new Exception("Failed to get master client.", e);
         }
-        final StringBuilder forwardMsg = new StringBuilder(String.format("forward to Master %s", thriftAddress));
+        final StringBuilder forwardMsg = new StringBuilder("forward to master FE %s" + thriftAddress.toString());
         if (!params.isSyncJournalOnly()) {
-            forwardMsg.append(", statement: %s").append(ctx.getStmtId());
+            forwardMsg.append(", statement id: ").append(ctx.getStmtId());
         }
         LOG.info(forwardMsg.toString());
 
@@ -131,7 +131,7 @@ public class MasterOpExecutor {
         } catch (TTransportException e) {
             // wrap the raw exception.
             forwardMsg.append(" : failed");
-            Exception exception = new ForwardToMasterException(String.format(forwardMsg.toString()), e);
+            Exception exception = new ForwardToMasterException(forwardMsg.toString(), e);
 
             boolean ok = ClientPool.frontendPool.reopen(client, thriftTimeoutMs);
             if (!ok) {


### PR DESCRIPTION
## Proposed changes

The call of `String.format()` contains orphan `%s` that will cause following error.
Introduced from #21205

```
2023-07-24 12:46:33,059 WARN (mysql-nio-pool-5|1393) [StmtExecutor.executeByLegacy():762] execute Exception. stmt[2032, 896ff544d0b049f2-856be29f0f7744e5]
java.util.MissingFormatArgumentException: Format specifier '%s'
        at java.util.Formatter.format(Formatter.java:2519) ~[?:1.8.0_192]
        at java.util.Formatter.format(Formatter.java:2455) ~[?:1.8.0_192]
        at java.lang.String.format(String.java:2940) ~[?:1.8.0_192]
        at org.apache.doris.qe.MasterOpExecutor.forward(MasterOpExecutor.java:134) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.MasterOpExecutor.execute(MasterOpExecutor.java:84) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.forwardToMaster(StmtExecutor.java:829) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.executeByLegacy(StmtExecutor.java:671) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:443) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:414) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:441) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.dispatch(ConnectProcessor.java:589) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.processOnce(ConnectProcessor.java:827) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52) ~[doris-fe.jar:1.2-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_192]
        at java.util.concurrent.ThreadPoo
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

