### PR TITLE
[fix](parquet) resolve offset check failed in parquet map type

### DIFF
--- a/regression-test/data/external_table_emr_p2/hive/test_complex_types.out
+++ b/regression-test/data/external_table_emr_p2/hive/test_complex_types.out
@@ -23,3 +23,9 @@
 -- !array_last --
 0.9899828598260161
 
+-- !offsets_check --
+0	[1, 2]	[[], [3], NULL]	{"a":1, "b":2}	{"e", NULL}
+1	[]	[]	{}	\N
+2	\N	\N	\N	{"h", 10}
+3	[5, NULL]	[[6, 7], [8, NULL], NULL]	{"f":1, "g":NULL}	{NULL, 9}
+

--- a/regression-test/suites/external_table_emr_p2/hive/test_complex_types.groovy
+++ b/regression-test/suites/external_table_emr_p2/hive/test_complex_types.groovy
@@ -50,5 +50,7 @@ suite("test_complex_types", "p2") {
         qt_array_filter """select count(array_size(array_filter(i -> (i > 0.99), capacity))) from byd where array_size(array_filter(i -> (i > 0.99), capacity))"""
 
         qt_array_last """select max(array_last(i -> i > 0, capacity)) from byd where array_last(i -> i > 0, capacity) < 0.99"""
+
+        qt_offsets_check """select * from complex_offsets_check order by id"""
     }
 }


### PR DESCRIPTION
## Proposed changes

Fix error when reading empty map values in parquet. The `offsets.back()` doesn't not equal the number of elements in map's key column.

### How does this happen
Map in parquet is stored as repeated group, and `repeated_parent_def_level` is set incorrectly when parsing map node in parquet schema.
```
the map definition in parquet:
 optional group <name> (MAP) {
   repeated group map (MAP_KEY_VALUE) {
     required <type> key;
     optional <type> value;
   }
}
```

### How to fix
Set the `repeated_parent_def_level` of key/value node as the definition level of map node.

`repeated_parent_def_level` is the definition level of the first ancestor node whose `repetition_type` equals `REPEATED`.  Empty array/map values are not stored in doris column, so have to use `repeated_parent_def_level` to skip the empty or null values in ancestor node.

For instance, considering an array of strings with 3 rows like the following:
`null, [], [a, b, c]`
We can store four elements in data column: `null, a, b, c`
and the offsets column is: `1, 1, 4`
and the null map is: `1, 0, 0`
For the `i-th` row in array column: range from `offsets[i - 1]` until `offsets[i]` represents the elements in this row, so we can't store empty array/map values in doris data column. As a comparison, spark does not require `repeated_parent_def_level`, because the spark column stores empty array/map values , and use anther length column to indicate empty values. Please reference: https://github.com/apache/spark/blob/master/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetColumnVector.java

Furthermore, we can also avoid store null array/map values in doris data column. The same three rows as above, We can only store three elements in data column: `a, b, c`
and the offsets column is: `0, 0, 3`
and the null map is: `1, 0, 0`



