### PR TITLE
[opt](stacktrace) Optimize stacktrace output

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1017,6 +1017,7 @@ DEFINE_Bool(allow_invalid_decimalv2_literal, "false");
 DEFINE_mInt64(kerberos_expiration_time_seconds, "43200");
 
 DEFINE_mString(get_stack_trace_tool, "libunwind");
+DEFINE_mString(dwarf_location_info_mode, "FAST");
 
 // the ratio of _prefetch_size/_batch_size in AutoIncIDBuffer
 DEFINE_mInt64(auto_inc_prefetch_size_ratio, "10");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1061,6 +1061,12 @@ DECLARE_mInt64(kerberos_expiration_time_seconds);
 // Values include `none`, `glog`, `boost`, `glibc`, `libunwind`
 DECLARE_mString(get_stack_trace_tool);
 
+// DISABLED: Don't resolve location info.
+// FAST: Perform CU lookup using .debug_aranges (might be incomplete).
+// FULL: Scan all CU in .debug_info (slow!) on .debug_aranges lookup failure.
+// FULL_WITH_INLINE: Scan .debug_info (super slower, use with caution) for inline functions in addition to FULL.
+DECLARE_mString(dwarf_location_info_mode);
+
 // the ratio of _prefetch_size/_batch_size in AutoIncIDBuffer
 DECLARE_mInt64(auto_inc_prefetch_size_ratio);
 

--- a/be/src/common/stack_trace.cpp
+++ b/be/src/common/stack_trace.cpp
@@ -34,11 +34,14 @@
 #include <unordered_map>
 
 #include "config.h"
+#include "util/string_util.h"
 #include "vec/common/demangle.h"
 #include "vec/common/hex.h"
 
 #if USE_UNWIND
 #include <libunwind.h>
+#else
+#include <execinfo.h>
 #endif
 
 namespace {
@@ -294,12 +297,14 @@ StackTrace::StackTrace(const ucontext_t& signal_context) {
 }
 
 void StackTrace::tryCapture() {
+    // When unw_backtrace is not available, fall back on the standard
+    // `backtrace` function from execinfo.h.
 #if USE_UNWIND
     size = unw_backtrace(frame_pointers.data(), capacity);
-    __msan_unpoison(frame_pointers.data(), size * sizeof(frame_pointers[0]));
 #else
-    size = 0;
+    size = backtrace(frame_pointers.data(), capacity);
 #endif
+    __msan_unpoison(frame_pointers.data(), size * sizeof(frame_pointers[0]));
 }
 
 /// ClickHouse uses bundled libc++ so type names will be the same on every system thus it's safe to hardcode them
@@ -340,7 +345,7 @@ constexpr bool operator<(const MaybeRef auto& left, const MaybeRef auto& right) 
            std::tuple {right.pointers, right.size, right.offset};
 }
 
