### PR TITLE
[fix](load) fix core at memtable writer mem_consumption

### DIFF
--- a/be/src/olap/memtable_writer.cpp
+++ b/be/src/olap/memtable_writer.cpp
@@ -344,12 +344,12 @@ int64_t MemTableWriter::mem_consumption(MemType mem) {
     {
         std::lock_guard<SpinLock> l(_mem_table_tracker_lock);
         if ((mem & MemType::WRITE) == MemType::WRITE) { // 3 & 2 = 2
-            for (auto mem_table_tracker : _mem_table_insert_trackers) {
+            for (const auto& mem_table_tracker : _mem_table_insert_trackers) {
                 mem_usage += mem_table_tracker->consumption();
             }
         }
         if ((mem & MemType::FLUSH) == MemType::FLUSH) { // 3 & 1 = 1
-            for (auto mem_table_tracker : _mem_table_flush_trackers) {
+            for (const auto& mem_table_tracker : _mem_table_flush_trackers) {
                 mem_usage += mem_table_tracker->consumption();
             }
         }

--- a/be/src/olap/memtable_writer.cpp
+++ b/be/src/olap/memtable_writer.cpp
@@ -335,7 +335,7 @@ const FlushStatistic& MemTableWriter::get_flush_token_stats() {
 }
 
 int64_t MemTableWriter::mem_consumption(MemType mem) {
-    if (_flush_token == nullptr) {
+    if (!_is_init) {
         // This method may be called before this writer is initialized.
         // So _flush_token may be null.
         return 0;

--- a/be/src/olap/memtable_writer.h
+++ b/be/src/olap/memtable_writer.h
@@ -120,7 +120,7 @@ private:
 
     void _init_profile(RuntimeProfile* profile);
 
-    bool _is_init = false;
+    std::atomic<bool> _is_init = false;
     bool _is_cancelled = false;
     bool _is_closed = false;
     Status _cancel_status;


### PR DESCRIPTION
## Proposed changes

Fix core when calculating mem consumption of MemTableWriter:

```
*** Aborted at 1691737795 (unix time) try "date -d @1691737795" if you are using GNU date ***
*** Current BE git commitID: ab2a5f9c4a ***
*** SIGSEGV unknown detail explain (@0x0) received by PID 88836 (TID 89127 OR 0x7fd30500a700) from PID 0; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk1/chenkaijie/palo/be/src/common/signal_handler.h:413
 1# os::Linux::chained_handler(int, siginfo*, void*) in /root/doris/java8/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /root/doris/java8/jre/lib/amd64/server/libjvm.so
 3# signalHandler(int, siginfo*, void*) in /root/doris/java8/jre/lib/amd64/server/libjvm.so
 4# 0x00007FD3548D3770 in /lib64/libc.so.6
 5# doris::MemTableWriter::mem_consumption(doris::MemType) at /mnt/disk1/chenkaijie/palo/be/src/olap/memtable_writer.cpp:347
 6# doris::MemTableMemoryLimiter::_refresh_mem_tracker_without_lock() at /mnt/disk1/chenkaijie/palo/be/src/olap/memtable_memory_limiter.cpp:217
 7# doris::Daemon::memtable_memory_limiter_tracker_refresh_thread() at /mnt/disk1/chenkaijie/palo/be/src/common/daemon.cpp:286
 8# doris::Thread::supervise_thread(void*) at /mnt/disk1/chenkaijie/palo/be/src/util/thread.cpp:466
 9# 0x00007FD3546F9FED in /lib64/libpthread.so.0
10# clone in /lib64/libc.so.6
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

