### PR TITLE
Revert "[fix](show-stmt) fix show create table missing storage_medium  info (#21757)"

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/DataProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/DataProperty.java
@@ -55,22 +55,6 @@ public class DataProperty implements Writable, GsonPostProcessable {
         // for persist
     }
 
-    public String getStorageMediumString() {
-        int val = storageMedium.getValue();
-        switch (val) {
-            case 0:
-                return "hdd";
-            case 1:
-                return "ssd";
-            case 2:
-                return "s3";
-            case 3:
-                return "remote_cache";
-            default:
-                return "unknown";
-        }
-    }
-
     public DataProperty(TStorageMedium medium) {
         this.storageMedium = medium;
         this.cooldownTimeMs = MAX_COOLDOWN_TIME_MS;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -3156,10 +3156,6 @@ public class Env {
             sb.append(",\n\"").append(PropertyAnalyzer.PROPERTIES_ENABLE_SINGLE_REPLICA_COMPACTION).append("\" = \"");
             sb.append(olapTable.enableSingleReplicaCompaction()).append("\"");
 
-            // storage medium
-            sb.append(",\n\"").append(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM).append("\" = \"");
-            sb.append(olapTable.getStorageMedium()).append("\"");
-
             // enable duplicate without keys by default
             if (olapTable.isDuplicateWithoutKey()) {
                 sb.append(",\n\"")

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -170,8 +170,6 @@ public class OlapTable extends Table {
 
     private AutoIncrementGenerator autoIncrementGenerator;
 
-    private String storageMedium;
-
     public OlapTable() {
         // for persist
         super(TableType.OLAP);
@@ -1316,13 +1314,6 @@ public class OlapTable extends Table {
         }
 
         tempPartitions.write(out);
-
-        if (storageMedium == null || storageMedium.length() == 0) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            Text.writeString(out, storageMedium);
-        }
     }
 
     @Override
@@ -1427,10 +1418,6 @@ public class OlapTable extends Table {
             }
         }
         tempPartitions.unsetPartitionInfo();
-
-        if (in.readBoolean()) {
-            storageMedium = Text.readString(in);
-        }
 
         // In the present, the fullSchema could be rebuilt by schema change while the properties is changed by MV.
         // After that, some properties of fullSchema and nameToColumn may be not same as properties of base columns.
@@ -1851,15 +1838,6 @@ public class OlapTable extends Table {
             return tableProperty.enableSingleReplicaCompaction();
         }
         return false;
-    }
-
-
-    public void setStorageMedium(String medium) {
-        storageMedium = medium;
-    }
-
-    public String getStorageMedium() {
-        return storageMedium;
     }
 
     public void setStoreRowColumn(boolean storeRowColumn) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -2162,7 +2162,6 @@ public class InternalCatalog implements CatalogIf<Database> {
             try {
                 dataProperty = PropertyAnalyzer.analyzeDataProperty(stmt.getProperties(),
                         new DataProperty(DataProperty.DEFAULT_STORAGE_MEDIUM));
-                olapTable.setStorageMedium(dataProperty.getStorageMediumString());
             } catch (AnalysisException e) {
                 throw new DdlException(e.getMessage());
             }
@@ -2329,12 +2328,10 @@ public class InternalCatalog implements CatalogIf<Database> {
             } else if (partitionInfo.getType() == PartitionType.RANGE
                     || partitionInfo.getType() == PartitionType.LIST) {
                 try {
-                    DataProperty dataProperty = null;
                     // just for remove entries in stmt.getProperties(),
                     // and then check if there still has unknown properties
-                    dataProperty = PropertyAnalyzer.analyzeDataProperty(stmt.getProperties(),
+                    PropertyAnalyzer.analyzeDataProperty(stmt.getProperties(),
                             new DataProperty(DataProperty.DEFAULT_STORAGE_MEDIUM));
-                    olapTable.setStorageMedium(dataProperty.getStorageMediumString());
                     if (partitionInfo.getType() == PartitionType.RANGE) {
                         DynamicPartitionUtil.checkAndSetDynamicPartitionProperty(olapTable, properties, db);
                     } else if (partitionInfo.getType() == PartitionType.LIST) {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableAsSelectStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableAsSelectStmtTest.java
@@ -96,8 +96,7 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                         + "\"storage_format\" = \"V2\",\n"
                         + "\"light_schema_change\" = \"true\",\n"
                         + "\"disable_auto_compaction\" = \"false\",\n"
-                        + "\"enable_single_replica_compaction\" = \"false\",\n"
-                        + "\"storage_medium\" = \"hdd\"\n"
+                        + "\"enable_single_replica_compaction\" = \"false\"\n"
                         + ");",
                 showCreateTableByName("select_decimal_table").getResultRows().get(0).get(1));
         String selectFromDecimal1 =
@@ -118,8 +117,7 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                             + "\"storage_format\" = \"V2\",\n"
                             + "\"light_schema_change\" = \"true\",\n"
                             + "\"disable_auto_compaction\" = \"false\",\n"
-                            + "\"enable_single_replica_compaction\" = \"false\",\n"
-                            + "\"storage_medium\" = \"hdd\"\n"
+                            + "\"enable_single_replica_compaction\" = \"false\"\n"
                             + ");",
                     showCreateTableByName("select_decimal_table_1").getResultRows().get(0).get(1));
         } else {
@@ -136,8 +134,7 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                             + "\"storage_format\" = \"V2\",\n"
                             + "\"light_schema_change\" = \"true\",\n"
                             + "\"disable_auto_compaction\" = \"false\",\n"
-                            + "\"enable_single_replica_compaction\" = \"false\",\n"
-                            + "\"storage_medium\" = \"hdd\"\n"
+                            + "\"enable_single_replica_compaction\" = \"false\"\n"
                             + ");",
                     showCreateTableByName("select_decimal_table_1").getResultRows().get(0).get(1));
         }
@@ -172,8 +169,7 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                         + "\"storage_format\" = \"V2\",\n"
                         + "\"light_schema_change\" = \"true\",\n"
                         + "\"disable_auto_compaction\" = \"false\",\n"
-                        + "\"enable_single_replica_compaction\" = \"false\",\n"
-                        + "\"storage_medium\" = \"hdd\"\n"
+                        + "\"enable_single_replica_compaction\" = \"false\"\n"
                         + ");",
                 showResultSet.getResultRows().get(0).get(1));
     }
