### PR TITLE
[bugfix](file cache) Fix the init file cache coredump

### DIFF
--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -424,9 +424,9 @@ int main(int argc, char** argv) {
         }
 
         file_cache_init_pool->wait();
-        for (int i = 0; i < cache_status.size(); ++i) {
-            if (!cache_status[i].ok()) {
-                LOG(FATAL) << "failed to init file cache: " << i << ", err: " << cache_status[i];
+        for (const auto& status : cache_status) {
+            if (!status.ok()) {
+                LOG(FATAL) << "failed to init file cache, err: " << status;
                 exit(-1);
             }
         }

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -408,26 +408,19 @@ int main(int argc, char** argv) {
                 .set_max_threads(cache_paths.size())
                 .build(&file_cache_init_pool);
 
-        std::vector<doris::Status> cache_status;
+        std::list<doris::Status> cache_status;
         for (auto& cache_path : cache_paths) {
             if (cache_path_set.find(cache_path.path) != cache_path_set.end()) {
                 LOG(WARNING) << fmt::format("cache path {} is duplicate", cache_path.path);
                 continue;
             }
 
-            cache_status.push_back(Status::OK());
             RETURN_IF_ERROR(file_cache_init_pool->submit_func(
                     std::bind(&doris::io::FileCacheFactory::create_file_cache,
                               &(doris::io::FileCacheFactory::instance()), cache_path.path,
-                              cache_path.init_settings(), &(cache_status.back()))));
+                              cache_path.init_settings(), &(cache_status.emplace_back()))));
 
             cache_path_set.emplace(cache_path.path);
-            // Status st = doris::io::FileCacheFactory::instance().create_file_cache(
-            //         cache_path.path, cache_path.init_settings());
-            // if (!st) {
-            //     LOG(FATAL) << st;
-            //     exit(-1);
-            // }
         }
 
         file_cache_init_pool->wait();


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
When init many file caches, the pointer `&(cache_status.back())` will be wild pointer because the vector will resize by push_back. So we need to resize the vector first.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

