### PR TITLE
[bugfix](vertical-compaction) Only can init the SegmentCacheHandle once

### DIFF
--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -210,13 +210,9 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
     _read_options.output_columns = read_context->output_columns;
 
     // load segments
-    // When doing vertical compaction, the load_segments is called many times
-    if (!_load_segment_once) {
-        bool should_use_cache = use_cache || read_context->reader_type == ReaderType::READER_QUERY;
-        RETURN_IF_ERROR(SegmentLoader::instance()->load_segments(_rowset, &_segment_cache_handle,
-                                                                should_use_cache));
-        _load_segment_once = true;
-    }
+    bool should_use_cache = use_cache || read_context->reader_type == ReaderType::READER_QUERY;
+    RETURN_IF_ERROR(SegmentLoader::instance()->load_segments(_rowset, &_segment_cache_handle,
+                                                             should_use_cache));
 
     // create iterator for each segment
     auto& segments = _segment_cache_handle.get_segments();

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -210,10 +210,13 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
     _read_options.output_columns = read_context->output_columns;
 
     // load segments
-    // use cache is true when do vertica compaction
-    bool should_use_cache = use_cache || read_context->reader_type == ReaderType::READER_QUERY;
-    RETURN_IF_ERROR(SegmentLoader::instance()->load_segments(_rowset, &_segment_cache_handle,
-                                                             should_use_cache));
+    // When doing vertical compaction, the load_segments is called many times
+    if (!_load_segment_once) {
+        bool should_use_cache = use_cache || read_context->reader_type == ReaderType::READER_QUERY;
+        RETURN_IF_ERROR(SegmentLoader::instance()->load_segments(_rowset, &_segment_cache_handle,
+                                                                should_use_cache));
+        _load_segment_once = true;
+    }
 
     // create iterator for each segment
     auto& segments = _segment_cache_handle.get_segments();

--- a/be/src/olap/rowset/beta_rowset_reader.h
+++ b/be/src/olap/rowset/beta_rowset_reader.h
@@ -97,7 +97,6 @@ private:
 
     // make sure this handle is initialized and valid before
     // reading data.
-    bool _load_segment_once {false};
     SegmentCacheHandle _segment_cache_handle;
 
     StorageReadOptions _read_options;

--- a/be/src/olap/rowset/beta_rowset_reader.h
+++ b/be/src/olap/rowset/beta_rowset_reader.h
@@ -97,6 +97,7 @@ private:
 
     // make sure this handle is initialized and valid before
     // reading data.
+    bool _load_segment_once {false};
     SegmentCacheHandle _segment_cache_handle;
 
     StorageReadOptions _read_options;

