### PR TITLE
[fix](compaction) print column name when checking block ColumnPtr is nullptr on get block byte

### DIFF
--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -401,8 +401,13 @@ size_t Block::bytes() const {
     size_t res = 0;
     for (const auto& elem : data) {
         if (!elem.column) {
+            std::stringstream ss;
+            for (const auto& e : data) {
+                ss << e.name + " ";
+            }
             LOG(FATAL) << fmt::format(
-                    "Column {} in block is nullptr, in method bytes.", elem.name);
+                    "Column {} in block is nullptr, in method bytes. All Columns are {}", elem.name,
+                    ss.str());
         }
         res += elem.column->byte_size();
     }
@@ -414,8 +419,13 @@ size_t Block::allocated_bytes() const {
     size_t res = 0;
     for (const auto& elem : data) {
         if (!elem.column) {
+            std::stringstream ss;
+            for (const auto& e : data) {
+                ss << e.name + " ";
+            }
             LOG(FATAL) << fmt::format(
-                    "Column {} in block is nullptr, in method allocated_bytes.", elem.name);
+                    "Column {} in block is nullptr, in method allocated_bytes. All Columns are {}",
+                    elem.name, ss.str());
         }
         res += elem.column->allocated_bytes();
     }

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -400,6 +400,10 @@ void Block::skip_num_rows(int64_t& length) {
 size_t Block::bytes() const {
     size_t res = 0;
     for (const auto& elem : data) {
+        if (!elem.column) {
+            LOG(FATAL) << fmt::format(
+                    "Column {} in block is nullptr, in method bytes.", elem.name);
+        }
         res += elem.column->byte_size();
     }
 
@@ -409,6 +413,10 @@ size_t Block::bytes() const {
 size_t Block::allocated_bytes() const {
     size_t res = 0;
     for (const auto& elem : data) {
+        if (!elem.column) {
+            LOG(FATAL) << fmt::format(
+                    "Column {} in block is nullptr, in method allocated_bytes.", elem.name);
+        }
         res += elem.column->allocated_bytes();
     }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
if block ColumnPtr is nullptr, get block byte will make be crash. For now i can't find the reason why ColumnPtr is nullptr, so i want to print more information to help figure out this problem. 
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

