### PR TITLE
[fix](sec) upgrade mysql:mysql-connector-java to 8.0.28

### DIFF
--- a/samples/doris-demo/spring-jdbc-demo/pom.xml
+++ b/samples/doris-demo/spring-jdbc-demo/pom.xml
@@ -60,7 +60,7 @@ under the License.
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.28</version>
         </dependency>
         <!-- SpringBoot Web -->
         <dependency>


### PR DESCRIPTION
### What happened？
There are 3 security vulnerabilities found in mysql:mysql-connector-java 8.0.15
- [CVE-2022-21363](https://www.oscs1024.com/hd/CVE-2022-21363)
- [CVE-2021-2471](https://www.oscs1024.com/hd/CVE-2021-2471)
- [CVE-2019-2692](https://www.oscs1024.com/hd/CVE-2019-2692)


### What did I do？
Upgrade mysql:mysql-connector-java from 8.0.15 to 8.0.28 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS