### PR TITLE
[Bug](runtime-filter) fix probe expr prepared twice on minmax runtime filter

### DIFF
--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -609,8 +609,7 @@ public:
         return 0;
     }
 
-    Status get_push_exprs(std::vector<vectorized::VExprSPtr>* container,
-                          const vectorized::VExprContextSPtr& prob_expr);
+    Status get_push_exprs(std::vector<vectorized::VExprSPtr>* container, const TExpr* probe_expr);
 
     Status merge(const RuntimePredicateWrapper* wrapper) {
         bool can_not_merge_in_or_bloom = _filter_type == RuntimeFilterType::IN_OR_BLOOM_FILTER &&
@@ -1069,6 +1068,7 @@ private:
     int32_t _max_in_num = -1;
 
     vectorized::SharedRuntimeFilterContext _context;
+    std::vector<vectorized::VExprContextSPtr> _probe_ctxs;
     bool _is_bloomfilter = false;
     bool _is_ignored_in_filter = false;
     std::string* _ignored_in_filter_msg = nullptr;
@@ -1162,7 +1162,7 @@ Status IRuntimeFilter::get_push_expr_ctxs(std::vector<vectorized::VExprSPtr>* pu
         _set_push_down();
     }
     _profile->add_info_string("Info", _format_status());
-    return _wrapper->get_push_exprs(push_exprs, _vprobe_ctx);
+    return _wrapper->get_push_exprs(push_exprs, _probe_expr);
 }
 
 bool IRuntimeFilter::await() {
@@ -1357,10 +1357,9 @@ Status IRuntimeFilter::init_with_desc(const TRuntimeFilterDesc* desc, const TQue
         DCHECK(is_consumer());
         const auto iter = desc->planId_to_target_expr.find(node_id);
         if (iter == desc->planId_to_target_expr.end()) {
-            DCHECK(false) << "runtime filter not found node_id:" << node_id;
-            return Status::InternalError("not found a node id");
+            return Status::InternalError("not found a node id:{}", node_id);
         }
-        RETURN_IF_ERROR(vectorized::VExpr::create_expr_tree(iter->second, _vprobe_ctx));
+        _probe_expr = &iter->second;
     }
 
     if (_state) {
@@ -1840,14 +1839,16 @@ Status IRuntimeFilter::update_filter(const UpdateRuntimeFilterParamsV2* param,
 }
 
 Status RuntimePredicateWrapper::get_push_exprs(std::vector<vectorized::VExprSPtr>* container,
-                                               const vectorized::VExprContextSPtr& prob_expr) {
-    DCHECK(container != nullptr);
-    DCHECK(_pool != nullptr);
-    DCHECK(prob_expr->root()->type().type == _column_return_type ||
-           (is_string_type(prob_expr->root()->type().type) &&
+                                               const TExpr* probe_expr) {
+    vectorized::VExprContextSPtr probe_ctx;
+    RETURN_IF_ERROR(vectorized::VExpr::create_expr_tree(*probe_expr, probe_ctx));
+    _probe_ctxs.push_back(probe_ctx);
+
+    DCHECK(probe_ctx->root()->type().type == _column_return_type ||
+           (is_string_type(probe_ctx->root()->type().type) &&
             is_string_type(_column_return_type)) ||
            _filter_type == RuntimeFilterType::BITMAP_FILTER)
-            << " prob_expr->root()->type().type: " << prob_expr->root()->type().type
+            << " prob_expr->root()->type().type: " << probe_ctx->root()->type().type
             << " _column_return_type: " << _column_return_type
             << " _filter_type: " << ::doris::to_string(_filter_type);
 
@@ -1868,8 +1869,7 @@ Status RuntimePredicateWrapper::get_push_exprs(std::vector<vectorized::VExprSPtr
 
             auto in_pred = vectorized::VDirectInPredicate::create_shared(node);
             in_pred->set_filter(_context.hybrid_set);
-            auto cloned_expr = prob_expr->root()->clone();
-            in_pred->add_child(cloned_expr);
+            in_pred->add_child(probe_ctx->root());
             auto wrapper = vectorized::VRuntimeFilterWrapper::create_shared(node, in_pred);
             container->push_back(wrapper);
         }
@@ -1879,27 +1879,29 @@ Status RuntimePredicateWrapper::get_push_exprs(std::vector<vectorized::VExprSPtr
         vectorized::VExprSPtr max_pred;
         // create max filter
         TExprNode max_pred_node;
-        RETURN_IF_ERROR(create_vbin_predicate(prob_expr->root()->type(), TExprOpcode::LE, max_pred,
+        RETURN_IF_ERROR(create_vbin_predicate(probe_ctx->root()->type(), TExprOpcode::LE, max_pred,
                                               &max_pred_node));
         vectorized::VExprSPtr max_literal;
-        RETURN_IF_ERROR(create_literal(prob_expr->root()->type(), _context.minmax_func->get_max(),
+        RETURN_IF_ERROR(create_literal(probe_ctx->root()->type(), _context.minmax_func->get_max(),
                                        max_literal));
-        auto cloned_expr = prob_expr->root()->clone();
-        max_pred->add_child(cloned_expr);
+        max_pred->add_child(probe_ctx->root());
         max_pred->add_child(max_literal);
         container->push_back(
                 vectorized::VRuntimeFilterWrapper::create_shared(max_pred_node, max_pred));
 
+        vectorized::VExprContextSPtr new_probe_ctx;
+        RETURN_IF_ERROR(vectorized::VExpr::create_expr_tree(*probe_expr, new_probe_ctx));
+        _probe_ctxs.push_back(new_probe_ctx);
+
         // create min filter
         vectorized::VExprSPtr min_pred;
         TExprNode min_pred_node;
-        RETURN_IF_ERROR(create_vbin_predicate(prob_expr->root()->type(), TExprOpcode::GE, min_pred,
-                                              &min_pred_node));
+        RETURN_IF_ERROR(create_vbin_predicate(new_probe_ctx->root()->type(), TExprOpcode::GE,
+                                              min_pred, &min_pred_node));
         vectorized::VExprSPtr min_literal;
-        RETURN_IF_ERROR(create_literal(prob_expr->root()->type(), _context.minmax_func->get_min(),
-                                       min_literal));
-        cloned_expr = prob_expr->root()->clone();
-        min_pred->add_child(cloned_expr);
+        RETURN_IF_ERROR(create_literal(new_probe_ctx->root()->type(),
+                                       _context.minmax_func->get_min(), min_literal));
+        min_pred->add_child(new_probe_ctx->root());
         min_pred->add_child(min_literal);
         container->push_back(
                 vectorized::VRuntimeFilterWrapper::create_shared(min_pred_node, min_pred));
@@ -1918,8 +1920,7 @@ Status RuntimePredicateWrapper::get_push_exprs(std::vector<vectorized::VExprSPtr
         node.__set_is_nullable(false);
         auto bloom_pred = vectorized::VBloomPredicate::create_shared(node);
         bloom_pred->set_filter(_context.bloom_filter_func);
-        auto cloned_expr = prob_expr->root()->clone();
-        bloom_pred->add_child(cloned_expr);
+        bloom_pred->add_child(probe_ctx->root());
         auto wrapper = vectorized::VRuntimeFilterWrapper::create_shared(node, bloom_pred);
         container->push_back(wrapper);
         break;
@@ -1937,8 +1938,7 @@ Status RuntimePredicateWrapper::get_push_exprs(std::vector<vectorized::VExprSPtr
         node.__set_is_nullable(false);
         auto bitmap_pred = vectorized::VBitmapPredicate::create_shared(node);
         bitmap_pred->set_filter(_context.bitmap_filter_func);
-        auto cloned_expr = prob_expr->root()->clone();
-        bitmap_pred->add_child(cloned_expr);
+        bitmap_pred->add_child(probe_ctx->root());
         auto wrapper = vectorized::VRuntimeFilterWrapper::create_shared(node, bitmap_pred);
         container->push_back(wrapper);
         break;

--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -221,7 +221,8 @@ public:
 
     RuntimeFilterType type() const { return _runtime_filter_type; }
 
-    Status get_push_expr_ctxs(std::vector<vectorized::VExprSPtr>* push_exprs, bool is_late_arrival);
+    Status get_push_expr_ctxs(std::list<vectorized::VExprContextSPtr>& probe_ctxs,
+                              std::vector<vectorized::VExprSPtr>& push_exprs, bool is_late_arrival);
 
     bool is_broadcast_join() const { return _is_broadcast_join; }
 

--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -376,7 +376,7 @@ protected:
     // this filter won't filter any data
     bool _always_true;
 
-    doris::vectorized::VExprContextSPtr _vprobe_ctx;
+    const TExpr* _probe_expr;
 
     // Indicate whether runtime filter expr has been ignored
     bool _is_ignored;

--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -376,7 +376,7 @@ protected:
     // this filter won't filter any data
     bool _always_true;
 
-    const TExpr* _probe_expr;
+    TExpr _probe_expr;
 
     // Indicate whether runtime filter expr has been ignored
     bool _is_ignored;

--- a/be/src/vec/exec/runtime_filter_consumer.cpp
+++ b/be/src/vec/exec/runtime_filter_consumer.cpp
@@ -95,7 +95,7 @@ Status RuntimeFilterConsumer::_acquire_runtime_filter() {
             ready = runtime_filter->await();
         }
         if (ready && !_runtime_filter_ctxs[i].apply_mark) {
-            RETURN_IF_ERROR(runtime_filter->get_push_expr_ctxs(&vexprs, false));
+            RETURN_IF_ERROR(runtime_filter->get_push_expr_ctxs(_probe_ctxs, vexprs, false));
             _runtime_filter_ctxs[i].apply_mark = true;
         } else if (runtime_filter->current_state() == RuntimeFilterState::NOT_READY &&
                    !_runtime_filter_ctxs[i].apply_mark) {
@@ -151,8 +151,8 @@ Status RuntimeFilterConsumer::try_append_late_arrival_runtime_filter(int* arrive
             ++current_arrived_rf_num;
             continue;
         } else if (_runtime_filter_ctxs[i].runtime_filter->is_ready()) {
-            RETURN_IF_ERROR(
-                    _runtime_filter_ctxs[i].runtime_filter->get_push_expr_ctxs(&exprs, true));
+            RETURN_IF_ERROR(_runtime_filter_ctxs[i].runtime_filter->get_push_expr_ctxs(
+                    _probe_ctxs, exprs, true));
             ++current_arrived_rf_num;
             _runtime_filter_ctxs[i].apply_mark = true;
         }

--- a/be/src/vec/exec/runtime_filter_consumer.h
+++ b/be/src/vec/exec/runtime_filter_consumer.h
@@ -70,6 +70,7 @@ private:
     int32_t _filter_id;
 
     std::vector<TRuntimeFilterDesc> _runtime_filter_descs;
+    std::list<vectorized::VExprContextSPtr> _probe_ctxs;
 
     const RowDescriptor& _row_descriptor_ref;
 

--- a/regression-test/suites/query_p0/sql_functions/test_in_expr.groovy
+++ b/regression-test/suites/query_p0/sql_functions/test_in_expr.groovy
@@ -147,7 +147,7 @@ suite("test_in_expr", "query") {
 
     test {
         sql """ select c_array, c_array in (null) from array_in_test; """
-        exception "NOT_IMPLEMENTED_ERROR"
+        exception "errCode"
     }
 
     sql " drop table if exists `json_in_test` "
@@ -165,7 +165,7 @@ suite("test_in_expr", "query") {
 
     test {
         sql """ select j, j in (null) from json_in_test; """
-        exception "NOT_IMPLEMENTED_ERROR"
+        exception "errCode"
     }
 
     sql " drop table if exists `bitmap_in_test` "
@@ -185,11 +185,11 @@ suite("test_in_expr", "query") {
     sql """ insert into bitmap_in_test values (20200622, 1, to_bitmap(243));"""
     test {
         sql """ select device_id, device_id in (to_bitmap(1)) from bitmap_in_test; """
-        exception "NOT_IMPLEMENTED_ERROR"
+        exception "errCode"
     }
     test {
         sql """ select device_id, device_id in (to_bitmap(1),to_bitmap(2),to_bitmap(243)) from bitmap_in_test; """
-        exception "NOT_IMPLEMENTED_ERROR"
+        exception "errCode"
     }
 
     sql " drop table if exists `hll_in_test` "
@@ -208,11 +208,11 @@ suite("test_in_expr", "query") {
     sql """ insert into hll_in_test values(1, hll_hash(1)) """
     test {
         sql """ select id, pv in (hll_hash(1)) from hll_in_test; """
-        exception "NOT_IMPLEMENTED_ERROR"
+        exception "errCode"
     }
     test {
         sql """ select id, pv in (hll_hash(1), hll_hash(2)) from hll_in_test; """
-        exception "NOT_IMPLEMENTED_ERROR"
+        exception "errCode"
     }
 
 }


### PR DESCRIPTION
## Proposed changes
fix probe expr prepared twice on minmax runtime filter
```cpp
0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:413
 1# 0x00007F8F52477090 in /lib/x86_64-linux-gnu/libc.so.6
 2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
 3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
 4# 0x0000564C7F098FD9 in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
 5# 0x0000564C7F08E5ED in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
 6# google::LogMessage::SendToLog() in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
 7# google::LogMessage::Flush() in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
 8# google::LogMessageFatal::~LogMessageFatal() in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
 9# doris::vectorized::VExprContext::fn_context(int) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exprs/vexpr_context.h:64
10# doris::vectorized::VExpr::init_function_context(doris::vectorized::VExprContext*, doris::FunctionContext::FunctionStateScope, std::shared_ptr const&) const at /home/zcp/repo_center/doris_master/doris/be/src/vec/exprs/vexpr.cpp:410
11# doris::vectorized::VCastExpr::open(doris::RuntimeState*, doris::vectorized::VExprContext*, doris::FunctionContext::FunctionStateScope) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exprs/vcast_expr.cpp:85
12# doris::vectorized::VExpr::open(doris::RuntimeState*, doris::vectorized::VExprContext*, doris::FunctionContext::FunctionStateScope) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exprs/vexpr.cpp:115
13# doris::vectorized::VCaseExpr::open(doris::RuntimeState*, doris::vectorized::VExprContext*, doris::FunctionContext::FunctionStateScope) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exprs/vcase_expr.cpp:82
14# doris::vectorized::VExpr::open(doris::RuntimeState*, doris::vectorized::VExprContext*, doris::FunctionContext::FunctionStateScope) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exprs/vexpr.cpp:115
15# doris::vectorized::VectorizedFnCall::open(doris::RuntimeState*, doris::vectorized::VExprContext*, doris::FunctionContext::FunctionStateScope) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exprs/vectorized_fn_call.cpp:124
16# doris::vectorized::VRuntimeFilterWrapper::open(doris::RuntimeState*, doris::vectorized::VExprContext*, doris::FunctionContext::FunctionStateScope) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exprs/vruntimefilter_wrapper.cpp:66
17# doris::vectorized::VExprContext::open(doris::RuntimeState*) in /mnt/ssd01/doris-master/VEC_UBSAN/be/lib/doris_be
18# doris::vectorized::RuntimeFilterConsumer::_append_rf_into_conjuncts(std::vector, std::allocator > > const&) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exec/runtime_filter_consumer.cpp:124
19# doris::vectorized::RuntimeFilterConsumer::_acquire_runtime_filter() at /home/zcp/repo_center/doris_master/doris/be/src/vec/exec/runtime_filter_consumer.cpp:108
20# doris::vectorized::VScanNode::alloc_resource(doris::RuntimeState*) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exec/scan/vscan_node.cpp:171
21# doris::pipeline::StreamingOperator::open(doris::RuntimeState*) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/exec/operator.h:332
22# doris::pipeline::PipelineTask::_open() at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/pipeline_task.cpp:179
23# doris::pipeline::PipelineTask::execute(bool*) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/pipeline_task.cpp:208
24# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/task_scheduler.cpp:275
25# void std::__invoke_impl(std::__invoke_memfun_deref, void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
26# std::__invoke_result::type std::__invoke(void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
27# void std::_Bind::__call(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420
28# void std::_Bind::operator()<, void>() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503
29# void std::__invoke_impl&>(std::__invoke_other, std::_Bind&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
30# std::enable_if&>, void>::type std::__invoke_r&>(std::_Bind&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
31# std::_Function_handler >::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
32# std::function::operator()() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
33# doris::FunctionRunnable::run() at /home/zcp/repo_center/doris_master/doris/be/src/util/threadpool.cpp:48
34# doris::ThreadPool::dispatch_thread() at /home/zcp/repo_center/doris_master/doris/be/src/util/threadpool.cpp:531
35# void std::__invoke_impl(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
36# std::__invoke_result::type std::__invoke(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
37# void std::_Bind::__call(std::tuple<>&&, std::_Index_tuple<0ul>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420
38# void std::_Bind::operator()<, void>() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503
39# void std::__invoke_impl&>(std::__invoke_other, std::_Bind&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
40# std::enable_if&>, void>::type std::__invoke_r&>(std::_Bind&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
41# std::_Function_handler >::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
42# std::function::operator()() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
43# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_master/doris/be/src/util/thread.cpp:465
44# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
45# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97
172.21.0.22 last coredump sql: 
```
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

