### PR TITLE
[Enhancement](multi-catalog) add a BE selection strategy for hdfs short-circuit-read.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsResource.java
@@ -95,7 +95,8 @@ public class HdfsResource extends Resource {
     }
 
     public static boolean enableShortCircuitRead(Map<String, String> properties) {
-        return properties.containsKey(HADOOP_SHORT_CIRCUIT) && properties.containsKey(HADOOP_SOCKET_PATH);
+        return "true".equalsIgnoreCase(properties.getOrDefault(HADOOP_SHORT_CIRCUIT, "true"))
+                    && properties.containsKey(HADOOP_SOCKET_PATH);
     }
 
     // Will be removed after BE unified storage params

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsResource.java
@@ -75,7 +75,7 @@ public class HdfsResource extends Resource {
     protected void setProperties(Map<String, String> properties) throws DdlException {
         // `dfs.client.read.shortcircuit` and `dfs.domain.socket.path` should be both set to enable short circuit read.
         // We should disable short circuit read if they are not both set because it will cause performance down.
-        if (!properties.containsKey(HADOOP_SHORT_CIRCUIT) || !properties.containsKey(HADOOP_SOCKET_PATH)) {
+        if (!(enableShortcircuitRead(properties))) {
             properties.put(HADOOP_SHORT_CIRCUIT, "false");
         }
         this.properties = properties;
@@ -92,6 +92,10 @@ public class HdfsResource extends Resource {
         for (Map.Entry<String, String> entry : properties.entrySet()) {
             result.addRow(Lists.newArrayList(name, lowerCaseType, entry.getKey(), entry.getValue()));
         }
+    }
+
+    public static boolean enableShortcircuitRead(Map<String, String> properties) {
+        return properties.containsKey(HADOOP_SHORT_CIRCUIT) && properties.containsKey(HADOOP_SOCKET_PATH);
     }
 
     // Will be removed after BE unified storage params

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsResource.java
@@ -75,7 +75,7 @@ public class HdfsResource extends Resource {
     protected void setProperties(Map<String, String> properties) throws DdlException {
         // `dfs.client.read.shortcircuit` and `dfs.domain.socket.path` should be both set to enable short circuit read.
         // We should disable short circuit read if they are not both set because it will cause performance down.
-        if (!(enableShortcircuitRead(properties))) {
+        if (!(enableShortCircuitRead(properties))) {
             properties.put(HADOOP_SHORT_CIRCUIT, "false");
         }
         this.properties = properties;
@@ -94,7 +94,7 @@ public class HdfsResource extends Resource {
         }
     }
 
-    public static boolean enableShortcircuitRead(Map<String, String> properties) {
+    public static boolean enableShortCircuitRead(Map<String, String> properties) {
         return properties.containsKey(HADOOP_SHORT_CIRCUIT) && properties.containsKey(HADOOP_SOCKET_PATH);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsResource.java
@@ -95,7 +95,7 @@ public class HdfsResource extends Resource {
     }
 
     public static boolean enableShortCircuitRead(Map<String, String> properties) {
-        return "true".equalsIgnoreCase(properties.getOrDefault(HADOOP_SHORT_CIRCUIT, "true"))
+        return "true".equalsIgnoreCase(properties.getOrDefault(HADOOP_SHORT_CIRCUIT, "false"))
                     && properties.containsKey(HADOOP_SOCKET_PATH);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileQueryScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileQueryScanNode.java
@@ -74,6 +74,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -326,7 +327,8 @@ public abstract class FileQueryScanNode extends FileScanNode {
             TScanRangeLocation location = new TScanRangeLocation();
             // Use consistent hash to assign the same scan range into the same backend among different queries
             Backend selectedBackend = ConnectContext.get().getSessionVariable().enableFileCache
-                    ? backendPolicy.getNextConsistentBe(curLocations) : backendPolicy.getNextBe();
+                    ? backendPolicy.getNextConsistentBe(curLocations)
+                    : backendPolicy.getNextLocalBe(Arrays.asList(fileSplit.getHosts()));
             location.setBackendId(selectedBackend.getId());
             location.setServer(new TNetworkAddress(selectedBackend.getHost(), selectedBackend.getBePort()));
             curLocations.addToLocations(location);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileQueryScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileQueryScanNode.java
@@ -272,6 +272,8 @@ public abstract class FileQueryScanNode extends FileScanNode {
             params.setProperties(locationProperties);
         }
 
+        boolean enableSqlCache = ConnectContext.get().getSessionVariable().enableFileCache;
+        boolean enableShortCircuitRead = HdfsResource.enableShortCircuitRead(locationProperties);
         List<String> pathPartitionKeys = getPathPartitionKeys();
         for (Split split : inputSplits) {
             FileSplit fileSplit = (FileSplit) split;
@@ -313,6 +315,7 @@ public abstract class FileQueryScanNode extends FileScanNode {
                 tableFormatFileDesc.setTransactionalHiveParams(transactionalHiveDesc);
                 rangeDesc.setTableFormatParams(tableFormatFileDesc);
             }
+
             // external data lake table
             if (fileSplit instanceof IcebergSplit) {
                 // TODO: extract all data lake split to factory
@@ -323,14 +326,19 @@ public abstract class FileQueryScanNode extends FileScanNode {
                 HudiScanNode.setHudiParams(rangeDesc, (HudiSplit) fileSplit);
             }
 
+            Backend selectedBackend;
+            if (enableSqlCache) {
+                // Use consistent hash to assign the same scan range into the same backend among different queries
+                selectedBackend = backendPolicy.getNextConsistentBe(curLocations);
+            } else if (enableShortCircuitRead) {
+                // Try to find a local BE if enable hdfs short circuit read
+                selectedBackend = backendPolicy.getNextLocalBe(Arrays.asList(fileSplit.getHosts()));
+            } else {
+                selectedBackend = backendPolicy.getNextBe();
+            }
+
             curLocations.getScanRange().getExtScanRange().getFileScanRange().addToRanges(rangeDesc);
             TScanRangeLocation location = new TScanRangeLocation();
-            // Use consistent hash to assign the same scan range into the same backend among different queries
-            Backend selectedBackend = ConnectContext.get().getSessionVariable().enableFileCache
-                    ? backendPolicy.getNextConsistentBe(curLocations)
-                    : (HdfsResource.enableShortCircuitRead(locationProperties)
-                        ? backendPolicy.getNextLocalBe(Arrays.asList(fileSplit.getHosts()))
-                        : backendPolicy.getNextBe());
             location.setBackendId(selectedBackend.getId());
             location.setServer(new TNetworkAddress(selectedBackend.getHost(), selectedBackend.getBePort()));
             curLocations.addToLocations(location);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileQueryScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileQueryScanNode.java
@@ -328,7 +328,9 @@ public abstract class FileQueryScanNode extends FileScanNode {
             // Use consistent hash to assign the same scan range into the same backend among different queries
             Backend selectedBackend = ConnectContext.get().getSessionVariable().enableFileCache
                     ? backendPolicy.getNextConsistentBe(curLocations)
-                    : backendPolicy.getNextLocalBe(Arrays.asList(fileSplit.getHosts()));
+                    : (HdfsResource.enableShortcircuitRead(locationProperties)
+                        ? backendPolicy.getNextLocalBe(Arrays.asList(fileSplit.getHosts()))
+                        : backendPolicy.getNextBe());
             location.setBackendId(selectedBackend.getId());
             location.setServer(new TNetworkAddress(selectedBackend.getHost(), selectedBackend.getBePort()));
             curLocations.addToLocations(location);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileQueryScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileQueryScanNode.java
@@ -328,7 +328,7 @@ public abstract class FileQueryScanNode extends FileScanNode {
             // Use consistent hash to assign the same scan range into the same backend among different queries
             Backend selectedBackend = ConnectContext.get().getSessionVariable().enableFileCache
                     ? backendPolicy.getNextConsistentBe(curLocations)
-                    : (HdfsResource.enableShortcircuitRead(locationProperties)
+                    : (HdfsResource.enableShortCircuitRead(locationProperties)
                         ? backendPolicy.getNextLocalBe(Arrays.asList(fileSplit.getHosts()))
                         : backendPolicy.getNextBe());
             location.setBackendId(selectedBackend.getId());

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/FederationBackendPolicyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/FederationBackendPolicyTest.java
@@ -69,7 +69,7 @@ public class FederationBackendPolicyTest {
         FederationBackendPolicy policy = new FederationBackendPolicy();
         policy.init();
         int backendNum = 200;
-        int invokeTimes = 10000;
+        int invokeTimes = 1000000;
         Assertions.assertEquals(policy.numBackends(), backendNum);
         Stopwatch sw = Stopwatch.createStarted();
         for (int i = 0; i < invokeTimes; i++) {
@@ -77,7 +77,7 @@ public class FederationBackendPolicyTest {
         }
         sw.stop();
         System.out.println("Invoke getNextBe() " + invokeTimes
-                    + " times cost [" + sw.elapsed(TimeUnit.SECONDS) + "] seconds");
+                    + " times cost [" + sw.elapsed(TimeUnit.MILLISECONDS) + "] seconds");
     }
 
     @Test
@@ -85,7 +85,7 @@ public class FederationBackendPolicyTest {
         FederationBackendPolicy policy = new FederationBackendPolicy();
         policy.init();
         int backendNum = 200;
-        int invokeTimes = 10000;
+        int invokeTimes = 1000000;
         Assertions.assertEquals(policy.numBackends(), backendNum);
         List<String> localHosts = Arrays.asList("192.168.1.197", "192.168.1.198", "192.168.1.199");
         Stopwatch sw = Stopwatch.createStarted();
@@ -94,6 +94,6 @@ public class FederationBackendPolicyTest {
         }
         sw.stop();
         System.out.println("Invoke getNextLocalBe() " + invokeTimes
-                    + " times cost [" + sw.elapsed(TimeUnit.SECONDS) + "] seconds");
+                    + " times cost [" + sw.elapsed(TimeUnit.MILLISECONDS) + "] seconds");
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/FederationBackendPolicyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/FederationBackendPolicyTest.java
@@ -44,8 +44,13 @@ public class FederationBackendPolicyTest {
 
         SystemInfoService service = new SystemInfoService();
 
-        for (int i = 0; i < 200; i++) {
+        for (int i = 0; i < 190; i++) {
             Backend backend = new Backend(Long.valueOf(i), "192.168.1." + i, 9050);
+            backend.setAlive(true);
+            service.addBackend(backend);
+        }
+        for (int i = 0; i < 10; i++) {
+            Backend backend = new Backend(Long.valueOf(190 + i), "192.168.1." + i, 9051);
             backend.setAlive(true);
             service.addBackend(backend);
         }
@@ -87,7 +92,7 @@ public class FederationBackendPolicyTest {
         int backendNum = 200;
         int invokeTimes = 1000000;
         Assertions.assertEquals(policy.numBackends(), backendNum);
-        List<String> localHosts = Arrays.asList("192.168.1.197", "192.168.1.198", "192.168.1.199");
+        List<String> localHosts = Arrays.asList("192.168.1.0", "192.168.1.1", "192.168.1.2");
         Stopwatch sw = Stopwatch.createStarted();
         for (int i = 0; i < invokeTimes; i++) {
             Assertions.assertTrue(localHosts.contains(policy.getNextLocalBe(localHosts).getHost()));

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/FederationBackendPolicyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/FederationBackendPolicyTest.java
@@ -77,7 +77,7 @@ public class FederationBackendPolicyTest {
         }
         sw.stop();
         System.out.println("Invoke getNextBe() " + invokeTimes
-                    + " times cost [" + sw.elapsed(TimeUnit.MILLISECONDS) + "] seconds");
+                    + " times cost [" + sw.elapsed(TimeUnit.MILLISECONDS) + "] ms");
     }
 
     @Test
@@ -94,6 +94,6 @@ public class FederationBackendPolicyTest {
         }
         sw.stop();
         System.out.println("Invoke getNextLocalBe() " + invokeTimes
-                    + " times cost [" + sw.elapsed(TimeUnit.MILLISECONDS) + "] seconds");
+                    + " times cost [" + sw.elapsed(TimeUnit.MILLISECONDS) + "] ms");
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/FederationBackendPolicyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/FederationBackendPolicyTest.java
@@ -1,0 +1,87 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.planner;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.UserException;
+import org.apache.doris.planner.external.FederationBackendPolicy;
+import org.apache.doris.system.Backend;
+import org.apache.doris.system.SystemInfoService;
+
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class FederationBackendPolicyTest {
+    @Mocked
+    private Env env;
+
+    @Before
+    public void setUp() {
+        Backend backend1 = new Backend(1L, "192.168.1.1", 9050);
+        backend1.setAlive(true);
+
+        Backend backend2 = new Backend(2L, "192.168.1.2", 9050);
+        backend2.setAlive(true);
+
+        Backend backend3 = new Backend(3L, "192.168.1.3", 9050);
+        backend3.setAlive(true);
+
+        Backend backend4 = new Backend(4L, "192.168.1.4", 9050);
+        backend4.setAlive(false);
+
+        SystemInfoService service = new SystemInfoService();
+        service.addBackend(backend1);
+        service.addBackend(backend2);
+        service.addBackend(backend3);
+        service.addBackend(backend4);
+
+        new MockUp<Env>() {
+            @Mock
+            public SystemInfoService getCurrentSystemInfo() {
+                return service;
+            }
+        };
+
+    }
+
+    @Test
+    public void testGetNextBe() throws UserException {
+        FederationBackendPolicy policy = new FederationBackendPolicy();
+        policy.init();
+        Assertions.assertTrue(policy.numBackends() == 3);
+        for (int i = 0; i < policy.numBackends(); i++) {
+            Assertions.assertNotEquals(policy.getNextBe().getHost(), "192.168.1.4");
+        }
+    }
+
+    @Test
+    public void testGetNextBeWithPreLocations() throws UserException {
+        FederationBackendPolicy policy = new FederationBackendPolicy();
+        policy.init();
+        Assertions.assertTrue(policy.numBackends() == 3);
+        List<String> preferredLocations = Arrays.asList("192.168.1.3");
+        Assertions.assertEquals(policy.getNextLocalBe(preferredLocations).getHost(), "192.168.1.3");
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/FederationBackendPolicyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/FederationBackendPolicyTest.java
@@ -77,11 +77,13 @@ public class FederationBackendPolicyTest {
     }
 
     @Test
-    public void testGetNextBeWithPreLocations() throws UserException {
+    public void testGetNextLocalBe() throws UserException {
         FederationBackendPolicy policy = new FederationBackendPolicy();
         policy.init();
         Assertions.assertTrue(policy.numBackends() == 3);
-        List<String> preferredLocations = Arrays.asList("192.168.1.3");
-        Assertions.assertEquals(policy.getNextLocalBe(preferredLocations).getHost(), "192.168.1.3");
+        List<String> localHosts = Arrays.asList("192.168.1.3");
+        for (int i = 0; i < 100; i++) {
+            Assertions.assertEquals(policy.getNextLocalBe(localHosts).getHost(), "192.168.1.3");
+        }
     }
 }


### PR DESCRIPTION

## Proposed changes

Issue Number: close #xxx

Sometimes the BEs will be deployed on the same node with DataNode, so we can use a more reasonable BE selection policy to use the hdfs short-circuit-read as much as possible.

![image](https://github.com/apache/doris/assets/5926365/089a2ea7-0324-4a98-8fa4-8730a8f83eb4)


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

