### PR TITLE
[Bug](exchange) fix core dump on send_local_block

### DIFF
--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -224,7 +224,9 @@ Status Channel::close_wait(RuntimeState* state) {
         _need_close = false;
         return st;
     }
-    _serializer->reset_block();
+    if (_serializer) {
+        _serializer->reset_block();
+    }
     return Status::OK();
 }
 

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -647,14 +647,14 @@ Status VDataStreamSender::try_close(RuntimeState* state, Status exec_status) {
         RETURN_IF_ERROR(_get_next_available_buffer(&block_holder));
         {
             SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
-            auto block = _serializer->get_block()->to_block();
+            Block block = _serializer->get_block()->to_block();
             RETURN_IF_ERROR(_serializer->serialize_block(&block, block_holder->get_block(),
                                                          _channels.size()));
             Status status;
             for (auto channel : _channels) {
                 if (!channel->is_receiver_eof()) {
                     if (channel->is_local()) {
-                        status = channel->send_local_block(block);
+                        status = channel->send_local_block(&block);
                     } else {
                         SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
                         status = channel->send_block(block_holder, false);


### PR DESCRIPTION
## Proposed changes
https://github.com/apache/doris/commit/d585a8acc18e4ceb4ab9e625b9721c80124d27f7
```cpp
*** Query id: bca04bf2c0454aef-b0ce0a43c0384b3d ***
*** Aborted at 1690938778 (unix time) try "date -d @1690938778" if you are using GNU date ***
*** Current BE git commitID: ff0fda460c ***
*** SIGSEGV address not mapped to object (@0x8) received by PID 68147 (TID 68442 OR 0x7fb05ab42700) from PID 8; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:413
 1# 0x00007FB75D620BF9 in /usr/lib/jvm/java-1.11.0-openjdk-amd64/lib/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-1.11.0-openjdk-amd64/lib/server/libjvm.so
 3# 0x00007FB75D61993C in /usr/lib/jvm/java-1.11.0-openjdk-amd64/lib/server/libjvm.so
 4# 0x00007FB7776580C0 in /lib/x86_64-linux-gnu/libc.so.6
 5# std::vector<COW<doris::vectorized::IColumn>::mutable_ptr<doris::vectorized::IColumn>, std::allocator<COW<doris::vectorized::IColumn>::mutable_ptr<doris::vectorized::IColumn> > >::size() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:919
 6# doris::vectorized::MutableBlock::to_block(int) at /home/zcp/repo_center/doris_master/doris/be/src/vec/core/block.cpp:969
 7# doris::vectorized::Channel::send_local_block(bool) at /home/zcp/repo_center/doris_master/doris/be/src/vec/sink/vdata_stream_sender.cpp:125
 8# doris::vectorized::VDataStreamSender::try_close(doris::RuntimeState*, doris::Status) at /home/zcp/repo_center/doris_master/doris/be/src/vec/sink/vdata_stream_sender.cpp:657
 9# doris::pipeline::DataSinkOperator<doris::pipeline::ExchangeSinkOperatorBuilder>::try_close(doris::RuntimeState*) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/exec/operator.h:288
10# doris::pipeline::PipelineTask::try_close() at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/pipeline_task.cpp:291
11# doris::pipeline::TaskScheduler::_try_close_task(doris::pipeline::PipelineTask*, doris::pipeline::PipelineTaskState) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/task_scheduler.cpp:335
12# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/task_scheduler.cpp:306
13# void std::__invoke_impl<void, void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&>(std::__invoke_memfun_deref, void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
14# std::__invoke_result<void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&>::type std::__invoke<void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&>(void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
15# void std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>::__call<void, , 0ul, 1ul>(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420
16# void std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>::operator()<, void>() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503
17# void std::__invoke_impl<void, std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>&>(std::__invoke_other, std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
18# std::enable_if<is_invocable_r_v<void, std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>&>, void>::type std::__invoke_r<void, std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>&>(std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
19# std::_Function_handler<void (), std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)> >::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
20# std::function<void ()>::operator()() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
21# doris::FunctionRunnable::run() at /home/zcp/repo_center/doris_master/doris/be/src/util/threadpool.cpp:48
22# doris::ThreadPool::dispatch_thread() at /home/zcp/repo_center/doris_master/doris/be/src/util/threadpool.cpp:531
23# void std::__invoke_impl<void, void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
24# std::__invoke_result<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>::type std::__invoke<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
25# void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420
26# void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::operator()<, void>() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503
27# void std::__invoke_impl<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
28# std::enable_if<is_invocable_r_v<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
29# std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
30# std::function<void ()>::operator()() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
31# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_master/doris/be/src/util/thread.cpp:465
32# start_thread at /build/glibc-sMfBJT/glibc-2.31/nptl/pthread_create.c:478
33# __clone in /lib/x86_64-linux-gnu/libc.so.6
```

```cpp
*** Query id: 64e3f7e9824f4e20-b4bce02a9ffdf273 ***
*** Aborted at 1690963384 (unix time) try "date -d @1690963384" if you are using GNU date ***
*** Current BE git commitID: e2ed2e99e2 ***
*** SIGSEGV address not mapped to object (@0x8) received by PID 3563551 (TID 3563983 OR 0x7facf5ff9700) from PID 8; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk1/xiaolei/incubator-doris/be/src/common/signal_handler.h:413
 1# 0x00007FADE0D05400 in /lib64/libc.so.6
 2# doris::vectorized::Channel::close_wait(doris::RuntimeState*) at /mnt/disk1/xiaolei/incubator-doris/be/src/vec/sink/vdata_stream_sender.cpp:227
 3# doris::vectorized::VDataStreamSender::close(doris::RuntimeState*, doris::Status) at /mnt/disk1/xiaolei/incubator-doris/be/src/vec/sink/vdata_stream_sender.cpp:714
 4# doris::PlanFragmentExecutor::close() at /mnt/disk1/xiaolei/incubator-doris/be/src/runtime/plan_fragment_executor.cpp:542
 5# doris::FragmentExecState::execute() at /mnt/disk1/xiaolei/incubator-doris/be/src/runtime/fragment_mgr.cpp:272
 6# doris::FragmentMgr::_exec_actual(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::RuntimeState*, doris::Status*)> const&) at /mnt/disk1/xiaolei/incubator-doris/be/src/runtime/fragment_mgr.cpp:533
 7# std::_Function_handler<void (), doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_0>::_M_invoke(std::_Any_data const&) at /mnt/disk1/xiaolei/ldb_16/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
 8# doris::ThreadPool::dispatch_thread() in /mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be
 9# doris::Thread::supervise_thread(void*) at /mnt/disk1/xiaolei/incubator-doris/be/src/util/thread.cpp:466
10# start_thread in /lib64/libpthread.so.0
11# __GI___clone in /lib64/libc.so.6

```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

