### PR TITLE
[improvement](compaction) optimize compaction mem tracker statistics

### DIFF
--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -358,8 +358,7 @@ Status Compaction::do_compaction_impl(int64_t permits) {
                                                  _process_block_mem_tracker);
         } else {
             res = Merger::vmerge_rowsets(_tablet, compaction_type(), _cur_tablet_schema,
-                                         _input_rs_readers, _output_rs_writer.get(), &stats,
-                                         _process_block_mem_tracker);
+                                         _input_rs_readers, _output_rs_writer.get(), &stats);
         }
     }
 

--- a/be/src/olap/compaction.h
+++ b/be/src/olap/compaction.h
@@ -104,6 +104,8 @@ private:
 protected:
     // the root tracker for this compaction
     std::shared_ptr<MemTrackerLimiter> _mem_tracker;
+    // the mem tracker for process block
+    std::shared_ptr<MemTracker> _process_block_mem_tracker;
 
     TabletSharedPtr _tablet;
 

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -268,7 +268,9 @@ Status Merger::vertical_compact_one_group(
         output_rows += block.rows();
         block.clear_column_data();
     }
-    process_block_mem_tracker->consume(total_process_block_mem);
+    if (process_block_mem_tracker != nullptr) {
+        process_block_mem_tracker->consume(total_process_block_mem);
+    }
     if (StorageEngine::instance()->stopped()) {
         return Status::Error<INTERNAL_ERROR>("tablet {} failed to do compaction, engine stopped",
                                              tablet->full_name());
@@ -284,7 +286,9 @@ Status Merger::vertical_compact_one_group(
         SCOPED_MEM_COUNT(&flush_mem_size);
         RETURN_IF_ERROR(dst_rowset_writer->flush_columns(is_key));
     }
-    process_block_mem_tracker->consume(flush_mem_size);
+    if (process_block_mem_tracker != nullptr) {
+        process_block_mem_tracker->consume(flush_mem_size);
+    }
 
     return Status::OK();
 }
@@ -383,7 +387,9 @@ Status Merger::vertical_merge_rowsets(TabletSharedPtr tablet, ReaderType reader_
         SCOPED_MEM_COUNT(&final_flush_mem_size);
         RETURN_IF_ERROR(dst_rowset_writer->final_flush());
     }
-    process_block_mem_tracker->consume(final_flush_mem_size);
+    if (process_block_mem_tracker != nullptr) {
+        process_block_mem_tracker->consume(final_flush_mem_size);
+    }
 
     return Status::OK();
 }

--- a/be/src/olap/merger.h
+++ b/be/src/olap/merger.h
@@ -63,7 +63,7 @@ public:
             TabletSharedPtr tablet, ReaderType reader_type, TabletSchemaSPtr tablet_schema,
             const std::vector<RowsetReaderSharedPtr>& src_rowset_readers,
             RowsetWriter* dst_rowset_writer, int64_t max_rows_per_segment, Statistics* stats_output,
-            std::shared_ptr<MemTracker> process_block_mem_tracker);
+            std::shared_ptr<MemTracker> process_block_mem_tracker = nullptr);
 
 public:
     // for vertical compaction

--- a/be/src/olap/merger.h
+++ b/be/src/olap/merger.h
@@ -58,12 +58,13 @@ public:
     static Status vmerge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
                                  TabletSchemaSPtr cur_tablet_schema,
                                  const std::vector<RowsetReaderSharedPtr>& src_rowset_readers,
-                                 RowsetWriter* dst_rowset_writer, Statistics* stats_output);
+                                 RowsetWriter* dst_rowset_writer, Statistics* stats_output,
+                                 std::shared_ptr<MemTracker> process_block_mem_tracker = nullptr);
     static Status vertical_merge_rowsets(
             TabletSharedPtr tablet, ReaderType reader_type, TabletSchemaSPtr tablet_schema,
             const std::vector<RowsetReaderSharedPtr>& src_rowset_readers,
-            RowsetWriter* dst_rowset_writer, int64_t max_rows_per_segment,
-            Statistics* stats_output);
+            RowsetWriter* dst_rowset_writer, int64_t max_rows_per_segment, Statistics* stats_output,
+            std::shared_ptr<MemTracker> process_block_mem_tracker);
 
 public:
     // for vertical compaction
@@ -74,8 +75,8 @@ public:
             bool is_key, const std::vector<uint32_t>& column_group,
             vectorized::RowSourcesBuffer* row_source_buf,
             const std::vector<RowsetReaderSharedPtr>& src_rowset_readers,