--- a/be/src/olap/segment_loader.cpp
+++ b/be/src/olap/segment_loader.cpp
@@ -65,6 +65,10 @@ void SegmentCache::erase(const SegmentCache::CacheKey& key) {
 
 Status SegmentLoader::load_segments(const BetaRowsetSharedPtr& rowset,
                                     SegmentCacheHandle* cache_handle, bool use_cache) {
+    if (cache_handle->is_inited()) {
+        return Status::OK();
+    }
+
     SegmentCache::CacheKey cache_key(rowset->rowset_id());
     if (_segment_cache->lookup(cache_key, cache_handle)) {
         return Status::OK();

--- a/be/src/olap/segment_loader.cpp
+++ b/be/src/olap/segment_loader.cpp
@@ -37,7 +37,7 @@ bool SegmentCache::lookup(const SegmentCache::CacheKey& key, SegmentCacheHandle*
     if (lru_handle == nullptr) {
         return false;
     }
-    *handle = SegmentCacheHandle(_cache.get(), lru_handle);
+    handle->init(_cache.get(), lru_handle);
     return true;
 }
 
@@ -56,7 +56,7 @@ void SegmentCache::insert(const SegmentCache::CacheKey& key, SegmentCache::Cache
 
     auto lru_handle = _cache->insert(key.encode(), &value, sizeof(SegmentCache::CacheValue),
                                      deleter, CachePriority::NORMAL, meta_mem_usage);
-    *handle = SegmentCacheHandle(_cache.get(), lru_handle);
+    handle->init(_cache.get(), lru_handle);
 }
 
 void SegmentCache::erase(const SegmentCache::CacheKey& key) {
@@ -67,10 +67,8 @@ Status SegmentLoader::load_segments(const BetaRowsetSharedPtr& rowset,
                                     SegmentCacheHandle* cache_handle, bool use_cache) {
     SegmentCache::CacheKey cache_key(rowset->rowset_id());
     if (_segment_cache->lookup(cache_key, cache_handle)) {
-        cache_handle->owned = false;
         return Status::OK();
     }
-    cache_handle->owned = !use_cache;
 
     std::vector<segment_v2::SegmentSharedPtr> segments;
     RETURN_IF_ERROR(rowset->load_segments(&segments));
@@ -81,9 +79,8 @@ Status SegmentLoader::load_segments(const BetaRowsetSharedPtr& rowset,
         cache_value->segments = std::move(segments);
         _segment_cache->insert(cache_key, *cache_value, cache_handle);
     } else {
-        cache_handle->segments = std::move(segments);
+        cache_handle->init(std::move(segments));
     }
-
     return Status::OK();
 }
 

--- a/be/src/olap/segment_loader.h
+++ b/be/src/olap/segment_loader.h
@@ -144,14 +144,14 @@ public:
     [[nodiscard]] bool is_inited() const { return _init; }
 
     void init(std::vector<segment_v2::SegmentSharedPtr> segments) {
-        DCHECK(_init);
+        DCHECK(!_init);
         _owned = true;
         _segments = std::move(segments);
         _init = true;
     }
 
     void init(Cache* cache, Cache::Handle* handle) {
-        DCHECK(_init);
+        DCHECK(!_init);
         _owned = false;
         _cache = cache;
         _handle = handle;

--- a/be/src/olap/segment_loader.h
+++ b/be/src/olap/segment_loader.h
@@ -128,13 +128,12 @@ private:
 class SegmentCacheHandle {
 public:
     SegmentCacheHandle() = default;
-    SegmentCacheHandle(Cache* cache, Cache::Handle* handle) : _cache(cache), _handle(handle) {}
 
     ~SegmentCacheHandle() {
         if (_handle != nullptr) {
             CHECK(_cache != nullptr);
-            CHECK(segments.empty()) << segments.size();
-            CHECK(!owned);
+            CHECK(_segments.empty()) << _segments.size();
+            CHECK(!_owned);
             // last_visit_time is set when release.
             // because it only be needed when pruning.
             ((SegmentCache::CacheValue*)_cache->value(_handle))->last_visit_time = UnixMillis();
@@ -142,35 +141,33 @@ public:
         }
     }
 
-    SegmentCacheHandle(SegmentCacheHandle&& other) noexcept {
-        std::swap(_cache, other._cache);
-        std::swap(_handle, other._handle);
-        this->owned = other.owned;
-        this->segments = std::move(other.segments);
+    void init(std::vector<segment_v2::SegmentSharedPtr> segments) {
+        DCHECK(_init);
+        _owned = true;
+        _segments = std::move(segments);
+        _init = true;
     }
 
-    SegmentCacheHandle& operator=(SegmentCacheHandle&& other) noexcept {
-        std::swap(_cache, other._cache);
-        std::swap(_handle, other._handle);
-        this->owned = other.owned;
-        this->segments = std::move(other.segments);
-        return *this;
+    void init(Cache* cache, Cache::Handle* handle) {
+        DCHECK(_init);
+        _owned = false;
+        _cache = cache;
+        _handle = handle;
+        _init = true;
     }
 
     std::vector<segment_v2::SegmentSharedPtr>& get_segments() {
-        if (owned) {
-            return segments;
+        if (_owned) {
+            return _segments;
         } else {
             return ((SegmentCache::CacheValue*)_cache->value(_handle))->segments;
         }
     }
 
-public:
-    // If set to true, the loaded segments will be saved in segments, not in lru cache;
-    bool owned = false;
-    std::vector<segment_v2::SegmentSharedPtr> segments;
-
 private:
+    bool _init {false};
+    bool _owned {false};
+    std::vector<segment_v2::SegmentSharedPtr> _segments;
     Cache* _cache = nullptr;
     Cache::Handle* _handle = nullptr;
 

--- a/be/src/olap/segment_loader.h
+++ b/be/src/olap/segment_loader.h
@@ -141,6 +141,8 @@ public:
         }
     }
 
+    [[nodiscard]] bool is_inited() const { return _init; }
+
     void init(std::vector<segment_v2::SegmentSharedPtr> segments) {
         DCHECK(_init);
         _owned = true;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

```
core stack
F0821 09:02:39.542575 2297202 segment_loader.h:136] Check failed: segments.empty() 16
*** Check failure stack trace: ***
    @     0x55df1e91b50d  google::LogMessage::Fail()
    @     0x55df1e91da49  google::LogMessage::SendToLog()
    @     0x55df1e91b076  google::LogMessage::Flush()
    @     0x55df1e91e0b9  google::LogMessageFatal::~LogMessageFatal()
    @     0x55defb649fed  doris::SegmentCacheHandle::~SegmentCacheHandle()
    @     0x55defb64e8b4  doris::BetaRowsetReader::~BetaRowsetReader()
    @     0x55defb64e929  doris::BetaRowsetReader::~BetaRowsetReader()
    @     0x55defb617caa  std::_Sp_counted_ptr<>::_M_dispose()
    @     0x55def9ae18d2  std::_Sp_counted_base<>::_M_release()
    @     0x55def9ae160a  std::__shared_count<>::~__shared_count()
    @     0x55def9f81b7b  std::__shared_ptr<>::~__shared_ptr()
    @     0x55def9f76845  std::shared_ptr<>::~shared_ptr()
    @     0x55def9f8c4b7  std::destroy_at<>()
    @     0x55def9f8c487  std::_Destroy<>()
    @     0x55def9f8c43b  std::_Destroy_aux<>::__destroy<>()
    @     0x55def9f8c3df  std::_Destroy<>()
    @     0x55def9f8c2a3  std::_Destroy<>()
    @     0x55def9f707c1  std::vector<>::~vector()
    @     0x55def9f529c8  doris::Compaction::~Compaction()
    @     0x55defc047a87  doris::CumulativeCompaction::~CumulativeCompaction()
    @     0x55defc047aa9  doris::CumulativeCompaction::~CumulativeCompaction()
    @     0x55defbe5ad6a  std::_Sp_counted_ptr<>::_M_dispose()
    @     0x55def9ae18d2  std::_Sp_counted_base<>::_M_release()
    @     0x55def9ae160a  std::__shared_count<>::~__shared_count()
    @     0x55defbe5a9cb  std::__shared_ptr<>::~__shared_ptr()
    @     0x55defc1508fb  std::__shared_ptr<>::reset()
    @     0x55defc0d9695  doris::Tablet::reset_compaction()
    @     0x55def9d3b16d  doris::StorageEngine::_submit_compaction_task()::$_0::operator()()
    @     0x55def9d3af37  std::__invoke_impl<>()
    @     0x55def9d3aea9  _ZSt10__invoke_rIvRZN5doris13StorageEngine23_submit_compaction_taskESt10shared_ptrINS0_6TabletEENS0_14CompactionTypeEbE3$_0JEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EES9_E4typeEOSA_DpOSB_
    @     0x55def9d3ac2f  std::_Function_handler<>::_M_invoke()
    @     0x55def9c9efe7  std::function<>::operator()()
```
When do vertical compaction，the _segment_cache_handle in beta_rowset_reader will be inited many time so that the check will failed.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

