### PR TITLE
[fix](executor)Fix query hang when query bitmap Orth intersect

### DIFF
--- a/be/src/util/bitmap_intersect.h
+++ b/be/src/util/bitmap_intersect.h
@@ -184,6 +184,9 @@ public:
     // intersection
     BitmapValue intersect() const {
         BitmapValue result;
+        if (_bitmaps.empty()) {
+            return result;
+        }
         auto it = _bitmaps.begin();
         result |= it->second;
         it++;


### PR DESCRIPTION
## Proposed changes

```
drop TABLE if exists test1;

CREATE TABLE test1 (
    dt1 date NOT NULL,
    dt2 date NOT NULL,
    id varchar(256) NULL,
    type smallint(6) MAX NULL,
    id_bitmap bitmap BITMAP_UNION NULL
) ENGINE = OLAP AGGREGATE KEY(dt1, dt2, id) PARTITION BY RANGE(dt1) (
    PARTITION p20230725
    VALUES
        [('2023-07-25'), ('2023-07-26')))
DISTRIBUTED BY HASH(dt1, dt2) BUCKETS 1 properties("replication_num"="1");

insert into test1
select
str_to_date('2023-07-25','%Y-%m-%d') as dt1,
str_to_date('2023-07-25','%Y-%m-%d') as dt2,
'aaaaaaaaaa' as id,
1 as type,
BITMAP_HASH64('aaaaaaaaaa') as id_bitmap;

set experimental_enable_nereids_planner=false;
set experimental_enable_pipeline_engine = true;
select count(distinct id), bitmap_count(orthogonal_bitmap_intersect(id_bitmap, type, 1)) as count2_bitmap from test1; 
```

Query will hang, because this sql contains orthogonal_bitmap_intersect, this is not correct usage.
For orthogonal_bitmap_intersect, it can only be correct for two phase agg, first update-serialize, then merge and finalize.
But this sql contains two AggNode when exec orthogonal_bitmap_intersect, first update-serialize, then merge-serialize, then update-serialize, then merge-finalize.
