### PR TITLE
[fix](iceberg) fix error when query iceberg v2 format

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileQueryScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileQueryScanNode.java
@@ -363,6 +363,10 @@ public abstract class FileQueryScanNode extends FileScanNode {
         } else if (locationType == TFileType.FILE_S3 && !params.isSetProperties()) {
             params.setProperties(locationProperties);
         }
+
+        if (!params.isSetFileType()) {
+            params.setFileType(locationType);
+        }
     }
 
     private TScanRangeLocations newLocations() {


### PR DESCRIPTION
## Proposed changes

This bug is introduced from #21771
Missing fileType field of TFileScanRangeParams, so the delete file of iceberg v2 will be treated as local file
and fail to read.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

