### PR TITLE
[fix](column) add unimplemented function of ColumnFixedLengthObject

### DIFF
--- a/be/src/vec/columns/column_fixed_length_object.h
+++ b/be/src/vec/columns/column_fixed_length_object.h
@@ -26,6 +26,7 @@
 #include "vec/common/arena.h"
 #include "vec/common/assert_cast.h"
 #include "vec/common/pod_array.h"
+#include "vec/common/sip_hash.h"
 
 namespace doris::vectorized {
 
@@ -169,7 +170,7 @@ public:
     }
 
     void update_hash_with_value(size_t n, SipHash& hash) const override {
-        LOG(FATAL) << "update_hash_with_value not supported";
+        hash.update(reinterpret_cast<const char*>(_data.data() + n * _item_size), _item_size);
     }
 
     [[noreturn]] ColumnPtr filter(const IColumn::Filter& filt,


### PR DESCRIPTION
## Proposed changes

```
F0825 02:16:39.995798 763129 column_fixed_length_object.h:172] update_hash_with_value not supported
*** Check failure stack trace: ***
    @     0x55845c7fb3fd  google::LogMessage::Fail()
    @     0x55845c7fd939  google::LogMessage::SendToLog()
    @     0x55845c7faf66  google::LogMessage::Flush()
    @     0x55845c7fdfa9  google::LogMessageFatal::~LogMessageFatal()
    @     0x558455d414b1  doris::vectorized::ColumnFixedLengthObject::update_hash_with_value()
    @     0x558457a94873  doris::vectorized::Block::update_hash()
    @     0x558455628dab  doris::EngineChecksumTask::_compute_checksum()
    @     0x5584556285b4  doris::EngineChecksumTask::execute()
    @     0x5584554e7a49  doris::StorageEngine::execute_task()
    @     0x558455510132  doris::TaskWorkerPool::_check_consistency_worker_thread_callback()
    @     0x5584558f2b4f  doris::ThreadPool::dispatch_thread()
    @     0x5584558e8c0c  doris::Thread::supervise_thread()
    @     0x7f862910b609  start_thread
    @     0x7f862939a133  clone
    @              (nil)  (unknown)
*** Query id: 0-0 ***
*** Aborted at 1692901000 (unix time) try "date -d @1692901000" if you are using GNU date ***
*** Current BE git commitID: c749bc93af ***
*** SIGABRT unknown detail explain (@0xba03d) received by PID 761917 (TID 763129 OR 0x7f8450e5b700) from PID 761917; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/common/signal_handler.h:413
 1# 0x00007F86292BE090 in /lib/x86_64-linux-gnu/libc.so.6
 2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
 3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
 4# 0x000055845C805DE9 in /mnt/hdd01/ci/branch20-deploy/be/lib/doris_be
 5# 0x000055845C7FB3FD in /mnt/hdd01/ci/branch20-deploy/be/lib/doris_be
 6# google::LogMessage::SendToLog() in /mnt/hdd01/ci/branch20-deploy/be/lib/doris_be
 7# google::LogMessage::Flush() in /mnt/hdd01/ci/branch20-deploy/be/lib/doris_be
 8# google::LogMessageFatal::~LogMessageFatal() in /mnt/hdd01/ci/branch20-deploy/be/lib/doris_be
 9# doris::vectorized::ColumnFixedLengthObject::update_hash_with_value(unsigned long, SipHash&) const in /mnt/hdd01/ci/branch20-deploy/be/lib/doris_be
10# doris::vectorized::Block::update_hash(SipHash&) const at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/vec/core/block.cpp:689
11# doris::EngineChecksumTask::_compute_checksum() at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/olap/task/engine_checksum_task.cpp:104
12# doris::EngineChecksumTask::execute() in /mnt/hdd01/ci/branch20-deploy/be/lib/doris_be
13# doris::StorageEngine::execute_task(doris::EngineTask*) at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/olap/storage_engine.cpp:1129
14# doris::TaskWorkerPool::_check_consistency_worker_thread_callback() at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/agent/task_worker_pool.cpp:547
15# doris::ThreadPool::dispatch_thread() in /mnt/hdd01/ci/branch20-deploy/be/lib/doris_be
16# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/util/thread.cpp:466
17# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
18# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

