### PR TITLE
[Fix](MoW) Fix dup key when do schema change add new key

### DIFF
--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -1273,8 +1273,7 @@ Status SchemaChangeHandler::_parse_request(const SchemaChangeParams& sc_params,
         return Status::OK();
     }
 
-    if (new_tablet_schema->keys_type() == KeysType::UNIQUE_KEYS &&
-        new_tablet->num_key_columns() > base_tablet_schema->num_key_columns()) {
+    if (new_tablet->enable_unique_key_merge_on_write()) {
         *sc_directly = true;
         return Status::OK();
     }

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -429,8 +429,6 @@ Status BlockChanger::_check_cast_valid(vectorized::ColumnPtr ref_column,
 Status LinkedSchemaChange::process(RowsetReaderSharedPtr rowset_reader, RowsetWriter* rowset_writer,
                                    TabletSharedPtr new_tablet, TabletSharedPtr base_tablet,
                                    TabletSchemaSPtr base_tablet_schema) {
-    // LinkedSchemaChange is useless, will remove it in the future.
-    DCHECK(false);
     // In some cases, there may be more than one type of rowset in a tablet,
     // in which case the conversion cannot be done directly by linked schema change,
     // but requires direct schema change to rewrite the data.
@@ -1273,7 +1271,8 @@ Status SchemaChangeHandler::_parse_request(const SchemaChangeParams& sc_params,
         return Status::OK();
     }
 
-    if (new_tablet->enable_unique_key_merge_on_write()) {
+    if (new_tablet->enable_unique_key_merge_on_write() &&
+        new_tablet->num_key_columns() > base_tablet_schema->num_key_columns()) {
         *sc_directly = true;
         return Status::OK();
     }

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -429,6 +429,8 @@ Status BlockChanger::_check_cast_valid(vectorized::ColumnPtr ref_column,
 Status LinkedSchemaChange::process(RowsetReaderSharedPtr rowset_reader, RowsetWriter* rowset_writer,
                                    TabletSharedPtr new_tablet, TabletSharedPtr base_tablet,
                                    TabletSchemaSPtr base_tablet_schema) {
+    // LinkedSchemaChange is useless, will remove it in the future.
+    DCHECK(false);
     // In some cases, there may be more than one type of rowset in a tablet,
     // in which case the conversion cannot be done directly by linked schema change,
     // but requires direct schema change to rewrite the data.
@@ -1268,6 +1270,12 @@ Status SchemaChangeHandler::_parse_request(const SchemaChangeParams& sc_params,
         // is less, which means the data in new tablet should be more aggregated.
         // so we use sorting schema change to sort and merge the data.
         *sc_sorting = true;
+        return Status::OK();
+    }
+
+    if (new_tablet_schema->keys_type() == KeysType::UNIQUE_KEYS &&
+        new_tablet->num_key_columns() > base_tablet_schema->num_key_columns()) {
+        *sc_directly = true;
         return Status::OK();
     }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

compaction.cpp:598] Check failed: false cumulative compaction: the merged rows(155) is not equal to missed rows(132) in rowid conversion, tablet_id: 21875169, table_id:21875059

Query id: 0-0 ***
Aborted at 1689610540 (unix time) try "date -d @1689610540" if you are using GNU date ***
Current BE git commitID: 05cf095506 ***
SIGABRT unknown detail explain (@0x303ab2) received by PID 3160754 (TID 3161952 OR 0x7f510c798700) from PID 3160754; stack trace: ***
0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:413

1# 0x00007F6295B3A0C0 in /lib/x86_64-linux-gnu/libc.so.6

2# raise in /lib/x86_64-linux-gnu/libc.so.6

3# abort in /lib/x86_64-linux-gnu/libc.so.6

4# 0x0000562BF3F09A99 in /mnt/ssd01/doris-master/NEREIDS_ASAN/be/lib/doris_be

5# 0x0000562BF3EFF0AD in /mnt/ssd01/doris-master/NEREIDS_ASAN/be/lib/doris_be

6# google::LogMessage::SendToLog() in /mnt/ssd01/doris-master/NEREIDS_ASAN/be/lib/doris_be

7# google::LogMessage::Flush() in /mnt/ssd01/doris-master/NEREIDS_ASAN/be/lib/doris_be

8# google::LogMessageFatal::~LogMessageFatal() in /mnt/ssd01/doris-master/NEREIDS_ASAN/be/lib/doris_be

9# doris::Compaction::modify_rowsets(doris::Merger::Statistics const*) in /mnt/ssd01/doris-master/NEREIDS_ASAN/be/lib/doris_be

10# doris::Compaction::do_compaction_impl(long) at /home/zcp/repo_center/doris_master/doris/be/src/olap/compaction.cpp:447

11# doris::Compaction::do_compaction(long) at /home/zcp/repo_center/doris_master/doris/be/src/olap/compaction.cpp:121

12# doris::CumulativeCompaction::execute_compact_impl() at /home/zcp/repo_center/doris_master/doris/be/src/olap/cumulative_compaction.cpp:87

13# doris::Compaction::execute_compact() at /home/zcp/repo_center/doris_master/doris/be/src/olap/compaction.cpp:103

14# doris::Tablet::execute_compaction(doris::CompactionType) at /home/zcp/repo_center/doris_master/doris/be/src/olap/tablet.cpp:1826

15# doris::StorageEngine::_submit_compaction_task(std::shared_ptr<doris::Tablet>, doris::CompactionType, bool)::$_0::operator()() const at /home/zcp/repo_center/doris_master/doris/be/src/olap/olap_server.cpp:960

16# void std::_invoke_impl<void, doris::StorageEngine::_submit_compaction_task(std::shared_ptr<doris::Tablet>, doris::CompactionType, bool)::$_0&>(std::_invoke_other, doris::StorageEngine::_submit_compaction_task(std::shared_ptr<doris::Tablet>, doris::CompactionType, bool)::$_0&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61

17# std::enable_if<is_invocable_r_v<void, doris::StorageEngine::submit_compaction_task(std::shared_ptr<doris::Tablet>, doris::CompactionType, bool)::$_0&>, void>::type std::_invoke_r<void, doris::StorageEngine::_submit_compaction_task(std::shared_ptr<doris::Tablet>, doris::CompactionType, bool)::$_0&>(doris::StorageEngine::_submit_compaction_task(std::shared_ptr<doris::Tablet>, doris::CompactionType, bool)::$_0&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117

18# std::_Function_handler<void (), doris::StorageEngine::_submit_compaction_task(std::shared_ptr<doris::Tablet>, doris::CompactionType, bool)::$_0>::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291

19# std::function<void ()>::operator()() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560

20# doris::FunctionRunnable::run() at /home/zcp/repo_center/doris_master/doris/be/src/util/threadpool.cpp:48

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