@@ -197,8 +193,7 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                         + "\"storage_format\" = \"V2\",\n"
                         + "\"light_schema_change\" = \"true\",\n"
                         + "\"disable_auto_compaction\" = \"false\",\n"
-                        + "\"enable_single_replica_compaction\" = \"false\",\n"
-                        + "\"storage_medium\" = \"hdd\"\n"
+                        + "\"enable_single_replica_compaction\" = \"false\"\n"
                         + ");",
                 showResultSet1.getResultRows().get(0).get(1));
 
@@ -224,8 +219,7 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                         + "\"storage_format\" = \"V2\",\n"
                         + "\"light_schema_change\" = \"true\",\n"
                         + "\"disable_auto_compaction\" = \"false\",\n"
-                        + "\"enable_single_replica_compaction\" = \"false\",\n"
-                        + "\"storage_medium\" = \"hdd\"\n"
+                        + "\"enable_single_replica_compaction\" = \"false\"\n"
                         + ");",
                 showResultSet2.getResultRows().get(0).get(1));
     }
@@ -248,8 +242,7 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                 + "\"storage_format\" = \"V2\",\n"
                 + "\"light_schema_change\" = \"true\",\n"
                 + "\"disable_auto_compaction\" = \"false\",\n"
-                + "\"enable_single_replica_compaction\" = \"false\",\n"
-                + "\"storage_medium\" = \"hdd\"\n"
+                + "\"enable_single_replica_compaction\" = \"false\"\n"
                 + ");", showResultSet1.getResultRows().get(0).get(1));
         String selectAlias2 = "create table `test`.`select_alias_2` PROPERTIES(\"replication_num\" = \"1\") "
                 + "as select userId as alias_name, username from `test`.`varchar_table`";
@@ -268,8 +261,7 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                         + "\"storage_format\" = \"V2\",\n"
                         + "\"light_schema_change\" = \"true\",\n"
                         + "\"disable_auto_compaction\" = \"false\",\n"
-                        + "\"enable_single_replica_compaction\" = \"false\",\n"
-                        + "\"storage_medium\" = \"hdd\"\n"
+                        + "\"enable_single_replica_compaction\" = \"false\"\n"
                         + ");",
                 showResultSet2.getResultRows().get(0).get(1));
     }
@@ -295,8 +287,7 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                         + "\"storage_format\" = \"V2\",\n"
                         + "\"light_schema_change\" = \"true\",\n"
                         + "\"disable_auto_compaction\" = \"false\",\n"
