### PR TITLE
[fix](broadcast shuffle) fix wrong result of broadcast shuffle

### DIFF
--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -111,7 +111,7 @@ Status Channel::send_current_block(bool eos) {
     }
     SCOPED_CONSUME_MEM_TRACKER(_parent->_mem_tracker.get());
     if (eos) {
-        RETURN_IF_ERROR(_serializer.serialize_block(_ch_cur_pb_block, 1));
+        RETURN_IF_ERROR(_serializer.serialize_block(_ch_cur_pb_block, 1, true));
     }
     RETURN_IF_ERROR(send_block(_ch_cur_pb_block, eos));
     ch_roll_pb_block();
@@ -202,8 +202,8 @@ Status Channel::add_rows(Block* block, const std::vector<int>& rows) {
     }
 
     bool serialized = false;
-    RETURN_IF_ERROR(
-            _serializer.next_serialized_block(block, _ch_cur_pb_block, 1, &serialized, &rows));
+    RETURN_IF_ERROR(_serializer.next_serialized_block(block, _ch_cur_pb_block, 1, &serialized,
+                                                      &rows, true));
     if (serialized) {
         RETURN_IF_ERROR(send_current_block(false));
     }
@@ -550,7 +550,7 @@ Status VDataStreamSender::send(RuntimeState* state, Block* block, bool eos) {
             } else {
                 SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
                 RETURN_IF_ERROR(
-                        _serializer.serialize_block(block, current_channel->ch_cur_pb_block()));
+                        _serializer.serialize_block(block, current_channel->ch_cur_pb_block(), 1));
                 auto status = current_channel->send_block(current_channel->ch_cur_pb_block(), eos);
                 HANDLE_CHANNEL_STATUS(state, current_channel, status);
                 current_channel->ch_roll_pb_block();

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -494,27 +494,30 @@ Status VDataStreamSender::send(RuntimeState* state, Block* block, bool eos) {
 
     if (_part_type == TPartitionType::UNPARTITIONED || _channels.size() == 1) {
 #ifndef BROADCAST_ALL_CHANNELS
-#define BROADCAST_ALL_CHANNELS(PBLOCK, PBLOCK_TO_SEND, POST_PROCESS)                              \
-    {                                                                                             \
-        SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());                                           \
-        bool serialized = false;                                                                  \
-        RETURN_IF_ERROR(                                                                          \
-                _serializer.next_serialized_block(block, PBLOCK, _channels.size(), &serialized)); \
-        if (serialized) {                                                                         \
-            Status status;                                                                        \
-            for (auto channel : _channels) {                                                      \
-                if (!channel->is_receiver_eof()) {                                                \
-                    if (channel->is_local()) {                                                    \
-                        status = channel->send_local_block(block);                                \
-                    } else {                                                                      \
-                        SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());                           \
-                        status = channel->send_block(PBLOCK_TO_SEND, false);                      \
-                    }                                                                             \
-                    HANDLE_CHANNEL_STATUS(state, channel, status);                                \
-                }                                                                                 \
-            }                                                                                     \
-            POST_PROCESS;                                                                         \
-        }                                                                                         \
+#define BROADCAST_ALL_CHANNELS(PBLOCK, PBLOCK_TO_SEND, POST_PROCESS)                       \
+    {                                                                                      \
+        SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());                                    \
+        bool serialized = false;                                                           \
+        RETURN_IF_ERROR(_serializer.next_serialized_block(block, PBLOCK, _channels.size(), \
+                                                          &serialized, nullptr, false));   \
+        if (serialized) {                                                                  \
+            Status status;                                                                 \
+            Block merged_block = _serializer.get_block()->to_block();                      \
+            for (auto channel : _channels) {                                               \
+                if (!channel->is_receiver_eof()) {                                         \
+                    if (channel->is_local()) {                                             \
+                        status = channel->send_local_block(&merged_block);                 \
+                    } else {                                                               \
+                        SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());                    \
+                        status = channel->send_block(PBLOCK_TO_SEND, false);               \
+                    }                                                                      \
+                    HANDLE_CHANNEL_STATUS(state, channel, status);                         \
+                }                                                                          \
+            }                                                                              \
+            merged_block.clear_column_data();                                              \
+            _serializer.get_block()->set_muatable_columns(merged_block.mutate_columns());  \
+            POST_PROCESS;                                                                  \
+        }                                                                                  \
     }
 #endif
         // 1. serialize depends on it is not local exchange