-            RowsetWriter* dst_rowset_writer, int64_t max_rows_per_segment,
-            Statistics* stats_output);
+            RowsetWriter* dst_rowset_writer, int64_t max_rows_per_segment, Statistics* stats_output,
+            std::shared_ptr<MemTracker> process_block_mem_tracker);
 
     // for segcompaction
     static Status vertical_compact_one_group(TabletSharedPtr tablet, ReaderType reader_type,

--- a/be/src/olap/merger.h
+++ b/be/src/olap/merger.h
@@ -58,8 +58,7 @@ public:
     static Status vmerge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
                                  TabletSchemaSPtr cur_tablet_schema,
                                  const std::vector<RowsetReaderSharedPtr>& src_rowset_readers,
-                                 RowsetWriter* dst_rowset_writer, Statistics* stats_output,
-                                 std::shared_ptr<MemTracker> process_block_mem_tracker = nullptr);
+                                 RowsetWriter* dst_rowset_writer, Statistics* stats_output);
     static Status vertical_merge_rowsets(
             TabletSharedPtr tablet, ReaderType reader_type, TabletSchemaSPtr tablet_schema,
             const std::vector<RowsetReaderSharedPtr>& src_rowset_readers,

--- a/be/src/olap/primary_key_index.cpp
+++ b/be/src/olap/primary_key_index.cpp
@@ -94,7 +94,11 @@ Status PrimaryKeyIndexBuilder::finalize(segment_v2::PrimaryKeyIndexMetaPB* meta)
 
 void PrimaryKeyIndexBuilder::update_mem_tracker() {
     if (_bloom_filter_index_mem_tracker.get() != nullptr) {
-        _bloom_filter_index_mem_tracker->set_consumption(_bloom_filter_index_builder->size());
+        if (_bloom_filter_index_builder.get() != nullptr) {
+            _bloom_filter_index_mem_tracker->set_consumption(_bloom_filter_index_builder->size());
+        } else {
+            _bloom_filter_index_mem_tracker->set_consumption(0);
+        }
     }
 }
 

--- a/be/src/olap/primary_key_index.cpp
+++ b/be/src/olap/primary_key_index.cpp
@@ -33,7 +33,7 @@
 
 namespace doris {
 PrimaryKeyIndexBuilder::~PrimaryKeyIndexBuilder() {
-        _bloom_filter_index_mem_tracker->release(_bloom_filter_index_mem_tracker->consumption());
+    _bloom_filter_index_mem_tracker->release(_bloom_filter_index_mem_tracker->consumption());
 }
 Status PrimaryKeyIndexBuilder::init() {
     // TODO(liaoxin) using the column type directly if there's only one column in unique key columns

--- a/be/src/olap/primary_key_index.h
+++ b/be/src/olap/primary_key_index.h
@@ -55,7 +55,9 @@ public:
               _num_rows(0),
               _size(0),
               _disk_size(0),
-              _seq_col_length(seq_col_length) {}
+              _seq_col_length(seq_col_length){}
+
+    ~PrimaryKeyIndexBuilder();
 
     Status init();
 
@@ -72,6 +74,8 @@ public:
 
     Status finalize(segment_v2::PrimaryKeyIndexMetaPB* meta);
 
+    void update_mem_tracker();
+
 private:
     io::FileWriter* _file_writer = nullptr;
     uint32_t _num_rows;
@@ -83,6 +87,8 @@ private:
     faststring _max_key;
     std::unique_ptr<segment_v2::IndexedColumnWriter> _primary_key_index_builder;
     std::unique_ptr<segment_v2::BloomFilterIndexWriter> _bloom_filter_index_builder;
+    // bloom filter index mem tracker
+    std::unique_ptr<MemTracker> _bloom_filter_index_mem_tracker;
 };
 
 class PrimaryKeyIndexReader {

--- a/be/src/olap/primary_key_index.h
+++ b/be/src/olap/primary_key_index.h
@@ -55,7 +55,7 @@ public:
               _num_rows(0),
               _size(0),
               _disk_size(0),
-              _seq_col_length(seq_col_length){}
+              _seq_col_length(seq_col_length) {}
 
     ~PrimaryKeyIndexBuilder();
 

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -743,6 +743,7 @@ Status SegmentWriter::append_block(const vectorized::Block* block, size_t row_po
                 _maybe_invalid_row_cache(key);
                 last_key = std::move(key);
             }
+            _primary_key_index_builder->update_mem_tracker();
         } else {
             // create short key indexes'
             // for min_max key
@@ -755,7 +756,6 @@ Status SegmentWriter::append_block(const vectorized::Block* block, size_t row_po
             }
         }
     }
-
     _num_rows_written += num_rows;
     _olap_data_convertor->clear_source_content();
     return Status::OK();
@@ -1050,7 +1050,9 @@ Status SegmentWriter::_write_short_key_index() {
 
 Status SegmentWriter::_write_primary_key_index() {
     CHECK(_primary_key_index_builder->num_rows() == _row_count);
-    return _primary_key_index_builder->finalize(_footer.mutable_primary_key_index_meta());
+    RETURN_IF_ERROR(_primary_key_index_builder->finalize(_footer.mutable_primary_key_index_meta()));
+    _primary_key_index_builder->update_mem_tracker();
+    return Status::OK();
 }
 
 Status SegmentWriter::_write_footer() {

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -165,7 +165,7 @@ void MemTrackerLimiter::make_process_snapshots(std::vector<MemTracker::Snapshot>
 }
 
 void MemTrackerLimiter::make_type_snapshots(std::vector<MemTracker::Snapshot>* snapshots,
-                                            MemTrackerLimiter::Type type, bool with_child = true) {
+                                            MemTrackerLimiter::Type type, bool with_child) {
     if (type == Type::GLOBAL) {
         std::lock_guard<std::mutex> l(mem_tracker_limiter_pool[0].group_lock);
         for (auto tracker : mem_tracker_limiter_pool[0].trackers) {

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -261,7 +261,7 @@ std::string MemTrackerLimiter::log_process_usage_str() {
     detail += "\nProcess Memory Summary:\n    " + MemTrackerLimiter::process_mem_log_str();
     std::vector<MemTracker::Snapshot> snapshots;
     MemTrackerLimiter::make_process_snapshots(&snapshots);
-    MemTrackerLimiter::make_type_snapshots(&snapshots, MemTrackerLimiter::Type::GLOBAL);
+    MemTrackerLimiter::make_type_snapshots(&snapshots, MemTrackerLimiter::Type::GLOBAL, false);
     MemTrackerLimiter::make_type_snapshots(&snapshots, MemTrackerLimiter::Type::COMPACTION, false);
     MemTrackerLimiter::make_type_snapshots(&snapshots, MemTrackerLimiter::Type::QUERY, false);
     MemTrackerLimiter::make_type_snapshots(&snapshots, MemTrackerLimiter::Type::LOAD, false);

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -261,10 +261,8 @@ std::string MemTrackerLimiter::log_process_usage_str() {
     detail += "\nProcess Memory Summary:\n    " + MemTrackerLimiter::process_mem_log_str();
     std::vector<MemTracker::Snapshot> snapshots;
     MemTrackerLimiter::make_process_snapshots(&snapshots);
-    MemTrackerLimiter::make_type_snapshots(&snapshots, MemTrackerLimiter::Type::GLOBAL, false);
+    MemTrackerLimiter::make_type_snapshots(&snapshots, MemTrackerLimiter::Type::GLOBAL, true);
     MemTrackerLimiter::make_type_snapshots(&snapshots, MemTrackerLimiter::Type::COMPACTION, false);
-    MemTrackerLimiter::make_type_snapshots(&snapshots, MemTrackerLimiter::Type::QUERY, false);
-    MemTrackerLimiter::make_type_snapshots(&snapshots, MemTrackerLimiter::Type::LOAD, false);
     MemTrackerLimiter::make_top_consumption_snapshots(&snapshots, 15);
 
     // Add additional tracker printed when memory exceeds limit.

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -165,7 +165,7 @@ public:
     // Returns a list of all the valid tracker snapshots.
     static void make_process_snapshots(std::vector<MemTracker::Snapshot>* snapshots);
     static void make_type_snapshots(std::vector<MemTracker::Snapshot>* snapshots, Type type,
-                                    bool with_child);
+                                    bool with_child = true);
     static void make_top_consumption_snapshots(std::vector<MemTracker::Snapshot>* snapshots,
                                                int top_num);
 

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -164,7 +164,8 @@ public:
     Snapshot make_snapshot() const override;
     // Returns a list of all the valid tracker snapshots.
     static void make_process_snapshots(std::vector<MemTracker::Snapshot>* snapshots);
-    static void make_type_snapshots(std::vector<MemTracker::Snapshot>* snapshots, Type type);
+    static void make_type_snapshots(std::vector<MemTracker::Snapshot>* snapshots, Type type,
+                                    bool with_child);
     static void make_top_consumption_snapshots(std::vector<MemTracker::Snapshot>* snapshots,
                                                int top_num);
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
now the mem tracker statistics of compaction is too simple, this pr will split compaction mem tracker to tow part: RowIdConversion and  ProcessBlock, ProcessBlock means the memory of reading and writing block when doing compaction. And  ProcessBlock-BloomFilterIndex is the main part of ProcessBlock. After apply this pr, the Memory Tracker Summary will be like this:
    Type=experimental, Used=0(0 B), Peak=0(0 B)
    Type=clone, Used=0(0 B), Peak=0(0 B)
    Type=schema_change, Used=0(0 B), Peak=0(0 B)
    Type=compaction, Used=388.22 MB(407081160 B), Peak=1.10 GB(1185359208 B)
    Type=load, Used=0(0 B), Peak=282.60 MB(296323000 B)
    Type=query, Used=0(0 B), Peak=0(0 B)
    Type=global, Used=1.82 GB(1953526650 B), Peak=1.82 GB(1953545090 B)
    Type=tc/jemalloc_free_memory, Used=1.42 GB(1519679464 B), Peak=-1.00 B(-1 B)
    Type=process, Used=3.61 GB(3880287274 B), Peak=-1.00 B(-1 B)
    MemTrackerLimiter Label=ObjLRUCache, Type=global, Limit=-1.00 B(-1 B), Used=0(0 B), Peak=0(0 B)
    MemTrackerLimiter Label=Orphan, Type=global, Limit=-1.00 B(-1 B), Used=1.30 GB(1397692289 B), Peak=1.41 GB(1513052944 B)
    MemTracker Label=PageNoCache, Parent Label=Orphan, Used=0(0 B), Peak=12.57 MB(13176378 B)
    MemTracker Label=IOBufBlockMemory, Parent Label=Orphan, Used=40.65 MB(42622976 B), Peak=41.86 MB(43892736 B)
    MemTracker Label=InvertedIndexSearcherCache, Parent Label=Orphan, Used=14.78 KB(15136 B), Peak=14.78 KB(15136 B)
    MemTracker Label=SegmentMeta, Parent Label=Orphan, Used=32.71 MB(34301512 B), Peak=48.74 MB(51106447 B)
    MemTrackerLimiter Label=DataPageCache, Type=global, Limit=-1.00 B(-1 B), Used=41.00 MB(42996839 B), Peak=41.00 MB(42996839 B)
    MemTrackerLimiter Label=IndexPageCache, Type=global, Limit=-1.00 B(-1 B), Used=0(0 B), Peak=0(0 B)
    MemTrackerLimiter Label=PKIndexPageCache, Type=global, Limit=-1.00 B(-1 B), Used=489.08 MB(512837522 B), Peak=489.08 MB(512837522 B)
    MemTrackerLimiter Label=RowCache, Type=global, Limit=-1.00 B(-1 B), Used=0(0 B), Peak=0(0 B)
    MemTrackerLimiter Label=SegmentCache, Type=global, Limit=-1.00 B(-1 B), Used=0(0 B), Peak=0(0 B)
    MemTrackerLimiter Label=SchemaCache, Type=global, Limit=-1.00 B(-1 B), Used=0(0 B), Peak=0(0 B)
    MemTrackerLimiter Label=LookupConnectionCache, Type=global, Limit=-1.00 B(-1 B), Used=0(0 B), Peak=0(0 B)
    MemTrackerLimiter Label=InvertedIndexSearcherCache, Type=global, Limit=-1.00 B(-1 B), Used=0(0 B), Peak=0(0 B)
    MemTrackerLimiter Label=InvertedIndexQueryCache, Type=global, Limit=-1.00 B(-1 B), Used=0(0 B), Peak=0(0 B)
    MemTrackerLimiter Label=LastestSuccessChannelCache, Type=global, Limit=-1.00 B(-1 B), Used=0(0 B), Peak=0(0 B)
    MemTrackerLimiter Label=TabletVersionCache, Type=global, Limit=-1.00 B(-1 B), Used=0(0 B), Peak=0(0 B)
    MemTrackerLimiter Label=DeleteBitmap AggCache, Type=global, Limit=-1.00 B(-1 B), Used=0(0 B), Peak=0(0 B)
    MemTrackerLimiter Label=BaseCompaction:22582, Type=compaction, Limit=-1.00 B(-1 B), Used=388.22 MB(407081160 B), Peak=619.40 MB(649489400 B)
    MemTracker Label=ProcessBlock, Parent Label=BaseCompaction:22582, Used=299.68 MB(314234912 B), Peak=528.01 MB(553657056 B)
    MemTracker Label=RowIdConversion, Parent Label=BaseCompaction:22582, Used=88.57 MB(92874776 B), Peak=88.57 MB(92874776 B)
    MemTracker Label=ProcessBlock-BloomFilterIndex, Parent Label=BaseCompaction:22582, Used=116.74 MB(122411694 B), Peak=116.74 MB(122411694 B)
    MemTrackerLimiter Label=MemTableMemoryLimiter, Type=load, Limit=-1.00 B(-1 B), Used=0(0 B), Peak=290.73 MB(304852040 B)
note: the mem tracker of bloom_filter_key_index,primary_key_index and rowid_conversion is the part of base_compaction
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