-                        + "\"enable_single_replica_compaction\" = \"false\",\n"
-                        + "\"storage_medium\" = \"hdd\"\n"
+                        + "\"enable_single_replica_compaction\" = \"false\"\n"
                         + ");",
                 showResultSet.getResultRows().get(0).get(1));
         String selectFromJoin1 = "create table `test`.`select_join1` PROPERTIES(\"replication_num\" = \"1\") "
@@ -319,8 +310,7 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                         + "\"storage_format\" = \"V2\",\n"
                         + "\"light_schema_change\" = \"true\",\n"
                         + "\"disable_auto_compaction\" = \"false\",\n"
-                        + "\"enable_single_replica_compaction\" = \"false\",\n"
-                        + "\"storage_medium\" = \"hdd\"\n"
+                        + "\"enable_single_replica_compaction\" = \"false\"\n"
                         + ");",
                 showResultSet1.getResultRows().get(0).get(1));
     }
@@ -347,8 +337,7 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                         + "\"storage_format\" = \"V2\",\n"
                         + "\"light_schema_change\" = \"true\",\n"
                         + "\"disable_auto_compaction\" = \"false\",\n"
-                        + "\"enable_single_replica_compaction\" = \"false\",\n"
-                        + "\"storage_medium\" = \"hdd\"\n"
+                        + "\"enable_single_replica_compaction\" = \"false\"\n"
                         + ");",
                 showResultSet.getResultRows().get(0).get(1));
     }
@@ -372,8 +361,7 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                         + "\"storage_format\" = \"V2\",\n"
                         + "\"light_schema_change\" = \"true\",\n"
                         + "\"disable_auto_compaction\" = \"false\",\n"
-                        + "\"enable_single_replica_compaction\" = \"false\",\n"
-                        + "\"storage_medium\" = \"hdd\"\n"
+                        + "\"enable_single_replica_compaction\" = \"false\"\n"
                         + ");", showResultSet.getResultRows().get(0).get(1));
     }
 
@@ -396,8 +384,7 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                         + "\"storage_format\" = \"V2\",\n"
                         + "\"light_schema_change\" = \"true\",\n"
                         + "\"disable_auto_compaction\" = \"false\",\n"
-                        + "\"enable_single_replica_compaction\" = \"false\",\n"
-                        + "\"storage_medium\" = \"hdd\"\n"
+                        + "\"enable_single_replica_compaction\" = \"false\"\n"
                         + ");",
                 showResultSet.getResultRows().get(0).get(1));
         String selectFromCteAndUnion = "create table `test`.`select_cte_union` PROPERTIES(\"replication_num\" = \"1\")"
@@ -416,8 +403,7 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                 + "\"storage_format\" = \"V2\",\n"
                 + "\"light_schema_change\" = \"true\",\n"
                 + "\"disable_auto_compaction\" = \"false\",\n"
-                + "\"enable_single_replica_compaction\" = \"false\",\n"
-                + "\"storage_medium\" = \"hdd\"\n"
+                + "\"enable_single_replica_compaction\" = \"false\"\n"
                 + ");", showResultSet1.getResultRows().get(0).get(1));
     }
 
@@ -443,8 +429,7 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                         + "\"storage_format\" = \"V2\",\n"
                         + "\"light_schema_change\" = \"true\",\n"
                         + "\"disable_auto_compaction\" = \"false\",\n"
-                        + "\"enable_single_replica_compaction\" = \"false\",\n"
-                        + "\"storage_medium\" = \"hdd\"\n"
+                        + "\"enable_single_replica_compaction\" = \"false\"\n"
                         + ");",
                 showResultSet.getResultRows().get(0).get(1));
     }
@@ -469,8 +454,7 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                         + "\"storage_format\" = \"V2\",\n"
                         + "\"light_schema_change\" = \"true\",\n"
                         + "\"disable_auto_compaction\" = \"false\",\n"
-                        + "\"enable_single_replica_compaction\" = \"false\",\n"
-                        + "\"storage_medium\" = \"hdd\"\n"
+                        + "\"enable_single_replica_compaction\" = \"false\"\n"
                         + ");",
                 showResultSet.getResultRows().get(0).get(1));
     }
@@ -494,8 +478,7 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                         + "\"storage_format\" = \"V2\",\n"
                         + "\"light_schema_change\" = \"true\",\n"
                         + "\"disable_auto_compaction\" = \"false\",\n"
-                        + "\"enable_single_replica_compaction\" = \"false\",\n"
-                        + "\"storage_medium\" = \"hdd\"\n"
+                        + "\"enable_single_replica_compaction\" = \"false\"\n"
                         + ");",
                 showResultSet.getResultRows().get(0).get(1));
     }
