### PR TITLE
[fix](broadcast join) fix bug of probe side early eos if enable shared hash table

### DIFF
--- a/be/src/vec/exec/join/vhash_join_node.h
+++ b/be/src/vec/exec/join/vhash_join_node.h
@@ -571,8 +571,8 @@ private:
                 (_build_blocks->empty() && _join_op == TJoinOp::RIGHT_ANTI_JOIN);
     }
 
-    bool _enable_hash_join_early_start_probe(RuntimeState* state) const;
-    bool _is_hash_join_early_start_probe_eos(RuntimeState* state) const;
+    bool _enable_early_start_probe(RuntimeState* state) const;
+    bool _is_early_start_probe_eos(RuntimeState* state) const;
 
     // probe expr
     VExprContextSPtrs _probe_expr_ctxs;
@@ -668,6 +668,8 @@ private:
     SharedHashTableContextPtr _shared_hash_table_context = nullptr;
 
     Status _materialize_build_side(RuntimeState* state) override;
+
+    void _notify_build_finish();
 
     Status _process_build_block(RuntimeState* state, Block& block, uint8_t offset);
 

--- a/be/src/vec/runtime/shared_hash_table_controller.cpp
+++ b/be/src/vec/runtime/shared_hash_table_controller.cpp
@@ -34,7 +34,6 @@ void SharedHashTableController::set_builder_and_consumers(TUniqueId builder,
     std::lock_guard<std::mutex> lock(_mutex);
     DCHECK(_builder_fragment_ids.find(node_id) == _builder_fragment_ids.cend());
     _builder_fragment_ids.insert({node_id, builder});
-    _ref_fragments[node_id].assign(consumers.cbegin(), consumers.cend());
 }
 
 bool SharedHashTableController::should_build_hash_table(const TUniqueId& fragment_instance_id,
@@ -60,6 +59,7 @@ SharedHashTableContextPtr SharedHashTableController::get_context(int my_node_id)
     if (!_shared_contexts.count(my_node_id)) {
         _shared_contexts.insert({my_node_id, std::make_shared<SharedHashTableContext>()});
     }
+    _shared_contexts[my_node_id]->fragment_instance_count++;
     return _shared_contexts[my_node_id];
 }
 


### PR DESCRIPTION

## Proposed changes

Issue Number: close #xxx

Introduced by #23044

For sharing hash table broadcast join, should check if all probe side data are empty to determin where to stop building hash table, also should notify other frament instances when stopped building hash table.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

