### PR TITLE
[refactor](predicate) refactor function parse_to_predicte 

### DIFF
--- a/be/src/olap/delete_handler.cpp
+++ b/be/src/olap/delete_handler.cpp
@@ -251,7 +251,7 @@ Status DeleteHandler::init(TabletSchemaSPtr tablet_schema,
         if (delete_pred->version().first > version) {
             continue;
         }
-        // Need the tablet schema at the delete condition to parse the accurate column unique id
+        // Need the tablet schema at the delete condition to parse the accurate column
         const auto& delete_pred_related_schema = delete_pred->tablet_schema();
         auto& delete_condition = delete_pred->delete_predicate();
         DeleteConditions temp;

--- a/be/src/olap/predicate_creator.h
+++ b/be/src/olap/predicate_creator.h
@@ -267,14 +267,9 @@ ColumnPredicate* create_list_predicate(const TabletColumn& column, int index,
 // This method is called in reader and in deletehandler.
 // When it is called by delete handler, then it should use the delete predicate's tablet schema
 // to parse the conditions.
-inline ColumnPredicate* parse_to_predicate(TabletSchemaSPtr tablet_schema,
+inline ColumnPredicate* parse_to_predicate(const TabletColumn& column, uint32_t index,
                                            const TCondition& condition, vectorized::Arena* arena,
                                            bool opposite = false) {
-    int32_t col_unique_id = condition.column_unique_id;
-    // TODO: not equal and not in predicate is not pushed down
-    const TabletColumn& column = tablet_schema->column_by_uid(col_unique_id);
-    uint32_t index = tablet_schema->field_index(col_unique_id);
-
     if (to_lower(condition.condition_op) == "is") {
         return new NullPredicate(index, to_lower(condition.condition_values[0]) == "null",
                                  opposite);

--- a/be/src/olap/predicate_creator.h
+++ b/be/src/olap/predicate_creator.h
@@ -265,8 +265,7 @@ ColumnPredicate* create_list_predicate(const TabletColumn& column, int index,
 }
 
 // This method is called in reader and in deletehandler.
-// When it is called by delete handler, then it should use the delete predicate's tablet schema
-// to parse the conditions.
+// The "column" parameter might represent a column resulting from the decomposition of a variant column.
 inline ColumnPredicate* parse_to_predicate(const TabletColumn& column, uint32_t index,
                                            const TCondition& condition, vectorized::Arena* arena,
                                            bool opposite = false) {

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -458,10 +458,10 @@ Status TabletReader::_init_orderby_keys_param(const ReaderParams& read_params) {
 
 Status TabletReader::_init_conditions_param(const ReaderParams& read_params) {
     for (auto& condition : read_params.conditions) {
-        // These conditions is passed from OlapScannode, but not set column unique id here, so that set it here because it
-        // is too complicated to modify related interface
         TCondition tmp_cond = condition;
         RETURN_IF_ERROR(_tablet_schema->have_column(tmp_cond.column_name));
+        // The "column" parameter might represent a column resulting from the decomposition of a variant column.
+        // Instead of using a "unique_id" for identification, we are utilizing a "path" to denote this column.
         const auto& column = _tablet_schema->column(tmp_cond.column_name);
         uint32_t index = _tablet_schema->field_index(tmp_cond.column_name);
         ColumnPredicate* predicate =


### PR DESCRIPTION
## Proposed changes


I've refactored the interface of the parse_to_predicte function, we will be utilizing this interface to support the decomposition of variant columns.

The "column" parameter might represent a column resulting from the decomposition of a variant column. Instead of using a "unique_id" for identification, we are utilizing a "path" to denote this column. 



Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

