### PR TITLE
[fix](show-table-status) fix priv error on show table status stmt

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -3822,12 +3822,12 @@ show_param ::=
     /* show table status */
     | KW_TABLE KW_STATUS opt_db:db opt_wild_where
     {:
-        RESULT = new ShowTableStatusStmt(db, null, parser.wild, parser.where);
+        RESULT = new ShowTableStatusStmt(null, db, parser.wild, parser.where);
     :}
     /* show table status */
     | KW_TABLE KW_STATUS from_or_in ident:ctl DOT ident:db opt_wild_where
     {:
-        RESULT = new ShowTableStatusStmt(db, ctl, parser.wild, parser.where);
+        RESULT = new ShowTableStatusStmt(ctl, db, parser.wild, parser.where);
     :}
     /* show tables */
     | opt_full KW_TABLES opt_db:db opt_wild_where

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowTableStatusStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowTableStatusStmt.java
@@ -59,25 +59,25 @@ public class ShowTableStatusStmt extends ShowStmt {
                     .addColumn(new Column("Comment", ScalarType.createVarchar(64)))
                     .build();
 
-    private String db;
     private String catalog;
+    private String db;
     private String wild;
     private Expr where;
     private SelectStmt selectStmt;
 
-    public ShowTableStatusStmt(String db, String catalog, String wild, Expr where) {
+    public ShowTableStatusStmt(String catalog, String db, String wild, Expr where) {
+        this.catalog = catalog;
         this.db = db;
         this.wild = wild;
         this.where = where;
-        this.catalog = catalog;
-    }
-
-    public String getDb() {
-        return db;
     }
 
     public String getCatalog() {
         return catalog;
+    }
+
+    public String getDb() {
+        return db;
     }
 
     public String getPattern() {
@@ -101,7 +101,7 @@ public class ShowTableStatusStmt extends ShowStmt {
             }
         }
 
-        if (!Env.getCurrentEnv().getAccessManager().checkDbPriv(ConnectContext.get(), db, PrivPredicate.SHOW)) {
+        if (!Env.getCurrentEnv().getAccessManager().checkDbPriv(ConnectContext.get(), catalog, db, PrivPredicate.SHOW)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_DBACCESS_DENIED_ERROR, analyzer.getQualifiedUser(), db);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowTableStatusStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowTableStatusStmt.java
@@ -101,7 +101,8 @@ public class ShowTableStatusStmt extends ShowStmt {
             }
         }
 
-        if (!Env.getCurrentEnv().getAccessManager().checkDbPriv(ConnectContext.get(), catalog, db, PrivPredicate.SHOW)) {
+        if (!Env.getCurrentEnv().getAccessManager().checkDbPriv(ConnectContext.get(),
+                catalog, db, PrivPredicate.SHOW)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_DBACCESS_DENIED_ERROR, analyzer.getQualifiedUser(), db);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -871,7 +871,7 @@ public class ShowExecutor {
 
                 // check tbl privs
                 if (!Env.getCurrentEnv().getAccessManager()
-                        .checkTblPriv(ConnectContext.get(), db.getFullName(), table.getName(), PrivPredicate.SHOW)) {
+                        .checkTblPriv(ConnectContext.get(), showStmt.getCatalog(), db.getFullName(), table.getName(), PrivPredicate.SHOW)) {
                     continue;
                 }
                 List<String> row = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -871,7 +871,8 @@ public class ShowExecutor {
 
                 // check tbl privs
                 if (!Env.getCurrentEnv().getAccessManager()
-                        .checkTblPriv(ConnectContext.get(), showStmt.getCatalog(), db.getFullName(), table.getName(), PrivPredicate.SHOW)) {
+                        .checkTblPriv(ConnectContext.get(), showStmt.getCatalog(),
+                                db.getFullName(), table.getName(), PrivPredicate.SHOW)) {
                     continue;
                 }
                 List<String> row = Lists.newArrayList();

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/ColumnPrivTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/ColumnPrivTest.java
@@ -26,6 +26,8 @@ import org.apache.doris.analysis.CreateViewStmt;
 import org.apache.doris.analysis.DropCatalogStmt;
 import org.apache.doris.analysis.GrantStmt;
 import org.apache.doris.analysis.ShowCatalogStmt;
+import org.apache.doris.analysis.ShowCreateFunctionStmt;
+import org.apache.doris.analysis.ShowTableStatusStmt;
 import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
@@ -39,6 +41,7 @@ import org.apache.doris.mysql.privilege.Auth;
 import org.apache.doris.mysql.privilege.CatalogAccessController;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.ShowExecutor;
 import org.apache.doris.qe.ShowResultSet;
 import org.apache.doris.utframe.TestWithFeService;
 
@@ -79,6 +82,17 @@ public class ColumnPrivTest extends TestWithFeService {
                         + ");",
                 rootCtx);
         env.getCatalogMgr().createCatalog(testCatalog);
+
+        CreateCatalogStmt testCatalog2 = (CreateCatalogStmt) parseAndAnalyzeStmt(
+                "create catalog test2 properties(\n"
+                        + "    \"type\" = \"test\",\n"
+                        + "    \"catalog_provider.class\" "
+                        + "= \"org.apache.doris.datasource.ColumnPrivTest$MockedCatalogProvider\",\n"
+                        + "    \"access_controller.properties.key1\" = \"val1\",\n"
+                        + "    \"access_controller.properties.key2\" = \"val2\"\n"
+                        + ");",
+                rootCtx);
+        env.getCatalogMgr().createCatalog(testCatalog2);
 
         // 2. create internal db and tbl
         CreateDbStmt createDbStmt = (CreateDbStmt) parseAndAnalyzeStmt("create database innerdb1");
@@ -132,7 +146,7 @@ public class ColumnPrivTest extends TestWithFeService {
         String showCatalogSql = "SHOW CATALOGS";
         ShowCatalogStmt showStmt = (ShowCatalogStmt) parseAndAnalyzeStmt(showCatalogSql);
         ShowResultSet showResultSet = mgr.showCatalogs(showStmt);
-        Assertions.assertEquals(2, showResultSet.getResultRows().size());
+        Assertions.assertEquals(3, showResultSet.getResultRows().size());
 
         CreateRoleStmt createRole1 = (CreateRoleStmt) parseAndAnalyzeStmt("create role role1;", rootCtx);
         auth.createRole(createRole1);
@@ -197,7 +211,33 @@ public class ColumnPrivTest extends TestWithFeService {
         testSql(user1Ctx, "select * from numbers(\"number\" = \"1\");", "0:VDataGenScanNode");
     }
 
+    @Test
+    public void testShowTableStatusPrivs() throws Exception {
+        ConnectContext root = createCtx(UserIdentity.ROOT, "127.0.0.1");
+        CreateUserStmt createUserStmt = (CreateUserStmt) parseAndAnalyzeStmt("create user show_table_status"
+                + " identified by '123456'", root);
+        auth.createUser(createUserStmt);
+        GrantStmt grant = (GrantStmt) parseAndAnalyzeStmt(
+                "grant select_priv on test2.*.* to show_table_status;", root);
+        auth.grant(grant);
+
+        UserIdentity user = UserIdentity.createAnalyzedUserIdentWithIp("default_cluster:show_table_status", "%");
+        ConnectContext userCtx = createCtx(user, "127.0.0.1");
+
+        ShowTableStatusStmt stmt = (ShowTableStatusStmt) parseAndAnalyzeStmt(
+                "show table status from test2.db1 LIKE \"%tbl%\";");
+        ShowExecutor executor = new ShowExecutor(userCtx, stmt);
+        ShowResultSet resultSet = executor.execute();
+        Assert.assertEquals(2, resultSet.getResultRows().size());
+    }
+
     private void testSql(ConnectContext ctx, String sql, String expectedMsg) throws Exception {
+        String res = getSQLPlanOrErrorMsg(ctx, "explain " + sql, false);
+        System.out.println(res);
+        Assert.assertTrue(res.contains(expectedMsg));
+    }
+
+    private void testShow(ConnectContext ctx, String sql, String expectedMsg) throws Exception {
         String res = getSQLPlanOrErrorMsg(ctx, "explain " + sql, false);
         System.out.println(res);
         Assert.assertTrue(res.contains(expectedMsg));

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/ColumnPrivTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/ColumnPrivTest.java
@@ -26,7 +26,6 @@ import org.apache.doris.analysis.CreateViewStmt;
 import org.apache.doris.analysis.DropCatalogStmt;
 import org.apache.doris.analysis.GrantStmt;
 import org.apache.doris.analysis.ShowCatalogStmt;
-import org.apache.doris.analysis.ShowCreateFunctionStmt;
 import org.apache.doris.analysis.ShowTableStatusStmt;
 import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Column;


### PR DESCRIPTION
## Proposed changes

When grant select_priv of `catalog.*.*` to a user, and then login as this user,
execute `show table status from catalog like "%tbl%"`, it will throw error like:

```
errCode = 2, detailMessage = Access denied for user 'default_cluster:user' to database 'default_cluster:db1'
```

This PR fix this issue

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

