### PR TITLE
[fix](bug) Fix page handle safe exit

### DIFF
--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -123,7 +123,7 @@ public:
     std::shared_ptr<MemTrackerLimiter> orphan_mem_tracker() { return _orphan_mem_tracker; }
     MemTrackerLimiter* orphan_mem_tracker_raw() { return _orphan_mem_tracker_raw; }
     MemTrackerLimiter* experimental_mem_tracker() { return _experimental_mem_tracker.get(); }
-    MemTracker* page_no_cache_mem_tracker() { return _page_no_cache_mem_tracker.get(); }
+    std::shared_ptr<MemTracker> page_no_cache_mem_tracker() { return _page_no_cache_mem_tracker; }
     MemTracker* brpc_iobuf_block_memory_tracker() { return _brpc_iobuf_block_memory_tracker.get(); }
 
     ThreadPool* send_batch_thread_pool() { return _send_batch_thread_pool.get(); }

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -87,7 +87,9 @@ MemTrackerLimiter::~MemTrackerLimiter() {
     // nor can it guarantee that the memory alloc and free are recorded in a one-to-one correspondence.
     // In order to ensure `consumption of all limiter trackers` + `orphan tracker consumption` = `process tracker consumption`
     // in real time. Merge its consumption into orphan when parent is process, to avoid repetition.
-    ExecEnv::GetInstance()->orphan_mem_tracker()->consume(_consumption->current_value());
+    if (ExecEnv::GetInstance()->initialized()) {
+        ExecEnv::GetInstance()->orphan_mem_tracker()->consume(_consumption->current_value());
+    }
     _consumption->set(0);
     {
         std::lock_guard<std::mutex> l(mem_tracker_limiter_pool[_group_num].group_lock);


### PR DESCRIPTION
## Proposed changes

page handle hold tracker shared ptr

```
*** SIGSEGV address not mapped to object (@0x28) received by PID 2344547 (TID 2344547 OR 0x7f92e3378e00) from PID 40; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at doris/be/src/common/signal_handler.h:413
 1# 0x00007F92C98770A7 in /usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 3# 0x00007F92C987002C in /usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 4# 0x00007F92E3535040 in /lib/x86_64-linux-gnu/libc.so.6
 5# std::__shared_ptr<doris::MemTracker::MemCounter, (__gnu_cxx::_Lock_policy)2>::get() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1291
 6# std::__shared_ptr_access<doris::MemTracker::MemCounter, (__gnu_cxx::_Lock_policy)2, false, false>::_M_get() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:990
 7# std::__shared_ptr_access<doris::MemTracker::MemCounter, (__gnu_cxx::_Lock_policy)2, false, false>::operator->() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:984
 8# doris::MemTracker::release(long) at doris/be/src/runtime/memory/mem_tracker.h:149
 9# doris::segment_v2::PageHandle::~PageHandle() at doris/be/src/olap/rowset/segment_v2/page_handle.h:64
10# doris::segment_v2::IndexedColumnReader::~IndexedColumnReader() at doris/be/src/olap/rowset/segment_v2/indexed_column_reader.h:49
11# std::default_delete<doris::segment_v2::IndexedColumnReader>::operator()(doris::segment_v2::IndexedColumnReader*) const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:85
12# std::unique_ptr<doris::segment_v2::IndexedColumnReader, std::default_delete<doris::segment_v2::IndexedColumnReader> >::~unique_ptr() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:361
13# doris::segment_v2::BitmapIndexReader::~BitmapIndexReader() at doris/be/src/olap/rowset/segment_v2/bitmap_index_reader.h:43
14# std::default_delete<doris::segment_v2::BitmapIndexReader>::operator()(doris::segment_v2::BitmapIndexReader*) const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:85
15# std::unique_ptr<doris::segment_v2::BitmapIndexReader, std::default_delete<doris::segment_v2::BitmapIndexReader> >::~unique_ptr() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:361
16# doris::segment_v2::ColumnReader::~ColumnReader() at doris/be/src/olap/rowset/segment_v2/column_reader.cpp:185
17# std::default_delete<doris::segment_v2::ColumnReader>::operator()(doris::segment_v2::ColumnReader*) const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:85
18# std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> >::~unique_ptr() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:361
19# std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >::~pair() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_iterator.h:2379
20# void std::destroy_at<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >(std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >*) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:89
21# void std::allocator_traits<std::allocator<std::_Rb_tree_node<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > > >::destroy<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >(std::allocator<std::_Rb_tree_node<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >&, std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >*) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:533
22# std::_Rb_tree<int, std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >, std::_Select1st<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::_M_destroy_node(std::_Rb_tree_node<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >*) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:626
23# std::_Rb_tree<int, std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >, std::_Select1st<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::_M_drop_node(std::_Rb_tree_node<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >*) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:631
24# std::_Rb_tree<int, std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >, std::_Select1st<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::_M_erase(std::_Rb_tree_node<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >*) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:1890
25# std::_Rb_tree<int, std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >, std::_Select1st<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::_M_erase(std::_Rb_tree_node<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >*) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:1888
26# std::_Rb_tree<int, std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >, std::_Select1st<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::_M_erase(std::_Rb_tree_node<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >*) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:1888
27# std::_Rb_tree<int, std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >, std::_Select1st<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::_M_erase(std::_Rb_tree_node<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >*) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:1888
28# std::_Rb_tree<int, std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >, std::_Select1st<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::_M_erase(std::_Rb_tree_node<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >*) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:1888
29# std::_Rb_tree<int, std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >, std::_Select1st<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::_M_erase(std::_Rb_tree_node<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >*) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:1888
30# std::_Rb_tree<int, std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >, std::_Select1st<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::~_Rb_tree() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:984
31# std::map<int, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::~map() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_map.h:302
32# doris::segment_v2::Segment::~Segment() at doris/be/src/olap/rowset/segment_v2/segment.cpp:112
33# std::_Sp_counted_ptr<doris::segment_v2::Segment*, (__gnu_cxx::_Lock_policy)2>::_M_dispose() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:348
34# std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:168
35# std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:703
36# std::__shared_ptr<doris::segment_v2::Segment, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1149
37# std::shared_ptr<doris::segment_v2::Segment>::~shared_ptr() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr.h:122
38# void std::destroy_at<std::shared_ptr<doris::segment_v2::Segment> >(std::shared_ptr<doris::segment_v2::Segment>*) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:89
39# void std::_Destroy<std::shared_ptr<doris::segment_v2::Segment> >(std::shared_ptr<doris::segment_v2::Segment>*) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:142
40# void std::_Destroy_aux<false>::__destroy<std::shared_ptr<doris::segment_v2::Segment>*>(std::shared_ptr<doris::segment_v2::Segment>*, std::shared_ptr<doris::segment_v2::Segment>*) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:151
41# void std::_Destroy<std::shared_ptr<doris::segment_v2::Segment>*>(std::shared_ptr<doris::segment_v2::Segment>*, std::shared_ptr<doris::segment_v2::Segment>*) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:186
42# void std::_Destroy<std::shared_ptr<doris::segment_v2::Segment>*, std::shared_ptr<doris::segment_v2::Segment> >(std::shared_ptr<doris::segment_v2::Segment>*, std::shared_ptr<doris::segment_v2::Segment>*, std::allocator<std::shared_ptr<doris::segment_v2::Segment> >&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:747
43# std::vector<std::shared_ptr<doris::segment_v2::Segment>, std::allocator<std::shared_ptr<doris::segment_v2::Segment> > >::_M_erase_at_end(std::shared_ptr<doris::segment_v2::Segment>*) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:1796
44# std::vector<std::shared_ptr<doris::segment_v2::Segment>, std::allocator<std::shared_ptr<doris::segment_v2::Segment> > >::clear() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:1499
45# doris::SegmentCache::insert(doris::SegmentCache::CacheKey const&, doris::SegmentCache::CacheValue&, doris::SegmentCacheHandle*)::$_0::operator()(doris::CacheKey const&, void*) const at doris/be/src/olap/segment_loader.cpp:49
46# doris::SegmentCache::insert(doris::SegmentCache::CacheKey const&, doris::SegmentCache::CacheValue&, doris::SegmentCacheHandle*)::$_0::__invoke(doris::CacheKey const&, void*) at doris/be/src/olap/segment_loader.cpp:46
47# doris::LRUHandle::free() at doris/be/src/olap/lru_cache.h:271
48# doris::LRUCache::prune() at doris/be/src/olap/lru_cache.cpp:461
49# doris::LRUCache::~LRUCache() at doris/be/src/olap/lru_cache.cpp:176
50# doris::ShardedLRUCache::~ShardedLRUCache() at doris/be/src/olap/lru_cache.cpp:577
51# doris::ShardedLRUCache::~ShardedLRUCache() at doris/be/src/olap/lru_cache.cpp:572
52# std::default_delete<doris::Cache>::operator()(doris::Cache*) const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:86
53# std::unique_ptr<doris::Cache, std::default_delete<doris::Cache> >::~unique_ptr() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:362
54# doris::LRUCachePolicy::~LRUCachePolicy() at doris/be/src/runtime/memory/lru_cache_policy.h:47
55# doris::SegmentCache::~SegmentCache() at doris/be/src/olap/segment_loader.h:58
56# doris::SegmentCache::~SegmentCache() at doris/be/src/olap/segment_loader.h:58
57# std::default_delete<doris::SegmentCache>::operator()(doris::SegmentCache*) const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:86
58# std::unique_ptr<doris::SegmentCache, std::default_delete<doris::SegmentCache> >::~unique_ptr() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:362
59# doris::SegmentLoader::~SegmentLoader() at doris/be/src/olap/segment_loader.h:92
60# 0x00007F92E3538147 in /lib/x86_64-linux-gnu/libc.so.6
61# on_exit in /lib/x86_64-linux-gnu/libc.so.6
62# __libc_start_main in /lib/x86_64-linux-gnu/libc.so.6
63# _start in /mnt/hdd01/dorisTestEnv/NEREIDS_ASAN/be/lib/doris_be
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

