### PR TITLE
[enhancement](Nereids): remove override child(int index)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/pattern/GroupExpressionMatching.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/pattern/GroupExpressionMatching.java
@@ -161,7 +161,8 @@ public class GroupExpressionMatching implements Iterable<Plan> {
 
             // assemble all combination of plan tree by current root plan and children plan
             while (offset < childrenPlans.size()) {
-                ImmutableList.Builder<Plan> childrenBuilder = ImmutableList.builder();
+                ImmutableList.Builder<Plan> childrenBuilder =
+                        ImmutableList.builderWithExpectedSize(childrenPlans.size());
                 for (int i = 0; i < childrenPlans.size(); i++) {
                     childrenBuilder.add(childrenPlans.get(i).get(childrenPlanIndex[i]));
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
@@ -466,7 +466,7 @@ public class RuntimeFilterGenerator extends PlanPostProcessor {
             Map<EqualTo, PhysicalHashJoin> equalCondToJoinMap = entry.getValue();
             for (Map.Entry<EqualTo, PhysicalHashJoin> innerEntry : equalCondToJoinMap.entrySet()) {
                 EqualTo equalTo = innerEntry.getKey();
-                PhysicalHashJoin join = innerEntry.getValue();
+                PhysicalHashJoin<? extends Plan, ? extends Plan> join = innerEntry.getValue();
                 Preconditions.checkState(join != null);
                 TRuntimeFilterType type = TRuntimeFilterType.IN_OR_BLOOM;
                 if (ctx.getSessionVariable().getEnablePipelineEngine()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/MergeProjects.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/MergeProjects.java
@@ -49,7 +49,7 @@ public class MergeProjects extends OneRewriteRuleFactory {
     }
 
     public static Plan mergeProjects(LogicalProject project) {
-        LogicalProject childProject = (LogicalProject) project.child();
+        LogicalProject<? extends Plan> childProject = (LogicalProject) project.child();
         List<NamedExpression> projectExpressions = project.mergeProjections(childProject);
         LogicalProject newProject = childProject.canEliminate() ? project : childProject;
         return newProject.withProjectsAndChild(projectExpressions, childProject.child(0));

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ReplaceLimitNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/ReplaceLimitNode.java
@@ -51,9 +51,9 @@ public class ReplaceLimitNode implements RewriteRuleFactory {
                 //limit->proj->sort ==> proj->topN
                 logicalLimit(logicalProject(logicalSort()))
                         .then(limit -> {
-                            LogicalProject project = limit.child();
-                            LogicalSort sort = limit.child().child();
-                            LogicalTopN topN = new LogicalTopN(sort.getOrderKeys(),
+                            LogicalProject<LogicalSort<Plan>> project = limit.child();
+                            LogicalSort<Plan> sort = limit.child().child();
+                            LogicalTopN<Plan> topN = new LogicalTopN<>(sort.getOrderKeys(),
                                     limit.getLimit(),
                                     limit.getOffset(),
                                     sort.child(0));

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/AbstractPlan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/AbstractPlan.java
@@ -155,12 +155,8 @@ public abstract class AbstractPlan extends AbstractTreeNode<Plan> implements Pla
     }
 
     @Override
-    public Plan child(int index) {
-        return super.child(index);
-    }
-
-    @Override
     public LogicalProperties getLogicalProperties() {
+        // TODO: use bound()?
         if (this instanceof Unbound) {
             return UnboundLogicalProperties.INSTANCE;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalProject.java
@@ -157,9 +157,8 @@ public class LogicalProject<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_
                 && canEliminate == that.canEliminate
                 && isDistinct == that.isDistinct;
         // TODO: should add exprId for UnBoundStar and BoundStar for equality comparasion
-        if (!projects.isEmpty() && (projects.get(0) instanceof UnboundStar || projects.get(0) instanceof BoundStar)
-                && (child().getClass() == that.child().getClass())) {
-            equal = Objects.equals(child(), that.child());
+        if (!projects.isEmpty() && (projects.get(0) instanceof UnboundStar || projects.get(0) instanceof BoundStar)) {
+            equal = child().equals(that.child());
         }
         return equal;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalProject.java
@@ -157,8 +157,9 @@ public class LogicalProject<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_
                 && canEliminate == that.canEliminate
                 && isDistinct == that.isDistinct;
         // TODO: should add exprId for UnBoundStar and BoundStar for equality comparasion
-        if (!projects.isEmpty() && (projects.get(0) instanceof UnboundStar || projects.get(0) instanceof BoundStar)) {
-            equal = child().equals(that.child());
+        if (!projects.isEmpty() && (projects.get(0) instanceof UnboundStar || projects.get(0) instanceof BoundStar)
+                && (child().getClass() == that.child().getClass())) {
+            equal = Objects.equals(child(), that.child());
         }
         return equal;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/visitor/DefaultPlanRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/visitor/DefaultPlanRewriter.java
@@ -21,8 +21,7 @@ import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalOlapScan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalStorageLayerAggregate;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Default implementation for plan rewriting, delegating to child plans and rewrite current root
@@ -45,8 +44,8 @@ public abstract class DefaultPlanRewriter<C> extends PlanVisitor<Plan, C> {
     }
 
     /** visitChildren */
-    public static final <P extends Plan, C> P visitChildren(DefaultPlanRewriter<C> rewriter, P plan, C context) {
-        List<Plan> newChildren = new ArrayList<>();
+    public static <P extends Plan, C> P visitChildren(DefaultPlanRewriter<C> rewriter, P plan, C context) {
+        ImmutableList.Builder<Plan> newChildren = ImmutableList.builderWithExpectedSize(plan.arity());
         boolean hasNewChildren = false;
         for (Plan child : plan.children()) {
             Plan newChild = child.accept(rewriter, context);
@@ -55,6 +54,6 @@ public abstract class DefaultPlanRewriter<C> extends PlanVisitor<Plan, C> {
             }
             newChildren.add(newChild);
         }
-        return hasNewChildren ? (P) plan.withChildren(newChildren) : plan;
+        return hasNewChildren ? (P) plan.withChildren(newChildren.build()) : plan;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
@@ -61,6 +61,7 @@ public class Statistics {
     public Statistics(Statistics another) {
         this.rowCount = another.rowCount;
         this.expressionToColumnStats = new HashMap<>(another.expressionToColumnStats);
+        this.tupleSize = another.tupleSize;
         this.width = another.width;
         this.penalty = another.penalty;
     }


### PR DESCRIPTION
## Proposed changes

method `child(int index)` use code `super.child(index)` will cause Pointer jump twice.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