-static void toStringEveryLineImpl([[maybe_unused]] bool fatal,
+static void toStringEveryLineImpl([[maybe_unused]] const std::string dwarf_location_info_mode,
                                   const StackTraceRefTriple& stack_trace,
                                   std::function<void(std::string_view)> callback) {
     if (stack_trace.size == 0) {
@@ -349,7 +354,20 @@ static void toStringEveryLineImpl([[maybe_unused]] bool fatal,
 #if defined(__ELF__) && !defined(__FreeBSD__)
 
     using enum doris::Dwarf::LocationInfoMode;
-    const auto mode = fatal ? FULL_WITH_INLINE : FAST;
+    doris::Dwarf::LocationInfoMode mode;
+    auto dwarf_location_info_mode_lower = doris::to_lower(dwarf_location_info_mode);
+    if (dwarf_location_info_mode_lower == "disabled") {
+        mode = DISABLED;
+    } else if (dwarf_location_info_mode_lower == "fast") {
+        mode = FAST;
+    } else if (dwarf_location_info_mode_lower == "full") {
+        mode = FULL;
+    } else if (dwarf_location_info_mode_lower == "full_with_inline") {
+        mode = FULL_WITH_INLINE;
+    } else {
+        LOG(INFO) << "invalid LocationInfoMode: " << dwarf_location_info_mode;
+        mode = DISABLED;
+    }
     auto symbol_index_ptr = doris::SymbolIndex::instance();
     const doris::SymbolIndex& symbol_index = *symbol_index_ptr;
     std::unordered_map<std::string, doris::Dwarf> dwarfs;
@@ -362,7 +380,21 @@ static void toStringEveryLineImpl([[maybe_unused]] bool fatal,
                 reinterpret_cast<const void*>(uintptr_t(virtual_addr) - virtual_offset);
 
         std::stringstream out;
-        out << i << ". ";
+        out << "\t" << i << ". ";
+        if (i < 10) { // for alignment
+            out << " ";
+        }
+
+        if (shouldShowAddress(physical_addr)) {
+            out << "@ ";
+            writePointerHex(physical_addr, out);
+        }
+
+        if (const auto* const symbol = symbol_index.findSymbol(virtual_addr)) {
+            out << "  " << collapseNames(demangle(symbol->name));
+        } else {
+            out << " ?";
+        }
 
         if (std::error_code ec; object && std::filesystem::exists(object->name, ec) && !ec) {
             auto dwarf_it = dwarfs.try_emplace(object->name, object->elf).first;
@@ -371,31 +403,20 @@ static void toStringEveryLineImpl([[maybe_unused]] bool fatal,
 
             if (dwarf_it->second.findAddress(uintptr_t(physical_addr), location, mode,
                                              inline_frames)) {
-                out << location.file.toString() << ":" << location.line << ": ";
+                out << "  " << location.file.toString() << ":" << location.line;
             }
         }
 
-        if (const auto* const symbol = symbol_index.findSymbol(virtual_addr)) {
-            out << collapseNames(demangle(symbol->name));
-        } else {
-            out << "?";
-        }
+        out << "  in " << (object ? object->name : "?");
 
-        if (shouldShowAddress(physical_addr)) {
-            out << " @ ";
-            writePointerHex(physical_addr, out);
-        }
-
-        out << " in " << (object ? object->name : "?");
+        callback(out.str());
 
         for (size_t j = 0; j < inline_frames.size(); ++j) {
             const auto& frame = inline_frames[j];
-            callback(fmt::format("{}.{}. inlined from {}:{}: {}", i, j + 1,
-                                 frame.location.file.toString(), frame.location.line,
-                                 collapseNames(demangle(frame.name))));
+            callback(fmt::format("\t{}.{}. inlined from {}: {}:{}", i, j + 1,
+                                 collapseNames(demangle(frame.name)),
+                                 frame.location.file.toString(), frame.location.line));
         }
-
-        callback(out.str());
     }
 #else
     for (size_t i = stack_trace.offset; i < stack_trace.size; ++i)
@@ -405,7 +426,7 @@ static void toStringEveryLineImpl([[maybe_unused]] bool fatal,
 }
 
 void StackTrace::toStringEveryLine(std::function<void(std::string_view)> callback) const {
-    toStringEveryLineImpl(true, {frame_pointers, offset, size}, std::move(callback));
+    toStringEveryLineImpl("FULL_WITH_INLINE", {frame_pointers, offset, size}, std::move(callback));
 }
 
 using StackTraceCache = std::map<StackTraceTriple, std::string, std::less<>>;
@@ -430,14 +451,18 @@ std::string toStringCached(const StackTrace::FramePointers& pointers, size_t off
         return it->second;
     } else {
         std::stringstream out;
-        toStringEveryLineImpl(false, key, [&](std::string_view str) { out << str << '\n'; });
+        toStringEveryLineImpl(doris::config::dwarf_location_info_mode, key,
+                              [&](std::string_view str) { out << str << '\n'; });
 
         return cache.emplace(StackTraceTriple {pointers, offset, size}, out.str()).first->second;
     }
 }
 
 std::string StackTrace::toString() const {
-    return toStringCached(frame_pointers, offset, size);
+    // Delete the first three frame pointers, which are inside the stacktrace.
+    StackTrace::FramePointers frame_pointers_raw {};
+    std::copy(frame_pointers.begin() + 3, frame_pointers.end(), frame_pointers_raw.begin());
+    return toStringCached(frame_pointers_raw, offset, size - 3);
 }
 
 std::string StackTrace::toString(void** frame_pointers_raw, size_t offset, size_t size) {

--- a/be/src/util/stack_util.cpp
+++ b/be/src/util/stack_util.cpp
@@ -45,11 +45,7 @@ std::string get_stack_trace() {
     } else if (tool == "glibc") {
         return get_stack_trace_by_glibc();
     } else if (tool == "libunwind") {
-#if USE_UNWIND
         return get_stack_trace_by_libunwind();
-#else
-        return get_stack_trace_by_glog();
-#endif
     } else {
         return "no stack";
     }
@@ -82,7 +78,7 @@ std::string get_stack_trace_by_glibc() {
 }
 
 std::string get_stack_trace_by_libunwind() {
-    return StackTrace().toString();
+    return "\n" + StackTrace().toString();
 }
 
 } // namespace doris

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1434,9 +1434,9 @@ build_jemalloc() {
 
 # libunwind
 build_libunwind() {
-    # https://github.com/libunwind/libunwind
-    # https://github.com/libunwind/libunwind/issues/189
-    # https://stackoverflow.com/questions/27842377/building-libunwind-for-mac
+    # There are two major variants of libunwind. libunwind on Linux
+    # (https://www.nongnu.org/libunwind/) provides unw_backtrace, and
+    # Apache/LLVM libunwind (notably used on Apple platforms) doesn't
     if [[ "${KERNEL}" != 'Darwin' ]]; then
         check_if_source_exist "${LIBUNWIND_SOURCE}"
         cd "${TP_SOURCE_DIR}/${LIBUNWIND_SOURCE}"


### PR DESCRIPTION
## Proposed changes

1. add dwarf location info mode,
- The default `FAST`, parse`elf .debug_aranges`, when there is inlined, the parsed file path and line number may incorrect.
- Set to `FULL_WITH_INLINE`, parse`elf .debug_info`, can get the correct file path and line number, but this will be about 3 times slower than `FAST`.

2. For Apple, when `unw_backtrace `is not available, fall back on the standard `backtrace` function from execinfo.h. `FAST` will have no line numbers, `FULL_WITH_INLINE` same as `libunwind` `unw_backtrace`, can get the correct file path and line number.

3. Optimize the print of stacktrace to be clearer.

dwarf location info mode is `FAST`
```
I0801 19:50:16.071725 4047591 memtable.cpp:170] doris::get_stack_trace() 5555
        0.  @ 0x000000000ad3e961  doris::MemTable::insert(doris::vectorized::Block const*, std::vector<int, std::allocator<int> > const&, bool)  /mnt/disk2/liyifan/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:187
 in /mnt/disk2/liyifan/doris/core/output_run/be/lib/doris_be
        1.  @ 0x000000000ad2f7ee  doris::DeltaWriter::write(doris::vectorized::Block const*, std::vector<int, std::allocator<int> > const&, bool)  /mnt/disk2/liyifan/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:173
 in /mnt/disk2/liyifan/doris/core/output_run/be/lib/doris_be
        2.  @ 0x000000000b75e752  std::_Function_handler<doris::Status (doris::DeltaWriter*), doris::TabletsChannel::add_batch(doris::PTabletWriterAddBlockRequest const&, doris::PTabletWriterAddBlockResult*)::$_3>::_M_invoke(std::_Any_data const&, doris::DeltaWriter*&&)
  /mnt/disk2/liyifan/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291  in /mnt/disk2/liyifan/doris/core/output_run/be/lib/doris_be
        3.  @ 0x000000000b75de6c  doris::TabletsChannel::add_batch(doris::PTabletWriterAddBlockRequest const&, doris::PTabletWriterAddBlockResult*)::$_1::operator()(unsigned int, std::function<doris::Status (doris::DeltaWriter*)>) const  /mnt/disk2/liyifan/doris/core/be
/src/common/status.h:414  in /mnt/disk2/liyifan/doris/core/output_run/be/lib/doris_be
        5.  @ 0x000000000b75d754  doris::TabletsChannel::add_batch(doris::PTabletWriterAddBlockRequest const&, doris::PTabletWriterAddBlockResult*)  /mnt/disk2/liyifan/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:
244  in /mnt/disk2/liyifan/doris/core/output_run/be/lib/doris_be
        6.  @ 0x000000000b6aa774  doris::LoadChannel::add_batch(doris::PTabletWriterAddBlockRequest const&, doris::PTabletWriterAddBlockResult*)  /mnt/disk2/liyifan/doris/core/be/src/common/status.h:414  in /mnt/disk2/liyifan/doris/core/output_run/be/lib/doris_be
        7.  @ 0x000000000b6a4ed5  doris::LoadChannelMgr::add_batch(doris::PTabletWriterAddBlockRequest const&, doris::PTabletWriterAddBlockResult*)  /mnt/disk2/liyifan/doris/core/be/src/common/status.h:414  in /mnt/disk2/liyifan/doris/core/output_run/be/lib/doris_be
        8.  @ 0x000000000b7a441f  std::_Function_handler<void (), doris::PInternalServiceImpl::_tablet_writer_add_block(google::protobuf::RpcController*, doris::PTabletWriterAddBlockRequest const*, doris::PTabletWriterAddBlockResult*, google::protobuf::Closure*)::$_0>::
_M_invoke(std::_Any_data const&)  /mnt/disk2/liyifan/doris/core/be/src/common/status.h:414  in /mnt/disk2/liyifan/doris/core/output_run/be/lib/doris_be
        9.  @ 0x000000000ad190f2  doris::PriorityThreadPool::work_thread(int)  /mnt/disk2/liyifan/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/atomic_base.h:646  in /mnt/disk2/liyifan/doris/core/output_run/be/lib/doris_be
        10.  @ 0x00000000151837e0  execute_native_thread_routine  /data/gcc-11.1.0/build/x86_64-pc-linux-gnu/libstdc++-v3/include/bits/unique_ptr.h:85  in /mnt/disk2/liyifan/doris/core/output_run/be/lib/doris_be
        11. @ 0x000000000000817a  start_thread  in /usr/lib64/libpthread-2.28.so
        12. @ 0x00000000000fcdf3  __GI___clone  in /usr/lib64/libc-2.28.so
```

dwarf location info mode is `FULL_WITH_INLINE`
```
I0801 19:47:43.947413 4032483 memtable.cpp:170] doris::get_stack_trace() 5555
        0.  @ 0x000000000ad3e961  doris::MemTable::insert(doris::vectorized::Block const*, std::vector<int, std::allocator<int> > const&, bool)  /mnt/disk2/liyifan/doris/core/be/src/olap/memtable.cpp:170  in /mnt/disk2/liyifan/doris/core/output_run/be/lib/doris_be
        0.1. inlined from std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_data() const: /mnt/disk2/liyifan/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:187
        0.2. inlined from std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::data() const: /mnt/disk2/liyifan/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:2319
        0.3. inlined from std::basic_ostream<char, std::char_traits<char> >& std::operator<< <char, std::char_traits<char>, std::allocator<char> >(std::basic_ostream<char, std::char_traits<char> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator
<char> > const&): /mnt/disk2/liyifan/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:6522
        1.  @ 0x000000000ad2f7ee  doris::DeltaWriter::write(doris::vectorized::Block const*, std::vector<int, std::allocator<int> > const&, bool)  /mnt/disk2/liyifan/doris/core/be/src/olap/delta_writer.cpp:266  in /mnt/disk2/liyifan/doris/core/output_run/be/lib/doris_be
        1.1. inlined from std::__uniq_ptr_impl<doris::MemTable, std::default_delete<doris::MemTable> >::_M_ptr() const: /mnt/disk2/liyifan/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:173
        1.2. inlined from std::unique_ptr<doris::MemTable, std::default_delete<doris::MemTable> >::get() const: /mnt/disk2/liyifan/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:422
        1.3. inlined from std::unique_ptr<doris::MemTable, std::default_delete<doris::MemTable> >::operator->() const: /mnt/disk2/liyifan/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:416
        2.  @ 0x000000000b75e752  std::_Function_handler<doris::Status (doris::DeltaWriter*), doris::TabletsChannel::add_batch(doris::PTabletWriterAddBlockRequest const&, doris::PTabletWriterAddBlockResult*)::$_3>::_M_invoke(std::_Any_data const&, doris::DeltaWriter*&&)
  /mnt/disk2/liyifan/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291  in /mnt/disk2/liyifan/doris/core/output_run/be/lib/doris_be
        3.  @ 0x000000000b75de6c  doris::TabletsChannel::add_batch(doris::PTabletWriterAddBlockRequest const&, doris::PTabletWriterAddBlockResult*)::$_1::operator()(unsigned int, std::function<doris::Status (doris::DeltaWriter*)>) const  /mnt/disk2/liyifan/doris/core/be
/src/runtime/tablets_channel.cpp:444  in /mnt/disk2/liyifan/doris/core/output_run/be/lib/doris_be
        3.1. inlined from doris::Status::ok() const: /mnt/disk2/liyifan/doris/core/be/src/common/status.h:414
        4.  @ 0x000000000b75d754  doris::TabletsChannel::add_batch(doris::PTabletWriterAddBlockRequest const&, doris::PTabletWriterAddBlockResult*)  /mnt/disk2/liyifan/doris/core/be/src/runtime/tablets_channel.cpp:469  in /mnt/disk2/liyifan/doris/core/output_run/be/lib/
doris_be
        4.1. inlined from ~_Function_base: /mnt/disk2/liyifan/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:244
        5.  @ 0x000000000b6aa774  doris::LoadChannel::add_batch(doris::PTabletWriterAddBlockRequest const&, doris::PTabletWriterAddBlockResult*)  /mnt/disk2/liyifan/doris/core/be/src/runtime/load_channel.cpp:126  in /mnt/disk2/liyifan/doris/core/output_run/be/lib/doris_
be
        5.1. inlined from doris::Status::ok() const: /mnt/disk2/liyifan/doris/core/be/src/common/status.h:414
        6.  @ 0x000000000b6a4ed5  doris::LoadChannelMgr::add_batch(doris::PTabletWriterAddBlockRequest const&, doris::PTabletWriterAddBlockResult*)  /mnt/disk2/liyifan/doris/core/be/src/runtime/load_channel_mgr.cpp:171  in /mnt/disk2/liyifan/doris/core/output_run/be/lib
/doris_be
        6.1. inlined from doris::Status::ok() const: /mnt/disk2/liyifan/doris/core/be/src/common/status.h:414
        7.  @ 0x000000000b7a441f  std::_Function_handler<void (), doris::PInternalServiceImpl::_tablet_writer_add_block(google::protobuf::RpcController*, doris::PTabletWriterAddBlockRequest const*, doris::PTabletWriterAddBlockResult*, google::protobuf::Closure*)::$_0>::
_M_invoke(std::_Any_data const&)  /mnt/disk2/liyifan/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291  in /mnt/disk2/liyifan/doris/core/output_run/be/lib/doris_be
        7.1. inlined from doris::Status::ok() const: /mnt/disk2/liyifan/doris/core/be/src/common/status.h:414
        7.2. inlined from operator(): /mnt/disk2/liyifan/doris/core/be/src/service/internal_service.cpp:382
        7.3. inlined from void std::__invoke_impl<void, doris::PInternalServiceImpl::_tablet_writer_add_block(google::protobuf::RpcController*, doris::PTabletWriterAddBlockRequest const*, doris::PTabletWriterAddBlockResult*, google::protobuf::Closure*)::$_0&>(std::__inv
oke_other, doris::PInternalServiceImpl::_tablet_writer_add_block(google::protobuf::RpcController*, doris::PTabletWriterAddBlockRequest const*, doris::PTabletWriterAddBlockResult*, google::protobuf::Closure*)::$_0&): /mnt/disk2/liyifan/doris/ldb_toolchain/bin/../lib/gcc/
x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
        7.4. inlined from std::enable_if<is_invocable_r_v<void, doris::PInternalServiceImpl::_tablet_writer_add_block(google::protobuf::RpcController*, doris::PTabletWriterAddBlockRequest const*, doris::PTabletWriterAddBlockResult*, google::protobuf::Closure*)::$_0&>, v
oid>::type std::__invoke_r<void, doris::PInternalServiceImpl::_tablet_writer_add_block(google::protobuf::RpcController*, doris::PTabletWriterAddBlockRequest const*, doris::PTabletWriterAddBlockResult*, google::protobuf::Closure*)::$_0&>(doris::PInternalServiceImpl::_tab
let_writer_add_block(google::protobuf::RpcController*, doris::PTabletWriterAddBlockRequest const*, doris::PTabletWriterAddBlockResult*, google::protobuf::Closure*)::$_0&): /mnt/disk2/liyifan/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/
11/bits/invoke.h:111
        8.  @ 0x000000000ad190f2  doris::PriorityThreadPool::work_thread(int)  /mnt/disk2/liyifan/doris/core/be/src/util/priority_thread_pool.hpp:147  in /mnt/disk2/liyifan/doris/core/output_run/be/lib/doris_be
        8.1. inlined from std::__atomic_base<int>::fetch_sub(int, std::memory_order): /mnt/disk2/liyifan/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/atomic_base.h:646
        8.2. inlined from std::__atomic_base<int>::operator--(int): /mnt/disk2/liyifan/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/atomic_base.h:370
        9.  @ 0x00000000151837e0  execute_native_thread_routine  /data/gcc-11.1.0/build/x86_64-pc-linux-gnu/libstdc++-v3/include/bits/unique_ptr.h:85  in /mnt/disk2/liyifan/doris/core/output_run/be/lib/doris_be
        10. @ 0x000000000000817a  start_thread  in /usr/lib64/libpthread-2.28.so
        11. @ 0x00000000000fcdf3  __GI___clone  in /usr/lib64/libc-2.28.so
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

