### PR TITLE
[Bug](exchange) disable implicit conversion of block to bool

### DIFF
--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -227,9 +227,6 @@ public:
     /// Approximate number of allocated bytes in memory - for profiling and limits.
     size_t allocated_bytes() const;
 
-    operator bool() const { return !!columns(); }
-    bool operator!() const { return !this->operator bool(); }
-
     /** Get a list of column names separated by commas. */
     std::string dump_names() const;
 

--- a/be/src/vec/core/materialize_block.cpp
+++ b/be/src/vec/core/materialize_block.cpp
@@ -28,7 +28,7 @@
 namespace doris::vectorized {
 
 Block materialize_block(const Block& block) {
-    if (!block) return block;
+    if (!block.columns()) return block;
 
     Block res = block;
     size_t columns = res.columns();

--- a/be/src/vec/core/sort_block.cpp
+++ b/be/src/vec/core/sort_block.cpp
@@ -64,7 +64,7 @@ struct PartialSortingLess {
 
 void sort_block(Block& src_block, Block& dest_block, const SortDescription& description,
                 UInt64 limit) {
-    if (!src_block) {
+    if (!src_block.columns()) {
         return;
     }
 
@@ -119,7 +119,7 @@ void sort_block(Block& src_block, Block& dest_block, const SortDescription& desc
 
 void stable_get_permutation(const Block& block, const SortDescription& description,
                             IColumn::Permutation& out_permutation) {
-    if (!block) {
+    if (!block.columns()) {
         return;
     }
 
@@ -137,7 +137,7 @@ void stable_get_permutation(const Block& block, const SortDescription& descripti
 }
 
 bool is_already_sorted(const Block& block, const SortDescription& description) {
-    if (!block) {
+    if (!block.columns()) {
         return true;
     }
 
@@ -173,7 +173,7 @@ bool is_already_sorted(const Block& block, const SortDescription& description) {
 }
 
 void stable_sort_block(Block& block, const SortDescription& description) {
-    if (!block) {
+    if (!block.columns()) {
         return;
     }
 

--- a/be/src/vec/olap/vertical_merge_iterator.cpp
+++ b/be/src/vec/olap/vertical_merge_iterator.cpp
@@ -240,7 +240,7 @@ Status RowSourcesBuffer::_deserialize() {
 
 // ----------  vertical merge iterator context ----------//
 Status VerticalMergeIteratorContext::block_reset(const std::shared_ptr<Block>& block) {
-    if (!*block) {
+    if (!block->columns()) {
         const Schema& schema = _iter->schema();
         const auto& column_ids = schema.column_ids();
         for (size_t i = 0; i < schema.num_column_ids(); ++i) {

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -89,7 +89,7 @@ Status VStatisticsIterator::next_batch(Block* block) {
 }
 
 Status VMergeIteratorContext::block_reset(const std::shared_ptr<Block>& block) {
-    if (!*block) {
+    if (!block->columns()) {
         const Schema& schema = _iter->schema();
         const auto& column_ids = schema.column_ids();
         for (size_t i = 0; i < schema.num_column_ids(); ++i) {

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -687,14 +687,14 @@ Status VDataStreamSender::close(RuntimeState* state, Status exec_status) {
             // send last block
             SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
             if (_serializer && _serializer->get_block() && _serializer->get_block()->rows() > 0) {
-                auto block = _serializer->get_block()->to_block();
+                Block block = _serializer->get_block()->to_block();
                 RETURN_IF_ERROR(
                         _serializer->serialize_block(&block, _cur_pb_block, _channels.size()));
                 Status status;
                 for (auto channel : _channels) {
                     if (!channel->is_receiver_eof()) {
                         if (channel->is_local()) {
-                            status = channel->send_local_block(block);
+                            status = channel->send_local_block(&block);
                         } else {
                             SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
                             status = channel->send_block(_cur_pb_block, false);

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -686,7 +686,7 @@ Status VDataStreamSender::close(RuntimeState* state, Status exec_status) {
         {
             // send last block
             SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
-            if (_serializer->get_block() && _serializer->get_block()->rows() > 0) {
+            if (_serializer && _serializer->get_block() && _serializer->get_block()->rows() > 0) {
                 auto block = _serializer->get_block()->to_block();
                 RETURN_IF_ERROR(
                         _serializer->serialize_block(&block, _cur_pb_block, _channels.size()));


### PR DESCRIPTION
## Proposed changes
disable implicit conversion of block to bool

```cpp
*** Query id: 658785ee6b464611-9a9d871c4557503e ***
*** Aborted at 1691006573 (unix time) try "date -d @1691006573" if you are using GNU date ***
*** Current BE git commitID: 781c1d5238 ***
*** SIGSEGV address not mapped to object (@0x8) received by PID 2599697 (TID 2599993 OR 0x7f3401788700) from PID 8; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:413
 1# 0x00007F34A637F2B7 in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 3# 0x00007F34A63780AC in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 4# 0x00007F34AB7880C0 in /lib/x86_64-linux-gnu/libc.so.6
 5# doris::vectorized::MutableBlock::to_block(int) at /home/zcp/repo_center/doris_master/doris/be/src/vec/core/block.cpp:969
 6# doris::vectorized::Channel::send_local_block(bool) at /home/zcp/repo_center/doris_master/doris/be/src/vec/sink/vdata_stream_sender.cpp:126
 7# doris::vectorized::VDataStreamSender::close(doris::RuntimeState*, doris::Status) at /home/zcp/repo_center/doris_master/doris/be/src/vec/sink/vdata_stream_sender.cpp:697
 8# doris::PlanFragmentExecutor::open_vectorized_internal() at /home/zcp/repo_center/doris_master/doris/be/src/runtime/plan_fragment_executor.cpp:342
 9# doris::PlanFragmentExecutor::open() at /home/zcp/repo_center/doris_master/doris/be/src/runtime/plan_fragment_executor.cpp:271
10# doris::FragmentExecState::execute() at /home/zcp/repo_center/doris_master/doris/be/src/runtime/fragment_mgr.cpp:265
11# doris::FragmentMgr::_exec_actual(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::RuntimeState*, doris::Status*)> const&) at /home/zcp/repo_center/doris_master/doris/be/src/runtime/fragment_mgr.cpp:533
12# std::_Function_handler<void (), doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_0>::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
13# doris::ThreadPool::dispatch_thread() in /mnt/hdd01/PERFORMANCE_DORIS_MASTER_DEFAULT_ENV/be/lib/doris_be
14# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_master/doris/be/src/util/thread.cpp:466
15# start_thread at /build/glibc-sMfBJT/glibc-2.31/nptl/pthread_create.c:478
16# __clone in /lib/x86_64-linux-gnu/libc.so.6

```
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

