### PR TITLE
[fix](load) Fix duplicate memtable writer register in limiter

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -97,6 +97,7 @@ Status DeltaWriter::init() {
     RETURN_IF_ERROR(
             _memtable_writer->init(_rowset_builder.rowset_writer(), _rowset_builder.tablet_schema(),
                                    _rowset_builder.tablet()->enable_unique_key_merge_on_write()));
+    ExecEnv::GetInstance()->memtable_memory_limiter()->register_writer(_memtable_writer);
     _is_init = true;
     return Status::OK();
 }

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -93,6 +93,9 @@ DeltaWriter::~DeltaWriter() {
 }
 
 Status DeltaWriter::init() {
+    if (_is_init) {
+        return Status::OK();
+    }
     RETURN_IF_ERROR(_rowset_builder.init());
     RETURN_IF_ERROR(
             _memtable_writer->init(_rowset_builder.rowset_writer(), _rowset_builder.tablet_schema(),

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -112,8 +112,6 @@ public:
     // For UT
     DeleteBitmapPtr get_delete_bitmap() { return _rowset_builder.get_delete_bitmap(); }
 
-    std::shared_ptr<MemTableWriter> memtable_writer() { return _memtable_writer; }
-
 private:
     DeltaWriter(WriteRequest* req, StorageEngine* storage_engine, RuntimeProfile* profile,
                 const UniqueId& load_id);

--- a/be/src/olap/delta_writer_v2.cpp
+++ b/be/src/olap/delta_writer_v2.cpp
@@ -92,6 +92,9 @@ DeltaWriterV2::~DeltaWriterV2() {
 }
 
 Status DeltaWriterV2::init() {
+    if (_is_init) {
+        return Status::OK();
+    }
     // build tablet schema in request level
     _build_current_tablet_schema(_req.index_id, _req.table_schema_param, *_req.tablet_schema.get());
     RowsetWriterContext context;
@@ -118,6 +121,7 @@ Status DeltaWriterV2::init() {
     _rowset_writer->init(context);
     _memtable_writer->init(_rowset_writer, _tablet_schema, _req.enable_unique_key_merge_on_write);
     _is_init = true;
+    ExecEnv::GetInstance()->memtable_memory_limiter()->register_writer(_memtable_writer);
     return Status::OK();
 }
 

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -111,7 +111,6 @@ Status LoadChannelMgr::open(const PTabletWriterOpenRequest& params) {
     }
 
     RETURN_IF_ERROR(channel->open(params));
-    _register_channel_all_writers(channel);
 
     return Status::OK();
 }

--- a/be/src/runtime/load_channel_mgr.h
+++ b/be/src/runtime/load_channel_mgr.h
@@ -71,12 +71,6 @@ private:
 
     Status _start_bg_worker();
 
-    void _register_channel_all_writers(std::shared_ptr<doris::LoadChannel> channel) {
-        for (auto& [_, tablet_channel] : channel->get_tablets_channels()) {
-            tablet_channel->register_memtable_memory_limiter();
-        }
-    }
-
 protected:
     // lock protect the load channel map
     std::mutex _lock;

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -496,19 +496,4 @@ bool TabletsChannel::_is_broken_tablet(int64_t tablet_id) {
     return _broken_tablets.find(tablet_id) != _broken_tablets.end();
 }
 
-void TabletsChannel::register_memtable_memory_limiter() {
-    auto memtable_memory_limiter = ExecEnv::GetInstance()->memtable_memory_limiter();
-    _memtable_writers_foreach([memtable_memory_limiter](std::shared_ptr<MemTableWriter> writer) {
-        memtable_memory_limiter->register_writer(writer);
-    });
-}
-
-void TabletsChannel::_memtable_writers_foreach(
-        std::function<void(std::shared_ptr<MemTableWriter>)> fn) {
-    std::lock_guard<SpinLock> l(_tablet_writers_lock);
-    for (auto& [_, delta_writer] : _tablet_writers) {
-        fn(delta_writer->memtable_writer());
-    }
-}
-
 } // namespace doris

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -113,8 +113,6 @@ public:
 
     void refresh_profile();
 
-    void register_memtable_memory_limiter();
-
 private:
     template <typename Request>
     Status _get_current_seq(int64_t& cur_seq, const Request& request);
@@ -133,7 +131,6 @@ private:
                            int64_t tablet_id, Status error);
     bool _is_broken_tablet(int64_t tablet_id);
     void _init_profile(RuntimeProfile* profile);
-    void _memtable_writers_foreach(std::function<void(std::shared_ptr<MemTableWriter>)> fn);
 
     // id of this load channel
     TabletsChannelKey _key;

--- a/be/src/vec/sink/vtablet_sink_v2.cpp
+++ b/be/src/vec/sink/vtablet_sink_v2.cpp
@@ -453,8 +453,6 @@ Status VOlapTableSinkV2::_write_memtable(std::shared_ptr<vectorized::Block> bloc
                 }
             }
             DeltaWriterV2::open(&req, &delta_writer, _profile);
-            ExecEnv::GetInstance()->memtable_memory_limiter()->register_writer(
-                    delta_writer->memtable_writer());
             for (auto stream : streams) {
                 delta_writer->add_stream(stream);
             }


### PR DESCRIPTION
## Proposed changes

Fix duplicate memtable writer register in memtable limiter.
Also avoid _tablet_writers_lock.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

