### PR TITLE
[pipelineX](refactor) propose a new pipeline execution model

### DIFF
--- a/be/src/pipeline/exec/aggregation_sink_operator.cpp
+++ b/be/src/pipeline/exec/aggregation_sink_operator.cpp
@@ -25,4 +25,903 @@ namespace doris::pipeline {
 
 OPERATOR_CODE_GENERATOR(AggSinkOperator, StreamingOperator)
 
+/// The minimum reduction factor (input rows divided by output rows) to grow hash tables
+/// in a streaming preaggregation, given that the hash tables are currently the given
+/// size or above. The sizes roughly correspond to hash table sizes where the bucket
+/// arrays will fit in  a cache level. Intuitively, we don't want the working set of the
+/// aggregation to expand to the next level of cache unless we're reducing the input
+/// enough to outweigh the increased memory latency we'll incur for each hash table
+/// lookup.
+///
+/// Note that the current reduction achieved is not always a good estimate of the
+/// final reduction. It may be biased either way depending on the ordering of the
+/// input. If the input order is random, we will underestimate the final reduction
+/// factor because the probability of a row having the same key as a previous row
+/// increases as more input is processed.  If the input order is correlated with the
+/// key, skew may bias the estimate. If high cardinality keys appear first, we
+/// may overestimate and if low cardinality keys appear first, we underestimate.
+/// To estimate the eventual reduction achieved, we estimate the final reduction
+/// using the planner's estimated input cardinality and the assumption that input
+/// is in a random order. This means that we assume that the reduction factor will
+/// increase over time.
+AggSinkLocalState::AggSinkLocalState(DataSinkOperatorX* parent, RuntimeState* state)
+        : PipelineXSinkLocalState(parent, state),
+          _hash_table_compute_timer(nullptr),
+          _hash_table_input_counter(nullptr),
+          _build_timer(nullptr),
+          _expr_timer(nullptr),
+          _exec_timer(nullptr),
+          _serialize_key_timer(nullptr),
+          _merge_timer(nullptr),
+          _serialize_data_timer(nullptr),
+          _deserialize_data_timer(nullptr),
+          _hash_table_size_counter(nullptr),
+          _max_row_size_counter(nullptr) {}
+
+Status AggSinkLocalState::init(RuntimeState* state, Dependency* dependency) {
+    _dependency = (AggDependency*)dependency;
+    _shared_state = (AggSharedState*)_dependency->shared_state();
+    _agg_data = _shared_state->agg_data.get();
+    _agg_arena_pool = _shared_state->agg_arena_pool.get();
+    auto& p = _parent->cast<AggSinkOperatorX>();
+    _dependency->set_align_aggregate_states(p._align_aggregate_states);
+    _dependency->set_total_size_of_aggregate_states(p._total_size_of_aggregate_states);
+    _dependency->set_offsets_of_aggregate_states(p._offsets_of_aggregate_states);
+    _dependency->set_make_nullable_keys(p._make_nullable_keys);
+    _shared_state->init_spill_partition_helper(p._spill_partition_count_bits);
+    for (auto& evaluator : p._aggregate_evaluators) {
+        _shared_state->aggregate_evaluators.push_back(evaluator->clone(state, p._pool));
+        _shared_state->aggregate_evaluators.back()->set_timer(_exec_timer, _merge_timer,
+                                                              _expr_timer);
+    }
+    _shared_state->probe_expr_ctxs.resize(p._probe_expr_ctxs.size());
+    for (size_t i = 0; i < _shared_state->probe_expr_ctxs.size(); i++) {
+        RETURN_IF_ERROR(p._probe_expr_ctxs[i]->clone(state, _shared_state->probe_expr_ctxs[i]));
+    }
+    std::string title = fmt::format("AggSinkLocalState");
+    _profile = p._pool->add(new RuntimeProfile(title));
+    _memory_usage_counter = ADD_LABEL_COUNTER(profile(), "MemoryUsage");
+    _hash_table_memory_usage =
+            ADD_CHILD_COUNTER(profile(), "HashTable", TUnit::BYTES, "MemoryUsage");
+    _serialize_key_arena_memory_usage =
+            profile()->AddHighWaterMarkCounter("SerializeKeyArena", TUnit::BYTES, "MemoryUsage");
+
+    _build_timer = ADD_TIMER(profile(), "BuildTime");
+    _build_table_convert_timer = ADD_TIMER(profile(), "BuildConvertToPartitionedTime");
+    _serialize_key_timer = ADD_TIMER(profile(), "SerializeKeyTime");
+    _exec_timer = ADD_TIMER(profile(), "ExecTime");
+    _merge_timer = ADD_TIMER(profile(), "MergeTime");
+    _expr_timer = ADD_TIMER(profile(), "ExprTime");
+    _serialize_data_timer = ADD_TIMER(profile(), "SerializeDataTime");
+    _deserialize_data_timer = ADD_TIMER(profile(), "DeserializeAndMergeTime");
+    _hash_table_compute_timer = ADD_TIMER(profile(), "HashTableComputeTime");
+    _hash_table_emplace_timer = ADD_TIMER(profile(), "HashTableEmplaceTime");
+    _hash_table_size_counter = ADD_COUNTER(profile(), "HashTableSize", TUnit::UNIT);
+    _hash_table_input_counter = ADD_COUNTER(profile(), "HashTableInputCount", TUnit::UNIT);
+    _max_row_size_counter = ADD_COUNTER(profile(), "MaxRowSizeInBytes", TUnit::UNIT);
+    COUNTER_SET(_max_row_size_counter, (int64_t)0);
+
+    _shared_state->agg_profile_arena = std::make_unique<vectorized::Arena>();
+
+    if (_shared_state->probe_expr_ctxs.empty()) {
+        _agg_data->init(vectorized::AggregatedDataVariants::Type::without_key);
+
+        _agg_data->without_key = reinterpret_cast<vectorized::AggregateDataPtr>(
+                _shared_state->agg_profile_arena->alloc(p._total_size_of_aggregate_states));
+
+        if (p._is_merge) {
+            _executor.execute = std::bind<Status>(&AggSinkLocalState::_merge_without_key, this,
+                                                  std::placeholders::_1);
+        } else {
+            _executor.execute = std::bind<Status>(&AggSinkLocalState::_execute_without_key, this,
+                                                  std::placeholders::_1);
+        }
+
+        _executor.update_memusage =
+                std::bind<void>(&AggSinkLocalState::_update_memusage_without_key, this);
+    } else {
+        _init_hash_method(_shared_state->probe_expr_ctxs);
+
+        std::visit(
+                [&](auto&& agg_method) {
+                    using HashTableType = std::decay_t<decltype(agg_method.data)>;
+                    using KeyType = typename HashTableType::key_type;
+
+                    /// some aggregate functions (like AVG for decimal) have align issues.
+                    _shared_state->aggregate_data_container.reset(
+                            new vectorized::AggregateDataContainer(
+                                    sizeof(KeyType), ((p._total_size_of_aggregate_states +
+                                                       p._align_aggregate_states - 1) /
+                                                      p._align_aggregate_states) *
+                                                             p._align_aggregate_states));
+                },
+                _agg_data->_aggregated_method_variant);
+        if (p._is_merge) {
+            _executor.execute = std::bind<Status>(&AggSinkLocalState::_merge_with_serialized_key,
+                                                  this, std::placeholders::_1);
+        } else {
+            _executor.execute = std::bind<Status>(&AggSinkLocalState::_execute_with_serialized_key,
+                                                  this, std::placeholders::_1);
+        }
+
+        _executor.update_memusage =
+                std::bind<void>(&AggSinkLocalState::_update_memusage_with_serialized_key, this);
+
+        _should_limit_output = p._limit != -1 &&       // has limit
+                               (!p._have_conjuncts) && // no having conjunct
+                               p._needs_finalize;      // agg's finalize step
+    }
+    return Status::OK();
+}
+
+Status AggSinkLocalState::_execute_without_key(vectorized::Block* block) {
+    DCHECK(_agg_data->without_key != nullptr);
+    SCOPED_TIMER(_build_timer);
+    for (int i = 0; i < _shared_state->aggregate_evaluators.size(); ++i) {
+        RETURN_IF_ERROR(_shared_state->aggregate_evaluators[i]->execute_single_add(
+                block,
+                _agg_data->without_key +
+                        _parent->cast<AggSinkOperatorX>()._offsets_of_aggregate_states[i],
+                _agg_arena_pool));
+    }
+    return Status::OK();
+}
+
+Status AggSinkLocalState::_merge_with_serialized_key(vectorized::Block* block) {
+    if (_reach_limit) {
+        return _merge_with_serialized_key_helper<true, false>(block);
+    } else {
+        return _merge_with_serialized_key_helper<false, false>(block);
+    }
+}
+
+size_t AggSinkLocalState::_memory_usage() const {
+    size_t usage = 0;
+    std::visit(
+            [&](auto&& agg_method) {
+                using HashMethodType = std::decay_t<decltype(agg_method)>;
+                if constexpr (vectorized::ColumnsHashing::IsPreSerializedKeysHashMethodTraits<
+                                      HashMethodType>::value) {
+                    usage += agg_method.keys_memory_usage;
+                }
+                usage += agg_method.data.get_buffer_size_in_bytes();
+            },
+            _agg_data->_aggregated_method_variant);
+
+    if (_agg_arena_pool) {
+        usage += _agg_arena_pool->size();
+    }
+
+    if (_shared_state->aggregate_data_container) {
+        usage += _shared_state->aggregate_data_container->memory_usage();
+    }
+
+    return usage;
+}
+
+void AggSinkLocalState::_update_memusage_with_serialized_key() {
+    std::visit(
+            [&](auto&& agg_method) -> void {
+                auto& data = agg_method.data;
+                auto arena_memory_usage = _agg_arena_pool->size() +
+                                          _shared_state->aggregate_data_container->memory_usage() -
+                                          _dependency->mem_usage_record().used_in_arena;
+                _dependency->mem_tracker()->consume(arena_memory_usage);
+                _dependency->mem_tracker()->consume(data.get_buffer_size_in_bytes() -
+                                                    _dependency->mem_usage_record().used_in_state);
+                _serialize_key_arena_memory_usage->add(arena_memory_usage);
+                COUNTER_UPDATE(_hash_table_memory_usage,
+                               data.get_buffer_size_in_bytes() -
+                                       _dependency->mem_usage_record().used_in_state);
+                _dependency->mem_usage_record().used_in_state = data.get_buffer_size_in_bytes();
+                _dependency->mem_usage_record().used_in_arena =
+                        _agg_arena_pool->size() +
+                        _shared_state->aggregate_data_container->memory_usage();
+            },
+            _agg_data->_aggregated_method_variant);
+}
+
+template <bool limit, bool for_spill>
+Status AggSinkLocalState::_merge_with_serialized_key_helper(vectorized::Block* block) {
+    SCOPED_TIMER(_merge_timer);
+
+    size_t key_size = _shared_state->probe_expr_ctxs.size();
+    vectorized::ColumnRawPtrs key_columns(key_size);
+
+    for (size_t i = 0; i < key_size; ++i) {
+        if constexpr (for_spill) {
+            key_columns[i] = block->get_by_position(i).column.get();
+        } else {
+            int result_column_id = -1;
+            RETURN_IF_ERROR(_shared_state->probe_expr_ctxs[i]->execute(block, &result_column_id));
+            block->replace_by_position_if_const(result_column_id);
+            key_columns[i] = block->get_by_position(result_column_id).column.get();
+        }
+    }
+
+    int rows = block->rows();
+    if (_places.size() < rows) {
+        _places.resize(rows);
+    }
+
+    if constexpr (limit) {
+        _find_in_hash_table(_places.data(), key_columns, rows);
+
+        for (int i = 0; i < _shared_state->aggregate_evaluators.size(); ++i) {
+            if (_shared_state->aggregate_evaluators[i]->is_merge()) {
+                int col_id = _get_slot_column_id(_shared_state->aggregate_evaluators[i]);
+                auto column = block->get_by_position(col_id).column;
+                if (column->is_nullable()) {
+                    column = ((vectorized::ColumnNullable*)column.get())->get_nested_column_ptr();
+                }
+
+                size_t buffer_size =
+                        _shared_state->aggregate_evaluators[i]->function()->size_of_data() * rows;
+                if (_deserialize_buffer.size() < buffer_size) {
+                    _deserialize_buffer.resize(buffer_size);
+                }
+
+                {
+                    SCOPED_TIMER(_deserialize_data_timer);
+                    _shared_state->aggregate_evaluators[i]
+                            ->function()
+                            ->deserialize_and_merge_vec_selected(
+                                    _places.data(),
+                                    _parent->cast<AggSinkOperatorX>()
+                                            ._offsets_of_aggregate_states[i],
+                                    _deserialize_buffer.data(),
+                                    (vectorized::ColumnString*)(column.get()), _agg_arena_pool,
+                                    rows);
+                }
+            } else {
+                RETURN_IF_ERROR(_shared_state->aggregate_evaluators[i]->execute_batch_add_selected(
+                        block, _parent->cast<AggSinkOperatorX>()._offsets_of_aggregate_states[i],
+                        _places.data(), _agg_arena_pool));
+            }
+        }
+    } else {
+        _emplace_into_hash_table(_places.data(), key_columns, rows);
+
+        for (int i = 0; i < _shared_state->aggregate_evaluators.size(); ++i) {
+            if (_shared_state->aggregate_evaluators[i]->is_merge() || for_spill) {
+                int col_id;
+                if constexpr (for_spill) {
+                    col_id = _shared_state->probe_expr_ctxs.size() + i;
+                } else {
+                    col_id = _get_slot_column_id(_shared_state->aggregate_evaluators[i]);
+                }
+                auto column = block->get_by_position(col_id).column;
+                if (column->is_nullable()) {
+                    column = ((vectorized::ColumnNullable*)column.get())->get_nested_column_ptr();
+                }
+
+                size_t buffer_size =
+                        _shared_state->aggregate_evaluators[i]->function()->size_of_data() * rows;
+                if (_deserialize_buffer.size() < buffer_size) {
+                    _deserialize_buffer.resize(buffer_size);
+                }
+
+                {
+                    SCOPED_TIMER(_deserialize_data_timer);
+                    _shared_state->aggregate_evaluators[i]->function()->deserialize_and_merge_vec(
+                            _places.data(),
+                            _parent->cast<AggSinkOperatorX>()._offsets_of_aggregate_states[i],
+                            _deserialize_buffer.data(), (vectorized::ColumnString*)(column.get()),
+                            _agg_arena_pool, rows);
+                }
+            } else {
+                RETURN_IF_ERROR(_shared_state->aggregate_evaluators[i]->execute_batch_add(
+                        block, _parent->cast<AggSinkOperatorX>()._offsets_of_aggregate_states[i],
+                        _places.data(), _agg_arena_pool));
+            }
+        }
+
+        if (_should_limit_output) {
+            _reach_limit = _get_hash_table_size() >= _parent->cast<AggSinkOperatorX>()._limit;
+        }
+    }
+
+    return Status::OK();
+}
+
+// We should call this function only at 1st phase.
+// 1st phase: is_merge=true, only have one SlotRef.
+// 2nd phase: is_merge=false, maybe have multiple exprs.
+int AggSinkLocalState::_get_slot_column_id(const vectorized::AggFnEvaluator* evaluator) {
+    auto ctxs = evaluator->input_exprs_ctxs();
+    CHECK(ctxs.size() == 1 && ctxs[0]->root()->is_slot_ref())
+            << "input_exprs_ctxs is invalid, input_exprs_ctx[0]="
+            << ctxs[0]->root()->debug_string();
+    return ((vectorized::VSlotRef*)ctxs[0]->root().get())->column_id();
+}
+
+Status AggSinkLocalState::_merge_without_key(vectorized::Block* block) {
+    SCOPED_TIMER(_merge_timer);
+    DCHECK(_agg_data->without_key != nullptr);
+    for (int i = 0; i < _shared_state->aggregate_evaluators.size(); ++i) {
+        if (_shared_state->aggregate_evaluators[i]->is_merge()) {
+            int col_id = _get_slot_column_id(_shared_state->aggregate_evaluators[i]);
+            auto column = block->get_by_position(col_id).column;
+            if (column->is_nullable()) {
+                column = ((vectorized::ColumnNullable*)column.get())->get_nested_column_ptr();
+            }
+
+            SCOPED_TIMER(_deserialize_data_timer);
+            _shared_state->aggregate_evaluators[i]->function()->deserialize_and_merge_from_column(
+                    _agg_data->without_key +
+                            _parent->cast<AggSinkOperatorX>()._offsets_of_aggregate_states[i],
+                    *column, _agg_arena_pool);
+        } else {
+            RETURN_IF_ERROR(_shared_state->aggregate_evaluators[i]->execute_single_add(
+                    block,
+                    _agg_data->without_key +
+                            _parent->cast<AggSinkOperatorX>()._offsets_of_aggregate_states[i],
+                    _agg_arena_pool));
+        }
+    }
+    return Status::OK();
+}
+
+void AggSinkLocalState::_update_memusage_without_key() {
+    auto arena_memory_usage =
+            _agg_arena_pool->size() - _dependency->mem_usage_record().used_in_arena;
+    _dependency->mem_tracker()->consume(arena_memory_usage);
+    _serialize_key_arena_memory_usage->add(arena_memory_usage);
+    _dependency->mem_usage_record().used_in_arena = _agg_arena_pool->size();
+}
+
+Status AggSinkLocalState::_execute_with_serialized_key(vectorized::Block* block) {
+    if (_reach_limit) {
+        return _execute_with_serialized_key_helper<true>(block);
+    } else {
+        return _execute_with_serialized_key_helper<false>(block);
+    }
+}
+
+template <bool limit>
+Status AggSinkLocalState::_execute_with_serialized_key_helper(vectorized::Block* block) {
+    SCOPED_TIMER(_build_timer);
+    DCHECK(!_shared_state->probe_expr_ctxs.empty());
+
+    size_t key_size = _shared_state->probe_expr_ctxs.size();
+    vectorized::ColumnRawPtrs key_columns(key_size);
+    {
+        SCOPED_TIMER(_expr_timer);
+        for (size_t i = 0; i < key_size; ++i) {
+            int result_column_id = -1;
+            RETURN_IF_ERROR(_shared_state->probe_expr_ctxs[i]->execute(block, &result_column_id));
+            block->get_by_position(result_column_id).column =
+                    block->get_by_position(result_column_id)
+                            .column->convert_to_full_column_if_const();
+            key_columns[i] = block->get_by_position(result_column_id).column.get();
+        }
+    }
+
+    int rows = block->rows();
+    if (_places.size() < rows) {
+        _places.resize(rows);
+    }
+
+    if constexpr (limit) {
+        _find_in_hash_table(_places.data(), key_columns, rows);
+
+        for (int i = 0; i < _shared_state->aggregate_evaluators.size(); ++i) {
+            RETURN_IF_ERROR(_shared_state->aggregate_evaluators[i]->execute_batch_add_selected(
+                    block, _parent->cast<AggSinkOperatorX>()._offsets_of_aggregate_states[i],
+                    _places.data(), _agg_arena_pool));
+        }
+    } else {
+        _emplace_into_hash_table(_places.data(), key_columns, rows);
+
+        for (int i = 0; i < _shared_state->aggregate_evaluators.size(); ++i) {
+            RETURN_IF_ERROR(_shared_state->aggregate_evaluators[i]->execute_batch_add(
+                    block, _parent->cast<AggSinkOperatorX>()._offsets_of_aggregate_states[i],
+                    _places.data(), _agg_arena_pool));
+        }
+
+        if (_should_limit_output) {
+            _reach_limit = _get_hash_table_size() >= _parent->cast<AggSinkOperatorX>()._limit;
+            if (_reach_limit && _parent->cast<AggSinkOperatorX>()._can_short_circuit) {
+                _dependency->set_done();
+                return Status::Error<ErrorCode::END_OF_FILE>("");
+            }
+        }
+    }
+
+    return Status::OK();
+}
+
+size_t AggSinkLocalState::_get_hash_table_size() {
+    return std::visit([&](auto&& agg_method) { return agg_method.data.size(); },
+                      _agg_data->_aggregated_method_variant);
+}
+
+void AggSinkLocalState::_emplace_into_hash_table(vectorized::AggregateDataPtr* places,
+                                                 vectorized::ColumnRawPtrs& key_columns,
+                                                 const size_t num_rows) {
+    std::visit(
+            [&](auto&& agg_method) -> void {
+                SCOPED_TIMER(_hash_table_compute_timer);
+                using HashMethodType = std::decay_t<decltype(agg_method)>;
+                using HashTableType = std::decay_t<decltype(agg_method.data)>;
+                using AggState = typename HashMethodType::State;
+                AggState state(key_columns, _shared_state->probe_key_sz, nullptr);
+
+                _pre_serialize_key_if_need(state, agg_method, key_columns, num_rows);
+
+                auto creator = [this](const auto& ctor, const auto& key) {
+                    using KeyType = std::decay_t<decltype(key)>;
+                    if constexpr (HashTableTraits<HashTableType>::is_string_hash_table &&
+                                  !std::is_same_v<StringRef, KeyType>) {
+                        StringRef string_ref = to_string_ref(key);
+                        vectorized::ArenaKeyHolder key_holder {string_ref, *_agg_arena_pool};
+                        key_holder_persist_key(key_holder);
+                        auto mapped = _shared_state->aggregate_data_container->append_data(
+                                key_holder.key);
+                        _dependency->create_agg_status(mapped);
+                        ctor(key, mapped);
+                    } else {
+                        auto mapped = _shared_state->aggregate_data_container->append_data(key);
+                        _dependency->create_agg_status(mapped);
+                        ctor(key, mapped);
+                    }
+                };
+
+                auto creator_for_null_key = [this](auto& mapped) {
+                    mapped = _agg_arena_pool->aligned_alloc(
+                            _parent->cast<AggSinkOperatorX>()._total_size_of_aggregate_states,
+                            _parent->cast<AggSinkOperatorX>()._align_aggregate_states);
+                    _dependency->create_agg_status(mapped);
+                };
+
+                if constexpr (HashTableTraits<HashTableType>::is_phmap) {
+                    auto keys = state.get_keys(num_rows);
+                    if (_hash_values.size() < num_rows) {
+                        _hash_values.resize(num_rows);
+                    }
+                    for (size_t i = 0; i < num_rows; ++i) {
+                        _hash_values[i] = agg_method.data.hash(keys[i]);
+                    }
+
+                    SCOPED_TIMER(_hash_table_emplace_timer);
+                    if constexpr (vectorized::ColumnsHashing::IsSingleNullableColumnMethod<
+                                          AggState>::value) {
+                        for (size_t i = 0; i < num_rows; ++i) {
+                            if (LIKELY(i + HASH_MAP_PREFETCH_DIST < num_rows)) {
+                                agg_method.data.prefetch_by_hash(
+                                        _hash_values[i + HASH_MAP_PREFETCH_DIST]);
+                            }
+
+                            places[i] = state.lazy_emplace_key(agg_method.data, i, *_agg_arena_pool,
+                                                               _hash_values[i], creator,
+                                                               creator_for_null_key);
+                        }
+                    } else {
+                        state.lazy_emplace_keys(agg_method.data, keys, _hash_values, creator,
+                                                places);
+                    }
+                } else {
+                    for (size_t i = 0; i < num_rows; ++i) {
+                        vectorized::AggregateDataPtr mapped = nullptr;
+                        if constexpr (vectorized::ColumnsHashing::IsSingleNullableColumnMethod<
+                                              AggState>::value) {
+                            mapped = state.lazy_emplace_key(agg_method.data, i, *_agg_arena_pool,
+                                                            creator, creator_for_null_key);
+                        } else {
+                            mapped = state.lazy_emplace_key(agg_method.data, i, *_agg_arena_pool,
+                                                            creator);
+                        }
+                        places[i] = mapped;
+                    }
+                }
+
+                COUNTER_UPDATE(_hash_table_input_counter, num_rows);
+            },
+            _agg_data->_aggregated_method_variant);
+}
+
+void AggSinkLocalState::_find_in_hash_table(vectorized::AggregateDataPtr* places,
+                                            vectorized::ColumnRawPtrs& key_columns,
+                                            size_t num_rows) {
+    std::visit(
+            [&](auto&& agg_method) -> void {
+                using HashMethodType = std::decay_t<decltype(agg_method)>;
+                using HashTableType = std::decay_t<decltype(agg_method.data)>;
+                using AggState = typename HashMethodType::State;
+                AggState state(key_columns, _shared_state->probe_key_sz, nullptr);
+
+                _pre_serialize_key_if_need(state, agg_method, key_columns, num_rows);
+
+                if constexpr (HashTableTraits<HashTableType>::is_phmap) {
+                    if (_hash_values.size() < num_rows) _hash_values.resize(num_rows);
+                    if constexpr (vectorized::ColumnsHashing::IsPreSerializedKeysHashMethodTraits<
+                                          AggState>::value) {
+                        for (size_t i = 0; i < num_rows; ++i) {
+                            _hash_values[i] = agg_method.data.hash(agg_method.keys[i]);
+                        }
+                    } else {
+                        for (size_t i = 0; i < num_rows; ++i) {
+                            _hash_values[i] =
+                                    agg_method.data.hash(state.get_key_holder(i, *_agg_arena_pool));
+                        }
+                    }
+                }
+
+                /// For all rows.
+                for (size_t i = 0; i < num_rows; ++i) {
+                    auto find_result = [&]() {
+                        if constexpr (HashTableTraits<HashTableType>::is_phmap) {
+                            if (LIKELY(i + HASH_MAP_PREFETCH_DIST < num_rows)) {
+                                agg_method.data.prefetch_by_hash(
+                                        _hash_values[i + HASH_MAP_PREFETCH_DIST]);
+                            }
+
+                            return state.find_key_with_hash(agg_method.data, _hash_values[i], i,
+                                                            *_agg_arena_pool);
+                        } else {
+                            return state.find_key(agg_method.data, i, *_agg_arena_pool);
+                        }
+                    }();
+
+                    if (find_result.is_found()) {
+                        places[i] = find_result.get_mapped();
+                    } else {
+                        places[i] = nullptr;
+                    }
+                }
+            },
+            _agg_data->_aggregated_method_variant);
+}
+
+void AggSinkLocalState::_init_hash_method(const vectorized::VExprContextSPtrs& probe_exprs) {
+    DCHECK(probe_exprs.size() >= 1);
+    if (probe_exprs.size() == 1) {
+        auto is_nullable = probe_exprs[0]->root()->is_nullable();
+        switch (probe_exprs[0]->root()->result_type()) {
+        case TYPE_TINYINT:
+        case TYPE_BOOLEAN:
+            _agg_data->init(vectorized::AggregatedDataVariants::Type::int8_key, is_nullable);
+            return;
+        case TYPE_SMALLINT:
+            _agg_data->init(vectorized::AggregatedDataVariants::Type::int16_key, is_nullable);
+            return;
+        case TYPE_INT:
+        case TYPE_FLOAT:
+        case TYPE_DATEV2:
+            if (_parent->cast<AggSinkOperatorX>()._is_first_phase)
+                _agg_data->init(vectorized::AggregatedDataVariants::Type::int32_key, is_nullable);
+            else
+                _agg_data->init(vectorized::AggregatedDataVariants::Type::int32_key_phase2,
+                                is_nullable);
+            return;
+        case TYPE_BIGINT:
+        case TYPE_DOUBLE:
+        case TYPE_DATE:
+        case TYPE_DATETIME:
+        case TYPE_DATETIMEV2:
+            if (_parent->cast<AggSinkOperatorX>()._is_first_phase)
+                _agg_data->init(vectorized::AggregatedDataVariants::Type::int64_key, is_nullable);
+            else
+                _agg_data->init(vectorized::AggregatedDataVariants::Type::int64_key_phase2,
+                                is_nullable);
+            return;
+        case TYPE_LARGEINT: {
+            if (_parent->cast<AggSinkOperatorX>()._is_first_phase)
+                _agg_data->init(vectorized::AggregatedDataVariants::Type::int128_key, is_nullable);
+            else
+                _agg_data->init(vectorized::AggregatedDataVariants::Type::int128_key_phase2,
+                                is_nullable);
+            return;
+        }
+        case TYPE_DECIMALV2:
+        case TYPE_DECIMAL32:
+        case TYPE_DECIMAL64:
+        case TYPE_DECIMAL128I: {
+            vectorized::DataTypePtr& type_ptr = probe_exprs[0]->root()->data_type();
+            vectorized::TypeIndex idx =
+                    is_nullable ? assert_cast<const vectorized::DataTypeNullable&>(*type_ptr)
+                                          .get_nested_type()
+                                          ->get_type_id()
+                                : type_ptr->get_type_id();
+            vectorized::WhichDataType which(idx);
+            if (which.is_decimal32()) {
+                if (_parent->cast<AggSinkOperatorX>()._is_first_phase)
+                    _agg_data->init(vectorized::AggregatedDataVariants::Type::int32_key,
+                                    is_nullable);
+                else
+                    _agg_data->init(vectorized::AggregatedDataVariants::Type::int32_key_phase2,
+                                    is_nullable);
+            } else if (which.is_decimal64()) {
+                if (_parent->cast<AggSinkOperatorX>()._is_first_phase)
+                    _agg_data->init(vectorized::AggregatedDataVariants::Type::int64_key,
+                                    is_nullable);
+                else
+                    _agg_data->init(vectorized::AggregatedDataVariants::Type::int64_key_phase2,
+                                    is_nullable);
+            } else {
+                if (_parent->cast<AggSinkOperatorX>()._is_first_phase)
+                    _agg_data->init(vectorized::AggregatedDataVariants::Type::int128_key,
+                                    is_nullable);
+                else
+                    _agg_data->init(vectorized::AggregatedDataVariants::Type::int128_key_phase2,
+                                    is_nullable);
+            }
+            return;
+        }
+        case TYPE_CHAR:
+        case TYPE_VARCHAR:
+        case TYPE_STRING: {
+            _agg_data->init(vectorized::AggregatedDataVariants::Type::string_key, is_nullable);
+            break;
+        }
+        default:
+            _agg_data->init(vectorized::AggregatedDataVariants::Type::serialized);
+        }
+    } else {
+        bool use_fixed_key = true;
+        bool has_null = false;
+        size_t key_byte_size = 0;
+        size_t bitmap_size = vectorized::get_bitmap_size(_shared_state->probe_expr_ctxs.size());
+
+        _shared_state->probe_key_sz.resize(_shared_state->probe_expr_ctxs.size());
+        for (int i = 0; i < _shared_state->probe_expr_ctxs.size(); ++i) {
+            const auto& expr = _shared_state->probe_expr_ctxs[i]->root();
+            const auto& data_type = expr->data_type();
+
+            if (!data_type->have_maximum_size_of_value()) {
+                use_fixed_key = false;
+                break;
+            }
+
+            auto is_null = data_type->is_nullable();
+            has_null |= is_null;
+            _shared_state->probe_key_sz[i] =
+                    data_type->get_maximum_size_of_value_in_memory() - (is_null ? 1 : 0);
+            key_byte_size += _shared_state->probe_key_sz[i];
+        }
+
+        if (!has_null) {
+            bitmap_size = 0;
+        }
+
+        if (bitmap_size + key_byte_size > sizeof(vectorized::UInt256)) {
+            use_fixed_key = false;
+        }
+
+        if (use_fixed_key) {
+            if (bitmap_size + key_byte_size <= sizeof(vectorized::UInt64)) {
+                if (_parent->cast<AggSinkOperatorX>()._is_first_phase) {
+                    _agg_data->init(vectorized::AggregatedDataVariants::Type::int64_keys, has_null);
+                } else {
+                    _agg_data->init(vectorized::AggregatedDataVariants::Type::int64_keys_phase2,
+                                    has_null);
+                }
+            } else if (bitmap_size + key_byte_size <= sizeof(vectorized::UInt128)) {
+                if (_parent->cast<AggSinkOperatorX>()._is_first_phase) {
+                    _agg_data->init(vectorized::AggregatedDataVariants::Type::int128_keys,
+                                    has_null);
+                } else {
+                    _agg_data->init(vectorized::AggregatedDataVariants::Type::int128_keys_phase2,
+                                    has_null);
+                }
+            } else if (bitmap_size + key_byte_size <= sizeof(vectorized::UInt136)) {
+                if (_parent->cast<AggSinkOperatorX>()._is_first_phase) {
+                    _agg_data->init(vectorized::AggregatedDataVariants::Type::int136_keys,
+                                    has_null);
+                } else {
+                    _agg_data->init(vectorized::AggregatedDataVariants::Type::int136_keys_phase2,
+                                    has_null);
+                }
+            } else {
+                if (_parent->cast<AggSinkOperatorX>()._is_first_phase) {
+                    _agg_data->init(vectorized::AggregatedDataVariants::Type::int256_keys,
+                                    has_null);
+                } else {
+                    _agg_data->init(vectorized::AggregatedDataVariants::Type::int256_keys_phase2,
+                                    has_null);
+                }
+            }
+
+        } else {
+            _agg_data->init(vectorized::AggregatedDataVariants::Type::serialized);
+        }
+    }
+}
+
+Status AggSinkLocalState::try_spill_disk(bool eos) {
+    if (_parent->cast<AggSinkOperatorX>()._external_agg_bytes_threshold == 0) {
+        return Status::OK();
+    }
+    return std::visit(
+            [&](auto&& agg_method) -> Status {
+                auto& hash_table = agg_method.data;
+                if (!eos &&
+                    _memory_usage() <
+                            _parent->cast<AggSinkOperatorX>()._external_agg_bytes_threshold) {
+                    return Status::OK();
+                }
+
+                if (_get_hash_table_size() == 0) {
+                    return Status::OK();
+                }
+
+                RETURN_IF_ERROR(_spill_hash_table(agg_method, hash_table));
+                return _dependency->reset_hash_table();
+            },
+            _agg_data->_aggregated_method_variant);
+}
+
+AggSinkOperatorX::AggSinkOperatorX(const int id, ObjectPool* pool, const TPlanNode& tnode,
+                                   const DescriptorTbl& descs)
+        : DataSinkOperatorX(id),
+          _intermediate_tuple_id(tnode.agg_node.intermediate_tuple_id),
+          _intermediate_tuple_desc(nullptr),
+          _output_tuple_id(tnode.agg_node.output_tuple_id),
+          _output_tuple_desc(nullptr),
+          _needs_finalize(tnode.agg_node.need_finalize),
+          _is_merge(false),
+          _pool(pool),
+          _limit(tnode.limit),
+          _have_conjuncts(tnode.__isset.vconjunct && !tnode.vconjunct.nodes.empty()) {
+    _is_first_phase = tnode.agg_node.__isset.is_first_phase && tnode.agg_node.is_first_phase;
+    _name = "AggSinkOperatorX";
+}
+
+Status AggSinkOperatorX::init(const TPlanNode& tnode, RuntimeState* state) {
+    // ignore return status for now , so we need to introduce ExecNode::init()
+    RETURN_IF_ERROR(
+            vectorized::VExpr::create_expr_trees(tnode.agg_node.grouping_exprs, _probe_expr_ctxs));
+
+    // init aggregate functions
+    _aggregate_evaluators.reserve(tnode.agg_node.aggregate_functions.size());
+    // In case of : `select * from (select GoodEvent from hits union select CounterID from hits) as h limit 10;`
+    // only union with limit: we can short circuit query the pipeline exec engine.
+    _can_short_circuit =
+            tnode.agg_node.aggregate_functions.empty() && state->enable_pipeline_exec();
+
+    TSortInfo dummy;
+    for (int i = 0; i < tnode.agg_node.aggregate_functions.size(); ++i) {
+        vectorized::AggFnEvaluator* evaluator = nullptr;
+        RETURN_IF_ERROR(vectorized::AggFnEvaluator::create(
+                _pool, tnode.agg_node.aggregate_functions[i],
+                tnode.agg_node.__isset.agg_sort_infos ? tnode.agg_node.agg_sort_infos[i] : dummy,
+                &evaluator));
+        _aggregate_evaluators.push_back(evaluator);
+    }
+
+    const auto& agg_functions = tnode.agg_node.aggregate_functions;
+    _external_agg_bytes_threshold = state->external_agg_bytes_threshold();
+
+    if (_external_agg_bytes_threshold > 0) {
+        _spill_partition_count_bits = 4;
+        if (state->query_options().__isset.external_agg_partition_bits) {
+            _spill_partition_count_bits = state->query_options().external_agg_partition_bits;
+        }
+    }
+
+    _is_merge = std::any_of(agg_functions.cbegin(), agg_functions.cend(),
+                            [](const auto& e) { return e.nodes[0].agg_expr.is_merge_agg; });
+
+    return Status::OK();
+}
+
+Status AggSinkOperatorX::prepare(RuntimeState* state) {
+    _intermediate_tuple_desc = state->desc_tbl().get_tuple_descriptor(_intermediate_tuple_id);
+    _output_tuple_desc = state->desc_tbl().get_tuple_descriptor(_output_tuple_id);
+    DCHECK_EQ(_intermediate_tuple_desc->slots().size(), _output_tuple_desc->slots().size());
+    RETURN_IF_ERROR(vectorized::VExpr::prepare(_probe_expr_ctxs, state, _child_x->row_desc()));
+
+    int j = _probe_expr_ctxs.size();
+    for (int i = 0; i < j; ++i) {
+        auto nullable_output = _output_tuple_desc->slots()[i]->is_nullable();
+        auto nullable_input = _probe_expr_ctxs[i]->root()->is_nullable();
+        if (nullable_output != nullable_input) {
+            DCHECK(nullable_output);
+            _make_nullable_keys.emplace_back(i);
+        }
+    }
+    for (int i = 0; i < _aggregate_evaluators.size(); ++i, ++j) {
+        SlotDescriptor* intermediate_slot_desc = _intermediate_tuple_desc->slots()[j];
+        SlotDescriptor* output_slot_desc = _output_tuple_desc->slots()[j];
+        RETURN_IF_ERROR(_aggregate_evaluators[i]->prepare(
+                state, _child_x->row_desc(), intermediate_slot_desc, output_slot_desc));
+    }
+
+    _offsets_of_aggregate_states.resize(_aggregate_evaluators.size());
+
+    for (size_t i = 0; i < _aggregate_evaluators.size(); ++i) {
+        _offsets_of_aggregate_states[i] = _total_size_of_aggregate_states;
+
+        const auto& agg_function = _aggregate_evaluators[i]->function();
+        // aggreate states are aligned based on maximum requirement
+        _align_aggregate_states = std::max(_align_aggregate_states, agg_function->align_of_data());
+        _total_size_of_aggregate_states += agg_function->size_of_data();
+
+        // If not the last aggregate_state, we need pad it so that next aggregate_state will be aligned.
+        if (i + 1 < _aggregate_evaluators.size()) {
+            size_t alignment_of_next_state =
+                    _aggregate_evaluators[i + 1]->function()->align_of_data();
+            if ((alignment_of_next_state & (alignment_of_next_state - 1)) != 0) {
+                return Status::RuntimeError("Logical error: align_of_data is not 2^N");
+            }
+
+            /// Extend total_size to next alignment requirement
+            /// Add padding by rounding up 'total_size_of_aggregate_states' to be a multiplier of alignment_of_next_state.
+            _total_size_of_aggregate_states =
+                    (_total_size_of_aggregate_states + alignment_of_next_state - 1) /
+                    alignment_of_next_state * alignment_of_next_state;
+        }
+    }
+
+    fmt::memory_buffer msg;
+    fmt::format_to(msg,
+                   "(_is_merge: {}, _needs_finalize: {},  agg size: "
+                   "{}, limit: {})",
+                   _is_merge ? "true" : "false", _needs_finalize ? "true" : "false",
+                   std::to_string(_aggregate_evaluators.size()), std::to_string(_limit));
+    std::string title = fmt::format("Aggregation Sink {}", fmt::to_string(msg));
+    _profile = _pool->add(new RuntimeProfile(title));
+    return Status::OK();
+}
+
+Status AggSinkOperatorX::open(doris::RuntimeState* state) {
+    RETURN_IF_ERROR(vectorized::VExpr::open(_probe_expr_ctxs, state));
+
+    for (int i = 0; i < _aggregate_evaluators.size(); ++i) {
+        RETURN_IF_ERROR(_aggregate_evaluators[i]->open(state));
+    }
+
+    return Status::OK();
+}
+
+Status AggSinkOperatorX::sink(doris::RuntimeState* state, vectorized::Block* in_block,
+                              SourceState source_state) {
+    auto& local_state = state->get_sink_local_state(id())->cast<AggSinkLocalState>();
+    local_state._shared_state->input_num_rows += in_block->rows();
+    if (in_block->rows() > 0) {
+        RETURN_IF_ERROR(local_state._executor.execute(in_block));
+        RETURN_IF_ERROR(local_state.try_spill_disk());
+        local_state._executor.update_memusage();
+    }
+    if (source_state == SourceState::FINISHED) {
+        if (local_state._shared_state->spill_context.has_data) {
+            local_state.try_spill_disk(true);
+            RETURN_IF_ERROR(local_state._shared_state->spill_context.prepare_for_reading());
+        }
+        local_state._dependency->set_done();
+    }
+    return Status::OK();
+}
+
+Status AggSinkOperatorX::setup_local_state(RuntimeState* state, Dependency* dependency) {
+    auto local_state = AggSinkLocalState::create_shared(this, state);
+    state->emplace_sink_local_state(id(), local_state);
+    return local_state->init(state, dependency);
+}
+
+Status AggSinkOperatorX::close(RuntimeState* state) {
+    auto& local_state = state->get_sink_local_state(id())->cast<AggSinkLocalState>();
+
+    /// _hash_table_size_counter may be null if prepare failed.
+    if (local_state._hash_table_size_counter) {
+        std::visit(
+                [&](auto&& agg_method) {
+                    COUNTER_SET(local_state._hash_table_size_counter,
+                                int64_t(agg_method.data.size()));
+                },
+                local_state._agg_data->_aggregated_method_variant);
+    }
+    local_state._preagg_block.clear();
+
+    vectorized::PODArray<vectorized::AggregateDataPtr> tmp_places;
+    local_state._places.swap(tmp_places);
+
+    std::vector<char> tmp_deserialize_buffer;
+    local_state._deserialize_buffer.swap(tmp_deserialize_buffer);
+
+    std::vector<size_t> tmp_hash_values;
+    local_state._hash_values.swap(tmp_hash_values);
+    return Status::OK();
+}
+
 } // namespace doris::pipeline

--- a/be/src/pipeline/exec/aggregation_sink_operator.cpp
+++ b/be/src/pipeline/exec/aggregation_sink_operator.cpp
@@ -135,7 +135,7 @@ Status AggSinkLocalState::init(RuntimeState* state, Dependency* dependency) {
                                                       p._align_aggregate_states) *
                                                              p._align_aggregate_states));
                 },
-                _agg_data->_aggregated_method_variant);
+                _agg_data->method_variant);
         if (p._is_merge) {
             _executor.execute = std::bind<Status>(&AggSinkLocalState::_merge_with_serialized_key,
                                                   this, std::placeholders::_1);
@@ -186,7 +186,7 @@ size_t AggSinkLocalState::_memory_usage() const {
                 }
                 usage += agg_method.data.get_buffer_size_in_bytes();
             },
-            _agg_data->_aggregated_method_variant);
+            _agg_data->method_variant);
 
     if (_agg_arena_pool) {
         usage += _agg_arena_pool->size();
@@ -218,7 +218,7 @@ void AggSinkLocalState::_update_memusage_with_serialized_key() {
                         _agg_arena_pool->size() +
                         _shared_state->aggregate_data_container->memory_usage();
             },
-            _agg_data->_aggregated_method_variant);
+            _agg_data->method_variant);
 }
 
 template <bool limit, bool for_spill>
@@ -433,7 +433,7 @@ Status AggSinkLocalState::_execute_with_serialized_key_helper(vectorized::Block*
 
 size_t AggSinkLocalState::_get_hash_table_size() {
     return std::visit([&](auto&& agg_method) { return agg_method.data.size(); },
-                      _agg_data->_aggregated_method_variant);
+                      _agg_data->method_variant);
 }
 
 void AggSinkLocalState::_emplace_into_hash_table(vectorized::AggregateDataPtr* places,
@@ -517,7 +517,7 @@ void AggSinkLocalState::_emplace_into_hash_table(vectorized::AggregateDataPtr* p
 
                 COUNTER_UPDATE(_hash_table_input_counter, num_rows);
             },
-            _agg_data->_aggregated_method_variant);
+            _agg_data->method_variant);
 }
 
 void AggSinkLocalState::_find_in_hash_table(vectorized::AggregateDataPtr* places,
@@ -570,7 +570,7 @@ void AggSinkLocalState::_find_in_hash_table(vectorized::AggregateDataPtr* places
                     }
                 }
             },
-            _agg_data->_aggregated_method_variant);
+            _agg_data->method_variant);
 }
 
 void AggSinkLocalState::_init_hash_method(const vectorized::VExprContextSPtrs& probe_exprs) {
@@ -748,7 +748,7 @@ Status AggSinkLocalState::try_spill_disk(bool eos) {
                 RETURN_IF_ERROR(_spill_hash_table(agg_method, hash_table));
                 return _dependency->reset_hash_table();
             },
-            _agg_data->_aggregated_method_variant);
+            _agg_data->method_variant);
 }
 
 AggSinkOperatorX::AggSinkOperatorX(const int id, ObjectPool* pool, const TPlanNode& tnode,
@@ -909,7 +909,7 @@ Status AggSinkOperatorX::close(RuntimeState* state) {
                     COUNTER_SET(local_state._hash_table_size_counter,
                                 int64_t(agg_method.data.size()));
                 },
-                local_state._agg_data->_aggregated_method_variant);
+                local_state._agg_data->method_variant);
     }
     local_state._preagg_block.clear();
 

--- a/be/src/pipeline/exec/aggregation_sink_operator.h
+++ b/be/src/pipeline/exec/aggregation_sink_operator.h
@@ -20,6 +20,9 @@
 #include <stdint.h>
 
 #include "operator.h"
+#include "pipeline/pipeline_x/dependency.h"
+#include "runtime/block_spill_manager.h"
+#include "runtime/exec_env.h"
 #include "vec/exec/vaggregation_node.h"
 
 namespace doris {
@@ -39,6 +42,328 @@ class AggSinkOperator final : public StreamingOperator<AggSinkOperatorBuilder> {
 public:
     AggSinkOperator(OperatorBuilderBase* operator_builder, ExecNode* node);
     bool can_write() override { return true; }
+};
+
+class AggSinkOperatorX;
+
+class AggSinkLocalState : public PipelineXSinkLocalState {
+    ENABLE_FACTORY_CREATOR(AggSinkLocalState);
+
+public:
+    AggSinkLocalState(DataSinkOperatorX* parent, RuntimeState* state);
+
+    Status init(RuntimeState* state, Dependency* dependency) override;
+
+    Status try_spill_disk(bool eos = false);
+
+private:
+    friend class AggSinkOperatorX;
+
+    Status _execute_without_key(vectorized::Block* block);
+    Status _merge_without_key(vectorized::Block* block);
+    void _update_memusage_without_key();
+    void _init_hash_method(const vectorized::VExprContextSPtrs& probe_exprs);
+    Status _execute_with_serialized_key(vectorized::Block* block);
+    Status _merge_with_serialized_key(vectorized::Block* block);
+    void _update_memusage_with_serialized_key();
+    template <bool limit>
+    Status _execute_with_serialized_key_helper(vectorized::Block* block);
+    void _find_in_hash_table(vectorized::AggregateDataPtr* places,
+                             vectorized::ColumnRawPtrs& key_columns, size_t num_rows);
+
+    template <typename AggState, typename AggMethod>
+    void _pre_serialize_key_if_need(AggState& state, AggMethod& agg_method,
+                                    const vectorized::ColumnRawPtrs& key_columns,
+                                    const size_t num_rows) {
+        if constexpr (vectorized::ColumnsHashing::IsPreSerializedKeysHashMethodTraits<
+                              AggState>::value) {
+            auto old_keys_memory = agg_method.keys_memory_usage;
+            SCOPED_TIMER(_serialize_key_timer);
+            int64_t row_size = (int64_t)(agg_method.serialize_keys(key_columns, num_rows));
+            COUNTER_SET(_max_row_size_counter, std::max(_max_row_size_counter->value(), row_size));
+            state.set_serialized_keys(agg_method.keys.data());
+
+            _serialize_key_arena_memory_usage->add(agg_method.keys_memory_usage - old_keys_memory);
+        }
+    }
+    void _emplace_into_hash_table(vectorized::AggregateDataPtr* places,
+                                  vectorized::ColumnRawPtrs& key_columns, const size_t num_rows);
+    size_t _get_hash_table_size();
+
+    template <bool limit, bool for_spill = false>
+    Status _merge_with_serialized_key_helper(vectorized::Block* block);
+
+    template <typename HashTableCtxType, typename HashTableType, typename KeyType>
+    Status _serialize_hash_table_to_block(HashTableCtxType& context, HashTableType& hash_table,
+                                          vectorized::Block& block, std::vector<KeyType>& keys_) {
+        int key_size = _shared_state->probe_expr_ctxs.size();
+        int agg_size = _shared_state->aggregate_evaluators.size();
+
+        vectorized::MutableColumns value_columns(agg_size);
+        vectorized::DataTypes value_data_types(agg_size);
+        vectorized::MutableColumns key_columns;
+
+        for (int i = 0; i < key_size; ++i) {
+            key_columns.emplace_back(
+                    _shared_state->probe_expr_ctxs[i]->root()->data_type()->create_column());
+        }
+
+        for (size_t i = 0; i < _shared_state->aggregate_evaluators.size(); ++i) {
+            value_data_types[i] =
+                    _shared_state->aggregate_evaluators[i]->function()->get_serialized_type();
+            value_columns[i] =
+                    _shared_state->aggregate_evaluators[i]->function()->create_serialize_column();
+        }
+
+        context.init_once();
+        const auto size = hash_table.size();
+        std::vector<KeyType> keys(size);
+        if (_shared_state->values.size() < size) {
+            _shared_state->values.resize(size);
+        }
+
+        size_t num_rows = 0;
+        _shared_state->aggregate_data_container->init_once();
+        auto& iter = _shared_state->aggregate_data_container->iterator;
+
+        {
+            while (iter != _shared_state->aggregate_data_container->end()) {
+                keys[num_rows] = iter.get_key<KeyType>();
+                _shared_state->values[num_rows] = iter.get_aggregate_data();
+                ++iter;
+                ++num_rows;
+            }
+        }
+
+        {
+            context.insert_keys_into_columns(keys, key_columns, num_rows,
+                                             _shared_state->probe_key_sz);
+        }
+
+        if (hash_table.has_null_key_data()) {
+            // only one key of group by support wrap null key
+            // here need additional processing logic on the null key / value
+            CHECK(key_columns.size() == 1);
+            CHECK(key_columns[0]->is_nullable());
+            key_columns[0]->insert_data(nullptr, 0);
+
+            // Here is no need to set `keys[num_rows]`, keep it as default value.
+            _shared_state->values[num_rows] = hash_table.get_null_key_data();
+            ++num_rows;
+        }
+
+        for (size_t i = 0; i < _shared_state->aggregate_evaluators.size(); ++i) {
+            _shared_state->aggregate_evaluators[i]->function()->serialize_to_column(
+                    _shared_state->values, _dependency->offsets_of_aggregate_states()[i],
+                    value_columns[i], num_rows);
+        }
+
+        vectorized::ColumnsWithTypeAndName columns_with_schema;
+        for (int i = 0; i < key_size; ++i) {
+            columns_with_schema.emplace_back(
+                    std::move(key_columns[i]),
+                    _shared_state->probe_expr_ctxs[i]->root()->data_type(),
+                    _shared_state->probe_expr_ctxs[i]->root()->expr_name());
+        }
+        for (int i = 0; i < agg_size; ++i) {
+            columns_with_schema.emplace_back(
+                    std::move(value_columns[i]), value_data_types[i],
+                    _shared_state->aggregate_evaluators[i]->function()->get_name());
+        }
+
+        block = columns_with_schema;
+        keys_.swap(keys);
+        return Status::OK();
+    }
+
+    template <typename HashTableCtxType, typename HashTableType>
+    Status _spill_hash_table(HashTableCtxType& agg_method, HashTableType& hash_table) {
+        vectorized::Block block;
+        std::vector<typename HashTableType::key_type> keys;
+        RETURN_IF_ERROR(_serialize_hash_table_to_block(agg_method, hash_table, block, keys));
+        CHECK_EQ(block.rows(), hash_table.size());
+        CHECK_EQ(keys.size(), block.rows());
+
+        if (!_shared_state->spill_context.has_data) {
+            _shared_state->spill_context.has_data = true;
+            _shared_state->spill_context.runtime_profile =
+                    profile()->create_child("Spill", true, true);
+        }
+
+        vectorized::BlockSpillWriterUPtr writer;
+        RETURN_IF_ERROR(ExecEnv::GetInstance()->block_spill_mgr()->get_writer(
+                std::numeric_limits<int32_t>::max(), writer,
+                _shared_state->spill_context.runtime_profile));
+        Defer defer {[&]() {
+            // redundant call is ok
+            writer->close();
+        }};
+        _shared_state->spill_context.stream_ids.emplace_back(writer->get_id());
+
+        std::vector<size_t> partitioned_indices(block.rows());
+        std::vector<size_t> blocks_rows(_shared_state->spill_partition_helper->partition_count);
+
+        // The last row may contain a null key.
+        const size_t rows = hash_table.has_null_key_data() ? block.rows() - 1 : block.rows();
+        for (size_t i = 0; i < rows; ++i) {
+            const auto index =
+                    _shared_state->spill_partition_helper->get_index(hash_table.hash(keys[i]));
+            partitioned_indices[i] = index;
+            blocks_rows[index]++;
+        }
+
+        if (hash_table.has_null_key_data()) {
+            // Here put the row with null key at the last partition.
+            const auto index = _shared_state->spill_partition_helper->partition_count - 1;
+            partitioned_indices[rows] = index;
+            blocks_rows[index]++;
+        }
+
+        for (size_t i = 0; i < _shared_state->spill_partition_helper->partition_count; ++i) {
+            vectorized::Block block_to_write = block.clone_empty();
+            if (blocks_rows[i] == 0) {
+                /// Here write one empty block to ensure there are enough blocks in the file,
+                /// blocks' count should be equal with partition_count.
+                writer->write(block_to_write);
+                continue;
+            }
+
+            vectorized::MutableBlock mutable_block(std::move(block_to_write));
+
+            for (auto& column : mutable_block.mutable_columns()) {
+                column->reserve(blocks_rows[i]);
+            }
+
+            size_t begin = 0;
+            size_t length = 0;
+            for (size_t j = 0; j < partitioned_indices.size(); ++j) {
+                if (partitioned_indices[j] != i) {
+                    if (length > 0) {
+                        mutable_block.add_rows(&block, begin, length);
+                    }
+                    length = 0;
+                    continue;
+                }
+
+                if (length == 0) {
+                    begin = j;
+                }
+                length++;
+            }
+
+            if (length > 0) {
+                mutable_block.add_rows(&block, begin, length);
+            }
+
+            CHECK_EQ(mutable_block.rows(), blocks_rows[i]);
+            RETURN_IF_ERROR(writer->write(mutable_block.to_block()));
+        }
+        RETURN_IF_ERROR(writer->close());
+
+        return Status::OK();
+    }
+    // We should call this function only at 1st phase.
+    // 1st phase: is_merge=true, only have one SlotRef.
+    // 2nd phase: is_merge=false, maybe have multiple exprs.
+    int _get_slot_column_id(const vectorized::AggFnEvaluator* evaluator);
+    size_t _memory_usage() const;
+
+    RuntimeProfile::Counter* _hash_table_compute_timer;
+    RuntimeProfile::Counter* _hash_table_emplace_timer;
+    RuntimeProfile::Counter* _hash_table_input_counter;
+    RuntimeProfile::Counter* _build_timer;
+    RuntimeProfile::Counter* _expr_timer;
+    RuntimeProfile::Counter* _exec_timer;
+    RuntimeProfile::Counter* _build_table_convert_timer;
+    RuntimeProfile::Counter* _serialize_key_timer;
+    RuntimeProfile::Counter* _merge_timer;
+    RuntimeProfile::Counter* _serialize_data_timer;
+    RuntimeProfile::Counter* _deserialize_data_timer;
+    RuntimeProfile::Counter* _hash_table_size_counter;
+    RuntimeProfile::Counter* _max_row_size_counter;
+    RuntimeProfile::Counter* _memory_usage_counter;
+    RuntimeProfile::Counter* _hash_table_memory_usage;
+    RuntimeProfile::HighWaterMarkCounter* _serialize_key_arena_memory_usage;
+
+    bool _should_limit_output = false;
+    bool _reach_limit = false;
+
+    vectorized::PODArray<vectorized::AggregateDataPtr> _places;
+    std::vector<char> _deserialize_buffer;
+
+    vectorized::Block _preagg_block = vectorized::Block();
+
+    AggDependency* _dependency;
+    vectorized::AggregatedDataVariants* _agg_data;
+    AggSharedState* _shared_state;
+    vectorized::Arena* _agg_arena_pool;
+    std::vector<size_t> _hash_values;
+
+    using vectorized_execute = std::function<Status(vectorized::Block* block)>;
+    using vectorized_update_memusage = std::function<void()>;
+
+    struct executor {
+        vectorized_execute execute;
+        vectorized_update_memusage update_memusage;
+    };
+
+    executor _executor;
+};
+
+class AggSinkOperatorX final : public DataSinkOperatorX {
+public:
+    AggSinkOperatorX(const int id, ObjectPool* pool, const TPlanNode& tnode,
+                     const DescriptorTbl& descs);
+    Status init(const TDataSink& tsink) override {
+        return Status::InternalError("{} should not init with TPlanNode", _name);
+    }
+
+    Status init(const TPlanNode& tnode, RuntimeState* state) override;
+
+    Status prepare(RuntimeState* state) override;
+    Status open(RuntimeState* state) override;
+    Status setup_local_state(RuntimeState* state, Dependency* dependency) override;
+
+    Status sink(RuntimeState* state, vectorized::Block* in_block,
+                SourceState source_state) override;
+
+    Status close(RuntimeState* state) override;
+    bool can_write(RuntimeState* state) override { return true; }
+
+    void get_dependency(DependencySPtr& dependency) override {
+        dependency.reset(new AggDependency());
+    }
+
+private:
+    friend class AggSinkLocalState;
+    std::vector<vectorized::AggFnEvaluator*> _aggregate_evaluators;
+    bool _can_short_circuit = false;
+
+    // may be we don't have to know the tuple id
+    TupleId _intermediate_tuple_id;
+    TupleDescriptor* _intermediate_tuple_desc;
+
+    TupleId _output_tuple_id;
+    TupleDescriptor* _output_tuple_desc;
+
+    bool _needs_finalize;
+    bool _is_merge;
+    bool _is_first_phase;
+
+    size_t _align_aggregate_states = 1;
+    /// The offset to the n-th aggregate function in a row of aggregate functions.
+    vectorized::Sizes _offsets_of_aggregate_states;
+    /// The total size of the row from the aggregate functions.
+    size_t _total_size_of_aggregate_states = 0;
+
+    size_t _external_agg_bytes_threshold;
+    // group by k1,k2
+    vectorized::VExprContextSPtrs _probe_expr_ctxs;
+    ObjectPool* _pool;
+    std::vector<size_t> _make_nullable_keys;
+    size_t _spill_partition_count_bits;
+    int64_t _limit; // -1: no limit
+    bool _have_conjuncts;
 };
 
 } // namespace pipeline

--- a/be/src/pipeline/exec/aggregation_source_operator.cpp
+++ b/be/src/pipeline/exec/aggregation_source_operator.cpp
@@ -20,11 +20,540 @@
 #include <string>
 
 #include "pipeline/exec/operator.h"
+#include "vec//utils/util.hpp"
 
 namespace doris {
 namespace pipeline {
 
 OPERATOR_CODE_GENERATOR(AggSourceOperator, SourceOperator)
+
+AggLocalState::AggLocalState(RuntimeState* state, OperatorXBase* parent)
+        : PipelineXLocalState(state, parent),
+          _get_results_timer(nullptr),
+          _serialize_result_timer(nullptr),
+          _hash_table_iterate_timer(nullptr),
+          _insert_keys_to_column_timer(nullptr),
+          _serialize_data_timer(nullptr) {}
+
+Status AggLocalState::init(RuntimeState* state, LocalStateInfo& info) {
+    RETURN_IF_ERROR(PipelineXLocalState::init(state, info));
+    _dependency = (AggDependency*)info.dependency;
+    _shared_state = ((AggSharedState*)_dependency->shared_state());
+    _agg_data = _shared_state->agg_data.get();
+    _get_results_timer = ADD_TIMER(profile(), "GetResultsTime");
+    _serialize_result_timer = ADD_TIMER(profile(), "SerializeResultTime");
+    _hash_table_iterate_timer = ADD_TIMER(profile(), "HashTableIterateTime");
+    _insert_keys_to_column_timer = ADD_TIMER(profile(), "InsertKeysToColumnTime");
+    _serialize_data_timer = ADD_TIMER(profile(), "SerializeDataTime");
+    auto& p = _parent->cast<AggSourceOperatorX>();
+    if (p._without_key) {
+        if (p._needs_finalize) {
+            _executor.get_result = std::bind<Status>(&AggLocalState::_get_without_key_result, this,
+                                                     std::placeholders::_1, std::placeholders::_2,
+                                                     std::placeholders::_3);
+        } else {
+            _executor.get_result = std::bind<Status>(&AggLocalState::_serialize_without_key, this,
+                                                     std::placeholders::_1, std::placeholders::_2,
+                                                     std::placeholders::_3);
+        }
+
+        _executor.close = std::bind<void>(&AggLocalState::_close_without_key, this);
+    } else {
+        if (p._needs_finalize) {
+            _executor.get_result = std::bind<Status>(
+                    &AggLocalState::_get_with_serialized_key_result, this, std::placeholders::_1,
+                    std::placeholders::_2, std::placeholders::_3);
+        } else {
+            _executor.get_result = std::bind<Status>(
+                    &AggLocalState::_serialize_with_serialized_key_result, this,
+                    std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
+        }
+        _executor.close = std::bind<void>(&AggLocalState::_close_with_serialized_key, this);
+    }
+
+    // move _create_agg_status to open not in during prepare,
+    // because during prepare and open thread is not the same one,
+    // this could cause unable to get JVM
+    if (_shared_state->probe_expr_ctxs.empty()) {
+        // _create_agg_status may acquire a lot of memory, may allocate failed when memory is very few
+        RETURN_IF_CATCH_EXCEPTION(_dependency->create_agg_status(_agg_data->without_key));
+        _agg_data_created_without_key = true;
+    }
+    return Status::OK();
+}
+
+void AggLocalState::_close_with_serialized_key() {
+    std::visit(
+            [&](auto&& agg_method) -> void {
+                auto& data = agg_method.data;
+                data.for_each_mapped([&](auto& mapped) {
+                    if (mapped) {
+                        _dependency->destroy_agg_status(mapped);
+                        mapped = nullptr;
+                    }
+                });
+                if (data.has_null_key_data()) {
+                    _dependency->destroy_agg_status(data.get_null_key_data());
+                }
+            },
+            _agg_data->_aggregated_method_variant);
+    _dependency->release_tracker();
+}
+
+void AggLocalState::_close_without_key() {
+    //because prepare maybe failed, and couldn't create agg data.
+    //but finally call close to destory agg data, if agg data has bitmapValue
+    //will be core dump, it's not initialized
+    if (_agg_data_created_without_key) {
+        _dependency->destroy_agg_status(_agg_data->without_key);
+        _agg_data_created_without_key = false;
+    }
+    _dependency->release_tracker();
+}
+
+Status AggLocalState::_serialize_with_serialized_key_result(RuntimeState* state,
+                                                            vectorized::Block* block,
+                                                            SourceState& source_state) {
+    if (_shared_state->spill_context.has_data) {
+        return _serialize_with_serialized_key_result_with_spilt_data(state, block, source_state);
+    } else {
+        return _serialize_with_serialized_key_result_non_spill(state, block, source_state);
+    }
+}
+
+Status AggLocalState::_serialize_with_serialized_key_result_with_spilt_data(
+        RuntimeState* state, vectorized::Block* block, SourceState& source_state) {
+    CHECK(!_shared_state->spill_context.stream_ids.empty());
+    CHECK(_shared_state->spill_partition_helper != nullptr)
+            << "_spill_partition_helper should not be null";
+    _shared_state->aggregate_data_container->init_once();
+    while (_shared_state->aggregate_data_container->iterator ==
+           _shared_state->aggregate_data_container->end()) {
+        if (_shared_state->spill_context.read_cursor ==
+            _shared_state->spill_partition_helper->partition_count) {
+            break;
+        }
+        RETURN_IF_ERROR(_dependency->reset_hash_table());
+        RETURN_IF_ERROR(_dependency->merge_spilt_data());
+        _shared_state->aggregate_data_container->init_once();
+    }
+
+    RETURN_IF_ERROR(_serialize_with_serialized_key_result_non_spill(state, block, source_state));
+    if (source_state == SourceState::FINISHED) {
+        source_state = _shared_state->spill_context.read_cursor ==
+                                       _shared_state->spill_partition_helper->partition_count
+                               ? SourceState::FINISHED
+                               : SourceState::DEPEND_ON_SOURCE;
+    }
+    CHECK(!block->empty() || source_state == SourceState::FINISHED);
+    return Status::OK();
+}
+Status AggLocalState::_serialize_with_serialized_key_result_non_spill(RuntimeState* state,
+                                                                      vectorized::Block* block,
+                                                                      SourceState& source_state) {
+    SCOPED_TIMER(_serialize_result_timer);
+    int key_size = _shared_state->probe_expr_ctxs.size();
+    int agg_size = _shared_state->aggregate_evaluators.size();
+    vectorized::MutableColumns value_columns(agg_size);
+    vectorized::DataTypes value_data_types(agg_size);
+
+    // non-nullable column(id in `_make_nullable_keys`) will be converted to nullable.
+    bool mem_reuse = _dependency->make_nullable_keys().empty() && block->mem_reuse();
+
+    vectorized::MutableColumns key_columns;
+    for (int i = 0; i < key_size; ++i) {
+        if (mem_reuse) {
+            key_columns.emplace_back(std::move(*block->get_by_position(i).column).mutate());
+        } else {
+            key_columns.emplace_back(
+                    _shared_state->probe_expr_ctxs[i]->root()->data_type()->create_column());
+        }
+    }
+
+    SCOPED_TIMER(_get_results_timer);
+    std::visit(
+            [&](auto&& agg_method) -> void {
+                agg_method.init_once();
+                auto& data = agg_method.data;
+                const auto size = std::min(data.size(), size_t(state->batch_size()));
+                using KeyType = std::decay_t<decltype(agg_method.iterator->get_first())>;
+                std::vector<KeyType> keys(size);
+                if (_shared_state->values.size() < size + 1) {
+                    _shared_state->values.resize(size + 1);
+                }
+
+                size_t num_rows = 0;
+                _shared_state->aggregate_data_container->init_once();
+                auto& iter = _shared_state->aggregate_data_container->iterator;
+
+                {
+                    SCOPED_TIMER(_hash_table_iterate_timer);
+                    while (iter != _shared_state->aggregate_data_container->end() &&
+                           num_rows < state->batch_size()) {
+                        keys[num_rows] = iter.get_key<KeyType>();
+                        _shared_state->values[num_rows] = iter.get_aggregate_data();
+                        ++iter;
+                        ++num_rows;
+                    }
+                }
+
+                {
+                    SCOPED_TIMER(_insert_keys_to_column_timer);
+                    agg_method.insert_keys_into_columns(keys, key_columns, num_rows,
+                                                        _shared_state->probe_key_sz);
+                }
+
+                if (iter == _shared_state->aggregate_data_container->end()) {
+                    if (agg_method.data.has_null_key_data()) {
+                        // only one key of group by support wrap null key
+                        // here need additional processing logic on the null key / value
+                        DCHECK(key_columns.size() == 1);
+                        DCHECK(key_columns[0]->is_nullable());
+                        if (agg_method.data.has_null_key_data()) {
+                            key_columns[0]->insert_data(nullptr, 0);
+                            _shared_state->values[num_rows] = agg_method.data.get_null_key_data();
+                            ++num_rows;
+                            source_state = SourceState::FINISHED;
+                        }
+                    } else {
+                        source_state = SourceState::FINISHED;
+                    }
+                }
+
+                {
+                    SCOPED_TIMER(_serialize_data_timer);
+                    for (size_t i = 0; i < _shared_state->aggregate_evaluators.size(); ++i) {
+                        value_data_types[i] = _shared_state->aggregate_evaluators[i]
+                                                      ->function()
+                                                      ->get_serialized_type();
+                        if (mem_reuse) {
+                            value_columns[i] =
+                                    std::move(*block->get_by_position(i + key_size).column)
+                                            .mutate();
+                        } else {
+                            value_columns[i] = _shared_state->aggregate_evaluators[i]
+                                                       ->function()
+                                                       ->create_serialize_column();
+                        }
+                        _shared_state->aggregate_evaluators[i]->function()->serialize_to_column(
+                                _shared_state->values,
+                                _dependency->offsets_of_aggregate_states()[i], value_columns[i],
+                                num_rows);
+                    }
+                }
+            },
+            _agg_data->_aggregated_method_variant);
+
+    if (!mem_reuse) {
+        vectorized::ColumnsWithTypeAndName columns_with_schema;
+        for (int i = 0; i < key_size; ++i) {
+            columns_with_schema.emplace_back(
+                    std::move(key_columns[i]),
+                    _shared_state->probe_expr_ctxs[i]->root()->data_type(),
+                    _shared_state->probe_expr_ctxs[i]->root()->expr_name());
+        }
+        for (int i = 0; i < agg_size; ++i) {
+            columns_with_schema.emplace_back(std::move(value_columns[i]), value_data_types[i], "");
+        }
+        *block = vectorized::Block(columns_with_schema);
+    }
+
+    return Status::OK();
+}
+
+Status AggLocalState::_get_with_serialized_key_result(RuntimeState* state, vectorized::Block* block,
+                                                      SourceState& source_state) {
+    if (_shared_state->spill_context.has_data) {
+        return _get_result_with_spilt_data(state, block, source_state);
+    } else {
+        return _get_result_with_serialized_key_non_spill(state, block, source_state);
+    }
+}
+
+Status AggLocalState::_get_result_with_spilt_data(RuntimeState* state, vectorized::Block* block,
+                                                  SourceState& source_state) {
+    CHECK(!_shared_state->spill_context.stream_ids.empty());
+    CHECK(_shared_state->spill_partition_helper != nullptr)
+            << "_spill_partition_helper should not be null";
+    _shared_state->aggregate_data_container->init_once();
+    while (_shared_state->aggregate_data_container->iterator ==
+           _shared_state->aggregate_data_container->end()) {
+        if (_shared_state->spill_context.read_cursor ==
+            _shared_state->spill_partition_helper->partition_count) {
+            break;
+        }
+        RETURN_IF_ERROR(_dependency->reset_hash_table());
+        RETURN_IF_ERROR(_dependency->merge_spilt_data());
+        _shared_state->aggregate_data_container->init_once();
+    }
+
+    RETURN_IF_ERROR(_get_result_with_serialized_key_non_spill(state, block, source_state));
+    if (source_state == SourceState::FINISHED) {
+        source_state = _shared_state->spill_context.read_cursor ==
+                                       _shared_state->spill_partition_helper->partition_count
+                               ? SourceState::FINISHED
+                               : SourceState::DEPEND_ON_SOURCE;
+    }
+    CHECK(!block->empty() || source_state == SourceState::FINISHED);
+    return Status::OK();
+}
+
+Status AggLocalState::_get_result_with_serialized_key_non_spill(RuntimeState* state,
+                                                                vectorized::Block* block,
+                                                                SourceState& source_state) {
+    // non-nullable column(id in `_make_nullable_keys`) will be converted to nullable.
+    bool mem_reuse = _dependency->make_nullable_keys().empty() && block->mem_reuse();
+
+    auto columns_with_schema = vectorized::VectorizedUtils::create_columns_with_type_and_name(
+            _parent->cast<AggSourceOperatorX>()._row_descriptor);
+    int key_size = _shared_state->probe_expr_ctxs.size();
+
+    vectorized::MutableColumns key_columns;
+    for (int i = 0; i < key_size; ++i) {
+        if (!mem_reuse) {
+            key_columns.emplace_back(columns_with_schema[i].type->create_column());
+        } else {
+            key_columns.emplace_back(std::move(*block->get_by_position(i).column).mutate());
+        }
+    }
+    vectorized::MutableColumns value_columns;
+    for (int i = key_size; i < columns_with_schema.size(); ++i) {
+        if (!mem_reuse) {
+            value_columns.emplace_back(columns_with_schema[i].type->create_column());
+        } else {
+            value_columns.emplace_back(std::move(*block->get_by_position(i).column).mutate());
+        }
+    }
+
+    SCOPED_TIMER(_get_results_timer);
+    std::visit(
+            [&](auto&& agg_method) -> void {
+                auto& data = agg_method.data;
+                agg_method.init_once();
+                const auto size = std::min(data.size(), size_t(state->batch_size()));
+                using KeyType = std::decay_t<decltype(agg_method.iterator->get_first())>;
+                std::vector<KeyType> keys(size);
+                if (_shared_state->values.size() < size) {
+                    _shared_state->values.resize(size);
+                }
+
+                size_t num_rows = 0;
+                _shared_state->aggregate_data_container->init_once();
+                auto& iter = _shared_state->aggregate_data_container->iterator;
+
+                {
+                    SCOPED_TIMER(_hash_table_iterate_timer);
+                    while (iter != _shared_state->aggregate_data_container->end() &&
+                           num_rows < state->batch_size()) {
+                        keys[num_rows] = iter.get_key<KeyType>();
+                        _shared_state->values[num_rows] = iter.get_aggregate_data();
+                        ++iter;
+                        ++num_rows;
+                    }
+                }
+
+                {
+                    SCOPED_TIMER(_insert_keys_to_column_timer);
+                    agg_method.insert_keys_into_columns(keys, key_columns, num_rows,
+                                                        _shared_state->probe_key_sz);
+                }
+
+                for (size_t i = 0; i < _shared_state->aggregate_evaluators.size(); ++i) {
+                    _shared_state->aggregate_evaluators[i]->insert_result_info_vec(
+                            _shared_state->values, _dependency->offsets_of_aggregate_states()[i],
+                            value_columns[i].get(), num_rows);
+                }
+
+                if (iter == _shared_state->aggregate_data_container->end()) {
+                    if (agg_method.data.has_null_key_data()) {
+                        // only one key of group by support wrap null key
+                        // here need additional processing logic on the null key / value
+                        DCHECK(key_columns.size() == 1);
+                        DCHECK(key_columns[0]->is_nullable());
+                        if (key_columns[0]->size() < state->batch_size()) {
+                            key_columns[0]->insert_data(nullptr, 0);
+                            auto mapped = agg_method.data.get_null_key_data();
+                            for (size_t i = 0; i < _shared_state->aggregate_evaluators.size(); ++i)
+                                _shared_state->aggregate_evaluators[i]->insert_result_info(
+                                        mapped + _dependency->offsets_of_aggregate_states()[i],
+                                        value_columns[i].get());
+                            source_state = SourceState::FINISHED;
+                        }
+                    } else {
+                        source_state = SourceState::FINISHED;
+                    }
+                }
+            },
+            _agg_data->_aggregated_method_variant);
+
+    if (!mem_reuse) {
+        *block = columns_with_schema;
+        vectorized::MutableColumns columns(block->columns());
+        for (int i = 0; i < block->columns(); ++i) {
+            if (i < key_size) {
+                columns[i] = std::move(key_columns[i]);
+            } else {
+                columns[i] = std::move(value_columns[i - key_size]);
+            }
+        }
+        block->set_columns(std::move(columns));
+    }
+
+    return Status::OK();
+}
+
+Status AggLocalState::_serialize_without_key(RuntimeState* state, vectorized::Block* block,
+                                             SourceState& source_state) {
+    // 1. `child(0)->rows_returned() == 0` mean not data from child
+    // in level two aggregation node should return NULL result
+    //    level one aggregation node set `eos = true` return directly
+    SCOPED_TIMER(_serialize_result_timer);
+    if (UNLIKELY(_shared_state->input_num_rows == 0)) {
+        source_state = SourceState::FINISHED;
+        return Status::OK();
+    }
+    block->clear();
+
+    DCHECK(_agg_data->without_key != nullptr);
+    int agg_size = _shared_state->aggregate_evaluators.size();
+
+    vectorized::MutableColumns value_columns(agg_size);
+    std::vector<vectorized::DataTypePtr> data_types(agg_size);
+    // will serialize data to string column
+    for (int i = 0; i < _shared_state->aggregate_evaluators.size(); ++i) {
+        data_types[i] = _shared_state->aggregate_evaluators[i]->function()->get_serialized_type();
+        value_columns[i] =
+                _shared_state->aggregate_evaluators[i]->function()->create_serialize_column();
+    }
+
+    for (int i = 0; i < _shared_state->aggregate_evaluators.size(); ++i) {
+        _shared_state->aggregate_evaluators[i]->function()->serialize_without_key_to_column(
+                _agg_data->without_key + _dependency->offsets_of_aggregate_states()[i],
+                *value_columns[i]);
+    }
+
+    {
+        vectorized::ColumnsWithTypeAndName data_with_schema;
+        for (int i = 0; i < _shared_state->aggregate_evaluators.size(); ++i) {
+            vectorized::ColumnWithTypeAndName column_with_schema = {nullptr, data_types[i], ""};
+            data_with_schema.push_back(std::move(column_with_schema));
+        }
+        *block = vectorized::Block(data_with_schema);
+    }
+
+    block->set_columns(std::move(value_columns));
+    source_state = SourceState::FINISHED;
+    return Status::OK();
+}
+
+Status AggLocalState::_get_without_key_result(RuntimeState* state, vectorized::Block* block,
+                                              SourceState& source_state) {
+    DCHECK(_agg_data->without_key != nullptr);
+    block->clear();
+
+    auto& p = _parent->cast<AggSourceOperatorX>();
+    *block = vectorized::VectorizedUtils::create_empty_columnswithtypename(p._row_descriptor);
+    int agg_size = _shared_state->aggregate_evaluators.size();
+
+    vectorized::MutableColumns columns(agg_size);
+    std::vector<vectorized::DataTypePtr> data_types(agg_size);
+    for (int i = 0; i < _shared_state->aggregate_evaluators.size(); ++i) {
+        data_types[i] = _shared_state->aggregate_evaluators[i]->function()->get_return_type();
+        columns[i] = data_types[i]->create_column();
+    }
+
+    for (int i = 0; i < _shared_state->aggregate_evaluators.size(); ++i) {
+        auto column = columns[i].get();
+        _shared_state->aggregate_evaluators[i]->insert_result_info(
+                _agg_data->without_key + _dependency->offsets_of_aggregate_states()[i], column);
+    }
+
+    const auto& block_schema = block->get_columns_with_type_and_name();
+    DCHECK_EQ(block_schema.size(), columns.size());
+    for (int i = 0; i < block_schema.size(); ++i) {
+        const auto column_type = block_schema[i].type;
+        if (!column_type->equals(*data_types[i])) {
+            if (!vectorized::is_array(remove_nullable(column_type))) {
+                if (!column_type->is_nullable() || data_types[i]->is_nullable() ||
+                    !remove_nullable(column_type)->equals(*data_types[i])) {
+                    return Status::InternalError(
+                            "column_type not match data_types, column_type={}, data_types={}",
+                            column_type->get_name(), data_types[i]->get_name());
+                }
+            }
+
+            if (column_type->is_nullable() && !data_types[i]->is_nullable()) {
+                vectorized::ColumnPtr ptr = std::move(columns[i]);
+                // unless `count`, other aggregate function dispose empty set should be null
+                // so here check the children row return
+                ptr = make_nullable(ptr, _shared_state->input_num_rows == 0);
+                columns[i] = ptr->assume_mutable();
+            }
+        }
+    }
+
+    block->set_columns(std::move(columns));
+    source_state = SourceState::FINISHED;
+    return Status::OK();
+}
+
+AggSourceOperatorX::AggSourceOperatorX(ObjectPool* pool, const TPlanNode& tnode,
+                                       const DescriptorTbl& descs, std::string op_name)
+        : OperatorXBase(pool, tnode, descs, op_name),
+          _needs_finalize(tnode.agg_node.need_finalize),
+          _without_key(tnode.agg_node.grouping_exprs.empty()) {}
+
+Status AggSourceOperatorX::get_block(RuntimeState* state, vectorized::Block* block,
+                                     SourceState& source_state) {
+    auto& local_state = state->get_local_state(id())->cast<AggLocalState>();
+    RETURN_IF_ERROR(local_state._executor.get_result(state, block, source_state));
+    local_state.make_nullable_output_key(block);
+    // dispose the having clause, should not be execute in prestreaming agg
+    RETURN_IF_ERROR(vectorized::VExprContext::filter_block(_conjuncts, block, block->columns()));
+    bool eos = false;
+    local_state.reached_limit(block, &eos);
+    source_state = eos ? SourceState::FINISHED : source_state;
+    return Status::OK();
+}
+
+void AggLocalState::make_nullable_output_key(vectorized::Block* block) {
+    if (block->rows() != 0) {
+        for (auto cid : _dependency->make_nullable_keys()) {
+            block->get_by_position(cid).column = make_nullable(block->get_by_position(cid).column);
+            block->get_by_position(cid).type = make_nullable(block->get_by_position(cid).type);
+        }
+    }
+}
+
+Status AggSourceOperatorX::close(RuntimeState* state) {
+    auto& local_state = state->get_local_state(id())->cast<AggLocalState>();
+    for (auto* aggregate_evaluator : local_state._shared_state->aggregate_evaluators) {
+        aggregate_evaluator->close(state);
+    }
+    if (local_state._executor.close) {
+        local_state._executor.close();
+    }
+
+    local_state._shared_state->agg_data = nullptr;
+    local_state._shared_state->aggregate_data_container = nullptr;
+    local_state._shared_state->agg_arena_pool = nullptr;
+    local_state._shared_state->agg_profile_arena = nullptr;
+
+    std::vector<vectorized::AggregateDataPtr> tmp_values;
+    local_state._shared_state->values.swap(tmp_values);
+    return Status::OK();
+}
+
+Status AggSourceOperatorX::setup_local_state(RuntimeState* state, LocalStateInfo& info) {
+    auto local_state = AggLocalState::create_shared(state, this);
+    state->emplace_local_state(id(), local_state);
+    return local_state->init(state, info);
+}
+
+bool AggSourceOperatorX::can_read(RuntimeState* state) {
+    auto& local_state = state->get_local_state(id())->cast<AggLocalState>();
+    return local_state._dependency->done();
+}
 
 } // namespace pipeline
 } // namespace doris

--- a/be/src/pipeline/exec/aggregation_source_operator.cpp
+++ b/be/src/pipeline/exec/aggregation_source_operator.cpp
@@ -96,7 +96,7 @@ void AggLocalState::_close_with_serialized_key() {
                     _dependency->destroy_agg_status(data.get_null_key_data());
                 }
             },
-            _agg_data->_aggregated_method_variant);
+            _agg_data->method_variant);
     _dependency->release_tracker();
 }
 
@@ -242,7 +242,7 @@ Status AggLocalState::_serialize_with_serialized_key_result_non_spill(RuntimeSta
                     }
                 }
             },
-            _agg_data->_aggregated_method_variant);
+            _agg_data->method_variant);
 
     if (!mem_reuse) {
         vectorized::ColumnsWithTypeAndName columns_with_schema;
@@ -384,7 +384,7 @@ Status AggLocalState::_get_result_with_serialized_key_non_spill(RuntimeState* st
                     }
                 }
             },
-            _agg_data->_aggregated_method_variant);
+            _agg_data->method_variant);
 
     if (!mem_reuse) {
         *block = columns_with_schema;

--- a/be/src/pipeline/exec/aggregation_source_operator.h
+++ b/be/src/pipeline/exec/aggregation_source_operator.h
@@ -20,6 +20,7 @@
 
 #include "common/status.h"
 #include "operator.h"
+#include "pipeline/pipeline_x/dependency.h"
 #include "vec/exec/vaggregation_node.h"
 
 namespace doris {
@@ -44,6 +45,89 @@ public:
     // should skip `alloc_resource()` function call, only sink operator
     // call the function
     Status open(RuntimeState*) override { return Status::OK(); }
+};
+
+class AggSourceOperatorX;
+class AggLocalState : public PipelineXLocalState {
+public:
+    ENABLE_FACTORY_CREATOR(AggLocalState);
+    AggLocalState(RuntimeState* state, OperatorXBase* parent);
+
+    Status init(RuntimeState* state, LocalStateInfo& info) override;
+
+    void make_nullable_output_key(vectorized::Block* block);
+
+private:
+    friend class AggSourceOperatorX;
+
+    void _close_without_key();
+    void _close_with_serialized_key();
+    Status _get_without_key_result(RuntimeState* state, vectorized::Block* block,
+                                   SourceState& source_state);
+    Status _serialize_without_key(RuntimeState* state, vectorized::Block* block,
+                                  SourceState& source_state);
+    Status _get_with_serialized_key_result(RuntimeState* state, vectorized::Block* block,
+                                           SourceState& source_state);
+    Status _serialize_with_serialized_key_result(RuntimeState* state, vectorized::Block* block,
+                                                 SourceState& source_state);
+    Status _get_result_with_serialized_key_non_spill(RuntimeState* state, vectorized::Block* block,
+                                                     SourceState& source_state);
+    Status _get_result_with_spilt_data(RuntimeState* state, vectorized::Block* block,
+                                       SourceState& source_state);
+
+    Status _serialize_with_serialized_key_result_non_spill(RuntimeState* state,
+                                                           vectorized::Block* block,
+                                                           SourceState& source_state);
+    Status _serialize_with_serialized_key_result_with_spilt_data(RuntimeState* state,
+                                                                 vectorized::Block* block,
+                                                                 SourceState& source_state);
+
+    RuntimeProfile::Counter* _get_results_timer;
+    RuntimeProfile::Counter* _serialize_result_timer;
+    RuntimeProfile::Counter* _hash_table_iterate_timer;
+    RuntimeProfile::Counter* _insert_keys_to_column_timer;
+    RuntimeProfile::Counter* _serialize_data_timer;
+
+    using vectorized_get_result = std::function<Status(
+            RuntimeState* state, vectorized::Block* block, SourceState& source_state)>;
+    using vectorized_closer = std::function<void()>;
+
+    struct executor {
+        vectorized_get_result get_result;
+        vectorized_closer close;
+    };
+
+    executor _executor;
+
+    AggDependency* _dependency;
+    AggSharedState* _shared_state;
+    vectorized::AggregatedDataVariants* _agg_data;
+    bool _agg_data_created_without_key = false;
+};
+
+class AggSourceOperatorX final : public OperatorXBase {
+public:
+    AggSourceOperatorX(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs,
+                       std::string op_name);
+    bool can_read(RuntimeState* state) override;
+
+    Status setup_local_state(RuntimeState* state, LocalStateInfo& info) override;
+
+    Status get_block(RuntimeState* state, vectorized::Block* block,
+                     SourceState& source_state) override;
+
+    Status close(RuntimeState* state) override;
+    bool is_source() const override { return true; }
+
+private:
+    friend class AggLocalState;
+
+    bool _needs_finalize;
+    bool _without_key;
+
+    // left / full join will change the key nullable make output/input solt
+    // nullable diff. so we need make nullable of it.
+    std::vector<size_t> _make_nullable_keys;
 };
 
 } // namespace pipeline

--- a/be/src/pipeline/exec/exchange_sink_buffer.cpp
+++ b/be/src/pipeline/exec/exchange_sink_buffer.cpp
@@ -35,6 +35,7 @@
 #include <utility>
 
 #include "common/status.h"
+#include "pipeline/exec/exchange_sink_operator.h"
 #include "pipeline/pipeline_fragment_context.h"
 #include "runtime/exec_env.h"
 #include "runtime/thread_context.h"
@@ -45,8 +46,10 @@
 
 namespace doris::pipeline {
 
-ExchangeSinkBuffer::ExchangeSinkBuffer(PUniqueId query_id, PlanNodeId dest_node_id, int send_id,
-                                       int be_number, PipelineFragmentContext* context)
+template <typename Parent>
+ExchangeSinkBuffer<Parent>::ExchangeSinkBuffer(PUniqueId query_id, PlanNodeId dest_node_id,
+                                               int send_id, int be_number,
+                                               PipelineFragmentContext* context)
         : _is_finishing(false),
           _query_id(query_id),
           _dest_node_id(dest_node_id),
@@ -54,15 +57,18 @@ ExchangeSinkBuffer::ExchangeSinkBuffer(PUniqueId query_id, PlanNodeId dest_node_
           _be_number(be_number),
           _context(context) {}
 
-ExchangeSinkBuffer::~ExchangeSinkBuffer() = default;
+template <typename Parent>
+ExchangeSinkBuffer<Parent>::~ExchangeSinkBuffer() = default;
 
-void ExchangeSinkBuffer::close() {
+template <typename Parent>
+void ExchangeSinkBuffer<Parent>::close() {
     _instance_to_broadcast_package_queue.clear();
     _instance_to_package_queue.clear();
     _instance_to_request.clear();
 }
 
-bool ExchangeSinkBuffer::can_write() const {
+template <typename Parent>
+bool ExchangeSinkBuffer<Parent>::can_write() const {
     size_t max_package_size = 64 * _instance_to_package_queue.size();
     size_t total_package_size = 0;
     for (auto& [_, q] : _instance_to_package_queue) {
@@ -71,11 +77,13 @@ bool ExchangeSinkBuffer::can_write() const {
     return total_package_size <= max_package_size;
 }
 
-bool ExchangeSinkBuffer::is_pending_finish() {
+template <typename Parent>
+bool ExchangeSinkBuffer<Parent>::is_pending_finish() {
     //note(wb) angly implementation here, because operator couples the scheduling logic
     // graceful implementation maybe as follows:
     // 1 make ExchangeSinkBuffer support try close which calls brpc::StartCancel
     // 2 make BlockScheduler calls tryclose when query is cancel
+    DCHECK(_context != nullptr);
     bool need_cancel = _context->is_canceled();
 
     for (auto& pair : _instance_to_package_queue_mutex) {
@@ -96,7 +104,8 @@ bool ExchangeSinkBuffer::is_pending_finish() {
     return false;
 }
 
-void ExchangeSinkBuffer::register_sink(TUniqueId fragment_instance_id) {
+template <typename Parent>
+void ExchangeSinkBuffer<Parent>::register_sink(TUniqueId fragment_instance_id) {
     if (_is_finishing) {
         return;
     }
@@ -106,9 +115,10 @@ void ExchangeSinkBuffer::register_sink(TUniqueId fragment_instance_id) {
     }
     _instance_to_package_queue_mutex[low_id] = std::make_unique<std::mutex>();
     _instance_to_seq[low_id] = 0;
-    _instance_to_package_queue[low_id] = std::queue<TransmitInfo, std::list<TransmitInfo>>();
+    _instance_to_package_queue[low_id] =
+            std::queue<TransmitInfo<Parent>, std::list<TransmitInfo<Parent>>>();
     _instance_to_broadcast_package_queue[low_id] =
-            std::queue<BroadcastTransmitInfo, std::list<BroadcastTransmitInfo>>();
+            std::queue<BroadcastTransmitInfo<Parent>, std::list<BroadcastTransmitInfo<Parent>>>();
     PUniqueId finst_id;
     finst_id.set_hi(fragment_instance_id.hi);
     finst_id.set_lo(fragment_instance_id.lo);
@@ -119,7 +129,8 @@ void ExchangeSinkBuffer::register_sink(TUniqueId fragment_instance_id) {
     _construct_request(low_id, finst_id);
 }
 
-Status ExchangeSinkBuffer::add_block(TransmitInfo&& request) {
+template <typename Parent>
+Status ExchangeSinkBuffer<Parent>::add_block(TransmitInfo<Parent>&& request) {
     if (_is_finishing) {
         return Status::OK();
     }
@@ -141,7 +152,8 @@ Status ExchangeSinkBuffer::add_block(TransmitInfo&& request) {
     return Status::OK();
 }
 
-Status ExchangeSinkBuffer::add_block(BroadcastTransmitInfo&& request) {
+template <typename Parent>
+Status ExchangeSinkBuffer<Parent>::add_block(BroadcastTransmitInfo<Parent>&& request) {
     if (_is_finishing) {
         return Status::OK();
     }
@@ -167,14 +179,16 @@ Status ExchangeSinkBuffer::add_block(BroadcastTransmitInfo&& request) {
     return Status::OK();
 }
 
-Status ExchangeSinkBuffer::_send_rpc(InstanceLoId id) {
+template <typename Parent>
+Status ExchangeSinkBuffer<Parent>::_send_rpc(InstanceLoId id) {
     std::unique_lock<std::mutex> lock(*_instance_to_package_queue_mutex[id]);
 
     DCHECK(_instance_to_sending_by_pipeline[id] == false);
 
-    std::queue<TransmitInfo, std::list<TransmitInfo>>& q = _instance_to_package_queue[id];
-    std::queue<BroadcastTransmitInfo, std::list<BroadcastTransmitInfo>>& broadcast_q =
-            _instance_to_broadcast_package_queue[id];
+    std::queue<TransmitInfo<Parent>, std::list<TransmitInfo<Parent>>>& q =
+            _instance_to_package_queue[id];
+    std::queue<BroadcastTransmitInfo<Parent>, std::list<BroadcastTransmitInfo<Parent>>>&
+            broadcast_q = _instance_to_broadcast_package_queue[id];
 
     if (_is_finishing) {
         _instance_to_sending_by_pipeline[id] = true;
@@ -292,7 +306,8 @@ Status ExchangeSinkBuffer::_send_rpc(InstanceLoId id) {
     return Status::OK();
 }
 
-void ExchangeSinkBuffer::_construct_request(InstanceLoId id, PUniqueId finst_id) {
+template <typename Parent>
+void ExchangeSinkBuffer<Parent>::_construct_request(InstanceLoId id, PUniqueId finst_id) {
     _instance_to_request[id] = std::make_unique<PTransmitDataParams>();
     _instance_to_request[id]->mutable_finst_id()->CopyFrom(finst_id);
     _instance_to_request[id]->mutable_query_id()->CopyFrom(_query_id);
@@ -302,29 +317,34 @@ void ExchangeSinkBuffer::_construct_request(InstanceLoId id, PUniqueId finst_id)
     _instance_to_request[id]->set_be_number(_be_number);
 }
 
-void ExchangeSinkBuffer::_ended(InstanceLoId id) {
+template <typename Parent>
+void ExchangeSinkBuffer<Parent>::_ended(InstanceLoId id) {
     std::unique_lock<std::mutex> lock(*_instance_to_package_queue_mutex[id]);
     _instance_to_sending_by_pipeline[id] = true;
 }
 
-void ExchangeSinkBuffer::_failed(InstanceLoId id, const std::string& err) {
+template <typename Parent>
+void ExchangeSinkBuffer<Parent>::_failed(InstanceLoId id, const std::string& err) {
     _is_finishing = true;
     _context->cancel(PPlanFragmentCancelReason::INTERNAL_ERROR, err);
     _ended(id);
 }
 
-void ExchangeSinkBuffer::_set_receiver_eof(InstanceLoId id) {
+template <typename Parent>
+void ExchangeSinkBuffer<Parent>::_set_receiver_eof(InstanceLoId id) {
     std::unique_lock<std::mutex> lock(*_instance_to_package_queue_mutex[id]);
     _instance_to_receiver_eof[id] = true;
     _instance_to_sending_by_pipeline[id] = true;
 }
 
-bool ExchangeSinkBuffer::_is_receiver_eof(InstanceLoId id) {
+template <typename Parent>
+bool ExchangeSinkBuffer<Parent>::_is_receiver_eof(InstanceLoId id) {
     std::unique_lock<std::mutex> lock(*_instance_to_package_queue_mutex[id]);
     return _instance_to_receiver_eof[id];
 }
 
-void ExchangeSinkBuffer::get_max_min_rpc_time(int64_t* max_time, int64_t* min_time) {
+template <typename Parent>
+void ExchangeSinkBuffer<Parent>::get_max_min_rpc_time(int64_t* max_time, int64_t* min_time) {
     int64_t local_max_time = 0;
     int64_t local_min_time = INT64_MAX;
     for (auto& [id, time] : _instance_to_rpc_time) {
@@ -337,7 +357,8 @@ void ExchangeSinkBuffer::get_max_min_rpc_time(int64_t* max_time, int64_t* min_ti
     *min_time = local_min_time;
 }
 
-int64_t ExchangeSinkBuffer::get_sum_rpc_time() {
+template <typename Parent>
+int64_t ExchangeSinkBuffer<Parent>::get_sum_rpc_time() {
     int64_t sum_time = 0;
     for (auto& [id, time] : _instance_to_rpc_time) {
         sum_time += time;
@@ -345,8 +366,9 @@ int64_t ExchangeSinkBuffer::get_sum_rpc_time() {
     return sum_time;
 }
 
-void ExchangeSinkBuffer::set_rpc_time(InstanceLoId id, int64_t start_rpc_time,
-                                      int64_t receive_rpc_time) {
+template <typename Parent>
+void ExchangeSinkBuffer<Parent>::set_rpc_time(InstanceLoId id, int64_t start_rpc_time,
+                                              int64_t receive_rpc_time) {
     _rpc_count++;
     int64_t rpc_spend_time = receive_rpc_time - start_rpc_time;
     DCHECK(_instance_to_rpc_time.find(id) != _instance_to_rpc_time.end());
@@ -355,7 +377,8 @@ void ExchangeSinkBuffer::set_rpc_time(InstanceLoId id, int64_t start_rpc_time,
     }
 }
 
-void ExchangeSinkBuffer::update_profile(RuntimeProfile* profile) {
+template <typename Parent>
+void ExchangeSinkBuffer<Parent>::update_profile(RuntimeProfile* profile) {
     auto* _max_rpc_timer = ADD_TIMER(profile, "RpcMaxTime");
     auto* _min_rpc_timer = ADD_TIMER(profile, "RpcMinTime");
     auto* _sum_rpc_timer = ADD_TIMER(profile, "RpcSumTime");
@@ -372,4 +395,9 @@ void ExchangeSinkBuffer::update_profile(RuntimeProfile* profile) {
     _sum_rpc_timer->set(sum_time);
     _avg_rpc_timer->set(sum_time / std::max(static_cast<int64_t>(1), _rpc_count.load()));
 }
+
+template class ExchangeSinkBuffer<vectorized::VDataStreamSender>;
+template class ExchangeSinkBuffer<pipeline::ExchangeSinkLocalState>;
+//
+//template bool ExchangeSinkBuffer<vectorized::VDataStreamSender>::can_write() const;
 } // namespace doris::pipeline

--- a/be/src/pipeline/exec/exchange_sink_buffer.h
+++ b/be/src/pipeline/exec/exchange_sink_buffer.h
@@ -43,6 +43,8 @@ class TUniqueId;
 using InstanceLoId = int64_t;
 
 namespace vectorized {
+class VDataStreamSender;
+template <typename>
 class PipChannel;
 
 template <typename T>
@@ -83,14 +85,16 @@ private:
 } // namespace vectorized
 
 namespace pipeline {
+template <typename Parent>
 struct TransmitInfo {
-    vectorized::PipChannel* channel;
+    vectorized::PipChannel<Parent>* channel;
     std::unique_ptr<PBlock> block;
     bool eos;
 };
 
+template <typename Parent>
 struct BroadcastTransmitInfo {
-    vectorized::PipChannel* channel;
+    vectorized::PipChannel<Parent>* channel;
     vectorized::BroadcastPBlockHolder* block_holder;
     bool eos;
 };
@@ -160,13 +164,15 @@ struct ExchangeRpcContext {
 };
 
 // Each ExchangeSinkOperator have one ExchangeSinkBuffer
+template <typename Parent>
 class ExchangeSinkBuffer {
 public:
     ExchangeSinkBuffer(PUniqueId, int, PlanNodeId, int, PipelineFragmentContext*);
     ~ExchangeSinkBuffer();
     void register_sink(TUniqueId);
-    Status add_block(TransmitInfo&& request);
-    Status add_block(BroadcastTransmitInfo&& request);
+
+    Status add_block(TransmitInfo<Parent>&& request);
+    Status add_block(BroadcastTransmitInfo<Parent>&& request);
     bool can_write() const;
     bool is_pending_finish();
     void close();
@@ -177,11 +183,12 @@ private:
     phmap::flat_hash_map<InstanceLoId, std::unique_ptr<std::mutex>>
             _instance_to_package_queue_mutex;
     // store data in non-broadcast shuffle
-    phmap::flat_hash_map<InstanceLoId, std::queue<TransmitInfo, std::list<TransmitInfo>>>
+    phmap::flat_hash_map<InstanceLoId,
+                         std::queue<TransmitInfo<Parent>, std::list<TransmitInfo<Parent>>>>
             _instance_to_package_queue;
     // store data in broadcast shuffle
-    phmap::flat_hash_map<InstanceLoId,
-                         std::queue<BroadcastTransmitInfo, std::list<BroadcastTransmitInfo>>>
+    phmap::flat_hash_map<InstanceLoId, std::queue<BroadcastTransmitInfo<Parent>,
+                                                  std::list<BroadcastTransmitInfo<Parent>>>>
             _instance_to_broadcast_package_queue;
     using PackageSeq = int64_t;
     // must init zero

--- a/be/src/pipeline/exec/exchange_sink_operator.cpp
+++ b/be/src/pipeline/exec/exchange_sink_operator.cpp
@@ -21,9 +21,14 @@
 #include <gen_cpp/Types_types.h>
 #include <gen_cpp/types.pb.h>
 
+#include <random>
+
 #include "common/status.h"
 #include "exchange_sink_buffer.h"
 #include "pipeline/exec/operator.h"
+#include "pipeline/pipeline_x/pipeline_x_fragment_context.h"
+#include "vec/columns/column_const.h"
+#include "vec/exprs/vexpr.h"
 #include "vec/sink/vdata_stream_sender.h"
 
 namespace doris {
@@ -64,8 +69,8 @@ Status ExchangeSinkOperator::prepare(RuntimeState* state) {
     PUniqueId id;
     id.set_hi(_state->query_id().hi);
     id.set_lo(_state->query_id().lo);
-    _sink_buffer = std::make_unique<ExchangeSinkBuffer>(id, _dest_node_id, _sink->_sender_id,
-                                                        _state->be_number(), _context);
+    _sink_buffer = std::make_unique<ExchangeSinkBuffer<vectorized::VDataStreamSender>>(
+            id, _dest_node_id, _sink->_sender_id, _state->be_number(), _context);
 
     RETURN_IF_ERROR(DataSinkOperator::prepare(state));
     _sink->registe_channels(_sink_buffer.get());
@@ -85,6 +90,487 @@ Status ExchangeSinkOperator::close(RuntimeState* state) {
     _sink_buffer->update_profile(_sink->profile());
     _sink_buffer->close();
     return Status::OK();
+}
+
+Status ExchangeSinkLocalState::serialize_block(vectorized::Block* src, PBlock* dest,
+                                               int num_receivers) {
+    return _parent->cast<ExchangeSinkOperatorX>().serialize_block(*this, src, dest, num_receivers);
+}
+
+bool ExchangeSinkLocalState::transfer_large_data_by_brpc() const {
+    return _parent->cast<ExchangeSinkOperatorX>()._transfer_large_data_by_brpc;
+}
+
+Status ExchangeSinkLocalState::init(RuntimeState* state, Dependency* dependency) {
+    _broadcast_pb_blocks.resize(config::num_broadcast_buffer);
+    _broadcast_pb_block_idx = 0;
+    auto& p = _parent->cast<ExchangeSinkOperatorX>();
+
+    std::map<int64_t, int64_t> fragment_id_to_channel_index;
+    for (int i = 0; i < p._dests.size(); ++i) {
+        const auto& fragment_instance_id = p._dests[i].fragment_instance_id;
+        if (fragment_id_to_channel_index.find(fragment_instance_id.lo) ==
+            fragment_id_to_channel_index.end()) {
+            channel_shared_ptrs.emplace_back(new vectorized::PipChannel<ExchangeSinkLocalState>(
+                    this, p._row_desc, p._dests[i].brpc_server, fragment_instance_id,
+                    p._dest_node_id, p._per_channel_buffer_size, false,
+                    p._send_query_statistics_with_every_batch));
+        }
+        fragment_id_to_channel_index.emplace(fragment_instance_id.lo,
+                                             channel_shared_ptrs.size() - 1);
+        channels.push_back(channel_shared_ptrs.back().get());
+    }
+
+    std::vector<std::string> instances;
+    for (const auto& channel : channels) {
+        instances.emplace_back(channel->get_fragment_instance_id_str());
+    }
+    std::string title = fmt::format("VDataStreamSender (dst_id={}, dst_fragments=[{}])",
+                                    p._dest_node_id, instances);
+    _profile = p._pool->add(new RuntimeProfile(title));
+    SCOPED_TIMER(_profile->total_time_counter());
+    _mem_tracker = std::make_unique<MemTracker>("ExchangeSinkLocalState:");
+    SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
+
+    int local_size = 0;
+    for (int i = 0; i < channels.size(); ++i) {
+        RETURN_IF_ERROR(channels[i]->init(state));
+        if (channels[i]->is_local()) {
+            local_size++;
+        }
+    }
+    if (p._part_type == TPartitionType::UNPARTITIONED || p._part_type == TPartitionType::RANDOM) {
+        std::random_device rd;
+        std::mt19937 g(rd());
+        shuffle(channels.begin(), channels.end(), g);
+    } else {
+        partition_expr_ctxs.resize(p._partition_expr_ctxs.size());
+        for (size_t i = 0; i < p._partition_expr_ctxs.size(); i++) {
+            RETURN_IF_ERROR(p._partition_expr_ctxs[i]->clone(state, partition_expr_ctxs[i]));
+        }
+    }
+    only_local_exchange = local_size == channels.size();
+
+    PUniqueId id;
+    id.set_hi(_state->query_id().hi);
+    id.set_lo(_state->query_id().lo);
+    _sink_buffer = std::make_unique<ExchangeSinkBuffer<ExchangeSinkLocalState>>(
+            id, p._dest_node_id, _sender_id, _state->be_number(), p._context);
+
+    register_channels(_sink_buffer.get());
+
+    _bytes_sent_counter = ADD_COUNTER(_profile, "BytesSent", TUnit::BYTES);
+    _uncompressed_bytes_counter = ADD_COUNTER(_profile, "UncompressedRowBatchSize", TUnit::BYTES);
+    _local_sent_rows = ADD_COUNTER(_profile, "LocalSentRows", TUnit::UNIT);
+    _serialize_batch_timer = ADD_TIMER(_profile, "SerializeBatchTime");
+    _compress_timer = ADD_TIMER(_profile, "CompressTime");
+    _brpc_send_timer = ADD_TIMER(_profile, "BrpcSendTime");
+    _brpc_wait_timer = ADD_TIMER(_profile, "BrpcSendTime.Wait");
+    _local_send_timer = ADD_TIMER(_profile, "LocalSendTime");
+    _split_block_hash_compute_timer = ADD_TIMER(_profile, "SplitBlockHashComputeTime");
+    _split_block_distribute_by_channel_timer =
+            ADD_TIMER(_profile, "SplitBlockDistributeByChannelTime");
+    _blocks_sent_counter = ADD_COUNTER(_profile, "BlocksSent", TUnit::UNIT);
+    _overall_throughput = _profile->add_derived_counter(
+            "OverallThroughput", TUnit::BYTES_PER_SECOND,
+            std::bind<int64_t>(&RuntimeProfile::units_per_second, _bytes_sent_counter,
+                               _profile->total_time_counter()),
+            "");
+    _merge_block_timer = ADD_TIMER(profile(), "MergeBlockTime");
+    _local_bytes_send_counter = ADD_COUNTER(_profile, "LocalBytesSent", TUnit::BYTES);
+    _memory_usage_counter = ADD_LABEL_COUNTER(profile(), "MemoryUsage");
+    _peak_memory_usage_counter =
+            profile()->AddHighWaterMarkCounter("PeakMemoryUsage", TUnit::BYTES, "MemoryUsage");
+    return Status::OK();
+}
+
+segment_v2::CompressionTypePB& ExchangeSinkLocalState::compression_type() {
+    return _parent->cast<ExchangeSinkOperatorX>()._compression_type;
+}
+
+ExchangeSinkOperatorX::ExchangeSinkOperatorX(
+        const int id, RuntimeState* state, ObjectPool* pool, const RowDescriptor& row_desc,
+        const TDataStreamSink& sink, const std::vector<TPlanFragmentDestination>& destinations,
+        int per_channel_buffer_size, bool send_query_statistics_with_every_batch,
+        PipelineXFragmentContext* context)
+        : DataSinkOperatorX(id),
+          _context(context),
+          _pool(pool),
+          _row_desc(row_desc),
+          _part_type(sink.output_partition.type),
+          _dests(destinations),
+          _per_channel_buffer_size(per_channel_buffer_size),
+          _send_query_statistics_with_every_batch(send_query_statistics_with_every_batch),
+          _dest_node_id(sink.dest_node_id),
+          _transfer_large_data_by_brpc(config::transfer_large_data_by_brpc) {
+    DCHECK_GT(destinations.size(), 0);
+    DCHECK(sink.output_partition.type == TPartitionType::UNPARTITIONED ||
+           sink.output_partition.type == TPartitionType::HASH_PARTITIONED ||
+           sink.output_partition.type == TPartitionType::RANDOM ||
+           sink.output_partition.type == TPartitionType::RANGE_PARTITIONED ||
+           sink.output_partition.type == TPartitionType::BUCKET_SHFFULE_HASH_PARTITIONED);
+    _name = "ExchangeSinkOperatorX";
+}
+
+ExchangeSinkOperatorX::ExchangeSinkOperatorX(
+        const int id, ObjectPool* pool, const RowDescriptor& row_desc, PlanNodeId dest_node_id,
+        const std::vector<TPlanFragmentDestination>& destinations, int per_channel_buffer_size,
+        bool send_query_statistics_with_every_batch, PipelineXFragmentContext* context)
+        : DataSinkOperatorX(id),
+          _context(context),
+          _pool(pool),
+          _row_desc(row_desc),
+          _part_type(TPartitionType::UNPARTITIONED),
+          _dests(destinations),
+          _per_channel_buffer_size(per_channel_buffer_size),
+          _send_query_statistics_with_every_batch(send_query_statistics_with_every_batch),
+          _dest_node_id(dest_node_id) {
+    _cur_pb_block = &_pb_block1;
+    _name = "ExchangeSinkOperatorX";
+}
+
+ExchangeSinkOperatorX::ExchangeSinkOperatorX(const int id, ObjectPool* pool,
+                                             const RowDescriptor& row_desc,
+                                             int per_channel_buffer_size,
+                                             bool send_query_statistics_with_every_batch,
+                                             PipelineXFragmentContext* context)
+        : DataSinkOperatorX(id),
+          _context(context),
+          _pool(pool),
+          _row_desc(row_desc),
+          _per_channel_buffer_size(per_channel_buffer_size),
+          _send_query_statistics_with_every_batch(send_query_statistics_with_every_batch),
+          _dest_node_id(0) {
+    _cur_pb_block = &_pb_block1;
+    _name = "ExchangeSinkOperatorX";
+}
+
+Status ExchangeSinkOperatorX::init(const TDataSink& tsink) {
+    RETURN_IF_ERROR(DataSinkOperatorX::init(tsink));
+    const TDataStreamSink& t_stream_sink = tsink.stream_sink;
+    if (_part_type == TPartitionType::HASH_PARTITIONED ||
+        _part_type == TPartitionType::BUCKET_SHFFULE_HASH_PARTITIONED) {
+        RETURN_IF_ERROR(vectorized::VExpr::create_expr_trees(
+                t_stream_sink.output_partition.partition_exprs, _partition_expr_ctxs));
+    } else if (_part_type == TPartitionType::RANGE_PARTITIONED) {
+        return Status::InternalError("TPartitionType::RANGE_PARTITIONED should not be used");
+    } else {
+        // UNPARTITIONED
+    }
+    return Status::OK();
+}
+
+Status ExchangeSinkOperatorX::setup_local_state(RuntimeState* state, Dependency* dependency) {
+    auto local_state = ExchangeSinkLocalState::create_shared(this, state);
+    state->emplace_sink_local_state(id(), local_state);
+    return local_state->init(state, dependency);
+}
+
+Status ExchangeSinkOperatorX::prepare(RuntimeState* state) {
+    _state = state;
+
+    std::string title = fmt::format("VDataStreamSender (dst_id={})", _dest_node_id);
+    _profile = _pool->add(new RuntimeProfile(title));
+    SCOPED_TIMER(_profile->total_time_counter());
+    _mem_tracker = std::make_unique<MemTracker>("ExchangeSinkOperatorX:");
+    SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
+
+    if (!(_part_type == TPartitionType::UNPARTITIONED) && !(_part_type == TPartitionType::RANDOM)) {
+        RETURN_IF_ERROR(vectorized::VExpr::prepare(_partition_expr_ctxs, state, _row_desc));
+    }
+    return Status::OK();
+}
+
+Status ExchangeSinkOperatorX::open(RuntimeState* state) {
+    DCHECK(state != nullptr);
+
+    SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
+    RETURN_IF_ERROR(vectorized::VExpr::open(_partition_expr_ctxs, state));
+
+    _compression_type = state->fragement_transmission_compression_type();
+    return Status::OK();
+}
+
+template <typename ChannelPtrType>
+void ExchangeSinkOperatorX::_handle_eof_channel(RuntimeState* state, ChannelPtrType channel,
+                                                Status st) {
+    channel->set_receiver_eof(st);
+    channel->close(state);
+}
+
+Status ExchangeSinkOperatorX::sink(RuntimeState* state, vectorized::Block* block,
+                                   SourceState source_state) {
+    auto& local_state = state->get_sink_local_state(id())->cast<ExchangeSinkLocalState>();
+    SCOPED_TIMER(_profile->total_time_counter());
+    local_state._peak_memory_usage_counter->set(_mem_tracker->peak_consumption());
+    bool all_receiver_eof = true;
+    for (auto channel : local_state.channels) {
+        if (!channel->is_receiver_eof()) {
+            all_receiver_eof = false;
+            break;
+        }
+    }
+    if (all_receiver_eof) {
+        return Status::EndOfFile("all data stream channels EOF");
+    }
+
+    if (_part_type == TPartitionType::UNPARTITIONED || local_state.channels.size() == 1) {
+        // 1. serialize depends on it is not local exchange
+        // 2. send block
+        // 3. rollover block
+        if (local_state.only_local_exchange) {
+            if (!block->empty()) {
+                Status status;
+                for (auto channel : local_state.channels) {
+                    if (!channel->is_receiver_eof()) {
+                        status = channel->send_local_block(block);
+                        HANDLE_CHANNEL_STATUS(state, channel, status);
+                    }
+                }
+            }
+        } else {
+            vectorized::BroadcastPBlockHolder* block_holder = nullptr;
+            RETURN_IF_ERROR(local_state.get_next_available_buffer(&block_holder));
+            {
+                SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
+                bool serialized = false;
+                RETURN_IF_ERROR(local_state._serializer.next_serialized_block(
+                        block, block_holder->get_block(), local_state.channels.size(), &serialized,
+                        source_state == SourceState::FINISHED));
+                if (serialized) {
+                    auto cur_block = local_state._serializer.get_block()->to_block();
+                    if (!cur_block.empty()) {
+                        local_state._serializer.serialize_block(
+                                &cur_block, block_holder->get_block(), local_state.channels.size());
+                    } else {
+                        block_holder->get_block()->Clear();
+                    }
+                    Status status;
+                    for (auto channel : local_state.channels) {
+                        if (!channel->is_receiver_eof()) {
+                            if (channel->is_local()) {
+                                status = channel->send_local_block(&cur_block);
+                            } else {
+                                SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
+                                status = channel->send_block(block_holder,
+                                                             source_state == SourceState::FINISHED);
+                            }
+                            HANDLE_CHANNEL_STATUS(state, channel, status);
+                        }
+                    }
+                    cur_block.clear_column_data();
+                    local_state._serializer.get_block()->set_muatable_columns(
+                            cur_block.mutate_columns());
+                }
+            }
+        }
+    } else if (_part_type == TPartitionType::RANDOM) {
+        // 1. select channel
+        vectorized::PipChannel<ExchangeSinkLocalState>* current_channel =
+                local_state.channels[local_state.current_channel_idx];
+        if (!current_channel->is_receiver_eof()) {
+            // 2. serialize, send and rollover block
+            if (current_channel->is_local()) {
+                auto status = current_channel->send_local_block(block);
+                HANDLE_CHANNEL_STATUS(state, current_channel, status);
+            } else {
+                SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
+                RETURN_IF_ERROR(local_state._serializer.serialize_block(
+                        block, current_channel->ch_cur_pb_block()));
+                auto status = current_channel->send_block(current_channel->ch_cur_pb_block(),
+                                                          source_state == SourceState::FINISHED);
+                HANDLE_CHANNEL_STATUS(state, current_channel, status);
+                current_channel->ch_roll_pb_block();
+            }
+        }
+        local_state.current_channel_idx =
+                (local_state.current_channel_idx + 1) % local_state.channels.size();
+    } else if (_part_type == TPartitionType::HASH_PARTITIONED ||
+               _part_type == TPartitionType::BUCKET_SHFFULE_HASH_PARTITIONED) {
+        // will only copy schema
+        // we don't want send temp columns
+        auto column_to_keep = block->columns();
+
+        int result_size = _partition_expr_ctxs.size();
+        int result[result_size];
+
+        // vectorized calculate hash
+        int rows = block->rows();
+        auto element_size = _part_type == TPartitionType::HASH_PARTITIONED
+                                    ? local_state.channels.size()
+                                    : local_state.channel_shared_ptrs.size();
+        std::vector<uint64_t> hash_vals(rows);
+        auto* __restrict hashes = hash_vals.data();
+
+        if (rows > 0) {
+            {
+                SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
+                RETURN_IF_ERROR(get_partition_column_result(block, result));
+            }
+            // TODO: after we support new shuffle hash method, should simple the code
+            if (_part_type == TPartitionType::HASH_PARTITIONED) {
+                SCOPED_TIMER(local_state._split_block_hash_compute_timer);
+                // result[j] means column index, i means rows index, here to calculate the xxhash value
+                for (int j = 0; j < result_size; ++j) {
+                    // complex type most not implement get_data_at() method which column_const will call
+                    unpack_if_const(block->get_by_position(result[j]).column)
+                            .first->update_hashes_with_value(hashes);
+                }
+
+                for (int i = 0; i < rows; i++) {
+                    hashes[i] = hashes[i] % element_size;
+                }
+
+                {
+                    SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
+                    vectorized::Block::erase_useless_column(block, column_to_keep);
+                }
+            } else {
+                for (int j = 0; j < result_size; ++j) {
+                    // complex type most not implement get_data_at() method which column_const will call
+                    unpack_if_const(block->get_by_position(result[j]).column)
+                            .first->update_crcs_with_value(
+                                    hash_vals, _partition_expr_ctxs[j]->root()->type().type);
+                }
+                for (int i = 0; i < rows; i++) {
+                    hashes[i] = hashes[i] % element_size;
+                }
+
+                {
+                    SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
+                    vectorized::Block::erase_useless_column(block, column_to_keep);
+                }
+            }
+        }
+        if (_part_type == TPartitionType::HASH_PARTITIONED) {
+            RETURN_IF_ERROR(channel_add_rows(state, local_state.channels, element_size, hashes,
+                                             rows, block, source_state == SourceState::FINISHED));
+        } else {
+            RETURN_IF_ERROR(channel_add_rows(state, local_state.channel_shared_ptrs, element_size,
+                                             hashes, rows, block,
+                                             source_state == SourceState::FINISHED));
+        }
+    } else {
+        // Range partition
+        // 1. calculate range
+        // 2. dispatch rows to channel
+    }
+    return Status::OK();
+}
+
+Status ExchangeSinkOperatorX::serialize_block(ExchangeSinkLocalState& state, vectorized::Block* src,
+                                              PBlock* dest, int num_receivers) {
+    {
+        SCOPED_TIMER(state.serialize_batch_timer());
+        dest->Clear();
+        size_t uncompressed_bytes = 0, compressed_bytes = 0;
+        RETURN_IF_ERROR(src->serialize(_state->be_exec_version(), dest, &uncompressed_bytes,
+                                       &compressed_bytes, _compression_type,
+                                       _transfer_large_data_by_brpc));
+        COUNTER_UPDATE(state.bytes_sent_counter(), compressed_bytes * num_receivers);
+        COUNTER_UPDATE(state.uncompressed_bytes_counter(), uncompressed_bytes * num_receivers);
+        COUNTER_UPDATE(state.compress_timer(), src->get_compress_time());
+    }
+
+    return Status::OK();
+}
+
+bool ExchangeSinkLocalState::channel_all_can_write() {
+    auto& p = _parent->cast<ExchangeSinkOperatorX>();
+    if ((p._part_type == TPartitionType::UNPARTITIONED || channels.size() == 1) &&
+        !only_local_exchange) {
+        // This condition means we need use broadcast buffer, so we should make sure
+        // there are available buffer before running pipeline
+        if (_broadcast_pb_block_idx == _broadcast_pb_blocks.size()) {
+            _broadcast_pb_block_idx = 0;
+        }
+
+        for (; _broadcast_pb_block_idx < _broadcast_pb_blocks.size(); _broadcast_pb_block_idx++) {
+            if (_broadcast_pb_blocks[_broadcast_pb_block_idx].available()) {
+                return true;
+            }
+        }
+        return false;
+    } else {
+        for (auto channel : channels) {
+            if (!channel->can_write()) {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+void ExchangeSinkLocalState::register_channels(
+        pipeline::ExchangeSinkBuffer<ExchangeSinkLocalState>* buffer) {
+    for (auto channel : channels) {
+        ((vectorized::PipChannel<ExchangeSinkLocalState>*)channel)->registe(buffer);
+    }
+}
+
+Status ExchangeSinkLocalState::get_next_available_buffer(
+        vectorized::BroadcastPBlockHolder** holder) {
+    DCHECK(_broadcast_pb_blocks[_broadcast_pb_block_idx].available());
+    *holder = &_broadcast_pb_blocks[_broadcast_pb_block_idx];
+    _broadcast_pb_block_idx++;
+    return Status::OK();
+}
+
+template <typename Channels>
+Status ExchangeSinkOperatorX::channel_add_rows(RuntimeState* state, Channels& channels,
+                                               int num_channels,
+                                               const uint64_t* __restrict channel_ids, int rows,
+                                               vectorized::Block* block, bool eos) {
+    std::vector<int> channel2rows[num_channels];
+
+    for (int i = 0; i < rows; i++) {
+        channel2rows[channel_ids[i]].emplace_back(i);
+    }
+
+    Status status;
+    for (int i = 0; i < num_channels; ++i) {
+        if (!channels[i]->is_receiver_eof() && !channel2rows[i].empty()) {
+            status = channels[i]->add_rows(block, channel2rows[i], eos);
+            HANDLE_CHANNEL_STATUS(state, channels[i], status);
+        }
+    }
+
+    return Status::OK();
+}
+
+Status ExchangeSinkOperatorX::try_close(RuntimeState* state) {
+    auto& local_state = state->get_sink_local_state(id())->cast<ExchangeSinkLocalState>();
+    DCHECK(local_state._serializer.get_block() == nullptr ||
+           local_state._serializer.get_block()->rows() == 0);
+    Status final_st = Status::OK();
+    for (int i = 0; i < local_state.channels.size(); ++i) {
+        Status st = local_state.channels[i]->close(state);
+        if (!st.ok() && final_st.ok()) {
+            final_st = st;
+        }
+    }
+    return final_st;
+}
+
+Status ExchangeSinkOperatorX::close(RuntimeState* state) {
+    auto& local_state = state->get_sink_local_state(id())->cast<ExchangeSinkLocalState>();
+    if (_closed) {
+        return Status::OK();
+    }
+    RETURN_IF_ERROR(DataSinkOperatorX::close(state));
+    local_state._sink_buffer->update_profile(local_state.profile());
+    local_state._sink_buffer->close();
+    return Status::OK();
+}
+
+bool ExchangeSinkOperatorX::can_write(RuntimeState* state) {
+    auto& local_state = state->get_sink_local_state(id())->cast<ExchangeSinkLocalState>();
+    return local_state._sink_buffer->can_write() && local_state.channel_all_can_write();
+}
+
+bool ExchangeSinkOperatorX::is_pending_finish(RuntimeState* state) const {
+    auto& local_state = state->get_sink_local_state(id())->cast<ExchangeSinkLocalState>();
+    return local_state._sink_buffer->is_pending_finish();
 }
 
 } // namespace doris::pipeline

--- a/be/src/pipeline/exec/exchange_sink_operator.cpp
+++ b/be/src/pipeline/exec/exchange_sink_operator.cpp
@@ -125,8 +125,7 @@ Status ExchangeSinkLocalState::init(RuntimeState* state, Dependency* dependency)
     for (const auto& channel : channels) {
         instances.emplace_back(channel->get_fragment_instance_id_str());
     }
-    std::string title = fmt::format("VDataStreamSender (dst_id={}, dst_fragments=[{}])",
-                                    p._dest_node_id, instances);
+    std::string title = "VDataStreamSender (dst_id={}, dst_fragments=[{}])";
     _profile = p._pool->add(new RuntimeProfile(title));
     SCOPED_TIMER(_profile->total_time_counter());
     _mem_tracker = std::make_unique<MemTracker>("ExchangeSinkLocalState:");

--- a/be/src/pipeline/exec/exchange_sink_operator.h
+++ b/be/src/pipeline/exec/exchange_sink_operator.h
@@ -33,6 +33,7 @@ class TDataSink;
 
 namespace pipeline {
 class PipelineFragmentContext;
+class PipelineXFragmentContext;
 
 class ExchangeSinkOperatorBuilder final
         : public DataSinkOperatorBuilder<vectorized::VDataStreamSender> {
@@ -63,11 +64,176 @@ public:
     RuntimeState* state() { return _state; }
 
 private:
-    std::unique_ptr<ExchangeSinkBuffer> _sink_buffer;
+    std::unique_ptr<ExchangeSinkBuffer<vectorized::VDataStreamSender>> _sink_buffer;
     int _dest_node_id = -1;
     RuntimeState* _state = nullptr;
     PipelineFragmentContext* _context;
     int _mult_cast_id = -1;
+};
+
+class ExchangeSinkLocalState : public PipelineXSinkLocalState {
+    ENABLE_FACTORY_CREATOR(ExchangeSinkLocalState);
+
+public:
+    ExchangeSinkLocalState(DataSinkOperatorX* parent, RuntimeState* state)
+            : PipelineXSinkLocalState(parent, state),
+              current_channel_idx(0),
+              only_local_exchange(false),
+              _serializer(this) {}
+
+    Status init(RuntimeState* state, Dependency* dependency) override;
+
+    Status serialize_block(vectorized::Block* src, PBlock* dest, int num_receivers = 1);
+    void register_channels(pipeline::ExchangeSinkBuffer<ExchangeSinkLocalState>* buffer);
+    bool channel_all_can_write();
+    Status get_next_available_buffer(vectorized::BroadcastPBlockHolder** holder);
+
+    RuntimeProfile::Counter* brpc_wait_timer() { return _brpc_wait_timer; }
+    RuntimeProfile::Counter* blocks_sent_counter() { return _blocks_sent_counter; }
+    RuntimeProfile::Counter* local_send_timer() { return _local_send_timer; }
+    RuntimeProfile::Counter* local_bytes_send_counter() { return _local_bytes_send_counter; }
+    RuntimeProfile::Counter* local_sent_rows() { return _local_sent_rows; }
+    RuntimeProfile::Counter* brpc_send_timer() { return _brpc_send_timer; }
+    RuntimeProfile::Counter* serialize_batch_timer() { return _serialize_batch_timer; }
+    RuntimeProfile::Counter* split_block_distribute_by_channel_timer() {
+        return _split_block_distribute_by_channel_timer;
+    }
+    RuntimeProfile::Counter* bytes_sent_counter() { return _bytes_sent_counter; }
+    RuntimeProfile::Counter* split_block_hash_compute_timer() {
+        return _split_block_hash_compute_timer;
+    }
+    RuntimeProfile::Counter* merge_block_timer() { return _merge_block_timer; }
+    RuntimeProfile::Counter* compress_timer() { return _compress_timer; }
+    RuntimeProfile::Counter* uncompressed_bytes_counter() { return _uncompressed_bytes_counter; }
+    [[nodiscard]] bool transfer_large_data_by_brpc() const;
+
+    [[nodiscard]] int sender_id() const { return _sender_id; }
+
+    segment_v2::CompressionTypePB& compression_type();
+
+    vectorized::VExprContextSPtrs partition_expr_ctxs;
+
+    std::vector<vectorized::PipChannel<ExchangeSinkLocalState>*> channels;
+    std::vector<std::shared_ptr<vectorized::PipChannel<ExchangeSinkLocalState>>>
+            channel_shared_ptrs;
+    int current_channel_idx; // index of current channel to send to if _random == true
+    bool only_local_exchange;
+
+private:
+    friend class ExchangeSinkOperatorX;
+    friend class vectorized::Channel<ExchangeSinkLocalState>;
+    friend class vectorized::PipChannel<ExchangeSinkLocalState>;
+    friend class vectorized::BlockSerializer<ExchangeSinkLocalState>;
+
+    std::unique_ptr<ExchangeSinkBuffer<ExchangeSinkLocalState>> _sink_buffer;
+    RuntimeProfile::Counter* _serialize_batch_timer;
+    RuntimeProfile::Counter* _compress_timer;
+    RuntimeProfile::Counter* _brpc_send_timer;
+    RuntimeProfile::Counter* _brpc_wait_timer;
+    RuntimeProfile::Counter* _bytes_sent_counter;
+    RuntimeProfile::Counter* _uncompressed_bytes_counter;
+    RuntimeProfile::Counter* _local_sent_rows;
+    RuntimeProfile::Counter* _local_send_timer;
+    RuntimeProfile::Counter* _split_block_hash_compute_timer;
+    RuntimeProfile::Counter* _split_block_distribute_by_channel_timer;
+    RuntimeProfile::Counter* _blocks_sent_counter;
+    // Throughput per total time spent in sender
+    RuntimeProfile::Counter* _overall_throughput;
+    // Used to counter send bytes under local data exchange
+    RuntimeProfile::Counter* _local_bytes_send_counter;
+    RuntimeProfile::Counter* _merge_block_timer;
+    RuntimeProfile::Counter* _memory_usage_counter;
+    RuntimeProfile::Counter* _peak_memory_usage_counter;
+
+    // Sender instance id, unique within a fragment.
+    int _sender_id;
+    std::vector<vectorized::BroadcastPBlockHolder> _broadcast_pb_blocks;
+    int _broadcast_pb_block_idx;
+
+    vectorized::BlockSerializer<ExchangeSinkLocalState> _serializer;
+};
+
+class ExchangeSinkOperatorX final : public DataSinkOperatorX {
+public:
+    ExchangeSinkOperatorX(const int id, RuntimeState* state, ObjectPool* pool,
+                          const RowDescriptor& row_desc, const TDataStreamSink& sink,
+                          const std::vector<TPlanFragmentDestination>& destinations,
+                          int per_channel_buffer_size, bool send_query_statistics_with_every_batch,
+                          PipelineXFragmentContext* context);
+    ExchangeSinkOperatorX(const int id, ObjectPool* pool, const RowDescriptor& row_desc,
+                          PlanNodeId dest_node_id,
+                          const std::vector<TPlanFragmentDestination>& destinations,
+                          int per_channel_buffer_size, bool send_query_statistics_with_every_batch,
+                          PipelineXFragmentContext* context);
+    ExchangeSinkOperatorX(const int id, ObjectPool* pool, const RowDescriptor& row_desc,
+                          int per_channel_buffer_size, bool send_query_statistics_with_every_batch,
+                          PipelineXFragmentContext* context);
+    Status init(const TDataSink& tsink) override;
+
+    RuntimeState* state() { return _state; }
+
+    Status prepare(RuntimeState* state) override;
+    Status open(RuntimeState* state) override;
+    Status setup_local_state(RuntimeState* state, Dependency* dependency) override;
+
+    Status sink(RuntimeState* state, vectorized::Block* in_block,
+                SourceState source_state) override;
+
+    Status serialize_block(ExchangeSinkLocalState& stete, vectorized::Block* src, PBlock* dest,
+                           int num_receivers = 1);
+
+    Status close(RuntimeState* state) override;
+    Status try_close(RuntimeState* state) override;
+    bool can_write(RuntimeState* state) override;
+    bool is_pending_finish(RuntimeState* state) const override;
+
+private:
+    friend class ExchangeSinkLocalState;
+
+    template <typename ChannelPtrType>
+    void _handle_eof_channel(RuntimeState* state, ChannelPtrType channel, Status st);
+
+    Status get_partition_column_result(vectorized::Block* block, int* result) const {
+        int counter = 0;
+        for (auto ctx : _partition_expr_ctxs) {
+            RETURN_IF_ERROR(ctx->execute(block, &result[counter++]));
+        }
+        return Status::OK();
+    }
+
+    template <typename Channels>
+    Status channel_add_rows(RuntimeState* state, Channels& channels, int num_channels,
+                            const uint64_t* channel_ids, int rows, vectorized::Block* block,
+                            bool eos);
+    RuntimeState* _state = nullptr;
+    PipelineXFragmentContext* _context;
+
+    ObjectPool* _pool;
+    const RowDescriptor& _row_desc;
+
+    TPartitionType::type _part_type;
+
+    // serialized batches for broadcasting; we need two so we can write
+    // one while the other one is still being sent
+    PBlock _pb_block1;
+    PBlock _pb_block2;
+    PBlock* _cur_pb_block = nullptr;
+
+    // compute per-row partition values
+    vectorized::VExprContextSPtrs _partition_expr_ctxs;
+
+    const std::vector<TPlanFragmentDestination> _dests;
+    const int _per_channel_buffer_size;
+    const bool _send_query_statistics_with_every_batch;
+
+    std::unique_ptr<MemTracker> _mem_tracker;
+    // Identifier of the destination plan node.
+    PlanNodeId _dest_node_id;
+
+    // User can change this config at runtime, avoid it being modified during query or loading process.
+    bool _transfer_large_data_by_brpc = false;
+
+    segment_v2::CompressionTypePB _compression_type;
 };
 
 } // namespace pipeline

--- a/be/src/pipeline/exec/exchange_source_operator.cpp
+++ b/be/src/pipeline/exec/exchange_source_operator.cpp
@@ -20,7 +20,12 @@
 #include <memory>
 
 #include "pipeline/exec/operator.h"
+#include "runtime/exec_env.h"
+#include "runtime/runtime_state.h"
+#include "vec/common/sort/vsort_exec_exprs.h"
 #include "vec/exec/vexchange_node.h"
+#include "vec/exprs/vexpr_context.h"
+#include "vec/runtime/vdata_stream_mgr.h"
 #include "vec/runtime/vdata_stream_recvr.h"
 
 namespace doris::pipeline {
@@ -33,5 +38,143 @@ bool ExchangeSourceOperator::can_read() {
 
 bool ExchangeSourceOperator::is_pending_finish() const {
     return false;
+}
+
+ExchangeLocalState::ExchangeLocalState(RuntimeState* state, OperatorXBase* parent)
+        : PipelineXLocalState(state, parent), num_rows_skipped(0) {}
+
+Status ExchangeLocalState::init(RuntimeState* state, LocalStateInfo& info) {
+    if (_init) {
+        return Status::OK();
+    }
+    RETURN_IF_ERROR(PipelineXLocalState::init(state, info));
+    auto& parent_ref = _parent->cast<ExchangeSourceOperatorX>();
+    stream_recvr = _state->exec_env()->vstream_mgr()->create_recvr(
+            _state, parent_ref._input_row_desc, _state->fragment_instance_id(), parent_ref._id,
+            parent_ref._num_senders, profile(), parent_ref._is_merging,
+            parent_ref._sub_plan_query_statistics_recvr);
+    RETURN_IF_ERROR(_parent->cast<ExchangeSourceOperatorX>()._vsort_exec_exprs.clone(
+            state, vsort_exec_exprs));
+    _init = true;
+    return Status::OK();
+}
+
+ExchangeSourceOperatorX::ExchangeSourceOperatorX(ObjectPool* pool, const TPlanNode& tnode,
+                                                 const DescriptorTbl& descs, std::string op_name,
+                                                 int num_senders)
+        : OperatorXBase(pool, tnode, descs, op_name),
+          _num_senders(num_senders),
+          _is_merging(tnode.exchange_node.__isset.sort_info),
+          _is_ready(false),
+          _input_row_desc(descs, tnode.exchange_node.input_row_tuples,
+                          std::vector<bool>(tnode.nullable_tuples.begin(),
+                                            tnode.nullable_tuples.begin() +
+                                                    tnode.exchange_node.input_row_tuples.size())),
+          _offset(tnode.exchange_node.__isset.offset ? tnode.exchange_node.offset : 0) {}
+
+Status ExchangeSourceOperatorX::init(const TPlanNode& tnode, RuntimeState* state) {
+    RETURN_IF_ERROR(OperatorXBase::init(tnode, state));
+    if (!_is_merging) {
+        return Status::OK();
+    }
+    RETURN_IF_ERROR(_vsort_exec_exprs.init(tnode.exchange_node.sort_info, _pool));
+    _is_asc_order = tnode.exchange_node.sort_info.is_asc_order;
+    _nulls_first = tnode.exchange_node.sort_info.nulls_first;
+
+    return Status::OK();
+}
+
+Status ExchangeSourceOperatorX::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(OperatorXBase::prepare(state));
+    DCHECK_GT(_num_senders, 0);
+    _sub_plan_query_statistics_recvr.reset(new QueryStatisticsRecvr());
+
+    if (_is_merging) {
+        RETURN_IF_ERROR(_vsort_exec_exprs.prepare(state, _row_descriptor, _row_descriptor));
+    }
+
+    return Status::OK();
+}
+
+Status ExchangeSourceOperatorX::open(RuntimeState* state) {
+    RETURN_IF_ERROR(OperatorXBase::open(state));
+    if (_is_merging) {
+        RETURN_IF_ERROR(_vsort_exec_exprs.open(state));
+    }
+    return Status::OK();
+}
+
+Status ExchangeSourceOperatorX::get_block(RuntimeState* state, vectorized::Block* block,
+                                          SourceState& source_state) {
+    auto& local_state = state->get_local_state(id())->cast<ExchangeLocalState>();
+    SCOPED_TIMER(local_state.profile()->total_time_counter());
+    if (_is_merging && !_is_ready) {
+        RETURN_IF_ERROR(local_state.stream_recvr->create_merger(
+                local_state.vsort_exec_exprs.lhs_ordering_expr_ctxs(), _is_asc_order, _nulls_first,
+                state->batch_size(), _limit, _offset));
+        _is_ready = true;
+        return Status::OK();
+    }
+    bool eos = false;
+    auto status = local_state.stream_recvr->get_next(block, &eos);
+    RETURN_IF_ERROR(doris::vectorized::VExprContext::filter_block(local_state.conjuncts(), block,
+                                                                  block->columns()));
+    // In vsortrunmerger, it will set eos=true, and block not empty
+    // so that eos==true, could not make sure that block not have valid data
+    if (!eos || block->rows() > 0) {
+        if (!_is_merging) {
+            if (local_state.num_rows_skipped + block->rows() < _offset) {
+                local_state.num_rows_skipped += block->rows();
+                block->set_num_rows(0);
+            } else if (local_state.num_rows_skipped < _offset) {
+                auto offset = _offset - local_state.num_rows_skipped;
+                local_state.num_rows_skipped = _offset;
+                block->set_num_rows(block->rows() - offset);
+            }
+        }
+        if (local_state.num_rows_returned() + block->rows() < _limit) {
+            local_state.add_num_rows_returned(block->rows());
+        } else {
+            eos = true;
+            auto limit = _limit - local_state.num_rows_returned();
+            block->set_num_rows(limit);
+            local_state.set_num_rows_returned(_limit);
+        }
+        COUNTER_SET(local_state.rows_returned_counter(), local_state.num_rows_returned());
+    }
+    if (eos) {
+        source_state = SourceState::FINISHED;
+    }
+    return status;
+}
+
+Status ExchangeSourceOperatorX::setup_local_state(RuntimeState* state, LocalStateInfo& info) {
+    auto local_state = ExchangeLocalState::create_shared(state, this);
+    state->emplace_local_state(id(), local_state);
+    return local_state->init(state, info);
+}
+
+bool ExchangeSourceOperatorX::can_read(RuntimeState* state) {
+    return state->get_local_state(id())->cast<ExchangeLocalState>().stream_recvr->ready_to_read();
+}
+
+bool ExchangeSourceOperatorX::is_pending_finish(RuntimeState* /*state*/) const {
+    return false;
+}
+
+Status ExchangeSourceOperatorX::close(RuntimeState* state) {
+    if (is_closed()) {
+        return Status::OK();
+    }
+    auto& local_state = state->get_local_state(id())->cast<ExchangeLocalState>();
+    if (local_state.stream_recvr != nullptr) {
+        local_state.stream_recvr->close();
+    }
+    if (_is_merging) {
+        _vsort_exec_exprs.close(state);
+        local_state.vsort_exec_exprs.close(state);
+    }
+    _is_closed = true;
+    return OperatorXBase::close(state);
 }
 } // namespace doris::pipeline

--- a/be/src/pipeline/exec/exchange_source_operator.h
+++ b/be/src/pipeline/exec/exchange_source_operator.h
@@ -26,6 +26,11 @@ namespace doris {
 class ExecNode;
 } // namespace doris
 
+namespace vectorized {
+class VDataStreamRecvr;
+class Block;
+} // namespace vectorized
+
 namespace doris::pipeline {
 
 class ExchangeSourceOperatorBuilder final : public OperatorBuilder<vectorized::VExchangeNode> {
@@ -42,6 +47,52 @@ public:
     ExchangeSourceOperator(OperatorBuilderBase*, ExecNode*);
     bool can_read() override;
     bool is_pending_finish() const override;
+};
+
+class ExchangeSourceOperatorX;
+class ExchangeLocalState : public PipelineXLocalState {
+    ENABLE_FACTORY_CREATOR(ExchangeLocalState);
+    ExchangeLocalState(RuntimeState* state, OperatorXBase* parent);
+
+    Status init(RuntimeState* state, LocalStateInfo& info) override;
+
+    std::shared_ptr<doris::vectorized::VDataStreamRecvr> stream_recvr;
+    doris::vectorized::VSortExecExprs vsort_exec_exprs;
+    int64_t num_rows_skipped;
+};
+
+class ExchangeSourceOperatorX final : public OperatorXBase {
+public:
+    ExchangeSourceOperatorX(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs,
+                            std::string op_name, int num_senders);
+    bool can_read(RuntimeState* state) override;
+    bool is_pending_finish(RuntimeState* state) const override;
+
+    Status init(const TPlanNode& tnode, RuntimeState* state) override;
+    Status prepare(RuntimeState* state) override;
+    Status open(RuntimeState* state) override;
+    Status setup_local_state(RuntimeState* state, LocalStateInfo& info) override;
+
+    Status get_block(RuntimeState* state, vectorized::Block* block,
+                     SourceState& source_state) override;
+
+    Status close(RuntimeState* state) override;
+    bool is_source() const override { return true; }
+
+private:
+    friend class ExchangeLocalState;
+    const int _num_senders;
+    const bool _is_merging;
+    bool _is_ready;
+    RowDescriptor _input_row_desc;
+    std::shared_ptr<QueryStatisticsRecvr> _sub_plan_query_statistics_recvr;
+
+    // use in merge sort
+    size_t _offset;
+
+    doris::vectorized::VSortExecExprs _vsort_exec_exprs;
+    std::vector<bool> _is_asc_order;
+    std::vector<bool> _nulls_first;
 };
 
 } // namespace doris::pipeline

--- a/be/src/pipeline/exec/olap_scan_operator.cpp
+++ b/be/src/pipeline/exec/olap_scan_operator.cpp
@@ -1,0 +1,486 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "pipeline/exec/olap_scan_operator.h"
+
+#include <fmt/format.h>
+
+#include <memory>
+
+#include "olap/storage_engine.h"
+#include "olap/tablet_manager.h"
+#include "pipeline/exec/scan_operator.h"
+#include "service/backend_options.h"
+#include "util/to_string.h"
+#include "vec/exec/runtime_filter_consumer.h"
+#include "vec/exec/scan/new_olap_scanner.h"
+#include "vec/exec/scan/pip_scanner_context.h"
+#include "vec/exec/scan/scanner_context.h"
+#include "vec/exec/scan/vscan_node.h"
+#include "vec/exprs/vcompound_pred.h"
+#include "vec/exprs/vectorized_fn_call.h"
+#include "vec/exprs/vexpr.h"
+#include "vec/exprs/vexpr_context.h"
+#include "vec/exprs/vin_predicate.h"
+#include "vec/exprs/vslot_ref.h"
+#include "vec/functions/in.h"
+
+namespace doris::pipeline {
+
+Status OlapScanLocalState::_init_profile() {
+    RETURN_IF_ERROR(ScanLocalState::_init_profile());
+    // 1. init segment profile
+    _segment_profile.reset(new RuntimeProfile("SegmentIterator"));
+    _scanner_profile->add_child(_segment_profile.get(), true, nullptr);
+
+    // 2. init timer and counters
+    _reader_init_timer = ADD_TIMER(_scanner_profile, "ReaderInitTime");
+    _scanner_init_timer = ADD_TIMER(_scanner_profile, "ScannerInitTime");
+    _process_conjunct_timer = ADD_TIMER(_runtime_profile, "ProcessConjunctTime");
+    _read_compressed_counter = ADD_COUNTER(_segment_profile, "CompressedBytesRead", TUnit::BYTES);
+    _read_uncompressed_counter =
+            ADD_COUNTER(_segment_profile, "UncompressedBytesRead", TUnit::BYTES);
+    _block_load_timer = ADD_TIMER(_segment_profile, "BlockLoadTime");
+    _block_load_counter = ADD_COUNTER(_segment_profile, "BlocksLoad", TUnit::UNIT);
+    _block_fetch_timer = ADD_TIMER(_scanner_profile, "BlockFetchTime");
+    _raw_rows_counter = ADD_COUNTER(_segment_profile, "RawRowsRead", TUnit::UNIT);
+    _block_convert_timer = ADD_TIMER(_scanner_profile, "BlockConvertTime");
+    _block_init_timer = ADD_TIMER(_segment_profile, "BlockInitTime");
+    _block_init_seek_timer = ADD_TIMER(_segment_profile, "BlockInitSeekTime");
+    _block_init_seek_counter = ADD_COUNTER(_segment_profile, "BlockInitSeekCount", TUnit::UNIT);
+    _block_conditions_filtered_timer = ADD_TIMER(_segment_profile, "BlockConditionsFilteredTime");
+
+    _rows_vec_cond_filtered_counter =
+            ADD_COUNTER(_segment_profile, "RowsVectorPredFiltered", TUnit::UNIT);
+    _rows_short_circuit_cond_filtered_counter =
+            ADD_COUNTER(_segment_profile, "RowsShortCircuitPredFiltered", TUnit::UNIT);
+    _rows_vec_cond_input_counter =
+            ADD_COUNTER(_segment_profile, "RowsVectorPredInput", TUnit::UNIT);
+    _rows_short_circuit_cond_input_counter =
+            ADD_COUNTER(_segment_profile, "RowsShortCircuitPredInput", TUnit::UNIT);
+    _vec_cond_timer = ADD_TIMER(_segment_profile, "VectorPredEvalTime");
+    _short_cond_timer = ADD_TIMER(_segment_profile, "ShortPredEvalTime");
+    _expr_filter_timer = ADD_TIMER(_segment_profile, "ExprFilterEvalTime");
+    _first_read_timer = ADD_TIMER(_segment_profile, "FirstReadTime");
+    _second_read_timer = ADD_TIMER(_segment_profile, "SecondReadTime");
+    _first_read_seek_timer = ADD_TIMER(_segment_profile, "FirstReadSeekTime");
+    _first_read_seek_counter = ADD_COUNTER(_segment_profile, "FirstReadSeekCount", TUnit::UNIT);
+
+    _lazy_read_timer = ADD_TIMER(_segment_profile, "LazyReadTime");
+    _lazy_read_seek_timer = ADD_TIMER(_segment_profile, "LazyReadSeekTime");
+    _lazy_read_seek_counter = ADD_COUNTER(_segment_profile, "LazyReadSeekCount", TUnit::UNIT);
+
+    _output_col_timer = ADD_TIMER(_segment_profile, "OutputColumnTime");
+
+    _stats_filtered_counter = ADD_COUNTER(_segment_profile, "RowsStatsFiltered", TUnit::UNIT);
+    _bf_filtered_counter = ADD_COUNTER(_segment_profile, "RowsBloomFilterFiltered", TUnit::UNIT);
+    _dict_filtered_counter = ADD_COUNTER(_segment_profile, "RowsDictFiltered", TUnit::UNIT);
+    _del_filtered_counter = ADD_COUNTER(_scanner_profile, "RowsDelFiltered", TUnit::UNIT);
+    _conditions_filtered_counter =
+            ADD_COUNTER(_segment_profile, "RowsConditionsFiltered", TUnit::UNIT);
+    _key_range_filtered_counter =
+            ADD_COUNTER(_segment_profile, "RowsKeyRangeFiltered", TUnit::UNIT);
+
+    _io_timer = ADD_TIMER(_segment_profile, "IOTimer");
+    _decompressor_timer = ADD_TIMER(_segment_profile, "DecompressorTimer");
+
+    _total_pages_num_counter = ADD_COUNTER(_segment_profile, "TotalPagesNum", TUnit::UNIT);
+    _cached_pages_num_counter = ADD_COUNTER(_segment_profile, "CachedPagesNum", TUnit::UNIT);
+
+    _bitmap_index_filter_counter =
+            ADD_COUNTER(_segment_profile, "RowsBitmapIndexFiltered", TUnit::UNIT);
+    _bitmap_index_filter_timer = ADD_TIMER(_segment_profile, "BitmapIndexFilterTimer");
+
+    _inverted_index_filter_counter =
+            ADD_COUNTER(_segment_profile, "RowsInvertedIndexFiltered", TUnit::UNIT);
+    _inverted_index_filter_timer = ADD_TIMER(_segment_profile, "InvertedIndexFilterTime");
+    _inverted_index_query_cache_hit_counter =
+            ADD_COUNTER(_segment_profile, "InvertedIndexQueryCacheHit", TUnit::UNIT);
+    _inverted_index_query_cache_miss_counter =
+            ADD_COUNTER(_segment_profile, "InvertedIndexQueryCacheMiss", TUnit::UNIT);
+    _inverted_index_query_timer = ADD_TIMER(_segment_profile, "InvertedIndexQueryTime");
+    _inverted_index_query_bitmap_copy_timer =
+            ADD_TIMER(_segment_profile, "InvertedIndexQueryBitmapCopyTime");
+    _inverted_index_query_bitmap_op_timer =
+            ADD_TIMER(_segment_profile, "InvertedIndexQueryBitmapOpTime");
+    _inverted_index_searcher_open_timer =
+            ADD_TIMER(_segment_profile, "InvertedIndexSearcherOpenTime");
+    _inverted_index_searcher_search_timer =
+            ADD_TIMER(_segment_profile, "InvertedIndexSearcherSearchTime");
+
+    _output_index_result_column_timer = ADD_TIMER(_segment_profile, "OutputIndexResultColumnTimer");
+
+    _filtered_segment_counter = ADD_COUNTER(_segment_profile, "NumSegmentFiltered", TUnit::UNIT);
+    _total_segment_counter = ADD_COUNTER(_segment_profile, "NumSegmentTotal", TUnit::UNIT);
+    _tablet_counter = ADD_COUNTER(_runtime_profile, "TabletNum", TUnit::UNIT);
+    return Status::OK();
+}
+
+Status OlapScanLocalState::_process_conjuncts() {
+    SCOPED_TIMER(_process_conjunct_timer);
+    RETURN_IF_ERROR(ScanLocalState::_process_conjuncts());
+    if (_eos) {
+        return Status::OK();
+    }
+    RETURN_IF_ERROR(_build_key_ranges_and_filters());
+    return Status::OK();
+}
+
+bool OlapScanLocalState::_is_key_column(const std::string& key_name) {
+    auto& p = _parent->cast<OlapScanOperatorX>();
+    // all column in dup_keys table or unique_keys with merge on write table olap scan node threat
+    // as key column
+    if (p._olap_scan_node.keyType == TKeysType::DUP_KEYS ||
+        (p._olap_scan_node.keyType == TKeysType::UNIQUE_KEYS &&
+         p._olap_scan_node.__isset.enable_unique_key_merge_on_write &&
+         p._olap_scan_node.enable_unique_key_merge_on_write)) {
+        return true;
+    }
+
+    auto res = std::find(p._olap_scan_node.key_column_name.begin(),
+                         p._olap_scan_node.key_column_name.end(), key_name);
+    return res != p._olap_scan_node.key_column_name.end();
+}
+
+Status OlapScanLocalState::_should_push_down_function_filter(
+        vectorized::VectorizedFnCall* fn_call, vectorized::VExprContext* expr_ctx,
+        StringRef* constant_str, doris::FunctionContext** fn_ctx,
+        vectorized::VScanNode::PushDownType& pdt) {
+    // Now only `like` function filters is supported to push down
+    if (fn_call->fn().name.function_name != "like") {
+        pdt = vectorized::VScanNode::PushDownType::UNACCEPTABLE;
+        return Status::OK();
+    }
+
+    const auto& children = fn_call->children();
+    doris::FunctionContext* func_cxt = expr_ctx->fn_context(fn_call->fn_context_index());
+    DCHECK(func_cxt != nullptr);
+    DCHECK(children.size() == 2);
+    for (size_t i = 0; i < children.size(); i++) {
+        if (vectorized::VExpr::expr_without_cast(children[i])->node_type() !=
+            TExprNodeType::SLOT_REF) {
+            // not a slot ref(column)
+            continue;
+        }
+        if (!children[1 - i]->is_constant()) {
+            // only handle constant value
+            pdt = vectorized::VScanNode::PushDownType::UNACCEPTABLE;
+            return Status::OK();
+        } else {
+            DCHECK(children[1 - i]->type().is_string_type());
+            std::shared_ptr<ColumnPtrWrapper> const_col_wrapper;
+            RETURN_IF_ERROR(children[1 - i]->get_const_col(expr_ctx, &const_col_wrapper));
+            if (const vectorized::ColumnConst* const_column =
+                        check_and_get_column<vectorized::ColumnConst>(
+                                const_col_wrapper->column_ptr)) {
+                *constant_str = const_column->get_data_at(0);
+            } else {
+                pdt = vectorized::VScanNode::PushDownType::UNACCEPTABLE;
+                return Status::OK();
+            }
+        }
+    }
+    *fn_ctx = func_cxt;
+    pdt = vectorized::VScanNode::PushDownType::ACCEPTABLE;
+    return Status::OK();
+}
+
+bool OlapScanLocalState::_should_push_down_common_expr() {
+    auto& p = _parent->cast<OlapScanOperatorX>();
+    return state()->enable_common_expr_pushdown() &&
+           (p._olap_scan_node.keyType == TKeysType::DUP_KEYS ||
+            (p._olap_scan_node.keyType == TKeysType::UNIQUE_KEYS &&
+             p._olap_scan_node.__isset.enable_unique_key_merge_on_write &&
+             p._olap_scan_node.enable_unique_key_merge_on_write));
+}
+
+Status OlapScanLocalState::_init_scanners(std::list<vectorized::VScannerSPtr>* scanners) {
+    if (_scan_ranges.empty()) {
+        _eos = true;
+        return Status::OK();
+    }
+    SCOPED_TIMER(_scanner_init_timer);
+    auto span = opentelemetry::trace::Tracer::GetCurrentSpan();
+
+    if (!_conjuncts.empty()) {
+        std::string message;
+        for (auto& conjunct : _conjuncts) {
+            if (conjunct->root()) {
+                if (!message.empty()) {
+                    message += ", ";
+                }
+                message += conjunct->root()->debug_string();
+            }
+        }
+        _runtime_profile->add_info_string("RemainedDownPredicates", message);
+    }
+    auto& p = _parent->cast<OlapScanOperatorX>();
+
+    if (!p._olap_scan_node.output_column_unique_ids.empty()) {
+        for (auto uid : p._olap_scan_node.output_column_unique_ids) {
+            _maybe_read_column_ids.emplace(uid);
+        }
+    }
+
+    // ranges constructed from scan keys
+    RETURN_IF_ERROR(_scan_keys.get_key_range(&_cond_ranges));
+    // if we can't get ranges from conditions, we give it a total range
+    if (_cond_ranges.empty()) {
+        _cond_ranges.emplace_back(new doris::OlapScanRange());
+    }
+    int scanners_per_tablet = std::max(1, 64 / (int)_scan_ranges.size());
+
+    auto build_new_scanner = [&](const TPaloScanRange& scan_range,
+                                 const std::vector<OlapScanRange*>& key_ranges) {
+        std::shared_ptr<vectorized::NewOlapScanner> scanner =
+                vectorized::NewOlapScanner::create_shared(
+                        state(), this, p._limit_per_scanner, p._olap_scan_node.is_preaggregation,
+                        scan_range, key_ranges, _scanner_profile.get());
+
+        RETURN_IF_ERROR(scanner->prepare(state(), _conjuncts));
+        scanner->set_compound_filters(_compound_filters);
+        scanners->push_back(scanner);
+        return Status::OK();
+    };
+    for (auto& scan_range : _scan_ranges) {
+        auto tablet_id = scan_range->tablet_id;
+        auto [tablet, status] =
+                StorageEngine::instance()->tablet_manager()->get_tablet_and_status(tablet_id, true);
+        RETURN_IF_ERROR(status);
+
+        std::vector<std::unique_ptr<doris::OlapScanRange>>* ranges = &_cond_ranges;
+        int size_based_scanners_per_tablet = 1;
+
+        if (config::doris_scan_range_max_mb > 0) {
+            size_based_scanners_per_tablet = std::max(
+                    1, (int)(tablet->tablet_footprint() / (config::doris_scan_range_max_mb << 20)));
+        }
+        int ranges_per_scanner =
+                std::max(1, (int)ranges->size() /
+                                    std::min(scanners_per_tablet, size_based_scanners_per_tablet));
+        int num_ranges = ranges->size();
+        for (int i = 0; i < num_ranges;) {
+            std::vector<doris::OlapScanRange*> scanner_ranges;
+            scanner_ranges.push_back((*ranges)[i].get());
+            ++i;
+            for (int j = 1; i < num_ranges && j < ranges_per_scanner &&
+                            (*ranges)[i]->end_include == (*ranges)[i - 1]->end_include;
+                 ++j, ++i) {
+                scanner_ranges.push_back((*ranges)[i].get());
+            }
+            RETURN_IF_ERROR(build_new_scanner(*scan_range, scanner_ranges));
+        }
+    }
+
+    return Status::OK();
+}
+
+TOlapScanNode& OlapScanLocalState::olap_scan_node() {
+    return _parent->cast<OlapScanOperatorX>()._olap_scan_node;
+}
+
+void OlapScanLocalState::set_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) {
+    for (auto& scan_range : scan_ranges) {
+        DCHECK(scan_range.scan_range.__isset.palo_scan_range);
+        _scan_ranges.emplace_back(new TPaloScanRange(scan_range.scan_range.palo_scan_range));
+        //        COUNTER_UPDATE(_tablet_counter, 1);
+    }
+    // telemetry::set_current_span_attribute(_tablet_counter);
+}
+
+static std::string olap_filter_to_string(const doris::TCondition& condition) {
+    auto op_name = condition.condition_op;
+    if (condition.condition_op == "*=") {
+        op_name = "IN";
+    } else if (condition.condition_op == "!*=") {
+        op_name = "NOT IN";
+    }
+    return fmt::format("{{{} {} {}}}", condition.column_name, op_name,
+                       condition.condition_values.size() > 128
+                               ? "[more than 128 elements]"
+                               : to_string(condition.condition_values));
+}
+
+static std::string olap_filters_to_string(const std::vector<doris::TCondition>& filters) {
+    std::string filters_string;
+    filters_string += "[";
+    for (auto it = filters.cbegin(); it != filters.cend(); it++) {
+        if (it != filters.cbegin()) {
+            filters_string += ", ";
+        }
+        filters_string += olap_filter_to_string(*it);
+    }
+    filters_string += "]";
+    return filters_string;
+}
+
+static std::string tablets_id_to_string(
+        const std::vector<std::unique_ptr<TPaloScanRange>>& scan_ranges) {
+    if (scan_ranges.empty()) {
+        return "[empty]";
+    }
+    std::stringstream ss;
+    ss << "[" << scan_ranges[0]->tablet_id;
+    for (int i = 1; i < scan_ranges.size(); ++i) {
+        ss << ", " << scan_ranges[i]->tablet_id;
+    }
+    ss << "]";
+    return ss.str();
+}
+
+inline std::string push_down_agg_to_string(const TPushAggOp::type& op) {
+    if (op == TPushAggOp::MINMAX) {
+        return "MINMAX";
+    } else if (op == TPushAggOp::COUNT) {
+        return "COUNT";
+    } else if (op == TPushAggOp::MIX) {
+        return "MIX";
+    } else {
+        return "NONE";
+    }
+}
+
+Status OlapScanLocalState::_build_key_ranges_and_filters() {
+    auto& p = _parent->cast<OlapScanOperatorX>();
+    if (p._push_down_agg_type == TPushAggOp::NONE) {
+        const std::vector<std::string>& column_names = p._olap_scan_node.key_column_name;
+        const std::vector<TPrimitiveType::type>& column_types = p._olap_scan_node.key_column_type;
+        DCHECK(column_types.size() == column_names.size());
+
+        // 1. construct scan key except last olap engine short key
+        _scan_keys.set_is_convertible(p.limit() == -1);
+
+        // we use `exact_range` to identify a key range is an exact range or not when we convert
+        // it to `_scan_keys`. If `exact_range` is true, we can just discard it from `_olap_filters`.
+        bool exact_range = true;
+        bool eos = false;
+        for (int column_index = 0;
+             column_index < column_names.size() && !_scan_keys.has_range_value() && !eos;
+             ++column_index) {
+            auto iter = _colname_to_value_range.find(column_names[column_index]);
+            if (_colname_to_value_range.end() == iter) {
+                break;
+            }
+
+            RETURN_IF_ERROR(std::visit(
+                    [&](auto&& range) {
+                        // make a copy or range and pass to extend_scan_key, keep the range unchanged
+                        // because extend_scan_key method may change the first parameter.
+                        // but the original range may be converted to olap filters, if it's not a exact_range.
+                        auto temp_range = range;
+                        if (range.get_fixed_value_size() <= p._max_pushdown_conditions_per_column) {
+                            RETURN_IF_ERROR(_scan_keys.extend_scan_key(
+                                    temp_range, p._max_scan_key_num, &exact_range, &eos));
+                            if (exact_range) {
+                                _colname_to_value_range.erase(iter->first);
+                            }
+                        } else {
+                            // if exceed max_pushdown_conditions_per_column, use whole_value_rang instead
+                            // and will not erase from _colname_to_value_range, it must be not exact_range
+                            temp_range.set_whole_value_range();
+                            RETURN_IF_ERROR(_scan_keys.extend_scan_key(
+                                    temp_range, p._max_scan_key_num, &exact_range, &eos));
+                        }
+                        return Status::OK();
+                    },
+                    iter->second));
+        }
+        _eos |= eos;
+
+        for (auto& iter : _colname_to_value_range) {
+            std::vector<TCondition> filters;
+            std::visit([&](auto&& range) { range.to_olap_filter(filters); }, iter.second);
+
+            for (const auto& filter : filters) {
+                _olap_filters.push_back(filter);
+            }
+        }
+
+        for (auto& iter : _compound_value_ranges) {
+            std::vector<TCondition> filters;
+            std::visit(
+                    [&](auto&& range) {
+                        if (range.is_in_compound_value_range()) {
+                            range.to_condition_in_compound(filters);
+                        } else if (range.is_match_value_range()) {
+                            range.to_match_condition(filters);
+                        }
+                    },
+                    iter);
+            for (const auto& filter : filters) {
+                _compound_filters.push_back(filter);
+            }
+        }
+
+        // Append value ranges in "_not_in_value_ranges"
+        for (auto& range : _not_in_value_ranges) {
+            std::visit([&](auto&& the_range) { the_range.to_in_condition(_olap_filters, false); },
+                       range);
+        }
+    } else {
+        _runtime_profile->add_info_string("PushDownAggregate",
+                                          push_down_agg_to_string(p._push_down_agg_type));
+    }
+
+    if (state()->enable_profile()) {
+        _runtime_profile->add_info_string("PushDownPredicates",
+                                          olap_filters_to_string(_olap_filters));
+        _runtime_profile->add_info_string("KeyRanges", _scan_keys.debug_string());
+        _runtime_profile->add_info_string("TabletIds", tablets_id_to_string(_scan_ranges));
+    }
+    VLOG_CRITICAL << _scan_keys.debug_string();
+
+    return Status::OK();
+}
+
+void OlapScanLocalState::add_filter_info(int id, const PredicateFilterInfo& update_info) {
+    std::unique_lock lock(_profile_mtx);
+    // update
+    _filter_info[id].filtered_row += update_info.filtered_row;
+    _filter_info[id].input_row += update_info.input_row;
+    _filter_info[id].type = update_info.type;
+    // to string
+    auto& info = _filter_info[id];
+    std::string filter_name = "RuntimeFilterInfo id ";
+    filter_name += std::to_string(id);
+    std::string info_str;
+    info_str += "type = " + type_to_string(static_cast<PredicateType>(info.type)) + ", ";
+    info_str += "input = " + std::to_string(info.input_row) + ", ";
+    info_str += "filtered = " + std::to_string(info.filtered_row);
+    info_str = "[" + info_str + "]";
+
+    // add info
+    _segment_profile->add_info_string(filter_name, info_str);
+}
+
+OlapScanOperatorX::OlapScanOperatorX(ObjectPool* pool, const TPlanNode& tnode,
+                                     const DescriptorTbl& descs, std::string op_name)
+        : ScanOperatorX(pool, tnode, descs, op_name), _olap_scan_node(tnode.olap_scan_node) {
+    _output_tuple_id = tnode.olap_scan_node.tuple_id;
+    _col_distribute_ids = tnode.olap_scan_node.distribute_column_ids;
+    if (_olap_scan_node.__isset.sort_info && _olap_scan_node.__isset.sort_limit) {
+        _limit_per_scanner = _olap_scan_node.sort_limit;
+    }
+}
+
+Status OlapScanOperatorX::setup_local_state(RuntimeState* state, LocalStateInfo& info) {
+    auto local_state = OlapScanLocalState::create_shared(state, this);
+    state->emplace_local_state(id(), local_state);
+    return local_state->init(state, info);
+}
+
+} // namespace doris::pipeline

--- a/be/src/pipeline/exec/olap_scan_operator.h
+++ b/be/src/pipeline/exec/olap_scan_operator.h
@@ -1,0 +1,190 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <stdint.h>
+
+#include <string>
+
+#include "common/status.h"
+#include "operator.h"
+#include "pipeline/exec/scan_operator.h"
+#include "vec/exec/scan/vscan_node.h"
+
+namespace doris {
+class ExecNode;
+
+namespace vectorized {
+class NewOlapScanner;
+}
+} // namespace doris
+
+namespace doris::pipeline {
+
+class OlapScanOperatorX;
+class OlapScanLocalState final : public ScanLocalState {
+    ENABLE_FACTORY_CREATOR(OlapScanLocalState);
+    OlapScanLocalState(RuntimeState* state, OperatorXBase* parent)
+            : ScanLocalState(state, parent) {}
+
+    TOlapScanNode& olap_scan_node();
+
+private:
+    friend class vectorized::NewOlapScanner;
+
+    void set_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) override;
+    Status _init_profile() override;
+    Status _process_conjuncts() override;
+    bool _is_key_column(const std::string& col_name) override;
+
+    Status _should_push_down_function_filter(vectorized::VectorizedFnCall* fn_call,
+                                             vectorized::VExprContext* expr_ctx,
+                                             StringRef* constant_str,
+                                             doris::FunctionContext** fn_ctx,
+                                             vectorized::VScanNode::PushDownType& pdt) override;
+
+    vectorized::VScanNode::PushDownType _should_push_down_bloom_filter() override {
+        return vectorized::VScanNode::PushDownType::ACCEPTABLE;
+    }
+
+    vectorized::VScanNode::PushDownType _should_push_down_bitmap_filter() override {
+        return vectorized::VScanNode::PushDownType::ACCEPTABLE;
+    }
+
+    vectorized::VScanNode::PushDownType _should_push_down_is_null_predicate() override {
+        return vectorized::VScanNode::PushDownType::ACCEPTABLE;
+    }
+
+    bool _should_push_down_common_expr() override;
+
+    Status _init_scanners(std::list<vectorized::VScannerSPtr>* scanners) override;
+
+    void add_filter_info(int id, const PredicateFilterInfo& info);
+
+    Status _build_key_ranges_and_filters();
+
+    std::vector<std::unique_ptr<TPaloScanRange>> _scan_ranges;
+    std::vector<std::unique_ptr<doris::OlapScanRange>> _cond_ranges;
+    OlapScanKeys _scan_keys;
+    std::vector<TCondition> _olap_filters;
+    // _compound_filters store conditions in the one compound relationship in conjunct expr tree except leaf node of `and` node,
+    // such as: "(a or b) and (c or d)", conditions for a,b,c,d will be stored
+    std::vector<TCondition> _compound_filters;
+    // If column id in this set, indicate that we need to read data after index filtering
+    std::set<int32_t> _maybe_read_column_ids;
+
+    std::unique_ptr<RuntimeProfile> _segment_profile;
+
+    RuntimeProfile::Counter* _num_disks_accessed_counter = nullptr;
+
+    RuntimeProfile::Counter* _tablet_counter = nullptr;
+    RuntimeProfile::Counter* _rows_pushed_cond_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _reader_init_timer = nullptr;
+    RuntimeProfile::Counter* _scanner_init_timer = nullptr;
+    RuntimeProfile::Counter* _process_conjunct_timer = nullptr;
+
+    RuntimeProfile::Counter* _io_timer = nullptr;
+    RuntimeProfile::Counter* _read_compressed_counter = nullptr;
+    RuntimeProfile::Counter* _decompressor_timer = nullptr;
+    RuntimeProfile::Counter* _read_uncompressed_counter = nullptr;
+    RuntimeProfile::Counter* _raw_rows_counter = nullptr;
+
+    RuntimeProfile::Counter* _rows_vec_cond_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _rows_short_circuit_cond_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _rows_vec_cond_input_counter = nullptr;
+    RuntimeProfile::Counter* _rows_short_circuit_cond_input_counter = nullptr;
+    RuntimeProfile::Counter* _vec_cond_timer = nullptr;
+    RuntimeProfile::Counter* _short_cond_timer = nullptr;
+    RuntimeProfile::Counter* _expr_filter_timer = nullptr;
+    RuntimeProfile::Counter* _output_col_timer = nullptr;
+    std::map<int, PredicateFilterInfo> _filter_info;
+
+    RuntimeProfile::Counter* _stats_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _bf_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _dict_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _del_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _conditions_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _key_range_filtered_counter = nullptr;
+
+    RuntimeProfile::Counter* _block_fetch_timer = nullptr;
+    RuntimeProfile::Counter* _block_load_timer = nullptr;
+    RuntimeProfile::Counter* _block_load_counter = nullptr;
+    // Add more detail seek timer and counter profile
+    // Read process is split into 3 stages: init, first read, lazy read
+    RuntimeProfile::Counter* _block_init_timer = nullptr;
+    RuntimeProfile::Counter* _block_init_seek_timer = nullptr;
+    RuntimeProfile::Counter* _block_init_seek_counter = nullptr;
+    RuntimeProfile::Counter* _block_conditions_filtered_timer = nullptr;
+    RuntimeProfile::Counter* _first_read_timer = nullptr;
+    RuntimeProfile::Counter* _second_read_timer = nullptr;
+    RuntimeProfile::Counter* _first_read_seek_timer = nullptr;
+    RuntimeProfile::Counter* _first_read_seek_counter = nullptr;
+    RuntimeProfile::Counter* _lazy_read_timer = nullptr;
+    RuntimeProfile::Counter* _lazy_read_seek_timer = nullptr;
+    RuntimeProfile::Counter* _lazy_read_seek_counter = nullptr;
+
+    RuntimeProfile::Counter* _block_convert_timer = nullptr;
+
+    // total pages read
+    // used by segment v2
+    RuntimeProfile::Counter* _total_pages_num_counter = nullptr;
+    // page read from cache
+    // used by segment v2
+    RuntimeProfile::Counter* _cached_pages_num_counter = nullptr;
+
+    // row count filtered by bitmap inverted index
+    RuntimeProfile::Counter* _bitmap_index_filter_counter = nullptr;
+    // time fro bitmap inverted index read and filter
+    RuntimeProfile::Counter* _bitmap_index_filter_timer = nullptr;
+
+    RuntimeProfile::Counter* _inverted_index_filter_counter = nullptr;
+    RuntimeProfile::Counter* _inverted_index_filter_timer = nullptr;
+    RuntimeProfile::Counter* _inverted_index_query_cache_hit_counter = nullptr;
+    RuntimeProfile::Counter* _inverted_index_query_cache_miss_counter = nullptr;
+    RuntimeProfile::Counter* _inverted_index_query_timer = nullptr;
+    RuntimeProfile::Counter* _inverted_index_query_bitmap_copy_timer = nullptr;
+    RuntimeProfile::Counter* _inverted_index_query_bitmap_op_timer = nullptr;
+    RuntimeProfile::Counter* _inverted_index_searcher_open_timer = nullptr;
+    RuntimeProfile::Counter* _inverted_index_searcher_search_timer = nullptr;
+
+    RuntimeProfile::Counter* _output_index_result_column_timer = nullptr;
+
+    // number of created olap scanners
+    RuntimeProfile::Counter* _num_scanners = nullptr;
+
+    // number of segment filtered by column stat when creating seg iterator
+    RuntimeProfile::Counter* _filtered_segment_counter = nullptr;
+    // total number of segment related to this scan node
+    RuntimeProfile::Counter* _total_segment_counter = nullptr;
+
+    std::mutex _profile_mtx;
+};
+
+class OlapScanOperatorX final : public ScanOperatorX {
+public:
+    OlapScanOperatorX(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs,
+                      std::string op_name);
+
+    Status setup_local_state(RuntimeState* state, LocalStateInfo& info) override;
+
+private:
+    friend class OlapScanLocalState;
+    TOlapScanNode _olap_scan_node;
+};
+
+} // namespace doris::pipeline

--- a/be/src/pipeline/exec/operator.cpp
+++ b/be/src/pipeline/exec/operator.cpp
@@ -17,6 +17,9 @@
 
 #include "operator.h"
 
+#include "vec/exprs/vexpr.h"
+#include "vec/exprs/vexpr_context.h"
+
 namespace doris {
 class RowDescriptor;
 class RuntimeState;
@@ -55,4 +58,121 @@ std::string OperatorBase::debug_string() const {
     return ss.str();
 }
 
+std::string OperatorXBase::debug_string() const {
+    std::stringstream ss;
+    ss << _op_name << ": is_source: " << is_source();
+    ss << ", is_closed: " << _is_closed;
+    return ss.str();
+}
+
+Status OperatorXBase::init(const TPlanNode& tnode, RuntimeState* /*state*/) {
+    _init_runtime_profile();
+
+    if (tnode.__isset.vconjunct) {
+        vectorized::VExprContextSPtr context;
+        RETURN_IF_ERROR(vectorized::VExpr::create_expr_tree(tnode.vconjunct, context));
+        _conjuncts.emplace_back(context);
+    } else if (tnode.__isset.conjuncts) {
+        for (auto& conjunct : tnode.conjuncts) {
+            vectorized::VExprContextSPtr context;
+            RETURN_IF_ERROR(vectorized::VExpr::create_expr_tree(conjunct, context));
+            _conjuncts.emplace_back(context);
+        }
+    }
+
+    // create the projections expr
+    if (tnode.__isset.projections) {
+        DCHECK(tnode.__isset.output_tuple_id);
+        RETURN_IF_ERROR(vectorized::VExpr::create_expr_trees(tnode.projections, _projections));
+    }
+    return Status::OK();
+}
+
+Status OperatorXBase::prepare(RuntimeState* state) {
+    for (auto& conjunct : _conjuncts) {
+        RETURN_IF_ERROR(conjunct->prepare(state, intermediate_row_desc()));
+    }
+
+    RETURN_IF_ERROR(vectorized::VExpr::prepare(_projections, state, intermediate_row_desc()));
+
+    if (_children) {
+        RETURN_IF_ERROR(_children->prepare(state));
+    }
+
+    return Status::OK();
+}
+
+Status OperatorXBase::open(RuntimeState* state) {
+    for (auto& conjunct : _conjuncts) {
+        RETURN_IF_ERROR(conjunct->open(state));
+    }
+    RETURN_IF_ERROR(vectorized::VExpr::open(_projections, state));
+    return Status::OK();
+}
+
+void OperatorXBase::_init_runtime_profile() {
+    std::stringstream ss;
+    ss << get_name() << " (id=" << _id << ")";
+    _runtime_profile.reset(new RuntimeProfile(ss.str()));
+    _runtime_profile->set_metadata(_id);
+}
+
+Status OperatorXBase::close(RuntimeState* state) {
+    if (_is_closed) {
+        return Status::OK();
+    }
+    auto local_state = state->get_local_state(id());
+    Status result;
+    _children->close(state);
+    if (local_state->_rows_returned_counter != nullptr) {
+        COUNTER_SET(local_state->_rows_returned_counter, local_state->_num_rows_returned);
+    }
+
+    local_state->profile()->add_to_span(local_state->_span);
+    _is_closed = true;
+    return Status::OK();
+}
+
+Status PipelineXLocalState::init(RuntimeState* state, LocalStateInfo& /*info*/) {
+    _runtime_profile.reset(new RuntimeProfile("LocalState " + _parent->get_name()));
+    _parent->get_runtime_profile()->add_child(_runtime_profile.get(), true, nullptr);
+    _conjuncts.resize(_parent->_conjuncts.size());
+    _projections.resize(_parent->_projections.size());
+    for (size_t i = 0; i < _conjuncts.size(); i++) {
+        RETURN_IF_ERROR(_parent->_conjuncts[i]->clone(state, _conjuncts[i]));
+    }
+    for (size_t i = 0; i < _projections.size(); i++) {
+        RETURN_IF_ERROR(_parent->_projections[i]->clone(state, _projections[i]));
+    }
+    DCHECK(_runtime_profile.get() != nullptr);
+    _rows_returned_counter = ADD_COUNTER(_runtime_profile, "RowsReturned", TUnit::UNIT);
+    _projection_timer = ADD_TIMER(_runtime_profile, "ProjectionTime");
+    _rows_returned_rate = profile()->add_derived_counter(
+            doris::ExecNode::ROW_THROUGHPUT_COUNTER, TUnit::UNIT_PER_SECOND,
+            std::bind<int64_t>(&RuntimeProfile::units_per_second, _rows_returned_counter,
+                               profile()->total_time_counter()),
+            "");
+    _mem_tracker = std::make_unique<MemTracker>("PipelineXLocalState:" + _runtime_profile->name());
+    return Status::OK();
+}
+
+bool PipelineXLocalState::reached_limit() const {
+    return _parent->_limit != -1 && _num_rows_returned >= _parent->_limit;
+}
+
+void PipelineXLocalState::reached_limit(vectorized::Block* block, bool* eos) {
+    if (_parent->_limit != -1 and _num_rows_returned + block->rows() >= _parent->_limit) {
+        block->set_num_rows(_parent->_limit - _num_rows_returned);
+        *eos = true;
+    }
+
+    _num_rows_returned += block->rows();
+    COUNTER_SET(_rows_returned_counter, _num_rows_returned);
+}
+
+std::string DataSinkOperatorX::debug_string() const {
+    std::stringstream ss;
+    ss << _name << ", is_closed: " << _is_closed;
+    return ss.str();
+}
 } // namespace doris::pipeline

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -31,6 +31,7 @@
 
 #include "common/status.h"
 #include "exec/exec_node.h"
+#include "pipeline/pipeline_x/dependency.h"
 #include "runtime/memory/mem_tracker.h"
 #include "runtime/runtime_state.h"
 #include "util/runtime_profile.h"
@@ -86,9 +87,16 @@ enum class SinkState : uint8_t {
 
 class OperatorBuilderBase;
 class OperatorBase;
+class OperatorXBase;
+class DataSinkOperatorX;
 
 using OperatorPtr = std::shared_ptr<OperatorBase>;
 using Operators = std::vector<OperatorPtr>;
+
+using OperatorXPtr = std::shared_ptr<OperatorXBase>;
+using OperatorXs = std::vector<OperatorXPtr>;
+
+using DataSinkOperatorXPtr = std::shared_ptr<DataSinkOperatorX>;
 
 using OperatorBuilderPtr = std::shared_ptr<OperatorBuilderBase>;
 using OperatorBuilders = std::vector<OperatorBuilderPtr>;
@@ -111,6 +119,7 @@ public:
     int32_t id() const { return _id; }
 
 protected:
+    // Exec node id.
     const int32_t _id;
     const std::string _name;
 
@@ -157,11 +166,11 @@ public:
     explicit OperatorBase(OperatorBuilderBase* operator_builder);
     virtual ~OperatorBase() = default;
 
-    std::string get_name() const { return _operator_builder->get_name(); }
+    virtual std::string get_name() const { return _operator_builder->get_name(); }
 
-    bool is_sink() const;
+    virtual bool is_sink() const;
 
-    bool is_source() const;
+    virtual bool is_source() const;
 
     virtual Status init(const TDataSink& tsink) { return Status::OK(); }
 
@@ -190,6 +199,14 @@ public:
             return Status::InternalError("source can not has child.");
         }
         _child = std::move(child);
+        return Status::OK();
+    }
+
+    Status set_child(OperatorXPtr child) {
+        if (is_source()) {
+            return Status::OK();
+        }
+        _child_x = std::move(child);
         return Status::OK();
     }
 
@@ -237,16 +254,19 @@ public:
 
     const OperatorBuilderBase* operator_builder() const { return _operator_builder; }
 
-    const RowDescriptor& row_desc();
+    virtual const RowDescriptor& row_desc();
 
     virtual std::string debug_string() const;
-    int32_t id() const { return _operator_builder->id(); }
+    virtual int32_t id() const { return _operator_builder->id(); }
 
     [[nodiscard]] virtual RuntimeProfile* get_runtime_profile() const = 0;
 
 protected:
     OperatorBuilderBase* _operator_builder;
     OperatorPtr _child;
+
+    // Used on pipeline X
+    OperatorXPtr _child_x;
 
     bool _is_closed = false;
 };
@@ -457,6 +477,317 @@ public:
 protected:
     std::unique_ptr<vectorized::Block> _child_block;
     SourceState _child_source_state;
+};
+
+// This struct is used only for initializing local state.
+struct LocalStateInfo {
+    const std::vector<TScanRangeParams> scan_ranges;
+    Dependency* dependency;
+};
+
+class PipelineXLocalState {
+public:
+    PipelineXLocalState(RuntimeState* state, OperatorXBase* parent)
+            : _num_rows_returned(0),
+              _rows_returned_counter(nullptr),
+              _rows_returned_rate(nullptr),
+              _memory_used_counter(nullptr),
+              _parent(parent),
+              _state(state) {}
+    virtual ~PipelineXLocalState() {}
+
+    virtual Status init(RuntimeState* state, LocalStateInfo& info);
+    template <class TARGET>
+    TARGET& cast() {
+        return reinterpret_cast<TARGET&>(*this);
+    }
+    template <class TARGET>
+    const TARGET& cast() const {
+        return reinterpret_cast<const TARGET&>(*this);
+    }
+
+    bool reached_limit() const;
+    void reached_limit(vectorized::Block* block, bool* eos);
+    RuntimeProfile* profile() { return _runtime_profile.get(); }
+
+    MemTracker* mem_tracker() { return _mem_tracker.get(); }
+    RuntimeProfile::Counter* rows_returned_counter() { return _rows_returned_counter; }
+    RuntimeProfile::Counter* rows_returned_rate() { return _rows_returned_rate; }
+    RuntimeProfile::Counter* memory_used_counter() { return _memory_used_counter; }
+    RuntimeProfile::Counter* projection_timer() { return _projection_timer; }
+
+    OperatorXBase* parent() { return _parent; }
+    RuntimeState* state() { return _state; }
+    vectorized::VExprContextSPtrs& conjuncts() { return _conjuncts; }
+    vectorized::VExprContextSPtrs& projections() { return _projections; }
+    int64_t num_rows_returned() const { return _num_rows_returned; }
+    void add_num_rows_returned(int64_t delta) { _num_rows_returned += delta; }
+    void set_num_rows_returned(int64_t value) { _num_rows_returned = value; }
+
+protected:
+    friend class OperatorXBase;
+
+    ObjectPool* _pool;
+    int64_t _num_rows_returned;
+
+    std::unique_ptr<RuntimeProfile> _runtime_profile;
+
+    // Record this node memory size. it is expected that artificial guarantees are accurate,
+    // which will providea reference for operator memory.
+    std::unique_ptr<MemTracker> _mem_tracker;
+
+    RuntimeProfile::Counter* _rows_returned_counter;
+    RuntimeProfile::Counter* _rows_returned_rate;
+    // Account for peak memory used by this node
+    RuntimeProfile::Counter* _memory_used_counter;
+    RuntimeProfile::Counter* _projection_timer;
+
+    OpentelemetrySpan _span;
+    OperatorXBase* _parent;
+    RuntimeState* _state;
+    vectorized::VExprContextSPtrs _conjuncts;
+    vectorized::VExprContextSPtrs _projections;
+    bool _init = false;
+};
+
+class OperatorXBase : public OperatorBase {
+public:
+    OperatorXBase(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs,
+                  std::string op_name)
+            : OperatorBase(nullptr),
+              _id(tnode.node_id),
+              _type(tnode.node_type),
+              _pool(pool),
+              _tuple_ids(tnode.row_tuples),
+              _children(nullptr),
+              _row_descriptor(descs, tnode.row_tuples, tnode.nullable_tuples),
+              _resource_profile(tnode.resource_profile),
+              _limit(tnode.limit),
+              _op_name(op_name) {
+        if (tnode.__isset.output_tuple_id) {
+            _output_row_descriptor.reset(new RowDescriptor(descs, {tnode.output_tuple_id}, {true}));
+        }
+    }
+
+    virtual Status init(const TPlanNode& tnode, RuntimeState* state);
+    Status init(const TDataSink& tsink) override {
+        LOG(FATAL) << "should not reach here!";
+        return Status::OK();
+    }
+    [[nodiscard]] RuntimeProfile* get_runtime_profile() const override {
+        return _runtime_profile.get();
+    }
+    [[nodiscard]] std::string get_name() const override { return _op_name; }
+
+    virtual Status prepare(RuntimeState* state) override;
+
+    virtual Status open(RuntimeState* state) override;
+
+    Status finalize(RuntimeState* state) override { return Status::OK(); }
+
+    bool can_read() override {
+        LOG(FATAL) << "should not reach here!";
+        return false;
+    }
+
+    bool can_write() override {
+        LOG(FATAL) << "should not reach here!";
+        return false;
+    }
+
+    bool is_pending_finish() const override {
+        LOG(FATAL) << "should not reach here!";
+        return false;
+    }
+
+    Status sink(RuntimeState* state, vectorized::Block* block, SourceState source_state) override {
+        LOG(FATAL) << "should not reach here!";
+        return Status::OK();
+    }
+
+    virtual Status close(RuntimeState* state) override;
+
+    virtual bool can_read(RuntimeState* state) { return false; }
+
+    virtual bool is_pending_finish(RuntimeState* state) const { return false; }
+
+    [[nodiscard]] virtual const RowDescriptor& intermediate_row_desc() const {
+        return _row_descriptor;
+    }
+
+    virtual std::string debug_string() const override;
+
+    virtual Status setup_local_state(RuntimeState* state, LocalStateInfo& info) = 0;
+
+    template <class TARGET>
+    TARGET& cast() {
+        DCHECK(dynamic_cast<TARGET*>(this));
+        return reinterpret_cast<TARGET&>(*this);
+    }
+    template <class TARGET>
+    const TARGET& cast() const {
+        DCHECK(dynamic_cast<const TARGET*>(this));
+        return reinterpret_cast<const TARGET&>(*this);
+    }
+
+    OperatorXPtr get_child() { return _child_x; }
+
+    vectorized::VExprContextSPtrs& conjuncts() { return _conjuncts; }
+    RowDescriptor& row_descriptor() { return _row_descriptor; }
+
+    [[nodiscard]] int id() const override { return _id; }
+
+    [[nodiscard]] int64_t limit() const { return _limit; }
+
+    const RowDescriptor& row_desc() override {
+        return _output_row_descriptor ? *_output_row_descriptor : _row_descriptor;
+    }
+
+    virtual bool is_source() const override { return false; }
+
+protected:
+    friend class PipelineXLocalState;
+    int _id; // unique w/in single plan tree
+    TPlanNodeType::type _type;
+    ObjectPool* _pool;
+    std::vector<TupleId> _tuple_ids;
+
+    vectorized::VExprContextSPtrs _conjuncts;
+
+    OperatorXBase* _children;
+    RowDescriptor _row_descriptor;
+    vectorized::Block _origin_block;
+
+    std::unique_ptr<RowDescriptor> _output_row_descriptor;
+    vectorized::VExprContextSPtrs _projections;
+
+    /// Resource information sent from the frontend.
+    const TBackendResourceProfile _resource_profile;
+
+    int64_t _limit; // -1: no limit
+    std::unique_ptr<RuntimeProfile> _runtime_profile;
+
+private:
+    void _init_runtime_profile();
+
+    std::string _op_name;
+};
+
+class DataSinkOperatorX;
+
+class PipelineXSinkLocalState {
+public:
+    PipelineXSinkLocalState(DataSinkOperatorX* parent_, RuntimeState* state_)
+            : _parent(parent_), _state(state_) {}
+    virtual ~PipelineXSinkLocalState() {}
+
+    virtual Status init(RuntimeState* state, Dependency* dependency) { return Status::OK(); }
+    template <class TARGET>
+    TARGET& cast() {
+        DCHECK(dynamic_cast<TARGET*>(this));
+        return reinterpret_cast<TARGET&>(*this);
+    }
+    template <class TARGET>
+    const TARGET& cast() const {
+        DCHECK(dynamic_cast<const TARGET*>(this));
+        return reinterpret_cast<const TARGET&>(*this);
+    }
+
+    DataSinkOperatorX* parent() { return _parent; }
+    RuntimeState* state() { return _state; }
+    RuntimeProfile* profile() { return _profile; }
+    MemTracker* mem_tracker() { return _mem_tracker.get(); }
+    QueryStatistics* query_statistics() { return _query_statistics.get(); }
+
+protected:
+    DataSinkOperatorX* _parent;
+    RuntimeState* _state;
+    RuntimeProfile* _profile;
+    std::unique_ptr<MemTracker> _mem_tracker;
+    // Maybe this will be transferred to BufferControlBlock.
+    std::shared_ptr<QueryStatistics> _query_statistics;
+};
+
+class DataSinkOperatorX : public OperatorBase {
+public:
+    DataSinkOperatorX(const int id) : OperatorBase(nullptr), _id(id) {}
+
+    ~DataSinkOperatorX() override = default;
+
+    // For agg/sort/join sink.
+    virtual Status init(const TPlanNode& tnode, RuntimeState* state) {
+        return Status::InternalError("{} should not init with TPlanNode", _name);
+    }
+
+    virtual Status init(const TDataSink& tsink) override { return Status::OK(); }
+
+    virtual Status setup_local_state(RuntimeState* state, Dependency* dependency) = 0;
+
+    template <class TARGET>
+    TARGET& cast() {
+        DCHECK(dynamic_cast<TARGET*>(this));
+        return reinterpret_cast<TARGET&>(*this);
+    }
+    template <class TARGET>
+    const TARGET& cast() const {
+        DCHECK(dynamic_cast<const TARGET*>(this));
+        return reinterpret_cast<const TARGET&>(*this);
+    }
+
+    virtual void get_dependency(DependencySPtr& dependency) {
+        dependency.reset((Dependency*)nullptr);
+    }
+
+    Status close(RuntimeState* state) override { return Status::OK(); }
+
+    bool can_read() override {
+        LOG(FATAL) << "should not reach here!";
+        return false;
+    }
+
+    bool can_write() override {
+        LOG(FATAL) << "should not reach here!";
+        return false;
+    }
+
+    bool is_pending_finish() const override {
+        LOG(FATAL) << "should not reach here!";
+        return false;
+    }
+
+    virtual bool can_write(RuntimeState* state) { return false; }
+
+    virtual bool is_pending_finish(RuntimeState* state) const { return false; }
+
+    virtual std::string debug_string() const override;
+
+    bool is_sink() const override { return true; }
+
+    bool is_source() const override { return false; }
+
+    virtual Status close(RuntimeState* state, Status exec_status) { return Status::OK(); }
+
+    [[nodiscard]] RuntimeProfile* get_runtime_profile() const override { return _profile; }
+
+    [[nodiscard]] int id() const override { return _id; }
+
+    [[nodiscard]] std::string get_name() const override { return _name; }
+
+    Status finalize(RuntimeState* state) override { return Status::OK(); }
+
+protected:
+    const int _id;
+    // Set to true after close() has been called. subclasses should check and set this in
+    // close().
+    bool _closed;
+    std::string _name;
+
+    // Maybe this will be transferred to BufferControlBlock.
+    std::shared_ptr<QueryStatistics> _query_statistics;
+
+    OpentelemetrySpan _span {};
+
+    RuntimeProfile* _profile = nullptr;
 };
 
 } // namespace doris::pipeline

--- a/be/src/pipeline/exec/result_sink_operator.cpp
+++ b/be/src/pipeline/exec/result_sink_operator.cpp
@@ -19,8 +19,15 @@
 
 #include <memory>
 
+#include "common/object_pool.h"
+#include "exec/rowid_fetcher.h"
 #include "pipeline/exec/operator.h"
 #include "runtime/buffer_control_block.h"
+#include "runtime/exec_env.h"
+#include "runtime/result_buffer_mgr.h"
+#include "vec/exprs/vexpr.h"
+#include "vec/exprs/vexpr_context.h"
+#include "vec/sink/vmysql_result_writer.h"
 #include "vec/sink/vresult_sink.h"
 
 namespace doris {
@@ -41,5 +48,145 @@ ResultSinkOperator::ResultSinkOperator(OperatorBuilderBase* operator_builder, Da
 
 bool ResultSinkOperator::can_write() {
     return _sink->_sender->can_sink();
+}
+
+Status ResultSinkLocalState::init(RuntimeState* state, Dependency* dependency) {
+    auto& p = _parent->cast<ResultSinkOperatorX>();
+    auto fragment_instance_id = state->fragment_instance_id();
+    auto title = fmt::format("VDataBufferSender (dst_fragment_instance_id={:x}-{:x})",
+                             fragment_instance_id.hi, fragment_instance_id.lo);
+    // create profile
+    _profile = state->obj_pool()->add(new RuntimeProfile(title));
+    // create sender
+    RETURN_IF_ERROR(state->exec_env()->result_mgr()->create_sender(state->fragment_instance_id(),
+                                                                   p._buf_size, &_sender, true,
+                                                                   state->execution_timeout()));
+    _output_vexpr_ctxs.resize(p._output_vexpr_ctxs.size());
+    for (size_t i = 0; i < _output_vexpr_ctxs.size(); i++) {
+        RETURN_IF_ERROR(p._output_vexpr_ctxs[i]->clone(state, _output_vexpr_ctxs[i]));
+    }
+    // create writer based on sink type
+    switch (p._sink_type) {
+    case TResultSinkType::MYSQL_PROTOCAL:
+        _writer.reset(new (std::nothrow) vectorized::VMysqlResultWriter(
+                _sender.get(), _output_vexpr_ctxs, _profile));
+        break;
+    default:
+        return Status::InternalError("Unknown result sink type");
+    }
+
+    RETURN_IF_ERROR(_writer->init(state));
+    return Status::OK();
+}
+
+ResultSinkOperatorX::ResultSinkOperatorX(const int id, const RowDescriptor& row_desc,
+                                         const std::vector<TExpr>& t_output_expr,
+                                         const TResultSink& sink, int buffer_size)
+        : DataSinkOperatorX(id),
+          _row_desc(row_desc),
+          _t_output_expr(t_output_expr),
+          _buf_size(buffer_size) {
+    if (!sink.__isset.type || sink.type == TResultSinkType::MYSQL_PROTOCAL) {
+        _sink_type = TResultSinkType::MYSQL_PROTOCAL;
+    } else {
+        _sink_type = sink.type;
+    }
+    _fetch_option = sink.fetch_option;
+    _name = "ResultSink";
+}
+
+Status ResultSinkOperatorX::prepare(RuntimeState* state) {
+    auto fragment_instance_id = state->fragment_instance_id();
+    auto title = fmt::format("VDataBufferSender (dst_fragment_instance_id={:x}-{:x})",
+                             fragment_instance_id.hi, fragment_instance_id.lo);
+    // create profile
+    _profile = state->obj_pool()->add(new RuntimeProfile(title));
+    // prepare output_expr
+    // From the thrift expressions create the real exprs.
+    RETURN_IF_ERROR(vectorized::VExpr::create_expr_trees(_t_output_expr, _output_vexpr_ctxs));
+    if (_fetch_option.use_two_phase_fetch) {
+        for (auto& expr_ctx : _output_vexpr_ctxs) {
+            // Must materialize if it a slot, or the slot column id will be -1
+            expr_ctx->set_force_materialize_slot();
+        }
+    }
+    // Prepare the exprs to run.
+    RETURN_IF_ERROR(vectorized::VExpr::prepare(_output_vexpr_ctxs, state, _row_desc));
+    return Status::OK();
+}
+
+Status ResultSinkOperatorX::open(RuntimeState* state) {
+    return vectorized::VExpr::open(_output_vexpr_ctxs, state);
+}
+
+Status ResultSinkOperatorX::setup_local_state(RuntimeState* state, Dependency* dependency) {
+    auto local_state = ResultSinkLocalState::create_shared(this, state);
+    state->emplace_sink_local_state(id(), local_state);
+    return local_state->init(state, dependency);
+}
+
+Status ResultSinkOperatorX::sink(RuntimeState* state, vectorized::Block* block,
+                                 SourceState source_state) {
+    auto& local_state = state->get_sink_local_state(id())->cast<ResultSinkLocalState>();
+    if (_fetch_option.use_two_phase_fetch && block->rows() > 0) {
+        RETURN_IF_ERROR(_second_phase_fetch_data(state, block));
+    }
+    RETURN_IF_ERROR(local_state._writer->append_block(*block));
+    if (_fetch_option.use_two_phase_fetch) {
+        // Block structure may be changed by calling _second_phase_fetch_data().
+        // So we should clear block in case of unmatched columns
+        block->clear();
+    }
+    return Status::OK();
+}
+
+Status ResultSinkOperatorX::_second_phase_fetch_data(RuntimeState* state,
+                                                     vectorized::Block* final_block) {
+    auto row_id_col = final_block->get_by_position(final_block->columns() - 1);
+    CHECK(row_id_col.name == BeConsts::ROWID_COL);
+    auto tuple_desc = _row_desc.tuple_descriptors()[0];
+    FetchOption fetch_option;
+    fetch_option.desc = tuple_desc;
+    fetch_option.t_fetch_opt = _fetch_option;
+    fetch_option.runtime_state = state;
+    RowIDFetcher id_fetcher(fetch_option);
+    RETURN_IF_ERROR(id_fetcher.init());
+    RETURN_IF_ERROR(id_fetcher.fetch(row_id_col.column, final_block));
+    return Status::OK();
+}
+
+Status ResultSinkOperatorX::close(RuntimeState* state) {
+    if (_closed) {
+        return Status::OK();
+    }
+
+    Status final_status = Status::OK();
+
+    auto& local_state = state->get_sink_local_state(id())->cast<ResultSinkLocalState>();
+    if (local_state._writer) {
+        // close the writer
+        Status st = local_state._writer->close();
+        if (!st.ok() && final_status.ok()) {
+            // close file writer failed, should return this error to client
+            final_status = st;
+        }
+    }
+
+    // close sender, this is normal path end
+    if (local_state._sender) {
+        if (local_state._writer)
+            local_state._sender->update_num_written_rows(local_state._writer->get_written_rows());
+        local_state._sender->update_max_peak_memory_bytes();
+        local_state._sender->close(final_status);
+    }
+    state->exec_env()->result_mgr()->cancel_at_time(
+            time(nullptr) + config::result_buffer_cancelled_interval_time,
+            state->fragment_instance_id());
+    return final_status;
+}
+
+bool ResultSinkOperatorX::can_write(RuntimeState* state) {
+    auto& local_state = state->get_sink_local_state(id())->cast<ResultSinkLocalState>();
+    return local_state._sender->can_sink();
 }
 } // namespace doris::pipeline

--- a/be/src/pipeline/exec/result_sink_operator.h
+++ b/be/src/pipeline/exec/result_sink_operator.h
@@ -41,5 +41,59 @@ public:
     bool can_write() override;
 };
 
+class ResultSinkLocalState : public PipelineXSinkLocalState {
+    ENABLE_FACTORY_CREATOR(ResultSinkLocalState);
+
+public:
+    ResultSinkLocalState(DataSinkOperatorX* parent, RuntimeState* state)
+            : PipelineXSinkLocalState(parent, state) {}
+
+    Status init(RuntimeState* state, Dependency* dependency) override;
+
+private:
+    friend class ResultSinkOperatorX;
+
+    vectorized::VExprContextSPtrs _output_vexpr_ctxs;
+
+    std::shared_ptr<BufferControlBlock> _sender;
+    std::shared_ptr<ResultWriter> _writer;
+    RuntimeProfile* _profile; // Allocated from _pool
+};
+
+class ResultSinkOperatorX final : public DataSinkOperatorX {
+public:
+    ResultSinkOperatorX(const int id, const RowDescriptor& row_desc,
+                        const std::vector<TExpr>& select_exprs, const TResultSink& sink,
+                        int buffer_size);
+    Status prepare(RuntimeState* state) override;
+    Status open(RuntimeState* state) override;
+    Status setup_local_state(RuntimeState* state, Dependency* dependency) override;
+
+    Status sink(RuntimeState* state, vectorized::Block* in_block,
+                SourceState source_state) override;
+
+    Status close(RuntimeState* state) override;
+    bool can_write(RuntimeState* state) override;
+
+private:
+    friend class ResultSinkLocalState;
+
+    Status _second_phase_fetch_data(RuntimeState* state, vectorized::Block* final_block);
+    TResultSinkType::type _sink_type;
+    // set file options when sink type is FILE
+    std::unique_ptr<vectorized::ResultFileOptions> _file_opts;
+
+    // Owned by the RuntimeState.
+    const RowDescriptor& _row_desc;
+
+    // Owned by the RuntimeState.
+    const std::vector<TExpr>& _t_output_expr;
+    vectorized::VExprContextSPtrs _output_vexpr_ctxs;
+    int _buf_size; // Allocated from _pool
+
+    // for fetch data by rowids
+    TFetchOption _fetch_option;
+};
+
 } // namespace pipeline
 } // namespace doris

--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -22,8 +22,17 @@
 #include <memory>
 
 #include "pipeline/exec/operator.h"
+#include "vec/exec/runtime_filter_consumer.h"
+#include "vec/exec/scan/pip_scanner_context.h"
 #include "vec/exec/scan/scanner_context.h"
 #include "vec/exec/scan/vscan_node.h"
+#include "vec/exprs/vcompound_pred.h"
+#include "vec/exprs/vectorized_fn_call.h"
+#include "vec/exprs/vexpr.h"
+#include "vec/exprs/vexpr_context.h"
+#include "vec/exprs/vin_predicate.h"
+#include "vec/exprs/vslot_ref.h"
+#include "vec/functions/in.h"
 
 namespace doris::pipeline {
 
@@ -74,6 +83,1284 @@ std::string ScanOperator::debug_string() const {
                        _node->_scanner_ctx->get_num_scheduling_ctx());
     }
     return fmt::to_string(debug_string_buffer);
+}
+
+#define RETURN_IF_PUSH_DOWN(stmt, status)                           \
+    if (pdt == vectorized::VScanNode::PushDownType::UNACCEPTABLE) { \
+        status = stmt;                                              \
+        if (!status.ok()) {                                         \
+            return;                                                 \
+        }                                                           \
+    } else {                                                        \
+        return;                                                     \
+    }
+
+ScanLocalState::ScanLocalState(RuntimeState* state_, OperatorXBase* parent_)
+        : PipelineXLocalState(state_, parent_),
+          vectorized::RuntimeFilterConsumer(_parent->id(),
+                                            _parent->cast<ScanOperatorX>().runtime_filter_descs(),
+                                            _parent->row_descriptor(), _parent->conjuncts()) {}
+
+bool ScanLocalState::ready_to_read() {
+    return !_scanner_ctx->empty_in_queue(0);
+}
+
+bool ScanLocalState::should_run_serial() const {
+    return _parent->cast<ScanOperatorX>()._should_run_serial;
+}
+
+Status ScanLocalState::init(RuntimeState* state, LocalStateInfo& info) {
+    if (_init) {
+        return Status::OK();
+    }
+
+    auto& p = _parent->cast<ScanOperatorX>();
+
+    set_scan_ranges(info.scan_ranges);
+
+    RETURN_IF_ERROR(PipelineXLocalState::init(state, info));
+    _common_expr_ctxs_push_down.resize(p._common_expr_ctxs_push_down.size());
+    for (size_t i = 0; i < _common_expr_ctxs_push_down.size(); i++) {
+        RETURN_IF_ERROR(
+                p._common_expr_ctxs_push_down[i]->clone(state, _common_expr_ctxs_push_down[i]));
+    }
+    _stale_expr_ctxs.resize(p._stale_expr_ctxs.size());
+    for (size_t i = 0; i < _stale_expr_ctxs.size(); i++) {
+        RETURN_IF_ERROR(p._stale_expr_ctxs[i]->clone(state, _stale_expr_ctxs[i]));
+    }
+    // init profile for runtime filter
+    RuntimeFilterConsumer::_init_profile(profile());
+
+    // 1: running at not pipeline mode will init profile.
+    // 2: the scan node should create scanner at pipeline mode will init profile.
+    // during pipeline mode with more instances, olap scan node maybe not new VScanner object,
+    // so the profile of VScanner and SegmentIterator infos are always empty, could not init those.
+    RETURN_IF_ERROR(_init_profile());
+    // if you want to add some profile in scan node, even it have not new VScanner object
+    // could add here, not in the _init_profile() function
+    _get_next_timer = ADD_TIMER(_runtime_profile, "GetNextTime");
+
+    _prepare_rf_timer(_runtime_profile.get());
+
+    _open_timer = ADD_TIMER(_runtime_profile, "OpenTime");
+    _alloc_resource_timer = ADD_TIMER(_runtime_profile, "AllocateResourceTime");
+
+    RETURN_IF_ERROR(_acquire_runtime_filter());
+    RETURN_IF_ERROR(_process_conjuncts());
+
+    auto status = !_eos ? _prepare_scanners(state->query_parallel_instance_num()) : Status::OK();
+    if (_scanner_ctx) {
+        DCHECK(!_eos && _num_scanners->value() > 0);
+        RETURN_IF_ERROR(_scanner_ctx->init());
+        RETURN_IF_ERROR(state->exec_env()->scanner_scheduler()->submit(_scanner_ctx.get()));
+    }
+    RETURN_IF_ERROR(status);
+    _init = true;
+    return Status::OK();
+}
+
+Status ScanLocalState::_normalize_conjuncts() {
+    auto& p = _parent->cast<ScanOperatorX>();
+    // The conjuncts is always on output tuple, so use _output_tuple_desc;
+    std::vector<SlotDescriptor*> slots = p._output_tuple_desc->slots();
+
+    for (int slot_idx = 0; slot_idx < slots.size(); ++slot_idx) {
+        p._colname_to_slot_id[slots[slot_idx]->col_name()] = slots[slot_idx]->id();
+
+        auto type = slots[slot_idx]->type().type;
+        if (slots[slot_idx]->type().type == TYPE_ARRAY) {
+            type = slots[slot_idx]->type().children[0].type;
+            if (type == TYPE_ARRAY) {
+                continue;
+            }
+        }
+        switch (type) {
+#define M(NAME)                                                                              \
+    case TYPE_##NAME: {                                                                      \
+        ColumnValueRange<TYPE_##NAME> range(                                                 \
+                slots[slot_idx]->col_name(), slots[slot_idx]->is_nullable(),                 \
+                slots[slot_idx]->type().precision, slots[slot_idx]->type().scale);           \
+        _slot_id_to_value_range[slots[slot_idx]->id()] = std::pair {slots[slot_idx], range}; \
+        break;                                                                               \
+    }
+#define APPLY_FOR_PRIMITIVE_TYPE(M) \
+    M(TINYINT)                      \
+    M(SMALLINT)                     \
+    M(INT)                          \
+    M(BIGINT)                       \
+    M(LARGEINT)                     \
+    M(CHAR)                         \
+    M(DATE)                         \
+    M(DATETIME)                     \
+    M(DATEV2)                       \
+    M(DATETIMEV2)                   \
+    M(VARCHAR)                      \
+    M(STRING)                       \
+    M(HLL)                          \
+    M(DECIMAL32)                    \
+    M(DECIMAL64)                    \
+    M(DECIMAL128I)                  \
+    M(DECIMALV2)                    \
+    M(BOOLEAN)
+            APPLY_FOR_PRIMITIVE_TYPE(M)
+#undef M
+        default: {
+            VLOG_CRITICAL << "Unsupported Normalize Slot [ColName=" << slots[slot_idx]->col_name()
+                          << "]";
+            break;
+        }
+        }
+    }
+
+    for (auto it = _conjuncts.begin(); it != _conjuncts.end();) {
+        auto& conjunct = *it;
+        if (conjunct->root()) {
+            vectorized::VExprSPtr new_root;
+            RETURN_IF_ERROR(_normalize_predicate(conjunct->root(), conjunct.get(), new_root));
+            if (new_root) {
+                conjunct->set_root(new_root);
+                if (_should_push_down_common_expr()) {
+                    _common_expr_ctxs_push_down.emplace_back(conjunct);
+                    it = _conjuncts.erase(it);
+                    continue;
+                }
+            } else { // All conjuncts are pushed down as predicate column
+                _stale_expr_ctxs.emplace_back(conjunct);
+                it = _conjuncts.erase(it);
+                continue;
+            }
+        }
+        ++it;
+    }
+    for (auto& it : _slot_id_to_value_range) {
+        std::visit(
+                [&](auto&& range) {
+                    if (range.is_empty_value_range()) {
+                        _eos = true;
+                    }
+                },
+                it.second.second);
+        _colname_to_value_range[it.second.first->col_name()] = it.second.second;
+    }
+
+    return Status::OK();
+}
+
+Status ScanLocalState::_normalize_predicate(const vectorized::VExprSPtr& conjunct_expr_root,
+                                            vectorized::VExprContext* context,
+                                            vectorized::VExprSPtr& output_expr) {
+    static constexpr auto is_leaf = [](auto&& expr) { return !expr->is_and_expr(); };
+    auto in_predicate_checker = [](const vectorized::VExprSPtrs& children,
+                                   std::shared_ptr<vectorized::VSlotRef>& slot,
+                                   vectorized::VExprSPtr& child_contains_slot) {
+        if (children.empty() || vectorized::VExpr::expr_without_cast(children[0])->node_type() !=
+                                        TExprNodeType::SLOT_REF) {
+            // not a slot ref(column)
+            return false;
+        }
+        slot = std::dynamic_pointer_cast<vectorized::VSlotRef>(
+                vectorized::VExpr::expr_without_cast(children[0]));
+        child_contains_slot = children[0];
+        return true;
+    };
+    auto eq_predicate_checker = [](const vectorized::VExprSPtrs& children,
+                                   std::shared_ptr<vectorized::VSlotRef>& slot,
+                                   vectorized::VExprSPtr& child_contains_slot) {
+        for (const auto& child : children) {
+            if (vectorized::VExpr::expr_without_cast(child)->node_type() !=
+                TExprNodeType::SLOT_REF) {
+                // not a slot ref(column)
+                continue;
+            }
+            slot = std::dynamic_pointer_cast<vectorized::VSlotRef>(
+                    vectorized::VExpr::expr_without_cast(child));
+            CHECK(slot != nullptr);
+            child_contains_slot = child;
+            return true;
+        }
+        return false;
+    };
+
+    if (conjunct_expr_root != nullptr) {
+        if (is_leaf(conjunct_expr_root)) {
+            auto impl = conjunct_expr_root->get_impl();
+            // If impl is not null, which means this a conjuncts from runtime filter.
+            auto cur_expr = impl ? impl.get() : conjunct_expr_root.get();
+            bool _is_runtime_filter_predicate =
+                    _rf_vexpr_set.find(conjunct_expr_root) != _rf_vexpr_set.end();
+            SlotDescriptor* slot = nullptr;
+            ColumnValueRangeType* range = nullptr;
+            vectorized::VScanNode::PushDownType pdt =
+                    vectorized::VScanNode::PushDownType::UNACCEPTABLE;
+            RETURN_IF_ERROR(_eval_const_conjuncts(cur_expr, context, &pdt));
+            if (pdt == vectorized::VScanNode::PushDownType::ACCEPTABLE) {
+                output_expr = nullptr;
+                return Status::OK();
+            }
+            if (_is_predicate_acting_on_slot(cur_expr, in_predicate_checker, &slot, &range) ||
+                _is_predicate_acting_on_slot(cur_expr, eq_predicate_checker, &slot, &range)) {
+                Status status = Status::OK();
+                std::visit(
+                        [&](auto& value_range) {
+                            Defer mark_runtime_filter_flag {[&]() {
+                                value_range.mark_runtime_filter_predicate(
+                                        _is_runtime_filter_predicate);
+                            }};
+                            RETURN_IF_PUSH_DOWN(_normalize_in_and_eq_predicate(
+                                                        cur_expr, context, slot, value_range, &pdt),
+                                                status);
+                            RETURN_IF_PUSH_DOWN(_normalize_not_in_and_not_eq_predicate(
+                                                        cur_expr, context, slot, value_range, &pdt),
+                                                status);
+                            RETURN_IF_PUSH_DOWN(_normalize_is_null_predicate(
+                                                        cur_expr, context, slot, value_range, &pdt),
+                                                status);
+                            RETURN_IF_PUSH_DOWN(_normalize_noneq_binary_predicate(
+                                                        cur_expr, context, slot, value_range, &pdt),
+                                                status);
+                            RETURN_IF_PUSH_DOWN(_normalize_match_predicate(cur_expr, context, slot,
+                                                                           value_range, &pdt),
+                                                status);
+                            if (_is_key_column(slot->col_name())) {
+                                RETURN_IF_PUSH_DOWN(
+                                        _normalize_bitmap_filter(cur_expr, context, slot, &pdt),
+                                        status);
+                                RETURN_IF_PUSH_DOWN(
+                                        _normalize_bloom_filter(cur_expr, context, slot, &pdt),
+                                        status);
+                                if (state()->enable_function_pushdown()) {
+                                    RETURN_IF_PUSH_DOWN(_normalize_function_filters(
+                                                                cur_expr, context, slot, &pdt),
+                                                        status);
+                                }
+                            }
+                        },
+                        *range);
+                RETURN_IF_ERROR(status);
+            }
+
+            if (pdt == vectorized::VScanNode::PushDownType::UNACCEPTABLE &&
+                TExprNodeType::COMPOUND_PRED == cur_expr->node_type()) {
+                _normalize_compound_predicate(cur_expr, context, &pdt, _is_runtime_filter_predicate,
+                                              in_predicate_checker, eq_predicate_checker);
+                output_expr = conjunct_expr_root; // remaining in conjunct tree
+                return Status::OK();
+            }
+
+            if (pdt == vectorized::VScanNode::PushDownType::ACCEPTABLE &&
+                TExprNodeType::MATCH_PRED == cur_expr->node_type()) {
+                // remaining it in the expr tree, in order to filter by function if the pushdown
+                // match_predicate failed to apply inverted index in the storage layer
+                output_expr = conjunct_expr_root; // remaining in conjunct tree
+                return Status::OK();
+            }
+
+            if (pdt == vectorized::VScanNode::PushDownType::ACCEPTABLE &&
+                _is_key_column(slot->col_name())) {
+                output_expr = nullptr;
+                return Status::OK();
+            } else {
+                // for PARTIAL_ACCEPTABLE and UNACCEPTABLE, do not remove expr from the tree
+                output_expr = conjunct_expr_root;
+                return Status::OK();
+            }
+        } else {
+            vectorized::VExprSPtr left_child;
+            RETURN_IF_ERROR(
+                    _normalize_predicate(conjunct_expr_root->children()[0], context, left_child));
+            vectorized::VExprSPtr right_child;
+            RETURN_IF_ERROR(
+                    _normalize_predicate(conjunct_expr_root->children()[1], context, right_child));
+
+            if (left_child != nullptr && right_child != nullptr) {
+                conjunct_expr_root->set_children({left_child, right_child});
+                output_expr = conjunct_expr_root;
+                return Status::OK();
+            } else {
+                if (left_child == nullptr) {
+                    conjunct_expr_root->children()[0]->close(context,
+                                                             context->get_function_state_scope());
+                }
+                if (right_child == nullptr) {
+                    conjunct_expr_root->children()[1]->close(context,
+                                                             context->get_function_state_scope());
+                }
+                // here only close the and expr self, do not close the child
+                conjunct_expr_root->set_children({});
+                conjunct_expr_root->close(context, context->get_function_state_scope());
+            }
+
+            // here do not close VExpr* now
+            output_expr = left_child != nullptr ? left_child : right_child;
+            return Status::OK();
+        }
+    }
+    output_expr = conjunct_expr_root;
+    return Status::OK();
+}
+
+Status ScanLocalState::_normalize_bloom_filter(vectorized::VExpr* expr,
+                                               vectorized::VExprContext* expr_ctx,
+                                               SlotDescriptor* slot,
+                                               vectorized::VScanNode::PushDownType* pdt) {
+    if (TExprNodeType::BLOOM_PRED == expr->node_type()) {
+        DCHECK(expr->children().size() == 1);
+        vectorized::VScanNode::PushDownType temp_pdt = _should_push_down_bloom_filter();
+        if (temp_pdt != vectorized::VScanNode::PushDownType::UNACCEPTABLE) {
+            _filter_predicates.bloom_filters.emplace_back(slot->col_name(),
+                                                          expr->get_bloom_filter_func());
+            *pdt = temp_pdt;
+        }
+    }
+    return Status::OK();
+}
+
+Status ScanLocalState::_normalize_bitmap_filter(vectorized::VExpr* expr,
+                                                vectorized::VExprContext* expr_ctx,
+                                                SlotDescriptor* slot,
+                                                vectorized::VScanNode::PushDownType* pdt) {
+    if (TExprNodeType::BITMAP_PRED == expr->node_type()) {
+        DCHECK(expr->children().size() == 1);
+        vectorized::VScanNode::PushDownType temp_pdt = _should_push_down_bitmap_filter();
+        if (temp_pdt != vectorized::VScanNode::PushDownType::UNACCEPTABLE) {
+            _filter_predicates.bitmap_filters.emplace_back(slot->col_name(),
+                                                           expr->get_bitmap_filter_func());
+            *pdt = temp_pdt;
+        }
+    }
+    return Status::OK();
+}
+
+Status ScanLocalState::_normalize_function_filters(vectorized::VExpr* expr,
+                                                   vectorized::VExprContext* expr_ctx,
+                                                   SlotDescriptor* slot,
+                                                   vectorized::VScanNode::PushDownType* pdt) {
+    bool opposite = false;
+    vectorized::VExpr* fn_expr = expr;
+    if (TExprNodeType::COMPOUND_PRED == expr->node_type() &&
+        expr->fn().name.function_name == "not") {
+        fn_expr = fn_expr->children()[0].get();
+        opposite = true;
+    }
+
+    if (TExprNodeType::FUNCTION_CALL == fn_expr->node_type()) {
+        doris::FunctionContext* fn_ctx = nullptr;
+        StringRef val;
+        vectorized::VScanNode::PushDownType temp_pdt;
+        RETURN_IF_ERROR(_should_push_down_function_filter(
+                reinterpret_cast<vectorized::VectorizedFnCall*>(fn_expr), expr_ctx, &val, &fn_ctx,
+                temp_pdt));
+        if (temp_pdt != vectorized::VScanNode::PushDownType::UNACCEPTABLE) {
+            std::string col = slot->col_name();
+            _push_down_functions.emplace_back(opposite, col, fn_ctx, val);
+            *pdt = temp_pdt;
+        }
+    }
+    return Status::OK();
+}
+
+bool ScanLocalState::_is_predicate_acting_on_slot(
+        vectorized::VExpr* expr,
+        const std::function<bool(const vectorized::VExprSPtrs&,
+                                 std::shared_ptr<vectorized::VSlotRef>&, vectorized::VExprSPtr&)>&
+                checker,
+        SlotDescriptor** slot_desc, ColumnValueRangeType** range) {
+    std::shared_ptr<vectorized::VSlotRef> slot_ref;
+    vectorized::VExprSPtr child_contains_slot;
+    if (!checker(expr->children(), slot_ref, child_contains_slot)) {
+        // not a slot ref(column)
+        return false;
+    }
+
+    auto entry = _slot_id_to_value_range.find(slot_ref->slot_id());
+    if (_slot_id_to_value_range.end() == entry) {
+        return false;
+    }
+    *slot_desc = entry->second.first;
+    DCHECK(child_contains_slot != nullptr);
+    if (child_contains_slot->type().type != (*slot_desc)->type().type ||
+        child_contains_slot->type().precision != (*slot_desc)->type().precision ||
+        child_contains_slot->type().scale != (*slot_desc)->type().scale) {
+        if (!_ignore_cast(*slot_desc, child_contains_slot.get())) {
+            // the type of predicate not match the slot's type
+            return false;
+        }
+    } else if (child_contains_slot->type().is_datetime_type() &&
+               child_contains_slot->node_type() == doris::TExprNodeType::CAST_EXPR) {
+        // Expr `CAST(CAST(datetime_col AS DATE) AS DATETIME) = datetime_literal` should not be
+        // push down.
+        return false;
+    }
+    *range = &(entry->second.second);
+    return true;
+}
+
+bool ScanLocalState::_ignore_cast(SlotDescriptor* slot, vectorized::VExpr* expr) {
+    if (slot->type().is_date_type() && expr->type().is_date_type()) {
+        return true;
+    }
+    if (slot->type().is_string_type() && expr->type().is_string_type()) {
+        return true;
+    }
+    if (slot->type().is_array_type()) {
+        if (slot->type().children[0].type == expr->type().type) {
+            return true;
+        }
+        if (slot->type().children[0].is_date_type() && expr->type().is_date_type()) {
+            return true;
+        }
+        if (slot->type().children[0].is_string_type() && expr->type().is_string_type()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+Status ScanLocalState::_eval_const_conjuncts(vectorized::VExpr* vexpr,
+                                             vectorized::VExprContext* expr_ctx,
+                                             vectorized::VScanNode::PushDownType* pdt) {
+    char* constant_val = nullptr;
+    if (vexpr->is_constant()) {
+        std::shared_ptr<ColumnPtrWrapper> const_col_wrapper;
+        RETURN_IF_ERROR(vexpr->get_const_col(expr_ctx, &const_col_wrapper));
+        if (const vectorized::ColumnConst* const_column =
+                    check_and_get_column<vectorized::ColumnConst>(const_col_wrapper->column_ptr)) {
+            constant_val = const_cast<char*>(const_column->get_data_at(0).data);
+            if (constant_val == nullptr || !*reinterpret_cast<bool*>(constant_val)) {
+                *pdt = vectorized::VScanNode::PushDownType::ACCEPTABLE;
+                _eos = true;
+            }
+        } else if (const vectorized::ColumnVector<vectorized::UInt8>* bool_column =
+                           check_and_get_column<vectorized::ColumnVector<vectorized::UInt8>>(
+                                   const_col_wrapper->column_ptr)) {
+            // TODO: If `vexpr->is_constant()` is true, a const column is expected here.
+            //  But now we still don't cover all predicates for const expression.
+            //  For example, for query `SELECT col FROM tbl WHERE 'PROMOTION' LIKE 'AAA%'`,
+            //  predicate `like` will return a ColumnVector<UInt8> which contains a single value.
+            LOG(WARNING) << "VExpr[" << vexpr->debug_string()
+                         << "] should return a const column but actually is "
+                         << const_col_wrapper->column_ptr->get_name();
+            DCHECK_EQ(bool_column->size(), 1);
+            if (bool_column->size() == 1) {
+                constant_val = const_cast<char*>(bool_column->get_data_at(0).data);
+                if (constant_val == nullptr || !*reinterpret_cast<bool*>(constant_val)) {
+                    *pdt = vectorized::VScanNode::PushDownType::ACCEPTABLE;
+                    _eos = true;
+                }
+            } else {
+                LOG(WARNING) << "Constant predicate in scan node should return a bool column with "
+                                "`size == 1` but actually is "
+                             << bool_column->size();
+            }
+        } else {
+            LOG(WARNING) << "VExpr[" << vexpr->debug_string()
+                         << "] should return a const column but actually is "
+                         << const_col_wrapper->column_ptr->get_name();
+        }
+    }
+    return Status::OK();
+}
+
+template <PrimitiveType T>
+Status ScanLocalState::_normalize_in_and_eq_predicate(vectorized::VExpr* expr,
+                                                      vectorized::VExprContext* expr_ctx,
+                                                      SlotDescriptor* slot,
+                                                      ColumnValueRange<T>& range,
+                                                      vectorized::VScanNode::PushDownType* pdt) {
+    auto temp_range = ColumnValueRange<T>::create_empty_column_value_range(
+            slot->is_nullable(), slot->type().precision, slot->type().scale);
+    // 1. Normalize in conjuncts like 'where col in (v1, v2, v3)'
+    if (TExprNodeType::IN_PRED == expr->node_type()) {
+        HybridSetBase::IteratorBase* iter = nullptr;
+        auto hybrid_set = expr->get_set_func();
+
+        if (hybrid_set != nullptr) {
+            // runtime filter produce VDirectInPredicate
+            if (hybrid_set->size() <=
+                _parent->cast<ScanOperatorX>()._max_pushdown_conditions_per_column) {
+                iter = hybrid_set->begin();
+            } else {
+                _filter_predicates.in_filters.emplace_back(slot->col_name(), expr->get_set_func());
+                *pdt = vectorized::VScanNode::PushDownType::ACCEPTABLE;
+                return Status::OK();
+            }
+        } else {
+            // normal in predicate
+            vectorized::VInPredicate* pred = static_cast<vectorized::VInPredicate*>(expr);
+            vectorized::VScanNode::PushDownType temp_pdt =
+                    _should_push_down_in_predicate(pred, expr_ctx, false);
+            if (temp_pdt == vectorized::VScanNode::PushDownType::UNACCEPTABLE) {
+                return Status::OK();
+            }
+
+            // begin to push InPredicate value into ColumnValueRange
+            vectorized::InState* state = reinterpret_cast<vectorized::InState*>(
+                    expr_ctx->fn_context(pred->fn_context_index())
+                            ->get_function_state(FunctionContext::FRAGMENT_LOCAL));
+
+            // xx in (col, xx, xx) should not be push down
+            if (!state->use_set) {
+                return Status::OK();
+            }
+
+            iter = state->hybrid_set->begin();
+        }
+
+        while (iter->has_next()) {
+            // column in (nullptr) is always false so continue to
+            // dispose next item
+            if (nullptr == iter->get_value()) {
+                iter->next();
+                continue;
+            }
+            auto value = const_cast<void*>(iter->get_value());
+            RETURN_IF_ERROR(_change_value_range<true>(
+                    temp_range, value, ColumnValueRange<T>::add_fixed_value_range, ""));
+            iter->next();
+        }
+        range.intersection(temp_range);
+        *pdt = vectorized::VScanNode::PushDownType::ACCEPTABLE;
+    } else if (TExprNodeType::BINARY_PRED == expr->node_type()) {
+        DCHECK(expr->children().size() == 2);
+        auto eq_checker = [](const std::string& fn_name) { return fn_name == "eq"; };
+
+        StringRef value;
+        int slot_ref_child = -1;
+
+        vectorized::VScanNode::PushDownType temp_pdt;
+        RETURN_IF_ERROR(_should_push_down_binary_predicate(
+                reinterpret_cast<vectorized::VectorizedFnCall*>(expr), expr_ctx, &value,
+                &slot_ref_child, eq_checker, temp_pdt));
+        if (temp_pdt == vectorized::VScanNode::PushDownType::UNACCEPTABLE) {
+            return Status::OK();
+        }
+        DCHECK(slot_ref_child >= 0);
+        // where A = nullptr should return empty result set
+        auto fn_name = std::string("");
+        if (value.data != nullptr) {
+            if constexpr (T == TYPE_CHAR || T == TYPE_VARCHAR || T == TYPE_STRING ||
+                          T == TYPE_HLL) {
+                auto val = StringRef(value.data, value.size);
+                RETURN_IF_ERROR(_change_value_range<true>(
+                        temp_range, reinterpret_cast<void*>(&val),
+                        ColumnValueRange<T>::add_fixed_value_range, fn_name));
+            } else {
+                if (sizeof(typename PrimitiveTypeTraits<T>::CppType) != value.size) {
+                    return Status::InternalError(
+                            "PrimitiveType {} meet invalid input value size {}, expect size {}", T,
+                            value.size, sizeof(typename PrimitiveTypeTraits<T>::CppType));
+                }
+                RETURN_IF_ERROR(_change_value_range<true>(
+                        temp_range, reinterpret_cast<void*>(const_cast<char*>(value.data)),
+                        ColumnValueRange<T>::add_fixed_value_range, fn_name));
+            }
+            range.intersection(temp_range);
+        }
+        *pdt = temp_pdt;
+    }
+
+    return Status::OK();
+}
+
+Status ScanLocalState::_should_push_down_binary_predicate(
+        vectorized::VectorizedFnCall* fn_call, vectorized::VExprContext* expr_ctx,
+        StringRef* constant_val, int* slot_ref_child,
+        const std::function<bool(const std::string&)>& fn_checker,
+        vectorized::VScanNode::PushDownType& pdt) {
+    if (!fn_checker(fn_call->fn().name.function_name)) {
+        pdt = vectorized::VScanNode::PushDownType::UNACCEPTABLE;
+        return Status::OK();
+    }
+
+    const auto& children = fn_call->children();
+    DCHECK(children.size() == 2);
+    for (size_t i = 0; i < children.size(); i++) {
+        if (vectorized::VExpr::expr_without_cast(children[i])->node_type() !=
+            TExprNodeType::SLOT_REF) {
+            // not a slot ref(column)
+            continue;
+        }
+        if (!children[1 - i]->is_constant()) {
+            // only handle constant value
+            pdt = vectorized::VScanNode::PushDownType::UNACCEPTABLE;
+            return Status::OK();
+        } else {
+            std::shared_ptr<ColumnPtrWrapper> const_col_wrapper;
+            RETURN_IF_ERROR(children[1 - i]->get_const_col(expr_ctx, &const_col_wrapper));
+            if (const vectorized::ColumnConst* const_column =
+                        check_and_get_column<vectorized::ColumnConst>(
+                                const_col_wrapper->column_ptr)) {
+                *slot_ref_child = i;
+                *constant_val = const_column->get_data_at(0);
+            } else {
+                pdt = vectorized::VScanNode::PushDownType::UNACCEPTABLE;
+                return Status::OK();
+            }
+        }
+    }
+    pdt = vectorized::VScanNode::PushDownType::ACCEPTABLE;
+    return Status::OK();
+}
+
+vectorized::VScanNode::PushDownType ScanLocalState::_should_push_down_in_predicate(
+        vectorized::VInPredicate* pred, vectorized::VExprContext* expr_ctx, bool is_not_in) {
+    if (pred->is_not_in() != is_not_in) {
+        return vectorized::VScanNode::PushDownType::UNACCEPTABLE;
+    }
+    return vectorized::VScanNode::PushDownType::ACCEPTABLE;
+}
+
+template <PrimitiveType T>
+Status ScanLocalState::_normalize_not_in_and_not_eq_predicate(
+        vectorized::VExpr* expr, vectorized::VExprContext* expr_ctx, SlotDescriptor* slot,
+        ColumnValueRange<T>& range, vectorized::VScanNode::PushDownType* pdt) {
+    bool is_fixed_range = range.is_fixed_value_range();
+    auto not_in_range = ColumnValueRange<T>::create_empty_column_value_range(
+            range.column_name(), slot->is_nullable(), slot->type().precision, slot->type().scale);
+    vectorized::VScanNode::PushDownType temp_pdt =
+            vectorized::VScanNode::PushDownType::UNACCEPTABLE;
+    // 1. Normalize in conjuncts like 'where col in (v1, v2, v3)'
+    if (TExprNodeType::IN_PRED == expr->node_type()) {
+        vectorized::VInPredicate* pred = static_cast<vectorized::VInPredicate*>(expr);
+        if ((temp_pdt = _should_push_down_in_predicate(pred, expr_ctx, true)) ==
+            vectorized::VScanNode::PushDownType::UNACCEPTABLE) {
+            return Status::OK();
+        }
+
+        // begin to push InPredicate value into ColumnValueRange
+        vectorized::InState* state = reinterpret_cast<vectorized::InState*>(
+                expr_ctx->fn_context(pred->fn_context_index())
+                        ->get_function_state(FunctionContext::FRAGMENT_LOCAL));
+
+        // xx in (col, xx, xx) should not be push down
+        if (!state->use_set) {
+            return Status::OK();
+        }
+
+        HybridSetBase::IteratorBase* iter = state->hybrid_set->begin();
+        auto fn_name = std::string("");
+        if (!is_fixed_range && state->null_in_set) {
+            _eos = true;
+        }
+        while (iter->has_next()) {
+            // column not in (nullptr) is always true
+            if (nullptr == iter->get_value()) {
+                continue;
+            }
+            auto value = const_cast<void*>(iter->get_value());
+            if (is_fixed_range) {
+                RETURN_IF_ERROR(_change_value_range<true>(
+                        range, value, ColumnValueRange<T>::remove_fixed_value_range, fn_name));
+            } else {
+                RETURN_IF_ERROR(_change_value_range<true>(
+                        not_in_range, value, ColumnValueRange<T>::add_fixed_value_range, fn_name));
+            }
+            iter->next();
+        }
+    } else if (TExprNodeType::BINARY_PRED == expr->node_type()) {
+        DCHECK(expr->children().size() == 2);
+
+        auto ne_checker = [](const std::string& fn_name) { return fn_name == "ne"; };
+        StringRef value;
+        int slot_ref_child = -1;
+        RETURN_IF_ERROR(_should_push_down_binary_predicate(
+                reinterpret_cast<vectorized::VectorizedFnCall*>(expr), expr_ctx, &value,
+                &slot_ref_child, ne_checker, temp_pdt));
+        if (temp_pdt == vectorized::VScanNode::PushDownType::UNACCEPTABLE) {
+            return Status::OK();
+        }
+
+        DCHECK(slot_ref_child >= 0);
+        // where A = nullptr should return empty result set
+        if (value.data != nullptr) {
+            auto fn_name = std::string("");
+            if constexpr (T == TYPE_CHAR || T == TYPE_VARCHAR || T == TYPE_STRING ||
+                          T == TYPE_HLL) {
+                auto val = StringRef(value.data, value.size);
+                if (is_fixed_range) {
+                    RETURN_IF_ERROR(_change_value_range<true>(
+                            range, reinterpret_cast<void*>(&val),
+                            ColumnValueRange<T>::remove_fixed_value_range, fn_name));
+                } else {
+                    RETURN_IF_ERROR(_change_value_range<true>(
+                            not_in_range, reinterpret_cast<void*>(&val),
+                            ColumnValueRange<T>::add_fixed_value_range, fn_name));
+                }
+            } else {
+                if (is_fixed_range) {
+                    RETURN_IF_ERROR(_change_value_range<true>(
+                            range, reinterpret_cast<void*>(const_cast<char*>(value.data)),
+                            ColumnValueRange<T>::remove_fixed_value_range, fn_name));
+                } else {
+                    RETURN_IF_ERROR(_change_value_range<true>(
+                            not_in_range, reinterpret_cast<void*>(const_cast<char*>(value.data)),
+                            ColumnValueRange<T>::add_fixed_value_range, fn_name));
+                }
+            }
+        }
+    } else {
+        return Status::OK();
+    }
+
+    if (is_fixed_range ||
+        not_in_range.get_fixed_value_size() <=
+                _parent->cast<ScanOperatorX>()._max_pushdown_conditions_per_column) {
+        if (!is_fixed_range) {
+            _not_in_value_ranges.push_back(not_in_range);
+        }
+        *pdt = temp_pdt;
+    }
+    return Status::OK();
+}
+
+template <bool IsFixed, PrimitiveType PrimitiveType, typename ChangeFixedValueRangeFunc>
+Status ScanLocalState::_change_value_range(ColumnValueRange<PrimitiveType>& temp_range, void* value,
+                                           const ChangeFixedValueRangeFunc& func,
+                                           const std::string& fn_name, int slot_ref_child) {
+    if constexpr (PrimitiveType == TYPE_DATE) {
+        vectorized::VecDateTimeValue tmp_value;
+        memcpy(&tmp_value, value, sizeof(vectorized::VecDateTimeValue));
+        if constexpr (IsFixed) {
+            if (!tmp_value.check_loss_accuracy_cast_to_date()) {
+                func(temp_range,
+                     reinterpret_cast<typename PrimitiveTypeTraits<PrimitiveType>::CppType*>(
+                             &tmp_value));
+            }
+        } else {
+            if (tmp_value.check_loss_accuracy_cast_to_date()) {
+                if (fn_name == "lt" || fn_name == "ge") {
+                    ++tmp_value;
+                }
+            }
+            func(temp_range, to_olap_filter_type(fn_name, slot_ref_child),
+                 reinterpret_cast<typename PrimitiveTypeTraits<PrimitiveType>::CppType*>(
+                         &tmp_value));
+        }
+    } else if constexpr (PrimitiveType == TYPE_DATETIME) {
+        if constexpr (IsFixed) {
+            func(temp_range,
+                 reinterpret_cast<typename PrimitiveTypeTraits<PrimitiveType>::CppType*>(value));
+        } else {
+            func(temp_range, to_olap_filter_type(fn_name, slot_ref_child),
+                 reinterpret_cast<typename PrimitiveTypeTraits<PrimitiveType>::CppType*>(
+                         reinterpret_cast<char*>(value)));
+        }
+    } else if constexpr ((PrimitiveType == TYPE_DECIMALV2) || (PrimitiveType == TYPE_CHAR) ||
+                         (PrimitiveType == TYPE_VARCHAR) || (PrimitiveType == TYPE_HLL) ||
+                         (PrimitiveType == TYPE_DATETIMEV2) || (PrimitiveType == TYPE_TINYINT) ||
+                         (PrimitiveType == TYPE_SMALLINT) || (PrimitiveType == TYPE_INT) ||
+                         (PrimitiveType == TYPE_BIGINT) || (PrimitiveType == TYPE_LARGEINT) ||
+                         (PrimitiveType == TYPE_DECIMAL32) || (PrimitiveType == TYPE_DECIMAL64) ||
+                         (PrimitiveType == TYPE_DECIMAL128I) || (PrimitiveType == TYPE_STRING) ||
+                         (PrimitiveType == TYPE_BOOLEAN) || (PrimitiveType == TYPE_DATEV2)) {
+        if constexpr (IsFixed) {
+            func(temp_range,
+                 reinterpret_cast<typename VecPrimitiveTypeTraits<PrimitiveType>::CppType*>(value));
+        } else {
+            func(temp_range, to_olap_filter_type(fn_name, slot_ref_child),
+                 reinterpret_cast<typename VecPrimitiveTypeTraits<PrimitiveType>::CppType*>(value));
+        }
+    } else {
+        static_assert(always_false_v<PrimitiveType>);
+    }
+
+    return Status::OK();
+}
+
+template <PrimitiveType T>
+Status ScanLocalState::_normalize_is_null_predicate(vectorized::VExpr* expr,
+                                                    vectorized::VExprContext* expr_ctx,
+                                                    SlotDescriptor* slot,
+                                                    ColumnValueRange<T>& range,
+                                                    vectorized::VScanNode::PushDownType* pdt) {
+    vectorized::VScanNode::PushDownType temp_pdt = _should_push_down_is_null_predicate();
+    if (temp_pdt == vectorized::VScanNode::PushDownType::UNACCEPTABLE) {
+        return Status::OK();
+    }
+
+    if (TExprNodeType::FUNCTION_CALL == expr->node_type()) {
+        if (reinterpret_cast<vectorized::VectorizedFnCall*>(expr)->fn().name.function_name ==
+            "is_null_pred") {
+            auto temp_range = ColumnValueRange<T>::create_empty_column_value_range(
+                    slot->is_nullable(), slot->type().precision, slot->type().scale);
+            temp_range.set_contain_null(true);
+            range.intersection(temp_range);
+            *pdt = temp_pdt;
+        } else if (reinterpret_cast<vectorized::VectorizedFnCall*>(expr)->fn().name.function_name ==
+                   "is_not_null_pred") {
+            auto temp_range = ColumnValueRange<T>::create_empty_column_value_range(
+                    slot->is_nullable(), slot->type().precision, slot->type().scale);
+            temp_range.set_contain_null(false);
+            range.intersection(temp_range);
+            *pdt = temp_pdt;
+        }
+    }
+    return Status::OK();
+}
+
+template <PrimitiveType T>
+Status ScanLocalState::_normalize_noneq_binary_predicate(vectorized::VExpr* expr,
+                                                         vectorized::VExprContext* expr_ctx,
+                                                         SlotDescriptor* slot,
+                                                         ColumnValueRange<T>& range,
+                                                         vectorized::VScanNode::PushDownType* pdt) {
+    if (TExprNodeType::BINARY_PRED == expr->node_type()) {
+        DCHECK(expr->children().size() == 2);
+
+        auto noneq_checker = [](const std::string& fn_name) {
+            return fn_name != "ne" && fn_name != "eq";
+        };
+        StringRef value;
+        int slot_ref_child = -1;
+        vectorized::VScanNode::PushDownType temp_pdt;
+        RETURN_IF_ERROR(_should_push_down_binary_predicate(
+                reinterpret_cast<vectorized::VectorizedFnCall*>(expr), expr_ctx, &value,
+                &slot_ref_child, noneq_checker, temp_pdt));
+        if (temp_pdt != vectorized::VScanNode::PushDownType::UNACCEPTABLE) {
+            DCHECK(slot_ref_child >= 0);
+            const std::string& fn_name =
+                    reinterpret_cast<vectorized::VectorizedFnCall*>(expr)->fn().name.function_name;
+
+            // where A = nullptr should return empty result set
+            if (value.data != nullptr) {
+                if constexpr (T == TYPE_CHAR || T == TYPE_VARCHAR || T == TYPE_STRING ||
+                              T == TYPE_HLL) {
+                    auto val = StringRef(value.data, value.size);
+                    RETURN_IF_ERROR(_change_value_range<false>(range, reinterpret_cast<void*>(&val),
+                                                               ColumnValueRange<T>::add_value_range,
+                                                               fn_name, slot_ref_child));
+                } else {
+                    RETURN_IF_ERROR(_change_value_range<false>(
+                            range, reinterpret_cast<void*>(const_cast<char*>(value.data)),
+                            ColumnValueRange<T>::add_value_range, fn_name, slot_ref_child));
+                }
+                *pdt = temp_pdt;
+            }
+        }
+    }
+    return Status::OK();
+}
+
+Status ScanLocalState::_normalize_compound_predicate(
+        vectorized::VExpr* expr, vectorized::VExprContext* expr_ctx,
+        vectorized::VScanNode::PushDownType* pdt, bool _is_runtime_filter_predicate,
+        const std::function<bool(const vectorized::VExprSPtrs&,
+                                 std::shared_ptr<vectorized::VSlotRef>&, vectorized::VExprSPtr&)>&
+                in_predicate_checker,
+        const std::function<bool(const vectorized::VExprSPtrs&,
+                                 std::shared_ptr<vectorized::VSlotRef>&, vectorized::VExprSPtr&)>&
+                eq_predicate_checker) {
+    if (TExprNodeType::COMPOUND_PRED == expr->node_type()) {
+        auto compound_fn_name = expr->fn().name.function_name;
+        auto children_num = expr->children().size();
+        for (auto i = 0; i < children_num; ++i) {
+            auto child_expr = expr->children()[i].get();
+            if (TExprNodeType::BINARY_PRED == child_expr->node_type()) {
+                SlotDescriptor* slot = nullptr;
+                ColumnValueRangeType* range_on_slot = nullptr;
+                if (_is_predicate_acting_on_slot(child_expr, in_predicate_checker, &slot,
+                                                 &range_on_slot) ||
+                    _is_predicate_acting_on_slot(child_expr, eq_predicate_checker, &slot,
+                                                 &range_on_slot)) {
+                    ColumnValueRangeType active_range =
+                            *range_on_slot; // copy, in order not to affect the range in the _colname_to_value_range
+                    std::visit(
+                            [&](auto& value_range) {
+                                Defer mark_runtime_filter_flag {[&]() {
+                                    value_range.mark_runtime_filter_predicate(
+                                            _is_runtime_filter_predicate);
+                                }};
+                                _normalize_binary_in_compound_predicate(child_expr, expr_ctx, slot,
+                                                                        value_range, pdt);
+                            },
+                            active_range);
+
+                    _compound_value_ranges.emplace_back(active_range);
+                }
+            } else if (TExprNodeType::MATCH_PRED == child_expr->node_type()) {
+                SlotDescriptor* slot = nullptr;
+                ColumnValueRangeType* range_on_slot = nullptr;
+                if (_is_predicate_acting_on_slot(child_expr, in_predicate_checker, &slot,
+                                                 &range_on_slot) ||
+                    _is_predicate_acting_on_slot(child_expr, eq_predicate_checker, &slot,
+                                                 &range_on_slot)) {
+                    ColumnValueRangeType active_range =
+                            *range_on_slot; // copy, in order not to affect the range in the _colname_to_value_range
+                    std::visit(
+                            [&](auto& value_range) {
+                                Defer mark_runtime_filter_flag {[&]() {
+                                    value_range.mark_runtime_filter_predicate(
+                                            _is_runtime_filter_predicate);
+                                }};
+                                _normalize_match_in_compound_predicate(child_expr, expr_ctx, slot,
+                                                                       value_range, pdt);
+                            },
+                            active_range);
+
+                    _compound_value_ranges.emplace_back(active_range);
+                }
+            } else if (TExprNodeType::COMPOUND_PRED == child_expr->node_type()) {
+                _normalize_compound_predicate(child_expr, expr_ctx, pdt,
+                                              _is_runtime_filter_predicate, in_predicate_checker,
+                                              eq_predicate_checker);
+            }
+        }
+    }
+
+    return Status::OK();
+}
+
+template <PrimitiveType T>
+Status ScanLocalState::_normalize_binary_in_compound_predicate(
+        vectorized::VExpr* expr, vectorized::VExprContext* expr_ctx, SlotDescriptor* slot,
+        ColumnValueRange<T>& range, vectorized::VScanNode::PushDownType* pdt) {
+    DCHECK(expr->children().size() == 2);
+    if (TExprNodeType::BINARY_PRED == expr->node_type()) {
+        auto eq_checker = [](const std::string& fn_name) { return fn_name == "eq"; };
+        auto ne_checker = [](const std::string& fn_name) { return fn_name == "ne"; };
+        auto noneq_checker = [](const std::string& fn_name) {
+            return fn_name != "ne" && fn_name != "eq";
+        };
+
+        StringRef value;
+        int slot_ref_child = -1;
+        vectorized::VScanNode::PushDownType eq_pdt;
+        vectorized::VScanNode::PushDownType ne_pdt;
+        vectorized::VScanNode::PushDownType noneq_pdt;
+        RETURN_IF_ERROR(_should_push_down_binary_predicate(
+                reinterpret_cast<vectorized::VectorizedFnCall*>(expr), expr_ctx, &value,
+                &slot_ref_child, eq_checker, eq_pdt));
+        RETURN_IF_ERROR(_should_push_down_binary_predicate(
+                reinterpret_cast<vectorized::VectorizedFnCall*>(expr), expr_ctx, &value,
+                &slot_ref_child, ne_checker, ne_pdt));
+        RETURN_IF_ERROR(_should_push_down_binary_predicate(
+                reinterpret_cast<vectorized::VectorizedFnCall*>(expr), expr_ctx, &value,
+                &slot_ref_child, noneq_checker, noneq_pdt));
+        if (eq_pdt == vectorized::VScanNode::PushDownType::UNACCEPTABLE &&
+            ne_pdt == vectorized::VScanNode::PushDownType::UNACCEPTABLE &&
+            noneq_pdt == vectorized::VScanNode::PushDownType::UNACCEPTABLE) {
+            return Status::OK();
+        }
+        DCHECK(slot_ref_child >= 0);
+        const std::string& fn_name =
+                reinterpret_cast<vectorized::VectorizedFnCall*>(expr)->fn().name.function_name;
+        if (eq_pdt == vectorized::VScanNode::PushDownType::ACCEPTABLE ||
+            ne_pdt == vectorized::VScanNode::PushDownType::ACCEPTABLE ||
+            noneq_pdt == vectorized::VScanNode::PushDownType::ACCEPTABLE) {
+            if (value.data != nullptr) {
+                if constexpr (T == TYPE_CHAR || T == TYPE_VARCHAR || T == TYPE_STRING ||
+                              T == TYPE_HLL) {
+                    auto val = StringRef(value.data, value.size);
+                    RETURN_IF_ERROR(_change_value_range<false>(
+                            range, reinterpret_cast<void*>(&val),
+                            ColumnValueRange<T>::add_compound_value_range, fn_name,
+                            slot_ref_child));
+                } else {
+                    RETURN_IF_ERROR(_change_value_range<false>(
+                            range, reinterpret_cast<void*>(const_cast<char*>(value.data)),
+                            ColumnValueRange<T>::add_compound_value_range, fn_name,
+                            slot_ref_child));
+                }
+            }
+            *pdt = vectorized::VScanNode::PushDownType::ACCEPTABLE;
+        }
+    }
+    return Status::OK();
+}
+
+template <PrimitiveType T>
+Status ScanLocalState::_normalize_match_in_compound_predicate(
+        vectorized::VExpr* expr, vectorized::VExprContext* expr_ctx, SlotDescriptor* slot,
+        ColumnValueRange<T>& range, vectorized::VScanNode::PushDownType* pdt) {
+    DCHECK(expr->children().size() == 2);
+    if (TExprNodeType::MATCH_PRED == expr->node_type()) {
+        RETURN_IF_ERROR(_normalize_match_predicate(expr, expr_ctx, slot, range, pdt));
+    }
+
+    return Status::OK();
+}
+
+template <PrimitiveType T>
+Status ScanLocalState::_normalize_match_predicate(vectorized::VExpr* expr,
+                                                  vectorized::VExprContext* expr_ctx,
+                                                  SlotDescriptor* slot, ColumnValueRange<T>& range,
+                                                  vectorized::VScanNode::PushDownType* pdt) {
+    if (TExprNodeType::MATCH_PRED == expr->node_type()) {
+        DCHECK(expr->children().size() == 2);
+
+        // create empty range as temp range, temp range should do intersection on range
+        auto temp_range = ColumnValueRange<T>::create_empty_column_value_range(
+                slot->is_nullable(), slot->type().precision, slot->type().scale);
+        // Normalize match conjuncts like 'where col match value'
+
+        auto match_checker = [](const std::string& fn_name) { return is_match_condition(fn_name); };
+        StringRef value;
+        int slot_ref_child = -1;
+        vectorized::VScanNode::PushDownType temp_pdt;
+        RETURN_IF_ERROR(_should_push_down_binary_predicate(
+                reinterpret_cast<vectorized::VectorizedFnCall*>(expr), expr_ctx, &value,
+                &slot_ref_child, match_checker, temp_pdt));
+        if (temp_pdt != vectorized::VScanNode::PushDownType::UNACCEPTABLE) {
+            DCHECK(slot_ref_child >= 0);
+            if (value.data != nullptr) {
+                using CppType = typename VecPrimitiveTypeTraits<T>::CppType;
+                if constexpr (T == TYPE_CHAR || T == TYPE_VARCHAR || T == TYPE_STRING ||
+                              T == TYPE_HLL) {
+                    auto val = StringRef(value.data, value.size);
+                    ColumnValueRange<T>::add_match_value_range(temp_range,
+                                                               to_match_type(expr->op()),
+                                                               reinterpret_cast<CppType*>(&val));
+                } else {
+                    ColumnValueRange<T>::add_match_value_range(
+                            temp_range, to_match_type(expr->op()),
+                            reinterpret_cast<CppType*>(const_cast<char*>(value.data)));
+                }
+                range.intersection(temp_range);
+            }
+            *pdt = temp_pdt;
+        }
+    }
+    return Status::OK();
+}
+
+Status ScanLocalState::_prepare_scanners(const int query_parallel_instance_num) {
+    std::list<vectorized::VScannerSPtr> scanners;
+    RETURN_IF_ERROR(_init_scanners(&scanners));
+    if (scanners.empty()) {
+        _eos = true;
+    } else {
+        COUNTER_SET(_num_scanners, static_cast<int64_t>(scanners.size()));
+        RETURN_IF_ERROR(_start_scanners(scanners, query_parallel_instance_num));
+    }
+    return Status::OK();
+}
+
+Status ScanLocalState::_start_scanners(const std::list<vectorized::VScannerSPtr>& scanners,
+                                       const int query_parallel_instance_num) {
+    auto& p = _parent->cast<ScanOperatorX>();
+    _scanner_ctx = PipScannerContext::create_shared(state(), this, p._output_tuple_desc, scanners,
+                                                    p.limit(), state()->scan_queue_mem_limit(),
+                                                    p._col_distribute_ids, 1);
+    return Status::OK();
+}
+
+const TupleDescriptor* ScanLocalState::input_tuple_desc() const {
+    return _parent->cast<ScanOperatorX>()._input_tuple_desc;
+}
+const TupleDescriptor* ScanLocalState::output_tuple_desc() const {
+    return _parent->cast<ScanOperatorX>()._output_tuple_desc;
+}
+
+TPushAggOp::type ScanLocalState::get_push_down_agg_type() {
+    return _parent->cast<ScanOperatorX>()._push_down_agg_type;
+}
+
+int64_t ScanLocalState::limit_per_scanner() {
+    return _parent->cast<ScanOperatorX>()._limit_per_scanner;
+}
+
+Status ScanLocalState::clone_conjunct_ctxs(vectorized::VExprContextSPtrs& conjuncts) {
+    if (!_conjuncts.empty()) {
+        std::unique_lock l(_rf_locks);
+        conjuncts.resize(_conjuncts.size());
+        for (size_t i = 0; i != _conjuncts.size(); ++i) {
+            RETURN_IF_ERROR(_conjuncts[i]->clone(state(), conjuncts[i]));
+        }
+    }
+    return Status::OK();
+}
+
+Status ScanLocalState::_init_profile() {
+    // 1. counters for scan node
+    _rows_read_counter = ADD_COUNTER(_runtime_profile, "RowsRead", TUnit::UNIT);
+    _total_throughput_counter =
+            profile()->add_rate_counter("TotalReadThroughput", _rows_read_counter);
+    _num_scanners = ADD_COUNTER(_runtime_profile, "NumScanners", TUnit::UNIT);
+
+    // 2. counters for scanners
+    _scanner_profile.reset(new RuntimeProfile("VScanner"));
+    profile()->add_child(_scanner_profile.get(), true, nullptr);
+
+    _memory_usage_counter = ADD_LABEL_COUNTER(_scanner_profile, "MemoryUsage");
+    _queued_blocks_memory_usage =
+            _scanner_profile->AddHighWaterMarkCounter("QueuedBlocks", TUnit::BYTES, "MemoryUsage");
+    _free_blocks_memory_usage =
+            _scanner_profile->AddHighWaterMarkCounter("FreeBlocks", TUnit::BYTES, "MemoryUsage");
+    _newly_create_free_blocks_num =
+            ADD_COUNTER(_scanner_profile, "NewlyCreateFreeBlocksNum", TUnit::UNIT);
+    // time of transfer thread to wait for block from scan thread
+    _scanner_wait_batch_timer = ADD_TIMER(_scanner_profile, "ScannerBatchWaitTime");
+    _scanner_sched_counter = ADD_COUNTER(_scanner_profile, "ScannerSchedCount", TUnit::UNIT);
+    _scanner_ctx_sched_counter = ADD_COUNTER(_scanner_profile, "ScannerCtxSchedCount", TUnit::UNIT);
+    _scanner_ctx_sched_time = ADD_TIMER(_scanner_profile, "ScannerCtxSchedTime");
+
+    _scan_timer = ADD_TIMER(_scanner_profile, "ScannerGetBlockTime");
+    _scan_cpu_timer = ADD_TIMER(_scanner_profile, "ScannerCpuTime");
+    _prefilter_timer = ADD_TIMER(_scanner_profile, "ScannerPrefilterTime");
+    _convert_block_timer = ADD_TIMER(_scanner_profile, "ScannerConvertBlockTime");
+    _filter_timer = ADD_TIMER(_scanner_profile, "ScannerFilterTime");
+
+    // time of scan thread to wait for worker thread of the thread pool
+    _scanner_wait_worker_timer = ADD_TIMER(_runtime_profile, "ScannerWorkerWaitTime");
+
+    _max_scanner_thread_num = ADD_COUNTER(_runtime_profile, "MaxScannerThreadNum", TUnit::UNIT);
+
+    return Status::OK();
+}
+
+ScanOperatorX::ScanOperatorX(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs,
+                             std::string op_name)
+        : OperatorXBase(pool, tnode, descs, op_name), _runtime_filter_descs(tnode.runtime_filters) {
+    if (!tnode.__isset.conjuncts || tnode.conjuncts.empty()) {
+        // Which means the request could be fullfilled in a single segment iterator request.
+        if (tnode.limit > 0 && tnode.limit < 1024) {
+            _should_run_serial = true;
+        }
+    }
+}
+
+bool ScanOperatorX::can_read(RuntimeState* state) {
+    auto& local_state = state->get_local_state(id())->cast<ScanLocalState>();
+    if (!local_state._init) {
+        return true;
+    } else {
+        if (local_state._eos || local_state._scanner_ctx->done()) {
+            // _eos: need eos
+            // _scanner_ctx->done(): need finish
+            // _scanner_ctx->no_schedule(): should schedule _scanner_ctx
+            return true;
+        } else {
+            if (local_state._scanner_ctx->get_num_running_scanners() == 0 &&
+                local_state._scanner_ctx->has_enough_space_in_blocks_queue()) {
+                local_state._scanner_ctx->reschedule_scanner_ctx();
+            }
+            return local_state.ready_to_read(); // there are some blocks to process
+        }
+    }
+}
+
+bool ScanOperatorX::is_pending_finish(RuntimeState* state) const {
+    auto& local_state = state->get_local_state(id())->cast<ScanLocalState>();
+    return local_state._scanner_ctx && !local_state._scanner_ctx->no_schedule();
+}
+
+Status ScanOperatorX::init(const TPlanNode& tnode, RuntimeState* state) {
+    RETURN_IF_ERROR(OperatorXBase::init(tnode, state));
+
+    const TQueryOptions& query_options = state->query_options();
+    if (query_options.__isset.max_scan_key_num) {
+        _max_scan_key_num = query_options.max_scan_key_num;
+    } else {
+        _max_scan_key_num = config::doris_max_scan_key_num;
+    }
+    if (query_options.__isset.max_pushdown_conditions_per_column) {
+        _max_pushdown_conditions_per_column = query_options.max_pushdown_conditions_per_column;
+    } else {
+        _max_pushdown_conditions_per_column = config::max_pushdown_conditions_per_column;
+    }
+    // tnode.olap_scan_node.push_down_agg_type_opt field is deprecated
+    // Introduced a new field : tnode.push_down_agg_type_opt
+    //
+    // make it compatible here
+    if (tnode.__isset.push_down_agg_type_opt) {
+        _push_down_agg_type = tnode.push_down_agg_type_opt;
+    } else if (tnode.olap_scan_node.__isset.push_down_agg_type_opt) {
+        _push_down_agg_type = tnode.olap_scan_node.push_down_agg_type_opt;
+
+    } else {
+        _push_down_agg_type = TPushAggOp::type::NONE;
+    }
+    return Status::OK();
+}
+
+Status ScanOperatorX::open(RuntimeState* state) {
+    _input_tuple_desc = state->desc_tbl().get_tuple_descriptor(_input_tuple_id);
+    _output_tuple_desc = state->desc_tbl().get_tuple_descriptor(_output_tuple_id);
+    RETURN_IF_ERROR(OperatorXBase::open(state));
+
+    RETURN_IF_CANCELLED(state);
+    return Status::OK();
+}
+
+Status ScanOperatorX::try_close(RuntimeState* state) {
+    auto& local_state = state->get_local_state(id())->cast<ScanLocalState>();
+    if (local_state._scanner_ctx.get()) {
+        // mark this scanner ctx as should_stop to make sure scanners will not be scheduled anymore
+        // TODO: there is a lock in `set_should_stop` may cause some slight impact
+        local_state._scanner_ctx->set_should_stop();
+    }
+    return Status::OK();
+}
+
+Status ScanOperatorX::close(RuntimeState* state) {
+    if (is_closed()) {
+        return Status::OK();
+    }
+    auto local_state_ptr = state->get_local_state(id());
+    auto& local_state = local_state_ptr->cast<ScanLocalState>();
+    if (local_state._scanner_ctx.get()) {
+        local_state._scanner_ctx->clear_and_join(
+                reinterpret_cast<ScanLocalState*>(local_state_ptr.get()), state);
+    }
+    _is_closed = true;
+    return OperatorXBase::close(state);
+}
+
+Status ScanOperatorX::get_block(RuntimeState* state, vectorized::Block* block,
+                                SourceState& source_state) {
+    auto& local_state = state->get_local_state(id())->cast<ScanLocalState>();
+    SCOPED_TIMER(local_state._get_next_timer);
+    SCOPED_TIMER(local_state.profile()->total_time_counter());
+    // in inverted index apply logic, in order to optimize query performance,
+    // we built some temporary columns into block, these columns only used in scan node level,
+    // remove them when query leave scan node to avoid other nodes use block->columns() to make a wrong decision
+    Defer drop_block_temp_column {[&]() {
+        std::unique_lock l(local_state._block_lock);
+        auto all_column_names = block->get_names();
+        for (auto& name : all_column_names) {
+            if (name.rfind(BeConsts::BLOCK_TEMP_COLUMN_PREFIX, 0) == 0) {
+                block->erase(name);
+            }
+        }
+    }};
+
+    if (state->is_cancelled()) {
+        // ISSUE: https://github.com/apache/doris/issues/16360
+        // _scanner_ctx may be null here, see: `VScanNode::alloc_resource` (_eos == null)
+        if (local_state._scanner_ctx) {
+            local_state._scanner_ctx->set_status_on_error(Status::Cancelled("query cancelled"));
+            return local_state._scanner_ctx->status();
+        } else {
+            return Status::Cancelled("query cancelled");
+        }
+    }
+
+    if (local_state._eos) {
+        source_state = SourceState::FINISHED;
+        return Status::OK();
+    }
+
+    vectorized::BlockUPtr scan_block = nullptr;
+    bool eos = false;
+    RETURN_IF_ERROR(local_state._scanner_ctx->get_block_from_queue(state, &scan_block, &eos, 0));
+    if (eos) {
+        source_state = SourceState::FINISHED;
+        DCHECK(scan_block == nullptr);
+        return Status::OK();
+    }
+
+    // get scanner's block memory
+    block->swap(*scan_block);
+    local_state._scanner_ctx->return_free_block(std::move(scan_block));
+
+    local_state.reached_limit(block, &eos);
+    if (eos) {
+        source_state = SourceState::FINISHED;
+        // reach limit, stop the scanners.
+        local_state._scanner_ctx->set_should_stop();
+    }
+
+    return Status::OK();
 }
 
 } // namespace doris::pipeline

--- a/be/src/pipeline/exec/scan_operator.h
+++ b/be/src/pipeline/exec/scan_operator.h
@@ -30,6 +30,7 @@ class ExecNode;
 } // namespace doris
 
 namespace doris::pipeline {
+class PipScannerContext;
 
 class ScanOperatorBuilder : public OperatorBuilder<vectorized::VScanNode> {
 public:
@@ -51,6 +52,307 @@ public:
     std::string debug_string() const override;
 
     Status try_close(RuntimeState* state) override;
+};
+
+class ScanOperatorX;
+class ScanLocalState : public PipelineXLocalState, public vectorized::RuntimeFilterConsumer {
+    ENABLE_FACTORY_CREATOR(ScanLocalState);
+    ScanLocalState(RuntimeState* state, OperatorXBase* parent);
+
+    virtual Status init(RuntimeState* state, LocalStateInfo& info) override;
+
+    bool ready_to_read();
+
+    [[nodiscard]] bool should_run_serial() const;
+
+    RuntimeProfile* scanner_profile() { return _scanner_profile.get(); }
+
+    [[nodiscard]] const TupleDescriptor* input_tuple_desc() const;
+    [[nodiscard]] const TupleDescriptor* output_tuple_desc() const;
+
+    int64_t limit_per_scanner();
+
+    [[nodiscard]] int runtime_filter_num() const { return (int)_runtime_filter_ctxs.size(); }
+
+    Status clone_conjunct_ctxs(vectorized::VExprContextSPtrs& conjuncts);
+    virtual void set_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) {}
+
+    TPushAggOp::type get_push_down_agg_type();
+
+protected:
+    friend class ScanOperatorX;
+    friend class vectorized::ScannerContext;
+    friend class vectorized::VScanner;
+
+    virtual Status _init_profile();
+    virtual Status _process_conjuncts() {
+        RETURN_IF_ERROR(_normalize_conjuncts());
+        return Status::OK();
+    }
+
+    virtual bool _should_push_down_common_expr() { return false; }
+    virtual bool _is_key_column(const std::string& col_name) { return false; }
+    virtual vectorized::VScanNode::PushDownType _should_push_down_bloom_filter() {
+        return vectorized::VScanNode::PushDownType::UNACCEPTABLE;
+    }
+    virtual vectorized::VScanNode::PushDownType _should_push_down_bitmap_filter() {
+        return vectorized::VScanNode::PushDownType::UNACCEPTABLE;
+    }
+    virtual vectorized::VScanNode::PushDownType _should_push_down_is_null_predicate() {
+        return vectorized::VScanNode::PushDownType::UNACCEPTABLE;
+    }
+    virtual Status _should_push_down_binary_predicate(
+            vectorized::VectorizedFnCall* fn_call, vectorized::VExprContext* expr_ctx,
+            StringRef* constant_val, int* slot_ref_child,
+            const std::function<bool(const std::string&)>& fn_checker,
+            vectorized::VScanNode::PushDownType& pdt);
+
+    virtual vectorized::VScanNode::PushDownType _should_push_down_in_predicate(
+            vectorized::VInPredicate* in_pred, vectorized::VExprContext* expr_ctx, bool is_not_in);
+
+    virtual Status _should_push_down_function_filter(vectorized::VectorizedFnCall* fn_call,
+                                                     vectorized::VExprContext* expr_ctx,
+                                                     StringRef* constant_str,
+                                                     doris::FunctionContext** fn_ctx,
+                                                     vectorized::VScanNode::PushDownType& pdt) {
+        pdt = vectorized::VScanNode::PushDownType::UNACCEPTABLE;
+        return Status::OK();
+    }
+
+    // Create a list of scanners.
+    // The number of scanners is related to the implementation of the data source,
+    // predicate conditions, and scheduling strategy.
+    // So this method needs to be implemented separately by the subclass of ScanNode.
+    // Finally, a set of scanners that have been prepared are returned.
+    virtual Status _init_scanners(std::list<vectorized::VScannerSPtr>* scanners) {
+        return Status::OK();
+    }
+
+    Status _normalize_conjuncts();
+    Status _normalize_predicate(const vectorized::VExprSPtr& conjunct_expr_root,
+                                vectorized::VExprContext* context,
+                                vectorized::VExprSPtr& output_expr);
+    Status _eval_const_conjuncts(vectorized::VExpr* vexpr, vectorized::VExprContext* expr_ctx,
+                                 vectorized::VScanNode::PushDownType* pdt);
+
+    Status _normalize_bloom_filter(vectorized::VExpr* expr, vectorized::VExprContext* expr_ctx,
+                                   SlotDescriptor* slot, vectorized::VScanNode::PushDownType* pdt);
+
+    Status _normalize_bitmap_filter(vectorized::VExpr* expr, vectorized::VExprContext* expr_ctx,
+                                    SlotDescriptor* slot, vectorized::VScanNode::PushDownType* pdt);
+
+    Status _normalize_function_filters(vectorized::VExpr* expr, vectorized::VExprContext* expr_ctx,
+                                       SlotDescriptor* slot,
+                                       vectorized::VScanNode::PushDownType* pdt);
+
+    bool _is_predicate_acting_on_slot(
+            vectorized::VExpr* expr,
+            const std::function<bool(const vectorized::VExprSPtrs&,
+                                     std::shared_ptr<vectorized::VSlotRef>&,
+                                     vectorized::VExprSPtr&)>& checker,
+            SlotDescriptor** slot_desc, ColumnValueRangeType** range);
+
+    template <PrimitiveType T>
+    Status _normalize_in_and_eq_predicate(vectorized::VExpr* expr,
+                                          vectorized::VExprContext* expr_ctx, SlotDescriptor* slot,
+                                          ColumnValueRange<T>& range,
+                                          vectorized::VScanNode::PushDownType* pdt);
+    template <PrimitiveType T>
+    Status _normalize_not_in_and_not_eq_predicate(vectorized::VExpr* expr,
+                                                  vectorized::VExprContext* expr_ctx,
+                                                  SlotDescriptor* slot, ColumnValueRange<T>& range,
+                                                  vectorized::VScanNode::PushDownType* pdt);
+
+    template <PrimitiveType T>
+    Status _normalize_noneq_binary_predicate(vectorized::VExpr* expr,
+                                             vectorized::VExprContext* expr_ctx,
+                                             SlotDescriptor* slot, ColumnValueRange<T>& range,
+                                             vectorized::VScanNode::PushDownType* pdt);
+
+    Status _normalize_compound_predicate(
+            vectorized::VExpr* expr, vectorized::VExprContext* expr_ctx,
+            vectorized::VScanNode::PushDownType* pdt, bool is_runtimer_filter_predicate,
+            const std::function<bool(const vectorized::VExprSPtrs&,
+                                     std::shared_ptr<vectorized::VSlotRef>&,
+                                     vectorized::VExprSPtr&)>& in_predicate_checker,
+            const std::function<bool(const vectorized::VExprSPtrs&,
+                                     std::shared_ptr<vectorized::VSlotRef>&,
+                                     vectorized::VExprSPtr&)>& eq_predicate_checker);
+
+    template <PrimitiveType T>
+    Status _normalize_binary_in_compound_predicate(vectorized::VExpr* expr,
+                                                   vectorized::VExprContext* expr_ctx,
+                                                   SlotDescriptor* slot, ColumnValueRange<T>& range,
+                                                   vectorized::VScanNode::PushDownType* pdt);
+
+    template <PrimitiveType T>
+    Status _normalize_match_in_compound_predicate(vectorized::VExpr* expr,
+                                                  vectorized::VExprContext* expr_ctx,
+                                                  SlotDescriptor* slot, ColumnValueRange<T>& range,
+                                                  vectorized::VScanNode::PushDownType* pdt);
+
+    template <PrimitiveType T>
+    Status _normalize_is_null_predicate(vectorized::VExpr* expr, vectorized::VExprContext* expr_ctx,
+                                        SlotDescriptor* slot, ColumnValueRange<T>& range,
+                                        vectorized::VScanNode::PushDownType* pdt);
+
+    template <PrimitiveType T>
+    Status _normalize_match_predicate(vectorized::VExpr* expr, vectorized::VExprContext* expr_ctx,
+                                      SlotDescriptor* slot, ColumnValueRange<T>& range,
+                                      vectorized::VScanNode::PushDownType* pdt);
+
+    bool _ignore_cast(SlotDescriptor* slot, vectorized::VExpr* expr);
+
+    template <bool IsFixed, PrimitiveType PrimitiveType, typename ChangeFixedValueRangeFunc>
+    Status _change_value_range(ColumnValueRange<PrimitiveType>& range, void* value,
+                               const ChangeFixedValueRangeFunc& func, const std::string& fn_name,
+                               int slot_ref_child = -1);
+
+    Status _prepare_scanners(const int query_parallel_instance_num);
+
+    // Submit the scanner to the thread pool and start execution
+    Status _start_scanners(const std::list<vectorized::VScannerSPtr>& scanners,
+                           const int query_parallel_instance_num);
+
+    // Every time vconjunct_ctx_ptr is updated, the old ctx will be stored in this vector
+    // so that it will be destroyed uniformly at the end of the query.
+    vectorized::VExprContextSPtrs _stale_expr_ctxs;
+    vectorized::VExprContextSPtrs _common_expr_ctxs_push_down;
+
+    std::shared_ptr<vectorized::ScannerContext> _scanner_ctx;
+
+    // indicate this scan node has no more data to return
+    bool _eos = false;
+
+    vectorized::FilterPredicates _filter_predicates {};
+
+    // Save all function predicates which may be pushed down to data source.
+    std::vector<FunctionFilter> _push_down_functions;
+
+    // slot id -> ColumnValueRange
+    // Parsed from conjuncts
+    phmap::flat_hash_map<int, std::pair<SlotDescriptor*, ColumnValueRangeType>>
+            _slot_id_to_value_range;
+    // column -> ColumnValueRange
+    // We use _colname_to_value_range to store a column and its conresponding value ranges.
+    std::unordered_map<std::string, ColumnValueRangeType> _colname_to_value_range;
+
+    /**
+     * _colname_to_value_range only store the leaf of and in the conjunct expr tree,
+     * we use _compound_value_ranges to store conresponding value ranges
+     * in the one compound relationship except the leaf of and node,
+     * such as `where a > 1 or b > 10 and c < 200`, the expr tree like:
+     *     or
+     *   /   \
+     *  a     and
+     *       /   \
+     *      b     c
+     * the value ranges of column a,b,c will all store into _compound_value_ranges
+     */
+    std::vector<ColumnValueRangeType> _compound_value_ranges;
+    // But if a col is with value range, eg: 1 < col < 10, which is "!is_fixed_range",
+    // in this case we can not merge "1 < col < 10" with "col not in (2)".
+    // So we have to save "col not in (2)" to another structure: "_not_in_value_ranges".
+    // When the data source try to use the value ranges, it should use both ranges in
+    // "_colname_to_value_range" and in "_not_in_value_ranges"
+    std::vector<ColumnValueRangeType> _not_in_value_ranges;
+
+    std::shared_ptr<RuntimeProfile> _scanner_profile;
+
+    // rows read from the scanner (including those discarded by (pre)filters)
+    RuntimeProfile::Counter* _rows_read_counter;
+    // Wall based aggregate read throughput [rows/sec]
+    RuntimeProfile::Counter* _total_throughput_counter;
+    RuntimeProfile::Counter* _num_scanners;
+
+    RuntimeProfile::Counter* _get_next_timer = nullptr;
+    RuntimeProfile::Counter* _open_timer = nullptr;
+    RuntimeProfile::Counter* _alloc_resource_timer = nullptr;
+    RuntimeProfile::Counter* _acquire_runtime_filter_timer = nullptr;
+    // time of get block from scanner
+    RuntimeProfile::Counter* _scan_timer = nullptr;
+    RuntimeProfile::Counter* _scan_cpu_timer = nullptr;
+    // time of prefilter input block from scanner
+    RuntimeProfile::Counter* _prefilter_timer = nullptr;
+    // time of convert input block to output block from scanner
+    RuntimeProfile::Counter* _convert_block_timer = nullptr;
+    // time of filter output block from scanner
+    RuntimeProfile::Counter* _filter_timer = nullptr;
+
+    RuntimeProfile::Counter* _scanner_sched_counter = nullptr;
+    RuntimeProfile::Counter* _scanner_ctx_sched_counter = nullptr;
+    RuntimeProfile::Counter* _scanner_ctx_sched_time = nullptr;
+    RuntimeProfile::Counter* _scanner_wait_batch_timer = nullptr;
+    RuntimeProfile::Counter* _scanner_wait_worker_timer = nullptr;
+    // Num of newly created free blocks when running query
+    RuntimeProfile::Counter* _newly_create_free_blocks_num = nullptr;
+    // Max num of scanner thread
+    RuntimeProfile::Counter* _max_scanner_thread_num = nullptr;
+
+    RuntimeProfile::Counter* _memory_usage_counter;
+    RuntimeProfile::HighWaterMarkCounter* _queued_blocks_memory_usage;
+    RuntimeProfile::HighWaterMarkCounter* _free_blocks_memory_usage;
+
+    doris::Mutex _block_lock;
+};
+
+class ScanOperatorX : public OperatorXBase {
+public:
+    ScanOperatorX(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs,
+                  std::string op_name);
+
+    //    bool runtime_filters_are_ready_or_timeout() override;
+
+    Status try_close(RuntimeState* state) override;
+
+    bool can_read(RuntimeState* state) override;
+    bool is_pending_finish(RuntimeState* state) const override;
+
+    Status init(const TPlanNode& tnode, RuntimeState* state) override;
+    Status prepare(RuntimeState* state) override { return OperatorXBase::prepare(state); }
+    Status open(RuntimeState* state) override;
+    Status get_block(RuntimeState* state, vectorized::Block* block,
+                     SourceState& source_state) override;
+    bool is_source() const override { return true; }
+
+    const std::vector<TRuntimeFilterDesc>& runtime_filter_descs() { return _runtime_filter_descs; }
+
+    Status close(RuntimeState* state) override;
+
+    TPushAggOp::type get_push_down_agg_type() { return _push_down_agg_type; }
+
+protected:
+    friend class ScanLocalState;
+    friend class OlapScanLocalState;
+
+    // For load scan node, there should be both input and output tuple descriptor.
+    // For query scan node, there is only output_tuple_desc.
+    TupleId _input_tuple_id = -1;
+    TupleId _output_tuple_id = -1;
+    const TupleDescriptor* _input_tuple_desc = nullptr;
+    const TupleDescriptor* _output_tuple_desc = nullptr;
+
+    // These two values are from query_options
+    int _max_scan_key_num;
+    int _max_pushdown_conditions_per_column;
+
+    // If the query like select * from table limit 10; then the query should run in
+    // single scanner to avoid too many scanners which will cause lots of useless read.
+    bool _should_run_serial = false;
+
+    // Every time vconjunct_ctx_ptr is updated, the old ctx will be stored in this vector
+    // so that it will be destroyed uniformly at the end of the query.
+    vectorized::VExprContextSPtrs _stale_expr_ctxs;
+    vectorized::VExprContextSPtrs _common_expr_ctxs_push_down;
+
+    // If sort info is set, push limit to each scanner;
+    int64_t _limit_per_scanner = -1;
+
+    std::unordered_map<std::string, int> _colname_to_slot_id;
+    std::vector<int> _col_distribute_ids;
+    std::vector<TRuntimeFilterDesc> _runtime_filter_descs;
+
+    TPushAggOp::type _push_down_agg_type;
 };
 
 } // namespace doris::pipeline

--- a/be/src/pipeline/pipeline.cpp
+++ b/be/src/pipeline/pipeline.cpp
@@ -53,6 +53,23 @@ Status Pipeline::add_operator(OperatorBuilderPtr& op) {
     return Status::OK();
 }
 
+Status Pipeline::add_operator(OperatorXPtr& op) {
+    if (_operators.empty() && !op->is_source()) {
+        return Status::InternalError("Should set source before other operator");
+    }
+    _operators.emplace_back(op);
+    return Status::OK();
+}
+
+Status Pipeline::prepare(RuntimeState* state) {
+    // TODO
+    RETURN_IF_ERROR(_operators[_operators.size() - 1]->prepare(state));
+    RETURN_IF_ERROR(_operators[_operators.size() - 1]->open(state));
+    RETURN_IF_ERROR(_sink_x->prepare(state));
+    RETURN_IF_ERROR(_sink_x->open(state));
+    return Status::OK();
+}
+
 Status Pipeline::set_sink(OperatorBuilderPtr& sink_) {
     if (_sink) {
         return Status::InternalError("set sink twice");
@@ -61,6 +78,17 @@ Status Pipeline::set_sink(OperatorBuilderPtr& sink_) {
         return Status::InternalError("should set a sink operator but {}", typeid(sink_).name());
     }
     _sink = sink_;
+    return Status::OK();
+}
+
+Status Pipeline::set_sink(DataSinkOperatorXPtr& sink) {
+    if (_sink_x) {
+        return Status::InternalError("set sink twice");
+    }
+    if (!sink->is_sink()) {
+        return Status::InternalError("should set a sink operator but {}", typeid(sink).name());
+    }
+    _sink_x = sink;
     return Status::OK();
 }
 

--- a/be/src/pipeline/pipeline.h
+++ b/be/src/pipeline/pipeline.h
@@ -73,13 +73,26 @@ public:
 
     Status add_operator(OperatorBuilderPtr& op);
 
+    // Add operators for pipelineX
+    Status add_operator(OperatorXPtr& op);
+    // prepare operators for pipelineX
+    Status prepare(RuntimeState* state);
+
     Status set_sink(OperatorBuilderPtr& sink_operator);
+    Status set_sink(DataSinkOperatorXPtr& sink_operator);
 
     OperatorBuilderBase* sink() { return _sink.get(); }
+    DataSinkOperatorX* sink_x() { return _sink_x.get(); }
+    OperatorXs& operator_xs() { return _operators; }
+    DataSinkOperatorXPtr sink_shared_pointer() { return _sink_x; }
 
     Status build_operators(Operators&);
 
     RuntimeProfile* pipeline_profile() { return _pipeline_profile.get(); }
+
+    const RowDescriptor& output_row_desc() const {
+        return _operators[_operators.size() - 1]->row_desc();
+    }
 
 private:
     void _init_profile();
@@ -96,6 +109,13 @@ private:
     int _previous_schedule_id = -1;
 
     std::unique_ptr<RuntimeProfile> _pipeline_profile;
+
+    // Operators for pipelineX. All pipeline tasks share operators from this.
+    // [SourceOperator -> ... -> SinkOperator]
+    OperatorXs _operators;
+    DataSinkOperatorXPtr _sink_x;
+
+    std::shared_ptr<ObjectPool> _obj_pool;
 };
 
 } // namespace doris::pipeline

--- a/be/src/pipeline/pipeline_fragment_context.h
+++ b/be/src/pipeline/pipeline_fragment_context.h
@@ -65,7 +65,7 @@ public:
                             const std::function<void(RuntimeState*, Status*)>& call_back,
                             const report_status_callback& report_status_cb);
 
-    ~PipelineFragmentContext();
+    virtual ~PipelineFragmentContext();
 
     PipelinePtr add_pipeline();
 
@@ -74,21 +74,26 @@ public:
     RuntimeState* get_runtime_state() { return _runtime_state.get(); }
 
     // should be protected by lock?
-    bool is_canceled() const { return _runtime_state->is_cancelled(); }
+    [[nodiscard]] bool is_canceled() const { return _runtime_state->is_cancelled(); }
 
     int32_t next_operator_builder_id() { return _next_operator_builder_id++; }
 
     Status prepare(const doris::TPipelineFragmentParams& request, const size_t idx);
 
-    Status submit();
+    virtual Status prepare(const doris::TPipelineFragmentParams& request) {
+        return Status::InternalError("Pipeline fragment context do not implement prepare");
+    }
 
-    void close_if_prepare_failed();
-    void close_sink();
+    virtual Status submit();
+
+    virtual void close_if_prepare_failed();
+    virtual void close_sink();
 
     void set_is_report_success(bool is_report_success) { _is_report_success = is_report_success; }
 
-    void cancel(const PPlanFragmentCancelReason& reason = PPlanFragmentCancelReason::INTERNAL_ERROR,
-                const std::string& msg = "");
+    virtual void cancel(
+            const PPlanFragmentCancelReason& reason = PPlanFragmentCancelReason::INTERNAL_ERROR,
+            const std::string& msg = "");
 
     // TODO: Support pipeline runtime filter
 
@@ -107,7 +112,7 @@ public:
 
     void send_report(bool);
 
-    void report_profile();
+    virtual void report_profile();
 
     Status update_status(Status status) {
         std::lock_guard<std::mutex> l(_status_lock);
@@ -121,13 +126,13 @@ public:
         return _task_group_entity;
     }
 
-private:
+protected:
     Status _create_sink(int sender_id, const TDataSink& t_data_sink, RuntimeState* state);
     Status _build_pipelines(ExecNode*, PipelinePtr);
-    Status _build_pipeline_tasks(const doris::TPipelineFragmentParams& request);
+    virtual Status _build_pipeline_tasks(const doris::TPipelineFragmentParams& request);
     template <bool is_intersect>
     Status _build_operators_for_set_operation_node(ExecNode*, PipelinePtr);
-    void _close_action();
+    virtual void _close_action();
     void _stop_report_thread();
     void _set_is_report_on_cancel(bool val) { _is_report_on_cancel = val; }
 
@@ -155,7 +160,6 @@ private:
     // After prepared, `_total_tasks` is equal to the size of `_tasks`.
     // When submit fail, `_total_tasks` is equal to the number of tasks submitted.
     int _total_tasks = 0;
-    std::vector<std::unique_ptr<PipelineTask>> _tasks;
 
     int32_t _next_operator_builder_id = 10000;
 
@@ -200,6 +204,9 @@ private:
     // If this is set to false, and '_is_report_success' is false as well,
     // This executor will not report status to FE on being cancelled.
     bool _is_report_on_cancel;
+
+private:
+    std::vector<std::unique_ptr<PipelineTask>> _tasks;
 };
 } // namespace pipeline
 } // namespace doris

--- a/be/src/pipeline/pipeline_task.h
+++ b/be/src/pipeline/pipeline_task.h
@@ -113,16 +113,20 @@ public:
                  OperatorPtr& sink, PipelineFragmentContext* fragment_context,
                  RuntimeProfile* parent_profile);
 
-    Status prepare(RuntimeState* state);
+    PipelineTask(PipelinePtr& pipeline, uint32_t index, RuntimeState* state,
+                 PipelineFragmentContext* fragment_context, RuntimeProfile* parent_profile);
+    virtual ~PipelineTask() = default;
 
-    Status execute(bool* eos);
+    virtual Status prepare(RuntimeState* state);
+
+    virtual Status execute(bool* eos);
 
     // Try to close this pipeline task. If there are still some resources need to be released after `try_close`,
     // this task will enter the `PENDING_FINISH` state.
-    Status try_close();
+    virtual Status try_close();
     // if the pipeline create a bunch of pipeline task
     // must be call after all pipeline task is finish to release resource
-    Status close();
+    virtual Status close();
 
     void put_in_runnable_queue() {
         _schedule_time++;
@@ -134,7 +138,7 @@ public:
     PipelineTaskState get_state() { return _cur_state; }
     void set_state(PipelineTaskState state);
 
-    bool is_pending_finish() {
+    virtual bool is_pending_finish() {
         bool source_ret = _source->is_pending_finish();
         if (source_ret) {
             return true;
@@ -151,15 +155,15 @@ public:
         return false;
     }
 
-    bool source_can_read() { return _source->can_read(); }
+    virtual bool source_can_read() { return _source->can_read(); }
 
-    bool runtime_filters_are_ready_or_timeout() {
+    virtual bool runtime_filters_are_ready_or_timeout() {
         return _source->runtime_filters_are_ready_or_timeout();
     }
 
-    bool sink_can_write() { return _sink->can_write(); }
+    virtual bool sink_can_write() { return _sink->can_write(); }
 
-    Status finalize();
+    virtual Status finalize();
 
     PipelineFragmentContext* fragment_context() { return _fragment_context; }
 
@@ -184,7 +188,7 @@ public:
 
     OperatorPtr get_root() { return _root; }
 
-    std::string debug_string();
+    virtual std::string debug_string();
 
     taskgroup::TaskGroupPipelineTaskEntity* get_task_group_entity() const;
 
@@ -242,24 +246,20 @@ public:
         }
     }
 
-private:
+protected:
     void _finish_p_dependency() {
         for (const auto& p : _pipeline->_parents) {
             p.lock()->finish_one_dependency(_previous_schedule_id);
         }
     }
 
-    Status _open();
+    virtual Status _open();
     void _init_profile();
     void _fresh_profile_counter();
 
     uint32_t _index;
     PipelinePtr _pipeline;
     bool _dependency_finish = false;
-    Operators _operators; // left is _source, right is _root
-    OperatorPtr _source;
-    OperatorPtr _root;
-    OperatorPtr _sink;
 
     bool _prepared;
     bool _opened;
@@ -344,5 +344,11 @@ private:
     int64_t _close_pipeline_time = 0;
 
     RuntimeProfile::Counter* _pip_task_total_timer;
+
+private:
+    Operators _operators; // left is _source, right is _root
+    OperatorPtr _source;
+    OperatorPtr _root;
+    OperatorPtr _sink;
 };
 } // namespace doris::pipeline

--- a/be/src/pipeline/pipeline_x/dependency.cpp
+++ b/be/src/pipeline/pipeline_x/dependency.cpp
@@ -1,0 +1,102 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "dependency.h"
+
+#include "runtime/memory/mem_tracker.h"
+
+namespace doris::pipeline {
+
+Status AggDependency::reset_hash_table() {
+    return std::visit(
+            [&](auto&& agg_method) {
+                auto& hash_table = agg_method.data;
+                using HashMethodType = std::decay_t<decltype(agg_method)>;
+                using HashTableType = std::decay_t<decltype(hash_table)>;
+
+                if constexpr (vectorized::ColumnsHashing::IsPreSerializedKeysHashMethodTraits<
+                                      HashMethodType>::value) {
+                    agg_method.reset();
+                }
+
+                hash_table.for_each_mapped([&](auto& mapped) {
+                    if (mapped) {
+                        destroy_agg_status(mapped);
+                        mapped = nullptr;
+                    }
+                });
+
+                _agg_state.aggregate_data_container.reset(new vectorized::AggregateDataContainer(
+                        sizeof(typename HashTableType::key_type),
+                        ((_total_size_of_aggregate_states + _align_aggregate_states - 1) /
+                         _align_aggregate_states) *
+                                _align_aggregate_states));
+                hash_table = HashTableType();
+                _agg_state.agg_arena_pool.reset(new vectorized::Arena);
+                return Status::OK();
+            },
+            _agg_state.agg_data->_aggregated_method_variant);
+}
+
+Status AggDependency::destroy_agg_status(vectorized::AggregateDataPtr data) {
+    for (int i = 0; i < _agg_state.aggregate_evaluators.size(); ++i) {
+        _agg_state.aggregate_evaluators[i]->function()->destroy(data +
+                                                                _offsets_of_aggregate_states[i]);
+    }
+    return Status::OK();
+}
+
+Status AggDependency::create_agg_status(vectorized::AggregateDataPtr data) {
+    for (int i = 0; i < _agg_state.aggregate_evaluators.size(); ++i) {
+        try {
+            _agg_state.aggregate_evaluators[i]->create(data + _offsets_of_aggregate_states[i]);
+        } catch (...) {
+            for (int j = 0; j < i; ++j) {
+                _agg_state.aggregate_evaluators[j]->destroy(data + _offsets_of_aggregate_states[j]);
+            }
+            throw;
+        }
+    }
+    return Status::OK();
+}
+
+Status AggDependency::merge_spilt_data() {
+    CHECK(!_agg_state.spill_context.stream_ids.empty());
+
+    for (auto& reader : _agg_state.spill_context.readers) {
+        CHECK_LT(_agg_state.spill_context.read_cursor, reader->block_count());
+        reader->seek(_agg_state.spill_context.read_cursor);
+        vectorized::Block block;
+        bool eos;
+        RETURN_IF_ERROR(reader->read(&block, &eos));
+
+        // TODO
+        //        if (!block.empty()) {
+        //            auto st = _merge_with_serialized_key_helper<false /* limit */, true /* for_spill */>(
+        //                    &block);
+        //            RETURN_IF_ERROR(st);
+        //        }
+    }
+    _agg_state.spill_context.read_cursor++;
+    return Status::OK();
+}
+
+void AggDependency::release_tracker() {
+    mem_tracker()->release(_mem_usage_record.used_in_state + _mem_usage_record.used_in_arena);
+}
+
+} // namespace doris::pipeline

--- a/be/src/pipeline/pipeline_x/dependency.cpp
+++ b/be/src/pipeline/pipeline_x/dependency.cpp
@@ -49,7 +49,7 @@ Status AggDependency::reset_hash_table() {
                 _agg_state.agg_arena_pool.reset(new vectorized::Arena);
                 return Status::OK();
             },
-            _agg_state.agg_data->_aggregated_method_variant);
+            _agg_state.agg_data->method_variant);
 }
 
 Status AggDependency::destroy_agg_status(vectorized::AggregateDataPtr data) {

--- a/be/src/pipeline/pipeline_x/dependency.h
+++ b/be/src/pipeline/pipeline_x/dependency.h
@@ -1,0 +1,121 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "vec/exec/vaggregation_node.h"
+
+namespace doris::pipeline {
+class Dependency;
+using DependencySPtr = std::shared_ptr<Dependency>;
+
+class Dependency {
+public:
+    Dependency() : _done(false) {}
+    virtual ~Dependency() = default;
+
+    [[nodiscard]] bool done() const { return _done; }
+    void set_done() { _done = true; }
+
+    virtual void* shared_state() = 0;
+
+private:
+    std::atomic<bool> _done;
+};
+
+struct AggSharedState {
+public:
+    AggSharedState() {
+        agg_data = std::make_unique<vectorized::AggregatedDataVariants>();
+        agg_arena_pool = std::make_unique<vectorized::Arena>();
+    }
+    void init_spill_partition_helper(size_t spill_partition_count_bits) {
+        spill_partition_helper =
+                std::make_unique<vectorized::SpillPartitionHelper>(spill_partition_count_bits);
+    }
+    vectorized::AggregatedDataVariantsUPtr agg_data;
+    std::unique_ptr<vectorized::AggregateDataContainer> aggregate_data_container;
+    vectorized::AggSpillContext spill_context;
+    vectorized::ArenaUPtr agg_arena_pool;
+    std::vector<vectorized::AggFnEvaluator*> aggregate_evaluators;
+    std::unique_ptr<vectorized::SpillPartitionHelper> spill_partition_helper;
+    // group by k1,k2
+    vectorized::VExprContextSPtrs probe_expr_ctxs;
+    std::vector<size_t> probe_key_sz;
+    size_t input_num_rows = 0;
+    std::vector<vectorized::AggregateDataPtr> values;
+    std::unique_ptr<vectorized::Arena> agg_profile_arena;
+};
+
+class AggDependency final : public Dependency {
+public:
+    AggDependency() : Dependency() {
+        _mem_tracker = std::make_unique<MemTracker>("AggregateOperator:");
+    }
+    ~AggDependency() override = default;
+
+    void* shared_state() override { return (void*)&_agg_state; };
+
+    Status reset_hash_table();
+
+    Status merge_spilt_data();
+
+    void set_total_size_of_aggregate_states(size_t total_size_of_aggregate_states) {
+        _total_size_of_aggregate_states = total_size_of_aggregate_states;
+    }
+    void set_align_aggregate_states(size_t align_aggregate_states) {
+        _align_aggregate_states = align_aggregate_states;
+    }
+
+    void set_offsets_of_aggregate_states(vectorized::Sizes& offsets_of_aggregate_states) {
+        _offsets_of_aggregate_states = offsets_of_aggregate_states;
+    }
+
+    Status destroy_agg_status(vectorized::AggregateDataPtr data);
+    Status create_agg_status(vectorized::AggregateDataPtr data);
+
+    const vectorized::Sizes& offsets_of_aggregate_states() { return _offsets_of_aggregate_states; }
+
+    void set_make_nullable_keys(std::vector<size_t>& make_nullable_keys) {
+        _make_nullable_keys = make_nullable_keys;
+    }
+
+    const std::vector<size_t>& make_nullable_keys() { return _make_nullable_keys; }
+    void release_tracker();
+
+    struct MemoryRecord {
+        MemoryRecord() : used_in_arena(0), used_in_state(0) {}
+        int64_t used_in_arena;
+        int64_t used_in_state;
+    };
+    MemoryRecord& mem_usage_record() { return _mem_usage_record; }
+
+    MemTracker* mem_tracker() { return _mem_tracker.get(); }
+
+private:
+    AggSharedState _agg_state;
+    /// The total size of the row from the aggregate functions.
+    size_t _total_size_of_aggregate_states = 0;
+    size_t _align_aggregate_states = 1;
+    /// The offset to the n-th aggregate function in a row of aggregate functions.
+    vectorized::Sizes _offsets_of_aggregate_states;
+    std::vector<size_t> _make_nullable_keys;
+
+    MemoryRecord _mem_usage_record;
+    std::unique_ptr<MemTracker> _mem_tracker;
+};
+} // namespace doris::pipeline

--- a/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
@@ -1,0 +1,592 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "pipeline_x_fragment_context.h"
+
+#include <gen_cpp/DataSinks_types.h>
+#include <gen_cpp/PaloInternalService_types.h>
+#include <gen_cpp/PlanNodes_types.h>
+#include <gen_cpp/Planner_types.h>
+#include <opentelemetry/nostd/shared_ptr.h>
+#include <opentelemetry/trace/span.h>
+#include <opentelemetry/trace/span_context.h>
+#include <opentelemetry/trace/tracer.h>
+#include <pthread.h>
+#include <stdlib.h>
+// IWYU pragma: no_include <bits/chrono.h>
+#include <chrono> // IWYU pragma: keep
+#include <map>
+#include <ostream>
+#include <typeinfo>
+#include <utility>
+
+#include "common/config.h"
+#include "common/logging.h"
+#include "exec/data_sink.h"
+#include "exec/exec_node.h"
+#include "exec/scan_node.h"
+#include "io/fs/stream_load_pipe.h"
+#include "pipeline/exec/aggregation_sink_operator.h"
+#include "pipeline/exec/aggregation_source_operator.h"
+#include "pipeline/exec/data_queue.h"
+#include "pipeline/exec/datagen_operator.h"
+#include "pipeline/exec/exchange_sink_operator.h"
+#include "pipeline/exec/exchange_source_operator.h"
+#include "pipeline/exec/olap_scan_operator.h"
+#include "pipeline/exec/result_sink_operator.h"
+#include "pipeline/exec/scan_operator.h"
+#include "pipeline/task_scheduler.h"
+#include "runtime/exec_env.h"
+#include "runtime/fragment_mgr.h"
+#include "runtime/runtime_filter_mgr.h"
+#include "runtime/runtime_state.h"
+#include "runtime/stream_load/new_load_stream_mgr.h"
+#include "runtime/stream_load/stream_load_context.h"
+#include "runtime/thread_context.h"
+#include "service/backend_options.h"
+#include "util/container_util.hpp"
+#include "util/debug_util.h"
+#include "util/telemetry/telemetry.h"
+#include "util/uid_util.h"
+#include "vec/common/assert_cast.h"
+#include "vec/exec/join/vhash_join_node.h"
+#include "vec/exec/scan/new_es_scan_node.h"
+#include "vec/exec/scan/new_file_scan_node.h"
+#include "vec/exec/scan/new_odbc_scan_node.h"
+#include "vec/exec/scan/new_olap_scan_node.h"
+#include "vec/exec/scan/vmeta_scan_node.h"
+#include "vec/exec/scan/vscan_node.h"
+#include "vec/exec/vaggregation_node.h"
+#include "vec/exec/vexchange_node.h"
+#include "vec/exec/vunion_node.h"
+#include "vec/runtime/vdata_stream_mgr.h"
+
+namespace doris::pipeline {
+
+#define FOR_EACH_RUNTIME_STATE(stmt)              \
+    for (auto& runtime_state : _runtime_states) { \
+        stmt                                      \
+    }
+
+PipelineXFragmentContext::PipelineXFragmentContext(
+        const TUniqueId& query_id, const int fragment_id, std::shared_ptr<QueryContext> query_ctx,
+        ExecEnv* exec_env, const std::function<void(RuntimeState*, Status*)>& call_back,
+        const report_status_callback& report_status_cb)
+        : PipelineFragmentContext(query_id, TUniqueId(), fragment_id, -1, query_ctx, exec_env,
+                                  call_back, report_status_cb) {}
+
+PipelineXFragmentContext::~PipelineXFragmentContext() {
+    if (!_runtime_states.empty()) {
+        // The memory released by the query end is recorded in the query mem tracker, main memory in _runtime_state.
+        SCOPED_ATTACH_TASK(_runtime_state.get());
+        FOR_EACH_RUNTIME_STATE(_call_back(runtime_state.get(), &_exec_status);
+                               runtime_state.reset();)
+    } else {
+        _call_back(nullptr, &_exec_status);
+    }
+    _runtime_state.reset();
+    DCHECK(!_report_thread_active);
+}
+
+void PipelineXFragmentContext::cancel(const PPlanFragmentCancelReason& reason,
+                                      const std::string& msg) {
+    if (_canceled) {
+        return;
+    }
+    _canceled = true;
+    if (!_query_ctx->is_cancelled()) {
+        std::lock_guard<std::mutex> l(_status_lock);
+        if (_query_ctx->is_cancelled()) {
+            return;
+        }
+        if (reason != PPlanFragmentCancelReason::LIMIT_REACH) {
+            _exec_status = Status::Cancelled(msg);
+        }
+        _query_ctx->set_is_cancelled(true);
+
+        LOG(WARNING) << "PipelineXFragmentContext Canceled. reason=" << msg;
+
+        // Print detail informations below when you debugging here.
+        //
+        // for (auto& task : _tasks) {
+        //     LOG(WARNING) << task->debug_string();
+        // }
+
+        FOR_EACH_RUNTIME_STATE(runtime_state->set_process_status(_exec_status);)
+
+        // Get pipe from new load stream manager and send cancel to it or the fragment may hang to wait read from pipe
+        // For stream load the fragment's query_id == load id, it is set in FE.
+        auto stream_load_ctx = _exec_env->new_load_stream_mgr()->get(_query_id);
+        if (stream_load_ctx != nullptr) {
+            stream_load_ctx->pipe->cancel(PPlanFragmentCancelReason_Name(reason));
+        }
+        _cancel_reason = reason;
+        _cancel_msg = msg;
+        // To notify wait_for_start()
+        _query_ctx->set_ready_to_execute(true);
+
+        // must close stream_mgr to avoid dead lock in Exchange Node
+        //        _exec_env->vstream_mgr()->cancel(_fragment_instance_id);
+        // Cancel the result queue manager used by spark doris connector
+        // TODO pipeline incomp
+        // _exec_env->result_queue_mgr()->update_queue_status(id, Status::Aborted(msg));
+    }
+}
+
+Status PipelineXFragmentContext::prepare(const doris::TPipelineFragmentParams& request) {
+    if (_prepared) {
+        return Status::InternalError("Already prepared");
+    }
+    _runtime_profile.reset(new RuntimeProfile("PipelineContext"));
+    _start_timer = ADD_TIMER(_runtime_profile, "StartTime");
+    COUNTER_UPDATE(_start_timer, _fragment_watcher.elapsed_time());
+    _prepare_timer = ADD_TIMER(_runtime_profile, "PrepareTime");
+    SCOPED_TIMER(_prepare_timer);
+
+    auto* fragment_context = this;
+    OpentelemetryTracer tracer = telemetry::get_noop_tracer();
+    if (opentelemetry::trace::Tracer::GetCurrentSpan()->GetContext().IsValid()) {
+        tracer = telemetry::get_tracer(print_id(_query_id));
+    }
+
+    LOG_INFO("PipelineXFragmentContext::prepare")
+            .tag("query_id", _query_id)
+            .tag("fragment_id", _fragment_id)
+            .tag("pthread_id", (uintptr_t)pthread_self());
+
+    if (request.query_options.__isset.is_report_success) {
+        fragment_context->set_is_report_success(request.query_options.is_report_success);
+    }
+
+    // 1. Set up the global runtime state.
+    _runtime_state = RuntimeState::create_unique(request.query_id, request.fragment_id,
+                                                 request.query_options, _query_ctx->query_globals,
+                                                 _exec_env);
+    _runtime_state->set_query_ctx(_query_ctx.get());
+    _runtime_state->set_query_mem_tracker(_query_ctx->query_mem_tracker);
+    _runtime_state->set_tracer(std::move(tracer));
+
+    SCOPED_ATTACH_TASK(get_runtime_state());
+    if (request.__isset.backend_id) {
+        _runtime_state->set_backend_id(request.backend_id);
+    }
+    if (request.__isset.import_label) {
+        _runtime_state->set_import_label(request.import_label);
+    }
+    if (request.__isset.db_name) {
+        _runtime_state->set_db_name(request.db_name);
+    }
+    if (request.__isset.load_job_id) {
+        _runtime_state->set_load_job_id(request.load_job_id);
+    }
+
+    auto* desc_tbl = _query_ctx->desc_tbl;
+    _runtime_state->set_desc_tbl(desc_tbl);
+    _runtime_state->set_num_per_fragment_instances(request.num_senders);
+
+    // 2. Build pipelines with operators in this fragment.
+    auto root_pipeline = add_pipeline();
+    RETURN_IF_ERROR_OR_CATCH_EXCEPTION(_build_pipelines(
+            _runtime_state->obj_pool(), request, *_query_ctx->desc_tbl, &_root_op, root_pipeline));
+
+    // 3. Create sink operator
+    if (request.fragment.__isset.output_sink) {
+        RETURN_IF_ERROR_OR_CATCH_EXCEPTION(_create_data_sink(
+                _runtime_state->obj_pool(), request.fragment.output_sink,
+                request.fragment.output_exprs, request, root_pipeline->output_row_desc(),
+                _runtime_state.get(), *desc_tbl));
+        RETURN_IF_ERROR(_sink->init(request.fragment.output_sink));
+        root_pipeline->set_sink(_sink);
+    }
+
+    // 4. Initialize global states in pipelines.
+    for (PipelinePtr& pipeline : _pipelines) {
+        pipeline->sink_x()->set_child(pipeline->operator_xs().back());
+        RETURN_IF_ERROR(pipeline->prepare(_runtime_state.get()));
+    }
+
+    // 5. Build pipeline tasks and initialize local state.
+    RETURN_IF_ERROR(_build_pipeline_tasks(request));
+    _runtime_state->runtime_profile()->add_child(_root_op->get_runtime_profile(), true, nullptr);
+    _runtime_state->runtime_profile()->add_child(_sink->get_runtime_profile(), true, nullptr);
+    _runtime_state->runtime_profile()->add_child(_runtime_profile.get(), true, nullptr);
+
+    _prepared = true;
+    return Status::OK();
+}
+
+Status PipelineXFragmentContext::_create_data_sink(ObjectPool* pool, const TDataSink& thrift_sink,
+                                                   const std::vector<TExpr>& output_exprs,
+                                                   const TPipelineFragmentParams& params,
+                                                   const RowDescriptor& row_desc,
+                                                   RuntimeState* state, DescriptorTbl& desc_tbl) {
+    switch (thrift_sink.type) {
+    case TDataSinkType::DATA_STREAM_SINK: {
+        if (!thrift_sink.__isset.stream_sink) {
+            return Status::InternalError("Missing data stream sink.");
+        }
+        bool send_query_statistics_with_every_batch =
+                params.__isset.send_query_statistics_with_every_batch
+                        ? params.send_query_statistics_with_every_batch
+                        : false;
+        _sink.reset(new ExchangeSinkOperatorX(
+                _sink_idx++, state, pool, row_desc, thrift_sink.stream_sink, params.destinations,
+                16 * 1024, send_query_statistics_with_every_batch, this));
+        break;
+    }
+    case TDataSinkType::RESULT_SINK: {
+        if (!thrift_sink.__isset.result_sink) {
+            return Status::InternalError("Missing data buffer sink.");
+        }
+
+        // TODO: figure out good buffer size based on size of output row
+        _sink.reset(new ResultSinkOperatorX(_sink_idx++, row_desc, output_exprs,
+                                            thrift_sink.result_sink, 4096));
+        break;
+    }
+    default:
+        return Status::InternalError("Unsuported sink type in pipeline: {}", thrift_sink.type);
+    }
+    return Status::OK();
+}
+
+Status PipelineXFragmentContext::_build_pipeline_tasks(
+        const doris::TPipelineFragmentParams& request) {
+    _total_tasks = 0;
+    int target_size = request.local_params.size();
+    _runtime_states.resize(target_size);
+    _tasks.resize(target_size);
+    std::vector<TScanRangeParams> no_scan_ranges;
+    for (size_t i = 0; i < target_size; i++) {
+        const auto& local_params = request.local_params[i];
+
+        _runtime_states[i] = RuntimeState::create_unique(local_params, request.query_id,
+                                                         request.fragment_id, request.query_options,
+                                                         _query_ctx->query_globals, _exec_env);
+        _runtime_states[i]->set_query_ctx(_query_ctx.get());
+        _runtime_states[i]->set_query_mem_tracker(_query_ctx->query_mem_tracker);
+        _runtime_states[i]->set_tracer(_runtime_state->get_tracer());
+
+        _runtime_states[i]->runtime_filter_mgr()->init();
+        _runtime_states[i]->set_be_number(local_params.backend_num);
+
+        if (request.__isset.backend_id) {
+            _runtime_states[i]->set_backend_id(request.backend_id);
+        }
+        if (request.__isset.import_label) {
+            _runtime_states[i]->set_import_label(request.import_label);
+        }
+        if (request.__isset.db_name) {
+            _runtime_states[i]->set_db_name(request.db_name);
+        }
+        if (request.__isset.load_job_id) {
+            _runtime_states[i]->set_load_job_id(request.load_job_id);
+        }
+
+        _runtime_states[i]->set_desc_tbl(_query_ctx->desc_tbl);
+
+        for (int pip_id = _pipelines.size() - 1; pip_id >= 0; pip_id--) {
+            auto scan_ranges = find_with_default(local_params.per_node_scan_ranges,
+                                                 _pipelines[pip_id]->operator_xs().front()->id(),
+                                                 no_scan_ranges);
+
+            auto task = std::make_unique<PipelineXTask>(
+                    _pipelines[pip_id], _total_tasks++, _runtime_states[i].get(), this,
+                    _pipelines[pip_id]->pipeline_profile(), scan_ranges);
+            RETURN_IF_ERROR(task->prepare(_runtime_states[i].get()));
+            _runtime_profile->add_child(_pipelines[pip_id]->pipeline_profile(), true, nullptr);
+            if (pip_id < _pipelines.size() - 1) {
+                task->set_upstream_dependency(_tasks[i].back()->get_downstream_dependency());
+            }
+            _tasks[i].emplace_back(std::move(task));
+        }
+    }
+    // register the profile of child data stream sender
+    //    for (auto& sender : _multi_cast_stream_sink_senders) {
+    //        _sink->profile()->add_child(sender->profile(), true, nullptr);
+    //    }
+
+    return Status::OK();
+}
+
+void PipelineXFragmentContext::report_profile() {
+    FOR_EACH_RUNTIME_STATE(
+            SCOPED_ATTACH_TASK(runtime_state.get());
+            VLOG_FILE << "report_profile(): instance_id=" << runtime_state->fragment_instance_id();
+
+            _report_thread_active = true;
+
+            std::unique_lock<std::mutex> l(_report_thread_lock);
+            // tell Open() that we started
+            _report_thread_started_cv.notify_one();
+
+            // Jitter the reporting time of remote fragments by a random amount between
+            // 0 and the report_interval.  This way, the coordinator doesn't get all the
+            // updates at once so its better for contention as well as smoother progress
+            // reporting.
+            int report_fragment_offset = rand() % config::status_report_interval;
+            // We don't want to wait longer than it takes to run the entire fragment.
+            _stop_report_thread_cv.wait_for(l, std::chrono::seconds(report_fragment_offset));
+            while (_report_thread_active) {
+                if (config::status_report_interval > 0) {
+                    // wait_for can return because the timeout occurred or the condition variable
+                    // was signaled.  We can't rely on its return value to distinguish between the
+                    // two cases (e.g. there is a race here where the wait timed out but before grabbing
+                    // the lock, the condition variable was signaled).  Instead, we will use an external
+                    // flag, _report_thread_active, to coordinate this.
+                    _stop_report_thread_cv.wait_for(
+                            l, std::chrono::seconds(config::status_report_interval));
+                } else {
+                    LOG(WARNING) << "config::status_report_interval is equal to or less than zero, "
+                                    "exiting "
+                                    "reporting thread.";
+                    break;
+                }
+
+                if (VLOG_FILE_IS_ON) {
+                    VLOG_FILE << "Reporting " << (!_report_thread_active ? "final " : " ")
+                              << "profile for instance " << runtime_state->fragment_instance_id();
+                    std::stringstream ss;
+                    runtime_state->runtime_profile()->compute_time_in_profile();
+                    runtime_state->runtime_profile()->pretty_print(&ss);
+                    if (runtime_state->load_channel_profile()) {
+                        // runtime_state->load_channel_profile()->compute_time_in_profile(); // TODO load channel profile add timer
+                        runtime_state->load_channel_profile()->pretty_print(&ss);
+                    }
+                    VLOG_FILE << ss.str();
+                }
+
+                if (!_report_thread_active) {
+                    break;
+                }
+
+                send_report(false);
+            }
+
+            VLOG_FILE
+            << "exiting reporting thread: instance_id=" << runtime_state->fragment_instance_id();)
+}
+
+Status PipelineXFragmentContext::_build_pipelines(ObjectPool* pool,
+                                                  const doris::TPipelineFragmentParams& request,
+                                                  const DescriptorTbl& descs, OperatorXPtr* root,
+                                                  PipelinePtr cur_pipe) {
+    if (request.fragment.plan.nodes.size() == 0) {
+        *root = nullptr;
+        return Status::OK();
+    }
+
+    int node_idx = 0;
+    RETURN_IF_ERROR(_create_tree_helper(pool, request.fragment.plan.nodes, request, descs, nullptr,
+                                        &node_idx, root, cur_pipe));
+
+    if (node_idx + 1 != request.fragment.plan.nodes.size()) {
+        // TODO: print thrift msg for diagnostic purposes.
+        return Status::InternalError(
+                "Plan tree only partially reconstructed. Not all thrift nodes were used.");
+    }
+
+    return Status::OK();
+}
+
+Status PipelineXFragmentContext::_create_tree_helper(ObjectPool* pool,
+                                                     const std::vector<TPlanNode>& tnodes,
+                                                     const doris::TPipelineFragmentParams& request,
+                                                     const DescriptorTbl& descs,
+                                                     OperatorXPtr parent, int* node_idx,
+                                                     OperatorXPtr* root, PipelinePtr& cur_pipe) {
+    // propagate error case
+    if (*node_idx >= tnodes.size()) {
+        // TODO: print thrift msg
+        return Status::InternalError("Failed to reconstruct plan tree from thrift.");
+    }
+    const TPlanNode& tnode = tnodes[*node_idx];
+
+    int num_children = tnodes[*node_idx].num_children;
+    OperatorXPtr op = nullptr;
+    RETURN_IF_ERROR(_create_operator(pool, tnodes[*node_idx], request, descs, op, cur_pipe));
+
+    // assert(parent != nullptr || (node_idx == 0 && root_expr != nullptr));
+    if (parent != nullptr) {
+        RETURN_IF_ERROR(parent->set_child(op));
+    } else {
+        *root = op;
+    }
+
+    for (int i = 0; i < num_children; i++) {
+        ++*node_idx;
+        RETURN_IF_ERROR(
+                _create_tree_helper(pool, tnodes, request, descs, op, node_idx, nullptr, cur_pipe));
+
+        // we are expecting a child, but have used all nodes
+        // this means we have been given a bad tree and must fail
+        if (*node_idx >= tnodes.size()) {
+            // TODO: print thrift msg
+            return Status::InternalError("Failed to reconstruct plan tree from thrift.");
+        }
+    }
+
+    RETURN_IF_ERROR(op->init(tnode, _runtime_state.get()));
+
+    if (op->get_child()) {
+        op->get_runtime_profile()->add_child(op->get_child()->get_runtime_profile(), true, nullptr);
+    }
+
+    return Status::OK();
+}
+
+Status PipelineXFragmentContext::_create_operator(ObjectPool* pool, const TPlanNode& tnode,
+                                                  const doris::TPipelineFragmentParams& request,
+                                                  const DescriptorTbl& descs, OperatorXPtr& op,
+                                                  PipelinePtr& cur_pipe) {
+    std::stringstream error_msg;
+
+    switch (tnode.node_type) {
+    case TPlanNodeType::OLAP_SCAN_NODE: {
+        op.reset(new OlapScanOperatorX(pool, tnode, descs, "ScanOperatorX"));
+        RETURN_IF_ERROR(cur_pipe->add_operator(op));
+        break;
+    }
+    case TPlanNodeType::EXCHANGE_NODE: {
+        int num_senders = find_with_default(request.per_exch_num_senders, tnode.node_id, 0);
+        DCHECK_GT(num_senders, 0);
+        op.reset(new ExchangeSourceOperatorX(pool, tnode, descs, "ExchangeSourceXOperator",
+                                             num_senders));
+        RETURN_IF_ERROR(cur_pipe->add_operator(op));
+        break;
+    }
+    case TPlanNodeType::AGGREGATION_NODE: {
+        op.reset(new AggSourceOperatorX(pool, tnode, descs, "AggSourceXOperator"));
+        RETURN_IF_ERROR(cur_pipe->add_operator(op));
+
+        cur_pipe = add_pipeline();
+        DataSinkOperatorXPtr sink;
+        sink.reset(new AggSinkOperatorX(_sink_idx++, pool, tnode, descs));
+        RETURN_IF_ERROR(cur_pipe->set_sink(sink));
+        RETURN_IF_ERROR(cur_pipe->sink_x()->init(tnode, _runtime_state.get()));
+        break;
+    }
+    default:
+        return Status::InternalError("Unsupported exec type in pipelineX: {}",
+                                     print_plan_node_type(tnode.node_type));
+    }
+
+    return Status::OK();
+}
+
+Status PipelineXFragmentContext::submit() {
+    if (_submitted) {
+        return Status::InternalError("submitted");
+    }
+    _submitted = true;
+
+    int submit_tasks = 0;
+    Status st;
+    auto* scheduler = _exec_env->pipeline_task_scheduler();
+    if (_task_group_entity) {
+        scheduler = _exec_env->pipeline_task_group_scheduler();
+    }
+    for (auto& task : _tasks) {
+        for (auto& t : task) {
+            st = scheduler->schedule_task(t.get());
+            if (!st) {
+                std::lock_guard<std::mutex> l(_status_lock);
+                cancel(PPlanFragmentCancelReason::INTERNAL_ERROR, "submit context fail");
+                _total_tasks = submit_tasks;
+                break;
+            }
+            submit_tasks++;
+        }
+    }
+    if (!st.ok()) {
+        std::lock_guard<std::mutex> l(_task_mutex);
+        if (_closed_tasks == _total_tasks) {
+            std::call_once(_close_once_flag, [this] { _close_action(); });
+        }
+        return Status::InternalError("Submit pipeline failed. err = {}, BE: {}", st.to_string(),
+                                     BackendOptions::get_localhost());
+    } else {
+        return st;
+    }
+}
+
+void PipelineXFragmentContext::close_sink() {
+    if (_prepared) {
+        FOR_EACH_RUNTIME_STATE(
+                _sink->close(runtime_state.get(), Status::RuntimeError("prepare failed"));)
+    } else {
+        FOR_EACH_RUNTIME_STATE(_sink->close(runtime_state.get(), Status::OK());)
+    }
+}
+
+void PipelineXFragmentContext::close_if_prepare_failed() {
+    if (_tasks.empty()) {
+        FOR_EACH_RUNTIME_STATE(_root_op->close(runtime_state.get()); _sink->close(
+                runtime_state.get(), Status::RuntimeError("prepare failed"));)
+    }
+    for (auto& task : _tasks) {
+        for (auto& t : task) {
+            DCHECK(!t->is_pending_finish());
+            WARN_IF_ERROR(t->close(), "close_if_prepare_failed failed: ");
+            close_a_pipeline();
+        }
+    }
+}
+
+void PipelineXFragmentContext::_close_action() {
+    _runtime_profile->total_time_counter()->update(_fragment_watcher.elapsed_time());
+    send_report(true);
+    _stop_report_thread();
+    // all submitted tasks done
+    _exec_env->fragment_mgr()->remove_pipeline_context(shared_from_this());
+}
+
+void PipelineXFragmentContext::send_report(bool done) {
+    Status exec_status = Status::OK();
+    {
+        std::lock_guard<std::mutex> l(_status_lock);
+        exec_status = _exec_status;
+    }
+
+    // If plan is done successfully, but _is_report_success is false,
+    // no need to send report.
+    if (!_is_report_success && done && exec_status.ok()) {
+        return;
+    }
+
+    // If both _is_report_success and _is_report_on_cancel are false,
+    // which means no matter query is success or failed, no report is needed.
+    // This may happen when the query limit reached and
+    // a internal cancellation being processed
+    if (!_is_report_success && !_is_report_on_cancel) {
+        return;
+    }
+
+    // TODO: only send rpc once
+    FOR_EACH_RUNTIME_STATE(
+            _report_status_cb(
+                    {exec_status, _is_report_success ? _runtime_state->runtime_profile() : nullptr,
+                     _is_report_success ? runtime_state->load_channel_profile() : nullptr,
+                     done || !exec_status.ok(), _query_ctx->coord_addr, _query_id, _fragment_id,
+                     runtime_state->fragment_instance_id(), _backend_num, runtime_state.get(),
+                     std::bind(&PipelineFragmentContext::update_status, this,
+                               std::placeholders::_1),
+                     std::bind(&PipelineFragmentContext::cancel, this, std::placeholders::_1,
+                               std::placeholders::_2)});)
+}
+
+} // namespace doris::pipeline

--- a/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
@@ -121,7 +121,6 @@ void PipelineXFragmentContext::cancel(const PPlanFragmentCancelReason& reason,
 
         LOG(WARNING) << "PipelineFragmentContext Canceled. reason=" << msg;
 
-
         // Get pipe from new load stream manager and send cancel to it or the fragment may hang to wait read from pipe
         // For stream load the fragment's query_id == load id, it is set in FE.
         auto stream_load_ctx = _exec_env->new_load_stream_mgr()->get(_query_id);
@@ -134,7 +133,7 @@ void PipelineXFragmentContext::cancel(const PPlanFragmentCancelReason& reason,
         _query_ctx->set_ready_to_execute(true);
 
         // must close stream_mgr to avoid dead lock in Exchange Node
-//
+        //
         // Cancel the result queue manager used by spark doris connector
         // TODO pipeline incomp
         // _exec_env->result_queue_mgr()->update_queue_status(id, Status::Aborted(msg));

--- a/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.h
+++ b/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.h
@@ -1,0 +1,132 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <gen_cpp/Types_types.h>
+#include <gen_cpp/types.pb.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <functional>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "common/status.h"
+#include "pipeline/pipeline.h"
+#include "pipeline/pipeline_fragment_context.h"
+#include "pipeline/pipeline_task.h"
+#include "pipeline/pipeline_x/pipeline_x_task.h"
+#include "runtime/query_context.h"
+#include "runtime/runtime_state.h"
+#include "util/runtime_profile.h"
+#include "util/stopwatch.hpp"
+
+namespace doris {
+class ExecNode;
+class DataSink;
+struct ReportStatusRequest;
+class ExecEnv;
+class RuntimeFilterMergeControllerEntity;
+class TDataSink;
+class TPipelineFragmentParams;
+
+namespace pipeline {
+
+class PipelineXFragmentContext : public PipelineFragmentContext {
+public:
+    // Callback to report execution status of plan fragment.
+    // 'profile' is the cumulative profile, 'done' indicates whether the execution
+    // is done or still continuing.
+    // Note: this does not take a const RuntimeProfile&, because it might need to call
+    // functions like PrettyPrint() or to_thrift(), neither of which is const
+    // because they take locks.
+    using report_status_callback = std::function<void(const ReportStatusRequest)>;
+    PipelineXFragmentContext(const TUniqueId& query_id, const int fragment_id,
+                             std::shared_ptr<QueryContext> query_ctx, ExecEnv* exec_env,
+                             const std::function<void(RuntimeState*, Status*)>& call_back,
+                             const report_status_callback& report_status_cb);
+
+    ~PipelineXFragmentContext() override;
+
+    void instance_ids(std::vector<TUniqueId>& ins_ids) const {
+        ins_ids.resize(_runtime_states.size());
+        for (size_t i = 0; i < _runtime_states.size(); i++) {
+            ins_ids[i] = _runtime_states[i]->fragment_instance_id();
+        }
+    }
+
+    //    bool is_canceled() const { return _runtime_state->is_cancelled(); }
+
+    // Prepare global information including global states and the unique operator tree shared by all pipeline tasks.
+    Status prepare(const doris::TPipelineFragmentParams& request) override;
+
+    Status submit() override;
+
+    void close_if_prepare_failed() override;
+    void close_sink() override;
+
+    void cancel(const PPlanFragmentCancelReason& reason = PPlanFragmentCancelReason::INTERNAL_ERROR,
+                const std::string& msg = "") override;
+
+    void send_report(bool);
+
+    void report_profile() override;
+
+private:
+    void _close_action() override;
+    Status _build_pipeline_tasks(const doris::TPipelineFragmentParams& request) override;
+
+    [[nodiscard]] Status _build_pipelines(ObjectPool* pool,
+                                          const doris::TPipelineFragmentParams& request,
+                                          const DescriptorTbl& descs, OperatorXPtr* root,
+                                          PipelinePtr cur_pipe);
+    Status _create_tree_helper(ObjectPool* pool, const std::vector<TPlanNode>& tnodes,
+                               const doris::TPipelineFragmentParams& request,
+                               const DescriptorTbl& descs, OperatorXPtr parent, int* node_idx,
+                               OperatorXPtr* root, PipelinePtr& cur_pipe);
+
+    Status _create_operator(ObjectPool* pool, const TPlanNode& tnode,
+                            const doris::TPipelineFragmentParams& request,
+                            const DescriptorTbl& descs, OperatorXPtr& node, PipelinePtr& cur_pipe);
+
+    Status _create_data_sink(ObjectPool* pool, const TDataSink& thrift_sink,
+                             const std::vector<TExpr>& output_exprs,
+                             const TPipelineFragmentParams& params, const RowDescriptor& row_desc,
+                             RuntimeState* state, DescriptorTbl& desc_tbl);
+    OperatorXPtr _root_op = nullptr;
+    // this is a [n * m] matrix. n is parallelism of pipeline engine and m is the number of pipelines.
+    std::vector<std::vector<std::unique_ptr<PipelineXTask>>> _tasks;
+
+    // Local runtime states for each pipeline task.
+    std::vector<std::unique_ptr<RuntimeState>> _runtime_states;
+
+    // TODO: remove the _sink and _multi_cast_stream_sink_senders to set both
+    // of it in pipeline task not the fragment_context
+    DataSinkOperatorXPtr _sink;
+
+    size_t _sink_idx = 0;
+
+    std::atomic_bool _canceled = false;
+};
+} // namespace pipeline
+} // namespace doris

--- a/be/src/pipeline/pipeline_x/pipeline_x_task.h
+++ b/be/src/pipeline/pipeline_x/pipeline_x_task.h
@@ -1,0 +1,115 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <stdint.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common/status.h"
+#include "pipeline/exec/operator.h"
+#include "pipeline/pipeline.h"
+#include "pipeline/pipeline_task.h"
+#include "runtime/task_group/task_group.h"
+#include "util/runtime_profile.h"
+#include "util/stopwatch.hpp"
+#include "vec/core/block.h"
+
+namespace doris {
+class QueryContext;
+class RuntimeState;
+namespace pipeline {
+class PipelineFragmentContext;
+} // namespace pipeline
+} // namespace doris
+
+namespace doris::pipeline {
+
+class TaskQueue;
+class PriorityTaskQueue;
+
+// The class do the pipeline task. Minest schdule union by task scheduler
+class PipelineXTask : public PipelineTask {
+public:
+    PipelineXTask(PipelinePtr& pipeline, uint32_t index, RuntimeState* state,
+                  PipelineFragmentContext* fragment_context, RuntimeProfile* parent_profile,
+                  const std::vector<TScanRangeParams>& scan_ranges);
+
+    Status prepare(RuntimeState* state) override;
+
+    Status execute(bool* eos) override;
+
+    // Try to close this pipeline task. If there are still some resources need to be released after `try_close`,
+    // this task will enter the `PENDING_FINISH` state.
+    Status try_close() override;
+    // if the pipeline create a bunch of pipeline task
+    // must be call after all pipeline task is finish to release resource
+    Status close() override;
+
+    bool source_can_read() override { return _source->can_read(_state); }
+
+    bool runtime_filters_are_ready_or_timeout() override {
+        return _source->runtime_filters_are_ready_or_timeout();
+    }
+
+    bool sink_can_write() override { return _sink->can_write(_state); }
+
+    Status finalize() override;
+
+    OperatorXPtr get_rootx() { return _root; }
+
+    std::string debug_string() override;
+
+    bool is_pending_finish() override {
+        bool source_ret = _source->is_pending_finish(_state);
+        if (source_ret) {
+            return true;
+        } else {
+            set_src_pending_finish_time();
+        }
+
+        bool sink_ret = _sink->is_pending_finish(_state);
+        if (sink_ret) {
+            return true;
+        } else {
+            set_dst_pending_finish_time();
+        }
+        return false;
+    }
+
+    DependencySPtr& get_downstream_dependency() { return _downstream_dependency; }
+    void set_upstream_dependency(DependencySPtr& upstream_dependency) {
+        _upstream_dependency = upstream_dependency;
+    }
+
+private:
+    Status _open() override;
+
+    const std::vector<TScanRangeParams> _scan_ranges;
+
+    OperatorXs _operators; // left is _source, right is _root
+    OperatorXPtr _source;
+    OperatorXPtr _root;
+    DataSinkOperatorXPtr _sink;
+
+    DependencySPtr _upstream_dependency;
+    DependencySPtr _downstream_dependency;
+};
+} // namespace doris::pipeline

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -56,6 +56,7 @@
 #include "io/fs/stream_load_pipe.h"
 #include "opentelemetry/trace/scope.h"
 #include "pipeline/pipeline_fragment_context.h"
+#include "pipeline/pipeline_x/pipeline_x_fragment_context.h"
 #include "runtime/client_cache.h"
 #include "runtime/descriptors.h"
 #include "runtime/exec_env.h"
@@ -657,6 +658,22 @@ void FragmentMgr::remove_pipeline_context(
     }
 }
 
+void FragmentMgr::remove_pipeline_context(
+        std::shared_ptr<pipeline::PipelineXFragmentContext> f_context) {
+    std::lock_guard<std::mutex> lock(_lock);
+    auto query_id = f_context->get_query_id();
+    auto* q_context = f_context->get_query_context();
+    std::vector<TUniqueId> ins_ids;
+    f_context->instance_ids(ins_ids);
+    bool all_done = q_context->countdown(ins_ids.size());
+    for (const auto& ins_id : ins_ids) {
+        _pipeline_map.erase(ins_id);
+    }
+    if (all_done) {
+        _query_ctx_map.erase(query_id);
+    }
+}
+
 template <typename Params>
 Status FragmentMgr::_get_query_ctx(const Params& params, TUniqueId query_id, bool pipeline,
                                    std::shared_ptr<QueryContext>& query_ctx) {
@@ -864,48 +881,19 @@ Status FragmentMgr::exec_plan_fragment(const TPipelineFragmentParams& params,
 
     std::shared_ptr<QueryContext> query_ctx;
     RETURN_IF_ERROR(_get_query_ctx(params, params.query_id, true, query_ctx));
-    auto pre_and_submit = [&](int i) {
-        const auto& local_params = params.local_params[i];
 
-        const TUniqueId& fragment_instance_id = local_params.fragment_instance_id;
-        {
-            std::lock_guard<std::mutex> lock(_lock);
-            auto iter = _pipeline_map.find(fragment_instance_id);
-            if (iter != _pipeline_map.end()) {
-                // Duplicated
-                return Status::OK();
-            }
-            query_ctx->fragment_ids.push_back(fragment_instance_id);
-        }
-        START_AND_SCOPE_SPAN(tracer, span, "exec_instance");
-        span->SetAttribute("instance_id", print_id(fragment_instance_id));
-
-        std::shared_ptr<FragmentExecState> exec_state(new FragmentExecState(
-                query_ctx->query_id, fragment_instance_id, local_params.backend_num, _exec_env,
-                query_ctx,
-                std::bind<void>(std::mem_fn(&FragmentMgr::coordinator_callback), this,
-                                std::placeholders::_1)));
-        if (params.__isset.need_wait_execution_trigger && params.need_wait_execution_trigger) {
-            // set need_wait_execution_trigger means this instance will not actually being executed
-            // until the execPlanFragmentStart RPC trigger to start it.
-            exec_state->set_need_wait_execution_trigger();
-        }
-
+    const bool enable_pipeline_x = params.query_options.__isset.enable_pipeline_x_engine &&
+                                   params.query_options.enable_pipeline_x_engine;
+    if (enable_pipeline_x) {
         int64_t duration_ns = 0;
-        if (!params.__isset.need_wait_execution_trigger || !params.need_wait_execution_trigger) {
-            query_ctx->set_ready_to_execute_only();
-        }
-        _setup_shared_hashtable_for_broadcast_join(
-                params, local_params, exec_state->executor()->runtime_state(), query_ctx.get());
         std::shared_ptr<pipeline::PipelineFragmentContext> context =
-                std::make_shared<pipeline::PipelineFragmentContext>(
-                        query_ctx->query_id, fragment_instance_id, params.fragment_id,
-                        local_params.backend_num, query_ctx, _exec_env, cb,
+                std::make_shared<pipeline::PipelineXFragmentContext>(
+                        query_ctx->query_id, params.fragment_id, query_ctx, _exec_env, cb,
                         std::bind<void>(std::mem_fn(&FragmentMgr::coordinator_callback), this,
                                         std::placeholders::_1));
         {
             SCOPED_RAW_TIMER(&duration_ns);
-            auto prepare_st = context->prepare(params, i);
+            auto prepare_st = context->prepare(params);
             if (!prepare_st.ok()) {
                 context->close_if_prepare_failed();
                 return prepare_st;
@@ -913,52 +901,158 @@ Status FragmentMgr::exec_plan_fragment(const TPipelineFragmentParams& params,
         }
         g_fragmentmgr_prepare_latency << (duration_ns / 1000);
 
-        std::shared_ptr<RuntimeFilterMergeControllerEntity> handler;
-        _runtimefilter_controller.add_entity(params, local_params, &handler,
-                                             context->get_runtime_state());
-        context->set_merge_controller_handler(handler);
+        //        std::shared_ptr<RuntimeFilterMergeControllerEntity> handler;
+        //        _runtimefilter_controller.add_entity(params, local_params, &handler,
+        //                                             context->get_runtime_state());
+        //        context->set_merge_controller_handler(handler);
 
+        for (size_t i = 0; i < params.local_params.size(); i++) {
+            const TUniqueId& fragment_instance_id = params.local_params[i].fragment_instance_id;
+            {
+                std::lock_guard<std::mutex> lock(_lock);
+                auto iter = _pipeline_map.find(fragment_instance_id);
+                if (iter != _pipeline_map.end()) {
+                    // Duplicated
+                    return Status::OK();
+                }
+                query_ctx->fragment_ids.push_back(fragment_instance_id);
+            }
+            START_AND_SCOPE_SPAN(tracer, span, "exec_instance");
+            span->SetAttribute("instance_id", print_id(fragment_instance_id));
+
+            std::shared_ptr<FragmentExecState> exec_state(new FragmentExecState(
+                    query_ctx->query_id, fragment_instance_id, params.local_params[i].backend_num,
+                    _exec_env, query_ctx,
+                    std::bind<void>(std::mem_fn(&FragmentMgr::coordinator_callback), this,
+                                    std::placeholders::_1)));
+            if (params.__isset.need_wait_execution_trigger && params.need_wait_execution_trigger) {
+                // set need_wait_execution_trigger means this instance will not actually being executed
+                // until the execPlanFragmentStart RPC trigger to start it.
+                exec_state->set_need_wait_execution_trigger();
+            }
+
+            if (!params.__isset.need_wait_execution_trigger ||
+                !params.need_wait_execution_trigger) {
+                query_ctx->set_ready_to_execute_only();
+            }
+            _setup_shared_hashtable_for_broadcast_join(params, params.local_params[i],
+                                                       exec_state->executor()->runtime_state(),
+                                                       query_ctx.get());
+        }
         {
             std::lock_guard<std::mutex> lock(_lock);
-            _pipeline_map.insert(std::make_pair(fragment_instance_id, context));
+            std::vector<TUniqueId> ins_ids;
+            reinterpret_cast<pipeline::PipelineXFragmentContext*>(context.get())
+                    ->instance_ids(ins_ids);
+            // TODO: simplify this mapping
+            for (const auto& ins_id : ins_ids) {
+                _pipeline_map.insert({ins_id, context});
+            }
+
             _cv.notify_all();
         }
 
-        return context->submit();
-    };
-
-    int target_size = params.local_params.size();
-    if (target_size > 1) {
-        int prepare_done = {0};
-        Status prepare_status[target_size];
-        std::mutex m;
-        std::condition_variable cv;
-
-        for (size_t i = 0; i < target_size; i++) {
-            _thread_pool->submit_func([&, i]() {
-                prepare_status[i] = pre_and_submit(i);
-                std::unique_lock<std::mutex> lock(m);
-                prepare_done++;
-                if (prepare_done == target_size) {
-                    cv.notify_one();
-                }
-            });
-        }
-
-        std::unique_lock<std::mutex> lock(m);
-        if (prepare_done != target_size) {
-            cv.wait(lock);
-
-            for (size_t i = 0; i < target_size; i++) {
-                if (!prepare_status[i].ok()) {
-                    return prepare_status[i];
-                }
-            }
-        }
+        RETURN_IF_ERROR(context->submit());
         return Status::OK();
     } else {
-        return pre_and_submit(0);
+        auto pre_and_submit = [&](int i) {
+            const auto& local_params = params.local_params[i];
+
+            const TUniqueId& fragment_instance_id = local_params.fragment_instance_id;
+            {
+                std::lock_guard<std::mutex> lock(_lock);
+                auto iter = _pipeline_map.find(fragment_instance_id);
+                if (iter != _pipeline_map.end()) {
+                    // Duplicated
+                    return Status::OK();
+                }
+                query_ctx->fragment_ids.push_back(fragment_instance_id);
+            }
+            START_AND_SCOPE_SPAN(tracer, span, "exec_instance");
+            span->SetAttribute("instance_id", print_id(fragment_instance_id));
+
+            std::shared_ptr<FragmentExecState> exec_state(new FragmentExecState(
+                    query_ctx->query_id, fragment_instance_id, local_params.backend_num, _exec_env,
+                    query_ctx,
+                    std::bind<void>(std::mem_fn(&FragmentMgr::coordinator_callback), this,
+                                    std::placeholders::_1)));
+            if (params.__isset.need_wait_execution_trigger && params.need_wait_execution_trigger) {
+                // set need_wait_execution_trigger means this instance will not actually being executed
+                // until the execPlanFragmentStart RPC trigger to start it.
+                exec_state->set_need_wait_execution_trigger();
+            }
+
+            int64_t duration_ns = 0;
+            if (!params.__isset.need_wait_execution_trigger ||
+                !params.need_wait_execution_trigger) {
+                query_ctx->set_ready_to_execute_only();
+            }
+            _setup_shared_hashtable_for_broadcast_join(
+                    params, local_params, exec_state->executor()->runtime_state(), query_ctx.get());
+            std::shared_ptr<pipeline::PipelineFragmentContext> context =
+                    std::make_shared<pipeline::PipelineFragmentContext>(
+                            query_ctx->query_id, fragment_instance_id, params.fragment_id,
+                            local_params.backend_num, query_ctx, _exec_env, cb,
+                            std::bind<void>(std::mem_fn(&FragmentMgr::coordinator_callback), this,
+                                            std::placeholders::_1));
+            {
+                SCOPED_RAW_TIMER(&duration_ns);
+                auto prepare_st = context->prepare(params, i);
+                if (!prepare_st.ok()) {
+                    context->close_if_prepare_failed();
+                    return prepare_st;
+                }
+            }
+            g_fragmentmgr_prepare_latency << (duration_ns / 1000);
+
+            std::shared_ptr<RuntimeFilterMergeControllerEntity> handler;
+            _runtimefilter_controller.add_entity(params, local_params, &handler,
+                                                 context->get_runtime_state());
+            context->set_merge_controller_handler(handler);
+
+            {
+                std::lock_guard<std::mutex> lock(_lock);
+                _pipeline_map.insert(std::make_pair(fragment_instance_id, context));
+                _cv.notify_all();
+            }
+
+            return context->submit();
+        };
+
+        int target_size = params.local_params.size();
+        if (target_size > 1) {
+            int prepare_done = {0};
+            Status prepare_status[target_size];
+            std::mutex m;
+            std::condition_variable cv;
+
+            for (size_t i = 0; i < target_size; i++) {
+                _thread_pool->submit_func([&, i]() {
+                    prepare_status[i] = pre_and_submit(i);
+                    std::unique_lock<std::mutex> lock(m);
+                    prepare_done++;
+                    if (prepare_done == target_size) {
+                        cv.notify_one();
+                    }
+                });
+            }
+
+            std::unique_lock<std::mutex> lock(m);
+            if (prepare_done != target_size) {
+                cv.wait(lock);
+
+                for (size_t i = 0; i < target_size; i++) {
+                    if (!prepare_status[i].ok()) {
+                        return prepare_status[i];
+                    }
+                }
+            }
+            return Status::OK();
+        } else {
+            return pre_and_submit(0);
+        }
     }
+    return Status::OK();
 }
 
 template <typename Param>

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -46,7 +46,8 @@ namespace doris {
 
 namespace pipeline {
 class PipelineFragmentContext;
-}
+class PipelineXFragmentContext;
+} // namespace pipeline
 class QueryContext;
 class ExecEnv;
 class FragmentExecState;
@@ -95,6 +96,9 @@ public:
 
     void remove_pipeline_context(
             std::shared_ptr<pipeline::PipelineFragmentContext> pipeline_context);
+
+    void remove_pipeline_context(
+            std::shared_ptr<pipeline::PipelineXFragmentContext> pipeline_context);
 
     // TODO(zc): report this is over
     Status exec_plan_fragment(const TExecPlanFragmentParams& params, const FinishCallback& cb);

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -30,10 +30,12 @@
 #include "common/logging.h"
 #include "common/object_pool.h"
 #include "common/status.h"
+#include "pipeline/exec/operator.h"
 #include "runtime/exec_env.h"
 #include "runtime/load_path_mgr.h"
 #include "runtime/memory/mem_tracker_limiter.h"
 #include "runtime/memory/thread_mem_tracker_mgr.h"
+#include "runtime/query_context.h"
 #include "runtime/runtime_filter_mgr.h"
 #include "runtime/thread_context.h"
 #include "util/timezone_utils.h"
@@ -127,6 +129,34 @@ RuntimeState::RuntimeState(const TPipelineInstanceParams& pipeline_params,
     }
     Status status =
             init(pipeline_params.fragment_instance_id, query_options, query_globals, exec_env);
+    DCHECK(status.ok());
+}
+
+RuntimeState::RuntimeState(const TUniqueId& query_id, int32_t fragment_id,
+                           const TQueryOptions& query_options, const TQueryGlobals& query_globals,
+                           ExecEnv* exec_env)
+        : _profile("PipelineX  " + std::to_string(fragment_id)),
+          _load_channel_profile("<unnamed>"),
+          _obj_pool(new ObjectPool()),
+          _runtime_filter_mgr(new RuntimeFilterMgr(query_id, this)),
+          _data_stream_recvrs_pool(new ObjectPool()),
+          _unreported_error_idx(0),
+          _query_id(query_id),
+          _fragment_id(fragment_id),
+          _is_cancelled(false),
+          _per_fragment_instance_idx(0),
+          _num_rows_load_total(0),
+          _num_rows_load_filtered(0),
+          _num_rows_load_unselected(0),
+          _num_rows_filtered_in_strict_mode_partial_update(0),
+          _num_print_error_rows(0),
+          _num_bytes_load_total(0),
+          _num_finished_scan_range(0),
+          _normal_row_number(0),
+          _error_row_number(0),
+          _error_log_file(nullptr) {
+    // TODO: do we really need instance id?
+    Status status = init(TUniqueId(), query_options, query_globals, exec_env);
     DCHECK(status.ok());
 }
 
@@ -274,6 +304,10 @@ void RuntimeState::get_unreported_errors(std::vector<std::string>* new_errors) {
     }
 }
 
+bool RuntimeState::is_cancelled() const {
+    return _is_cancelled.load() || (_query_ctx && _query_ctx->is_cancelled());
+}
+
 Status RuntimeState::set_mem_limit_exceeded(const std::string& msg) {
     {
         std::lock_guard<std::mutex> l(_process_status_lock);
@@ -379,6 +413,27 @@ int64_t RuntimeState::get_load_mem_limit() {
     } else {
         return _query_mem_tracker->limit();
     }
+}
+
+void RuntimeState::emplace_local_state(
+        int id, std::shared_ptr<doris::pipeline::PipelineXLocalState> state) {
+    _op_id_to_local_state.emplace(id, state);
+}
+
+std::shared_ptr<doris::pipeline::PipelineXLocalState> RuntimeState::get_local_state(int id) {
+    DCHECK(_op_id_to_local_state.find(id) != _op_id_to_local_state.end());
+    return _op_id_to_local_state[id];
+}
+
+void RuntimeState::emplace_sink_local_state(
+        int id, std::shared_ptr<doris::pipeline::PipelineXSinkLocalState> state) {
+    _op_id_to_sink_local_state.emplace(id, state);
+}
+
+std::shared_ptr<doris::pipeline::PipelineXSinkLocalState> RuntimeState::get_sink_local_state(
+        int id) {
+    DCHECK(_op_id_to_sink_local_state.find(id) != _op_id_to_sink_local_state.end());
+    return _op_id_to_sink_local_state[id];
 }
 
 } // end namespace doris

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -305,7 +305,7 @@ void RuntimeState::get_unreported_errors(std::vector<std::string>* new_errors) {
 }
 
 bool RuntimeState::is_cancelled() const {
-    return _is_cancelled.load() || (_query_ctx && _query_ctx->is_cancelled());
+    return _is_cancelled.load();
 }
 
 Status RuntimeState::set_mem_limit_exceeded(const std::string& msg) {

--- a/be/src/vec/common/sort/vsort_exec_exprs.cpp
+++ b/be/src/vec/common/sort/vsort_exec_exprs.cpp
@@ -22,6 +22,7 @@
 #include <stddef.h>
 
 #include "vec/exprs/vexpr.h"
+#include "vec/exprs/vexpr_context.h"
 
 namespace doris {
 class ObjectPool;
@@ -85,5 +86,25 @@ Status VSortExecExprs::open(RuntimeState* state) {
 }
 
 void VSortExecExprs::close(RuntimeState* state) {}
+
+Status VSortExecExprs::clone(RuntimeState* state, VSortExecExprs& new_exprs) {
+    new_exprs._lhs_ordering_expr_ctxs.resize(_lhs_ordering_expr_ctxs.size());
+    new_exprs._rhs_ordering_expr_ctxs.resize(_rhs_ordering_expr_ctxs.size());
+    for (size_t i = 0; i < _lhs_ordering_expr_ctxs.size(); i++) {
+        RETURN_IF_ERROR(
+                _lhs_ordering_expr_ctxs[i]->clone(state, new_exprs._lhs_ordering_expr_ctxs[i]));
+    }
+    for (size_t i = 0; i < _rhs_ordering_expr_ctxs.size(); i++) {
+        RETURN_IF_ERROR(
+                _rhs_ordering_expr_ctxs[i]->clone(state, new_exprs._rhs_ordering_expr_ctxs[i]));
+    }
+    for (size_t i = 0; i < _sort_tuple_slot_expr_ctxs.size(); i++) {
+        RETURN_IF_ERROR(_sort_tuple_slot_expr_ctxs[i]->clone(
+                state, new_exprs._sort_tuple_slot_expr_ctxs[i]));
+    }
+    new_exprs._materialize_tuple = _materialize_tuple;
+    new_exprs._need_convert_to_nullable_flags = _need_convert_to_nullable_flags;
+    return Status::OK();
+}
 
 } // namespace doris::vectorized

--- a/be/src/vec/common/sort/vsort_exec_exprs.h
+++ b/be/src/vec/common/sort/vsort_exec_exprs.h
@@ -69,6 +69,8 @@ public:
         return _need_convert_to_nullable_flags;
     }
 
+    Status clone(RuntimeState* state, VSortExecExprs& new_exprs);
+
 private:
     // Create two VExprContexts for evaluating over the TupleRows.
     VExprContextSPtrs _lhs_ordering_expr_ctxs;

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -47,6 +47,7 @@
 #include "olap/tablet_meta.h"
 #include "olap/tablet_schema.h"
 #include "olap/tablet_schema_cache.h"
+#include "pipeline/exec/olap_scan_operator.h"
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
 #include "service/backend_options.h"
@@ -87,6 +88,33 @@ NewOlapScanner::NewOlapScanner(RuntimeState* state, NewOlapScanNode* parent, int
     _is_init = false;
 }
 
+NewOlapScanner::NewOlapScanner(RuntimeState* state, pipeline::ScanLocalState* local_state,
+                               int64_t limit, bool aggregation, const TPaloScanRange& scan_range,
+                               const std::vector<OlapScanRange*>& key_ranges,
+                               RuntimeProfile* profile)
+        : VScanner(state, local_state, limit, profile),
+          _aggregation(aggregation),
+          _version(-1),
+          _scan_range(scan_range),
+          _key_ranges(key_ranges) {
+    _tablet_schema = std::make_shared<TabletSchema>();
+    _is_init = false;
+}
+
+NewOlapScanner::NewOlapScanner(RuntimeState* state, pipeline::ScanLocalState* local_state,
+                               int64_t limit, bool aggregation, const TPaloScanRange& scan_range,
+                               const std::vector<OlapScanRange*>& key_ranges,
+                               const std::vector<RowSetSplits>& rs_splits, RuntimeProfile* profile)
+        : VScanner(state, local_state, limit, profile),
+          _aggregation(aggregation),
+          _version(-1),
+          _scan_range(scan_range),
+          _key_ranges(key_ranges) {
+    _tablet_reader_params.rs_splits = rs_splits;
+    _tablet_schema = std::make_shared<TabletSchema>();
+    _is_init = false;
+}
+
 static std::string read_columns_to_string(TabletSchemaSPtr tablet_schema,
                                           const std::vector<uint32_t>& read_columns) {
     // avoid too long for one line,
@@ -118,11 +146,19 @@ Status NewOlapScanner::prepare(RuntimeState* state, const VExprContextSPtrs& con
 Status NewOlapScanner::init() {
     _is_init = true;
     auto parent = static_cast<NewOlapScanNode*>(_parent);
-
-    for (auto& ctx : parent->_common_expr_ctxs_push_down) {
-        VExprContextSPtr context;
-        RETURN_IF_ERROR(ctx->clone(_state, context));
-        _common_expr_ctxs_push_down.emplace_back(context);
+    auto local_state = static_cast<pipeline::OlapScanLocalState*>(_local_state);
+    if (_parent) {
+        for (auto& ctx : parent->_common_expr_ctxs_push_down) {
+            VExprContextSPtr context;
+            RETURN_IF_ERROR(ctx->clone(_state, context));
+            _common_expr_ctxs_push_down.emplace_back(context);
+        }
+    } else {
+        for (auto& ctx : local_state->_common_expr_ctxs_push_down) {
+            VExprContextSPtr context;
+            RETURN_IF_ERROR(ctx->clone(_state, context));
+            _common_expr_ctxs_push_down.emplace_back(context);
+        }
     }
 
     // set limit to reduce end of rowset and segment mem use
@@ -143,7 +179,8 @@ Status NewOlapScanner::init() {
                 StorageEngine::instance()->tablet_manager()->get_tablet_and_status(tablet_id, true);
         RETURN_IF_ERROR(status);
         _tablet = std::move(tablet);
-        TOlapScanNode& olap_scan_node = ((NewOlapScanNode*)_parent)->_olap_scan_node;
+        TOlapScanNode& olap_scan_node =
+                _parent ? parent->_olap_scan_node : local_state->olap_scan_node();
         if (olap_scan_node.__isset.schema_version && olap_scan_node.__isset.columns_desc &&
             !olap_scan_node.columns_desc.empty() &&
             olap_scan_node.columns_desc[0].col_unique_id >= 0) {
@@ -203,9 +240,10 @@ Status NewOlapScanner::init() {
             }
 
             // Initialize tablet_reader_params
-            RETURN_IF_ERROR(_init_tablet_reader_params(_key_ranges, parent->_olap_filters,
-                                                       parent->_filter_predicates,
-                                                       parent->_push_down_functions));
+            RETURN_IF_ERROR(_init_tablet_reader_params(
+                    _key_ranges, parent ? parent->_olap_filters : local_state->_olap_filters,
+                    parent ? parent->_filter_predicates : local_state->_filter_predicates,
+                    parent ? parent->_push_down_functions : local_state->_push_down_functions));
         }
     }
 
@@ -253,8 +291,10 @@ Status NewOlapScanner::_init_tablet_reader_params(
         _tablet_reader_params.direct_mode = true;
         _aggregation = true;
     } else {
-        _tablet_reader_params.direct_mode = _aggregation || single_version ||
-                                            (_parent->get_push_down_agg_type() != TPushAggOp::NONE);
+        _tablet_reader_params.direct_mode =
+                _aggregation || single_version ||
+                (_parent ? _parent->get_push_down_agg_type()
+                         : _local_state->get_push_down_agg_type()) != TPushAggOp::NONE;
     }
 
     RETURN_IF_ERROR(_init_return_columns());
@@ -263,7 +303,8 @@ Status NewOlapScanner::_init_tablet_reader_params(
     _tablet_reader_params.tablet_schema = _tablet_schema;
     _tablet_reader_params.reader_type = ReaderType::READER_QUERY;
     _tablet_reader_params.aggregation = _aggregation;
-    _tablet_reader_params.push_down_agg_type_opt = _parent->get_push_down_agg_type();
+    _tablet_reader_params.push_down_agg_type_opt =
+            _parent ? _parent->get_push_down_agg_type() : _local_state->get_push_down_agg_type();
     _tablet_reader_params.version = Version(0, _version);
 
     // TODO: If a new runtime filter arrives after `_conjuncts` move to `_common_expr_ctxs_push_down`,
@@ -278,7 +319,9 @@ Status NewOlapScanner::_init_tablet_reader_params(
     }
 
     _tablet_reader_params.common_expr_ctxs_push_down = _common_expr_ctxs_push_down;
-    _tablet_reader_params.output_columns = ((NewOlapScanNode*)_parent)->_maybe_read_column_ids;
+    _tablet_reader_params.output_columns =
+            _parent ? ((NewOlapScanNode*)_parent)->_maybe_read_column_ids
+                    : ((pipeline::OlapScanLocalState*)_local_state)->_maybe_read_column_ids;
 
     // Condition
     for (auto& filter : filters) {
@@ -330,7 +373,7 @@ Status NewOlapScanner::_init_tablet_reader_params(
         _tablet_reader_params.end_key.push_back(key_range->end_scan_range);
     }
 
-    _tablet_reader_params.profile = _parent->runtime_profile();
+    _tablet_reader_params.profile = _parent ? _parent->runtime_profile() : _local_state->profile();
     _tablet_reader_params.runtime_state = _state;
 
     _tablet_reader_params.origin_return_columns = &_return_columns;
@@ -377,11 +420,14 @@ Status NewOlapScanner::_init_tablet_reader_params(
     }
 
     if (!_state->skip_storage_engine_merge()) {
-        TOlapScanNode& olap_scan_node = ((NewOlapScanNode*)_parent)->_olap_scan_node;
+        TOlapScanNode& olap_scan_node =
+                _parent ? ((NewOlapScanNode*)_parent)->_olap_scan_node
+                        : ((pipeline::OlapScanLocalState*)_local_state)->olap_scan_node();
         // order by table keys optimization for topn
         // will only read head/tail of data file since it's already sorted by keys
         if (olap_scan_node.__isset.sort_info && olap_scan_node.sort_info.is_asc_order.size() > 0) {
-            _limit = _parent->_limit_per_scanner;
+            _limit = _parent ? ((NewOlapScanNode*)_parent)->_limit_per_scanner
+                             : _local_state->limit_per_scanner();
             _tablet_reader_params.read_orderby_key = true;
             if (!olap_scan_node.sort_info.is_asc_order[0]) {
                 _tablet_reader_params.read_orderby_key_reverse = true;
@@ -393,8 +439,7 @@ Status NewOlapScanner::_init_tablet_reader_params(
         }
 
         // runtime predicate push down optimization for topn
-        _tablet_reader_params.use_topn_opt =
-                ((NewOlapScanNode*)_parent)->_olap_scan_node.use_topn_opt;
+        _tablet_reader_params.use_topn_opt = olap_scan_node.use_topn_opt;
     }
 
     // If this is a Two-Phase read query, and we need to delay the release of Rowset
@@ -493,13 +538,18 @@ Status NewOlapScanner::close(RuntimeState* state) {
 }
 
 void NewOlapScanner::_update_realtime_counters() {
-    NewOlapScanNode* olap_parent = (NewOlapScanNode*)_parent;
+    NewOlapScanNode* olap_parent = static_cast<NewOlapScanNode*>(_parent);
+    pipeline::OlapScanLocalState* local_state =
+            static_cast<pipeline::OlapScanLocalState*>(_local_state);
     auto& stats = _tablet_reader->stats();
-    COUNTER_UPDATE(olap_parent->_read_compressed_counter, stats.compressed_bytes_read);
+    COUNTER_UPDATE(olap_parent ? olap_parent->_read_compressed_counter
+                               : local_state->_read_compressed_counter,
+                   stats.compressed_bytes_read);
     _compressed_bytes_read += stats.compressed_bytes_read;
     _tablet_reader->mutable_stats()->compressed_bytes_read = 0;
 
-    COUNTER_UPDATE(olap_parent->_raw_rows_counter, stats.raw_rows_read);
+    COUNTER_UPDATE(olap_parent ? olap_parent->_raw_rows_counter : local_state->_raw_rows_counter,
+                   stats.raw_rows_read);
     // if raw_rows_read is reset, scanNode will scan all table rows which may cause BE crash
     _raw_rows_read += stats.raw_rows_read;
     _tablet_reader->mutable_stats()->raw_rows_read = 0;
@@ -513,95 +563,93 @@ void NewOlapScanner::_update_counters_before_close() {
 
     VScanner::_update_counters_before_close();
 
-    // Update counters for NewOlapScanner
-    NewOlapScanNode* olap_parent = (NewOlapScanNode*)_parent;
+#ifndef INCR_COUNTER
+#define INCR_COUNTER(Parent)                                                                      \
+    COUNTER_UPDATE(Parent->_io_timer, stats.io_ns);                                               \
+    COUNTER_UPDATE(Parent->_read_compressed_counter, stats.compressed_bytes_read);                \
+    _compressed_bytes_read += stats.compressed_bytes_read;                                        \
+    COUNTER_UPDATE(Parent->_decompressor_timer, stats.decompress_ns);                             \
+    COUNTER_UPDATE(Parent->_read_uncompressed_counter, stats.uncompressed_bytes_read);            \
+    COUNTER_UPDATE(Parent->_block_load_timer, stats.block_load_ns);                               \
+    COUNTER_UPDATE(Parent->_block_load_counter, stats.blocks_load);                               \
+    COUNTER_UPDATE(Parent->_block_fetch_timer, stats.block_fetch_ns);                             \
+    COUNTER_UPDATE(Parent->_block_convert_timer, stats.block_convert_ns);                         \
+    COUNTER_UPDATE(Parent->_raw_rows_counter, stats.raw_rows_read);                               \
+    _raw_rows_read += _tablet_reader->mutable_stats()->raw_rows_read;                             \
+    COUNTER_UPDATE(Parent->_vec_cond_timer, stats.vec_cond_ns);                                   \
+    COUNTER_UPDATE(Parent->_short_cond_timer, stats.short_cond_ns);                               \
+    COUNTER_UPDATE(Parent->_expr_filter_timer, stats.expr_filter_ns);                             \
+    COUNTER_UPDATE(Parent->_block_init_timer, stats.block_init_ns);                               \
+    COUNTER_UPDATE(Parent->_block_init_seek_timer, stats.block_init_seek_ns);                     \
+    COUNTER_UPDATE(Parent->_block_init_seek_counter, stats.block_init_seek_num);                  \
+    COUNTER_UPDATE(Parent->_block_conditions_filtered_timer, stats.block_conditions_filtered_ns); \
+    COUNTER_UPDATE(Parent->_first_read_timer, stats.first_read_ns);                               \
+    COUNTER_UPDATE(Parent->_second_read_timer, stats.second_read_ns);                             \
+    COUNTER_UPDATE(Parent->_first_read_seek_timer, stats.block_first_read_seek_ns);               \
+    COUNTER_UPDATE(Parent->_first_read_seek_counter, stats.block_first_read_seek_num);            \
+    COUNTER_UPDATE(Parent->_lazy_read_timer, stats.lazy_read_ns);                                 \
+    COUNTER_UPDATE(Parent->_lazy_read_seek_timer, stats.block_lazy_read_seek_ns);                 \
+    COUNTER_UPDATE(Parent->_lazy_read_seek_counter, stats.block_lazy_read_seek_num);              \
+    COUNTER_UPDATE(Parent->_output_col_timer, stats.output_col_ns);                               \
+    COUNTER_UPDATE(Parent->_rows_vec_cond_filtered_counter, stats.rows_vec_cond_filtered);        \
+    COUNTER_UPDATE(Parent->_rows_short_circuit_cond_filtered_counter,                             \
+                   stats.rows_short_circuit_cond_filtered);                                       \
+    COUNTER_UPDATE(Parent->_rows_vec_cond_input_counter, stats.vec_cond_input_rows);              \
+    COUNTER_UPDATE(Parent->_rows_short_circuit_cond_input_counter,                                \
+                   stats.short_circuit_cond_input_rows);                                          \
+    for (auto& [id, info] : stats.filter_info) {                                                  \
+        Parent->add_filter_info(id, info);                                                        \
+    }                                                                                             \
+    COUNTER_UPDATE(Parent->_stats_filtered_counter, stats.rows_stats_filtered);                   \
+    COUNTER_UPDATE(Parent->_dict_filtered_counter, stats.rows_dict_filtered);                     \
+    COUNTER_UPDATE(Parent->_bf_filtered_counter, stats.rows_bf_filtered);                         \
+    COUNTER_UPDATE(Parent->_del_filtered_counter, stats.rows_del_filtered);                       \
+    COUNTER_UPDATE(Parent->_del_filtered_counter, stats.rows_del_by_bitmap);                      \
+    COUNTER_UPDATE(Parent->_del_filtered_counter, stats.rows_vec_del_cond_filtered);              \
+    COUNTER_UPDATE(Parent->_conditions_filtered_counter, stats.rows_conditions_filtered);         \
+    COUNTER_UPDATE(Parent->_key_range_filtered_counter, stats.rows_key_range_filtered);           \
+    COUNTER_UPDATE(Parent->_total_pages_num_counter, stats.total_pages_num);                      \
+    COUNTER_UPDATE(Parent->_cached_pages_num_counter, stats.cached_pages_num);                    \
+    COUNTER_UPDATE(Parent->_bitmap_index_filter_counter, stats.rows_bitmap_index_filtered);       \
+    COUNTER_UPDATE(Parent->_bitmap_index_filter_timer, stats.bitmap_index_filter_timer);          \
+    COUNTER_UPDATE(Parent->_inverted_index_filter_counter, stats.rows_inverted_index_filtered);   \
+    COUNTER_UPDATE(Parent->_inverted_index_filter_timer, stats.inverted_index_filter_timer);      \
+    COUNTER_UPDATE(Parent->_inverted_index_query_cache_hit_counter,                               \
+                   stats.inverted_index_query_cache_hit);                                         \
+    COUNTER_UPDATE(Parent->_inverted_index_query_cache_miss_counter,                              \
+                   stats.inverted_index_query_cache_miss);                                        \
+    COUNTER_UPDATE(Parent->_inverted_index_query_timer, stats.inverted_index_query_timer);        \
+    COUNTER_UPDATE(Parent->_inverted_index_query_bitmap_copy_timer,                               \
+                   stats.inverted_index_query_bitmap_copy_timer);                                 \
+    COUNTER_UPDATE(Parent->_inverted_index_query_bitmap_op_timer,                                 \
+                   stats.inverted_index_query_bitmap_op_timer);                                   \
+    COUNTER_UPDATE(Parent->_inverted_index_searcher_open_timer,                                   \
+                   stats.inverted_index_searcher_open_timer);                                     \
+    COUNTER_UPDATE(Parent->_inverted_index_searcher_search_timer,                                 \
+                   stats.inverted_index_searcher_search_timer);                                   \
+    if (config::enable_file_cache) {                                                              \
+        io::FileCacheProfileReporter cache_profile(Parent->_segment_profile.get());               \
+        cache_profile.update(&stats.file_cache_stats);                                            \
+    }                                                                                             \
+    COUNTER_UPDATE(Parent->_output_index_result_column_timer,                                     \
+                   stats.output_index_result_column_timer);                                       \
+    COUNTER_UPDATE(Parent->_filtered_segment_counter, stats.filtered_segment_number);             \
+    COUNTER_UPDATE(Parent->_total_segment_counter, stats.total_segment_number);
 
+    // Update counters for NewOlapScanner
     // Update counters from tablet reader's stats
     auto& stats = _tablet_reader->stats();
-    COUNTER_UPDATE(olap_parent->_io_timer, stats.io_ns);
-    COUNTER_UPDATE(olap_parent->_read_compressed_counter, stats.compressed_bytes_read);
-    _compressed_bytes_read += stats.compressed_bytes_read;
-    COUNTER_UPDATE(olap_parent->_decompressor_timer, stats.decompress_ns);
-    COUNTER_UPDATE(olap_parent->_read_uncompressed_counter, stats.uncompressed_bytes_read);
 
-    COUNTER_UPDATE(olap_parent->_block_load_timer, stats.block_load_ns);
-    COUNTER_UPDATE(olap_parent->_block_load_counter, stats.blocks_load);
-    COUNTER_UPDATE(olap_parent->_block_fetch_timer, stats.block_fetch_ns);
-    COUNTER_UPDATE(olap_parent->_block_convert_timer, stats.block_convert_ns);
-
-    COUNTER_UPDATE(olap_parent->_raw_rows_counter, stats.raw_rows_read);
-    // if raw_rows_read is reset, scanNode will scan all table rows which may cause BE crash
-    _raw_rows_read += _tablet_reader->mutable_stats()->raw_rows_read;
-    COUNTER_UPDATE(olap_parent->_vec_cond_timer, stats.vec_cond_ns);
-    COUNTER_UPDATE(olap_parent->_short_cond_timer, stats.short_cond_ns);
-    COUNTER_UPDATE(olap_parent->_expr_filter_timer, stats.expr_filter_ns);
-    COUNTER_UPDATE(olap_parent->_block_init_timer, stats.block_init_ns);
-    COUNTER_UPDATE(olap_parent->_block_init_seek_timer, stats.block_init_seek_ns);
-    COUNTER_UPDATE(olap_parent->_block_init_seek_counter, stats.block_init_seek_num);
-    COUNTER_UPDATE(olap_parent->_block_conditions_filtered_timer,
-                   stats.block_conditions_filtered_ns);
-    COUNTER_UPDATE(olap_parent->_first_read_timer, stats.first_read_ns);
-    COUNTER_UPDATE(olap_parent->_second_read_timer, stats.second_read_ns);
-    COUNTER_UPDATE(olap_parent->_first_read_seek_timer, stats.block_first_read_seek_ns);
-    COUNTER_UPDATE(olap_parent->_first_read_seek_counter, stats.block_first_read_seek_num);
-    COUNTER_UPDATE(olap_parent->_lazy_read_timer, stats.lazy_read_ns);
-    COUNTER_UPDATE(olap_parent->_lazy_read_seek_timer, stats.block_lazy_read_seek_ns);
-    COUNTER_UPDATE(olap_parent->_lazy_read_seek_counter, stats.block_lazy_read_seek_num);
-    COUNTER_UPDATE(olap_parent->_output_col_timer, stats.output_col_ns);
-    COUNTER_UPDATE(olap_parent->_rows_vec_cond_filtered_counter, stats.rows_vec_cond_filtered);
-    COUNTER_UPDATE(olap_parent->_rows_short_circuit_cond_filtered_counter,
-                   stats.rows_short_circuit_cond_filtered);
-    COUNTER_UPDATE(olap_parent->_rows_vec_cond_input_counter, stats.vec_cond_input_rows);
-    COUNTER_UPDATE(olap_parent->_rows_short_circuit_cond_input_counter,
-                   stats.short_circuit_cond_input_rows);
-
-    for (auto& [id, info] : stats.filter_info) {
-        olap_parent->add_filter_info(id, info);
+    if (_parent) {
+        NewOlapScanNode* olap_parent = (NewOlapScanNode*)_parent;
+        INCR_COUNTER(olap_parent);
+    } else {
+        pipeline::OlapScanLocalState* local_state = (pipeline::OlapScanLocalState*)_local_state;
+        INCR_COUNTER(local_state);
     }
 
-    COUNTER_UPDATE(olap_parent->_stats_filtered_counter, stats.rows_stats_filtered);
-    COUNTER_UPDATE(olap_parent->_dict_filtered_counter, stats.rows_dict_filtered);
-    COUNTER_UPDATE(olap_parent->_bf_filtered_counter, stats.rows_bf_filtered);
-    COUNTER_UPDATE(olap_parent->_del_filtered_counter, stats.rows_del_filtered);
-    COUNTER_UPDATE(olap_parent->_del_filtered_counter, stats.rows_del_by_bitmap);
-    COUNTER_UPDATE(olap_parent->_del_filtered_counter, stats.rows_vec_del_cond_filtered);
-
-    COUNTER_UPDATE(olap_parent->_conditions_filtered_counter, stats.rows_conditions_filtered);
-    COUNTER_UPDATE(olap_parent->_key_range_filtered_counter, stats.rows_key_range_filtered);
-
-    COUNTER_UPDATE(olap_parent->_total_pages_num_counter, stats.total_pages_num);
-    COUNTER_UPDATE(olap_parent->_cached_pages_num_counter, stats.cached_pages_num);
-
-    COUNTER_UPDATE(olap_parent->_bitmap_index_filter_counter, stats.rows_bitmap_index_filtered);
-    COUNTER_UPDATE(olap_parent->_bitmap_index_filter_timer, stats.bitmap_index_filter_timer);
-
-    COUNTER_UPDATE(olap_parent->_inverted_index_filter_counter, stats.rows_inverted_index_filtered);
-    COUNTER_UPDATE(olap_parent->_inverted_index_filter_timer, stats.inverted_index_filter_timer);
-    COUNTER_UPDATE(olap_parent->_inverted_index_query_cache_hit_counter,
-                   stats.inverted_index_query_cache_hit);
-    COUNTER_UPDATE(olap_parent->_inverted_index_query_cache_miss_counter,
-                   stats.inverted_index_query_cache_miss);
-    COUNTER_UPDATE(olap_parent->_inverted_index_query_timer, stats.inverted_index_query_timer);
-    COUNTER_UPDATE(olap_parent->_inverted_index_query_bitmap_copy_timer,
-                   stats.inverted_index_query_bitmap_copy_timer);
-    COUNTER_UPDATE(olap_parent->_inverted_index_query_bitmap_op_timer,
-                   stats.inverted_index_query_bitmap_op_timer);
-    COUNTER_UPDATE(olap_parent->_inverted_index_searcher_open_timer,
-                   stats.inverted_index_searcher_open_timer);
-    COUNTER_UPDATE(olap_parent->_inverted_index_searcher_search_timer,
-                   stats.inverted_index_searcher_search_timer);
-
-    if (config::enable_file_cache) {
-        io::FileCacheProfileReporter cache_profile(olap_parent->_segment_profile.get());
-        cache_profile.update(&stats.file_cache_stats);
-    }
-
-    COUNTER_UPDATE(olap_parent->_output_index_result_column_timer,
-                   stats.output_index_result_column_timer);
-
-    COUNTER_UPDATE(olap_parent->_filtered_segment_counter, stats.filtered_segment_number);
-    COUNTER_UPDATE(olap_parent->_total_segment_counter, stats.total_segment_number);
-
+#undef INCR_COUNTER
+#endif
     // Update metrics
     DorisMetrics::instance()->query_scan_bytes->increment(_compressed_bytes_read);
     DorisMetrics::instance()->query_scan_rows->increment(_raw_rows_read);

--- a/be/src/vec/exec/scan/new_olap_scanner.h
+++ b/be/src/vec/exec/scan/new_olap_scanner.h
@@ -61,6 +61,15 @@ public:
                    const TPaloScanRange& scan_range, const std::vector<OlapScanRange*>& key_ranges,
                    const std::vector<RowSetSplits>& rs_splits, RuntimeProfile* profile);
 
+    NewOlapScanner(RuntimeState* state, pipeline::ScanLocalState* parent, int64_t limit,
+                   bool aggregation, const TPaloScanRange& scan_range,
+                   const std::vector<OlapScanRange*>& key_ranges, RuntimeProfile* profile);
+
+    NewOlapScanner(RuntimeState* state, pipeline::ScanLocalState* parent, int64_t limit,
+                   bool aggregation, const TPaloScanRange& scan_range,
+                   const std::vector<OlapScanRange*>& key_ranges,
+                   const std::vector<RowSetSplits>& rs_splits, RuntimeProfile* profile);
+
     Status init() override;
 
     Status open(RuntimeState* state) override;

--- a/be/src/vec/exec/scan/pip_scanner_context.h
+++ b/be/src/vec/exec/scan/pip_scanner_context.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "pipeline/exec/scan_operator.h"
 #include "runtime/descriptors.h"
 #include "scanner_context.h"
 
@@ -35,6 +36,17 @@ public:
                       const int num_parallel_instances)
             : vectorized::ScannerContext(state, parent, output_tuple_desc, scanners, limit,
                                          max_bytes_in_blocks_queue, num_parallel_instances),
+              _col_distribute_ids(col_distribute_ids),
+              _need_colocate_distribute(!_col_distribute_ids.empty()) {}
+
+    PipScannerContext(RuntimeState* state, ScanLocalState* local_state,
+                      const TupleDescriptor* output_tuple_desc,
+                      const std::list<vectorized::VScannerSPtr>& scanners, int64_t limit,
+                      int64_t max_bytes_in_blocks_queue, const std::vector<int>& col_distribute_ids,
+                      const int num_parallel_instances)
+            : vectorized::ScannerContext(state, nullptr, output_tuple_desc, scanners, limit,
+                                         max_bytes_in_blocks_queue, num_parallel_instances,
+                                         local_state),
               _col_distribute_ids(col_distribute_ids),
               _need_colocate_distribute(!_col_distribute_ids.empty()) {}
 

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -29,6 +29,7 @@
 
 #include "common/config.h"
 #include "common/status.h"
+#include "pipeline/exec/scan_operator.h"
 #include "runtime/descriptors.h"
 #include "runtime/exec_env.h"
 #include "runtime/query_context.h"
@@ -45,9 +46,11 @@ namespace doris::vectorized {
 ScannerContext::ScannerContext(doris::RuntimeState* state_, doris::vectorized::VScanNode* parent,
                                const doris::TupleDescriptor* output_tuple_desc,
                                const std::list<VScannerSPtr>& scanners_, int64_t limit_,
-                               int64_t max_bytes_in_blocks_queue_, const int num_parallel_instances)
+                               int64_t max_bytes_in_blocks_queue_, const int num_parallel_instances,
+                               pipeline::ScanLocalState* local_state)
         : _state(state_),
           _parent(parent),
+          _local_state(local_state),
           _output_tuple_desc(output_tuple_desc),
           _process_status(Status::OK()),
           _batch_size(state_->batch_size()),
@@ -71,7 +74,7 @@ Status ScannerContext::init() {
     // TODO: now the max thread num <= config::doris_scanner_thread_pool_thread_num / 4
     // should find a more reasonable value.
     _max_thread_num = config::doris_scanner_thread_pool_thread_num / 4;
-    if (_parent->_shared_scan_opt) {
+    if (_parent && _parent->_shared_scan_opt) {
         DCHECK(_num_parallel_instances > 0);
         _max_thread_num *= _num_parallel_instances;
     }
@@ -79,18 +82,31 @@ Status ScannerContext::init() {
     DCHECK(_max_thread_num > 0);
     _max_thread_num = std::min(_max_thread_num, (int32_t)_scanners.size());
     // For select * from table limit 10; should just use one thread.
-    if (_parent->should_run_serial()) {
+    if ((_parent && _parent->should_run_serial()) ||
+        (_local_state && _local_state->should_run_serial())) {
         _max_thread_num = 1;
     }
 
-    _scanner_profile = _parent->_scanner_profile;
-    _scanner_sched_counter = _parent->_scanner_sched_counter;
-    _scanner_ctx_sched_counter = _parent->_scanner_ctx_sched_counter;
-    _scanner_ctx_sched_time = _parent->_scanner_ctx_sched_time;
-    _free_blocks_memory_usage = _parent->_free_blocks_memory_usage;
-    _newly_create_free_blocks_num = _parent->_newly_create_free_blocks_num;
-    _queued_blocks_memory_usage = _parent->_queued_blocks_memory_usage;
-    _scanner_wait_batch_timer = _parent->_scanner_wait_batch_timer;
+    if (_parent) {
+        _scanner_profile = _parent->_scanner_profile;
+        _scanner_sched_counter = _parent->_scanner_sched_counter;
+        _scanner_ctx_sched_counter = _parent->_scanner_ctx_sched_counter;
+        _scanner_ctx_sched_time = _parent->_scanner_ctx_sched_time;
+        _free_blocks_memory_usage = _parent->_free_blocks_memory_usage;
+        _newly_create_free_blocks_num = _parent->_newly_create_free_blocks_num;
+        _queued_blocks_memory_usage = _parent->_queued_blocks_memory_usage;
+        _scanner_wait_batch_timer = _parent->_scanner_wait_batch_timer;
+    } else {
+        _scanner_profile = _local_state->_scanner_profile;
+        _scanner_sched_counter = _local_state->_scanner_sched_counter;
+        _scanner_ctx_sched_counter = _local_state->_scanner_ctx_sched_counter;
+        _scanner_ctx_sched_time = _local_state->_scanner_ctx_sched_time;
+        _free_blocks_memory_usage = _local_state->_free_blocks_memory_usage;
+        _newly_create_free_blocks_num = _local_state->_newly_create_free_blocks_num;
+        _queued_blocks_memory_usage = _local_state->_queued_blocks_memory_usage;
+        _scanner_wait_batch_timer = _local_state->_scanner_wait_batch_timer;
+    }
+
     // 2. Calculate the number of free blocks that all scanners can use.
     // The calculation logic is as follows:
     //  1. Assuming that at most M rows can be scanned in one scan(config::doris_scanner_row_num),
@@ -116,9 +132,15 @@ Status ScannerContext::init() {
 
     _num_unfinished_scanners = _scanners.size();
 
-    COUNTER_SET(_parent->_max_scanner_thread_num, (int64_t)_max_thread_num);
-    _parent->_runtime_profile->add_info_string("UseSpecificThreadToken",
-                                               thread_token == nullptr ? "False" : "True");
+    if (_parent) {
+        COUNTER_SET(_parent->_max_scanner_thread_num, (int64_t)_max_thread_num);
+        _parent->_runtime_profile->add_info_string("UseSpecificThreadToken",
+                                                   thread_token == nullptr ? "False" : "True");
+    } else {
+        COUNTER_SET(_local_state->_max_scanner_thread_num, (int64_t)_max_thread_num);
+        _local_state->_runtime_profile->add_info_string("UseSpecificThreadToken",
+                                                        thread_token == nullptr ? "False" : "True");
+    }
 
     return Status::OK();
 }
@@ -225,7 +247,8 @@ bool ScannerContext::set_status_on_error(const Status& status, bool need_lock) {
     return false;
 }
 
-Status ScannerContext::_close_and_clear_scanners(VScanNode* node, RuntimeState* state) {
+template <typename Parent>
+Status ScannerContext::_close_and_clear_scanners(Parent* parent, RuntimeState* state) {
     std::unique_lock l(_scanners_lock);
     if (state->enable_profile()) {
         std::stringstream scanner_statistics;
@@ -262,10 +285,11 @@ Status ScannerContext::_close_and_clear_scanners(VScanNode* node, RuntimeState* 
         scanner_statistics << "]";
         scanner_rows_read << "]";
         scanner_wait_worker_time << "]";
-        node->_scanner_profile->add_info_string("PerScannerRunningTime", scanner_statistics.str());
-        node->_scanner_profile->add_info_string("PerScannerRowsRead", scanner_rows_read.str());
-        node->_scanner_profile->add_info_string("PerScannerWaitTime",
-                                                scanner_wait_worker_time.str());
+        parent->scanner_profile()->add_info_string("PerScannerRunningTime",
+                                                   scanner_statistics.str());
+        parent->scanner_profile()->add_info_string("PerScannerRowsRead", scanner_rows_read.str());
+        parent->scanner_profile()->add_info_string("PerScannerWaitTime",
+                                                   scanner_wait_worker_time.str());
     }
     // Only unfinished scanners here
     for (auto& scanner : _scanners) {
@@ -277,7 +301,8 @@ Status ScannerContext::_close_and_clear_scanners(VScanNode* node, RuntimeState* 
     return Status::OK();
 }
 
-void ScannerContext::clear_and_join(VScanNode* node, RuntimeState* state) {
+template <typename Parent>
+void ScannerContext::clear_and_join(Parent* parent, RuntimeState* state) {
     std::unique_lock l(_transfer_lock);
     do {
         if (_num_running_scanners == 0 && _num_scheduling_ctx == 0) {
@@ -296,7 +321,7 @@ void ScannerContext::clear_and_join(VScanNode* node, RuntimeState* state) {
     }
     // Must wait all running scanners stop running.
     // So that we can make sure to close all scanners.
-    _close_and_clear_scanners(node, state);
+    _close_and_clear_scanners(parent, state);
 
     _blocks_queue.clear();
 }
@@ -393,5 +418,8 @@ void ScannerContext::get_next_batch_of_scanners(std::list<VScannerSPtr>* current
 taskgroup::TaskGroup* ScannerContext::get_task_group() const {
     return _state->get_query_ctx()->get_task_group();
 }
+
+template void ScannerContext::clear_and_join(pipeline::ScanLocalState* parent, RuntimeState* state);
+template void ScannerContext::clear_and_join(VScanNode* parent, RuntimeState* state);
 
 } // namespace doris::vectorized

--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -41,6 +41,10 @@ class ThreadPoolToken;
 class RuntimeState;
 class TupleDescriptor;
 
+namespace pipeline {
+class ScanLocalState;
+} // namespace pipeline
+
 namespace taskgroup {
 class TaskGroup;
 } // namespace taskgroup
@@ -66,7 +70,8 @@ public:
     ScannerContext(RuntimeState* state_, VScanNode* parent,
                    const TupleDescriptor* output_tuple_desc,
                    const std::list<VScannerSPtr>& scanners_, int64_t limit_,
-                   int64_t max_bytes_in_blocks_queue_, const int num_parallel_instances = 0);
+                   int64_t max_bytes_in_blocks_queue_, const int num_parallel_instances = 0,
+                   pipeline::ScanLocalState* local_state = nullptr);
 
     virtual ~ScannerContext() = default;
     virtual Status init();
@@ -121,7 +126,8 @@ public:
 
     void get_next_batch_of_scanners(std::list<VScannerSPtr>* current_run);
 
-    void clear_and_join(VScanNode* node, RuntimeState* state);
+    template <typename Parent>
+    void clear_and_join(Parent* parent, RuntimeState* state);
 
     bool no_schedule();
 
@@ -162,13 +168,15 @@ public:
     std::vector<bthread_t> _btids;
 
 private:
-    Status _close_and_clear_scanners(VScanNode* node, RuntimeState* state);
+    template <typename Parent>
+    Status _close_and_clear_scanners(Parent* parent, RuntimeState* state);
 
 protected:
     virtual void _dispose_coloate_blocks_not_in_queue() {}
 
     RuntimeState* _state;
     VScanNode* _parent;
+    pipeline::ScanLocalState* _local_state;
 
     // the comment of same fields in VScanNode
     const TupleDescriptor* _output_tuple_desc;

--- a/be/src/vec/exec/scan/vscan_node.h
+++ b/be/src/vec/exec/scan/vscan_node.h
@@ -175,6 +175,8 @@ public:
         PARTIAL_ACCEPTABLE
     };
 
+    RuntimeProfile* scanner_profile() { return _scanner_profile.get(); }
+
 protected:
     // Different data sources register different profiles by implementing this method
     virtual Status _init_profile();

--- a/be/src/vec/exec/scan/vscanner.cpp
+++ b/be/src/vec/exec/scan/vscanner.cpp
@@ -20,6 +20,7 @@
 #include <glog/logging.h>
 
 #include "common/config.h"
+#include "pipeline/exec/scan_operator.h"
 #include "runtime/descriptors.h"
 #include "util/runtime_profile.h"
 #include "vec/core/column_with_type_and_name.h"
@@ -31,10 +32,22 @@ namespace doris::vectorized {
 VScanner::VScanner(RuntimeState* state, VScanNode* parent, int64_t limit, RuntimeProfile* profile)
         : _state(state),
           _parent(parent),
+          _local_state(nullptr),
           _limit(limit),
           _profile(profile),
           _output_tuple_desc(parent->output_tuple_desc()) {
     _total_rf_num = _parent->runtime_filter_num();
+}
+
+VScanner::VScanner(RuntimeState* state, pipeline::ScanLocalState* local_state, int64_t limit,
+                   RuntimeProfile* profile)
+        : _state(state),
+          _parent(nullptr),
+          _local_state(local_state),
+          _limit(limit),
+          _profile(profile),
+          _output_tuple_desc(_local_state->output_tuple_desc()) {
+    _total_rf_num = _local_state->runtime_filter_num();
 }
 
 Status VScanner::prepare(RuntimeState* state, const VExprContextSPtrs& conjuncts) {
@@ -72,7 +85,8 @@ Status VScanner::get_block(RuntimeState* state, Block* block, bool* eof) {
             block->clear_same_bit();
             // 1. Get input block from scanner
             {
-                SCOPED_TIMER(_parent->_scan_timer);
+                auto timer = _parent ? _parent->_scan_timer : _local_state->_scan_timer;
+                SCOPED_TIMER(timer);
                 RETURN_IF_ERROR(_get_block_impl(state, block, eof));
                 if (*eof) {
                     DCHECK(block->rows() == 0);
@@ -83,7 +97,8 @@ Status VScanner::get_block(RuntimeState* state, Block* block, bool* eof) {
 
             // 2. Filter the output block finally.
             {
-                SCOPED_TIMER(_parent->_filter_timer);
+                auto timer = _parent ? _parent->_filter_timer : _local_state->_filter_timer;
+                SCOPED_TIMER(timer);
                 RETURN_IF_ERROR(_filter_output_block(block));
             }
             // record rows return (after filter) for _limit check
@@ -123,7 +138,11 @@ Status VScanner::try_append_late_arrival_runtime_filter() {
     DCHECK(_applied_rf_num < _total_rf_num);
 
     int arrived_rf_num = 0;
-    RETURN_IF_ERROR(_parent->try_append_late_arrival_runtime_filter(&arrived_rf_num));
+    if (_parent) {
+        RETURN_IF_ERROR(_parent->try_append_late_arrival_runtime_filter(&arrived_rf_num));
+    } else {
+        RETURN_IF_ERROR(_local_state->try_append_late_arrival_runtime_filter(&arrived_rf_num));
+    }
 
     if (arrived_rf_num == _applied_rf_num) {
         // No newly arrived runtime filters, just return;
@@ -137,7 +156,11 @@ Status VScanner::try_append_late_arrival_runtime_filter() {
     }
     // Notice that the number of runtime filters may be larger than _applied_rf_num.
     // But it is ok because it will be updated at next time.
-    RETURN_IF_ERROR(_parent->clone_conjunct_ctxs(_conjuncts));
+    if (_parent) {
+        RETURN_IF_ERROR(_parent->clone_conjunct_ctxs(_conjuncts));
+    } else {
+        RETURN_IF_ERROR(_local_state->clone_conjunct_ctxs(_conjuncts));
+    }
     _applied_rf_num = arrived_rf_num;
     return Status::OK();
 }
@@ -147,15 +170,24 @@ Status VScanner::close(RuntimeState* state) {
         return Status::OK();
     }
 
-    COUNTER_UPDATE(_parent->_scanner_wait_worker_timer, _scanner_wait_worker_timer);
+    if (_parent) {
+        COUNTER_UPDATE(_parent->_scanner_wait_worker_timer, _scanner_wait_worker_timer);
+    } else {
+        COUNTER_UPDATE(_local_state->_scanner_wait_worker_timer, _scanner_wait_worker_timer);
+    }
     _is_closed = true;
     return Status::OK();
 }
 
 void VScanner::_update_counters_before_close() {
-    COUNTER_UPDATE(_parent->_scan_cpu_timer, _scan_cpu_timer);
+    if (_parent) {
+        COUNTER_UPDATE(_parent->_scan_cpu_timer, _scan_cpu_timer);
+        COUNTER_UPDATE(_parent->_rows_read_counter, _num_rows_read);
+    } else {
+        COUNTER_UPDATE(_local_state->_scan_cpu_timer, _scan_cpu_timer);
+        COUNTER_UPDATE(_local_state->_rows_read_counter, _num_rows_read);
+    }
     if (!_state->enable_profile() && !_is_load) return;
-    COUNTER_UPDATE(_parent->_rows_read_counter, _num_rows_read);
     // Update stats for load
     _state->update_num_rows_load_filtered(_counter.num_rows_filtered);
     _state->update_num_rows_load_unselected(_counter.num_rows_unselected);

--- a/be/src/vec/exec/scan/vscanner.h
+++ b/be/src/vec/exec/scan/vscanner.h
@@ -36,6 +36,10 @@ class TupleDescriptor;
 namespace vectorized {
 class VExprContext;
 } // namespace vectorized
+
+namespace pipeline {
+class ScanLocalState;
+} // namespace pipeline
 } // namespace doris
 
 namespace doris::vectorized {
@@ -53,6 +57,8 @@ struct ScannerCounter {
 class VScanner {
 public:
     VScanner(RuntimeState* state, VScanNode* parent, int64_t limit, RuntimeProfile* profile);
+    VScanner(RuntimeState* state, pipeline::ScanLocalState* local_state, int64_t limit,
+             RuntimeProfile* profile);
 
     virtual ~VScanner() = default;
 
@@ -156,6 +162,7 @@ protected:
 
     RuntimeState* _state;
     VScanNode* _parent;
+    pipeline::ScanLocalState* _local_state;
     // Set if scan node has sort limit info
     int64_t _limit = -1;
 

--- a/be/src/vec/exprs/vectorized_agg_fn.cpp
+++ b/be/src/vec/exprs/vectorized_agg_fn.cpp
@@ -318,4 +318,27 @@ Status AggFnEvaluator::_calc_argument_columns(Block* block) {
     return Status::OK();
 }
 
+AggFnEvaluator* AggFnEvaluator::clone(RuntimeState* state, ObjectPool* pool) {
+    return pool->add(AggFnEvaluator::create_unique(*this, state).release());
+}
+
+AggFnEvaluator::AggFnEvaluator(AggFnEvaluator& evaluator, RuntimeState* state)
+        : _fn(evaluator._fn),
+          _is_merge(evaluator._is_merge),
+          _argument_types_with_sort(evaluator._argument_types_with_sort),
+          _real_argument_types(evaluator._real_argument_types),
+          _return_type(evaluator._return_type),
+          _intermediate_slot_desc(evaluator._intermediate_slot_desc),
+          _output_slot_desc(evaluator._output_slot_desc),
+          _sort_description(evaluator._sort_description),
+          _data_type(evaluator._data_type),
+          _function(evaluator._function),
+          _expr_name(evaluator._expr_name),
+          _agg_columns(evaluator._agg_columns) {
+    _input_exprs_ctxs.resize(evaluator._input_exprs_ctxs.size());
+    for (size_t i = 0; i < _input_exprs_ctxs.size(); i++) {
+        WARN_IF_ERROR(evaluator._input_exprs_ctxs[i]->clone(state, _input_exprs_ctxs[i]), "");
+    }
+}
+
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/vectorized_agg_fn.h
+++ b/be/src/vec/exprs/vectorized_agg_fn.h
@@ -103,12 +103,15 @@ public:
 
     void set_version(const int version) { _function->set_version(version); }
 
+    AggFnEvaluator* clone(RuntimeState* state, ObjectPool* pool);
+
 private:
     const TFunction _fn;
 
     const bool _is_merge;
 
     AggFnEvaluator(const TExprNode& desc);
+    AggFnEvaluator(AggFnEvaluator& evaluator, RuntimeState* state);
 
     Status _calc_argument_columns(Block* block);
 

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -33,6 +33,7 @@
 
 #include "common/object_pool.h"
 #include "common/status.h"
+#include "pipeline/exec/exchange_sink_operator.h"
 #include "runtime/descriptors.h"
 #include "runtime/memory/mem_tracker.h"
 #include "runtime/runtime_state.h"
@@ -48,7 +49,8 @@
 
 namespace doris::vectorized {
 
-Status Channel::init(RuntimeState* state) {
+template <typename Parent>
+Status Channel<Parent>::init(RuntimeState* state) {
     _be_number = state->be_number();
 
     if (_brpc_dest_addr.hostname.empty()) {
@@ -67,7 +69,7 @@ Status Channel::init(RuntimeState* state) {
     _brpc_request.set_allocated_query_id(&_query_id);
 
     _brpc_request.set_node_id(_dest_node_id);
-    _brpc_request.set_sender_id(_parent->_sender_id);
+    _brpc_request.set_sender_id(_parent->sender_id());
     _brpc_request.set_be_number(_be_number);
 
     _brpc_timeout_ms = std::min(3600, state->execution_timeout()) * 1000;
@@ -105,13 +107,14 @@ Status Channel::init(RuntimeState* state) {
     return Status::OK();
 }
 
-Status Channel::send_current_block(bool eos) {
+template <typename Parent>
+Status Channel<Parent>::send_current_block(bool eos) {
     // FIXME: Now, local exchange will cause the performance problem is in a multi-threaded scenario
     // so this feature is turned off here by default. We need to re-examine this logic
     if (is_local()) {
         return send_local_block(eos);
     }
-    SCOPED_CONSUME_MEM_TRACKER(_parent->_mem_tracker.get());
+    SCOPED_CONSUME_MEM_TRACKER(_parent->mem_tracker());
     if (eos) {
         RETURN_IF_ERROR(_serializer.serialize_block(_ch_cur_pb_block, 1));
     }
@@ -120,17 +123,18 @@ Status Channel::send_current_block(bool eos) {
     return Status::OK();
 }
 
-Status Channel::send_local_block(bool eos) {
-    SCOPED_TIMER(_parent->_local_send_timer);
+template <typename Parent>
+Status Channel<Parent>::send_local_block(bool eos) {
+    SCOPED_TIMER(_parent->local_send_timer());
     Block block = _serializer.get_block()->to_block();
     _serializer.get_block()->set_muatable_columns(block.clone_empty_columns());
     if (_recvr_is_valid()) {
-        COUNTER_UPDATE(_parent->_local_bytes_send_counter, block.bytes());
-        COUNTER_UPDATE(_parent->_local_sent_rows, block.rows());
-        COUNTER_UPDATE(_parent->_blocks_sent_counter, 1);
-        _local_recvr->add_block(&block, _parent->_sender_id, true);
+        COUNTER_UPDATE(_parent->local_bytes_send_counter(), block.bytes());
+        COUNTER_UPDATE(_parent->local_sent_rows(), block.rows());
+        COUNTER_UPDATE(_parent->blocks_sent_counter(), 1);
+        _local_recvr->add_block(&block, _parent->sender_id(), true);
         if (eos) {
-            _local_recvr->remove_sender(_parent->_sender_id, _be_number);
+            _local_recvr->remove_sender(_parent->sender_id(), _be_number);
         }
         return Status::OK();
     } else {
@@ -139,22 +143,24 @@ Status Channel::send_local_block(bool eos) {
     }
 }
 
-Status Channel::send_local_block(Block* block) {
-    SCOPED_TIMER(_parent->_local_send_timer);
+template <typename Parent>
+Status Channel<Parent>::send_local_block(Block* block) {
+    SCOPED_TIMER(_parent->local_send_timer());
     if (_recvr_is_valid()) {
-        COUNTER_UPDATE(_parent->_local_bytes_send_counter, block->bytes());
-        COUNTER_UPDATE(_parent->_local_sent_rows, block->rows());
-        COUNTER_UPDATE(_parent->_blocks_sent_counter, 1);
-        _local_recvr->add_block(block, _parent->_sender_id, false);
+        COUNTER_UPDATE(_parent->local_bytes_send_counter(), block->bytes());
+        COUNTER_UPDATE(_parent->local_sent_rows(), block->rows());
+        COUNTER_UPDATE(_parent->blocks_sent_counter(), 1);
+        _local_recvr->add_block(block, _parent->sender_id(), false);
         return Status::OK();
     } else {
         return _receiver_status;
     }
 }
 
-Status Channel::send_block(PBlock* block, bool eos) {
-    SCOPED_TIMER(_parent->_brpc_send_timer);
-    COUNTER_UPDATE(_parent->_blocks_sent_counter, 1);
+template <typename Parent>
+Status Channel<Parent>::send_block(PBlock* block, bool eos) {
+    SCOPED_TIMER(_parent->brpc_send_timer());
+    COUNTER_UPDATE(_parent->blocks_sent_counter(), 1);
     if (_closure == nullptr) {
         _closure = new RefCountClosure<PTransmitDataResult>();
         _closure->ref();
@@ -163,12 +169,12 @@ Status Channel::send_block(PBlock* block, bool eos) {
         SCOPED_TRACK_MEMORY_TO_UNKNOWN();
         _closure->cntl.Reset();
     }
-    VLOG_ROW << "Channel::send_batch() instance_id=" << _fragment_instance_id
+    VLOG_ROW << "Channel<Parent>::send_batch() instance_id=" << _fragment_instance_id
              << " dest_node=" << _dest_node_id << " to_host=" << _brpc_dest_addr.hostname
              << " _packet_seq=" << _packet_seq << " row_desc=" << _row_desc.debug_string();
     if (_is_transfer_chain && (_send_query_statistics_with_every_batch || eos)) {
         auto statistic = _brpc_request.mutable_query_statistics();
-        _parent->_query_statistics->to_pb(statistic);
+        _parent->query_statistics()->to_pb(statistic);
     }
 
     _brpc_request.set_eos(eos);
@@ -185,7 +191,7 @@ Status Channel::send_block(PBlock* block, bool eos) {
 
     {
         SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->orphan_mem_tracker());
-        if (enable_http_send_block(_brpc_request, _parent->_transfer_large_data_by_brpc)) {
+        if (enable_http_send_block(_brpc_request, _parent->transfer_large_data_by_brpc())) {
             RETURN_IF_ERROR(transmit_block_http(_state, _closure, _brpc_request, _brpc_dest_addr));
         } else {
             transmit_block(*_brpc_stub, _closure, _brpc_request);
@@ -198,7 +204,8 @@ Status Channel::send_block(PBlock* block, bool eos) {
     return Status::OK();
 }
 
-Status Channel::add_rows(Block* block, const std::vector<int>& rows, bool eos) {
+template <typename Parent>
+Status Channel<Parent>::add_rows(Block* block, const std::vector<int>& rows, bool eos) {
     if (_fragment_instance_id.lo == -1) {
         return Status::OK();
     }
@@ -213,7 +220,8 @@ Status Channel::add_rows(Block* block, const std::vector<int>& rows, bool eos) {
     return Status::OK();
 }
 
-Status Channel::close_wait(RuntimeState* state) {
+template <typename Parent>
+Status Channel<Parent>::close_wait(RuntimeState* state) {
     if (_need_close) {
         Status st = _wait_last_brpc();
         if (st.is<ErrorCode::END_OF_FILE>()) {
@@ -228,7 +236,8 @@ Status Channel::close_wait(RuntimeState* state) {
     return Status::OK();
 }
 
-Status Channel::close_internal() {
+template <typename Parent>
+Status Channel<Parent>::close_internal() {
     if (!_need_close) {
         return Status::OK();
     }
@@ -244,10 +253,10 @@ Status Channel::close_internal() {
     if (_serializer.get_block() != nullptr && _serializer.get_block()->rows() > 0) {
         status = send_current_block(true);
     } else {
-        SCOPED_CONSUME_MEM_TRACKER(_parent->_mem_tracker.get());
+        SCOPED_CONSUME_MEM_TRACKER(_parent->mem_tracker());
         if (is_local()) {
             if (_recvr_is_valid()) {
-                _local_recvr->remove_sender(_parent->_sender_id, _be_number);
+                _local_recvr->remove_sender(_parent->sender_id(), _be_number);
             }
         } else {
             status = send_block((PBlock*)nullptr, true);
@@ -261,7 +270,8 @@ Status Channel::close_internal() {
     }
 }
 
-Status Channel::close(RuntimeState* state) {
+template <typename Parent>
+Status Channel<Parent>::close(RuntimeState* state) {
     if (_closed) {
         return Status::OK();
     }
@@ -274,7 +284,8 @@ Status Channel::close(RuntimeState* state) {
     return st;
 }
 
-void Channel::ch_roll_pb_block() {
+template <typename Parent>
+void Channel<Parent>::ch_roll_pb_block() {
     _ch_cur_pb_block = (_ch_cur_pb_block == &_ch_pb_block1 ? &_ch_pb_block2 : &_ch_pb_block1);
 }
 
@@ -317,7 +328,7 @@ VDataStreamSender::VDataStreamSender(RuntimeState* state, ObjectPool* pool, int 
         if (fragment_id_to_channel_index.find(fragment_instance_id.lo) ==
             fragment_id_to_channel_index.end()) {
             if (_enable_pipeline_exec) {
-                _channel_shared_ptrs.emplace_back(new PipChannel(
+                _channel_shared_ptrs.emplace_back(new PipChannel<VDataStreamSender>(
                         this, row_desc, destinations[i].brpc_server, fragment_instance_id,
                         sink.dest_node_id, per_channel_buffer_size, is_transfer_chain,
                         send_query_statistics_with_every_batch));
@@ -570,7 +581,7 @@ Status VDataStreamSender::send(RuntimeState* state, Block* block, bool eos) {
         }
     } else if (_part_type == TPartitionType::RANDOM) {
         // 1. select channel
-        Channel* current_channel = _channels[_current_channel_idx];
+        Channel<VDataStreamSender>* current_channel = _channels[_current_channel_idx];
         if (!current_channel->is_receiver_eof()) {
             // 2. serialize, send and rollover block
             if (current_channel->is_local()) {
@@ -720,27 +731,29 @@ Status VDataStreamSender::close(RuntimeState* state, Status exec_status) {
     return final_st;
 }
 
-BlockSerializer::BlockSerializer(VDataStreamSender* parent, bool is_local)
+template <typename Parent>
+BlockSerializer<Parent>::BlockSerializer(Parent* parent, bool is_local)
         : _parent(parent), _is_local(is_local), _batch_size(parent->state()->batch_size()) {}
 
-Status BlockSerializer::next_serialized_block(Block* block, PBlock* dest, int num_receivers,
-                                              bool* serialized, bool eos,
-                                              const std::vector<int>* rows) {
+template <typename Parent>
+Status BlockSerializer<Parent>::next_serialized_block(Block* block, PBlock* dest, int num_receivers,
+                                                      bool* serialized, bool eos,
+                                                      const std::vector<int>* rows) {
     if (_mutable_block == nullptr) {
-        SCOPED_CONSUME_MEM_TRACKER(_parent->_mem_tracker.get());
+        SCOPED_CONSUME_MEM_TRACKER(_parent->mem_tracker());
         _mutable_block = MutableBlock::create_unique(block->clone_empty());
     }
 
     {
-        SCOPED_CONSUME_MEM_TRACKER(_parent->_mem_tracker.get());
+        SCOPED_CONSUME_MEM_TRACKER(_parent->mem_tracker());
         if (rows) {
             if (rows->size() > 0) {
-                SCOPED_TIMER(_parent->_split_block_distribute_by_channel_timer);
+                SCOPED_TIMER(_parent->split_block_distribute_by_channel_timer());
                 const int* begin = &(*rows)[0];
                 _mutable_block->add_rows(block, begin, begin + rows->size());
             }
         } else if (!block->empty()) {
-            SCOPED_TIMER(_parent->_merge_block_timer);
+            SCOPED_TIMER(_parent->merge_block_timer());
             RETURN_IF_ERROR(_mutable_block->merge(*block));
         }
     }
@@ -756,7 +769,8 @@ Status BlockSerializer::next_serialized_block(Block* block, PBlock* dest, int nu
     return Status::OK();
 }
 
-Status BlockSerializer::serialize_block(PBlock* dest, int num_receivers) {
+template <typename Parent>
+Status BlockSerializer<Parent>::serialize_block(PBlock* dest, int num_receivers) {
     if (_mutable_block && _mutable_block->rows() > 0) {
         auto block = _mutable_block->to_block();
         RETURN_IF_ERROR(serialize_block(&block, dest, num_receivers));
@@ -767,14 +781,15 @@ Status BlockSerializer::serialize_block(PBlock* dest, int num_receivers) {
     return Status::OK();
 }
 
-Status BlockSerializer::serialize_block(const Block* src, PBlock* dest, int num_receivers) {
+template <typename Parent>
+Status BlockSerializer<Parent>::serialize_block(const Block* src, PBlock* dest, int num_receivers) {
     {
         SCOPED_TIMER(_parent->_serialize_batch_timer);
         dest->Clear();
         size_t uncompressed_bytes = 0, compressed_bytes = 0;
         RETURN_IF_ERROR(src->serialize(
                 _parent->_state->be_exec_version(), dest, &uncompressed_bytes, &compressed_bytes,
-                _parent->_compression_type, _parent->_transfer_large_data_by_brpc));
+                _parent->compression_type(), _parent->transfer_large_data_by_brpc()));
         COUNTER_UPDATE(_parent->_bytes_sent_counter, compressed_bytes * num_receivers);
         COUNTER_UPDATE(_parent->_uncompressed_bytes_counter, uncompressed_bytes * num_receivers);
         COUNTER_UPDATE(_parent->_compress_timer, src->get_compress_time());
@@ -801,9 +816,9 @@ Status VDataStreamSender::_get_next_available_buffer(BroadcastPBlockHolder** hol
     return Status::OK();
 }
 
-void VDataStreamSender::registe_channels(pipeline::ExchangeSinkBuffer* buffer) {
+void VDataStreamSender::registe_channels(pipeline::ExchangeSinkBuffer<VDataStreamSender>* buffer) {
     for (auto channel : _channels) {
-        ((PipChannel*)channel)->registe(buffer);
+        ((PipChannel<VDataStreamSender>*)channel)->registe(buffer);
     }
 }
 
@@ -831,5 +846,10 @@ bool VDataStreamSender::channel_all_can_write() {
         return true;
     }
 }
+
+template class Channel<pipeline::ExchangeSinkLocalState>;
+template class Channel<VDataStreamSender>;
+template class BlockSerializer<pipeline::ExchangeSinkLocalState>;
+template class BlockSerializer<VDataStreamSender>;
 
 } // namespace doris::vectorized

--- a/be/src/vec/sink/vdata_stream_sender.h
+++ b/be/src/vec/sink/vdata_stream_sender.h
@@ -63,15 +63,18 @@ enum CompressionTypePB : int;
 
 namespace pipeline {
 class ExchangeSinkOperator;
-}
+class ExchangeSinkOperatorX;
+} // namespace pipeline
 
 namespace vectorized {
+template <typename>
 class Channel;
 class VDataStreamSender;
 
+template <typename Parent>
 class BlockSerializer {
 public:
-    BlockSerializer(VDataStreamSender* parent, bool is_local = true);
+    BlockSerializer(Parent* parent, bool is_local = true);
     Status next_serialized_block(Block* src, PBlock* dest, int num_receivers, bool* serialized,
                                  bool eos, const std::vector<int>* rows = nullptr);
     Status serialize_block(PBlock* dest, int num_receivers = 1);
@@ -84,7 +87,7 @@ public:
     void set_is_local(bool is_local) { _is_local = is_local; }
 
 private:
-    VDataStreamSender* _parent;
+    Parent* _parent;
     std::unique_ptr<MutableBlock> _mutable_block;
 
     bool _is_local;
@@ -118,17 +121,34 @@ public:
 
     RuntimeState* state() { return _state; }
 
-    void registe_channels(pipeline::ExchangeSinkBuffer* buffer);
+    void registe_channels(pipeline::ExchangeSinkBuffer<VDataStreamSender>* buffer);
 
     bool channel_all_can_write();
 
     const RowDescriptor& row_desc() { return _row_desc; }
 
+    int sender_id() const { return _sender_id; }
+
+    RuntimeProfile::Counter* brpc_wait_timer() { return _brpc_wait_timer; }
+    RuntimeProfile::Counter* blocks_sent_counter() { return _blocks_sent_counter; }
+    RuntimeProfile::Counter* local_send_timer() { return _local_send_timer; }
+    RuntimeProfile::Counter* local_bytes_send_counter() { return _local_bytes_send_counter; }
+    RuntimeProfile::Counter* local_sent_rows() { return _local_sent_rows; }
+    RuntimeProfile::Counter* brpc_send_timer() { return _brpc_send_timer; }
+    RuntimeProfile::Counter* split_block_distribute_by_channel_timer() {
+        return _split_block_distribute_by_channel_timer;
+    }
+    MemTracker* mem_tracker() { return _mem_tracker.get(); }
+    QueryStatistics* query_statistics() { return _query_statistics.get(); }
+    bool transfer_large_data_by_brpc() { return _transfer_large_data_by_brpc; }
+    RuntimeProfile::Counter* merge_block_timer() { return _merge_block_timer; }
+    segment_v2::CompressionTypePB& compression_type() { return _compression_type; }
+
 protected:
-    friend class Channel;
-    friend class PipChannel;
-    friend class pipeline::ExchangeSinkBuffer;
-    friend class BlockSerializer;
+    friend class BlockSerializer<VDataStreamSender>;
+    friend class Channel<VDataStreamSender>;
+    friend class PipChannel<VDataStreamSender>;
+    friend class pipeline::ExchangeSinkBuffer<VDataStreamSender>;
 
     void _roll_pb_block();
     Status _get_next_available_buffer(BroadcastPBlockHolder** holder);
@@ -172,8 +192,8 @@ protected:
     // compute per-row partition values
     VExprContextSPtrs _partition_expr_ctxs;
 
-    std::vector<Channel*> _channels;
-    std::vector<std::shared_ptr<Channel>> _channel_shared_ptrs;
+    std::vector<Channel<VDataStreamSender>*> _channels;
+    std::vector<std::shared_ptr<Channel<VDataStreamSender>>> _channel_shared_ptrs;
 
     RuntimeProfile* _profile; // Allocated from _pool
     RuntimeProfile::Counter* _serialize_batch_timer;
@@ -208,21 +228,21 @@ protected:
     bool _only_local_exchange = false;
     bool _enable_pipeline_exec = false;
 
-    BlockSerializer _serializer;
+    BlockSerializer<VDataStreamSender> _serializer;
 };
 
+template <typename Parent = VDataStreamSender>
 class Channel {
 public:
     friend class VDataStreamSender;
-    friend class pipeline::ExchangeSinkBuffer;
+    friend class pipeline::ExchangeSinkBuffer<Parent>;
     // Create channel to send data to particular ipaddress/port/query/node
     // combination. buffer_size is specified in bytes and a soft limit on
     // how much tuple data is getting accumulated before being sent; it only applies
     // when data is added via add_row() and not sent directly via send_batch().
-    Channel(VDataStreamSender* parent, const RowDescriptor& row_desc,
-            const TNetworkAddress& brpc_dest, const TUniqueId& fragment_instance_id,
-            PlanNodeId dest_node_id, int buffer_size, bool is_transfer_chain,
-            bool send_query_statistics_with_every_batch)
+    Channel(Parent* parent, const RowDescriptor& row_desc, const TNetworkAddress& brpc_dest,
+            const TUniqueId& fragment_instance_id, PlanNodeId dest_node_id, int buffer_size,
+            bool is_transfer_chain, bool send_query_statistics_with_every_batch)
             : _parent(parent),
               _row_desc(row_desc),
               _fragment_instance_id(fragment_instance_id),
@@ -303,7 +323,7 @@ public:
         // if local recvr queue mem over the exchange node mem limit, we must ensure each queue
         // has one block to do merge sort in exchange node to prevent the logic dead lock
         return !_local_recvr || _local_recvr->is_closed() || !_local_recvr->exceeds_limit(0) ||
-               _local_recvr->sender_queue_empty(_parent->_sender_id);
+               _local_recvr->sender_queue_empty(_parent->sender_id());
     }
 
     bool is_receiver_eof() const { return _receiver_status.is<ErrorCode::END_OF_FILE>(); }
@@ -320,7 +340,7 @@ protected:
     }
 
     Status _wait_last_brpc() {
-        SCOPED_TIMER(_parent->_brpc_wait_timer);
+        SCOPED_TIMER(_parent->brpc_wait_timer());
         if (_closure == nullptr) {
             return Status::OK();
         }
@@ -345,7 +365,7 @@ protected:
     Status send_current_batch(bool eos = false);
     Status close_internal();
 
-    VDataStreamSender* _parent;
+    Parent* _parent;
 
     const RowDescriptor& _row_desc;
     TUniqueId _fragment_instance_id;
@@ -384,7 +404,7 @@ protected:
     PBlock _ch_pb_block1;
     PBlock _ch_pb_block2;
 
-    BlockSerializer _serializer;
+    BlockSerializer<Parent> _serializer;
 };
 
 #define HANDLE_CHANNEL_STATUS(state, channel, status)    \
@@ -426,20 +446,21 @@ Status VDataStreamSender::channel_add_rows(RuntimeState* state, Channels& channe
     return Status::OK();
 }
 
-class PipChannel final : public Channel {
+template <typename Parent = VDataStreamSender>
+class PipChannel final : public Channel<Parent> {
 public:
-    PipChannel(VDataStreamSender* parent, const RowDescriptor& row_desc,
-               const TNetworkAddress& brpc_dest, const TUniqueId& fragment_instance_id,
-               PlanNodeId dest_node_id, int buffer_size, bool is_transfer_chain,
-               bool send_query_statistics_with_every_batch)
-            : Channel(parent, row_desc, brpc_dest, fragment_instance_id, dest_node_id, buffer_size,
-                      is_transfer_chain, send_query_statistics_with_every_batch) {
+    PipChannel(Parent* parent, const RowDescriptor& row_desc, const TNetworkAddress& brpc_dest,
+               const TUniqueId& fragment_instance_id, PlanNodeId dest_node_id, int buffer_size,
+               bool is_transfer_chain, bool send_query_statistics_with_every_batch)
+            : Channel<Parent>(parent, row_desc, brpc_dest, fragment_instance_id, dest_node_id,
+                              buffer_size, is_transfer_chain,
+                              send_query_statistics_with_every_batch) {
         ch_roll_pb_block();
     }
 
     ~PipChannel() override {
-        if (_ch_cur_pb_block) {
-            delete _ch_cur_pb_block;
+        if (Channel<Parent>::_ch_cur_pb_block) {
+            delete Channel<Parent>::_ch_cur_pb_block;
         }
     }
 
@@ -450,7 +471,7 @@ public:
         // 2. Create a new PBlock every time. In this way we don't need a lock but have to allocate
         //    new memory.
         // Now we use the second way.
-        _ch_cur_pb_block = new PBlock();
+        Channel<Parent>::_ch_cur_pb_block = new PBlock();
     }
 
     // Asynchronously sends a block
@@ -458,7 +479,7 @@ public:
     // rpc (or OK if there wasn't one that hasn't been reported yet).
     // if batch is nullptr, send the eof packet
     Status send_block(PBlock* block, bool eos = false) override {
-        COUNTER_UPDATE(_parent->_blocks_sent_counter, 1);
+        COUNTER_UPDATE(Channel<Parent>::_parent->blocks_sent_counter(), 1);
         std::unique_ptr<PBlock> pblock_ptr;
         pblock_ptr.reset(block);
 
@@ -476,7 +497,7 @@ public:
     }
 
     Status send_block(BroadcastPBlockHolder* block, bool eos = false) override {
-        COUNTER_UPDATE(_parent->_blocks_sent_counter, 1);
+        COUNTER_UPDATE(Channel<Parent>::_parent->blocks_sent_counter(), 1);
         if (eos) {
             if (_eos_send) {
                 return Status::OK();
@@ -491,14 +512,14 @@ public:
     }
 
     Status add_rows(Block* block, const std::vector<int>& rows, bool eos) override {
-        if (_fragment_instance_id.lo == -1) {
+        if (Channel<Parent>::_fragment_instance_id.lo == -1) {
             return Status::OK();
         }
 
         bool serialized = false;
         _pblock = std::make_unique<PBlock>();
-        RETURN_IF_ERROR(_serializer.next_serialized_block(block, _pblock.get(), 1, &serialized, eos,
-                                                          &rows));
+        RETURN_IF_ERROR(Channel<Parent>::_serializer.next_serialized_block(
+                block, _pblock.get(), 1, &serialized, eos, &rows));
         if (serialized) {
             RETURN_IF_ERROR(send_current_block(eos));
         }
@@ -508,17 +529,17 @@ public:
 
     // send _mutable_block
     Status send_current_block(bool eos) override {
-        if (is_local()) {
-            return send_local_block(eos);
+        if (Channel<Parent>::is_local()) {
+            return Channel<Parent>::send_local_block(eos);
         }
-        SCOPED_CONSUME_MEM_TRACKER(_parent->_mem_tracker.get());
+        SCOPED_CONSUME_MEM_TRACKER(Channel<Parent>::_parent->mem_tracker());
         RETURN_IF_ERROR(send_block(_pblock.release(), eos));
         return Status::OK();
     }
 
-    void registe(pipeline::ExchangeSinkBuffer* buffer) {
+    void registe(pipeline::ExchangeSinkBuffer<Parent>* buffer) {
         _buffer = buffer;
-        _buffer->register_sink(_fragment_instance_id);
+        _buffer->register_sink(Channel<Parent>::_fragment_instance_id);
     }
 
     pipeline::SelfDeleteClosure<PTransmitDataResult>* get_closure(
@@ -535,7 +556,7 @@ public:
 private:
     friend class VDataStreamSender;
 
-    pipeline::ExchangeSinkBuffer* _buffer = nullptr;
+    pipeline::ExchangeSinkBuffer<Parent>* _buffer = nullptr;
     bool _eos_send = false;
     std::unique_ptr<pipeline::SelfDeleteClosure<PTransmitDataResult>> _closure = nullptr;
     std::unique_ptr<PBlock> _pblock;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -199,6 +199,8 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String ENABLE_PIPELINE_ENGINE = "enable_pipeline_engine";
 
+    public static final String ENABLE_PIPELINE_X_ENGINE = "enable_pipeline_x_engine";
+
     public static final String ENABLE_AGG_STATE = "enable_agg_state";
 
     public static final String ENABLE_RPC_OPT_FOR_PIPELINE = "enable_rpc_opt_for_pipeline";
@@ -649,6 +651,9 @@ public class SessionVariable implements Serializable, Writable {
 
     @VariableMgr.VarAttr(name = ENABLE_PIPELINE_ENGINE, fuzzy = true, varType = VariableAnnotation.EXPERIMENTAL)
     private boolean enablePipelineEngine = true;
+
+    @VariableMgr.VarAttr(name = ENABLE_PIPELINE_X_ENGINE, fuzzy = false, varType = VariableAnnotation.EXPERIMENTAL)
+    private boolean enablePipelineXEngine = false;
 
     @VariableMgr.VarAttr(name = ENABLE_AGG_STATE, fuzzy = false, varType = VariableAnnotation.EXPERIMENTAL)
     public boolean enableAggState = false;
@@ -1523,7 +1528,7 @@ public class SessionVariable implements Serializable, Writable {
     }
 
     public int getParallelExecInstanceNum() {
-        if (enablePipelineEngine && parallelPipelineTaskNum == 0) {
+        if (getEnablePipelineEngine() && parallelPipelineTaskNum == 0) {
             int size = Env.getCurrentSystemInfo().getMinPipelineExecutorSize();
             int autoInstance = (size + 1) / 2;
             return Math.min(autoInstance, maxInstanceNum);
@@ -1746,6 +1751,10 @@ public class SessionVariable implements Serializable, Writable {
 
     public void setEnablePipelineEngine(boolean enablePipelineEngine) {
         this.enablePipelineEngine = enablePipelineEngine;
+    }
+
+    public void setEnablePipelineXEngine(boolean enablePipelineXEngine) {
+        this.enablePipelineXEngine = enablePipelineXEngine;
     }
 
     public boolean enablePushDownNoGroupAgg() {
@@ -2119,6 +2128,7 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setCodegenLevel(codegenLevel);
         tResult.setBeExecVersion(Config.be_exec_version);
         tResult.setEnablePipelineEngine(enablePipelineEngine);
+        tResult.setEnablePipelineXEngine(enablePipelineXEngine);
         tResult.setParallelInstance(getParallelExecInstanceNum());
         tResult.setReturnObjectDataAsBinary(returnObjectDataAsBinary);
         tResult.setTrimTailingSpacesForExternalTableQuery(trimTailingSpacesForExternalTableQuery);
@@ -2479,7 +2489,11 @@ public class SessionVariable implements Serializable, Writable {
     }
 
     public boolean getEnablePipelineEngine() {
-        return enablePipelineEngine;
+        return enablePipelineEngine || enablePipelineXEngine;
+    }
+
+    public boolean getEnablePipelineXEngine() {
+        return enablePipelineXEngine;
     }
 
     public static boolean enablePipelineEngine() {
@@ -2487,7 +2501,8 @@ public class SessionVariable implements Serializable, Writable {
         if (connectContext == null) {
             return false;
         }
-        return connectContext.getSessionVariable().enablePipelineEngine;
+        return connectContext.getSessionVariable().enablePipelineEngine
+                || connectContext.getSessionVariable().enablePipelineXEngine;
     }
 
     public static boolean enableAggState() {

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -231,6 +231,8 @@ struct TQueryOptions {
   77: optional bool truncate_char_or_varchar_columns = false
 
   78: optional bool enable_hash_join_early_start_probe = false
+
+  79: optional bool enable_pipeline_x_engine = false;
 }
 
 


### PR DESCRIPTION
## Proposed change

Propose a new pipeline execution model. Different from the former one, we use a shared operator tree and all global state for each pipeline task and separated local states. This will avoid the unnecessary overhead for initializing and reduce the RPC overhead between BE instances.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

