### PR TITLE
[refactor](load) use smart pointers to manage writers in memtable memory limiter

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -66,7 +66,7 @@ DeltaWriter::DeltaWriter(WriteRequest* req, StorageEngine* storage_engine, Runti
                          const UniqueId& load_id)
         : _req(*req),
           _rowset_builder(*req, storage_engine, profile),
-          _memtable_writer(new MemTableWriter(*req, profile)),
+          _memtable_writer(new MemTableWriter(*req)),
           _storage_engine(storage_engine) {
     _init_profile(profile);
 }
@@ -142,7 +142,7 @@ Status DeltaWriter::build_rowset() {
             << "delta writer is supposed be to initialized before build_rowset() being called";
 
     SCOPED_TIMER(_close_wait_timer);
-    RETURN_IF_ERROR(_memtable_writer->close_wait());
+    RETURN_IF_ERROR(_memtable_writer->close_wait(_profile));
     return _rowset_builder.build_rowset();
 }
 

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -66,7 +66,7 @@ DeltaWriter::DeltaWriter(WriteRequest* req, StorageEngine* storage_engine, Runti
                          const UniqueId& load_id)
         : _req(*req),
           _rowset_builder(*req, storage_engine, profile),
-          _memtable_writer(*req, profile),
+          _memtable_writer(new MemTableWriter(*req, profile)),
           _storage_engine(storage_engine) {
     _init_profile(profile);
 }
@@ -83,10 +83,10 @@ DeltaWriter::~DeltaWriter() {
     }
 
     // cancel and wait all memtables in flush queue to be finished
-    _memtable_writer.cancel();
+    _memtable_writer->cancel();
 
     if (_rowset_builder.tablet() != nullptr) {
-        const FlushStatistic& stat = _memtable_writer.get_flush_token_stats();
+        const FlushStatistic& stat = _memtable_writer->get_flush_token_stats();
         _rowset_builder.tablet()->flush_bytes->increment(stat.flush_size_bytes);
         _rowset_builder.tablet()->flush_finish_count->increment(stat.flush_finish_count);
     }
