### PR TITLE
[improvement](profile) add table name for file scan node

### DIFF
--- a/be/src/vec/exec/scan/new_file_scan_node.cpp
+++ b/be/src/vec/exec/scan/new_file_scan_node.cpp
@@ -40,6 +40,7 @@ NewFileScanNode::NewFileScanNode(ObjectPool* pool, const TPlanNode& tnode,
                                  const DescriptorTbl& descs)
         : VScanNode(pool, tnode, descs) {
     _output_tuple_id = tnode.file_scan_node.tuple_id;
+    _table_name = tnode.file_scan_node.__isset.table_name ? tnode.file_scan_node.table_name : "";
 }
 
 Status NewFileScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
@@ -126,6 +127,10 @@ Status NewFileScanNode::_init_scanners(std::list<VScannerSPtr>* scanners) {
     }
 
     return Status::OK();
+}
+
+std::string NewFileScanNode::get_name() {
+    return fmt::format("VFILE_SCAN_NODE({0})", _table_name);
 }
 
 }; // namespace doris::vectorized

--- a/be/src/vec/exec/scan/new_file_scan_node.h
+++ b/be/src/vec/exec/scan/new_file_scan_node.h
@@ -49,6 +49,8 @@ public:
 
     void set_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) override;
 
+    std::string get_name() override;
+
 protected:
     Status _init_profile() override;
     Status _process_conjuncts() override;
@@ -62,5 +64,7 @@ private:
     // 2. parquet file meta
     // KVCache<std::string> _kv_cache;
     std::unique_ptr<ShardedKVCache> _kv_cache;
+
+    std::string _table_name;
 };
 } // namespace doris::vectorized

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileScanNode.java
@@ -79,6 +79,9 @@ public abstract class FileScanNode extends ExternalScanNode {
         planNode.setNodeType(TPlanNodeType.FILE_SCAN_NODE);
         TFileScanNode fileScanNode = new TFileScanNode();
         fileScanNode.setTupleId(desc.getId().asInt());
+        if (desc.getTable() != null) {
+            fileScanNode.setTableName(desc.getTable().getName());
+        }
         planNode.setFileScanNode(fileScanNode);
     }
 

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -506,6 +506,7 @@ struct TBrokerScanNode {
 
 struct TFileScanNode {
     1: optional Types.TTupleId tuple_id
+    2: optional string table_name
 }
 
 struct TEsScanNode {


### PR DESCRIPTION
## Proposed changes

```
VFILE_SCAN_NODE(region)  (id=0):(Active:  3.537us,  %  non-child:  0.00%)
                                -  RuntimeFilters:  :  
                              -  UseSpecificThreadToken:  False
                              -  AcquireRuntimeFilterTime:  501ns
                              -  AllocateResourceTime:  105.598us
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

