### PR TITLE
[wip-feature](Policies) Support show partitions using storage policy

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1593,6 +1593,9 @@ void Tablet::build_tablet_report_info(TTabletInfo* tablet_info,
     tablet_info->__set_schema_hash(_tablet_meta->schema_hash());
     tablet_info->__set_row_count(_tablet_meta->num_rows());
     tablet_info->__set_data_size(_tablet_meta->tablet_local_size());
+    if (auto policy_id = storage_policy_id(); policy_id > 0) {
+        tablet_info->__set_storage_policy_id(policy_id);
+    }
 
     // Here we need to report to FE if there are any missing versions of tablet.
     // We start from the initial version and traverse backwards until we meet a discontinuous version.

--- a/be/src/vec/exec/scan/vmeta_scanner.cpp
+++ b/be/src/vec/exec/scan/vmeta_scanner.cpp
@@ -222,6 +222,9 @@ Status VMetaScanner::_fetch_metadata(const TMetaScanRange& meta_scan_range) {
     case TMetadataType::CATALOGS:
         RETURN_IF_ERROR(_build_catalogs_metadata_request(meta_scan_range, &request));
         break;
+    case TMetadataType::STORAGE_POLICY:
+        RETURN_IF_ERROR(_build_storage_policy_metadata_request(meta_scan_range, &request));
+        break;
     default:
         _meta_eos = true;
         return Status::OK();
@@ -307,6 +310,25 @@ Status VMetaScanner::_build_frontends_metadata_request(const TMetaScanRange& met
     TMetadataTableRequestParams metadata_table_params;
     metadata_table_params.__set_metadata_type(TMetadataType::FRONTENDS);
     metadata_table_params.__set_frontends_metadata_params(meta_scan_range.frontends_params);
+
+    request->__set_metada_table_params(metadata_table_params);
+    return Status::OK();
+}
+
+Status VMetaScanner::_build_storage_policy_metadata_request(const TMetaScanRange& meta_scan_range,
+                                                            TFetchSchemaTableDataRequest* request) {
+    VLOG_CRITICAL << "VMetaScanner::_build_storage_policy_metadata_request";
+    if (!meta_scan_range.__isset.storage_policy_params) {
+        return Status::InternalError("Can not find TStoragePolicyParams from meta_scan_range.");
+    }
+    // create request
+    request->__set_cluster_name("");
+    request->__set_schema_table_name(TSchemaTableName::METADATA_TABLE);
+
+    // create TMetadataTableRequestParams
+    TMetadataTableRequestParams metadata_table_params;
+    metadata_table_params.__set_metadata_type(TMetadataType::STORAGE_POLICY);
+    metadata_table_params.__set_storage_policy_params(meta_scan_range.storage_policy_params);
 
     request->__set_metada_table_params(metadata_table_params);
     return Status::OK();

--- a/be/src/vec/exec/scan/vmeta_scanner.h
+++ b/be/src/vec/exec/scan/vmeta_scanner.h
@@ -77,6 +77,8 @@ private:
                                                    TFetchSchemaTableDataRequest* request);
     Status _build_catalogs_metadata_request(const TMetaScanRange& meta_scan_range,
                                             TFetchSchemaTableDataRequest* request);
+    Status _build_storage_policy_metadata_request(const TMetaScanRange& meta_scan_range,
+                                                  TFetchSchemaTableDataRequest* request);
     bool _meta_eos;
     TupleId _tuple_id;
     TUserIdentity _user_identity;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/DataProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/DataProperty.java
@@ -95,7 +95,7 @@ public class DataProperty implements Writable, GsonPostProcessable {
     }
 
     public String getStoragePolicy() {
-        return storagePolicy;
+        return storagePolicy == null ? "" : storagePolicy;
     }
 
     public void setStoragePolicy(String storagePolicy) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ListPartitionInfo.java
@@ -222,8 +222,8 @@ public class ListPartitionInfo extends PartitionInfo {
             }
             sb.append(")");
 
-            Optional.ofNullable(this.idToStoragePolicy.get(entry.getKey())).ifPresent(p -> {
-                if (!p.equals("")) {
+            Optional.ofNullable(this.idToDataProperty.get(entry.getKey())).ifPresent(p -> {
+                if (!p.getStoragePolicy().equals("")) {
                     sb.append("PROPERTIES (\"STORAGE POLICY\" = \"");
                     sb.append(p).append("\")");
                 }
@@ -261,9 +261,9 @@ public class ListPartitionInfo extends PartitionInfo {
             PartitionKeyDesc partitionKeyDesc = PartitionKeyDesc.createIn(inValues);
 
             Map<String, String> properties = Maps.newHashMap();
-            Optional.ofNullable(this.idToStoragePolicy.get(entry.getKey())).ifPresent(p -> {
-                if (!p.equals("")) {
-                    properties.put("STORAGE POLICY", p);
+            Optional.ofNullable(this.idToDataProperty.get(entry.getKey())).ifPresent(p -> {
+                if (!p.getStoragePolicy().equals("")) {
+                    properties.put("STORAGE POLICY", p.getStoragePolicy());
                 }
             });
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -815,9 +815,20 @@ public class OlapTable extends Table {
         }
     }
 
+    private void refreshPolicyMgrInfo(Partition partition, boolean delete) {
+        if (partitionInfo.getStoragePolicy(partition.getId()).equals("")) {
+            return;
+        }
+
+        Env.getCurrentEnv()
+                .getPolicyMgr().updatePolicyNameToPartitionMap(partitionInfo.getStoragePolicy(partition.getId()),
+                        partition.getId(), delete);
+    }
+
     public void addPartition(Partition partition) {
         idToPartition.put(partition.getId(), partition);
         nameToPartition.put(partition.getName(), partition);
+        refreshPolicyMgrInfo(partition, false);
     }
 
     // This is a private method.
@@ -874,6 +885,7 @@ public class OlapTable extends Table {
 
             // drop partition info
             partitionInfo.dropPartition(partition.getId());
+            refreshPolicyMgrInfo(partition, true);
         }
         return partition;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/PartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/PartitionInfo.java
@@ -65,8 +65,6 @@ public class PartitionInfo implements Writable {
     // partition id -> data property
     @SerializedName("IdToDataProperty")
     protected Map<Long, DataProperty> idToDataProperty;
-    // partition id -> storage policy
-    protected Map<Long, String> idToStoragePolicy;
     // partition id -> replication allocation
     @SerializedName("IdToReplicaAllocation")
     protected Map<Long, ReplicaAllocation> idToReplicaAllocation;
@@ -87,7 +85,6 @@ public class PartitionInfo implements Writable {
         this.idToReplicaAllocation = new HashMap<>();
         this.idToInMemory = new HashMap<>();
         this.idToTabletType = new HashMap<>();
-        this.idToStoragePolicy = new HashMap<>();
     }
 
     public PartitionInfo(PartitionType type) {
@@ -96,7 +93,6 @@ public class PartitionInfo implements Writable {
         this.idToReplicaAllocation = new HashMap<>();
         this.idToInMemory = new HashMap<>();
         this.idToTabletType = new HashMap<>();
-        this.idToStoragePolicy = new HashMap<>();
     }
 
     public PartitionInfo(PartitionType type, List<Column> partitionColumns) {
@@ -150,7 +146,6 @@ public class PartitionInfo implements Writable {
         idToDataProperty.put(partitionId, desc.getPartitionDataProperty());
         idToReplicaAllocation.put(partitionId, desc.getReplicaAlloc());
         idToInMemory.put(partitionId, desc.isInMemory());
-        idToStoragePolicy.put(partitionId, desc.getStoragePolicy());
 
         return partitionItem;
     }
@@ -166,7 +161,6 @@ public class PartitionInfo implements Writable {
         idToDataProperty.put(partitionId, dataProperty);
         idToReplicaAllocation.put(partitionId, replicaAlloc);
         idToInMemory.put(partitionId, isInMemory);
-        idToStoragePolicy.put(partitionId, "");
         //TODO
         //idToMutable.put(partitionId, isMutable);
     }
@@ -231,18 +225,29 @@ public class PartitionInfo implements Writable {
     }
 
     public void refreshTableStoragePolicy(String storagePolicy) {
-        idToStoragePolicy.replaceAll((k, v) -> storagePolicy);
         idToDataProperty.entrySet().forEach(entry -> {
             entry.getValue().setStoragePolicy(storagePolicy);
         });
     }
 
+    public boolean isStoragePolicyUsed(String storagePolicy) {
+        return idToDataProperty.entrySet().stream().anyMatch(entry -> {
+            return entry.getValue().getStoragePolicy().equals(storagePolicy);
+        });
+    }
+
     public String getStoragePolicy(long partitionId) {
-        return idToStoragePolicy.getOrDefault(partitionId, "");
+        if (null == idToDataProperty.get(partitionId)) {
+            return "";
+        }
+        return idToDataProperty.get(partitionId).getStoragePolicy();
     }
 
     public void setStoragePolicy(long partitionId, String storagePolicy) {
-        idToStoragePolicy.put(partitionId, storagePolicy);
+        if (null == idToDataProperty.get(partitionId)) {
+            return ;
+        }
+        idToDataProperty.get(partitionId).setStoragePolicy(storagePolicy);
     }
 
     public ReplicaAllocation getReplicaAllocation(long partitionId) {
@@ -436,14 +441,14 @@ public class PartitionInfo implements Writable {
         return isMultiColumnPartition == that.isMultiColumnPartition && type == that.type && Objects.equals(
                 partitionColumns, that.partitionColumns) && Objects.equals(idToItem, that.idToItem)
                 && Objects.equals(idToTempItem, that.idToTempItem) && Objects.equals(idToDataProperty,
-                that.idToDataProperty) && Objects.equals(idToStoragePolicy, that.idToStoragePolicy)
-                && Objects.equals(idToReplicaAllocation, that.idToReplicaAllocation) && Objects.equals(
-                idToInMemory, that.idToInMemory) && Objects.equals(idToTabletType, that.idToTabletType);
+                that.idToDataProperty) && Objects.equals(idToReplicaAllocation, that.idToReplicaAllocation)
+                && Objects.equals(idToInMemory, that.idToInMemory)
+                && Objects.equals(idToTabletType, that.idToTabletType);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, partitionColumns, idToItem, idToTempItem, idToDataProperty, idToStoragePolicy,
+        return Objects.hash(type, partitionColumns, idToItem, idToTempItem, idToDataProperty,
                 idToReplicaAllocation, isMultiColumnPartition, idToInMemory, idToTabletType);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RangePartitionInfo.java
@@ -278,8 +278,8 @@ public class RangePartitionInfo extends PartitionInfo {
             sb.append(range.lowerEndpoint().toSql());
             sb.append(", ").append(range.upperEndpoint().toSql()).append(")");
 
-            Optional.ofNullable(this.idToStoragePolicy.get(entry.getKey())).ifPresent(p -> {
-                if (!p.equals("")) {
+            Optional.ofNullable(this.idToDataProperty.get(entry.getKey())).ifPresent(p -> {
+                if (!p.getStoragePolicy().equals("")) {
                     sb.append("PROPERTIES (\"STORAGE POLICY\" = \"");
                     sb.append(p).append("\")");
                 }
@@ -317,9 +317,9 @@ public class RangePartitionInfo extends PartitionInfo {
                     PartitionInfo.toPartitionValue(range.upperEndpoint()));
 
             Map<String, String> properties = Maps.newHashMap();
-            Optional.ofNullable(this.idToStoragePolicy.get(entry.getKey())).ifPresent(p -> {
-                if (!p.equals("")) {
-                    properties.put("STORAGE POLICY", p);
+            Optional.ofNullable(this.idToDataProperty.get(entry.getKey())).ifPresent(p -> {
+                if (!p.getStoragePolicy().equals("")) {
+                    properties.put("STORAGE POLICY", p.getStoragePolicy());
                 }
             });
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -34,6 +34,7 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.datasource.CatalogMgr;
 import org.apache.doris.policy.Policy;
+import org.apache.doris.policy.PolicyTypeEnum;
 import org.apache.doris.policy.StoragePolicy;
 import org.apache.doris.resource.Tag;
 import org.apache.doris.system.SystemInfoService;
@@ -252,7 +253,7 @@ public class PropertyAnalyzer {
             // check remote storage policy
             StoragePolicy checkedPolicy = StoragePolicy.ofCheck(newStoragePolicy);
             Policy policy = Env.getCurrentEnv().getPolicyMgr().getPolicy(checkedPolicy);
-            if (!(policy instanceof StoragePolicy)) {
+            if (policy.getType() != PolicyTypeEnum.STORAGE) {
                 throw new AnalysisException("No PolicyStorage: " + newStoragePolicy);
             }
 
@@ -268,7 +269,7 @@ public class PropertyAnalyzer {
                 // check remote storage policy
                 StoragePolicy oldPolicy = StoragePolicy.ofCheck(oldStoragePolicy);
                 Policy p = Env.getCurrentEnv().getPolicyMgr().getPolicy(oldPolicy);
-                if ((p instanceof StoragePolicy)) {
+                if ((policy.getType() == PolicyTypeEnum.STORAGE)) {
                     String newResource = storagePolicy.getStorageResource();
                     String oldResource = ((StoragePolicy) p).getStorageResource();
                     if (!newResource.equals(oldResource)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -265,7 +265,7 @@ public class PropertyAnalyzer {
             // changing the policy to a different policy with different resource is disabled.
             // As for the case where the resource is the same, modifying the cooldown time is allowed,
             // as this will not affect the already cooled data, but only the new data after modifying the policy.
-            if (null != oldStoragePolicy && !oldStoragePolicy.equals(newStoragePolicy)) {
+            if (!Strings.isNullOrEmpty(oldStoragePolicy) && !oldStoragePolicy.equals(newStoragePolicy)) {
                 // check remote storage policy
                 StoragePolicy oldPolicy = StoragePolicy.ofCheck(oldStoragePolicy);
                 Policy p = Env.getCurrentEnv().getPolicyMgr().getPolicy(oldPolicy);

--- a/fe/fe-core/src/main/java/org/apache/doris/policy/Policy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/policy/Policy.java
@@ -102,6 +102,23 @@ public abstract class Policy implements Writable, GsonPostProcessable {
         this.version = 0;
     }
 
+    @Override
+    public int hashCode() {
+        return Long.hashCode(id);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        Policy other = (Policy) obj;
+        return id == other.id;
+    }
+
     /**
      * Trans stmt to Policy.
      **/

--- a/fe/fe-core/src/main/java/org/apache/doris/policy/PolicyMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/policy/PolicyMgr.java
@@ -256,7 +256,8 @@ public class PolicyMgr implements Writable {
         readLock();
         try {
             Set<Policy> policies = getPoliciesByType(checkedPolicy.getType());
-            return policies.stream().filter(p -> p.equals(checkedPolicy)).findAny().orElse(null);
+            return policies.stream().filter(p -> p.getPolicyName().equals(checkedPolicy.getPolicyName()))
+                    .findAny().orElse(null);
         } finally {
             readUnlock();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/policy/RowPolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/policy/RowPolicy.java
@@ -149,6 +149,22 @@ public class RowPolicy extends Policy {
         }
     }
 
+    public int hashCode() {
+        return Long.hashCode(id);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        Policy other = (Policy) obj;
+        return id == other.id;
+    }
+
     @Override
     public RowPolicy clone() {
         return new RowPolicy(this.id, this.policyName, this.dbId, this.user, this.roleName, this.originStmt,

--- a/fe/fe-core/src/main/java/org/apache/doris/policy/StoragePolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/policy/StoragePolicy.java
@@ -140,6 +140,23 @@ public class StoragePolicy extends Policy {
         return storagePolicy;
     }
 
+    @Override
+    public int hashCode() {
+        return Long.hashCode(id);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        Policy other = (Policy) obj;
+        return id == other.id;
+    }
+
     /**
      * Init props for storage policy.
      *

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
@@ -92,6 +92,9 @@ public class MetadataGenerator {
             case CATALOGS:
                 result = catalogsMetadataResult(params);
                 break;
+            case STORAGE_POLICY:
+                result = storagePoliciesMetadataResult(params);
+                break;
             default:
                 return errorResult("Metadata table params is not set.");
         }
@@ -259,6 +262,30 @@ public class MetadataGenerator {
         List<TRow> dataBatch = Lists.newArrayList();
         List<List<String>> infos = Lists.newArrayList();
         FrontendsProcNode.getFrontendsInfo(Env.getCurrentEnv(), infos);
+        for (List<String> info : infos) {
+            TRow trow = new TRow();
+            for (String item : info) {
+                trow.addToColumnValue(new TCell().setStringVal(item));
+            }
+            dataBatch.add(trow);
+        }
+
+        result.setDataBatch(dataBatch);
+        result.setStatus(new TStatus(TStatusCode.OK));
+        return result;
+    }
+
+    private static TFetchSchemaTableDataResult storagePoliciesMetadataResult(TMetadataTableRequestParams params) {
+        if (!params.isSetStoragePolicyParams()) {
+            return errorResult("storage policy name metadata param is not set.");
+        }
+
+        TFetchSchemaTableDataResult result = new TFetchSchemaTableDataResult();
+
+        List<TRow> dataBatch = Lists.newArrayList();
+        List<List<String>> infos = Lists.newArrayList();
+        Env.getCurrentEnv().getPolicyMgr()
+                .getStoragePolicyPartitionInfo(params.getStoragePolicyParams().getPolicyId(), infos);
         for (List<String> info : infos) {
             TRow trow = new TRow();
             for (String item : info) {

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataTableValuedFunction.java
@@ -41,6 +41,8 @@ public abstract class MetadataTableValuedFunction extends TableValuedFunctionIf 
                 return WorkloadGroupsTableValuedFunction.getColumnIndexFromColumnName(columnName);
             case CATALOGS:
                 return CatalogsTableValuedFunction.getColumnIndexFromColumnName(columnName);
+            case STORAGE_POLICY:
+                return StoragePolicyTableValuedFunction.getColumnIndexFromColumnName(columnName);
             default:
                 throw new AnalysisException("Unknown Metadata TableValuedFunction type");
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/StoragePolicyTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/StoragePolicyTableValuedFunction.java
@@ -1,0 +1,96 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.tablefunction;
+
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.ScalarType;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.thrift.TMetaScanRange;
+import org.apache.doris.thrift.TMetadataType;
+import org.apache.doris.thrift.TStoragePolicyMetadataParam;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class StoragePolicyTableValuedFunction extends MetadataTableValuedFunction {
+    public static final String NAME = "storage_policy";
+
+    private static final ImmutableList<Column> SCHEMA = ImmutableList.of(
+            new Column("StoragePolicyId", ScalarType.createStringType()),
+            new Column("PartitionID", ScalarType.createStringType()));
+
+    private static final ImmutableMap<String, Integer> COLUMN_TO_INDEX;
+
+    private Long storagePolicyId;
+
+    static {
+        ImmutableMap.Builder<String, Integer> builder = new ImmutableMap.Builder();
+        for (int i = 0; i < SCHEMA.size(); i++) {
+            builder.put(SCHEMA.get(i).getName().toLowerCase(), i);
+        }
+        COLUMN_TO_INDEX = builder.build();
+    }
+
+    public static Integer getColumnIndexFromColumnName(String columnName) {
+        return COLUMN_TO_INDEX.get(columnName.toLowerCase());
+    }
+
+    public StoragePolicyTableValuedFunction(Map<String, String> params) throws
+            org.apache.doris.nereids.exceptions.AnalysisException {
+        if (params.size() != 1) {
+            throw new org.apache.doris.nereids
+                .exceptions.AnalysisException("storage policy table-valued-function needs only one param");
+        }
+        Optional<Map.Entry<String, String>> opt = params.entrySet().stream()
+                    .filter(entry -> entry.getKey().toLowerCase().equals("storage_policy")).findAny();
+        if (!opt.isPresent()) {
+            throw new org.apache.doris.nereids
+                .exceptions.AnalysisException("storage policy table-valued-function needs storage_policy id");
+        }
+        storagePolicyId = Long.valueOf(opt.get().getValue());
+    }
+
+    @Override
+    public String getTableName() {
+        return NAME;
+    }
+
+    @Override
+    public List<Column> getTableColumns() throws AnalysisException {
+        return SCHEMA;
+    }
+
+    @Override
+    public TMetadataType getMetadataType() {
+        return TMetadataType.STORAGE_POLICY;
+    }
+
+    @Override
+    public TMetaScanRange getMetaScanRange() {
+        TMetaScanRange metaScanRange = new TMetaScanRange();
+        metaScanRange.setMetadataType(TMetadataType.STORAGE_POLICY);
+        TStoragePolicyMetadataParam storagePolicyMetadataParam = new TStoragePolicyMetadataParam();
+        storagePolicyMetadataParam.setPolicyId(storagePolicyId);
+        metaScanRange.setStoragePolicyParams(storagePolicyMetadataParam);
+        return metaScanRange;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/TableValuedFunctionIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/TableValuedFunctionIf.java
@@ -66,6 +66,8 @@ public abstract class TableValuedFunctionIf {
                 return new WorkloadGroupsTableValuedFunction(params);
             case CatalogsTableValuedFunction.NAME:
                 return new CatalogsTableValuedFunction(params);
+            case StoragePolicyTableValuedFunction.NAME:
+                return new StoragePolicyTableValuedFunction(params);
             default:
                 throw new AnalysisException("Could not find table function " + funcName);
         }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -854,6 +854,7 @@ struct TMetadataTableRequestParams {
   4: optional list<string> columns_name
   5: optional PlanNodes.TFrontendsMetadataParams frontends_metadata_params
   6: optional Types.TUserIdentity current_user_ident
+  7: optional PlanNodes.TStoragePolicyMetadataParam storage_policy_params
 }
 
 struct TFetchSchemaTableDataRequest {

--- a/gensrc/thrift/MasterService.thrift
+++ b/gensrc/thrift/MasterService.thrift
@@ -46,6 +46,7 @@ struct TTabletInfo {
     // 18: optional bool is_cooldown
     19: optional i64 cooldown_term
     20: optional Types.TUniqueId cooldown_meta_id
+    21: optional i64 storage_policy_id
 }
 
 struct TFinishTaskRequest {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -457,11 +457,16 @@ struct TFrontendsMetadataParams {
   1: optional string cluster_name
 }
 
+struct TStoragePolicyMetadataParam  {
+  1: optional i64 policy_id
+}
+
 struct TMetaScanRange {
   1: optional Types.TMetadataType metadata_type
   2: optional TIcebergMetadataParams iceberg_params
   3: optional TBackendsMetadataParams backends_params
   4: optional TFrontendsMetadataParams frontends_params
+  5: optional TStoragePolicyMetadataParam storage_policy_params
 }
 
 // Specification of an individual data range which is held in its entirety

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -692,6 +692,7 @@ enum TMetadataType {
   FRONTENDS,
   CATALOGS,
   FRONTENDS_DISKS,
+  STORAGE_POLICY,
 }
 
 enum TIcebergQueryType {

--- a/regression-test/suites/cold_heat_separation/policy/select.groovy
+++ b/regression-test/suites/cold_heat_separation/policy/select.groovy
@@ -1,0 +1,120 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("show_policy") {
+    def get_storage_policy = { name ->
+        def show_storage_policy = sql """
+        SHOW STORAGE POLICY;
+        """
+        for(policy in show_storage_policy){
+            if(name == policy[0]){
+                return policy;
+            }
+        }
+        return [];
+    }
+
+    if (get_storage_policy.call("showPolicy_1_policy").isEmpty()){
+        def create_s3_resource = try_sql """
+            CREATE RESOURCE "showPolicy_1_resource"
+            PROPERTIES(
+                "type"="s3",
+                "AWS_REGION" = "bj",
+                "AWS_ENDPOINT" = "bj.s3.comaaaa",
+                "AWS_ROOT_PATH" = "path/to/rootaaaa",
+                "AWS_SECRET_KEY" = "aaaa",
+                "AWS_ACCESS_KEY" = "bbba",
+                "AWS_BUCKET" = "test-bucket",
+                "s3_validity_check" = "false"
+            );
+        """
+        def create_succ_1 = try_sql """
+            CREATE STORAGE POLICY showPolicy_1_policy
+            PROPERTIES(
+            "storage_resource" = "showPolicy_1_resource",
+            "cooldown_datetime" = "2022-06-08 00:00:00"
+            );
+        """
+        def create_succ_2 = try_sql """
+            CREATE STORAGE POLICY showPolicy_2_policy
+            PROPERTIES(
+            "storage_resource" = "showPolicy_1_resource",
+            "cooldown_datetime" = "2022-06-08 00:00:00"
+            );
+        """
+    }
+    sql """
+    CREATE TABLE IF NOT EXISTS create_table_use_created_policy 
+    (
+        k1 BIGINT,
+        date DATE
+    )
+    DUPLICATE KEY(k1)
+    PARTITION BY RANGE(`date`)
+    (
+        PARTITION `p201701` VALUES LESS THAN ("2017-02-01") ("storage_policy" = "showPolicy_1_policy"),
+        PARTITION `p201702` VALUES LESS THAN ("2017-03-01") ("storage_policy" = "showPolicy_2_policy"),,
+        PARTITION `p201703` VALUES LESS THAN ("2017-04-01")
+    )
+    DISTRIBUTED BY HASH (k1) BUCKETS 1
+    PROPERTIES(
+        "replication_num" = "1"
+    )
+    """
+
+    def policies = sql """
+    show storage policy
+    """
+    def policyId1 = "0";
+    def policyId2 = "0";
+
+    for (pol in policies) {
+        if (pol[0] == "showPolicy_1_policy") {
+            policyId1 = pol[1];
+        }
+        if (pol[0] == "showPolicy_2_policy") {
+            policyId2 = pol[1];
+        }
+    }
+
+    assertTrue(policyId1 != "0")
+    assertTrue(policyId2 != "0")
+
+    // wait for the tablet report to be done
+    sleep(300000)
+
+    def partitions = sql """
+    select * from storage_policy("storage_policy" = '${policyId1}')
+    """
+
+    assertEquals(partitions.size(), 1)
+    
+    sql """
+    DROP TABLE create_table_use_created_policy FORCE
+    """
+
+    sql """
+    DROP STORAGE POLICY showPolicy_1_policy;
+    """
+    sql """
+    DROP STORAGE POLICY showPolicy_2_policy;
+    """
+
+    sql """
+    DROP RESOURCE "showPolicy_1_resource";
+    """
+}


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
Previously, there was no method to query which partitions were using a storage policy. This pull request adds the functionality of querying which partitions are using a storage policy by including the storage policy information in the tablet report task of the backend.

User can use such tvf like
```
mysql> select * from storage_policy("storage_policy" = '13006') ;
+-----------------+-------------+
| StoragePolicyId | PartitionID |
+-----------------+-------------+
| 13006           | 13008       |
| 13006           | 13009       |
| 13006           | 13010       |
+-----------------+-------------+
3 rows in set (0.89 sec)
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

