### PR TITLE
[improvement](compaction) reduce the memory using on vertical compaction

### DIFF
--- a/be/src/olap/primary_key_index.cpp
+++ b/be/src/olap/primary_key_index.cpp
@@ -84,6 +84,8 @@ Status PrimaryKeyIndexBuilder::finalize(segment_v2::PrimaryKeyIndexMetaPB* meta)
     RETURN_IF_ERROR(
             _bloom_filter_index_builder->finish(_file_writer, meta->mutable_bloom_filter_index()));
     _disk_size += _file_writer->bytes_appended() - start_size;
+    _primary_key_index_builder.reset(nullptr);
+    _bloom_filter_index_builder.reset(nullptr);
     return Status::OK();
 }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
My test show that primary_key_index and bloom_filter_index will occupy many of memory when doing vertical compaction on MOW table, after writing primary key, these memory will not be used any more, so we can delete these two object on finalize function to reduce memory using on vertical compaction. the relevant pr is https://github.com/apache/doris/pull/23385
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

