### PR TITLE
[typo](docs),array_zip function is supported since 2.0

### DIFF
--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_zip.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_zip.md
@@ -24,7 +24,7 @@ under the License.
 
 ## array_zip
 
-<version since="1.2.3">
+<version since="2.0">
 
 array_zip
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_zip.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_zip.md
@@ -24,7 +24,7 @@ under the License.
 
 ## array_zip
 
-<version since="1.2.3">
+<version since="2.0">
 
 array_zip
 


### PR DESCRIPTION

I have tested the array_zip function, it is supported since 2.0，not 1.2.3