### PR TITLE
[fix](cache) Fix enable sql cache lead to FE Full GC or OOM

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/Cache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/Cache.java
@@ -41,6 +41,7 @@ public abstract class Cache {
     protected TUniqueId queryId;
     protected SelectStmt selectStmt;
     protected RowBatchBuilder rowBatchBuilder;
+    protected boolean disableCache = false;
     protected CacheAnalyzer.CacheTable latestTable;
     protected CacheProxy proxy;
     protected HitRange hitRange;
@@ -81,16 +82,20 @@ public abstract class Cache {
     public abstract void updateCache();
 
     protected boolean checkRowLimit() {
-        if (rowBatchBuilder == null) {
+        if (disableCache || rowBatchBuilder == null) {
             return false;
         }
         if (rowBatchBuilder.getRowSize() > Config.cache_result_max_row_count) {
             LOG.debug("can not be cached. rowbatch size {} is more than {}", rowBatchBuilder.getRowSize(),
                     Config.cache_result_max_row_count);
+            rowBatchBuilder.clear();
+            disableCache = true;
             return false;
         } else if (rowBatchBuilder.getDataSize() > Config.cache_result_max_data_size) {
             LOG.debug("can not be cached. rowbatch data size {} is more than {}", rowBatchBuilder.getDataSize(),
                     Config.cache_result_max_data_size);
+            rowBatchBuilder.clear();
+            disableCache = true;
             return false;
         } else {
             return true;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/PartitionCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/PartitionCache.java
@@ -123,6 +123,9 @@ public class PartitionCache extends Cache {
             rowBatchBuilder.buildPartitionIndex(selectStmt.getResultExprs(), selectStmt.getColLabels(),
                     partColumn, range.buildUpdatePartitionRange());
         }
+        if (!super.checkRowLimit()) {
+            return;
+        }
         rowBatchBuilder.copyRowData(rowBatch);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/RowBatchBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/RowBatchBuilder.java
@@ -103,6 +103,14 @@ public class RowBatchBuilder {
         }
     }
 
+    public void clear() {
+        rowList = Lists.newArrayList();
+        cachePartMap = new HashMap<>();
+        batchSize = 0;
+        rowSize = 0;
+        dataSize = 0;
+    }
+
     public InternalService.PUpdateCacheRequest buildSqlUpdateRequest(
             String sql, long partitionKey, long lastVersion, long lastestTime) {
         if (updateRequest == null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/SqlCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/SqlCache.java
@@ -78,6 +78,9 @@ public class SqlCache extends Cache {
         if (rowBatchBuilder == null) {
             rowBatchBuilder = new RowBatchBuilder(CacheAnalyzer.CacheMode.Sql);
         }
+        if (!super.checkRowLimit()) {
+            return;
+        }
         rowBatchBuilder.copyRowData(rowBatch);
     }
 


### PR DESCRIPTION
## Proposed changes

Enable sql cache will keep the complete query results in FE during the query process. After the query is completed, the size of the results will be judged and inserted into the cache. 
This will cause FE Full GC or OOM when the query results are too large.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

