### PR TITLE
[bugfix](fd) Recycle the segment file fds directly when delete stale rowset

### DIFF
--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -249,9 +249,8 @@ Status StorageEngine::start_bg_threads() {
 }
 
 void StorageEngine::_cache_clean_callback() {
-    int32_t interval = 600;
+    int32_t interval = config::cache_prune_stale_interval;
     while (!_stop_background_threads_latch.wait_for(std::chrono::seconds(interval))) {
-        interval = config::cache_prune_stale_interval;
         if (interval <= 0) {
             LOG(WARNING) << "config of cache clean interval is illegal: [" << interval
                          << "], force set to 3600 ";

--- a/be/src/olap/segment_loader.cpp
+++ b/be/src/olap/segment_loader.cpp
@@ -87,7 +87,7 @@ Status SegmentLoader::load_segments(const BetaRowsetSharedPtr& rowset,
     return Status::OK();
 }
 
-void SegmentLoader::erase_segment(const SegmentCache::CacheKey& key) {
+void SegmentLoader::erase_segments(const SegmentCache::CacheKey& key) {
     _segment_cache->erase(key);
 }
 

--- a/be/src/olap/segment_loader.h
+++ b/be/src/olap/segment_loader.h
@@ -111,7 +111,7 @@ public:
     Status load_segments(const BetaRowsetSharedPtr& rowset, SegmentCacheHandle* cache_handle,
                          bool use_cache = false);
 
-    void erase_segment(const SegmentCache::CacheKey& key);
+    void erase_segments(const SegmentCache::CacheKey& key);
 
 private:
     SegmentLoader();

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -665,6 +665,8 @@ void Tablet::_delete_stale_rowset_by_version(const Version& version) {
         return;
     }
     _tablet_meta->delete_stale_rs_meta_by_version(version);
+    // If the stale rowset was deleted, it need to remove the fds directly
+    SegmentLoader::instance()->erase_segments(SegmentCache::CacheKey(rowset_meta->rowset_id()));
     VLOG_NOTICE << "delete stale rowset. tablet=" << full_name() << ", version=" << version;
 }
 

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -378,7 +378,7 @@ Status TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id,
             rowset->merge_rowset_meta(transient_rowset->rowset_meta());
 
             // erase segment cache cause we will add a segment to rowset
-            SegmentLoader::instance()->erase_segment(rowset->rowset_id());
+            SegmentLoader::instance()->erase_segments(rowset->rowset_id());
         }
         stats->partial_update_write_segment_us = MonotonicMicros() - t3;
         int64_t t4 = MonotonicMicros();

--- a/be/src/vec/olap/vertical_block_reader.cpp
+++ b/be/src/vec/olap/vertical_block_reader.cpp
@@ -69,8 +69,9 @@ Status VerticalBlockReader::_get_segment_iterators(const ReaderParams& read_para
         // segment iterator will be inited here
         // In vertical compaction, every group will load segment so we should cache
         // segment to avoid tot many s3 head request
+        bool use_cache = !rs_split.rs_reader->rowset()->is_local();
         RETURN_IF_ERROR(rs_split.rs_reader->get_segment_iterators(&_reader_context, segment_iters,
-                                                                  {}, true));
+                                                                  {}, use_cache));
         // if segments overlapping, all segment iterator should be inited in
         // heap merge iterator. If segments are none overlapping, only first segment of this
         // rowset will be inited and push to heap, other segment will be inited later when current


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
When load frequently, BE will do compaciton frequently. And because of set enable_vertical_compaction is true, when doing vectical compaction, it will cache the segments in segment cache. When the stale rowset is evicted, the segment cache doesn't recycle the fds in time because the recycle is lazy. So it will make mistakes because of "Too many open file".
Fix by tow methods:
1. Recycle fds directly when delete stale rowsets.
2. Don't cache fd when doing vectical compaction.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

