### PR TITLE
[fix](merge-on-write) should use write lock of tablet's header lock in #23047

### DIFF
--- a/be/src/olap/task/index_builder.cpp
+++ b/be/src/olap/task/index_builder.cpp
@@ -449,8 +449,8 @@ Status IndexBuilder::modify_rowsets(const Merger::Statistics* stats) {
 
     if (_tablet->keys_type() == KeysType::UNIQUE_KEYS &&
         _tablet->enable_unique_key_merge_on_write()) {
-        std::lock_guard<std::mutex> wlock(_tablet->get_rowset_update_lock());
-        std::shared_lock<std::shared_mutex> rlock(_tablet->get_header_lock());
+        std::lock_guard<std::mutex> rowset_update_wlock(_tablet->get_rowset_update_lock());
+        std::lock_guard<std::shared_mutex> meta_wlock(_tablet->get_header_lock());
         DeleteBitmapPtr delete_bitmap = std::make_shared<DeleteBitmap>(_tablet->tablet_id());
         for (auto i = 0; i < _input_rowsets.size(); ++i) {
             RowsetId input_rowset_id = _input_rowsets[i]->rowset_id();


### PR DESCRIPTION
## Proposed changes

#23047 change delete bitmap in Tablet's meta directly, it should hold write lock at that time

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

