### PR TITLE
[Bug](planner) add expr valid check on aggregation node

### DIFF
--- a/regression-test/data/nereids_p0/aggregate/aggregate.out
+++ b/regression-test/data/nereids_p0/aggregate/aggregate.out
@@ -377,3 +377,9 @@ TESTING	AGAIN
 -- !select_quantile_percent --
 5000.0
 
+-- !sql --
+
+-- !sql --
+
+-- !sql --
+


### PR DESCRIPTION
## Proposed changes
```sql
mysql [regression_test_nereids_p0_aggregate]>explain select k2, max(k3) from t group by k3;
ERROR 1105 (HY000): AnalysisException, msg: Input slot(s) not in child's output: k2#1 in plan: LogicalProject[73] ( distinct=false, projects=[k2#1, max(k3)#4], excepts=[], canEliminate=true ), child output is: [k3#2, max(k3)#4]
```
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

