### PR TITLE
fix: github_events sync

### DIFF
--- a/regression-test/suites/github_events_p2/load.groovy
+++ b/regression-test/suites/github_events_p2/load.groovy
@@ -39,7 +39,7 @@ suite("load") {
         timeout 72000
     }
     sql "sync"
-    sql """ ANALYZE TABLE github_events WITH SYNC """;
+    sql """ ANALYZE TABLE github_events """;
     qt_sql_select_count """ select count(*) from github_events; """
 }
 /**


### PR DESCRIPTION
## Proposed changes

github_events is too big to analyze with sync, so change to analyze