### PR TITLE
[Fix](multi_catalog) Fix the problem that sometimes external table file cache statistics in profile are lost  when disable `experimental_enable_pipeline_engine`. 

### DIFF
--- a/be/src/vec/exec/scan/vfile_scanner.h
+++ b/be/src/vec/exec/scan/vfile_scanner.h
@@ -87,6 +87,8 @@ protected:
     // TODO: cast input block columns type to string.
     Status _cast_src_block(Block* block) { return Status::OK(); }
 
+    void _update_counters_before_close() override;
+
 protected:
     std::unique_ptr<TextConverter> _text_converter;
     const TFileScanRangeParams* _params;


### PR DESCRIPTION
## Proposed changes

### Issue

Sometimes external table file cache statistics in profile are lost when disable `experimental_enable_pipeline_engine`. 

Because file cache statistics updated to the `RuntimeProfile` in the scanner `close()`, but in some case it will called after    `stop_report_thread()` and` send_report(true)` in the end of `PlanFragmentExecutor::open()`.  For example: a simple sql without aggregation `select * from table limit 10`.  And in this case, scanner `close()` will be called in the `PlanFragmentExecutor::close()`.

BTW,  some operation will call `_children[0]->close(state) ` in the `open()` functions. So if `_children` is scan node, it will call `close()`.

File cache statistics:
```
  -  FileCache:  0ns
      -  BytesScannedFromCache:  599.00  B
      -  BytesScannedFromRemote:  0.00  
      -  BytesWriteIntoCache:  0.00  
      -  LocalIOUseTimer:  5.771us
      -  NumLocalIOTotal:  1
      -  NumRemoteIOTotal:  0
      -  NumSkipCacheIOTotal:  0
      -  RemoteIOUseTimer:  0ns
      -  WriteCacheIOUseTimer:  0ns
```

### Resolution
This PR use a workaround resolution to update file cache statistics to the `RuntimeProfile` in the `FileScanner::_update_counters_before_close()` which like `NewOlapScanner`. Because I don't know whether we can put  
`stop_report_thread()` and` send_report(true)` in `PlanFragmentExecutor::close()`.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

