### PR TITLE
[fix](InternalService) add short-cut return when offer failed

### DIFF
--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -278,6 +278,7 @@ void PInternalServiceImpl::tablet_writer_open(google::protobuf::RpcController* c
     });
     if (!ret) {
         offer_failed(response, done, _light_work_pool);
+        return;
     }
 }
 
@@ -290,6 +291,7 @@ void PInternalServiceImpl::exec_plan_fragment(google::protobuf::RpcController* c
     });
     if (!ret) {
         offer_failed(response, done, _light_work_pool);
+        return;
     }
 }
 
@@ -326,6 +328,7 @@ void PInternalServiceImpl::exec_plan_fragment_prepare(google::protobuf::RpcContr
     });
     if (!ret) {
         offer_failed(response, done, _light_work_pool);
+        return;
     }
 }
 
@@ -342,6 +345,7 @@ void PInternalServiceImpl::exec_plan_fragment_start(google::protobuf::RpcControl
     });
     if (!ret) {
         offer_failed(result, done, _light_work_pool);
+        return;
     }
 }
 
@@ -354,6 +358,7 @@ void PInternalServiceImpl::tablet_writer_add_block(google::protobuf::RpcControll
     });
     if (!ret) {
         offer_failed(response, done, _heavy_work_pool);
+        return;
     }
 }
 
@@ -375,6 +380,7 @@ void PInternalServiceImpl::tablet_writer_add_block_by_http(
     });
     if (!ret) {
         offer_failed(response, done, _heavy_work_pool);
+        return;
     }
 }
 
@@ -404,6 +410,7 @@ void PInternalServiceImpl::_tablet_writer_add_block(google::protobuf::RpcControl
     });
     if (!ret) {
         offer_failed(response, done, _heavy_work_pool);
+        return;
     }
 }
 
@@ -425,6 +432,7 @@ void PInternalServiceImpl::tablet_writer_cancel(google::protobuf::RpcController*
     });
     if (!ret) {
         offer_failed(response, done, _light_work_pool);
+        return;
     }
 }
 
@@ -502,6 +510,7 @@ void PInternalServiceImpl::cancel_plan_fragment(google::protobuf::RpcController*
     });
     if (!ret) {
         offer_failed(result, done, _light_work_pool);
+        return;
     }
 }
 
@@ -515,6 +524,7 @@ void PInternalServiceImpl::fetch_data(google::protobuf::RpcController* controlle
     });
     if (!ret) {
         offer_failed(result, done, _heavy_work_pool);
+        return;
     }
 }
 
@@ -627,6 +637,7 @@ void PInternalServiceImpl::fetch_table_schema(google::protobuf::RpcController* c
     });
     if (!ret) {
         offer_failed(result, done, _heavy_work_pool);
+        return;
     }
 }
 
@@ -654,6 +665,7 @@ void PInternalServiceImpl::tablet_fetch_data(google::protobuf::RpcController* co
     });
     if (!ret) {
         offer_failed(response, done, _light_work_pool);
+        return;
     }
 }
 
@@ -666,6 +678,7 @@ void PInternalServiceImpl::get_column_ids_by_tablet_ids(google::protobuf::RpcCon
     });
     if (!ret) {
         offer_failed(response, done, _light_work_pool);
+        return;
     }
 }
 
@@ -798,6 +811,7 @@ void PInternalServiceImpl::get_info(google::protobuf::RpcController* controller,
     });
     if (!ret) {
         offer_failed(response, done, _heavy_work_pool);
+        return;
     }
 }
 
@@ -810,6 +824,7 @@ void PInternalServiceImpl::update_cache(google::protobuf::RpcController* control
     });
     if (!ret) {
         offer_failed(response, done, _light_work_pool);
+        return;
     }
 }
 
@@ -822,6 +837,7 @@ void PInternalServiceImpl::fetch_cache(google::protobuf::RpcController* controll
     });
     if (!ret) {
         offer_failed(result, done, _heavy_work_pool);
+        return;
     }
 }
 
@@ -834,6 +850,7 @@ void PInternalServiceImpl::clear_cache(google::protobuf::RpcController* controll
     });
     if (!ret) {
         offer_failed(response, done, _light_work_pool);
+        return;
     }
 }
 
