### PR TITLE
[fix](metric) fix issue that the counter of rejected transactions does not cover some failed situations for load

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -355,13 +355,6 @@ public class DatabaseTransactionMgr {
             }
 
             return tid;
-        } catch (DuplicatedRequestException e) {
-            throw e;
-        } catch (Exception e) {
-            if (MetricRepo.isInit) {
-                MetricRepo.COUNTER_TXN_REJECT.increase(1L);
-            }
-            throw e;
         } finally {
             writeUnlock();
         }


### PR DESCRIPTION
## Proposed changes

For now，when data exceed database data quota or set invalid timeout, the transaction will be reject without count in  metric  of rejected transactions，the user may be confused while all transactions metric is ok，but the load task still failed
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

