### PR TITLE
[improvement](file-scan) reduce the min size of file split

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileScanNode.java
@@ -60,7 +60,7 @@ import java.util.Map;
 public abstract class FileScanNode extends ExternalScanNode {
     private static final Logger LOG = LogManager.getLogger(FileScanNode.class);
 
-    public static final long DEFAULT_SPLIT_SIZE = 128 * 1024 * 1024; // 128MB
+    public static final long DEFAULT_SPLIT_SIZE = 8 * 1024 * 1024; // 8MB
 
     // For explain
     protected long inputSplitsNum = 0;
@@ -69,7 +69,7 @@ public abstract class FileScanNode extends ExternalScanNode {
     protected long readPartitionNum = 0;
 
     public FileScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName, StatisticalType statisticalType,
-                            boolean needCheckColumnPriv) {
+            boolean needCheckColumnPriv) {
         super(id, desc, planNodeName, statisticalType, needCheckColumnPriv);
         this.needCheckColumnPriv = needCheckColumnPriv;
     }


### PR DESCRIPTION
## Proposed changes

Reduce from 128MB to 8MB.
So that user can set `file_split_size` more flexible.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

