### PR TITLE
[opt](stats) Use single connect context for each olap analyze task

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
@@ -96,17 +96,23 @@ public class AnalysisManager extends Daemon implements Writable {
 
     private static final Logger LOG = LogManager.getLogger(AnalysisManager.class);
 
-    private ConcurrentMap<Long, Map<Long, BaseAnalysisTask>> analysisJobIdToTaskMap = new ConcurrentHashMap<>();
+    // Tracking running manually submitted async tasks, keep in mem only
+    private final ConcurrentMap<Long, Map<Long, BaseAnalysisTask>> analysisJobIdToTaskMap = new ConcurrentHashMap<>();
 
     private StatisticsCache statisticsCache;
 
     private AnalysisTaskExecutor taskExecutor;
 
+    // Store task information in metadata.
     private final Map<Long, AnalysisInfo> analysisTaskInfoMap = Collections.synchronizedMap(new TreeMap<>());
+
+    // Store job information in metadata
     private final Map<Long, AnalysisInfo> analysisJobInfoMap = Collections.synchronizedMap(new TreeMap<>());
 
+    // Tracking system submitted job, keep in mem only
     private final Map<Long, AnalysisInfo> systemJobInfoMap = new ConcurrentHashMap<>();
 
+    // Tracking and control sync analyze tasks, keep in mem only
     private final ConcurrentMap<ConnectContext, SyncTaskCollection> ctxToSyncTask = new ConcurrentHashMap<>();
 
     private final Function<TaskStatusWrapper, Void> userJobStatusUpdater = w -> {
@@ -127,6 +133,10 @@ public class AnalysisManager extends Daemon implements Writable {
         }
         info.lastExecTimeInMs = time;
         AnalysisInfo job = analysisJobInfoMap.get(info.jobId);
+        // Job may get deleted during execution.
+        if (job == null) {
+            return null;
+        }
         // Synchronize the job state change in job level.
         synchronized (job) {
             job.lastExecTimeInMs = time;
@@ -333,8 +343,6 @@ public class AnalysisManager extends Daemon implements Writable {
         if (!isSync) {
             persistAnalysisJob(jobInfo);
             analysisJobIdToTaskMap.put(jobInfo.jobId, analysisTaskInfos);
-        }
-        if (!isSync) {
             try {
                 updateTableStats(jobInfo);
             } catch (Throwable e) {

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisTaskExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisTaskExecutorTest.java
@@ -89,7 +89,7 @@ public class AnalysisTaskExecutorTest extends TestWithFeService {
 
         new MockUp<OlapAnalysisTask>() {
             @Mock
-            public void execSQL(String sql) throws Exception {
+            public void execSQLs(List<String> sqls) throws Exception {
             }
         };
 


### PR DESCRIPTION
1. Add some comment for codes of AnalysisManager
2. Fix potential NPE caused by deleting a running analyze job
3. Use single connect  context for each olap analyze task

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

