### PR TITLE
[bug](java-udf) fix java-udf not return const column when all args are const values

### DIFF
--- a/be/src/vec/functions/function_java_udf.cpp
+++ b/be/src/vec/functions/function_java_udf.cpp
@@ -121,9 +121,9 @@ Status JavaFunctionCall::open(FunctionContext* context, FunctionContext::Functio
     return Status::OK();
 }
 
-Status JavaFunctionCall::execute(FunctionContext* context, Block& block,
-                                 const ColumnNumbers& arguments, size_t result, size_t num_rows,
-                                 bool dry_run) {
+Status JavaFunctionCall::execute_impl(FunctionContext* context, Block& block,
+                                      const ColumnNumbers& arguments, size_t result,
+                                      size_t num_rows) const {
     JNIEnv* env = nullptr;
     RETURN_IF_ERROR(JniUtil::GetJNIEnv(&env));
     JniContext* jni_ctx = reinterpret_cast<JniContext*>(


### PR DESCRIPTION
eg: udf('asd'), this need return a const column, otherwise will be failed use the return column as other function params.

mysql> select concat('a', 'b', cuuid9('a'), ':c');
ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.6)[CANCELLED][INTERNAL_ERROR]const check failed, expr=VectorizedFn[VectorizedFnCall[concat](arguments=,return=Nullable(String))]{
VLiteral (name = String, type = String, value = (a)),
VLiteral (name = String, type = String, value = (b)),
VectorizedFn[VectorizedFnCall[cuuid9](arguments=,return=Nullable(String))]
{ VLiteral (name = String, type = String, value = (a))}
,
VLiteral (name = String, type = String, value = (:c))}

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

