### PR TITLE
[fix](nereids) fix runtime filter on cte sender and set operation

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
@@ -220,6 +220,7 @@ public class RuntimeFilterGenerator extends PlanPostProcessor {
         Map<NamedExpression, Pair<PhysicalRelation, Slot>> aliasTransferMap
                 = context.getRuntimeFilterContext().getAliasTransferMap();
         // change key when encounter alias.
+        // TODO: same action will be taken for set operation
         for (Expression expression : project.getProjects()) {
             if (expression.children().isEmpty()) {
                 continue;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalCTEConsumer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalCTEConsumer.java
@@ -145,8 +145,9 @@ public class PhysicalCTEConsumer extends PhysicalRelation {
                                          AbstractPhysicalJoin builderNode,
                                          Expression src, Expression probeExpr,
                                          TRuntimeFilterType type, long buildSideNdv, int exprOrder) {
-        // TODO: current cte internal pushing down is too complicated and it is not convenient to move the logic here.
-        // will refine it in the future.
-        return false;
+        // push down rf on cte sender
+        // TODO: refactor pushing down into cte internal here
+        return super.pushDownRuntimeFilter(context, generator, builderNode,
+                src, probeExpr, type, buildSideNdv, exprOrder);
     }
 }


### PR DESCRIPTION
## Proposed changes

Current rf pushdown framework doesn't handle cte sender right. On cte consumer, it just return false and this will cause the rf is generated at the wrong place and lead the expr_order checking failed, but actually it should be pushed down on the cte sender. Also, set operation pushing down is unreachable if the outer stmt uses the alias of set operation's output before probeSlot's translation. Both of the above issues will be fixed in this pr.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

