### PR TITLE
[Fix](planner)fix delete stmt contains where but delete all data.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DeleteStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DeleteStmt.java
@@ -118,7 +118,6 @@ public class DeleteStmt extends DdlStmt {
         // analyze predicate
         if (fromClause == null) {
             ExprRewriter exprRewriter = new ExprRewriter(EXPR_NORMALIZE_RULES);
-            Expr copy = wherePredicate.clone();
             wherePredicate = exprRewriter.rewrite(wherePredicate, analyzer);
             try {
                 analyzePredicate(wherePredicate, analyzer);
@@ -126,7 +125,7 @@ public class DeleteStmt extends DdlStmt {
                 if (!(((OlapTable) targetTable).getKeysType() == KeysType.UNIQUE_KEYS)) {
                     throw new AnalysisException(e.getMessage(), e.getCause());
                 }
-                wherePredicate = copy;
+                wherePredicate.reset();
                 constructInsertStmt();
             }
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DeleteStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DeleteStmt.java
@@ -118,6 +118,7 @@ public class DeleteStmt extends DdlStmt {
         // analyze predicate
         if (fromClause == null) {
             ExprRewriter exprRewriter = new ExprRewriter(EXPR_NORMALIZE_RULES);
+            Expr copy = wherePredicate.clone();
             wherePredicate = exprRewriter.rewrite(wherePredicate, analyzer);
             try {
                 analyzePredicate(wherePredicate, analyzer);
@@ -125,6 +126,7 @@ public class DeleteStmt extends DdlStmt {
                 if (!(((OlapTable) targetTable).getKeysType() == KeysType.UNIQUE_KEYS)) {
                     throw new AnalysisException(e.getMessage(), e.getCause());
                 }
+                wherePredicate = copy;
                 constructInsertStmt();
             }
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DeleteCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DeleteCommand.java
@@ -112,7 +112,7 @@ public class DeleteCommand extends Command implements ForwardWithSync, Explainab
         logicalQuery = new LogicalProject<>(selectLists, logicalQuery);
 
         boolean isPartialUpdate = false;
-        if (((OlapTable) targetTable).getEnableUniqueKeyMergeOnWrite()
+        if (targetTable.getEnableUniqueKeyMergeOnWrite()
                 && cols.size() < targetTable.getColumns().size()) {
             isPartialUpdate = true;
         }

--- a/regression-test/data/delete_p0/test_delete.out
+++ b/regression-test/data/delete_p0/test_delete.out
@@ -131,3 +131,7 @@ abc	5
 \N	\N	6.6
 5	\N	5.5
 
+-- !delete_fn --
+a	a
+ccc	ccc
+

--- a/regression-test/suites/delete_p0/test_delete.groovy
+++ b/regression-test/suites/delete_p0/test_delete.groovy
@@ -218,4 +218,24 @@ suite("test_delete") {
 
     sql """ delete from  delete_test_tb2 where k1 is null and k2 = 4.45; """
     qt_check_numeric4 """ select k1, k2, v1 from delete_test_tb2 order by k1, k2; """;
+    
+    sql '''
+        CREATE TABLE test1 (
+            x varchar NOT NULL,
+            id varchar NOT NULL
+        )
+        ENGINE=OLAP
+        UNIQUE KEY(`x`)COMMENT "OLAP"
+        DISTRIBUTED BY HASH(`x`) 
+        BUCKETS 96
+        PROPERTIES (
+            "replication_num" = "1",
+            "enable_unique_key_merge_on_write" = "true"
+        ); 
+    '''
+    
+    sql 'insert into test1 values("a", "a"), ("bb", "bb"), ("ccc", "ccc")'
+    sql 'delete from test1 where length(x)=2'
+    
+    qt_delete_fn 'select * from test1 order by x'
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

```sql

CREATE TABLE test1 (
    x varchar NOT NULL,
    id varchar NOT NULL
)
ENGINE=OLAP
UNIQUE KEY(`x`)COMMENT "OLAP"
DISTRIBUTED BY HASH(`x`) 
BUCKETS 96
PROPERTIES (
    "replication_num" = "1",
    "enable_unique_key_merge_on_write" = "true"
); 

insert into test1 values("a", "a"), ("bb", "bb"), ("ccc", "ccc"); 

delete from test where length(x) = 2
```
after delete, the table will be empty because the expression is analyzed when build insert stmt. We fix it by copying the expression and analyze the copy.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

