### PR TITLE
[fix](load) sharding the lock for tablet_writers map

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -960,6 +960,7 @@ DEFINE_Validator(file_cache_min_file_segment_size, [](const int64_t config) -> b
 });
 DEFINE_Bool(clear_file_cache, "false");
 DEFINE_Bool(enable_file_cache_query_limit, "false");
+DEFINE_mInt32(tablet_writers_shard_num, "128");
 
 DEFINE_mInt32(index_cache_entry_stay_time_after_lookup_s, "1800");
 DEFINE_mInt32(inverted_index_cache_stale_sweep_time_sec, "600");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -993,6 +993,7 @@ DECLARE_Int64(file_cache_min_file_segment_size);
 DECLARE_Int64(file_cache_max_file_segment_size);
 DECLARE_Bool(clear_file_cache);
 DECLARE_Bool(enable_file_cache_query_limit);
+DECLARE_mInt32(tablet_writers_shard_num);
 
 // inverted index searcher cache
 // cache entry stay time after lookup

--- a/be/src/olap/memtable_memory_limiter.cpp
+++ b/be/src/olap/memtable_memory_limiter.cpp
@@ -44,7 +44,6 @@ MemTableMemoryLimiter::~MemTableMemoryLimiter() {
     DEREGISTER_HOOK_METRIC(memtable_memory_limiter_mem_consumption);
     for (auto writer : _writers) {
         if (writer != nullptr) {
-            delete writer;
             writer = nullptr;
         }
     }
@@ -61,12 +60,12 @@ Status MemTableMemoryLimiter::init(int64_t process_mem_limit) {
     return Status::OK();
 }
 
-void MemTableMemoryLimiter::register_writer(DeltaWriter* writer) {
+void MemTableMemoryLimiter::register_writer(std::shared_ptr<DeltaWriter> writer) {
     std::lock_guard<std::mutex> l(_lock);
     _writers.insert(writer);
 }
 
-void MemTableMemoryLimiter::deregister_writer(DeltaWriter* writer) {
+void MemTableMemoryLimiter::deregister_writer(std::shared_ptr<DeltaWriter> writer) {
     std::lock_guard<std::mutex> l(_lock);
     _writers.erase(writer);
 }

--- a/be/src/olap/memtable_memory_limiter.h
+++ b/be/src/olap/memtable_memory_limiter.h
@@ -26,7 +26,7 @@
 namespace doris {
 class DeltaWriter;
 struct WriterMemItem {
-    DeltaWriter* writer;
+    std::shared_ptr<DeltaWriter> writer;
     int64_t mem_size;
 };
 class MemTableMemoryLimiter {
@@ -40,9 +40,9 @@ public:
     // If yes, it will flush memtable to try to reduce memory consumption.
     void handle_memtable_flush();
 
-    void register_writer(DeltaWriter* writer);
+    void register_writer(std::shared_ptr<DeltaWriter> writer);
 
-    void deregister_writer(DeltaWriter* writer);
+    void deregister_writer(std::shared_ptr<DeltaWriter> writer);
 
     void refresh_mem_tracker() {
         std::lock_guard<std::mutex> l(_lock);
@@ -66,6 +66,6 @@ private:
     int64_t _load_soft_mem_limit = -1;
     bool _soft_reduce_mem_in_progress = false;
 
-    std::unordered_set<DeltaWriter*> _writers;
+    std::unordered_set<std::shared_ptr<DeltaWriter>> _writers;
 };
 } // namespace doris

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -103,7 +103,7 @@ protected:
             auto tablet_channel_it = _tablets_channels.find(index_id);
             if (tablet_channel_it != _tablets_channels.end()) {
                 for (auto& writer_it : tablet_channel_it->second->get_tablet_writers()) {
-                    memtable_memory_limiter->deregister_writer(writer_it.second);
+                    memtable_memory_limiter->deregister_writer(writer_it);
                 }
             }
         }

--- a/be/src/runtime/load_channel_mgr.h
+++ b/be/src/runtime/load_channel_mgr.h
@@ -72,7 +72,7 @@ private:
     void _register_channel_all_writers(std::shared_ptr<doris::LoadChannel> channel) {
         for (auto& tablet_channel_it : channel->get_tablets_channels()) {
             for (auto& writer_it : tablet_channel_it.second->get_tablet_writers()) {
-                _memtable_memory_limiter->register_writer(writer_it.second);
+                _memtable_memory_limiter->register_writer(writer_it);
             }
         }
     }
@@ -80,7 +80,7 @@ private:
     void _deregister_channel_all_writers(std::shared_ptr<doris::LoadChannel> channel) {
         for (auto& tablet_channel_it : channel->get_tablets_channels()) {
             for (auto& writer_it : tablet_channel_it.second->get_tablet_writers()) {
-                _memtable_memory_limiter->deregister_writer(writer_it.second);
+                _memtable_memory_limiter->deregister_writer(writer_it);
             }
         }
     }

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -27,9 +27,9 @@
 #include <utility>
 
 #include "bvar/bvar.h"
-#include "olap/memtable_memory_limiter.h"
 #include "runtime/exec_env.h"
 #include "runtime/fragment_mgr.h"
+#include "runtime/memory/mem_tracker_limiter.h"
 #include "runtime/task_group/task_group.h"
 #include "service/backend_options.h"
 #include "util/mem_info.h"


### PR DESCRIPTION
Lock overhead is too large when doing heavy high concurrent load. This commit, we split the lock to 128 (configurable) sharding to relief the problem.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

