### PR TITLE
[fix](sec) upgrade org.apache.hadoop:hadoop-common to 3.2.4

### DIFF
--- a/regression-test/framework/pom.xml
+++ b/regression-test/framework/pom.xml
@@ -75,7 +75,7 @@ under the License.
         <groovy-eclipse-batch.version>3.0.7-01</groovy-eclipse-batch.version>
         <groovy-eclipse-compiler.version>3.7.0</groovy-eclipse-compiler.version>
         <antlr.version>4.9.3</antlr.version>
-        <hadoop.version>2.8.0</hadoop.version>
+        <hadoop.version>3.3.3</hadoop.version>
     </properties>
     <build>
         <plugins>


### PR DESCRIPTION
### What happened？
There are 7 security vulnerabilities found in org.apache.hadoop:hadoop-common 2.8.0
- [CVE-2017-15713](https://www.oscs1024.com/hd/CVE-2017-15713)
- [CVE-2018-8009](https://www.oscs1024.com/hd/CVE-2018-8009)
- [CVE-2022-25168](https://www.oscs1024.com/hd/CVE-2022-25168)
- [CVE-2022-26612](https://www.oscs1024.com/hd/CVE-2022-26612)
- [CVE-2022-25168](https://www.oscs1024.com/hd/CVE-2022-25168)
- [CVE-2018-11765](https://www.oscs1024.com/hd/CVE-2018-11765)
- [CVE-2017-7669](https://www.oscs1024.com/hd/CVE-2017-7669)


### What did I do？
Upgrade org.apache.hadoop:hadoop-common from 2.8.0 to 3.2.4 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS