### PR TITLE
[perf](move-memtable) only connect to nodes with tablets

### DIFF
--- a/be/src/runtime/load_stream.cpp
+++ b/be/src/runtime/load_stream.cpp
@@ -189,7 +189,7 @@ Status IndexStream::append_data(const PStreamHeader& header, butil::IOBuf* data)
 
 Status IndexStream::close(std::vector<int64_t>* success_tablet_ids,
                         std::vector<int64_t>* failed_tablet_ids,
-                        std::vector<NeedCommitTabletInfo>* need_commit_tablet_info) {
+                        std::vector<PTabletWithPartition>* need_commit_tablet_info) {
     std::lock_guard lock_guard(_lock);
     SCOPED_TIMER(_close_wait_timer);
     // open all need commit tablets
@@ -249,7 +249,7 @@ Status LoadStream::init(const POpenStreamSinkRequest* request) {
 
 Status LoadStream::close(uint32_t sender_id, std::vector<int64_t>* success_tablet_ids,
                          std::vector<int64_t>* failed_tablet_ids,
-                         std::vector<NeedCommitTabletInfo>* need_commit_tablet_info) {
+                         std::vector<PTabletWithPartition>* need_commit_tablet_info) {
     if (sender_id >= _senders_status.size()) {
         LOG(WARNING) << "out of range sender id " << sender_id << "  num "
                      << _senders_status.size();
@@ -402,7 +402,7 @@ int LoadStream::on_received_messages(StreamId id, butil::IOBuf* const messages[]
             std::vector<int64_t> success_tablet_ids;
             std::vector<int64_t> failed_tablet_ids;
             auto& need_commit_tablet_info = hdr.need_commit_tablet_info();
-            std::vector<NeedCommitTabletInfo> info(need_commit_tablet_info.begin(), need_commit_tablet_info.end());
+            std::vector<PTabletWithPartition> info(need_commit_tablet_info.begin(), need_commit_tablet_info.end());
             auto st = close(hdr.sender_id(), &success_tablet_ids, &failed_tablet_ids,
                             &info);
             _report_result(id, st, &success_tablet_ids, &failed_tablet_ids);

--- a/be/src/runtime/load_stream.h
+++ b/be/src/runtime/load_stream.h
@@ -79,7 +79,7 @@ public:
 
     void flush(uint32_t sender_id);
     Status close(std::vector<int64_t>* success_tablet_ids, std::vector<int64_t>* failed_tablet_ids,
-               std::vector<NeedCommitTabletInfo>* need_commit_tablet_info);
+               std::vector<PTabletWithPartition>* need_commit_tablet_info);
 
 private:
     int64_t _id;
@@ -110,7 +110,7 @@ public:
 
     Status close(uint32_t sender_id, std::vector<int64_t>* success_tablet_ids,
                  std::vector<int64_t>* failed_tablet_ids,
-                 std::vector<NeedCommitTabletInfo>* need_commit_tablet_info);
+                 std::vector<PTabletWithPartition>* need_commit_tablet_info);
 
     // callbacks called by brpc
     int on_received_messages(StreamId id, butil::IOBuf* const messages[], size_t size) override;

--- a/be/src/vec/sink/vtablet_sink_v2.h
+++ b/be/src/vec/sink/vtablet_sink_v2.h
@@ -87,6 +87,16 @@ using NodeIdForStream = std::unordered_map<brpc::StreamId, int64_t>;
 using NodePartitionTabletMapping =
         std::unordered_map<int64_t, std::unordered_map<int64_t, std::unordered_set<int64_t>>>;
 
+struct TabletWithPartition {
+    int64_t partition_id;
+    int64_t tablet_id;
+};
+
+struct TabletWithIndex {
+    int64_t index_id;
+    int64_t tablet_id;
+};
+
 class StreamSinkHandler : public brpc::StreamInputHandler {
 public:
     StreamSinkHandler(VOlapTableSinkV2* sink) : _sink(sink) {}
@@ -141,7 +151,7 @@ private:
 
     Status _init_stream_pools();
 
-    void _build_node_partition_tablet_mapping();
+    void _build_tablet_node_mapping();
 
     void _generate_rows_for_tablet(RowsForTablet& rows_for_tablet,
                                    const VOlapTablePartition* partition, uint32_t tablet_index,
@@ -221,7 +231,8 @@ private:
 
     std::unordered_set<int64_t> _opened_partitions;
 
-    NodePartitionTabletMapping _node_partition_tablet_mapping;
+    std::unordered_map<int64_t, std::vector<TabletWithPartition>> _tablets_for_node;
+    std::unordered_map<int64_t, std::vector<TabletWithIndex>> _indexes_from_node;
 
     std::shared_ptr<StreamPoolForNode> _stream_pool_for_node;
     std::shared_ptr<NodeIdForStream> _node_id_for_stream;

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -733,11 +733,6 @@ message SegmentStatisticsPB {
     optional KeyBoundsPB key_bounds = 4;
 }
 
-message NeedCommitTabletInfo {
-    required int64 tablet_id= 1;
-    required int64 partition_id = 2;
-}
-
 message PStreamHeader {
     enum Opcode {
         APPEND_DATA = 1;
@@ -753,7 +748,7 @@ message PStreamHeader {
     optional bool segment_eos = 7;
     optional uint32 sender_id = 8;
     optional SegmentStatisticsPB segment_statistics = 9;
-    repeated NeedCommitTabletInfo need_commit_tablet_info = 10;
+    repeated PTabletWithPartition need_commit_tablet_info = 10;
 }
 
 service PBackendService {


### PR DESCRIPTION
## Proposed changes

`node_info` contains all nodes in the cluster

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

