### PR TITLE
[1.2][enhancement](data type) add use_mysql_bigint_for_largeint config Tell Doris to use bigint when returning largeint type to mysql jdbc 

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/PrimitiveType.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/PrimitiveType.java
@@ -1132,6 +1132,12 @@ public enum PrimitiveType {
                 return MysqlColType.MYSQL_TYPE_LONG;
             case BIGINT:
                 return MysqlColType.MYSQL_TYPE_LONGLONG;
+            case LARGEINT:
+                if (Config.use_mysql_bigint_for_largeint) {
+                    return MysqlColType.MYSQL_TYPE_LONGLONG;
+                } else {
+                    return MysqlColType.MYSQL_TYPE_STRING;
+                }
             case FLOAT:
                 return MysqlColType.MYSQL_TYPE_FLOAT;
             case DOUBLE:

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2040,5 +2040,8 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true)
     public static boolean infodb_support_ext_catalog = false;
+
+    @ConfField(mutable = true)
+    public static boolean use_mysql_bigint_for_largeint = false;
 }
 


### PR DESCRIPTION

## Proposed changes

Issue Number: close #xxx

cherry-pick from #22835

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

