### PR TITLE
[fix](hudi) the required fields are empty if only reading partition columns

### DIFF
--- a/be/src/vec/exec/jni_connector.cpp
+++ b/be/src/vec/exec/jni_connector.cpp
@@ -156,37 +156,39 @@ Status JniConnector::close() {
     if (!_closed) {
         JNIEnv* env = nullptr;
         RETURN_IF_ERROR(JniUtil::GetJNIEnv(&env));
-        // update scanner metrics
-        for (const auto& metric : get_statistics(env)) {
-            std::vector<std::string> type_and_name = split(metric.first, ":");
-            if (type_and_name.size() != 2) {
-                LOG(WARNING) << "Name of JNI Scanner metric should be pattern like "
-                             << "'metricType:metricName'";
-                continue;
+        if (_scanner_initialized) {
+            // update scanner metrics
+            for (const auto& metric : get_statistics(env)) {
+                std::vector<std::string> type_and_name = split(metric.first, ":");
+                if (type_and_name.size() != 2) {
+                    LOG(WARNING) << "Name of JNI Scanner metric should be pattern like "
+                                 << "'metricType:metricName'";
+                    continue;
+                }
+                long metric_value = std::stol(metric.second);
+                RuntimeProfile::Counter* scanner_counter;
+                if (type_and_name[0] == "timer") {
+                    scanner_counter =
+                            ADD_CHILD_TIMER(_profile, type_and_name[1], _connector_name.c_str());
+                } else if (type_and_name[0] == "counter") {
+                    scanner_counter = ADD_CHILD_COUNTER(_profile, type_and_name[1], TUnit::UNIT,
+                                                        _connector_name.c_str());
+                } else if (type_and_name[0] == "bytes") {
+                    scanner_counter = ADD_CHILD_COUNTER(_profile, type_and_name[1], TUnit::BYTES,
+                                                        _connector_name.c_str());
+                } else {
+                    LOG(WARNING) << "Type of JNI Scanner metric should be timer, counter or bytes";
+                    continue;
+                }
+                COUNTER_UPDATE(scanner_counter, metric_value);
             }
-            long metric_value = std::stol(metric.second);
-            RuntimeProfile::Counter* scanner_counter;
-            if (type_and_name[0] == "timer") {
-                scanner_counter =
-                        ADD_CHILD_TIMER(_profile, type_and_name[1], _connector_name.c_str());
-            } else if (type_and_name[0] == "counter") {
-                scanner_counter = ADD_CHILD_COUNTER(_profile, type_and_name[1], TUnit::UNIT,
-                                                    _connector_name.c_str());
-            } else if (type_and_name[0] == "bytes") {
-                scanner_counter = ADD_CHILD_COUNTER(_profile, type_and_name[1], TUnit::BYTES,
-                                                    _connector_name.c_str());
-            } else {
-                LOG(WARNING) << "Type of JNI Scanner metric should be timer, counter or bytes";
-                continue;
-            }
-            COUNTER_UPDATE(scanner_counter, metric_value);
-        }
 
-        // _fill_block may be failed and returned, we should release table in close.
-        // org.apache.doris.common.jni.JniScanner#releaseTable is idempotent
-        env->CallVoidMethod(_jni_scanner_obj, _jni_scanner_release_table);
-        env->CallVoidMethod(_jni_scanner_obj, _jni_scanner_close);
-        env->DeleteGlobalRef(_jni_scanner_obj);
+            // _fill_block may be failed and returned, we should release table in close.
+            // org.apache.doris.common.jni.JniScanner#releaseTable is idempotent
+            env->CallVoidMethod(_jni_scanner_obj, _jni_scanner_release_table);
+            env->CallVoidMethod(_jni_scanner_obj, _jni_scanner_close);
+            env->DeleteGlobalRef(_jni_scanner_obj);
+        }
         env->DeleteGlobalRef(_jni_scanner_cls);
         _closed = true;
         jthrowable exc = (env)->ExceptionOccurred();
@@ -222,6 +224,7 @@ Status JniConnector::_init_jni_scanner(JNIEnv* env, int batch_size) {
     _jni_scanner_get_statistics =
             env->GetMethodID(_jni_scanner_cls, "getStatistics", "()Ljava/util/Map;");
     RETURN_IF_ERROR(JniUtil::LocalToGlobalRef(env, jni_scanner_obj, &_jni_scanner_obj));
+    _scanner_initialized = true;
     env->DeleteLocalRef(jni_scanner_obj);
     RETURN_ERROR_IF_EXC(env);
     return Status::OK();

--- a/be/src/vec/exec/jni_connector.h
+++ b/be/src/vec/exec/jni_connector.h
@@ -257,6 +257,7 @@ private:
     size_t _has_read = 0;
 
     bool _closed = false;
+    bool _scanner_initialized = false;
     jclass _jni_scanner_cls;
     jobject _jni_scanner_obj;
     jmethodID _jni_scanner_open;


### PR DESCRIPTION
## Proposed changes

Fix errors when analyzing hudi tables or reading hudi partition columns:
The `required_fields` is an empty string when only reading partition columns, so errors are thrown when parsing column types.
```
W0724 16:44:38.431789 296139 jni-util.cpp:239] java.util.NoSuchElementException: key not found:
        at scala.collection.MapLike.default(MapLike.scala:236)
        at scala.collection.MapLike.default$(MapLike.scala:235)
        at scala.collection.AbstractMap.default(Map.scala:65)
        at scala.collection.MapLike.apply(MapLike.scala:144)
        at scala.collection.MapLike.apply$(MapLike.scala:143)
        at scala.collection.AbstractMap.apply(Map.scala:65)
        at org.apache.doris.hudi.HoodieSplit.$anonfun$requiredTypes$1(BaseSplitReader.scala:89)
        at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:286)
        at scala.collection.IndexedSeqOptimized.foreach(IndexedSeqOptimized.scala:36)
        at scala.collection.IndexedSeqOptimized.foreach$(IndexedSeqOptimized.scala:33)
        at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:198)
        at scala.collection.TraversableLike.map(TraversableLike.scala:286)
        at scala.collection.TraversableLike.map$(TraversableLike.scala:279)
        at scala.collection.mutable.ArrayOps$ofRef.map(ArrayOps.scala:198)
        at org.apache.doris.hudi.HoodieSplit.<init>(BaseSplitReader.scala:88)
        at org.apache.doris.hudi.HudiJniScanner.<init>(HudiJniScanner.java:66)
```
The `HudiJniScanner.<init>` is failed, and the `_jni_scanner_obj` is not initialized, so we can't call the java methods in `_jni_scanner_obj`.
```
5# JNI_ArgumentPusherVaArg::JNI_ArgumentPusherVaArg(_jmethodID*, __va_list_tag*) in /mnt/datadisk0/gaoxin/app/jdk1.8.0_131/jre/lib/amd64/server/[libjvm.so](http://libjvm.so/)
 6# jni_CallObjectMethodV in /mnt/datadisk0/gaoxin/app/jdk1.8.0_131/jre/lib/amd64/server/[libjvm.so](http://libjvm.so/)
 7# JNIEnv_::CallObjectMethod(_jobject*, _jmethodID*, ...) in /mnt/datadisk0/gaoxin/doris/output/be/lib/doris_be
 8# doris::vectorized::JniConnector::close() in /mnt/datadisk0/gaoxin/doris/output/be/lib/doris_be
 9# doris::vectorized::JniConnector::~JniConnector() in /mnt/datadisk0/gaoxin/doris/output/be/lib/doris_be
10# doris::vectorized::HudiJniReader::~HudiJniReader() in /mnt/datadisk0/gaoxin/doris/output/be/lib/doris_be
11# doris::vectorized::VFileScanner::~VFileScanner() in /mnt/datadisk0/gaoxin/doris/output/be/lib/doris_be
12# doris::vectorized::VFileScanner::~VFileScanner() in /mnt/datadisk0/gaoxin/doris/output/be/lib/doris_be
13# doris::vectorized::ScannerContext::_close_and_clear_scanners(doris::vectorized::VScanNode*, doris::RuntimeState*) in /mnt/datadisk0/gaoxin/doris/output/be/lib/doris_be
```

## How to fix
1. If only read the partition columns, the `JniConnector` will produce empty required fields, so `HudiJniScanner` should read the "_hoodie_record_key" field at least to know how many rows in current hoodie split. Even if the `JniConnector` doesn't read this field, the call of `releaseTable` in `JniConnector` will reclaim the resource.

2. To prevent BE failure and exit, `JniConnector` should call release methods after `HudiJniScanner` is initialized. It should be noted that `VectorTable` is created lazily in `JniScanner`,  so we don't need to reclaim the resource when `HudiJniScanner` is failed to initialize.

## Remaining works
Other jni readers like `paimon` and `maxcompute` may encounter the same problems, the jni reader need to handle this abnormal situation on its own, and currently this fix can only ensure that BE will not exit.





