### PR TITLE
[exceptionsafe](expr) exprcontext's open and prepare method should catch exception

### DIFF
--- a/be/src/vec/exprs/vexpr_context.cpp
+++ b/be/src/vec/exprs/vexpr_context.cpp
@@ -67,7 +67,9 @@ doris::Status VExprContext::execute(doris::vectorized::Block* block, int* result
 doris::Status VExprContext::prepare(doris::RuntimeState* state,
                                     const doris::RowDescriptor& row_desc) {
     _prepared = true;
-    return _root->prepare(state, row_desc, this);
+    Status st;
+    RETURN_IF_CATCH_EXCEPTION({ st = _root->prepare(state, row_desc, this); });
+    return st;
 }
 
 doris::Status VExprContext::open(doris::RuntimeState* state) {
@@ -80,7 +82,9 @@ doris::Status VExprContext::open(doris::RuntimeState* state) {
     // original's fragment state and only need to have thread-local state initialized.
     FunctionContext::FunctionStateScope scope =
             _is_clone ? FunctionContext::THREAD_LOCAL : FunctionContext::FRAGMENT_LOCAL;
-    return _root->open(state, this, scope);
+    Status st;
+    RETURN_IF_CATCH_EXCEPTION({ st = _root->open(state, this, scope); });
+    return st;
 }
 
 void VExprContext::close() {


### PR DESCRIPTION
## Proposed changes

ExprContext may throw exception during expr->open, and it will core in non-pipeline mode.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

