### PR TITLE
[fix](Unique-Key) fix version upgrade caused MOR to become MOW

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
@@ -389,7 +389,7 @@ public class TableProperty implements Writable {
 
     public boolean getEnableUniqueKeyMergeOnWrite() {
         return Boolean.parseBoolean(properties.getOrDefault(
-                PropertyAnalyzer.ENABLE_UNIQUE_KEY_MERGE_ON_WRITE, "true"));
+                PropertyAnalyzer.ENABLE_UNIQUE_KEY_MERGE_ON_WRITE, "false"));
     }
 
     public void setSequenceMapCol(String colName) {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

We found that when the unique-key table is upgraded from a version that does not support MOW (e.g. 1.1.5) to a version that supports MOW (e.g. 1.2.1), and then further upgraded to 2.0-beta, an issue occurs where MOR changes to MOW. Therefore, this code is primarily aimed at fixing this problem.

When a unique-key table does not have the property "ENABLE_UNIQUE_KEY_MERGE_ON_WRITE," it means that it is upgraded from a version that does not support the Merge On Write feature. Therefore, this table is using Merge On Read, and as a result and the value of "ENABLE_UNIQUE_KEY_MERGE_ON_WRITE" should be false, but in FE, our code mistakenly regarded it as true.


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

