### PR TITLE
[chore](workflow) Increase the build space for building third-party libraries

### DIFF
--- a/.github/workflows/build-thirdparty.yml
+++ b/.github/workflows/build-thirdparty.yml
@@ -51,6 +51,21 @@ jobs:
     if: ${{ needs.changes.outputs.thirdparty_changes == 'true' }}
     runs-on: ubuntu-22.04
     steps:
+      - name: Checkout easimon/maximize-build-space
+        run: |
+          git clone -b v7 https://github.com/easimon/maximize-build-space
+
+      - name: Maximize build space
+        uses: ./maximize-build-space
+        with:
+            root-reserve-mb: 4096
+            swap-size-mb: 8192
+            remove-dotnet: 'true'
+            remove-android: 'true'
+            remove-haskell: 'true'
+            remove-codeql: 'true'
+            remove-docker-images: 'true'
+
       - name: Checkout ${{ github.ref }}
         uses: actions/checkout@v3
 


### PR DESCRIPTION
## Proposed changes

~~Issue Number: close #xxx~~

Recently, the workflow for building third-party libraries failed due to lack of disk space in [apache/doris-thirdparty](https://github.com/apache/doris-thirdparty). Therefore, we should increase the disk space for building third-party libraries.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

