### PR TITLE
[Fix](executor)Fix incorrect mem_limit return value  type

### DIFF
--- a/be/src/runtime/task_group/task_group.h
+++ b/be/src/runtime/task_group/task_group.h
@@ -115,7 +115,7 @@ public:
         return _enable_memory_overcommit;
     };
 
-    bool memory_limit() const {
+    int64_t memory_limit() const {
         std::shared_lock<std::shared_mutex> r_lock(_mutex);
         return _memory_limit;
     };

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -256,9 +256,9 @@ int64_t MemInfo::tg_soft_memory_limit_gc(int64_t request_free_memory, RuntimePro
     std::vector<int64_t> used_memorys;
     std::vector<int64_t> exceeded_memorys;
     for (const auto& task_group : task_groups) {
-        auto used_memory = task_group->memory_used();
-        auto exceeded = used_memory - task_group->memory_limit();
-        auto exceeded_memory = exceeded > 0 ? exceeded : 0;
+        int64_t used_memory = task_group->memory_used();
+        int64_t exceeded = used_memory - task_group->memory_limit();
+        int64_t exceeded_memory = exceeded > 0 ? exceeded : 0;
         total_exceeded_memory += exceeded_memory;
         used_memorys.emplace_back(used_memory);
         exceeded_memorys.emplace_back(exceeded_memory);


### PR DESCRIPTION
## Proposed changes

Fix a typo for task group's mem limit, this may cause incorrect calculation for memory gc.
