### PR TITLE
[fix](stats) Load partition stats unexpectedly

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisJobTest.java
@@ -108,6 +108,12 @@ public class AnalysisJobTest extends TestWithFeService {
             public void execUpdate(String sql) throws Exception {
             }
         };
+        new MockUp<StatisticsCache>() {
+
+            @Mock
+            public void syncLoadColStats(long tableId, long idxId, String colName) {
+            }
+        };
         new Expectations() {
             {
                 stmtExecutor.execute();

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisTaskExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisTaskExecutorTest.java
@@ -90,7 +90,13 @@ public class AnalysisTaskExecutorTest extends TestWithFeService {
         new MockUp<OlapAnalysisTask>() {
             @Mock
             public void execSQL(String sql) throws Exception {
+            }
+        };
 
+        new MockUp<StatisticsCache>() {
+
+            @Mock
+            public void syncLoadColStats(long tableId, long idxId, String colName) {
             }
         };
 


### PR DESCRIPTION
## Proposed changes

 `syncLoadColStats` method invoke stale method to deserialize columnstats after supporting load part stats,

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

