### PR TITLE
[fix](Nereids) use Stopwatch as timeout checker

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
@@ -35,6 +35,7 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.OriginStatement;
 
+import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
@@ -53,6 +54,8 @@ import javax.annotation.concurrent.GuardedBy;
 public class StatementContext {
 
     private ConnectContext connectContext;
+
+    private final Stopwatch stopwatch = Stopwatch.createUnstarted();
 
     @GuardedBy("this")
     private final Map<String, Supplier<Object>> contextCacheMap = Maps.newLinkedHashMap();
@@ -106,6 +109,10 @@ public class StatementContext {
 
     public OriginStatement getOriginStatement() {
         return originStatement;
+    }
+
+    public Stopwatch getStopwatch() {
+        return stopwatch;
     }
 
     public void setMaxNAryInnerJoin(int maxNAryInnerJoin) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/scheduler/SimpleJobScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/scheduler/SimpleJobScheduler.java
@@ -20,6 +20,8 @@ package org.apache.doris.nereids.jobs.scheduler;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.jobs.Job;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * Single thread, serial scheduler.
  */
@@ -29,7 +31,8 @@ public class SimpleJobScheduler implements JobScheduler {
         JobPool pool = scheduleContext.getJobPool();
         while (!pool.isEmpty()) {
             CascadesContext context = (CascadesContext) scheduleContext;
-            if (context.isTimeout()) {
+            if (context.getConnectContext().getSessionVariable().enableNereidsTimeout
+                    && context.getStatementContext().getStopwatch().elapsed(TimeUnit.MILLISECONDS) > 5000) {
                 throw new RuntimeException("Nereids cost too much time ( > 5s )");
             }
             Job job = pool.pop();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/AnalyzeCTE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/AnalyzeCTE.java
@@ -25,6 +25,7 @@ import org.apache.doris.nereids.rules.Rule;
 import org.apache.doris.nereids.rules.RuleType;
 import org.apache.doris.nereids.trees.expressions.CTEId;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalCTE;
 import org.apache.doris.nereids.trees.plans.logical.LogicalCTEAnchor;
@@ -89,7 +90,7 @@ public class AnalyzeCTE extends OneAnalysisRuleFactory {
             innerCascadesCtx.newAnalyzer().analyze();
             LogicalPlan analyzedCtePlan = (LogicalPlan) innerCascadesCtx.getRewritePlan();
             checkColumnAlias(aliasQuery, analyzedCtePlan.getOutput());
-            CTEId cteId = cascadesContext.getStatementContext().getNextCTEId();
+            CTEId cteId = StatementScopeIdGenerator.newCTEId();
             LogicalSubQueryAlias<Plan> logicalSubQueryAlias =
                     aliasQuery.withChildren(ImmutableList.of(analyzedCtePlan));
             outerCteCtx = new CTEContext(cteId, logicalSubQueryAlias, outerCteCtx);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

1. avoid thread leak if exception thrown in planning
2. avoid memory release delays since the timer task hold CascadesContext object

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

