### PR TITLE
[fix](Nereids) disable or expansion when pipeline engine is disable

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/OrExpansion.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/OrExpansion.java
@@ -35,6 +35,7 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.nereids.trees.plans.logical.LogicalUnion;
 import org.apache.doris.nereids.util.ExpressionUtils;
 import org.apache.doris.nereids.util.JoinUtils;
+import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -59,7 +60,8 @@ public class OrExpansion extends OneExplorationRuleFactory {
     public Rule build() {
         return logicalJoin()
                 .when(JoinUtils::shouldNestedLoopJoin)
-                .when(join -> join.getJoinType().isInnerJoin())
+                .when(join -> join.getJoinType().isInnerJoin()
+                        && ConnectContext.get().getSessionVariable().getEnablePipelineEngine())
                 .thenApply(ctx -> {
                     LogicalJoin<? extends Plan, ? extends Plan> join = ctx.root;
                     Preconditions.checkArgument(join.getHashJoinConjuncts().isEmpty(),

--- a/regression-test/suites/nereids_p0/union/or_expansion.groovy
+++ b/regression-test/suites/nereids_p0/union/or_expansion.groovy
@@ -18,6 +18,7 @@
 suite("or_expansion") {
     sql "SET enable_nereids_planner=true"
     sql "SET enable_fallback_to_original_planner=false"
+    sql "SET enable_pipeline_engine = true"
     def db = "nereids_test_query_db"
     sql "use ${db}"
 


### PR DESCRIPTION
## Proposed changes

Execute engine can support multi-consumer of CTE when pipeline engine is enabled. 
Therefore, or expansion rule should be forbidden when the pipeline engine is disabled because this rule needs to create multiple CTE-consumers.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

