### PR TITLE
[improvement](case function) add check to avoid stack overflow

### DIFF
--- a/be/src/vec/functions/function_case.h
+++ b/be/src/vec/functions/function_case.h
@@ -197,12 +197,15 @@ public:
     template <typename ColumnType, bool when_null, bool then_null>
     Status execute_impl(const DataTypePtr& data_type, Block& block, size_t result,
                         CaseWhenColumnHolder column_holder) {
+        int rows_count = column_holder.rows_count;
+        // some operators batch size may be exceeding 4096,
+        // so we added some tolerance to check 65536 to prevent stack overflow.
+        DCHECK(rows_count < 65536) << "rows count needs to be less than 65536 in function case";
+
         if (column_holder.pair_count > UINT8_MAX) {
             return execute_short_circuit<ColumnType, when_null, then_null>(data_type, block, result,
                                                                            column_holder);
         }
-
-        int rows_count = column_holder.rows_count;
 
         // `then` data index corresponding to each row of results, 0 represents `else`.
         uint8_t then_idx[rows_count];


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

add check for batch size to avoid stack overflow, some operators batch size may be exceeding 4096, so we added some tolerance to check 65536 to prevent stack overflow.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

