### PR TITLE
[improve](nereids) expand runtime filter target by hashJoin's equal condition

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterContext.java
@@ -23,6 +23,7 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.trees.expressions.CTEId;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.ExprId;
+import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
@@ -39,6 +40,7 @@ import org.apache.doris.planner.RuntimeFilterGenerator.FilterSizeLimits;
 import org.apache.doris.planner.RuntimeFilterId;
 import org.apache.doris.planner.ScanNode;
 import org.apache.doris.qe.SessionVariable;
+import org.apache.doris.thrift.TRuntimeFilterType;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -56,12 +58,50 @@ import java.util.Set;
  * runtime filter context used at post process and translation.
  */
 public class RuntimeFilterContext {
+
+    /**
+     * the combination of src expr, filter type and source join node, use to identify the filter
+      */
+    public class RuntimeFilterIdentity {
+        final Expression expr;
+        final TRuntimeFilterType type;
+        final AbstractPhysicalJoin join;
+
+        public RuntimeFilterIdentity(Expression expr, TRuntimeFilterType type, AbstractPhysicalJoin join) {
+            this.expr = expr;
+            this.type = type;
+            this.join = join;
+        }
+
+        @Override
+        public int hashCode() {
+            return 0;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (other == null) {
+                return false;
+            }
+            if (other instanceof RuntimeFilterIdentity) {
+                RuntimeFilterIdentity otherId = (RuntimeFilterIdentity) other;
+                return expr.equals(otherId.expr) && type.equals(otherId.type) && join.equals(otherId.join);
+            }
+            return false;
+        }
+    }
+
     public List<RuntimeFilter> prunedRF = Lists.newArrayList();
 
     private final IdGenerator<RuntimeFilterId> generator = RuntimeFilterId.createGenerator();
 
     // exprId of target to runtime filter.
     private final Map<ExprId, List<RuntimeFilter>> targetExprIdToFilter = Maps.newHashMap();
+
+    private final Map<RuntimeFilterIdentity, RuntimeFilter> runtimeFilterIdentityToFilter = Maps.newHashMap();
 
     private final Map<PlanNodeId, DataStreamSink> planNodeIdToCTEDataSinkMap = Maps.newHashMap();
     private final Map<Plan, List<ExprId>> joinToTargetExprId = Maps.newHashMap();
@@ -166,6 +206,16 @@ public class RuntimeFilterContext {
 
     public void setTargetsOnScanNode(RelationId id, Slot slot) {
         this.targetOnOlapScanNodeMap.computeIfAbsent(id, k -> Lists.newArrayList()).add(slot);
+    }
+
+    public RuntimeFilter getRuntimeFilterBySrcAndType(Expression src,
+                                                      TRuntimeFilterType type, AbstractPhysicalJoin join) {
+        return runtimeFilterIdentityToFilter.get(new RuntimeFilterIdentity(src, type, join));
+    }
+
+    public void setRuntimeFilterIdentityToFilter(Expression src, TRuntimeFilterType type,
+                                                 AbstractPhysicalJoin join, RuntimeFilter rf) {
+        runtimeFilterIdentityToFilter.put(new RuntimeFilterIdentity(src, type, join), rf);
     }
 
     public Map<ExprId, SlotRef> getExprIdToOlapScanNodeSlotRef() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
@@ -508,6 +508,7 @@ public class RuntimeFilterGenerator extends PlanPostProcessor {
                     for (Slot slot : targetList) {
                         ctx.setTargetExprIdToFilter(slot.getExprId(), filter);
                     }
+                    ctx.setRuntimeFilterIdentityToFilter(equalTo.right(), type, join, filter);
                 }
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
@@ -25,6 +25,7 @@ import org.apache.doris.nereids.processor.post.RuntimeFilterContext;
 import org.apache.doris.nereids.processor.post.RuntimeFilterGenerator;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
+import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.MarkJoinSlotReference;
@@ -39,12 +40,13 @@ import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.util.MutableState;
 import org.apache.doris.nereids.util.Utils;
 import org.apache.doris.planner.RuntimeFilterId;
+import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.statistics.Statistics;
 import org.apache.doris.thrift.TRuntimeFilterType;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 import java.util.Comparator;
 import java.util.List;
@@ -234,11 +236,26 @@ public class PhysicalHashJoin<
         Preconditions.checkState(leftNode != null && rightNode != null,
                 "join child node is null");
 
-        pushedDown |= leftNode.pushDownRuntimeFilter(context, generator, builderNode,
-                srcExpr, probeExpr, type, buildSideNdv, exprOrder);
-        pushedDown |= rightNode.pushDownRuntimeFilter(context, generator, builderNode,
-                srcExpr, probeExpr, type, buildSideNdv, exprOrder);
-
+        Set<Expression> probExprList = Sets.newHashSet(probeExpr);
+        if (ConnectContext.get() != null && ConnectContext.get().getSessionVariable().expandRuntimeFilterByInnerJoin) {
+            if (!this.equals(builderNode) && this.getJoinType() == JoinType.INNER_JOIN) {
+                for (Expression expr : this.getHashJoinConjuncts()) {
+                    EqualTo equalTo = (EqualTo) expr;
+                    if (probeExpr.equals(equalTo.left())) {
+                        probExprList.add(equalTo.right());
+                    } else if (probeExpr.equals(equalTo.right())) {
+                        probExprList.add(equalTo.left());
+                    }
+                }
+                probExprList.remove(srcExpr);
+            }
+        }
+        for (Expression prob : probExprList) {
+            pushedDown |= leftNode.pushDownRuntimeFilter(context, generator, builderNode,
+                    srcExpr, prob, type, buildSideNdv, exprOrder);
+            pushedDown |= rightNode.pushDownRuntimeFilter(context, generator, builderNode,
+                    srcExpr, prob, type, buildSideNdv, exprOrder);
+        }
         // currently, we can ensure children in the two side are corresponding to the equal_to's.
         // so right maybe an expression and left is a slot
         Slot probeSlot = RuntimeFilterGenerator.checkTargetChild(probeExpr);
@@ -255,24 +272,7 @@ public class PhysicalHashJoin<
             return false;
         }
 
-        // TODO: if can't push down into join's chidren, try to
-        // find possible chance in upper layer
-        if (pushedDown) {
-            return true;
-        }
-
-        // in-filter is not friendly to pipeline
-        if (type == TRuntimeFilterType.IN_OR_BLOOM
-                && ctx.getSessionVariable().getEnablePipelineEngine()
-                && RuntimeFilterGenerator.hasRemoteTarget(this, scan)) {
-            type = TRuntimeFilterType.BLOOM;
-        }
-        RuntimeFilter filter = new RuntimeFilter(generator.getNextId(),
-                srcExpr, ImmutableList.of(olapScanSlot), type, exprOrder, this, buildSideNdv);
-        ctx.addJoinToTargetMap(this, olapScanSlot.getExprId());
-        ctx.setTargetExprIdToFilter(olapScanSlot.getExprId(), filter);
-        ctx.setTargetsOnScanNode(aliasTransferMap.get(probeSlot).first.getRelationId(), olapScanSlot);
-        return true;
+        return pushedDown;
     }
 
     private class ExprComparator implements Comparator<Expression> {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/RuntimeFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/RuntimeFilter.java
@@ -23,6 +23,7 @@ import org.apache.doris.planner.RuntimeFilterId;
 import org.apache.doris.thrift.TRuntimeFilterType;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
 import java.util.List;
 
@@ -61,8 +62,8 @@ public class RuntimeFilter {
             long buildSideNdv) {
         this.id = id;
         this.srcSlot = src;
-        this.targetSlots = ImmutableList.copyOf(targets);
-        this.targetExpressions = ImmutableList.copyOf(targetExpressions);
+        this.targetSlots = Lists.newArrayList(targets);
+        this.targetExpressions = Lists.newArrayList(targetExpressions);
         this.type = type;
         this.exprOrder = exprOrder;
         this.builderNode = builderNode;
@@ -105,6 +106,14 @@ public class RuntimeFilter {
 
     public long getBuildSideNdv() {
         return buildSideNdv;
+    }
+
+    public void addTargetSlot(Slot target) {
+        targetSlots.add(target);
+    }
+
+    public void addTargetExpressoin(Expression targetExpr) {
+        targetExpressions.add(targetExpr);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -405,6 +405,8 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String FULL_AUTO_ANALYZE_END_TIME = "full_auto_analyze_end_time";
 
+    public static final String EXPAND_RUNTIME_FILTER_BY_INNER_JION = "expand_runtime_filter_by_inner_join";
+
     public static final List<String> DEBUG_VARIABLES = ImmutableList.of(
             SKIP_DELETE_PREDICATE,
             SKIP_DELETE_BITMAP,
@@ -418,6 +420,9 @@ public class SessionVariable implements Serializable, Writable {
     // check stmt is or not [select /*+ SET_VAR(...)*/ ...]
     // if it is setStmt, we needn't collect session origin value
     public boolean isSingleSetVar = false;
+
+    @VariableMgr.VarAttr(name = EXPAND_RUNTIME_FILTER_BY_INNER_JION)
+    public boolean expandRuntimeFilterByInnerJoin = false;
 
     @VariableMgr.VarAttr(name = JDBC_CLICKHOUSE_QUERY_FINAL)
     public boolean jdbcClickhouseQueryFinal = false;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/RuntimeFilterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/RuntimeFilterTest.java
@@ -29,11 +29,16 @@ import org.apache.doris.nereids.trees.plans.physical.RuntimeFilter;
 import org.apache.doris.nereids.util.PlanChecker;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class RuntimeFilterTest extends SSBTestBase {
 
@@ -192,11 +197,13 @@ public class RuntimeFilterTest extends SSBTestBase {
                 + " on b.c_custkey = a.lo_custkey) c inner join (select lo_custkey from customer inner join lineorder"
                 + " on c_custkey = lo_custkey) d on c.c_custkey = d.lo_custkey";
         List<RuntimeFilter> filters = getRuntimeFilters(sql).get();
-        Assertions.assertEquals(5, filters.size());
-        checkRuntimeFilterExprs(filters, ImmutableList.of(
-                Pair.of("lo_custkey", "c_custkey"), Pair.of("c_custkey", "lo_custkey"),
-                Pair.of("d_datekey", "lo_orderdate"), Pair.of("s_suppkey", "c_custkey"),
-                Pair.of("lo_custkey", "c_custkey")));
+        Assertions.assertEquals(4, filters.size());
+        Map<String, Set<String>> srcTargets = Maps.newHashMap();
+        srcTargets.put("lo_custkey", Sets.newHashSet("c_custkey", "c_custkey", "s_suppkey", "lo_custkey"));
+        srcTargets.put("s_suppkey", Sets.newHashSet("c_custkey"));
+        srcTargets.put("d_datekey", Sets.newHashSet("lo_orderdate"));
+        srcTargets.put("c_custkey", Sets.newHashSet("lo_custkey"));
+        checkRuntimeFilterExprs(filters, srcTargets);
     }
 
     @Test
@@ -207,10 +214,13 @@ public class RuntimeFilterTest extends SSBTestBase {
                 + " on b.c_custkey = a.lo_custkey) c inner join (select lo_custkey from customer inner join lineorder"
                 + " on c_custkey = lo_custkey) d on c.c_custkey = d.lo_custkey";
         List<RuntimeFilter> filters = getRuntimeFilters(sql).get();
-        Assertions.assertEquals(4, filters.size());
-        checkRuntimeFilterExprs(filters, ImmutableList.of(
-                Pair.of("c_custkey", "lo_custkey"), Pair.of("d_datekey", "lo_orderdate"),
-                Pair.of("lo_custkey", "c_custkey"), Pair.of("lo_custkey", "c_custkey")));
+        Assertions.assertEquals(3, filters.size());
+        Map<String, Set<String>> srcTargets = Maps.newHashMap();
+        srcTargets.put("lo_custkey", Sets.newHashSet("c_custkey", "c_custkey", "lo_custkey"));
+        srcTargets.put("d_datekey", Sets.newHashSet("lo_orderdate"));
+        srcTargets.put("c_custkey", Sets.newHashSet("lo_custkey"));
+
+        checkRuntimeFilterExprs(filters, srcTargets);
     }
 
     @Test
@@ -230,6 +240,29 @@ public class RuntimeFilterTest extends SSBTestBase {
         Assertions.assertEquals(1, filters.size());
         checkRuntimeFilterExprs(filters, ImmutableList.of(
                 Pair.of("s_name", "p_name")));
+    }
+
+    @Test
+    public void testExpandRfByInnerJoin() {
+        String sql = "select * "
+                + "from lineorder join part on lo_partkey=p_partkey "
+                + "join supplier on s_suppkey=lo_partkey";
+        List<RuntimeFilter> filters = getRuntimeFilters(sql).get();
+        Assertions.assertEquals(2, filters.size());
+        checkRuntimeFilterExprs(filters, ImmutableList.of(
+                Pair.of("s_suppkey", "lo_partkey"),
+                Pair.of("p_partkey", "lo_partkey")));
+        connectContext.getSessionVariable().expandRuntimeFilterByInnerJoin = true;
+        filters = getRuntimeFilters(sql).get();
+        Assertions.assertEquals(2, filters.size());
+        Map<String, Set<String>> srcTargets = Maps.newHashMap();
+        Set<String> target1 = Sets.newHashSet("lo_partkey");
+        srcTargets.put("p_partkey", target1);
+        Set<String> target2 = Sets.newHashSet("p_partkey", "lo_partkey");
+        srcTargets.put("s_suppkey", target2);
+        checkRuntimeFilterExprs(filters, srcTargets);
+        connectContext.getSessionVariable().expandRuntimeFilterByInnerJoin = false;
+
     }
 
     private Optional<List<RuntimeFilter>> getRuntimeFilters(String sql) {
@@ -253,6 +286,16 @@ public class RuntimeFilterTest extends SSBTestBase {
             Assertions.assertTrue(colNames.contains(Pair.of(
                     filter.getSrcExpr().toSql(),
                     filter.getTargetExprs().get(0).getName())));
+        }
+    }
+
+    private void checkRuntimeFilterExprs(List<RuntimeFilter> filters, Map<String, Set<String>> srcTargets) {
+        Assertions.assertEquals(filters.size(), srcTargets.size());
+        for (RuntimeFilter filter : filters) {
+            Set<String> targets = srcTargets.get(filter.getSrcExpr().toSql());
+            Assertions.assertNotNull(targets);
+            targets.containsAll(
+                    filter.getTargetExprs().stream().map(expr -> expr.toSql()).collect(Collectors.toList()));
         }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/RuntimeFilterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/RuntimeFilterTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.nereids.postprocess;
 
-import com.clearspring.analytics.util.Lists;
 import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.datasets.ssb.SSBTestBase;
 import org.apache.doris.nereids.datasets.ssb.SSBUtils;
@@ -30,13 +29,11 @@ import org.apache.doris.nereids.trees.plans.physical.RuntimeFilter;
 import org.apache.doris.nereids.util.PlanChecker;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -229,7 +226,7 @@ public class RuntimeFilterTest extends SSBTestBase {
         Assertions.assertEquals(4, filters.size());
         Set<Pair<String, Set<String>>> srcTargets = Sets.newHashSet();
         srcTargets.add(Pair.of("lo_custkey", Sets.newHashSet("c_custkey")));
-        srcTargets.add(Pair.of("lo_custkey", Sets.newHashSet( "c_custkey", "lo_custkey")));
+        srcTargets.add(Pair.of("lo_custkey", Sets.newHashSet("c_custkey", "lo_custkey")));
         srcTargets.add(Pair.of("d_datekey", Sets.newHashSet("lo_orderdate")));
         srcTargets.add(Pair.of("c_custkey", Sets.newHashSet("lo_custkey")));
         checkRuntimeFilterExprs(filters, srcTargets);
@@ -239,7 +236,7 @@ public class RuntimeFilterTest extends SSBTestBase {
         Assertions.assertEquals(4, filters.size());
         srcTargets = Sets.newHashSet();
         srcTargets.add(Pair.of("lo_custkey", Sets.newHashSet("c_custkey")));
-        srcTargets.add(Pair.of("lo_custkey", Sets.newHashSet( "c_custkey", "lo_custkey")));
+        srcTargets.add(Pair.of("lo_custkey", Sets.newHashSet("c_custkey", "lo_custkey")));
         srcTargets.add(Pair.of("d_datekey", Sets.newHashSet("lo_orderdate")));
         srcTargets.add(Pair.of("c_custkey", Sets.newHashSet("lo_custkey")));
         checkRuntimeFilterExprs(filters, srcTargets);

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf2.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf2.groovy
@@ -110,5 +110,5 @@ suite("ds_rf2") {
     // File file = new File(outFile)
     // file.write(getRuntimeFilters(plan))
     
-     assertEquals("RF0[d_date_sk->[ws_sold_date_sk],RF1[d_date_sk->[cs_sold_date_sk],RF3[d_week_seq->[d_week_seq],RF2[d_week_seq->[d_week_seq]", getRuntimeFilters(plan))
+     assertEquals("RF0[d_date_sk->[ws_sold_date_sk, cs_sold_date_sk],RF2[d_week_seq->[d_week_seq],RF1[d_week_seq->[d_week_seq]", getRuntimeFilters(plan))
 }

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf5.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf5.groovy
@@ -178,5 +178,5 @@ suite("ds_rf5") {
     // File file = new File(outFile)
     // file.write(getRuntimeFilters(plan))
 
-     assertEquals("RF2[s_store_sk->[ss_store_sk],RF3[s_store_sk->[sr_store_sk],RF0[d_date_sk->[ss_sold_date_sk],RF1[d_date_sk->[sr_returned_date_sk],RF6[cp_catalog_page_sk->[cs_catalog_page_sk],RF7[cp_catalog_page_sk->[cr_catalog_page_sk],RF4[d_date_sk->[cs_sold_date_sk],RF5[d_date_sk->[cr_returned_date_sk],RF12[web_site_sk->[ws_web_site_sk],RF13[web_site_sk->[ws_web_site_sk],RF10[d_date_sk->[ws_sold_date_sk],RF11[d_date_sk->[wr_returned_date_sk],RF8[wr_item_sk->[ws_item_sk],RF9[wr_order_number->[ws_order_number]", getRuntimeFilters(plan))
+     assertEquals("RF1[s_store_sk->[ss_store_sk, sr_store_sk],RF0[d_date_sk->[ss_sold_date_sk, sr_returned_date_sk],RF3[cp_catalog_page_sk->[cs_catalog_page_sk, cr_catalog_page_sk],RF2[d_date_sk->[cs_sold_date_sk, cr_returned_date_sk],RF7[web_site_sk->[ws_web_site_sk, ws_web_site_sk],RF6[d_date_sk->[ws_sold_date_sk, wr_returned_date_sk],RF4[wr_item_sk->[ws_item_sk],RF5[wr_order_number->[ws_order_number]", getRuntimeFilters(plan))
 }

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf54.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf54.groovy
@@ -106,5 +106,5 @@ suite("ds_rf54") {
     // File file = new File(outFile)
     // file.write(getRuntimeFilters(plan))
     
-     assertEquals("RF6[s_county->[ca_county],RF7[s_state->[ca_state],RF5[d_date_sk->[ss_sold_date_sk],RF4[c_customer_sk->[ss_customer_sk],RF3[c_current_addr_sk->[ca_address_sk],RF2[customer_sk->[c_customer_sk],RF0[i_item_sk->[cs_item_sk],RF1[i_item_sk->[ws_item_sk]", getRuntimeFilters(plan))
+     assertEquals("RF5[s_county->[ca_county],RF6[s_state->[ca_state],RF4[d_date_sk->[ss_sold_date_sk],RF3[c_customer_sk->[ss_customer_sk],RF2[c_current_addr_sk->[ca_address_sk],RF1[customer_sk->[c_customer_sk],RF0[i_item_sk->[cs_item_sk, ws_item_sk]", getRuntimeFilters(plan))
 }


### PR DESCRIPTION
## Proposed changes

### generate more runtime filters
example:

`lineitem join partsupp on l_partkey= ps_partkey
               join filter(part) on ps_partkey=p_partkey
`
we need two RFs:
RF1: p_partkey->ps_partkey
RF2: p_partkey->l_partkey

This pr will generate RF2, but current version will not.

### merge runtime filters
current version, if one src could affect 2 targets, we will generate 2 runtime filters.
after this pr, the two rf will be merged.
refer to regression test: ds_rf2/ds_rf5/ds_rf54


Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

