### PR TITLE
[bugfix] (dynamic partition) dynamicPartitionTableInfo is removed when table is being synced

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogGcer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogGcer.java
@@ -58,7 +58,7 @@ public class BinlogGcer extends MasterDaemon {
             if (tombstones != null && !tombstones.isEmpty()) {
                 LOG.info("tomebstones size: {}", tombstones.size());
             } else {
-                LOG.info("no gc binlogg");
+                LOG.info("no gc binlog");
                 return;
             }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
@@ -501,10 +501,11 @@ public class DynamicPartitionScheduler extends MasterDaemon {
             olapTable = (OlapTable) db.getTableNullable(tableId);
             // Only OlapTable has DynamicPartitionProperty
             if (olapTable == null
-                    || olapTable.isBeingSynced()
                     || !olapTable.dynamicPartitionExists()
                     || !olapTable.getTableProperty().getDynamicPartitionProperty().getEnable()) {
                 iterator.remove();
+                continue;
+            } else if (olapTable.isBeingSynced()) {
                 continue;
             }
             olapTable.readLock();


### PR DESCRIPTION
## BUG:
Table dynamicPartitionTableInfo is removed by mistake when it is_being_synced = true

## FIX:
Do not remove dynamicPartitionTableInfo iter when is_being_synced = true