### PR TITLE
[fix](Nereids) fix num-nulls bug

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
@@ -358,10 +358,9 @@ public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationCo
             Expression expr = entry.getKey();
             ColumnStatistic originColStats = entry.getValue();
             ColumnStatistic childColStats = childStats.findColumnStatistics(expr);
-            double originNonNullCount = Math.max(originColStats.count - originColStats.numNulls, 0);
-            double childNonNullCount = Math.max(childColStats.count - childColStats.numNulls, 0);
-            double supersetValuesPerDistinctValue = StatsMathUtil.divide(originNonNullCount, originColStats.ndv);
-            double subsetValuesPerDistinctValue = StatsMathUtil.divide(childNonNullCount, childColStats.ndv);
+
+            double supersetValuesPerDistinctValue = StatsMathUtil.divide(originColStats.count, originColStats.ndv);
+            double subsetValuesPerDistinctValue = StatsMathUtil.divide(childColStats.count, childColStats.ndv);
             double ndv;
             if (supersetValuesPerDistinctValue <= subsetValuesPerDistinctValue) {
                 ndv = Math.max(originColStats.ndv - childColStats.ndv, 0);

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
@@ -315,8 +315,9 @@ public class ColumnStatistic {
 
     @Override
     public String toString() {
-        return isUnKnown ? "unknown" : String.format("ndv=%.4f, min=%f(%s), max=%f(%s), count=%.4f, avgSizeByte=%f",
-                ndv, minValue, minExpr, maxValue, maxExpr, count, avgSizeByte);
+        return isUnKnown ? "unknown" : String.format(
+                "ndv=%.4f, min=%f(%s), max=%f(%s), count=%.4f, avgSizeByte=%f, numNulls=%f",
+                ndv, minValue, minExpr, maxValue, maxExpr, count, avgSizeByte, numNulls);
     }
 
     public JSONObject toJson() {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
@@ -111,7 +111,12 @@ public class Statistics {
             ColumnStatistic columnStatistic = entry.getValue();
             ColumnStatisticBuilder columnStatisticBuilder = new ColumnStatisticBuilder(columnStatistic);
             columnStatisticBuilder.setNdv(Math.min(columnStatistic.ndv, rowCount));
-            columnStatisticBuilder.setNumNulls(rowCount - columnStatistic.numNulls);
+
+            double numNulls = Math.min(columnStatistic.numNulls, rowCount - columnStatistic.ndv);
+            columnStatisticBuilder.setNumNulls(numNulls);
+
+            // columnStatisticBuilder.setNumNulls(rowCount - columnStatistic.numNulls);
+
             columnStatisticBuilder.setCount(rowCount);
             expressionToColumnStats.put(entry.getKey(), columnStatisticBuilder.build());
         }


### PR DESCRIPTION
## Proposed changes

after this fix, ds 95 plan is not good.
需要两个后续修改之一才能恢复 ds95的性能
1. 扩展rf 多路下压的模式，或
2. 子查询消除
所以这个pr需要等待后续两个功能之一完成后再提交

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

