### PR TITLE
[fix](merge-on-write) process error of delete bitmap calculation

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -3262,8 +3262,8 @@ Status Tablet::update_delete_bitmap_without_lock(const RowsetSharedPtr& rowset) 
     auto token = StorageEngine::instance()->calc_delete_bitmap_executor()->create_token();
     RETURN_IF_ERROR(calc_delete_bitmap(rowset, segments, specified_rowsets, delete_bitmap,
                                        cur_version - 1, token.get()));
-    token->wait();
-    token->get_delete_bitmap(delete_bitmap);
+    RETURN_IF_ERROR(token->wait());
+    RETURN_IF_ERROR(token->get_delete_bitmap(delete_bitmap));
     size_t total_rows = std::accumulate(
             segments.begin(), segments.end(), 0,
             [](size_t sum, const segment_v2::SegmentSharedPtr& s) { return sum += s->num_rows(); });
@@ -3363,8 +3363,8 @@ Status Tablet::update_delete_bitmap(const RowsetSharedPtr& rowset,
     auto token = StorageEngine::instance()->calc_delete_bitmap_executor()->create_token();
     RETURN_IF_ERROR(calc_delete_bitmap(rowset, segments, specified_rowsets, delete_bitmap,
                                        cur_version - 1, token.get(), rowset_writer));
-    token->wait();
-    token->get_delete_bitmap(delete_bitmap);
+    RETURN_IF_ERROR(token->wait());
+    RETURN_IF_ERROR(token->get_delete_bitmap(delete_bitmap));
     size_t total_rows = std::accumulate(
             segments.begin(), segments.end(), 0,
             [](size_t sum, const segment_v2::SegmentSharedPtr& s) { return sum += s->num_rows(); });


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

```
W0821 21:43:16.879952 13571 calc_delete_bitmap_executor.cpp:51] failed to calc segment delete bitmap, ftablet_id: 82558 rowset: 02000000000020ab8742fbc43a7ed0b08d05c75e73fa348d seg_id: 0 version: 41
W0821 21:43:16.892997 13588 calc_delete_bitmap_executor.cpp:51] failed to calc segment delete bitmap, ftablet_id: 83550 rowset: 02000000000020528742fbc43a7ed0b08d05c75e73fa348d seg_id: 0 version: 41
W0821 21:43:16.962687 13580 calc_delete_bitmap_executor.cpp:51] failed to calc segment delete bitmap, tablet_id: 82022 rowset: 0200000000000203a8742fbc43a7ed0b08d05c75e73fa348d seg_id: 0 version: 41
```
Current logic don't handle error of delete bitmap calculation, which might cause the duplicate key in unique key mow table

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

