### PR TITLE
[opt](stats) don't load stats when task is killed

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
@@ -180,6 +180,9 @@ public abstract class BaseAnalysisTask {
     public abstract void doExecute() throws Exception;
 
     protected void afterExecution() {
+        if (killed) {
+            return;
+        }
         Env.getCurrentEnv().getStatisticsCache().syncLoadColStats(tbl.getId(), -1, col.getName());
     }
 


### PR DESCRIPTION
## Proposed changes

Sync cache after analyze task is killed is meaningless and make error  message confused

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

