### PR TITLE
[fix](jdbc catalog) fix adaptation to Oracle special character `/` table names

### DIFF
--- a/docker/thirdparties/docker-compose/oracle/init/03-create-table.sql
+++ b/docker/thirdparties/docker-compose/oracle/init/03-create-table.sql
@@ -112,3 +112,15 @@ create table doris_test.test_clob (
   id number(11) not null primary key,
   num1 clob
 );
+
+create table doris_test."AA/D" (
+     id number(5),
+     name varchar2(20),
+     age number(2),
+     score number(3,1)
+);
+
+create table doris_test.aaad (
+     id number(5),
+     name varchar2(20)
+);

--- a/docker/thirdparties/docker-compose/oracle/init/04-insert.sql
+++ b/docker/thirdparties/docker-compose/oracle/init/04-insert.sql
@@ -77,4 +77,7 @@ insert into doris_test.test_number4 values (1, 12345678);
 insert into doris_test.test_number4 values (2, 123456789012);
 insert into doris_test.test_clob values (10086, 'yidong');
 insert into doris_test.test_clob values (10010, 'liantong');
+
+insert into doris_test."AA/D" values (1, 'alice', 20, 99.5);
+insert into doris_test.aaad values (1, 'alice');
 commit;

--- a/docs/en/docs/lakehouse/multi-catalog/jdbc.md
+++ b/docs/en/docs/lakehouse/multi-catalog/jdbc.md
@@ -284,6 +284,8 @@ As for data mapping from Oracle to Doris, one Database in Doris corresponds to o
 | Database |   User   |
 |  Table   |  Table   |
 
+**NOTE:** Synchronizing Oracle's SYNONYM TABLE is not currently supported.
+
 #### Type Mapping
 
 | ORACLE Type                       | Doris Type                           | Comment                                                                                                                                                                       |

