### PR TITLE
[fix](tablet clone) fix partition rebalancer apply move exception

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TwoDimensionalGreedyRebalanceAlgo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TwoDimensionalGreedyRebalanceAlgo.java
@@ -288,8 +288,13 @@ public class TwoDimensionalGreedyRebalanceAlgo {
      */
     public static boolean applyMove(PartitionMove move, TreeMultimap<Long, Long> beByTotalReplicaCount,
                                     TreeMultimap<Long, PartitionBalanceInfo> skewMap) {
-        // Update the total counts
-        moveOneReplica(move.fromBe, move.toBe, beByTotalReplicaCount);
+        try {
+            // Update the total counts
+            moveOneReplica(move.fromBe, move.toBe, beByTotalReplicaCount);
+        } catch (IllegalStateException e) {
+            LOG.info("{} apply failed, {}", move, e.getMessage());
+            return false;
+        }
 
         try {
             PartitionBalanceInfo partitionBalanceInfo = null;


### PR DESCRIPTION
## Proposed changes

For partition rebalancer's cache moves, if src backend or dest backend is not available (dead or decommission)， then  moveOneReplica will precondition check failed. It should ignore this error.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

