### PR TITLE
[branch2.0](fix) fix varchar len in ctas

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
@@ -316,11 +316,14 @@ public class ColumnDef {
         if (typeDef.getType().isScalarType()) {
             final ScalarType targetType = (ScalarType) typeDef.getType();
             if (targetType.getPrimitiveType().isStringType() && !targetType.isLengthSet()) {
-                if (targetType.getPrimitiveType() != PrimitiveType.STRING) {
-                    targetType.setLength(1);
-                } else {
+                if (targetType.getPrimitiveType() == PrimitiveType.VARCHAR) {
+                    // always set varchar length MAX_VARCHAR_LENGTH
+                    targetType.setLength(ScalarType.MAX_VARCHAR_LENGTH);
+                } else if (targetType.getPrimitiveType() == PrimitiveType.STRING) {
                     // always set text length MAX_STRING_LENGTH
                     targetType.setLength(ScalarType.MAX_STRING_LENGTH);
+                } else {
+                    targetType.setLength(1);
                 }
             }
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableAsSelectStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableAsSelectStmtTest.java
@@ -576,4 +576,32 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
         }
         Assert.assertEquals(2, createStmts.size());
     }
+
+    @Test
+    public void testVarcharLength() throws Exception {
+        String createSql =
+                "create table `test`.`varchar_len1` PROPERTIES (\"replication_num\" = \"1\")"
+                        + " as select 'abc', concat('xx', userId), userId from `test`.`varchar_table`";
+        createTableAsSelect(createSql);
+        ShowResultSet showResultSet = showCreateTableByName("varchar_len1");
+        String showStr = showResultSet.getResultRows().get(0).get(1);
+        Assertions.assertEquals(
+                "CREATE TABLE `varchar_len1` (\n"
+                        + "  `_col0` varchar(65533) NULL,\n"
+                        + "  `_col1` varchar(65533) NULL,\n"
+                        + "  `userId` varchar(255) NOT NULL\n"
+                        + ") ENGINE=OLAP\n"
+                        + "DUPLICATE KEY(`_col0`)\n"
+                        + "COMMENT 'OLAP'\n"
+                        + "DISTRIBUTED BY HASH(`_col0`) BUCKETS 10\n"
+                        + "PROPERTIES (\n"
+                        + "\"replication_allocation\" = \"tag.location.default: 1\",\n"
+                        + "\"is_being_synced\" = \"false\",\n"
+                        + "\"storage_format\" = \"V2\",\n"
+                        + "\"light_schema_change\" = \"true\",\n"
+                        + "\"disable_auto_compaction\" = \"false\",\n"
+                        + "\"enable_single_replica_compaction\" = \"false\"\n"
+                        + ");",
+                showStr);
+    }
 }


### PR DESCRIPTION
This is only for branch-2.0
related to #21754 and #21302

After this, the length of varchar in ctas will be as follows:

1. If derived from a origin column, eg: `create table tbl1 as select col1 from tbl2`, the length will be same os the origin column.
2. If derived from a function, eg: `create table tbl1 as select func(col1) from tbl2`, the length will be 65533.
3. If derived from a constant value, eg: `create table tbl1 as select "abc" from tbl2`, the length will be 65533.