### PR TITLE
[Fix](RoutineLoad)Fix when Unique (MoW) RoutineLoad imports unspecified Sequence column

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/LoadScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/LoadScanProvider.java
@@ -190,7 +190,7 @@ public class LoadScanProvider {
                         .filter(c -> c.getColumnName().equalsIgnoreCase(finalSequenceCol)).findAny();
                 // if `columnDescs.descs` is empty, that means it's not a partial update load, and user not specify
                 // column name.
-                if (foundCol.isPresent() || columnDescs.descs.isEmpty()) {
+                if (foundCol.isPresent() || columnDescs.descs.isEmpty() || shouldAddSequenceColumn(columnDescs)) {
                     columnDescs.descs.add(new ImportColumnDesc(Column.SEQUENCE_COL,
                             new SlotRef(null, sequenceCol)));
                 } else if (!fileGroupInfo.isPartialUpdate()) {
@@ -224,6 +224,17 @@ public class LoadScanProvider {
             slotInfo.setIsFileSlot(i < numColumnsFromFile);
             context.params.addToRequiredSlots(slotInfo);
         }
+    }
+
+    /**
+     * if not set sequence column and column size is null or only have deleted sign ,return true
+     */
+    private boolean shouldAddSequenceColumn(LoadTaskInfo.ImportColumnDescs columnDescs) {
+        if (columnDescs.descs.isEmpty()) {
+            return true;
+        }
+        return columnDescs.descs.size() == 1 && columnDescs.descs.get(0).getColumnName()
+                .equalsIgnoreCase(Column.DELETE_SIGN);
     }
 
     private TFileFormatType formatType(String fileFormat, String path) throws UserException {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/LoadScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/LoadScanProvider.java
@@ -190,7 +190,7 @@ public class LoadScanProvider {
                         .filter(c -> c.getColumnName().equalsIgnoreCase(finalSequenceCol)).findAny();
                 // if `columnDescs.descs` is empty, that means it's not a partial update load, and user not specify
                 // column name.
-                if (foundCol.isPresent() || columnDescs.descs.isEmpty() || shouldAddSequenceColumn(columnDescs)) {
+                if (foundCol.isPresent() || shouldAddSequenceColumn(columnDescs)) {
                     columnDescs.descs.add(new ImportColumnDesc(Column.SEQUENCE_COL,
                             new SlotRef(null, sequenceCol)));
                 } else if (!fileGroupInfo.isPartialUpdate()) {


### PR DESCRIPTION
**effect version 2.0**
- How to reproduce：
```
CREATE TABLE `user` (
  `id` bigint(20) NOT NULL COMMENT '用户ID',
  `user_name` text NULL,
  `password` text NULL,
   ...
) ENGINE=OLAP
UNIQUE KEY(`id`)
COMMENT 'OLAP'
PARTITION BY RANGE(`id`)
(PARTITION i1 VALUES [("-9223372036854775808"), ("5000000")),
PARTITION i2 VALUES [("5000000"), ("10000000")),
DISTRIBUTED BY HASH(`id`) BUCKETS 16
PROPERTIES (
"replication_allocation" = "tag.location.default: 1",
"is_being_synced" = "false",
"storage_format" = "V2",
"enable_unique_key_merge_on_write" = "true",
"light_schema_change" = "true",
"function_column.sequence_col" = "order_id",
"disable_auto_compaction" = "false",
"enable_single_replica_compaction" = "false"
);
```

Routine Load Sql

```
CREATE ROUTINE LOAD test_load ON user
WITH MERGE
COLUMNS TERMINATED BY ",",
DELETE ON `y_n` = -1,
ORDER BY order_id
PROPERTIES
(
"desired_concurrent_number" = "1",
"max_error_number" = "0",
"max_batch_interval" = "5",
"max_batch_rows" = "300000",
"max_batch_size" = "209715200",
"format" = "json",
"strip_outer_array" = "false",
"num_as_string" = "false",
"fuzzy_parse" = "false",
"strict_mode" = "false",
"timezone" = "Asia/Shanghai",
"exec_mem_limit" = "2147483648"
)
FROM kafka(
...
)
```


error log

``` fe.log
org.apache.doris.common.UserException: errCode = 2, detailMessage = Table t_user has sequence column, need to specify the sequence column
	at org.apache.doris.planner.external.LoadScanProvider.initColumns(LoadScanProvider.java:197) ~[classes/:?]
	at org.apache.doris.planner.external.LoadScanProvider.createContext(LoadScanProvider.java:104) ~[classes/:?]
	at org.apache.doris.planner.FileLoadScanNode.initParamCreateContexts(FileLoadScanNode.java:131) ~[classes/:?]
	at org.apache.doris.planner.FileLoadScanNode.init(FileLoadScanNode.java:125) ~[classes/:?]
	at org.apache.doris.planner.StreamLoadPlanner.plan(StreamLoadPlanner.java:254) ~[classes/:?]
	at org.apache.doris.planner.StreamLoadPlanner.plan(StreamLoadPlanner.java:115) ~[classes/:?]
	at org.apache.doris.load.routineload.RoutineLoadJob.plan(RoutineLoadJob.java:872) ~[classes/:?]
	at org.apache.doris.load.routineload.KafkaTaskInfo.rePlan(KafkaTaskInfo.java:129) ~[classes/:?]
	at org.apache.doris.load.routineload.KafkaTaskInfo.createRoutineLoadTask(KafkaTaskInfo.java:98) ~[classes/:?]
	at org.apache.doris.load.routineload.RoutineLoadTaskScheduler.scheduleOneTask(RoutineLoadTaskScheduler.java:184) ~[classes/:?]
	at org.apache.doris.load.routineload.RoutineLoadTaskScheduler.process(RoutineLoadTaskScheduler.java:111) ~[classes/:?]
	at org.apache.doris.load.routineload.RoutineLoadTaskScheduler.runAfterCatalogReady(RoutineLoadTaskScheduler.java:84) ~[classes/:?]
	at org.apache.doris.common.util.MasterDaemon.runOneCycle(MasterDaemon.java:58) ~[classes/:?]
	at org.apache.doris.common.util.Daemon.run(Daemon.java:116) ~[classes/:?]
```


- Fix
When the column is not set, the sequence column is automatically added to it

