### PR TITLE
[fix](load) fix nullptr in memtable limiter flush

### DIFF
--- a/be/src/olap/memtable_flush_executor.cpp
+++ b/be/src/olap/memtable_flush_executor.cpp
@@ -72,7 +72,7 @@ Status FlushToken::submit(std::unique_ptr<MemTable> mem_table) {
     if (s != OK) {
         return Status::Error(s, "FlushToken meet error");
     }
-    if (mem_table->empty()) {
+    if (mem_table == nullptr || mem_table->empty()) {
         return Status::OK();
     }
     int64_t submit_task_time = MonotonicNanos();

--- a/be/src/olap/memtable_writer.cpp
+++ b/be/src/olap/memtable_writer.cpp
@@ -164,7 +164,7 @@ Status MemTableWriter::flush_memtable_and_wait(bool need_wait) {
 Status MemTableWriter::wait_flush() {
     {
         std::lock_guard<std::mutex> l(_lock);
-        if (!_is_init) {
+        if (!_is_init || _is_closed) {
             // return OK instead of Status::Error<ALREADY_CANCELLED>() for same reason
             // as described in flush_memtable_and_wait()
             return Status::OK();

--- a/be/src/olap/memtable_writer.cpp
+++ b/be/src/olap/memtable_writer.cpp
@@ -133,8 +133,8 @@ Status MemTableWriter::_flush_memtable_async() {
 Status MemTableWriter::flush_memtable_and_wait(bool need_wait) {
     std::lock_guard<std::mutex> l(_lock);
     if (!_is_init || _is_closed) {
-        // This writer is not initialized before flushing. Do nothing
-        // But we return OK instead of Status::Error<ALREADY_CANCELLED>(),
+        // This writer is uninitialized or closed before flushing, do nothing.
+        // We return OK instead of NOT_INITIALIZED or ALREADY_CLOSED.
         // Because this method maybe called when trying to reduce mem consumption,
         // and at that time, the writer may not be initialized yet and that is a normal case.
         return Status::OK();
@@ -165,7 +165,7 @@ Status MemTableWriter::wait_flush() {
     {
         std::lock_guard<std::mutex> l(_lock);
         if (!_is_init || _is_closed) {
-            // return OK instead of Status::Error<ALREADY_CANCELLED>() for same reason
+            // return OK instead of NOT_INITIALIZED or ALREADY_CLOSED for same reason
             // as described in flush_memtable_and_wait()
             return Status::OK();
         }

--- a/be/src/olap/memtable_writer.cpp
+++ b/be/src/olap/memtable_writer.cpp
@@ -132,7 +132,7 @@ Status MemTableWriter::_flush_memtable_async() {
 
 Status MemTableWriter::flush_memtable_and_wait(bool need_wait) {
     std::lock_guard<std::mutex> l(_lock);
-    if (!_is_init) {
+    if (!_is_init || _is_closed) {
         // This writer is not initialized before flushing. Do nothing
         // But we return OK instead of Status::Error<ALREADY_CANCELLED>(),
         // Because this method maybe called when trying to reduce mem consumption,


### PR DESCRIPTION
## Proposed changes

`MemTableMemLimiter` may call `MemTableWriter::flush_memtable_and_wait` when it's already closed. 
In that case, memtable is `nullptr`, which causes BE core.

In #23019, the following code was removed, which causes this issue.

```cpp
        // close will reset deltawriter memtable and should deregister writer before it.
        {
            std::lock_guard<SpinLock> l(_tablets_channels_lock);
            auto tablet_channel_it = _tablets_channels.find(index_id);
            if (tablet_channel_it != _tablets_channels.end()) {
                tablet_channel_it->second->deregister_memtable_memory_limiter();
            }
        }
```

After this change, it's safe to call `flush_memtable_and_wait` even if `MemTableWriter` is closed.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

