### PR TITLE
[Bug](jdbc) support get_default on complex type

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -225,14 +225,17 @@ function(TRY_TO_CHANGE_LINKER LINKER_COMMAND LINKER_NAME)
     endif()
 endfunction()
 
-# In terms of performance, mold> lld> gold> ld
-set(CUSTUM_LINKER_COMMAND "ld")
-TRY_TO_CHANGE_LINKER("mold" "mold")
-TRY_TO_CHANGE_LINKER("lld" "LLD")
-TRY_TO_CHANGE_LINKER("gold" "GNU gold")
-if (NOT CUSTUM_LINKER_COMMAND STREQUAL "ld")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=${CUSTUM_LINKER_COMMAND}")
+if (NOT OS_MACOSX) # MACOSX's lld will core dump
+    # In terms of performance, mold> lld> gold> ld
+    set(CUSTUM_LINKER_COMMAND "ld")
+    TRY_TO_CHANGE_LINKER("mold" "mold")
+    TRY_TO_CHANGE_LINKER("lld" "LLD")
+    TRY_TO_CHANGE_LINKER("gold" "GNU gold")
+    if (NOT CUSTUM_LINKER_COMMAND STREQUAL "ld")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=${CUSTUM_LINKER_COMMAND}")
+    endif()
 endif()
+
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_C_STANDARD 17)

--- a/be/src/vec/common/field_visitors.h
+++ b/be/src/vec/common/field_visitors.h
@@ -63,64 +63,6 @@ typename std::decay_t<Visitor>::ResultType apply_visitor(Visitor&& visitor, F&& 
         return visitor(field.template get<DecimalField<Decimal128>>());
     case Field::Types::Decimal128I:
         return visitor(field.template get<DecimalField<Decimal128I>>());
-    case Field::Types::AggregateFunctionState:
-        return visitor(field.template get<AggregateFunctionStateData>());
-
-    default:
-        LOG(FATAL) << "Bad type of Field";
-        return {};
-    }
-}
-
-template <typename Visitor, typename F1, typename F2>
-typename std::decay_t<Visitor>::ResultType apply_visitor(Visitor&& visitor, F1&& field1,
-                                                         F2&& field2) {
-    switch (field1.getType()) {
-    case Field::Types::Null:
-        return apply_binary_visitor_impl(std::forward<Visitor>(visitor),
-                                         field1.template get<Null>(), std::forward<F2>(field2));
-    case Field::Types::UInt64:
-        return apply_binary_visitor_impl(std::forward<Visitor>(visitor),
-                                         field1.template get<UInt64>(), std::forward<F2>(field2));
-    case Field::Types::UInt128:
-        return apply_binary_visitor_impl(std::forward<Visitor>(visitor),
-                                         field1.template get<UInt128>(), std::forward<F2>(field2));
-    case Field::Types::Int64:
-        return apply_binary_visitor_impl(std::forward<Visitor>(visitor),
-                                         field1.template get<Int64>(), std::forward<F2>(field2));
-    case Field::Types::Float64:
-        return apply_binary_visitor_impl(std::forward<Visitor>(visitor),
-                                         field1.template get<Float64>(), std::forward<F2>(field2));
-    case Field::Types::String:
-        return apply_binary_visitor_impl(std::forward<Visitor>(visitor),
-                                         field1.template get<String>(), std::forward<F2>(field2));
-    case Field::Types::Array:
-        return apply_binary_visitor_impl(std::forward<Visitor>(visitor),
-                                         field1.template get<Array>(), std::forward<F2>(field2));
-    case Field::Types::Tuple:
-        return apply_binary_visitor_impl(std::forward<Visitor>(visitor),
-                                         field1.template get<Tuple>(), std::forward<F2>(field2));
-    case Field::Types::Decimal32:
-        return apply_binary_visitor_impl(std::forward<Visitor>(visitor),
-                                         field1.template get<DecimalField<Decimal32>>(),
-                                         std::forward<F2>(field2));
-    case Field::Types::Decimal64:
-        return apply_binary_visitor_impl(std::forward<Visitor>(visitor),
-                                         field1.template get<DecimalField<Decimal64>>(),
-                                         std::forward<F2>(field2));
-    case Field::Types::Decimal128:
-        return apply_binary_visitor_impl(std::forward<Visitor>(visitor),
-                                         field1.template get<DecimalField<Decimal128>>(),
-                                         std::forward<F2>(field2));
-    case Field::Types::Decimal128I:
-        return apply_binary_visitor_impl(std::forward<Visitor>(visitor),
-                                         field1.template get<DecimalField<Decimal128I>>(),
-                                         std::forward<F2>(field2));
-    case Field::Types::AggregateFunctionState:
-        return apply_binary_visitor_impl(std::forward<Visitor>(visitor),
-                                         field1.template get<AggregateFunctionStateData>(),
-                                         std::forward<F2>(field2));
-
     default:
         LOG(FATAL) << "Bad type of Field";
         return {};

--- a/be/src/vec/core/field.cpp
+++ b/be/src/vec/core/field.cpp
@@ -83,13 +83,6 @@ void read_binary(Array& x, BufferReadable& buf) {
             x.push_back(value);
             break;
         }
-        case Field::Types::AggregateFunctionState: {
-            AggregateFunctionStateData value;
-            doris::vectorized::read_string_binary(value.name, buf);
-            doris::vectorized::read_string_binary(value.data, buf);
-            x.push_back(value);
-            break;
-        }
         }
     }
 }
