### PR TITLE
[fix](window_funnel_function) fix upgrade compatibility due to the added field in `WindowFunnelState`

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1051,6 +1051,9 @@ DEFINE_mInt64(lookup_connection_cache_bytes_limit, "4294967296");
 // level of compression when using LZ4_HC, whose defalut value is LZ4HC_CLEVEL_DEFAULT
 DEFINE_mInt64(LZ4_HC_compression_level, "9");
 
+// enable window_funnel_function with different modes
+DEFINE_Bool(enable_window_funnel_function_v2, "false");
+
 #ifdef BE_TEST
 // test s3
 DEFINE_String(test_s3_resource, "resource");

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1052,7 +1052,7 @@ DEFINE_mInt64(lookup_connection_cache_bytes_limit, "4294967296");
 DEFINE_mInt64(LZ4_HC_compression_level, "9");
 
 // enable window_funnel_function with different modes
-DEFINE_Bool(enable_window_funnel_function_v2, "false");
+DEFINE_mBool(enable_window_funnel_function_v2, "false");
 
 #ifdef BE_TEST
 // test s3

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1080,6 +1080,9 @@ DECLARE_mInt64(lookup_connection_cache_bytes_limit);
 // level of compression when using LZ4_HC, whose defalut value is LZ4HC_CLEVEL_DEFAULT
 DECLARE_mInt64(LZ4_HC_compression_level);
 
+// enable window_funnel_function with different modes
+DECLARE_Bool(enable_window_funnel_function_v2);
+
 #ifdef BE_TEST
 // test s3
 DECLARE_String(test_s3_resource);

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1081,7 +1081,7 @@ DECLARE_mInt64(lookup_connection_cache_bytes_limit);
 DECLARE_mInt64(LZ4_HC_compression_level);
 
 // enable window_funnel_function with different modes
-DECLARE_Bool(enable_window_funnel_function_v2);
+DECLARE_mBool(enable_window_funnel_function_v2);
 
 #ifdef BE_TEST
 // test s3

--- a/be/src/vec/aggregate_functions/aggregate_function_window_funnel.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window_funnel.h
@@ -212,8 +212,10 @@ struct WindowFunnelState {
     void write(BufferWritable& out) const {
         write_var_int(max_event_level, out);
         write_var_int(window, out);
-        write_var_int(static_cast<std::underlying_type_t<WindowFunnelMode>>(window_funnel_mode),
-                      out);
+        if (config::enable_window_funnel_function_v2) {
+            write_var_int(static_cast<std::underlying_type_t<WindowFunnelMode>>(window_funnel_mode),
+                          out);
+        }
         write_var_int(events.size(), out);
 
         for (int64_t i = 0; i < events.size(); i++) {
@@ -229,9 +231,12 @@ struct WindowFunnelState {
         read_var_int(event_level, in);
         max_event_level = (int)event_level;
         read_var_int(window, in);
-        int64_t mode;
-        read_var_int(mode, in);
-        window_funnel_mode = static_cast<WindowFunnelMode>(mode);
+        window_funnel_mode = WindowFunnelMode::DEFAULT;
+        if (config::enable_window_funnel_function_v2) {
+            int64_t mode;
+            read_var_int(mode, in);
+            window_funnel_mode = static_cast<WindowFunnelMode>(mode);
+        }
         int64_t size = 0;
         read_var_int(size, in);
         for (int64_t i = 0; i < size; i++) {

--- a/regression-test/suites/nereids_p0/aggregate/window_funnel.groovy
+++ b/regression-test/suites/nereids_p0/aggregate/window_funnel.groovy
@@ -105,6 +105,16 @@ suite("window_funnel") {
     """
     sql """ DROP TABLE IF EXISTS ${tableName} """
 
+    String backend_id;
+    def backendId_to_backendIP = [:]
+    def backendId_to_backendHttpPort = [:]
+    getBackendIpHttpPort(backendId_to_backendIP, backendId_to_backendHttpPort);
+    for (String backendId in backendId_to_backendIP.keySet()) {
+        String be_host = backendId_to_backendIP[backendId]
+        String be_http_port = backendId_to_backendHttpPort[backendId]
+        curl("POST", "http://${be_host}:${be_http_port}/api/update_config?enable_window_funnel_function_v2=true")
+    }
+
     sql """ DROP TABLE IF EXISTS ${tableName} """
     sql """
         CREATE TABLE IF NOT EXISTS ${tableName} (

--- a/regression-test/suites/query_p0/aggregate/window_funnel.groovy
+++ b/regression-test/suites/query_p0/aggregate/window_funnel.groovy
@@ -104,6 +104,16 @@ suite("window_funnel") {
     """
     sql """ DROP TABLE IF EXISTS ${tableName} """
 
+    String backend_id;
+    def backendId_to_backendIP = [:]
+    def backendId_to_backendHttpPort = [:]
+    getBackendIpHttpPort(backendId_to_backendIP, backendId_to_backendHttpPort);
+    for (String backendId in backendId_to_backendIP.keySet()) {
+        String be_host = backendId_to_backendIP[backendId]
+        String be_http_port = backendId_to_backendHttpPort[backendId]
+        curl("POST", "http://${be_host}:${be_http_port}/api/update_config?enable_window_funnel_function_v2=true")
+    }
+
     sql """ DROP TABLE IF EXISTS ${tableName} """
     sql """
         CREATE TABLE IF NOT EXISTS ${tableName} (


### PR DESCRIPTION
## Proposed changes

the added variable `window_funnel_mode` in `WindowFunnelState` will cause the serialization result of new BE different from old version BE, which may lead to coredump when new version BE and old version BE deserialize from each others serialization result. So this PR add a config variable to control if we use the new window funnel function. This config should be turned off during the process of upgrade. After all the BE have upgrade to the new version the config can be turned on to use the new version of window_funnel_function

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

