### PR TITLE
[fix][jdbc_case]Change the method of obtaining the driver for case test_doris_jdbc_catalog 0724

### DIFF
--- a/regression-test/suites/jdbc_catalog_p0/test_doris_jdbc_catalog.groovy
+++ b/regression-test/suites/jdbc_catalog_p0/test_doris_jdbc_catalog.groovy
@@ -21,7 +21,9 @@ suite("test_doris_jdbc_catalog", "p0") {
     String jdbcUrl = context.config.jdbcUrl + "&sessionVariables=return_object_data_as_binary=true"
     String jdbcUser = context.config.jdbcUser
     String jdbcPassword = context.config.jdbcPassword
-    String driver_url = "https://doris-community-test-1308700295.cos.ap-hongkong.myqcloud.com/jdbc_driver/mysql-connector-java-8.0.25.jar"
+    String s3_endpoint = getS3Endpoint()
+    String bucket = getS3BucketName()
+    String driver_url = "https://${bucket}.${s3_endpoint}/regression/jdbc_driver/mysql-connector-java-8.0.25.jar"
 
     String resource_name = "jdbc_resource_catalog_doris"
     String catalog_name = "doris_jdbc_catalog";


### PR DESCRIPTION
## Proposed changes

<!--Describe your changes.-->
Change the method of obtaining the driver for case test_doris_jdbc_catalog.
The previous driver_url is written dead, which is not conducive to subsequent extension.
This mysql driver jar has been uploaded to object storage in Beijing and Hong Kong respectively.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

