### PR TITLE
[fix](vec) Arena was not initialized in PartitionMethodSerialized

### DIFF
--- a/be/src/vec/exec/vpartition_sort_node.h
+++ b/be/src/vec/exec/vpartition_sort_node.h
@@ -103,7 +103,10 @@ struct PartitionMethodSerialized {
     bool inited = false;
     std::vector<StringRef> keys;
     size_t keys_memory_usage = 0;
-    PartitionMethodSerialized() : _serialized_key_buffer_size(0), _serialized_key_buffer(nullptr) {}
+    PartitionMethodSerialized() : _serialized_key_buffer_size(0), _serialized_key_buffer(nullptr) {
+        _arena.reset(new Arena());
+        _serialize_key_arena.reset(new Arena());
+    }
 
     using State = ColumnsHashing::HashMethodSerialized<typename Data::value_type, Mapped, true>;
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

```
*** Query id: 9dc71d976d5b48e9-9a15d4a01bd6bf1e ***
*** Aborted at 1690299297 (unix time) try "date -d @1690299297" if you are using GNU date ***
*** Current BE git commitID: 6dd0ca6d0b ***
*** SIGSEGV address not mapped to object (@0x10) received by PID 3133802 (TID 3134087 OR 0x7f19d21cc700) from PID 16; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:413
 1# 0x00007F20E18770A7 in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 3# 0x00007F20E187002C in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 4# 0x00007F20FB7590C0 in /lib/x86_64-linux-gnu/libc.so.6
 5# doris::vectorized::Arena::clear() at /root/doris/be/src/vec/common/arena.h:294
 6# doris::vectorized::PartitionMethodSerialized, false> >::serialize_keys(std::vector > const&, unsigned long) at /root/doris/be/src/vec/exec/vpartition_sort_node.h:137
 7# void doris::vectorized::VPartitionSortNode::_pre_serialize_key_if_need, doris::vectorized::PartitionBlocks*, true>, doris::vectorized::PartitionMethodSerialized, false> > >(doris::vectorized::ColumnsHashing::HashMethodSerialized, doris::vectorized::PartitionBlocks*, true>&, doris::vectorized::PartitionMethodSerialized, false> >&, std::vector > const&, unsigned long) at /root/doris/be/src/vec/exec/vpartition_sort_node.h:463
 8# void doris::vectorized::VPartitionSortNode::_emplace_into_hash_table(std::vector > const&, doris::vectorized::Block const*, int)::$_0::operator(), false> >&>(doris::vectorized::PartitionMethodSerialized, false> >&) const at /root/doris/be/src/vec/exec/vpartition_sort_node.cpp:112
 9# void std::__invoke_impl > const&, doris::vectorized::Block const*, int)::$_0, doris::vectorized::PartitionMethodSerialized, false> >&>(std::__invoke_other, doris::vectorized::VPartitionSortNode::_emplace_into_hash_table(std::vector > const&, doris::vectorized::Block const*, int)::$_0&&, doris::vectorized::PartitionMethodSerialized, false> >&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
10# std::__invoke_result > const&, doris::vectorized::Block const*, int)::$_0, doris::vectorized::PartitionMethodSerialized, false> >&>::type std::__invoke > const&, doris::vectorized::Block const*, int)::$_0, doris::vectorized::PartitionMethodSerialized, false> >&>(doris::vectorized::VPartitionSortNode::_emplace_into_hash_table(std::vector > const&, doris::vectorized::Block const*, int)::$_0&&, doris::vectorized::PartitionMethodSerialized, false> >&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
11# _ZNSt8__detail9__variant17__gen_vtable_implINS0_12_Multi_arrayIPFNS0_21__deduce_visit_resultIvEEOZN5doris10vectorized18VPartitionSortNode24_emplace_into_hash_tableERKSt6vectorIPKNS6_7IColumnESaISB_EEPKNS6_5BlockEiE3$_0RSt7variantIJNS6_25PartitionMethodSerializedI9PHHashMapINS5_9StringRefEPNS6_15PartitionBlocksE11DefaultHashISO_vELb0EEEENS6_24PartitionMethodOneNumberIh12FixedHashMapIhSQ_28FixedHashMapImplicitZeroCellIhSQ_16HashTableNoStateE28FixedHashTableCalculatedSizeISZ_E9AllocatorILb1ELb1ELb0EEELb0EEENSV_ItSW_ItSQ_SX_ItSQ_SY_E24FixedHashTableStoredSizeIS16_ES13_ELb0EEENSV_IjSN_IjSQ_9HashCRC32IjELb0EELb0EEENSV_ImSN_ImSQ_S1B_ImELb0EELb0EEENSV_INS6_7UInt128ESN_IS1I_SQ_S1B_IS1I_ELb0EELb0EEENS6_35PartitionMethodSingleNullableColumnINSV_IhNS6_24PartitionDataWithNullKeyIS14_EELb0EEEEENS1M_INSV_ItNS1N_IS19_EELb0EEEEENS1M_INSV_IjNS1N_IS1D_EELb0EEEEENS1M_INSV_ImNS1N_IS1G_EELb0EEEEENS1M_INSV_IS1I_NS1N_IS1K_EELb0EEEEENS6_24PartitionMethodKeysFixedIS1G_Lb0EEENS23_IS1G_Lb1EEENS23_IS1K_Lb0EEENS23_IS1K_Lb1EEENS23_ISN_INS6_7UInt256ESQ_S1B_IS28_ELb0EELb0EEENS23_IS2A_Lb1EEENS6_28PartitionMethodStringNoCacheI13StringHashMapISQ_S13_EEENS1M_INS2D_INS1N_IS2F_EEEEEEEEEJEEESt16integer_sequenceImJLm0EEEE14__visit_invokeESK_S2L_ at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1013
12# _ZSt10__do_visitINSt8__detail9__variant21__deduce_visit_resultIvEEZN5doris10vectorized18VPartitionSortNode24_emplace_into_hash_tableERKSt6vectorIPKNS5_7IColumnESaISA_EEPKNS5_5BlockEiE3$_0JRSt7variantIJNS5_25PartitionMethodSerializedI9PHHashMapINS4_9StringRefEPNS5_15PartitionBlocksE11DefaultHashISM_vELb0EEEENS5_24PartitionMethodOneNumberIh12FixedHashMapIhSO_28FixedHashMapImplicitZeroCellIhSO_16HashTableNoStateE28FixedHashTableCalculatedSizeISX_E9AllocatorILb1ELb1ELb0EEELb0EEENST_ItSU_ItSO_SV_ItSO_SW_E24FixedHashTableStoredSizeIS14_ES11_ELb0EEENST_IjSL_IjSO_9HashCRC32IjELb0EELb0EEENST_ImSL_ImSO_S19_ImELb0EELb0EEENST_INS5_7UInt128ESL_IS1G_SO_S19_IS1G_ELb0EELb0EEENS5_35PartitionMethodSingleNullableColumnINST_IhNS5_24PartitionDataWithNullKeyIS12_EELb0EEEEENS1K_INST_ItNS1L_IS17_EELb0EEEEENS1K_INST_IjNS1L_IS1B_EELb0EEEEENS1K_INST_ImNS1L_IS1E_EELb0EEEEENS1K_INST_IS1G_NS1L_IS1I_EELb0EEEEENS5_24PartitionMethodKeysFixedIS1E_Lb0EEENS21_IS1E_Lb1EEENS21_IS1I_Lb0EEENS21_IS1I_Lb1EEENS21_ISL_INS5_7UInt256ESO_S19_IS26_ELb0EELb0EEENS21_IS28_Lb1EEENS5_28PartitionMethodStringNoCacheI13StringHashMapISO_S11_EEENS1K_INS2B_INS1L_IS2D_EEEEEEEEEEDcOT0_DpOT1_ at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1716
13# _ZSt5visitIZN5doris10vectorized18VPartitionSortNode24_emplace_into_hash_tableERKSt6vectorIPKNS1_7IColumnESaIS6_EEPKNS1_5BlockEiE3$_0JRSt7variantIJNS1_25PartitionMethodSerializedI9PHHashMapINS0_9StringRefEPNS1_15PartitionBlocksE11DefaultHashISI_vELb0EEEENS1_24PartitionMethodOneNumberIh12FixedHashMapIhSK_28FixedHashMapImplicitZeroCellIhSK_16HashTableNoStateE28FixedHashTableCalculatedSizeIST_E9AllocatorILb1ELb1ELb0EEELb0EEENSP_ItSQ_ItSK_SR_ItSK_SS_E24FixedHashTableStoredSizeIS10_ESX_ELb0EEENSP_IjSH_IjSK_9HashCRC32IjELb0EELb0EEENSP_ImSH_ImSK_S15_ImELb0EELb0EEENSP_INS1_7UInt128ESH_IS1C_SK_S15_IS1C_ELb0EELb0EEENS1_35PartitionMethodSingleNullableColumnINSP_IhNS1_24PartitionDataWithNullKeyISY_EELb0EEEEENS1G_INSP_ItNS1H_IS13_EELb0EEEEENS1G_INSP_IjNS1H_IS17_EELb0EEEEENS1G_INSP_ImNS1H_IS1A_EELb0EEEEENS1G_INSP_IS1C_NS1H_IS1E_EELb0EEEEENS1_24PartitionMethodKeysFixedIS1A_Lb0EEENS1X_IS1A_Lb1EEENS1X_IS1E_Lb0EEENS1X_IS1E_Lb1EEENS1X_ISH_INS1_7UInt256ESK_S15_IS22_ELb0EELb0EEENS1X_IS24_Lb1EEENS1_28PartitionMethodStringNoCacheI13StringHashMapISK_SX_EEENS1G_INS27_INS1H_IS29_EEEEEEEEEEDcOT_DpOT0_ at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1772
14# doris::vectorized::VPartitionSortNode::_emplace_into_hash_table(std::vector > const&, doris::vectorized::Block const*, int) at /root/doris/be/src/vec/exec/vpartition_sort_node.cpp:103
15# doris::vectorized::VPartitionSortNode::_split_block_by_partition(doris::vectorized::Block*, int) at /root/doris/be/src/vec/exec/vpartition_sort_node.cpp:96
16# doris::vectorized::VPartitionSortNode::sink(doris::RuntimeState*, doris::vectorized::Block*, bool) at /root/doris/be/src/vec/exec/vpartition_sort_node.cpp:190
17# doris::pipeline::StreamingOperator::sink(doris::RuntimeState*, doris::vectorized::Block*, doris::pipeline::SourceState) at /root/doris/be/src/pipeline/exec/operator.h:337
18# doris::pipeline::PipelineTask::execute(bool*) at /root/doris/be/src/pipeline/pipeline_task.cpp:260
19# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /root/doris/be/src/pipeline/task_scheduler.cpp:275
20# void std::__invoke_impl(std::__invoke_memfun_deref, void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
21# std::__invoke_result::type std::__invoke(void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
22# void std::_Bind::__call(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420
23# void std::_Bind::operator()<, void>() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503
24# void std::__invoke_impl&>(std::__invoke_other, std::_Bind&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
25# std::enable_if&>, void>::type std::__invoke_r&>(std::_Bind&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
26# std::_Function_handler >::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
27# std::function::operator()() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
28# doris::FunctionRunnable::run() at /root/doris/be/src/util/threadpool.cpp:48
29# doris::ThreadPool::dispatch_thread() at /root/doris/be/src/util/threadpool.cpp:531
30# void std::__invoke_impl(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
31# std::__invoke_result::type std::__invoke(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
32# void std::_Bind::__call(std::tuple<>&&, std::_Index_tuple<0ul>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420
33# void std::_Bind::operator()<, void>() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503
34# void std::__invoke_impl&>(std::__invoke_other, std::_Bind&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
35# std::enable_if&>, void>::type std::__invoke_r&>(std::_Bind&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
36# std::_Function_handler >::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
37# std::function::operator()() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
38# doris::Thread::supervise_thread(void*) at /root/doris/be/src/util/thread.cpp:465
39# start_thread at /build/glibc-sMfBJT/glibc-2.31/nptl/pthread_create.c:478
40# __clone in /lib/x86_64-linux-gnu/libc.so.6
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

