### PR TITLE
[Improvement](statistics)Improve show analyze performance.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfo.java
@@ -39,6 +39,7 @@ import java.lang.reflect.Type;
 import java.text.ParseException;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringJoiner;
@@ -79,8 +80,13 @@ public class AnalysisInfo implements Writable {
     @SerializedName("jobId")
     public final long jobId;
 
+    // When this AnalysisInfo represent a task, this is the task id for it.
     @SerializedName("taskId")
     public final long taskId;
+
+    // When this AnalysisInfo represent a job, this is the list of task ids belong to this job.
+    @SerializedName("taskIds")
+    public final List<Long> taskIds;
 
     @SerializedName("catalogName")
     public final String catalogName;
@@ -161,7 +167,7 @@ public class AnalysisInfo implements Writable {
 
     public CronExpression cronExpression;
 
-    public AnalysisInfo(long jobId, long taskId, String catalogName, String dbName, String tblName,
+    public AnalysisInfo(long jobId, long taskId, List<Long> taskIds, String catalogName, String dbName, String tblName,
             Map<String, Set<String>> colToPartitions, Set<String> partitionNames, String colName, Long indexId,
             JobType jobType, AnalysisMode analysisMode, AnalysisMethod analysisMethod, AnalysisType analysisType,
             int samplePercent, int sampleRows, int maxBucketNum, long periodTimeInMs, String message,
@@ -170,6 +176,7 @@ public class AnalysisInfo implements Writable {
             CronExpression cronExpression) {
         this.jobId = jobId;
         this.taskId = taskId;
+        this.taskIds = taskIds;
         this.catalogName = catalogName;
         this.dbName = dbName;
         this.tblName = tblName;
@@ -239,6 +246,10 @@ public class AnalysisInfo implements Writable {
 
     public boolean isJob() {
         return taskId == -1;
+    }
+
+    public void addTaskId(long taskId) {
+        taskIds.add(taskId);
     }
 
     // TODO: use thrift

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfoBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfoBuilder.java
@@ -25,12 +25,14 @@ import org.apache.doris.statistics.AnalysisInfo.ScheduleType;
 
 import org.quartz.CronExpression;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 public class AnalysisInfoBuilder {
     private long jobId;
     private long taskId;
+    private List<Long> taskIds;
     private String catalogName;
     private String dbName;
     private String tblName;
@@ -63,6 +65,7 @@ public class AnalysisInfoBuilder {
     public AnalysisInfoBuilder(AnalysisInfo info) {
         jobId = info.jobId;
         taskId = info.taskId;
+        taskIds = info.taskIds;
         catalogName = info.catalogName;
         dbName = info.dbName;
         tblName = info.tblName;
@@ -95,6 +98,11 @@ public class AnalysisInfoBuilder {
 
     public AnalysisInfoBuilder setTaskId(long taskId) {
         this.taskId = taskId;
+        return this;
+    }
+
+    public AnalysisInfoBuilder setTaskIds(List<Long> taskIds) {
+        this.taskIds = taskIds;
         return this;
     }
 
@@ -218,7 +226,7 @@ public class AnalysisInfoBuilder {
     }
 
     public AnalysisInfo build() {
-        return new AnalysisInfo(jobId, taskId, catalogName, dbName, tblName, colToPartitions, partitionNames,
+        return new AnalysisInfo(jobId, taskId, taskIds, catalogName, dbName, tblName, colToPartitions, partitionNames,
                 colName, indexId, jobType, analysisMode, analysisMethod, analysisType, samplePercent,
                 sampleRows, maxBucketNum, periodTimeInMs, message, lastExecTimeInMs, timeCostInMs, state, scheduleType,
                 externalTableLevelTask, partitionOnly, samplingPartition, cronExpression);
@@ -228,6 +236,7 @@ public class AnalysisInfoBuilder {
         return new AnalysisInfoBuilder()
                 .setJobId(jobId)
                 .setTaskId(taskId)
+                .setTaskIds(taskIds)
                 .setCatalogName(catalogName)
                 .setDbName(dbName)
                 .setTblName(tblName)

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
@@ -59,6 +59,7 @@ import org.apache.doris.statistics.AnalysisInfo.ScheduleType;
 import org.apache.doris.statistics.util.StatisticsUtil;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.logging.log4j.LogManager;
@@ -452,6 +453,7 @@ public class AnalysisManager extends Daemon implements Writable {
         Map<String, Set<String>> colToPartitions = validateAndGetPartitions(table, columnNames,
                 partitionNames, analysisType, analysisMode);
         taskInfoBuilder.setColToPartitions(colToPartitions);
+        taskInfoBuilder.setTaskIds(Lists.newArrayList());
 
         return taskInfoBuilder.build();
     }
@@ -524,6 +526,7 @@ public class AnalysisManager extends Daemon implements Writable {
                 AnalysisInfoBuilder indexTaskInfoBuilder = new AnalysisInfoBuilder(jobInfo);
                 AnalysisInfo analysisInfo = indexTaskInfoBuilder.setIndexId(indexId)
                         .setTaskId(taskId).setLastExecTimeInMs(System.currentTimeMillis()).build();
+                jobInfo.addTaskId(taskId);
                 if (isSync) {
                     return;
                 }
@@ -550,6 +553,7 @@ public class AnalysisManager extends Daemon implements Writable {
             AnalysisInfo analysisInfo = colTaskInfoBuilder.setColName(colName).setIndexId(indexId)
                     .setTaskId(taskId).setLastExecTimeInMs(System.currentTimeMillis()).build();
             analysisTasks.put(taskId, createTask(analysisInfo));
+            jobInfo.addTaskId(taskId);
             if (isSync) {
                 continue;
             }
@@ -593,6 +597,7 @@ public class AnalysisManager extends Daemon implements Writable {
         AnalysisInfo analysisInfo = colTaskInfoBuilder.setIndexId(-1L).setLastExecTimeInMs(System.currentTimeMillis())
                 .setTaskId(taskId).setColName("TableRowCount").setExternalTableLevelTask(true).build();
         analysisTasks.put(taskId, createTask(analysisInfo));
+        jobInfo.addTaskId(taskId);
         if (isSync) {
             // For sync job, don't need to persist, return here and execute it immediately.
             return;
@@ -721,7 +726,10 @@ public class AnalysisManager extends Daemon implements Writable {
     }
 
     public String getJobProgress(long jobId) {
-        List<AnalysisInfo> tasks = findTasks(jobId);
+        List<AnalysisInfo> tasks = findTasksByTaskIds(jobId);
+        if (tasks == null) {
+            return "N/A";
+        }
         int finished = 0;
         int failed = 0;
         int inProgress = 0;
@@ -944,6 +952,14 @@ public class AnalysisManager extends Daemon implements Writable {
         synchronized (analysisTaskInfoMap) {
             return analysisTaskInfoMap.values().stream().filter(i -> i.jobId == jobId).collect(Collectors.toList());
         }
+    }
+
+    public List<AnalysisInfo> findTasksByTaskIds(long jobId) {
+        AnalysisInfo jobInfo = analysisJobInfoMap.get(jobId);
+        if (jobInfo != null && jobInfo.taskIds != null) {
+            return jobInfo.taskIds.stream().map(id -> analysisTaskInfoMap.get(id)).collect(Collectors.toList());
+        }
+        return null;
     }
 
     public void removeAll(List<AnalysisInfo> analysisInfos) {


### PR DESCRIPTION
The origin show analyze code would traverse the task id to task map for each job to get all the tasks for this job, which is very slow.
This pr keep the task ids for each job in the job info class, so that we can get the tasks by task ids directly.
To show 1100+ jobs with 11000+ tasks, the time costing is reduced from 0.14s to 0.01s.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

