### PR TITLE
[enhance](S3FIleWriter) Add md5 check for small file not suitable for multi part upload

### DIFF
--- a/be/src/io/fs/s3_file_write_bufferpool.h
+++ b/be/src/io/fs/s3_file_write_bufferpool.h
@@ -71,7 +71,7 @@ struct S3FileBuffer : public std::enable_shared_from_this<S3FileBuffer> {
     // get the size of the content already appendded
     size_t get_size() const { return _size; }
     // get the underlying stream containing
-    std::shared_ptr<std::iostream> get_stream() const { return _stream_ptr; }
+    const std::shared_ptr<std::iostream>& get_stream() const { return _stream_ptr; }
     // get file offset corresponding to the buffer
     size_t get_file_offset() const { return _offset; }
     // set the offset of the buffer

--- a/be/src/io/fs/s3_file_writer.cpp
+++ b/be/src/io/fs/s3_file_writer.cpp
@@ -123,13 +123,20 @@ Status S3FileWriter::_create_multi_upload_request() {
                            _bucket, _path.native(), _upload_id, outcome.GetError().GetMessage());
 }
 
-void S3FileWriter::_wait_until_finish(std::string task_name) {
+void S3FileWriter::_wait_until_finish(std::string_view task_name) {
     auto msg =
             fmt::format("{} multipart upload already takes 5 min, bucket={}, key={}, upload_id={}",
-                        std::move(task_name), _bucket, _path.native(), _upload_id);
-    while (!_wait.wait()) {
-        LOG(WARNING) << msg;
-    }
+                        task_name, _bucket, _path.native(), _upload_id);
+    timespec current_time;
+    // We don't need high accuracy here, so we use time(nullptr)
+    // since it's the fastest way to get current time(second)
+    auto current_time_second = time(nullptr);
+    current_time.tv_sec = current_time_second;
+    current_time.tv_nsec = 0;
+    // bthread::countdown_event::timed_wait() should use absolute time
+    do {
+        current_time.tv_sec += 300;
+    } while (0 != _countdown_event.timed_wait(current_time));
 }
 
 Status S3FileWriter::abort() {
@@ -184,7 +191,7 @@ Status S3FileWriter::close() {
             _pending_buf->set_upload_remote_callback(
                     [this, buf = _pending_buf]() { _put_object(*buf); });
         }
-        _wait.add();
+        _countdown_event.add_count();
         _pending_buf->submit();
         _pending_buf = nullptr;
     }
@@ -212,7 +219,7 @@ Status S3FileWriter::appendv(const Slice* data, size_t data_cnt) {
                         });
                 _pending_buf->set_file_offset(_bytes_appended);
                 // later we might need to wait all prior tasks to be finished
-                _pending_buf->set_finish_upload([this]() { _wait.done(); });
+                _pending_buf->set_finish_upload([this]() { _countdown_event.signal(); });
                 _pending_buf->set_is_cancel([this]() { return _failed.load(); });
                 _pending_buf->set_on_failed([this, part_num = _cur_part_num](Status st) {
                     VLOG_NOTICE << "failed at key: " << _key << ", load part " << part_num
@@ -241,7 +248,7 @@ Status S3FileWriter::appendv(const Slice* data, size_t data_cnt) {
                     RETURN_IF_ERROR(_create_multi_upload_request());
                 }
                 _cur_part_num++;
-                _wait.add();
+                _countdown_event.add_count();
                 _pending_buf->submit();
                 _pending_buf = nullptr;
             }
@@ -259,7 +266,7 @@ void S3FileWriter::_upload_one_part(int64_t part_num, S3FileBuffer& buf) {
     upload_request.WithBucket(_bucket).WithKey(_key).WithPartNumber(part_num).WithUploadId(
             _upload_id);
 
-    auto _stream_ptr = buf.get_stream();
+    const auto& _stream_ptr = buf.get_stream();
 
     upload_request.SetBody(buf.get_stream());
 
@@ -286,7 +293,7 @@ void S3FileWriter::_upload_one_part(int64_t part_num, S3FileBuffer& buf) {
 
     std::unique_ptr<CompletedPart> completed_part = std::make_unique<CompletedPart>();
     completed_part->SetPartNumber(part_num);
-    auto etag = upload_part_outcome.GetResult().GetETag();
+    const auto& etag = upload_part_outcome.GetResult().GetETag();
     // DCHECK(etag.empty());
     completed_part->SetETag(etag);
 
@@ -345,7 +352,7 @@ Status S3FileWriter::finalize() {
             _pending_buf->set_upload_remote_callback(
                     [this, buf = _pending_buf]() { _put_object(*buf); });
         }
-        _wait.add();
+        _countdown_event.add_count();
         _pending_buf->submit();
         _pending_buf = nullptr;
     }
@@ -357,6 +364,10 @@ void S3FileWriter::_put_object(S3FileBuffer& buf) {
     DCHECK(!_closed) << "closed " << _closed;
     Aws::S3::Model::PutObjectRequest request;
     request.WithBucket(_bucket).WithKey(_key);
+    const auto& _stream_ptr = buf.get_stream();
+    request.SetBody(buf.get_stream());
+    Aws::Utils::ByteBuffer part_md5(Aws::Utils::HashingUtils::CalculateMD5(*_stream_ptr));
+    request.SetContentMD5(Aws::Utils::HashingUtils::Base64Encode(part_md5));
     request.SetBody(buf.get_stream());
     request.SetContentLength(buf.get_size());
     request.SetContentType("application/octet-stream");

--- a/be/src/io/fs/s3_file_writer.cpp
+++ b/be/src/io/fs/s3_file_writer.cpp
@@ -365,7 +365,6 @@ void S3FileWriter::_put_object(S3FileBuffer& buf) {
     Aws::S3::Model::PutObjectRequest request;
     request.WithBucket(_bucket).WithKey(_key);
     const auto& _stream_ptr = buf.get_stream();
-    request.SetBody(buf.get_stream());
     Aws::Utils::ByteBuffer part_md5(Aws::Utils::HashingUtils::CalculateMD5(*_stream_ptr));
     request.SetContentMD5(Aws::Utils::HashingUtils::Base64Encode(part_md5));
     request.SetBody(buf.get_stream());


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
Add md5 check for small file which is not suitable for multi part upload.
Plus this pr removes the wait group implementation which might cost too much, and adapt it to one lightweight implementation inside brpc.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

