### PR TITLE
[Fix](Planner) fix create view tosql not include partition

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TableRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TableRef.java
@@ -249,13 +249,6 @@ public class TableRef implements ParseNode, Writable {
             output.append("[").append(Joiner.on(", ").join(joinHints)).append("] ");
         }
         output.append(tableRefToSql()).append(" ");
-        if (partitionNames != null) {
-            StringJoiner sj = new StringJoiner(",", "", " ");
-            for (String partName : partitionNames.getPartitionNames()) {
-                sj.add(partName);
-            }
-            output.append(sj.toString());
-        }
         if (usingColNames != null) {
             output.append("USING (").append(Joiner.on(", ").join(usingColNames)).append(")");
         } else if (onClause != null) {
@@ -780,6 +773,13 @@ public class TableRef implements ParseNode, Writable {
             for (LateralViewRef viewRef : lateralViewRefs) {
                 tblName += " " + viewRef.toSql();
             }
+        }
+        if (partitionNames != null) {
+            StringJoiner sj = new StringJoiner(",", "", " ");
+            for (String partName : partitionNames.getPartitionNames()) {
+                sj.add(partName);
+            }
+            return tblName + " PARTITION(" + sj.toString() + ")";
         }
         return tblName;
     }

--- a/regression-test/suites/ddl_p0/test_create_view.groovy
+++ b/regression-test/suites/ddl_p0/test_create_view.groovy
@@ -69,4 +69,46 @@ suite("test_create_view") {
     sql """select * from test_count_distinct"""
     sql """DROP VIEW IF EXISTS test_count_distinct"""
     sql """DROP TABLE IF EXISTS count_distinct"""
+
+    sql """DROP TABLE IF EXISTS t1"""
+    sql """
+    CREATE TABLE `t1` (
+        k1 int,
+        k2 date,
+        v1 int
+        ) ENGINE=OLAP
+        UNIQUE KEY(`k1`,`k2`)
+        COMMENT '测试'
+        PARTITION BY RANGE(k2) (
+        PARTITION p1 VALUES [('2023-07-01'), ('2023-07-10')),
+        PARTITION p2 VALUES [('2023-07-11'), ('2023-07-20'))
+        )
+        DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1"
+        );"""
+    sql """DROP TABLE IF EXISTS t2"""
+    sql """
+    CREATE TABLE `t2` (
+        k1 int,
+        k2 date,
+        v1 int
+        ) ENGINE=OLAP
+        UNIQUE KEY(`k1`,`k2`)
+        COMMENT '测试'
+        PARTITION BY RANGE(k2) (
+        PARTITION p1 VALUES [('2023-07-01'), ('2023-07-05')),
+        PARTITION p2 VALUES [('2023-07-05'), ('2023-07-15'))
+        )
+        DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1"
+        ); """
+    sql """
+        CREATE VIEW IF NOT EXISTS my_view AS
+        SELECT t1.* FROM t1 PARTITION(p1) JOIN t2 PARTITION(p2) ON t1.k1 = t2.k1; """
+    sql """SELECT * FROM my_view"""
+    sql """DROP VIEW IF EXISTS my_view"""
+    sql """DROP TABLE IF EXISTS t1"""
+    sql """DROP TABLE IF EXISTS t2"""
 }


### PR DESCRIPTION
## Proposed changes

Problem:
When create view with join in table partitions, an error would rise like "Unknown column"

Example:
CREATE VIEW my_view AS SELECT t1.* FROM t1 PARTITION(p1) JOIN t2 PARTITION(p2) ON t1.k1 = t2.k1;
select * from my_view  ==> errCode = 2, detailMessage = Unknown column 'k1' in 't2'

Reason:
When create view, we do tosql first in order to persistent view sql. And when doing tosql of table reference, partition key 
word was removed to keep neat of sql string. But here when we remove partition keyword it would regarded as an alias.
So "PARTITION" keyword can not be removed.

Solved:
Add “PARTITION” keyword back to tosql string.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

