### PR TITLE
[Bug](scan) fix coredump when limit<0 and limit!=-1 with 1.2 fe

### DIFF
--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -62,6 +62,9 @@ ScannerContext::ScannerContext(doris::RuntimeState* state_, doris::vectorized::V
     if (_scanners.empty()) {
         _is_finished = true;
     }
+    if (limit < 0) {
+        limit = -1;
+    }
 }
 
 // After init function call, should not access _parent


### PR DESCRIPTION
## Proposed changes

same with https://github.com/apache/doris/pull/21463

```cpp
0x602000803dfc at pc 0x5578b2e1d034 bp 0x7f022069c640 sp 0x7f022069be10
WRITE of size 4 at 0x602000803dfc thread T2214 (FragmentMgrThre)
    #0 0x5578b2e1d033 in __asan_memset (/mnt/ssd01/doris-master/VEC_ASAN/be/lib/doris_be+0x15ec7033) (BuildId: fa78a996ce122fa6)
    #1 0x5578b33ccc2c in void doris::vectorized::PODArrayBase<4ul, 4096ul, Allocator<false, false, false>, 15ul, 16ul>::alloc<>(unsigned long) /mnt/hdd04/zgx_temp/repo_center/doris_branch-2.0/doris/be/src/vec/common/pod_array.h:132:23
    #2 0x5578b33cc929 in void doris::vectorized::PODArrayBase<4ul, 4096ul, Allocator<false, false, false>, 15ul, 16ul>::realloc<>(unsigned long) /mnt/hdd04/zgx_temp/repo_center/doris_branch-2.0/doris/be/src/vec/common/pod_array.h:146:13
    #3 0x5578b33bb151 in void doris::vectorized::PODArrayBase<4ul, 4096ul, Allocator<false, false, false>, 15ul, 16ul>::reserve<>(unsigned long) /mnt/hdd04/zgx_temp/repo_center/doris_branch-2.0/doris/be/src/vec/common/pod_array.h:220:13
    #4 0x5578c1653d00 in doris::vectorized::ColumnVector<int>::reserve(unsigned long) /mnt/hdd04/zgx_temp/repo_center/doris_branch-2.0/doris/be/src/vec/columns/column_vector.h:351:44
    #5 0x5578c14f9e3b in doris::vectorized::ColumnNullable::reserve(unsigned long) /mnt/hdd04/zgx_temp/repo_center/doris_branch-2.0/doris/be/src/vec/columns/column_nullable.cpp:465:25
    #6 0x5578c1a2151d in doris::vectorized::Block::Block(std::vector<doris::SlotDescriptor*, std::allocator<doris::SlotDescriptor*>> const&, unsigned long, bool) /mnt/hdd04/zgx_temp/repo_center/doris_branch-2.0/doris/be/src/vec/core/block.cpp:81:21
    #7 0x5578c67ad7b4 in std::unique_ptr<doris::vectorized::Block, std::default_delete<doris::vectorized::Block>> doris::vectorized::Block::create_unique<std::vector<doris::SlotDescriptor*, std::allocator<doris::SlotDescriptor*>> const&, int&, bool>(std::vector<doris::SlotDescriptor*, std::allocator<doris::SlotDescriptor*>> const&, int&, bool&&) /mnt/hdd04/zgx_temp/repo_center/doris_branch-2.0/doris/be/src/vec/core/block.h:72:5
    #8 0x5578c67a0f6e in doris::vectorized::ScannerContext::_init_free_block(int, int) /mnt/hdd04/zgx_temp/repo_center/doris_branch-2.0/doris/be/src/vec/exec/scan/scanner_context.cpp:134:22
    #9 0x5578c67a084e in doris::vectorized::ScannerContext::init() /mnt/hdd04/zgx_temp/repo_center/doris_branch-2.0/doris/be/src/vec/exec/scan/scanner_context.cpp:109:5
    #10 0x5578c6880ebe in doris::vectorized::VScanNode::alloc_resource(doris::RuntimeState*) /mnt/hdd04/zgx_temp/repo_center/doris_branch-2.0/doris/be/src/vec/exec/scan/vscan_node.cpp:201:13
    #11 0x5578b58ad9f3 in doris::ExecNode::open(doris::RuntimeState*) /mnt/hdd04/zgx_temp/repo_center/doris_branch-2.0/doris/be/src/exec/exec_node.cpp:161:12
    #12 0x5578c687f74f in doris::vectorized::VScanNode::open(doris::RuntimeState*) /mnt/hdd04/zgx_temp/repo_center/doris_branch-2.0/doris/be/src/vec/exec/scan/vscan_node.cpp:160:22
    #13 0x5578b58907fa in doris::PlanFragmentExecutor::open_vectorized_internal() /mnt/hdd04/zgx_temp/repo_center/doris_branch-2.0/doris/be/src/runtime/plan_fragment_executor.cpp:308:9
    #14 0x5578b588f783 in doris::PlanFragmentExecutor::open() /mnt/hdd04/zgx_temp/repo_center/doris_branch-2.0/doris/be/src/runtime/plan_fragment_executor.cpp:271:14
    #15 0x5578b566a98a in doris::FragmentExecState::execute() /mnt/hdd04/zgx_temp/repo_center/doris_branch-2.0/doris/be/src/runtime/fragment_mgr.cpp:264:31
    #16 0x5578b5674460 in doris::FragmentMgr::_exec_actual(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::RuntimeState*, doris::Status*)> const&) /mnt/hdd04/zgx_temp/repo_center/doris_branch-2.0/doris/be/src/runtime/fragment_mgr.cpp:532:29
    #17 0x5578b568d76b in doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_0::operator()() const /mnt/hdd04/zgx_temp/repo_center/doris_branch-2.0/doris/be/src/runtime/fragment_mgr.cpp:831:17
    #18 0x5578b568d624 in void std::__invoke_impl<void, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_0&>(std::__invoke_other, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_0&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #19 0x5578b568d5c4 in std::enable_if<is_invocable_r_v<void, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_0&>, void>::type std::__invoke_r<void, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_0&>(doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_0&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

