### PR TITLE
[fix](Nereids) fix ends calculation when there are constant project

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/Edge.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/Edge.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.jobs.joinorder.hypergraph;
 
+import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.jobs.joinorder.hypergraph.bitmap.LongBitmap;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
@@ -26,6 +27,7 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 
 import com.google.common.base.Preconditions;
 
+import java.util.BitSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -38,23 +40,36 @@ public class Edge {
     final LogicalJoin<? extends Plan, ? extends Plan> join;
     final double selectivity;
 
-    // The endpoints (hyperNodes) of this hyperEdge.
-    // left and right may not overlap, and both must have at least one bit set.
-    private long left = LongBitmap.newBitmap();
-    private long right = LongBitmap.newBitmap();
-
-    private long originalLeft = LongBitmap.newBitmap();
-    private long originalRight = LongBitmap.newBitmap();
+    // "RequiredNodes" refers to the nodes that can activate this edge based on
+    // specific requirements. These requirements are established during the building process.
+    // "ExtendNodes" encompasses both the "RequiredNodes" and any additional nodes
+    // added by the graph simplifier.
+    private long leftRequiredNodes = LongBitmap.newBitmap();
+    private long rightRequiredNodes = LongBitmap.newBitmap();
+    private long leftExtendedNodes = LongBitmap.newBitmap();
+    private long rightExtendedNodes = LongBitmap.newBitmap();
 
     private long referenceNodes = LongBitmap.newBitmap();
+
+    // record the left child edges and right child edges in origin plan tree
+    private BitSet leftChildEdges;
+    private BitSet rightChildEdges;
+
+    // record the edges in the same operator
+    private BitSet curJoinEdges = new BitSet();
+    // record all sub nodes behind in this operator. It's T function in paper
+    private Long subTreeNodes;
 
     /**
      * Create simple edge.
      */
-    public Edge(LogicalJoin join, int index) {
+    public Edge(LogicalJoin join, int index, BitSet leftChildEdges, BitSet rightChildEdges, Long subTreeNodes) {
         this.index = index;
         this.join = join;
         this.selectivity = 1.0;
+        this.leftChildEdges = leftChildEdges;
+        this.rightChildEdges = rightChildEdges;
+        this.subTreeNodes = subTreeNodes;
     }
 
     public LogicalJoin getJoin() {
@@ -66,65 +81,107 @@ public class Edge {
     }
 
     public boolean isSimple() {
-        return LongBitmap.getCardinality(left) == 1 && LongBitmap.getCardinality(right) == 1;
+        return LongBitmap.getCardinality(leftExtendedNodes) == 1 && LongBitmap.getCardinality(rightExtendedNodes) == 1;
     }
 
     public void addLeftNode(long left) {
-        this.left = LongBitmap.or(this.left, left);
+        this.leftExtendedNodes = LongBitmap.or(this.leftExtendedNodes, left);
         referenceNodes = LongBitmap.or(referenceNodes, left);
     }
 
     public void addLeftNodes(long... bitmaps) {
         for (long bitmap : bitmaps) {
-            this.left = LongBitmap.or(this.left, bitmap);
+            this.leftExtendedNodes = LongBitmap.or(this.leftExtendedNodes, bitmap);
             referenceNodes = LongBitmap.or(referenceNodes, bitmap);
         }
     }
 
     public void addRightNode(long right) {
-        this.right = LongBitmap.or(this.right, right);
+        this.rightExtendedNodes = LongBitmap.or(this.rightExtendedNodes, right);
         referenceNodes = LongBitmap.or(referenceNodes, right);
     }
 
     public void addRightNodes(long... bitmaps) {
         for (long bitmap : bitmaps) {
-            LongBitmap.or(this.right, bitmap);
+            LongBitmap.or(this.rightExtendedNodes, bitmap);
             LongBitmap.or(referenceNodes, bitmap);
         }
     }
 
-    public long getLeft() {
-        return left;
+    public long getSubTreeNodes() {
+        return this.subTreeNodes;
     }
 
-    public void setLeft(long left) {
+    public long getLeftExtendedNodes() {
+        return leftExtendedNodes;
+    }
+
+    public BitSet getLeftChildEdges() {
+        return leftChildEdges;
+    }
+
+    public Pair<BitSet, Long> getLeftEdgeNodes(List<Edge> edges) {
+        return Pair.of(leftChildEdges, getLeftSubNodes(edges));
+    }
+
+    public Pair<BitSet, Long> getRightEdgeNodes(List<Edge> edges) {
+        return Pair.of(rightChildEdges, getRightSubNodes(edges));
+    }
+
+    public long getLeftSubNodes(List<Edge> edges) {
+        if (leftChildEdges.isEmpty()) {
+            return leftRequiredNodes;
+        }
+        return edges.get(leftChildEdges.nextSetBit(0)).getSubTreeNodes();
+    }
+
+    public long getRightSubNodes(List<Edge> edges) {
+        if (rightChildEdges.isEmpty()) {
+            return rightRequiredNodes;
+        }
+        return edges.get(rightChildEdges.nextSetBit(0)).getSubTreeNodes();
+    }
+
+    public void setLeftExtendedNodes(long leftExtendedNodes) {
         referenceNodes = LongBitmap.clear(referenceNodes);
-        this.left = left;
+        this.leftExtendedNodes = leftExtendedNodes;
     }
 
-    public long getRight() {
-        return right;
+    public long getRightExtendedNodes() {
+        return rightExtendedNodes;
     }
 
-    public void setRight(long right) {
+    public BitSet getRightChildEdges() {
+        return rightChildEdges;
+    }
+
+    public void setRightExtendedNodes(long rightExtendedNodes) {
         referenceNodes = LongBitmap.clear(referenceNodes);
-        this.right = right;
+        this.rightExtendedNodes = rightExtendedNodes;
     }
 
-    public long getOriginalLeft() {
-        return originalLeft;
+    public long getLeftRequiredNodes() {
+        return leftRequiredNodes;
     }
 
-    public void setOriginalLeft(long left) {
-        this.originalLeft = left;
+    public void setLeftRequiredNodes(long left) {
+        this.leftRequiredNodes = left;
     }
 
-    public long getOriginalRight() {
-        return originalRight;
+    public long getRightRequiredNodes() {
+        return rightRequiredNodes;
     }
 
-    public void setOriginalRight(long right) {
-        this.originalRight = right;
+    public void setRightRequiredNodes(long right) {
+        this.rightRequiredNodes = right;
+    }
+
+    public void addCurJoinEdges(BitSet edges) {
+        curJoinEdges.or(edges);
+    }
+
+    public BitSet getCurJoinEdges() {
+        return curJoinEdges;
     }
 
     public boolean isSub(Edge edge) {
@@ -135,9 +192,13 @@ public class Edge {
 
     public long getReferenceNodes() {
         if (LongBitmap.getCardinality(referenceNodes) == 0) {
-            referenceNodes = LongBitmap.newBitmapUnion(left, right);
+            referenceNodes = LongBitmap.newBitmapUnion(leftExtendedNodes, rightExtendedNodes);
         }
         return referenceNodes;
+    }
+
+    public long getRequireNodes() {
+        return LongBitmap.newBitmapUnion(leftRequiredNodes, rightRequiredNodes);
     }
 
     public int getIndex() {
@@ -165,7 +226,8 @@ public class Edge {
 
     @Override
     public String toString() {
-        return String.format("<%s - %s>", LongBitmap.toString(left), LongBitmap.toString(right));
+        return String.format("<%s - %s>", LongBitmap.toString(leftExtendedNodes), LongBitmap.toString(
+                rightExtendedNodes));
     }
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/GraphSimplifier.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/GraphSimplifier.java
@@ -108,10 +108,10 @@ public class GraphSimplifier {
                 Edge edge1 = graph.getEdge(i);
                 Edge edge2 = graph.getEdge(j);
                 List<Long> superset = new ArrayList<>();
-                tryGetSuperset(edge1.getLeft(), edge2.getLeft(), superset);
-                tryGetSuperset(edge1.getLeft(), edge2.getRight(), superset);
-                tryGetSuperset(edge1.getRight(), edge2.getLeft(), superset);
-                tryGetSuperset(edge1.getRight(), edge2.getRight(), superset);
+                tryGetSuperset(edge1.getLeftExtendedNodes(), edge2.getLeftExtendedNodes(), superset);
+                tryGetSuperset(edge1.getLeftExtendedNodes(), edge2.getRightExtendedNodes(), superset);
+                tryGetSuperset(edge1.getRightExtendedNodes(), edge2.getLeftExtendedNodes(), superset);
+                tryGetSuperset(edge1.getRightExtendedNodes(), edge2.getRightExtendedNodes(), superset);
                 if (!circleDetector.checkCircleWithEdge(i, j) && !circleDetector.checkCircleWithEdge(j, i)
                         && !edge2.isSub(edge1) && !edge1.isSub(edge2) && !superset.isEmpty()) {
                     return false;
@@ -213,8 +213,8 @@ public class GraphSimplifier {
         BestSimplification bestSimplification = priorityQueue.poll();
         bestSimplification.isInQueue = false;
         SimplificationStep bestStep = bestSimplification.getStep();
-        while (bestSimplification.bestNeighbor == -1 || !circleDetector.tryAddDirectedEdge(bestStep.beforeIndex,
-                bestStep.afterIndex)) {
+        while (bestSimplification.bestNeighbor == -1
+                || !circleDetector.tryAddDirectedEdge(bestStep.beforeIndex, bestStep.afterIndex)) {
             processNeighbors(bestStep.afterIndex, 0, edgeSize);
             if (priorityQueue.isEmpty()) {
                 return null;
@@ -307,10 +307,14 @@ public class GraphSimplifier {
                 || circleDetector.checkCircleWithEdge(edgeIndex2, edgeIndex1)) {
             return Optional.empty();
         }
-        long left1 = edge1.getLeft();
-        long right1 = edge1.getRight();
-        long left2 = edge2.getLeft();
-        long right2 = edge2.getRight();
+        long left1 = edge1.getLeftExtendedNodes();
+        long right1 = edge1.getRightExtendedNodes();
+        long left2 = edge2.getLeftExtendedNodes();
+        long right2 = edge2.getRightExtendedNodes();
+        if (!cacheStats.containsKey(left1) || !cacheStats.containsKey(right1)
+                || !cacheStats.containsKey(left2) || !cacheStats.containsKey(right2)) {
+            return Optional.empty();
+        }
         Pair<Statistics, Edge> edge1Before2;
         Pair<Statistics, Edge> edge2Before1;
         List<Long> superBitset = new ArrayList<>();
@@ -351,13 +355,14 @@ public class GraphSimplifier {
         Statistics leftStats = JoinEstimation.estimate(cacheStats.get(bitmap1), cacheStats.get(bitmap2),
                 edge1.getJoin());
         Statistics joinStats = JoinEstimation.estimate(leftStats, cacheStats.get(bitmap3), edge2.getJoin());
-        Edge edge = new Edge(edge2.getJoin(), -1);
+        Edge edge = new Edge(
+                edge2.getJoin(), -1, edge2.getLeftChildEdges(), edge2.getRightChildEdges(), edge2.getSubTreeNodes());
         long newLeft = LongBitmap.newBitmapUnion(bitmap1, bitmap2);
         // To avoid overlapping the left and the right, the newLeft is calculated, Note the
         // newLeft is not totally include the bitset1 and bitset2, we use circle detector to trace the dependency
         newLeft = LongBitmap.andNot(newLeft, bitmap3);
         edge.addLeftNodes(newLeft);
-        edge.addRightNode(edge2.getRight());
+        edge.addRightNode(edge2.getRightExtendedNodes());
         cacheStats.put(newLeft, leftStats);
         cacheCost.put(newLeft, calCost(edge2, leftStats, cacheStats.get(bitmap1), cacheStats.get(bitmap2)));
         return Pair.of(joinStats, edge);
@@ -370,11 +375,12 @@ public class GraphSimplifier {
         Statistics rightStats = JoinEstimation.estimate(cacheStats.get(bitmap2), cacheStats.get(bitmap3),
                 edge2.getJoin());
         Statistics joinStats = JoinEstimation.estimate(cacheStats.get(bitmap1), rightStats, edge1.getJoin());
-        Edge edge = new Edge(edge1.getJoin(), -1);
+        Edge edge = new Edge(
+                edge1.getJoin(), -1, edge1.getLeftChildEdges(), edge1.getRightChildEdges(), edge1.getSubTreeNodes());
 
         long newRight = LongBitmap.newBitmapUnion(bitmap2, bitmap3);
         newRight = LongBitmap.andNot(newRight, bitmap1);
-        edge.addLeftNode(edge1.getLeft());
+        edge.addLeftNode(edge1.getLeftExtendedNodes());
         edge.addRightNode(newRight);
         cacheStats.put(newRight, rightStats);
         cacheCost.put(newRight, calCost(edge2, rightStats, cacheStats.get(bitmap2), cacheStats.get(bitmap3)));
@@ -384,11 +390,11 @@ public class GraphSimplifier {
     private SimplificationStep orderJoin(Pair<Statistics, Edge> edge1Before2,
             Pair<Statistics, Edge> edge2Before1, int edgeIndex1, int edgeIndex2) {
         Cost cost1Before2 = calCost(edge1Before2.second, edge1Before2.first,
-                cacheStats.get(edge1Before2.second.getLeft()),
-                cacheStats.get(edge1Before2.second.getRight()));
+                cacheStats.get(edge1Before2.second.getLeftExtendedNodes()),
+                cacheStats.get(edge1Before2.second.getRightExtendedNodes()));
         Cost cost2Before1 = calCost(edge2Before1.second, edge1Before2.first,
-                cacheStats.get(edge1Before2.second.getLeft()),
-                cacheStats.get(edge1Before2.second.getRight()));
+                cacheStats.get(edge1Before2.second.getLeftExtendedNodes()),
+                cacheStats.get(edge1Before2.second.getRightExtendedNodes()));
         double benefit = Double.MAX_VALUE;
         SimplificationStep step;
         // Choose the plan with smaller cost and make the simplification step to replace the old edge by it.
@@ -397,17 +403,17 @@ public class GraphSimplifier {
                 benefit = cost2Before1.getValue() / cost1Before2.getValue();
             }
             // choose edge1Before2
-            step = new SimplificationStep(benefit, edgeIndex1, edgeIndex2, edge1Before2.second.getLeft(),
-                    edge1Before2.second.getRight(), graph.getEdge(edgeIndex2).getLeft(),
-                    graph.getEdge(edgeIndex2).getRight());
+            step = new SimplificationStep(benefit, edgeIndex1, edgeIndex2, edge1Before2.second.getLeftExtendedNodes(),
+                    edge1Before2.second.getRightExtendedNodes(), graph.getEdge(edgeIndex2).getLeftExtendedNodes(),
+                    graph.getEdge(edgeIndex2).getRightExtendedNodes());
         } else {
             if (cost2Before1.getValue() != 0) {
                 benefit = cost1Before2.getValue() / cost2Before1.getValue();
             }
             // choose edge2Before1
-            step = new SimplificationStep(benefit, edgeIndex2, edgeIndex1, edge2Before1.second.getLeft(),
-                    edge2Before1.second.getRight(), graph.getEdge(edgeIndex1).getLeft(),
-                    graph.getEdge(edgeIndex1).getRight());
+            step = new SimplificationStep(benefit, edgeIndex2, edgeIndex1, edge2Before1.second.getLeftExtendedNodes(),
+                    edge2Before1.second.getRightExtendedNodes(), graph.getEdge(edgeIndex1).getLeftExtendedNodes(),
+                    graph.getEdge(edgeIndex1).getRightExtendedNodes());
         }
         return step;
     }
@@ -438,8 +444,8 @@ public class GraphSimplifier {
                     join.left(),
                     join.right());
             cost = CostCalculator.calculateCost(nestedLoopJoin, planContext);
-            cost = CostCalculator.addChildCost(nestedLoopJoin, cost, cacheCost.get(edge.getLeft()), 0);
-            cost = CostCalculator.addChildCost(nestedLoopJoin, cost, cacheCost.get(edge.getRight()), 1);
+            cost = CostCalculator.addChildCost(nestedLoopJoin, cost, cacheCost.get(edge.getLeftExtendedNodes()), 0);
+            cost = CostCalculator.addChildCost(nestedLoopJoin, cost, cacheCost.get(edge.getRightExtendedNodes()), 1);
         } else {
             PhysicalHashJoin hashJoin = new PhysicalHashJoin<>(
                     join.getJoinType(),
@@ -451,8 +457,8 @@ public class GraphSimplifier {
                     join.left(),
                     join.right());
             cost = CostCalculator.calculateCost(hashJoin, planContext);
-            cost = CostCalculator.addChildCost(hashJoin, cost, cacheCost.get(edge.getLeft()), 0);
-            cost = CostCalculator.addChildCost(hashJoin, cost, cacheCost.get(edge.getRight()), 1);
+            cost = CostCalculator.addChildCost(hashJoin, cost, cacheCost.get(edge.getLeftExtendedNodes()), 0);
+            cost = CostCalculator.addChildCost(hashJoin, cost, cacheCost.get(edge.getRightExtendedNodes()), 1);
         }
 
         return cost;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/SubgraphEnumerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/SubgraphEnumerator.java
@@ -225,8 +225,8 @@ public class SubgraphEnumerator {
             neighborhoods = LongBitmap.andNot(neighborhoods, forbiddenNodes);
             forbiddenNodes = LongBitmap.or(forbiddenNodes, neighborhoods);
             for (Edge edge : edgeCalculator.foundComplexEdgesContain(subgraph)) {
-                long left = edge.getLeft();
-                long right = edge.getRight();
+                long left = edge.getLeftExtendedNodes();
+                long right = edge.getRightExtendedNodes();
                 if (LongBitmap.isSubset(left, subgraph) && !LongBitmap.isOverlap(right, forbiddenNodes)) {
                     neighborhoods = LongBitmap.set(neighborhoods, LongBitmap.lowestOneIndex(right));
                 } else if (LongBitmap.isSubset(right, subgraph) && !LongBitmap.isOverlap(left, forbiddenNodes)) {
@@ -362,14 +362,14 @@ public class SubgraphEnumerator {
         }
 
         private boolean isContainEdge(long subgraph, Edge edge) {
-            int containLeft = LongBitmap.isSubset(edge.getLeft(), subgraph) ? 0 : 1;
-            int containRight = LongBitmap.isSubset(edge.getRight(), subgraph) ? 0 : 1;
+            int containLeft = LongBitmap.isSubset(edge.getLeftExtendedNodes(), subgraph) ? 0 : 1;
+            int containRight = LongBitmap.isSubset(edge.getRightExtendedNodes(), subgraph) ? 0 : 1;
             return containLeft + containRight == 1;
         }
 
         private boolean isOverlapEdge(long subgraph, Edge edge) {
-            int overlapLeft = LongBitmap.isOverlap(edge.getLeft(), subgraph) ? 0 : 1;
-            int overlapRight = LongBitmap.isOverlap(edge.getRight(), subgraph) ? 0 : 1;
+            int overlapLeft = LongBitmap.isOverlap(edge.getLeftExtendedNodes(), subgraph) ? 0 : 1;
+            int overlapRight = LongBitmap.isOverlap(edge.getRightExtendedNodes(), subgraph) ? 0 : 1;
             return overlapLeft + overlapRight == 1;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/receiver/PlanReceiver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/receiver/PlanReceiver.java
@@ -60,6 +60,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 /**
@@ -102,15 +103,14 @@ public class PlanReceiver implements AbstractReceiver {
     public boolean emitCsgCmp(long left, long right, List<Edge> edges) {
         Preconditions.checkArgument(planTable.containsKey(left));
         Preconditions.checkArgument(planTable.containsKey(right));
-
         processMissedEdges(left, right, edges);
 
-        Memo memo = jobContext.getCascadesContext().getMemo();
         emitCount += 1;
         if (emitCount > limit) {
             return false;
         }
 
+        Memo memo = jobContext.getCascadesContext().getMemo();
         GroupPlan leftPlan = new GroupPlan(planTable.get(left));
         GroupPlan rightPlan = new GroupPlan(planTable.get(right));
 
@@ -118,6 +118,7 @@ public class PlanReceiver implements AbstractReceiver {
         // In this step, we don't generate logical expression because they are useless in DPhyp.
         List<Expression> hashConjuncts = new ArrayList<>();
         List<Expression> otherConjuncts = new ArrayList<>();
+
         JoinType joinType = extractJoinTypeAndConjuncts(edges, hashConjuncts, otherConjuncts);
         if (joinType == null) {
             return true;
@@ -126,6 +127,7 @@ public class PlanReceiver implements AbstractReceiver {
 
         List<Plan> physicalJoins = proposeAllPhysicalJoins(joinType, leftPlan, rightPlan, hashConjuncts,
                 otherConjuncts);
+
         List<Plan> physicalPlans = proposeProject(physicalJoins, edges, left, right);
 
         // Second, we copy all physical plan to Group and generate properties and calculate cost
@@ -188,7 +190,7 @@ public class PlanReceiver implements AbstractReceiver {
         // find the edge which is not in usedEdgesBitmap and its referenced nodes is subset of allReferenceNodes
         for (Edge edge : hyperGraph.getEdges()) {
             long referenceNodes =
-                    LongBitmap.newBitmapUnion(edge.getOriginalLeft(), edge.getOriginalRight());
+                    LongBitmap.newBitmapUnion(edge.getLeftRequiredNodes(), edge.getRightRequiredNodes());
             if (LongBitmap.isSubset(referenceNodes, allReferenceNodes)
                     && !usedEdgesBitmap.get(edge.getIndex())) {
                 // add the missed edge to edges
@@ -344,7 +346,6 @@ public class PlanReceiver implements AbstractReceiver {
         long fullKey = LongBitmap.newBitmapUnion(left, right);
         List<Slot> outputs = allChild.get(0).getOutput();
         Set<Slot> outputSet = allChild.get(0).getOutputSet();
-        List<NamedExpression> allProjects = Lists.newArrayList();
 
         List<NamedExpression> complexProjects = new ArrayList<>();
         // Calculate complex expression should be done by current(fullKey) node
@@ -358,43 +359,23 @@ public class PlanReceiver implements AbstractReceiver {
 
         // complexProjectMap is created by a bottom up traverse of join tree, so child node is put before parent node
         // in the bitmaps
+        bitmaps.sort(Long::compare);
         for (long bitmap : bitmaps) {
             if (complexProjects.isEmpty()) {
-                complexProjects = complexProjectMap.get(bitmap);
+                complexProjects.addAll(complexProjectMap.get(bitmap));
             } else {
-                // The top project of (T1, T2, T3) is different after reorder
-                // we need merge Project1 and Project2 as Project4 after reorder
-                // T1 join T2 join T3:
-                //    Project1(a, e + f)
-                //        join(a = e)
-                //            Project2(a, b + d as e)
-                //                join(a = c)
-                //                    T1(a, b)
-                //                    T2(c, d)
-                //        T3(e, f)
-                //
-                // after reorder:
-                // T1 join T3 join T2:
-                //    Project4(a, b + d + f)
-                //        join(a = c)
-                //            Project3(a, b, f)
-                //                join(a = e)
-                //                    T1(a, b)
-                //                    T3(e, f)
-                //        T2(c, d)
-                //
-                complexProjects =
-                        PlanUtils.mergeProjections(complexProjects, complexProjectMap.get(bitmap));
+                // Rewrite project expression by its children
+                complexProjects.addAll(
+                        PlanUtils.mergeProjections(complexProjects, complexProjectMap.get(bitmap)));
             }
         }
-        allProjects.addAll(complexProjects);
 
         // calculate required columns by all parents
         Set<Slot> requireSlots = calculateRequiredSlots(left, right, edges);
-
-        // add output slots belong to required slots to project list
-        allProjects.addAll(outputs.stream().filter(e -> requireSlots.contains(e))
-                .collect(Collectors.toList()));
+        List<NamedExpression> allProjects = Stream.concat(
+                outputs.stream().filter(e -> requireSlots.contains(e)),
+                complexProjects.stream().filter(e -> requireSlots.contains(e.toSlot()))
+        ).collect(Collectors.toList());
 
         // propose physical project
         if (allProjects.isEmpty()) {
@@ -416,7 +397,13 @@ public class PlanReceiver implements AbstractReceiver {
                     .map(c -> new PhysicalProject<>(projects, projectProperties, c))
                     .collect(Collectors.toList());
         }
-        Preconditions.checkState(!projects.isEmpty() && projects.size() == allProjects.size());
+        if (!(!projects.isEmpty() && projects.size() == allProjects.size())) {
+            Set<NamedExpression> s1 = projects.stream().collect(Collectors.toSet());
+            List<NamedExpression> s2 = allProjects.stream().filter(e -> !s1.contains(e)).collect(Collectors.toList());
+            System.out.println(s2);
+        }
+        Preconditions.checkState(!projects.isEmpty() && projects.size() == allProjects.size(),
+                " there are some projects left " + projects + allProjects);
 
         return allChild;
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/OtherJoinTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/OtherJoinTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.jobs.joinorder.hypergraph;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.datasets.tpch.TPCHTestBase;
 import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.nereids.util.HyperGraphBuilder;
 import org.apache.doris.nereids.util.MemoTestUtils;
 import org.apache.doris.nereids.util.PlanChecker;
@@ -32,23 +33,37 @@ import java.util.Set;
 
 public class OtherJoinTest extends TPCHTestBase {
     @Test
-    public void randomTest() {
+    public void test() {
+        for (int t = 3; t < 10; t++) {
+            for (int e = t - 1; e <= (t * (t - 1)) / 2; e++) {
+                for (int i = 0; i < 10; i++) {
+                    System.out.println(String.valueOf(t) + " " + e + ": " + i);
+                    randomTest(t, e);
+                }
+            }
+        }
+    }
+
+    private void randomTest(int tableNum, int edgeNum) {
         HyperGraphBuilder hyperGraphBuilder = new HyperGraphBuilder();
         Plan plan = hyperGraphBuilder
-                .randomBuildPlanWith(10, 20);
-        Set<List<Integer>> res1 = hyperGraphBuilder.evaluate(plan);
+                .randomBuildPlanWith(tableNum, edgeNum);
+        plan = new LogicalProject(plan.getOutput(), plan);
+        Set<List<String>> res1 = hyperGraphBuilder.evaluate(plan);
         CascadesContext cascadesContext = MemoTestUtils.createCascadesContext(connectContext, plan);
         hyperGraphBuilder.initStats(cascadesContext);
         Plan optimizedPlan = PlanChecker.from(cascadesContext)
-                        .dpHypOptimize()
-                        .getBestPlanTree();
+                .dpHypOptimize()
+                .getBestPlanTree();
 
-        Set<List<Integer>> res2 = hyperGraphBuilder.evaluate(optimizedPlan);
+        Set<List<String>> res2 = hyperGraphBuilder.evaluate(optimizedPlan);
         if (!res1.equals(res2)) {
-            System.out.println(res1);
-            System.out.println(res2);
             System.out.println(plan.treeString());
             System.out.println(optimizedPlan.treeString());
+            cascadesContext = MemoTestUtils.createCascadesContext(connectContext, plan);
+            PlanChecker.from(cascadesContext).dpHypOptimize().getBestPlanTree();
+            System.out.println(res1);
+            System.out.println(res2);
         }
         Assertions.assertTrue(res1.equals(res2));
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/SubgraphEnumeratorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/SubgraphEnumeratorTest.java
@@ -130,8 +130,8 @@ public class SubgraphEnumeratorTest {
             visited.add(left);
             visited.add(right);
             for (Edge edge : hyperGraph.getEdges()) {
-                if ((LongBitmap.isSubset(edge.getLeft(), left) && LongBitmap.isSubset(edge.getRight(), right)) || (
-                        LongBitmap.isSubset(edge.getLeft(), right) && LongBitmap.isSubset(edge.getRight(), left))) {
+                if ((LongBitmap.isSubset(edge.getLeftExtendedNodes(), left) && LongBitmap.isSubset(edge.getRightExtendedNodes(), right)) || (
+                        LongBitmap.isSubset(edge.getLeftExtendedNodes(), right) && LongBitmap.isSubset(edge.getRightExtendedNodes(), left))) {
                     count += countAndCheck(left, hyperGraph, counter, cache) * countAndCheck(right, hyperGraph,
                             counter, cache);
                     break;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/sqltest/JoinOrderJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/sqltest/JoinOrderJobTest.java
@@ -88,6 +88,20 @@ public class JoinOrderJobTest extends SqlTestBase {
     }
 
     @Test
+    protected void testConstantJoin() {
+        String sql = "select count(*) \n"
+                + "from \n"
+                + "T1 \n"
+                + " join (\n"
+                + "select * , now() as t from T2 \n"
+                + ") subTable on T1.id = t; \n";
+        PlanChecker.from(connectContext)
+                .analyze(sql)
+                .rewrite()
+                .dpHypOptimize();
+    }
+
+    @Test
     protected void testCountJoin() {
         String sql = "select count(*) \n"
                 + "from \n"

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/HyperGraphBuilder.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/HyperGraphBuilder.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.util;
 
+import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.jobs.joinorder.JoinOrderJob;
@@ -26,6 +27,7 @@ import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
@@ -35,6 +37,7 @@ import org.apache.doris.nereids.trees.plans.physical.AbstractPhysicalJoin;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalOlapScan;
 import org.apache.doris.statistics.ColumnStatistic;
 import org.apache.doris.statistics.Statistics;
+import org.apache.doris.statistics.StatisticsCacheKey;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -88,6 +91,12 @@ public class HyperGraphBuilder {
         assert plans.size() == 1 : "there are cross join";
         Plan plan = plans.values().iterator().next();
         return buildHyperGraph(plan);
+    }
+
+    public Plan buildPlan() {
+        assert plans.size() == 1 : "there are cross join";
+        Plan plan = plans.values().iterator().next();
+        return plan;
     }
 
     public Plan buildJoinPlan() {
@@ -166,9 +175,14 @@ public class HyperGraphBuilder {
         for (Group group : context.getMemo().getGroups()) {
             GroupExpression groupExpression = group.getLogicalExpression();
             if (groupExpression.getPlan() instanceof LogicalOlapScan) {
+                LogicalOlapScan scan = (LogicalOlapScan) groupExpression.getPlan();
                 Statistics stats = injectRowcount((LogicalOlapScan) groupExpression.getPlan());
-                groupExpression.setStatDerived(true);
-                group.setStatistics(stats);
+                for (Expression expr : stats.columnStatistics().keySet()) {
+                    SlotReference slot = (SlotReference) expr;
+                    Env.getCurrentEnv().getStatisticsCache().putCache(
+                            new StatisticsCacheKey(scan.getTable().getId(), -1, slot.getName()),
+                            stats.columnStatistics().get(expr));
+                }
             }
         }
     }
@@ -364,7 +378,7 @@ public class HyperGraphBuilder {
         return hashConjunts;
     }
 
-    public Set<List<Integer>> evaluate(Plan plan) {
+    public Set<List<String>> evaluate(Plan plan) {
         JoinEvaluator evaluator = new JoinEvaluator(rowCounts);
         Map<Slot, List<Integer>> res = evaluator.evaluate(plan);
         int rowCount = 0;
@@ -376,11 +390,12 @@ public class HyperGraphBuilder {
                         (slot1, slot2) ->
                                 String.CASE_INSENSITIVE_ORDER.compare(slot1.toString(), slot2.toString()))
                 .collect(Collectors.toList());
-        Set<List<Integer>> tuples = new HashSet<>();
+        Set<List<String>> tuples = new HashSet<>();
+        tuples.add(keySet.stream().map(s -> s.toString()).collect(Collectors.toList()));
         for (int i = 0; i < rowCount; i++) {
-            List<Integer> tuple = new ArrayList<>();
+            List<String> tuple = new ArrayList<>();
             for (Slot key : keySet) {
-                tuple.add(res.get(key).get(i));
+                tuple.add(String.valueOf(res.get(key).get(i)));
             }
             tuples.add(tuple);
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/PlanChecker.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/PlanChecker.java
@@ -33,7 +33,6 @@ import org.apache.doris.nereids.jobs.joinorder.JoinOrderJob;
 import org.apache.doris.nereids.jobs.rewrite.PlanTreeRewriteBottomUpJob;
 import org.apache.doris.nereids.jobs.rewrite.PlanTreeRewriteTopDownJob;
 import org.apache.doris.nereids.jobs.rewrite.RootPlanTreeRewriteJob;
-import org.apache.doris.nereids.memo.CopyInResult;
 import org.apache.doris.nereids.memo.Group;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.memo.Memo;
@@ -243,23 +242,13 @@ public class PlanChecker {
 
     public PlanChecker dpHypOptimize() {
         double now = System.currentTimeMillis();
+        cascadesContext.getStatementContext().setDpHyp(true);
+        cascadesContext.getConnectContext().getSessionVariable().enableDPHypOptimizer = true;
         Group root = cascadesContext.getMemo().getRoot();
-        boolean changeRoot = false;
-        if (root.isValidJoinGroup()) {
-            // If the root group is join group, DPHyp can change the root group.
-            // To keep the root group is not changed, we add a dummy project operator above join
-            List<Slot> outputs = root.getLogicalExpression().getPlan().getOutput();
-            LogicalPlan plan = new LogicalProject(outputs, root.getLogicalExpression().getPlan());
-            CopyInResult copyInResult = cascadesContext.getMemo().copyIn(plan, null, false);
-            root = copyInResult.correspondingExpression.getOwnerGroup();
-            changeRoot = true;
-        }
         cascadesContext.pushJob(new JoinOrderJob(root, cascadesContext.getCurrentJobContext()));
+        cascadesContext.pushJob(new DeriveStatsJob(root.getLogicalExpression(),
+                cascadesContext.getCurrentJobContext()));
         cascadesContext.getJobScheduler().executeJobPool(cascadesContext);
-        if (changeRoot) {
-            cascadesContext.getMemo().setRoot(root.getLogicalExpression().child(0));
-        }
-        // if the root is not join, we need to optimize again.
         optimize();
         System.out.println("DPhyp:" + (System.currentTimeMillis() - now));
         return this;
@@ -602,7 +591,7 @@ public class PlanChecker {
     }
 
     public PhysicalPlan getBestPlanTree() {
-        return chooseBestPlan(cascadesContext.getMemo().getRoot(), PhysicalProperties.ANY);
+        return chooseBestPlan(cascadesContext.getMemo().getRoot(), PhysicalProperties.GATHER);
     }
 
     public PhysicalPlan getBestPlanTree(PhysicalProperties properties) {


### PR DESCRIPTION
## Proposed changes

When there are constant aliases involved in the join operator above this project operator, we have the flexibility to connect this constant slot to any node below it. For example:
```
                 Left Outer Join time1 = t.time2 
                         /                   \
project now() as time.        t
                       |
                    Join
                   /  ... \
                 t1  ... tn
```
we can put the slot to any node between t1 to tn


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

