### PR TITLE
[fix](planner)fix bug of unexpected nest loop join

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -2102,7 +2102,7 @@ public class SingleNodePlanner {
 
         for (Expr e : candidates) {
             // Ignore predicate if one of its children is a constant.
-            if (e.getChild(0).isConstant() || e.getChild(1).isConstant()) {
+            if (e.getChild(0).isLiteral() || e.getChild(1).isLiteral()) {
                 LOG.debug("double is constant.");
                 continue;
             }

--- a/regression-test/suites/correctness_p0/test_push_conjuncts_inlineview.groovy
+++ b/regression-test/suites/correctness_p0/test_push_conjuncts_inlineview.groovy
@@ -75,6 +75,20 @@ explain {
         contains "= '123'"
     }
 
+explain {
+        sql("""SELECT *
+                FROM 
+                    (SELECT `a`.`a_key` AS `a_key`,
+                    now() as d
+                    FROM `push_conjunct_table` a) t1
+                    join 
+                    (SELECT `a`.`a_key` AS `a_key`,
+                    b_key
+                    FROM `push_conjunct_table` a) t2
+                    on t1. d = t2.b_key;""")
+        notContains "VNESTED LOOP JOIN"
+    }
+
 sql """
     WITH ttt AS
     (SELECT c1,


### PR DESCRIPTION
## Proposed changes

use isLiteral instead of isConstant to check if the expr is a literal. This prevent the unexpected nest loop join, see the test case for detail

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

