### PR TITLE
[Bug](upgrade) fix core dump at join node when rolling upgrade

### DIFF
--- a/be/src/vec/columns/column_nullable.cpp
+++ b/be/src/vec/columns/column_nullable.cpp
@@ -261,7 +261,7 @@ void ColumnNullable::insert_range_from(const IColumn& src, size_t start, size_t 
 
 void ColumnNullable::insert_indices_from(const IColumn& src, const int* indices_begin,
                                          const int* indices_end) {
-    const ColumnNullable& src_concrete = assert_cast<const ColumnNullable&>(src);
+    const ColumnNullable& src_concrete = assert_cast_safe<const ColumnNullable&>(src);
     get_nested_column().insert_indices_from(src_concrete.get_nested_column(), indices_begin,
                                             indices_end);
     _get_null_map_column().insert_indices_from(src_concrete.get_null_map_column(), indices_begin,


### PR DESCRIPTION
## Proposed changes
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/hdd04/zgx_temp/repo_center/doris_branch-2.0/doris/be/src/common/signal_handler.h:413
 1# 0x00007FD67BCD30C0 in /lib/x86_64-linux-gnu/libc.so.6
 2# raise in /lib/x86_64-linux-gnu/libc.so.6
 3# abort in /lib/x86_64-linux-gnu/libc.so.6
 4# 0x0000564F0BB38719 in /mnt/ssd01/doris-master/VEC_ASAN/be/lib/doris_be
 5# 0x0000564F0BB2DD2D in /mnt/ssd01/doris-master/VEC_ASAN/be/lib/doris_be
 6# google::LogMessage::SendToLog() in /mnt/ssd01/doris-master/VEC_ASAN/be/lib/doris_be
 7# google::LogMessage::Flush() in /mnt/ssd01/doris-master/VEC_ASAN/be/lib/doris_be
 8# google::LogMessageFatal::~LogMessageFatal() in /mnt/ssd01/doris-master/VEC_ASAN/be/lib/doris_be
 9# doris::vectorized::ColumnNullable const& assert_cast<doris::vectorized::ColumnNullable const&, doris::vectorized::IColumn const&>(doris::vectorized::IColumn const&) in /mnt/ssd01/doris-master/VEC_ASAN/be/lib/doris_be
10# doris::vectorized::ColumnNullable::insert_indices_from(doris::vectorized::IColumn const&, int const*, int const*) at /mnt/hdd04/zgx_temp/repo_center/doris_branch-2.0/doris/be/src/vec/columns/column_nullable.cpp:296
11# void doris::vectorized::ProcessHashTableProbe<0>::build_side_output_column<false>(std::vector<COW<doris::vectorized::IColumn>::mutable_ptr<doris::vectorized::IColumn>, std::allocator<COW<doris::vectorized::IColumn>::mutable_ptr<doris::vectorized::IColumn> > >&, int, int, std::vector<bool, std::allocator<bool> > const&, int) at /mnt/hdd04/zgx_temp/repo_center/doris_branch-2.0/doris/be/src/vec/exec/join/process_hash_table_probe_impl.h:74
12# doris::Status doris::vectorized::ProcessHashTableProbe<0>::do_process<true, true, doris::vectorized::SerializedHashTableContext<doris::vectorized::RowRefList> >(doris::vectorized::SerializedHashTableContext<doris::vectorized::RowRefList>&, doris::vectorized::PODArray<unsigned char, 4096ul, Allocator<false, false, false>, 15ul, 16ul> const*, doris::vectorized::MutableBlock&, doris::vectorized::Block*, unsigned long, bool) at /mnt/hdd04/zgx_temp/repo_center/doris_branch-2.0/doris/be/src/vec/exec/join/process_hash_table_probe_impl.h:398
13# auto doris::vectorized::HashJoinNode::pull(doris::RuntimeState*, doris::vectorized::Block*, bool*)::$_0::operator()<doris::vectorized::SerializedHashTableContext<doris::vectorized::RowRefList>&, doris::vectorized::ProcessHashTableProbe<0>&, std::integral_constant<bool, true>, std::integral_constant<bool, true> >(doris::vectorized::SerializedHashTableContext<doris::vectorized::RowRefList>&, doris::vectorized::ProcessHashTableProbe<0>&, std::integral_constant<bool, true>, std::integral_constant<bool, true>) const at /mnt/hdd04/zgx_temp/repo_center/doris_branch-2.0/doris/be/src/vec/exec/join/vhash_join_node.cpp:545
14# void std::__invoke_impl<void, doris::vectorized::HashJoinNode::pull(doris::RuntimeState*, doris::vectorized::Block*, bool*)::$_0, doris::vectorized::SerializedHashTableContext<doris::vectorized::RowRefList>&, doris::vectorized::ProcessHashTableProbe<0>&, std::integral_constant<bool, true>, std::integral_constant<bool, true> >(std::__invoke_other, doris::vectorized::HashJoinNode::pull(doris::RuntimeState*, doris::vectorized::Block*, bool*)::$_0&&, doris::vectorized::SerializedHashTableContext<doris::vectorized::RowRefList>&, doris::vectorized::ProcessHashTableProbe<0>&, std::integral_constant<bool, true>&&, std::integral_constant<bool, true>&&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
15# std::__invoke_result<doris::vectorized::HashJoinNode::pull(doris::RuntimeState*, doris::vectorized::Block*, bool*)::$_0, doris::vectorized::SerializedHashTableContext<doris::vectorized::RowRefList>&, doris::vectorized::ProcessHashTableProbe<0>&, std::integral_constant<bool, true>, std::integral_constant<bool, true> >::type std::__invoke<doris::vectorized::HashJoinNode::pull(doris::RuntimeState*, doris::vectorized::Block*, bool*)::$_0, doris::vectorized::SerializedHashTableContext<doris::vectorized::RowRefList>&, doris::vectorized::ProcessHashTableProbe<0>&, std::integral_constant<bool, true>, std::integral_constant<bool, true> >(doris::vectorized::HashJoinNode::pull(doris::RuntimeState*, doris::vectorized::Block*, bool*)::$_0&&, doris::vectorized::SerializedHashTableContext<doris::vectorized::RowRefList>&, doris::vectorized::ProcessHashTableProbe<0>&, std::integral_constant<bool, true>&&, std::integral_constant<bool, true>&&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
16# 
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

