### PR TITLE
[typo](docs) fix array_intersect function sample error

### DIFF
--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_intersect.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_intersect.md
@@ -74,8 +74,8 @@ mysql> select k1,k2,k3,array_intersect(k2,k3) from array_type_table_varchar;
 +------+----------------------------+----------------------------------+-----------------------------+
 |    1 | ['hello', 'world', 'c++']  | ['I', 'am', 'c++']               | ['c++']                     |
 |    2 | ['a1', 'equals', 'b1']     | ['a2', 'equals', 'b2']           | ['equals']                  |
-|    3 | ['hasnull', NULL, 'value'] | ['nohasnull', 'nonull', 'value'] | [NULL, 'value']             |
-|    3 | ['hasnull', NULL, 'value'] | ['hasnull', NULL, 'value']       | ['hasnull', 'value']        |
+|    3 | ['hasnull', NULL, 'value'] | ['nohasnull', 'nonull', 'value'] | ['value']                   |
+|    3 | ['hasnull', NULL, 'value'] | ['hasnull', NULL, 'value']       | [ NULL,'hasnull', 'value']  |
 +------+----------------------------+----------------------------------+-----------------------------+
 
 mysql> select k1,k2,k3,array_intersect(k2,k3) from array_type_table_decimal;

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_intersect.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_intersect.md
@@ -73,8 +73,8 @@ mysql> select k1,k2,k3,array_intersect(k2,k3) from array_type_table_varchar;
 +------+----------------------------+----------------------------------+-----------------------------+
 |    1 | ['hello', 'world', 'c++']  | ['I', 'am', 'c++']               | ['c++']                     |
 |    2 | ['a1', 'equals', 'b1']     | ['a2', 'equals', 'b2']           | ['equals']                  |
-|    3 | ['hasnull', NULL, 'value'] | ['nohasnull', 'nonull', 'value'] | [NULL, 'value']             |
-|    3 | ['hasnull', NULL, 'value'] | ['hasnull', NULL, 'value']       | ['hasnull', 'value']        |
+|    3 | ['hasnull', NULL, 'value'] | ['nohasnull', 'nonull', 'value'] | ['value']                   |
+|    3 | ['hasnull', NULL, 'value'] | ['hasnull', NULL, 'value']       | [ NULL,'hasnull', 'value']  |
 +------+----------------------------+----------------------------------+-----------------------------+
 
 mysql> select k1,k2,k3,array_intersect(k2,k3) from array_type_table_decimal;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
The result of array_intersect in the documentation example:
![rPn5TU5tdZ](https://github.com/apache/doris/assets/31833513/51730018-f170-467e-9ca3-079bec95028a)



2.0-beta:
![QrBsFjun2r](https://github.com/apache/doris/assets/31833513/56b2b915-eece-48f5-97af-0ebbc6dd0754)


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

