### PR TITLE
[fix](load) remove incorrect DCHECK in BetaRowsetWriter dtor

### DIFF
--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -87,7 +87,6 @@ BetaRowsetWriter::~BetaRowsetWriter() {
         if (!fs) {
             return;
         }
-        DCHECK_LE(_segment_start_id + _num_segment, _segment_creator.next_segment_id());
         for (int i = _segment_start_id; i < _segment_creator.next_segment_id(); ++i) {
             std::string seg_path =
                     BetaRowset::segment_file_path(_context.rowset_dir, _context.rowset_id, i);


### PR DESCRIPTION
The DCHECK may not always be right in case of Vertical compaction. remove it to let DEBUG run.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

