### PR TITLE
[fix](tablets_channel) fix the process when erasing elements from `std::set`

### DIFF
--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -196,7 +196,7 @@ Status TabletsChannel::close(
         }
 
         // 3. build rowset
-        for (auto it = need_wait_writers.begin(); it != need_wait_writers.end(); it++) {
+        for (auto it = need_wait_writers.begin(); it != need_wait_writers.end();) {
             Status st = (*it)->build_rowset();
             if (!st.ok()) {
                 _add_error_tablet(tablet_errors, (*it)->tablet_id(), st);
@@ -210,16 +210,18 @@ Status TabletsChannel::close(
                 it = need_wait_writers.erase(it);
                 continue;
             }
+            it++;
         }
 
         // 4. wait for delete bitmap calculation complete if necessary
-        for (auto it = need_wait_writers.begin(); it != need_wait_writers.end(); it++) {
+        for (auto it = need_wait_writers.begin(); it != need_wait_writers.end();) {
             Status st = (*it)->wait_calc_delete_bitmap();
             if (!st.ok()) {
                 _add_error_tablet(tablet_errors, (*it)->tablet_id(), st);
                 it = need_wait_writers.erase(it);
                 continue;
             }
+            it++;
         }
 
         // 5. commit all writers


### PR DESCRIPTION
## Proposed changes

`container::erase(iterator)` will return the iterator of the next element of the erased element, ,so we should not call `it++` if we erased an element.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

