### PR TITLE
[fix](UT) fix flaky test in LoadStreamMgrTest

### DIFF
--- a/be/test/runtime/load_stream_test.cpp
+++ b/be/test/runtime/load_stream_test.cpp
@@ -1091,7 +1091,7 @@ TEST_F(LoadStreamMgrTest, two_client_one_index_one_tablet_three_segment) {
 
     EXPECT_EQ(g_response_stat.num, 0);
     // CLOSE_LOAD
-    close_load(clients[0], 1);
+    close_load(clients[1], 1);
     wait_for_ack(1);
     EXPECT_EQ(g_response_stat.num, 1);
     EXPECT_EQ(g_response_stat.success_tablet_ids.size(), 0);


### PR DESCRIPTION
## Proposed changes

In LoadStreamMgrTest.two_client_one_index_one_tablet_three_segment,
client 0 was sending CLOSE_LOAD on behalf of client 1,
causing some APPEND_DATA from client 1 to arrive after CLOSE_LOAD.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

