### PR TITLE
[fix](export)Export does not support viewing clear error messages

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
@@ -235,8 +235,8 @@ public class ExportJob implements Writable {
         exportTable.readLock();
         try {
             if (exportTable.getType().name().equalsIgnoreCase("VIEW")) {
-                LOG.info("Table Type unsupport export, ExportTable type : {}", exportTable.getType());
-                throw new UserException("Table Type unsupport export :" + exportTable.getType());
+                LOG.info("Table Type {} is not supported in export", exportTable.getType());
+                throw new UserException("Table Type is not supported in export: " + exportTable.getType());
             }		
             // generateQueryStmtOld
             generateQueryStmt();

--- a/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
@@ -234,6 +234,10 @@ public class ExportJob implements Writable {
     public void analyze() throws UserException {
         exportTable.readLock();
         try {
+            if (exportTable.getType().name().equalsIgnoreCase("VIEW")) {
+                LOG.info("Table Type unsupport export, ExportTable type : {}", exportTable.getType());
+                throw new UserException("Table Type unsupport export :" + exportTable.getType());
+            }		
             // generateQueryStmtOld
             generateQueryStmt();
         } finally {


### PR DESCRIPTION
## Proposed changes
export does not support exporting views, but the submission can be successful. The information given to the user here is wrong. It should be clearly indicated that it is not supported, instead of allowing the user to view it through the show export command, and the information seen by the show export command is also inaccurate. Yes, but the prompt was canceled without knowing the specific reason。

Previous assignment submissions：
![cf48106e-13f6-4477-8caa-2f212dc8d4f6](https://github.com/apache/doris/assets/820301/33240b73-718a-428d-92a5-4ff42628f578)

current job submission：
![image](https://github.com/apache/doris/assets/820301/b6e71aed-da26-48e4-ad7a-fa60b6b380f1)


Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

