### PR TITLE
[fix](Nereids) infer predicates generate wrong result

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PullUpPredicates.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PullUpPredicates.java
@@ -154,7 +154,7 @@ public class PullUpPredicates extends PlanVisitor<ImmutableSet<Expression>, Void
 
     private ImmutableSet<Expression> getAvailableExpressions(Collection<Expression> predicates, Plan plan) {
         Set<Expression> expressions = Sets.newHashSet(predicates);
-        expressions.addAll(propagation.infer(expressions));
+        expressions.addAll(propagation.infer(expressions.stream().collect(Collectors.toMap(e -> e, e -> false))));
         return expressions.stream()
                 .filter(p -> plan.getOutputSet().containsAll(p.getInputSlots()))
                 .collect(ImmutableSet.toImmutableSet());

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/InferPredicatesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/InferPredicatesTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.rules.rewrite;
 
+import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.util.MemoPatternMatchSupported;
 import org.apache.doris.nereids.util.PlanChecker;
 import org.apache.doris.utframe.TestWithFeService;
@@ -602,6 +603,26 @@ public class InferPredicatesTest extends TestWithFeService implements MemoPatter
                             )
                         )
                     )
+                );
+    }
+
+    @Test
+    public void shouldNotSaveOnClausePredicates() {
+        String sql = "select * from student s1"
+                + " left join (select sid as id1, sid as id2, grade from score) s2 on s1.id = s2.id1 and s1.id = 1"
+                + " join (select sid as id1, sid as id2, grade from score) s3 on s1.id = s3.id1 where s1.id = 2";
+        PlanChecker.from(connectContext).analyze(sql).rewrite().printlnTree();
+        PlanChecker.from(connectContext)
+                .analyze(sql)
+                .rewrite()
+                .matches(
+                        logicalJoin(
+                                logicalFilter(
+                                        logicalOlapScan()
+                                ).when(filter -> filter.getConjuncts().size() == 1
+                                        && filter.getPredicate().toSql().contains("id = 2")),
+                                any()
+                        ).when(join -> join.getJoinType() == JoinType.LEFT_OUTER_JOIN)
                 );
     }
 }


### PR DESCRIPTION
we use two facilities to do predicate infer: PredicatePropagation and PullUpPredicates. When we do propagation in PredicatePropagation, we save the source predicates could be used in the upper node. However, we shoud not save any predicates from join on clause. Because these expression is not same with predicate in filter and could not prepagate to other not except the join's Immediate children.

For example:

```sql
select a.c1
   from a
   left join b on a.c2 = b.c2 and a.c1 = '1'
   left join c on a.c2 = c.c2 and a.c1 = '2'
   inner join d on a.c3=d.c3
```

the predicates `a.c1 = '1'` and `a.c1 = '2'` should not be inferred as filter to relation `a`
