### PR TITLE
[improvement](resource-tag) Add Backend tag location check

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/ModifyBackendTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/ModifyBackendTest.java
@@ -149,13 +149,13 @@ public class ModifyBackendTest {
         // it will fail because of we check tag location during the analysis process, so we check AnalysisException
         String partName = tbl.getPartitionNames().stream().findFirst().get();
         String wrongAlterStr = "alter table test.tbl4 modify partition " + partName
-            + " set ('replication_allocation' = 'tag.location.zonex:1')";
+                + " set ('replication_allocation' = 'tag.location.zonex:1')";
         ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "errCode = 2, detailMessage = "
                 + "errCode = 2, detailMessage = Failed to find enough backend, "
                 + "please check the replication num,replication tag and storage medium.\n"
                 + "Create failed replications:\n"
                 + "replication tag: {\"location\" : \"zonex\"}, replication num: 1, storage medium: null",
-            () -> UtFrameUtils.parseAndAnalyzeStmt(wrongAlterStr, connectContext));
+                () -> UtFrameUtils.parseAndAnalyzeStmt(wrongAlterStr, connectContext));
         tblProperties = tableProperty.getProperties();
         Assert.assertTrue(tblProperties.containsKey("default.replication_allocation"));
 

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/ModifyBackendTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/ModifyBackendTest.java
@@ -21,6 +21,7 @@ import org.apache.doris.analysis.AlterSystemStmt;
 import org.apache.doris.analysis.AlterTableStmt;
 import org.apache.doris.analysis.CreateDbStmt;
 import org.apache.doris.analysis.CreateTableStmt;
+import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ExceptionChecker;
 import org.apache.doris.qe.ConnectContext;
@@ -134,23 +135,27 @@ public class ModifyBackendTest {
         Assert.assertEquals("tag.location.default: 3", tblProperties.get("default.replication_allocation"));
 
         // modify default replica
-        String alterStr = "alter table test.tbl4 set ('default.replication_allocation' = 'tag.location.zonex:1')";
+        String alterStr = "alter table test.tbl4 set ('default.replication_allocation' = 'tag.location.zone1:1')";
         AlterTableStmt alterStmt = (AlterTableStmt) UtFrameUtils.parseAndAnalyzeStmt(alterStr, connectContext);
         ExceptionChecker.expectThrowsNoException(() -> DdlExecutor.execute(Env.getCurrentEnv(), alterStmt));
         defaultAlloc = tbl.getDefaultReplicaAllocation();
         ReplicaAllocation expectedAlloc = new ReplicaAllocation();
-        expectedAlloc.put(Tag.create(Tag.TYPE_LOCATION, "zonex"), (short) 1);
+        expectedAlloc.put(Tag.create(Tag.TYPE_LOCATION, "zone1"), (short) 1);
         Assert.assertEquals(expectedAlloc, defaultAlloc);
         tblProperties = tableProperty.getProperties();
         Assert.assertTrue(tblProperties.containsKey("default.replication_allocation"));
 
         // modify partition replica with wrong zone
+        // it will fail because of we check tag location during the analysis process, so we check AnalysisException
         String partName = tbl.getPartitionNames().stream().findFirst().get();
-        alterStr = "alter table test.tbl4 modify partition " + partName
-                + " set ('replication_allocation' = 'tag.location.zonex:1')";
-        AlterTableStmt alterStmt2 = (AlterTableStmt) UtFrameUtils.parseAndAnalyzeStmt(alterStr, connectContext);
-        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "Failed to find enough host with tag",
-                () -> DdlExecutor.execute(Env.getCurrentEnv(), alterStmt2));
+        String wrongAlterStr = "alter table test.tbl4 modify partition " + partName
+            + " set ('replication_allocation' = 'tag.location.zonex:1')";
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "errCode = 2, detailMessage = "
+                + "errCode = 2, detailMessage = Failed to find enough backend, "
+                + "please check the replication num,replication tag and storage medium.\n"
+                + "Create failed replications:\n"
+                + "replication tag: {\"location\" : \"zonex\"}, replication num: 1, storage medium: null",
+            () -> UtFrameUtils.parseAndAnalyzeStmt(wrongAlterStr, connectContext));
         tblProperties = tableProperty.getProperties();
         Assert.assertTrue(tblProperties.containsKey("default.replication_allocation"));
 

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/ReplicaAllocationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/ReplicaAllocationTest.java
@@ -18,14 +18,21 @@
 package org.apache.doris.catalog;
 
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ExceptionChecker;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.util.PropertyAnalyzer;
 import org.apache.doris.meta.MetaContext;
 import org.apache.doris.resource.Tag;
+import org.apache.doris.system.SystemInfoService;
+import org.apache.doris.thrift.TStorageMedium;
 
 import com.google.common.collect.Maps;
+import mockit.Delegate;
+import mockit.Expectations;
+import mockit.Mocked;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.DataInputStream;
@@ -34,9 +41,27 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Map;
 
 public class ReplicaAllocationTest {
+    @Mocked
+    SystemInfoService systemInfoService;
+
+    @Before
+    public void setUp() throws DdlException {
+        new Expectations() {
+            {
+                systemInfoService.selectBackendIdsForReplicaCreation((ReplicaAllocation) any, (TStorageMedium) any, false, true);
+                minTimes = 0;
+                result = new Delegate() {
+                    Map<Tag, List<Long>> selectBackendIdsForReplicaCreation() {
+                        return Maps.newHashMap();
+                    }
+                };
+            }
+        };
+    }
 
     @Test
     public void testNormal() throws AnalysisException {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #22671

<!--Describe your changes.-->
Add Backend tag location check.
Avoid user set a bad backend tag, cause create table and dynamic partitions failed.
For example, the default value for all backends tag is `default`, When setting the replication_allocation of a table, user use the following command: `ALTER TABLE example_db.mysql_table SET ("replication_allocation" = "tag.location.tag1: 1");`, it can set success, but tag1 is not exist, cause dynamic partition can't create.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

