### PR TITLE
[docs](load) fix indentation in stream load manual

### DIFF
--- a/docs/en/docs/data-operate/import/import-way/stream-load-manual.md
+++ b/docs/en/docs/data-operate/import/import-way/stream-load-manual.md
@@ -137,7 +137,7 @@ Stream load uses HTTP protocol, so all parameters related to import tasks are se
 
 	``` dpp.norm.ALL ``` refers to the number of correct data in the import process. The correct amount of data for the import task can be queried by the ``SHOW LOAD` command.
 
-The number of rows in the original file = `dpp.abnorm.ALL + dpp.norm.ALL`
+  The number of rows in the original file = `dpp.abnorm.ALL + dpp.norm.ALL`
 
 + where
 


### PR DESCRIPTION
## Proposed changes

This line should be indented:

![image](https://github.com/apache/doris/assets/5821159/7a13a8c1-3976-4c1c-8dc8-19d39441af7f)


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

