### PR TITLE
[Fix](executor)use push to send keep alive signal

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1056,6 +1056,8 @@ DEFINE_Int32(hdfs_hedged_read_threshold_time, "500");
 
 DEFINE_mBool(enable_merge_on_write_correctness_check, "true");
 
+DEFINE_mInt32(pipeline_keep_alive_timeout_ms, "60000");
+
 // The secure path with user files, used in the `local` table function.
 DEFINE_mString(user_files_secure_path, "${DORIS_HOME}");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1120,6 +1120,8 @@ DECLARE_mString(user_files_secure_path);
 // and if this threshold is exceeded, the remaining data will be pass through to other node directly.
 DECLARE_Int32(partition_topn_partition_threshold);
 
+DECLARE_mInt32(pipeline_keep_alive_timeout_ms);
+
 #ifdef BE_TEST
 // test s3
 DECLARE_String(test_s3_resource);

--- a/be/src/pipeline/exec/exchange_sink_buffer.cpp
+++ b/be/src/pipeline/exec/exchange_sink_buffer.cpp
@@ -201,7 +201,8 @@ Status ExchangeSinkBuffer<Parent>::_send_rpc(InstanceLoId id) {
         auto& brpc_request = _instance_to_request[id];
         brpc_request->set_eos(request.eos);
         brpc_request->set_packet_seq(_instance_to_seq[id]++);
-        if (request.block) {
+        // when request.block->column_metas_size() == 0, it means send a empty block to server to keep shuffle alive
+        if (request.block && request.block->column_metas_size()) {
             brpc_request->set_allocated_block(request.block.get());
         }
         auto* closure = request.channel->get_closure(id, request.eos, nullptr);

--- a/be/src/pipeline/exec/exchange_sink_operator.h
+++ b/be/src/pipeline/exec/exchange_sink_operator.h
@@ -63,6 +63,8 @@ public:
 
     RuntimeState* state() { return _state; }
 
+    bool should_sink_keep_alive() override { return true; }
+
 private:
     std::unique_ptr<ExchangeSinkBuffer<vectorized::VDataStreamSender>> _sink_buffer;
     int _dest_node_id = -1;

--- a/be/src/pipeline/exec/exchange_source_operator.h
+++ b/be/src/pipeline/exec/exchange_source_operator.h
@@ -47,6 +47,7 @@ public:
     ExchangeSourceOperator(OperatorBuilderBase*, ExecNode*);
     bool can_read() override;
     bool is_pending_finish() const override;
+    bool should_source_keep_alive() override { return true; }
 };
 
 class ExchangeSourceOperatorX;

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -261,6 +261,10 @@ public:
 
     [[nodiscard]] virtual RuntimeProfile* get_runtime_profile() const = 0;
 
+    virtual bool should_sink_keep_alive() { return false; }
+
+    virtual bool should_source_keep_alive() { return false; }
+
 protected:
     OperatorBuilderBase* _operator_builder;
     OperatorPtr _child;

--- a/be/src/pipeline/pipeline_task.h
+++ b/be/src/pipeline/pipeline_task.h
@@ -29,6 +29,7 @@
 #include "runtime/task_group/task_group.h"
 #include "util/runtime_profile.h"
 #include "util/stopwatch.hpp"
+#include "util/time.h"
 #include "vec/core/block.h"
 
 namespace doris {
@@ -246,6 +247,12 @@ public:
         }
     }
 
