### PR TITLE
[fix](tablet clone) fix tablet sched failed when tablet missing tag and version incomplete

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
@@ -510,15 +510,15 @@ public class Tablet extends MetaObject implements Writable {
                     needFurtherRepairReplica = replica;
                 }
 
-                short aliveAllocNum = stableAllocMap.getOrDefault(backend.getLocationTag(), (short) 0);
-                stableAllocMap.put(backend.getLocationTag(), (short) (aliveAllocNum + 1));
+                short allocNum = stableAllocMap.getOrDefault(backend.getLocationTag(), (short) 0);
+                stableAllocMap.put(backend.getLocationTag(), (short) (allocNum + 1));
 
                 if (versionCompleted) {
                     stable++;
                     versions.add(replica.getVersionCount());
 
-                    short stableAllocNum = stableCompleteAllocMap.getOrDefault(backend.getLocationTag(), (short) 0);
-                    stableCompleteAllocMap.put(backend.getLocationTag(), (short) (stableAllocNum + 1));
+                    allocNum = stableCompleteAllocMap.getOrDefault(backend.getLocationTag(), (short) 0);
+                    stableCompleteAllocMap.put(backend.getLocationTag(), (short) (allocNum + 1));
                 }
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
@@ -476,7 +476,8 @@ public class Tablet extends MetaObject implements Writable {
 
 
         Map<Tag, Short> allocMap = replicaAlloc.getAllocMap();
-        Map<Tag, Short> currentAllocMap = Maps.newHashMap();
+        Map<Tag, Short> stableAllocMap = Maps.newHashMap();
+        Map<Tag, Short> stableCompleteAllocMap = Maps.newHashMap();
 
         short replicationNum = replicaAlloc.getTotalReplicaNum();
         int alive = 0;
@@ -496,32 +497,30 @@ public class Tablet extends MetaObject implements Writable {
                 // ATTN: Replicas on same host is a bug of previous Doris version, so we fix it by this way.
                 continue;
             }
+
             alive++;
 
-            // this replica is alive but version incomplete
-            if (replica.getLastFailedVersion() > 0 || replica.getVersion() < visibleVersion) {
-                if (replica.needFurtherRepair() && backend.isScheduleAvailable()) {
+            boolean versionCompleted = replica.getLastFailedVersion() < 0 && replica.getVersion() >= visibleVersion;
+            if (versionCompleted) {
+                aliveAndVersionComplete++;
+            }
+
+            if (backend.isScheduleAvailable()) {
+                if (replica.needFurtherRepair() && (needFurtherRepairReplica == null || !versionCompleted)) {
                     needFurtherRepairReplica = replica;
                 }
-                continue;
+
+                short aliveAllocNum = stableAllocMap.getOrDefault(backend.getLocationTag(), (short) 0);
+                stableAllocMap.put(backend.getLocationTag(), (short) (aliveAllocNum + 1));
+
+                if (versionCompleted) {
+                    stable++;
+                    versions.add(replica.getVersionCount());
+
+                    short stableAllocNum = stableCompleteAllocMap.getOrDefault(backend.getLocationTag(), (short) 0);
+                    stableCompleteAllocMap.put(backend.getLocationTag(), (short) (stableAllocNum + 1));
+                }
             }
-
-            aliveAndVersionComplete++;
-
-            if (!backend.isScheduleAvailable()) {
-                // this replica is alive, version complete, but backend is not available
-                continue;
-            }
-            stable++;
-
-            if (replica.needFurtherRepair() && needFurtherRepairReplica == null) {
-                needFurtherRepairReplica = replica;
-            }
-
-            versions.add(replica.getVersionCount());
-
-            short curNum = currentAllocMap.getOrDefault(backend.getLocationTag(), (short) 0);
-            currentAllocMap.put(backend.getLocationTag(), (short) (curNum + 1));
         }
 
         // 0. We can not choose a good replica as src to repair this tablet.
@@ -583,9 +582,12 @@ public class Tablet extends MetaObject implements Writable {
 
         // 4. got enough healthy replicas, check tag
         for (Map.Entry<Tag, Short> alloc : allocMap.entrySet()) {
-            if (!currentAllocMap.containsKey(alloc.getKey())
-                    || currentAllocMap.get(alloc.getKey()) < alloc.getValue()) {
-                return Pair.of(TabletStatus.REPLICA_MISSING_FOR_TAG, TabletSchedCtx.Priority.NORMAL);
+            if (stableCompleteAllocMap.getOrDefault(alloc.getKey(), (short) 0) < alloc.getValue()) {
+                if (stableAllocMap.getOrDefault(alloc.getKey(), (short) 0) >= alloc.getValue()) {
+                    return Pair.of(TabletStatus.VERSION_INCOMPLETE, TabletSchedCtx.Priority.NORMAL);
+                } else {
+                    return Pair.of(TabletStatus.REPLICA_MISSING_FOR_TAG, TabletSchedCtx.Priority.NORMAL);
+                }
             }
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
@@ -477,7 +477,7 @@ public class Tablet extends MetaObject implements Writable {
 
         Map<Tag, Short> allocMap = replicaAlloc.getAllocMap();
         Map<Tag, Short> stableAllocMap = Maps.newHashMap();
-        Map<Tag, Short> stableCompleteAllocMap = Maps.newHashMap();
+        Map<Tag, Short> stableVersionCompleteAllocMap = Maps.newHashMap();
 
         short replicationNum = replicaAlloc.getTotalReplicaNum();
         int alive = 0;
@@ -517,8 +517,8 @@ public class Tablet extends MetaObject implements Writable {
                     stable++;
                     versions.add(replica.getVersionCount());
 
-                    allocNum = stableCompleteAllocMap.getOrDefault(backend.getLocationTag(), (short) 0);
-                    stableCompleteAllocMap.put(backend.getLocationTag(), (short) (allocNum + 1));
+                    allocNum = stableVersionCompleteAllocMap.getOrDefault(backend.getLocationTag(), (short) 0);
+                    stableVersionCompleteAllocMap.put(backend.getLocationTag(), (short) (allocNum + 1));
                 }
             }
         }
@@ -582,7 +582,7 @@ public class Tablet extends MetaObject implements Writable {
 
         // 4. got enough healthy replicas, check tag
         for (Map.Entry<Tag, Short> alloc : allocMap.entrySet()) {
-            if (stableCompleteAllocMap.getOrDefault(alloc.getKey(), (short) 0) < alloc.getValue()) {
+            if (stableVersionCompleteAllocMap.getOrDefault(alloc.getKey(), (short) 0) < alloc.getValue()) {
                 if (stableAllocMap.getOrDefault(alloc.getKey(), (short) 0) >= alloc.getValue()) {
                     return Pair.of(TabletStatus.VERSION_INCOMPLETE, TabletSchedCtx.Priority.NORMAL);
                 } else {


### PR DESCRIPTION
## Proposed changes

Tablet sched will always failed for case below:
1. At the beginning, 4 BE: A, B, C,  D;  replica alloc num=3;  three replicas are on A,  B, C;
2. User change BE  B/C/D to tag:foo,  also change table and partitions to tag:foo;
3. Tablet  scheduler will migrate replica from A => D. 
4. Firstly, D clone a replica. During cloning, table loads data. After cloning, there are 4 replicas:
    a) A: version complete,  tag mismatch;
    b) B: version complete,  tag match;
    c) C: version complete,  tag match;
    d) D:  version incomplete,  tag match; 
5. Tablet's aliveAndVersionComplete is ok(3 replicas: A,B,C),  then it check if  replicas of each tag are enough ,  it will found tag:foo 's replica is not engough,  it has 2 replicas: B, C (cause the alloc map excludes version incompleted D),  so this tablet's health status is REPLICA_MISSING_FOR_TAG;
6. Scheduler will try to find another BE to clone a new replica,  then it will failed.

The PR is to fix this. For a tag,  if the alive replicas are enough,   but version complete replicas are not enough, then the tablet's status should be VERSION_INCOMPLETE.



## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

