### PR TITLE
[fix](stacktrace) Fix Jemalloc enable profile fail to run BE after rewrites `dl_iterate_phdr`.

### DIFF
--- a/be/src/common/phdr_cache.cpp
+++ b/be/src/common/phdr_cache.cpp
@@ -74,6 +74,15 @@ std::atomic<PHDRCache*> phdr_cache {};
 
 } // namespace
 
+// Jemalloc heap profile follows libgcc's way of backtracing by default.
+// rewrites dl_iterate_phdr will cause Jemalloc to fail to run after enable profile.
+
+// TODO, two solutions:
+// 1. Jemalloc specifies GNU libunwind as the prof backtracing way, but my test failed,
+//    `--enable-prof-libunwind` not work: https://github.com/jemalloc/jemalloc/issues/2504
+// 2. ClickHouse/libunwind solves Jemalloc profile backtracing, but the branch of ClickHouse/libunwind
+//    has been out of touch with GNU libunwind and LLVM libunwind, which will leave the fate to others.
+/*
 extern "C"
 #ifndef __clang__
         [[gnu::visibility("default")]] [[gnu::externally_visible]]
@@ -95,6 +104,7 @@ extern "C"
     }
     return result;
 }
+*/
 
 extern "C" {
 #ifdef ADDRESS_SANITIZER

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -417,7 +417,8 @@ int main(int argc, char** argv) {
 
     // PHDR speed up exception handling, but exceptions from dynamically loaded libraries (dlopen)
     // will work only after additional call of this function.
-    updatePHDRCache();
+    // rewrites dl_iterate_phdr will cause Jemalloc to fail to run after enable profile. see #
+    // updatePHDRCache();
 
     // Load file cache before starting up daemon threads to make sure StorageEngine is read.
     doris::Daemon daemon;

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -308,7 +308,7 @@ if [[ -z ${JEMALLOC_CONF} ]]; then
 fi
 
 if [[ -z ${JEMALLOC_PROF_PRFIX} ]]; then
-    export JEMALLOC_CONF="${JEMALLOC_CONF}"
+    export JEMALLOC_CONF="${JEMALLOC_CONF},prof_prefix:"
 else
     JEMALLOC_PROF_PRFIX="${DORIS_HOME}/log/${JEMALLOC_PROF_PRFIX}"
     export JEMALLOC_CONF="${JEMALLOC_CONF},prof_prefix:${JEMALLOC_PROF_PRFIX}"


### PR DESCRIPTION
## Proposed changes

Jemalloc heap profile follows libgcc's way of backtracing by default.
rewrites dl_iterate_phdr will cause Jemalloc to fail to run after enable profile.

TODO, two solutions:
1. Jemalloc specifies GNU libunwind as the prof backtracing way, but my test failed,
   `--enable-prof-libunwind` not work: https://github.com/jemalloc/jemalloc/issues/2504
2. ClickHouse/libunwind solves Jemalloc profile backtracing, but the branch of ClickHouse/libunwind
    has been out of touch with GNU libunwind and LLVM libunwind, which will leave the fate to others.

Maybe the error of jeprof dump profile can also be solved
![image](https://github.com/apache/doris/assets/13197424/edcfe46e-7a8b-45c4-9979-51f0d1d08742)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

