### PR TITLE
[fix](Nereids) forbid gather sort with explict shuffle

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/implementation/LogicalSortToPhysicalQuickSort.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/implementation/LogicalSortToPhysicalQuickSort.java
@@ -38,14 +38,14 @@ public class LogicalSortToPhysicalQuickSort extends OneImplementationRuleFactory
                 .toRule(RuleType.LOGICAL_SORT_TO_PHYSICAL_QUICK_SORT_RULE);
     }
 
-    private List<PhysicalQuickSort<? extends Plan>> twoPhaseSort(LogicalSort logicalSort) {
-        PhysicalQuickSort localSort = new PhysicalQuickSort(logicalSort.getOrderKeys(),
+    private List<PhysicalQuickSort<? extends Plan>> twoPhaseSort(LogicalSort<? extends Plan> logicalSort) {
+        PhysicalQuickSort<Plan> localSort = new PhysicalQuickSort<>(logicalSort.getOrderKeys(),
                 SortPhase.LOCAL_SORT, logicalSort.getLogicalProperties(), logicalSort.child(0));
-        PhysicalQuickSort twoPhaseSort = new PhysicalQuickSort<>(
+        PhysicalQuickSort<Plan> twoPhaseSort = new PhysicalQuickSort<>(
                 logicalSort.getOrderKeys(),
                 SortPhase.MERGE_SORT, logicalSort.getLogicalProperties(),
                 localSort);
-        PhysicalQuickSort onePhaseSort = new PhysicalQuickSort<>(
+        PhysicalQuickSort<Plan> onePhaseSort = new PhysicalQuickSort<>(
                 logicalSort.getOrderKeys(),
                 SortPhase.GATHER_SORT, logicalSort.getLogicalProperties(),
                 localSort.child(0));

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/implementation/LogicalTopNToPhysicalTopN.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/implementation/LogicalTopNToPhysicalTopN.java
@@ -44,14 +44,15 @@ public class LogicalTopNToPhysicalTopN extends OneImplementationRuleFactory {
      *     gatherTopN(limit, off, require gather)
      *     mergeTopN(limit, off, require gather) -> localTopN(off+limit, 0, require any)
      */
-    private List<PhysicalTopN<? extends Plan>> twoPhaseSort(LogicalTopN logicalTopN) {
-        PhysicalTopN localSort = new PhysicalTopN(logicalTopN.getOrderKeys(),
+    private List<PhysicalTopN<? extends Plan>> twoPhaseSort(LogicalTopN<? extends Plan> logicalTopN) {
+        PhysicalTopN<Plan> localSort = new PhysicalTopN<>(logicalTopN.getOrderKeys(),
                 logicalTopN.getLimit() + logicalTopN.getOffset(), 0, SortPhase.LOCAL_SORT,
                 logicalTopN.getLogicalProperties(), logicalTopN.child(0));
-        PhysicalTopN twoPhaseSort = new PhysicalTopN<>(logicalTopN.getOrderKeys(), logicalTopN.getLimit(),
+        PhysicalTopN<Plan> twoPhaseSort = new PhysicalTopN<>(logicalTopN.getOrderKeys(), logicalTopN.getLimit(),
                 logicalTopN.getOffset(), SortPhase.MERGE_SORT, logicalTopN.getLogicalProperties(), localSort);
-        PhysicalTopN onePhaseSort = new PhysicalTopN<>(logicalTopN.getOrderKeys(), logicalTopN.getLimit(),
-                logicalTopN.getOffset(), SortPhase.GATHER_SORT, logicalTopN.getLogicalProperties(), localSort.child(0));
+        PhysicalTopN<Plan> onePhaseSort = new PhysicalTopN<>(logicalTopN.getOrderKeys(), logicalTopN.getLimit(),
+                logicalTopN.getOffset(), SortPhase.GATHER_SORT,
+                logicalTopN.getLogicalProperties(), localSort.child(0));
         return Lists.newArrayList(twoPhaseSort, onePhaseSort);
     }
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

gather sort with explict shuffle usually bad, forbid it

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

