### PR TITLE
[feature](nereids) Enable auto sample for column stats collection

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.common;
 
+import java.util.concurrent.TimeUnit;
+
 public class Config extends ConfigBase {
 
     @ConfField(description = {"用户自定义配置文件的路径，用于存放 fe_custom.conf。该文件中的配置会覆盖 fe.conf 中的配置",
@@ -2117,4 +2119,16 @@ public class Config extends ConfigBase {
 
     @ConfField
     public static int table_stats_health_threshold = 80;
+
+    @ConfField
+    public static long huge_table_auto_analyze_interval_in_millis = TimeUnit.HOURS.toMillis(12);
+
+    @ConfField
+    public static long huge_table_lower_bound_size_in_bytes = 5L * 1024 * 1024 * 1024;
+
+    @ConfField
+    public static int huge_table_default_sample_rate = 20;
+
+    @ConfField
+    public static boolean enable_auto_sample = true;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -219,7 +219,7 @@ import org.apache.doris.scheduler.registry.TimerJobRegister;
 import org.apache.doris.service.ExecuteEnv;
 import org.apache.doris.service.FrontendOptions;
 import org.apache.doris.statistics.AnalysisManager;
-import org.apache.doris.statistics.StatisticsAutoAnalyzer;
+import org.apache.doris.statistics.StatisticsAutoCollector;
 import org.apache.doris.statistics.StatisticsCache;
 import org.apache.doris.statistics.StatisticsCleaner;
 import org.apache.doris.statistics.query.QueryStats;
@@ -468,7 +468,7 @@ public class Env {
      */
     private final LoadManagerAdapter loadManagerAdapter;
 
-    private StatisticsAutoAnalyzer statisticsAutoAnalyzer;
+    private StatisticsAutoCollector statisticsAutoCollector;
 
     private HiveTransactionMgr hiveTransactionMgr;
 
@@ -680,7 +680,7 @@ public class Env {
         this.extMetaCacheMgr = new ExternalMetaCacheMgr();
         this.analysisManager = new AnalysisManager();
         this.statisticsCleaner = new StatisticsCleaner();
-        this.statisticsAutoAnalyzer = new StatisticsAutoAnalyzer();
+        this.statisticsAutoCollector = new StatisticsAutoCollector();
         this.globalFunctionMgr = new GlobalFunctionMgr();
         this.workloadGroupMgr = new WorkloadGroupMgr();
         this.queryStats = new QueryStats();
@@ -926,8 +926,8 @@ public class Env {
         if (statisticsCleaner != null) {
             statisticsCleaner.start();
         }
-        if (statisticsAutoAnalyzer != null) {
-            statisticsAutoAnalyzer.start();
+        if (statisticsAutoCollector != null) {
+            statisticsAutoCollector.start();
         }
     }
 
@@ -5456,8 +5456,8 @@ public class Env {
         return loadManagerAdapter;
     }
 
-    public StatisticsAutoAnalyzer getStatisticsAutoAnalyzer() {
-        return statisticsAutoAnalyzer;
+    public StatisticsAutoCollector getStatisticsAutoAnalyzer() {
+        return statisticsAutoCollector;
     }
 
     public QueryStats getQueryStats() {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
@@ -236,5 +236,9 @@ public interface TableIf {
     default long getLastUpdateTime() {
         return -1L;
     }
+
+    default long getDataSize() {
+        return 0;
+    }
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
@@ -180,6 +180,9 @@ public abstract class BaseAnalysisTask {
     public abstract void doExecute() throws Exception;
 
     protected void afterExecution() {
+        if (killed) {
+            return;
+        }
         Env.getCurrentEnv().getStatisticsCache().syncLoadColStats(tbl.getId(), -1, col.getName());
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -158,12 +158,17 @@ public class StatisticsUtil {
     }
 
     public static AutoCloseConnectContext buildConnectContext() {
+        return buildConnectContext(false);
+    }
+
+    public static AutoCloseConnectContext buildConnectContext(boolean limitScan) {
         ConnectContext connectContext = new ConnectContext();
         SessionVariable sessionVariable = connectContext.getSessionVariable();
         sessionVariable.internalSession = true;
         sessionVariable.setMaxExecMemByte(Config.statistics_sql_mem_limit_in_bytes);
         sessionVariable.cpuResourceLimit = Config.cpu_resource_limit_per_analyze_task;
         sessionVariable.setEnableInsertStrict(true);
+        sessionVariable.enableScanRunSerial = limitScan;
         sessionVariable.parallelExecInstanceNum = Config.statistics_sql_parallel_exec_instance_num;
         sessionVariable.parallelPipelineTaskNum = Config.statistics_sql_parallel_exec_instance_num;
         sessionVariable.setEnableNereidsPlanner(false);

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/OlapAnalysisTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/OlapAnalysisTaskTest.java
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.statistics;
+
+import org.apache.doris.catalog.DatabaseIf;
+import org.apache.doris.catalog.TableIf;
+import org.apache.doris.datasource.CatalogIf;
+import org.apache.doris.statistics.AnalysisInfo.AnalysisMethod;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class OlapAnalysisTaskTest {
+
+    @Test
+    public void testAutoSample(@Mocked CatalogIf catalogIf, @Mocked DatabaseIf databaseIf, @Mocked TableIf tableIf) {
+        new Expectations() {
+            {
+                tableIf.getDataSize();
+                result = 60_0000_0000L;
+            }
+        };
+
+        AnalysisInfoBuilder analysisInfoBuilder = new AnalysisInfoBuilder()
+                .setSamplePercent(10)
+                .setAnalysisMethod(AnalysisMethod.FULL);
+        OlapAnalysisTask olapAnalysisTask = new OlapAnalysisTask();
+        olapAnalysisTask.info = analysisInfoBuilder.build();
+        olapAnalysisTask.tbl = tableIf;
+        String sampleExpr = olapAnalysisTask.getSampleExpression();
+        Assertions.assertEquals("TABLESAMPLE(20 PERCENT)", sampleExpr);
+
+        new Expectations() {
+            {
+                tableIf.getDataSize();
+                result = 1_0000_0000L;
+            }
+        };
+        sampleExpr = olapAnalysisTask.getSampleExpression();
+        Assertions.assertEquals("", sampleExpr);
+
+        analysisInfoBuilder.setSampleRows(10);
+        analysisInfoBuilder.setAnalysisMethod(AnalysisMethod.SAMPLE);
+        olapAnalysisTask.info = analysisInfoBuilder.build();
+        sampleExpr = olapAnalysisTask.getSampleExpression();
+        Assertions.assertEquals("TABLESAMPLE(10 ROWS)", sampleExpr);
+
+    }
+
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/StatisticsAutoCollectorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/StatisticsAutoCollectorTest.java
@@ -50,7 +50,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-public class StatisticsAutoAnalyzerTest {
+public class StatisticsAutoCollectorTest {
 
     @Test
     public void testAnalyzeAll(@Injectable AnalysisInfo analysisInfo) {
@@ -66,7 +66,7 @@ public class StatisticsAutoAnalyzerTest {
                 return databaseIfs;
             }
         };
-        new MockUp<StatisticsAutoAnalyzer>() {
+        new MockUp<StatisticsAutoCollector>() {
             @Mock
             public List<AnalysisInfo> constructAnalysisInfo(DatabaseIf<TableIf> db) {
                 return Arrays.asList(analysisInfo, analysisInfo);
@@ -86,7 +86,7 @@ public class StatisticsAutoAnalyzerTest {
             }
         };
 
-        StatisticsAutoAnalyzer saa = new StatisticsAutoAnalyzer();
+        StatisticsAutoCollector saa = new StatisticsAutoCollector();
         saa.runAfterCatalogReady();
         new Expectations() {
             {
@@ -132,7 +132,7 @@ public class StatisticsAutoAnalyzerTest {
                 return columns;
             }
         };
-        StatisticsAutoAnalyzer saa = new StatisticsAutoAnalyzer();
+        StatisticsAutoCollector saa = new StatisticsAutoCollector();
         List<AnalysisInfo> analysisInfos =
                 saa.constructAnalysisInfo(new Database(1, "anydb"));
         Assertions.assertEquals(1, analysisInfos.size());
@@ -175,7 +175,7 @@ public class StatisticsAutoAnalyzerTest {
             }
         };
 
-        new MockUp<StatisticsAutoAnalyzer>() {
+        new MockUp<StatisticsAutoCollector>() {
             @Mock
             public Set<String> findReAnalyzeNeededPartitions(TableIf table, long lastExecTimeInMs) {
                 Set<String> partitionNames = new HashSet<>();
@@ -190,13 +190,13 @@ public class StatisticsAutoAnalyzerTest {
                 return new AnalysisInfoBuilder().build();
             }
         };
-        StatisticsAutoAnalyzer statisticsAutoAnalyzer = new StatisticsAutoAnalyzer();
+        StatisticsAutoCollector statisticsAutoCollector = new StatisticsAutoCollector();
         AnalysisInfo analysisInfo2 = new AnalysisInfoBuilder()
                 .setCatalogName("cname")
                 .setDbName("db")
                 .setTblName("tbl").build();
-        Assertions.assertNotNull(statisticsAutoAnalyzer.getReAnalyzeRequiredPart(analysisInfo2));
-        Assertions.assertNull(statisticsAutoAnalyzer.getReAnalyzeRequiredPart(analysisInfo2));
-        Assertions.assertNotNull(statisticsAutoAnalyzer.getReAnalyzeRequiredPart(analysisInfo2));
+        Assertions.assertNotNull(statisticsAutoCollector.getReAnalyzeRequiredPart(analysisInfo2));
+        Assertions.assertNull(statisticsAutoCollector.getReAnalyzeRequiredPart(analysisInfo2));
+        Assertions.assertNotNull(statisticsAutoCollector.getReAnalyzeRequiredPart(analysisInfo2));
     }
 }


### PR DESCRIPTION
## Proposed changes

1. Use sample(20 percent) automatically when the table size is greater than 5GiB
2. Limit scan threads number as 1 for backgroud system analyze tasks

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

