### PR TITLE
[Bug](exchange) fix dcheck fail when VDataStreamRecvr input empty block

### DIFF
--- a/be/src/vec/runtime/shared_hash_table_controller.cpp
+++ b/be/src/vec/runtime/shared_hash_table_controller.cpp
@@ -57,8 +57,7 @@ bool SharedHashTableController::should_build_hash_table(const TUniqueId& fragmen
 
 SharedHashTableContextPtr SharedHashTableController::get_context(int my_node_id) {
     std::lock_guard<std::mutex> lock(_mutex);
-    auto it = _shared_contexts.find(my_node_id);
-    if (it == _shared_contexts.cend()) {
+    if (!_shared_contexts.count(my_node_id)) {
         _shared_contexts.insert({my_node_id, std::make_shared<SharedHashTableContext>()});
     }
     return _shared_contexts[my_node_id];

--- a/be/src/vec/runtime/vdata_stream_recvr.cpp
+++ b/be/src/vec/runtime/vdata_stream_recvr.cpp
@@ -159,7 +159,9 @@ void VDataStreamRecvr::SenderQueue::add_block(const PBlock& pblock, int be_numbe
     COUNTER_UPDATE(_recvr->_rows_produced_counter, block->rows());
     COUNTER_UPDATE(_recvr->_blocks_produced_counter, 1);
 
-    if (block->rows()) {
+    bool empty = !block->rows();
+
+    if (!empty) {
         _block_queue.emplace_back(std::move(block), block_byte_size);
     }
     // if done is nullptr, this function can't delay this response
@@ -171,7 +173,7 @@ void VDataStreamRecvr::SenderQueue::add_block(const PBlock& pblock, int be_numbe
         *done = nullptr;
     }
     _recvr->_blocks_memory_usage->add(block_byte_size);
-    if (block->rows()) {
+    if (!empty) {
         _data_arrival_cv.notify_one();
     }
 }
@@ -209,7 +211,9 @@ void VDataStreamRecvr::SenderQueue::add_block(Block* block, bool use_move) {
     COUNTER_UPDATE(_recvr->_rows_produced_counter, block->rows());
     COUNTER_UPDATE(_recvr->_blocks_produced_counter, 1);
 
-    if (block->rows()) {
+        bool empty = !block->rows();
+
+    if (!empty) {
         _block_queue.emplace_back(std::move(nblock), block_mem_size);
         _data_arrival_cv.notify_one();
     }

--- a/be/src/vec/runtime/vdata_stream_recvr.cpp
+++ b/be/src/vec/runtime/vdata_stream_recvr.cpp
@@ -211,7 +211,7 @@ void VDataStreamRecvr::SenderQueue::add_block(Block* block, bool use_move) {
     COUNTER_UPDATE(_recvr->_rows_produced_counter, block->rows());
     COUNTER_UPDATE(_recvr->_blocks_produced_counter, 1);
 
-        bool empty = !block->rows();
+    bool empty = !block->rows();
 
     if (!empty) {
         _block_queue.emplace_back(std::move(nblock), block_mem_size);

--- a/be/src/vec/runtime/vdata_stream_recvr.cpp
+++ b/be/src/vec/runtime/vdata_stream_recvr.cpp
@@ -211,7 +211,7 @@ void VDataStreamRecvr::SenderQueue::add_block(Block* block, bool use_move) {
     COUNTER_UPDATE(_recvr->_rows_produced_counter, block->rows());
     COUNTER_UPDATE(_recvr->_blocks_produced_counter, 1);
 
-    bool empty = !block->rows();
+    bool empty = !nblock->rows();
 
     if (!empty) {
         _block_queue.emplace_back(std::move(nblock), block_mem_size);

--- a/be/src/vec/runtime/vdata_stream_recvr.cpp
+++ b/be/src/vec/runtime/vdata_stream_recvr.cpp
@@ -159,7 +159,9 @@ void VDataStreamRecvr::SenderQueue::add_block(const PBlock& pblock, int be_numbe
     COUNTER_UPDATE(_recvr->_rows_produced_counter, block->rows());
     COUNTER_UPDATE(_recvr->_blocks_produced_counter, 1);
 
-    _block_queue.emplace_back(std::move(block), block_byte_size);
+    if (block->rows()) {
+        _block_queue.emplace_back(std::move(block), block_byte_size);
+    }
     // if done is nullptr, this function can't delay this response
     if (done != nullptr && _recvr->exceeds_limit(block_byte_size)) {
         MonotonicStopWatch monotonicStopWatch;
@@ -169,7 +171,9 @@ void VDataStreamRecvr::SenderQueue::add_block(const PBlock& pblock, int be_numbe
         *done = nullptr;
     }
     _recvr->_blocks_memory_usage->add(block_byte_size);
-    _data_arrival_cv.notify_one();
+    if (block->rows()) {
+        _data_arrival_cv.notify_one();
+    }
 }
 
 void VDataStreamRecvr::SenderQueue::add_block(Block* block, bool use_move) {
@@ -205,8 +209,10 @@ void VDataStreamRecvr::SenderQueue::add_block(Block* block, bool use_move) {
     COUNTER_UPDATE(_recvr->_rows_produced_counter, block->rows());
     COUNTER_UPDATE(_recvr->_blocks_produced_counter, 1);
 
-    _block_queue.emplace_back(std::move(nblock), block_mem_size);
-    _data_arrival_cv.notify_one();
+    if (block->rows()) {
+        _block_queue.emplace_back(std::move(nblock), block_mem_size);
+        _data_arrival_cv.notify_one();
+    }
 
     if (_recvr->exceeds_limit(block_mem_size)) {
         // yiguolei
@@ -384,8 +390,8 @@ bool VDataStreamRecvr::sender_queue_empty(int sender_id) {
 }
 
 bool VDataStreamRecvr::ready_to_read() {
-    for (size_t i = 0; i < _sender_queues.size(); i++) {
-        if (_sender_queues[i]->should_wait()) {
+    for (const auto& queue : _sender_queues) {
+        if (queue->should_wait()) {
             return false;
         }
     }

--- a/be/src/vec/runtime/vdata_stream_recvr.h
+++ b/be/src/vec/runtime/vdata_stream_recvr.h
@@ -237,7 +237,9 @@ public:
     }
 
     void add_block(Block* block, bool use_move) override {
-        if (block->rows() == 0) return;
+        if (block->rows() == 0) {
+            return;
+        }
         {
             std::unique_lock<std::mutex> l(_lock);
             if (_is_cancelled) {


### PR DESCRIPTION
## Proposed changes

<img width="661" alt="图片" src="https://github.com/apache/doris/assets/7939630/66420c20-c92e-4659-803c-980fdac4e7cc">

0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:413
12:56:30    1# 0x00007FE9D4797090 in /lib/x86_64-linux-gnu/libc.so.6
12:56:30    2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
12:56:30    3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
12:56:30    4# 0x0000564104666E49 in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
12:56:30    5# google::LogMessage::SendToLog() in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
12:56:30    6# google::LogMessage::Flush() in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
12:56:30    7# google::LogMessageFatal::~LogMessageFatal() in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
12:56:30    8# doris::vectorized::VDataStreamRecvr::PipSenderQueue::get_batch(doris::vectorized::Block*, bool*) in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
12:56:30    9# std::_Function_handler<doris::Status (doris::vectorized::Block*, bool*), std::_Bind<std::_Mem_fn<doris::Status (doris::vectorized::VDataStreamRecvr::SenderQueue::*)(doris::vectorized::Block*, bool*)> (doris::vectorized::VDataStreamRecvr::SenderQueue*, std::_Placeholder<1>, std::_Placeholder<2>)> >::_M_invoke(std::_Any_data const&, doris::vectorized::Block*&&, bool*&&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
12:56:30   10# doris::vectorized::BlockSupplierSortCursorImpl::has_next_block() at /root/doris/be/src/vec/core/sort_cursor.h:234
12:56:30   11# doris::vectorized::BlockSupplierSortCursorImpl::BlockSupplierSortCursorImpl(std::function<doris::Status (doris::vectorized::Block*, bool*)> const&, std::vector<std::shared_ptr<doris::vectorized::VExprContext>, std::allocator<std::shared_ptr<doris::vectorized::VExprContext> > > const&, std::vector<bool, std::allocator<bool> > const&, std::vector<bool, std::allocator<bool> > const&) at /root/doris/be/src/vec/core/sort_cursor.h:222
12:56:30   12# void std::vector<doris::vectorized::BlockSupplierSortCursorImpl, std::allocator<doris::vectorized::BlockSupplierSortCursorImpl> >::_M_realloc_insert<std::function<doris::Status (doris::vectorized::Block*, bool*)> const&, std::vector<std::shared_ptr<doris::vectorized::VExprContext>, std::allocator<std::shared_ptr<doris::vectorized::VExprContext> > > const&, std::vector<bool, std::allocator<bool> > const&, std::vector<bool, std::allocator<bool> > const&>(__gnu_cxx::__normal_iterator<doris::vectorized::BlockSupplierSortCursorImpl*, std::vector<doris::vectorized::BlockSupplierSortCursorImpl, std::allocator<doris::vectorized::BlockSupplierSortCursorImpl> > >, std::function<doris::Status (doris::vectorized::Block*, bool*)> const&, std::vector<std::shared_ptr<doris::vectorized::VExprContext>, std::allocator<std::shared_ptr<doris::vectorized::VExprContext> > > const&, std::vector<bool, std::allocator<bool> > const&, std::vector<bool, std::allocator<bool> > const&) in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
12:56:30   13# doris::vectorized::VSortedRunMerger::prepare(std::vector<std::function<doris::Status (doris::vectorized::Block*, bool*)>, std::allocator<std::function<doris::Status (doris::vectorized::Block*, bool*)> > > const&) at /root/doris/be/src/vec/runtime/vsorted_run_merger.cpp:74
12:56:30   14# doris::vectorized::VDataStreamRecvr::create_merger(std::vector<std::shared_ptr<doris::vectorized::VExprContext>, std::allocator<std::shared_ptr<doris::vectorized::VExprContext> > > const&, std::vector<bool, std::allocator<bool> > const&, std::vector<bool, std::allocator<bool> > const&, unsigned long, long, unsigned long) in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
12:56:30   15# doris::vectorized::VExchangeNode::get_next(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /root/doris/be/src/vec/exec/vexchange_node.cpp:101
12:56:30   16# doris::ExecNode::pull(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /root/doris/be/src/exec/exec_node.h:127
12:56:30   17# std::_Function_handler<doris::Status (doris::RuntimeState*, doris::vectorized::Block*, bool*), std::_Bind<doris::Status (doris::ExecNode::*(doris::vectorized::VExchangeNode*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)> >::_M_invoke(std::_Any_data const&, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
12:56:30   18# doris::ExecNode::get_next_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*, std::function<doris::Status (doris::RuntimeState*, doris::vectorized::Block*, bool*)> const&, bool) at /root/doris/be/src/exec/exec_node.cpp:584
12:56:30   19# doris::pipeline::SourceOperator<doris::pipeline::ExchangeSourceOperatorBuilder>::get_block(doris::RuntimeState*, doris::vectorized::Block*, doris::pipeline::SourceState&) at /root/doris/be/src/pipeline/exec/operator.h:390
12:56:30   20# doris::pipeline::PipelineTask::execute(bool*) in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
12:56:30   21# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /root/doris/be/src/pipeline/task_scheduler.cpp:275
12:56:30   22# doris::ThreadPool::dispatch_thread() at /root/doris/be/src/util/threadpool.cpp:539
12:56:30   23# doris::Thread::supervise_thread(void*) at /root/doris/be/src/util/thread.cpp:466
12:56:30   24# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
12:56:30   25# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97 

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

