### PR TITLE
[fix](planner)fix bug of push conjuncts through second phase agg

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -2687,7 +2687,12 @@ public class SingleNodePlanner {
         if (aggregateInfo == null || aggregateInfo.getGroupingExprs().isEmpty()) {
             return;
         }
-        final List<Expr> predicates = getBoundPredicates(analyzer, aggregateInfo.getOutputTupleDesc());
+        // The output of the 1st phase agg is the 1st phase intermediate.
+        // see createSecondPhaseAggInfo method
+        final List<Expr> predicates = getBoundPredicates(analyzer,
+                aggregateInfo.getSecondPhaseDistinctAggInfo() != null
+                        ? aggregateInfo.getIntermediateTupleDesc()
+                        : aggregateInfo.getOutputTupleDesc());
         if (predicates.isEmpty()) {
             return;
         }
@@ -2713,7 +2718,11 @@ public class SingleNodePlanner {
         }
         final AggregateInfo secondPhaseAggInfo = firstPhaseAggInfo.getSecondPhaseDistinctAggInfo();
 
-        final List<TupleId> firstPhaseTupleIds = Lists.newArrayList(firstPhaseAggInfo.getOutputTupleId());
+        // The output of the 1st phase agg is the 1st phase intermediate.
+        // see createSecondPhaseAggInfo method
+        final List<TupleId> firstPhaseTupleIds = Lists.newArrayList(
+                secondPhaseAggInfo != null ? firstPhaseAggInfo.getIntermediateTupleId()
+                        : firstPhaseAggInfo.getOutputTupleId());
         pushDownPredicatesPastAggregationOnePhase(secondPhaseAggInfo, analyzer, stmt, firstPhaseTupleIds);
         pushDownPredicatesPastAggregationOnePhase(firstPhaseAggInfo, analyzer, stmt, stmt.getTableRefIds());
     }

--- a/regression-test/suites/correctness_p0/test_distinct_agg.groovy
+++ b/regression-test/suites/correctness_p0/test_distinct_agg.groovy
@@ -55,4 +55,18 @@ suite("test_distinct_agg") {
         '''
         result([['1', '2023-01-10', 1L]])
     }
+
+    sql '''SELECT `b`.`dt` AS `dt`
+            FROM 
+                (SELECT `dt`AS `dt`,
+                    count(DISTINCT `role_id`) AS `pay_role`,
+                    avg(`cost`) AS `avg_cost`
+                FROM 
+                    (SELECT `k6` AS `dt`,
+                    `k1` AS `role_id`,
+                    sum(CAST(`k2` AS INT)) AS `cost`
+                    FROM `t`
+                    GROUP BY  `dt`, `role_id`) a
+                    GROUP BY  `dt`) b 
+                WHERE `dt` = '2023-06-18';'''
 }


### PR DESCRIPTION
## Proposed changes

If there is a second phase agg, the output of the 1st phase agg is its intermediate tuple not the output tuple. This pr fix it

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

