### PR TITLE
[opt](executor) Change pipeline task's report_profile func to asynchronous

### DIFF
--- a/be/src/pipeline/exec/exchange_sink_buffer.cpp
+++ b/be/src/pipeline/exec/exchange_sink_buffer.cpp
@@ -367,7 +367,7 @@ void ExchangeSinkBuffer::get_max_min_rpc_time(int64_t* max_time, int64_t* min_ti
     }
     *max_time = local_max_time;
     *max_callback_time = local_max_callback_time;
-    *max_callback_exec_time = local_min_callback_time;
+    *max_callback_exec_time = local_max_callback_exec_time;
     *min_time = local_min_time;
     *min_callback_time = local_min_callback_time;
     *min_callback_exec_time = local_min_callback_exec_time;
@@ -386,8 +386,8 @@ void ExchangeSinkBuffer::set_rpc_time(InstanceLoId id, int64_t start_rpc_time, i
     _rpc_count++;
     DCHECK(_instance_to_rpc_time.find(id) != _instance_to_rpc_time.end());
     int64_t rpc_forward_time = receive_time - start_rpc_time;
-    int64_t rpc_callback_time = receive_time - start_rpc_time;
-    int64_t callback_exec_time = receive_time - start_rpc_time;
+    int64_t rpc_callback_time = callback_start_time - receive_time;
+    int64_t callback_exec_time = callback_end_time - callback_start_time;
     if (rpc_forward_time > 0) {
         _instance_to_rpc_time[id] += rpc_forward_time;
     }

--- a/be/src/pipeline/exec/exchange_sink_buffer.cpp
+++ b/be/src/pipeline/exec/exchange_sink_buffer.cpp
@@ -426,11 +426,11 @@ void ExchangeSinkBuffer::update_profile(RuntimeProfile* profile) {
     _sum_rpc_timer->set(sum_time);
     _avg_rpc_timer->set(sum_time / std::max(static_cast<int64_t>(1), _rpc_count.load()));
 
-    int64_t max_end_time = 0;
+    uint64_t max_end_time = 0;
     for (auto& [id, timer] : _instance_watcher) {
         max_end_time = std::max(timer.elapsed_time(), max_end_time);
     }
     auto* _max_end_timer = ADD_TIMER(profile, "MaxRpcEndTime");
-    _max_end_timer->set(max_end_time);
+    _max_end_timer->set(static_cast<int64_t>(max_end_time));
 }
 } // namespace doris::pipeline

