### PR TITLE
[BugFix](Es Catalog) fix bug that es catalog will return error when query partial columns

### DIFF
--- a/be/src/exec/es/es_scroll_parser.cpp
+++ b/be/src/exec/es/es_scroll_parser.cpp
@@ -593,7 +593,7 @@ Status ScrollParser::fill_columns(const TupleDescriptor* tuple_desc,
                 if (pure_doc_value) {
                     if (col.Empty()) {
                         break;
-                    } else if (col.IsArray() && !col[0].IsString()) {
+                    } else if (!col[0].IsString()) {
                         val = json_value_to_string(col[0]);
                     } else {
                         val = col[0].GetString();

--- a/be/src/exec/es/es_scroll_parser.cpp
+++ b/be/src/exec/es/es_scroll_parser.cpp
@@ -489,8 +489,10 @@ Status ScrollParser::fill_columns(const TupleDescriptor* tuple_desc,
             // because of reading value from _source, we can not process all json type and then just transfer the value to original string representation
             // this may be a tricky, but we can work around this issue
             std::string val;
-            if (pure_doc_value && !col.Empty()) {
-                if (!col[0].IsString()) {
+            if (pure_doc_value) {
+                if (col.Empty()) {
+                    break;
+                } else if (!col[0].IsString()) {
                     val = json_value_to_string(col[0]);
                 } else {
                     val = col[0].GetString();
@@ -588,8 +590,10 @@ Status ScrollParser::fill_columns(const TupleDescriptor* tuple_desc,
                 data.assign_from_double(col.GetDouble());
             } else {
                 std::string val;
-                if (pure_doc_value && !col.Empty()) {
-                    if (!col[0].IsString()) {
+                if (pure_doc_value) {
+                    if (col.Empty()) {
+                        break;
+                    } else if (col.IsArray() && !col[0].IsString()) {
                         val = json_value_to_string(col[0]);
                     } else {
                         val = col[0].GetString();


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Bug：
When the value of some ES column is empty, querying these value in `doc_values mode` will receive an error.

Reson：
In `doc values mode`, these values are empty, We need to determine if the array is empty

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

