### PR TITLE
[Fix](Nereids)fix insert into return npe from follower node.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/txn/Transaction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/txn/Transaction.java
@@ -198,7 +198,8 @@ public class Transaction {
         // 2. transaction failed but Config.using_old_load_usage_pattern is true.
         // we will record the load job info for these 2 cases
         try {
-            StatementBase statement = planner.getCascadesContext().getStatementContext().getParsedStatement();
+            // the statement parsed by Nereids is saved at executor::parsedStmt.
+            StatementBase statement = executor.getParsedStmt();
             ctx.getEnv().getLoadManager()
                     .recordFinishedLoadJob(labelName, txnId, database.getFullName(),
                             table.getId(),
@@ -207,14 +208,6 @@ public class Transaction {
         } catch (MetaNotFoundException e) {
             LOG.warn("Record info of insert load with error {}", e.getMessage(), e);
             errMsg = "Record info of insert load with error " + e.getMessage();
-        } catch (Exception e) {
-            if (coordinator == null) {
-                LOG.warn("coordinator is null, maybe the query is forwarded to master node and this node is follower");
-            }
-            StatementBase statement = planner.getCascadesContext().getStatementContext().getParsedStatement();
-            if (statement == null) {
-                LOG.warn("statement is null, maybe the query is parsed at follower node");
-            }
         }
 
         // {'label':'my_label1', 'status':'visible', 'txnId':'123'}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/txn/Transaction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/txn/Transaction.java
@@ -207,6 +207,14 @@ public class Transaction {
         } catch (MetaNotFoundException e) {
             LOG.warn("Record info of insert load with error {}", e.getMessage(), e);
             errMsg = "Record info of insert load with error " + e.getMessage();
+        } catch (Exception e) {
+            if (coordinator == null) {
+                LOG.warn("coordinator is null, maybe the query is forwarded to master node and this node is follower");
+            }
+            StatementBase statement = planner.getCascadesContext().getStatementContext().getParsedStatement();
+            if (statement == null) {
+                LOG.warn("statement is null, maybe the query is parsed at follower node");
+            }
         }
 
         // {'label':'my_label1', 'status':'visible', 'txnId':'123'}


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

insert into table command run at a follower node, it will forward to the master node, and the parsed statement is not set to the cascades context, but set to the executor::parsedStmt, we use the latter to get the user info.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