@@ -707,7 +710,8 @@ BlockSerializer::BlockSerializer(VDataStreamSender* parent, bool is_local)
         : _parent(parent), _is_local(is_local), _batch_size(parent->state()->batch_size()) {}
 
 Status BlockSerializer::next_serialized_block(Block* block, PBlock* dest, int num_receivers,
-                                              bool* serialized, const std::vector<int>* rows) {
+                                              bool* serialized, const std::vector<int>* rows,
+                                              bool clear_after_serialize) {
     if (_mutable_block == nullptr) {
         SCOPED_CONSUME_MEM_TRACKER(_parent->_mem_tracker.get());
         _mutable_block = MutableBlock::create_unique(block->clone_empty());
@@ -727,7 +731,7 @@ Status BlockSerializer::next_serialized_block(Block* block, PBlock* dest, int nu
 
     if (_mutable_block->rows() >= _batch_size) {
         if (!_is_local) {
-            RETURN_IF_ERROR(serialize_block(dest, num_receivers));
+            RETURN_IF_ERROR(serialize_block(dest, num_receivers, clear_after_serialize));
         }
         *serialized = true;
         return Status::OK();
@@ -736,18 +740,21 @@ Status BlockSerializer::next_serialized_block(Block* block, PBlock* dest, int nu
     return Status::OK();
 }
 
-Status BlockSerializer::serialize_block(PBlock* dest, int num_receivers) {
+Status BlockSerializer::serialize_block(PBlock* dest, int num_receivers,
+                                        bool clear_after_serialize) {
     if (_mutable_block && _mutable_block->rows() > 0) {
         auto block = _mutable_block->to_block();
         RETURN_IF_ERROR(serialize_block(&block, dest, num_receivers));
-        block.clear_column_data();
+        if (clear_after_serialize) {
+            block.clear_column_data();
+        }
         _mutable_block->set_muatable_columns(block.mutate_columns());
     }
 
     return Status::OK();
 }
 
-Status BlockSerializer::serialize_block(Block* src, PBlock* dest, int num_receivers) {
+Status BlockSerializer::serialize_block(const Block* src, PBlock* dest, int num_receivers) {
     {
         SCOPED_TIMER(_parent->_serialize_batch_timer);
         dest->Clear();

--- a/be/src/vec/sink/vdata_stream_sender.h
+++ b/be/src/vec/sink/vdata_stream_sender.h
@@ -73,9 +73,10 @@ class BlockSerializer {
 public:
     BlockSerializer(VDataStreamSender* parent, bool is_local = false);
     Status next_serialized_block(Block* src, PBlock* dest, int num_receivers, bool* serialized,
-                                 const std::vector<int>* rows = nullptr);
-    Status serialize_block(PBlock* dest, int num_receivers = 1);
-    Status serialize_block(Block* src, PBlock* dest, int num_receivers = 1);
+                                 const std::vector<int>* rows = nullptr,
+                                 bool clear_after_serialize = true);
+    Status serialize_block(PBlock* dest, int num_receivers = 1, bool clear_after_serialize = true);
+    Status serialize_block(const Block* src, PBlock* dest, int num_receivers = 1);
 
     MutableBlock* get_block() const { return _mutable_block.get(); }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

When data stream sender is doing broadcast shuffle, it accumulate to batch size and then send blocks to destinations, but  for local receivers, it ONLY send the current block, which will cause data loss.

This issue is introduced by https://github.com/apache/doris/pull/22218. 

If #22218  is pick to 2.0 branch, then also need to pick this PR.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

