### PR TITLE
[fix](point query) Fix ArrayIndexOutOfBoundsException if close a prep…

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -289,6 +289,10 @@ public class ConnectContext {
         this.preparedStmtCtxs.put(stmtName, ctx);
     }
 
+    public void removePrepareStmt(String stmtName) {
+        this.preparedStmtCtxs.remove(stmtName);
+    }
+
     public PrepareStmtContext getPreparedStmt(String stmtName) {
         return this.preparedStmtCtxs.get(stmtName);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -180,6 +180,16 @@ public class ConnectProcessor {
         ctx.getState().setOk();
     }
 
+    private void handleStmtClose() {
+        packetBuf = packetBuf.order(ByteOrder.LITTLE_ENDIAN);
+        int stmtId = packetBuf.getInt();
+        LOG.debug("close stmt id: {}", stmtId);
+        ConnectContext.get().removePrepareStmt(String.valueOf(stmtId));
+        // No response packet is sent back to the client, see
+        // https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_stmt_close.html
+        ctx.getState().setNoop();
+    }
+
     private void debugPacket() {
         byte[] bytes = packetBuf.array();
         StringBuilder printB = new StringBuilder();
@@ -597,8 +607,7 @@ public class ConnectProcessor {
                 handleStmtReset();
                 break;
             case COM_STMT_CLOSE:
-                // TODO
-                handleStmtReset();
+                handleStmtClose();
                 break;
             default:
                 ctx.getState().setError(ErrorCode.ERR_UNKNOWN_COM_ERROR, "Unsupported command(" + command + ")");

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/QueryState.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/QueryState.java
@@ -69,6 +69,10 @@ public class QueryState {
         return stateType;
     }
 
+    public void setNoop() {
+        stateType = MysqlStateType.NOOP;
+    }
+
     public void setEof() {
         stateType = MysqlStateType.EOF;
     }

--- a/regression-test/suites/point_query_p0/test_point_query.groovy
+++ b/regression-test/suites/point_query_p0/test_point_query.groovy
@@ -142,6 +142,7 @@ suite("test_point_query") {
       stmt.setBigDecimal(2, new BigDecimal("120939.11130"))
       stmt.setString(3, generateString(298))
       qe_point_select stmt
+      stmt.close()
 
       stmt = prepareStatement "select * from ${tableName} where k1 = 1235 and k2 = ? and k3 = ?"
       assertEquals(stmt.class, com.mysql.cj.jdbc.ServerPreparedStatement);


### PR DESCRIPTION
…are stmt

## Proposed changes
When close a server prepare stmt and execute a new stmt, get the following exception:
```
java.lang.ArrayIndexOutOfBoundsException: 10
        at com.mysql.cj.protocol.a.NativePacketPayload.readInteger(NativePacketPayload.java:398)
        at com.mysql.cj.protocol.a.ColumnDefinitionReader.unpackField(ColumnDefinitionReader.java:105)
        at com.mysql.cj.protocol.a.ColumnDefinitionReader.read(ColumnDefinitionReader.java:68)
        at com.mysql.cj.protocol.a.ColumnDefinitionReader.read(ColumnDefinitionReader.java:40)
        at com.mysql.cj.protocol.a.NativeProtocol.read(NativeProtocol.java:1648)
        at com.mysql.cj.ServerPreparedQuery.serverPrepare(ServerPreparedQuery.java:152)
        at com.mysql.cj.jdbc.ServerPreparedStatement.serverPrepare(ServerPreparedStatement.java:564)
        at com.mysql.cj.jdbc.ServerPreparedStatement.<init>(ServerPreparedStatement.java:130)
        at com.mysql.cj.jdbc.ServerPreparedStatement.getInstance(ServerPreparedStatement.java:98)
        at com.mysql.cj.jdbc.ConnectionImpl.prepareStatement(ConnectionImpl.java:1603)
        at com.mysql.cj.jdbc.ConnectionImpl.prepareStatement(ConnectionImpl.java:1535)
```


Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

