### PR TITLE
[chore](pom) Bump Apache Parent POM from 29 to 30

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>29</version>
+        <version>30</version>
     </parent>
     <groupId>org.apache.doris</groupId>
     <artifactId>fe</artifactId>

--- a/fe_plugins/pom.xml
+++ b/fe_plugins/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>29</version>
+        <version>30</version>
     </parent>
     <groupId>org.apache.doris</groupId>
     <artifactId>fe-plugins</artifactId>

--- a/fs_brokers/apache_hdfs_broker/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>29</version>
+        <version>30</version>
     </parent>
     <groupId>org.apache.doris</groupId>
     <artifactId>apache-hdfs-broker</artifactId>

--- a/regression-test/framework/pom.xml
+++ b/regression-test/framework/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>29</version>
+        <version>30</version>
     </parent>
     <groupId>org.apache.doris</groupId>
     <artifactId>regression-test</artifactId>


### PR DESCRIPTION
## Proposed changes

This PR aims to bump Apache Parent POM to 30. 

Release Note, ref to : https://github.com/apache/maven-apache-parent/releases/tag/apache-30

Diff from 29, ref to : https://github.com/apache/maven-apache-parent/compare/apache-29...apache-30

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

