### PR TITLE
[Improvement](aggregate) optimization for AggregationMethodKeysFixed::insert_keys_into_columns

### DIFF
--- a/be/src/vec/columns/column_vector.h
+++ b/be/src/vec/columns/column_vector.h
@@ -227,9 +227,7 @@ public:
         use by date, datetime, basic type
     */
     void insert_many_fix_len_data(const char* data_ptr, size_t num) override {
-        if constexpr (!std::is_same_v<T, vectorized::Int64>) {
-            insert_many_in_copy_way(data_ptr, num);
-        } else if (IColumn::is_date) {
+        if (IColumn::is_date) {
             insert_date_column(data_ptr, num);
         } else if (IColumn::is_date_time) {
             insert_datetime_column(data_ptr, num);

--- a/be/src/vec/exec/vaggregation_node.h
+++ b/be/src/vec/exec/vaggregation_node.h
@@ -154,14 +154,6 @@ struct AggregationMethodSerialized {
         return max_one_row_byte_size;
     }
 
-    static void insert_key_into_columns(const StringRef& key, MutableColumns& key_columns,
-                                        const Sizes&) {
-        auto pos = key.data;
-        for (auto& column : key_columns) {
-            pos = column->deserialize_and_insert_from_arena(pos);
-        }
-    }
-
     static void insert_keys_into_columns(std::vector<StringRef>& keys, MutableColumns& key_columns,
                                          const size_t num_rows, const Sizes&) {
         for (auto& column : key_columns) {
@@ -215,11 +207,6 @@ struct AggregationMethodStringNoCache {
 
     static const bool low_cardinality_optimization = false;
 
-    static void insert_key_into_columns(const StringRef& key, MutableColumns& key_columns,
-                                        const Sizes&) {
-        key_columns[0]->insert_data(key.data, key.size);
-    }
-
     static void insert_keys_into_columns(std::vector<StringRef>& keys, MutableColumns& key_columns,
                                          const size_t num_rows, const Sizes&) {
         key_columns[0]->reserve(num_rows);
@@ -255,14 +242,6 @@ struct AggregationMethodOneNumber {
     /// To use one `Method` in different threads, use different `State`.
     using State = ColumnsHashing::HashMethodOneNumber<typename Data::value_type, Mapped, FieldType,
                                                       consecutive_keys_optimization>;
-
-    // Insert the key from the hash table into columns.
-    static void insert_key_into_columns(const Key& key, MutableColumns& key_columns,
-                                        const Sizes& /*key_sizes*/) {
-        const auto* key_holder = reinterpret_cast<const char*>(&key);
-        auto* column = static_cast<ColumnVectorHelper*>(key_columns[0].get());
-        column->insert_raw_data<sizeof(FieldType)>(key_holder);
-    }
 
     static void insert_keys_into_columns(std::vector<Key>& keys, MutableColumns& key_columns,
                                          const size_t num_rows, const Sizes&) {
@@ -328,74 +307,23 @@ struct AggregationMethodKeysFixed {
     using State = ColumnsHashing::HashMethodKeysFixed<typename Data::value_type, Key, Mapped,
                                                       has_nullable_keys, false>;
 
-    static void insert_key_into_columns(const Key& key, MutableColumns& key_columns,
-                                        const Sizes& key_sizes) {
-        size_t keys_size = key_columns.size();
-
-        static constexpr auto bitmap_size =
-                has_nullable_keys ? std::tuple_size<KeysNullMap<Key>>::value : 0;
-        /// In any hash key value, column values to be read start just after the bitmap, if it exists.
-        size_t pos = bitmap_size;
-
-        for (size_t i = 0; i < keys_size; ++i) {
-            IColumn* observed_column;
-            ColumnUInt8* null_map;
-
-            bool column_nullable = false;
-            if constexpr (has_nullable_keys) {
-                column_nullable = is_column_nullable(*key_columns[i]);
-            }
-
-            /// If we have a nullable column, get its nested column and its null map.
-            if (column_nullable) {
-                ColumnNullable& nullable_col = assert_cast<ColumnNullable&>(*key_columns[i]);
-                observed_column = &nullable_col.get_nested_column();
-                null_map = assert_cast<ColumnUInt8*>(&nullable_col.get_null_map_column());
-            } else {
-                observed_column = key_columns[i].get();
-                null_map = nullptr;
-            }
-
-            bool is_null = false;
-            if (column_nullable) {
-                /// The current column is nullable. Check if the value of the
-                /// corresponding key is nullable. Update the null map accordingly.
-                size_t bucket = i / 8;
-                size_t offset = i % 8;
-                UInt8 val = (reinterpret_cast<const UInt8*>(&key)[bucket] >> offset) & 1;
-                null_map->insert_value(val);
-                is_null = val == 1;
-            }
-
-            if (has_nullable_keys && is_null) {
-                observed_column->insert_default();
-            } else {
-                size_t size = key_sizes[i];
-                observed_column->insert_data(reinterpret_cast<const char*>(&key) + pos, size);
-                pos += size;
-            }
-        }
-    }
-
     static void insert_keys_into_columns(std::vector<Key>& keys, MutableColumns& key_columns,
                                          const size_t num_rows, const Sizes& key_sizes) {
         // In any hash key value, column values to be read start just after the bitmap, if it exists.
-        vector<size_t> pos(num_rows,
-                           has_nullable_keys ? std::tuple_size<KeysNullMap<Key>>::value : 0);
-        vector<char> buffer;
+        size_t pos = has_nullable_keys ? std::tuple_size<KeysNullMap<Key>>::value : 0;
 
         for (size_t i = 0; i < key_columns.size(); ++i) {
             size_t size = key_sizes[i];
-            buffer.resize(num_rows * size);
-
-            IColumn* observed_column = nullptr;
-
+            key_columns[i]->resize(num_rows);
             // If we have a nullable column, get its nested column and its null map.
             if (is_column_nullable(*key_columns[i])) {
                 ColumnNullable& nullable_col = assert_cast<ColumnNullable&>(*key_columns[i]);
-                observed_column = &nullable_col.get_nested_column();
-                ColumnUInt8* null_map =
-                        assert_cast<ColumnUInt8*>(&nullable_col.get_null_map_column());
+
+                char* data =
+                        const_cast<char*>(nullable_col.get_nested_column().get_raw_data().data);
+                UInt8* nullmap = assert_cast<ColumnUInt8*>(&nullable_col.get_null_map_column())
+                                         ->get_data()
+                                         .data();
 
                 // The current column is nullable. Check if the value of the
                 // corresponding key is nullable. Update the null map accordingly.
@@ -404,23 +332,19 @@ struct AggregationMethodKeysFixed {
                 for (size_t j = 0; j < num_rows; j++) {
                     const Key& key = keys[j];
                     UInt8 val = (reinterpret_cast<const UInt8*>(&key)[bucket] >> offset) & 1;
-                    null_map->insert_value(val);
+                    nullmap[j] = val;
                     if (!val) {
-                        memcpy(buffer.data() + j * size,
-                               reinterpret_cast<const char*>(&key) + pos[j], size);
-                        pos[j] += size;
+                        memcpy(data + j * size, reinterpret_cast<const char*>(&key) + pos, size);
                     }
                 }
             } else {
-                observed_column = key_columns[i].get();
+                char* data = const_cast<char*>(key_columns[i]->get_raw_data().data);
                 for (size_t j = 0; j < num_rows; j++) {
                     const Key& key = keys[j];
-                    memcpy(buffer.data() + j * size, reinterpret_cast<const char*>(&key) + pos[j],
-                           size);
-                    pos[j] += size;
+                    memcpy(data + j * size, reinterpret_cast<const char*>(&key) + pos, size);
                 }
             }
-            observed_column->insert_many_fix_len_data(buffer.data(), num_rows);
+            pos += size;
         }
     }
 
@@ -450,17 +374,6 @@ struct AggregationMethodSingleNullableColumn : public SingleColumnMethod {
     explicit AggregationMethodSingleNullableColumn(const Other& other) : Base(other) {}
 
     using State = ColumnsHashing::HashMethodSingleLowNullableColumn<BaseState, Mapped, true>;
-
-    static void insert_key_into_columns(const Key& key, MutableColumns& key_columns,
-                                        const Sizes& /*key_sizes*/) {
-        auto col = key_columns[0].get();
-
-        if constexpr (std::is_same_v<Key, StringRef>) {
-            col->insert_data(key.data, key.size);
-        } else {
-            col->insert_data(reinterpret_cast<const char*>(&key), sizeof(key));
-        }
-    }
 
     static void insert_keys_into_columns(std::vector<Key>& keys, MutableColumns& key_columns,
                                          const size_t num_rows, const Sizes&) {


### PR DESCRIPTION
## Proposed changes
```sql
select count(1) from (
select ss_customer_sk customer_sk
      ,ss_item_sk item_sk
from store_sales,date_dim
where ss_sold_date_sk = d_date_sk
  and d_month_seq between 1199 and 1199 + 11 and ss_sold_date_sk IS NOT NULL
group by ss_customer_sk
        ,ss_item_sk
) a;
```
```
uint256 original
12.27 sec
                              -  HashTableInputCount:  55.286154M  (55286154)
                              -  HashTableIterateTime:  347.592ms
                              -  HashTableSize:  54.116764M  (54116764)
                              -  InsertKeysToColumnTime:  1s79ms
                              -  MaxRowSizeInBytes:  0
                              -  MemoryUsage:  
                                  -  HashTable:  2.50  GB
                                  -  SerializeKeyArena:  1.63  GB
                              -  MergeTime:  0ns
                              -  PeakMemoryUsage:  4.13  GB

stringref
17.81 sec

                              -  HashTableInputCount:  55.285529M  (55285529)
                              -  HashTableIterateTime:  222.769ms
                              -  HashTableSize:  54.116764M  (54116764)
                              -  InsertKeysToColumnTime:  340.796ms
                              -  MaxRowSizeInBytes:  17
                              -  MemoryUsage:  
                                  -  HashTable:  1.50  GB
                                  -  SerializeKeyArena:  1.76  GB
                              -  MergeTime:  0ns
                              -  PeakMemoryUsage:  3.26  GB

uint256 opt
11.20 sec

                              -  HashTableInputCount:  55.285554M  (55285554)
                              -  HashTableIterateTime:  278.187ms
                              -  HashTableSize:  54.116764M  (54116764)
                              -  InsertKeysToColumnTime:  467.894ms
                              -  MaxRowSizeInBytes:  0
                              -  MemoryUsage:  
                                  -  HashTable:  2.50  GB
                                  -  SerializeKeyArena:  1.63  GB
                              -  MergeTime:  0ns
                              -  PeakMemoryUsage:  4.13  GB

```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