+    void update_last_sink_time_ms() { _last_sink_time_ms = MonotonicMillis(); }
+
+    void sink_keep_alive();
+
+    bool is_source_keep_alive_timeout();
+
 protected:
     void _finish_p_dependency() {
         for (const auto& p : _pipeline->_parents) {
@@ -284,6 +291,7 @@ protected:
     int _core_id = 0;
 
     bool _try_close_flag = false;
+    int64_t _last_sink_time_ms = 0;
 
     RuntimeProfile* _parent_profile;
     std::unique_ptr<RuntimeProfile> _task_profile;

--- a/be/src/pipeline/task_scheduler.cpp
+++ b/be/src/pipeline/task_scheduler.cpp
@@ -137,6 +137,13 @@ void BlockedTaskScheduler::_schedule() {
                 if (task->source_can_read()) {
                     _make_task_run(local_blocked_tasks, iter, ready_tasks);
                 } else {
+                    task->sink_keep_alive();
+                    bool ret = task->is_source_keep_alive_timeout();
+                    if (ret) {
+                        task->fragment_context()->cancel(PPlanFragmentCancelReason::TIMEOUT);
+                        LOG(INFO) << "query id " << print_id(task->query_context()->query_id)
+                                  << " is cancel because source is keep alive timeout";
+                    }
                     iter++;
                 }
             } else if (state == PipelineTaskState::BLOCKED_FOR_RF) {

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -179,6 +179,8 @@ public:
     FileMetaCache* file_meta_cache() { return _file_meta_cache; }
     MemTableMemoryLimiter* memtable_memory_limiter() { return _memtable_memory_limiter.get(); }
 
+    void update_keep_alive_time(TUniqueId query_id);
+
     // only for unit test
     void set_master_info(TMasterInfo* master_info) { this->_master_info = master_info; }
     void set_new_load_stream_mgr(std::shared_ptr<NewLoadStreamMgr> new_load_stream_mgr) {

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -426,4 +426,8 @@ void ExecEnv::destroy(ExecEnv* env) {
     env->_destroy();
 }
 
+void ExecEnv::update_keep_alive_time(TUniqueId query_id) {
+    fragment_mgr()->update_keep_alive_time(query_id);
+}
+
 } // namespace doris

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -1440,6 +1440,13 @@ Status FragmentMgr::merge_filter(const PMergeFilterRequest* request,
     return Status::OK();
 }
 
+void FragmentMgr::update_keep_alive_time(TUniqueId query_id) {
+    std::lock_guard<std::mutex> lock(_lock);
+    if (_query_ctx_map.find(query_id) != _query_ctx_map.end()) {
+        _query_ctx_map[query_id]->source_last_keep_alive_time_ms.store(MonotonicMillis());
+    }
+}
+
 void FragmentMgr::_setup_shared_hashtable_for_broadcast_join(const TExecPlanFragmentParams& params,
                                                              RuntimeState* state,
                                                              QueryContext* query_ctx) {

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -145,6 +145,8 @@ public:
 
     ThreadPool* get_thread_pool() { return _thread_pool.get(); }
 
+    void update_keep_alive_time(TUniqueId query_id);
+
 private:
     void _exec_actual(std::shared_ptr<FragmentExecState> exec_state, const FinishCallback& cb);
 

--- a/be/src/runtime/query_context.h
+++ b/be/src/runtime/query_context.h
@@ -212,6 +212,8 @@ public:
     // only for file scan node
     std::map<int, TFileScanRangeParams> file_scan_range_params_map;
 
+    std::atomic<int64_t> source_last_keep_alive_time_ms;
+
 private:
     ExecEnv* _exec_env;
     vectorized::VecDateTimeValue _start_time;

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -1053,10 +1053,15 @@ void PInternalServiceImpl::_transmit_block(google::protobuf::RpcController* cont
                                            const Status& extract_st) {
     std::string query_id;
     TUniqueId finst_id;
+    TUniqueId tquery_id;
     if (request->has_query_id()) {
         query_id = print_id(request->query_id());
         finst_id.__set_hi(request->finst_id().hi());
         finst_id.__set_lo(request->finst_id().lo());
+
+        tquery_id.hi = request->query_id().hi();
+        tquery_id.lo = request->query_id().lo();
+        _exec_env->fragment_mgr()->update_keep_alive_time(tquery_id);
     }
     VLOG_ROW << "transmit block: fragment_instance_id=" << print_id(request->finst_id())
              << " query_id=" << query_id << " node=" << request->node_id();


### PR DESCRIPTION
## Proposed changes

Add a keep alive feature for Doris shuffle, when a shuffle sink's BE process is dead or restart, shuffle receiver can't receive data forever, but it can not be cancelled until query timeout.
So we need introduce a shuffle keep alive feature, the shuffle sink send data periodically even no data is produced.
When no data produced, shuffle sink send a empty block to shuffle receiver to notify it  sink is alive and just wait.
Shuffle receiver could cancel itself when no signal is received exceed keep_alive_timeout.