### PR TITLE
[fix](memory) enable Jemalloc arena dirty pages

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -516,6 +516,7 @@ DEFINE_Bool(enable_quadratic_probing, "false");
 DEFINE_String(pprof_profile_dir, "${DORIS_HOME}/log");
 // for jeprofile in jemalloc
 DEFINE_mString(jeprofile_dir, "${DORIS_HOME}/log");
+DEFINE_mBool(enable_je_purge_dirty_pages, "true");
 
 // to forward compatibility, will be removed later
 DEFINE_mBool(enable_token_check, "true");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -565,6 +565,8 @@ DECLARE_Bool(enable_quadratic_probing);
 DECLARE_String(pprof_profile_dir);
 // for jeprofile in jemalloc
 DECLARE_mString(jeprofile_dir);
+// Purge all unused dirty pages for all arenas.
+DECLARE_mBool(enable_je_purge_dirty_pages);
 
 // to forward compatibility, will be removed later
 DECLARE_mBool(enable_token_check);

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -111,14 +111,18 @@ public:
     static inline void je_purge_all_arena_dirty_pages() {
 #ifdef USE_JEMALLOC
         // https://github.com/jemalloc/jemalloc/issues/2470
-        // Occasional core dump during stress test, purge should be turned on after the heap corruption is resolved.
-        // try {
-        //     // Purge all unused dirty pages for arena <i>, or for all arenas if <i> equals MALLCTL_ARENAS_ALL.
-        //     jemallctl(fmt::format("arena.{}.purge", MALLCTL_ARENAS_ALL).c_str(), nullptr, nullptr,
-        //               nullptr, 0);
-        // } catch (...) {
-        //     LOG(WARNING) << "Purge all unused dirty pages for all arenas failed";
-        // }
+        // If there is a core dump here, it may cover up the real stack, if stack trace indicates heap corruption
+        // (which led to invalid jemalloc metadata), like double free or use-after-free in the application.
+        // Try sanitizers such as ASAN, or build jemalloc with --enable-debug to investigate further.
+        if (config::enable_je_purge_dirty_pages) {
+            try {
+                // Purge all unused dirty pages for arena <i>, or for all arenas if <i> equals MALLCTL_ARENAS_ALL.
+                jemallctl(fmt::format("arena.{}.purge", MALLCTL_ARENAS_ALL).c_str(), nullptr,
+                          nullptr, nullptr, 0);
+            } catch (...) {
+                LOG(WARNING) << "Purge all unused dirty pages for all arenas failed";
+            }
+        }
 #endif
     }
 

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -38,6 +38,7 @@
 #else
 #include <gperftools/malloc_extension.h>
 #endif
+#include "common/config.h"
 #include "util/perf_counters.h"
 
 namespace doris {


### PR DESCRIPTION
## Proposed changes

If there is a core dump here, it may cover up the real stack, if stack trace indicates heap corruption
(which led to invalid jemalloc metadata), like double free or use-after-free in the application.
Try sanitizers such as ASAN, or build jemalloc with --enable-debug to investigate further.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

