### PR TITLE
[improvement](binlog) Gc BE binlog metas when tablet is dropped

### DIFF
--- a/be/src/olap/binlog.h
+++ b/be/src/olap/binlog.h
@@ -25,8 +25,9 @@
 #include "olap/olap_common.h"
 
 namespace doris {
-constexpr std::string_view kBinlogPrefix = "binglog_";
+constexpr std::string_view kBinlogPrefix = "binlog_";
 constexpr std::string_view kBinlogMetaPrefix = "binlog_meta_";
+constexpr std::string_view kBinlogDataPrefix = "binlog_data_";
 
 inline auto make_binlog_meta_key(std::string_view tablet, int64_t version,
                                  std::string_view rowset) {
@@ -82,7 +83,7 @@ inline bool starts_with_binlog_meta(std::string_view str) {
 }
 
 inline std::string get_binlog_data_key_from_meta_key(std::string_view meta_key) {
-    // like "binglog_meta_6943f1585fe834b5-e542c2b83a21d0b7" => "binglog_data-6943f1585fe834b5-e542c2b83a21d0b7"
+    // like "binlog_meta_6943f1585fe834b5-e542c2b83a21d0b7" => "binlog_data-6943f1585fe834b5-e542c2b83a21d0b7"
     return fmt::format("{}data_{}", kBinlogPrefix, meta_key.substr(kBinlogMetaPrefix.length()));
 }
 } // namespace doris

--- a/be/src/olap/olap_meta.cpp
+++ b/be/src/olap/olap_meta.cpp
@@ -277,12 +277,18 @@ Status OlapMeta::remove(const int column_family_index, const std::vector<std::st
 
 Status OlapMeta::iterate(const int column_family_index, const std::string& prefix,
                          std::function<bool(const std::string&, const std::string&)> const& func) {
+    return iterate(column_family_index, prefix, prefix, func);
+}
+
+Status OlapMeta::iterate(const int column_family_index, const std::string& seek_key,
+                         const std::string& prefix,
+                         std::function<bool(const std::string&, const std::string&)> const& func) {
     auto& handle = _handles[column_family_index];
     std::unique_ptr<Iterator> it(_db->NewIterator(ReadOptions(), handle.get()));
-    if (prefix == "") {
+    if (seek_key == "") {
         it->SeekToFirst();
     } else {
-        it->Seek(prefix);
+        it->Seek(seek_key);
     }
     rocksdb::Status status = it->status();
     if (!status.ok()) {

--- a/be/src/olap/olap_meta.h
+++ b/be/src/olap/olap_meta.h
@@ -60,6 +60,9 @@ public:
 
     Status iterate(const int column_family_index, const std::string& prefix,
                    std::function<bool(const std::string&, const std::string&)> const& func);
+    Status iterate(const int column_family_index, const std::string& seek_key,
+                   const std::string& prefix,
+                   std::function<bool(const std::string&, const std::string&)> const& func);
 
     std::string get_root_path() const { return _root_path; }
 

--- a/be/src/olap/rowset/rowset_meta_manager.h
+++ b/be/src/olap/rowset/rowset_meta_manager.h
@@ -64,9 +64,14 @@ public:
 
     static Status remove(OlapMeta* meta, TabletUid tablet_uid, const RowsetId& rowset_id);
 
-    static Status traverse_rowset_metas(
-            OlapMeta* meta,
-            std::function<bool(const TabletUid&, const RowsetId&, const std::string&)> const& func);
+    static Status remove_binlog(OlapMeta* meta, const std::string& suffix);
+
+    static Status traverse_rowset_metas(OlapMeta* meta,
+                                        std::function<bool(const TabletUid&, const RowsetId&,
+                                                           const std::string&)> const& collector);
+
+    static Status traverse_binlog_metas(
+            OlapMeta* meta, std::function<bool(const string&, const string&, bool)> const& func);
 
     static Status load_json_rowset_meta(OlapMeta* meta, const std::string& rowset_meta_path);
 

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -693,6 +693,9 @@ Status StorageEngine::start_trash_sweep(double* usage, bool ignore_guard) {
     // clean unused rowset metas in OlapMeta
     _clean_unused_rowset_metas();
 
+    // clean unused binlog metas in OlapMeta
+    _clean_unused_binlog_metas();
+
     // cleand unused delete bitmap for deleted tablet
     _clean_unused_delete_bitmap();
 
@@ -771,6 +774,39 @@ void StorageEngine::_clean_unused_rowset_metas() {
         LOG(INFO) << "remove " << invalid_rowset_metas.size()
                   << " invalid rowset meta from dir: " << data_dir->path();
         invalid_rowset_metas.clear();
+    }
+}
+
+void StorageEngine::_clean_unused_binlog_metas() {
+    std::vector<std::string> unused_binlog_key_suffixes;
+    auto unused_binlog_collector = [this, &unused_binlog_key_suffixes](const std::string& key,
+                                                                       const std::string& value,
+                                                                       bool need_check) -> bool {
+        if (need_check) {
+            BinlogMetaEntryPB binlog_meta_pb;
+            if (UNLIKELY(!binlog_meta_pb.ParseFromString(value))) {
+                LOG(WARNING) << "parse rowset meta string failed for binlog meta key: " << key;
+            } else if (_tablet_manager->get_tablet(binlog_meta_pb.tablet_id()) == nullptr) {
+                LOG(INFO) << "failed to find tablet " << binlog_meta_pb.tablet_id()
+                          << " for binlog rowset: " << binlog_meta_pb.rowset_id()
+                          << ", tablet may be dropped";
+            } else {
+                return false;
+            }
+        }
+
+        unused_binlog_key_suffixes.emplace_back(key.substr(kBinlogMetaPrefix.size()));
+        return true;
+    };
+    auto data_dirs = get_stores();
+    for (auto data_dir : data_dirs) {
+        RowsetMetaManager::traverse_binlog_metas(data_dir->get_meta(), unused_binlog_collector);
+        for (const auto& suffix : unused_binlog_key_suffixes) {
+            RowsetMetaManager::remove_binlog(data_dir->get_meta(), suffix);
+        }
+        LOG(INFO) << "remove " << unused_binlog_key_suffixes.size()
+                  << " invalid binlog meta from dir: " << data_dir->path();
+        unused_binlog_key_suffixes.clear();
     }
 }
 

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -254,6 +254,8 @@ private:
 
     void _clean_unused_rowset_metas();
 
+    void _clean_unused_binlog_metas();
+
     void _clean_unused_delete_bitmap();
 
     void _clean_unused_pending_publish_info();

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -3569,7 +3569,7 @@ void Tablet::gc_binlogs(int64_t version) {
         if (binlog_meta_entry_pb.has_rowset_id_v2()) {
             rowset_id = binlog_meta_entry_pb.rowset_id_v2();
         } else {
-            // key is 'binglog_meta_6943f1585fe834b5-e542c2b83a21d0b7_00000000000000000069_020000000000000135449d7cd7eadfe672aa0f928fa99593', extract last part '020000000000000135449d7cd7eadfe672aa0f928fa99593'
+            // key is 'binlog_meta_6943f1585fe834b5-e542c2b83a21d0b7_00000000000000000069_020000000000000135449d7cd7eadfe672aa0f928fa99593', extract last part '020000000000000135449d7cd7eadfe672aa0f928fa99593'
             auto pos = key.rfind('_');
             if (pos == std::string::npos) {
                 LOG(WARNING) << fmt::format("invalid binlog meta key:{}", key);

--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogTombstone.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogTombstone.java
@@ -23,7 +23,6 @@ import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 public class BinlogTombstone {
@@ -35,12 +34,6 @@ public class BinlogTombstone {
 
     @SerializedName(value = "commitSeq")
     private long commitSeq;
-
-    // TODO(deadlinefen): delete this field later
-    // This is a reserved field for the transition between new and old versions.
-    // It will be deleted later
-    @SerializedName(value = "tableIds")
-    private List<Long> tableIds;
 
     @SerializedName(value = "tableCommitSeqMap")
     private Map<Long, Long> tableCommitSeqMap;
@@ -54,7 +47,6 @@ public class BinlogTombstone {
         this.dbBinlogTombstone = isDbTombstone;
         this.dbId = dbId;
         this.commitSeq = -1;
-        this.tableIds = Collections.emptyList();
         this.tableCommitSeqMap = Maps.newHashMap();
     }
 
@@ -62,7 +54,6 @@ public class BinlogTombstone {
         this.dbBinlogTombstone = false;
         this.dbId = -1;
         this.commitSeq = commitSeq;
-        this.tableIds = Collections.emptyList();
         this.tableCommitSeqMap = Collections.singletonMap(tableId, commitSeq);
     }
 
@@ -90,14 +81,6 @@ public class BinlogTombstone {
 
     public long getDbId() {
         return dbId;
-    }
-
-    // TODO(deadlinefen): deprecated this code later
-    public List<Long> getTableIds() {
-        if (tableIds == null) {
-            tableIds = Collections.emptyList();
-        }
-        return tableIds;
     }
 
     public Map<Long, Long> getTableCommitSeqMap() {

--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/DBBinlog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/DBBinlog.java
@@ -424,17 +424,6 @@ public class DBBinlog {
         }
 
         Map<Long, Long> tableCommitSeqMap = tombstone.getTableCommitSeqMap();
-        // TODO(deadlinefen): delete this code
-        // This is a reserved code for the transition between new and old versions.
-        // It will be deleted later
-        if (tableCommitSeqMap.isEmpty()) {
-            long commitSeq = tombstone.getCommitSeq();
-            List<Long> tableIds = tombstone.getTableIds();
-            for (long tableId : tableIds) {
-                tableCommitSeqMap.put(tableId, commitSeq);
-            }
-        }
-
         for (TableBinlog tableBinlog : tableBinlogs) {
             long tableId = tableBinlog.getTableId();
             if (tableCommitSeqMap.containsKey(tableId)) {


### PR DESCRIPTION
## Proposed changes

GC BE binlog metas when tablet is dropped.  

Add a timed GC binlog metas task in the timed GC task of BE. When cleaning, it will traverse all keys starting with binlog_meta_ in the metadata, and get its corresponding rowset meta and check whether the tablet belonging to the rowset meta exists. If it does not exist (that is, it has been dropped), clean up all binlog_meta and binlog_data corresponding to this tablet.  

In the implementation details, because the key of rocksdb is internally ordered, the same tablet will be traversed continuously, so if the tablet uuid obtained this time is the same as the last time, you can skip the check directly and execute the last operation (cleaned up or skipped).   

At the same time, the deletion of binlog_meta and binlog_data corresponding to the same tablet-rowset must be in the same transaction, in order to ensure that metadata leakage does not occur.

## Note

If there are existing binlog meta and tombstone in the cluster, they need to be GCed before upgrading to this version. This upgrade is not a smooth upgrade.
