### PR TITLE
[Fix](statistics)Fix update cached column stats bug.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -87,7 +87,6 @@ import org.apache.doris.qe.QeProcessorImpl;
 import org.apache.doris.qe.QueryState;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.qe.VariableMgr;
-import org.apache.doris.statistics.ColumnStatistic;
 import org.apache.doris.statistics.StatisticsCacheKey;
 import org.apache.doris.statistics.query.QueryStats;
 import org.apache.doris.system.Backend;
@@ -2943,8 +2942,13 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     @Override
     public TStatus updateStatsCache(TUpdateFollowerStatsCacheRequest request) throws TException {
         StatisticsCacheKey key = GsonUtils.GSON.fromJson(request.key, StatisticsCacheKey.class);
-        ColumnStatistic columnStatistic = GsonUtils.GSON.fromJson(request.colStats, ColumnStatistic.class);
-        Env.getCurrentEnv().getStatisticsCache().putCache(key, columnStatistic);
+        /*
+         TODO: Need to handle minExpr and maxExpr, so that we can generate the columnStatistic
+          here and use putCache to update cached directly.
+         ColumnStatistic columnStatistic = GsonUtils.GSON.fromJson(request.colStats, ColumnStatistic.class);
+         Env.getCurrentEnv().getStatisticsCache().putCache(key, columnStatistic);
+        */
+        Env.getCurrentEnv().getStatisticsCache().refreshColStatsSync(key.tableId, key.idxId, key.colName);
         return new TStatus(TStatusCode.OK);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCache.java
@@ -257,6 +257,10 @@ public class StatisticsCache {
         updateFollowerStatsCacheRequest.key = GsonUtils.GSON.toJson(k);
         updateFollowerStatsCacheRequest.colStats = GsonUtils.GSON.toJson(c);
         for (Frontend frontend : Env.getCurrentEnv().getFrontends(FrontendNodeType.FOLLOWER)) {
+            if (frontend.getHost().equals(Env.getCurrentEnv().getSelfNode().getHost())) {
+                // Doesn't need to send request to current node.
+                continue;
+            }
             TNetworkAddress address = new TNetworkAddress(frontend.getHost(),
                     frontend.getRpcPort());
             FrontendService.Client client = null;


### PR DESCRIPTION
`show column cached stats` sometimes show wrong min/max value:
```
mysql> show column cached stats hive.tpch100.region;
+-------------+-------+------+----------+-----------+---------------+------+------+--------------+
| column_name | count | ndv  | num_null | data_size | avg_size_byte | min  | max  | updated_time |
+-------------+-------+------+----------+-----------+---------------+------+------+--------------+
| r_regionkey | 5.0   | 5.0  | 0.0      | 24.0      | 4.0           | N/A  | N/A  | null         |
| r_comment   | 5.0   | 5.0  | 0.0      | 396.0     | 66.0          | N/A  | N/A  | null         |
| r_name      | 5.0   | 5.0  | 0.0      | 40.8      | 6.8           | N/A  | N/A  | null         |
+-------------+-------+------+----------+-----------+---------------+------+------+--------------+
```
This pr is to fix this bug. It is because while transferring ColumnStatistic object to JSON, it doesn't contain the minExpr and maxExpr attribute. 

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

