### PR TITLE
[fix](string-column) fix unescape result length error

### DIFF
--- a/be/src/exec/text_converter.cpp
+++ b/be/src/exec/text_converter.cpp
@@ -488,6 +488,7 @@ bool TextConverter::write_vec_column(const SlotDescriptor* slot_desc,
 }
 
 void TextConverter::unescape_string_on_spot(const char* src, size_t* len) {
+    const char* start = src;
     char* dest_ptr = const_cast<char*>(src);
     const char* end = src + *len;
     bool escape_next_char = false;
@@ -506,7 +507,7 @@ void TextConverter::unescape_string_on_spot(const char* src, size_t* len) {
         }
     }
 
-    *len = dest_ptr - src;
+    *len = dest_ptr - start;
 }
 
 } // namespace doris


### PR DESCRIPTION
## Proposed changes

While working on #22382, found that text convertor got error result while doing unescape, due to result length error.
Related case is in  #22382.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

