### PR TITLE
[improvement](multi-catalog)add scanner isolation class loader

### DIFF
--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -153,7 +153,8 @@ jmethodID JniUtil::throwable_to_stack_trace_id_ = NULL;
 jmethodID JniUtil::get_jvm_metrics_id_ = NULL;
 jmethodID JniUtil::get_jvm_threads_id_ = NULL;
 jmethodID JniUtil::get_jmx_json_ = NULL;
-jmethodID JniUtil::load_jni_scanners_ = NULL;
+jobject JniUtil::jni_scanner_loader_obj_ = NULL;
+jmethodID JniUtil::jni_scanner_loader_method_ = NULL;
 
 Status JniUtfCharGuard::create(JNIEnv* env, jstring jstr, JniUtfCharGuard* out) {
     DCHECK(jstr != nullptr);
@@ -341,13 +342,57 @@ Status JniUtil::LocalToGlobalRef(JNIEnv* env, jobject local_ref, jobject* global
     return Status::OK();
 }
 
+Status JniUtil::init_jni_scanner_loader(JNIEnv* env) {
+    // Get scanner loader;
+    jclass jni_scanner_loader_cls;
+    std::string jni_scanner_loader_str = "org/apache/doris/common/classloader/ScannerLoader";
+    RETURN_IF_ERROR(JniUtil::GetGlobalClassRef(env, jni_scanner_loader_str.c_str(),
+                                               &jni_scanner_loader_cls));
+    jmethodID jni_scanner_loader_constructor =
+            env->GetMethodID(jni_scanner_loader_cls, "<init>", "()V");
+    RETURN_ERROR_IF_EXC(env);
+    jni_scanner_loader_method_ = env->GetMethodID(jni_scanner_loader_cls, "getLoadedClass",
+                                                  "(Ljava/lang/String;)Ljava/lang/Class;");
+    if (jni_scanner_loader_method_ == NULL) {
+        if (env->ExceptionOccurred()) env->ExceptionDescribe();
+        return Status::InternalError("Failed to find ScannerLoader.getLoadedClass method.");
+    }
+    RETURN_ERROR_IF_EXC(env);
+    jmethodID load_jni_scanner =
+            env->GetMethodID(jni_scanner_loader_cls, "loadAllScannerJars", "()V");
+    RETURN_ERROR_IF_EXC(env);
+
+    jni_scanner_loader_obj_ =
+            env->NewObject(jni_scanner_loader_cls, jni_scanner_loader_constructor);
+    RETURN_ERROR_IF_EXC(env);
+    if (jni_scanner_loader_obj_ == NULL) {
+        if (env->ExceptionOccurred()) env->ExceptionDescribe();
+        return Status::InternalError("Failed to create ScannerLoader object.");
+    }
+    env->CallVoidMethod(jni_scanner_loader_obj_, load_jni_scanner);
+    RETURN_ERROR_IF_EXC(env);
+    return Status::OK();
+}
+
+Status JniUtil::get_jni_scanner_class(JNIEnv* env, std::string classname,
+                                      jclass* jni_scanner_class) {
+    // Get JNI scanner class by class name;
+    jobject loaded_class_obj =
+            env->CallObjectMethod(jni_scanner_loader_obj_, jni_scanner_loader_method_,
+                                  env->NewStringUTF(classname.c_str()));
+    RETURN_ERROR_IF_EXC(env);
+    *jni_scanner_class = reinterpret_cast<jclass>(env->NewGlobalRef(loaded_class_obj));
+    RETURN_ERROR_IF_EXC(env);
+    return Status::OK();
+}
+
 Status JniUtil::Init() {
     RETURN_IF_ERROR(LibJVMLoader::instance().load());
 
     // Get the JNIEnv* corresponding to current thread.
     JNIEnv* env;
     RETURN_IF_ERROR(JniUtil::GetJNIEnv(&env));
-    
+
     if (env == NULL) return Status::InternalError("Failed to get/create JVM");
     // Find JniUtil class and create a global ref.
     jclass local_jni_util_cl = env->FindClass("org/apache/doris/common/jni/utils/JniUtil");
@@ -456,13 +501,7 @@ Status JniUtil::Init() {
         if (env->ExceptionOccurred()) env->ExceptionDescribe();
         return Status::InternalError("Failed to find JniUtil.getJMXJson method.");
     }
-
-    load_jni_scanners_ = env->GetStaticMethodID(jni_util_cl_, "loadJNIScanner", "()V");
-    if (load_jni_scanners_ == NULL) {
-        if (env->ExceptionOccurred()) env->ExceptionDescribe();
-        return Status::InternalError("Failed to find JniUtil.loadJNIScanner method.");
-    }
-
+    RETURN_IF_ERROR(init_jni_scanner_loader(env));
     jvm_inited_ = true;
     return Status::OK();
 }

--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -153,6 +153,7 @@ jmethodID JniUtil::throwable_to_stack_trace_id_ = NULL;
 jmethodID JniUtil::get_jvm_metrics_id_ = NULL;
 jmethodID JniUtil::get_jvm_threads_id_ = NULL;
 jmethodID JniUtil::get_jmx_json_ = NULL;
+jmethodID JniUtil::load_jni_scanners_ = NULL;
 
 Status JniUtfCharGuard::create(JNIEnv* env, jstring jstr, JniUtfCharGuard* out) {
     DCHECK(jstr != nullptr);
@@ -346,6 +347,7 @@ Status JniUtil::Init() {
     // Get the JNIEnv* corresponding to current thread.
     JNIEnv* env;
     RETURN_IF_ERROR(JniUtil::GetJNIEnv(&env));
+    
     if (env == NULL) return Status::InternalError("Failed to get/create JVM");
     // Find JniUtil class and create a global ref.
     jclass local_jni_util_cl = env->FindClass("org/apache/doris/common/jni/utils/JniUtil");
@@ -454,6 +456,13 @@ Status JniUtil::Init() {
         if (env->ExceptionOccurred()) env->ExceptionDescribe();
         return Status::InternalError("Failed to find JniUtil.getJMXJson method.");
     }
+
+    load_jni_scanners_ = env->GetStaticMethodID(jni_util_cl_, "loadJNIScanner", "()V");
+    if (load_jni_scanners_ == NULL) {
+        if (env->ExceptionOccurred()) env->ExceptionDescribe();
+        return Status::InternalError("Failed to find JniUtil.loadJNIScanner method.");
+    }
+
     jvm_inited_ = true;
     return Status::OK();
 }

--- a/be/src/util/jni-util.h
+++ b/be/src/util/jni-util.h
@@ -30,7 +30,7 @@
 #include "util/thrift_util.h"
 
 #ifdef USE_HADOOP_HDFS
-// defined in hadoop_hdfs/hdfs.h
+// defined in hadoop/hadoop-hdfs-project/hadoop-hdfs/src/main/native/libhdfs/jni_helper.c
 extern "C" JNIEnv* getJNIEnv(void);
 #endif
 
@@ -74,12 +74,13 @@ public:
     static inline int64_t IncreaseReservedBufferSize(int n) {
         return INITIAL_RESERVED_BUFFER_SIZE << n;
     }
-
+    static Status get_jni_scanner_class(JNIEnv* env, std::string classname, jclass* loaded_class);
     static jobject convert_to_java_map(JNIEnv* env, const std::map<std::string, std::string>& map);
     static std::map<std::string, std::string> convert_to_cpp_map(JNIEnv* env, jobject map);
 
 private:
     static Status GetJNIEnvSlowPath(JNIEnv** env);
+    static Status init_jni_scanner_loader(JNIEnv* env);
 
     static bool jvm_inited_;
     static jclass internal_exc_cl_;
@@ -90,8 +91,9 @@ private:
     static jmethodID get_jvm_metrics_id_;
     static jmethodID get_jvm_threads_id_;
     static jmethodID get_jmx_json_;
-    static jmethodID load_jni_scanners_;
-
+    // JNI scanner loader
+    static jobject jni_scanner_loader_obj_;
+    static jmethodID jni_scanner_loader_method_;
     // Thread-local cache of the JNIEnv for this thread.
     static __thread JNIEnv* tls_env_;
 };

--- a/be/src/util/jni-util.h
+++ b/be/src/util/jni-util.h
@@ -90,6 +90,7 @@ private:
     static jmethodID get_jvm_metrics_id_;
     static jmethodID get_jvm_threads_id_;
     static jmethodID get_jmx_json_;
+    static jmethodID load_jni_scanners_;
 
     // Thread-local cache of the JNIEnv for this thread.
     static __thread JNIEnv* tls_env_;

--- a/be/src/vec/exec/jni_connector.cpp
+++ b/be/src/vec/exec/jni_connector.cpp
@@ -201,7 +201,12 @@ Status JniConnector::close() {
 }
 
 Status JniConnector::_init_jni_scanner(JNIEnv* env, int batch_size) {
-    RETURN_IF_ERROR(JniUtil::GetGlobalClassRef(env, _connector_class.c_str(), &_jni_scanner_cls));
+    RETURN_IF_ERROR(JniUtil::get_jni_scanner_class(env, _connector_class, &_jni_scanner_cls));
+    if (_jni_scanner_cls == NULL) {
+        if (env->ExceptionOccurred()) env->ExceptionDescribe();
+        return Status::InternalError("Fail to get JniScanner class.");
+    }
+    RETURN_ERROR_IF_EXC(env);
     jmethodID scanner_constructor =
             env->GetMethodID(_jni_scanner_cls, "<init>", "(ILjava/util/Map;)V");
     RETURN_ERROR_IF_EXC(env);

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -78,7 +78,7 @@ if [[ "${MAX_FILE_COUNT}" -lt 65536 ]]; then
 fi
 
 # add java libs
-for f in "${DORIS_HOME}/lib/java_extensions"/*.jar; do
+for f in "${DORIS_HOME}/lib/java_extensions/java-udf"/*.jar; do
     if [[ -z "${DORIS_CLASSPATH}" ]]; then
         export DORIS_CLASSPATH="${f}"
     else

--- a/build.sh
+++ b/build.sh
@@ -667,8 +667,7 @@ EOF
         cp -r -p "${DORIS_HOME}/bin/run-fs-benchmark.sh" "${DORIS_OUTPUT}/be/bin/"/
     fi
 
-    extensions_modules=("")
-    extensions_modules+=("java-udf")
+    extensions_modules=("java-udf")
     extensions_modules+=("jdbc-scanner")
     extensions_modules+=("hudi-scanner")
     extensions_modules+=("paimon-scanner")
@@ -680,8 +679,9 @@ EOF
     mkdir "${BE_JAVA_EXTENSIONS_DIR}"
     for extensions_module in "${extensions_modules[@]}"; do
         module_path="${DORIS_HOME}/fe/be-java-extensions/${extensions_module}/target/${extensions_module}-jar-with-dependencies.jar"
+        mkdir "${BE_JAVA_EXTENSIONS_DIR}"/"${extensions_module}"
         if [[ -f "${module_path}" ]]; then
-            cp "${module_path}" "${BE_JAVA_EXTENSIONS_DIR}"/
+            cp "${module_path}" "${BE_JAVA_EXTENSIONS_DIR}"/"${extensions_module}"
         fi
     done
 

--- a/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/classloader/JniScannerClassLoader.java
+++ b/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/classloader/JniScannerClassLoader.java
@@ -17,12 +17,8 @@
 
 package org.apache.doris.common.classloader;
 
-import sun.misc.CompoundEnumeration;
-
-import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.Enumeration;
 import java.util.List;
 
 public class JniScannerClassLoader extends URLClassLoader {
@@ -30,7 +26,7 @@ public class JniScannerClassLoader extends URLClassLoader {
     private final String scannerName;
 
     public JniScannerClassLoader(String scannerName, List<URL> urls) {
-        super(urls.toArray(new URL[0]));
+        super(urls.toArray(new URL[0]), ClassLoader.getSystemClassLoader());
         this.scannerName = scannerName;
     }
 
@@ -39,41 +35,5 @@ public class JniScannerClassLoader extends URLClassLoader {
         return "JniScannerClassLoader{"
                 + "scannerName='" + scannerName
                 + '}';
-    }
-
-    @Override
-    public final Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
-        synchronized (getClassLoadingLock(name)) {
-            Class<?> loadedClass = findLoadedClass(name);
-            if (loadedClass != null) {
-                return resolveClass(loadedClass, resolve);
-            }
-            return super.loadClass(name, resolve);
-        }
-    }
-
-    private Class<?> resolveClass(Class<?> loadedClass, boolean resolve) {
-        if (resolve) {
-            resolveClass(loadedClass);
-        }
-        return loadedClass;
-    }
-
-    @Override
-    public URL getResource(String name) {
-        URL url = findResource(name);
-        if (url != null) {
-            return url;
-        }
-        return super.getResource(name);
-    }
-
-    @Override
-    public Enumeration<URL> getResources(String name) throws IOException {
-        @SuppressWarnings("unchecked")
-        Enumeration<URL>[] tmp = (Enumeration<URL>[]) new Enumeration<?>[2];
-        tmp[0] = findResources(name);
-        tmp[1] = super.getResources(name);
-        return new CompoundEnumeration<>(tmp);
     }
 }

--- a/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/classloader/JniScannerClassLoader.java
+++ b/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/classloader/JniScannerClassLoader.java
@@ -1,0 +1,79 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.classloader;
+
+import sun.misc.CompoundEnumeration;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Enumeration;
+import java.util.List;
+
+public class JniScannerClassLoader extends URLClassLoader {
+
+    private final String scannerName;
+
+    public JniScannerClassLoader(String scannerName, List<URL> urls) {
+        super(urls.toArray(new URL[0]));
+        this.scannerName = scannerName;
+    }
+
+    @Override
+    public String toString() {
+        return "JniScannerClassLoader{"
+                + "scannerName='" + scannerName
+                + '}';
+    }
+
+    @Override
+    public final Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        synchronized (getClassLoadingLock(name)) {
+            Class<?> loadedClass = findLoadedClass(name);
+            if (loadedClass != null) {
+                return resolveClass(loadedClass, resolve);
+            }
+            return super.loadClass(name, resolve);
+        }
+    }
+
+    private Class<?> resolveClass(Class<?> loadedClass, boolean resolve) {
+        if (resolve) {
+            resolveClass(loadedClass);
+        }
+        return loadedClass;
+    }
+
+    @Override
+    public URL getResource(String name) {
+        URL url = findResource(name);
+        if (url != null) {
+            return url;
+        }
+        return super.getResource(name);
+    }
+
+    @Override
+    public Enumeration<URL> getResources(String name) throws IOException {
+        @SuppressWarnings("unchecked")
+        Enumeration<URL>[] tmp = (Enumeration<URL>[]) new Enumeration<?>[2];
+        tmp[0] = findResources(name);
+        tmp[1] = super.getResources(name);
+        return new CompoundEnumeration<>(tmp);
+    }
+}

--- a/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/classloader/ScannerLoader.java
+++ b/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/classloader/ScannerLoader.java
@@ -1,0 +1,120 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.classloader;
+
+import org.apache.doris.common.jni.JniScanner;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Streams;
+import org.apache.log4j.Logger;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+
+public class ScannerLoader {
+    private static final Logger LOG = Logger.getLogger(ScannerLoader.class);
+
+    public static void load() {
+        LOG.info("--- scanner load class");
+        String basePath = System.getenv("DORIS_HOME");
+        File library = new File(basePath, "/lib/java_extensions/");
+        listFiles(library).stream().filter(File::isDirectory).forEach(e -> {
+            JniScannerClassLoader classLoader = createScannerClassLoader(e.getName(), buildClassPath(e));
+            LOG.info("scanner Classpath for plugin: " + e.getName());
+            for (URL url : classLoader.getURLs()) {
+                LOG.info("scanner " + url.getPath());
+            }
+            try (ThreadClassLoaderContext ignored = new ThreadClassLoaderContext(classLoader)) {
+                ServiceLoader<JniScanner> serviceLoader = ServiceLoader.load(JniScanner.class, classLoader);
+                List<JniScanner> scanners = ImmutableList.copyOf(serviceLoader);
+                if (scanners.isEmpty()) {
+                    LOG.warn("No service providers of type " + JniScanner.class.getName()
+                            + " in the classpath: " + Lists.asList(null, classLoader.getURLs()));
+                }
+                for (JniScanner scanner : scanners) {
+                    LOG.info("Loaded " + scanner.getClass().getName());
+                }
+            }
+        });
+    }
+
+    private static JniScannerClassLoader createScannerClassLoader(String name, List<URL> classPaths) {
+        return new JniScannerClassLoader(name, classPaths);
+    }
+
+    private static List<URL> buildClassPath(File path) {
+        return listFiles(path).stream()
+                .map(ScannerLoader::fileToUrl)
+                .collect(Collectors.toList());
+    }
+
+    private static URL fileToUrl(File file) {
+        try {
+            return file.toURI().toURL();
+        } catch (MalformedURLException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public static List<File> listFiles(File library) {
+        LOG.info("---scanner dir: " + library.toPath());
+        try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(library.toPath())) {
+            return Streams.stream(directoryStream)
+                    .map(Path::toFile)
+                    .sorted()
+                    .collect(Collectors.toList());
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @VisibleForTesting
+    public static void loadJarClass(String path) throws IOException {
+        Enumeration<JarEntry> entryEnumeration;
+        try (JarFile jar = new JarFile(path)) {
+            entryEnumeration = jar.entries();
+            while (entryEnumeration.hasMoreElements()) {
+                JarEntry entry = entryEnumeration.nextElement();
+                String clazzName = entry.getName();
+                if (clazzName.endsWith(".class")) {
+                    clazzName = clazzName.substring(0, clazzName.length() - 6);
+                    clazzName = clazzName.replace("/", ".");
+                    Class.forName(clazzName);
+                }
+            }
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/classloader/ThreadClassLoaderContext.java
+++ b/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/classloader/ThreadClassLoaderContext.java
@@ -18,7 +18,6 @@
 package org.apache.doris.common.classloader;
 
 import java.io.Closeable;
-import java.io.IOException;
 
 public class ThreadClassLoaderContext implements Closeable {
 

--- a/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/classloader/ThreadClassLoaderContext.java
+++ b/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/classloader/ThreadClassLoaderContext.java
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.classloader;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+public class ThreadClassLoaderContext implements Closeable {
+
+    private final ClassLoader originClassLoader;
+
+    public ThreadClassLoaderContext(ClassLoader contextClassLoader) {
+        this.originClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(contextClassLoader);
+    }
+
+    @Override
+    public void close() {
+        Thread.currentThread().setContextClassLoader(originClassLoader);
+    }
+}

--- a/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/utils/JniUtil.java
+++ b/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/utils/JniUtil.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.common.jni.utils;
 
+import org.apache.doris.common.classloader.ScannerLoader;
 import org.apache.doris.common.exception.InternalException;
 import org.apache.doris.thrift.TGetJMXJsonResponse;
 import org.apache.doris.thrift.TGetJvmMemoryMetricsResponse;
@@ -268,5 +269,9 @@ public class JniUtil {
             sb.append(entry.getKey() + ":" + entry.getValue() + "\n");
         }
         return sb.toString();
+    }
+
+    public static void loadJNIScanner() {
+        ScannerLoader.load();
     }
 }

--- a/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/utils/JniUtil.java
+++ b/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/utils/JniUtil.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.common.jni.utils;
 
-import org.apache.doris.common.classloader.ScannerLoader;
 import org.apache.doris.common.exception.InternalException;
 import org.apache.doris.thrift.TGetJMXJsonResponse;
 import org.apache.doris.thrift.TGetJvmMemoryMetricsResponse;
@@ -269,9 +268,5 @@ public class JniUtil {
             sb.append(entry.getKey() + ":" + entry.getValue() + "\n");
         }
         return sb.toString();
-    }
-
-    public static void loadJNIScanner() {
-        ScannerLoader.load();
     }
 }


### PR DESCRIPTION
## Proposed changes

Add scanner isolation class loader to make each plugin non-conflicting.
The BE will get scanner classes by JNI call and use JniClassLoader load them.
In the last version，we always get canner classes  from the system class path by default, so it cannot isolate the classes for each scanner,

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

