### PR TITLE
[fix](partial-update) sequence column not updated if using function_column.sequence_type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
@@ -158,8 +158,9 @@ public class StreamLoadPlanner {
                                 + col.getName());
                         }
                         partialUpdateInputColumns.add(col.getName());
-                        if (destTable.hasSequenceCol() && destTable.getSequenceMapCol() != null
-                                && destTable.getSequenceMapCol().equalsIgnoreCase(col.getName())) {
+                        if (destTable.hasSequenceCol() && (taskInfo.hasSequenceCol() || (
+                                destTable.getSequenceMapCol() != null
+                                        && destTable.getSequenceMapCol().equalsIgnoreCase(col.getName())))) {
                             partialUpdateInputColumns.add(Column.SEQUENCE_COL);
                         }
                         existInExpr = true;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

If user specify the `function_column.sequence_type` while create table，the __DORIS_SEQUENCE_COL__ is filtered while planning, and the data of __DORIS_SEQUENCE_COL__ is not loaded.

```
mysql> select * from test_seq;
+------+---------+-------+------+------+-------------+-----------------------+-----------------------+------------------------+
| id   | name    | score | test | dft  | update_time | __DORIS_DELETE_SIGN__ | __DORIS_VERSION_COL__ | __DORIS_SEQUENCE_COL__ |
+------+---------+-------+------+------+-------------+-----------------------+-----------------------+------------------------+
|    1 | doris   |  2300 | 2300 |    1 | 2021-05-19  |                     0 |                     3 |                   NULL |
|    2 | doris2  |  3500 | 2500 |    1 | 2020-03-19  |                     0 |                     3 |                   NULL |
|    3 | unknown |  2000 | 2400 | 4321 | 2022-02-18  |                     0 |                     3 |                   NULL |
+------+---------+-------+------+------+-------------+-----------------------+-----------------------+------------------------+
3 rows in set (0.03 sec)
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

