### PR TITLE
[Fix](Job)Fix Job schedule calculation start time

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/scheduler/manager/AsyncJobManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/scheduler/manager/AsyncJobManager.java
@@ -156,19 +156,20 @@ public class AsyncJobManager implements Closeable, Writable {
     }
 
     private Long findFistExecuteTime(Long currentTimeMs, Long startTimeMs, Long intervalMs, boolean isCycleJob) {
+        // if job not delay, first execute time is start time
         if (startTimeMs != 0L && startTimeMs > currentTimeMs) {
             return startTimeMs;
         }
-        // if it's not cycle job and already delay, next execute time is current time
-        if (!isCycleJob) {
+        // if job already delay, first execute time is current time
+        if (startTimeMs != 0L && startTimeMs < currentTimeMs) {
             return currentTimeMs;
         }
-
-        long cycle = (currentTimeMs - startTimeMs) / intervalMs;
-        if ((currentTimeMs - startTimeMs) % intervalMs > 0) {
-            cycle += 1;
+        // if it's cycle job and not set start tine, first execute time is current time + interval
+        if (isCycleJob && startTimeMs == 0L) {
+            return currentTimeMs + intervalMs;
         }
-        return startTimeMs + cycle * intervalMs;
+        // if it's not cycle job and already delay, first execute time is current time
+        return currentTimeMs;
     }
 
     public void unregisterJob(Long jobId) {


### PR DESCRIPTION
Since we use division calculation, when the start time is not specified, it may have a wrong deviation from our expected time.

For example, if it is the 7th minute now, the cycle is executed every two minutes Then it is calculated that the first execution is 8 minutes Because 7/2=3
3+1=4
But ideally we think it should be executed at the 9th minute

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

