### PR TITLE
[fix](merge-on-write) add sentinel mark when do compaction

### DIFF
--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -658,11 +658,9 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
                     _tablet->calc_compaction_output_rowset_delete_bitmap(
                             _input_rowsets, _rowid_conversion, 0, UINT64_MAX, &missed_rows,
                             &location_map, *it.delete_bitmap.get(), &output_delete_bitmap);
-                    if (config::enable_merge_on_write_correctness_check &&
-                        !output_delete_bitmap.empty()) {
+                    if (config::enable_merge_on_write_correctness_check) {
                         RowsetIdUnorderedSet rowsetids;
-                        rowsetids.insert(
-                                std::get<0>(output_delete_bitmap.delete_bitmap.begin()->first));
+                        rowsetids.insert(_output_rowset->rowset_id());
                         _tablet->add_sentinel_mark_to_delete_bitmap(&output_rowset_delete_bitmap,
                                                                     rowsetids);
                     }

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -464,7 +464,7 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
     CHECK(use_default_or_null_flag.size() == num_rows);
 
     if (config::enable_merge_on_write_correctness_check) {
-        _tablet->add_sentinel_mark_to_delete_bitmap(_mow_context->delete_bitmap,
+        _tablet->add_sentinel_mark_to_delete_bitmap(_mow_context->delete_bitmap.get(),
                                                     _mow_context->rowset_ids);
     }
 

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2993,7 +2993,7 @@ Status Tablet::calc_segment_delete_bitmap(RowsetSharedPtr rowset,
                       << "[add_sentinel_mark_to_delete_bitmap][end_version:" << end_version << "]"
                       << "add:" << rowset->rowset_id();
         }
-        add_sentinel_mark_to_delete_bitmap(delete_bitmap, rowsetids);
+        add_sentinel_mark_to_delete_bitmap(delete_bitmap.get(), rowsetids);
     }
 
     if (pos > 0) {
@@ -3403,6 +3403,11 @@ void Tablet::calc_compaction_output_rowset_delete_bitmap(
             }
         }
     }
+    if (dst.rowset_id != RowsetId {}) {
+        RowsetIdUnorderedSet rowsetids;
+        rowsetids.insert(dst.rowset_id);
+        add_sentinel_mark_to_delete_bitmap(output_rowset_delete_bitmap, rowsetids);
+    }
 }
 
 void Tablet::merge_delete_bitmap(const DeleteBitmap& delete_bitmap) {
@@ -3684,7 +3689,7 @@ Status Tablet::calc_delete_bitmap_between_segments(
     return Status::OK();
 }
 
-void Tablet::add_sentinel_mark_to_delete_bitmap(DeleteBitmapPtr delete_bitmap,
+void Tablet::add_sentinel_mark_to_delete_bitmap(DeleteBitmap* delete_bitmap,
                                                 const RowsetIdUnorderedSet& rowsetids) {
     for (const auto& rowsetid : rowsetids) {
         delete_bitmap->add({rowsetid, DeleteBitmap::INVALID_SEGMENT_ID, 0},

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -3403,11 +3403,6 @@ void Tablet::calc_compaction_output_rowset_delete_bitmap(
             }
         }
     }
-    if (config::enable_merge_on_write_correctness_check && dst.rowset_id != RowsetId {}) {
-        RowsetIdUnorderedSet rowsetids;
-        rowsetids.insert(dst.rowset_id);
-        add_sentinel_mark_to_delete_bitmap(output_rowset_delete_bitmap, rowsetids);
-    }
 }
 
 void Tablet::merge_delete_bitmap(const DeleteBitmap& delete_bitmap) {

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -3403,7 +3403,7 @@ void Tablet::calc_compaction_output_rowset_delete_bitmap(
             }
         }
     }
-    if (dst.rowset_id != RowsetId {}) {
+    if (config::enable_merge_on_write_correctness_check && dst.rowset_id != RowsetId {}) {
         RowsetIdUnorderedSet rowsetids;
         rowsetids.insert(dst.rowset_id);
         add_sentinel_mark_to_delete_bitmap(output_rowset_delete_bitmap, rowsetids);

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -549,7 +549,7 @@ public:
     int64_t binlog_max_bytes() const { return _tablet_meta->binlog_config().max_bytes(); }
 
     void set_binlog_config(BinlogConfig binlog_config);
-    void add_sentinel_mark_to_delete_bitmap(DeleteBitmapPtr delete_bitmap,
+    void add_sentinel_mark_to_delete_bitmap(DeleteBitmap* delete_bitmap,
                                             const RowsetIdUnorderedSet& rowsetids);
 
 private:


### PR DESCRIPTION
## Proposed changes

`Tablet::calc_compaction_output_rowset_delete_bitmap` may introduce new rowset and we should also add sentinel mark In delete bitmap

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

