### PR TITLE
[improvement](compaction) add an option on delete stale rowset by judging _stale_rs_metas size when doing compaction

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -286,6 +286,9 @@ DEFINE_mInt32(default_num_rows_per_column_file_block, "1024");
 DEFINE_mInt32(pending_data_expire_time_sec, "1800");
 // inc_rowset snapshot rs sweep time interval
 DEFINE_mInt32(tablet_rowset_stale_sweep_time_sec, "300");
+// tablet stale rowset sweep by threshold size
+DEFINE_Bool(tablet_rowset_stale_sweep_by_size, "false");
+DEFINE_mInt32(tablet_rowset_stale_sweep_threshold_size, "100");
 // garbage sweep policy
 DEFINE_Int32(max_garbage_sweep_interval, "3600");
 DEFINE_Int32(min_garbage_sweep_interval, "180");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -332,6 +332,9 @@ DECLARE_mInt32(default_num_rows_per_column_file_block);
 DECLARE_mInt32(pending_data_expire_time_sec);
 // inc_rowset snapshot rs sweep time interval
 DECLARE_mInt32(tablet_rowset_stale_sweep_time_sec);
+// tablet stale rowset sweep by threshold size
+DECLARE_Bool(tablet_rowset_stale_sweep_by_size);
+DECLARE_mInt32(tablet_rowset_stale_sweep_threshold_size);
 // garbage sweep policy
 DECLARE_Int32(max_garbage_sweep_interval);
 DECLARE_Int32(min_garbage_sweep_interval);

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -692,15 +692,16 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
 
             _tablet->merge_delete_bitmap(output_rowset_delete_bitmap);
             RETURN_IF_ERROR(_tablet->modify_rowsets(output_rowsets, _input_rowsets, true));
-            if (config::tablet_rowset_stale_sweep_by_size &&
-                _tablet->tablet_meta()->all_stale_rs_metas().size() >=
-                        config::tablet_rowset_stale_sweep_threshold_size) {
-                _tablet->delete_expired_stale_rowset();
-            }
         }
     } else {
         std::lock_guard<std::shared_mutex> wrlock(_tablet->get_header_lock());
         RETURN_IF_ERROR(_tablet->modify_rowsets(output_rowsets, _input_rowsets, true));
+    }
+
+    if (config::tablet_rowset_stale_sweep_by_size &&
+        _tablet->tablet_meta()->all_stale_rs_metas().size() >=
+                config::tablet_rowset_stale_sweep_threshold_size) {
+        _tablet->delete_expired_stale_rowset();
     }
 
     int64_t cur_max_version = 0;

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -692,6 +692,11 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
 
             _tablet->merge_delete_bitmap(output_rowset_delete_bitmap);
             RETURN_IF_ERROR(_tablet->modify_rowsets(output_rowsets, _input_rowsets, true));
+            if (config::tablet_rowset_stale_sweep_by_size &&
+                _tablet->tablet_meta()->all_stale_rs_metas().size() >=
+                        config::tablet_rowset_stale_sweep_threshold_size) {
+                _tablet->delete_expired_stale_rowset();
+            }
         }
     } else {
         std::lock_guard<std::shared_mutex> wrlock(_tablet->get_header_lock());

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -676,6 +676,9 @@ void Tablet::delete_expired_stale_rowset() {
     // Compute the end time to delete rowsets, when a expired rowset createtime less then this time, it will be deleted.
     double expired_stale_sweep_endtime =
             ::difftime(now, config::tablet_rowset_stale_sweep_time_sec);
+    if (config::tablet_rowset_stale_sweep_by_size) {
+        expired_stale_sweep_endtime = now;
+    }
 
     std::vector<int64_t> path_id_vec;
     // capture the path version to delete


### PR DESCRIPTION
## Proposed changes
when stale rowset is too large, compaction  modify_rowsets will failed in save_meta because serialize probuf has size limit, so now add an option that deleting stale rowset judge by _stale_rs_metas  size to limit stale rowset
Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

