### PR TITLE
[Bug](thread-pool) try to fix pv operator of work thread pool

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -311,7 +311,8 @@ constexpr bool capture_stacktrace(int code) {
         && code != ErrorCode::KEY_NOT_FOUND
         && code != ErrorCode::KEY_ALREADY_EXISTS
         && code != ErrorCode::CANCELLED
-        && code != ErrorCode::UNINITIALIZED;
+        && code != ErrorCode::UNINITIALIZED
+        && code != ErrorCode::PIP_WAIT_FOR_SC;
 }
 // clang-format on
 

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -391,7 +391,7 @@ void PInternalServiceImpl::open_stream_sink(google::protobuf::RpcController* con
         // TODO : set idle timeout
         // stream_options.idle_timeout_ms =
 
-        StreamId streamid;
+        StreamId streamid = {};
         if (brpc::StreamAccept(&streamid, *cntl, &stream_options) != 0) {
             st = Status::Cancelled("Fail to accept stream {}", streamid);
             st.to_protobuf(response->mutable_status());
@@ -1107,7 +1107,7 @@ void PInternalServiceImpl::transmit_block(google::protobuf::RpcController* contr
     }
 
     FifoThreadPool& pool = request->has_block() ? _heavy_work_pool : _light_work_pool;
-    bool ret = pool.offer([this, controller, request, response, done]() {
+    bool ret = pool.try_offer([this, controller, request, response, done]() {
         _transmit_block(controller, request, response, done, Status::OK());
     });
     if (!ret) {

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -1107,7 +1107,7 @@ void PInternalServiceImpl::transmit_block(google::protobuf::RpcController* contr
     }
 
     FifoThreadPool& pool = request->has_block() ? _heavy_work_pool : _light_work_pool;
-    bool ret = pool.try_offer([this, controller, request, response, done]() {
+    bool ret = pool.offer([this, controller, request, response, done]() {
         _transmit_block(controller, request, response, done, Status::OK());
     });
     if (!ret) {

--- a/be/src/util/blocking_priority_queue.hpp
+++ b/be/src/util/blocking_priority_queue.hpp
@@ -44,7 +44,6 @@ public:
     using BlockingQueue<T>::_max_elements;
     using BlockingQueue<T>::_total_get_wait_time;
     using BlockingQueue<T>::_total_put_wait_time;
-    using BlockingQueue<T>::_notify_one;
 
     // Get an element from the queue, waiting indefinitely (or until timeout) for one to become available.
     // Returns false if we were shut down prior to getting the element, and there
@@ -98,7 +97,7 @@ public:
                 _queue.pop();
                 ++_upgrade_counter;
                 unique_lock.unlock();
-                _notify_one();
+                _put_cv.notify_one();
                 return true;
             } else {
                 assert(_shutdown);
@@ -135,7 +134,7 @@ public:
             ++_upgrade_counter;
             _total_get_wait_time += timer.elapsed_time();
             unique_lock.unlock();
-            _notify_one();
+            _put_cv.notify_one();
             return true;
         }
 
@@ -159,7 +158,7 @@ public:
 
         _queue.push(val);
         unique_lock.unlock();
-        _notify_one();
+        _get_cv.notify_one();
         return true;
     }
 
@@ -169,7 +168,7 @@ public:
         if (_queue.size() < BlockingQueue<T>::_max_elements && !_shutdown) {
             _queue.push(val);
             unique_lock.unlock();
-            _notify_one();
+            _get_cv.notify_one();
             return true;
         }
         return false;

--- a/be/src/util/blocking_queue.hpp
+++ b/be/src/util/blocking_queue.hpp
@@ -128,7 +128,6 @@ public:
     uint64_t total_put_wait_time() const { return _total_put_wait_time; }
 
 protected:
-
     bool _shutdown;
     const int _max_elements;
     std::condition_variable _get_cv; // 'get' callers wait on this

--- a/be/src/util/blocking_queue.hpp
+++ b/be/src/util/blocking_queue.hpp
@@ -55,7 +55,7 @@ public:
             *out = _list.front();
             _list.pop_front();
             unique_lock.unlock();
-            _notify_one();
+            _put_cv.notify_one();
             return true;
         } else {
             assert(_shutdown);
@@ -78,7 +78,7 @@ public:
 
         _list.push_back(val);
         unique_lock.unlock();
-        _notify_one();
+        _get_cv.notify_one();
         return true;
     }
 
@@ -99,7 +99,7 @@ public:
 
         _list.push_back(val);
         unique_lock.unlock();
-        _notify_one();
+        _get_cv.notify_one();
         return true;
     }
 
@@ -128,10 +128,6 @@ public:
     uint64_t total_put_wait_time() const { return _total_put_wait_time; }
 
 protected:
-    void _notify_one() {
-        _get_cv.notify_one(); // notify get_cv first
-        _put_cv.notify_one();
-    }
 
     bool _shutdown;
     const int _max_elements;


### PR DESCRIPTION
## Proposed changes
I think get_cv is not notified enough

 errCode = 2, detailMessage = (172.21.0.37)[CANCELLED]exchange req success but status isn't ok: [CANCELLED]fail to offer request to the work pool, pool=PriorityThreadPool(name=brpc_heavy, queue_size=10240/10240, active_thread=3/128, total_get_wait_time=132638923328525, total_put_wait_time=350913870127)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

