### PR TITLE
[fix][branch-2.0] change lazy open regression test name

### DIFF
--- a/regression-test/suites/rollup_p0/test_materialized_view_lazy_open.groovy
+++ b/regression-test/suites/rollup_p0/test_materialized_view_lazy_open.groovy
@@ -15,15 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_materialized_view_lazy_open", "rollup") {
+suite("test_materialized_view_load_open", "rollup") {
 
     // because nereids cannot support rollup correctly forbid it temporary
     sql """set enable_nereids_planner=false"""
 
-    def tbName1 = "test_materialized_view_lazy_open"
-    def tbName2 = "test_materialized_view_lazy_open_dynamic_partition"
-    def tbName3 = "test_materialized_view_lazy_open_schema_change"
-    def tbName4 = "test_materialized_view_lazy_open_dynamic_partition_schema_change"
+    def tbName1 = "test_materialized_view_load_open"
+    def tbName2 = "test_materialized_view_load_open_dynamic_partition"
+    def tbName3 = "test_materialized_view_load_open_schema_change"
+    def tbName4 = "test_materialized_view_load_open_dynamic_partition_schema_change"
+
 
     def getJobState = { tableName ->
         def jobStateResult = sql """  SHOW ALTER TABLE MATERIALIZED VIEW WHERE TableName='${tableName}' ORDER BY CreateTime DESC LIMIT 1; """
@@ -131,7 +132,7 @@ suite("test_materialized_view_lazy_open", "rollup") {
             );
         """
     
-    sql "CREATE materialized VIEW test_lazy_open AS SELECT k1 FROM ${tbName1} GROUP BY k1;"
+    sql "CREATE materialized VIEW test_load_open AS SELECT k1 FROM ${tbName1} GROUP BY k1;"
     int max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName1)
@@ -147,7 +148,7 @@ suite("test_materialized_view_lazy_open", "rollup") {
         }
     }
 
-    sql "CREATE materialized VIEW test_lazy_open_dynamic_partition AS SELECT k1 FROM ${tbName2} GROUP BY k1;"
+    sql "CREATE materialized VIEW test_load_open_dynamic_partition AS SELECT k1 FROM ${tbName2} GROUP BY k1;"
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName2)
@@ -163,7 +164,7 @@ suite("test_materialized_view_lazy_open", "rollup") {
         }
     }
 
-    sql "CREATE materialized VIEW test_lazy_open_schema_change AS SELECT k1 FROM ${tbName3} GROUP BY k1;"
+    sql "CREATE materialized VIEW test_load_open_schema_change AS SELECT k1 FROM ${tbName3} GROUP BY k1;"
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName3)
@@ -179,7 +180,7 @@ suite("test_materialized_view_lazy_open", "rollup") {
         }
     }
 
-    sql "CREATE materialized VIEW test_lazy_open_dynamic_partition_schema_change AS SELECT k1 FROM ${tbName4} GROUP BY k1;"
+    sql "CREATE materialized VIEW test_load_open_dynamic_partition_schema_change AS SELECT k1 FROM ${tbName4} GROUP BY k1;"
     max_try_secs = 60
     while (max_try_secs--) {
         String res = getJobState(tbName4)

--- a/regression-test/suites/rollup_p0/test_materialized_view_lazy_open.groovy
+++ b/regression-test/suites/rollup_p0/test_materialized_view_lazy_open.groovy
@@ -25,7 +25,6 @@ suite("test_materialized_view_load_open", "rollup") {
     def tbName3 = "test_materialized_view_load_open_schema_change"
     def tbName4 = "test_materialized_view_load_open_dynamic_partition_schema_change"
 
-
     def getJobState = { tableName ->
         def jobStateResult = sql """  SHOW ALTER TABLE MATERIALIZED VIEW WHERE TableName='${tableName}' ORDER BY CreateTime DESC LIMIT 1; """
         return jobStateResult[0][8]


### PR DESCRIPTION
## Proposed changes

Lazy open feature revert in https://github.com/apache/doris/pull/22130, but the test suites for open, it should change name and can reuse.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

