### PR TITLE
[fix](binlog) Fix BinlogUtils getExpiredMs overflow

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogUtils.java
@@ -119,6 +119,10 @@ public class BinlogUtils {
 
     public static long getExpiredMs(long ttlSeconds) {
         long currentSeconds = System.currentTimeMillis() / 1000;
+        if (currentSeconds < ttlSeconds) {
+            return Long.MIN_VALUE;
+        }
+
         long expireSeconds = currentSeconds - ttlSeconds;
         return expireSeconds * 1000;
     }


### PR DESCRIPTION
## Proposed changes

Fix BinlogUtils getExpiredMs overflow

![39a775a4-7592-40f0-a906-ef13fff3dfa1](https://github.com/apache/doris/assets/3295714/a38ca98e-9f8a-4aea-a6c6-32cfcbc1440e)


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

