### PR TITLE
[Log](Alter) Print table's state when `checkNormalStateForAlter()` failed

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -1548,7 +1548,8 @@ public class OlapTable extends Table {
 
     public void checkNormalStateForAlter() throws DdlException {
         if (state != OlapTableState.NORMAL) {
-            throw new DdlException("Table[" + name + "]'s state is not NORMAL. Do not allow doing ALTER ops");
+            throw new DdlException("Table[" + name + "]'s state(" + state.toString()
+                    + ") is not NORMAL. Do not allow doing ALTER ops");
         }
     }
 

--- a/regression-test/suites/schema_change/test_alter_table_status.groovy
+++ b/regression-test/suites/schema_change/test_alter_table_status.groovy
@@ -35,7 +35,7 @@ suite("test_alter_table_status") {
         // try alter table comment
         test {
             sql """ ALTER TABLE ${tbName1} MODIFY COMMENT 'test'; """
-            exception "Table[${tbName1}]'s state is not NORMAL. Do not allow doing ALTER ops"
+            exception "Table[alter_table_status]'s state(ROLLUP) is not NORMAL. Do not allow doing ALTER ops"
         }
 
         // set table state to NORMAL


### PR DESCRIPTION
## Proposed changes


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

