### PR TITLE
[refactor](brpc) move thread pool from internal service to exec env

### DIFF
--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -188,6 +188,9 @@ public:
         this->_stream_load_executor = stream_load_executor;
     }
 
+    FifoThreadPool* heavy_work_pool() { return _heavy_work_pool.get(); }
+    FifoThreadPool* light_work_pool() { return _light_work_pool.get(); }
+
 private:
     Status _init(const std::vector<StorePath>& store_paths);
     void _destroy();
@@ -263,6 +266,13 @@ private:
     // To save meta info of external file, such as parquet footer.
     FileMetaCache* _file_meta_cache = nullptr;
     std::unique_ptr<MemTableMemoryLimiter> _memtable_memory_limiter;
+
+    // every brpc service request should put into thread pool
+    // the reason see issue #16634
+    // define the interface for reading and writing data as heavy interface
+    // otherwise as light interface
+    std::unique_ptr<FifoThreadPool> _heavy_work_pool;
+    std::unique_ptr<FifoThreadPool> _light_work_pool;
 };
 
 template <>

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -156,20 +156,20 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
             .set_max_queue_size(config::fragment_pool_queue_size)
             .build(&_join_node_thread_pool);
 
-    _heavy_work_pool.reset(new FifoThreadPool(config::brpc_heavy_work_pool_threads != -1
-                                                      ? config::brpc_heavy_work_pool_threads
-                                                      : std::max(128, CpuInfo::num_cores() * 4),
-                                              config::brpc_heavy_work_pool_max_queue_size != -1
-                                                      ? config::brpc_heavy_work_pool_max_queue_size
-                                                      : std::max(10240, CpuInfo::num_cores() * 320),
-                                              "brpc_heavy"));
-    _light_work_pool.reset(new FifoThreadPool(config::brpc_light_work_pool_threads != -1
-                                                      ? config::brpc_light_work_pool_threads
-                                                      : std::max(128, CpuInfo::num_cores() * 4),
-                                              config::brpc_light_work_pool_max_queue_size != -1
-                                                      ? config::brpc_light_work_pool_max_queue_size
-                                                      : std::max(10240, CpuInfo::num_cores() * 320),
-                                              "brpc_light"));
+    _heavy_work_pool = std::make_unique<FifoThreadPool>(
+            config::brpc_heavy_work_pool_threads != -1 ? config::brpc_heavy_work_pool_threads
+                                                       : std::max(128, CpuInfo::num_cores() * 4),
+            config::brpc_heavy_work_pool_max_queue_size != -1
+                    ? config::brpc_heavy_work_pool_max_queue_size
+                    : std::max(10240, CpuInfo::num_cores() * 320),
+            "brpc_heavy");
+    _light_work_pool = std::make_unique<FifoThreadPool>(
+            config::brpc_light_work_pool_threads != -1 ? config::brpc_light_work_pool_threads
+                                                       : std::max(128, CpuInfo::num_cores() * 4),
+            config::brpc_light_work_pool_max_queue_size != -1
+                    ? config::brpc_light_work_pool_max_queue_size
+                    : std::max(10240, CpuInfo::num_cores() * 320),
+            "brpc_light");
 
     RETURN_IF_ERROR(init_pipeline_task_scheduler());
     _task_group_manager = new taskgroup::TaskGroupManager();

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -97,6 +97,16 @@ DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(send_batch_thread_pool_queue_size, MetricUnit
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(download_cache_thread_pool_thread_num, MetricUnit::NOUNIT);
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(download_cache_thread_pool_queue_size, MetricUnit::NOUNIT);
 
+DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(heavy_work_pool_queue_size, MetricUnit::NOUNIT);
+DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(light_work_pool_queue_size, MetricUnit::NOUNIT);
+DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(heavy_work_active_threads, MetricUnit::NOUNIT);
+DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(light_work_active_threads, MetricUnit::NOUNIT);
+
+DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(heavy_work_pool_max_queue_size, MetricUnit::NOUNIT);
+DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(light_work_pool_max_queue_size, MetricUnit::NOUNIT);
+DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(heavy_work_max_threads, MetricUnit::NOUNIT);
+DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(light_work_max_threads, MetricUnit::NOUNIT);
+
 Status ExecEnv::init(ExecEnv* env, const std::vector<StorePath>& store_paths) {
     return env->_init(store_paths);
 }
@@ -145,6 +155,21 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
             .set_max_threads(std::numeric_limits<int>::max())
             .set_max_queue_size(config::fragment_pool_queue_size)
             .build(&_join_node_thread_pool);
+
+    _heavy_work_pool.reset(new FifoThreadPool(config::brpc_heavy_work_pool_threads != -1
+                                                      ? config::brpc_heavy_work_pool_threads
+                                                      : std::max(128, CpuInfo::num_cores() * 4),
+                                              config::brpc_heavy_work_pool_max_queue_size != -1
+                                                      ? config::brpc_heavy_work_pool_max_queue_size
+                                                      : std::max(10240, CpuInfo::num_cores() * 320),
+                                              "brpc_heavy"));
+    _light_work_pool.reset(new FifoThreadPool(config::brpc_light_work_pool_threads != -1
+                                                      ? config::brpc_light_work_pool_threads
+                                                      : std::max(128, CpuInfo::num_cores() * 4),
+                                              config::brpc_light_work_pool_max_queue_size != -1
+                                                      ? config::brpc_light_work_pool_max_queue_size
+                                                      : std::max(10240, CpuInfo::num_cores() * 320),
+                                              "brpc_light"));
 
     RETURN_IF_ERROR(init_pipeline_task_scheduler());
     _task_group_manager = new taskgroup::TaskGroupManager();
@@ -363,6 +388,24 @@ void ExecEnv::_register_metrics() {
 
     REGISTER_HOOK_METRIC(download_cache_thread_pool_queue_size,
                          [this]() { return _download_cache_thread_pool->get_queue_size(); });
+
+    REGISTER_HOOK_METRIC(heavy_work_pool_queue_size,
+                         [this]() { return _heavy_work_pool->get_queue_size(); });
+    REGISTER_HOOK_METRIC(light_work_pool_queue_size,
+                         [this]() { return _light_work_pool->get_queue_size(); });
+    REGISTER_HOOK_METRIC(heavy_work_active_threads,
+                         [this]() { return _heavy_work_pool->get_active_threads(); });
+    REGISTER_HOOK_METRIC(light_work_active_threads,
+                         [this]() { return _light_work_pool->get_active_threads(); });
+
+    REGISTER_HOOK_METRIC(heavy_work_pool_max_queue_size,
+                         []() { return config::brpc_heavy_work_pool_max_queue_size; });
+    REGISTER_HOOK_METRIC(light_work_pool_max_queue_size,
+                         []() { return config::brpc_light_work_pool_max_queue_size; });
+    REGISTER_HOOK_METRIC(heavy_work_max_threads,
+                         []() { return config::brpc_heavy_work_pool_threads; });
+    REGISTER_HOOK_METRIC(light_work_max_threads,
+                         []() { return config::brpc_light_work_pool_threads; });
 }
 
 void ExecEnv::_deregister_metrics() {
@@ -371,6 +414,16 @@ void ExecEnv::_deregister_metrics() {
     DEREGISTER_HOOK_METRIC(send_batch_thread_pool_queue_size);
     DEREGISTER_HOOK_METRIC(download_cache_thread_pool_thread_num);
     DEREGISTER_HOOK_METRIC(download_cache_thread_pool_queue_size);
+
+    DEREGISTER_HOOK_METRIC(heavy_work_pool_queue_size);
+    DEREGISTER_HOOK_METRIC(light_work_pool_queue_size);
+    DEREGISTER_HOOK_METRIC(heavy_work_active_threads);
+    DEREGISTER_HOOK_METRIC(light_work_active_threads);
+
+    DEREGISTER_HOOK_METRIC(heavy_work_pool_max_queue_size);
+    DEREGISTER_HOOK_METRIC(light_work_pool_max_queue_size);
+    DEREGISTER_HOOK_METRIC(heavy_work_max_threads);
+    DEREGISTER_HOOK_METRIC(light_work_max_threads);
 }
 
 void ExecEnv::_destroy() {

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -235,8 +235,8 @@ private:
     // the reason see issue #16634
     // define the interface for reading and writing data as heavy interface
     // otherwise as light interface
-    FifoThreadPool _heavy_work_pool;
-    FifoThreadPool _light_work_pool;
+    FifoThreadPool& _heavy_work_pool;
+    FifoThreadPool& _light_work_pool;
 };
 
 } // namespace doris


### PR DESCRIPTION
## Proposed changes

Move thread pool from internal service to exec env, so we can share thread pool between multiple rpc instances.
And it will be easier to offload some heavy work into the thread pool deep inside rpc handler.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

