### PR TITLE
[fix](common) implement the move assignment operator for Status

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -311,7 +311,7 @@ consteval bool capture_stacktrace(int code) {
 
 class Status {
 public:
-    Status() : _code(ErrorCode::OK) {}
+    Status() : _code(ErrorCode::OK), _err_msg(nullptr) {}
 
     // copy c'tor makes copy of error detail so Status can be returned by value
     Status(const Status& rhs) { *this = rhs; }
@@ -329,7 +329,13 @@ public:
     }
 
     // move assign
-    Status& operator=(Status&& rhs) noexcept = default;
+    Status& operator=(Status&& rhs) noexcept {
+        _code = rhs._code;
+        if (rhs._err_msg) {
+            _err_msg = std::move(rhs._err_msg);
+        }
+        return *this;
+    }
 
     Status static create(const TStatus& status) {
         return Error<true>(status.status_code,


### PR DESCRIPTION
## Proposed changes

`Status`'s move assignment operator is a default function, which can't move the unique pointer of `_err_msg` correctly, and `_err_msg` may be an uninitialized pointer when assigning `OK`.
In the process of return value optimization, the move assignment operator will be called, so the following error is thrown when initializing the `BE`'s file cache:
```
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk1/lidongyang/doris/be/src/common/signal_handler.h:413
 1# os::Linux::chained_handler(int, siginfo_t*, void*) in /usr/lib/jvm/java-11-openjdk-amd64/lib/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-11-openjdk-amd64/lib/server/libjvm.so
 3# signalHandler(int, siginfo_t*, void*) in /usr/lib/jvm/java-11-openjdk-amd64/lib/server/libjvm.so
 4# 0x00007F0336132090 in /lib/x86_64-linux-gnu/libc.so.6
 5# doris::io::FileCacheFactory::create_file_cache(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, doris::io::FileCacheSettings const&, doris::Status*) at /mnt/disk1/lidongyang/doris/be/src/io/cache/block/block_file_cache_factory.cpp:75
 6# doris::ThreadPool::dispatch_thread() in /root/20230822114947-doris-branch-2_0-9c0138f1ca/be/lib/doris_be
 7# doris::Thread::supervise_thread(void*) at /mnt/disk1/lidongyang/doris/be/src/util/thread.cpp:466
 8# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
 9# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97
```
Where `*status = cache->initialize()` will call  the move assignment operator, but `_err_msg` is not a nullptr with unexpected value.

## Complete Error Stack in GDB
```
Thread 43 "FileCacheInitTh" hit Catchpoint 1 (signal SIGSEGV), std::__uniq_ptr_impl<doris::Status::ErrMsg, std::default_delete<doris::Status::ErrMsg> >::reset (this=0x7fffcfc56558, __p=0x0)
    at /mnt/datadisk0/gaoxin/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:182
182	/mnt/datadisk0/gaoxin/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h: No such file or directory.
(gdb) bt
#0  std::__uniq_ptr_impl<doris::Status::ErrMsg, std::default_delete<doris::Status::ErrMsg> >::reset (this=0x7fffcfc56558, __p=0x0)
    at /mnt/datadisk0/gaoxin/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:182
#1  std::__uniq_ptr_impl<doris::Status::ErrMsg, std::default_delete<doris::Status::ErrMsg> >::operator= (this=0x7fffcfc56558, __u=...)
    at /mnt/datadisk0/gaoxin/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:167
#2  std::__uniq_ptr_data<doris::Status::ErrMsg, std::default_delete<doris::Status::ErrMsg>, true, true>::operator= (
    this=0x7fffcfc56558)
    at /mnt/datadisk0/gaoxin/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:212
#3  std::unique_ptr<doris::Status::ErrMsg, std::default_delete<doris::Status::ErrMsg> >::operator= (this=0x7fffcfc56558)
    at /mnt/datadisk0/gaoxin/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:371
#4  doris::Status::operator= (this=0x7fffcfc56550, rhs=...) at /mnt/datadisk0/gaoxin/ws/doris/be/src/common/status.h:335
#5  doris::io::FileCacheFactory::create_file_cache (this=0x55556b349190 <doris::io::FileCacheFactory::instance()::ret>,
    cache_base_path=..., file_cache_settings=..., status=0x7fffcfc56550)
    at /mnt/datadisk0/gaoxin/ws/doris/be/src/io/cache/block/block_file_cache_factory.cpp:75
#6  0x000055556104ffbf in doris::ThreadPool::dispatch_thread (this=0x7fffd47a44c0)
    at /mnt/datadisk0/gaoxin/ws/doris/be/src/util/threadpool.cpp:531
#7  0x000055556104725c in std::function<void ()>::operator()() const (this=0x7fffd371c2d8)
    at /mnt/datadisk0/gaoxin/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
#8  doris::Thread::supervise_thread (arg=0x7fffd3e0ed60) at /mnt/datadisk0/gaoxin/ws/doris/be/src/util/thread.cpp:465
#9  0x00007ffff7c37609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#10 0x00007ffff7ec6133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
(gdb) up 2
#2  std::__uniq_ptr_data<doris::Status::ErrMsg, std::default_delete<doris::Status::ErrMsg>, true, true>::operator= (
    this=0x7fffcfc56558)
    at /mnt/datadisk0/gaoxin/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:212
212	in /mnt/datadisk0/gaoxin/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h
(gdb) up 2
#4  doris::Status::operator= (this=0x7fffcfc56550, rhs=...) at /mnt/datadisk0/gaoxin/ws/doris/be/src/common/status.h:335
335	/mnt/datadisk0/gaoxin/ws/doris/be/src/common/status.h: No such file or directory.
(gdb) bt
#0  std::__uniq_ptr_impl<doris::Status::ErrMsg, std::default_delete<doris::Status::ErrMsg> >::reset (this=0x7fffcfc56558, __p=0x0)
    at /mnt/datadisk0/gaoxin/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:182
#1  std::__uniq_ptr_impl<doris::Status::ErrMsg, std::default_delete<doris::Status::ErrMsg> >::operator= (this=0x7fffcfc56558, __u=...)
    at /mnt/datadisk0/gaoxin/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:167
#2  std::__uniq_ptr_data<doris::Status::ErrMsg, std::default_delete<doris::Status::ErrMsg>, true, true>::operator= (
    this=0x7fffcfc56558)
    at /mnt/datadisk0/gaoxin/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:212
#3  std::unique_ptr<doris::Status::ErrMsg, std::default_delete<doris::Status::ErrMsg> >::operator= (this=0x7fffcfc56558)
    at /mnt/datadisk0/gaoxin/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:371
#4  doris::Status::operator= (this=0x7fffcfc56550, rhs=...) at /mnt/datadisk0/gaoxin/ws/doris/be/src/common/status.h:335
#5  doris::io::FileCacheFactory::create_file_cache (this=0x55556b349190 <doris::io::FileCacheFactory::instance()::ret>,
    cache_base_path=..., file_cache_settings=..., status=0x7fffcfc56550)
    at /mnt/datadisk0/gaoxin/ws/doris/be/src/io/cache/block/block_file_cache_factory.cpp:75
#6  0x000055556104ffbf in doris::ThreadPool::dispatch_thread (this=0x7fffd47a44c0)
    at /mnt/datadisk0/gaoxin/ws/doris/be/src/util/threadpool.cpp:531
#7  0x000055556104725c in std::function<void ()>::operator()() const (this=0x7fffd371c2d8)
    at /mnt/datadisk0/gaoxin/doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
#8  doris::Thread::supervise_thread (arg=0x7fffd3e0ed60) at /mnt/datadisk0/gaoxin/ws/doris/be/src/util/thread.cpp:465
#9  0x00007ffff7c37609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#10 0x00007ffff7ec6133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

