### PR TITLE
[fix](tablet clone) fix not add colocate replica and print some logs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletChecker.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletChecker.java
@@ -214,7 +214,7 @@ public class TabletChecker extends MasterDaemon {
         LOG.debug(stat.incrementalBrief());
     }
 
-    private static class CheckerCounter {
+    public static class CheckerCounter {
         public long totalTabletNum = 0;
         public long unhealthyTabletNum = 0;
         public long addToSchedulerTabletNum = 0;

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
@@ -127,7 +127,6 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         RUNNING, // tablet is being scheduled
         FINISHED, // task is finished
         CANCELLED, // task is failed
-        TIMEOUT, // task is timeout
         UNEXPECTED // other unexpected errors
     }
 
@@ -656,7 +655,9 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
      */
     public void chooseDestReplicaForVersionIncomplete(Map<Long, PathSlot> backendsWorkingSlots)
             throws SchedException {
-        List<Replica> candidates = Lists.newArrayList();
+        List<Replica> decommissionCand = Lists.newArrayList();
+        List<Replica> colocateCand = Lists.newArrayList();
+        List<Replica> notColocateCand = Lists.newArrayList();
         for (Replica replica : tablet.getReplicas()) {
             if (replica.isBad()) {
                 LOG.debug("replica {} is bad, skip. tablet: {}",
@@ -671,21 +672,35 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                 continue;
             }
 
-            // check version and replica state.
-            // if the replica's state is DECOMMISSION, it may be chose as dest replica,
-            // and its state will be set to NORMAL later.
+            // not enough version completed replicas, then try add back the decommission replica.
+            if (replica.getState() == ReplicaState.DECOMMISSION) {
+                decommissionCand.add(replica);
+                continue;
+            }
+
             if (replica.getLastFailedVersion() <= 0
-                    && replica.getVersion() >= visibleVersion
-                    && replica.getState() != ReplicaState.DECOMMISSION) {
+                    && replica.getVersion() >= visibleVersion) {
                 // skip healthy replica
                 LOG.debug("replica {} version {} is healthy, visible version {}, replica state {}, skip. tablet: {}",
                         replica.getId(), replica.getVersion(), visibleVersion, replica.getState(), tabletId);
                 continue;
             }
 
-            candidates.add(replica);
+            if (colocateBackendsSet != null && colocateBackendsSet.contains(replica.getBackendId())) {
+                colocateCand.add(replica);
+            } else {
+                notColocateCand.add(replica);
+            }
         }
 
+        List<Replica> candidates = null;
+        if (!colocateCand.isEmpty()) {
+            candidates = colocateCand;
+        } else if (!notColocateCand.isEmpty()) {
+            candidates = notColocateCand;
+        } else {
+            candidates = decommissionCand;
+        }
         if (candidates.isEmpty()) {
             throw new SchedException(Status.UNRECOVERABLE, "unable to choose dest replica");
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
@@ -1160,6 +1160,7 @@ public class ReportHandler extends Daemon {
             // colocate table will delete Replica in meta when balance
             // but we need to rely on MetaNotFoundException to decide whether delete the tablet in backend
             // if the tablet is healthy, delete it.
+            boolean isColocateBackend = false;
             ColocateTableIndex colocateTableIndex = Env.getCurrentColocateIndex();
             if (colocateTableIndex.isColocateTable(olapTable.getId())) {
                 ColocateTableIndex.GroupId groupId = colocateTableIndex.getGroup(tableId);
@@ -1173,6 +1174,10 @@ public class ReportHandler extends Daemon {
                 if (status == TabletStatus.HEALTHY) {
                     return false;
                 }
+
+                if (backendsSet.contains(backendId)) {
+                    isColocateBackend = true;
+                }
             }
 
             SystemInfoService infoService = Env.getCurrentSystemInfo();
@@ -1180,7 +1185,8 @@ public class ReportHandler extends Daemon {
             Pair<TabletStatus, TabletSchedCtx.Priority> status = tablet.getHealthStatusWithPriority(infoService,
                     visibleVersion, replicaAlloc, aliveBeIds);
 
-            if (status.first == TabletStatus.VERSION_INCOMPLETE || status.first == TabletStatus.REPLICA_MISSING
+            if (isColocateBackend || status.first == TabletStatus.VERSION_INCOMPLETE
+                    || status.first == TabletStatus.REPLICA_MISSING
                     || status.first == TabletStatus.UNRECOVERABLE) {
                 long lastFailedVersion = -1L;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/task/CloneTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/CloneTask.java
@@ -98,7 +98,7 @@ public class CloneTask extends AgentTask {
         sb.append("tablet id: ").append(tabletId).append(", replica id: ").append(replicaId).append(", schema hash: ")
                 .append(schemaHash);
         sb.append(", storageMedium: ").append(storageMedium.name());
-        sb.append(", visible version(hash): ").append(visibleVersion);
+        sb.append(", visible version: ").append(visibleVersion);
         sb.append(", src backend: ").append(srcBackends.get(0).getHost())
                 .append(", src path hash: ").append(srcPathHash);
         sb.append(", src backend: ").append(srcBackends.get(0).getHost()).append(", src path hash: ")


### PR DESCRIPTION
## Proposed changes

1. When be reports its tablets to FE,  if this be is one of the tablet's colocate backends, then add it back.
2. When chosing a dest replica for a version incomplete replica,  prefer to choose the colocate backend.
3. Add some logs too.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

