### PR TITLE
[fix](planner) should not change SlotRef to NullLiteral

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
@@ -934,7 +934,7 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
             // being cast to a non-NULL type, the type doesn't matter and we can cast it
             // arbitrarily.
             Preconditions.checkState(this instanceof NullLiteral || this instanceof SlotRef);
-            return NullLiteral.create(ScalarType.BOOLEAN).treeToThrift();
+            type = ScalarType.BOOLEAN;
         }
         TExpr result = new TExpr();
         treeToThriftHelper(result);


### PR DESCRIPTION
## Proposed changes

When executing the NullLiteral expression, a new column will be created, whereas executing the SlotRef expression does not create a new column. This difference can result in one unexpected column in the block.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

