### PR TITLE
[fix](meta) set broadcast_right_table_scale_factor when upgrading from 1.2 to 2.x

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -1377,10 +1377,16 @@ public class Env {
                 // when switch to pipeline engine, otherwise it may impact the load of entire cluster
                 // because the default parallelism of pipeline engine is higher than previous version.
                 // so set parallel_pipeline_task_num to parallel_fragment_exec_instance_num
-                int newVal = VariableMgr.newSessionVariable().parallelExecInstanceNum;
-                VariableMgr.setGlobalPipelineTask(newVal);
+                int newParaVal = VariableMgr.newSessionVariable().parallelExecInstanceNum;
+                VariableMgr.setGlobalPipelineTask(newParaVal);
                 LOG.info("upgrade FE from 1.x to 2.0, set parallel_pipeline_task_num "
-                        + "to parallel_fragment_exec_instance_num: {}", newVal);
+                        + "to parallel_fragment_exec_instance_num: {}", newParaVal);
+
+                // similar reason as above, need to upgrade broadcast scale factor during 1.2 to 2.0
+                double newBcFactorVal = VariableMgr.newSessionVariable().getBroadcastRightTableScaleFactor();
+                VariableMgr.setGlobalBroadcastScaleFactor(newBcFactorVal);
+                LOG.info("upgrade FE from 1.x to 2.0, set broadcast_right_table_scale_factor "
+                        + "to new default value: {}", newBcFactorVal);
             }
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -1377,17 +1377,17 @@ public class Env {
                 // when switch to pipeline engine, otherwise it may impact the load of entire cluster
                 // because the default parallelism of pipeline engine is higher than previous version.
                 // so set parallel_pipeline_task_num to parallel_fragment_exec_instance_num
-                int newParaVal = VariableMgr.newSessionVariable().parallelExecInstanceNum;
-                VariableMgr.setGlobalPipelineTask(newParaVal);
+                int newVal = VariableMgr.newSessionVariable().parallelExecInstanceNum;
+                VariableMgr.setGlobalPipelineTask(newVal);
                 LOG.info("upgrade FE from 1.x to 2.0, set parallel_pipeline_task_num "
-                        + "to parallel_fragment_exec_instance_num: {}", newParaVal);
-
-                // similar reason as above, need to upgrade broadcast scale factor during 1.2 to 2.0
-                double newBcFactorVal = VariableMgr.newSessionVariable().getBroadcastRightTableScaleFactor();
-                VariableMgr.setGlobalBroadcastScaleFactor(newBcFactorVal);
-                LOG.info("upgrade FE from 1.x to 2.0, set broadcast_right_table_scale_factor "
-                        + "to new default value: {}", newBcFactorVal);
+                        + "to parallel_fragment_exec_instance_num: {}", newVal);
             }
+            // similar reason as above, need to upgrade broadcast scale factor during 1.2 to 2.x
+            // if the default value has been updated
+            double newBcFactorVal = VariableMgr.newSessionVariable().getBroadcastRightTableScaleFactor();
+            VariableMgr.setGlobalBroadcastScaleFactor(newBcFactorVal);
+            LOG.info("upgrade FE from 1.x to 2.x, set broadcast_right_table_scale_factor "
+                    + "to new default value: {}", newBcFactorVal);
         }
 
         getPolicyMgr().createDefaultStoragePolicy();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -1381,13 +1381,14 @@ public class Env {
                 VariableMgr.setGlobalPipelineTask(newVal);
                 LOG.info("upgrade FE from 1.x to 2.0, set parallel_pipeline_task_num "
                         + "to parallel_fragment_exec_instance_num: {}", newVal);
+
+                // similar reason as above, need to upgrade broadcast scale factor during 1.2 to 2.x
+                // if the default value has been upgraded
+                double newBcFactorVal = VariableMgr.newSessionVariable().getBroadcastRightTableScaleFactor();
+                VariableMgr.setGlobalBroadcastScaleFactor(newBcFactorVal);
+                LOG.info("upgrade FE from 1.x to 2.x, set broadcast_right_table_scale_factor "
+                        + "to new default value: {}", newBcFactorVal);
             }
-            // similar reason as above, need to upgrade broadcast scale factor during 1.2 to 2.x
-            // if the default value has been updated
-            double newBcFactorVal = VariableMgr.newSessionVariable().getBroadcastRightTableScaleFactor();
-            VariableMgr.setGlobalBroadcastScaleFactor(newBcFactorVal);
-            LOG.info("upgrade FE from 1.x to 2.x, set broadcast_right_table_scale_factor "
-                    + "to new default value: {}", newBcFactorVal);
         }
 
         getPolicyMgr().createDefaultStoragePolicy();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -392,6 +392,26 @@ public class VariableMgr {
         }
     }
 
+    public static void setGlobalBroadcastScaleFactor(double factor) {
+        wlock.lock();
+        try {
+            VarContext ctx = ctxByVarName.get(SessionVariable.BROADCAST_RIGHT_TABLE_SCALE_FACTOR);
+            try {
+                setValue(ctx.getObj(), ctx.getField(), String.valueOf(factor));
+            } catch (DdlException e) {
+                LOG.warn("failed to set global variable: {}", SessionVariable.BROADCAST_RIGHT_TABLE_SCALE_FACTOR, e);
+                return;
+            }
+
+            // write edit log
+            GlobalVarPersistInfo info = new GlobalVarPersistInfo(defaultSessionVariable,
+                    Lists.newArrayList(SessionVariable.BROADCAST_RIGHT_TABLE_SCALE_FACTOR));
+            Env.getCurrentEnv().getEditLog().logGlobalVariableV2(info);
+        } finally {
+            wlock.unlock();
+        }
+    }
+
     public static void setLowerCaseTableNames(int mode) throws DdlException {
         VarContext ctx = ctxByVarName.get(GlobalVariable.LOWER_CASE_TABLE_NAMES);
         setGlobalVarAndWriteEditLog(ctx, GlobalVariable.LOWER_CASE_TABLE_NAMES, "" + mode);


### PR DESCRIPTION
…m 1.2 to 2.x

When upgrading from 1.2 to 2.x(future version higher than 2.0), the default value of parameter broadcast_right_table_scale_factor may not be upgraded from old default value 10.0 to new default 0.0, which will cause the broadcast join behavior unexpected and may have a big performance impact. This pr will force to reset the value to new default value 0.0, to make sure the behavior correct.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

