### PR TITLE
[Fix](Partial update) Fix wrong position using in segment writer

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -388,10 +388,17 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
     // locate rows in base data
 
     int64_t num_rows_filtered = 0;
-    for (size_t pos = row_pos; pos < row_pos + num_rows; pos++) {
-        std::string key = _full_encode_keys(key_columns, pos);
+    for (size_t block_pos = row_pos; block_pos < row_pos + num_rows; block_pos++) {
+        // block   segment
+        //   2   ->   0
+        //   3   ->   1
+        //   4   ->   2
+        //   5   ->   3
+        // here row_pos = 2, num_rows = 4.
+        size_t segment_pos = block_pos - row_pos;
+        std::string key = _full_encode_keys(key_columns, block_pos);
         if (have_input_seq_column) {
-            _encode_seq_column(seq_column, pos, &key);
+            _encode_seq_column(seq_column, segment_pos, &key);
         }
         // If the table have sequence column, and the include-cids don't contain the sequence
         // column, we need to update the primary key index builder at the end of this method.
@@ -411,7 +418,7 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
                 ++num_rows_filtered;
                 // delete the invalid newly inserted row
                 _mow_context->delete_bitmap->add({_opts.rowset_ctx->rowset_id, _segment_id, 0},
-                                                 pos);
+                                                 segment_pos);
             }
 
             if (!_tablet_schema->can_insert_new_rows_in_partial_update()) {
@@ -431,20 +438,21 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
         // if the delete sign is marked, it means that the value columns of the row
         // will not be read. So we don't need to read the missing values from the previous rows.
         // But we still need to mark the previous row on delete bitmap
-        if (delete_sign_column_data != nullptr && delete_sign_column_data[pos - row_pos] != 0) {
+        if (delete_sign_column_data != nullptr && delete_sign_column_data[segment_pos] != 0) {
             has_default_or_nullable = true;
             use_default_or_null_flag.emplace_back(true);
         } else {
             // partial update should not contain invisible columns
             use_default_or_null_flag.emplace_back(false);
             _rsid_to_rowset.emplace(rowset->rowset_id(), rowset);
-            _tablet->prepare_to_read(loc, pos, &_rssid_to_rid);
+            _tablet->prepare_to_read(loc, block_pos, &_rssid_to_rid);
         }
 
         if (st.is<ALREADY_EXIST>()) {
             // although we need to mark delete current row, we still need to read missing columns
             // for this row, we need to ensure that each column is aligned
-            _mow_context->delete_bitmap->add({_opts.rowset_ctx->rowset_id, _segment_id, 0}, pos);
+            _mow_context->delete_bitmap->add({_opts.rowset_ctx->rowset_id, _segment_id, 0},
+                                             segment_pos);
         } else {
             _mow_context->delete_bitmap->add({loc.rowset_id, loc.segment_id, 0}, loc.row_id);
         }
@@ -500,9 +508,10 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
                     "index builder num rows: {}",
                     _num_rows_written, row_pos, _primary_key_index_builder->num_rows());
         }
-        for (size_t pos = row_pos; pos < row_pos + num_rows; pos++) {
-            std::string key = _full_encode_keys(key_columns, pos);
-            _encode_seq_column(seq_column, pos, &key);
+        for (size_t block_pos = row_pos; block_pos < row_pos + num_rows; block_pos++) {
+            size_t segment_pos = block_pos - row_pos;
+            std::string key = _full_encode_keys(key_columns, block_pos);
+            _encode_seq_column(seq_column, segment_pos, &key);
             RETURN_IF_ERROR(_primary_key_index_builder->add_item(key));
         }
     }

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -399,7 +399,7 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
         //   5   ->   3
         // here row_pos = 2, num_rows = 4.
         size_t delta_pos = block_pos - row_pos;
-        std::string key = _full_encode_keys(key_columns, block_pos);
+        std::string key = _full_encode_keys(key_columns, delta_pos);
         if (have_input_seq_column) {
             _encode_seq_column(seq_column, delta_pos, &key);
         }
