### PR TITLE
[fix](vertical compaction) compaction block reader should return error  when reading next block failed

### DIFF
--- a/be/src/vec/olap/block_reader.cpp
+++ b/be/src/vec/olap/block_reader.cpp
@@ -384,7 +384,7 @@ Status BlockReader::_unique_key_next_block(Block* block, bool* eof) {
                                                          std::make_shared<DataTypeUInt8>(),
                                                          "__DORIS_COMPACTION_FILTER__"};
         block->insert(column_with_type_and_name);
-        Block::filter_block(block, target_columns.size(), target_columns.size());
+        RETURN_IF_ERROR(Block::filter_block(block, target_columns.size(), target_columns.size()));
         _stats.rows_del_filtered += target_block_row - block->rows();
         DCHECK(block->try_get_by_name("__DORIS_COMPACTION_FILTER__") == nullptr);
     }

--- a/be/src/vec/olap/olap_data_convertor.cpp
+++ b/be/src/vec/olap/olap_data_convertor.cpp
@@ -185,7 +185,7 @@ OlapBlockDataConvertor::create_olap_column_data_convertor(const TabletColumn& co
 
 void OlapBlockDataConvertor::set_source_content(const vectorized::Block* block, size_t row_pos,
                                                 size_t num_rows) {
-    assert(block && num_rows > 0 && row_pos + num_rows <= block->rows() &&
+    DCHECK(block && num_rows > 0 && row_pos + num_rows <= block->rows() &&
            block->columns() == _convertors.size());
     size_t cid = 0;
     for (const auto& typed_column : *block) {
@@ -197,7 +197,7 @@ void OlapBlockDataConvertor::set_source_content(const vectorized::Block* block, 
 void OlapBlockDataConvertor::set_source_content_with_specifid_columns(
         const vectorized::Block* block, size_t row_pos, size_t num_rows,
         std::vector<uint32_t> cids) {
-    assert(block && num_rows > 0 && row_pos + num_rows <= block->rows() &&
+    DCHECK(block && num_rows > 0 && row_pos + num_rows <= block->rows() &&
            block->columns() <= _convertors.size());
     for (auto i : cids) {
         _convertors[i]->set_source_column(block->get_by_position(i), row_pos, num_rows);

--- a/be/src/vec/olap/vertical_block_reader.cpp
+++ b/be/src/vec/olap/vertical_block_reader.cpp
@@ -476,7 +476,8 @@ Status VerticalBlockReader::_unique_key_next_block(Block* block, bool* eof) {
                                                              std::make_shared<DataTypeUInt8>(),
                                                              "__DORIS_COMPACTION_FILTER__"};
             block->insert(column_with_type_and_name);
-            Block::filter_block(block, target_columns.size(), target_columns.size());
+            RETURN_IF_ERROR(
+                    Block::filter_block(block, target_columns.size(), target_columns.size()));
             _stats.rows_del_filtered += block_rows - block->rows();
             DCHECK(block->try_get_by_name("__DORIS_COMPACTION_FILTER__") == nullptr);
         }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

compaction block reader may read failed in filter_block, like encountering MEM_LIMIT_EXCEEDED, so it should return error when reading next block failed, this sence can lead to compaction core when going to append block. 
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

