### PR TITLE
[improvement](create tablet) backend create tablet round robin among disks

### DIFF
--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -849,12 +849,6 @@ void DataDir::update_trash_capacity() {
     LOG(INFO) << "path: " << _path << " trash capacity: " << _trash_used_bytes;
 }
 
-double DataDir::get_used_percent() const {
-    return _disk_capacity_bytes == 0
-                   ? 1.0
-                   : (_disk_capacity_bytes - _available_bytes) / (double)_disk_capacity_bytes;
-}
-
 void DataDir::update_local_data_size(int64_t size) {
     disks_local_used_capacity->set_value(size);
 }
@@ -863,7 +857,15 @@ void DataDir::update_remote_data_size(int64_t size) {
     disks_remote_used_capacity->set_value(size);
 }
 
-size_t DataDir::tablet_size() const {
+size_t DataDir::disk_capacity() const {
+    return _disk_capacity_bytes;
+}
+
+size_t DataDir::disk_available() const {
+    return _available_bytes;
+}
+
+size_t DataDir::tablet_num() const {
     std::lock_guard<std::mutex> l(_mutex);
     return _tablet_set.size();
 }

--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -849,6 +849,12 @@ void DataDir::update_trash_capacity() {
     LOG(INFO) << "path: " << _path << " trash capacity: " << _trash_used_bytes;
 }
 
+double DataDir::get_used_percent() const {
+    return _disk_capacity_bytes == 0
+                   ? 1.0
+                   : (_disk_capacity_bytes - _available_bytes) / (double)_disk_capacity_bytes;
+}
+
 void DataDir::update_local_data_size(int64_t size) {
     disks_local_used_capacity->set_value(size);
 }

--- a/be/src/olap/data_dir.h
+++ b/be/src/olap/data_dir.h
@@ -133,6 +133,8 @@ public:
 
     void update_trash_capacity();
 
+    double get_used_percent() const;
+
     void update_local_data_size(int64_t size);
 
     void update_remote_data_size(int64_t size);

--- a/be/src/olap/data_dir.h
+++ b/be/src/olap/data_dir.h
@@ -133,13 +133,15 @@ public:
 
     void update_trash_capacity();
 
-    double get_used_percent() const;
-
     void update_local_data_size(int64_t size);
 
     void update_remote_data_size(int64_t size);
 
-    size_t tablet_size() const;
+    size_t disk_capacity() const;
+
+    size_t disk_available() const;
+
+    size_t tablet_num() const;
 
     void disks_compaction_score_increment(int64_t delta);
 

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -462,7 +462,7 @@ std::vector<DataDir*> StorageEngine::get_stores_for_create_tablet(
         next_index = _store_next_index[storage_medium]++;
         if (next_index < 0) {
             next_index = 0;
-            _store_next_index[storage_medium] = 0;
+            _store_next_index[storage_medium] = next_index + 1;
         }
         for (auto& it : _store_map) {
             DataDir* data_dir = it.second;

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -486,6 +486,8 @@ private:
     bool _clear_segment_cache = false;
 
     std::atomic<bool> _need_clean_trash {false};
+    // next index for create tablet
+    std::map<TStorageMedium::type, int> _store_next_index;
 
     DISALLOW_COPY_AND_ASSIGN(StorageEngine);
 };


### PR DESCRIPTION
## Proposed changes

Backend choose disk by  disk available bytes and tablet num. If both are equal, round robin among them.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

