### PR TITLE
[fix](planner)literal expr should do nothing in substituteImpl() method

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LiteralExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LiteralExpr.java
@@ -267,4 +267,10 @@ public abstract class LiteralExpr extends Expr implements Comparable<LiteralExpr
     public String toString() {
         return getStringValue();
     }
+
+    @Override
+    protected Expr substituteImpl(ExprSubstitutionMap smap, ExprSubstitutionMap disjunctsMap,
+            Analyzer analyzer) {
+        return this;
+    }
 }


### PR DESCRIPTION
## Proposed changes

substitute a literal expr is pointless and wrong. This pr keep literal expr unchanged during substitute process

pick from master https://github.com/apache/doris/pull/23438

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

