### PR TITLE
[fix](catalog) Convert hive catalog event to lowercase when configure notifaction

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterTableEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterTableEvent.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.messaging.json.JSONAlterTableMessage;
 
 import java.util.List;
+import java.util.Locale;
 
 /**
  * MetastoreEvent for ALTER_TABLE event type
@@ -64,6 +65,7 @@ public class AlterTableEvent extends MetastoreTableEvent {
                     (JSONAlterTableMessage) MetastoreEventsProcessor.getMessageDeserializer(event.getMessageFormat())
                             .getAlterTableMessage(event.getMessage());
             tableAfter = Preconditions.checkNotNull(alterTableMessage.getTableObjAfter());
+            tableAfter.setTableName(tableAfter.getTableName().toLowerCase(Locale.ROOT));
             tableBefore = Preconditions.checkNotNull(alterTableMessage.getTableObjBefore());
         } catch (Exception e) {
             throw new MetastoreNotificationException(

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/CreateTableEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/CreateTableEvent.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.messaging.CreateTableMessage;
 
 import java.util.List;
+import java.util.Locale;
 
 /**
  * MetastoreEvent for CREATE_TABLE event type
@@ -51,6 +52,7 @@ public class CreateTableEvent extends MetastoreTableEvent {
                     MetastoreEventsProcessor.getMessageDeserializer(event.getMessageFormat())
                             .getCreateTableMessage(event.getMessage());
             hmsTbl = Preconditions.checkNotNull(createTableMessage.getTableObj());
+            hmsTbl.setTableName(hmsTbl.getTableName().toLowerCase(Locale.ROOT));
         } catch (Exception e) {
             throw new MetastoreNotificationException(
                     debugString("Unable to deserialize the event message"), e);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreEvent.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -70,7 +71,7 @@ public abstract class MetastoreEvent {
 
     protected MetastoreEvent(NotificationEvent event, String catalogName) {
         this.event = event;
-        this.dbName = event.getDbName();
+        this.dbName = event.getDbName().toLowerCase(Locale.ROOT);
         this.tblName = event.getTableName();
         this.eventId = event.getEventId();
         this.eventType = MetastoreEventType.from(event.getEventType());


### PR DESCRIPTION
…ame and db name in Hive operator are in uppercase

## Proposed changes

Issue Number: close #22433 

<!--Describe your changes.-->

Now hive metastore notification table name and dbname are maybe upper case, in doris will has some issue(see 22433), should  modify to lower case

The name synchronized with the refresh command is converted to lowercase, but the name synchronized through event is not converted, so we need to handle it

