### PR TITLE
[Bug](exchange) init _instance_to_rpc_ctx on register_sink

### DIFF
--- a/be/src/pipeline/exec/exchange_sink_buffer.cpp
+++ b/be/src/pipeline/exec/exchange_sink_buffer.cpp
@@ -113,6 +113,7 @@ void ExchangeSinkBuffer::register_sink(TUniqueId fragment_instance_id) {
     finst_id.set_hi(fragment_instance_id.hi);
     finst_id.set_lo(fragment_instance_id.lo);
     _instance_to_sending_by_pipeline[low_id] = true;
+    _instance_to_rpc_ctx[low_id] = {};
     _instance_to_receiver_eof[low_id] = false;
     _instance_to_rpc_time[low_id] = 0;
     _construct_request(low_id, finst_id);
@@ -191,10 +192,8 @@ Status ExchangeSinkBuffer::_send_rpc(InstanceLoId id) {
         }
         auto* closure = request.channel->get_closure(id, request.eos, nullptr);
 
-        ExchangeRpcContext rpc_ctx;
-        rpc_ctx._closure = closure;
-        rpc_ctx.is_cancelled = false;
-        _instance_to_rpc_ctx[id] = rpc_ctx;
+        _instance_to_rpc_ctx[id]._closure = closure;
+        _instance_to_rpc_ctx[id].is_cancelled = false;
 
         closure->cntl.set_timeout_ms(request.channel->_brpc_timeout_ms);
         if (config::exchange_sink_ignore_eovercrowded) {


### PR DESCRIPTION
## Proposed changes

F0815 07:39:44.856573 65243 percentile.h:87] Check failed: rhs._num_samples == rhs._num_added (65278 vs. 4278124286)                                                                         *** Check failure stack trace: ***                                                                                                                                                               @     0x56336b4c70b9  google::LogMessageFatal::~LogMessageFatal()                                                                                                                            @     0x56336bb0f675  bvar::detail::PercentileInterval<>::merge<>()                                                                                                                          @     0x56336bb0e6db  bvar::detail::AgentCombiner<>::reset_all_agents()                                                                                                                      @     0x56336bb0e041  bvar::detail::Percentile::reset()                                                                                                                                      @     0x56336bb19093  bvar::detail::ReducerSampler<>::take_sample()                                                                                                                          @     0x56336bb105a9  bvar::detail::SamplerCollector::run()                                                                                                                                  @     0x56336bb10f89  bvar::detail::SamplerCollector::sampling_thread()                                                                                                                      @     0x7eff18771dd5  start_thread                                                                                                                                                           @     0x7eff18f89ead  __clone                                                                                                                                                                @              (nil)  (unknown)                                                                                                                                                           0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk2/liyuanyuan/doris_test/2.0/doris/be/src/common/signal_handler.h:413                       1# os::Linux::chained_handler(int, siginfo*, void*) in /opt/jdk1.8.0_211/jre/lib/amd64/server/libjvm.so                                                                                      2# JVM_handle_linux_signal in /opt/jdk1.8.0_211/jre/lib/amd64/server/libjvm.so                                                                                                               3# signalHandler(int, siginfo*, void*) in /opt/jdk1.8.0_211/jre/lib/amd64/server/libjvm.so                                                                                                   4# 0x00007EFF18EC2280 in /lib64/libc.so.6                                                                                                                                                    5# phmap::priv::raw_hash_set, phmap::Hash, phmap::EqualTo, std::allocator:pipeline::ExchangeRpcContext> > >::drop_deletes_without_resize() at /mnt/disk2/liyuanyuan/doris_test/2.0/doris/thirdparty/installed/include/parallel_hashmap/phmap.h:2055                    6# phmap::priv::raw_hash_set, phmap::Hash, phmap::EqualTo, std::allocator:pipeline::ExchangeRpcContext> > >::prepare_insert(unsigned long) at /mnt/disk2/liyuanyuan/doris_test/2.0/doris/thirdparty/installed/include/parallel_hashmap/phmap.h:2199                    7# doris::pipeline::ExchangeSinkBuffer::_send_rpc(long) at /mnt/disk2/liyuanyuan/doris_test/2.0/doris/be/src/pipeline/exec/exchange_sink_buffer.cpp:197                                      8# std::_Function_handler::_M_invoke(std::_Any_data const&, long const&, bool const&, doris::PTransmitDataResult const&, long const&) at /mnt/disk2/liyuanyuan/ldb/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291                                                                                                                                                                     9# doris::pipeline::SelfDeleteClosure::Run() at /mnt/disk2/liyuanyuan/doris_test/2.0/doris/be/src/pipeline/exec/exchange_sink_buffer.h:143                      10# brpc::Controller::EndRPC(brpc::Controller::CompletionInfo const&) in /opt/doris-service/doris-branch-2.0/be/lib/doris_be                                                                 11# brpc::Controller::OnVersionedRPCReturned(brpc::Controller::CompletionInfo const&, bool, int) in /opt/doris-service/doris-branch-2.0/be/lib/doris_be                                      12# brpc::policy::ProcessRpcResponse(brpc::InputMessageBase*) in /opt/doris-service/doris-branch-2.0/be/lib/doris_be                                                                         13# brpc::InputMessenger::InputMessageClosure::~InputMessageClosure() in /opt/doris-service/doris-branch-2.0/be/lib/doris_be                                                                 14# brpc::InputMessenger::OnNewMessages(brpc::Socket*) in /opt/doris-service/doris-branch-2.0/be/lib/doris_be                                                                                15# brpc::Socket::ProcessEvent(void*) in /opt/doris-service/doris-branch-2.0/be/lib/doris_be                                                                                                 16# bthread::TaskGroup::task_runner(long) in /opt/doris-service/doris-branch-2.0/be/lib/doris_be                                                                                             17# bthread_make_fcontext in /opt/doris-service/doris-branch-2.0/be/lib/doris_be  

