### PR TITLE
[bugfix](S3FileSystem) assign correct use virtual address value

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1159,7 +1159,7 @@ void TaskWorkerPool::_push_storage_policy_worker_thread_callback() {
                 s3_conf.request_timeout_ms = resource.s3_storage_param.request_timeout_ms;
                 // When using cold heat separation in minio, user might use ip address directly,
                 // which needs enable use_virtual_addressing to true
-                s3_conf.use_virtual_addressing = resource.s3_storage_param.use_path_style;
+                s3_conf.use_virtual_addressing = !resource.s3_storage_param.use_path_style;
                 std::shared_ptr<io::S3FileSystem> fs;
                 if (existed_resource.fs == nullptr) {
                     st = io::S3FileSystem::create(s3_conf, std::to_string(resource.id), &fs);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
Formerly the `s3_conf.use_virtual_addressing` is mistakenly assigned one opposite value. This pr fixes it and examine using one minio environment.

![image](https://github.com/apache/doris/assets/43750022/49a39d20-5f5e-4e88-89dd-900793373c90)


![image](https://github.com/apache/doris/assets/43750022/ac93a8c6-556c-4a2e-8fcc-37a0f486eda2)

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

