### PR TITLE
[fix](Nereids): LogicalSink equals() shouldn't invoke super.equals()

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSink.java
@@ -72,9 +72,6 @@ public abstract class LogicalSink<CHILD_TYPE extends Plan> extends LogicalUnary<
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        if (!super.equals(o)) {
-            return false;
-        }
         LogicalSink<?> that = (LogicalSink<?>) o;
         return Objects.equals(outputExprs, that.outputExprs);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanEqualsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanEqualsTest.java
@@ -35,6 +35,7 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
+import org.apache.doris.nereids.trees.plans.logical.LogicalResultSink;
 import org.apache.doris.nereids.trees.plans.logical.LogicalSort;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalFilter;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalHashAggregate;
@@ -55,10 +56,10 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Optional;
 
-public class PlanEqualsTest {
+class PlanEqualsTest {
     /* *************************** Logical *************************** */
     @Test
-    public void testLogicalAggregate(@Mocked Plan child) {
+    void testLogicalAggregate(@Mocked Plan child) {
         LogicalAggregate<Plan> actual = new LogicalAggregate<>(Lists.newArrayList(), ImmutableList.of(
                 new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList())),
                 child);
@@ -90,7 +91,7 @@ public class PlanEqualsTest {
     }
 
     @Test
-    public void testLogicalFilter(@Mocked Plan child) {
+    void testLogicalFilter(@Mocked Plan child) {
         LogicalFilter<Plan> actual = new LogicalFilter<>(ImmutableSet.of(new EqualTo(Literal.of(1), Literal.of(1))), child);
 
         LogicalFilter<Plan> expected = new LogicalFilter<>(ImmutableSet.of(new EqualTo(Literal.of(1), Literal.of(1))), child);
@@ -101,7 +102,7 @@ public class PlanEqualsTest {
     }
 
     @Test
-    public void testLogicalJoin(@Mocked Plan left, @Mocked Plan right) {
+    void testLogicalJoin(@Mocked Plan left, @Mocked Plan right) {
         LogicalJoin<Plan, Plan> actual = new LogicalJoin<>(JoinType.INNER_JOIN, Lists.newArrayList(new EqualTo(
                 new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList()),
                 new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList()))),
@@ -121,7 +122,7 @@ public class PlanEqualsTest {
     }
 
     @Test
-    public void testLogicalProject(@Mocked Plan child) {
+    void testLogicalProject(@Mocked Plan child) {
         LogicalProject<Plan> actual = new LogicalProject<>(
                 ImmutableList.of(
                         new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList())),
@@ -147,7 +148,7 @@ public class PlanEqualsTest {
     }
 
     @Test
-    public void testLogicalSort(@Mocked Plan child) {
+    void testLogicalSort(@Mocked Plan child) {
         LogicalSort<Plan> actual = new LogicalSort<>(
                 ImmutableList.of(new OrderKey(
                         new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList()), true,
@@ -169,9 +170,26 @@ public class PlanEqualsTest {
         Assertions.assertNotEquals(unexpected, actual);
     }
 
+    @Test
+    void testLogicalResultSink(@Mocked Plan child) {
+        LogicalResultSink<Plan> actual = new LogicalResultSink<>(
+                ImmutableList.of(new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList())),
+                child);
+
+        LogicalResultSink<Plan> expected = new LogicalResultSink<>(
+                ImmutableList.of(new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList())),
+                child);
+        Assertions.assertEquals(expected, actual);
+
+        LogicalResultSink<Plan> unexpected = new LogicalResultSink<>(
+                ImmutableList.of(new SlotReference(new ExprId(1), "a", BigIntType.INSTANCE, true, Lists.newArrayList())),
+                child);
+        Assertions.assertNotEquals(unexpected, actual);
+    }
+
     /* *************************** Physical *************************** */
     @Test
-    public void testPhysicalAggregate(@Mocked Plan child, @Mocked LogicalProperties logicalProperties) {
+    void testPhysicalAggregate(@Mocked Plan child, @Mocked LogicalProperties logicalProperties) {
         List<NamedExpression> outputExpressionList = ImmutableList.of(
                 new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList()));
         PhysicalHashAggregate<Plan> actual = new PhysicalHashAggregate<>(Lists.newArrayList(), outputExpressionList,
@@ -196,7 +214,7 @@ public class PlanEqualsTest {
     }
 
     @Test
-    public void testPhysicalFilter(@Mocked Plan child, @Mocked LogicalProperties logicalProperties) {
+    void testPhysicalFilter(@Mocked Plan child, @Mocked LogicalProperties logicalProperties) {
         PhysicalFilter<Plan> actual = new PhysicalFilter<>(ImmutableSet.of(new EqualTo(Literal.of(1), Literal.of(2))),
                 logicalProperties, child);
 
@@ -210,7 +228,7 @@ public class PlanEqualsTest {
     }
 
     @Test
-    public void testPhysicalJoin(@Mocked Plan left, @Mocked Plan right, @Mocked LogicalProperties logicalProperties) {
+    void testPhysicalJoin(@Mocked Plan left, @Mocked Plan right, @Mocked LogicalProperties logicalProperties) {
         PhysicalHashJoin<Plan, Plan> actual = new PhysicalHashJoin<>(JoinType.INNER_JOIN,
                 Lists.newArrayList(new EqualTo(
                         new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList()),
@@ -233,7 +251,7 @@ public class PlanEqualsTest {
     }
 
     @Test
-    public void testPhysicalOlapScan(
+    void testPhysicalOlapScan(
             @Mocked LogicalProperties logicalProperties,
             @Mocked OlapTable olapTable,
             @Mocked DistributionSpecHash distributionSpecHash) {
@@ -261,7 +279,7 @@ public class PlanEqualsTest {
     }
 
     @Test
-    public void testPhysicalProject(@Mocked Plan child, @Mocked LogicalProperties logicalProperties) {
+    void testPhysicalProject(@Mocked Plan child, @Mocked LogicalProperties logicalProperties) {
         PhysicalProject<Plan> actual = new PhysicalProject<>(
                 ImmutableList.of(
                         new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList())),
@@ -291,7 +309,7 @@ public class PlanEqualsTest {
     }
 
     @Test
-    public void testPhysicalSort(@Mocked Plan child, @Mocked LogicalProperties logicalProperties) {
+    void testPhysicalSort(@Mocked Plan child, @Mocked LogicalProperties logicalProperties) {
 
         PhysicalQuickSort<Plan> actual = new PhysicalQuickSort<>(
                 ImmutableList.of(new OrderKey(


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

