### PR TITLE
[enhancement](merge-on-write) Add delete bitmap correctness check in commit phase

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -163,7 +163,7 @@ Status DeltaWriter::commit_txn(const PSlaveTabletNodes& slave_tablet_nodes,
                                const bool write_single_replica) {
     std::lock_guard<std::mutex> l(_lock);
     SCOPED_TIMER(_commit_txn_timer);
-    _rowset_builder.commit_txn();
+    RETURN_IF_ERROR(_rowset_builder.commit_txn());
 
     if (write_single_replica) {
         for (auto node_info : slave_tablet_nodes.slave_nodes()) {

--- a/be/src/olap/rowset_builder.cpp
+++ b/be/src/olap/rowset_builder.cpp
@@ -250,9 +250,17 @@ Status RowsetBuilder::wait_calc_delete_bitmap() {
 
 Status RowsetBuilder::commit_txn() {
     if (_tablet->enable_unique_key_merge_on_write() &&
-        config::enable_merge_on_write_correctness_check) {
-        RETURN_IF_ERROR(_tablet->check_delete_bitmap_correctness(
-                _delete_bitmap, _rowset->end_version() - 1, _req.txn_id, _rowset_ids));
+        config::enable_merge_on_write_correctness_check && _rowset->num_rows() != 0) {
+        auto st = _tablet->check_delete_bitmap_correctness(
+                _delete_bitmap, _rowset->end_version() - 1, _req.txn_id, _rowset_ids);
+        if (!st.ok()) {
+            LOG(WARNING) << fmt::format(
+                    "[tablet_id:{}][txn_id:{}][load_id:{}][partition_id:{}] "
+                    "delete bitmap correctness check failed in commit phase!",
+                    _req.tablet_id, _req.txn_id, UniqueId(_req.load_id).to_string(),
+                    _req.partition_id);
+            return st;
+        }
     }
 
     std::lock_guard<std::mutex> l(_lock);

--- a/be/src/olap/rowset_builder.cpp
+++ b/be/src/olap/rowset_builder.cpp
@@ -249,6 +249,12 @@ Status RowsetBuilder::wait_calc_delete_bitmap() {
 }
 
 Status RowsetBuilder::commit_txn() {
+    if (_tablet->enable_unique_key_merge_on_write() &&
+        config::enable_merge_on_write_correctness_check) {
+        RETURN_IF_ERROR(_tablet->check_delete_bitmap_correctness(
+                _delete_bitmap, _rowset->end_version() - 1, _req.txn_id, _rowset_ids));
+    }
+
     std::lock_guard<std::mutex> l(_lock);
     SCOPED_TIMER(_commit_txn_timer);
     Status res = _storage_engine->txn_manager()->commit_txn(_req.partition_id, _tablet, _req.txn_id,

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -3257,7 +3257,7 @@ Status Tablet::update_delete_bitmap_without_lock(const RowsetSharedPtr& rowset) 
     if (config::enable_merge_on_write_correctness_check) {
         // check if all the rowset has ROWSET_SENTINEL_MARK
         RETURN_IF_ERROR(check_delete_bitmap_correctness(delete_bitmap, cur_version - 1, -1,
-                                                         cur_rowset_ids, &specified_rowsets));
+                                                        cur_rowset_ids, &specified_rowsets));
         _remove_sentinel_mark_from_delete_bitmap(delete_bitmap);
     }
     for (auto iter = delete_bitmap->delete_bitmap.begin();
@@ -3361,7 +3361,7 @@ Status Tablet::update_delete_bitmap(const RowsetSharedPtr& rowset,
         // only do correctness check if the rowset has at least one row written
         // check if all the rowset has ROWSET_SENTINEL_MARK
         RETURN_IF_ERROR(check_delete_bitmap_correctness(delete_bitmap, cur_version - 1, txn_id,
-                                                         cur_rowset_ids));
+                                                        cur_rowset_ids));
         _remove_sentinel_mark_from_delete_bitmap(delete_bitmap);
     }
 
@@ -3718,9 +3718,9 @@ void Tablet::_remove_sentinel_mark_from_delete_bitmap(DeleteBitmapPtr delete_bit
 }
 
 Status Tablet::check_delete_bitmap_correctness(DeleteBitmapPtr delete_bitmap, int64_t max_version,
-                                                int64_t txn_id,
-                                                const RowsetIdUnorderedSet& rowset_ids,
-                                                std::vector<RowsetSharedPtr>* rowsets) {
+                                               int64_t txn_id,
+                                               const RowsetIdUnorderedSet& rowset_ids,
+                                               std::vector<RowsetSharedPtr>* rowsets) {
     RowsetIdUnorderedSet missing_ids;
     for (const auto& rowsetid : rowset_ids) {
         if (!delete_bitmap->delete_bitmap.contains(

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -3256,7 +3256,7 @@ Status Tablet::update_delete_bitmap_without_lock(const RowsetSharedPtr& rowset) 
               << "(us), total rows: " << total_rows;
     if (config::enable_merge_on_write_correctness_check) {
         // check if all the rowset has ROWSET_SENTINEL_MARK
-        RETURN_IF_ERROR(_check_delete_bitmap_correctness(delete_bitmap, cur_version - 1, -1,
+        RETURN_IF_ERROR(check_delete_bitmap_correctness(delete_bitmap, cur_version - 1, -1,
                                                          cur_rowset_ids, &specified_rowsets));
         _remove_sentinel_mark_from_delete_bitmap(delete_bitmap);
     }
@@ -3360,7 +3360,7 @@ Status Tablet::update_delete_bitmap(const RowsetSharedPtr& rowset,
     if (config::enable_merge_on_write_correctness_check && rowset->num_rows() != 0) {
         // only do correctness check if the rowset has at least one row written
         // check if all the rowset has ROWSET_SENTINEL_MARK
-        RETURN_IF_ERROR(_check_delete_bitmap_correctness(delete_bitmap, cur_version - 1, txn_id,
+        RETURN_IF_ERROR(check_delete_bitmap_correctness(delete_bitmap, cur_version - 1, txn_id,
                                                          cur_rowset_ids));
         _remove_sentinel_mark_from_delete_bitmap(delete_bitmap);
     }
@@ -3717,7 +3717,7 @@ void Tablet::_remove_sentinel_mark_from_delete_bitmap(DeleteBitmapPtr delete_bit
     }
 }
 
-Status Tablet::_check_delete_bitmap_correctness(DeleteBitmapPtr delete_bitmap, int64_t max_version,
+Status Tablet::check_delete_bitmap_correctness(DeleteBitmapPtr delete_bitmap, int64_t max_version,
                                                 int64_t txn_id,
                                                 const RowsetIdUnorderedSet& rowset_ids,
                                                 std::vector<RowsetSharedPtr>* rowsets) {

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -552,6 +552,9 @@ public:
     void set_binlog_config(BinlogConfig binlog_config);
     void add_sentinel_mark_to_delete_bitmap(DeleteBitmap* delete_bitmap,
                                             const RowsetIdUnorderedSet& rowsetids);
+    Status check_delete_bitmap_correctness(DeleteBitmapPtr delete_bitmap, int64_t max_version,
+                                           int64_t txn_id, const RowsetIdUnorderedSet& rowset_ids,
+                                           std::vector<RowsetSharedPtr>* rowsets = nullptr);
 
 private:
     Status _init_once_action();
@@ -597,9 +600,6 @@ private:
     ////////////////////////////////////////////////////////////////////////////
 
     void _remove_sentinel_mark_from_delete_bitmap(DeleteBitmapPtr delete_bitmap);
-    Status _check_delete_bitmap_correctness(DeleteBitmapPtr delete_bitmap, int64_t max_version,
-                                            int64_t txn_id, const RowsetIdUnorderedSet& rowset_ids,
-                                            std::vector<RowsetSharedPtr>* rowsets = nullptr);
     std::string _get_rowset_info_str(RowsetSharedPtr rowset, bool delete_flag);
 
 public:


### PR DESCRIPTION
## Proposed changes
related PR: https://github.com/apache/doris/pull/22282
In #22282, we do delete bitmap correctness check in publish phase. But due to 2PC, we can't do anything but printing logs if we found inconsistency in publish phase. This PR adds delete bitmap correctness check in commit phase and if we found inconsistency we can abort the current trnsaction immediately
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

