### PR TITLE
[Fix](Nereids) fix that `select...from tablets()` are invalidated when there exists predicates

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PruneOlapScanTablet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PruneOlapScanTablet.java
@@ -55,14 +55,18 @@ public class PruneOlapScanTablet extends OneRewriteRuleFactory {
                     LogicalOlapScan olapScan = filter.child();
                     OlapTable table = olapScan.getTable();
                     Builder<Long> selectedTabletIdsBuilder = ImmutableList.builder();
-                    for (Long id : olapScan.getSelectedPartitionIds()) {
-                        Partition partition = table.getPartition(id);
-                        MaterializedIndex index = partition.getIndex(olapScan.getSelectedIndexId());
-                        selectedTabletIdsBuilder
-                                .addAll(getSelectedTabletIds(filter.getConjuncts(), index,
-                                        olapScan.getSelectedIndexId() == olapScan.getTable()
-                                                .getBaseIndexId(),
-                                        partition.getDistributionInfo()));
+                    if (olapScan.getSelectedTabletIds().isEmpty()) {
+                        for (Long id : olapScan.getSelectedPartitionIds()) {
+                            Partition partition = table.getPartition(id);
+                            MaterializedIndex index = partition.getIndex(olapScan.getSelectedIndexId());
+                            selectedTabletIdsBuilder
+                                    .addAll(getSelectedTabletIds(filter.getConjuncts(), index,
+                                            olapScan.getSelectedIndexId() == olapScan.getTable()
+                                                    .getBaseIndexId(),
+                                            partition.getDistributionInfo()));
+                        }
+                    } else {
+                        selectedTabletIdsBuilder.addAll(olapScan.getSelectedTabletIds());
                     }
                     List<Long> selectedTabletIds = selectedTabletIdsBuilder.build();
                     if (new HashSet(selectedTabletIds).equals(new HashSet(olapScan.getSelectedTabletIds()))) {

--- a/regression-test/data/nereids_p0/select_tablets/select_with_tablets.out
+++ b/regression-test/data/nereids_p0/select_tablets/select_with_tablets.out
@@ -14,8 +14,27 @@
 -- !select4 --
 
 -- !select5 --
+1	doris	19
 
 -- !select6 --
+2	nereids	18
+
+-- !select7 --
+1	doris	19
+
+-- !select8 --
+1	doris	19
+
+-- !select9 --
+
+-- !select10 --
+1	doris	19
+
+-- !select11 --
+
+-- !select12 --
+
+-- !select13 --
 
 -- !no_partition_1 --
 1	doris	19
@@ -28,4 +47,12 @@
 1	doris	19
 
 -- !no_partition_4 --
+
+-- !no_partition_5 --
+2	nereids	18
+
+-- !no_partition_6 --
+2	nereids	18
+
+-- !no_partition_7 --
 

--- a/regression-test/suites/nereids_p0/select_tablets/select_with_tablets.groovy
+++ b/regression-test/suites/nereids_p0/select_tablets/select_with_tablets.groovy
@@ -54,14 +54,24 @@ suite("select_with_tablets") {
     // result should be empty because TABLET(${res[0][0]}) is not belonged to partition between_20_70.
     order_qt_select4 """ SELECT * FROM ${table_name1} PARTITION between_20_70 TABLET(${res[0][0]}) """
 
+    order_qt_select5 """ SELECT * FROM ${table_name1} where id < 2 """
+    order_qt_select6 """ SELECT * FROM ${table_name1} TABLET(${res[0][0]}) where id = 2 """
+    order_qt_select7 """ SELECT * FROM ${table_name1} TABLET(${res[0][0]}) where id < 2 """
+    order_qt_select8 """ SELECT * FROM ${table_name1} PARTITION less_than_20 TABLET(${res[0][0]}) where id < 2 """
+    // result of order_qt_select9 should be empty
+    order_qt_select9 """ SELECT * FROM ${table_name1} PARTITION between_20_70 TABLET(${res[0][0]}) where id < 2"""
+    order_qt_select10 """ SELECT * FROM ${table_name1} PARTITION less_than_20 where id < 2"""
+    // result of order_qt_select11 should be empty
+    order_qt_select11 """ SELECT * FROM ${table_name1} PARTITION between_20_70 where id < 2"""
+
     res = sql """ show tablets from ${table_name1} where version = 1 """
     assertTrue(res.size() == 2)
     assertEquals("1", res[0][4])
     assertEquals("1", res[1][4])
     // result should be empty because TABLET(${res[0][0]}) does not have data.
-    order_qt_select5 """ SELECT * FROM ${table_name1} TABLET(${res[0][0]}) """
+    order_qt_select12 """ SELECT * FROM ${table_name1} TABLET(${res[0][0]}) """
     // result should be empty because TABLET(${res[1][0]}) does not have data.
-    order_qt_select6 """ SELECT * FROM ${table_name1} TABLET(${res[1][0]}) """
+    order_qt_select13 """ SELECT * FROM ${table_name1} TABLET(${res[1][0]}) """
 
     // Test non-partitioned table
     def table_no_partition = "table_no_partition"
@@ -87,4 +97,8 @@ suite("select_with_tablets") {
     order_qt_no_partition_2 """ SELECT * FROM ${table_no_partition} TABLET(${res[0][0]}) """
     order_qt_no_partition_3 """ SELECT * FROM ${table_no_partition} TABLET(${res[1][0]}) """
     order_qt_no_partition_4 """ SELECT * FROM ${table_no_partition} TABLET(${res[2][0]}) """
+
+    order_qt_no_partition_5 """ SELECT * FROM ${table_no_partition} where id = 2 """
+    order_qt_no_partition_6 """ SELECT * FROM ${table_no_partition} TABLET(${res[0][0]}) where id = 2 """
+    order_qt_no_partition_7 """ SELECT * FROM ${table_no_partition} TABLET(${res[0][0]}) where id > 2 """
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
Problem: `select...from tablets()` are invalidated when there exists predicates, such as:
```sql
// The all data is:
mysql> select * from student3;
+------+------+------+
| id   | name | age  |
+------+------+------+
|    1 | ftw  |   18 |
|    3 | yy   |   19 |
|    4 | xx   |   21 |
|    2 | cyx  |   20 |
+------+------+------+

// when we specified tablet to read:
mysql> select * from student3 tablet(131131);
+------+------+------+
| id   | name | age  |
+------+------+------+
|    1 | ftw  |   18 |
|    3 | yy   |   19 |
+------+------+------+

// Howerver, when there exists predicates, the `tablet(131131)` is invalidated
mysql> select * from student3 tablet(131131) where id > 1;
+------+------+------+
| id   | name | age  |
+------+------+------+
|    4 | xx   |   21 |
|    3 | yy   |   19 |
|    2 | cyx  |   20 |
+------+------+------+
```

After the fix, we get promising data
```sql
mysql> select * from student3 tablet(131131) where id > 1;
+------+------+------+
| id   | name | age  |
+------+------+------+
|    3 | yy   |   19 |
+------+------+------+
```




<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

