### PR TITLE
[fix](move-memtable) fix BE core when LoadStreamWriter init failed

### DIFF
--- a/be/src/runtime/load_stream.cpp
+++ b/be/src/runtime/load_stream.cpp
@@ -76,7 +76,9 @@ Status TabletStream::init(OlapTableSchemaParam* schema, int64_t index_id, int64_
 }
 
 Status TabletStream::append_data(const PStreamHeader& header, butil::IOBuf* data) {
-    // TODO failed early
+    if (!_failed_st->ok()) {
+        return *failed_st;
+    }
 
     // dispatch add_segment request
     if (header.opcode() == PStreamHeader::ADD_SEGMENT) {

--- a/be/src/runtime/load_stream_writer.cpp
+++ b/be/src/runtime/load_stream_writer.cpp
@@ -83,10 +83,12 @@ Status LoadStreamWriter::init() {
 }
 
 Status LoadStreamWriter::append_data(uint32_t segid, butil::IOBuf buf) {
-    DCHECK(_is_init);
     io::FileWriter* file_writer = nullptr;
     {
         std::lock_guard lock_guard(_lock);
+        if (!_is_init) {
+            RETURN_IF_ERROR(init());
+        }
         if (segid + 1 > _segment_file_writers.size()) {
             for (size_t i = _segment_file_writers.size(); i <= segid; i++) {
                 Status st;


### PR DESCRIPTION
## Proposed changes

Fix BE core when LoadStreamWriter init failed. The uninitialized LoadStreamWriter was accessable by following writes.
Also return saved error if TabletStream failed.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

