### PR TITLE
[Fix](Nereids) fix sql-cache for nereids.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/CascadesContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/CascadesContext.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids;
 import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.TableIf;
+import org.apache.doris.catalog.View;
 import org.apache.doris.common.Pair;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.nereids.analyzer.Scope;
@@ -61,6 +62,7 @@ import org.apache.doris.statistics.Statistics;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -97,6 +99,7 @@ public class CascadesContext implements ScheduleContext {
     private final RuntimeFilterContext runtimeFilterContext;
     private Optional<Scope> outerScope = Optional.empty();
     private List<TableIf> tables = null;
+    private Set<View> views = Sets.newHashSet();
 
     private boolean isRewriteRoot;
     private volatile boolean isTimeout = false;
@@ -353,6 +356,14 @@ public class CascadesContext implements ScheduleContext {
             throw new AnalysisException("Minidump cache can not find table:" + tableName);
         }
         return null;
+    }
+
+    public void addView(View view) {
+        this.views.add(view);
+    }
+
+    public List<View> getViews() {
+        return ImmutableList.copyOf(views);
     }
 
     public List<TableIf> getTables() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/CascadesContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/CascadesContext.java
@@ -99,7 +99,6 @@ public class CascadesContext implements ScheduleContext {
     private final RuntimeFilterContext runtimeFilterContext;
     private Optional<Scope> outerScope = Optional.empty();
     private List<TableIf> tables = null;
-    private Set<View> views = Sets.newHashSet();
 
     private boolean isRewriteRoot;
     private volatile boolean isTimeout = false;
@@ -356,14 +355,6 @@ public class CascadesContext implements ScheduleContext {
             throw new AnalysisException("Minidump cache can not find table:" + tableName);
         }
         return null;
-    }
-
-    public void addView(View view) {
-        this.views.add(view);
-    }
-
-    public List<View> getViews() {
-        return ImmutableList.copyOf(views);
     }
 
     public List<TableIf> getTables() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/CascadesContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/CascadesContext.java
@@ -20,7 +20,6 @@ package org.apache.doris.nereids;
 import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.TableIf;
-import org.apache.doris.catalog.View;
 import org.apache.doris.common.Pair;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.nereids.analyzer.Scope;
@@ -62,7 +61,6 @@ import org.apache.doris.statistics.Statistics;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Sets;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -133,6 +133,7 @@ public class NereidsPlanner extends Planner {
         ArrayList<String> columnLabelList = physicalPlan.getOutput().stream().map(NamedExpression::getName)
                 .collect(Collectors.toCollection(ArrayList::new));
         logicalPlanAdapter.setColLabels(columnLabelList);
+        logicalPlanAdapter.setTables(cascadesContext.getTables());
     }
 
     @VisibleForTesting

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -133,7 +133,7 @@ public class NereidsPlanner extends Planner {
         ArrayList<String> columnLabelList = physicalPlan.getOutput().stream().map(NamedExpression::getName)
                 .collect(Collectors.toCollection(ArrayList::new));
         logicalPlanAdapter.setColLabels(columnLabelList);
-        logicalPlanAdapter.setViews(cascadesContext.getViews());
+        logicalPlanAdapter.setViews(statementContext.getViews());
     }
 
     @VisibleForTesting

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -133,7 +133,7 @@ public class NereidsPlanner extends Planner {
         ArrayList<String> columnLabelList = physicalPlan.getOutput().stream().map(NamedExpression::getName)
                 .collect(Collectors.toCollection(ArrayList::new));
         logicalPlanAdapter.setColLabels(columnLabelList);
-        logicalPlanAdapter.setTables(cascadesContext.getTables());
+        logicalPlanAdapter.setViews(cascadesContext.getViews());
     }
 
     @VisibleForTesting

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
@@ -17,8 +17,6 @@
 
 package org.apache.doris.nereids;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Sets;
 import org.apache.doris.analysis.StatementBase;
 import org.apache.doris.catalog.View;
 import org.apache.doris.common.IdGenerator;
@@ -39,7 +37,9 @@ import org.apache.doris.qe.OriginStatement;
 
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 
 import java.util.HashMap;
 import java.util.List;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
