### PR TITLE
[Fix](View)varchar type conversion error

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/ScalarType.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/ScalarType.java
@@ -575,7 +575,7 @@ public class ScalarType extends Type {
                 break;
             case VARCHAR:
                 if (isWildcardVarchar()) {
-                    stringBuilder.append("varchar(*)");
+                    stringBuilder.append("varchar");
                 } else if (Strings.isNullOrEmpty(lenStr)) {
                     stringBuilder.append("varchar").append("(").append(len).append(")");
                 } else {

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/TableFunctionPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/TableFunctionPlanTest.java
@@ -79,7 +79,7 @@ public class TableFunctionPlanTest {
                 explainString.contains("table function: explode_split(`default_cluster:db1`.`tbl1`.`k2`, ',')"));
         Assert.assertTrue(explainString.contains("tuple ids: 0 1"));
         Assert.assertTrue(explainString.contains("TupleDescriptor{id=1, tbl=tmp, byteSize=16}"));
-        Assert.assertTrue(explainString.contains("SlotDescriptor{id=1, col=e1, colUniqueId=-1, type=varchar(*)"));
+        Assert.assertTrue(explainString.contains("SlotDescriptor{id=1, col=e1, colUniqueId=-1, type=varchar"));
     }
 
     /* Case2 without output explode column
@@ -95,7 +95,7 @@ public class TableFunctionPlanTest {
                 explainString.contains("table function: explode_split(`default_cluster:db1`.`tbl1`.`k2`, ',')"));
         Assert.assertTrue(explainString.contains("tuple ids: 0 1"));
         Assert.assertTrue(explainString.contains("TupleDescriptor{id=1, tbl=tmp, byteSize=16}"));
-        Assert.assertTrue(explainString.contains("SlotDescriptor{id=1, col=e1, colUniqueId=-1, type=varchar(*)"));
+        Assert.assertTrue(explainString.contains("SlotDescriptor{id=1, col=e1, colUniqueId=-1, type=varchar"));
     }
 
     /* Case3 group by explode column
@@ -116,7 +116,7 @@ public class TableFunctionPlanTest {
                 explainString.contains("table function: explode_split(`default_cluster:db1`.`tbl1`.`k2`, ',')"));
         Assert.assertTrue(explainString.contains("tuple ids: 0 1"));
         Assert.assertTrue(explainString.contains("TupleDescriptor{id=1, tbl=tmp, byteSize=16}"));
-        Assert.assertTrue(explainString.contains("SlotDescriptor{id=1, col=e1, colUniqueId=-1, type=varchar(*)"));
+        Assert.assertTrue(explainString.contains("SlotDescriptor{id=1, col=e1, colUniqueId=-1, type=varchar"));
         // group by tuple
         Assert.assertTrue(explainString.contains("TupleDescriptor{id=2, tbl=null, byteSize=32}"));
     }
@@ -135,7 +135,7 @@ public class TableFunctionPlanTest {
         Assert.assertTrue(explainString.contains("PREDICATES: `e1` = '1'"));
         Assert.assertTrue(explainString.contains("tuple ids: 0 1"));
         Assert.assertTrue(explainString.contains("TupleDescriptor{id=1, tbl=tmp, byteSize=16}"));
-        Assert.assertTrue(explainString.contains("SlotDescriptor{id=1, col=e1, colUniqueId=-1, type=varchar(*)"));
+        Assert.assertTrue(explainString.contains("SlotDescriptor{id=1, col=e1, colUniqueId=-1, type=varchar"));
     }
 
     /* Case5 where normal column
@@ -151,7 +151,7 @@ public class TableFunctionPlanTest {
                 explainString.contains("table function: explode_split(`default_cluster:db1`.`tbl1`.`k2`, ',')"));
         Assert.assertTrue(explainString.contains("tuple ids: 0 1"));
         Assert.assertTrue(explainString.contains("TupleDescriptor{id=1, tbl=tmp, byteSize=16}"));
-        Assert.assertTrue(explainString.contains("SlotDescriptor{id=1, col=e1, colUniqueId=-1, type=varchar(*)"));
+        Assert.assertTrue(explainString.contains("SlotDescriptor{id=1, col=e1, colUniqueId=-1, type=varchar"));
         Assert.assertTrue(UtFrameUtils.checkPlanResultContainsNode(explainString, 0, "OlapScanNode"));
         Assert.assertTrue(explainString.contains("PREDICATES: `k1` = 1"));
     }
@@ -171,10 +171,10 @@ public class TableFunctionPlanTest {
         Assert.assertTrue(explainString.contains("lateral view tuple id: 1 2"));
         // lateral view 2 tuple
         Assert.assertTrue(explainString.contains("TupleDescriptor{id=1, tbl=tmp2, byteSize=16}"));
-        Assert.assertTrue(explainString.contains("SlotDescriptor{id=1, col=e2, colUniqueId=-1, type=varchar(*)"));
+        Assert.assertTrue(explainString.contains("SlotDescriptor{id=1, col=e2, colUniqueId=-1, type=varchar"));
         // lateral view 1 tuple
         Assert.assertTrue(explainString.contains("TupleDescriptor{id=2, tbl=tmp1, byteSize=16}"));
-        Assert.assertTrue(explainString.contains("SlotDescriptor{id=2, col=e1, colUniqueId=-1, type=varchar(*)"));
+        Assert.assertTrue(explainString.contains("SlotDescriptor{id=2, col=e1, colUniqueId=-1, type=varchar"));
     }
 
     // test explode_split function
@@ -203,7 +203,7 @@ public class TableFunctionPlanTest {
         String sql = "explain select /*+ SET_VAR(enable_nereids_planner=false) */ k1 from db1.tbl1 where explode_split(k2, \",\");";
         String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(ctx, sql);
         Assert.assertTrue(
-                explainString.contains("No matching function with signature: explode_split(varchar(1), varchar(*))."));
+                explainString.contains("No matching function with signature: explode_split(varchar(1), varchar)."));
     }
 
     // test projection