--- a/docs/zh-CN/docs/lakehouse/multi-catalog/jdbc.md
+++ b/docs/zh-CN/docs/lakehouse/multi-catalog/jdbc.md
@@ -284,6 +284,8 @@ CREATE CATALOG jdbc_oracle PROPERTIES (
 | Database |   User   |
 |  Table   |  Table   |
 
+**注意：** 当前不支持同步 Oracle 的 SYNONYM TABLE
+
 #### 类型映射
 
 | ORACLE Type                       | Doris Type                           | Comment                                                                                                                                         |

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcClient.java
@@ -229,13 +229,18 @@ public abstract class JdbcClient {
      * get all tables of one database
      */
     public List<String> getTablesNameList(String dbName) {
+        String currentDbName = dbName;
         List<String> tablesName = Lists.newArrayList();
         String[] tableTypes = getTableTypes();
         if (isLowerCaseTableNames) {
-            dbName = lowerDBToRealDB.get(dbName);
+            currentDbName = lowerDBToRealDB.get(dbName);
+            if (currentDbName == null) {
+                getDatabaseNameList();
+                currentDbName = lowerDBToRealDB.get(dbName);
+            }
         }
-        String finalDbName = dbName;
-        processTable(dbName, null, tableTypes, (rs) -> {
+        String finalDbName = currentDbName;
+        processTable(finalDbName, null, tableTypes, (rs) -> {
             try {
                 while (rs.next()) {
                     String tableName = rs.getString("TABLE_NAME");
@@ -253,15 +258,25 @@ public abstract class JdbcClient {
     }
 
     public boolean isTableExist(String dbName, String tableName) {
+        String currentDbName = dbName;
+        String currentTableName = tableName;
         final boolean[] isExist = {false};
         if (isLowerCaseTableNames) {
-            dbName = lowerDBToRealDB.get(dbName);
-            tableName = lowerTableToRealTable.get(tableName);
+            currentDbName = lowerDBToRealDB.get(dbName);
+            currentTableName = lowerTableToRealTable.get(tableName);
+            if (currentDbName == null) {
+                getDatabaseNameList();
+                currentDbName  = lowerDBToRealDB.get(dbName);
+            }
+            if (currentTableName == null) {
+                getTablesNameList(dbName);
+                currentTableName = lowerTableToRealTable.get(tableName);
+            }
         }
         String[] tableTypes = getTableTypes();
-        String finalTableName = tableName;
-        String finalDbName = dbName;
-        processTable(dbName, tableName, tableTypes, (rs) -> {
+        String finalTableName = currentTableName;
+        String finalDbName = currentDbName;
+        processTable(finalDbName, finalTableName, tableTypes, (rs) -> {
             try {
                 if (rs.next()) {
                     isExist[0] = true;
@@ -283,19 +298,27 @@ public abstract class JdbcClient {
         List<JdbcFieldSchema> tableSchema = Lists.newArrayList();
         // if isLowerCaseTableNames == true, tableName is lower case
         // but databaseMetaData.getColumns() is case sensitive
+        String currentDbName = dbName;
+        String currentTableName = tableName;
         if (isLowerCaseTableNames) {
-            dbName = lowerDBToRealDB.get(dbName);
-            tableName = lowerTableToRealTable.get(tableName);
+            currentDbName = lowerDBToRealDB.get(dbName);
+            currentTableName = lowerTableToRealTable.get(tableName);
+            if (currentDbName == null) {
+                getDatabaseNameList();
+                currentDbName  = lowerDBToRealDB.get(dbName);
+            }
+            if (currentTableName == null) {
+                getTablesNameList(dbName);
+                currentTableName = lowerTableToRealTable.get(tableName);
+            }
         }
+        String finalDbName = currentDbName;
+        String finalTableName = currentTableName;
         try {
             DatabaseMetaData databaseMetaData = conn.getMetaData();
             String catalogName = getCatalogName(conn);
-            tableName = modifyTableNameIfNecessary(tableName);
-            rs = getColumns(databaseMetaData, catalogName, dbName, tableName);
+            rs = getColumns(databaseMetaData, catalogName, finalDbName, finalTableName);
             while (rs.next()) {
-                if (isTableModified(tableName, rs.getString("TABLE_NAME"))) {
-                    continue;
-                }
                 JdbcFieldSchema field = new JdbcFieldSchema();
                 field.setColumnName(rs.getString("COLUMN_NAME"));
                 field.setDataType(rs.getInt("DATA_TYPE"));
@@ -320,7 +343,7 @@ public abstract class JdbcClient {
                 tableSchema.add(field);
             }
         } catch (SQLException e) {
-            throw new JdbcClientException("failed to get table name list from jdbc for table %s:%s", e, tableName,
+            throw new JdbcClientException("failed to get table name list from jdbc for table %s:%s", e, finalTableName,
                     Util.getRootCauseMessage(e));
         } finally {
             close(rs, conn);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcMySQLClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcMySQLClient.java
@@ -139,15 +139,11 @@ public class JdbcMySQLClient extends JdbcClient {
         try {
             DatabaseMetaData databaseMetaData = conn.getMetaData();
             String catalogName = getCatalogName(conn);
-            tableName = modifyTableNameIfNecessary(tableName);
             rs = getColumns(databaseMetaData, catalogName, dbName, tableName);
             List<String> primaryKeys = getPrimaryKeys(databaseMetaData, catalogName, dbName, tableName);
             boolean needGetDorisColumns = true;
             Map<String, String> mapFieldtoType = null;
             while (rs.next()) {
-                if (isTableModified(tableName, rs.getString("TABLE_NAME"))) {
-                    continue;
-                }
                 JdbcFieldSchema field = new JdbcFieldSchema();
                 field.setColumnName(rs.getString("COLUMN_NAME"));
                 field.setDataType(rs.getInt("DATA_TYPE"));

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcOracleClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcOracleClient.java
@@ -19,6 +19,15 @@ package org.apache.doris.datasource.jdbc.client;
 
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
+import org.apache.doris.common.util.Util;
+
+import com.google.common.collect.Lists;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
 
 public class JdbcOracleClient extends JdbcClient {
 
@@ -29,6 +38,125 @@ public class JdbcOracleClient extends JdbcClient {
     @Override
     protected String getDatabaseQuery() {
         return "SELECT DISTINCT OWNER FROM all_tables";
+    }
+
+    @Override
+    protected String getCatalogName(Connection conn) throws SQLException {
+        return conn.getCatalog();
+    }
+
+    @Override
+    public List<String> getDatabaseNameList() {
+        Connection conn = getConnection();
+        ResultSet rs = null;
+        if (isOnlySpecifiedDatabase && includeDatabaseMap.isEmpty() && excludeDatabaseMap.isEmpty()) {
+            return getSpecifiedDatabase(conn);
+        }
+        List<String> databaseNames = Lists.newArrayList();
+        try {
+            rs = conn.getMetaData().getSchemas(conn.getCatalog(), null);
+            List<String> tempDatabaseNames = Lists.newArrayList();
+            while (rs.next()) {
+                String databaseName = rs.getString("TABLE_SCHEM");
+                if (isLowerCaseTableNames) {
+                    lowerDBToRealDB.put(databaseName.toLowerCase(), databaseName);
+                    databaseName = databaseName.toLowerCase();
+                }
+                tempDatabaseNames.add(databaseName);
+            }
+            if (isOnlySpecifiedDatabase) {
+                for (String db : tempDatabaseNames) {
+                    // Exclude database map take effect with higher priority over include database map
+                    if (!excludeDatabaseMap.isEmpty() && excludeDatabaseMap.containsKey(db)) {
+                        continue;
+                    }
+                    if (!includeDatabaseMap.isEmpty() && !includeDatabaseMap.containsKey(db)) {
+                        continue;
+                    }
+                    databaseNames.add(db);
+                }
+            } else {
+                databaseNames = tempDatabaseNames;
+            }
+        } catch (SQLException e) {
+            throw new JdbcClientException("failed to get database name list from jdbc", e);
+        } finally {
+            close(rs, conn);
+        }
+        return databaseNames;
+    }
+
+    @Override
+    public List<JdbcFieldSchema> getJdbcColumnsInfo(String dbName, String tableName) {
+        Connection conn = getConnection();
+        ResultSet rs = null;
+        List<JdbcFieldSchema> tableSchema = Lists.newArrayList();
+        String currentDbName = dbName;
+        String currentTableName = tableName;
+        if (isLowerCaseTableNames) {
+            currentDbName = lowerDBToRealDB.get(dbName);
+            currentTableName = lowerTableToRealTable.get(tableName);
+            if (currentDbName == null) {
+                getDatabaseNameList();
+                currentDbName  = lowerDBToRealDB.get(dbName);
+            }
+            if (currentTableName == null) {
+                getTablesNameList(dbName);
+                currentTableName = lowerTableToRealTable.get(tableName);
+            }
+        }
+        String finalDbName = currentDbName;
+        String finalTableName = currentTableName;
+        try {
+            DatabaseMetaData databaseMetaData = conn.getMetaData();
+            String catalogName = getCatalogName(conn);
+            String modifiedTableName;
+            boolean isModify = false;
+            if (finalTableName.contains("/")) {
+                modifiedTableName = modifyTableNameIfNecessary(finalTableName);
+                isModify = !modifiedTableName.equals(finalTableName);
+                if (isModify) {
+                    rs = getColumns(databaseMetaData, catalogName, finalDbName, modifiedTableName);
+                } else {
+                    rs = getColumns(databaseMetaData, catalogName, finalDbName, finalTableName);
+                }
+            } else {
+                rs = getColumns(databaseMetaData, catalogName, finalDbName, finalTableName);
+            }
+            while (rs.next()) {
+                if (isModify && isTableModified(rs.getString("TABLE_NAME"), finalTableName)) {
+                    continue;
+                }
+                JdbcFieldSchema field = new JdbcFieldSchema();
+                field.setColumnName(rs.getString("COLUMN_NAME"));
+                field.setDataType(rs.getInt("DATA_TYPE"));
+                field.setDataTypeName(rs.getString("TYPE_NAME"));
+                /*
+                   We used this method to retrieve the key column of the JDBC table, but since we only tested mysql,
+                   we kept the default key behavior in the parent class and only overwrite it in the mysql subclass
+                */
+                field.setKey(true);
+                field.setColumnSize(rs.getInt("COLUMN_SIZE"));
+                field.setDecimalDigits(rs.getInt("DECIMAL_DIGITS"));
+                field.setNumPrecRadix(rs.getInt("NUM_PREC_RADIX"));
+                /*
+                   Whether it is allowed to be NULL
+                   0 (columnNoNulls)
+                   1 (columnNullable)
+                   2 (columnNullableUnknown)
+                 */
+                field.setAllowNull(rs.getInt("NULLABLE") != 0);
+                field.setRemarks(rs.getString("REMARKS"));
+                field.setCharOctetLength(rs.getInt("CHAR_OCTET_LENGTH"));
+                tableSchema.add(field);
+            }
+        } catch (SQLException e) {
+            throw new JdbcClientException("failed to get table name list from jdbc for table %s:%s", e, finalTableName,
+                Util.getRootCauseMessage(e));
+        } finally {
+            close(rs, conn);
+        }
+        return tableSchema;
     }
 
     @Override

--- a/regression-test/data/external_table_p0/jdbc/test_oracle_jdbc_catalog.out
+++ b/regression-test/data/external_table_p0/jdbc/test_oracle_jdbc_catalog.out
@@ -114,3 +114,9 @@ DORIS_TEST
 10010	liantong
 10086	yidong
 
+-- !query_ad1 --
+1	alice	20	99.5
+
+-- !query_ad2 --
+1	alice
+

--- a/regression-test/suites/external_table_p0/jdbc/test_oracle_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_oracle_jdbc_catalog.groovy
@@ -156,5 +156,19 @@ suite("test_oracle_jdbc_catalog", "p0,external,oracle,external_docker,external_d
         sql """ switch ${catalog_name} """
         qt_query_clob """ select * from doris_test.test_clob order by id; """
 
+        // test for `AA/D`
+        sql """create catalog if not exists ${catalog_name} properties(
+                    "type"="jdbc",
+                    "user"="doris_test",
+                    "password"="123456",
+                    "jdbc_url" = "jdbc:oracle:thin:@${externalEnvIp}:${oracle_port}:${SID}",
+                    "driver_url" = "${driver_url}",
+                    "driver_class" = "oracle.jdbc.driver.OracleDriver",
+                    "lower_case_table_names" = "true"
+        );"""
+        sql """ switch ${catalog_name} """
+        qt_query_ad1 """ select * from doris_test.`aa/d` order by id; """
+        qt_query_ad2 """ select * from doris_test.aaad order by id; """
+
     }
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

The changes of this PR for JdbcOracleClient are as follows:

#### bug fixes:
  1. Fix the problem that if there is an approximate table name for Schema synchronization with a table name with `/` characters, the synchronization Column will be confused
  2. Fix the NPE problem of metadata synchronization after enabling lower_case_table_names configuration

#### improvement:
  1. Modify the method of synchronizing Oracle User to Doris Database mapping, use `metadata.getSchemas` instead of `SELECT DISTINCT OWNER FROM all_tables`
  2. When synchronizing metadata, change `null` at the catalog level to `conn.getcatalog`

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

