### PR TITLE
[Fix](multi-catalog) Fix load string dict issue for transactional hive tables.

### DIFF
--- a/be/src/vec/exec/format/orc/vorc_reader.h
+++ b/be/src/vec/exec/format/orc/vorc_reader.h
@@ -510,10 +510,10 @@ private:
     std::list<std::string> _read_cols_lower_case;
     std::list<std::string> _missing_cols;
     std::unordered_map<std::string, int> _colname_to_idx;
-    // Column name in Orc file to column name to schema.
+    // Column name in Orc file after removed acid(remove row.) to column name to schema.
     // This is used for Hive 1.x which use internal column name in Orc file.
     // _col0, _col1...
-    std::unordered_map<std::string, std::string> _file_col_to_schema_col;
+    std::unordered_map<std::string, std::string> _removed_acid_file_col_name_to_schema_col;
     // Flag for hive engine. True if the external table engine is Hive.
     bool _is_hive = false;
     std::unordered_map<std::string, std::string> _col_name_to_file_col_name;

--- a/regression-test/pipeline/p0/conf/regression-conf.groovy
+++ b/regression-test/pipeline/p0/conf/regression-conf.groovy
@@ -54,9 +54,7 @@ testDirectories = ""
 // this groups will not be executed
 excludeGroups = ""
 // this suites will not be executed
-
-excludeSuites = "test_full_compaction,test_default_limit,test_profile,test_broker_load,test_spark_load,test_refresh_mtmv,test_bitmap_filter,test_export_parquet,test_doris_jdbc_catalog,test_transactional_hive,nereids_delete_mow_partial_update,test_hdfs_tvf"
-
+excludeSuites = "test_full_compaction,test_default_limit,test_profile,test_broker_load,test_spark_load,test_refresh_mtmv,test_bitmap_filter,test_export_parquet,test_doris_jdbc_catalog,nereids_delete_mow_partial_update,test_hdfs_tvf"
 // this directories will not be executed
 excludeDirectories = "workload_manager_p1"
 


### PR DESCRIPTION

## Proposed changes

Fix load string dict issue for transactional hive tables. The column name need to pass `'row.column_name'`.

https://github.com/apache/doris-thirdparty/pull/112
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

