### PR TITLE
[Fix](Planner) fix window function in aggregation

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -1343,6 +1343,16 @@ public class SelectStmt extends QueryStmt {
             }
         }
 
+        // can't contain analytic exprs
+        ArrayList<Expr> aggExprsForChecking = Lists.newArrayList();
+        TreeNode.collect(resultExprs, Expr.isAggregatePredicate(), aggExprsForChecking);
+        ArrayList<Expr> analyticExprs = Lists.newArrayList();
+        TreeNode.collect(aggExprsForChecking, AnalyticExpr.class, analyticExprs);
+        if (!analyticExprs.isEmpty()) {
+            throw new AnalysisException(
+                "AGGREGATE clause must not contain analytic expressions");
+        }
+
         // Collect the aggregate expressions from the SELECT, HAVING and ORDER BY clauses
         // of this statement.
         ArrayList<FunctionCallExpr> aggExprs = Lists.newArrayList();

--- a/regression-test/suites/query_p0/sql_functions/window_functions/test_window_fn.groovy
+++ b/regression-test/suites/query_p0/sql_functions/window_functions/test_window_fn.groovy
@@ -365,6 +365,29 @@ suite("test_window_fn") {
     """
 
     sql "DROP TABLE IF EXISTS example_window_tb;"
+
+    sql """
+        CREATE TABLE IF NOT EXISTS test_window_in_agg
+        (
+            `c1`  int ,
+            `c2`  int ,
+            `c3`  int
+        )
+        ENGINE=OLAP
+        DUPLICATE KEY(`c1`)
+        COMMENT ""
+        DISTRIBUTED BY HASH(`c1`) BUCKETS 1
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1",
+        "in_memory" = "false",
+        "storage_format" = "V2"
+        );
+        """
+    test {
+        sql """SELECT SUM(MAX(c1) OVER (PARTITION BY c2, c3)) FROM  test_window_in_agg;"""
+        exception "errCode = 2, detailMessage = AGGREGATE clause must not contain analytic expressions"
+    }
+    sql "DROP TABLE IF EXISTS test_window_in_agg;"
 }
 
 


### PR DESCRIPTION
## Proposed changes

Problem:
When window function in aggregation function, executor would report an error like:  Required field 'node_type' was not present! 

Example:
SELECT SUM(MAX(c1) OVER (PARTITION BY c2, c3)) FROM  test_window_in_agg;

Reason:
When analyze aggregate, analytic expr (window function carrior when analyze) transfered to slot and loss message. So when 
serialize to thrift package, TExpr can not determine node_type of analytic expr. 

Solved:
We do not support aggregate(window function) yet. So we report an error when analyze.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