@@ -127,11 +120,6 @@ void write_binary(const Array& x, BufferWritable& buf) {
         }
         case Field::Types::JSONB: {
             doris::vectorized::write_json_binary(get<JsonbField>(*it), buf);
-            break;
-        }
-        case Field::Types::AggregateFunctionState: {
-            doris::vectorized::write_string_binary(it->get<AggregateFunctionStateData>().name, buf);
-            doris::vectorized::write_string_binary(it->get<AggregateFunctionStateData>().data, buf);
             break;
         }
         }

--- a/be/src/vec/data_types/convert_field_to_type.cpp
+++ b/be/src/vec/data_types/convert_field_to_type.cpp
@@ -82,9 +82,6 @@ public:
     [[noreturn]] String operator()(const DecimalField<Decimal128I>& x) const {
         LOG(FATAL) << "not implemeted";
     }
-    [[noreturn]] String operator()(const AggregateFunctionStateData& x) const {
-        LOG(FATAL) << "not implemeted";
-    }
 };
 
 namespace {

--- a/be/src/vec/data_types/data_type_bitmap.h
+++ b/be/src/vec/data_types/data_type_bitmap.h
@@ -94,10 +94,7 @@ public:
     }
     void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
 
-    [[noreturn]] virtual Field get_default() const override {
-        LOG(FATAL) << "Method get_default() is not implemented for data type " << get_name();
-        __builtin_unreachable();
-    }
+    Field get_default() const override { return BitmapValue(); }
 
     [[noreturn]] Field get_field(const TExprNode& node) const override {
         LOG(FATAL) << "Unimplemented get_field for BitMap";

--- a/be/src/vec/data_types/data_type_hll.h
+++ b/be/src/vec/data_types/data_type_hll.h
@@ -91,11 +91,7 @@ public:
     void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
     Status from_string(ReadBuffer& rb, IColumn* column) const override;
 
-    Field get_default() const override {
-        LOG(FATAL) << "Method get_default() is not implemented for data type " << get_name();
-        // unreachable
-        return String();
-    }
+    Field get_default() const override { return HyperLogLog::empty(); }
 
     [[noreturn]] Field get_field(const TExprNode& node) const override {
         LOG(FATAL) << "Unimplemented get_field for HLL";

--- a/be/src/vec/data_types/data_type_quantilestate.h
+++ b/be/src/vec/data_types/data_type_quantilestate.h
@@ -93,10 +93,7 @@ public:
     }
     void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
 
-    [[noreturn]] virtual Field get_default() const override {
-        LOG(FATAL) << "Method get_default() is not implemented for data type " << get_name();
-        __builtin_unreachable();
-    }
+    Field get_default() const override { return QuantileState<T>(); }
 
     [[noreturn]] Field get_field(const TExprNode& node) const override {
         LOG(FATAL) << "Unimplemented get_field for quantilestate";

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/MaterializedIndexMetaTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/MaterializedIndexMetaTest.java
@@ -105,6 +105,7 @@ public class MaterializedIndexMetaTest {
         // 2. Read objects from file
         DataInputStream in = new DataInputStream(Files.newInputStream(path));
         MaterializedIndexMeta readIndexMeta = MaterializedIndexMeta.read(in);
+        readIndexMeta.parseStmt(null);
         Assert.assertEquals(1, readIndexMeta.getIndexId());
         List<Column> resultColumns = readIndexMeta.getSchema();
         for (Column column : resultColumns) {

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/MaterializedIndexMetaTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/MaterializedIndexMetaTest.java
@@ -105,7 +105,6 @@ public class MaterializedIndexMetaTest {
         // 2. Read objects from file
         DataInputStream in = new DataInputStream(Files.newInputStream(path));
         MaterializedIndexMeta readIndexMeta = MaterializedIndexMeta.read(in);
-        readIndexMeta.parseStmt(null);
         Assert.assertEquals(1, readIndexMeta.getIndexId());
         List<Column> resultColumns = readIndexMeta.getSchema();
         for (Column column : resultColumns) {


### PR DESCRIPTION
## Proposed changes
```
F0821 23:09:31.825775 1585356 data_type_hll.h:95] Method get_default() is not implemented for data type HLL
*** Check failure stack trace: ***
    @     0x564bc2e3248d  google::LogMessage::Fail()
    @     0x564bc2e349c9  google::LogMessage::SendToLog()
    @     0x564bc2e31ff6  google::LogMessage::Flush()
    @     0x564bc2e35039  google::LogMessageFatal::~LogMessageFatal()
    @     0x564bb06f78ce  doris::vectorized::DataTypeHLL::get_default()
    @     0x564bb0654220  doris::vectorized::IDataType::create_column_const_with_default_value()
    @     0x564bb6099912  doris::vectorized::JdbcConnector::_cast_string_to_hll()
    @     0x564bb6092361  doris::vectorized::JdbcConnector::get_next()
    @     0x564bb585e0d8  doris::vectorized::NewJdbcScanner::_get_block_impl()
    @     0x564bb5d57a44  doris::vectorized::VScanner::get_block()
    @     0x564bb5a2e8a2  doris::vectorized::ScannerScheduler::_scanner_scan()
    @     0x564bb5a3271f  _ZZZN5doris10vectorized16ScannerScheduler18_schedule_scannersEPNS0_14ScannerContextEENK3$_1clEvENKUlvE2_clEv
    @     0x564bb5a325d5  _ZSt13__invoke_implIvRZZN5doris10vectorized16ScannerScheduler18_schedule_scannersEPNS1_14ScannerContextEENK3$_1clEvEUlvE2_JEET_St14__invoke_otherOT0_DpOT1_
    @     0x564bb5a32575  _ZSt10__invoke_rIvRZZN5doris10vectorized16ScannerScheduler18_schedule_scannersEPNS1_14ScannerContextEENK3$_1clEvEUlvE2_JEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EES9_E4typeEOSA_DpOSB_
    @     0x564bb5a322ed  _ZNSt17_Function_handlerIFvvEZZN5doris10vectorized16ScannerScheduler18_schedule_scannersEPNS2_14ScannerContextEENK3$_1clEvEUlvE2_E9_M_invokeERKSt9_Any_data
    @     0x564b9fc17893  std::function<>::operator()()
    @     0x564ba2de4269  doris::FunctionRunnable::run()
    @     0x564ba2dd1807  doris::ThreadPool::dispatch_thread()
    @     0x564ba2df7314  std::__invoke_impl<>()
    @     0x564ba2df71ed  std::__invoke<>()
    @     0x564ba2df7175  _ZNSt5_BindIFMN5doris10ThreadPoolEFvvEPS1_EE6__callIvJEJLm0EEEET_OSt5tupleIJDpT0_EESt12_Index_tupleIJXspT1_EEE
    @     0x564ba2df701e  std::_Bind<>::operator()<>()
    @     0x564ba2df6f35  std::__invoke_impl<>()
    @     0x564ba2df6ed5  _ZSt10__invoke_rIvRSt5_BindIFMN5doris10ThreadPoolEFvvEPS2_EEJEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EESA_E4typeEOSB_DpOSC_
    @     0x564ba2df6bfd  std::_Function_handler<>::_M_invoke()
    @     0x564b9fc17893  std::function<>::operator()()
    @     0x564ba2d9eb07  doris::Thread::supervise_thread()
    @     0x7f8cc0ad9609  start_thread
    @     0x7f8cc0d68133  clone
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

