### PR TITLE
[Bug](materialized-view) fix where clause not analyzed after fe restart

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -654,6 +654,14 @@ public class Analyzer {
         }
     }
 
+    public void registerTupleDescriptor(TupleDescriptor desc) {
+        tupleByAlias.put(desc.getAlias(), desc);
+        for (SlotDescriptor slot : desc.getSlots()) {
+            String key = desc.getAlias() + "." + slot.getColumn().getName();
+            slotRefMap.put(key, slot);
+        }
+    }
+
     /**
      * Creates an returns an empty TupleDescriptor for the given table ref and registers
      * it against all its legal aliases. For tables refs with an explicit alias, only the

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -146,9 +146,6 @@ public class Analyzer {
     private String schemaWild;
     private String schemaTable; // table used in DESCRIBE Table
 
-    // True if the corresponding select block has a limit and/or offset clause.
-    private boolean hasLimitOffsetClause = false;
-
     // Current depth of nested analyze() calls. Used for enforcing a
     // maximum expr-tree depth. Needs to be manually maintained by the user
     // of this Analyzer with incrementCallDepth() and decrementCallDepth().
@@ -1816,10 +1813,6 @@ public class Analyzer {
 
     public boolean hasEmptySpjResultSet() {
         return hasEmptySpjResultSet;
-    }
-
-    public void setHasLimitOffsetClause(boolean hasLimitOffset) {
-        this.hasLimitOffsetClause = hasLimitOffset;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/NativeInsertStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/NativeInsertStmt.java
@@ -849,7 +849,7 @@ public class NativeInsertStmt extends InsertStmt {
 
     public void complete() throws UserException {
         if (!isExplain() && targetTable instanceof OlapTable) {
-            ((OlapTableSink) dataSink).complete();
+            ((OlapTableSink) dataSink).complete(analyzer);
             // add table indexes to transaction state
             TransactionState txnState = Env.getCurrentGlobalTransactionMgr()
                     .getTransactionState(db.getId(), transactionId);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
@@ -201,7 +201,9 @@ public class SlotRef extends Expr {
 
     @Override
     public void analyzeImpl(Analyzer analyzer) throws AnalysisException {
-        desc = analyzer.registerColumnRef(tblName, col);
+        if (desc == null) {
+            desc = analyzer.registerColumnRef(tblName, col);
+        }
         type = desc.getType();
         if (this.type.equals(Type.CHAR)) {
             this.type = Type.VARCHAR;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
@@ -201,9 +201,7 @@ public class SlotRef extends Expr {
 
     @Override
     public void analyzeImpl(Analyzer analyzer) throws AnalysisException {
-        if (desc == null) {
-            desc = analyzer.registerColumnRef(tblName, col);
-        }
+        desc = analyzer.registerColumnRef(tblName, col);
         type = desc.getType();
         if (this.type.equals(Type.CHAR)) {
             this.type = Type.VARCHAR;

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadingTaskPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadingTaskPlanner.java
@@ -171,7 +171,7 @@ public class LoadingTaskPlanner {
         OlapTableSink olapTableSink = new OlapTableSink(table, destTupleDesc, partitionIds,
                 Config.enable_single_replica_load);
         olapTableSink.init(loadId, txnId, dbId, timeoutS, sendBatchParallelism, false, strictMode);
-        olapTableSink.complete();
+        olapTableSink.complete(analyzer);
 
         // 3. Plan fragment
         PlanFragment sinkFragment = new PlanFragment(new PlanFragmentId(0), scanNode, DataPartition.RANDOM);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/InsertIntoTableCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/InsertIntoTableCommand.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.trees.plans.commands;
 
+import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.util.ProfileManager.ProfileType;
@@ -123,7 +124,7 @@ public class InsertIntoTableCommand extends Command implements ForwardWithSync, 
                 ctx.getExecTimeout(),
                 ctx.getSessionVariable().getSendBatchParallelism(), false, false);
 
-        sink.complete();
+        sink.complete(new Analyzer(Env.getCurrentEnv(), ctx));
         TransactionState state = Env.getCurrentGlobalTransactionMgr().getTransactionState(
                 physicalOlapTableSink.getDatabase().getId(),
                 txn.getTxnId());

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
@@ -255,7 +255,8 @@ public class OlapTableSink extends DataSink {
                 Expr expr = indexMeta.getWhereClause().clone();
                 expr.replaceSlot(tupleDescriptor);
                 if (analyzer != null) {
-                    analyzer.addSlotDescriptor(tupleDescriptor);
+                    tupleDescriptor.setTable(table);
+                    analyzer.registerTupleDescriptor(tupleDescriptor);
                     expr.analyze(analyzer);
                 }
                 indexSchema.setWhereClause(expr.treeToThrift());

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
@@ -266,7 +266,7 @@ public class StreamLoadPlanner {
         olapTableSink.init(loadId, taskInfo.getTxnId(), db.getId(), timeout,
                 taskInfo.getSendBatchParallelism(), taskInfo.isLoadToSingleTablet(), taskInfo.isStrictMode());
         olapTableSink.setPartialUpdateInputColumns(isPartialUpdate, partialUpdateInputColumns);
-        olapTableSink.complete();
+        olapTableSink.complete(analyzer);
 
         // for stream load, we only need one fragment, ScanNode -> DataSink.
         // OlapTableSink can dispatch data to corresponding node.
@@ -476,7 +476,7 @@ public class StreamLoadPlanner {
         olapTableSink.init(loadId, taskInfo.getTxnId(), db.getId(), timeout,
                 taskInfo.getSendBatchParallelism(), taskInfo.isLoadToSingleTablet(), taskInfo.isStrictMode());
         olapTableSink.setPartialUpdateInputColumns(isPartialUpdate, partialUpdateInputColumns);
-        olapTableSink.complete();
+        olapTableSink.complete(analyzer);
 
         // for stream load, we only need one fragment, ScanNode -> DataSink.
         // OlapTableSink can dispatch data to corresponding node.

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/OlapTableSinkTest.java
@@ -108,7 +108,7 @@ public class OlapTableSinkTest {
         dstTable.getPartitionInfo().setIsMutable(partition.getId(), true);
         OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(2L), false);
         sink.init(new TUniqueId(1, 2), 3, 4, 1000, 1, false, false);
-        sink.complete();
+        sink.complete(null);
         LOG.info("sink is {}", sink.toThrift());
         LOG.info("{}", sink.getExplainString("", TExplainLevel.NORMAL));
     }
@@ -146,7 +146,7 @@ public class OlapTableSinkTest {
         OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(p1.getId()), false);
         sink.init(new TUniqueId(1, 2), 3, 4, 1000, 1, false, false);
         try {
-            sink.complete();
+            sink.complete(null);
         } catch (UserException e) {
             // CHECKSTYLE IGNORE THIS LINE
         }
@@ -170,7 +170,7 @@ public class OlapTableSinkTest {
 
         OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(unknownPartId), false);
         sink.init(new TUniqueId(1, 2), 3, 4, 1000, 1, false, false);
-        sink.complete();
+        sink.complete(null);
         LOG.info("sink is {}", sink.toThrift());
         LOG.info("{}", sink.getExplainString("", TExplainLevel.NORMAL));
     }
@@ -208,7 +208,7 @@ public class OlapTableSinkTest {
         OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(p1.getId()), false);
         sink.init(new TUniqueId(1, 2), 3, 4, 1000, 1, false, false);
         try {
-            sink.complete();
+            sink.complete(null);
         } catch (UserException e) {
             // CHECKSTYLE IGNORE THIS LINE
         }

--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_schema_change.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_schema_change.groovy
@@ -64,12 +64,15 @@ suite("test_partial_update_schema_change", "p0") {
     
     // schema change
     sql " ALTER table ${tableName} add column c10 INT DEFAULT '0' "
+    def try_times=100
     while(true){
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
+        Thread.sleep(1000)
         if(res[0][9].toString() == "FINISHED"){
             break;
         }
-        Thread.sleep(500)
+        assert(try_times>0)
+        try_times--
     }
     
     // test load data without new column
@@ -174,12 +177,15 @@ suite("test_partial_update_schema_change", "p0") {
     
     // schema change
     sql " ALTER table ${tableName} DROP COLUMN c8 "
+    try_times=100
     while(true){
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
+        Thread.sleep(1000)
         if(res[0][9].toString() == "FINISHED"){
             break;
         }
-        Thread.sleep(500)
+        assert(try_times>0)
+        try_times--
     }
 
     // test load data without delete column
@@ -283,12 +289,15 @@ suite("test_partial_update_schema_change", "p0") {
     
     // schema change
     sql " ALTER table ${tableName} MODIFY COLUMN c2 double "
+    try_times=100
     while(true){
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
+        Thread.sleep(1000)
         if(res[0][9].toString() == "FINISHED"){
             break;
         }
-        Thread.sleep(500)
+        assert(try_times>0)
+        try_times--
     }
 
     // test load data with update column
@@ -358,20 +367,27 @@ suite("test_partial_update_schema_change", "p0") {
     
     // schema change
     sql " ALTER table ${tableName} ADD COLUMN c1 int key null "
+    try_times=100
     while(true){
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
+        Thread.sleep(1000)
         if(res[0][9].toString() == "FINISHED"){
             break;
         }
-        Thread.sleep(500)
+        assert(try_times>0)
+        try_times--
     }
+
     sql " ALTER table ${tableName} ADD COLUMN c2 int null "
+    try_times=100
     while(true){
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
+        Thread.sleep(1000)
         if(res[0][9].toString() == "FINISHED"){
             break;
         }
-        Thread.sleep(500)
+        assert(try_times>0)
+        try_times--
     }
 
     // test load data with all key column
@@ -451,12 +467,15 @@ suite("test_partial_update_schema_change", "p0") {
     qt_sql10 " select * from ${tableName} order by c0 "
     
     sql " CREATE INDEX test ON ${tableName} (c1) USING BITMAP "
+    try_times=100
     while(true){
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
+        Thread.sleep(1000)
         if(res[0][9].toString() == "FINISHED"){
             break;
         }
-        Thread.sleep(500)
+        assert(try_times>0)
+        try_times--
     }
 
     //test load data with create index
@@ -605,12 +624,15 @@ suite("test_partial_update_schema_change", "p0") {
     
     // schema change
     sql " ALTER table ${tableName} add column c10 INT DEFAULT '0' "
+    try_times=100
     while(true){
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
+        Thread.sleep(1000)
         if(res[0][9].toString() == "FINISHED"){
             break;
         }
-        Thread.sleep(500)
+        assert(try_times>0)
+        try_times--
     }
     
     // test load data without new column
@@ -714,12 +736,15 @@ suite("test_partial_update_schema_change", "p0") {
     
     // schema change
     sql " ALTER table ${tableName} DROP COLUMN c8 "
+    try_times=100
     while(true){
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
+        Thread.sleep(1000)
         if(res[0][9].toString() == "FINISHED"){
             break;
         }
-        Thread.sleep(500)
+        assert(try_times>0)
+        try_times--
     }
 
     // test load data without delete column
@@ -822,12 +847,15 @@ suite("test_partial_update_schema_change", "p0") {
     
     // schema change
     sql " ALTER table ${tableName} MODIFY COLUMN c2 double "
+    try_times=100
     while(true){
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
+        Thread.sleep(1000)
         if(res[0][9].toString() == "FINISHED"){
             break;
         }
-        Thread.sleep(500)
+        assert(try_times>0)
+        try_times--
     }
 
     // test load data with update column
@@ -896,20 +924,26 @@ suite("test_partial_update_schema_change", "p0") {
     
     // schema change
     sql " ALTER table ${tableName} ADD COLUMN c1 int key null "
+    try_times=100
     while(true){
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
+        Thread.sleep(1000)
         if(res[0][9].toString() == "FINISHED"){
             break;
         }
-        Thread.sleep(500)
+        assert(try_times>0)
+        try_times--
     }
     sql " ALTER table ${tableName} ADD COLUMN c2 int null "
+    try_times=100
     while(true){
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
+        Thread.sleep(1000)
         if(res[0][9].toString() == "FINISHED"){
             break;
         }
-        Thread.sleep(500)
+        assert(try_times>0)
+        try_times--
     }
 
     // test load data with all key column
@@ -987,12 +1021,15 @@ suite("test_partial_update_schema_change", "p0") {
     qt_sql23 " select * from ${tableName} order by c0 "
     
     sql " CREATE INDEX test ON ${tableName} (c1) USING BITMAP "
+    try_times=100
     while(true){
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
+        Thread.sleep(1000)
         if(res[0][9].toString() == "FINISHED"){
             break;
         }
-        Thread.sleep(500)
+        assert(try_times>0)
+        try_times--
     }
 
     //test load data with create index


### PR DESCRIPTION
## Proposed changes
fix where clause not analyzed after fe restart
```sql
mysql [regression_test_mv_p0_ssb_multiple_ssb]>INSERT INTO lineorder_flat (LO_ORDERDATE, LO_ORDERKEY, LO_LINENUMBER, LO_CUSTKEY, LO_PARTKEY, LO_SUPPKEY, LO_ORDERPRIORITY, LO_SHIPPRIORITY, LO_QUANTITY, LO_EXTENDEDPRICE, LO_ORDTOTALPRICE, LO_DISCOUNT, LO_REVENUE, LO_SUPPLYCOST, LO_TAX, LO_COMMITDATE, LO_SHIPMODE, C_NAME, C_ADDRESS, C_CITY, C_NATION, C_REGION, C_PHONE, C_MKTSEGMENT, S_NAME, S_ADDRESS, S_CITY, S_NATION, S_REGION, S_PHONE, P_NAME, P_MFGR, P_CATEGORY, P_BRAND, P_COLOR,P_TYPE,P_SIZE,P_CONTAINER) VALUES (19930101 , 1 , 1 , 1 , 1 , 1 , '1' , 1 , 1 , 1 , 1 , 100 , 1 , 1 , 1 , '2023-06-09' , 'shipmode' , 'name' , 'address' , 'city' , 'nation' , 'AMERICA' , 'phone' , 'mktsegment' , 'name' , 'address' , 'city' , 'nation' , 'AMERICA' ,'phone', 'name', 'MFGR#12', 'MFGR#12', 'brand', 'color', 'type', 4 ,'container');
ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INTERNAL_ERROR]create expr failed, TExprNode=TExprNode {
  01: node_type (i32) = 16,
  02: type (struct) = TTypeDesc {
    01: types (list) = list<struct>[1] {
      [0] = TTypeNode {
        01: type (i32) = 0,
        02: scalar_type (struct) = TScalarType {
          01: type (i32) = 0,
        },
      },
    },
    03: byte_size (i64) = -1,
  },
  04: num_children (i32) = 0,
  15: slot_ref (struct) = TSlotRef {
    01: slot_id (i32) = 21,
    02: tuple_id (i32)
```
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

