### PR TITLE
[fix](nereids) Fix full auto analyze

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2054,7 +2054,7 @@ public class Config extends ConfigBase {
     public static int force_olap_table_replication_num = 0;
 
     @ConfField
-    public static int full_auto_analyze_simultaneously_running_task_num = 1;
+    public static int full_auto_analyze_simultaneously_running_task_num = 5;
 
     @ConfField
     public static int cpu_resource_limit_per_analyze_task = 1;

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsAutoAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsAutoAnalyzer.java
@@ -57,6 +57,7 @@ public class StatisticsAutoAnalyzer extends MasterDaemon {
         super("Automatic Analyzer",
                 TimeUnit.MINUTES.toMillis(Config.auto_check_statistics_in_minutes) / 2);
         analysisTaskExecutor = new AnalysisTaskExecutor(Config.full_auto_analyze_simultaneously_running_task_num);
+        analysisTaskExecutor.start();
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes

1. System jobs would never get cancelled, since canceller isn't started
2. Increase the  default thread count for auto analyzing

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

