### PR TITLE
[opt](conf) Modify brpc eovercrowded conf

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -474,6 +474,7 @@ DEFINE_mInt32(streaming_load_rpc_max_alive_time_sec, "1200");
 DEFINE_Int32(tablet_writer_open_rpc_timeout_sec, "60");
 // You can ignore brpc error '[E1011]The server is overcrowded' when writing data.
 DEFINE_mBool(tablet_writer_ignore_eovercrowded, "true");
+DEFINE_mBool(exchange_sink_ignore_eovercrowded, "true");
 DEFINE_mInt32(slave_replica_writer_rpc_timeout_sec, "60");
 // Whether to enable stream load record function, the default is false.
 // False: disable stream load record

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -644,8 +644,7 @@ DEFINE_String(default_rowset_type, "BETA");
 
 // Maximum size of a single message body in all protocols
 DEFINE_Int64(brpc_max_body_size, "3147483648");
-// Max unwritten bytes in each socket, if the limit is reached, Socket.Write fails with EOVERCROWDED
-DEFINE_Int64(brpc_socket_max_unwritten_bytes, "1073741824");
+DEFINE_Int64(brpc_socket_max_unwritten_bytes, "-1");
 // TODO(zxy): expect to be true in v1.3
 // Whether to embed the ProtoBuf Request serialized string together with Tuple/Block data into
 // Controller Attachment and send it through http brpc when the length of the Tuple/Block data

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -521,6 +521,7 @@ DECLARE_mInt32(streaming_load_rpc_max_alive_time_sec);
 DECLARE_Int32(tablet_writer_open_rpc_timeout_sec);
 // You can ignore brpc error '[E1011]The server is overcrowded' when writing data.
 DECLARE_mBool(tablet_writer_ignore_eovercrowded);
+DECLARE_mBool(exchange_sink_ignore_eovercrowded);
 DECLARE_mInt32(slave_replica_writer_rpc_timeout_sec);
 // Whether to enable stream load record function, the default is false.
 // False: disable stream load record

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -692,6 +692,8 @@ DECLARE_String(default_rowset_type);
 // Maximum size of a single message body in all protocols
 DECLARE_Int64(brpc_max_body_size);
 // Max unwritten bytes in each socket, if the limit is reached, Socket.Write fails with EOVERCROWDED
+// Default, if the physical memory is less than or equal to 64G, the value is 1G
+//          if the physical memory is greater than 64G, the value is physical memory * mem_limit(0.8) / 1024 * 20
 DECLARE_Int64(brpc_socket_max_unwritten_bytes);
 // TODO(zxy): expect to be true in v1.3
 // Whether to embed the ProtoBuf Request serialized string together with Tuple/Block data into

