### PR TITLE
[opt](inverted index) add session variable enable_inverted_index_query to control whether query with inverted index

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -713,6 +713,9 @@ Status SegmentIterator::_apply_bitmap_index_except_leafnode_of_andnode(
 
 Status SegmentIterator::_apply_inverted_index_except_leafnode_of_andnode(
         ColumnPredicate* pred, roaring::Roaring* output_result) {
+    if (!_opts.runtime_state->query_options().enable_inverted_index_query) {
+        return Status::OK();
+    }
     int32_t unique_id = _schema->unique_id(pred->column_id());
     RETURN_IF_ERROR(pred->evaluate(*_schema, _inverted_index_iterators[unique_id].get(), num_rows(),
                                    output_result));
@@ -963,6 +966,9 @@ bool SegmentIterator::_need_read_data(ColumnId cid) {
 
 Status SegmentIterator::_apply_inverted_index() {
     SCOPED_RAW_TIMER(&_opts.stats->inverted_index_filter_timer);
+    if (!_opts.runtime_state->query_options().enable_inverted_index_query) {
+        return Status::OK();
+    }
     size_t input_rows = _row_bitmap.cardinality();
     std::vector<ColumnPredicate*> remaining_predicates;
     std::set<const ColumnPredicate*> no_need_to_pass_column_predicate_set;

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -713,7 +713,7 @@ Status SegmentIterator::_apply_bitmap_index_except_leafnode_of_andnode(
 
 Status SegmentIterator::_apply_inverted_index_except_leafnode_of_andnode(
         ColumnPredicate* pred, roaring::Roaring* output_result) {
-    if (!_opts.runtime_state->query_options().enable_inverted_index_query) {
+    if (_opts.runtime_state && !_opts.runtime_state->query_options().enable_inverted_index_query) {
         return Status::OK();
     }
     int32_t unique_id = _schema->unique_id(pred->column_id());
@@ -966,7 +966,7 @@ bool SegmentIterator::_need_read_data(ColumnId cid) {
 
 Status SegmentIterator::_apply_inverted_index() {
     SCOPED_RAW_TIMER(&_opts.stats->inverted_index_filter_timer);
-    if (!_opts.runtime_state->query_options().enable_inverted_index_query) {
+    if (_opts.runtime_state && !_opts.runtime_state->query_options().enable_inverted_index_query) {
         return Status::OK();
     }
     size_t input_rows = _row_bitmap.cardinality();

--- a/docs/en/docs/advanced/variables.md
+++ b/docs/en/docs/advanced/variables.md
@@ -618,6 +618,10 @@ Translated with www.DeepL.com/Translator (free version)
 
     Specify the storage path of the block file cache on BE, default 'random', and randomly select the storage path configured by BE.
 
+* `enable_inverted_index_query`
+
+    Set wether to use inverted index query, default true.
+
 * `topn_opt_limit_threshold`
 
     Set threshold for limit of topn query (eg. SELECT * FROM t ORDER BY k LIMIT n). If n <= threshold, topn optimizations(runtime predicate pushdown, two phase result fetch and read order by key) will enable automatically, otherwise disable. Default value is 1024.

--- a/docs/zh-CN/docs/advanced/variables.md
+++ b/docs/zh-CN/docs/advanced/variables.md
@@ -603,6 +603,11 @@ try (Connection conn = DriverManager.getConnection("jdbc:mysql://127.0.0.1:9030/
 * `file_cache_base_path`
 
     指定block file cache在BE上的存储路径，默认 'random'，随机选择BE配置的存储路径。
+
+* `enable_inverted_index_query`
+
+    控制是否启用inverted index query，默认 true.
+
 	
 * `topn_opt_limit_threshold`
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -310,6 +310,8 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String FILE_CACHE_BASE_PATH = "file_cache_base_path";
 
+    public static final String ENABLE_INVERTED_INDEX_QUERY = "enable_inverted_index_query";
+
     public static final String GROUP_BY_AND_HAVING_USE_ALIAS_FIRST = "group_by_and_having_use_alias_first";
     public static final String DROP_TABLE_IF_CTAS_FAILED = "drop_table_if_ctas_failed";
 
@@ -961,6 +963,11 @@ public class SessionVariable implements Serializable, Writable {
             "Specify the storage path of the block file cache on BE, default 'random', "
                     + "and randomly select the storage path configured by BE."})
     public String fileCacheBasePath = "random";
+
+    // Whether enable query with inverted index.
+    @VariableMgr.VarAttr(name = ENABLE_INVERTED_INDEX_QUERY, needForward = true, description = {
+            "是否启用inverted index query。", "Set wether to use inverted index query."})
+    public boolean enableInvertedIndexQuery = true;
 
     // Whether drop table when create table as select insert data appear error.
     @VariableMgr.VarAttr(name = DROP_TABLE_IF_CTAS_FAILED, needForward = true)
@@ -1994,6 +2001,14 @@ public class SessionVariable implements Serializable, Writable {
         this.fileCacheBasePath = basePath;
     }
 
+    public boolean isEnableInvertedIndexQuery() {
+        return enableInvertedIndexQuery;
+    }
+
+    public void setEnableInvertedIndexQuery(boolean enableInvertedIndexQuery) {
+        this.enableInvertedIndexQuery = enableInvertedIndexQuery;
+    }
+
     public int getMaxTableCountUseCascadesJoinReorder() {
         return this.maxTableCountUseCascadesJoinReorder;
     }
@@ -2086,6 +2101,8 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setEnableFileCache(enableFileCache);
 
         tResult.setFileCacheBasePath(fileCacheBasePath);
+
+        tResult.setEnableInvertedIndexQuery(enableInvertedIndexQuery);
 
         if (dryRunQuery) {
             tResult.setDryRunQuery(true);

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -225,6 +225,8 @@ struct TQueryOptions {
   74: optional bool enable_scan_node_run_serial = false; 
 
   75: optional bool enable_insert_strict = false;
+
+  76: optional bool enable_inverted_index_query = true;
 }
 
 


### PR DESCRIPTION
## Proposed changes

add the `enable_inverted_index_query` session variable to control whether query with inverted index, the variable default true.

```
mysql> show variables like "%inverted%";
+-----------------------------+-------+
| Variable_name               | Value |
+-----------------------------+-------+
| enable_inverted_index_query | true  |
+-----------------------------+-------+
1 row in set (0.00 sec)
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

