### PR TITLE
[Enhancement](Nereids)fix push down global limit to avoid gather.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/MergeLimits.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/MergeLimits.java
@@ -42,14 +42,15 @@ public class MergeLimits extends OneRewriteRuleFactory {
     @Override
     public Rule build() {
         return logicalLimit(logicalLimit())
-                .when(upperLimit -> upperLimit.getPhase().equals(upperLimit.child().getPhase()))
+                .when(upperLimit -> upperLimit.getPhase().equals(upperLimit.child().getPhase())
+                        || (upperLimit.getPhase().isLocal() && upperLimit.child().getPhase().isGlobal()))
                 .then(upperLimit -> {
                     LogicalLimit<? extends Plan> bottomLimit = upperLimit.child();
                     return new LogicalLimit<>(
                             Math.min(upperLimit.getLimit(),
                                     Math.max(bottomLimit.getLimit() - upperLimit.getOffset(), 0)),
                             bottomLimit.getOffset() + upperLimit.getOffset(),
-                            bottomLimit.getPhase(), bottomLimit.child()
+                            upperLimit.getPhase(), bottomLimit.child()
                     );
                 }).toRule(RuleType.MERGE_LIMITS);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ReplaceLimitNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ReplaceLimitNode.java
@@ -1,0 +1,72 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.rewrite;
+
+import org.apache.doris.nereids.rules.Rule;
+import org.apache.doris.nereids.rules.RuleType;
+import org.apache.doris.nereids.trees.UnaryNode;
+import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalEmptyRelation;
+import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
+import org.apache.doris.nereids.trees.plans.logical.LogicalSort;
+import org.apache.doris.nereids.trees.plans.logical.LogicalTopN;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+import java.util.List;
+
+/**
+ * rule to eliminate limit node by replace to other nodes.
+ */
+public class ReplaceLimitNode implements RewriteRuleFactory {
+    @Override
+    public List<Rule> buildRules() {
+        return ImmutableList.of(
+                // limit -> sort ==> topN
+                logicalLimit(logicalSort())
+                        .then(limit -> {
+                            LogicalSort<Plan> sort = limit.child();
+                            return new LogicalTopN<>(sort.getOrderKeys(),
+                                    limit.getLimit(),
+                                    limit.getOffset(),
+                                    sort.child(0));
+                        }).toRule(RuleType.PUSH_LIMIT_INTO_SORT),
+                //limit->proj->sort ==> proj->topN
+                logicalLimit(logicalProject(logicalSort()))
+                        .then(limit -> {
+                            LogicalProject project = limit.child();
+                            LogicalSort sort = limit.child().child();
+                            LogicalTopN topN = new LogicalTopN(sort.getOrderKeys(),
+                                    limit.getLimit(),
+                                    limit.getOffset(),
+                                    sort.child(0));
+                            return project.withChildren(Lists.newArrayList(topN));
+                        }).toRule(RuleType.PUSH_LIMIT_INTO_SORT),
+                logicalLimit(logicalOneRowRelation())
+                        .then(limit -> limit.getLimit() > 0 && limit.getOffset() == 0
+                                ? limit.child() : new LogicalEmptyRelation(StatementScopeIdGenerator.newRelationId(),
+                                limit.child().getOutput()))
+                        .toRule(RuleType.ELIMINATE_LIMIT_ON_ONE_ROW_RELATION),
+                logicalLimit(logicalEmptyRelation())
+                        .then(UnaryNode::child)
+                        .toRule(RuleType.ELIMINATE_LIMIT_ON_EMPTY_RELATION)
+        );
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/LimitPhase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/LimitPhase.java
@@ -35,4 +35,8 @@ public enum LimitPhase {
     public boolean isLocal() {
         return this == LOCAL;
     }
+
+    public boolean isGlobal() {
+        return this == GLOBAL;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalLimit.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalLimit.java
@@ -86,7 +86,8 @@ public class LogicalLimit<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_TY
     public String toString() {
         return Utils.toSqlString("LogicalLimit",
                 "limit", limit,
-                "offset", offset
+                "offset", offset,
+                "phase", phase
         );
     }
 
@@ -114,6 +115,10 @@ public class LogicalLimit<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_TY
 
     public List<? extends Expression> getExpressions() {
         return ImmutableList.of();
+    }
+
+    public LogicalLimit<Plan> withLimitPhase(LimitPhase phase) {
+        return new LogicalLimit<>(limit, offset, phase, child());
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanToStringTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanToStringTest.java
@@ -48,7 +48,7 @@ public class PlanToStringTest {
     public void testLogicalLimit(@Mocked Plan child) {
         LogicalLimit<Plan> plan = new LogicalLimit<>(0, 0, LimitPhase.ORIGIN, child);
 
-        Assertions.assertEquals("LogicalLimit ( limit=0, offset=0 )", plan.toString());
+        Assertions.assertEquals("LogicalLimit ( limit=0, offset=0, phase=ORIGIN )", plan.toString());
     }
 
     @Test

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query28.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query28.out
@@ -2,62 +2,61 @@
 -- !ds_shape_28 --
 PhysicalResultSink
 --PhysicalLimit
-----PhysicalLimit
-------PhysicalProject
---------NestedLoopJoin[CROSS_JOIN]
-----------PhysicalLimit
-------------NestedLoopJoin[CROSS_JOIN]
---------------PhysicalLimit
-----------------NestedLoopJoin[CROSS_JOIN]
-------------------PhysicalLimit
---------------------NestedLoopJoin[CROSS_JOIN]
-----------------------PhysicalLimit
-------------------------NestedLoopJoin[CROSS_JOIN]
---------------------------PhysicalLimit
-----------------------------hashAgg[GLOBAL]
-------------------------------PhysicalDistribute
---------------------------------hashAgg[LOCAL]
-----------------------------------PhysicalProject
-------------------------------------filter((store_sales.ss_quantity <= 5)((((store_sales.ss_list_price >= 131.00) AND (store_sales.ss_list_price <= 141.00)) OR ((store_sales.ss_coupon_amt >= 16798.00) AND (store_sales.ss_coupon_amt <= 17798.00))) OR ((store_sales.ss_wholesale_cost >= 25.00) AND (store_sales.ss_wholesale_cost <= 45.00)))(store_sales.ss_quantity >= 0))
---------------------------------------PhysicalOlapScan[store_sales]
---------------------------PhysicalDistribute
-----------------------------PhysicalLimit
-------------------------------hashAgg[GLOBAL]
---------------------------------PhysicalDistribute
-----------------------------------hashAgg[LOCAL]
-------------------------------------PhysicalProject
---------------------------------------filter((store_sales.ss_quantity <= 10)((((store_sales.ss_list_price >= 145.00) AND (store_sales.ss_list_price <= 155.00)) OR ((store_sales.ss_coupon_amt >= 14792.00) AND (store_sales.ss_coupon_amt <= 15792.00))) OR ((store_sales.ss_wholesale_cost >= 46.00) AND (store_sales.ss_wholesale_cost <= 66.00)))(store_sales.ss_quantity >= 6))
-----------------------------------------PhysicalOlapScan[store_sales]
-----------------------PhysicalDistribute
+----PhysicalProject
+------NestedLoopJoin[CROSS_JOIN]
+--------PhysicalLimit
+----------NestedLoopJoin[CROSS_JOIN]
+------------PhysicalLimit
+--------------NestedLoopJoin[CROSS_JOIN]
+----------------PhysicalLimit
+------------------NestedLoopJoin[CROSS_JOIN]
+--------------------PhysicalLimit
+----------------------NestedLoopJoin[CROSS_JOIN]
 ------------------------PhysicalLimit
 --------------------------hashAgg[GLOBAL]
 ----------------------------PhysicalDistribute
 ------------------------------hashAgg[LOCAL]
 --------------------------------PhysicalProject
-----------------------------------filter(((((store_sales.ss_list_price >= 1.5E+2) AND (store_sales.ss_list_price <= 1.6E+2)) OR ((store_sales.ss_coupon_amt >= 6.6E+3) AND (store_sales.ss_coupon_amt <= 7.6E+3))) OR ((store_sales.ss_wholesale_cost >= 9.00) AND (store_sales.ss_wholesale_cost <= 29.00)))(store_sales.ss_quantity >= 11)(store_sales.ss_quantity <= 15))
+----------------------------------filter((store_sales.ss_quantity <= 5)((((store_sales.ss_list_price >= 131.00) AND (store_sales.ss_list_price <= 141.00)) OR ((store_sales.ss_coupon_amt >= 16798.00) AND (store_sales.ss_coupon_amt <= 17798.00))) OR ((store_sales.ss_wholesale_cost >= 25.00) AND (store_sales.ss_wholesale_cost <= 45.00)))(store_sales.ss_quantity >= 0))
 ------------------------------------PhysicalOlapScan[store_sales]
-------------------PhysicalDistribute
---------------------PhysicalLimit
-----------------------hashAgg[GLOBAL]
 ------------------------PhysicalDistribute
---------------------------hashAgg[LOCAL]
-----------------------------PhysicalProject
-------------------------------filter((store_sales.ss_quantity <= 20)((((store_sales.ss_list_price >= 91.00) AND (store_sales.ss_list_price <= 101.00)) OR ((store_sales.ss_coupon_amt >= 13493.00) AND (store_sales.ss_coupon_amt <= 14493.00))) OR ((store_sales.ss_wholesale_cost >= 36.00) AND (store_sales.ss_wholesale_cost <= 56.00)))(store_sales.ss_quantity >= 16))
---------------------------------PhysicalOlapScan[store_sales]
---------------PhysicalDistribute
-----------------PhysicalLimit
-------------------hashAgg[GLOBAL]
+--------------------------PhysicalLimit
+----------------------------hashAgg[GLOBAL]
+------------------------------PhysicalDistribute
+--------------------------------hashAgg[LOCAL]
+----------------------------------PhysicalProject
+------------------------------------filter((store_sales.ss_quantity <= 10)((((store_sales.ss_list_price >= 145.00) AND (store_sales.ss_list_price <= 155.00)) OR ((store_sales.ss_coupon_amt >= 14792.00) AND (store_sales.ss_coupon_amt <= 15792.00))) OR ((store_sales.ss_wholesale_cost >= 46.00) AND (store_sales.ss_wholesale_cost <= 66.00)))(store_sales.ss_quantity >= 6))
+--------------------------------------PhysicalOlapScan[store_sales]
 --------------------PhysicalDistribute
-----------------------hashAgg[LOCAL]
-------------------------PhysicalProject
---------------------------filter(((((store_sales.ss_list_price >= 0.00) AND (store_sales.ss_list_price <= 10.00)) OR ((store_sales.ss_coupon_amt >= 7629.00) AND (store_sales.ss_coupon_amt <= 8629.00))) OR ((store_sales.ss_wholesale_cost >= 6.00) AND (store_sales.ss_wholesale_cost <= 26.00)))(store_sales.ss_quantity <= 25)(store_sales.ss_quantity >= 21))
-----------------------------PhysicalOlapScan[store_sales]
-----------PhysicalDistribute
-------------PhysicalLimit
---------------hashAgg[GLOBAL]
+----------------------PhysicalLimit
+------------------------hashAgg[GLOBAL]
+--------------------------PhysicalDistribute
+----------------------------hashAgg[LOCAL]
+------------------------------PhysicalProject
+--------------------------------filter(((((store_sales.ss_list_price >= 1.5E+2) AND (store_sales.ss_list_price <= 1.6E+2)) OR ((store_sales.ss_coupon_amt >= 6.6E+3) AND (store_sales.ss_coupon_amt <= 7.6E+3))) OR ((store_sales.ss_wholesale_cost >= 9.00) AND (store_sales.ss_wholesale_cost <= 29.00)))(store_sales.ss_quantity >= 11)(store_sales.ss_quantity <= 15))
+----------------------------------PhysicalOlapScan[store_sales]
 ----------------PhysicalDistribute
-------------------hashAgg[LOCAL]
---------------------PhysicalProject
-----------------------filter((store_sales.ss_quantity >= 26)((((store_sales.ss_list_price >= 89.00) AND (store_sales.ss_list_price <= 99.00)) OR ((store_sales.ss_coupon_amt >= 15257.00) AND (store_sales.ss_coupon_amt <= 16257.00))) OR ((store_sales.ss_wholesale_cost >= 31.00) AND (store_sales.ss_wholesale_cost <= 51.00)))(store_sales.ss_quantity <= 30))
-------------------------PhysicalOlapScan[store_sales]
+------------------PhysicalLimit
+--------------------hashAgg[GLOBAL]
+----------------------PhysicalDistribute
+------------------------hashAgg[LOCAL]
+--------------------------PhysicalProject
+----------------------------filter((store_sales.ss_quantity <= 20)((((store_sales.ss_list_price >= 91.00) AND (store_sales.ss_list_price <= 101.00)) OR ((store_sales.ss_coupon_amt >= 13493.00) AND (store_sales.ss_coupon_amt <= 14493.00))) OR ((store_sales.ss_wholesale_cost >= 36.00) AND (store_sales.ss_wholesale_cost <= 56.00)))(store_sales.ss_quantity >= 16))
+------------------------------PhysicalOlapScan[store_sales]
+------------PhysicalDistribute
+--------------PhysicalLimit
+----------------hashAgg[GLOBAL]
+------------------PhysicalDistribute
+--------------------hashAgg[LOCAL]
+----------------------PhysicalProject
+------------------------filter(((((store_sales.ss_list_price >= 0.00) AND (store_sales.ss_list_price <= 10.00)) OR ((store_sales.ss_coupon_amt >= 7629.00) AND (store_sales.ss_coupon_amt <= 8629.00))) OR ((store_sales.ss_wholesale_cost >= 6.00) AND (store_sales.ss_wholesale_cost <= 26.00)))(store_sales.ss_quantity <= 25)(store_sales.ss_quantity >= 21))
+--------------------------PhysicalOlapScan[store_sales]
+--------PhysicalDistribute
+----------PhysicalLimit
+------------hashAgg[GLOBAL]
+--------------PhysicalDistribute
+----------------hashAgg[LOCAL]
+------------------PhysicalProject
+--------------------filter((store_sales.ss_quantity >= 26)((((store_sales.ss_list_price >= 89.00) AND (store_sales.ss_list_price <= 99.00)) OR ((store_sales.ss_coupon_amt >= 15257.00) AND (store_sales.ss_coupon_amt <= 16257.00))) OR ((store_sales.ss_wholesale_cost >= 31.00) AND (store_sales.ss_wholesale_cost <= 51.00)))(store_sales.ss_quantity <= 30))
+----------------------PhysicalOlapScan[store_sales]
 

--- a/regression-test/suites/nereids_syntax_p0/sub_query_diff_old_optimize.groovy
+++ b/regression-test/suites/nereids_syntax_p0/sub_query_diff_old_optimize.groovy
@@ -159,7 +159,7 @@ suite ("sub_query_diff_old_optimize") {
         sql """
             select * from sub_query_diff_old_optimize_subquery1 where sub_query_diff_old_optimize_subquery1.k1 not in (select sub_query_diff_old_optimize_subquery3.k3 from sub_query_diff_old_optimize_subquery3 where sub_query_diff_old_optimize_subquery3.v2 = sub_query_diff_old_optimize_subquery1.k2 limit 1);
         """
-        exception "java.sql.SQLException: errCode = 2, detailMessage = Unexpected exception: Unsupported correlated subquery with a LIMIT clause LogicalLimit ( limit=1, offset=0 )"
+        exception "java.sql.SQLException: errCode = 2, detailMessage = Unexpected exception: Unsupported correlated subquery with a LIMIT clause LogicalLimit ( limit=1, offset=0, phase=ORIGIN )"
 
     }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

the global limit will create a gather action, and all the data will be calculated in one instance. If we push down the global limit, the node run after the limit node will run slowly.
We fix it by push down only local limit.

a join plan tree before fixing:

```
LogicalLimit(global)
    LogicalLimit(local)
        Plan()
            LogicalLimit(global)
                LogicalLimit(local)
                    LogicalJoin
                        LogicalLimit(global)
                            LogicalLimit(local)
                                Plan()
                        LogicalLimit(global)
                            LogicalLimit(local)
                                Plan()    

after fixing:
LogicalLimit(global)
    LogicalLimit(local)      
        Plan()
            LogicalLimit(local)
                LogicalJoin
                    LogicalLimit(local)
                        Plan()
                    LogicalLimit(local)
                        Plan()
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

