### PR TITLE
[Feature](inverted index) add inverted index tool

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -1067,6 +1067,10 @@ if (BUILD_META_TOOL AND BUILD_META_TOOL STREQUAL "ON")
     add_subdirectory(${SRC_DIR}/tools)
 endif()
 
+if (BUILD_INDEX_TOOL AND BUILD_INDEX_TOOL STREQUAL "ON")
+    add_subdirectory(${SRC_DIR}/index-tools)
+endif()
+
 add_subdirectory(${SRC_DIR}/util)
 add_subdirectory(${SRC_DIR}/vec)
 add_subdirectory(${SRC_DIR}/pipeline)

--- a/be/src/index-tools/CMakeLists.txt
+++ b/be/src/index-tools/CMakeLists.txt
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# where to put generated libraries
+set(LIBRARY_OUTPUT_PATH "${BUILD_DIR}/src/index-tools")
+
+# where to put generated binaries
+set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/src/index-tools")
+
+add_executable(index_tool
+    index_tool.cpp
+)
+
+pch_reuse(index_tool)
+
+# This permits libraries loaded by dlopen to link to the symbols in the program.
+set_target_properties(index_tool PROPERTIES ENABLE_EXPORTS 1)
+
+
+target_link_libraries(index_tool
+    ${DORIS_LINK_LIBS}
+)
+
+install(DIRECTORY DESTINATION ${OUTPUT_DIR}/lib/)
+install(TARGETS index_tool DESTINATION ${OUTPUT_DIR}/lib/)

