### PR TITLE
[fix](be) fix the crash when there is no tzfile in docker env

### DIFF
--- a/be/src/util/timezone_utils.cpp
+++ b/be/src/util/timezone_utils.cpp
@@ -54,6 +54,11 @@ void TimezoneUtils::load_timezone_names() {
     path += tzdir;
     path += '/';
 
+    if (!std::filesystem::exists(path)) {
+        LOG_WARNING("Cannot find system tzfile. Abandon to preload timezone name cache.");
+        return;
+    }
+
     auto path_prefix_len = path.size();
     for (auto const& dir_entry : std::filesystem::recursive_directory_iterator {path}) {
         if (dir_entry.is_regular_file()) {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

core stack:
```
I0822 07:30:44.917544  2932 daemon.cpp:438] Physical Memory: 7.67 GB
Memory Limt: 6.13 GB
CGroup Info: Process CGroup Info: memory.limit_in_bytes=[NOT_FOUND]Could not find subsystem memory in /proc/self/cgroup, cpu cfs limits: [NOT_FOUND]Could not find subsystem cpuacct in /proc/self/cgroup
I0822 07:30:44.918236  2932 backend_options.cpp:87] local host ip=172.17.0.3
terminate called after throwing an instance of 'std::filesystem::__cxx11::filesystem_error'
  what():  filesystem error: recursive directory iterator cannot open directory: No such file or directory [/usr/share/zoneinfo/]
Query id: 0-0 ***
Aborted at 1692689444 (unix time) try "date -d @1692689444" if you are using GNU date ***
Current BE git commitID: fcfa7762c5 ***
SIGABRT unknown detail explain (@0xb74) received by PID 2932 (TID 2932 OR 0xffff94c04040) from PID 2932; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/yunyou/doris/be/src/common/signal_handler.h:413
 1# 0x0000FFFF94EC6790 in linux-vdso.so.1
 2# raise in /lib/aarch64-linux-gnu/libc.so.6
 3# abort in /lib/aarch64-linux-gnu/libc.so.6
 4# _gnu_cxx::_verbose_terminate_handler() in /doris/apache-doris-2.0.0-bin-arm64/be/lib/doris_be
 5# _cxxabiv1::_terminate(void ()) in /doris/apache-doris-2.0.0-bin-arm64/be/lib/doris_be
 6# _cxxabiv1::_unexpected(void ()) in /doris/apache-doris-2.0.0-bin-arm64/be/lib/doris_be
 7# 0x0000AAAAD2AD6D34 in /doris/apache-doris-2.0.0-bin-arm64/be/lib/doris_be
 8# std::filesystem::_cxx11::recursive_directory_iterator::recursive_directory_iterator(std::filesystem::_cxx11::path const&, std::filesystem::directory_options, std::error_code*) in /doris/apache-doris-2.0.0-bin-arm64/be/lib/doris_be
 9# doris::TimezoneUtils::load_timezone_names() at /root/yunyou/doris/be/src/util/timezone_utils.cpp:58
10# doris::ExecEnv::_init(std::vector<doris::StorePath, std::allocator<doris::StorePath> > const&) at /root/yunyou/doris/be/src/runtime/exec_env_init.cpp:123
11# doris::ExecEnv::init(doris::ExecEnv*, std::vector<doris::StorePath, std::allocator<doris::StorePath> > const&) at /root/yunyou/doris/be/src/runtime/exec_env_init.cpp:100
12# main at /root/yunyou/doris/be/src/service/doris_main.cpp:434
13# __libc_start_main in /lib/aarch64-linux-gnu/libc.so.6
14# 0x0000AAAAC9724034 in /doris/apache-doris-2.0.0-bin-arm64/be/lib/doris_be
./be/bin/start_be.sh: line 325:  2932 Aborted                 ${LIMIT:+${LIMIT}} "${DORIS_HOME}/lib/doris_be" "$@" 2>&1 < /dev/null
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

