### PR TITLE
[fix](Nereids) infer predicates generate wrong result

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PredicatePropagation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PredicatePropagation.java
@@ -41,16 +41,10 @@ import java.util.stream.Collectors;
 public class PredicatePropagation {
 
     /**
-     * equal predicate with literal in one side would be chosen to be source predicates and used to infer all predicates
-     */
-    private Set<Expression> sourcePredicates = Sets.newHashSet();
-
-    /**
      * infer additional predicates.
      */
     public Set<Expression> infer(Set<Expression> predicates) {
         Set<Expression> inferred = Sets.newHashSet();
-        predicates.addAll(sourcePredicates);
         for (Expression predicate : predicates) {
             if (canEquivalentInfer(predicate)) {
                 List<Expression> newInferred = predicates.stream()
@@ -61,7 +55,6 @@ public class PredicatePropagation {
             }
         }
         inferred.removeAll(predicates);
-        sourcePredicates.addAll(inferred);
         return inferred;
     }
 
@@ -83,10 +76,8 @@ public class PredicatePropagation {
             public Expression visitComparisonPredicate(ComparisonPredicate cp, Void context) {
                 // we need to get expression covered by cast, because we want to infer different datatype
                 if (ExpressionUtils.isExpressionSlotCoveredByCast(cp.left()) && (cp.right().isConstant())) {
-                    sourcePredicates.add(cp);
                     return replaceSlot(cp, ExpressionUtils.getDatatypeCoveredByCast(cp.left()));
                 } else if (ExpressionUtils.isExpressionSlotCoveredByCast(cp.right()) && cp.left().isConstant()) {
-                    sourcePredicates.add(cp);
                     return replaceSlot(cp, ExpressionUtils.getDatatypeCoveredByCast(cp.right()));
                 }
                 return super.visit(cp, context);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PullUpPredicates.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PullUpPredicates.java
@@ -73,32 +73,8 @@ public class PullUpPredicates extends PlanVisitor<ImmutableSet<Expression>, Void
             Set<Expression> predicates = Sets.newHashSet();
             ImmutableSet<Expression> leftPredicates = join.left().accept(this, context);
             ImmutableSet<Expression> rightPredicates = join.right().accept(this, context);
-            switch (join.getJoinType()) {
-                case INNER_JOIN:
-                case CROSS_JOIN:
-                    predicates.addAll(leftPredicates);
-                    predicates.addAll(rightPredicates);
-                    join.getOnClauseCondition().map(on -> predicates.addAll(ExpressionUtils.extractConjunction(on)));
-                    break;
-                case LEFT_SEMI_JOIN:
-                    predicates.addAll(leftPredicates);
-                    join.getOnClauseCondition().map(on -> predicates.addAll(ExpressionUtils.extractConjunction(on)));
-                    break;
-                case RIGHT_SEMI_JOIN:
-                    predicates.addAll(rightPredicates);
-                    join.getOnClauseCondition().map(on -> predicates.addAll(ExpressionUtils.extractConjunction(on)));
-                    break;
-                case LEFT_OUTER_JOIN:
-                case LEFT_ANTI_JOIN:
-                case NULL_AWARE_LEFT_ANTI_JOIN:
-                    predicates.addAll(leftPredicates);
-                    break;
-                case RIGHT_OUTER_JOIN:
-                case RIGHT_ANTI_JOIN:
-                    predicates.addAll(rightPredicates);
-                    break;
-                default:
-            }
+            predicates.addAll(leftPredicates);
+            predicates.addAll(rightPredicates);
             return getAvailableExpressions(predicates, join);
         });
     }

--- a/regression-test/suites/nereids_p0/infer_predicate/infer_predicate.groovy
+++ b/regression-test/suites/nereids_p0/infer_predicate/infer_predicate.groovy
@@ -53,5 +53,6 @@ suite("test_infer_predicate") {
         sql "select * from infer_tb1 left join infer_tb2 on infer_tb1.k1 = infer_tb2.k3 left join infer_tb3 on " +
                 "infer_tb2.k3 = infer_tb3.k2 where infer_tb1.k1 = 1;"
         contains "PREDICATES: k3"
+        contains "PREDICATES: k2"
     }
 }


### PR DESCRIPTION
We use two facilities to do predicate infer: PredicatePropagation and PullUpPredicates. In the prvious implementation, we use a set to save the intermediate result of PredicatePropagation. The purpose is infer new predicate though two equal relation. However, it is the wrong way. Because it could infer wrong predicate through outer join. For example

```sql
select a.c1
   from a
   left join b on a.c2 = b.c2 and a.c1 = '1'
   left join c on a.c2 = c.c2 and a.c1 = '2'
   inner join d on a.c3=d.c3
```

the predicates `a.c1 = '1'` and `a.c1 = '2'` should not be inferred as filter to relation `a`.

This PR:
1. revert the change from PR #22145, commit 3c58e9ba
2. Remove the unreasonable restrict in PullupPredicate.
3. Use new Filter node rather than new otherCondition on join node to save infer predicates



