### PR TITLE
[fix](bug) fix be custom conf persistence path and read path are inconsistent

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1401,7 +1401,7 @@ Status persist_config(const std::string& field, const std::string& value) {
     // lock to make sure only one thread can modify the be_custom.conf
     std::lock_guard<std::mutex> l(custom_conf_lock);
 
-    static const std::string conffile = std::string(getenv("DORIS_HOME")) + "/conf/be_custom.conf";
+    static const std::string conffile = config::custom_config_dir + "/be_custom.conf";
 
     Properties tmp_props;
     if (!tmp_props.load(conffile.c_str(), false)) {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

be_custom.conf persistence path is ${doris_home}/conf/be_custom.conf, but if we set  ${custom_config_dir} is a different path, will cause be can't read be_custom.conf from ${custom_config_dir}.

<!--Describe your changes.-->
set be_custom.conf persist path to ${custom_config_dir}.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

