### PR TITLE
[fix][load] fix memtable reset cause nullptr

### DIFF
--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -96,7 +96,7 @@ protected:
         bool finished = false;
         auto index_id = request.index_id();
         // close will reset deltawriter memtable and should deregister writer before it.
-        if (finished) {
+        {
             std::lock_guard<SpinLock> l(_tablets_channels_lock);
             auto memtable_memory_limiter = ExecEnv::GetInstance()->memtable_memory_limiter();
             auto tablet_channel_it = _tablets_channels.find(index_id);

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -95,6 +95,18 @@ protected:
         _self_profile->add_info_string("EosHost", fmt::format("{}", request.backend_id()));
         bool finished = false;
         auto index_id = request.index_id();
+        // close will reset deltawriter memtable and should deregister writer before it.
+        if (finished) {
+            std::lock_guard<SpinLock> l(_tablets_channels_lock);
+            auto memtable_memory_limiter = ExecEnv::GetInstance()->memtable_memory_limiter();
+            auto tablet_channel_it = _tablets_channels.find(index_id);
+            if (tablet_channel_it != _tablets_channels.end()) {
+                for (auto& writer_it : tablet_channel_it->second->get_tablet_writers()) {
+                    memtable_memory_limiter->deregister_writer(writer_it.second);
+                }
+            }
+        }
+
         RETURN_IF_ERROR(channel->close(
                 this, request.sender_id(), request.backend_id(), &finished, request.partition_ids(),
                 response->mutable_tablet_vec(), response->mutable_tablet_errors(),
@@ -104,14 +116,7 @@ protected:
             std::lock_guard<std::mutex> l(_lock);
             {
                 std::lock_guard<SpinLock> l(_tablets_channels_lock);
-                auto memtable_memory_limiter = ExecEnv::GetInstance()->memtable_memory_limiter();
-                auto tablet_channel_it = _tablets_channels.find(index_id);
-                if (tablet_channel_it != _tablets_channels.end()) {
-                    for (auto& writer_it : tablet_channel_it->second->get_tablet_writers()) {
-                        memtable_memory_limiter->deregister_writer(writer_it.second);
-                    }
-                    _tablets_channels.erase(index_id);
-                }
+                _tablets_channels.erase(index_id);
             }
             _finished_channel_ids.emplace(index_id);
         }

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -82,6 +82,7 @@ public:
     RuntimeProfile::Counter* get_handle_mem_limit_timer() { return _handle_mem_limit_timer; }
 
     std::unordered_map<int64_t, std::shared_ptr<TabletsChannel>> get_tablets_channels() {
+        std::lock_guard<SpinLock> l(_tablets_channels_lock);
         return _tablets_channels;
     }
 

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -113,7 +113,7 @@ Status LoadChannelMgr::open(const PTabletWriterOpenRequest& params) {
 
     RETURN_IF_ERROR(channel->open(params));
     _register_channel_all_writers(channel);
-    
+
     return Status::OK();
 }
 

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -169,6 +169,10 @@ Status LoadChannelMgr::add_batch(const PTabletWriterAddBlockRequest& request,
     // this case will be handled in load channel's add batch method.
     Status st = channel->add_batch(request, response);
     if (UNLIKELY(!st.ok())) {
+        {
+            std::lock_guard<std::mutex> l(_lock);
+            _deregister_channel_all_writers(channel);
+        }
         channel->cancel();
         return st;
     }

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -112,10 +112,8 @@ Status LoadChannelMgr::open(const PTabletWriterOpenRequest& params) {
     }
 
     RETURN_IF_ERROR(channel->open(params));
-    {
-        std::lock_guard<std::mutex> l(_lock);
-        _register_channel_all_writers(channel);
-    }
+    _register_channel_all_writers(channel);
+    
     return Status::OK();
 }
 
@@ -169,10 +167,7 @@ Status LoadChannelMgr::add_batch(const PTabletWriterAddBlockRequest& request,
     // this case will be handled in load channel's add batch method.
     Status st = channel->add_batch(request, response);
     if (UNLIKELY(!st.ok())) {
-        {
-            std::lock_guard<std::mutex> l(_lock);
-            _deregister_channel_all_writers(channel);
-        }
+        _deregister_channel_all_writers(channel);
         channel->cancel();
         return st;
     }

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -69,6 +69,8 @@ TabletsChannel::TabletsChannel(const TabletsChannelKey& key, const UniqueId& loa
 TabletsChannel::~TabletsChannel() {
     _s_tablet_writer_count -= _tablet_writers.size();
     for (auto& it : _tablet_writers) {
+        auto memtable_memory_limiter = ExecEnv::GetInstance()->memtable_memory_limiter();
+        memtable_memory_limiter->deregister_writer(it.second);
         delete it.second;
     }
     delete _schema;

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -112,7 +112,10 @@ public:
 
     void refresh_profile();
 
-    std::unordered_map<int64_t, DeltaWriter*> get_tablet_writers() { return _tablet_writers; }
+    std::unordered_map<int64_t, DeltaWriter*> get_tablet_writers() {
+        std::lock_guard<SpinLock> l(_tablet_writers_lock);
+        return _tablet_writers;
+    }
 
 private:
     template <typename Request>

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -112,10 +112,7 @@ public:
 
     void refresh_profile();
 
-    std::unordered_map<int64_t, DeltaWriter*> get_tablet_writers() {
-        std::lock_guard<SpinLock> l(_tablet_writers_lock);
-        return _tablet_writers;
-    }
+    std::unordered_map<int64_t, DeltaWriter*> get_tablet_writers() { return _tablet_writers; }
 
 private:
     template <typename Request>


### PR DESCRIPTION
## Proposed changes

When memtable flush actively, delta writer's memtable may had been reset, it will cause nullptr.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

