### PR TITLE
[fix](bitmap) fix wrong result of bitmap intersect functions

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_orthogonal_bitmap.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_orthogonal_bitmap.h
@@ -105,6 +105,7 @@ public:
             return;
         }
         result |= rhs.result;
+        AggOrthBitmapBaseData<T>::first_init = false;
     }
 
     void write(BufferWritable& buf) {
@@ -139,6 +140,7 @@ public:
             return;
         }
         AggOrthBitmapBaseData<T>::bitmap.merge(rhs.bitmap);
+        AggOrthBitmapBaseData<T>::first_init = false;
     }
 
     void write(BufferWritable& buf) {
@@ -174,6 +176,7 @@ public:
             return;
         }
         result += rhs.result;
+        AggOrthBitmapBaseData<T>::first_init = false;
     }
 
     void write(BufferWritable& buf) {

--- a/regression-test/data/query_p0/sql_functions/bitmap_functions/test_bitmap_function.out
+++ b/regression-test/data/query_p0/sql_functions/bitmap_functions/test_bitmap_function.out
@@ -492,3 +492,42 @@ true
 \N
 \N
 
+-- !sql_bitmap_intersect_check0 --
+1
+
+-- !sql_bitmap_intersect_check1 --
+1
+
+-- !sql_bitmap_intersect_check2 --
+1
+
+-- !sql_bitmap_intersect_nereids0 --
+1	1
+
+-- !sql_bitmap_intersect_nereids1 --
+1	1
+
+-- !sql_bitmap_intersect_no_nereids0 --
+1	0
+
+-- !sql_bitmap_intersect_no_nereids1 --
+1	1
+
+-- !sql_orthogonal_bitmap_intersect_nereids1 --
+1	1
+
+-- !sql_orthogonal_bitmap_intersect_not_nereids1 --
+1	1
+
+-- !sql_orthogonal_bitmap_intersect_count_nereids0 --
+1	1
+
+-- !sql_orthogonal_bitmap_intersect_count_nereids1 --
+1	1
+
+-- !sql_orthogonal_bitmap_intersect_count_not_nereids0 --
+1	0
+
+-- !sql_orthogonal_bitmap_intersect_count_not_nereids1 --
+1	1
+

--- a/regression-test/data/query_p0/sql_functions/bitmap_functions/test_bitmap_function.out
+++ b/regression-test/data/query_p0/sql_functions/bitmap_functions/test_bitmap_function.out
@@ -508,7 +508,7 @@ true
 1	1
 
 -- !sql_bitmap_intersect_no_nereids0 --
-1	0
+1	1
 
 -- !sql_bitmap_intersect_no_nereids1 --
 1	1
@@ -526,7 +526,7 @@ true
 1	1
 
 -- !sql_orthogonal_bitmap_intersect_count_not_nereids0 --
-1	0
+1	1
 
 -- !sql_orthogonal_bitmap_intersect_count_not_nereids1 --
 1	1


### PR DESCRIPTION
## Proposed changes

Issue Number: close #22476

Agg result of bitmap `intersect_count`, `orthogonal_bitmap_intersect` and `orthogonal_bitmap_intersect_count` should set `first_init` to false after merging.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

