### PR TITLE
[fix](regression) Improve the robustness when close target connection

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/SyncerContext.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/SyncerContext.groovy
@@ -212,6 +212,8 @@ class SyncerContext {
     }
 
     void closeConn() {
-        targetConnection.close()
+        if (targetConnection != null) {
+            targetConnection.close()
+        }
     }
 }


### PR DESCRIPTION
bugfix:  
Improper use of syncer in the regression test framework may cause syncer to not initialize targetConnect when closing, resulting in a segment-fault. This PR adds a check for whether targetConnect exists