### PR TITLE
[enhancement](MOW) refactor delete bitmap calculator and enhance the deletion bitmap calculation for full duplicate load

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1059,6 +1059,9 @@ DEFINE_mBool(enable_merge_on_write_correctness_check, "true");
 // The secure path with user files, used in the `local` table function.
 DEFINE_mString(user_files_secure_path, "${DORIS_HOME}");
 
+// minium rows required to use merge primary key iterator for calculating delete-bitmap
+DEFINE_Int64(min_rows_to_use_merge_pk_iterator_for_delete_bitmap, "50000000");
+
 #ifdef BE_TEST
 // test s3
 DEFINE_String(test_s3_resource, "resource");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1116,6 +1116,9 @@ DECLARE_mBool(enable_merge_on_write_correctness_check);
 // The secure path with user files, used in the `local` table function.
 DECLARE_mString(user_files_secure_path);
 
+// minium rows required to use merge primary key iterator for calculating delete-bitmap
+DECLARE_Int64(min_rows_to_use_merge_pk_iterator_for_delete_bitmap);
+
 #ifdef BE_TEST
 // test s3
 DECLARE_String(test_s3_resource);

--- a/be/src/olap/delete_bitmap_calculator.cpp
+++ b/be/src/olap/delete_bitmap_calculator.cpp
@@ -267,21 +267,21 @@ Status MergedPKIndexDeleteBitmapCalculator::process(DeleteBitmapPtr delete_bitma
 }
 
 Status MergedPKIndexDeleteBitmapCalculator::step() {
-    // `ctxs_to_seek` are the smallest contexts of same type of data (eithor base data or delta data).
+    // `ctxs_to_seek` are the smallest contexts of same type of data (either base data or delta data).
     // `target_ctx` is the context next to `ctxs_to_seek`
     std::vector<MergedPKIndexDeleteBitmapCalculatorContext*> ctxs_to_seek;
     MergedPKIndexDeleteBitmapCalculatorContext* target_ctx = nullptr;
     while (!_heap->empty()) {
         auto ctx = _heap->top();
         if (!ctxs_to_seek.empty() &&
-            ctx->is_base_segment() != ctxs_to_seek.back()->is_base_segment()) {
+            ctx->is_delta_segment() != ctxs_to_seek.back()->is_delta_segment()) {
             target_ctx = ctx;
             break;
         }
         _heap->pop();
         ctxs_to_seek.emplace_back(ctx);
     }
-    // If `target_ctx` is nullptr, we can say that the contexts are the same type of data.
+    // If `target_ctx` is nullptr, we can say that all of the contexts in heap are the same type of data.
     // So there is no duplicate keys, and we should end this algorithm by returning not found error.
     if (target_ctx == nullptr) {
         return Status::NotFound("No target found");

--- a/be/src/olap/delete_bitmap_calculator.cpp
+++ b/be/src/olap/delete_bitmap_calculator.cpp
@@ -99,9 +99,9 @@ bool MergedPKIndexDeleteBitmapCalculatorContext::Comparator::operator()(
     Slice key1, key2;
     Status st;
     st = lhs->get_current_key(&key1);
-    CHECK(LIKELY(st.ok())) << fmt::format("Reading key1 but get st = {}", st);
+    DCHECK(LIKELY(st.ok())) << fmt::format("Reading key1 but get st = {}", st);
     st = rhs->get_current_key(&key2);
-    CHECK(LIKELY(st.ok())) << fmt::format("Reading key2 but get st = {}", st);
+    DCHECK(LIKELY(st.ok())) << fmt::format("Reading key2 but get st = {}", st);
     // We start by comparing the key portions of the two records.
     // If they are not equal, we want the record with the smaller key to be popped from the heap first.
     // Therefore, we need to return the result of key1 > key2.

--- a/be/src/olap/delete_bitmap_calculator.cpp
+++ b/be/src/olap/delete_bitmap_calculator.cpp
@@ -134,7 +134,7 @@ int MergedPKIndexDeleteBitmapCalculatorContext::Comparator::compare_key(Slice co
 
 int MergedPKIndexDeleteBitmapCalculatorContext::Comparator::compare_seq(Slice const& lhs,
                                                                         Slice const& rhs) const {
-    if (UNLIKELY(_sequence_length == 0)) {
+    if (LIKELY(_sequence_length == 0)) {
         return 0;
     }
     auto lhs_seq = Slice(lhs.get_data() + lhs.get_size() - _sequence_length, _sequence_length);

--- a/be/src/olap/delete_bitmap_calculator.cpp
+++ b/be/src/olap/delete_bitmap_calculator.cpp
@@ -232,7 +232,7 @@ Status MergedPKIndexDeleteBitmapCalculator::process(DeleteBitmapPtr delete_bitma
             }
         }
         // We pop two context ctx1 and ctx2 from the heap.
-        // Apprently, ctx1's key is smaller than or equal to ctx2' key.
+        // Apprently, ctx1's key is smaller than or equal to ctx2's key.
         auto ctx1 = _heap->top();
         _heap->pop();
         auto ctx2 = _heap->top();

--- a/be/src/olap/delete_bitmap_calculator.h
+++ b/be/src/olap/delete_bitmap_calculator.h
@@ -108,11 +108,6 @@ class MergedPKIndexDeleteBitmapCalculator {
 public:
     MergedPKIndexDeleteBitmapCalculator() = default;
 
-    // Through the MergedPKIndexDeleteBitmapCalculator, we .
-    // In the calculator, we create a context for each segment of both the base data and delta data.
-    // These contexts can be viewed as iterators, which are then placed into a heap.
-    // We use a method similar to merge sorting to identify duplicate keys and update the delete-bitmap accordingly.
-    //
     // This calculator can calculate two types of delete bitmap: delete-bitmap inside a rowset and delete-bitmap between rowsets.
     //
     // `segments` are the delta data

--- a/be/src/olap/delete_bitmap_calculator.h
+++ b/be/src/olap/delete_bitmap_calculator.h
@@ -145,7 +145,6 @@ private:
     std::unique_ptr<std::vector<std::unique_ptr<SegmentCacheHandle>>> _seg_caches;
     MergedPKIndexDeleteBitmapCalculatorContext::Comparator _comparator {0};
     std::unique_ptr<Heap> _heap;
-    std::string _last_key;
     size_t _seq_col_length;
     bool _calc_delete_bitmap_between_rowsets;
 };

--- a/be/src/olap/delete_bitmap_calculator.h
+++ b/be/src/olap/delete_bitmap_calculator.h
@@ -108,6 +108,16 @@ class MergedPKIndexDeleteBitmapCalculator {
 public:
     MergedPKIndexDeleteBitmapCalculator() = default;
 
+    // Through the MergedPKIndexDeleteBitmapCalculator, we aim to find the
+    // positions of those rows covered by the newly added segments and
+    // record them in the delete bitmap.
+    // In the calculator, we create a context for each segment of both the base data and delta data.
+    // These contexts can be viewed as iterators, which are then placed into a heap.
+    // We use a method similar to merge sorting to identify duplicate keys and update the delete-bitmap accordingly.
+    //
+    // `segments` are the delta data
+    // `specified_rowsets` are the base data
+    // `calc_delete_bitmap_between_segments` stands for whether we should find duplicate keys in `segments`
     Status init(std::vector<SegmentSharedPtr> const& segments,
                 const std::vector<RowsetSharedPtr>* specified_rowsets = nullptr,
                 bool calc_delete_bitmap_between_segments = false, size_t seq_col_length = 0,

--- a/be/src/olap/delete_bitmap_calculator.h
+++ b/be/src/olap/delete_bitmap_calculator.h
@@ -66,14 +66,14 @@ public:
     MergedPKIndexDeleteBitmapCalculatorContext(
             std::unique_ptr<segment_v2::IndexedColumnIterator> iter,
             vectorized::DataTypePtr index_type, RowsetId rowset_id, size_t end_version,
-            int32_t segment_id, bool is_base_segment, size_t num_rows,
+            int32_t segment_id, bool is_delta_segment, size_t num_rows,
             size_t batch_max_size = kMergedPKIteratorReadBatchSize)
             : _iter(std::move(iter)),
               _index_type(index_type),
               _num_rows(num_rows),
               _max_batch_size(batch_max_size),
               _end_version(end_version),
-              _base_segment(is_base_segment),
+              _delta_segment(is_delta_segment),
               _rowset_id(rowset_id),
               _segment_id(segment_id) {}
     Status get_current_key(Slice* slice);
@@ -84,7 +84,7 @@ public:
     [[nodiscard]] int32_t segment_id() const { return _segment_id; }
     [[nodiscard]] RowsetId rowset_id() const { return _rowset_id; }
     [[nodiscard]] int64_t end_version() const { return _end_version; }
-    [[nodiscard]] bool is_base_segment() const { return _base_segment; }
+    [[nodiscard]] bool is_delta_segment() const { return _delta_segment; }
 
 private:
     Status _next_batch(size_t row_id);
@@ -98,7 +98,7 @@ private:
     size_t const _num_rows;
     size_t const _max_batch_size;
     size_t const _end_version;
-    bool const _base_segment;
+    bool const _delta_segment;
     RowsetId const _rowset_id;
     int32_t const _segment_id;
     bool _excat_match;

--- a/be/src/olap/delete_bitmap_calculator.h
+++ b/be/src/olap/delete_bitmap_calculator.h
@@ -73,9 +73,9 @@ public:
               _num_rows(num_rows),
               _max_batch_size(batch_max_size),
               _end_version(end_version),
+              _base_segment(is_base_segment),
               _rowset_id(rowset_id),
-              _segment_id(segment_id),
-              _base_segment(is_base_segment) {}
+              _segment_id(segment_id) {}
     Status get_current_key(Slice* slice);
     Status advance();
     Status seek_at_or_after(Slice const& key);
@@ -98,10 +98,10 @@ private:
     size_t const _num_rows;
     size_t const _max_batch_size;
     size_t const _end_version;
+    bool const _base_segment;
     RowsetId const _rowset_id;
     int32_t const _segment_id;
     bool _excat_match;
-    bool _base_segment;
 };
 
 class MergedPKIndexDeleteBitmapCalculator {

--- a/be/src/olap/delete_bitmap_calculator.h
+++ b/be/src/olap/delete_bitmap_calculator.h
@@ -108,16 +108,23 @@ class MergedPKIndexDeleteBitmapCalculator {
 public:
     MergedPKIndexDeleteBitmapCalculator() = default;
 
-    // Through the MergedPKIndexDeleteBitmapCalculator, we aim to find the
-    // positions of those rows covered by the newly added segments and
-    // record them in the delete bitmap.
+    // Through the MergedPKIndexDeleteBitmapCalculator, we .
     // In the calculator, we create a context for each segment of both the base data and delta data.
     // These contexts can be viewed as iterators, which are then placed into a heap.
     // We use a method similar to merge sorting to identify duplicate keys and update the delete-bitmap accordingly.
     //
+    // This calculator can calculate two types of delete bitmap: delete-bitmap inside a rowset and delete-bitmap between rowsets.
+    //
     // `segments` are the delta data
     // `specified_rowsets` are the base data
-    // `calc_delete_bitmap_between_segments` stands for whether we should find duplicate keys in `segments`
+    //
+    // If `specified_rowsets` is nullptr, this calculator will calculate the delete-bitmap between `segments`.
+    // Otherwise, this calculator will find the positions of those rows(in `specified_rowsets`)
+    // covered by the newly added segments(`segments`) and record them in the delete bitmap.
+    //
+    // If you want to calculate the delete bitmap inside a rowset, you need to set `specified_rowsets` as nullptr
+    // If you want to calculate the delete bitmap between rowsets but not inside a rowset,
+    // you need to pass the base rowsets to `specified_rowsets`
     Status init(std::vector<SegmentSharedPtr> const& segments,
                 const std::vector<RowsetSharedPtr>* specified_rowsets = nullptr,
                 size_t seq_col_length = 0, size_t max_batch_size = kMergedPKIteratorReadBatchSize);

--- a/be/src/olap/delete_bitmap_calculator.h
+++ b/be/src/olap/delete_bitmap_calculator.h
@@ -120,14 +120,13 @@ public:
     // `calc_delete_bitmap_between_segments` stands for whether we should find duplicate keys in `segments`
     Status init(std::vector<SegmentSharedPtr> const& segments,
                 const std::vector<RowsetSharedPtr>* specified_rowsets = nullptr,
-                bool calc_delete_bitmap_between_segments = false, size_t seq_col_length = 0,
-                size_t max_batch_size = kMergedPKIteratorReadBatchSize);
+                size_t seq_col_length = 0, size_t max_batch_size = kMergedPKIteratorReadBatchSize);
 
     Status process(DeleteBitmapPtr delete_bitmap);
 
 private:
     Status init(std::vector<SegmentSharedPtr> const& segments,
-                const std::vector<int64_t>* end_versions, size_t num_base_segments,
+                const std::vector<int64_t>* end_versions, size_t num_delta_segments,
                 size_t seq_col_length, size_t max_batch_size);
 
     Status step();
@@ -141,7 +140,7 @@ private:
     std::unique_ptr<Heap> _heap;
     std::string _last_key;
     size_t _seq_col_length;
-    bool _calc_delete_bitmap_between_segments;
+    bool _calc_delete_bitmap_between_rowsets;
 };
 
 } // namespace doris

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -3703,7 +3703,7 @@ Status Tablet::calc_delete_bitmap_between_segments(
     }
 
     MergedPKIndexDeleteBitmapCalculator calculator;
-    RETURN_IF_ERROR(calculator.init(segments, nullptr, true, seq_col_length));
+    RETURN_IF_ERROR(calculator.init(segments, nullptr, seq_col_length));
     RETURN_IF_ERROR(calculator.process(delete_bitmap));
 
     LOG(INFO) << fmt::format(

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -3079,7 +3079,7 @@ Status Tablet::calc_delete_bitmap_with_heap(
     }
 
     MergedPKIndexDeleteBitmapCalculator calculator;
-    RETURN_IF_ERROR(calculator.init(segments, &specified_rowsets, seq_col_length));
+    RETURN_IF_ERROR(calculator.init(segments, &specified_rowsets, false, seq_col_length));
     RETURN_IF_ERROR(calculator.process(delete_bitmap));
 
     LOG(INFO) << fmt::format("calc rowsetwise delete bitmap of rowset{}, cost: {}(us)",
@@ -3703,7 +3703,7 @@ Status Tablet::calc_delete_bitmap_between_segments(
     }
 
     MergedPKIndexDeleteBitmapCalculator calculator;
-    RETURN_IF_ERROR(calculator.init(segments, nullptr, seq_col_length));
+    RETURN_IF_ERROR(calculator.init(segments, nullptr, true, seq_col_length));
     RETURN_IF_ERROR(calculator.process(delete_bitmap));
 
     LOG(INFO) << fmt::format(

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -450,6 +450,18 @@ public:
                               DeleteBitmapPtr delete_bitmap, int64_t version,
                               CalcDeleteBitmapToken* token, RowsetWriter* rowset_writer = nullptr);
 
+    Status calc_delete_bitmap_parallel(RowsetSharedPtr rowset,
+                                       const std::vector<segment_v2::SegmentSharedPtr>& segments,
+                                       const std::vector<RowsetSharedPtr>& specified_rowsets,
+                                       DeleteBitmapPtr delete_bitmap, int64_t version,
+                                       CalcDeleteBitmapToken* token,
+                                       RowsetWriter* rowset_writer = nullptr);
+
+    Status calc_delete_bitmap_with_heap(RowsetSharedPtr rowset,
+                                        const std::vector<segment_v2::SegmentSharedPtr>& segments,
+                                        const std::vector<RowsetSharedPtr>& specified_rowsets,
+                                        DeleteBitmapPtr delete_bitmap);
+
     std::vector<RowsetSharedPtr> get_rowset_by_ids(
             const RowsetIdUnorderedSet* specified_rowset_ids);
 

--- a/be/test/olap/delete_bitmap_calculator_test.cpp
+++ b/be/test/olap/delete_bitmap_calculator_test.cpp
@@ -223,15 +223,15 @@ public:
 
         // find the location of rows to be deleted using `MergeIndexDeleteBitmapCalculator`
         // and the result is `result1`
-        MergeIndexDeleteBitmapCalculator calculator;
+        MergedPKIndexDeleteBitmapCalculator calculator;
         size_t seq_col_len = 0;
         if (has_sequence_col) {
             seq_col_len = tablet_schema->column(tablet_schema->sequence_col_idx()).length();
         }
 
-        ASSERT_TRUE(calculator.init(rowset_id, segments, seq_col_len).ok());
+        ASSERT_TRUE(calculator.init(segments, nullptr, seq_col_len).ok());
         DeleteBitmapPtr delete_bitmap = std::make_shared<DeleteBitmap>(0);
-        ASSERT_TRUE(calculator.calculate_all(delete_bitmap).ok());
+        ASSERT_TRUE(calculator.process(delete_bitmap).ok());
 
         std::set<std::pair<size_t, size_t>> result1;
         for (auto [bitmap_key, row_ids] : delete_bitmap->delete_bitmap) {

--- a/be/test/olap/delete_bitmap_calculator_test.cpp
+++ b/be/test/olap/delete_bitmap_calculator_test.cpp
@@ -229,7 +229,7 @@ public:
             seq_col_len = tablet_schema->column(tablet_schema->sequence_col_idx()).length();
         }
 
-        ASSERT_TRUE(calculator.init(segments, nullptr, true, seq_col_len).ok());
+        ASSERT_TRUE(calculator.init(segments, nullptr, seq_col_len).ok());
         DeleteBitmapPtr delete_bitmap = std::make_shared<DeleteBitmap>(0);
         ASSERT_TRUE(calculator.process(delete_bitmap).ok());
 

--- a/be/test/olap/delete_bitmap_calculator_test.cpp
+++ b/be/test/olap/delete_bitmap_calculator_test.cpp
@@ -229,7 +229,7 @@ public:
             seq_col_len = tablet_schema->column(tablet_schema->sequence_col_idx()).length();
         }
 
-        ASSERT_TRUE(calculator.init(segments, nullptr, seq_col_len).ok());
+        ASSERT_TRUE(calculator.init(segments, nullptr, true, seq_col_len).ok());
         DeleteBitmapPtr delete_bitmap = std::make_shared<DeleteBitmap>(0);
         ASSERT_TRUE(calculator.process(delete_bitmap).ok());
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

We propose a new approach based on multi-way merge sort to calculate the delete bitmap between new and old records. Specifically, under the Unique-Key model, in the previous implementation, we would individually search for each newly added record within the existing rowsets using a primary key index to identify records that needed to be marked for deletion. However, this method's efficiency is significantly compromised when performing full duplicate loads especially when the number of rowset gets larger.

This patch does not exhibit significant performance degradation on average, but in the context of 't+1 load' scenarios (where multiple minor updates are performed on a substantial existing dataset before a full-scale replacement update), there is a notable performance improvement.

For example, let's say we create a unique-key table with a composite key of 3 integers. We then adopt the following import approach: first, perform a full import of all the data (40M rows), followed by several, say 20, smaller-scale imports (1M rows), and then another full import (40M rows). In the final import, on our machine, we observed that the unoptimized code took 89 seconds to import, whereas after implementing optimizations, the code only required 50 seconds.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

