### PR TITLE
[performance](executor) optimize time_round function only one arg

### DIFF
--- a/be/src/vec/functions/function_datetime_floor_ceil.cpp
+++ b/be/src/vec/functions/function_datetime_floor_ceil.cpp
@@ -507,13 +507,16 @@ struct TimeRound {
             part = ts2.minute() + ts2.second();
         }
         if constexpr (Impl::Unit == MINUTE) {
-            diff = ts2.daynr() * 24 * 60 + ts2.hour() * 60 + ts2.minute();
+            diff = ts2.daynr() * 24L * 60 + ts2.hour() * 60 + ts2.minute();
             part = ts2.second();
         }
         if constexpr (Impl::Unit == SECOND) {
-            diff = ts2.daynr() * 24 * 60 * 60 + ts2.hour() * 60 * 60 + ts2.minute() * 60 +
+            diff = ts2.daynr() * 24L * 60 * 60 + ts2.hour() * 60L * 60 + ts2.minute() * 60L +
                    ts2.second();
             part = 0;
+            if constexpr (std::is_same_v<DateValueType, DateV2Value<DateTimeV2ValueType>>) {
+                part = ts2.microsecond();
+            }
         }
 
         if constexpr (Impl::Type == CEIL) {

--- a/be/src/vec/functions/function_datetime_floor_ceil.cpp
+++ b/be/src/vec/functions/function_datetime_floor_ceil.cpp
@@ -489,7 +489,6 @@ struct TimeRound {
     static void time_round(const DateValueType& ts2, DateValueType& ts1, UInt8& is_null) {
         // ts2 --- > ts1
         constexpr Int32 period = 1;
-        ts1 = ts2;
         int64_t diff;
         int64_t trivial_part_ts1;
         int64_t trivial_part_ts2;

--- a/be/src/vec/functions/function_datetime_floor_ceil.cpp
+++ b/be/src/vec/functions/function_datetime_floor_ceil.cpp
@@ -494,7 +494,7 @@ struct TimeRound {
     static constexpr uint64_t MASK_SECOND_FLOOR =
             0b1111111111111111111111111111111111111111111100000000000000000000;
 
-    static constexpr bool use_Optimize_floor =
+    static constexpr bool USE_OPTIMIZE_FLOOR =
             Impl::Unit == DAY || Impl::Unit == HOUR || Impl::Unit == MINUTE || Impl::Unit == SECOND;
     template <typename NativeType, typename DateValueType>
     static void datetimev2_floor(const DateValueType& ts2, DateValueType& ts1) {
@@ -517,7 +517,7 @@ struct TimeRound {
     static void time_round(const DateValueType& ts2, DateValueType& ts1, UInt8& is_null) {
         static_assert(Impl::Unit != WEEK);
         if constexpr (std::is_same_v<DateValueType, DateV2Value<DateTimeV2ValueType>> &&
-                      Impl::Type == FLOOR && use_Optimize_floor) {
+                      Impl::Type == FLOOR && USE_OPTIMIZE_FLOOR) {
             datetimev2_floor<NativeType, DateValueType>(ts2, ts1);
             is_null = false;
             return;

--- a/be/src/vec/functions/function_datetime_floor_ceil.cpp
+++ b/be/src/vec/functions/function_datetime_floor_ceil.cpp
@@ -487,150 +487,97 @@ struct TimeRound {
 
     template <typename NativeType, typename DateValueType>
     static void time_round(const DateValueType& ts2, DateValueType& ts1, UInt8& is_null) {
-        // ts2 --- > ts1
-        constexpr Int32 period = 1;
+        static_assert(Impl::Unit != WEEK);
+        // ts2 --- > ts1 , ts1 = 0
         int64_t diff;
-        int64_t trivial_part_ts1;
-        int64_t trivial_part_ts2;
+        int64_t part;
         if constexpr (std::is_same_v<DateValueType, VecDateTimeValue>) {
             if constexpr (Impl::Unit == YEAR) {
-                diff = (ts2.year() - ts1.year());
-                trivial_part_ts2 = ts2.to_int64() % 10000000000;
-                trivial_part_ts1 = ts1.to_int64() % 10000000000;
+                diff = ts2.year();
+                part = ts2.to_int64() % 10000000000;
             }
             if constexpr (Impl::Unit == MONTH) {
                 diff = (ts2.year() - ts1.year()) * 12 + (ts2.month() - ts1.month());
-                trivial_part_ts2 = ts2.to_int64() % 100000000;
-                trivial_part_ts1 = ts1.to_int64() % 100000000;
-            }
-            if constexpr (Impl::Unit == WEEK) {
-                diff = ts2.daynr() / 7 - ts1.daynr() / 7;
-                trivial_part_ts2 = ts2.daynr() % 7 * 24 * 3600 + ts2.hour() * 3600 +
-                                   ts2.minute() * 60 + ts2.second();
-                trivial_part_ts1 = ts1.daynr() % 7 * 24 * 3600 + ts1.hour() * 3600 +
-                                   ts1.minute() * 60 + ts1.second();
+                part = ts2.to_int64() % 100000000;
             }
             if constexpr (Impl::Unit == DAY) {
-                diff = ts2.daynr() - ts1.daynr();
-                trivial_part_ts2 = ts2.hour() * 3600 + ts2.minute() * 60 + ts2.second();
-                trivial_part_ts1 = ts1.hour() * 3600 + ts1.minute() * 60 + ts1.second();
+                diff = ts2.daynr();
+                part = ts2.hour() * 3600 + ts2.minute() * 60 + ts2.second();
             }
             if constexpr (Impl::Unit == HOUR) {
-                diff = (ts2.daynr() - ts1.daynr()) * 24 + (ts2.hour() - ts1.hour());
-                trivial_part_ts2 = ts2.minute() * 60 + ts2.second();
-                trivial_part_ts1 = ts1.minute() * 60 + ts1.second();
+                diff = ts2.daynr() * 24 + ts2.hour();
+                part = ts2.minute() * 60 + ts2.second();
             }
             if constexpr (Impl::Unit == MINUTE) {
-                diff = (ts2.daynr() - ts1.daynr()) * 24 * 60 + (ts2.hour() - ts1.hour()) * 60 +
-                       (ts2.minute() - ts1.minute());
-                trivial_part_ts2 = ts2.second();
-                trivial_part_ts1 = ts1.second();
+                diff = ts2.daynr() * 24 * 60 + ts2.hour() * 60 + ts2.minute();
+                part = ts2.second();
             }
             if constexpr (Impl::Unit == SECOND) {
-                diff = ts2.second_diff(ts1);
-                trivial_part_ts1 = 0;
-                trivial_part_ts2 = 0;
+                diff = ts2.daynr() * 24 * 60 * 60 + ts2.hour() * 60 * 60 + ts2.minute() * 60 +
+                       ts2.second();
+                part = 0;
             }
         } else if constexpr (std::is_same_v<DateValueType, DateV2Value<DateV2ValueType>>) {
             if constexpr (Impl::Unit == YEAR) {
-                diff = (ts2.year() - ts1.year());
-                trivial_part_ts2 = ts2.to_date_int_val() & MASK_YEAR_FOR_DATEV2;
-                trivial_part_ts1 = ts1.to_date_int_val() & MASK_YEAR_FOR_DATEV2;
+                diff = ts2.year();
+                part = ts2.to_date_int_val() & MASK_YEAR_FOR_DATEV2;
             }
             if constexpr (Impl::Unit == MONTH) {
-                diff = (ts2.year() - ts1.year()) * 12 + (ts2.month() - ts1.month());
-                trivial_part_ts2 = ts2.to_date_int_val() & MASK_YEAR_MONTH_FOR_DATEV2;
-                trivial_part_ts1 = ts1.to_date_int_val() & MASK_YEAR_MONTH_FOR_DATEV2;
-            }
-            if constexpr (Impl::Unit == WEEK) {
-                diff = ts2.daynr() / 7 - ts1.daynr() / 7;
-                trivial_part_ts2 = ts2.daynr() % 7 * 24 * 3600 + ts2.hour() * 3600 +
-                                   ts2.minute() * 60 + ts2.second();
-                trivial_part_ts1 = ts1.daynr() % 7 * 24 * 3600 + ts1.hour() * 3600 +
-                                   ts1.minute() * 60 + ts1.second();
+                diff = ts2.year() * 12 + ts2.month();
+                part = ts2.to_date_int_val() & MASK_YEAR_MONTH_FOR_DATEV2;
             }
             if constexpr (Impl::Unit == DAY) {
-                diff = ts2.daynr() - ts1.daynr();
-                trivial_part_ts2 = ts2.hour() * 3600 + ts2.minute() * 60 + ts2.second();
-                trivial_part_ts1 = ts1.hour() * 3600 + ts1.minute() * 60 + ts1.second();
+                diff = ts2.daynr();
+                part = ts2.hour() * 3600 + ts2.minute() * 60 + ts2.second();
             }
             if constexpr (Impl::Unit == HOUR) {
-                diff = (ts2.daynr() - ts1.daynr()) * 24 + (ts2.hour() - ts1.hour());
-                trivial_part_ts2 = ts2.minute() * 60 + ts2.second();
-                trivial_part_ts1 = ts1.minute() * 60 + ts1.second();
+                diff = ts2.daynr() * 24 + ts2.hour();
+                part = ts2.minute() * 60 + ts2.second();
             }
             if constexpr (Impl::Unit == MINUTE) {
-                diff = (ts2.daynr() - ts1.daynr()) * 24 * 60 + (ts2.hour() - ts1.hour()) * 60 +
-                       (ts2.minute() - ts1.minute());
-                trivial_part_ts2 = ts2.second();
-                trivial_part_ts1 = ts1.second();
+                diff = ts2.daynr() * 24 * 60 + ts2.hour() * 60 + ts2.minute();
+                part = ts2.second();
             }
             if constexpr (Impl::Unit == SECOND) {
-                diff = ts2.second_diff(ts1);
-                trivial_part_ts1 = 0;
-                trivial_part_ts2 = 0;
+                diff = ts2.daynr() * 24 * 60 * 60 + ts2.hour() * 60 * 60 + ts2.minute() * 60 +
+                       ts2.second();
+                part = 0;
             }
         } else if constexpr (std::is_same_v<DateValueType, DateV2Value<DateTimeV2ValueType>>) {
             if constexpr (Impl::Unit == YEAR) {
-                diff = (ts2.year() - ts1.year());
-                trivial_part_ts2 = ts2.to_date_int_val() & MASK_YEAR_FOR_DATETIMEV2;
-                trivial_part_ts1 = ts1.to_date_int_val() & MASK_YEAR_FOR_DATETIMEV2;
+                diff = ts2.year();
+                part = ts2.to_date_int_val() & MASK_YEAR_FOR_DATETIMEV2;
             }
             if constexpr (Impl::Unit == MONTH) {
-                diff = (ts2.year() - ts1.year()) * 12 + (ts2.month() - ts1.month());
-                trivial_part_ts2 = ts2.to_date_int_val() & MASK_YEAR_MONTH_FOR_DATETIMEV2;
-                trivial_part_ts1 = ts1.to_date_int_val() & MASK_YEAR_MONTH_FOR_DATETIMEV2;
-            }
-            if constexpr (Impl::Unit == WEEK) {
-                diff = ts2.daynr() / 7 - ts1.daynr() / 7;
-                trivial_part_ts2 = ts2.daynr() % 7 * 24 * 3600 + ts2.hour() * 3600 +
-                                   ts2.minute() * 60 + ts2.second();
-                trivial_part_ts1 = ts1.daynr() % 7 * 24 * 3600 + ts1.hour() * 3600 +
-                                   ts1.minute() * 60 + ts1.second();
+                diff = ts2.year() * 12 + ts2.month();
+                part = ts2.to_date_int_val() & MASK_YEAR_MONTH_FOR_DATETIMEV2;
             }
             if constexpr (Impl::Unit == DAY) {
-                diff = ts2.daynr() - ts1.daynr();
-                trivial_part_ts2 = ts2.hour() * 3600 + ts2.minute() * 60 + ts2.second();
-                trivial_part_ts1 = ts1.hour() * 3600 + ts1.minute() * 60 + ts1.second();
+                diff = ts2.daynr();
+                part = ts2.hour() * 3600 + ts2.minute() * 60 + ts2.second();
             }
             if constexpr (Impl::Unit == HOUR) {
-                diff = (ts2.daynr() - ts1.daynr()) * 24 + (ts2.hour() - ts1.hour());
-                trivial_part_ts2 = ts2.minute() * 60 + ts2.second();
-                trivial_part_ts1 = ts1.minute() * 60 + ts1.second();
+                diff = ts2.daynr() * 24 + ts2.hour();
+                part = ts2.minute() * 60 + ts2.second();
             }
             if constexpr (Impl::Unit == MINUTE) {
-                diff = (ts2.daynr() - ts1.daynr()) * 24 * 60 + (ts2.hour() - ts1.hour()) * 60 +
-                       (ts2.minute() - ts1.minute());
-                trivial_part_ts2 = ts2.second();
-                trivial_part_ts1 = ts1.second();
+                diff = ts2.daynr() * 24 * 60 + ts2.hour() * 60 + ts2.minute();
+                part = ts2.second();
             }
             if constexpr (Impl::Unit == SECOND) {
-                diff = ts2.second_diff(ts1);
-                trivial_part_ts1 = 0;
-                trivial_part_ts2 = 0;
+                diff = ts2.daynr() * 24 * 60 * 60 + ts2.hour() * 60 * 60 + ts2.minute() * 60 +
+                       ts2.second();
+                part = 0;
             }
         }
 
-        //round down/up to specific time-unit(HOUR/DAY/MONTH...) by increase/decrease diff variable
         if constexpr (Impl::Type == CEIL) {
-            //e.g. hour_ceil(ts: 00:00:40, origin: 00:00:30), ts should be rounded to 01:00:30
-            diff += trivial_part_ts2 > trivial_part_ts1;
+            if (part) {
+                diff++;
+            }
         }
-        if constexpr (Impl::Type == FLOOR) {
-            //e.g. hour_floor(ts: 01:00:20, origin: 00:00:30), ts should be rounded to 00:00:30
-            diff -= trivial_part_ts2 < trivial_part_ts1;
-        }
-
-        //round down/up inside time period(several time-units)
-        int64_t count = period;
-        int64_t delta_inside_period = (diff % count + count) % count;
-        int64_t step = diff - delta_inside_period +
-                       (Impl::Type == FLOOR        ? 0
-                        : delta_inside_period == 0 ? 0
-                                                   : count);
-        bool is_neg = step < 0;
-        TimeInterval interval(Impl::Unit, is_neg ? -step : step, is_neg);
-        is_null = !ts1.template date_add_interval<Impl::Unit>(interval);
+        TimeInterval interval(Impl::Unit, diff, 1);
+        is_null = !ts1.template date_set_interval<Impl::Unit>(interval);
     }
 
     template <typename NativeType, typename DateValueType>
@@ -673,13 +620,13 @@ struct TimeRound {
         }
         auto& ts1 = (DateValueType&)(res);
         if constexpr (Impl::Unit != WEEK) {
-            ts1.from_olap_datetime(FIRST_DAY);
+            ts1.from_olap_datetime(0);
+            TimeRound<Impl>::template time_round<NativeType, DateValueType>(ts2, ts1, is_null);
         } else {
             // Only week use the FIRST SUNDAY
             ts1.from_olap_datetime(FIRST_SUNDAY);
+            TimeRound<Impl>::template time_round<NativeType, DateValueType>(ts2, 1, ts1, is_null);
         }
-
-        TimeRound<Impl>::template time_round<NativeType, DateValueType>(ts2, ts1, is_null);
     }
 };
 

--- a/be/src/vec/runtime/vdatetime_value.h
+++ b/be/src/vec/runtime/vdatetime_value.h
@@ -481,6 +481,10 @@ public:
     template <TimeUnit unit>
     bool date_add_interval(const TimeInterval& interval);
 
+    // set interval
+    template <TimeUnit unit>
+    bool date_set_interval(const TimeInterval& interval);
+
     template <TimeUnit unit>
     bool datetime_trunc(); //datetime trunc, like trunc minute = 0
 
@@ -934,6 +938,9 @@ public:
 
     template <TimeUnit unit>
     bool date_add_interval(const TimeInterval& interval);
+
+    template <TimeUnit unit>
+    bool date_set_interval(const TimeInterval& interval);
 
     template <TimeUnit unit>
     bool datetime_trunc(); //datetime trunc, like trunc minute = 0

--- a/be/src/vec/runtime/vdatetime_value.h
+++ b/be/src/vec/runtime/vdatetime_value.h
@@ -1168,6 +1168,8 @@ public:
 
     void format_datetime(uint32_t* date_v, bool* carry_bits) const;
 
+    void set_int_val(uint64_t val) { this->int_val_ = val; }
+
 private:
     static uint8_t calc_week(const uint32_t& day_nr, const uint16_t& year, const uint8_t& month,
                              const uint8_t& day, uint8_t mode, uint16_t* to_year,


### PR DESCRIPTION
## Proposed changes

test now 

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

