### PR TITLE
[improvement](old planner)Prune extra slots with old planner for sql like select count(1) from view

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
@@ -2507,9 +2507,14 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
                 if (e instanceof FunctionCallExpr) {
                     FunctionCallExpr funcExpr = (FunctionCallExpr) e;
                     Function f = funcExpr.fn;
-                    if (f.getFunctionName().getFunction().equals("count")
-                            && funcExpr.children.stream().anyMatch(Expr::isConstant)) {
-                        return true;
+                    // Return true if count function include non-literal expr child.
+                    // In this case, agg output must be materialized whether outer query block required or not.
+                    if (f.getFunctionName().getFunction().equals("count")) {
+                        for (Expr expr : funcExpr.children) {
+                            if (expr.isConstant && !(expr instanceof LiteralExpr)) {
+                                return true;
+                            }
+                        }
                     }
                 }
                 return false;

--- a/regression-test/suites/external_table_p2/tvf/test_tvf_view_count_p2.groovy
+++ b/regression-test/suites/external_table_p2/tvf/test_tvf_view_count_p2.groovy
@@ -1,0 +1,51 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_tvf_view_count_p2", "p2,external,tvf,external_remote,external_remote_tvf") {
+    String enabled = context.config.otherConfigs.get("enableExternalHiveTest")
+    if (enabled != null && enabled.equalsIgnoreCase("true")) {
+        String nameNodeHost = context.config.otherConfigs.get("extHiveHmsHost")
+        String hdfsPort = context.config.otherConfigs.get("extHdfsPort")
+
+        sql """drop database if exists test_tvf_view_count_p2"""
+        sql """create database test_tvf_view_count_p2"""
+        sql """use test_tvf_view_count_p2"""
+        sql """set enable_nereids_planner=false"""
+        sql """create view tvf_view_count as select * from hdfs (
+            "uri"="hdfs://${nameNodeHost}:${hdfsPort}:/usr/hive/warehouse/tpch_1000_parquet.db/part/000091_0",
+            "fs.defaultFS"="hdfs://${nameNodeHost}:${hdfsPort}",
+            "hadoop.username" = "hadoop",
+            "format"="parquet");"""
+
+        def result = sql """explain verbose select count(1) from tvf_view_count;"""
+        def contain0 = false;
+        def contain1 = false;
+        for (String value : result) {
+            if (value.contains("SlotDescriptor{id=0,")) {
+                contain0 = true;
+            }
+            if (value.contains("SlotDescriptor{id=1,")) {
+                contain1 = true;
+            }
+        }
+        assertTrue(contain0)
+        assertFalse(contain1)
+
+        sql """drop database if exists test_tvf_view_count_p2"""
+    }
+}
+


### PR DESCRIPTION
The sql like 
```Select count(1) from view ```
 would contain all the columns in old planner's execution plan, which is slow, because BE need to read all the column in data files. This pr is to improve the plan to only contain one column.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

