### PR TITLE
[fix](compaction) fix time series compaction policy corner case

### DIFF
--- a/be/src/olap/cumulative_compaction_time_series_policy.cpp
+++ b/be/src/olap/cumulative_compaction_time_series_policy.cpp
@@ -164,7 +164,12 @@ int TimeSeriesCumulativeCompactionPolicy::pick_input_rowsets(
     input_rowsets->clear();
     int64_t total_size = 0;
 
-    for (auto& rowset : candidate_rowsets) {
+    std::vector<RowsetSharedPtr> filtered_rowsets;
+    const auto& first_rowset_iter = std::find_if(candidate_rowsets.begin(), candidate_rowsets.end(), [](const RowsetSharedPtr& rs){
+        return rs->start_version() == rs->end_version();
+    });
+    filtered_rowsets.assign(first_rowset_iter, candidate_rowsets.end());
+    for (auto& rowset : filtered_rowsets) {
         // check whether this rowset is delete version
         if (rowset->rowset_meta()->has_delete_predicate()) {
             *last_delete_version = rowset->version();

--- a/be/src/olap/cumulative_compaction_time_series_policy.cpp
+++ b/be/src/olap/cumulative_compaction_time_series_policy.cpp
@@ -82,7 +82,7 @@ uint32_t TimeSeriesCumulativeCompactionPolicy::calc_cumulative_compaction_score(
         if (cumu_interval > (config::time_series_compaction_time_threshold_seconds * 1000)) {
             return score;
         }
-    } else {
+    } else if (score > 0) {
         // If the compaction process has not been successfully executed,
         // the condition for triggering compaction based on the last successful compaction time (condition 3) will never be met
         tablet->set_last_cumu_compaction_success_time(now);

--- a/be/src/olap/cumulative_compaction_time_series_policy.cpp
+++ b/be/src/olap/cumulative_compaction_time_series_policy.cpp
@@ -168,15 +168,14 @@ int TimeSeriesCumulativeCompactionPolicy::pick_input_rowsets(
     input_rowsets->clear();
     int64_t total_size = 0;
 
-    std::vector<RowsetSharedPtr> filtered_rowsets;
     // when single replica compaction is enabled and BE1 fetchs merged rowsets from BE2, and then BE2 goes offline.
     // BE1 should performs compaction on its own, the time series compaction may re-compact previously fetched rowsets.
     // time series compaction policy needs to skip over the fetched rowset
     const auto& first_rowset_iter = std::find_if(
             candidate_rowsets.begin(), candidate_rowsets.end(),
             [](const RowsetSharedPtr& rs) { return rs->start_version() == rs->end_version(); });
-    filtered_rowsets.assign(first_rowset_iter, candidate_rowsets.end());
-    for (auto& rowset : filtered_rowsets) {
+    for (auto it = first_rowset_iter; it != candidate_rowsets.end(); ++it) {
+        const auto& rowset = *it;
         // check whether this rowset is delete version
         if (rowset->rowset_meta()->has_delete_predicate()) {
             *last_delete_version = rowset->version();


### PR DESCRIPTION
## Proposed changes

1. When single replica compaction is enabled and BE1 fetchs merged rowsets from BE2, and then BE2 goes offline.
     BE1 should perform compaction on its own, the time series compaction may re-compact previously fetched rowsets.
    Time series compaction policy needs to skip over the fetched rowset.

2. If the compaction process has not been successfully executed, the condition for triggering compaction based on the last successful compaction time (condition 3) will never be met.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