--- a/be/src/pipeline/exec/exchange_sink_buffer.cpp
+++ b/be/src/pipeline/exec/exchange_sink_buffer.cpp
@@ -80,7 +80,6 @@ bool ExchangeSinkBuffer::is_pending_finish() {
 
     for (auto& pair : _instance_to_package_queue_mutex) {
         std::unique_lock lock(*(pair.second));
-//        std::unique_lock<std::mutex> lock(*(pair.second));
         auto& id = pair.first;
         if (!_instance_to_sending_by_pipeline.at(id)) {
             // when pending finish, we need check whether current query is cancelled
@@ -340,10 +339,8 @@ bool ExchangeSinkBuffer::_is_receiver_eof(InstanceLoId id) {
 
 void ExchangeSinkBuffer::get_max_min_rpc_time(int64_t* max_time, int64_t* min_time,
                                               int64_t* max_exec_delay_time,
-                                              int64_t* min_exec_delay_time,
-                                              int64_t* max_exec_time,
-                                              int64_t* min_exec_time,
-                                              int64_t* max_callback_time,
+                                              int64_t* min_exec_delay_time, int64_t* max_exec_time,
+                                              int64_t* min_exec_time, int64_t* max_callback_time,
                                               int64_t* min_callback_time,
                                               int64_t* max_callback_exec_time,
                                               int64_t* min_callback_exec_time) {
@@ -406,8 +403,8 @@ int64_t ExchangeSinkBuffer::get_sum_rpc_time() {
 }
 
 void ExchangeSinkBuffer::set_rpc_time(InstanceLoId id, int64_t start_rpc_time, int64_t receive_time,
-                                      int64_t exec_start, int64_t exec_end, int64_t callback_start_time,
-                                      int64_t callback_end_time) {
+                                      int64_t exec_start, int64_t exec_end,
+                                      int64_t callback_start_time, int64_t callback_end_time) {
     _rpc_count++;
     DCHECK(_instance_to_rpc_time.find(id) != _instance_to_rpc_time.end());
     int64_t rpc_forward_time = receive_time - start_rpc_time;

--- a/be/src/pipeline/exec/exchange_sink_buffer.cpp
+++ b/be/src/pipeline/exec/exchange_sink_buffer.cpp
@@ -439,14 +439,14 @@ void ExchangeSinkBuffer::update_profile(RuntimeProfile* profile) {
     auto* _max_rpc_exec_delay_timer = ADD_TIMER(profile, "Rpc2MaxExecDelayTime");
     auto* _min_rpc_exec_delay_timer = ADD_TIMER(profile, "Rpc2MinExecDelayTime");
 
-    auto* _max_rpc_exec_timer = ADD_TIMER(profile, "Rpc2MaxExecTime");
-    auto* _min_rpc_exec_timer = ADD_TIMER(profile, "Rpc2MinExecTime");
+    auto* _max_rpc_exec_timer = ADD_TIMER(profile, "Rpc3MaxExecTime");
+    auto* _min_rpc_exec_timer = ADD_TIMER(profile, "Rpc3MinExecTime");
 
-    auto* _max_rpc_callback_timer = ADD_TIMER(profile, "Rpc3MaxCallbackTime");
-    auto* _min_rpc_callback_timer = ADD_TIMER(profile, "Rpc3MinCallbackTime");
+    auto* _max_rpc_callback_timer = ADD_TIMER(profile, "Rpc4MaxCallbackTime");
+    auto* _min_rpc_callback_timer = ADD_TIMER(profile, "Rpc4MinCallbackTime");
 
-    auto* _max_rpc_callback_exec_timer = ADD_TIMER(profile, "Rpc4MaxCallbackExecTime");
-    auto* _min_rpc_callback_exec_timer = ADD_TIMER(profile, "Rpc4MinCallbackExecTime");
+    auto* _max_rpc_callback_exec_timer = ADD_TIMER(profile, "Rpc5MaxCallbackExecTime");
+    auto* _min_rpc_callback_exec_timer = ADD_TIMER(profile, "Rpc5MinCallbackExecTime");
 
     int64_t max_rpc_time = 0, min_rpc_time = 0, max_exec_delay_t = 0, min_exec_delay_t = 0,
             max_exec_t, min_exec_t = 0, max_callback_t = 0, min_callback_t = 0,

--- a/be/src/pipeline/exec/exchange_sink_buffer.h
+++ b/be/src/pipeline/exec/exchange_sink_buffer.h
@@ -190,6 +190,7 @@ private:
     phmap::flat_hash_map<InstanceLoId, PackageSeq> _instance_to_seq;
     phmap::flat_hash_map<InstanceLoId, std::unique_ptr<PTransmitDataParams>> _instance_to_request;
     phmap::flat_hash_map<InstanceLoId, bool> _instance_to_sending_by_pipeline;
+    phmap::flat_hash_map<InstanceLoId, MonotonicStopWatch> _instance_watcher;
     phmap::flat_hash_map<InstanceLoId, bool> _instance_to_receiver_eof;
     phmap::flat_hash_map<InstanceLoId, int64_t> _instance_to_rpc_time;
     phmap::flat_hash_map<InstanceLoId, int64_t> _instance_to_rpc_callback_time;

--- a/be/src/pipeline/exec/exchange_sink_buffer.h
+++ b/be/src/pipeline/exec/exchange_sink_buffer.h
@@ -170,7 +170,8 @@ public:
     bool can_write() const;
     bool is_pending_finish();
     void close();
-    void set_rpc_time(InstanceLoId id, int64_t start_rpc_time, int64_t receive_rpc_time);
+    void set_rpc_time(InstanceLoId id, int64_t start_rpc_time, int64_t receive_time,
+                      int64_t callback_start_time, int64_t callback_end_time);
     void update_profile(RuntimeProfile* profile);
 
 private:
@@ -191,6 +192,8 @@ private:
     phmap::flat_hash_map<InstanceLoId, bool> _instance_to_sending_by_pipeline;
     phmap::flat_hash_map<InstanceLoId, bool> _instance_to_receiver_eof;
     phmap::flat_hash_map<InstanceLoId, int64_t> _instance_to_rpc_time;
+    phmap::flat_hash_map<InstanceLoId, int64_t> _instance_to_rpc_callback_time;
+    phmap::flat_hash_map<InstanceLoId, int64_t> _instance_to_rpc_callback_exec_time;
     phmap::flat_hash_map<InstanceLoId, ExchangeRpcContext> _instance_to_rpc_ctx;
 
     std::atomic<bool> _is_finishing;
@@ -209,7 +212,9 @@ private:
     inline void _failed(InstanceLoId id, const std::string& err);
     inline void _set_receiver_eof(InstanceLoId id);
     inline bool _is_receiver_eof(InstanceLoId id);
-    void get_max_min_rpc_time(int64_t* max_time, int64_t* min_time);
+    void get_max_min_rpc_time(int64_t* max_time, int64_t* min_time, int64_t* max_callback_time,
+                              int64_t* min_callback_time, int64_t* max_callback_exec_time,
+                              int64_t* min_callback_exec_time);
     int64_t get_sum_rpc_time();
 };
 

--- a/be/src/pipeline/exec/exchange_sink_buffer.h
+++ b/be/src/pipeline/exec/exchange_sink_buffer.h
@@ -171,8 +171,9 @@ public:
     bool can_write() const;
     bool is_pending_finish();
     void close();
-    void set_rpc_time(InstanceLoId id, int64_t start_rpc_time, int64_t receive_time,
-                      int64_t callback_start_time, int64_t callback_end_time);
+    void set_rpc_time(InstanceLoId id, int64_t start_rpc_time, int64_t receive_time, int64_t,
+                      exec_start, int64_t exec_end, int64_t callback_start_time,
+                      int64_t callback_end_time);
     void update_profile(RuntimeProfile* profile);
 
 private:
@@ -194,6 +195,8 @@ private:
     phmap::flat_hash_map<InstanceLoId, MonotonicStopWatch> _instance_watcher;
     phmap::flat_hash_map<InstanceLoId, bool> _instance_to_receiver_eof;
     phmap::flat_hash_map<InstanceLoId, int64_t> _instance_to_rpc_time;
+    phmap::flat_hash_map<InstanceLoId, int64_t> _instance_to_rpc_exec_delay_time;
+    phmap::flat_hash_map<InstanceLoId, int64_t> _instance_to_rpc_exec_time;
     phmap::flat_hash_map<InstanceLoId, int64_t> _instance_to_rpc_callback_time;
     phmap::flat_hash_map<InstanceLoId, int64_t> _instance_to_rpc_callback_exec_time;
     phmap::flat_hash_map<InstanceLoId, ExchangeRpcContext> _instance_to_rpc_ctx;
@@ -214,7 +217,9 @@ private:
     inline void _failed(InstanceLoId id, const std::string& err);
     inline void _set_receiver_eof(InstanceLoId id);
     inline bool _is_receiver_eof(InstanceLoId id);
-    void get_max_min_rpc_time(int64_t* max_time, int64_t* min_time, int64_t* max_callback_time,
+    void get_max_min_rpc_time(int64_t* max_time, int64_t* min_time, int64_t* max_exec_delay_time,
+                              int64_t* min_exec_delay_time, int64_t* max_exec_time,
+                              int64_t* min_exec_time, int64_t* max_callback_time,
                               int64_t* min_callback_time, int64_t* max_callback_exec_time,
                               int64_t* min_callback_exec_time);
     int64_t get_sum_rpc_time();

--- a/be/src/pipeline/exec/exchange_sink_buffer.h
+++ b/be/src/pipeline/exec/exchange_sink_buffer.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <brpc/controller.h>
+#include <bthread/mutex.h>
 #include <gen_cpp/data.pb.h>
 #include <gen_cpp/internal_service.pb.h>
 #include <gen_cpp/types.pb.h>
@@ -25,7 +26,6 @@
 #include <stdint.h>
 
 #include <atomic>
-#include <bthread/mutex.h>
 #include <list>
 #include <memory>
 #include <mutex>

--- a/be/src/pipeline/exec/exchange_sink_buffer.h
+++ b/be/src/pipeline/exec/exchange_sink_buffer.h
@@ -171,8 +171,8 @@ public:
     bool can_write() const;
     bool is_pending_finish();
     void close();
-    void set_rpc_time(InstanceLoId id, int64_t start_rpc_time, int64_t receive_time, int64_t,
-                      exec_start, int64_t exec_end, int64_t callback_start_time,
+    void set_rpc_time(InstanceLoId id, int64_t start_rpc_time, int64_t receive_time,
+                      int64_t exec_start, int64_t exec_end, int64_t callback_start_time,
                       int64_t callback_end_time);
     void update_profile(RuntimeProfile* profile);
 

--- a/be/src/pipeline/exec/exchange_sink_buffer.h
+++ b/be/src/pipeline/exec/exchange_sink_buffer.h
@@ -25,6 +25,7 @@
 #include <stdint.h>
 
 #include <atomic>
+#include <bthread/mutex.h>
 #include <list>
 #include <memory>
 #include <mutex>
@@ -175,7 +176,7 @@ public:
     void update_profile(RuntimeProfile* profile);
 
 private:
-    phmap::flat_hash_map<InstanceLoId, std::unique_ptr<std::mutex>>
+    phmap::flat_hash_map<InstanceLoId, std::unique_ptr<bthread::Mutex>>
             _instance_to_package_queue_mutex;
     // store data in non-broadcast shuffle
     phmap::flat_hash_map<InstanceLoId, std::queue<TransmitInfo, std::list<TransmitInfo>>>

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -751,10 +751,10 @@ Status PipelineFragmentContext::_create_sink(int sender_id, const TDataSink& thr
 }
 
 void PipelineFragmentContext::_close_action() {
-    auto close_time = _fragment_watcher.elapsed_time()
+    auto close_time = _fragment_watcher.elapsed_time();
     _runtime_profile->total_time_counter()->update(close_time);
     COUNTER_UPDATE(_close_timer, close_time);
-    this->_send_report();
+    this->send_report();
     // all submitted tasks done
     auto share_this = shared_from_this();
     _exec_env->fragment_mgr()->remove_pipeline_context(share_this);
@@ -767,7 +767,7 @@ void PipelineFragmentContext::_close_action() {
         } else {
             _finish_call_back(_runtime_state.get(), &_exec_status);
         }
-    })
+    });
 }
 
 void PipelineFragmentContext::close_a_pipeline() {
@@ -778,7 +778,7 @@ void PipelineFragmentContext::close_a_pipeline() {
     }
 }
 
-void PipelineFragmentContext::_send_report() {
+void PipelineFragmentContext::send_report() {
     Status exec_status = Status::OK();
     {
         std::lock_guard<std::mutex> l(_status_lock);

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -198,9 +198,8 @@ Status PipelineFragmentContext::prepare(const doris::TPipelineFragmentParams& re
     COUNTER_UPDATE(_start_timer, _fragment_watcher.elapsed_time());
     _prepare_timer = ADD_TIMER(_runtime_profile, "PipCtx2PrepareTime");
     _close_timer = ADD_TIMER(_runtime_profile, "PipCtx3CloseTime");
-    Defer prepare_defer {[&]() {
-        COUNTER_UPDATE(_prepare_timer, _fragment_watcher.elapsed_time());
-    }};
+    Defer prepare_defer {
+            [&]() { COUNTER_UPDATE(_prepare_timer, _fragment_watcher.elapsed_time()); }};
 
     auto* fragment_context = this;
     OpentelemetryTracer tracer = telemetry::get_noop_tracer();

--- a/be/src/pipeline/pipeline_fragment_context.h
+++ b/be/src/pipeline/pipeline_fragment_context.h
@@ -103,7 +103,7 @@ public:
         _merge_controller_handler = handler;
     }
 
-    void _send_report();
+    void send_report();
 
     Status update_status(Status status) {
         std::lock_guard<std::mutex> l(_status_lock);

--- a/be/src/pipeline/pipeline_fragment_context.h
+++ b/be/src/pipeline/pipeline_fragment_context.h
@@ -103,7 +103,7 @@ public:
         _merge_controller_handler = handler;
     }
 
-    void _send_report() const;
+    void _send_report();
 
     Status update_status(Status status) {
         std::lock_guard<std::mutex> l(_status_lock);

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -102,26 +102,36 @@ void PipelineTask::_init_profile() {
     _wait_sink_timer = ADD_TIMER(_task_profile, "WaitSinkTime");
     _wait_worker_timer = ADD_TIMER(_task_profile, "WaitWorkerTime");
     _wait_schedule_timer = ADD_TIMER(_task_profile, "WaitScheduleTime");
-    _block_counts = ADD_COUNTER(_task_profile, "NumBlockedTimes", TUnit::UNIT);
-    _block_by_source_counts = ADD_COUNTER(_task_profile, "NumBlockedBySrcTimes", TUnit::UNIT);
-    _block_by_sink_counts = ADD_COUNTER(_task_profile, "NumBlockedBySinkTimes", TUnit::UNIT);
+
+    static const char* num_blocked_times = "NumBlockedTimes";
+    _block_counts = ADD_COUNTER(_task_profile, num_blocked_times, TUnit::UNIT);
+    _block_by_source_counts = ADD_CHILD_COUNTER(_task_profile, "NumBlockedBySrcTimes", TUnit::UNIT,
+                                                num_blocked_times);
+    _block_by_sink_counts = ADD_CHILD_COUNTER(_task_profile, "NumBlockedBySinkTimes", TUnit::UNIT,
+                                              num_blocked_times);
     _schedule_counts = ADD_COUNTER(_task_profile, "NumScheduleTimes", TUnit::UNIT);
     _yield_counts = ADD_COUNTER(_task_profile, "NumYieldTimes", TUnit::UNIT);
     _core_change_times = ADD_COUNTER(_task_profile, "CoreChangeTimes", TUnit::UNIT);
 
     _begin_execute_timer = ADD_TIMER(_task_profile, "Task1BeginExecuteTime");
     _eos_timer = ADD_TIMER(_task_profile, "Task2EosTime");
-    _try_close_timer = ADD_TIMER(_task_profile, "Task23TryCloseTime");
-    _src_pending_finish_check_timer = ADD_TIMER(_task_profile, "Task3SrcPendingFinishCheckTime");
-    _src_pending_finish_over_timer = ADD_TIMER(_task_profile, "Task3SrcPendingFinishOverTime");
-    _src_pending_finish_over_timer1 = ADD_TIMER(_task_profile, "Task3SrcPendingFinishOverTime1");
+    _try_close_timer = ADD_TIMER(_task_profile, "Task3TryCloseTime");
 
-    _dst_pending_finish_over_timer = ADD_TIMER(_task_profile, "Task4DstPendingFinishOverTime");
-    _dst_pending_finish_check_timer =
-            ADD_TIMER(_task_profile, "Task4DstPendingFinishCheckTime");
-    _dst_pending_finish_over_timer1 = ADD_TIMER(_task_profile, "Task4DstPendingFinishOverTime1");
-    _pip_task_total_timer = ADD_TIMER(_task_profile, "Task5TotalTime");
-    _close_pipeline_timer = ADD_TIMER(_task_profile, "Task6ClosePipelineTime");
+    static const char* src_pending_finish_over_time = "Task4SrcPendingFinishOverTime";
+    _src_pending_finish_over_timer = ADD_TIMER(_task_profile, src_pending_finish_over_time);
+    _src_pending_finish_check_timer = ADD_CHILD_TIMER(
+            _task_profile, "Task4SrcPendingFinishCheckTime", src_pending_finish_over_time);
+    _src_pending_finish_over_timer1 = ADD_CHILD_TIMER(
+            _task_profile, "Task4SrcPendingFinishFirstOverTime", src_pending_finish_over_time);
+
+    static const char* dst_pending_finish_over_time = "Task5DstPendingFinishOverTime";
+    _dst_pending_finish_over_timer = ADD_TIMER(_task_profile, dst_pending_finish_over_time);
+    _dst_pending_finish_check_timer = ADD_CHILD_TIMER(
+            _task_profile, "Task4DstPendingFinishCheckTime", dst_pending_finish_over_time);
+    _dst_pending_finish_over_timer1 = ADD_CHILD_TIMER(
+            _task_profile, "Task5DstPendingFinishFirstOverTime", dst_pending_finish_over_time);
+    _pip_task_total_timer = ADD_TIMER(_task_profile, "Task6TotalTime");
+    _close_pipeline_timer = ADD_TIMER(_task_profile, "Task7ClosePipelineTime");
 }
 
 Status PipelineTask::prepare(RuntimeState* state) {

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -115,8 +115,9 @@ void PipelineTask::_init_profile() {
     _src_pending_finish_over_timer = ADD_TIMER(_task_profile, "Task3SrcPendingFinishOverTime");
     _src_pending_finish_over_timer1 = ADD_TIMER(_task_profile, "Task3SrcPendingFinishOverTime1");
 
-    _dst_pending_finish_check_timer = ADD_TIMER(_task_profile, "Task4DstPendingFinishCheckTime");
     _dst_pending_finish_over_timer = ADD_TIMER(_task_profile, "Task4DstPendingFinishOverTime");
+    _dst_pending_finish_check_timer =
+            ADD_TIMER(_dst_pending_finish_over_timer, "Task4DstPendingFinishCheckTime");
     _dst_pending_finish_over_timer1 = ADD_TIMER(_task_profile, "Task4DstPendingFinishOverTime1");
     _pip_task_total_timer = ADD_TIMER(_task_profile, "Task5TotalTime");
     _close_pipeline_timer = ADD_TIMER(_task_profile, "Task6ClosePipelineTime");

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -111,6 +111,7 @@ void PipelineTask::_init_profile() {
 
     _begin_execute_timer = ADD_TIMER(_task_profile, "Task1BeginExecuteTime");
     _eos_timer = ADD_TIMER(_task_profile, "Task2EosTime");
+    _try_close_timer = ADD_TIMER(_task_profile, "Task23TryCloseTime");
     _src_pending_finish_check_timer = ADD_TIMER(_task_profile, "Task3SrcPendingFinishCheckTime");
     _src_pending_finish_over_timer = ADD_TIMER(_task_profile, "Task3SrcPendingFinishOverTime");
     _src_pending_finish_over_timer1 = ADD_TIMER(_task_profile, "Task3SrcPendingFinishOverTime1");
@@ -298,9 +299,11 @@ Status PipelineTask::try_close() {
         return Status::OK();
     }
     _try_close_flag = true;
+    _pipeline_task_watcher.elapsed_time();
     if (!_prepared) {
         return Status::OK();
     }
+    COUNTER_SET(_try_close_timer, (int64_t)_pipeline_task_watcher.elapsed_time());
     Status status1;
     {
         SCOPED_TIMER(_try_close_sink_timer);

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -127,7 +127,7 @@ void PipelineTask::_init_profile() {
     static const char* dst_pending_finish_over_time = "Task5DstPendingFinishOverTime";
     _dst_pending_finish_over_timer = ADD_TIMER(_task_profile, dst_pending_finish_over_time);
     _dst_pending_finish_check_timer = ADD_CHILD_TIMER(
-            _task_profile, "Task4DstPendingFinishCheckTime", dst_pending_finish_over_time);
+            _task_profile, "Task5DstPendingFinishCheckTime", dst_pending_finish_over_time);
     _dst_pending_finish_over_timer1 = ADD_CHILD_TIMER(
             _task_profile, "Task5DstPendingFinishFirstOverTime", dst_pending_finish_over_time);
     _pip_task_total_timer = ADD_TIMER(_task_profile, "Task6TotalTime");

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -117,7 +117,7 @@ void PipelineTask::_init_profile() {
 
     _dst_pending_finish_over_timer = ADD_TIMER(_task_profile, "Task4DstPendingFinishOverTime");
     _dst_pending_finish_check_timer =
-            ADD_TIMER(_dst_pending_finish_over_timer, "Task4DstPendingFinishCheckTime");
+            ADD_TIMER(_task_profile, "Task4DstPendingFinishCheckTime");
     _dst_pending_finish_over_timer1 = ADD_TIMER(_task_profile, "Task4DstPendingFinishOverTime1");
     _pip_task_total_timer = ADD_TIMER(_task_profile, "Task5TotalTime");
     _close_pipeline_timer = ADD_TIMER(_task_profile, "Task6ClosePipelineTime");

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -70,7 +70,9 @@ void PipelineTask::_fresh_profile_counter() {
     COUNTER_SET(_begin_execute_timer, _begin_execute_time);
     COUNTER_SET(_eos_timer, _eos_time);
     COUNTER_SET(_src_pending_finish_over_timer, _src_pending_finish_over_time);
+    COUNTER_SET(_src_pending_finish_over_timer1, _src_pending_finish_over_time1);
     COUNTER_SET(_dst_pending_finish_over_timer, _dst_pending_finish_over_time);
+    COUNTER_SET(_dst_pending_finish_over_timer1, _dst_pending_finish_over_time1);
     COUNTER_SET(_pip_task_total_timer, (int64_t)_pipeline_task_watcher.elapsed_time());
 }
 
@@ -109,8 +111,13 @@ void PipelineTask::_init_profile() {
 
     _begin_execute_timer = ADD_TIMER(_task_profile, "Task1BeginExecuteTime");
     _eos_timer = ADD_TIMER(_task_profile, "Task2EosTime");
+    _src_pending_finish_check_timer = ADD_TIMER(_task_profile, "Task3SrcPendingFinishCheckTime");
     _src_pending_finish_over_timer = ADD_TIMER(_task_profile, "Task3SrcPendingFinishOverTime");
+    _src_pending_finish_over_timer1 = ADD_TIMER(_task_profile, "Task3SrcPendingFinishOverTime1");
+
+    _dst_pending_finish_check_timer = ADD_TIMER(_task_profile, "Task4DstPendingFinishCheckTime");
     _dst_pending_finish_over_timer = ADD_TIMER(_task_profile, "Task4DstPendingFinishOverTime");
+    _dst_pending_finish_over_timer1 = ADD_TIMER(_task_profile, "Task4DstPendingFinishOverTime1");
     _pip_task_total_timer = ADD_TIMER(_task_profile, "Task5TotalTime");
     _close_pipeline_timer = ADD_TIMER(_task_profile, "Task6ClosePipelineTime");
 }

--- a/be/src/pipeline/pipeline_task.h
+++ b/be/src/pipeline/pipeline_task.h
@@ -137,7 +137,7 @@ public:
     bool is_pending_finish() {
         bool source_ret;
         {
-            SCOPED_TIMER(_src_pending_finish_check_timer)
+            SCOPED_TIMER(_src_pending_finish_check_timer);
             source_ret = _source->is_pending_finish();
         }
         if (source_ret) {

--- a/be/src/pipeline/pipeline_task.h
+++ b/be/src/pipeline/pipeline_task.h
@@ -144,11 +144,12 @@ public:
 
         bool sink_ret = _sink->is_pending_finish();
         if (sink_ret) {
+            clear_dst_pending_finish_time();
             return true;
         } else {
             this->set_dst_pending_finish_time();
+            return false;
         }
-        return false;
     }
 
     bool source_can_read() { return _source->can_read(); }
@@ -227,6 +228,13 @@ public:
         }
     }
 
+    void clear_dst_pending_finish_time() {
+        if (_is_dst_pending_finish_over) {
+            _dst_pending_finish_over_time = 0;
+            _is_dst_pending_finish_over = false;
+        }
+    }
+
     void set_dst_pending_finish_time() {
         if (!_is_dst_pending_finish_over) {
             _dst_pending_finish_over_time = _pipeline_task_watcher.elapsed_time();
@@ -296,6 +304,8 @@ private:
     RuntimeProfile::Counter* _sink_timer;
     RuntimeProfile::Counter* _finalize_timer;
     RuntimeProfile::Counter* _close_timer;
+    RuntimeProfile::Counter* _try_close_sink_timer;
+    RuntimeProfile::Counter* _try_close_source_timer;
     RuntimeProfile::Counter* _block_counts;
     RuntimeProfile::Counter* _block_by_source_counts;
     RuntimeProfile::Counter* _block_by_sink_counts;

--- a/be/src/pipeline/pipeline_task.h
+++ b/be/src/pipeline/pipeline_task.h
@@ -365,6 +365,8 @@ private:
     bool _is_eos = false;
     RuntimeProfile::Counter* _eos_timer;
     int64_t _eos_time = 0;
+    RuntimeProfile::Counter* _try_close_timer;
+
     //time 3
     bool _is_src_pending_finish_over = false;
     bool _is_src_pending_finish_over1 = false;

--- a/be/src/pipeline/task_scheduler.cpp
+++ b/be/src/pipeline/task_scheduler.cpp
@@ -261,7 +261,7 @@ void TaskScheduler::_do_work(size_t index) {
 
             // If pipeline is canceled caused by memory limit, we should send report to FE in order
             // to cancel all pipeline tasks in this query
-            fragment_ctx->send_report(true);
+            fragment_ctx->send_report();
             _try_close_task(task, PipelineTaskState::CANCELED);
             continue;
         }
@@ -287,7 +287,7 @@ void TaskScheduler::_do_work(size_t index) {
 
             // exec failed，cancel all fragment instance
             fragment_ctx->cancel(PPlanFragmentCancelReason::INTERNAL_ERROR, status.to_string());
-            fragment_ctx->send_report(true);
+            fragment_ctx->send_report();
             _try_close_task(task, PipelineTaskState::CANCELED);
             continue;
         }

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -428,15 +428,12 @@ void FragmentMgr::remove_pipeline_context(
         std::shared_ptr<pipeline::PipelineFragmentContext>& f_context) {
     std::lock_guard<std::mutex> lock(_lock);
     auto query_id = f_context->get_query_id();
-    LOG(INFO) << "remove 1 " << print_id(query_id);
     auto* q_context = f_context->get_query_context();
-    LOG(INFO) << "remove 2 " << q_context;
     bool all_done = q_context->countdown();
-    LOG(INFO) << "remove 3 " << all_done;
     auto ins_id = f_context->get_fragment_instance_id();
     _pipeline_map.erase(f_context->get_fragment_instance_id());
-    LOG(INFO) << "remove 4" << print_id(ins_id) << ", q_id " << print_id(query_id) << ", all_done "
-              << all_done;
+    LOG(INFO) << "remove pip context " << print_id(ins_id) << ", q_id " << print_id(query_id)
+              << ", all_done " << all_done;
     if (all_done) {
         _query_ctx_map.erase(query_id);
     }

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -584,7 +584,7 @@ Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params,
 
     exec_state.reset(
             new FragmentExecState(query_ctx->query_id, params.params.fragment_instance_id,
-                                  params.backend_num, _exec_env, query_ctx, this,
+                                  params.backend_num, _exec_env, this, query_ctx,
                                   std::bind<void>(std::mem_fn(&FragmentMgr::coordinator_callback),
                                                   this, std::placeholders::_1)));
     if (params.__isset.need_wait_execution_trigger && params.need_wait_execution_trigger) {

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -424,14 +424,20 @@ void FragmentMgr::remove_fragment_exec_state(std::shared_ptr<FragmentExecState> 
 }
 
 void FragmentMgr::remove_pipeline_context(
-    std::shared_ptr<pipeline::PipelineFragmentContext>& share_pip_ctx) {
+        std::shared_ptr<pipeline::PipelineFragmentContext>& f_context) {
     std::lock_guard<std::mutex> lock(_lock);
-    auto query_id = share_pip_ctx->get_query_id();
-    auto* q_context = share_pip_ctx->get_query_context();
+    auto query_id = f_context->get_query_id();
+    LOG(INFO) << "remove 1 " << print_id(query_id);
+    auto* q_context = f_context->get_query_context();
+    LOG(INFO) << "remove 2 " << q_context;
     bool all_done = q_context->countdown();
-    this->_pipeline_map.erase(share_pip_ctx->get_fragment_instance_id());
+    LOG(INFO) << "remove 3 " << all_done;
+    auto ins_id = f_context->get_fragment_instance_id();
+    _pipeline_map.erase(f_context->get_fragment_instance_id());
+    LOG(INFO) << "remove 4" << print_id(ins_id) << ", q_id " << print_id(query_id) << ", all_done "
+              << all_done;
     if (all_done) {
-        this->_query_ctx_map.erase(query_id);
+        _query_ctx_map.erase(query_id);
     }
 }
 
@@ -698,7 +704,9 @@ Status FragmentMgr::exec_plan_fragment(const TPipelineFragmentParams& params,
 
         {
             std::lock_guard<std::mutex> lock(_lock);
+
             _pipeline_map.insert(std::make_pair(fragment_instance_id, context));
+            LOG(INFO) << "insert " << print_id(fragment_instance_id);
             _cv.notify_all();
         }
 

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -584,7 +584,7 @@ Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params,
 
     exec_state.reset(
             new FragmentExecState(query_ctx->query_id, params.params.fragment_instance_id,
-                                  params.backend_num, _exec_env, query_ctx,
+                                  params.backend_num, _exec_env, query_ctx, this,
                                   std::bind<void>(std::mem_fn(&FragmentMgr::coordinator_callback),
                                                   this, std::placeholders::_1)));
     if (params.__isset.need_wait_execution_trigger && params.need_wait_execution_trigger) {
@@ -664,7 +664,7 @@ Status FragmentMgr::exec_plan_fragment(const TPipelineFragmentParams& params,
 
         std::shared_ptr<FragmentExecState> exec_state(new FragmentExecState(
                 query_ctx->query_id, fragment_instance_id, local_params.backend_num, _exec_env,
-                query_ctx,
+                this, query_ctx,
                 std::bind<void>(std::mem_fn(&FragmentMgr::coordinator_callback), this,
                                 std::placeholders::_1)));
         if (params.__isset.need_wait_execution_trigger && params.need_wait_execution_trigger) {

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -315,7 +315,8 @@ void FragmentMgr::coordinator_callback(const ReportStatusRequest& req) {
 
 static void empty_function(RuntimeState*, Status*) {}
 
-void FragmentMgr::_exec_actual(std::shared_ptr<FragmentExecState> exec_state, const FinishCallback& cb) {
+void FragmentMgr::_exec_actual(std::shared_ptr<FragmentExecState> exec_state,
+                               const FinishCallback& cb) {
     exec_state->execute(cb);
 }
 

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -424,18 +424,15 @@ void FragmentMgr::remove_fragment_exec_state(std::shared_ptr<FragmentExecState> 
 }
 
 void FragmentMgr::remove_pipeline_context(
-        std::shared_ptr<pipeline::PipelineFragmentContext>& f_context) {
-    auto share_pip_ctx = f_context;
-    _exec_env->send_report_thread_pool()->submit_func([&, this] {
-        std::lock_guard<std::mutex> lock(_lock);
-        auto query_id = share_pip_ctx->get_query_id();
-        auto* q_context = share_pip_ctx->get_query_context();
-        bool all_done = q_context->countdown();
-        this->_pipeline_map.erase(share_pip_ctx->get_fragment_instance_id());
-        if (all_done) {
-            this->_query_ctx_map.erase(query_id);
-        }
-    });
+    std::shared_ptr<pipeline::PipelineFragmentContext>& share_pip_ctx) {
+    std::lock_guard<std::mutex> lock(_lock);
+    auto query_id = share_pip_ctx->get_query_id();
+    auto* q_context = share_pip_ctx->get_query_context();
+    bool all_done = q_context->countdown();
+    this->_pipeline_map.erase(share_pip_ctx->get_fragment_instance_id());
+    if (all_done) {
+        this->_query_ctx_map.erase(query_id);
+    }
 }
 
 template <typename Params>

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -93,8 +93,9 @@ public:
 
     Status exec_plan_fragment(const TPipelineFragmentParams& params);
 
+    void remove_fragment_exec_state(std::shared_ptr<FragmentExecState> f_state);
     void remove_pipeline_context(
-            std::shared_ptr<pipeline::PipelineFragmentContext> pipeline_context);
+            std::shared_ptr<pipeline::PipelineFragmentContext>& pipeline_context);
 
     // TODO(zc): report this is over
     Status exec_plan_fragment(const TExecPlanFragmentParams& params, const FinishCallback& cb);

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -50,6 +50,7 @@
 #include "runtime/query_statistics.h"
 #include "runtime/result_queue_mgr.h"
 #include "runtime/runtime_filter_mgr.h"
+#include "runtime/stream_load/new_load_stream_mgr.h"
 #include "runtime/thread_context.h"
 #include "util/container_util.hpp"
 #include "util/defer_op.h"
@@ -611,7 +612,7 @@ Status FragmentExecState::prepare(const TExecPlanFragmentParams& params) {
 void FragmentExecState::execute(const FinishCallback& cb) {
     std::string func_name {"FragmentExecState::execute"};
 #ifndef BE_TEST
-    SCOPED_ATTACH_TASK(_executor->runtime_state());
+    SCOPED_ATTACH_TASK(_executor.runtime_state());
 #endif
 
     LOG_INFO(func_name)
@@ -624,14 +625,14 @@ void FragmentExecState::execute(const FinishCallback& cb) {
         cancel(PPlanFragmentCancelReason::INTERNAL_ERROR, "exec_state execute failed");
     }
 
-    _executor->exec_env()->fragment_mgr()->remove_fragment_exec_state(shared_from_this());
+    _executor.exec_env()->fragment_mgr()->remove_fragment_exec_state(shared_from_this());
 
     // Callback after remove from this id
-    auto status = _executor->status();
-    cb(_executor->runtime_state(), &status);
+    auto status = _executor.status();
+    cb(_executor.runtime_state(), &status);
 }
 
-Status FragmentExecState::_execute() const {
+Status FragmentExecState::_execute() {
     if (_need_wait_execution_trigger) {
         // if _need_wait_execution_trigger is true, which means this instance
         // is prepared but need to wait for the signal to do the rest execution.

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -51,6 +51,7 @@
 #include "runtime/result_queue_mgr.h"
 #include "runtime/runtime_filter_mgr.h"
 #include "runtime/stream_load/new_load_stream_mgr.h"
+#include "runtime/stream_load/stream_load_context.h"
 #include "runtime/thread_context.h"
 #include "util/container_util.hpp"
 #include "util/defer_op.h"

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -45,6 +45,7 @@
 #include "io/fs/stream_load_pipe.h"
 #include "runtime/descriptors.h"
 #include "runtime/exec_env.h"
+#include "runtime/fragment_mgr.h"
 #include "runtime/memory/mem_tracker_limiter.h"
 #include "runtime/query_context.h"
 #include "runtime/query_statistics.h"
@@ -74,6 +75,7 @@
 namespace doris {
 using namespace ErrorCode;
 
+#ifndef BE_TEST
 PlanFragmentExecutor::PlanFragmentExecutor(ExecEnv* exec_env,
                                            const report_status_callback& report_status_cb)
         : _exec_env(exec_env),
@@ -571,6 +573,7 @@ void PlanFragmentExecutor::close() {
     profile()->add_to_span(_span);
     _closed = true;
 }
+#endif
 
 ///////////////// FragmentExecState //////////////
 

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -579,11 +579,13 @@ void PlanFragmentExecutor::close() {
 
 FragmentExecState::FragmentExecState(const TUniqueId& query_id,
                                      const TUniqueId& fragment_instance_id, int backend_num,
-                                     ExecEnv* exec_env, std::shared_ptr<QueryContext> query_ctx,
+                                     ExecEnv* exec_env, FragmentMgr* fragment_mgr,
+                                     std::shared_ptr<QueryContext> query_ctx,
                                      const report_status_callback_impl& report_status_cb_impl)
         : _query_id(query_id),
           _fragment_instance_id(fragment_instance_id),
           _backend_num(backend_num),
+          _fragment_mgr(fragment_mgr),
           _query_ctx(std::move(query_ctx)),
           _executor(exec_env, std::bind<void>(std::mem_fn(&FragmentExecState::coordinator_callback),
                                               this, std::placeholders::_1, std::placeholders::_2,
@@ -629,7 +631,7 @@ void FragmentExecState::execute(const FinishCallback& cb) {
         cancel(PPlanFragmentCancelReason::INTERNAL_ERROR, "exec_state execute failed");
     }
 
-    _executor.exec_env()->fragment_mgr()->remove_fragment_exec_state(shared_from_this());
+    _fragment_mgr->remove_fragment_exec_state(shared_from_this());
 
     // Callback after remove from this id
     auto status = _executor.status();

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -45,7 +45,6 @@
 #include "io/fs/stream_load_pipe.h"
 #include "runtime/descriptors.h"
 #include "runtime/exec_env.h"
-#include "runtime/fragment_mgr.h"
 #include "runtime/memory/mem_tracker_limiter.h"
 #include "runtime/query_context.h"
 #include "runtime/query_statistics.h"

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -42,6 +42,7 @@
 #include "exec/data_sink.h"
 #include "exec/exec_node.h"
 #include "exec/scan_node.h"
+#include "io/fs/stream_load_pipe.h"
 #include "runtime/descriptors.h"
 #include "runtime/exec_env.h"
 #include "runtime/fragment_mgr.h"

--- a/be/src/runtime/plan_fragment_executor.h
+++ b/be/src/runtime/plan_fragment_executor.h
@@ -34,7 +34,6 @@
 #include <vector>
 
 #include "common/status.h"
-#include "runtime/fragment_mgr.h"
 #include "runtime/runtime_filter_mgr.h"
 #include "runtime/runtime_state.h"
 #include "util/runtime_profile.h"

--- a/be/src/runtime/plan_fragment_executor.h
+++ b/be/src/runtime/plan_fragment_executor.h
@@ -46,6 +46,7 @@ class RowDescriptor;
 class DataSink;
 class DescriptorTbl;
 class ExecEnv;
+class FragmentMgr;
 class ObjectPool;
 class QueryStatistics;
 struct ReportStatusRequest;

--- a/be/src/runtime/plan_fragment_executor.h
+++ b/be/src/runtime/plan_fragment_executor.h
@@ -34,9 +34,9 @@
 #include <vector>
 
 #include "common/status.h"
+#include "runtime/fragment_mgr.h"
 #include "runtime/runtime_filter_mgr.h"
 #include "runtime/runtime_state.h"
-#include "runtime/fragment_mgr.h"
 #include "util/runtime_profile.h"
 
 namespace doris {

--- a/be/src/runtime/plan_fragment_executor.h
+++ b/be/src/runtime/plan_fragment_executor.h
@@ -256,7 +256,8 @@ public:
     using report_status_callback_impl = std::function<void(const ReportStatusRequest)>;
     // Constructor by using QueryContext
     FragmentExecState(const TUniqueId& query_id, const TUniqueId& instance_id, int backend_num,
-                      ExecEnv* exec_env, std::shared_ptr<QueryContext> query_ctx,
+                      ExecEnv* exec_env, FragmentMgr* fragment_mgr,
+                      std::shared_ptr<QueryContext> query_ctx,
                       const report_status_callback_impl& report_status_cb_impl);
     Status prepare(const TExecPlanFragmentParams& params);
 
@@ -325,6 +326,7 @@ private:
     int _backend_num;
     TNetworkAddress _coord_addr;
 
+    FragmentMgr* _fragment_mgr;
     // This context is shared by all fragments of this host in a query.
     // _query_ctx should be the last one to be destructed, because _executor's
     // destruct method will call close and it will depend on query context,

--- a/be/src/runtime/plan_fragment_executor.h
+++ b/be/src/runtime/plan_fragment_executor.h
@@ -36,6 +36,7 @@
 #include "common/status.h"
 #include "runtime/runtime_filter_mgr.h"
 #include "runtime/runtime_state.h"
+#include "runtime/fragment_mgr.h"
 #include "util/runtime_profile.h"
 
 namespace doris {
@@ -312,7 +313,7 @@ public:
     void set_need_wait_execution_trigger() { _need_wait_execution_trigger = true; }
 
 private:
-    Status _execute() const;
+    Status _execute();
     void coordinator_callback(const Status& status, RuntimeProfile* profile,
                               RuntimeProfile* load_channel_profile, bool done);
 

--- a/be/src/runtime/plan_fragment_executor.h
+++ b/be/src/runtime/plan_fragment_executor.h
@@ -48,6 +48,7 @@ class DescriptorTbl;
 class ExecEnv;
 class ObjectPool;
 class QueryStatistics;
+struct ReportStatusRequest;
 
 namespace vectorized {
 class Block;

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -1019,7 +1019,7 @@ void PInternalServiceImpl::transmit_block(google::protobuf::RpcController* contr
         return;
     }
     FifoThreadPool& pool = request->has_block() ? _heavy_work_pool : _light_work_pool;
-    bool ret = pool.try_offer([this, controller, request, response, done]() {
+    bool ret = pool.try_offer([this, controller, request, response, done, receive_time]() {
         int64_t start_exec_time = GetCurrentTimeNanos();
         _transmit_block(controller, request, response, done, Status::OK(), receive_time,
                         start_exec_time);

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -1015,7 +1015,8 @@ void PInternalServiceImpl::transmit_block(google::protobuf::RpcController* contr
 
     if (!request->has_block() && config::brpc_light_work_pool_threads == -1) {
         // under high concurrency, thread pool will have a lot of lock contention.
-        _transmit_block(controller, request, response, done, Status::OK(), receive_time, receive_time);
+        _transmit_block(controller, request, response, done, Status::OK(), receive_time,
+                        receive_time);
         return;
     }
     FifoThreadPool& pool = request->has_block() ? _heavy_work_pool : _light_work_pool;

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -211,7 +211,7 @@ private:
     void _transmit_block(::google::protobuf::RpcController* controller,
                          const ::doris::PTransmitDataParams* request,
                          ::doris::PTransmitDataResult* response, ::google::protobuf::Closure* done,
-                         const Status& extract_st);
+                         const Status& extract_st, int64_t receive_time, int64_t start_exec_time);
 
     void _tablet_writer_add_block(google::protobuf::RpcController* controller,
                                   const PTabletWriterAddBlockRequest* request,

--- a/be/src/vec/runtime/vdata_stream_mgr.cpp
+++ b/be/src/vec/runtime/vdata_stream_mgr.cpp
@@ -90,7 +90,7 @@ std::shared_ptr<VDataStreamRecvr> VDataStreamMgr::find_recvr(const TUniqueId& fr
 }
 
 Status VDataStreamMgr::transmit_block(const PTransmitDataParams* request,
-                                      ::google::protobuf::Closure** done) {
+                                      ::google::protobuf::Closure** done, int64_t wait_exec_time) {
     const PUniqueId& finst_id = request->finst_id();
     TUniqueId t_finst_id;
     t_finst_id.hi = finst_id.hi();
@@ -121,7 +121,7 @@ Status VDataStreamMgr::transmit_block(const PTransmitDataParams* request,
     bool eos = request->eos();
     if (request->has_block()) {
         recvr->add_block(request->block(), request->sender_id(), request->be_number(),
-                         request->packet_seq(), eos ? nullptr : done);
+                         request->packet_seq(), eos ? nullptr : done, wait_exec_time);
     }
 
     if (eos) {

--- a/be/src/vec/runtime/vdata_stream_mgr.h
+++ b/be/src/vec/runtime/vdata_stream_mgr.h
@@ -61,7 +61,8 @@ public:
 
     Status deregister_recvr(const TUniqueId& fragment_instance_id, PlanNodeId node_id);
 
-    Status transmit_block(const PTransmitDataParams* request, ::google::protobuf::Closure** done);
+    Status transmit_block(const PTransmitDataParams* request, ::google::protobuf::Closure** done,
+                          int64_t wait_exec_time);
 
     void cancel(const TUniqueId& fragment_instance_id);
 

--- a/be/src/vec/runtime/vdata_stream_recvr.cpp
+++ b/be/src/vec/runtime/vdata_stream_recvr.cpp
@@ -283,7 +283,7 @@ void VDataStreamRecvr::SenderQueue::close() {
         for (auto closure_pair : _pending_closures) {
             closure_pair.first->Run();
             closure_pair.second.stop();
-            auto t = closure_pair.second.elapsed_time();
+            int64_t t = closure_pair.second.elapsed_time();
             total_ += t;
             max_ = std::max(max_, t);
         }

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -803,6 +803,7 @@ Status VDataStreamSender::_get_next_available_buffer(BroadcastPBlockHolder** hol
 
 void VDataStreamSender::registe_channels(pipeline::ExchangeSinkBuffer* buffer) {
     for (auto channel : _channels) {
+        // TODO local channel no need to register??
         ((PipChannel*)channel)->registe(buffer);
     }
 }

--- a/be/test/vec/runtime/vdata_stream_test.cpp
+++ b/be/test/vec/runtime/vdata_stream_test.cpp
@@ -78,7 +78,7 @@ public:
         // give response a default value to avoid null pointers in high concurrency.
         Status st;
         st.to_protobuf(response->mutable_status());
-        st = stream_mgr->transmit_block(request, &done);
+        st = stream_mgr->transmit_block(request, &done, 0);
         if (!st.ok()) {
             LOG(WARNING) << "transmit_block failed, message=" << st
                          << ", fragment_instance_id=" << print_id(request->finst_id())

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -54,6 +54,8 @@ message PTransmitDataParams {
 message PTransmitDataResult {
     optional PStatus status = 1;
     optional int64 receive_time = 2;
+    optional int64 exec_start_time = 3;
+    optional int64 exec_end_time = 4;
 };
 
 message PTabletWithPartition {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
1. Because `FragmentExecState` is just for none pipeline query. So, I move it to `plan_fragment_executor` frp, `FragmentMgr`.
2. Change pipeline task's `report_profile` to asynchronous
3. Add some profile

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

