### PR TITLE
[Bug](pipeline) make sure sink is not blocked before try close

### DIFF
--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -273,15 +273,12 @@ public:
 
     Status sink(RuntimeState* state, vectorized::Block* in_block,
                 SourceState source_state) override {
-        if (in_block->rows() > 0) {
-            auto st = _sink->send(state, in_block, source_state == SourceState::FINISHED);
-            // TODO: improvement: if sink returned END_OF_FILE, pipeline task can be finished
-            if (st.template is<ErrorCode::END_OF_FILE>()) {
-                return Status::OK();
-            }
-            return st;
+        auto st = _sink->send(state, in_block, source_state == SourceState::FINISHED);
+        // TODO: improvement: if sink returned END_OF_FILE, pipeline task can be finished
+        if (st.template is<ErrorCode::END_OF_FILE>()) {
+            return Status::OK();
         }
-        return Status::OK();
+        return st;
     }
 
     Status try_close(RuntimeState* state) override {

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -196,14 +196,14 @@ Status Channel::send_block(PBlock* block, bool eos) {
     return Status::OK();
 }
 
-Status Channel::add_rows(Block* block, const std::vector<int>& rows) {
+Status Channel::add_rows(Block* block, const std::vector<int>& rows, bool eos) {
     if (_fragment_instance_id.lo == -1) {
         return Status::OK();
     }
 
     bool serialized = false;
     RETURN_IF_ERROR(
-            _serializer.next_serialized_block(block, _ch_cur_pb_block, 1, &serialized, &rows));
+            _serializer.next_serialized_block(block, _ch_cur_pb_block, 1, &serialized, eos, &rows));
     if (serialized) {
         RETURN_IF_ERROR(send_current_block(false));
     }
@@ -493,49 +493,72 @@ Status VDataStreamSender::send(RuntimeState* state, Block* block, bool eos) {
     }
 
     if (_part_type == TPartitionType::UNPARTITIONED || _channels.size() == 1) {
-#ifndef BROADCAST_ALL_CHANNELS
-#define BROADCAST_ALL_CHANNELS(PBLOCK, PBLOCK_TO_SEND, POST_PROCESS)                              \
-    {                                                                                             \
-        SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());                                           \
-        bool serialized = false;                                                                  \
-        RETURN_IF_ERROR(                                                                          \
-                _serializer.next_serialized_block(block, PBLOCK, _channels.size(), &serialized)); \
-        if (serialized) {                                                                         \
-            Status status;                                                                        \
-            for (auto channel : _channels) {                                                      \
-                if (!channel->is_receiver_eof()) {                                                \
-                    if (channel->is_local()) {                                                    \
-                        status = channel->send_local_block(block);                                \
-                    } else {                                                                      \
-                        SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());                           \
-                        status = channel->send_block(PBLOCK_TO_SEND, false);                      \
-                    }                                                                             \
-                    HANDLE_CHANNEL_STATUS(state, channel, status);                                \
-                }                                                                                 \
-            }                                                                                     \
-            POST_PROCESS;                                                                         \
-        }                                                                                         \
-    }
-#endif
         // 1. serialize depends on it is not local exchange
         // 2. send block
         // 3. rollover block
         if (_only_local_exchange) {
-            Status status;
-            for (auto channel : _channels) {
-                if (!channel->is_receiver_eof()) {
-                    status = channel->send_local_block(block);
-                    HANDLE_CHANNEL_STATUS(state, channel, status);
+            if (!block->empty()) {
+                Status status;
+                for (auto channel : _channels) {
+                    if (!channel->is_receiver_eof()) {
+                        status = channel->send_local_block(block);
+                        HANDLE_CHANNEL_STATUS(state, channel, status);
+                    }
                 }
             }
         } else if (_enable_pipeline_exec) {
             BroadcastPBlockHolder* block_holder = nullptr;
             RETURN_IF_ERROR(_get_next_available_buffer(&block_holder));
-            BROADCAST_ALL_CHANNELS(block_holder->get_block(), block_holder, );
+            {
+                SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
+                bool serialized = false;
+                RETURN_IF_ERROR(_serializer.next_serialized_block(
+                        block, block_holder->get_block(), _channels.size(), &serialized, eos));
+                if (serialized) {
+                    auto cur_block = _serializer.get_block()->to_block();
+                    if (!cur_block.empty()) {
+                        _serializer.serialize_block(&cur_block, block_holder->get_block(),
+                                                    _channels.size());
+                    } else {
+                        block_holder->get_block()->Clear();
+                    }
+                    Status status;
+                    for (auto channel : _channels) {
+                        if (!channel->is_receiver_eof()) {
+                            if (channel->is_local()) {
+                                status = channel->send_local_block(block);
+                            } else {
+                                SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
+                                status = channel->send_block(block_holder, eos);
+                            }
+                            HANDLE_CHANNEL_STATUS(state, channel, status);
+                        }
+                    }
+                    cur_block.clear_column_data();
+                    _serializer.get_block()->set_muatable_columns(cur_block.mutate_columns());
+                }
+            }
         } else {
-            BROADCAST_ALL_CHANNELS(_cur_pb_block, _cur_pb_block, _roll_pb_block());
+            SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
+            bool serialized = false;
+            RETURN_IF_ERROR(_serializer.next_serialized_block(
+                    block, _cur_pb_block, _channels.size(), &serialized, false));
+            if (serialized) {
+                Status status;
+                for (auto channel : _channels) {
+                    if (!channel->is_receiver_eof()) {
+                        if (channel->is_local()) {
+                            status = channel->send_local_block(block);
+                        } else {
+                            SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
+                            status = channel->send_block(_cur_pb_block, false);
+                        }
+                        HANDLE_CHANNEL_STATUS(state, channel, status);
+                    }
+                }
+                _roll_pb_block();
+            }
         }
-#undef BROADCAST_ALL_CHANNELS
     } else if (_part_type == TPartitionType::RANDOM) {
         // 1. select channel
         Channel* current_channel = _channels[_current_channel_idx];
@@ -562,10 +585,6 @@ Status VDataStreamSender::send(RuntimeState* state, Block* block, bool eos) {
 
         int result_size = _partition_expr_ctxs.size();
         int result[result_size];
-        {
-            SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
-            RETURN_IF_ERROR(get_partition_column_result(block, result));
-        }
 
         // vectorized calculate hash
         int rows = block->rows();
@@ -573,44 +592,53 @@ Status VDataStreamSender::send(RuntimeState* state, Block* block, bool eos) {
         std::vector<uint64_t> hash_vals(rows);
         auto* __restrict hashes = hash_vals.data();
 
-        // TODO: after we support new shuffle hash method, should simple the code
+        if (rows > 0) {
+            {
+                SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
+                RETURN_IF_ERROR(get_partition_column_result(block, result));
+            }
+            // TODO: after we support new shuffle hash method, should simple the code
+            if (_part_type == TPartitionType::HASH_PARTITIONED) {
+                SCOPED_TIMER(_split_block_hash_compute_timer);
+                // result[j] means column index, i means rows index, here to calculate the xxhash value
+                for (int j = 0; j < result_size; ++j) {
+                    // complex type most not implement get_data_at() method which column_const will call
+                    unpack_if_const(block->get_by_position(result[j]).column)
+                            .first->update_hashes_with_value(hashes);
+                }
+
+                for (int i = 0; i < rows; i++) {
+                    hashes[i] = hashes[i] % element_size;
+                }
+
+                {
+                    SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
+                    Block::erase_useless_column(block, column_to_keep);
+                }
+            } else {
+                for (int j = 0; j < result_size; ++j) {
+                    // complex type most not implement get_data_at() method which column_const will call
+                    unpack_if_const(block->get_by_position(result[j]).column)
+                            .first->update_crcs_with_value(
+                                    hash_vals, _partition_expr_ctxs[j]->root()->type().type);
+                }
+                element_size = _channel_shared_ptrs.size();
+                for (int i = 0; i < rows; i++) {
+                    hashes[i] = hashes[i] % element_size;
+                }
+
+                {
+                    SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
+                    Block::erase_useless_column(block, column_to_keep);
+                }
+            }
+        }
         if (_part_type == TPartitionType::HASH_PARTITIONED) {
-            SCOPED_TIMER(_split_block_hash_compute_timer);
-            // result[j] means column index, i means rows index, here to calculate the xxhash value
-            for (int j = 0; j < result_size; ++j) {
-                // complex type most not implement get_data_at() method which column_const will call
-                unpack_if_const(block->get_by_position(result[j]).column)
-                        .first->update_hashes_with_value(hashes);
-            }
-
-            for (int i = 0; i < rows; i++) {
-                hashes[i] = hashes[i] % element_size;
-            }
-
-            {
-                SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
-                Block::erase_useless_column(block, column_to_keep);
-            }
-
-            RETURN_IF_ERROR(channel_add_rows(state, _channels, element_size, hashes, rows, block));
+            RETURN_IF_ERROR(channel_add_rows(state, _channels, element_size, hashes, rows, block,
+                                             _enable_pipeline_exec ? eos : false));
         } else {
-            for (int j = 0; j < result_size; ++j) {
-                // complex type most not implement get_data_at() method which column_const will call
-                unpack_if_const(block->get_by_position(result[j]).column)
-                        .first->update_crcs_with_value(
-                                hash_vals, _partition_expr_ctxs[j]->root()->type().type);
-            }
-            element_size = _channel_shared_ptrs.size();
-            for (int i = 0; i < rows; i++) {
-                hashes[i] = hashes[i] % element_size;
-            }
-
-            {
-                SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
-                Block::erase_useless_column(block, column_to_keep);
-            }
             RETURN_IF_ERROR(channel_add_rows(state, _channel_shared_ptrs, element_size, hashes,
-                                             rows, block));
+                                             rows, block, _enable_pipeline_exec ? eos : false));
         }
     } else {
         // Range partition
@@ -621,28 +649,7 @@ Status VDataStreamSender::send(RuntimeState* state, Block* block, bool eos) {
 }
 
 Status VDataStreamSender::try_close(RuntimeState* state, Status exec_status) {
-    if (_serializer.get_block() && _serializer.get_block()->rows() > 0) {
-        BroadcastPBlockHolder* block_holder = nullptr;
-        RETURN_IF_ERROR(_get_next_available_buffer(&block_holder));
-        {
-            SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
-            Block block = _serializer.get_block()->to_block();
-            RETURN_IF_ERROR(_serializer.serialize_block(&block, block_holder->get_block(),
-                                                        _channels.size()));
-            Status status;
-            for (auto channel : _channels) {
-                if (!channel->is_receiver_eof()) {
-                    if (channel->is_local()) {
-                        status = channel->send_local_block(&block);
-                    } else {
-                        SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
-                        status = channel->send_block(block_holder, false);
-                    }
-                    HANDLE_CHANNEL_STATUS(state, channel, status);
-                }
-            }
-        }
-    }
+    DCHECK(_serializer.get_block() == nullptr || _serializer.get_block()->rows() == 0);
     Status final_st = Status::OK();
     for (int i = 0; i < _channels.size(); ++i) {
         Status st = _channels[i]->close(state);
@@ -707,7 +714,8 @@ BlockSerializer::BlockSerializer(VDataStreamSender* parent, bool is_local)
         : _parent(parent), _is_local(is_local), _batch_size(parent->state()->batch_size()) {}
 
 Status BlockSerializer::next_serialized_block(Block* block, PBlock* dest, int num_receivers,
-                                              bool* serialized, const std::vector<int>* rows) {
+                                              bool* serialized, bool eos,
+                                              const std::vector<int>* rows) {
     if (_mutable_block == nullptr) {
         SCOPED_CONSUME_MEM_TRACKER(_parent->_mem_tracker.get());
         _mutable_block = MutableBlock::create_unique(block->clone_empty());
@@ -716,16 +724,18 @@ Status BlockSerializer::next_serialized_block(Block* block, PBlock* dest, int nu
     {
         SCOPED_CONSUME_MEM_TRACKER(_parent->_mem_tracker.get());
         if (rows) {
-            SCOPED_TIMER(_parent->_split_block_distribute_by_channel_timer);
-            const int* begin = &(*rows)[0];
-            _mutable_block->add_rows(block, begin, begin + rows->size());
-        } else {
+            if (rows->size() > 0) {
+                SCOPED_TIMER(_parent->_split_block_distribute_by_channel_timer);
+                const int* begin = &(*rows)[0];
+                _mutable_block->add_rows(block, begin, begin + rows->size());
+            }
+        } else if (!block->empty()) {
             SCOPED_TIMER(_parent->_merge_block_timer);
             RETURN_IF_ERROR(_mutable_block->merge(*block));
         }
     }
 
-    if (_mutable_block->rows() >= _batch_size) {
+    if (_mutable_block->rows() >= _batch_size || eos) {
         if (!_is_local) {
             RETURN_IF_ERROR(serialize_block(dest, num_receivers));
         }

--- a/be/src/vec/sink/vdata_stream_sender.h
+++ b/be/src/vec/sink/vdata_stream_sender.h
@@ -73,9 +73,9 @@ class BlockSerializer {
 public:
     BlockSerializer(VDataStreamSender* parent, bool is_local = false);
     Status next_serialized_block(Block* src, PBlock* dest, int num_receivers, bool* serialized,
-                                 const std::vector<int>* rows, bool clear_after_serialize);
-    Status serialize_block(PBlock* dest, int num_receivers, bool clear_after_serialize);
-    Status serialize_block(const Block* src, PBlock* dest, int num_receivers);
+                                 const std::vector<int>* rows = nullptr);
+    Status serialize_block(PBlock* dest, int num_receivers = 1);
+    Status serialize_block(Block* src, PBlock* dest, int num_receivers = 1);
 
     MutableBlock* get_block() const { return _mutable_block.get(); }
 
@@ -486,8 +486,8 @@ public:
 
         bool serialized = false;
         _pblock = std::make_unique<PBlock>();
-        RETURN_IF_ERROR(_serializer.next_serialized_block(block, _pblock.get(), 1, &serialized,
-                                                          &rows, true));
+        RETURN_IF_ERROR(
+                _serializer.next_serialized_block(block, _pblock.get(), 1, &serialized, &rows));
         if (serialized) {
             RETURN_IF_ERROR(send_current_block(false));
         }
@@ -503,7 +503,7 @@ public:
         SCOPED_CONSUME_MEM_TRACKER(_parent->_mem_tracker.get());
         if (eos) {
             _pblock = std::make_unique<PBlock>();
-            RETURN_IF_ERROR(_serializer.serialize_block(_pblock.get(), 1, true));
+            RETURN_IF_ERROR(_serializer.serialize_block(_pblock.get(), 1));
         }
         RETURN_IF_ERROR(send_block(_pblock.release(), eos));
         return Status::OK();


### PR DESCRIPTION
## Proposed changes

==1101422==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x61e004772f80 at pc 0x5572a5249d71 bp 0x7f207bdaf080 sp 0x7f207bdaf078
READ of size 4 at 0x61e004772f80 thread T282 (TaskSchedulerTh)
    #0 0x5572a5249d70 in std::__atomic_base::load(std::memory_order) const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/atomic_base.h:481:9
    #1 0x5572a5249d70 in std::__atomic_base::operator unsigned int() const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/atomic_base.h:341:16
    #2 0x5572c7a128b4 in doris::vectorized::BroadcastPBlockHolder::available() /home/zcp/repo_center/doris_master/doris/be/src/pipeline/exec/exchange_sink_buffer.h:75:31
    #3 0x5572c7a03100 in doris::vectorized::VDataStreamSender::_get_next_available_buffer(doris::vectorized::BroadcastPBlockHolder**) /home/zcp/repo_center/doris_master/doris/be/src/vec/sink/vdata_stream_sender.cpp:771:5
    #4 0x5572c7a041ac in doris::vectorized::VDataStreamSender::try_close(doris::RuntimeState*, doris::Status) /home/zcp/repo_center/doris_master/doris/be/src/vec/sink/vdata_stream_sender.cpp:626:9
    #5 0x5572c7dbcb57 in doris::pipeline::DataSinkOperator::try_close(doris::RuntimeState*) /home/zcp/repo_center/doris_master/doris/be/src/pipeline/exec/operator.h:288:23
    #6 0x5572c7de0253 in doris::pipeline::PipelineTask::try_close() /home/zcp/repo_center/doris_master/doris/be/src/pipeline/pipeline_task.cpp:291:29
    #7 0x5572c7e05ac7 in doris::pipeline::TaskScheduler::_try_close_task(doris::pipeline::PipelineTask*, doris::pipeline::PipelineTaskState) /home/zcp/repo_center/doris_master/doris/be/src/pipeline/task_scheduler.cpp:335:25
    #8 0x5572c7e0534e in doris::pipeline::TaskScheduler::_do_work(unsigned long) /home/zcp/repo_center/doris_master/doris/be/src/pipeline/task_scheduler.cpp:306:17
    #9 0x5572c7e14d28 in void std::__invoke_impl(std::__invoke_memfun_deref, void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74:14
    #10 0x5572c7e14b94 in std::__invoke_result::type std::__invoke(void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96:14
    #11 0x5572c7e14b03 in void std::_Bind::__call(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420:11
    #12 0x5572c7e1496d in void std::_Bind::operator()() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503:17
    #13 0x5572c7e14884 in void std::__invoke_impl&>(std::__invoke_other, std::_Bind&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #14 0x5572c7e14824 in std::enable_if&>, void>::type std::__invoke_r&>(std::_Bind&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #15 0x5572c7e1451c in std::_Function_handler>::_M_invoke(std::_Any_data const&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #16 0x5572a51a51f2 in std::function::operator()() const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #17 0x5572a8319c88 in doris::FunctionRunnable::run() /home/zcp/repo_center/doris_master/doris/be/src/util/threadpool.cpp:48:27
    #18 0x5572a83073f6 in doris::ThreadPool::dispatch_thread() /home/zcp/repo_center/doris_master/doris/be/src/util/threadpool.cpp:531:24
    #19 0x5572a832c9e3 in void std::__invoke_impl(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74:14
    #20 0x5572a832c8bc in std::__invoke_result::type std::__invoke(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96:14
    #21 0x5572a832c844 in void std::_Bind::__call(std::tuple<>&&, std::_Index_tuple<0ul>) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420:11
    #22 0x5572a832c6ed in void std::_Bind::operator()() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503:17
    #23 0x5572a832c604 in void std::__invoke_impl&>(std::__invoke_other, std::_Bind&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #24 0x5572a832c5a4 in std::enable_if&>, void>::type std::__invoke_r&>(std::_Bind&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #25 0x5572a832c2cc in std::_Function_handler>::_M_invoke(std::_Any_data const&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #26 0x5572a51a51f2 in std::function::operator()() const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #27 0x5572a82d4bb6 in doris::Thread::supervise_thread(void*) /home/zcp/repo_center/doris_master/doris/be/src/util/thread.cpp:465:5
    #28 0x7f279f898608 in start_thread /build/glibc-sMfBJT/glibc-2.31/nptl/pthread_create.c:477:8
    #29 0x7f279fb27162 in __clone /build/glibc-sMfBJT/glibc-2.31/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

