### PR TITLE
[feature](move-memtable)[2/7] add protos for memtable on sink node

### DIFF
--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -24,6 +24,7 @@
 #include <optional>
 
 #include "common/factory_creator.h"
+#include "gen_cpp/olap_file.pb.h"
 #include "gutil/macros.h"
 #include "olap/column_mapping.h"
 #include "olap/rowset/rowset.h"
@@ -38,7 +39,30 @@ struct SegmentStatistics {
     int64_t data_size;
     int64_t index_size;
     KeyBoundsPB key_bounds;
+
+    SegmentStatistics() = default;
+
+    SegmentStatistics(SegmentStatisticsPB pb)
+            : row_num(pb.row_num()),
+              data_size(pb.data_size()),
+              index_size(pb.index_size()),
+              key_bounds(pb.key_bounds()) {}
+
+    void to_pb(SegmentStatisticsPB* segstat_pb) {
+        segstat_pb->set_row_num(row_num);
+        segstat_pb->set_data_size(data_size);
+        segstat_pb->set_index_size(index_size);
+        segstat_pb->mutable_key_bounds()->CopyFrom(key_bounds);
+    }
+
+    std::string to_string() {
+        std::stringstream ss;
+        ss << "row_num: " << row_num << ", data_size: " << data_size
+           << ", index_size: " << index_size << ", key_bounds: " << key_bounds.ShortDebugString();
+        return ss.str();
+    }
 };
+using SegmentStatisticsSharedPtr = std::shared_ptr<SegmentStatistics>;
 
 class RowsetWriter {
 public:

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -701,7 +701,7 @@ message PGlobResponse {
 message POpenStreamSinkRequest {
     optional PUniqueId load_id = 1;
     optional int64 txn_id = 2;
-    optional int32 src_id = 3;
+    optional int64 src_id = 3;
     optional POlapTableSchemaParam schema = 4;
     repeated PTabletID tablets = 5;
     optional bool enable_profile = 6 [default = false];
@@ -738,7 +738,7 @@ message PStreamHeader {
     optional int32 segment_id = 5;
     optional Opcode opcode = 6;
     optional bool segment_eos = 7;
-    optional uint32 src_id = 8;
+    optional int64 src_id = 8;
     optional SegmentStatisticsPB segment_statistics = 9;
     repeated PTabletID tablets_to_commit = 10;
 }

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -61,6 +61,12 @@ message PTabletWithPartition {
     required int64 tablet_id = 2;
 }
 
+message PTabletID {
+    optional int64 partition_id = 1;
+    optional int64 index_id = 2;
+    optional int64 tablet_id = 3;
+}
+
 message PTabletInfo {
     required int64 tablet_id = 1;
     required int32 schema_hash = 2;
@@ -692,6 +698,51 @@ message PGlobResponse {
     repeated PFileInfo files = 2;
 }
 
+message POpenStreamSinkRequest {
+    optional PUniqueId load_id = 1;
+    optional int64 txn_id = 2;
+    optional int32 src_id = 3;
+    optional POlapTableSchemaParam schema = 4;
+    repeated PTabletID tablets = 5;
+    optional bool enable_profile = 6 [default = false];
+}
+
+message PTabletSchemaWithIndex {
+    optional int64 index_id = 1;
+    optional TabletSchemaPB tablet_schema = 2;
+    optional bool enable_unique_key_merge_on_write = 3;
+}
+
+message POpenStreamSinkResponse {
+    optional PStatus status = 1;
+    repeated PTabletSchemaWithIndex tablet_schemas = 2;
+}
+
+message PWriteStreamSinkResponse {
+    optional PStatus status = 1;
+    repeated int64 success_tablet_ids = 2;
+    repeated int64 failed_tablet_ids = 3;
+    optional bytes load_stream_profile = 4;
+}
+
+message PStreamHeader {
+    enum Opcode {
+        APPEND_DATA = 1;
+        CLOSE_LOAD = 2;
+        ADD_SEGMENT = 3;
+    }
+    optional PUniqueId load_id = 1;
+    optional int64 partition_id = 2;
+    optional int64 index_id = 3;
+    optional int64 tablet_id = 4;
+    optional int32 segment_id = 5;
+    optional Opcode opcode = 6;
+    optional bool segment_eos = 7;
+    optional uint32 src_id = 8;
+    optional SegmentStatisticsPB segment_statistics = 9;
+    repeated PTabletID tablets_to_commit = 10;
+}
+
 service PBackendService {
     rpc transmit_data(PTransmitDataParams) returns (PTransmitDataResult);
     rpc transmit_data_by_http(PEmptyRequest) returns (PTransmitDataResult);
@@ -703,6 +754,7 @@ service PBackendService {
     rpc cancel_plan_fragment(PCancelPlanFragmentRequest) returns (PCancelPlanFragmentResult);
     rpc fetch_data(PFetchDataRequest) returns (PFetchDataResult);
     rpc tablet_writer_open(PTabletWriterOpenRequest) returns (PTabletWriterOpenResult);
+    rpc open_stream_sink(POpenStreamSinkRequest) returns (POpenStreamSinkResponse);
     rpc tablet_writer_add_block(PTabletWriterAddBlockRequest) returns (PTabletWriterAddBlockResult);
     rpc tablet_writer_add_block_by_http(PEmptyRequest) returns (PTabletWriterAddBlockResult);
     rpc tablet_writer_cancel(PTabletWriterCancelRequest) returns (PTabletWriterCancelResult);

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -115,6 +115,13 @@ message RowsetMetaPB {
     optional SegmentsOverlapPB segments_overlap_pb = 51 [default = OVERLAP_UNKNOWN];
 }
 
+message SegmentStatisticsPB {
+    optional int64 row_num = 1;
+    optional int64 data_size = 2;
+    optional int64 index_size = 3;
+    optional KeyBoundsPB key_bounds = 4;
+}
+
 // kv value for reclaiming remote rowset
 message RemoteRowsetGcPB {
     required string resource_id = 1;


### PR DESCRIPTION
## Proposed changes

Add brpc streaming protos in internal service for memtable on sink node.
This is the 2nd PR of #23135.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

