### PR TITLE
[bug](distinct-agg) fix distinct-agg outblock columns size not equal key size

### DIFF
--- a/be/src/pipeline/exec/distinct_streaming_aggregation_source_operator.cpp
+++ b/be/src/pipeline/exec/distinct_streaming_aggregation_source_operator.cpp
@@ -46,7 +46,7 @@ Status DistinctStreamingAggSourceOperator::pull_data(RuntimeState* state, vector
     RETURN_IF_ERROR(_data_queue->get_block_from_queue(&agg_block));
     if (agg_block != nullptr) {
         block->swap(*agg_block);
-        agg_block->clear_column_data(_node->row_desc().num_materialized_slots());
+        agg_block->clear_column_data(block->columns());
         _data_queue->push_free_block(std::move(agg_block));
     }
     if (_data_queue->data_exhausted()) { //the sink is eos or reached limit

--- a/fe/fe-core/src/main/jflex/sql_scanner.flex
+++ b/fe/fe-core/src/main/jflex/sql_scanner.flex
@@ -778,5 +778,16 @@ EndOfLineComment = "--" !({HintContent}|{ContainsLineTerminator}) {LineTerminato
     return newToken(SqlParserSymbols.NUMERIC_OVERFLOW, yytext());
 }
 
+{DoubleLiteral} {
+  BigDecimal decimal_val;
+  try {
+    decimal_val = new BigDecimal(yytext());
+  } catch (NumberFormatException e) {
+    return newToken(SqlParserSymbols.NUMERIC_OVERFLOW, yytext());
+  }
+
+  return newToken(SqlParserSymbols.DECIMAL_LITERAL, decimal_val);
+}
+
 {Comment} { /* ignore */ }
 {Whitespace} { /* ignore */ }

--- a/fe/fe-core/src/main/jflex/sql_scanner.flex
+++ b/fe/fe-core/src/main/jflex/sql_scanner.flex
@@ -778,16 +778,5 @@ EndOfLineComment = "--" !({HintContent}|{ContainsLineTerminator}) {LineTerminato
     return newToken(SqlParserSymbols.NUMERIC_OVERFLOW, yytext());
 }
 
-{DoubleLiteral} {
-  BigDecimal decimal_val;
-  try {
-    decimal_val = new BigDecimal(yytext());
-  } catch (NumberFormatException e) {
-    return newToken(SqlParserSymbols.NUMERIC_OVERFLOW, yytext());
-  }
-
-  return newToken(SqlParserSymbols.DECIMAL_LITERAL, decimal_val);
-}
-
 {Comment} { /* ignore */ }
 {Whitespace} { /* ignore */ }


### PR DESCRIPTION
## Proposed changes

this agg used by get distinct rows, the group by key is customer_sk and item_sk. and have a projections: customer_sk.
so the output block after call clear_column_data with num_materialized_slots will be remove item_sk column, 
But the block will be push back to data_queue to reuse, those will cause the block column not equal.


|   6:VAGGREGATE (merge finalize)                                                
|   |  group by: customer_sk[#58], item_sk[#59]                                  
|   |  cardinality=35,999,628                                                    
|   |  projections: customer_sk[#60]                                             
|   |  project output tuple id: 7

|   4:VAGGREGATE (update serialize)                                              
|   |  STREAMING                                                                 
|   |  group by: customer_sk[#56], item_sk[#57]                                  
|   |  cardinality=71,999,256


Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

