### PR TITLE
[chore](third-party) Fix the build order for libunwind

### DIFF
--- a/be/src/common/stack_trace.h
+++ b/be/src/common/stack_trace.h
@@ -22,6 +22,7 @@
 
 #include <array>
 #include <csignal>
+#include <cstdint>
 #include <functional>
 #include <optional>
 #include <string>

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1450,8 +1450,8 @@ build_libunwind() {
         # LIBUNWIND_NO_HEAP: https://reviews.llvm.org/D11897
         # LIBUNWIND_IS_NATIVE_ONLY: https://lists.llvm.org/pipermail/cfe-commits/Week-of-Mon-20160523/159802.html
         # -nostdinc++ only required for gcc compilation
-        cflags='-std=c99 -D_LIBUNWIND_NO_HEAP=1 -D_DEBUG -D_LIBUNWIND_IS_NATIVE_ONLY -O3 -fno-exceptions -funwind-tables -fno-sanitize=all -nostdinc++ -fno-rtti'
-        CFLAGS="${cflags}" ../configure --prefix="${TP_INSTALL_DIR}"
+        cflags="-I${TP_INCLUDE_DIR} -std=c99 -D_LIBUNWIND_NO_HEAP=1 -D_DEBUG -D_LIBUNWIND_IS_NATIVE_ONLY -O3 -fno-exceptions -funwind-tables -fno-sanitize=all -nostdinc++ -fno-rtti"
+        CFLAGS="${cflags}" LDFLAGS="-L${TP_LIB_DIR} -llzma" ../configure --prefix="${TP_INSTALL_DIR}" --disable-shared --enable-static
 
         make -j "${PARALLEL}"
         make install
@@ -1616,7 +1616,6 @@ build_hadoop_libs() {
 
 if [[ "${#packages[@]}" -eq 0 ]]; then
     packages=(
-        libunwind
         libunixodbc
         openssl
         libevent
@@ -1674,6 +1673,7 @@ if [[ "${#packages[@]}" -eq 0 ]]; then
         xxhash
         concurrentqueue
         fast_float
+        libunwind
     )
     if [[ "$(uname -s)" == 'Darwin' ]]; then
         read -r -a packages <<<"binutils gettext ${packages[*]}"


### PR DESCRIPTION
## Proposed changes

~~Issue Number: close #xxx~~

1. libunwind depends on lzma
2. Fix the missing headers issues reported by GCC-13

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

