### PR TITLE
[fix](load) load core dump print load id

### DIFF
--- a/be/src/common/signal_handler.h
+++ b/be/src/common/signal_handler.h
@@ -422,6 +422,16 @@ void FailureSignalHandler(int signal_number, siginfo_t* signal_info, void* ucont
 
 } // namespace
 
+inline void set_signal_task_id(PUniqueId tid) {
+    query_id_hi = tid.hi();
+    query_id_lo = tid.lo();
+}
+
+inline void set_signal_task_id(TUniqueId tid) {
+    query_id_hi = tid.hi;
+    query_id_lo = tid.lo;
+}
+
 inline void InstallFailureSignalHandler() {
     // Build the sigaction struct.
     struct sigaction sig_action;

--- a/be/src/runtime/thread_context.cpp
+++ b/be/src/runtime/thread_context.cpp
@@ -33,24 +33,15 @@ ThreadContextPtr::ThreadContextPtr() {
 AttachTask::AttachTask(const std::shared_ptr<MemTrackerLimiter>& mem_tracker,
                        const TUniqueId& task_id, const TUniqueId& fragment_instance_id) {
     SwitchBthreadLocal::switch_to_bthread_local();
-    doris::signal::query_id_hi = task_id.hi;
-    doris::signal::query_id_lo = task_id.lo;
+    signal::set_signal_task_id(task_id);
     thread_context()->attach_task(task_id, fragment_instance_id, mem_tracker);
 }
 
 AttachTask::AttachTask(RuntimeState* runtime_state) {
     SwitchBthreadLocal::switch_to_bthread_local();
-    doris::signal::query_id_hi = runtime_state->query_id().hi;
-    doris::signal::query_id_lo = runtime_state->query_id().lo;
+    signal::set_signal_task_id(runtime_state->query_id());
     thread_context()->attach_task(runtime_state->query_id(), runtime_state->fragment_instance_id(),
                                   runtime_state->query_mem_tracker());
-}
-
-AttachTask::AttachTask(const TUniqueId& task_id) {
-    SwitchBthreadLocal::switch_to_bthread_local();
-    doris::signal::query_id_hi = task_id.hi;
-    doris::signal::query_id_lo = task_id.lo;
-    thread_context()->attach_task(task_id);
 }
 
 AttachTask::~AttachTask() {

--- a/be/src/runtime/thread_context.cpp
+++ b/be/src/runtime/thread_context.cpp
@@ -33,6 +33,8 @@ ThreadContextPtr::ThreadContextPtr() {
 AttachTask::AttachTask(const std::shared_ptr<MemTrackerLimiter>& mem_tracker,
                        const TUniqueId& task_id, const TUniqueId& fragment_instance_id) {
     SwitchBthreadLocal::switch_to_bthread_local();
+    doris::signal::query_id_hi = task_id.hi;
+    doris::signal::query_id_lo = task_id.lo;
     thread_context()->attach_task(task_id, fragment_instance_id, mem_tracker);
 }
 
@@ -42,6 +44,13 @@ AttachTask::AttachTask(RuntimeState* runtime_state) {
     doris::signal::query_id_lo = runtime_state->query_id().lo;
     thread_context()->attach_task(runtime_state->query_id(), runtime_state->fragment_instance_id(),
                                   runtime_state->query_mem_tracker());
+}
+
+AttachTask::AttachTask(const TUniqueId& task_id) {
+    SwitchBthreadLocal::switch_to_bthread_local();
+    doris::signal::query_id_hi = task_id.hi;
+    doris::signal::query_id_lo = task_id.lo;
+    thread_context()->attach_task(task_id);
 }
 
 AttachTask::~AttachTask() {

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -155,9 +155,7 @@ class ThreadContext {
 public:
     ThreadContext() {
         thread_mem_tracker_mgr.reset(new ThreadMemTrackerMgr());
-        if (ExecEnv::GetInstance()->initialized()) {
-            thread_mem_tracker_mgr->init();
-        }
+        if (ExecEnv::GetInstance()->initialized()) thread_mem_tracker_mgr->init();
     }
 
     ~ThreadContext() { thread_context_ptr.init = false; }
@@ -167,16 +165,13 @@ public:
 #ifndef BE_TEST
         // will only attach_task at the beginning of the thread function, there should be no duplicate attach_task.
         DCHECK(mem_tracker);
+        // Orphan is thread default tracker.
+        DCHECK(thread_mem_tracker()->label() == "Orphan")
+                << ", attach mem tracker label: " << mem_tracker->label();
 #endif
-        is_reset();
         _task_id = task_id;
         _fragment_instance_id = fragment_instance_id;
         thread_mem_tracker_mgr->attach_limiter_tracker(mem_tracker, fragment_instance_id);
-    }
-
-    void attach_task(const TUniqueId& task_id) {
-        is_reset();
-        _task_id = task_id;
     }
 
     void detach_task() {
@@ -185,8 +180,8 @@ public:
         thread_mem_tracker_mgr->detach_limiter_tracker();
     }
 
-    [[nodiscard]] const TUniqueId& task_id() const { return _task_id; }
-    [[nodiscard]] const TUniqueId& fragment_instance_id() const { return _fragment_instance_id; }
+    const TUniqueId& task_id() const { return _task_id; }
+    const TUniqueId& fragment_instance_id() const { return _fragment_instance_id; }
 
     std::string get_thread_id() {
         std::stringstream ss;
@@ -201,7 +196,7 @@ public:
     // to nullptr, but the object it points to is not initialized. At this time, when the memory
     // is released somewhere, the TCMalloc hook is triggered to cause the crash.
     std::unique_ptr<ThreadMemTrackerMgr> thread_mem_tracker_mgr;
-    [[nodiscard]] MemTrackerLimiter* thread_mem_tracker() const {
+    MemTrackerLimiter* thread_mem_tracker() {
         return thread_mem_tracker_mgr->limiter_mem_tracker_raw();
     }
 
@@ -212,12 +207,6 @@ public:
     int switch_bthread_local_count = 0;
     int skip_memory_check = 0;
     bool large_memory_check = true;
-
-    void is_reset() const {
-        // Orphan is thread default tracker.
-        DCHECK(_task_id == TUniqueId() && _fragment_instance_id == TUniqueId() &&
-               thread_mem_tracker()->label() == "Orphan");
-    }
 
 private:
     TUniqueId _task_id;
@@ -316,8 +305,6 @@ public:
                         const TUniqueId& fragment_instance_id = TUniqueId());
 
     explicit AttachTask(RuntimeState* runtime_state);
-
-    explicit AttachTask(const TUniqueId& task_id);
 
     ~AttachTask();
 };

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -51,6 +51,7 @@
 #include "common/config.h"
 #include "common/exception.h"
 #include "common/logging.h"
+#include "common/signal_handler.h"
 #include "common/status.h"
 #include "gutil/integral_types.h"
 #include "http/http_client.h"
@@ -233,10 +234,7 @@ void PInternalServiceImpl::tablet_writer_open(google::protobuf::RpcController* c
     bool ret = _light_work_pool.try_offer([this, request, response, done]() {
         VLOG_RPC << "tablet writer open, id=" << request->id()
                  << ", index_id=" << request->index_id() << ", txn_id=" << request->txn_id();
-        TUniqueId tid;
-        tid.__set_hi(request->id().hi());
-        tid.__set_lo(request->id().lo());
-        SCOPED_ATTACH_TASK(tid);
+        signal::set_signal_task_id(request->id());
         brpc::ClosureGuard closure_guard(done);
         auto st = _exec_env->load_channel_mgr()->open(*request);
         if (!st.ok()) {
@@ -377,10 +375,7 @@ void PInternalServiceImpl::_tablet_writer_add_block(google::protobuf::RpcControl
         int64_t execution_time_ns = 0;
         {
             SCOPED_RAW_TIMER(&execution_time_ns);
-            TUniqueId tid;
-            tid.__set_hi(request->id().hi());
-            tid.__set_lo(request->id().lo());
-            SCOPED_ATTACH_TASK(tid);
+            signal::set_signal_task_id(request->id());
             auto st = _exec_env->load_channel_mgr()->add_batch(*request, response);
             if (!st.ok()) {
                 LOG(WARNING) << "tablet writer add block failed, message=" << st
@@ -408,10 +403,7 @@ void PInternalServiceImpl::tablet_writer_cancel(google::protobuf::RpcController*
     bool ret = _light_work_pool.try_offer([this, request, done]() {
         VLOG_RPC << "tablet writer cancel, id=" << request->id()
                  << ", index_id=" << request->index_id() << ", sender_id=" << request->sender_id();
-        TUniqueId tid;
-        tid.__set_hi(request->id().hi());
-        tid.__set_lo(request->id().lo());
-        SCOPED_ATTACH_TASK(tid);
+        signal::set_signal_task_id(request->id());
         brpc::ClosureGuard closure_guard(done);
         auto st = _exec_env->load_channel_mgr()->cancel(*request);
         if (!st.ok()) {

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -233,6 +233,10 @@ void PInternalServiceImpl::tablet_writer_open(google::protobuf::RpcController* c
     bool ret = _light_work_pool.try_offer([this, request, response, done]() {
         VLOG_RPC << "tablet writer open, id=" << request->id()
                  << ", index_id=" << request->index_id() << ", txn_id=" << request->txn_id();
+        TUniqueId tid;
+        tid.__set_hi(request->id().hi());
+        tid.__set_lo(request->id().lo());
+        SCOPED_ATTACH_TASK(tid);
         brpc::ClosureGuard closure_guard(done);
         auto st = _exec_env->load_channel_mgr()->open(*request);
         if (!st.ok()) {
@@ -373,6 +377,10 @@ void PInternalServiceImpl::_tablet_writer_add_block(google::protobuf::RpcControl
         int64_t execution_time_ns = 0;
         {
             SCOPED_RAW_TIMER(&execution_time_ns);
+            TUniqueId tid;
+            tid.__set_hi(request->id().hi());
+            tid.__set_lo(request->id().lo());
+            SCOPED_ATTACH_TASK(tid);
             auto st = _exec_env->load_channel_mgr()->add_batch(*request, response);
             if (!st.ok()) {
                 LOG(WARNING) << "tablet writer add block failed, message=" << st
@@ -400,6 +408,10 @@ void PInternalServiceImpl::tablet_writer_cancel(google::protobuf::RpcController*
     bool ret = _light_work_pool.try_offer([this, request, done]() {
         VLOG_RPC << "tablet writer cancel, id=" << request->id()
                  << ", index_id=" << request->index_id() << ", sender_id=" << request->sender_id();
+        TUniqueId tid;
+        tid.__set_hi(request->id().hi());
+        tid.__set_lo(request->id().lo());
+        SCOPED_ATTACH_TASK(tid);
         brpc::ClosureGuard closure_guard(done);
         auto st = _exec_env->load_channel_mgr()->cancel(*request);
         if (!st.ok()) {


### PR DESCRIPTION
## Proposed changes

save the load id to the thread context,
expect all task ids to be saved in thread context, compaction/schema change/etc.
![image](https://github.com/apache/doris/assets/13197424/2574a6aa-2236-4b1d-b61b-99329281dad5)


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