--- a/be/src/index-tools/CMakeLists.txt
+++ b/be/src/index-tools/CMakeLists.txt
@@ -37,3 +37,11 @@ target_link_libraries(index_tool
 
 install(DIRECTORY DESTINATION ${OUTPUT_DIR}/lib/)
 install(TARGETS index_tool DESTINATION ${OUTPUT_DIR}/lib/)
+if (NOT OS_MACOSX)
+# strip debug info to save space
+add_custom_command(TARGET index_tool POST_BUILD
+    COMMAND ${CMAKE_OBJCOPY} --only-keep-debug $<TARGET_FILE:index_tool> $<TARGET_FILE:index_tool>.dbg
+    COMMAND ${CMAKE_STRIP} --strip-debug --strip-unneeded $<TARGET_FILE:index_tool>
+    COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=$<TARGET_FILE:index_tool>.dbg $<TARGET_FILE:index_tool>
+    )
+endif()

--- a/be/src/index-tools/index_tool.cpp
+++ b/be/src/index-tools/index_tool.cpp
@@ -1,0 +1,181 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <CLucene/CLConfig.h>
+#include <CLucene/SharedHeader.h>
+#include <CLucene/debug/error.h>
+#include <CLucene/store/Directory.h>
+#include <CLucene/store/FSDirectory.h>
+#include <gflags/gflags.h>
+
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "CLucene/config/repl_wchar.h"
+#include "io/fs/local_file_system.h"
+#include "olap/rowset/segment_v2/inverted_index_compound_directory.h"
+#include "olap/rowset/segment_v2/inverted_index_compound_reader.h"
+
+using doris::segment_v2::DorisCompoundReader;
+using doris::segment_v2::DorisCompoundDirectory;
+using namespace lucene::analysis;
+using namespace lucene::index;
+using namespace lucene::util;
+using namespace lucene::search;
+
+DEFINE_string(operation, "show_files", "valid operation: show_files,check_terms,term_query_equal");
+
+DEFINE_string(root_path, "./", "storage root path");
+DEFINE_string(idx_file_path, "", "inverted index file path");
+DEFINE_string(term, "", "inverted index term to query");
+DEFINE_string(column_name, "", "inverted index column_name to query");
+//DEFINE_string(nested_file, "", "inverted index nested file name");
+
+std::string get_usage(const std::string& progname) {
+    std::stringstream ss;
+    ss << progname << " is the Doris Inverted index file tool.\n";
+    ss << "Stop BE first before use this tool.\n";
+    ss << "Usage:\n";
+    ss << "./index_tool --operation=show_files --root_path=directory "
+          "--idx_file_path=path/to/file\n";
+    ss << "./index_tool --operation=check_terms_stats --root_path=directory "
+          "--idx_file_path=path/to/file\n";
+    ss << "./index_tool --operation=term_query_equal --root_path=directory "
+          "--idx_file_path=path/to/file --term=term --column_name=column_name\n";
+    //ss << "./index_tool --operation=check_nested_file --root_path=directory --idx_file_path=path/to/file --nested_file=nested_file_name\n";
+    return ss.str();
+}
+
+void SearchFiles(lucene::store::Directory* dir, std::string& field, std::string& token) {
+    IndexReader* reader = IndexReader::open(dir);
+
+    IndexReader* newreader = reader->reopen();
+    if (newreader != reader) {
+        _CLLDELETE(reader);
+        reader = newreader;
+    }
+    IndexSearcher s(reader);
+
+    std::wstring field_ws(field.begin(), field.end());
+    std::wstring token_ws(token.begin(), token.end());
+    lucene::index::Term* term = _CLNEW lucene::index::Term(field_ws.c_str(), token_ws.c_str());
+    auto q = _CLNEW lucene::search::TermQuery(term);
+    _CLDECDELETE(term);
+
+    std::vector<uint32_t> result;
+    int total = 0;
+    s._search(q, [&result, &total](const int32_t docid, const float_t /*score*/) {
+        // docid equal to rowid in segment
+        result.push_back(docid);
+        printf("RowID is %d\n", docid);
+        total += 1;
+    });
+    std::cout << "Term queried count:" << total << std::endl;
+    _CLLDELETE(q);
+
+    s.close();
+    reader->close();
+    _CLLDELETE(reader);
+}
+
+void check_terms_stats(lucene::store::Directory* dir) {
+    IndexReader* r = IndexReader::open(dir);
+    //printf("Statistics for %s\n", directory);
+    printf("==================================\n");
+
+    printf("Max Docs: %d\n", r->maxDoc());
+    printf("Num Docs: %d\n", r->numDocs());
+
+    int64_t ver = r->getCurrentVersion(dir);
+    printf("Current Version: %f\n", (float_t)ver);
+
+    TermEnum* te = r->terms();
+    int32_t nterms;
+    for (nterms = 0; te->next() == true; nterms++) {
+        /* empty */
+        std::string token = lucene_wcstoutf8string(te->term()->text(), te->term()->textLength());
+
+        printf("Term: %s ", token.c_str());
+        printf("Freq: %d\n", te->docFreq());
+    }
+    printf("Term count: %d\n\n", nterms);
+    _CLLDELETE(te);
+
+    r->close();
+    _CLLDELETE(r);
+}
+
+int main(int argc, char** argv) {
+    std::string usage = get_usage(argv[0]);
+    gflags::SetUsageMessage(usage);
+    google::ParseCommandLineFlags(&argc, &argv, true);
+
+    if (FLAGS_operation == "show_files") {
+        if (FLAGS_idx_file_path == "") {
+            std::cout << "no file flag for show " << std::endl;
+            return -1;
+        }
+        auto fs = doris::io::global_local_filesystem();
+        try {
+            lucene::store::Directory* dir =
+                    DorisCompoundDirectory::getDirectory(fs, FLAGS_root_path.c_str());
+            auto reader = new DorisCompoundReader(dir, FLAGS_idx_file_path.c_str(), 4096);
+            std::vector<std::string> files;
+            reader->list(&files);
+            for (auto& file : files) {
+                std::cout << file << std::endl;
+            }
+        } catch (CLuceneError& err) {
+            std::cerr << "error occurred when show files: " << err.what() << std::endl;
+        }
+    } else if (FLAGS_operation == "check_terms_stats") {
+        if (FLAGS_idx_file_path == "") {
+            std::cout << "no file flag for check " << std::endl;
+            return -1;
+        }
+        auto fs = doris::io::global_local_filesystem();
+        try {
+            lucene::store::Directory* dir =
+                    DorisCompoundDirectory::getDirectory(fs, FLAGS_root_path.c_str());
+            auto reader = new DorisCompoundReader(dir, FLAGS_idx_file_path.c_str(), 4096);
+            check_terms_stats(reader);
+        } catch (CLuceneError& err) {
+            std::cerr << "error occurred when check_terms_stats: " << err.what() << std::endl;
+        }
+    } else if (FLAGS_operation == "term_query_equal") {
+        if (FLAGS_idx_file_path == "" || FLAGS_term == "" || FLAGS_column_name == "") {
+            std::cout << "invalid params for term_query_equal " << std::endl;
+            return -1;
+        }
+        auto fs = doris::io::global_local_filesystem();
+        try {
+            lucene::store::Directory* dir =
+                    DorisCompoundDirectory::getDirectory(fs, FLAGS_root_path.c_str());
+            auto reader = new DorisCompoundReader(dir, FLAGS_idx_file_path.c_str(), 4096);
+            SearchFiles(reader, FLAGS_column_name, FLAGS_term);
+        } catch (CLuceneError& err) {
+            std::cerr << "error occurred when check_terms_stats: " << err.what() << std::endl;
+        }
+    } else {
+        std::cout << "invalid operation: " << FLAGS_operation << "\n" << usage << std::endl;
+        return -1;
+    }
+    gflags::ShutDownCommandLineFlags();
+    return 0;
+}

--- a/be/src/index-tools/index_tool.cpp
+++ b/be/src/index-tools/index_tool.cpp
@@ -204,6 +204,9 @@ int main(int argc, char** argv) {
                 for (auto& f : files) {
                     try {
                         auto file_str = f.file_name;
+                        if (!file_str.ends_with(".idx")) {
+                            continue;
+                        }
                         auto reader = new DorisCompoundReader(dir, file_str.c_str(), 4096);
                         std::cout << "Search " << FLAGS_column_name << ":" << FLAGS_term << " from "
                                   << file_str << std::endl;

--- a/be/src/index-tools/index_tool.cpp
+++ b/be/src/index-tools/index_tool.cpp
@@ -54,7 +54,7 @@ std::string get_usage(const std::string& progname) {
     ss << "Usage:\n";
     ss << "./index_tool --operation=show_nested_files --idx_file_path=path/to/file\n";
     ss << "./index_tool --operation=check_terms_stats --idx_file_path=path/to/file\n";
-    ss << "./index_tool --operation=term_query --dir=directory "
+    ss << "./index_tool --operation=term_query --directory=directory "
           "--idx_file_name=file --print_row_id --term=term --column_name=column_name "
           "--pred_type=eq/lt/gt/le/ge/match etc\n";
     return ss.str();

--- a/build.sh
+++ b/build.sh
@@ -42,6 +42,7 @@ Usage: $0 <options>
      --fe                   build Frontend and Spark DPP application. Default ON.
      --be                   build Backend. Default ON.
      --meta-tool            build Backend meta tool. Default OFF.
+     --index-tool           build Backend inverted index tool. Default OFF.
      --broker               build Broker. Default ON.
      --audit                build audit loader. Default ON.
      --spark-dpp            build Spark DPP application. Default ON.
@@ -60,6 +61,7 @@ Usage: $0 <options>
     $0                                      build all
     $0 --be                                 build Backend
     $0 --meta-tool                          build Backend meta tool
+    $0 --index-tool                         build Backend inverted index tool
     $0 --fe --clean                         clean and build Frontend and Spark Dpp application
     $0 --fe --be --clean                    clean and build Frontend, Spark Dpp application and Backend
     $0 --spark-dpp                          build Spark DPP application alone
@@ -117,6 +119,7 @@ if ! OPTS="$(getopt \
     -l 'broker' \
     -l 'audit' \
     -l 'meta-tool' \
+    -l 'index-tool' \
     -l 'spark-dpp' \
     -l 'hive-udf' \
     -l 'be-java-extensions' \
@@ -137,6 +140,7 @@ BUILD_BE=0
 BUILD_BROKER=0
 BUILD_AUDIT=0
 BUILD_META_TOOL='OFF'
+BUILD_INDEX_TOOL='OFF'
 BUILD_SPARK_DPP=0
 BUILD_BE_JAVA_EXTENSIONS=0
 BUILD_HIVE_UDF=0
@@ -152,6 +156,7 @@ if [[ "$#" == 1 ]]; then
     BUILD_BROKER=1
     BUILD_AUDIT=1
     BUILD_META_TOOL='OFF'
+    BUILD_INDEX_TOOL='OFF'
     BUILD_SPARK_DPP=1
     BUILD_HIVE_UDF=1
     BUILD_BE_JAVA_EXTENSIONS=1
@@ -181,6 +186,10 @@ else
             ;;
         --meta-tool)
             BUILD_META_TOOL='ON'
+            shift
+            ;;
+        --index-tool)
+            BUILD_INDEX_TOOL='ON'
             shift
             ;;
         --spark-dpp)
@@ -237,6 +246,7 @@ else
         BUILD_BROKER=1
         BUILD_AUDIT=1
         BUILD_META_TOOL='ON'
+        BUILD_INDEX_TOOL='ON'
         BUILD_SPARK_DPP=1
         BUILD_HIVE_UDF=1
         BUILD_BE_JAVA_EXTENSIONS=1
@@ -392,6 +402,7 @@ echo "Get params:
     BUILD_BROKER                -- ${BUILD_BROKER}
     BUILD_AUDIT                 -- ${BUILD_AUDIT}
     BUILD_META_TOOL             -- ${BUILD_META_TOOL}
+    BUILD_INDEX_TOOL            -- ${BUILD_INDEX_TOOL}
     BUILD_SPARK_DPP             -- ${BUILD_SPARK_DPP}
     BUILD_BE_JAVA_EXTENSIONS    -- ${BUILD_BE_JAVA_EXTENSIONS}
     BUILD_HIVE_UDF              -- ${BUILD_HIVE_UDF}
@@ -487,6 +498,7 @@ if [[ "${BUILD_BE}" -eq 1 ]]; then
         -DWITH_LZO="${WITH_LZO}" \
         -DUSE_LIBCPP="${USE_LIBCPP}" \
         -DBUILD_META_TOOL="${BUILD_META_TOOL}" \
+        -DBUILD_INDEX_TOOL="${BUILD_INDEX_TOOL}" \
         -DSTRIP_DEBUG_INFO="${STRIP_DEBUG_INFO}" \
         -DUSE_DWARF="${USE_DWARF}" \
         -DUSE_UNWIND="${USE_UNWIND}" \
@@ -640,6 +652,10 @@ EOF
 
     if [[ "${BUILD_META_TOOL}" = "ON" ]]; then
         cp -r -p "${DORIS_HOME}/be/output/lib/meta_tool" "${DORIS_OUTPUT}/be/lib"/
+    fi
+
+    if [[ "${BUILD_INDEX_TOOL}" = "ON" ]]; then
+        cp -r -p "${DORIS_HOME}/be/output/lib/index_tool" "${DORIS_OUTPUT}/be/lib"/
     fi
 
     cp -r -p "${DORIS_HOME}/webroot/be"/* "${DORIS_OUTPUT}/be/www"/


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

add inverted index tool, it is used as following:
```
Usage:
./index_tool --operation=show_nested_files --idx_file_path=path/to/file
./index_tool --operation=check_terms_stats --idx_file_path=path/to/file
./index_tool --operation=term_query --directory=directory --idx_file_name=file --print_row_id=true --term=term --column_name=column_name --pred_type=eq/lt/gt/le/ge/match etc
```
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

