### PR TITLE
[Fix](planner)fix incorrect nullable in ctas.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableAsSelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableAsSelectStmt.java
@@ -20,7 +20,11 @@ package org.apache.doris.analysis;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.UserException;
+import org.apache.doris.planner.OriginalPlanner;
+import org.apache.doris.planner.PlanFragment;
+import org.apache.doris.qe.ConnectContext;
 
+import com.google.common.base.Preconditions;
 import lombok.Getter;
 
 import java.util.ArrayList;
@@ -67,6 +71,18 @@ public class CreateTableAsSelectStmt extends DdlStmt {
         QueryStmt tmpStmt = queryStmt.clone();
         tmpStmt.analyze(dummyRootAnalyzer);
         this.queryStmt = tmpStmt;
+        // to adjust the nullable of the result expression, we have to create plan fragment from the query stmt.
+        OriginalPlanner planner = new OriginalPlanner(dummyRootAnalyzer);
+        planner.createPlanFragments(queryStmt, dummyRootAnalyzer, ConnectContext.get().getSessionVariable().toThrift());
+        PlanFragment root = planner.getFragments().get(0);
+        List<Expr> outputs = root.getOutputExprs();
+        Preconditions.checkArgument(outputs.size() == queryStmt.getResultExprs().size());
+        for (int i = 0; i < outputs.size(); ++i) {
+            if (queryStmt.getResultExprs().get(i).getSrcSlotRef().getColumn() != null) {
+                queryStmt.getResultExprs().get(i).getSrcSlotRef().getColumn()
+                        .setIsAllowNull(outputs.get(i).isNullable());
+            }
+        }
         ArrayList<Expr> resultExprs = getQueryStmt().getResultExprs();
         if (columnNames != null && columnNames.size() != resultExprs.size()) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_COL_NUMBER_NOT_MATCH);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableAsSelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableAsSelectStmt.java
