### PR TITLE
[fix](json)Fix the bug that does not stop when reading json files

### DIFF
--- a/be/src/vec/exec/format/json/new_json_reader.cpp
+++ b/be/src/vec/exec/format/json/new_json_reader.cpp
@@ -1054,6 +1054,7 @@ Status NewJsonReader::_read_one_message(std::unique_ptr<uint8_t[]>* file_buf, si
         file_buf->reset(new uint8_t[file_size]);
         Slice result(file_buf->get(), file_size);
         RETURN_IF_ERROR(_file_reader->read_at(_current_offset, result, read_size, _io_ctx));
+        _current_offset += *read_size;
         break;
     }
     case TFileType::FILE_STREAM: {

--- a/regression-test/data/external_table_p0/tvf/test_hdfs_tvf.out
+++ b/regression-test/data/external_table_p0/tvf/test_hdfs_tvf.out
@@ -257,6 +257,43 @@
 8	chengdu	2345678
 9	xian	2345679
 
+-- !json_limit --
+1	beijing	2345671
+10	hefei	23456710
+11	\N	23456711
+12	hefei	\N
+2	shanghai	2345672
+3	guangzhou	2345673
+4	shenzhen	2345674
+5	hangzhou	2345675
+6	nanjing	2345676
+7	wuhan	2345677
+8	chengdu	2345678
+9	xian	2345679
+
+-- !json_limit --
+1	beijing	1454547
+10	hefei	2345676
+2	shanghai	1244264
+3	guangzhou	528369
+4	shenzhen	594201
+5	hangzhou	594201
+6	nanjing	2345672
+7	wuhan	2345673
+8	chengdu	2345674
+9	xian	2345675
+
+-- !json_limit --
+1	{"id": 1, "city": "beijing", "code": 2345671}
+2	{"id": 2, "city": "shanghai", "code": 2345672}
+3	{"id": 3, "city": "hangzhou", "code": 2345673}
+4	{"id": 4, "city": "shenzhen", "code": 2345674}
+5	{"id": 5, "city": "guangzhou", "code": 2345675}
+
+-- !json_limit --
+1	{"id": 1, "city": "beijing", "code": 2345671}
+2	{"id": 2, "city": "shanghai", "code": 2345672}
+
 -- !json_root --
 1	beijing	2345671
 2	shanghai	2345672

--- a/regression-test/data/external_table_p0/tvf/test_hdfs_tvf.out
+++ b/regression-test/data/external_table_p0/tvf/test_hdfs_tvf.out
@@ -257,7 +257,7 @@
 8	chengdu	2345678
 9	xian	2345679
 
--- !json_limit --
+-- !json_limit1 --
 1	beijing	2345671
 10	hefei	23456710
 11	\N	23456711
@@ -271,7 +271,7 @@
 8	chengdu	2345678
 9	xian	2345679
 
--- !json_limit --
+-- !json_limit2 --
 1	beijing	1454547
 10	hefei	2345676
 2	shanghai	1244264
@@ -283,14 +283,14 @@
 8	chengdu	2345674
 9	xian	2345675
 
--- !json_limit --
+-- !json_limit3 --
 1	{"id": 1, "city": "beijing", "code": 2345671}
 2	{"id": 2, "city": "shanghai", "code": 2345672}
 3	{"id": 3, "city": "hangzhou", "code": 2345673}
 4	{"id": 4, "city": "shenzhen", "code": 2345674}
 5	{"id": 5, "city": "guangzhou", "code": 2345675}
 
--- !json_limit --
+-- !json_limit4 --
 1	{"id": 1, "city": "beijing", "code": 2345671}
 2	{"id": 2, "city": "shanghai", "code": 2345672}
 

--- a/regression-test/suites/external_table_p0/tvf/test_hdfs_tvf.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_hdfs_tvf.groovy
@@ -132,6 +132,46 @@ suite("test_hdfs_tvf","external,hive,tvf,external_docker") {
                         "strip_outer_array" = "false",
                         "read_json_by_line" = "true") order by id; """
 
+
+           uri = "${defaultFS}" + "/user/doris/preinstalled_data/json_format_test/simple_object_json.json"
+            format = "json"
+            qt_json_limit """ select * from HDFS(
+                        "uri" = "${uri}",
+                        "fs.defaultFS"= "${defaultFS}",
+                        "hadoop.username" = "${hdfsUserName}",
+                        "format" = "${format}",
+                        "strip_outer_array" = "false",
+                        "read_json_by_line" = "true") order by id limit 100; """
+
+           uri = "${defaultFS}" + "/user/doris/preinstalled_data/json_format_test/one_array_json.json"
+            format = "json"
+            qt_json_limit """ select * from HDFS(
+                        "uri" = "${uri}",
+                        "fs.defaultFS"= "${defaultFS}",
+                        "hadoop.username" = "${hdfsUserName}",
+                        "format" = "${format}",
+                        "strip_outer_array" = "true",
+                        "read_json_by_line" = "false") order by id limit 100; """
+           uri = "${defaultFS}" + "/user/doris/preinstalled_data/json_format_test/nest_json.json"
+            format = "json"
+            qt_json_limit """ select * from HDFS(
+                        "uri" = "${uri}",
+                        "fs.defaultFS"= "${defaultFS}",
+                        "hadoop.username" = "${hdfsUserName}",
+                        "format" = "${format}",
+                        "strip_outer_array" = "false",
+                        "read_json_by_line" = "true") order by no  limit 100; """
+           uri = "${defaultFS}" + "/user/doris/preinstalled_data/json_format_test/nest_json.json"
+            format = "json"
+            qt_json_limit """ select * from HDFS(
+                        "uri" = "${uri}",
+                        "fs.defaultFS"= "${defaultFS}",
+                        "hadoop.username" = "${hdfsUserName}",
+                        "format" = "${format}",
+                        "strip_outer_array" = "false",
+                        "read_json_by_line" = "true") order by no limit 2; """
+
+
             // test json root
             uri = "${defaultFS}" + "/user/doris/preinstalled_data/json_format_test/nest_json.json"
             format = "json"

--- a/regression-test/suites/external_table_p0/tvf/test_hdfs_tvf.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_hdfs_tvf.groovy
@@ -135,7 +135,7 @@ suite("test_hdfs_tvf","external,hive,tvf,external_docker") {
 
            uri = "${defaultFS}" + "/user/doris/preinstalled_data/json_format_test/simple_object_json.json"
             format = "json"
-            qt_json_limit """ select * from HDFS(
+            qt_json_limit1 """ select * from HDFS(
                         "uri" = "${uri}",
                         "fs.defaultFS"= "${defaultFS}",
                         "hadoop.username" = "${hdfsUserName}",
@@ -145,7 +145,7 @@ suite("test_hdfs_tvf","external,hive,tvf,external_docker") {
 
            uri = "${defaultFS}" + "/user/doris/preinstalled_data/json_format_test/one_array_json.json"
             format = "json"
-            qt_json_limit """ select * from HDFS(
+            qt_json_limit2 """ select * from HDFS(
                         "uri" = "${uri}",
                         "fs.defaultFS"= "${defaultFS}",
                         "hadoop.username" = "${hdfsUserName}",
@@ -154,7 +154,7 @@ suite("test_hdfs_tvf","external,hive,tvf,external_docker") {
                         "read_json_by_line" = "false") order by id limit 100; """
            uri = "${defaultFS}" + "/user/doris/preinstalled_data/json_format_test/nest_json.json"
             format = "json"
-            qt_json_limit """ select * from HDFS(
+            qt_json_limit3 """ select * from HDFS(
                         "uri" = "${uri}",
                         "fs.defaultFS"= "${defaultFS}",
                         "hadoop.username" = "${hdfsUserName}",
@@ -163,7 +163,7 @@ suite("test_hdfs_tvf","external,hive,tvf,external_docker") {
                         "read_json_by_line" = "true") order by no  limit 100; """
            uri = "${defaultFS}" + "/user/doris/preinstalled_data/json_format_test/nest_json.json"
             format = "json"
-            qt_json_limit """ select * from HDFS(
+            qt_json_limit4 """ select * from HDFS(
                         "uri" = "${uri}",
                         "fs.defaultFS"= "${defaultFS}",
                         "hadoop.username" = "${hdfsUserName}",


### PR DESCRIPTION
## Proposed changes
one_array_json.json ：  This file has only 10 lines . 
before : 
```mysql
select * from HDFS(                             
"uri" = "hdfs://127.0.0.1:8120/user/doris/preinstalled_data/json_format_test/one_array_json.json",  
 "fs.defaultFS"= "hdfs://127.0.0.1:8120",                             
"hadoop.username" = "doris",                            
 "format" = "json",                            
 "strip_outer_array" = "true",                             
 "read_json_by_line" = "false" ) limit 13;
+------+-----------+---------+
| id   | city      | code    |
+------+-----------+---------+
| 1    | beijing   | 1454547 |
| 2    | shanghai  | 1244264 |
| 3    | guangzhou | 528369  |
| 4    | shenzhen  | 594201  |
| 5    | hangzhou  | 594201  |
| 6    | nanjing   | 2345672 |
| 7    | wuhan     | 2345673 |
| 8    | chengdu   | 2345674 |
| 9    | xian      | 2345675 |
| 10   | hefei     | 2345676 |
| 1    | beijing   | 1454547 |
| 2    | shanghai  | 1244264 |
| 3    | guangzhou | 528369  |
+------+-----------+---------+
13 rows in set (0.13 sec)
```
when you `select * from ...  `  , read json file will not stop 

 



after : 

```mysql
select * from HDFS(                             
"uri" = "hdfs://127.0.0.1:8120/user/doris/preinstalled_data/json_format_test/one_array_json.json",                             "fs.defaultFS"= "hdfs://127.0.0.1:8120",                             
"hadoop.username" = "doris",                             
"format" = "json",                             
"strip_outer_array" = "true",                              
"read_json_by_line" = "false" ) limit 21;
+------+-----------+---------+
| id   | city      | code    |
+------+-----------+---------+
| 1    | beijing   | 1454547 |
| 2    | shanghai  | 1244264 |
| 3    | guangzhou | 528369  |
| 4    | shenzhen  | 594201  |
| 5    | hangzhou  | 594201  |
| 6    | nanjing   | 2345672 |
| 7    | wuhan     | 2345673 |
| 8    | chengdu   | 2345674 |
| 9    | xian      | 2345675 |
| 10   | hefei     | 2345676 |
+------+-----------+---------+
10 rows in set (0.03 sec)


```


Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