@@ -853,6 +870,7 @@ void PInternalServiceImpl::merge_filter(::google::protobuf::RpcController* contr
     });
     if (!ret) {
         offer_failed(response, done, _light_work_pool);
+        return;
     }
 }
 
@@ -874,6 +892,7 @@ void PInternalServiceImpl::apply_filter(::google::protobuf::RpcController* contr
     });
     if (!ret) {
         offer_failed(response, done, _light_work_pool);
+        return;
     }
 }
 
@@ -895,6 +914,7 @@ void PInternalServiceImpl::apply_filterv2(::google::protobuf::RpcController* con
     });
     if (!ret) {
         offer_failed(response, done, _light_work_pool);
+        return;
     }
 }
 
@@ -928,6 +948,7 @@ void PInternalServiceImpl::send_data(google::protobuf::RpcController* controller
     });
     if (!ret) {
         offer_failed(response, done, _heavy_work_pool);
+        return;
     }
 }
 
@@ -951,6 +972,7 @@ void PInternalServiceImpl::commit(google::protobuf::RpcController* controller,
     });
     if (!ret) {
         offer_failed(response, done, _light_work_pool);
+        return;
     }
 }
 
@@ -973,6 +995,7 @@ void PInternalServiceImpl::rollback(google::protobuf::RpcController* controller,
     });
     if (!ret) {
         offer_failed(response, done, _light_work_pool);
+        return;
     }
 }
 
@@ -991,6 +1014,7 @@ void PInternalServiceImpl::fold_constant_expr(google::protobuf::RpcController* c
     });
     if (!ret) {
         offer_failed(response, done, _light_work_pool);
+        return;
     }
 }
 
@@ -1025,6 +1049,7 @@ void PInternalServiceImpl::transmit_block(google::protobuf::RpcController* contr
     });
     if (!ret) {
         offer_failed(response, done, pool);
+        return;
     }
 }
 
@@ -1043,6 +1068,7 @@ void PInternalServiceImpl::transmit_block_by_http(google::protobuf::RpcControlle
     });
     if (!ret) {
         offer_failed(response, done, _heavy_work_pool);
+        return;
     }
 }
 
@@ -1109,6 +1135,7 @@ void PInternalServiceImpl::check_rpc_channel(google::protobuf::RpcController* co
     });
     if (!ret) {
         offer_failed(response, done, _light_work_pool);
+        return;
     }
 }
 
@@ -1147,6 +1174,7 @@ void PInternalServiceImpl::reset_rpc_channel(google::protobuf::RpcController* co
     });
     if (!ret) {
         offer_failed(response, done, _light_work_pool);
+        return;
     }
 }
 
@@ -1163,6 +1191,7 @@ void PInternalServiceImpl::hand_shake(google::protobuf::RpcController* controlle
     });
     if (!ret) {
         offer_failed(response, done, _light_work_pool);
+        return;
     }
 }
 
@@ -1381,6 +1410,7 @@ void PInternalServiceImpl::request_slave_tablet_pull_rowset(
     });
     if (!ret) {
         offer_failed(response, done, _heavy_work_pool);
+        return;
     }
     Status::OK().to_protobuf(response->mutable_status());
 }
@@ -1452,6 +1482,7 @@ void PInternalServiceImpl::response_slave_tablet_pull_rowset(
     });
     if (!ret) {
         offer_failed(response, done, _heavy_work_pool);
+        return;
     }
 }
 
@@ -1625,6 +1656,7 @@ void PInternalServiceImpl::multiget_data(google::protobuf::RpcController* contro
     });
     if (!ret) {
         offer_failed(response, done, _heavy_work_pool);
+        return;
     }
 }
 
@@ -1655,6 +1687,7 @@ void PInternalServiceImpl::glob(google::protobuf::RpcController* controller,
     });
     if (!ret) {
         offer_failed(response, done, _heavy_work_pool);
+        return;
     }
 }
 


### PR DESCRIPTION
During offer_failed(), rpc done will be executed so the response will be sent and released. Further access to such object will cause NPE error. So let us just return after offer_failed().

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

