### PR TITLE
[fix](memory) remove memory tracker profile refresh thread

### DIFF
--- a/be/src/common/daemon.h
+++ b/be/src/common/daemon.h
@@ -48,7 +48,6 @@ private:
     void memory_maintenance_thread();
     void memory_gc_thread();
     void memtable_memory_limiter_tracker_refresh_thread();
-    void memory_tracker_profile_refresh_thread();
     void calculate_metrics_thread();
     void block_spill_gc_thread();
 
@@ -57,7 +56,6 @@ private:
     scoped_refptr<Thread> _memory_maintenance_thread;
     scoped_refptr<Thread> _memory_gc_thread;
     scoped_refptr<Thread> _memtable_memory_limiter_tracker_refresh_thread;
-    scoped_refptr<Thread> _memory_tracker_profile_refresh_thread;
     scoped_refptr<Thread> _calculate_metrics_thread;
     scoped_refptr<Thread> _block_spill_gc_thread;
 };


### PR DESCRIPTION
## Proposed changes

Memtrackers are usually bound to operators in query/load. If a large number of query/loads are stuck, memtrackers will be very large. memory tracker profile refresh thread will get stuck on the lock.

This pr is for branch-2.0, I will rewrite the memory profile in the next pr

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

