### PR TITLE
[Improvement](statistics)Return meaningful error message when show column stats column name doesn't exist.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowColumnStatsStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowColumnStatsStmt.java
@@ -39,8 +39,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -91,15 +89,15 @@ public class ShowColumnStatsStmt extends ShowStmt {
         }
         CatalogIf<DatabaseIf> catalog = Env.getCurrentEnv().getCatalogMgr().getCatalog(tableName.getCtl());
         if (catalog == null) {
-            ErrorReport.reportAnalysisException("Catalog: {} not exists", tableName.getCtl());
+            ErrorReport.reportAnalysisException("Catalog: %s not exists", tableName.getCtl());
         }
         DatabaseIf<TableIf> db = catalog.getDb(tableName.getDb()).orElse(null);
         if (db == null) {
-            ErrorReport.reportAnalysisException("DB: {} not exists", tableName.getDb());
+            ErrorReport.reportAnalysisException("DB: %s not exists", tableName.getDb());
         }
         table = db.getTable(tableName.getTbl()).orElse(null);
         if (table == null) {
-            ErrorReport.reportAnalysisException("Table: {} not exists", tableName.getTbl());
+            ErrorReport.reportAnalysisException("Table: %s not exists", tableName.getTbl());
         }
 
         if (!Env.getCurrentEnv().getAccessManager()
@@ -110,12 +108,10 @@ public class ShowColumnStatsStmt extends ShowStmt {
         }
 
         if (columnNames != null) {
-            Optional<Column> nullColumn = columnNames.stream()
-                    .map(table::getColumn)
-                    .filter(Objects::isNull)
-                    .findFirst();
-            if (nullColumn.isPresent()) {
-                ErrorReport.reportAnalysisException("Column: {} not exists", nullColumn.get());
+            for (String name : columnNames) {
+                if (table.getColumn(name) == null) {
+                    ErrorReport.reportAnalysisException("Column: %s not exists", name);
+                }
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
@@ -81,6 +81,8 @@ public class SummaryProfile {
             WRITE_RESULT_TIME, WAIT_FETCH_RESULT_TIME, DORIS_VERSION, IS_NEREIDS, IS_PIPELINE,
             IS_CACHED, TOTAL_INSTANCES_NUM, INSTANCES_NUM_PER_BE, PARALLEL_FRAGMENT_EXEC_INSTANCE, TRACE_ID);
 
+    // Ident of each item. Default is 0, which doesn't need to present in this Map.
+    // Please set this map for new profile items if they need ident.
     public static ImmutableMap<String, Integer> EXECUTION_SUMMARY_KEYS_IDENTATION = ImmutableMap.of();
 
     {


### PR DESCRIPTION
The error message was not good for not exist column while show column stats:
```
MySQL [hive.tpch100]> show column stats `lineitem` (l_extendedpric);
ERROR 1105 (HY000): errCode = 2, detailMessage = Unexpected exception: null
```

This pr show a meaningful message:
```
mysql> show column stats `lineitem` (l_extendedpric);
ERROR 1105 (HY000): errCode = 2, detailMessage = Column: l_extendedpric not exists
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

