### PR TITLE
[enhance](ColdHeatSeparation) forbid change storage policy to another one with different storage resource

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -188,7 +188,8 @@ public class PropertyAnalyzer {
 
         TStorageMedium storageMedium = oldDataProperty.getStorageMedium();
         long cooldownTimestamp = oldDataProperty.getCooldownTimeMs();
-        String newStoragePolicy = oldDataProperty.getStoragePolicy();
+        String newStoragePolicy;
+        final String oldStoragePolicy = oldDataProperty.getStoragePolicy();
         boolean hasStoragePolicy = false;
         boolean storageMediumSpecified = false;
 
@@ -250,6 +251,19 @@ public class PropertyAnalyzer {
             }
 
             StoragePolicy storagePolicy = (StoragePolicy) policy;
+            if (null != oldStoragePolicy && !oldStoragePolicy.equals(newStoragePolicy)) {
+                // check remote storage policy
+                StoragePolicy oldPolicy = StoragePolicy.ofCheck(oldStoragePolicy);
+                Policy p = Env.getCurrentEnv().getPolicyMgr().getPolicy(oldPolicy);
+                if ((p instanceof StoragePolicy)) {
+                    String newResource = storagePolicy.getStorageResource();
+                    String oldResource = ((StoragePolicy) p).getStorageResource();
+                    if (!newResource.equals(oldResource)) {
+                        throw new AnalysisException("currently do not support change origin "
+                                + "storage policy to another one with different resource: ");
+                    }
+                }
+            }
             // check remote storage cool down timestamp
             if (storagePolicy.getCooldownTimestampMs() != -1) {
                 if (storagePolicy.getCooldownTimestampMs() <= currentTimeMs) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -188,10 +188,11 @@ public class PropertyAnalyzer {
 
         TStorageMedium storageMedium = oldDataProperty.getStorageMedium();
         long cooldownTimestamp = oldDataProperty.getCooldownTimeMs();
-        // newStoragePolicy would be assigned with one valid value once
-        // hasStoragePolicy is assigned true
-        String newStoragePolicy = null;
         final String oldStoragePolicy = oldDataProperty.getStoragePolicy();
+        // When we create one table with table's property set storage policy,
+        // the properties wouldn't contain storage policy so the hasStoragePolicy would be false,
+        // then we would just set the partition's storage policy the same as the table's
+        String newStoragePolicy = oldStoragePolicy;
         boolean hasStoragePolicy = false;
         boolean storageMediumSpecified = false;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -188,7 +188,9 @@ public class PropertyAnalyzer {
 
         TStorageMedium storageMedium = oldDataProperty.getStorageMedium();
         long cooldownTimestamp = oldDataProperty.getCooldownTimeMs();
-        String newStoragePolicy;
+        // newStoragePolicy would be assigned with one valid value once
+        // hasStoragePolicy is assigned true
+        String newStoragePolicy = null;
         final String oldStoragePolicy = oldDataProperty.getStoragePolicy();
         boolean hasStoragePolicy = false;
         boolean storageMediumSpecified = false;
@@ -251,6 +253,13 @@ public class PropertyAnalyzer {
             }
 
             StoragePolicy storagePolicy = (StoragePolicy) policy;
+            // Consider a scenario where if cold data has already been uploaded to resource A,
+            // and the user attempts to modify the policy to upload it to resource B,
+            // the data needs to be transferred from A to B.
+            // However, Doris currently does not support cross-bucket data transfer, therefore,
+            // changing the policy to a different policy with different resource is disabled.
+            // As for the case where the resource is the same, modifying the cooldown time is allowed,
+            // as this will not affect the already cooled data, but only the new data after modifying the policy.
             if (null != oldStoragePolicy && !oldStoragePolicy.equals(newStoragePolicy)) {
                 // check remote storage policy
                 StoragePolicy oldPolicy = StoragePolicy.ofCheck(oldStoragePolicy);

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/AlterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/AlterTest.java
@@ -160,6 +160,10 @@ public class AlterTest {
                 "CREATE STORAGE POLICY testPolicy2\n" + "PROPERTIES(\n" + "  \"storage_resource\" = \"remote_s3\",\n"
                         + "  \"cooldown_ttl\" = \"1\"\n" + ");");
 
+        createRemoteStoragePolicy(
+                "CREATE STORAGE POLICY testPolicyAnotherResource\n" + "PROPERTIES(\n" + "  \"storage_resource\" = \"remote_s3_1\",\n"
+                        + "  \"cooldown_ttl\" = \"1\"\n" + ");");
+
         createTable("CREATE TABLE test.tbl_remote\n" + "(\n" + "    k1 date,\n" + "    k2 int,\n" + "    v1 int sum\n"
                 + ")\n" + "PARTITION BY RANGE(k1)\n" + "(\n" + "    PARTITION p1 values less than('2020-02-01'),\n"
                 + "    PARTITION p2 values less than('2020-03-01'),\n"
@@ -597,8 +601,13 @@ public class AlterTest {
         }
         Assert.assertEquals(oldDataProperty, tblRemote.getPartitionInfo().getDataProperty(p1.getId()));
 
-        // alter remote_storage
+        // alter remote_storage to one not exist policy
         stmt = "alter table test.tbl_remote modify partition (p2, p3, p4) set ('storage_policy' = 'testPolicy3')";
+        alterTable(stmt, true);
+        Assert.assertEquals(oldDataProperty, tblRemote.getPartitionInfo().getDataProperty(p1.getId()));
+
+        // alter remote_storage to one another one which points to another resource
+        stmt = "alter table test.tbl_remote modify partition (p2, p3, p4) set ('storage_policy' = 'testPolicyAnotherResource')";
         alterTable(stmt, true);
         Assert.assertEquals(oldDataProperty, tblRemote.getPartitionInfo().getDataProperty(p1.getId()));
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
Consider a scenario where if cold data has already been uploaded to resource A, and the user attempts to modify the policy to upload it to resource B, the data needs to be transferred from A to B. However, Doris currently does not support cross-bucket data transfer, therefore, changing the policy to a different resource is disabled in the new policy.
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

