### PR TITLE
fix(sec): upgrade com.fasterxml.jackson.core:jackson-databind to 2.14.0-rc1

### DIFF
--- a/samples/doris-demo/doris-source-demo/pom.xml
+++ b/samples/doris-demo/doris-source-demo/pom.xml
@@ -33,7 +33,7 @@ under the License.
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <thrift-service.version>1.0.0</thrift-service.version>
         <arrow.version>5.0.0</arrow.version>
-        <jackson.version>2.13.3</jackson.version>
+        <jackson.version>2.14.0-rc1</jackson.version>
         <junit.version>4.11</junit.version>
         <netty.version>4.1.77.Final</netty.version>
     </properties>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.fasterxml.jackson.core:jackson-databind 2.13.3
- [CVE-2022-42004](https://www.oscs1024.com/hd/CVE-2022-42004)


### What did I do？
Upgrade com.fasterxml.jackson.core:jackson-databind from 2.13.3 to 2.14.0-rc1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS