### PR TITLE
[enhancement](binlog) CreateTable inherit db binlog && Add some checks

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -2799,7 +2799,6 @@ public class SchemaChangeHandler extends AlterHandler {
 
     public boolean updateBinlogConfig(Database db, OlapTable olapTable, List<AlterClause> alterClauses)
             throws DdlException, UserException {
-        // TODO(Drogon): check olapTable read binlog thread safety
         List<Partition> partitions = Lists.newArrayList();
         BinlogConfig oldBinlogConfig;
         BinlogConfig newBinlogConfig;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -269,6 +269,9 @@ public class CreateTableStmt extends DdlStmt {
     }
 
     public Map<String, String> getProperties() {
+        if (this.properties == null) {
+            this.properties = Maps.newHashMap();
+        }
         return this.properties;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/BinlogConfig.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/BinlogConfig.java
@@ -64,6 +64,10 @@ public class BinlogConfig implements Writable {
     }
 
     public void mergeFromProperties(Map<String, String> properties) {
+        if (properties == null) {
+            return;
+        }
+
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_ENABLE)) {
             enable = Boolean.parseBoolean(properties.get(
                     PropertyAnalyzer.PROPERTIES_BINLOG_ENABLE));

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableStmtTest.java
@@ -111,7 +111,7 @@ public class CreateTableStmtTest {
         stmt.analyze(analyzer);
         Assert.assertEquals("testCluster:db1", stmt.getDbName());
         Assert.assertEquals("table1", stmt.getTableName());
-        Assert.assertNull(stmt.getProperties());
+        Assert.assertTrue(stmt.getProperties() == null || stmt.getProperties().isEmpty());
     }
 
     @Test
@@ -121,7 +121,7 @@ public class CreateTableStmtTest {
         stmt.analyze(analyzer);
         Assert.assertEquals("testCluster:db1", stmt.getDbName());
         Assert.assertEquals("table1", stmt.getTableName());
-        Assert.assertNull(stmt.getProperties());
+        Assert.assertTrue(stmt.getProperties() == null || stmt.getProperties().isEmpty());
         Assert.assertTrue(stmt.toSql().contains("DISTRIBUTED BY RANDOM\nBUCKETS 6"));
     }
 
@@ -242,7 +242,7 @@ public class CreateTableStmtTest {
         stmt.analyze(analyzer);
         Assert.assertEquals("testCluster:db1", stmt.getDbName());
         Assert.assertEquals("table1", stmt.getTableName());
-        Assert.assertNull(stmt.getProperties());
+        Assert.assertTrue(stmt.getProperties() == null || stmt.getProperties().isEmpty());
         Assert.assertTrue(stmt.toSql()
                 .contains("rollup( `index1` (`col1`, `col2`) FROM `table1`, `index2` (`col2`, `col3`) FROM `table1`)"));
     }
@@ -256,7 +256,7 @@ public class CreateTableStmtTest {
         Assert.assertEquals("testDb", stmt.getDbName());
         Assert.assertEquals("table1", stmt.getTableName());
         Assert.assertNull(stmt.getPartitionDesc());
-        Assert.assertNull(stmt.getProperties());
+        Assert.assertTrue(stmt.getProperties() == null || stmt.getProperties().isEmpty());
     }
 
     @Test(expected = AnalysisException.class)

--- a/regression-test/suites/ccr_syncer_p0/test_create_table_with_binlog_config.groovy
+++ b/regression-test/suites/ccr_syncer_p0/test_create_table_with_binlog_config.groovy
@@ -1,0 +1,88 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_create_table_with_binlog_config") {
+    sql "drop database if exists test_table_binlog"
+
+    sql """
+        create database test_table_binlog
+        """
+    result = sql "show create database test_table_binlog"
+    logger.info("${result}")
+
+    // Case 1: database disable binlog, create table with binlog disable
+    sql """
+        CREATE TABLE test_table_binlog.t1 ( k1 INT ) ENGINE = olap DISTRIBUTED BY HASH(k1) BUCKETS 3 PROPERTIES ( "replication_num" = "1", "binlog.enable" = "false" );
+        """
+    result = sql "show create table test_table_binlog.t1"
+    logger.info("${result}")
+    assertTrue(result.toString().containsIgnoreCase('"binlog.enable" = "false"'))
+    sql """
+        drop table if exists test_table_binlog.t1
+        """
+
+    // Case 2: database disable binlog, create table with binlog enable
+    sql """
+        CREATE TABLE test_table_binlog.t1 ( k1 INT ) ENGINE = olap DISTRIBUTED BY HASH(k1) BUCKETS 3 PROPERTIES ( "replication_num" = "1", "binlog.enable" = "true" );
+        """
+    result = sql "show create table test_table_binlog.t1"
+    logger.info("${result}")
+    assertTrue(result.toString().containsIgnoreCase('"binlog.enable" = "true"'))
+    sql """
+        drop table if exists test_table_binlog.t1
+        """
+
+    // Case 3: database enable binlog, create table with binlog disable
+    sql """
+        alter database test_table_binlog set properties ("binlog.enable" = "true")
+        """
+    assertThrows(Exception.class, {
+        sql """
+            CREATE TABLE test_table_binlog.t1 ( k1 INT ) ENGINE = olap DISTRIBUTED BY HASH(k1) BUCKETS 3 PROPERTIES ( "replication_num" = "1", "binlog.enable" = "false" );
+            """
+    })
+    sql """
+        drop table if exists test_table_binlog.t1
+        """
+
+    // Case 4: database enable binlog, create table with binlog enable
+    sql """
+        alter database test_table_binlog set properties ("binlog.enable" = "true")
+        """
+    sql """
+        CREATE TABLE test_table_binlog.t1 ( k1 INT ) ENGINE = olap DISTRIBUTED BY HASH(k1) BUCKETS 3 PROPERTIES ( "replication_num" = "1", "binlog.enable" = "true" );
+        """
+    result = sql "show create table test_table_binlog.t1"
+    logger.info("${result}")
+    assertTrue(result.toString().containsIgnoreCase('"binlog.enable" = "true"'))
+    sql """
+        drop table if exists test_table_binlog.t1
+        """
+
+    // Case 5: database enable binlog, create table inherit database binlog config
+    sql """
+        CREATE TABLE test_table_binlog.t1 ( k1 INT ) ENGINE = olap DISTRIBUTED BY HASH(k1) BUCKETS 3 PROPERTIES ( "replication_num" = "1" );
+        """
+    result = sql "show create table test_table_binlog.t1"
+    logger.info("${result}")
+    assertTrue(result.toString().containsIgnoreCase('"binlog.enable" = "true"'))
+    sql """
+        drop table if exists test_table_binlog.t1
+        """
+
+    sql "drop database if exists test_table_binlog"
+}


### PR DESCRIPTION
## Proposed changes

Create table inherit db binlog, but it can use some standalone binlog. Binlog enable should be checked by comparing with db. We can't create a table with binlog disable when db binlog is enable

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

