### PR TITLE
[bugfix](auth)fix table.getDbName throw NullPointerException

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -347,6 +347,9 @@ public abstract class ExternalCatalog
     @Nullable
     @Override
     public ExternalDatabase<? extends ExternalTable> getDbNullable(String dbName) {
+        if (StringUtils.isEmpty(dbName)) {
+            return null;
+        }
         try {
             makeSureInitialized();
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -246,6 +246,9 @@ public class InternalCatalog implements CatalogIf<Database> {
     @Nullable
     @Override
     public Database getDbNullable(String dbName) {
+        if (StringUtils.isEmpty(dbName)) {
+            return null;
+        }
         if (fullNameToDb.containsKey(dbName)) {
             return fullNameToDb.get(dbName);
         } else {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

generate by: https://github.com/apache/doris/pull/22147

Caused by: java.lang.NullPointerException
	at java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:936) ~[?:1.8.0_131]
	at java.util.concurrent.ConcurrentHashMap.containsKey(ConcurrentHashMap.java:964) ~[?:1.8.0_131]
	at org.apache.doris.datasource.InternalCatalog.getDbNullable(InternalCatalog.java:249) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.catalog.Table.getDatabase(Table.java:550) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.nereids.rules.analysis.UserAuthentication.checkPermission(UserAuthentication.java:54

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

