### PR TITLE
[test](ctas) add some ut for testing varchar length in ctas

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableAsSelectStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableAsSelectStmtTest.java
@@ -576,4 +576,32 @@ public class CreateTableAsSelectStmtTest extends TestWithFeService {
         }
         Assert.assertEquals(2, createStmts.size());
     }
+
+    @Test
+    public void testVarcharLength() throws Exception {
+        String createSql =
+                "create table `test`.`varchar_len1` PROPERTIES (\"replication_num\" = \"1\")"
+                        + " as select 'abc', concat('xx', userId), userId from `test`.`varchar_table`";
+        createTableAsSelect(createSql);
+        ShowResultSet showResultSet = showCreateTableByName("varchar_len1");
+        String showStr = showResultSet.getResultRows().get(0).get(1);
+        Assertions.assertEquals(
+                "CREATE TABLE `varchar_len1` (\n"
+                        + "  `_col0` varchar(65533) NULL,\n"
+                        + "  `_col1` varchar(65533) NULL,\n"
+                        + "  `userId` varchar(255) NOT NULL\n"
+                        + ") ENGINE=OLAP\n"
+                        + "DUPLICATE KEY(`_col0`)\n"
+                        + "COMMENT 'OLAP'\n"
+                        + "DISTRIBUTED BY HASH(`_col0`) BUCKETS 10\n"
+                        + "PROPERTIES (\n"
+                        + "\"replication_allocation\" = \"tag.location.default: 1\",\n"
+                        + "\"is_being_synced\" = \"false\",\n"
+                        + "\"storage_format\" = \"V2\",\n"
+                        + "\"light_schema_change\" = \"true\",\n"
+                        + "\"disable_auto_compaction\" = \"false\",\n"
+                        + "\"enable_single_replica_compaction\" = \"false\"\n"
+                        + ");",
+                showStr);
+    }
 }


### PR DESCRIPTION
## Proposed changes

1. If derived from a origin column, eg: `create table tbl1 as select col1 from tbl2`, the length will be same os the origin column.
2. If derived from a function, eg: `create table tbl1 as select func(col1) from tbl2`, the length will be 65533.
3. If derived from a constant value, eg: `create table tbl1 as select "abc" from tbl2`, the length will be 65533.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

