### PR TITLE
[fix](nereids)only allow inner join in dphyper join reorder

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
@@ -378,7 +378,8 @@ public class Group {
     public boolean isValidJoinGroup() {
         Plan plan = getLogicalExpression().getPlan();
         if (plan instanceof LogicalJoin
-                && ((LogicalJoin) plan).getJoinType() == JoinType.INNER_JOIN) {
+                && ((LogicalJoin) plan).getJoinType() == JoinType.INNER_JOIN
+                && !((LogicalJoin) plan).isMarkJoin()) {
             Preconditions.checkArgument(!((LogicalJoin) plan).getExpressions().isEmpty(),
                     "inner join must have join conjuncts");
             if (((LogicalJoin) plan).getHashJoinConjuncts().isEmpty()

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
@@ -21,6 +21,8 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.cost.Cost;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
+import org.apache.doris.nereids.trees.expressions.literal.Literal;
+import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
@@ -375,9 +377,19 @@ public class Group {
      */
     public boolean isValidJoinGroup() {
         Plan plan = getLogicalExpression().getPlan();
-        return plan instanceof LogicalJoin
-                && !((LogicalJoin) plan).isMarkJoin()
-                && ((LogicalJoin) plan).getExpressions().size() > 0;
+        if (plan instanceof LogicalJoin
+                && ((LogicalJoin) plan).getJoinType() == JoinType.INNER_JOIN) {
+            Preconditions.checkArgument(!((LogicalJoin) plan).getExpressions().isEmpty(),
+                    "inner join must have join conjuncts");
+            if (((LogicalJoin) plan).getHashJoinConjuncts().isEmpty()
+                    && ((LogicalJoin) plan).getOtherJoinConjuncts().get(0) instanceof Literal) {
+                return false;
+            } else {
+                // Right now, we only support inner join with some conjuncts referencing any side of the child's output
+                return true;
+            }
+        }
+        return false;
     }
 
     public boolean isProjectGroup() {


### PR DESCRIPTION
## Proposed changes

current dphyper join reorder hasn't consider the join conjunct referencing only one side of the child. This is common case in outer join conjunct. So we need disable outer join reorder in dphyper until this problem is addressed.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

