### PR TITLE
[fix](load) add rowset builder init error handling

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -93,9 +93,10 @@ DeltaWriter::~DeltaWriter() {
 }
 
 Status DeltaWriter::init() {
-    _rowset_builder.init();
-    _memtable_writer->init(_rowset_builder.rowset_writer(), _rowset_builder.tablet_schema(),
-                           _rowset_builder.tablet()->enable_unique_key_merge_on_write());
+    RETURN_IF_ERROR(_rowset_builder.init());
+    RETURN_IF_ERROR(
+            _memtable_writer->init(_rowset_builder.rowset_writer(), _rowset_builder.tablet_schema(),
+                                   _rowset_builder.tablet()->enable_unique_key_merge_on_write()));
     _is_init = true;
     return Status::OK();
 }


### PR DESCRIPTION
## Proposed changes
There happens null point and cause core when run be.
`0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:413
 1# 0x00007F4592DA9BF9 in /usr/lib/jvm/java-1.11.0-openjdk-amd64/lib/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-1.11.0-openjdk-amd64/lib/server/libjvm.so
 3# 0x00007F4592DA293C in /usr/lib/jvm/java-1.11.0-openjdk-amd64/lib/server/libjvm.so
 4# 0x00007F4597AE10C0 in /lib/x86_64-linux-gnu/libc.so.6
 5# doris::MemTableFlushExecutor::create_flush_token(std::unique_ptr<doris::FlushToken, std::default_delete<doris::FlushToken> >&, doris::RowsetWriter*, bool, bool) in /mnt/hdd01/STRESS_ENV/be/lib/doris_be
 6# doris::MemTableWriter::init(std::shared_ptr<doris::RowsetWriter>, std::shared_ptr<doris::TabletSchema>, bool) at /home/zcp/repo_center/doris_master/doris/be/src/olap/memtable_writer.cpp:77
 7# doris::DeltaWriter::init() at /home/zcp/repo_center/doris_master/doris/be/src/olap/delta_writer.cpp:97
 8# doris::DeltaWriter::close() at /home/zcp/repo_center/doris_master/doris/be/src/olap/delta_writer.cpp:134
 9# doris::TabletsChannel::close(doris::LoadChannel*, int, long, bool*, google::protobuf::RepeatedField<long> const&, google::protobuf::RepeatedPtrField<doris::PTabletInfo>*, google::protobuf::RepeatedPtrField<doris::PTabletError>*, google::protobuf::Map<long, doris::PSlaveTabletNodes> const&, google::protobuf::Map<long, doris::PSuccessSlaveTabletNodeIds>*, bool) at /home/zcp/repo_center/doris_master/doris/be/src/runtime/tablets_channel.cpp:154
10# doris::LoadChannel::_handle_eos(std::shared_ptr<doris::TabletsChannel>&, doris::PTabletWriterAddBlockRequest const&, doris::PTabletWriterAddBlockResult*) at /home/zcp/repo_center/doris_master/doris/be/src/runtime/load_channel.h:100
11# doris::LoadChannel::add_batch(doris::PTabletWriterAddBlockRequest const&, doris::PTabletWriterAddBlockResult*) at /home/zcp/repo_center/doris_master/doris/be/src/runtime/load_channel.cpp:137
12# doris::LoadChannelMgr::add_batch(doris::PTabletWriterAddBlockRequest const&, doris::PTabletWriterAddBlockResult*) at /home/zcp/repo_center/doris_master/doris/be/src/runtime/load_channel_mgr.cpp:168
13# std::_Function_handler<void (), doris::PInternalServiceImpl::_tablet_writer_add_block(google::protobuf::RpcController*, doris::PTabletWriterAddBlockRequest const*, doris::PTabletWriterAddBlockResult*, google::protobuf::Closure*)::$_0>::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
14# doris::WorkThreadPool<false>::work_thread(int) at /home/zcp/repo_center/doris_master/doris/be/src/util/work_thread_pool.hpp:161
15# execute_native_thread_routine at ../../../../../libstdc++-v3/src/c++11/thread.cc:84
16# start_thread at /build/glibc-sMfBJT/glibc-2.31/nptl/pthread_create.c:478
17# __clone in /lib/x86_64-linux-gnu/libc.so.6
`

**why it happen.**
There is no error handle when rowset builder init error in delta writer.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

