### PR TITLE
[fix](compaction) remove check rowset overlapping in base compaction

### DIFF
--- a/be/src/olap/base_compaction.cpp
+++ b/be/src/olap/base_compaction.cpp
@@ -205,5 +205,4 @@ Status BaseCompaction::pick_rowsets_to_compact() {
             interval_since_last_base_compaction);
 }
 
-
 } // namespace doris

--- a/be/src/olap/base_compaction.cpp
+++ b/be/src/olap/base_compaction.cpp
@@ -122,7 +122,6 @@ void BaseCompaction::_filter_input_rowset() {
 Status BaseCompaction::pick_rowsets_to_compact() {
     _input_rowsets = _tablet->pick_candidate_rowsets_to_base_compaction();
     RETURN_IF_ERROR(check_version_continuity(_input_rowsets));
-    RETURN_IF_ERROR(_check_rowset_overlapping(_input_rowsets));
     _filter_input_rowset();
     if (_input_rowsets.size() <= 1) {
         return Status::Error<BE_NO_SUITABLE_VERSION>("_input_rowsets.size() is 1");
@@ -206,17 +205,5 @@ Status BaseCompaction::pick_rowsets_to_compact() {
             interval_since_last_base_compaction);
 }
 
-Status BaseCompaction::_check_rowset_overlapping(const std::vector<RowsetSharedPtr>& rowsets) {
-    for (auto& rs : rowsets) {
-        if (rs->rowset_meta()->is_segments_overlapping()) {
-            return Status::Error<BE_SEGMENTS_OVERLAPPING>(
-                    "There is overlapping rowset before cumulative point, rowset version={}-{}, "
-                    "cumulative point={}, tablet={}",
-                    rs->start_version(), rs->end_version(), _tablet->cumulative_layer_point(),
-                    _tablet->full_name());
-        }
-    }
-    return Status::OK();
-}
 
 } // namespace doris

--- a/be/src/olap/base_compaction.h
+++ b/be/src/olap/base_compaction.h
@@ -52,7 +52,6 @@ protected:
     ReaderType compaction_type() const override { return ReaderType::READER_BASE_COMPACTION; }
 
 private:
-
     // filter input rowset in some case:
     // 1. dup key without delete predicate
     void _filter_input_rowset();

--- a/be/src/olap/base_compaction.h
+++ b/be/src/olap/base_compaction.h
@@ -52,9 +52,6 @@ protected:
     ReaderType compaction_type() const override { return ReaderType::READER_BASE_COMPACTION; }
 
 private:
-    // check if all input rowsets are non overlapping among segments.
-    // a rowset with overlapping segments should be compacted by cumulative compaction first.
-    Status _check_rowset_overlapping(const vector<RowsetSharedPtr>& rowsets);
 
     // filter input rowset in some case:
     // 1. dup key without delete predicate


### PR DESCRIPTION
## Proposed changes
when a version publish late, cmululative compaction won't pick corresponding rowset to do compaction, because the version won't be in tablet _rs_version_map. After this round cmululative compaction, the cmululative point will update and the late publish version will never have chance to do cmululative compaction unless restar be to recalculate cmululative point. However now base compaction will check rowset overlapping first, and it will fail in this situation. After checking the code, i think check overlapping can remove in base compaction, and check version continuity is enough. The diffrent between base compaction and cmululative compaction is that base compaction will filter deleted row, and block reader they are used is same, so no need to worry about data aggregation in agg type.
Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

