### PR TITLE
[refactor](load) rename flush_memtable_and_wait to flush_async

### DIFF
--- a/be/src/olap/memtable_memory_limiter.cpp
+++ b/be/src/olap/memtable_memory_limiter.cpp
@@ -124,7 +124,7 @@ void MemTableMemoryLimiter::handle_memtable_flush() {
             }
             int64_t mem_size = mem_item.mem_size;
             writers_to_reduce_mem.emplace_back(writer, mem_size);
-            st = writer->flush_memtable_and_wait(false);
+            st = writer->flush_async();
             if (!st.ok()) {
                 auto err_msg = fmt::format(
                         "tablet writer failed to reduce mem consumption by flushing memtable, "

--- a/be/src/olap/memtable_writer.h
+++ b/be/src/olap/memtable_writer.h
@@ -91,15 +91,12 @@ public:
     Status cancel();
     Status cancel_with_status(const Status& st);
 
-    // submit current memtable to flush queue, and wait all memtables in flush queue
-    // to be flushed.
-    // This is currently for reducing mem consumption of this delta writer.
-    // If need_wait is true, it will wait for all memtable in flush queue to be flushed.
-    // Otherwise, it will just put memtables to the flush queue and return.
-    Status flush_memtable_and_wait(bool need_wait);
-
     int64_t mem_consumption(MemType mem);
     int64_t active_memtable_mem_consumption();
+
+    // Submit current memtable to flush queue, and return without waiting.
+    // This is currently for reducing mem consumption of this memtable writer.
+    Status flush_async();
 
     // Wait all memtable in flush queue to be flushed
     Status wait_flush();


### PR DESCRIPTION
## Proposed changes

This is the only usage of `flush_memtable_and_wait`, and `need_wait` is always `false`.
The name is misleading, so change it to `flush_async`.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

