### PR TITLE
[chore](log)Move non-user-friendly error message to be.WARNING

### DIFF
--- a/be/src/io/fs/benchmark/benchmark_factory.hpp
+++ b/be/src/io/fs/benchmark/benchmark_factory.hpp
@@ -98,7 +98,6 @@ public:
     Status init_env() {
         std::string conffile = std::string(getenv("DORIS_HOME")) + "/conf/be.conf";
         if (!doris::config::init(conffile.c_str(), true, true, true)) {
-            fprintf(stderr, "error read config file. \n");
             return Status::Error<INTERNAL_ERROR>("error read config file.");
         }
         doris::CpuInfo::init();

--- a/be/src/olap/delete_handler.cpp
+++ b/be/src/olap/delete_handler.cpp
@@ -62,8 +62,8 @@ Status DeleteHandler::generate_delete_predicate(const TabletSchema& schema,
     for (const TCondition& condition : conditions) {
         if (check_condition_valid(schema, condition) != Status::OK()) {
             // Error will print log, no need to do it manually.
-            return Status::Error<DELETE_INVALID_CONDITION>("invalid condition on Column {}.",
-                                                           condition.column_name);
+            return Status::Error<DELETE_INVALID_CONDITION>("invalid condition. condition={}",
+                                                           ThriftDebugString(condition));
         }
     }
 

--- a/be/src/olap/delete_handler.cpp
+++ b/be/src/olap/delete_handler.cpp
@@ -61,9 +61,9 @@ Status DeleteHandler::generate_delete_predicate(const TabletSchema& schema,
     // Check whether the delete condition meets the requirements
     for (const TCondition& condition : conditions) {
         if (check_condition_valid(schema, condition) != Status::OK()) {
-            LOG(WARNING) << "invalid condition. condition=" << ThriftDebugString(condition);
-            return Status::Error<DELETE_INVALID_CONDITION>("invalid condition. condition={}",
-                                                           ThriftDebugString(condition));
+            // Error will print log, no need to do it manually.
+            return Status::Error<DELETE_INVALID_CONDITION>("invalid condition on Column {}.",
+                                                           condition.column_name);
         }
     }
 

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -445,9 +445,6 @@ Status TabletReader::_init_orderby_keys_param(const ReaderParams& read_params) {
             }
         }
         if (read_params.read_orderby_key_num_prefix_columns != _orderby_key_columns.size()) {
-            LOG(WARNING) << "read_orderby_key_num_prefix_columns != _orderby_key_columns.size "
-                         << read_params.read_orderby_key_num_prefix_columns << " vs. "
-                         << _orderby_key_columns.size();
             return Status::Error<ErrorCode::INTERNAL_ERROR>(
                     "read_orderby_key_num_prefix_columns != _orderby_key_columns.size, "
                     "read_params.read_orderby_key_num_prefix_columns={}, "

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
@@ -618,7 +618,6 @@ Status BkdIndexReader::try_query(OlapReaderStatistics* stats, const std::string&
         }
         *count = r->estimate_point_count(visitor.get());
     } catch (const CLuceneError& e) {
-        LOG(WARNING) << "BKD Query CLuceneError Occurred, error msg: " << e.what();
         return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
                 "BKD Query CLuceneError Occurred, error msg: {}", e.what());
     }

--- a/be/src/olap/utils.cpp
+++ b/be/src/olap/utils.cpp
@@ -411,7 +411,7 @@ Status gen_timestamp_string(std::string* out_string) {
     if (localtime_r(&now, &local_tm) == nullptr) {
         return Status::Error<OS_ERROR>("fail to localtime_r time. time={}", now);
     }
-    char time_suffix[16] = {0}; // Example: 20150706111404, 长度是15个字符
+    char time_suffix[16] = {0}; // Example: 20150706111404's length is 15
     if (strftime(time_suffix, sizeof(time_suffix), "%Y%m%d%H%M%S", &local_tm) == 0) {
         return Status::Error<OS_ERROR>("fail to strftime time. time={}", now);
     }

--- a/be/src/vec/exprs/vexpr.cpp
+++ b/be/src/vec/exprs/vexpr.cpp
@@ -28,6 +28,7 @@
 #include "common/config.h"
 #include "common/exception.h"
 #include "common/object_pool.h"
+#include "common/status.h"
 #include "vec/columns/column_vector.h"
 #include "vec/columns/columns_number.h"
 #include "vec/data_types/data_type_factory.hpp"
@@ -212,8 +213,11 @@ Status VExpr::create_expr(const TExprNode& expr_node, VExprSPtr& expr) {
             return Status::InternalError("Unknown expr node type: {}", expr_node.node_type);
         }
     } catch (const Exception& e) {
-        return Status::InternalError("create expr failed, TExprNode={}, reason={}",
-                                     apache::thrift::ThriftDebugString(expr_node), e.what());
+        if (e.code() == ErrorCode::INTERNAL_ERROR) {
+            return Status::InternalError("Create Expr failed because {}\nTExprNode={}", e.what(),
+                                         apache::thrift::ThriftDebugString(expr_node));
+        }
+        return Status::Error(e.code(), "Create Expr failed because {}", e.what());
     }
     if (!expr->data_type()) {
         return Status::InvalidArgument("Unknown expr type: {}", expr_node.node_type);

--- a/be/src/vec/exprs/vexpr.cpp
+++ b/be/src/vec/exprs/vexpr.cpp
@@ -217,7 +217,9 @@ Status VExpr::create_expr(const TExprNode& expr_node, VExprSPtr& expr) {
             return Status::InternalError("Create Expr failed because {}\nTExprNode={}", e.what(),
                                          apache::thrift::ThriftDebugString(expr_node));
         }
-        return Status::Error(e.code(), "Create Expr failed because {}", e.what());
+        return Status::Error<false>(e.code(), "Create Expr failed because {}", e.what());
+        LOG(WARNING) << "create expr failed, TExprNode={}, reason={}"
+                     << apache::thrift::ThriftDebugString(expr_node) << e.what();
     }
     if (!expr->data_type()) {
         return Status::InvalidArgument("Unknown expr type: {}", expr_node.node_type);

--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/ScalarType.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/ScalarType.java
@@ -684,13 +684,15 @@ public class ScalarType extends Type {
             case DECIMAL64:
             case DECIMAL128:
             case DATETIMEV2: {
-                Preconditions.checkArgument(precision >= scale);
+                Preconditions.checkArgument(precision >= scale,
+                        String.format("given precision %d is out of scale bound %d", precision, scale));
                 scalarType.setScale(scale);
                 scalarType.setPrecision(precision);
                 break;
             }
             case TIMEV2: {
-                Preconditions.checkArgument(precision >= scale);
+                Preconditions.checkArgument(precision >= scale,
+                        String.format("given precision %d is out of scale bound %d", precision, scale));
                 scalarType.setScale(scale);
                 scalarType.setPrecision(precision);
                 break;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

before:
```
mysql [(none)]>select now(7);
ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.8)[INTERNAL_ERROR]create expr failed, TExprNode=TExprNode {
  01: node_type (i32) = 20,
  02: type (struct) = TTypeDesc {
    01: types (list) = list<struct>[1] {
      [0] = TTypeNode {
        01: type (i32) = 0,
        02: scalar_type (struct) = TScalarType {
          01: type (i32) = 27,
          03: precision (i32) = 18,
          04: scale (i32) = 7,
        },
      },
    },
    03: byte_size (i64) = -1,
  },
  04: num_children (i32) = 1,
  20: output_scale
```
now:
```
cale_value 7 > 6
```

there's no need to `LOG(XXX)` since `Status::Error` will decide.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

