### PR TITLE
[typo](docs) Change the jdk version on the macOS to 11

### DIFF
--- a/docs/en/community/developer-guide/mac-dev/dev-prepare.md
+++ b/docs/en/community/developer-guide/mac-dev/dev-prepare.md
@@ -28,9 +28,11 @@ under the License.
 
 ```shell
 brew install automake autoconf libtool pkg-config texinfo coreutils gnu-getopt \
-python@3 cmake ninja ccache bison byacc gettext wget pcre maven llvm@16 openjdk@8 npm
+python@3 cmake ninja ccache bison byacc gettext wget pcre maven llvm@16 openjdk@11 npm
 ```
-   
+
+*The version of jdk installed using brew is 11, because on macOS, the arm64 version of brew does not have version 8 of jdk by default*
+
 **Dependency description:**
 1. Java, Maven, etc. can be downloaded separately for easy management
     - Mac recommend [Zulu JDK8](https://www.azul.com/downloads/?version=java-8-lts&os=macos&package=jdk#zulu)

--- a/docs/en/docs/install/source-install/compilation-mac.md
+++ b/docs/en/docs/install/source-install/compilation-mac.md
@@ -38,8 +38,12 @@ This topic is about how to compile Doris from source with macOS (both x86_64 and
 1. Use [Homebrew](https://brew.sh/) to install dependencies.
     ```shell
     brew install automake autoconf libtool pkg-config texinfo coreutils gnu-getopt \
-        python@3 cmake ninja ccache bison byacc gettext wget pcre maven llvm@16 openjdk@8 npm
+        python@3 cmake ninja ccache bison byacc gettext wget pcre maven llvm@16 openjdk@11 npm
     ```
+
+:::tip
+The version of jdk installed using brew is 11, because on macOS, the arm64 version of brew does not have version 8 of jdk by default
+:::
 
 2. Compile from source.
     ```shell
@@ -110,4 +114,5 @@ This topic is about how to compile Doris from source with macOS (both x86_64 and
    To fix this, please refer to the "Start-up" section above and reset  `file descriptors`.
 
 2. Java Version
-   Java 8 is recommended.
+
+   The version of jdk installed with brew is 11, because on macOS, the arm64 version of brew does not have version 8 of jdk by default, and you can also download the jdk installation package for installation

--- a/docs/zh-CN/community/developer-guide/mac-dev/dev-prepare.md
+++ b/docs/zh-CN/community/developer-guide/mac-dev/dev-prepare.md
@@ -28,7 +28,7 @@ under the License.
 
 ```shell
 brew install automake autoconf libtool pkg-config texinfo coreutils gnu-getopt \
-python@3 cmake ninja ccache bison byacc gettext wget pcre maven llvm@16 openjdk@8 npm
+python@3 cmake ninja ccache bison byacc gettext wget pcre maven llvm@16 openjdk@11 npm
 ```
 
 *使用 brew 安装的 jdk 版本为 11，因为在 macOS上，arm64 版本的 brew 默认没有 8 版本的 jdk*

--- a/docs/zh-CN/community/developer-guide/mac-dev/dev-prepare.md
+++ b/docs/zh-CN/community/developer-guide/mac-dev/dev-prepare.md
@@ -30,7 +30,9 @@ under the License.
 brew install automake autoconf libtool pkg-config texinfo coreutils gnu-getopt \
 python@3 cmake ninja ccache bison byacc gettext wget pcre maven llvm@16 openjdk@8 npm
 ```
-   
+
+*使用 brew 安装的 jdk 版本为 11，因为在 macOS上，arm64 版本的 brew 默认没有 8 版本的 jdk*
+
 **依赖说明：**
 1. Java、Maven 等可以单独下载，方便管理
     - Mac 推荐 [Zulu JDK8](https://www.azul.com/downloads/?version=java-8-lts&os=macos&package=jdk#zulu)

--- a/docs/zh-CN/docs/install/source-install/compilation-mac.md
+++ b/docs/zh-CN/docs/install/source-install/compilation-mac.md
@@ -38,8 +38,12 @@ under the License.
 1. 使用[Homebrew](https://brew.sh/)安装依赖
     ```shell
     brew install automake autoconf libtool pkg-config texinfo coreutils gnu-getopt \
-        python@3 cmake ninja ccache bison byacc gettext wget pcre maven llvm@16 openjdk@8 npm
+        python@3 cmake ninja ccache bison byacc gettext wget pcre maven llvm@16 openjdk@11 npm
     ```
+
+:::tip
+使用 brew 安装的 jdk 版本为 11，因为在 macOS上，arm64 版本的 brew 默认没有 8 版本的 jdk
+:::
 
 2. 编译源码
     ```shell
@@ -111,4 +115,4 @@ under the License.
 
 2. Java版本
 
-   推荐使用Java 8。
+   使用 brew 安装的 jdk 版本为 11，因为在 macOS上，arm64 版本的 brew 默认没有 8 版本的 jdk，也可以自行下载 jdk 的安装包进行安装


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

This is because brew cannot install openjdk@8 on an arm64 MacOS

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

