### PR TITLE
[Fix](nereids) Fix Olap table qualifier only contains db name bug.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
@@ -170,10 +170,10 @@ public class BindRelation extends OneAnalysisRuleFactory {
         List<Long> partIds = getPartitionIds(table, unboundRelation);
         if (!CollectionUtils.isEmpty(partIds)) {
             scan = new LogicalOlapScan(unboundRelation.getRelationId(),
-                    (OlapTable) table, ImmutableList.of(tableQualifier.get(1)), partIds, unboundRelation.getHints());
+                    (OlapTable) table, tableQualifier, partIds, unboundRelation.getHints());
         } else {
             scan = new LogicalOlapScan(unboundRelation.getRelationId(),
-                    (OlapTable) table, ImmutableList.of(tableQualifier.get(1)), unboundRelation.getHints());
+                    (OlapTable) table, tableQualifier, unboundRelation.getHints());
         }
         if (!Util.showHiddenColumns() && scan.getTable().hasDeleteSign()
                 && !ConnectContext.get().getSessionVariable()

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCatalogRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCatalogRelation.java
@@ -67,15 +67,12 @@ public abstract class LogicalCatalogRelation extends LogicalRelation implements 
 
     @Override
     public DatabaseIf getDatabase() throws AnalysisException {
-        Preconditions.checkArgument(!qualifier.isEmpty(), "qualifier can not be empty");
+        Preconditions.checkArgument(qualifier.size() == 3, "qualifier format incorrect.");
         try {
-            CatalogIf catalog = qualifier.size() == 3
-                    ? Env.getCurrentEnv().getCatalogMgr().getCatalogOrException(qualifier.get(0),
-                        s -> new Exception("Catalog [" + qualifier.get(0) + "] does not exist."))
-                    : Env.getCurrentEnv().getCurrentCatalog();
-            return catalog.getDbOrException(qualifier.size() == 3 ? qualifier.get(1) : qualifier.get(0),
-                    s -> new Exception("Database [" + qualifier.get(1) + "] does not exist in catalog ["
-                        + qualifier.get(0) + "]."));
+            CatalogIf catalog = Env.getCurrentEnv().getCatalogMgr().getCatalogOrException(qualifier.get(0),
+                        s -> new Exception("Catalog [" + qualifier.get(0) + "] does not exist."));
+            return catalog.getDbOrException(qualifier.get(1),
+                    s -> new Exception("Database [" + qualifiedName() + "] does not exist."));
         } catch (Exception e) {
             throw new AnalysisException(e.getMessage(), e);
         }
@@ -97,13 +94,13 @@ public abstract class LogicalCatalogRelation extends LogicalRelation implements 
      * Full qualified name parts, i.e., concat qualifier and name into a list.
      */
     public List<String> qualified() {
-        return Utils.qualifiedNameParts(qualifier, table.getName());
+        return qualifier;
     }
 
     /**
      * Full qualified table name, concat qualifier and name with `.` as separator.
      */
     public String qualifiedName() {
-        return Utils.qualifiedName(qualifier, table.getName());
+        return Utils.qualifiedName(qualifier);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/Utils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/Utils.java
@@ -123,6 +123,13 @@ public class Utils {
     }
 
     /**
+     * Fully qualified identifier name, concat qualifier with `.` as separator.
+     */
+    public static String qualifiedName(List<String> qualifier) {
+        return StringUtils.join(qualifier, ".");
+    }
+
+    /**
      * Get sql string for plan.
      *
      * @param planName name of plan, like LogicalJoin.


### PR DESCRIPTION
While creating LogicalOlapScan, the qualifier only includes database name (without catalog name). This will cause getDatabase function in LogicalCatalogRelation fail to find the correct database, because without catalog name, it only search current catalog. This will cause an error because current catalog may be an external catalog, and Olap database only exist in internal catalog.
This pr pass the whole qualifier to LogicalOlapScan, including catalog name, db name and table name.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

