### PR TITLE
[Bug](materialized-view) fix loaddb analyze failed on MaterializedIndexMeta

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.catalog;
 
+import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.catalog.TableIf.TableType;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
@@ -608,6 +609,12 @@ public class Database extends MetaObject implements Writable, DatabaseIf<Table> 
                 iterator.remove();
                 idToTable.remove(entry.getValue().getId());
             }
+        }
+    }
+
+    public void analyze(Analyzer analyzer) {
+        for (Table table : nameToTable.values()) {
+            table.analyze(analyzer);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedIndexMeta.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedIndexMeta.java
@@ -28,10 +28,8 @@ import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.SqlParserUtils;
 import org.apache.doris.persist.gson.GsonPostProcessable;
 import org.apache.doris.persist.gson.GsonUtils;
-import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.OriginStatement;
 import org.apache.doris.qe.SqlModeHelper;
-import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TStorageType;
 
 import com.google.common.base.Preconditions;
@@ -292,16 +290,9 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
     @Override
     public void gsonPostProcess() throws IOException {
         initColumnNameMap();
-        parseStmt(null);
     }
 
     public void parseStmt(Analyzer analyzer) throws IOException {
-        if (analyzer == null && dbName != null) {
-            ConnectContext connectContext = new ConnectContext();
-            connectContext.setCluster(SystemInfoService.DEFAULT_CLUSTER);
-            connectContext.setDatabase(dbName);
-            analyzer = new Analyzer(Env.getCurrentEnv(), connectContext);
-        }
         // analyze define stmt
         if (defineStmt == null) {
             return;
@@ -316,7 +307,7 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
                 try {
                     stmt.analyze(analyzer);
                 } catch (Exception e) {
-                    LOG.warn("CreateMaterializedViewStmt analyze failed, reason=", e);
+                    LOG.warn("CreateMaterializedViewStmt analyze failed, mv=" + defineStmt.originStmt + ", reason=", e);
                     return;
                 }
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -2262,4 +2262,14 @@ public class OlapTable extends Table {
             }
         }
     }
+
+    public void analyze(Analyzer analyzer) {
+        for (MaterializedIndexMeta meta : indexIdToMeta.values()) {
+            try {
+                meta.parseStmt(analyzer);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -2263,6 +2263,7 @@ public class OlapTable extends Table {
         }
     }
 
+    @Override
     public void analyze(Analyzer analyzer) {
         for (MaterializedIndexMeta meta : indexIdToMeta.values()) {
             try {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Table.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Table.java
@@ -18,6 +18,7 @@
 package org.apache.doris.catalog;
 
 import org.apache.doris.alter.AlterCancelException;
+import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.analysis.CreateTableStmt;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.MetaNotFoundException;
@@ -569,5 +570,8 @@ public abstract class Table extends MetaObject implements Writable, TableIf {
     @Override
     public Optional<ColumnStatistic> getColumnStatistic(String colName) {
         return Optional.empty();
+    }
+
+    public void analyze(Analyzer analyzer) {
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -3106,6 +3106,12 @@ public class InternalCatalog implements CatalogIf<Database> {
             idToDb.put(db.getId(), db);
             fullNameToDb.put(db.getFullName(), db);
             Env.getCurrentGlobalTransactionMgr().addDatabaseTransactionMgr(db.getId());
+
+            ConnectContext connectContext = new ConnectContext();
+            connectContext.setCluster(SystemInfoService.DEFAULT_CLUSTER);
+            connectContext.setDatabase(db.getFullName());
+            Analyzer analyzer = new Analyzer(Env.getCurrentEnv(), connectContext);
+            db.analyze(analyzer);
         }
         // ATTN: this should be done after load Db, and before loadAlterJob
         recreateTabletInvertIndex();

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/MaterializedIndexMetaTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/MaterializedIndexMetaTest.java
@@ -105,6 +105,7 @@ public class MaterializedIndexMetaTest {
         // 2. Read objects from file
         DataInputStream in = new DataInputStream(Files.newInputStream(path));
         MaterializedIndexMeta readIndexMeta = MaterializedIndexMeta.read(in);
+        readIndexMeta.parseStmt(null);
         Assert.assertEquals(1, readIndexMeta.getIndexId());
         List<Column> resultColumns = readIndexMeta.getSchema();
         for (Column column : resultColumns) {


### PR DESCRIPTION
## Proposed changes
```java
     2023-08-24 17:49:29,584 WARN (main|1) [MaterializedIndexMeta.parseStmt():319] CreateMaterializedViewStmt analyze failed, mv=create materialized view trade_result as select clientid,SUM(CAST(volume AS INT)) AS activevolumn from TradeData  GROUP BY clientid, reason=
org.apache.doris.common.AnalysisException: errCode = 2, detailMessage = Unknown database 'default_cluster:test'
	at org.apache.doris.datasource.CatalogIf.lambda$getDbOrAnalysisException$4(CatalogIf.java:141) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.datasource.CatalogIf.getDbOrException(CatalogIf.java:106) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.datasource.CatalogIf.getDbOrAnalysisException(CatalogIf.java:140) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.analysis.Analyzer.resolveTableRef(Analyzer.java:803) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.analysis.FromClause.analyze(FromClause.java:132) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.analysis.SelectStmt.analyze(SelectStmt.java:485) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.analysis.CreateMaterializedViewStmt.analyze(CreateMaterializedViewStmt.java:168) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.catalog.MaterializedIndexMeta.parseStmt(MaterializedIndexMeta.java:317) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.catalog.MaterializedIndexMeta.gsonPostProcess(MaterializedIndexMeta.java:295) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.persist.gson.GsonUtils$PostProcessTypeAdapterFactory$1.read(GsonUtils.java:547) ~[doris-fe.jar:1.2-SNAPSHOT]
	at com.google.gson.Gson.fromJson(Gson.java:963) ~[gson-2.8.9.jar:?]
	at com.google.gson.Gson.fromJson(Gson.java:928) ~[gson-2.8.9.jar:?]
	at com.google.gson.Gson.fromJson(Gson.java:877) ~[gson-2.8.9.jar:?]
	at com.google.gson.Gson.fromJson(Gson.java:848) ~[gson-2.8.9.jar:?]
	at org.apache.doris.catalog.MaterializedIndexMeta.read(MaterializedIndexMeta.java:289) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.catalog.OlapTable.readFields(OlapTable.java:1336) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.catalog.Table.read(Table.java:390) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.catalog.Database.readFields(Database.java:623) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.datasource.InternalCatalog.loadDb(InternalCatalog.java:3104) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.catalog.Env.loadDb(Env.java:1788) ~[doris-fe.jar:1.2-SNAPSHOT]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_131]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_131]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_131]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_131]
	at org.apache.doris.persist.meta.MetaReader.read(MetaReader.java:116) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.catalog.Env.loadImage(Env.java:1725) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.catalog.Env.initialize(Env.java:904) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.DorisFE.start(DorisFE.java:147) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.DorisFE.main(DorisFE.java:73) ~[doris-fe.jar:1.2-SNAPSHOT]
```
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

