### PR TITLE
[enhancement](data type) add use_mysql_bigint_for_largeint config Tell Doris to use bigint when returning largeint type to mysql jdbc

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/PrimitiveType.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/PrimitiveType.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.catalog;
 
+import org.apache.doris.common.Config;
 import org.apache.doris.thrift.TPrimitiveType;
 
 import com.google.common.base.Preconditions;
@@ -1180,6 +1181,12 @@ public enum PrimitiveType {
                 return MysqlColType.MYSQL_TYPE_LONG;
             case BIGINT:
                 return MysqlColType.MYSQL_TYPE_LONGLONG;
+            case LARGEINT:
+                if (Config.use_mysql_bigint_for_largeint) {
+                    return MysqlColType.MYSQL_TYPE_LONGLONG;
+                } else {
+                    return MysqlColType.MYSQL_TYPE_STRING;
+                }
             case FLOAT:
                 return MysqlColType.MYSQL_TYPE_FLOAT;
             case DOUBLE:

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2068,4 +2068,9 @@ public class Config extends ConfigBase {
             "Export任务允许的最大并行数",
             "The maximum parallelism allowed by Export job"})
     public static int maximum_parallelism_of_export_job = 50;
+
+    @ConfField(mutable = true, description = {
+            "是否用 mysql 的 bigint 类型来返回 Doris 的 largeint 类型",
+            "Whether to use mysql's bigint type to return Doris's largeint type"})
+    public static boolean use_mysql_bigint_for_largeint = false;
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