--- a/be/src/pipeline/exec/exchange_sink_buffer.cpp
+++ b/be/src/pipeline/exec/exchange_sink_buffer.cpp
@@ -197,6 +197,7 @@ Status ExchangeSinkBuffer::_send_rpc(InstanceLoId id) {
         _instance_to_rpc_ctx[id] = rpc_ctx;
 
         closure->cntl.set_timeout_ms(request.channel->_brpc_timeout_ms);
+        closure->cntl.ignore_eovercrowded();
         closure->addFailedHandler(
                 [&](const InstanceLoId& id, const std::string& err) { _failed(id, err); });
         closure->start_rpc_time = GetCurrentTimeNanos();
@@ -247,6 +248,7 @@ Status ExchangeSinkBuffer::_send_rpc(InstanceLoId id) {
         _instance_to_rpc_ctx[id] = rpc_ctx;
 
         closure->cntl.set_timeout_ms(request.channel->_brpc_timeout_ms);
+        closure->cntl.ignore_eovercrowded();
         closure->addFailedHandler(
                 [&](const InstanceLoId& id, const std::string& err) { _failed(id, err); });
         closure->start_rpc_time = GetCurrentTimeNanos();

--- a/be/src/pipeline/exec/exchange_sink_buffer.cpp
+++ b/be/src/pipeline/exec/exchange_sink_buffer.cpp
@@ -197,7 +197,9 @@ Status ExchangeSinkBuffer::_send_rpc(InstanceLoId id) {
         _instance_to_rpc_ctx[id] = rpc_ctx;
 
         closure->cntl.set_timeout_ms(request.channel->_brpc_timeout_ms);
-        closure->cntl.ignore_eovercrowded();
+        if (config::exchange_sink_ignore_eovercrowded) {
+            closure->cntl.ignore_eovercrowded();
+        }
         closure->addFailedHandler(
                 [&](const InstanceLoId& id, const std::string& err) { _failed(id, err); });
         closure->start_rpc_time = GetCurrentTimeNanos();
@@ -248,7 +250,9 @@ Status ExchangeSinkBuffer::_send_rpc(InstanceLoId id) {
         _instance_to_rpc_ctx[id] = rpc_ctx;
 
         closure->cntl.set_timeout_ms(request.channel->_brpc_timeout_ms);
-        closure->cntl.ignore_eovercrowded();
+        if (config::exchange_sink_ignore_eovercrowded) {
+            closure->cntl.ignore_eovercrowded();
+        }
         closure->addFailedHandler(
                 [&](const InstanceLoId& id, const std::string& err) { _failed(id, err); });
         closure->start_rpc_time = GetCurrentTimeNanos();

--- a/be/src/service/brpc_service.cpp
+++ b/be/src/service/brpc_service.cpp
@@ -31,6 +31,7 @@
 #include "common/logging.h"
 #include "service/backend_options.h"
 #include "service/internal_service.h"
+#include "util/mem_info.h"
 
 namespace brpc {
 
@@ -44,7 +45,10 @@ namespace doris {
 BRpcService::BRpcService(ExecEnv* exec_env) : _exec_env(exec_env), _server(new brpc::Server()) {
     // Set config
     brpc::FLAGS_max_body_size = config::brpc_max_body_size;
-    brpc::FLAGS_socket_max_unwritten_bytes = config::brpc_socket_max_unwritten_bytes;
+    brpc::FLAGS_socket_max_unwritten_bytes =
+            config::brpc_socket_max_unwritten_bytes != -1
+                    ? config::brpc_socket_max_unwritten_bytes
+                    : std::max(1073741824L, (MemInfo::mem_limit() / 1024) * 20);
 }
 
 BRpcService::~BRpcService() = default;

--- a/be/src/service/brpc_service.cpp
+++ b/be/src/service/brpc_service.cpp
@@ -48,7 +48,7 @@ BRpcService::BRpcService(ExecEnv* exec_env) : _exec_env(exec_env), _server(new b
     brpc::FLAGS_socket_max_unwritten_bytes =
             config::brpc_socket_max_unwritten_bytes != -1
                     ? config::brpc_socket_max_unwritten_bytes
-                    : std::max(1073741824L, (MemInfo::mem_limit() / 1024) * 20);
+                    : std::max((int64_t)1073741824, (MemInfo::mem_limit() / 1024) * 20);
 }
 
 BRpcService::~BRpcService() = default;

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -178,6 +178,7 @@ Status Channel::send_block(PBlock* block, bool eos) {
 
     _closure->ref();
     _closure->cntl.set_timeout_ms(_brpc_timeout_ms);
+    _closure->cntl.ignore_eovercrowded();
 
     {
         SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->orphan_mem_tracker());

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -178,7 +178,9 @@ Status Channel::send_block(PBlock* block, bool eos) {
 
     _closure->ref();
     _closure->cntl.set_timeout_ms(_brpc_timeout_ms);
-    _closure->cntl.ignore_eovercrowded();
+    if (config::exchange_sink_ignore_eovercrowded) {
+        _closure->cntl.ignore_eovercrowded();
+    }
 
     {
         SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->orphan_mem_tracker());


### PR DESCRIPTION
## Proposed changes

1. brpc ignore eovercrowded of data stream sender and exchange sink buffer
2. Modify the default value of brpc_socket_max_unwritten_bytes

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

