### PR TITLE
[enhancement](file-cache) limit the file cache handle num and init the file cache concurrently

### DIFF
--- a/be/src/io/cache/block/block_file_cache.h
+++ b/be/src/io/cache/block/block_file_cache.h
@@ -303,8 +303,12 @@ private:
             s_file_name_to_reader;
     static inline std::mutex s_file_reader_cache_mtx;
     static inline std::atomic_bool s_read_only {false};
+    static inline uint64_t _max_file_reader_cache_size = 65533;
 
 public:
+    // should be call when BE start
+    static void init();
+
     static void set_read_only(bool read_only);
 
     static bool read_only() { return s_read_only; }

--- a/be/src/io/cache/block/block_file_cache_factory.cpp
+++ b/be/src/io/cache/block/block_file_cache_factory.cpp
@@ -58,8 +58,9 @@ size_t FileCacheFactory::try_release(const std::string& base_path) {
     return 0;
 }
 
-Status FileCacheFactory::create_file_cache(const std::string& cache_base_path,
-                                           const FileCacheSettings& file_cache_settings) {
+void FileCacheFactory::create_file_cache(const std::string& cache_base_path,
+                                         const FileCacheSettings& file_cache_settings,
+                                         Status* status) {
     if (config::clear_file_cache) {
         auto fs = global_local_filesystem();
         bool res = false;
@@ -71,12 +72,22 @@ Status FileCacheFactory::create_file_cache(const std::string& cache_base_path,
 
     std::unique_ptr<IFileCache> cache =
             std::make_unique<LRUFileCache>(cache_base_path, file_cache_settings);
-    RETURN_IF_ERROR(cache->initialize());
-    _path_to_cache[cache_base_path] = cache.get();
-    _caches.push_back(std::move(cache));
+    *status = cache->initialize();
+    if (!status->ok()) {
+        return;
+    }
+
+    {
+        // the create_file_cache() may be called concurrently,
+        // so need to protect it with lock
+        std::lock_guard<std::mutex> lock(_cache_mutex);
+        _path_to_cache[cache_base_path] = cache.get();
+        _caches.push_back(std::move(cache));
+    }
     LOG(INFO) << "[FileCache] path: " << cache_base_path
               << " total_size: " << file_cache_settings.total_size;
-    return Status::OK();
+    *status = Status::OK();
+    return;
 }
 
 CloudFileCachePtr FileCacheFactory::get_by_path(const IFileCache::Key& key) {

--- a/be/src/io/cache/block/block_file_cache_factory.h
+++ b/be/src/io/cache/block/block_file_cache_factory.h
@@ -39,8 +39,8 @@ class FileCacheFactory {
 public:
     static FileCacheFactory& instance();
 
-    Status create_file_cache(const std::string& cache_base_path,
-                             const FileCacheSettings& file_cache_settings);
+    void create_file_cache(const std::string& cache_base_path,
+                           const FileCacheSettings& file_cache_settings, Status* status);
 
     size_t try_release();
 
@@ -55,6 +55,8 @@ public:
     FileCacheFactory(const FileCacheFactory&) = delete;
 
 private:
+    // to protect following containers
+    std::mutex _cache_mutex;
     std::vector<std::unique_ptr<IFileCache>> _caches;
     std::unordered_map<std::string, CloudFileCachePtr> _path_to_cache;
 };

--- a/be/test/io/cache/file_block_cache_test.cpp
+++ b/be/test/io/cache/file_block_cache_test.cpp
@@ -916,6 +916,7 @@ TEST(LRUFileCache, fd_cache_evict) {
     context.cache_type = io::CacheType::NORMAL;
     auto key = io::LRUFileCache::hash("key1");
     config::file_cache_max_file_reader_cache_size = 2;
+    IFileCache::init();
     {
         auto holder = cache.get_or_set(key, 0, 9, context); /// Add range [0, 8]
         auto segments = fromHolder(holder);

--- a/regression-test/suites/external_table_p2/hive/test_truncate_char_or_varchar_columns.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_truncate_char_or_varchar_columns.groovy
@@ -35,17 +35,17 @@ suite("test_truncate_char_or_varchar_columns", "p2,external,hive,external_remote
         // test parquet format
         def q01_parquet = {
             qt_q01 """ select * from multi_catalog.test_truncate_char_or_varchar_columns_parquet order by id """
-            qt_q02 """ select city, concat("at ", city, " in ", country) from regression.multi_catalog.test_truncate_char_or_varchar_columns_parquet order by id """
+            qt_q02 """ select city, concat("at ", city, " in ", country) from ${catalog_name}.multi_catalog.test_truncate_char_or_varchar_columns_parquet order by id """
         }
         // test orc format
         def q01_orc = {
             qt_q01 """ select * from multi_catalog.test_truncate_char_or_varchar_columns_orc order by id """
-            qt_q02 """ select city, concat("at ", city, " in ", country) from regression.multi_catalog.test_truncate_char_or_varchar_columns_orc order by id """
+            qt_q02 """ select city, concat("at ", city, " in ", country) from ${catalog_name}.multi_catalog.test_truncate_char_or_varchar_columns_orc order by id """
         }
         // test text format
         def q01_text = {
             qt_q01 """ select * from multi_catalog.test_truncate_char_or_varchar_columns_text order by id """
-            qt_q02 """ select city, concat("at ", city, " in ", country) from regression.multi_catalog.test_truncate_char_or_varchar_columns_text order by id """
+            qt_q02 """ select city, concat("at ", city, " in ", country) from ${catalog_name}.multi_catalog.test_truncate_char_or_varchar_columns_text order by id """
         }
         sql """ use `multi_catalog`; """
         q01_parquet()
@@ -57,17 +57,17 @@ suite("test_truncate_char_or_varchar_columns", "p2,external,hive,external_remote
         // test parquet format
         def q02_parquet = {
             qt_q01 """ select * from multi_catalog.test_truncate_char_or_varchar_columns_parquet order by id """
-            qt_q02 """ select city, concat("at ", city, " in ", country) from regression.multi_catalog.test_truncate_char_or_varchar_columns_parquet order by id """
+            qt_q02 """ select city, concat("at ", city, " in ", country) from ${catalog_name}.multi_catalog.test_truncate_char_or_varchar_columns_parquet order by id """
         }
         // test orc format
         def q02_orc = {
             qt_q01 """ select * from multi_catalog.test_truncate_char_or_varchar_columns_orc order by id """
-            qt_q02 """ select city, concat("at ", city, " in ", country) from regression.multi_catalog.test_truncate_char_or_varchar_columns_orc order by id """
+            qt_q02 """ select city, concat("at ", city, " in ", country) from ${catalog_name}.multi_catalog.test_truncate_char_or_varchar_columns_orc order by id """
         }
         // test text format
         def q02_text = {
             qt_q01 """ select * from multi_catalog.test_truncate_char_or_varchar_columns_text order by id """
-            qt_q02 """ select city, concat("at ", city, " in ", country) from regression.multi_catalog.test_truncate_char_or_varchar_columns_text order by id """
+            qt_q02 """ select city, concat("at ", city, " in ", country) from ${catalog_name}.multi_catalog.test_truncate_char_or_varchar_columns_text order by id """
         }
         sql """ use `multi_catalog`; """
         q02_parquet()


### PR DESCRIPTION
## Proposed changes

1. the real value of BE config `file_cache_max_file_reader_cache_size` will be the 1/3 of process's max open file number.
2. use thread pool to create or init the file cache concurrently.
    To solve the issue that when there are lots of files in file cache dir, the starting time of BE will be very slow because
    it will traverse all file cache dirs sequentially.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

