### PR TITLE
[improve](alter-job) Add a config for forbiding doing alter job

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2108,5 +2108,5 @@ public class Config extends ConfigBase {
     public static boolean use_mysql_bigint_for_largeint = false;
 
     @ConfField
-    public static boolean forbid_alter_job = false;
+    public static boolean forbid_altering_job = false;
 }

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2108,5 +2108,5 @@ public class Config extends ConfigBase {
     public static boolean use_mysql_bigint_for_largeint = false;
 
     @ConfField
-    public static boolean forbid_altering_job = false;
+    public static boolean forbid_running_alter_job = false;
 }

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2106,4 +2106,7 @@ public class Config extends ConfigBase {
             "是否用 mysql 的 bigint 类型来返回 Doris 的 largeint 类型",
             "Whether to use mysql's bigint type to return Doris's largeint type"})
     public static boolean use_mysql_bigint_for_largeint = false;
+
+    @ConfField
+    public static boolean forbid_alter_job = false;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -1602,6 +1602,9 @@ public class SchemaChangeHandler extends AlterHandler {
     }
 
     private void runAlterJobV2() {
+        if (!Config.forbid_alter_job) {
+            return;
+        }
         runnableSchemaChangeJobV2.values().forEach(alterJobsV2 -> {
             if (!alterJobsV2.isDone() && !activeSchemaChangeJobsV2.containsKey(alterJobsV2.getJobId())
                     && activeSchemaChangeJobsV2.size() < MAX_ACTIVE_SCHEMA_CHANGE_JOB_V2_SIZE) {

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -1602,8 +1602,7 @@ public class SchemaChangeHandler extends AlterHandler {
     }
 
     private void runAlterJobV2() {
-        if (Config.forbid_altering_job) {
-            LOG.info("forbid altering job");
+        if (Config.forbid_running_alter_job) {
             return;
         }
         runnableSchemaChangeJobV2.values().forEach(alterJobsV2 -> {

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -1602,7 +1602,8 @@ public class SchemaChangeHandler extends AlterHandler {
     }
 
     private void runAlterJobV2() {
-        if (!Config.forbid_alter_job) {
+        if (Config.forbid_altering_job) {
+            LOG.info("forbid altering job");
             return;
         }
         runnableSchemaChangeJobV2.values().forEach(alterJobsV2 -> {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
When the FE/BE is killed because of doing schema change, the FE/BE will be killed though it restart because of replaying schema change job. For reboot the FE/BE, we need a config to forbid replaying schema change job and cancel the wrong job.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

