### PR TITLE
[refactor](config) rename segcompaction_max_threads

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -377,9 +377,6 @@ DEFINE_mInt64(compaction_min_size_mbytes, "64");
 DEFINE_mInt64(cumulative_compaction_min_deltas, "5");
 DEFINE_mInt64(cumulative_compaction_max_deltas, "1000");
 
-// This config can be set to limit thread number in  segcompaction thread pool.
-DEFINE_mInt32(seg_compaction_max_threads, "10");
-
 // This config can be set to limit thread number in  multiget thread pool.
 DEFINE_mInt32(multi_get_max_threads, "10");
 
@@ -917,6 +914,9 @@ DEFINE_Int32(segcompaction_threshold_segment_num, "10");
 
 // The segment whose row number above the threshold will be compacted during segcompaction
 DEFINE_Int32(segcompaction_small_threshold, "1048576");
+
+// This config can be set to limit thread number in  segcompaction thread pool.
+DEFINE_mInt32(segcompaction_max_threads, "10");
 
 // enable java udf and jdbc scannode
 DEFINE_Bool(enable_java_support, "true");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -423,9 +423,6 @@ DECLARE_mInt64(compaction_min_size_mbytes);
 DECLARE_mInt64(cumulative_compaction_min_deltas);
 DECLARE_mInt64(cumulative_compaction_max_deltas);
 
-// This config can be set to limit thread number in  segcompaction thread pool.
-DECLARE_mInt32(seg_compaction_max_threads);
-
 // This config can be set to limit thread number in  multiget thread pool.
 DECLARE_mInt32(multi_get_max_threads);
 
@@ -956,6 +953,9 @@ DECLARE_Int32(segcompaction_threshold_segment_num);
 
 // The segment whose row number above the threshold will be compacted during segcompaction
 DECLARE_Int32(segcompaction_small_threshold);
+
+// This config can be set to limit thread number in  segcompaction thread pool.
+DECLARE_mInt32(segcompaction_max_threads);
 
 // enable java udf and jdbc scannode
 DECLARE_Bool(enable_java_support);

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -131,8 +131,8 @@ Status StorageEngine::start_bg_threads() {
 
     if (config::enable_segcompaction) {
         ThreadPoolBuilder("SegCompactionTaskThreadPool")
-                .set_min_threads(config::seg_compaction_max_threads)
-                .set_max_threads(config::seg_compaction_max_threads)
+                .set_min_threads(config::segcompaction_max_threads)
+                .set_max_threads(config::segcompaction_max_threads)
                 .build(&_seg_compaction_thread_pool);
     }
     ThreadPoolBuilder("ColdDataCompactionTaskThreadPool")


### PR DESCRIPTION
## Proposed changes

Rename `seg_compaction_max_threads` to `segcompaction_max_threads`.
And move it closer to other segcompaction configs.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