@@ -78,7 +78,7 @@ public class CreateTableAsSelectStmt extends DdlStmt {
         List<Expr> outputs = root.getOutputExprs();
         Preconditions.checkArgument(outputs.size() == queryStmt.getResultExprs().size());
         for (int i = 0; i < outputs.size(); ++i) {
-            if (queryStmt.getResultExprs().get(i).getSrcSlotRef().getColumn() != null) {
+            if (queryStmt.getResultExprs().get(i).getSrcSlotRef() != null) {
                 queryStmt.getResultExprs().get(i).getSrcSlotRef().getColumn()
                         .setIsAllowNull(outputs.get(i).isNullable());
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
@@ -264,24 +264,6 @@ public class OriginalPlanner extends Planner {
 
         Collections.reverse(fragments);
 
-        // the nullable mode will be changed in create plan fragment, we should adjust the ones in querystmt's result
-        // exprs.
-        if (queryStmt instanceof SelectStmt) {
-            PlanFragment root = fragments.get(0);
-            List<SlotDescriptor> slots = analyzer.getDescTbl()
-                    .getTupleDesc(root.getPlanRoot().getOutputTupleIds().get(0))
-                    .getSlots();
-            // to exclude the cases that outputs contain an expression.
-            if (queryStmt.getResultExprs().size() == slots.size()) {
-                for (int i = 0; i < slots.size(); ++i) {
-                    if (queryStmt.getResultExprs().get(i).getSrcSlotRef() != null) {
-                        queryStmt.getResultExprs().get(i).getSrcSlotRef().getColumn()
-                                .setIsAllowNull(slots.get(i).getIsNullable());
-                    }
-                }
-            }
-        }
-
         pushDownResultFileSink(analyzer);
 
         pushOutColumnUniqueIdsToOlapScan(rootFragment, analyzer);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
@@ -264,6 +264,15 @@ public class OriginalPlanner extends Planner {
 
         Collections.reverse(fragments);
 
+        // the nullable mode will be changed in create plan fragment, we should adjust the ones in querystmt's result
+        // exprs.
+        PlanFragment root = fragments.get(0);
+        List<SlotDescriptor> slots = root.getPlanRoot().getOutputTupleDesc().getSlots();
+        Preconditions.checkArgument(queryStmt.getResultExprs().size() == slots.size());
+        for (int i = 0; i < slots.size(); ++i) {
+            queryStmt.getResultExprs().get(i).getSrcSlotRef().getColumn().setIsAllowNull(slots.get(i).getIsNullable());
+        }
+
         pushDownResultFileSink(analyzer);
 
         pushOutColumnUniqueIdsToOlapScan(rootFragment, analyzer);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
@@ -268,12 +268,14 @@ public class OriginalPlanner extends Planner {
         // exprs.
         if (queryStmt instanceof SelectStmt) {
             PlanFragment root = fragments.get(0);
-            List<Expr> slots = root.getOutputExprs();
+            List<SlotDescriptor> slots = analyzer.getDescTbl()
+                    .getTupleDesc(root.getPlanRoot().getOutputTupleIds().get(0))
+                    .getSlots();
             Preconditions.checkArgument(queryStmt.getResultExprs().size() == slots.size());
             for (int i = 0; i < slots.size(); ++i) {
                 if (queryStmt.getResultExprs().get(i).getSrcSlotRef() != null) {
                     queryStmt.getResultExprs().get(i).getSrcSlotRef().getColumn()
-                            .setIsAllowNull(slots.get(i).isNullable());
+                            .setIsAllowNull(slots.get(i).getIsNullable());
                 }
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
@@ -271,11 +271,13 @@ public class OriginalPlanner extends Planner {
             List<SlotDescriptor> slots = analyzer.getDescTbl()
                     .getTupleDesc(root.getPlanRoot().getOutputTupleIds().get(0))
                     .getSlots();
-            Preconditions.checkArgument(queryStmt.getResultExprs().size() == slots.size());
-            for (int i = 0; i < slots.size(); ++i) {
-                if (queryStmt.getResultExprs().get(i).getSrcSlotRef() != null) {
-                    queryStmt.getResultExprs().get(i).getSrcSlotRef().getColumn()
-                            .setIsAllowNull(slots.get(i).getIsNullable());
+            // to exclude the cases that outputs contain an expression.
+            if (queryStmt.getResultExprs().size() == slots.size()) {
+                for (int i = 0; i < slots.size(); ++i) {
+                    if (queryStmt.getResultExprs().get(i).getSrcSlotRef() != null) {
+                        queryStmt.getResultExprs().get(i).getSrcSlotRef().getColumn()
+                                .setIsAllowNull(slots.get(i).getIsNullable());
+                    }
                 }
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
@@ -271,8 +271,10 @@ public class OriginalPlanner extends Planner {
             List<Expr> slots = root.getOutputExprs();
             Preconditions.checkArgument(queryStmt.getResultExprs().size() == slots.size());
             for (int i = 0; i < slots.size(); ++i) {
-                queryStmt.getResultExprs().get(i).getSrcSlotRef().getColumn()
-                        .setIsAllowNull(slots.get(i).isNullable());
+                if (queryStmt.getResultExprs().get(i).getSrcSlotRef() != null) {
+                    queryStmt.getResultExprs().get(i).getSrcSlotRef().getColumn()
+                            .setIsAllowNull(slots.get(i).isNullable());
+                }
             }
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
@@ -266,11 +266,14 @@ public class OriginalPlanner extends Planner {
 
         // the nullable mode will be changed in create plan fragment, we should adjust the ones in querystmt's result
         // exprs.
-        PlanFragment root = fragments.get(0);
-        List<SlotDescriptor> slots = root.getPlanRoot().getOutputTupleDesc().getSlots();
-        Preconditions.checkArgument(queryStmt.getResultExprs().size() == slots.size());
-        for (int i = 0; i < slots.size(); ++i) {
-            queryStmt.getResultExprs().get(i).getSrcSlotRef().getColumn().setIsAllowNull(slots.get(i).getIsNullable());
+        if (queryStmt instanceof SelectStmt) {
+            PlanFragment root = fragments.get(0);
+            List<Expr> slots = root.getOutputExprs();
+            Preconditions.checkArgument(queryStmt.getResultExprs().size() == slots.size());
+            for (int i = 0; i < slots.size(); ++i) {
+                queryStmt.getResultExprs().get(i).getSrcSlotRef().getColumn()
+                        .setIsAllowNull(slots.get(i).isNullable());
+            }
         }
 
         pushDownResultFileSink(analyzer);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -1055,7 +1055,7 @@ public class SingleNodePlanner {
                 // reset assigned conjuncts of analyzer in every compare
                 analyzer.setAssignedConjuncts(root.getAssignedConjuncts());
                 PlanNode candidate = createJoinNode(analyzer, root, rootPlanNodeOfCandidate, tblRefOfCandidate);
-                // (ML): 这里还需要吗？应该不会返回null吧
+                // it may not return null, but protect.
                 if (candidate == null) {
                     continue;
                 }

--- a/regression-test/suites/ddl_p0/test_ctas.groovy
+++ b/regression-test/suites/ddl_p0/test_ctas.groovy
@@ -205,6 +205,39 @@ suite("test_ctas") {
             DROP TABLE IF EXISTS ctas_113815
         """
     }
+    
+    try {
+        sql '''create table a (
+                id int not null,
+                        name varchar(20) not null
+        )
+        distributed by hash(id) buckets 4
+        properties (
+                "replication_num"="1"
+        );
+        '''
 
+        sql '''create table b (
+                id int not null,
+                        age int not null
+        )
+        distributed by hash(id) buckets 4
+        properties (
+                "replication_num"="1"
+        );
+        '''
+
+        sql 'insert into a values(1, \'ww\'), (2, \'zs\');'
+        sql 'insert into b values(1, 22);'
+
+        sql 'create table c properties("replication_num"="1") as select a.id, a.name, b.age from a left join b on a.id = b.id;'
+        
+        String desc = sql 'desc c'
+        assertTrue(desc.contains('Yes'))
+    } finally {
+        sql 'drop table a'
+        sql 'drop table b'
+        sql 'drop table c'
+    }
 }
 

--- a/regression-test/suites/delete_p0/test_delete.groovy
+++ b/regression-test/suites/delete_p0/test_delete.groovy
@@ -233,7 +233,7 @@ suite("test_delete") {
         PROPERTIES (
             "replication_num" = "1",
             "enable_unique_key_merge_on_write" = "true"
-        ); 
+        );
     '''
     
     sql 'insert into test1 values("a", "a"), ("bb", "bb"), ("ccc", "ccc")'


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

ctas with outer join like
```sql
create table a (
        id int not null,
        name varchar(20) not null
)
distributed by hash(id) buckets 4
properties (
        "replication_num"="1"
);

create table b (
        id int not null,
        age int not null
)
distributed by hash(id) buckets 4
properties (
        "replication_num"="1"
);

insert into a values(1, 'ww'), (2, 'zs');
insert into b values(1, 22);

create table c properties("replication_num"="1") as select a.id, a.name, b.age from a left join b on a.id = b.id;
```
the column 'age' in c is not null, but nullable is expected, we fix it by use the nullable mode of the outputs of root plan fragment.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

