### PR TITLE
[fix](taskgroup) Fix task group overcommit memory GC profile

### DIFF
--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -125,8 +125,9 @@ bool MemInfo::process_minor_gc() {
         je_purge_all_arena_dirty_pages();
         std::stringstream ss;
         profile->pretty_print(&ss);
-        LOG(INFO) << fmt::format("End Minor GC, Free Memory {} Bytes. cost(us): {}, details: {}",
-                                 freed_mem, watch.elapsed_time() / 1000, ss.str());
+        LOG(INFO) << fmt::format("End Minor GC, Free Memory {}. cost(us): {}, details: {}",
+                                 PrettyPrinter::print(freed_mem, TUnit::BYTES),
+                                 watch.elapsed_time() / 1000, ss.str());
     }};
 
     freed_mem += CacheManager::instance()->for_each_cache_prune_stale(profile.get());
@@ -174,8 +175,9 @@ bool MemInfo::process_full_gc() {
         je_purge_all_arena_dirty_pages();
         std::stringstream ss;
         profile->pretty_print(&ss);
-        LOG(INFO) << fmt::format("End Full GC Free, Memory {} Bytes. cost(us): {}, details: {}",
-                                 freed_mem, watch.elapsed_time() / 1000, ss.str());
+        LOG(INFO) << fmt::format("End Full GC, Free Memory {}. cost(us): {}, details: {}",
+                                 PrettyPrinter::print(freed_mem, TUnit::BYTES),
+                                 watch.elapsed_time() / 1000, ss.str());
     }};
 
     freed_mem += CacheManager::instance()->for_each_cache_prune_all(profile.get());
@@ -235,9 +237,10 @@ int64_t MemInfo::tg_hard_memory_limit_gc() {
             std::stringstream ss;
             tg_profile->pretty_print(&ss);
             LOG(INFO) << fmt::format(
-                    "End Task Group Overcommit Memory GC, Free Memory {} Bytes. cost(us): {}, "
+                    "End Task Group Overcommit Memory GC, Free Memory {}. cost(us): {}, "
                     "details: {}",
-                    total_free_memory, watch.elapsed_time() / 1000, ss.str());
+                    PrettyPrinter::print(total_free_memory, TUnit::BYTES),
+                    watch.elapsed_time() / 1000, ss.str());
         }
     }};
 

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -232,7 +232,6 @@ int64_t MemInfo::tg_hard_memory_limit_gc() {
 
     Defer defer {[&]() {
         if (total_free_memory > 0) {
-            je_purge_all_arena_dirty_pages();
             std::stringstream ss;
             tg_profile->pretty_print(&ss);
             LOG(INFO) << fmt::format(


### PR DESCRIPTION
## Proposed changes

Print log after task group overcommit memory GC ends

```
0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at doris/be/src/common/signal_handler.h:413                                                                                                                                                                    
 1# os::Linux::chained_handler(int, siginfo*, void*) in /opt/jdk1.8.0_211/jre/lib/amd64/server/[libjvm.so](http://libjvm.so/)                                                              
 2# JVM_handle_linux_signal in /opt/jdk1.8.0_211/jre/lib/amd64/server/[libjvm.so](http://libjvm.so/)                                                                                       
 3# signalHandler(int, siginfo*, void*) in /opt/jdk1.8.0_211/jre/lib/amd64/server/[libjvm.so](http://libjvm.so/)                                                                           
 4# 0x00007FCDDEFA5280 in /lib64/libc.so.6                                                                                                                            
 5# __pthread_mutex_lock in /lib64/libpthread.so.0                                                                                                                    
 6# pthread_mutex_lock in /opt/doris-service/doris-branch-2.0/be/lib/doris_be                                                                                         
 7# doris::RuntimeProfile::merge(doris::RuntimeProfile*) at doris/be/src/util/runtime_profile.cpp:69                             
 8# long doris::MemTrackerLimiter::free_top_overcommit_query(long, doris::MemTrackerLimiter::Type, std::vector
up::TgTrackerLimiterGroup, std::allocator >&, std::function, std::all
ocator > (long, std::__cxx11::basic_string, std::allocator > const&)> const&, doris::RuntimeProfile*) in /opt/doris-service/d
oris-branch-2.0/be/lib/doris_be                                                                                                                                       
 9# doris::MemTrackerLimiter::tg_memory_limit_gc(long, long, unsigned long, std::__cxx11::basic_string, std::allocator > const&, lo
ng, std::vector >&, doris::RuntimeProfile*) in /opt/doris-service/dor
is-branch-2.0/be/lib/doris_be                                                                                                                                         
10# doris::MemInfo::tg_hard_memory_limit_gc() in /opt/doris-service/doris-branch-2.0/be/lib/doris_be                                                                  
11# doris::Daemon::memory_gc_thread() at doris/be/src/common/daemon.cpp:241                                                      
12# doris::Thread::supervise_thread(void*) at doris/be/src/util/thread.cpp:466                                                   
13# start_thread in /lib64/libpthread.so.0                                                                                                                            
14# __clone in /lib64/libc.so.6
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

