### PR TITLE
[fix](iceberg) fix iceberg count(*) short circuit read bug

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PlanTranslatorContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PlanTranslatorContext.java
@@ -41,6 +41,7 @@ import org.apache.doris.planner.PlanFragmentId;
 import org.apache.doris.planner.PlanNode;
 import org.apache.doris.planner.PlanNodeId;
 import org.apache.doris.planner.ScanNode;
+import org.apache.doris.thrift.TPushAggOp;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
@@ -92,6 +93,8 @@ public class PlanTranslatorContext {
     private final Map<CTEId, PhysicalCTEConsumer> cteConsumerMap = Maps.newHashMap();
 
     private final Map<PlanFragmentId, CTEScanNode> cteScanNodeMap = Maps.newHashMap();
+
+    private final Map<Long, TPushAggOp> tablePushAggOp = Maps.newHashMap();
 
     public PlanTranslatorContext(CascadesContext ctx) {
         this.translator = new RuntimeFilterTranslator(ctx.getRuntimeFilterContext());
@@ -234,5 +237,13 @@ public class PlanTranslatorContext {
 
     public DescriptorTable getDescTable() {
         return descTable;
+    }
+
+    public void setTablePushAggOp(Long tableId, TPushAggOp aggOp) {
+        tablePushAggOp.put(tableId, aggOp);
+    }
+
+    public TPushAggOp getTablePushAggOp(Long tableId) {
+        return tablePushAggOp.getOrDefault(tableId, TPushAggOp.NONE);
     }
 }


### PR DESCRIPTION
## Proposed changes

When using the nereids optimizer, the `count` operation needs to be pushed down before fetching split.
So the current order is: 
1. create a ScanNode
2. set the filter
3. set the push down operation of the ScanNode, such as `count`
4. generate split for this ScanNode

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

