### PR TITLE
[Bug](pipeline) add check for _get_next_available_buffer

### DIFF
--- a/be/src/vec/sink/vdata_stream_sender.h
+++ b/be/src/vec/sink/vdata_stream_sender.h
@@ -129,7 +129,7 @@ protected:
     friend class BlockSerializer;
 
     void _roll_pb_block();
-    Status _get_next_available_buffer(BroadcastPBlockHolder** holder);
+    Status _get_next_available_buffer(BroadcastPBlockHolder*& holder);
 
     Status get_partition_column_result(Block* block, int* result) const {
         int counter = 0;


### PR DESCRIPTION
## Proposed changes
add check for _get_next_available_buffer

*** Query id: e37e2a5b952441cd-89a6af43cd10694a ***
*** Aborted at 1691648139 (unix time) try "date -d @1691648139" if you are using GNU date ***
*** Current BE git commitID: 0d75a54d6c ***
*** SIGABRT unknown detail explain (@0x313168) received by PID 3223912 (TID 3224191 OR 0x7efccb37d700) from PID 3223912; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:413
 1# 0x00007F027888F0C0 in /lib/x86_64-linux-gnu/libc.so.6
 2# raise in /lib/x86_64-linux-gnu/libc.so.6
 3# abort in /lib/x86_64-linux-gnu/libc.so.6
 4# 0x00005604B3766839 in /mnt/ssd01/doris-master/NEREIDS_UBSAN/be/lib/doris_be
 5# 0x00005604B375BE4D in /mnt/ssd01/doris-master/NEREIDS_UBSAN/be/lib/doris_be
 6# google::LogMessage::SendToLog() in /mnt/ssd01/doris-master/NEREIDS_UBSAN/be/lib/doris_be
 7# google::LogMessage::Flush() in /mnt/ssd01/doris-master/NEREIDS_UBSAN/be/lib/doris_be
 8# google::LogMessageFatal::~LogMessageFatal() in /mnt/ssd01/doris-master/NEREIDS_UBSAN/be/lib/doris_be
 9# 0x00005604B3F99756 in /mnt/ssd01/doris-master/NEREIDS_UBSAN/be/lib/doris_be
10# google::protobuf::internal::LogMessage::Finish() in /mnt/ssd01/doris-master/NEREIDS_UBSAN/be/lib/doris_be
11# google::protobuf::internal::ArenaStringPtr::Set(std::__cxx11::basic_string, std::allocator > const*, std::__cxx11::basic_string, std::allocator >&&, google::protobuf::Arena*) in /mnt/ssd01/doris-master/NEREIDS_UBSAN/be/lib/doris_be
12# doris::PBlock::set_column_values(void const*, unsigned long) at /home/zcp/repo_center/doris_master/doris/be/../gensrc/build/gen_cpp/data.pb.h:2438
13# doris::vectorized::Block::serialize(int, doris::PBlock*, unsigned long*, unsigned long*, doris::segment_v2::CompressionTypePB, bool) const at /home/zcp/repo_center/doris_master/doris/be/src/vec/core/block.cpp:850
14# doris::vectorized::BlockSerializer::serialize_block(doris::vectorized::Block*, doris::PBlock*, int) at /home/zcp/repo_center/doris_master/doris/be/src/vec/sink/vdata_stream_sender.cpp:755
15# doris::vectorized::VDataStreamSender::try_close(doris::RuntimeState*, doris::Status) at /home/zcp/repo_center/doris_master/doris/be/src/vec/sink/vdata_stream_sender.cpp:630
16# doris::pipeline::DataSinkOperator::try_close(doris::RuntimeState*) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/exec/operator.h:288
17# doris::pipeline::PipelineTask::try_close() at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/pipeline_task.cpp:291
18# doris::pipeline::TaskScheduler::_try_close_task(doris::pipeline::PipelineTask*, doris::pipeline::PipelineTaskState) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/task_scheduler.cpp:335

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

