### PR TITLE
[bugfix](segment cache) Recycle the fds when drop table

### DIFF
--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -175,6 +175,8 @@ Status BetaRowset::remove() {
     VLOG_NOTICE << "begin to remove files in rowset " << unique_id()
                 << ", version:" << start_version() << "-" << end_version()
                 << ", tabletid:" << _rowset_meta->tablet_id();
+    // If the rowset was removed, it need to remove the fds in segment cache directly
+    SegmentLoader::instance()->erase_segments(SegmentCache::CacheKey(rowset_id()));
     auto fs = _rowset_meta->fs();
     if (!fs) {
         return Status::Error<INIT_FAILED>("get fs failed");

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -665,8 +665,6 @@ void Tablet::_delete_stale_rowset_by_version(const Version& version) {
         return;
     }
     _tablet_meta->delete_stale_rs_meta_by_version(version);
-    // If the stale rowset was deleted, it need to remove the fds directly
-    SegmentLoader::instance()->erase_segments(SegmentCache::CacheKey(rowset_meta->rowset_id()));
     VLOG_NOTICE << "delete stale rowset. tablet=" << full_name() << ", version=" << version;
 }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
When drop table directly, the rowsets will not be removed or change to unused stat so that the fds in schema cache cannot be recycled. When the data files in trash are recycled, the fds will leak. So when drop table, we should close the fds directly too.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

