### PR TITLE
[fix](load) check TOO_MANY_SEGMENTS only at build rowset

### DIFF
--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -147,7 +147,7 @@ private:
                       std::unique_ptr<segment_v2::SegmentWriter>& writer);
 
     Status _create_file_writer(std::string path, io::FileWriterPtr& file_writer);
-    Status _check_segment_number_limit();
+    Status _check_segment_number_limit(int64_t num_segment);
     Status _create_segment_writer(std::unique_ptr<segment_v2::SegmentWriter>& writer,
                                   int32_t segment_id, bool no_compression = false,
                                   TabletSchemaSPtr flush_schema = nullptr);


### PR DESCRIPTION
## Proposed changes

Previously we were checking TOO_MANY_SEGMENTS on each segment writer creation.
Users might get false positives if write is too fast and segment compaction cannot keep up. 

In this PR, I propose to delay this check until build rowset.
Thus allowing number of segment to temporary exceed limit.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

