### PR TITLE
[fix](compile) compile be failed with gcc12

### DIFF
--- a/be/src/olap/rowset/rowset_meta_manager.cpp
+++ b/be/src/olap/rowset/rowset_meta_manager.cpp
@@ -414,7 +414,8 @@ Status RowsetMetaManager::remove(OlapMeta* meta, TabletUid tablet_uid, const Row
 
 Status RowsetMetaManager::remove_binlog(OlapMeta* meta, const std::string& suffix) {
     return meta->remove(META_COLUMN_FAMILY_INDEX,
-                        {kBinlogMetaPrefix.data() + suffix, kBinlogDataPrefix.data() + suffix});
+                        std::vector<std::string> {kBinlogMetaPrefix.data() + suffix,
+                                                  kBinlogDataPrefix.data() + suffix});
 }
 
 Status RowsetMetaManager::ingest_binlog_metas(OlapMeta* meta, TabletUid tablet_uid,


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
While compile be with gcc12, we got following error:
```
/home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/core/be/src/olap/rowset/rowset_meta_manager.cpp: In static member function 'static doris::Status doris::RowsetMetaManager::remove_binlog(doris::OlapMeta*, const std::string&)':
/home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/core/be/src/olap/rowset/rowset_meta_manager.cpp:416:24: error: call of overloaded 'remove(doris::ColumnFamilyIndex, <brace-enclosed initializer list>)' is ambiguous
  416 |     return meta->remove(META_COLUMN_FAMILY_INDEX,
      |            ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
  417 |                         {kBinlogMetaPrefix.data() + suffix, kBinlogDataPrefix.data() + suffix});
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/core/be/src/olap/rowset/rowset_meta_manager.cpp:35:
/home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/core/be/src/olap/olap_meta.h:58:12: note: candidate: 'doris::Status doris::OlapMeta::remove(int, const std::string&)'
   58 |     Status remove(const int column_family_index, const std::string& key);
      |            ^~~~~~
/home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/core/be/src/olap/olap_meta.h:59:12: note: candidate: 'doris::Status doris::OlapMeta::remove(int, const std::vector<std::basic_string<char> >&)'
   59 |     Status remove(const int column_family_index, const std::vector<std::string>& keys);
      |            ^~~~~~
[564/1144] Building CXX object src/olap/CMakeFiles/Olap.dir/reader.cpp.o
```

It seems gcc12 is not smart enough:
test code:
```
$ cat test.cpp
#include <iostream>
#include <vector>

void foo(const std::string& s) {
    std::cout << "foo with string" << std::endl;
}
void foo(const std::vector<std::string>& v) {
    std::cout << "foo with vector string" << std::endl;
}
int main(int argc, char** argv) {
    foo({"123","456"});
}
```

g++ version
```
$ g++ --version
g++ (GCC) 12.1.0
Copyright (C) 2022 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

compile error:
```
$ g++ test.cpp
test.cpp: In function ‘int main(int, char**)’:
test.cpp:11:8: error: call of overloaded ‘foo(<brace-enclosed initializer list>)’ is ambiguous
   11 |     foo({"123","456"});
      |     ~~~^~~~~~~~~~~~~~~
test.cpp:4:6: note: candidate: ‘void foo(const std::string&)’
    4 | void foo(const std::string& s) {
      |      ^~~
test.cpp:7:6: note: candidate: ‘void foo(const std::vector<std::basic_string<char> >&)’
    7 | void foo(const std::vector<std::string>& v) {
      |      ^~~
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