@@ -41,7 +41,6 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.Maps;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
@@ -17,7 +17,10 @@
 
 package org.apache.doris.nereids;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
 import org.apache.doris.analysis.StatementBase;
+import org.apache.doris.catalog.View;
 import org.apache.doris.common.IdGenerator;
 import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.memo.Group;
@@ -38,6 +41,7 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.Maps;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -78,6 +82,7 @@ public class StatementContext {
     // Used to update consumer's stats
     private final Map<CTEId, List<Pair<Map<Slot, Slot>, Group>>> cteIdToConsumerGroup = new HashMap<>();
     private final Map<CTEId, LogicalPlan> rewrittenCtePlan = new HashMap<>();
+    private final Set<View> views = Sets.newHashSet();
 
     public StatementContext() {
         this.connectContext = ConnectContext.get();
@@ -206,5 +211,13 @@ public class StatementContext {
 
     public Map<CTEId, LogicalPlan> getRewrittenCtePlan() {
         return rewrittenCtePlan;
+    }
+
+    public void addView(View view) {
+        this.views.add(view);
+    }
+
+    public List<View> getViews() {
+        return ImmutableList.copyOf(views);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/LogicalPlanAdapter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/LogicalPlanAdapter.java
@@ -23,6 +23,7 @@ import org.apache.doris.analysis.OutFileClause;
 import org.apache.doris.analysis.Queriable;
 import org.apache.doris.analysis.RedirectStatus;
 import org.apache.doris.analysis.StatementBase;
+import org.apache.doris.catalog.TableIf;
 import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.commands.ExplainCommand;
@@ -43,6 +44,7 @@ public class LogicalPlanAdapter extends StatementBase implements Queriable {
     private final LogicalPlan logicalPlan;
     private List<Expr> resultExprs;
     private ArrayList<String> colLabels;
+    private List<TableIf> tables;
 
     public LogicalPlanAdapter(LogicalPlan logicalPlan, StatementContext statementContext) {
         this.logicalPlan = logicalPlan;
@@ -79,6 +81,10 @@ public class LogicalPlanAdapter extends StatementBase implements Queriable {
         return colLabels;
     }
 
+    public List<TableIf> getTables() {
+        return tables;
+    }
+
     @Override
     public List<Expr> getResultExprs() {
         return resultExprs;
@@ -90,6 +96,10 @@ public class LogicalPlanAdapter extends StatementBase implements Queriable {
 
     public void setColLabels(ArrayList<String> colLabels) {
         this.colLabels = colLabels;
+    }
+
+    public void setTables(List<TableIf> tables) {
+        this.tables = tables;
     }
 
     public StatementContext getStatementContext() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/LogicalPlanAdapter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/LogicalPlanAdapter.java
@@ -23,7 +23,7 @@ import org.apache.doris.analysis.OutFileClause;
 import org.apache.doris.analysis.Queriable;
 import org.apache.doris.analysis.RedirectStatus;
 import org.apache.doris.analysis.StatementBase;
-import org.apache.doris.catalog.TableIf;
+import org.apache.doris.catalog.View;
 import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.commands.ExplainCommand;
@@ -44,7 +44,7 @@ public class LogicalPlanAdapter extends StatementBase implements Queriable {
     private final LogicalPlan logicalPlan;
     private List<Expr> resultExprs;
     private ArrayList<String> colLabels;
-    private List<TableIf> tables;
+    private List<View> views;
 
     public LogicalPlanAdapter(LogicalPlan logicalPlan, StatementContext statementContext) {
         this.logicalPlan = logicalPlan;
@@ -81,8 +81,8 @@ public class LogicalPlanAdapter extends StatementBase implements Queriable {
         return colLabels;
     }
 
-    public List<TableIf> getTables() {
-        return tables;
+    public List<View> getViews() {
+        return views;
     }
 
     @Override
@@ -98,8 +98,8 @@ public class LogicalPlanAdapter extends StatementBase implements Queriable {
         this.colLabels = colLabels;
     }
 
-    public void setTables(List<TableIf> tables) {
-        this.tables = tables;
+    public void setViews(List<View> views) {
+        this.views = views;
     }
 
     public StatementContext getStatementContext() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
@@ -203,7 +203,7 @@ public class BindRelation extends OneAnalysisRuleFactory {
             case OLAP:
                 return makeOlapScan(table, unboundRelation, tableQualifier);
             case VIEW:
-                cascadesContext.addView((View) table);
+                cascadesContext.getStatementContext().addView((View) table);
                 Plan viewPlan = parseAndAnalyzeView(((View) table).getDdlSql(), cascadesContext);
                 return new LogicalSubQueryAlias<>(tableQualifier, viewPlan);
             case HMS_EXTERNAL_TABLE:
@@ -252,10 +252,6 @@ public class BindRelation extends OneAnalysisRuleFactory {
         CascadesContext viewContext = CascadesContext.initContext(
                 parentContext.getStatementContext(), parsedViewPlan, PhysicalProperties.ANY);
         viewContext.newAnalyzer().analyze();
-
-        for (View view : viewContext.getViews()) {
-            parentContext.addView(view);
-        }
         // we should remove all group expression of the plan which in other memo, so the groupId would not conflict
         return viewContext.getRewritePlan();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
@@ -203,6 +203,7 @@ public class BindRelation extends OneAnalysisRuleFactory {
             case OLAP:
                 return makeOlapScan(table, unboundRelation, tableQualifier);
             case VIEW:
+                cascadesContext.addView((View) table);
                 Plan viewPlan = parseAndAnalyzeView(((View) table).getDdlSql(), cascadesContext);
                 return new LogicalSubQueryAlias<>(tableQualifier, viewPlan);
             case HMS_EXTERNAL_TABLE:
@@ -252,6 +253,9 @@ public class BindRelation extends OneAnalysisRuleFactory {
                 parentContext.getStatementContext(), parsedViewPlan, PhysicalProperties.ANY);
         viewContext.newAnalyzer().analyze();
 
+        for (View view : viewContext.getViews()) {
+            parentContext.addView(view);
+        }
         // we should remove all group expression of the plan which in other memo, so the groupId would not conflict
         return viewContext.getRewritePlan();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
@@ -237,7 +237,7 @@ public class CacheAnalyzer {
         if (enableSqlCache()
                 && (now - latestTable.latestTime) >= Config.cache_last_version_interval_second * 1000L) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("TIME:{},{},{}", now, latestTable.latestTime,
+                LOG.debug("Query cache time:{},{},{}", now, latestTable.latestTime,
                         Config.cache_last_version_interval_second * 1000);
             }
             cache = new SqlCache(this.queryId, this.selectStmt);
@@ -339,7 +339,7 @@ public class CacheAnalyzer {
         if (enableSqlCache()
                 && (now - latestTable.latestTime) >= Config.cache_last_version_interval_second * 1000L) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("TIME:{},{},{}", now, latestTable.latestTime,
+                LOG.debug("Query cache time:{},{},{}", now, latestTable.latestTime,
                         Config.cache_last_version_interval_second * 1000);
             }
             cache = new SqlCache(this.queryId, parsedStmt.toSql());

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/SqlCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/SqlCache.java
@@ -50,7 +50,9 @@ public class SqlCache extends Cache {
 
     public String getSqlWithViewStmt() {
         String originSql = selectStmt != null ? selectStmt.toSql() : this.originSql;
-        return originSql + "|" + allViewExpandStmtListStr;
+        String cacheKey = originSql + "|" + allViewExpandStmtListStr;
+        LOG.debug("Cache key: {}", cacheKey);
+        return cacheKey;
     }
 
     public InternalService.PFetchCacheResult getCacheData(Status status) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/SqlCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/SqlCache.java
@@ -31,12 +31,16 @@ import org.apache.logging.log4j.Logger;
 public class SqlCache extends Cache {
     private static final Logger LOG = LogManager.getLogger(SqlCache.class);
 
+    private String originSql;
+
     public SqlCache(TUniqueId queryId, SelectStmt selectStmt) {
         super(queryId, selectStmt);
     }
 
-    public SqlCache(TUniqueId queryId) {
+    // For SetOperationStmt and Nereids
+    public SqlCache(TUniqueId queryId, String originSql) {
         super(queryId);
+        this.originSql = originSql;
     }
 
     public void setCacheInfo(CacheAnalyzer.CacheTable latestTable, String allViewExpandStmtListStr) {
@@ -45,11 +49,8 @@ public class SqlCache extends Cache {
     }
 
     public String getSqlWithViewStmt() {
-        if (selectStmt != null)  {
-            return selectStmt.toSql() + "|" + allViewExpandStmtListStr;
-        } else {
-            return allViewExpandStmtListStr;
-        }
+        String originSql = selectStmt != null ? selectStmt.toSql() : this.originSql;
+        return originSql + "|" + allViewExpandStmtListStr;
     }
 
     public InternalService.PFetchCacheResult getCacheData(Status status) {

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/PartitionCacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/PartitionCacheTest.java
@@ -1144,7 +1144,7 @@ public class PartitionCacheTest {
     @Test
     public void testSqlCacheKeyWithViewForNereids() {
         Env.getCurrentSystemInfo();
-        StatementBase parseStmt = parseSql("SELECT * from testDb.view1");
+        StatementBase parseStmt = parseSqlByNereids("SELECT * from testDb.view1");
         ArrayList<Long> selectedPartitionIds
                 = Lists.newArrayList(20200112L, 20200113L, 20200114L);
         List<ScanNode> scanNodes = Lists.newArrayList(createEventScanNode(selectedPartitionIds));
@@ -1189,7 +1189,7 @@ public class PartitionCacheTest {
     @Test
     public void testSqlCacheKeyWithSubSelectViewForNereids() {
         Env.getCurrentSystemInfo();
-        StatementBase parseStmt = parseSql(
+        StatementBase parseStmt = parseSqlByNereids(
                 "select origin.eventdate as eventdate, origin.userid as userid\n"
                         + "from (\n"
                         + "    select view2.eventdate as eventdate, view2.userid as userid \n"
@@ -1306,8 +1306,8 @@ public class PartitionCacheTest {
         SqlCache sqlCache = (SqlCache) ca.getCache();
         String cacheKey = sqlCache.getSqlWithViewStmt();
         Assert.assertEquals(cacheKey, "SELECT * from testDb.view4"
-                    + "|select eventdate, COUNT(userid) FROM view2 " +
-                    "WHERE eventdate>=\"2020-01-12\" and eventdate<=\"2020-01-14\" GROUP BY eventdate"
+                    + "|select eventdate, COUNT(userid) FROM view2 "
+                    + "WHERE eventdate>=\"2020-01-12\" and eventdate<=\"2020-01-14\" GROUP BY eventdate"
                     + "|select eventdate, userid FROM appevent");
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/PartitionCacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/PartitionCacheTest.java
@@ -1293,7 +1293,7 @@ public class PartitionCacheTest {
     }
 
     @Test
-    public void testSqlCacheKeyWithNestedViewByNereids() {
+    public void testSqlCacheKeyWithNestedViewForNereids() {
         Env.getCurrentSystemInfo();
         StatementBase parseStmt = parseSqlByNereids("SELECT * from testDb.view4");
         ArrayList<Long> selectedPartitionIds

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/PartitionCacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/PartitionCacheTest.java
@@ -45,6 +45,7 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.common.telemetry.Telemetry;
 import org.apache.doris.common.util.SqlParserUtils;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.datasource.CatalogMgr;
@@ -54,6 +55,11 @@ import org.apache.doris.mysql.MysqlChannel;
 import org.apache.doris.mysql.MysqlSerializer;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.MockedAuth;
+import org.apache.doris.nereids.NereidsPlanner;
+import org.apache.doris.nereids.StatementContext;
+import org.apache.doris.nereids.glue.LogicalPlanAdapter;
+import org.apache.doris.nereids.parser.NereidsParser;
+import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.planner.OlapScanNode;
 import org.apache.doris.planner.PlanNodeId;
 import org.apache.doris.planner.ScanNode;
@@ -235,6 +241,9 @@ public class PartitionCacheTest {
         QueryState state = new QueryState();
         channel.reset();
 
+        SessionVariable sessionVariable = new SessionVariable();
+        Deencapsulation.setField(sessionVariable, "beNumber", 1);
+
         new Expectations(channel) {
             {
                 channel.getSerializer();
@@ -296,7 +305,6 @@ public class PartitionCacheTest {
                 minTimes = 0;
                 result = dbName;
 
-                SessionVariable sessionVariable = new SessionVariable();
                 ctx.getSessionVariable();
                 minTimes = 0;
                 result = sessionVariable;
@@ -307,6 +315,18 @@ public class PartitionCacheTest {
                 ctx.getStmtId();
                 minTimes = 0;
                 result = 1L;
+
+                ctx.getTracer();
+                minTimes = 0;
+                result = Telemetry.getNoopTracer();
+
+                ctx.getCurrentCatalog();
+                minTimes = 0;
+                result = catalog;
+
+                ctx.getCatalog(anyString);
+                minTimes = 0;
+                result = catalog;
             }
         };
 
@@ -466,10 +486,14 @@ public class PartitionCacheTest {
 
         List<Column> column = Lists.newArrayList();
         column.add(column1);
+        column.add(column2);
+        column.add(column3);
+        column.add(column4);
+        column.add(column5);
 
         table.setIndexMeta(new Long(2), "test", column, 1, 1, shortKeyColumnCount, TStorageType.COLUMN,
                 KeysType.AGG_KEYS);
-        Deencapsulation.setField(table, "baseIndexId", 1000);
+        Deencapsulation.setField(table, "baseIndexId", 2);
 
         table.addPartition(part12);
         table.addPartition(part13);
@@ -517,6 +541,24 @@ public class PartitionCacheTest {
         OlapScanNode node = new OlapScanNode(new PlanNodeId(30004), desc, "appeventnode");
         node.setSelectedPartitionIds(selectedPartitionIds);
         return node;
+    }
+
+    private StatementBase parseSqlByNereids(String sql) {
+        StatementBase stmt = null;
+        try {
+            LogicalPlan plan = new NereidsParser().parseSingle(sql);
+            OriginStatement originStatement = new OriginStatement(sql, 0);
+            StatementContext statementContext = new StatementContext(ctx, originStatement);
+            NereidsPlanner nereidsPlanner = new NereidsPlanner(statementContext);
+            LogicalPlanAdapter adapter = new LogicalPlanAdapter(plan, statementContext);
+            nereidsPlanner.plan(adapter);
+            statementContext.setParsedStatement(adapter);
+            stmt = adapter;
+        } catch (Throwable throwable) {
+            LOG.warn("Part,an_ex={}", throwable);
+            Assert.fail(throwable.getMessage());
+        }
+        return stmt;
     }
 
     private StatementBase parseSql(String sql) {
@@ -1100,6 +1142,24 @@ public class PartitionCacheTest {
     }
 
     @Test
+    public void testSqlCacheKeyWithViewForNereids() {
+        Env.getCurrentSystemInfo();
+        StatementBase parseStmt = parseSql("SELECT * from testDb.view1");
+        ArrayList<Long> selectedPartitionIds
+                = Lists.newArrayList(20200112L, 20200113L, 20200114L);
+        List<ScanNode> scanNodes = Lists.newArrayList(createEventScanNode(selectedPartitionIds));
+        CacheAnalyzer ca = new CacheAnalyzer(context, parseStmt, scanNodes);
+        ca.checkCacheModeForNereids(1579053661000L); //2020-1-15 10:01:01
+        Assert.assertEquals(ca.getCacheMode(), CacheMode.Sql);
+
+        SqlCache sqlCache = (SqlCache) ca.getCache();
+        String cacheKey = sqlCache.getSqlWithViewStmt();
+        Assert.assertEquals(cacheKey, "SELECT * from testDb.view1"
+                    + "|select eventdate, COUNT(userid) FROM appevent "
+                    + "WHERE eventdate>=\"2020-01-12\" and eventdate<=\"2020-01-14\" GROUP BY eventdate");
+    }
+
+    @Test
     public void testSqlCacheKeyWithSubSelectView() {
         Env.getCurrentSystemInfo();
         StatementBase parseStmt = parseSql(
@@ -1123,6 +1183,35 @@ public class PartitionCacheTest {
                 + "`userid` FROM (SELECT `view2`.`eventdate` AS `eventdate`, `view2`.`userid` AS `userid` FROM "
                 + "`testCluster:testDb`.`view2` view2 WHERE `view2`.`eventdate` >= '2020-01-12' AND `view2`.`eventdate` "
                 + "<= '2020-01-14') origin|select eventdate, userid FROM appevent");
+    }
+
+
+    @Test
+    public void testSqlCacheKeyWithSubSelectViewForNereids() {
+        Env.getCurrentSystemInfo();
+        StatementBase parseStmt = parseSql(
+                "select origin.eventdate as eventdate, origin.userid as userid\n"
+                        + "from (\n"
+                        + "    select view2.eventdate as eventdate, view2.userid as userid \n"
+                        + "    from testDb.view2 view2 \n"
+                        + "    where view2.eventdate >=\"2020-01-12\" and view2.eventdate <= \"2020-01-14\"\n"
+                        + ") origin"
+        );
+        ArrayList<Long> selectedPartitionIds
+                = Lists.newArrayList(20200112L, 20200113L, 20200114L);
+        List<ScanNode> scanNodes = Lists.newArrayList(createEventScanNode(selectedPartitionIds));
+        CacheAnalyzer ca = new CacheAnalyzer(context, parseStmt, scanNodes);
+        ca.checkCacheModeForNereids(1579053661000L); //2020-1-15 10:01:01
+        Assert.assertEquals(ca.getCacheMode(), CacheMode.Sql);
+
+        SqlCache sqlCache = (SqlCache) ca.getCache();
+        String cacheKey = sqlCache.getSqlWithViewStmt();
+        Assert.assertEquals(cacheKey, "select origin.eventdate as eventdate, origin.userid as userid\n"
+                    + "from (\n"
+                    + "    select view2.eventdate as eventdate, view2.userid as userid \n"
+                    + "    from testDb.view2 view2 \n"
+                    + "    where view2.eventdate >=\"2020-01-12\" and view2.eventdate <= \"2020-01-14\"\n"
+                    + ") origin" + "|select eventdate, userid FROM appevent");
     }
 
     @Test
@@ -1201,6 +1290,25 @@ public class PartitionCacheTest {
                 + "`testCluster:testDb`.`view4`.`count(`userid`)` AS `count(``userid``)` FROM `testCluster:testDb`.`view4`|select "
                 + "eventdate, COUNT(userid) FROM view2 WHERE eventdate>=\"2020-01-12\" and "
                 + "eventdate<=\"2020-01-14\" GROUP BY eventdate|select eventdate, userid FROM appevent");
+    }
+
+    @Test
+    public void testSqlCacheKeyWithNestedViewByNereids() {
+        Env.getCurrentSystemInfo();
+        StatementBase parseStmt = parseSqlByNereids("SELECT * from testDb.view4");
+        ArrayList<Long> selectedPartitionIds
+                = Lists.newArrayList(20200112L, 20200113L, 20200114L);
+        List<ScanNode> scanNodes = Lists.newArrayList(createEventScanNode(selectedPartitionIds));
+        CacheAnalyzer ca = new CacheAnalyzer(context, parseStmt, scanNodes);
+        ca.checkCacheModeForNereids(1579053661000L); //2020-1-15 10:01:01
+        Assert.assertEquals(ca.getCacheMode(), CacheMode.Sql);
+
+        SqlCache sqlCache = (SqlCache) ca.getCache();
+        String cacheKey = sqlCache.getSqlWithViewStmt();
+        Assert.assertEquals(cacheKey, "SELECT * from testDb.view4"
+                    + "|select eventdate, COUNT(userid) FROM view2 " +
+                    "WHERE eventdate>=\"2020-01-12\" and eventdate<=\"2020-01-14\" GROUP BY eventdate"
+                    + "|select eventdate, userid FROM appevent");
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

1. should not use `((LogicalPlanAdapter)parsedStmt).getStatementContext().getOriginStatement().originStmt.toLowerCase()` as the cache key (do not invoke `toLowerCase()`), for example: `select * from tbl1 where k1 = 'a'` is different with `select * from tbl1 where k1 = 'A'`, so the cache should be missed.
2. according to [issue 6735](https://github.com/apache/doris/issues/6735) , the cache key should contains all views' s ddl sql (including nested views)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

