### PR TITLE
[Fix](Nereids)add nereids load function in read fields of GlobalFunctionMgr and Database

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -635,7 +635,7 @@ public class Database extends MetaObject implements Writable, DatabaseIf<Table> 
         dbState = DbState.valueOf(Text.readString(in));
         attachDbName = Text.readString(in);
 
-        FunctionUtil.readFields(in, name2Function);
+        FunctionUtil.readFields(in, this.getFullName(), name2Function);
 
         // read encryptKeys
         if (Env.getCurrentEnvJournalVersion() >= FeMetaVersion.VERSION_102) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
@@ -157,7 +157,6 @@ public class FunctionRegistry {
                 .collect(Collectors.joining(", ", "[", "]"));
     }
 
-
     public void addUdf(String dbName, String name, UdfBuilder builder) {
         if (dbName == null) {
             dbName = GLOBAL_FUNCTION;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionUtil.java
@@ -181,7 +181,8 @@ public class FunctionUtil {
         }
     }
 
-    public static void readFields(DataInput in, ConcurrentMap<String, ImmutableList<Function>> name2Function)
+    public static void readFields(DataInput in, String dbName,
+            ConcurrentMap<String, ImmutableList<Function>> name2Function)
             throws IOException {
         int numEntries = in.readInt();
         for (int i = 0; i < numEntries; ++i) {
@@ -191,7 +192,11 @@ public class FunctionUtil {
             for (int j = 0; j < numFunctions; ++j) {
                 builder.add(Function.read(in));
             }
-            name2Function.put(name, builder.build());
+            ImmutableList<Function> functions = builder.build();
+            name2Function.put(name, functions);
+            for (Function f : functions) {
+                translateToNereids(dbName, f);
+            }
         }
     }
 
@@ -234,8 +239,11 @@ public class FunctionUtil {
                 JavaUdaf.translateToNereidsFunction(dbName, ((AggregateFunction) function));
             }
         } catch (Exception e) {
-            LOG.warn("Nereids create function {}:{} failed", dbName, function.getFunctionName().getFunction(), e);
+            LOG.warn("Nereids create function {}:{} failed, caused by: {}", dbName == null ? "_global_" : dbName,
+                    function.getFunctionName().getFunction(), e);
         }
+        LOG.info(String.format("Nereids add function: %s:%s OK!", dbName == null ? "_global_" : dbName,
+                function.getFunctionName().getFunction()));
         return true;
     }
 
@@ -246,8 +254,11 @@ public class FunctionUtil {
                     .collect(Collectors.toList());
             Env.getCurrentEnv().getFunctionRegistry().dropUdf(dbName, fnName, argTypes);
         } catch (Exception e) {
-            LOG.warn("Nereids drop function {}:{} failed", dbName, function.getName(), e);
+            LOG.warn("Nereids drop function {}:{} failed, caused by: {}", dbName == null ? "_global_" : dbName,
+                    function.getName(), e);
         }
+        LOG.info(String.format("Nereids drop function: %s:%s OK!", dbName == null ? "_global_" : dbName,
+                function.getName()));
         return false;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionUtil.java
@@ -242,8 +242,6 @@ public class FunctionUtil {
             LOG.warn("Nereids create function {}:{} failed, caused by: {}", dbName == null ? "_global_" : dbName,
                     function.getFunctionName().getFunction(), e);
         }
-        LOG.info(String.format("Nereids add function: %s:%s OK!", dbName == null ? "_global_" : dbName,
-                function.getFunctionName().getFunction()));
         return true;
     }
 
@@ -257,8 +255,6 @@ public class FunctionUtil {
             LOG.warn("Nereids drop function {}:{} failed, caused by: {}", dbName == null ? "_global_" : dbName,
                     function.getName(), e);
         }
-        LOG.info(String.format("Nereids drop function: %s:%s OK!", dbName == null ? "_global_" : dbName,
-                function.getName()));
         return false;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/GlobalFunctionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/GlobalFunctionMgr.java
@@ -57,7 +57,7 @@ public class GlobalFunctionMgr extends MetaObject {
     @Override
     public void readFields(DataInput in) throws IOException {
         super.readFields(in);
-        FunctionUtil.readFields(in, name2Function);
+        FunctionUtil.readFields(in, null, name2Function);
     }
 
     public synchronized void addFunction(Function function, boolean ifNotExists) throws UserException {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/UdfTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/UdfTest.java
@@ -40,8 +40,14 @@ import org.apache.doris.nereids.util.PlanChecker;
 import org.apache.doris.nereids.util.PlanPatternMatchSupported;
 import org.apache.doris.utframe.TestWithFeService;
 
+import avro.shaded.com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 
 public class UdfTest extends TestWithFeService implements PlanPatternMatchSupported {
     @Override
@@ -170,5 +176,21 @@ public class UdfTest extends TestWithFeService implements PlanPatternMatchSuppor
                                 .when(relation -> relation.getProjects().size() == 1
                                         && relation.getProjects().get(0).child(0).equals(expected))
                 );
+    }
+
+    @Test
+    public void testReadFromStream() throws Exception {
+        createFunction("create global alias function f8(int) with parameter(n) as hours_add(now(3), n)");
+        Env.getCurrentEnv().getFunctionRegistry().dropUdf(null, "f8",
+                ImmutableList.of(IntegerType.INSTANCE));
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        Env.getCurrentEnv().getGlobalFunctionMgr().write(new DataOutputStream(outputStream));
+        byte[] buffer = outputStream.toByteArray();
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(buffer);
+        Env.getCurrentEnv().getGlobalFunctionMgr().readFields(new DataInputStream(inputStream));
+
+        Assertions.assertEquals(1, Env.getCurrentEnv().getFunctionRegistry()
+                .findUdfBuilder(connectContext.getDatabase(), "f8").size());
     }
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

cherry-pick from master #23248
commit-id: c3327b51b9eb69b6189e527e50dc55fb123a1a15

add nereids load function in read fields of GlobalFunctionMgr and Database to fix some udf is lost when restart FE and
query with Nereids.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

