### PR TITLE
[fix](nereids)bind slot failed because of "default_cluster"

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ExpressionTrait.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ExpressionTrait.java
@@ -66,7 +66,7 @@ public interface ExpressionTrait extends TreeNode<Expression> {
     }
 
     default DataType getDataType() throws UnboundException {
-        throw new UnboundException("dataType");
+        throw new UnboundException(toSql() + ".getDataType()");
     }
 
     default String toSql() throws UnboundException {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Random.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Random.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.FunctionSignature;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
 import org.apache.doris.nereids.trees.expressions.functions.Nondeterministic;
+import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.types.DoubleType;
@@ -53,6 +54,8 @@ public class Random extends ScalarFunction
      */
     public Random(Expression arg) {
         super("random", arg);
+        // align with original planner behavior, refer to: org/apache/doris/analysis/Expr.getBuiltinFunction()
+        Preconditions.checkState(arg instanceof Literal, "The param of rand function must be literal");
     }
 
     /**

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
@@ -508,14 +508,12 @@ public class SelectStmtTest {
 
     @Test
     public void testDeleteSign() throws Exception {
-        String sql1 = "SELECT * FROM db1.table1  LEFT ANTI JOIN db1.table2 ON db1.table1.siteid = db1.table2.siteid;";
+        String sql1 = "SELECT /*+ SET_VAR(enable_nereids_planner=true, ENABLE_FALLBACK_TO_ORIGINAL_PLANNER=false) */ * FROM db1.table1  LEFT ANTI JOIN db1.table2 ON db1.table1.siteid = db1.table2.siteid;";
         String explain = dorisAssert.query(sql1).explainQuery();
         Assert.assertTrue(explain
-                .contains("PREDICATES: `default_cluster:db1`.`table1`.`__DORIS_DELETE_SIGN__` = 0"));
-        Assert.assertTrue(explain
-                .contains("PREDICATES: `default_cluster:db1`.`table2`.`__DORIS_DELETE_SIGN__` = 0"));
+                .contains("PREDICATES: __DORIS_DELETE_SIGN__ = 0"));
         Assert.assertFalse(explain.contains("other predicates:"));
-        String sql2 = "SELECT * FROM db1.table1 JOIN db1.table2 ON db1.table1.siteid = db1.table2.siteid;";
+        String sql2 = "SELECT /*+ SET_VAR(enable_nereids_planner=false) */ * FROM db1.table1 JOIN db1.table2 ON db1.table1.siteid = db1.table2.siteid;";
         explain = dorisAssert.query(sql2).explainQuery();
         Assert.assertTrue(explain
                 .contains("PREDICATES: `default_cluster:db1`.`table1`.`__DORIS_DELETE_SIGN__` = 0"));

--- a/regression-test/suites/nereids_p0/except/test_bound_exception.groovy
+++ b/regression-test/suites/nereids_p0/except/test_bound_exception.groovy
@@ -50,6 +50,6 @@ suite("test_bound_exception") {
     }
     test {
         sql "SELECT id FROM ${tbName} WHERE id123 = 123 ORDER BY id"
-        exception "errCode = 2, detailMessage = Unexpected exception: Invalid call to dataType on unbound object"
+        exception "errCode = 2, detailMessage = Unexpected exception: Invalid call to id123.getDataType() on unbound object"
     }
 }


### PR DESCRIPTION
## Proposed changes
slot bind failed for following querys:
`select tpch.lineitem.* from lineitem`
`select tpch.lineitem.l_partkey from lineitem`

the unbound slot is `tpch.lineitem.l_partkey`, but the bounded slot is `default_cluster:tpch.lineitem.l_partkey`. They are not matched.
we need to ignore `default_cluster:` when compare dbName

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

