### PR TITLE
[Fix](multi-catalog) Fix NPE when file cache is enabled.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileQueryScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileQueryScanNode.java
@@ -326,6 +326,8 @@ public abstract class FileQueryScanNode extends FileScanNode {
                 HudiScanNode.setHudiParams(rangeDesc, (HudiSplit) fileSplit);
             }
 
+            curLocations.getScanRange().getExtScanRange().getFileScanRange().addToRanges(rangeDesc);
+            TScanRangeLocation location = new TScanRangeLocation();
             Backend selectedBackend;
             if (enableSqlCache) {
                 // Use consistent hash to assign the same scan range into the same backend among different queries
@@ -336,9 +338,6 @@ public abstract class FileQueryScanNode extends FileScanNode {
             } else {
                 selectedBackend = backendPolicy.getNextBe();
             }
-
-            curLocations.getScanRange().getExtScanRange().getFileScanRange().addToRanges(rangeDesc);
-            TScanRangeLocation location = new TScanRangeLocation();
             location.setBackendId(selectedBackend.getId());
             location.setServer(new TNetworkAddress(selectedBackend.getHost(), selectedBackend.getBePort()));
             curLocations.addToLocations(location);


### PR DESCRIPTION
## Proposed changes

Error msg:
```
Caused by: java.lang.NullPointerException
        at org.apache.doris.planner.external.FederationBackendPolicy$ScanRangeHash.funnel(FederationBackendPolicy.java:148) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.external.FederationBackendPolicy$ScanRangeHash.funnel(FederationBackendPolicy.java:144) ~[doris-fe.jar:1.2-SNAPSHOT]
        at com.google.common.hash.AbstractHasher.putObject(AbstractHasher.java:133) ~[guava-32.1.2-jre.jar:?]
        at org.apache.doris.common.util.ConsistentHash.getNode(ConsistentHash.java:97) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.external.FederationBackendPolicy.getNextConsistentBe(FederationBackendPolicy.java:111) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.external.FileQueryScanNode.createScanRangeLocations(FileQueryScanNode.java:332) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.external.FileQueryScanNode.doFinalize(FileQueryScanNode.java:213) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.external.FileQueryScanNode.finalizeForNereids(FileQueryScanNode.java:205) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.util.Utils.execWithUncheckedException(Utils.java:65) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator.visitPhysicalFileScan(PhysicalPlanTranslator.java:447) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator.visitPhysicalFileScan(PhysicalPlanTranslator.java:204) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.physical.PhysicalFileScan.accept(PhysicalFileScan.java:80) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator.visitPhysicalLimit(PhysicalPlanTranslator.java:1429) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator.visitPhysicalLimit(PhysicalPlanTranslator.java:204) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.physical.PhysicalLimit.accept(PhysicalLimit.java:154) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator.visitPhysicalDistribute(PhysicalPlanTranslator.java:249) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator.visitPhysicalDistribute(PhysicalPlanTranslator.java:204) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.physical.PhysicalDistribute.accept(PhysicalDistribute.java:96) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator.visitPhysicalLimit(PhysicalPlanTranslator.java:1429) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator.visitPhysicalLimit(PhysicalPlanTranslator.java:204) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.physical.PhysicalLimit.accept(PhysicalLimit.java:154) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator.visitPhysicalResultSink(PhysicalPlanTranslator.java:322) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator.visitPhysicalResultSink(PhysicalPlanTranslator.java:204) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.trees.plans.physical.PhysicalResultSink.accept(PhysicalResultSink.java:74) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator.translatePlan(PhysicalPlanTranslator.java:231) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.nereids.NereidsPlanner.plan(NereidsPlanner.java:123) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.executeByNereids(StmtExecutor.java:544) ~[doris-fe.jar:1.2-SNAPSHOT]
        ... 9 more
2023-08-18 11:57:20,421 INFO (tablet scheduler|56) [BeLoadRebalancer.selectAlternativeTabletsForCluster():92] all low load backends is dead: [10035, 10037] with medium: HDD. skip
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

