### PR TITLE
[fix](delete-pred) fix special char in delete sub condition

### DIFF
--- a/be/src/olap/delete_handler.cpp
+++ b/be/src/olap/delete_handler.cpp
@@ -214,7 +214,7 @@ bool DeleteHandler::_parse_condition(const std::string& condition_str, TConditio
         //  group2:  ((?:=)|(?:!=)|(?:>>)|(?:<<)|(?:>=)|(?:<=)|(?:\*=)|(?:IS)) matches  "="
         //  group3:  ((?:[\s\S]+)?) matches "1597751948193618247  and length(source)<1;\n;\n"
         const char* const CONDITION_STR_PATTERN =
-                R"((\w+)\s*((?:=)|(?:!=)|(?:>>)|(?:<<)|(?:>=)|(?:<=)|(?:\*=)|(?:IS))\s*('((?:[\s\S]+)?)'|(?:[\s\S]+)?))";
+                R"(([\w$#%]+)\s*((?:=)|(?:!=)|(?:>>)|(?:<<)|(?:>=)|(?:<=)|(?:\*=)|(?:IS))\s*('((?:[\s\S]+)?)'|(?:[\s\S]+)?))";
         regex ex(CONDITION_STR_PATTERN);
         if (regex_match(condition_str, what, ex)) {
             if (condition_str.size() != what[0].str().size()) {

--- a/be/test/olap/delete_handler_test.cpp
+++ b/be/test/olap/delete_handler_test.cpp
@@ -162,6 +162,12 @@ static void set_default_create_tablet_request(TCreateTabletReq* request) {
     k12.column_type.type = TPrimitiveType::CHAR;
     request->tablet_schema.columns.push_back(k12);
 
+    TColumn kSpecial;
+    kSpecial.column_name = "k$1";
+    kSpecial.__set_is_key(true);
+    kSpecial.column_type.type = TPrimitiveType::SMALLINT;
+    request->tablet_schema.columns.push_back(kSpecial);
+
     TColumn k13;
     k13.column_name = "k13";
     k13.__set_is_key(true);
@@ -241,6 +247,12 @@ static void set_create_duplicate_tablet_request(TCreateTabletReq* request) {
     k12.column_type.__set_len(64);
     k12.column_type.type = TPrimitiveType::CHAR;
     request->tablet_schema.columns.push_back(k12);
+
+    TColumn kSpecial;
+    kSpecial.column_name = "k$1";
+    kSpecial.__set_is_key(true);
+    kSpecial.column_type.type = TPrimitiveType::SMALLINT;
+    request->tablet_schema.columns.push_back(kSpecial);
 
     TColumn k13;
     k13.column_name = "k13";
@@ -352,6 +364,12 @@ TEST_F(TestDeleteConditionHandler, StoreCondSucceed) {
     condition.condition_values.push_back("9");
     conditions.push_back(condition);
 
+    condition.column_name = "k$1";
+    condition.condition_op = ">";
+    condition.condition_values.clear();
+    condition.condition_values.push_back("1");
+    conditions.push_back(condition);
+
     condition.column_name = "k13";
     condition.condition_op = "*=";
     condition.condition_values.clear();
@@ -365,13 +383,14 @@ TEST_F(TestDeleteConditionHandler, StoreCondSucceed) {
     EXPECT_EQ(Status::OK(), success_res);
 
     // 验证存储在header中的过滤条件正确
-    EXPECT_EQ(size_t(6), del_pred.sub_predicates_size());
+    EXPECT_EQ(size_t(7), del_pred.sub_predicates_size());
     EXPECT_STREQ("k1='1'", del_pred.sub_predicates(0).c_str());
     EXPECT_STREQ("k2>>'3'", del_pred.sub_predicates(1).c_str());
     EXPECT_STREQ("k3<='5'", del_pred.sub_predicates(2).c_str());
     EXPECT_STREQ("k4 IS NULL", del_pred.sub_predicates(3).c_str());
     EXPECT_STREQ("k5='7'", del_pred.sub_predicates(4).c_str());
     EXPECT_STREQ("k12!='9'", del_pred.sub_predicates(5).c_str());
+    EXPECT_STREQ("k$1>>'1'", del_pred.sub_predicates(6).c_str());
 
     EXPECT_EQ(size_t(1), del_pred.in_predicates_size());
     EXPECT_FALSE(del_pred.in_predicates(0).is_not_in());
@@ -1044,6 +1063,7 @@ TEST_F(TestDeleteHandler, FilterDataSubconditions) {
     data_str.push_back("2014-01-01");
     data_str.push_back("2014-01-01 00:00:00");
     data_str.push_back("YWFH");
+    data_str.push_back("1");
     data_str.push_back("YWFH==");
     data_str.push_back("1");
     OlapTuple tuple1(data_str);
@@ -1127,6 +1147,7 @@ TEST_F(TestDeleteHandler, FilterDataConditions) {
     data_str.push_back("2014-01-01");
     data_str.push_back("2014-01-01 00:00:00");
     data_str.push_back("YWFH");
+    data_str.push_back("1");
     data_str.push_back("YWFH==");
     data_str.push_back("1");
     OlapTuple tuple(data_str);
@@ -1190,6 +1211,7 @@ TEST_F(TestDeleteHandler, FilterDataVersion) {
     data_str.push_back("2014-01-01");
     data_str.push_back("2014-01-01 00:00:00");
     data_str.push_back("YWFH");
+    data_str.push_back("1");
     data_str.push_back("YWFH==");
     data_str.push_back("1");
     OlapTuple tuple(data_str);


### PR DESCRIPTION
## Proposed changes

For some users, their delete condition may contain special chars like '$', which will cause failure in parsing delete condition.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

