### PR TITLE
[bug](shuffle) Fix DCHECK failure if exchange node has limit

### DIFF
--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -519,8 +519,8 @@ Status VDataStreamSender::send(RuntimeState* state, Block* block, bool eos) {
                 if (serialized) {
                     auto cur_block = _serializer.get_block()->to_block();
                     if (!cur_block.empty()) {
-                        _serializer.serialize_block(&cur_block, block_holder->get_block(),
-                                                    _channels.size());
+                        RETURN_IF_ERROR(_serializer.serialize_block(
+                                &cur_block, block_holder->get_block(), _channels.size()));
                     } else {
                         block_holder->get_block()->Clear();
                     }
@@ -548,7 +548,8 @@ Status VDataStreamSender::send(RuntimeState* state, Block* block, bool eos) {
             if (serialized) {
                 auto cur_block = _serializer.get_block()->to_block();
                 if (!cur_block.empty()) {
-                    _serializer.serialize_block(&cur_block, _cur_pb_block, _channels.size());
+                    RETURN_IF_ERROR(_serializer.serialize_block(&cur_block, _cur_pb_block,
+                                                                _channels.size()));
                 }
                 Status status;
                 for (auto channel : _channels) {
@@ -658,7 +659,7 @@ Status VDataStreamSender::send(RuntimeState* state, Block* block, bool eos) {
 }
 
 Status VDataStreamSender::try_close(RuntimeState* state, Status exec_status) {
-    DCHECK(_serializer.get_block() == nullptr || _serializer.get_block()->rows() == 0);
+    _serializer.reset_block();
     Status final_st = Status::OK();
     for (int i = 0; i < _channels.size(); ++i) {
         Status st = _channels[i]->close(state);


### PR DESCRIPTION
## Proposed changes

F0815 01:36:54.033484 687205 vdata_stream_sender.cpp:660] Check failed: _serializer.get_block() == nullptr || _serializer.get_block()->rows() == 0 
*** Check failure stack trace: ***
F0815 01:36:54.033531 687218 vdata_stream_sender.cpp:660] Check failed: _serializer.get_block() == nullptr || _serializer.get_block()->rows() == 0 
*** Check failure stack trace: ***
    @     0x556add1b81ad  google::LogMessage::Fail()
    @     0x556add1b81ad  google::LogMessage::Fail()
    @     0x556add1ba6e9  google::LogMessage::SendToLog()
    @     0x556add1ba6e9  google::LogMessage::SendToLog()
    @     0x556add1b7d16  google::LogMessage::Flush()
    @     0x556add1b7d16  google::LogMessage::Flush()
    @     0x556add1bad59  google::LogMessageFatal::~LogMessageFatal()
    @     0x556add1bad59  google::LogMessageFatal::~LogMessageFatal()
    @     0x556adcd8a011  doris::vectorized::VDataStreamSender::try_close()
    @     0x556adcd8a011  doris::vectorized::VDataStreamSender::try_close()
    @     0x556add141fd8  doris::pipeline::DataSinkOperator<>::try_close()
    @     0x556add141fd8  doris::pipeline::DataSinkOperator<>::try_close()
    @     0x556add165634  doris::pipeline::PipelineTask::try_close()
    @     0x556add165634  doris::pipeline::PipelineTask::try_close()
    @     0x556add18aea8  doris::pipeline::TaskScheduler::_try_close_task()
    @     0x556add18aea8  doris::pipeline::TaskScheduler::_try_close_task()
    @     0x556add189aaf  doris::pipeline::TaskScheduler::_do_work()
    @     0x556add189aaf  doris::pipeline::TaskScheduler::_do_work()
    @     0x556add19a109  std::__invoke_impl<>()
    @     0x556add19a109  std::__invoke_impl<>()
    @     0x556add199f75  std::__invoke<>()
    @     0x556add199f75  std::__invoke<>()
    @     0x556add199ee4  _ZNSt5_BindIFMN5doris8pipeline13TaskSchedulerEFvmEPS2_mEE6__callIvJEJLm0ELm1EEEET_OSt5tupleIJDpT0_EESt12_Index_tupleIJXspT1_EEE
    @     0x556add199ee4  _ZNSt5_BindIFMN5doris8pipeline13TaskSchedulerEFvmEPS2_mEE6__callIvJEJLm0ELm1EEEET_OSt5tupleIJDpT0_EESt12_Index_tupleIJXspT1_EEE
    @     0x556add199d4e  std::_Bind<>::operator()<>()
    @     0x556add199d4e  std::_Bind<>::operator()<>()
    @     0x556add199c65  std::__invoke_impl<>()
    @     0x556add199c65  std::__invoke_impl<>()
    @     0x556add199c05  _ZSt10__invoke_rIvRSt5_BindIFMN5doris8pipeline13TaskSchedulerEFvmEPS3_mEEJEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EESB_E4typeEOSC_DpOSD_
    @     0x556add199c05  _ZSt10__invoke_rIvRSt5_BindIFMN5doris8pipeline13TaskSchedulerEFvmEPS3_mEEJEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EESB_E4typeEOSC_DpOSD_
    @     0x556add1998fd  std::_Function_handler<>::_M_invoke()
    @     0x556add1998fd  std::_Function_handler<>::_M_invoke()
    @     0x556aba412373  std::function<>::operator()()
    @     0x556aba412373  std::function<>::operator()()
    @     0x556abd5bce79  doris::FunctionRunnable::run()
    @     0x556abd5bce79  doris::FunctionRunnable::run()
    @     0x556abd5aa5e7  doris::ThreadPool::dispatch_thread()
    @     0x556abd5aa5e7  doris::ThreadPool::dispatch_thread()
    @     0x556abd5cfbd4  std::__invoke_impl<>()
    @     0x556abd5cfbd4  std::__invoke_impl<>()
    @     0x556abd5cfaad  std::__invoke<>()
    @     0x556abd5cfaad  std::__invoke<>()
    @     0x556abd5cfa35  _ZNSt5_BindIFMN5doris10ThreadPoolEFvvEPS1_EE6__callIvJEJLm0EEEET_OSt5tupleIJDpT0_EESt12_Index_tupleIJXspT1_EEE
    @     0x556abd5cfa35  _ZNSt5_BindIFMN5doris10ThreadPoolEFvvEPS1_EE6__callIvJEJLm0EEEET_OSt5tupleIJDpT0_EESt12_Index_tupleIJXspT1_EEE
    @     0x556abd5cf8de  std::_Bind<>::operator()<>()
    @     0x556abd5cf8de  std::_Bind<>::operator()<>()
    @     0x556abd5cf7f5  std::__invoke_impl<>()
    @     0x556abd5cf7f5  std::__invoke_impl<>()
    @     0x556abd5cf795  _ZSt10__invoke_rIvRSt5_BindIFMN5doris10ThreadPoolEFvvEPS2_EEJEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EESA_E4typeEOSB_DpOSC_
    @     0x556abd5cf795  _ZSt10__invoke_rIvRSt5_BindIFMN5doris10ThreadPoolEFvvEPS2_EEJEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EESA_E4typeEOSB_DpOSC_
    @     0x556abd5cf4bd  std::_Function_handler<>::_M_invoke()
    @     0x556abd5cf4bd  std::_Function_handler<>::_M_invoke()
    @     0x556aba412373  std::function<>::operator()()
    @     0x556aba412373  std::function<>::operator()()
    @     0x556abd577da7  doris::Thread::supervise_thread()
    @     0x556abd577da7  doris::Thread::supervise_thread()
    @     0x7ff15ad73609  start_thread
    @     0x7ff15ad73609  start_thread
    @     0x7ff15b002163  clone
    @     0x7ff15b002163  clone
    @              (nil)  (unknown)
*** Query id: 43b68faefbdc4e88-b1168a31129f345b ***
*** Aborted at 1692034614 (unix time) try "date -d @1692034614" if you are using GNU date ***
*** Current BE git commitID: 7bc98748cf ***
*** SIGABRT unknown detail explain (@0xa7ac4) received by PID 686788 (TID 687218 OR 0x7fe9d45d1700) from PID 686788; stack trace: ***
    @              (nil)  (unknown)
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:413
 1# 0x00007FF15AF260C0 in /lib/x86_64-linux-gnu/libc.so.6
 2# raise in /lib/x86_64-linux-gnu/libc.so.6
 3# abort in /lib/x86_64-linux-gnu/libc.so.6
 4# 0x0000556ADD1C2C09 in /mnt/ssd01/doris-master/VEC_ASAN/be/lib/doris_be
 5# 0x0000556ADD1B81AD in /mnt/ssd01/doris-master/VEC_ASAN/be/lib/doris_be
 6# google::LogMessage::SendToLog() in /mnt/ssd01/doris-master/VEC_ASAN/be/lib/doris_be
 7# google::LogMessage::Flush() in /mnt/ssd01/doris-master/VEC_ASAN/be/lib/doris_be
 8# google::LogMessageFatal::~LogMessageFatal() in /mnt/ssd01/doris-master/VEC_ASAN/be/lib/doris_be
 9# doris::vectorized::VDataStreamSender::try_close(doris::RuntimeState*, doris::Status) in /mnt/ssd01/doris-master/VEC_ASAN/be/lib/doris_be
10# doris::pipeline::DataSinkOperator::try_close(doris::RuntimeState*) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/exec/operator.h:285
11# doris::pipeline::PipelineTask::try_close() at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/pipeline_task.cpp:291
12# doris::pipeline::TaskScheduler::_try_close_task(doris::pipeline::PipelineTask*, doris::pipeline::PipelineTaskState) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/task_scheduler.cpp:335
13# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/task_scheduler.cpp:265
14# void std::__invoke_impl(std::__invoke_memfun_deref, void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
15# std::__invoke_result::type std::__invoke(void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
16# void std::_Bind::__call(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420
17# void std::_Bind::operator()<, void>() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503
18# void std::__invoke_impl&>(std::__invoke_other, std::_Bind&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
19# std::enable_if&>, void>::type std::__invoke_r&>(std::_Bind&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
20# std::_Function_handler >::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
21# std::function::operator()() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
22# doris::FunctionRunnable::run() at /home/zcp/repo_center/doris_master/doris/be/src/util/threadpool.cpp:48
23# doris::ThreadPool::dispatch_thread() at /home/zcp/repo_center/doris_master/doris/be/src/util/threadpool.cpp:531
24# void std::__invoke_impl(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
25# std::__invoke_result::type std::__invoke(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
26# void std::_Bind::__call(std::tuple<>&&, std::_Index_tuple<0ul>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420
27# void std::_Bind::operator()<, void>() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503
28# void std::__invoke_impl&>(std::__invoke_other, std::_Bind&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
29# std::enable_if&>, void>::type std::__invoke_r&>(std::_Bind&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
30# std::_Function_handler >::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
31# std::function::operator()() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
32# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_master/doris/be/src/util/thread.cpp:465
33# start_thread at /build/glibc-sMfBJT/glibc-2.31/nptl/pthread_create.c:478
34# __clone in /lib/x86_64-linux-gnu/libc.so.6
172.21.0.37 last coredump sql: 2023-08-15 01:36:47,442 [query] |Client=172.21.0.22:44858|User=root|Db=test_query_db|State=EOF|ErrorCode=0|ErrorMessage=|Time(ms)=36|ScanBytes=0|ScanRows=0|ReturnRows=5|StmtId=20371|QueryId=43b68faefbdc4e88-b1168a31129f345b|IsQuery=true|isNereids=false|feIp=172.21.0.38|Stmt=             with cte as (                 select baseall.* from baseall, bigtable where baseall.k1 = bigtable.k1             )             select * from baseall, (select k1 from cte) c where c.k1 = baseall.k1         |CpuTimeMS=0|SqlHash=c2f0d6fb2bb98bcce18c49b83760c307|peakMemoryBytes=0|SqlDigest=|TraceId=|FuzzyVariables=max_execution_time=-1,batch_size=4064,disable_streaming_preaggregations=true,parallel_fragment_exec_instance_num=4,parallel_pipeline_task_num=1,enable_pipeline_engine=true,enable_fold_constant_by_be=false,runtime_filter_type=8,enable_nereids_planner=false,rewrite_or_to_in_predicate_threshold=2,enable_function_pushdown=true,enable_common_expr_pushdown=true,enable_local_exchange=false,partitioned_hash_join_rows_threshold=8,partitioned_hash_agg_rows_threshold=8,partition_pruning_expand_threshold=10,enable_share_hash_table_for_broadcast_join=true,external_sort_bytes_threshold=0,external_agg_bytes_threshold=0,external_agg_partition_bits=8,enable_two_phase_read_opt=true
####### 172.21.0.38 #######
172.21.0.38 corefile: 172.21.0.38:/var/lib/apport/coredump/corepackage.core._mnt_ssd01_doris-master_VEC_ASAN_be_lib_doris_be-305928-20230815T01:36:49.lz4
172.21.0.38 be.out: start time: Tue 15 Aug 2023 01:27:05 AM CST
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/mnt/ssd01/doris-master/VEC_ASAN/be/lib/java_extensions/java-udf/java-udf-jar-with-dependencies.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/mnt/ssd01/doris-master/VEC_ASAN/be/lib/hadoop_hdfs/common/lib/slf4j-reload4j-1.7.36.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory]
F0815 01:36:47.011548 306603 vdata_stream_sender.cpp:660] Check failed: _serializer.get_block() == nullptr || _serializer.get_block()->rows() == 0 
*** Check failure stack trace: ***

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