@@ -368,7 +368,7 @@ public class TableFunctionPlanTest {
         Assert.assertTrue(explainString.contains("lateral view tuple id: 2"));
         Assert.assertTrue(explainString.contains("output slot id: 2"));
         Assert.assertTrue(explainString.contains("tuple ids: 0 2"));
-        Assert.assertTrue(explainString.contains("SlotDescriptor{id=2, col=e1, colUniqueId=-1, type=varchar(*)"));
+        Assert.assertTrue(explainString.contains("SlotDescriptor{id=2, col=e1, colUniqueId=-1, type=varchar"));
     }
 
     /*
@@ -384,7 +384,7 @@ public class TableFunctionPlanTest {
         Assert.assertTrue(explainString.contains("lateral view tuple id: 3"));
         Assert.assertTrue(explainString.contains("output slot id: 3"));
         Assert.assertTrue(explainString.contains("tuple ids: 1 3"));
-        Assert.assertTrue(explainString.contains("SlotDescriptor{id=3, col=e1, colUniqueId=-1, type=varchar(*)"));
+        Assert.assertTrue(explainString.contains("SlotDescriptor{id=3, col=e1, colUniqueId=-1, type=varchar"));
     }
 
     /*
@@ -412,10 +412,10 @@ public class TableFunctionPlanTest {
                 "SlotDescriptor{id=2,col=k1,colUniqueId=0,type=int"
         ));
         Assert.assertTrue(formatString.contains(
-                "SlotDescriptor{id=3,col=null,colUniqueId=null,type=varchar(*)"
+                "SlotDescriptor{id=3,col=null,colUniqueId=null,type=varchar"
         ));
         Assert.assertTrue(formatString.contains(
-                "SlotDescriptor{id=6,col=e1,colUniqueId=-1,type=varchar(*)"
+                "SlotDescriptor{id=6,col=e1,colUniqueId=-1,type=varchar"
         ));
     }
 

--- a/regression-test/data/view_p0/view_p0.out
+++ b/regression-test/data/view_p0/view_p0.out
@@ -2,3 +2,6 @@
 -- !sql --
 1	4x0fdjDNBZAJxCD7qm/EHg==
 
+-- !sql --
+1
+

--- a/regression-test/suites/view_p0/view_p0.groovy
+++ b/regression-test/suites/view_p0/view_p0.groovy
@@ -21,4 +21,21 @@ suite("view_p0") {
         create view test_view as select 1,to_base64(AES_ENCRYPT('doris','doris')); 
     """
     qt_sql "select * from test_view;"
+    
+    sql """DROP TABLE IF EXISTS test_view_table"""
+    
+    sql """ 
+        create table test_view_table (id int) distributed by hash(id) properties('replication_num'='1');
+    """
+    
+    sql """insert into test_view_table values(1);"""
+    
+    sql """DROP VIEW IF EXISTS test_varchar_view"""
+    
+    sql """ 
+        create view test_varchar_view (id) as  SELECT GROUP_CONCAT(cast( id as varchar)) from test_view_table; 
+    """
+    
+    qt_sql "select * from test_varchar_view;"
+    
 }


### PR DESCRIPTION
## Proposed changes

`varchar` will be converted to `varchar (*)` when create VIEW, so View creation errors

```
create view example_view5 
(
id
) as  
SELECT GROUP_CONCAT(cast( id as varchar)) from person;
```
```fe.log
2023-08-16 11:07:48,079 INFO (colocate group clone checker|106) [ColocateTableCheckerAndBalancer.matchGroup():309] finished to check tablets. unhealth/total/added/in_sched/not_ready: 0/3/0/0/0, cost: 0 ms
2023-08-16 11:07:49,442 INFO (mysql-nio-pool-0|185) [View.init():171] stmt is SELECT group_concat(CAST(`id` AS varchar(*))) AS `id` FROM `default_cluster:calvin`.`one`
2023-08-16 11:07:49,442 INFO (mysql-nio-pool-0|185) [View.init():172] exception because: 
org.apache.doris.common.AnalysisException: errCode = 2, detailMessage = Syntax error
        at org.apache.doris.analysis.SqlParser.unrecovered_syntax_error(SqlParser.java:2822) ~[classes/:?]
        at java_cup.runtime.lr_parser.parse(lr_parser.java:619) ~[java-cup-runtime-0.11-a-czt01-cdh.jar:?]
        at org.apache.doris.common.util.SqlParserUtils.getFirstStmt(SqlParserUtils.java:46) ~[classes/:?]
        at org.apache.doris.catalog.View.init(View.java:169) ~[classes/:?]
        at org.apache.doris.catalog.Env.createView(Env.java:4798) ~[classes/:?]
        at org.apache.doris.qe.DdlExecutor.execute(DdlExecutor.java:238) ~[classes/:?]
        at org.apache.doris.qe.StmtExecutor.handleDdlStmt(StmtExecutor.java:2196) ~[classes/:?]
        at org.apache.doris.qe.StmtExecutor.executeByLegacy(StmtExecutor.java:736) ~[classes/:?]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:448) ~[classes/:?]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:419) ~[classes/:?]
        at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:441) ~[classes/:?]
        at org.apache.doris.qe.ConnectProcessor.dispatch(ConnectProcessor.java:589) ~[classes/:?]
        at org.apache.doris.qe.ConnectProcessor.processOnce(ConnectProcessor.java:829) ~[classes/:?]
        at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52) ~[classes/:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_362]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_362]
        at java.lang.Thread.run(Thread.java:750) ~[?:1.8.0_362]
2023-08-16 11:07:49,443 INFO (mysql-nio-pool-0|185) [View.init():173] msg is SELECT group_concat(CAST(`id` AS varchar(*))) AS `id` FROM `default_cluster:calvin`.`one`
2023-08-16 11:07:49,444 WARN (mysql-nio-pool-0|185) [StmtExecutor.handleDdlStmt():2205] DDL statement(create view fail_test 
(
id
) as  
SELECT GROUP_CONCAT(cast( id as varchar)) from one) process failed.
org.apache.doris.common.DdlException: errCode = 2, detailMessage = failed to init view stmt
        at org.apache.doris.catalog.Env.createView(Env.java:4800) ~[classes/:?]
        at org.apache.doris.qe.DdlExecutor.execute(DdlExecutor.java:238) ~[classes/:?]
        at org.apache.doris.qe.StmtExecutor.handleDdlStmt(StmtExecutor.java:2196) ~[classes/:?]
        at org.apache.doris.qe.StmtExecutor.executeByLegacy(StmtExecutor.java:736) ~[classes/:?]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:448) ~[classes/:?]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:419) ~[classes/:?]
        at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:441) ~[classes/:?]
        at org.apache.doris.qe.ConnectProcessor.dispatch(ConnectProcessor.java:589) ~[classes/:?]
        at org.apache.doris.qe.ConnectProcessor.processOnce(ConnectProcessor.java:829) ~[classes/:?]
        at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52) ~[classes/:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_362]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_362]
        at java.lang.Thread.run(Thread.java:750) ~[?:1.8.0_362]
Caused by: org.apache.doris.common.UserException: errCode = 2, detailMessage = Failed to parse view-definition statement of view: fail_test
        at org.apache.doris.catalog.View.init(View.java:177) ~[classes/:?]
        at org.apache.doris.catalog.Env.createView(Env.java:4798) ~[classes/:?]
        ... 12 more

```


![981b179c-3314-477d-9da7-2927aaef0932](https://github.com/apache/doris/assets/16631152/bee766e6-d2a4-4b81-aa69-13bb67a13691)


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

