### PR TITLE
[fix](load) Crashing caused updating counter with an invalid runtime profile

### DIFF
--- a/be/src/io/fs/buffered_reader.h
+++ b/be/src/io/fs/buffered_reader.h
@@ -383,6 +383,7 @@ protected:
                         const IOContext* io_ctx) override;
 
 private:
+    Status _close_internal();
     size_t get_buffer_pos(int64_t position) const {
         return (position % _whole_pre_buffer_size) / s_max_pre_buffer_size;
     }
@@ -436,6 +437,7 @@ protected:
                         const IOContext* io_ctx) override;
 
 private:
+    Status _close_internal();
     io::FileReaderSPtr _reader;
     std::unique_ptr<char[]> _data = nullptr;
     size_t _size;

--- a/be/src/io/fs/stream_load_pipe.h
+++ b/be/src/io/fs/stream_load_pipe.h
@@ -60,7 +60,9 @@ public:
 
     // called when consumer finished
     Status close() override {
-        cancel("closed");
+        if (!(_finished || _cancelled)) {
+            cancel("closed");
+        }
         return Status::OK();
     }
 

--- a/be/src/vec/exec/format/csv/csv_reader.cpp
+++ b/be/src/vec/exec/format/csv/csv_reader.cpp
@@ -753,4 +753,14 @@ Status CsvReader::_parse_col_types(size_t col_nums, std::vector<TypeDescriptor>*
     return Status::OK();
 }
 
+void CsvReader::close() {
+    if (_line_reader) {
+        _line_reader->close();
+    }
+
+    if (_file_reader) {
+        _file_reader->close();
+    }
+}
+
 } // namespace doris::vectorized

--- a/be/src/vec/exec/format/csv/csv_reader.h
+++ b/be/src/vec/exec/format/csv/csv_reader.h
@@ -80,6 +80,8 @@ public:
     Status get_parsed_schema(std::vector<std::string>* col_names,
                              std::vector<TypeDescriptor>* col_types) override;
 
+    void close() override;
+
 private:
     // used for stream/broker load of csv file.
     Status _create_decompressor();

--- a/be/src/vec/exec/format/generic_reader.h
+++ b/be/src/vec/exec/format/generic_reader.h
@@ -67,6 +67,8 @@ public:
         return Status::OK();
     }
 
+    virtual void close() {}
+
 protected:
     const size_t _MIN_BATCH_SIZE = 4064; // 4094 - 32(padding)
 