@@ -94,8 +94,8 @@ DeltaWriter::~DeltaWriter() {
 
 Status DeltaWriter::init() {
     _rowset_builder.init();
-    _memtable_writer.init(_rowset_builder.rowset_writer(), _rowset_builder.tablet_schema(),
-                          _rowset_builder.tablet()->enable_unique_key_merge_on_write());
+    _memtable_writer->init(_rowset_builder.rowset_writer(), _rowset_builder.tablet_schema(),
+                           _rowset_builder.tablet()->enable_unique_key_merge_on_write());
     _is_init = true;
     return Status::OK();
 }
@@ -115,10 +115,10 @@ Status DeltaWriter::write(const vectorized::Block* block, const std::vector<int>
     if (!_is_init && !_is_cancelled) {
         RETURN_IF_ERROR(init());
     }
-    return _memtable_writer.write(block, row_idxs, is_append);
+    return _memtable_writer->write(block, row_idxs, is_append);
 }
 Status DeltaWriter::wait_flush() {
-    return _memtable_writer.wait_flush();
+    return _memtable_writer->wait_flush();
 }
 
 Status DeltaWriter::close() {
@@ -133,7 +133,7 @@ Status DeltaWriter::close() {
         // for this tablet when being closed.
         RETURN_IF_ERROR(init());
     }
-    return _memtable_writer.close();
+    return _memtable_writer->close();
 }
 
 Status DeltaWriter::build_rowset() {
@@ -142,7 +142,7 @@ Status DeltaWriter::build_rowset() {
             << "delta writer is supposed be to initialized before build_rowset() being called";
 
     SCOPED_TIMER(_close_wait_timer);
-    RETURN_IF_ERROR(_memtable_writer.close_wait());
+    RETURN_IF_ERROR(_memtable_writer->close_wait());
     return _rowset_builder.build_rowset();
 }
 
@@ -193,13 +193,13 @@ Status DeltaWriter::cancel_with_status(const Status& st) {
     if (_is_cancelled) {
         return Status::OK();
     }
-    RETURN_IF_ERROR(_memtable_writer.cancel_with_status(st));
+    RETURN_IF_ERROR(_memtable_writer->cancel_with_status(st));
     _is_cancelled = true;
     return Status::OK();
 }
 
 int64_t DeltaWriter::mem_consumption(MemType mem) {
-    return _memtable_writer.mem_consumption(mem);
+    return _memtable_writer->mem_consumption(mem);
 }
 
 void DeltaWriter::_request_slave_tablet_pull_rowset(PNodeInfo node_info) {

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -112,7 +112,7 @@ public:
     // For UT
     DeleteBitmapPtr get_delete_bitmap() { return _rowset_builder.get_delete_bitmap(); }
 
-    MemTableWriter* memtable_writer() { return _memtable_writer.get(); }
+    std::shared_ptr<MemTableWriter> memtable_writer() { return _memtable_writer; }
 
 private:
     DeltaWriter(WriteRequest* req, StorageEngine* storage_engine, RuntimeProfile* profile,

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -112,7 +112,7 @@ public:
     // For UT
     DeleteBitmapPtr get_delete_bitmap() { return _rowset_builder.get_delete_bitmap(); }
 
-    MemTableWriter* memtable_writer() { return &_memtable_writer; }
+    MemTableWriter* memtable_writer() { return _memtable_writer.get(); }
 
 private:
     DeltaWriter(WriteRequest* req, StorageEngine* storage_engine, RuntimeProfile* profile,
@@ -126,7 +126,7 @@ private:
     bool _is_cancelled = false;
     WriteRequest _req;
     RowsetBuilder _rowset_builder;
-    MemTableWriter _memtable_writer;
+    std::shared_ptr<MemTableWriter> _memtable_writer;
 
     StorageEngine* _storage_engine;
 

--- a/be/src/olap/memtable_memory_limiter.cpp
+++ b/be/src/olap/memtable_memory_limiter.cpp
@@ -223,7 +223,7 @@ void MemTableMemoryLimiter::_refresh_mem_tracker_without_lock() {
             _writers.pop_back();
         }
     }
-    LOG(INFO) << "refreshed mem_tracker, num writers: " << _writers.size();
+    VLOG_DEBUG << "refreshed mem_tracker, num writers: " << _writers.size();
     THREAD_MEM_TRACKER_TRANSFER_TO(_mem_usage - _mem_tracker->consumption(), _mem_tracker.get());
 }
 

--- a/be/src/olap/memtable_memory_limiter.cpp
+++ b/be/src/olap/memtable_memory_limiter.cpp
@@ -61,14 +61,14 @@ Status MemTableMemoryLimiter::init(int64_t process_mem_limit) {
     return Status::OK();
 }
 
-void MemTableMemoryLimiter::register_writer(MemTableWriter* writer) {
+void MemTableMemoryLimiter::register_writer(std::shared_ptr<MemTableWriter> writer) {
     std::lock_guard<std::mutex> l(_lock);
-    _writers.insert(writer);
+    _writers.insert(writer.get());
 }
 
-void MemTableMemoryLimiter::deregister_writer(MemTableWriter* writer) {
+void MemTableMemoryLimiter::deregister_writer(std::shared_ptr<MemTableWriter> writer) {
     std::lock_guard<std::mutex> l(_lock);
-    _writers.erase(writer);
+    _writers.erase(writer.get());
 }
 
 void MemTableMemoryLimiter::handle_memtable_flush() {

--- a/be/src/olap/memtable_memory_limiter.cpp
+++ b/be/src/olap/memtable_memory_limiter.cpp
@@ -223,6 +223,7 @@ void MemTableMemoryLimiter::_refresh_mem_tracker_without_lock() {
             _writers.pop_back();
         }
     }
+    LOG(INFO) << "refreshed mem_tracker, num writers: " << _writers.size();
     THREAD_MEM_TRACKER_TRANSFER_TO(_mem_usage - _mem_tracker->consumption(), _mem_tracker.get());
 }
 

--- a/be/src/olap/memtable_memory_limiter.h
+++ b/be/src/olap/memtable_memory_limiter.h
@@ -40,9 +40,9 @@ public:
     // If yes, it will flush memtable to try to reduce memory consumption.
     void handle_memtable_flush();
 
-    void register_writer(MemTableWriter* writer);
+    void register_writer(std::shared_ptr<MemTableWriter> writer);
 
-    void deregister_writer(MemTableWriter* writer);
+    void deregister_writer(std::shared_ptr<MemTableWriter> writer);
 
     void refresh_mem_tracker() {
         std::lock_guard<std::mutex> l(_lock);

--- a/be/src/olap/memtable_memory_limiter.h
+++ b/be/src/olap/memtable_memory_limiter.h
@@ -26,7 +26,7 @@
 namespace doris {
 class MemTableWriter;
 struct WriterMemItem {
-    MemTableWriter* writer;
+    std::weak_ptr<MemTableWriter> writer;
     int64_t mem_size;
 };
 class MemTableMemoryLimiter {
@@ -66,6 +66,6 @@ private:
     int64_t _load_soft_mem_limit = -1;
     bool _soft_reduce_mem_in_progress = false;
 
-    std::unordered_set<MemTableWriter*> _writers;
+    std::unordered_set<std::weak_ptr<MemTableWriter>> _writers;
 };
 } // namespace doris

--- a/be/src/olap/memtable_memory_limiter.h
+++ b/be/src/olap/memtable_memory_limiter.h
@@ -40,9 +40,7 @@ public:
     // If yes, it will flush memtable to try to reduce memory consumption.
     void handle_memtable_flush();
 
-    void register_writer(std::shared_ptr<MemTableWriter> writer);
-
-    void deregister_writer(std::shared_ptr<MemTableWriter> writer);
+    void register_writer(std::weak_ptr<MemTableWriter> writer);
 
     void refresh_mem_tracker() {
         std::lock_guard<std::mutex> l(_lock);
@@ -66,6 +64,6 @@ private:
     int64_t _load_soft_mem_limit = -1;
     bool _soft_reduce_mem_in_progress = false;
 
-    std::unordered_set<std::weak_ptr<MemTableWriter>> _writers;
+    std::vector<std::weak_ptr<MemTableWriter>> _writers;
 };
 } // namespace doris

--- a/be/src/olap/memtable_writer.cpp
+++ b/be/src/olap/memtable_writer.cpp
@@ -54,6 +54,8 @@ MemTableWriter::MemTableWriter(const WriteRequest& req, RuntimeProfile* profile)
 }
 
 void MemTableWriter::_init_profile(RuntimeProfile* profile) {
+    // NOTE: MemTableWriter may live longer than the scope of profile because of MemTableMemoryLimiter.
+    // To avoid accessing dangling pointers, we should only update profile in MemTableWriter::close_wait()
     _profile = profile->create_child(fmt::format("MemTableWriter {}", _req.tablet_id), true, true);
     _lock_timer = ADD_TIMER(_profile, "LockTime");
     _sort_timer = ADD_TIMER(_profile, "MemTableSortTime");

--- a/be/src/olap/memtable_writer.cpp
+++ b/be/src/olap/memtable_writer.cpp
@@ -280,6 +280,8 @@ Status MemTableWriter::_do_close_wait() {
 }
 
 void MemTableWriter::_update_profile(RuntimeProfile* profile) {
+    // NOTE: MemTableWriter may be accessed when profile is out of scope, in MemTableMemoryLimiter.
+    // To avoid accessing dangling pointers, we cannot make profile as a member of MemTableWriter.
     auto child =
             profile->create_child(fmt::format("MemTableWriter {}", _req.tablet_id), true, true);
     auto lock_timer = ADD_TIMER(child, "LockTime");

--- a/be/src/olap/memtable_writer.cpp
+++ b/be/src/olap/memtable_writer.cpp
@@ -49,29 +49,7 @@
 namespace doris {
 using namespace ErrorCode;
 
-MemTableWriter::MemTableWriter(const WriteRequest& req, RuntimeProfile* profile) : _req(req) {
-    _init_profile(profile);
-}
-
-void MemTableWriter::_init_profile(RuntimeProfile* profile) {
-    // NOTE: MemTableWriter may live longer than the scope of profile because of MemTableMemoryLimiter.
-    // To avoid accessing dangling pointers, we should only update profile in MemTableWriter::close_wait()
-    _profile = profile->create_child(fmt::format("MemTableWriter {}", _req.tablet_id), true, true);
-    _lock_timer = ADD_TIMER(_profile, "LockTime");
-    _sort_timer = ADD_TIMER(_profile, "MemTableSortTime");
-    _agg_timer = ADD_TIMER(_profile, "MemTableAggTime");
-    _memtable_duration_timer = ADD_TIMER(_profile, "MemTableDurationTime");
-    _segment_writer_timer = ADD_TIMER(_profile, "SegmentWriterTime");
-    _wait_flush_timer = ADD_TIMER(_profile, "MemTableWaitFlushTime");
-    _put_into_output_timer = ADD_TIMER(_profile, "MemTablePutIntoOutputTime");
-    _delete_bitmap_timer = ADD_TIMER(_profile, "DeleteBitmapTime");
-    _close_wait_timer = ADD_TIMER(_profile, "CloseWaitTime");
-    _sort_times = ADD_COUNTER(_profile, "MemTableSortTimes", TUnit::UNIT);
-    _agg_times = ADD_COUNTER(_profile, "MemTableAggTimes", TUnit::UNIT);
-    _segment_num = ADD_COUNTER(_profile, "SegmentNum", TUnit::UNIT);
-    _raw_rows_num = ADD_COUNTER(_profile, "RawRowNum", TUnit::UNIT);
-    _merged_rows_num = ADD_COUNTER(_profile, "MergedRowNum", TUnit::UNIT);
-}
+MemTableWriter::MemTableWriter(const WriteRequest& req) : _req(req) {}
 
 MemTableWriter::~MemTableWriter() {
     if (!_is_init) {
@@ -229,7 +207,7 @@ void MemTableWriter::_reset_mem_table() {
                                   _unique_key_mow, mem_table_insert_tracker,
                                   mem_table_flush_tracker));
 
-    COUNTER_UPDATE(_segment_num, 1);
+    _segment_num++;
 }
 
 Status MemTableWriter::close() {
@@ -258,8 +236,8 @@ Status MemTableWriter::close() {
     }
 }
 
-Status MemTableWriter::close_wait() {
-    SCOPED_TIMER(_close_wait_timer);
+Status MemTableWriter::_do_close_wait() {
+    SCOPED_RAW_TIMER(&_close_wait_time_ns);
     std::lock_guard<std::mutex> l(_lock);
     DCHECK(_is_init)
             << "delta writer is supposed be to initialized before close_wait() being called";
@@ -298,20 +276,42 @@ Status MemTableWriter::close_wait() {
                   << _wait_flush_timer->elapsed_time() << "(ns), stats: " << stat;
     }*/
 
-    COUNTER_UPDATE(_lock_timer, _lock_watch.elapsed_time() / 1000);
-    COUNTER_SET(_delete_bitmap_timer, _rowset_writer->delete_bitmap_ns());
-    COUNTER_SET(_segment_writer_timer, _rowset_writer->segment_writer_ns());
-    COUNTER_SET(_wait_flush_timer, _wait_flush_time_ns);
-    const auto& memtable_stat = _flush_token->memtable_stat();
-    COUNTER_SET(_sort_timer, memtable_stat.sort_ns);
-    COUNTER_SET(_agg_timer, memtable_stat.agg_ns);
-    COUNTER_SET(_memtable_duration_timer, memtable_stat.duration_ns);
-    COUNTER_SET(_put_into_output_timer, memtable_stat.put_into_output_ns);
-    COUNTER_SET(_sort_times, memtable_stat.sort_times);
-    COUNTER_SET(_agg_times, memtable_stat.agg_times);
-    COUNTER_SET(_raw_rows_num, memtable_stat.raw_rows);
-    COUNTER_SET(_merged_rows_num, memtable_stat.merged_rows);
     return Status::OK();
+}
+
+void MemTableWriter::_update_profile(RuntimeProfile* profile) {
+    auto child =
+            profile->create_child(fmt::format("MemTableWriter {}", _req.tablet_id), true, true);
+    auto lock_timer = ADD_TIMER(child, "LockTime");
+    auto sort_timer = ADD_TIMER(child, "MemTableSortTime");
+    auto agg_timer = ADD_TIMER(child, "MemTableAggTime");
+    auto memtable_duration_timer = ADD_TIMER(child, "MemTableDurationTime");
+    auto segment_writer_timer = ADD_TIMER(child, "SegmentWriterTime");
+    auto wait_flush_timer = ADD_TIMER(child, "MemTableWaitFlushTime");
+    auto put_into_output_timer = ADD_TIMER(child, "MemTablePutIntoOutputTime");
+    auto delete_bitmap_timer = ADD_TIMER(child, "DeleteBitmapTime");
+    auto close_wait_timer = ADD_TIMER(child, "CloseWaitTime");
+    auto sort_times = ADD_COUNTER(child, "MemTableSortTimes", TUnit::UNIT);
+    auto agg_times = ADD_COUNTER(child, "MemTableAggTimes", TUnit::UNIT);
+    auto segment_num = ADD_COUNTER(child, "SegmentNum", TUnit::UNIT);
+    auto raw_rows_num = ADD_COUNTER(child, "RawRowNum", TUnit::UNIT);
+    auto merged_rows_num = ADD_COUNTER(child, "MergedRowNum", TUnit::UNIT);
+
+    COUNTER_UPDATE(lock_timer, _lock_watch.elapsed_time());
+    COUNTER_SET(delete_bitmap_timer, _rowset_writer->delete_bitmap_ns());
+    COUNTER_SET(segment_writer_timer, _rowset_writer->segment_writer_ns());
+    COUNTER_SET(wait_flush_timer, _wait_flush_time_ns);
+    COUNTER_SET(close_wait_timer, _close_wait_time_ns);
+    COUNTER_SET(segment_num, _segment_num);
+    const auto& memtable_stat = _flush_token->memtable_stat();
+    COUNTER_SET(sort_timer, memtable_stat.sort_ns);
+    COUNTER_SET(agg_timer, memtable_stat.agg_ns);
+    COUNTER_SET(memtable_duration_timer, memtable_stat.duration_ns);
+    COUNTER_SET(put_into_output_timer, memtable_stat.put_into_output_ns);
+    COUNTER_SET(sort_times, memtable_stat.sort_times);
+    COUNTER_SET(agg_times, memtable_stat.agg_times);
+    COUNTER_SET(raw_rows_num, memtable_stat.raw_rows);
+    COUNTER_SET(merged_rows_num, memtable_stat.merged_rows);
 }
 
 Status MemTableWriter::cancel() {

--- a/be/src/olap/memtable_writer.h
+++ b/be/src/olap/memtable_writer.h
@@ -62,7 +62,7 @@ enum MemType { WRITE = 1, FLUSH = 2, ALL = 3 };
 // This class is NOT thread-safe, external synchronization is required.
 class MemTableWriter {
 public:
-    MemTableWriter(const WriteRequest& req, RuntimeProfile* profile);
+    MemTableWriter(const WriteRequest& req);
 
     ~MemTableWriter();
 
@@ -78,7 +78,13 @@ public:
     Status close();
     // wait for all memtables to be flushed.
     // mem_consumption() should be 0 after this function returns.
-    Status close_wait();
+    Status close_wait(RuntimeProfile* profile = nullptr) {
+        RETURN_IF_ERROR(_do_close_wait());
+        if (profile != nullptr) {
+            _update_profile(profile);
+        }
+        return Status::OK();
+    }
 
     // abandon current memtable and wait for all pending-flushing memtables to be destructed.
     // mem_consumption() should be 0 after this function returns.
@@ -110,7 +116,8 @@ private:
 
     void _reset_mem_table();
 
-    void _init_profile(RuntimeProfile* profile);
+    Status _do_close_wait();
+    void _update_profile(RuntimeProfile* profile);
 
     std::atomic<bool> _is_init = false;
     bool _is_cancelled = false;
@@ -133,22 +140,8 @@ private:
     // total rows num written by MemTableWriter
     int64_t _total_received_rows = 0;
     int64_t _wait_flush_time_ns = 0;
-
-    RuntimeProfile* _profile = nullptr;
-    RuntimeProfile::Counter* _lock_timer = nullptr;
-    RuntimeProfile::Counter* _sort_timer = nullptr;
-    RuntimeProfile::Counter* _agg_timer = nullptr;
-    RuntimeProfile::Counter* _wait_flush_timer = nullptr;
-    RuntimeProfile::Counter* _delete_bitmap_timer = nullptr;
-    RuntimeProfile::Counter* _segment_writer_timer = nullptr;
-    RuntimeProfile::Counter* _memtable_duration_timer = nullptr;
-    RuntimeProfile::Counter* _put_into_output_timer = nullptr;
-    RuntimeProfile::Counter* _sort_times = nullptr;
-    RuntimeProfile::Counter* _agg_times = nullptr;
-    RuntimeProfile::Counter* _close_wait_timer = nullptr;
-    RuntimeProfile::Counter* _segment_num = nullptr;
-    RuntimeProfile::Counter* _raw_rows_num = nullptr;
-    RuntimeProfile::Counter* _merged_rows_num = nullptr;
+    int64_t _close_wait_time_ns = 0;
+    int64_t _segment_num = 0;
 
     MonotonicStopWatch _lock_watch;
 };

--- a/be/src/olap/memtable_writer.h
+++ b/be/src/olap/memtable_writer.h
@@ -76,7 +76,7 @@ public:
 
     // flush the last memtable to flush queue, must call it before close_wait()
     Status close();
-    // wait for all memtables to be flushed.
+    // wait for all memtables to be flushed, update profiles if provided.
     // mem_consumption() should be 0 after this function returns.
     Status close_wait(RuntimeProfile* profile = nullptr) {
         RETURN_IF_ERROR(_do_close_wait());

--- a/be/src/olap/memtable_writer.h
+++ b/be/src/olap/memtable_writer.h
@@ -132,6 +132,7 @@ private:
 
     // total rows num written by MemTableWriter
     int64_t _total_received_rows = 0;
+    int64_t _wait_flush_time_ns = 0;
 
     RuntimeProfile* _profile = nullptr;
     RuntimeProfile::Counter* _lock_timer = nullptr;

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -96,14 +96,6 @@ protected:
         _self_profile->add_info_string("EosHost", fmt::format("{}", request.backend_id()));
         bool finished = false;
         auto index_id = request.index_id();
-        // close will reset deltawriter memtable and should deregister writer before it.
-        {
-            std::lock_guard<SpinLock> l(_tablets_channels_lock);
-            auto tablet_channel_it = _tablets_channels.find(index_id);
-            if (tablet_channel_it != _tablets_channels.end()) {
-                tablet_channel_it->second->deregister_memtable_memory_limiter();
-            }
-        }
 
         RETURN_IF_ERROR(channel->close(
                 this, request.sender_id(), request.backend_id(), &finished, request.partition_ids(),
@@ -141,7 +133,6 @@ private:
     // lock protect the tablets channel map
     std::mutex _lock;
     // index id -> tablets channel
-    // when you erase, you should call deregister_writer method in MemTableMemoryLimiter;
     std::unordered_map<int64_t, std::shared_ptr<TabletsChannel>> _tablets_channels;
     SpinLock _tablets_channels_lock;
     // This is to save finished channels id, to handle the retry request.

--- a/be/src/runtime/load_channel_mgr.h
+++ b/be/src/runtime/load_channel_mgr.h
@@ -77,17 +77,10 @@ private:
         }
     }
 
-    void _deregister_channel_all_writers(std::shared_ptr<doris::LoadChannel> channel) {
-        for (auto& [_, tablet_channel] : channel->get_tablets_channels()) {
-            tablet_channel->deregister_memtable_memory_limiter();
-        }
-    }
-
 protected:
     // lock protect the load channel map
     std::mutex _lock;
     // load id -> load channel
-    // when you erase, you should call deregister_writer method in MemTableMemoryLimiter ;
     std::unordered_map<UniqueId, std::shared_ptr<LoadChannel>> _load_channels;
     Cache* _last_success_channel = nullptr;
 

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -500,19 +500,20 @@ bool TabletsChannel::_is_broken_tablet(int64_t tablet_id) {
 
 void TabletsChannel::register_memtable_memory_limiter() {
     auto memtable_memory_limiter = ExecEnv::GetInstance()->memtable_memory_limiter();
-    _memtable_writers_foreach([memtable_memory_limiter](MemTableWriter* writer) {
+    _memtable_writers_foreach([memtable_memory_limiter](std::shared_ptr<MemTableWriter> writer) {
         memtable_memory_limiter->register_writer(writer);
     });
 }
 
 void TabletsChannel::deregister_memtable_memory_limiter() {
     auto memtable_memory_limiter = ExecEnv::GetInstance()->memtable_memory_limiter();
-    _memtable_writers_foreach([memtable_memory_limiter](MemTableWriter* writer) {
+    _memtable_writers_foreach([memtable_memory_limiter](std::shared_ptr<MemTableWriter> writer) {
         memtable_memory_limiter->deregister_writer(writer);
     });
 }
 
-void TabletsChannel::_memtable_writers_foreach(std::function<void(MemTableWriter*)> fn) {
+void TabletsChannel::_memtable_writers_foreach(
+        std::function<void(std::shared_ptr<MemTableWriter>)> fn) {
     std::lock_guard<SpinLock> l(_tablet_writers_lock);
     for (auto& [_, delta_writer] : _tablet_writers) {
         fn(delta_writer->memtable_writer());

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -68,9 +68,7 @@ TabletsChannel::TabletsChannel(const TabletsChannelKey& key, const UniqueId& loa
 
 TabletsChannel::~TabletsChannel() {
     _s_tablet_writer_count -= _tablet_writers.size();
-    auto memtable_memory_limiter = ExecEnv::GetInstance()->memtable_memory_limiter();
     for (auto& it : _tablet_writers) {
-        memtable_memory_limiter->deregister_writer(it.second->memtable_writer());
         delete it.second;
     }
     delete _schema;
@@ -502,13 +500,6 @@ void TabletsChannel::register_memtable_memory_limiter() {
     auto memtable_memory_limiter = ExecEnv::GetInstance()->memtable_memory_limiter();
     _memtable_writers_foreach([memtable_memory_limiter](std::shared_ptr<MemTableWriter> writer) {
         memtable_memory_limiter->register_writer(writer);
-    });
-}
-
-void TabletsChannel::deregister_memtable_memory_limiter() {
-    auto memtable_memory_limiter = ExecEnv::GetInstance()->memtable_memory_limiter();
-    _memtable_writers_foreach([memtable_memory_limiter](std::shared_ptr<MemTableWriter> writer) {
-        memtable_memory_limiter->deregister_writer(writer);
     });
 }
 

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -135,7 +135,7 @@ private:
                            int64_t tablet_id, Status error);
     bool _is_broken_tablet(int64_t tablet_id);
     void _init_profile(RuntimeProfile* profile);
-    void _memtable_writers_foreach(std::function<void(MemTableWriter*)> fn);
+    void _memtable_writers_foreach(std::function<void(std::shared_ptr<MemTableWriter>)> fn);
 
     // id of this load channel
     TabletsChannelKey _key;

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -115,8 +115,6 @@ public:
 
     void register_memtable_memory_limiter();
 
-    void deregister_memtable_memory_limiter();
-
 private:
     template <typename Request>
     Status _get_current_seq(int64_t& cur_seq, const Request& request);
@@ -170,7 +168,6 @@ private:
     Status _close_status;
 
     // tablet_id -> TabletChannel
-    // when you erase, you should call deregister_writer method in MemTableMemoryLimiter;
     std::unordered_map<int64_t, DeltaWriter*> _tablet_writers;
     // broken tablet ids.
     // If a tablet write fails, it's id will be added to this set.

--- a/be/test/olap/memtable_memory_limiter_test.cpp
+++ b/be/test/olap/memtable_memory_limiter_test.cpp
@@ -173,10 +173,6 @@ TEST_F(MemTableMemoryLimiterTest, handle_memtable_flush_test) {
     }
     _mgr->handle_memtable_flush();
     CHECK_EQ(0, memtable_writer->active_memtable_mem_consumption());
-    {
-        std::lock_guard<std::mutex> l(lock);
-        _mgr->deregister_writer(memtable_writer);
-    }
 
     res = delta_writer->close();
     EXPECT_EQ(Status::OK(), res);


### PR DESCRIPTION
## Proposed changes

Use smart pointer to manage MemTableWriters in MemTableMemoryLimiter.
We no longer need to deregister writers in MemTableMemoryLimiter.

### Test

The log is changed to VLOG_DEBUG in the final version.

```
I0815 20:44:14.725538 1158747 vtablet_sink.cpp:1584] finished to close olap table sink. load_id=db481b50e1a84028-8216c3dab1a7c0b3, txn_id=16020, node add batch time(ms)/wait execution time(ms)/close time(ms)/num: {10039:(570)(0)(674)(2)} {10040:(389)(0)(528)(2)} {10041:(491)(0)(528)(2)}
I0815 20:44:14.729375 1158747 query_context.h:69] Deregister query/load memory tracker, queryId=db481b50e1a84028-8216c3dab1a7c0b3, Limit=2.00 GB, CurrUsed=32.84 MB, PeakUsed=379.68 MB
I0815 20:44:14.795511 1158496 memtable_memory_limiter.cpp:226] refreshed mem_tracker, num writers: 2304
I0815 20:44:14.895648 1158496 memtable_memory_limiter.cpp:226] refreshed mem_tracker, num writers: 2304
I0815 20:44:14.995826 1158496 memtable_memory_limiter.cpp:226] refreshed mem_tracker, num writers: 2304
I0815 20:44:15.095990 1158496 memtable_memory_limiter.cpp:226] refreshed mem_tracker, num writers: 2304
I0815 20:44:15.196146 1158496 memtable_memory_limiter.cpp:226] refreshed mem_tracker, num writers: 2304
I0815 20:44:15.296309 1158496 memtable_memory_limiter.cpp:226] refreshed mem_tracker, num writers: 2304
I0815 20:44:15.396457 1158496 memtable_memory_limiter.cpp:226] refreshed mem_tracker, num writers: 2304
I0815 20:44:15.407001 1161561 load_channel.cpp:49] load channel removed load_id=db481b50e1a84028-8216c3dab1a7c0b3, is high priority=0, sender_ip=10.16.10.7
I0815 20:44:15.496557 1158496 memtable_memory_limiter.cpp:226] refreshed mem_tracker, num writers: 0
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