@@ -514,7 +514,7 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
                     _num_rows_written, row_pos, _primary_key_index_builder->num_rows());
         }
         for (size_t block_pos = row_pos; block_pos < row_pos + num_rows; block_pos++) {
-            std::string key = _full_encode_keys(key_columns, block_pos);
+            std::string key = _full_encode_keys(key_columns, block_pos - row_pos);
             _encode_seq_column(seq_column, block_pos - row_pos, &key);
             RETURN_IF_ERROR(_primary_key_index_builder->add_item(key));
         }

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -377,7 +377,7 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
         delete_sign_column != nullptr) {
         auto& delete_sign_col =
                 reinterpret_cast<const vectorized::ColumnInt8&>(*(delete_sign_column->column));
-        if (delete_sign_col.size() == num_rows) {
+        if (delete_sign_col.size() == row_pos + num_rows) {
             delete_sign_column_data = delete_sign_col.get_data().data();
         }
     }
@@ -442,7 +442,7 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
         // if the delete sign is marked, it means that the value columns of the row
         // will not be read. So we don't need to read the missing values from the previous rows.
         // But we still need to mark the previous row on delete bitmap
-        if (delete_sign_column_data != nullptr && delete_sign_column_data[delta_pos] != 0) {
+        if (delete_sign_column_data != nullptr && delete_sign_column_data[block_pos] != 0) {
             has_default_or_nullable = true;
             use_default_or_null_flag.emplace_back(true);
         } else {

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -22,7 +22,6 @@
 #include <parallel_hashmap/phmap.h>
 
 #include <algorithm>
-#include <cstddef>
 #include <ostream>
 #include <unordered_map>
 #include <utility>

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -377,7 +377,7 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
         delete_sign_column != nullptr) {
         auto& delete_sign_col =
                 reinterpret_cast<const vectorized::ColumnInt8&>(*(delete_sign_column->column));
-        if (delete_sign_col.size() == row_pos + num_rows) {
+        if (delete_sign_col.size() >= row_pos + num_rows) {
             delete_sign_column_data = delete_sign_col.get_data().data();
         }
     }

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -422,7 +422,6 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
                 // delete the invalid newly inserted row
                 _mow_context->delete_bitmap->add({_opts.rowset_ctx->rowset_id, _segment_id, 0},
                                                  segment_pos);
-                ++segment_pos;
             }
 
             if (!_tablet_schema->can_insert_new_rows_in_partial_update()) {
@@ -432,6 +431,7 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
             }
             has_default_or_nullable = true;
             use_default_or_null_flag.emplace_back(true);
+            ++segment_pos;
             continue;
         }
         if (!st.ok() && !st.is<ALREADY_EXIST>()) {
@@ -457,10 +457,10 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
             // for this row, we need to ensure that each column is aligned
             _mow_context->delete_bitmap->add({_opts.rowset_ctx->rowset_id, _segment_id, 0},
                                              segment_pos);
-            ++segment_pos;
         } else {
             _mow_context->delete_bitmap->add({loc.rowset_id, loc.segment_id, 0}, loc.row_id);
         }
+        ++segment_pos;
     }
     CHECK(use_default_or_null_flag.size() == num_rows);
 

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -511,9 +511,9 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
                     "index builder num rows: {}",
                     _num_rows_written, row_pos, _primary_key_index_builder->num_rows());
         }
-        for (size_t pos = row_pos; pos < row_pos + num_rows; pos++) {
-            std::string key = _full_encode_keys(key_columns, pos);
-            _encode_seq_column(seq_column, pos - row_pos, &key);
+        for (size_t block_pos = row_pos; block_pos < row_pos + num_rows; block_pos++) {
+            std::string key = _full_encode_keys(key_columns, block_pos);
+            _encode_seq_column(seq_column, block_pos - row_pos, &key);
             RETURN_IF_ERROR(_primary_key_index_builder->add_item(key));
         }
     }

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -422,6 +422,7 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
                 // delete the invalid newly inserted row
                 _mow_context->delete_bitmap->add({_opts.rowset_ctx->rowset_id, _segment_id, 0},
                                                  segment_pos);
+                ++segment_pos;
             }
 
             if (!_tablet_schema->can_insert_new_rows_in_partial_update()) {
@@ -456,6 +457,7 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
             // for this row, we need to ensure that each column is aligned
             _mow_context->delete_bitmap->add({_opts.rowset_ctx->rowset_id, _segment_id, 0},
                                              segment_pos);
+            ++segment_pos;
         } else {
             _mow_context->delete_bitmap->add({loc.rowset_id, loc.segment_id, 0}, loc.row_id);
         }

--- a/be/src/olap/rowset/segment_v2/segment_writer.h
+++ b/be/src/olap/rowset/segment_v2/segment_writer.h
@@ -131,7 +131,7 @@ public:
     void set_mow_context(std::shared_ptr<MowContext> mow_context);
     Status fill_missing_columns(vectorized::MutableColumns& mutable_full_columns,
                                 const std::vector<bool>& use_default_or_null_flag,
-                                bool has_default_or_nullable);
+                                bool has_default_or_nullable, const size_t& segment_start_pos);
 
 private:
     DISALLOW_COPY_AND_ASSIGN(SegmentWriter);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

In the process of writing data from block to the segment by the partial update, there will be three different positions, block_pos, delta_pos and segment_pos, and their relationship is shown in the figure below. This PR fixes the use of the wrong positions.

block   segment
   2   ->   0
   3   ->   1   *
   4   ->   2
   5   ->   3
Take the behavior example with *, we will add block 2-5 rows to segment 0-3 rows. Here * row block_pos = 3, segment_pos = 1, delta_pos = 3-2 = 1.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc..