### PR TITLE
[fix](Nereids): PushdownDistinctThroughJoin don't push distinct for relation

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushdownDistinctThroughJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PushdownDistinctThroughJoin.java
@@ -19,11 +19,13 @@ package org.apache.doris.nereids.rules.rewrite;
 
 import org.apache.doris.nereids.jobs.JobContext;
 import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.algebra.Relation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.nereids.trees.plans.visitor.CustomRewriter;
 import org.apache.doris.nereids.trees.plans.visitor.DefaultPlanRewriter;
+import org.apache.doris.nereids.util.PlanUtils;
 
 import com.google.common.collect.ImmutableList;
 
@@ -80,6 +82,9 @@ public class PushdownDistinctThroughJoin extends DefaultPlanRewriter<JobContext>
     }
 
     private Plan withDistinct(Plan plan) {
+        if (PlanUtils.skipProjectFilterLimit(plan) instanceof Relation) {
+            return plan;
+        }
         return new LogicalAggregate<>(ImmutableList.copyOf(plan.getOutput()), true, true, plan);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/PlanUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/PlanUtils.java
@@ -24,6 +24,7 @@ import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
+import org.apache.doris.nereids.trees.plans.logical.LogicalLimit;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 
 import com.google.common.collect.ImmutableList;
@@ -95,5 +96,13 @@ public class PlanUtils {
                 return getAlias == null ? expr : getAlias;
             }
         }).collect(ImmutableList.toImmutableList());
+    }
+
+    public static Plan skipProjectFilterLimit(Plan plan) {
+        if (plan instanceof LogicalProject && ((LogicalProject<?>) plan).isAllSlots()
+                || plan instanceof LogicalFilter || plan instanceof LogicalLimit) {
+            return plan.child(0);
+        }
+        return plan;
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushdownDistinctThroughJoinTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PushdownDistinctThroughJoinTest.java
@@ -51,7 +51,7 @@ class PushdownDistinctThroughJoinTest implements MemoPatternMatchSupported {
                         logicalAggregate(
                                 logicalJoin(
                                         logicalAggregate(logicalJoin()),
-                                        logicalAggregate(logicalOlapScan())
+                                        logicalOlapScan()
                                 )
                         )
                 )
@@ -75,7 +75,7 @@ class PushdownDistinctThroughJoinTest implements MemoPatternMatchSupported {
                         logicalAggregate(
                                 logicalJoin(
                                         logicalAggregate(logicalProject(logicalJoin())),
-                                        logicalAggregate(logicalOlapScan())
+                                        logicalOlapScan()
                                 )
                         )
                 )


### PR DESCRIPTION
## Proposed changes

when pushdown distinct, we don't push for Relation

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