--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -100,7 +100,7 @@ ParquetReader::ParquetReader(const TFileScanRangeParams& params, const TFileRang
 }
 
 ParquetReader::~ParquetReader() {
-    close();
+    _close_internal();
 }
 
 void ParquetReader::_init_profile() {
@@ -162,6 +162,10 @@ void ParquetReader::_init_profile() {
 }
 
 void ParquetReader::close() {
+    _close_internal();
+}
+
+void ParquetReader::_close_internal() {
     if (!_closed) {
         if (_profile != nullptr) {
             COUNTER_UPDATE(_parquet_profile.filtered_row_groups, _statistics.filtered_row_groups);

--- a/be/src/vec/exec/format/parquet/vparquet_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.h
@@ -119,7 +119,7 @@ public:
 
     Status get_next_block(Block* block, size_t* read_rows, bool* eof) override;
 
-    void close();
+    void close() override;
 
     RowRange get_whole_range() { return _whole_range; }
 
@@ -182,6 +182,7 @@ private:
 
     Status _open_file();
     void _init_profile();
+    void _close_internal();
     Status _next_row_group_reader();
     RowGroupReader::PositionDeleteContext _get_position_delete_ctx(
             const tparquet::RowGroup& row_group,

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -558,6 +558,9 @@ Status VFileScanner::_convert_to_output_block(Block* block) {
 
 Status VFileScanner::_get_next_reader() {
     while (true) {
+        if (_cur_reader) {
+            _cur_reader->close();
+        }
         _cur_reader.reset(nullptr);
         _src_block_init = false;
         if (_next_range >= _ranges.size()) {
@@ -934,6 +937,10 @@ Status VFileScanner::close(RuntimeState* state) {
     if (config::enable_file_cache && _state->query_options().enable_file_cache) {
         io::FileCacheProfileReporter cache_profile(_profile);
         cache_profile.update(_file_cache_statistics.get());
+    }
+
+    if (_cur_reader) {
+        _cur_reader->close();
     }
 
     RETURN_IF_ERROR(VScanner::close(state));


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

```
==4165385==ERROR: AddressSanitizer: heap-use-after-free on address 0x6030dcd3c740 at pc 0x55ccf2565c73 bp 0x7f715effffd0 sp 0x7f715effffc8
READ of size 8 at 0x6030dcd3c740 thread T454 (_scanner_scan)
    #0 0x55ccf2565c72 in doris::io::PrefetchBufferedReader::PrefetchBufferedReader(doris::RuntimeProfile*, std::shared_ptr, doris::io::PrefetchRange, doris::io::IOContext const*, long)::$_0::operator()(doris::io::PrefetchBuffer&) const /root/doris/be/src/io/fs/buffered_reader.cpp:609:13
    #1 0x55ccf2565bbe in void std::__invoke_impl, doris::io::PrefetchRange, doris::io::IOContext const*, long)::$_0&, doris::io::PrefetchBuffer&>(std::__invoke_other, doris::io::PrefetchBufferedReader::PrefetchBufferedReader(doris::RuntimeProfile*, std::shared_ptr, doris::io::PrefetchRange, doris::io::IOContext const*, long)::$_0&, doris::io::PrefetchBuffer&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #2 0x55ccf2565b20 in std::enable_if, doris::io::PrefetchRange, doris::io::IOContext const*, long)::$_0&, doris::io::PrefetchBuffer&>, void>::type std::__invoke_r, doris::io::PrefetchRange, doris::io::IOContext const*, long)::$_0&, doris::io::PrefetchBuffer&>(doris::io::PrefetchBufferedReader::PrefetchBufferedReader(doris::RuntimeProfile*, std::shared_ptr, doris::io::PrefetchRange, doris::io::IOContext const*, long)::$_0&, doris::io::PrefetchBuffer&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #3 0x55ccf25658f6 in std::_Function_handler, doris::io::PrefetchRange, doris::io::IOContext const*, long)::$_0>::_M_invoke(std::_Any_data const&, doris::io::PrefetchBuffer&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #4 0x55ccf256d3be in std::function::operator()(doris::io::PrefetchBuffer&) const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #5 0x55ccf255d92c in doris::io::PrefetchBuffer::close() /root/doris/be/src/io/fs/buffered_reader.cpp:578:9
    #6 0x55ccf2563ff2 in doris::io::PrefetchBufferedReader::close()::$_0::operator()(std::shared_ptr&) const /root/doris/be/src/io/fs/buffered_reader.cpp:660:77
    #7 0x55ccf2560aa0 in doris::io::PrefetchBufferedReader::close()::$_0 std::for_each<__gnu_cxx::__normal_iterator*, std::vector, std::allocator>>>, doris::io::PrefetchBufferedReader::close()::$_0>(__gnu_cxx::__normal_iterator*, std::vector, std::allocator>>>, __gnu_cxx::__normal_iterator*, std::vector, std::allocator>>>, doris::io::PrefetchBufferedReader::close()::$_0) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_algo.h:3820:2
    #8 0x55ccf256082e in doris::io::PrefetchBufferedReader::close() /root/doris/be/src/io/fs/buffered_reader.cpp:659:9
    #9 0x55ccf255fc4b in doris::io::PrefetchBufferedReader::~PrefetchBufferedReader() /root/doris/be/src/io/fs/buffered_reader.cpp:627:5
    #10 0x55ccf2580a5e in void std::destroy_at(doris::io::PrefetchBufferedReader*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:88:15
    #11 0x55ccf2580979 in void std::allocator_traits>::destroy(std::allocator&, doris::io::PrefetchBufferedReader*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:533:4
    #12 0x55ccf2580347 in std::_Sp_counted_ptr_inplace, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:528:2
    #13 0x55cce238f911 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:168:6
    #14 0x55cce238f649 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:702:11
    #15 0x55cce2390a7a in std::__shared_ptr::~__shared_ptr() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1149:31
    #16 0x55cce2390a44 in std::shared_ptr::~shared_ptr() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr.h:122:11
    #17 0x55ccf251af7d in doris::vectorized::CsvReader::~CsvReader() /root/doris/be/src/vec/exec/format/csv/csv_reader.cpp:129:23
    #18 0x55ccf251aff8 in doris::vectorized::CsvReader::~CsvReader() /root/doris/be/src/vec/exec/format/csv/csv_reader.cpp:129:23
    #19 0x55cce4c79874 in std::default_delete::operator()(doris::vectorized::GenericReader*) const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:85:2
    #20 0x55cce4c50ceb in std::unique_ptr>::~unique_ptr() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:361:4
    #21 0x55ccf767142b in doris::vectorized::VFileScanner::~VFileScanner() /root/doris/be/src/vec/exec/scan/vfile_scanner.h:60:7
    #22 0x55ccf7671468 in doris::vectorized::VFileScanner::~VFileScanner() /root/doris/be/src/vec/exec/scan/vfile_scanner.h:60:7
    #23 0x55ccf744bb24 in std::default_delete::operator()(doris::vectorized::VFileScanner*) const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:85:2
    #24 0x55ccf744c8db in std::_Sp_counted_deleter, std::allocator, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:442:9
    #25 0x55cce238f911 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:168:6
    #26 0x55cce238f649 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:702:11
    #27 0x55ccf73b378a in std::__shared_ptr::~__shared_ptr() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1149:31
    #28 0x55ccf73b1094 in std::shared_ptr::~shared_ptr() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr.h:122:11
    #29 0x55ccf76029b8 in doris::vectorized::ScannerScheduler::_schedule_scanners(doris::vectorized::ScannerContext*)::$_1::operator()() const::'lambda1'()::~() /root/doris/be/src/vec/exec/scan/scanner_scheduler.cpp:214:65
    #30 0x55ccf76048b2 in std::_Function_base::_Base_manager::_M_destroy(std::_Any_data&, std::integral_constant) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:174:4
    #31 0x55ccf7604759 in std::_Function_base::_Base_manager::_M_manager(std::_Any_data&, std::_Any_data const&, std::_Manager_operation) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:200:8
    #32 0x55ccf760414b in std::_Function_handler::_M_manager(std::_Any_data&, std::_Any_data const&, std::_Manager_operation) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:283:6
    #33 0x55cce2414d52 in std::_Function_base::~_Function_base() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:245:2
    #34 0x55cce2478094 in std::function::~function() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:111:11
    #35 0x55cce5aafe38 in doris::FunctionRunnable::~FunctionRunnable() /root/doris/be/src/util/threadpool.cpp:44:7
    #36 0x55cce5aaffb2 in void std::destroy_at(doris::FunctionRunnable*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:88:15
    #37 0x55cce5aafec9 in void std::allocator_traits>::destroy(std::allocator&, doris::FunctionRunnable*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:533:4
    #38 0x55cce5aaf867 in std::_Sp_counted_ptr_inplace, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:528:2
    #39 0x55cce238f911 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:168:6
    #40 0x55cce238f649 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:702:11
    #41 0x55cce470870a in std::__shared_ptr::~__shared_ptr() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1149:31
    #42 0x55cce5aa5f3a in std::__shared_ptr::reset() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1267:9
    #43 0x55cce5a9b200 in doris::ThreadPool::dispatch_thread() /root/doris/be/src/util/threadpool.cpp:539:23
    #44 0x55cce5ac4cd5 in void std::__invoke_impl(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74:14
    #45 0x55cce5ac4b7e in std::__invoke_result::type std::__invoke(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96:14
    #46 0x55cce5ac4af6 in void std::_Bind::__call(std::tuple<>&&, std::_Index_tuple<0ul>) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420:11
    #47 0x55cce5ac498f in void std::_Bind::operator()() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503:17
    #48 0x55cce5ac4896 in void std::__invoke_impl&>(std::__invoke_other, std::_Bind&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #49 0x55cce5ac4808 in std::enable_if&>, void>::type std::__invoke_r&>(std::_Bind&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #50 0x55cce5ac445e in std::_Function_handler>::_M_invoke(std::_Any_data const&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #51 0x55cce2552536 in std::function::operator()() const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #52 0x55cce5a64bff in doris::Thread::supervise_thread(void*) /root/doris/be/src/util/thread.cpp:465:5
    #53 0x7f7db06bc608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477:8
    #54 0x7f7db094b132 in __clone /build/glibc-SzIz7B/glibc-2.31/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