@@ -520,8 +503,7 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                         + "\"storage_format\" = \"V2\",\n"
                         + "\"light_schema_change\" = \"true\",\n"
                         + "\"disable_auto_compaction\" = \"false\",\n"
-                        + "\"enable_single_replica_compaction\" = \"false\",\n"
-                        + "\"storage_medium\" = \"hdd\"\n"
+                        + "\"enable_single_replica_compaction\" = \"false\"\n"
                         + ");",
                 showResultSet.getResultRows().get(0).get(1));
     }
@@ -570,8 +552,7 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                                 + "\"storage_format\" = \"V2\",\n"
                                 + "\"light_schema_change\" = \"true\",\n"
                                 + "\"disable_auto_compaction\" = \"false\",\n"
-                                + "\"enable_single_replica_compaction\" = \"false\",\n"
-                                + "\"storage_medium\" = \"hdd\"\n"
+                                + "\"enable_single_replica_compaction\" = \"false\"\n"
                                 + ");",
                         createTableStmts.get(0));
             } else {
@@ -588,8 +569,7 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
                                 + "\"storage_format\" = \"V2\",\n"
                                 + "\"light_schema_change\" = \"true\",\n"
                                 + "\"disable_auto_compaction\" = \"false\",\n"
-                                + "\"enable_single_replica_compaction\" = \"false\",\n"
-                                + "\"storage_medium\" = \"hdd\"\n"
+                                + "\"enable_single_replica_compaction\" = \"false\"\n"
                                 + ");",
                         createTableStmts.get(0));
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateTableTest.java
@@ -146,16 +146,6 @@ public class CreateTableTest {
                 .expectThrowsNoException(() -> createTable("create table test.tb7(key1 int, key2 varchar(10)) \n"
                         + "distributed by hash(key1) buckets 1 properties('replication_num' = '1', 'storage_medium' = 'ssd');"));
 
-        ConfigBase.setMutableConfig("disable_storage_medium_check", "true");
-        ExceptionChecker
-                .expectThrowsNoException(() -> createTable("create table test.tb7_1(key1 int, key2 varchar(10))\n"
-                                + "PARTITION BY RANGE(`key1`) (\n"
-                                + "    PARTITION `p1` VALUES LESS THAN (\"10\"),\n"
-                                + "    PARTITION `p2` VALUES LESS THAN (\"20\"),\n"
-                                + "    PARTITION `p3` VALUES LESS THAN (\"30\"))\n"
-                                + "distributed by hash(key1)\n"
-                                + "buckets 1 properties('replication_num' = '1', 'storage_medium' = 'ssd');"));
-
         ExceptionChecker
                 .expectThrowsNoException(() -> createTable("create table test.compression1(key1 int, key2 varchar(10)) \n"
                         + "distributed by hash(key1) buckets 1 \n"
@@ -309,19 +299,6 @@ public class CreateTableTest {
                                 + "Create failed replications:\n"
                                 + "replication tag: {\"location\" : \"default\"}, replication num: 1, storage medium: SSD",
                         () -> createTable("create table test.tb7(key1 int, key2 varchar(10)) distributed by hash(key1) \n"
-                                + "buckets 1 properties('replication_num' = '1', 'storage_medium' = 'ssd');"));
-
-        ConfigBase.setMutableConfig("disable_storage_medium_check", "false");
-        ExceptionChecker
-                .expectThrowsWithMsg(DdlException.class, "Failed to find enough backend, please check the replication num,replication tag and storage medium.\n"
-                                + "Create failed replications:\n"
-                                + "replication tag: {\"location\" : \"default\"}, replication num: 1, storage medium: SSD",
-                        () -> createTable("create table test.tb7_1(key1 int, key2 varchar(10))\n"
-                                + "PARTITION BY RANGE(`key1`) (\n"
-                                + "    PARTITION `p1` VALUES LESS THAN (\"10\"),\n"
-                                + "    PARTITION `p2` VALUES LESS THAN (\"20\"),\n"
-                                + "    PARTITION `p3` VALUES LESS THAN (\"30\"))\n"
-                                + "distributed by hash(key1)\n"
                                 + "buckets 1 properties('replication_num' = '1', 'storage_medium' = 'ssd');"));
 
         ExceptionChecker


### PR DESCRIPTION

This reverts commit ec72383d3372b519e7957f237fad456130230804.

## Proposed changes

It will cause FE could not upgrade from 2.0 beta.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

