### PR TITLE
[imporvement](table property) support for alter table property: skip wirte index , single compaction

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -505,12 +505,16 @@ void TaskWorkerPool::_update_tablet_meta_worker_thread_callback() {
             }
             if (tablet_meta_info.__isset.enable_single_replica_compaction) {
                 std::shared_lock rlock(tablet->get_header_lock());
-                tablet->tablet_meta()->mutable_tablet_schema()->set_enable_single_replica_compaction(
-                        tablet_meta_info.enable_single_replica_compaction);
+                tablet->tablet_meta()
+                        ->mutable_tablet_schema()
+                        ->set_enable_single_replica_compaction(
+                                tablet_meta_info.enable_single_replica_compaction);
                 for (auto& rowset_meta : tablet->tablet_meta()->all_mutable_rs_metas()) {
-                    rowset_meta->tablet_schema()->set_enable_single_replica_compaction(tablet_meta_info.enable_single_replica_compaction);
+                    rowset_meta->tablet_schema()->set_enable_single_replica_compaction(
+                            tablet_meta_info.enable_single_replica_compaction);
                 }
-                tablet->tablet_schema_unlocked()->set_enable_single_replica_compaction(tablet_meta_info.enable_single_replica_compaction);
+                tablet->tablet_schema_unlocked()->set_enable_single_replica_compaction(
+                        tablet_meta_info.enable_single_replica_compaction);
                 need_to_save = true;
             }
 
@@ -519,9 +523,11 @@ void TaskWorkerPool::_update_tablet_meta_worker_thread_callback() {
                 tablet->tablet_meta()->mutable_tablet_schema()->set_skip_write_index_on_load(
                         tablet_meta_info.skip_write_index_on_load);
                 for (auto& rowset_meta : tablet->tablet_meta()->all_mutable_rs_metas()) {
-                    rowset_meta->tablet_schema()->set_skip_write_index_on_load(tablet_meta_info.skip_write_index_on_load);
+                    rowset_meta->tablet_schema()->set_skip_write_index_on_load(
+                            tablet_meta_info.skip_write_index_on_load);
                 }
-                tablet->tablet_schema_unlocked()->set_skip_write_index_on_load(tablet_meta_info.skip_write_index_on_load);
+                tablet->tablet_schema_unlocked()->set_skip_write_index_on_load(
+                        tablet_meta_info.skip_write_index_on_load);
                 need_to_save = true;
             }
             if (need_to_save) {

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -503,6 +503,27 @@ void TaskWorkerPool::_update_tablet_meta_worker_thread_callback() {
                 tablet->set_binlog_config(new_binlog_config);
                 need_to_save = true;
             }
+            if (tablet_meta_info.__isset.enable_single_replica_compaction) {
+                std::shared_lock rlock(tablet->get_header_lock());
+                tablet->tablet_meta()->mutable_tablet_schema()->set_enable_single_replica_compaction(
+                        tablet_meta_info.enable_single_replica_compaction);
+                for (auto& rowset_meta : tablet->tablet_meta()->all_mutable_rs_metas()) {
+                    rowset_meta->tablet_schema()->set_enable_single_replica_compaction(tablet_meta_info.enable_single_replica_compaction);
+                }
+                tablet->tablet_schema_unlocked()->set_enable_single_replica_compaction(tablet_meta_info.enable_single_replica_compaction);
+                need_to_save = true;
+            }
+
+            if (tablet_meta_info.__isset.skip_write_index_on_load) {
+                std::shared_lock rlock(tablet->get_header_lock());
+                tablet->tablet_meta()->mutable_tablet_schema()->set_skip_write_index_on_load(
+                        tablet_meta_info.skip_write_index_on_load);
+                for (auto& rowset_meta : tablet->tablet_meta()->all_mutable_rs_metas()) {
+                    rowset_meta->tablet_schema()->set_skip_write_index_on_load(tablet_meta_info.skip_write_index_on_load);
+                }
+                tablet->tablet_schema_unlocked()->set_skip_write_index_on_load(tablet_meta_info.skip_write_index_on_load);
+                need_to_save = true;
+            }
             if (need_to_save) {
                 std::shared_lock rlock(tablet->get_header_lock());
                 tablet->save_meta();

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
@@ -211,14 +211,6 @@ public class Alter {
         } else if (currentAlterOps.checkIsBeingSynced(alterClauses)) {
             olapTable.setIsBeingSynced(currentAlterOps.isBeingSynced(alterClauses));
             needProcessOutsideTableLock = true;
-        } else if (currentAlterOps.checkCompactionPolicy(alterClauses)) {
-            needProcessOutsideTableLock = true;
-        } else if (currentAlterOps.checkTimeSeriesCompactionGoalSizeMbytes(alterClauses)) {
-            needProcessOutsideTableLock = true;
-        } else if (currentAlterOps.checkTimeSeriesCompactionFileCountThreshold(alterClauses)) {
-            needProcessOutsideTableLock = true;
-        } else if (currentAlterOps.checkTimeSeriesCompactionTimeThresholdSeconds(alterClauses)) {
-            needProcessOutsideTableLock = true;
         } else if (currentAlterOps.checkBinlogConfigChange(alterClauses)) {
             if (!Config.enable_feature_binlog) {
                 throw new DdlException("Binlog feature is not enabled");
@@ -528,7 +520,11 @@ public class Alter {
                         || properties
                             .containsKey(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_FILE_COUNT_THRESHOLD)
                         || properties
-                            .containsKey(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_TIME_THRESHOLD_SECONDS));
+                            .containsKey(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_TIME_THRESHOLD_SECONDS)
+                        || properties
+                            .containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_SINGLE_REPLICA_COMPACTION)
+                        || properties
+                            .containsKey(PropertyAnalyzer.PROPERTIES_SKIP_WRITE_INDEX_ON_LOAD));
                 ((SchemaChangeHandler) schemaChangeHandler).updateTableProperties(db, tableName, properties);
             } else {
                 throw new DdlException("Invalid alter operation: " + alterClause.getOpType());

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/AlterOperations.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/AlterOperations.java
@@ -93,60 +93,6 @@ public class AlterOperations {
             || clause.getProperties().containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_MAX_HISTORY_NUMS));
     }
 
-    public boolean checkCompactionPolicy(List<AlterClause> alterClauses) {
-        return alterClauses.stream().filter(clause ->
-            clause instanceof ModifyTablePropertiesClause
-        ).anyMatch(clause -> clause.getProperties().containsKey(PropertyAnalyzer.PROPERTIES_COMPACTION_POLICY));
-    }
-
-    public String getCompactionPolicy(List<AlterClause> alterClauses) {
-        return alterClauses.stream().filter(clause ->
-            clause instanceof ModifyTablePropertiesClause
-        ).map(c -> ((ModifyTablePropertiesClause) c).compactionPolicy()).findFirst().orElse("");
-    }
-
-    public boolean checkTimeSeriesCompactionGoalSizeMbytes(List<AlterClause> alterClauses) {
-        return alterClauses.stream().filter(clause ->
-            clause instanceof ModifyTablePropertiesClause
-        ).anyMatch(clause -> clause.getProperties()
-                    .containsKey(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_GOAL_SIZE_MBYTES));
-    }
-
-    public long getTimeSeriesCompactionGoalSizeMbytes(List<AlterClause> alterClauses) {
-        return alterClauses.stream().filter(clause ->
-            clause instanceof ModifyTablePropertiesClause
-        ).map(c -> ((ModifyTablePropertiesClause) c)
-        .timeSeriesCompactionGoalSizeMbytes()).findFirst().orElse((long) -1);
-    }
-
-    public boolean checkTimeSeriesCompactionFileCountThreshold(List<AlterClause> alterClauses) {
-        return alterClauses.stream().filter(clause ->
-            clause instanceof ModifyTablePropertiesClause
-        ).anyMatch(clause -> clause.getProperties()
-                    .containsKey(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_FILE_COUNT_THRESHOLD));
-    }
-
-    public long getTimeSeriesCompactionFileCountThreshold(List<AlterClause> alterClauses) {
-        return alterClauses.stream().filter(clause ->
-            clause instanceof ModifyTablePropertiesClause
-        ).map(c -> ((ModifyTablePropertiesClause) c)
-        .timeSeriesCompactionFileCountThreshold()).findFirst().orElse((long) -1);
-    }
-
-    public boolean checkTimeSeriesCompactionTimeThresholdSeconds(List<AlterClause> alterClauses) {
-        return alterClauses.stream().filter(clause ->
-            clause instanceof ModifyTablePropertiesClause
-        ).anyMatch(clause -> clause.getProperties()
-                    .containsKey(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_TIME_THRESHOLD_SECONDS));
-    }
-
-    public long getTimeSeriesCompactionTimeThresholdSeconds(List<AlterClause> alterClauses) {
-        return alterClauses.stream().filter(clause ->
-            clause instanceof ModifyTablePropertiesClause
-        ).map(c -> ((ModifyTablePropertiesClause) c)
-        .timeSeriesCompactionTimeThresholdSeconds()).findFirst().orElse((long) -1);
-    }
-
     public boolean isBeingSynced(List<AlterClause> alterClauses) {
         return alterClauses.stream().filter(clause ->
             clause instanceof ModifyTablePropertiesClause

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -2172,14 +2172,28 @@ public class SchemaChangeHandler extends AlterHandler {
         }
 
         if (isInMemory < 0 && storagePolicyId < 0 && compactionPolicy == null && timeSeriesCompactionConfig.isEmpty()
-                && !properties.containsKey(PropertyAnalyzer.PROPERTIES_IS_BEING_SYNCED)) {
+                && !properties.containsKey(PropertyAnalyzer.PROPERTIES_IS_BEING_SYNCED)
+                && !properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_SINGLE_REPLICA_COMPACTION)
+                && !properties.containsKey(PropertyAnalyzer.PROPERTIES_SKIP_WRITE_INDEX_ON_LOAD)) {
             LOG.info("Properties already up-to-date");
             return;
         }
 
+        String singleCompaction = properties.get(PropertyAnalyzer.PROPERTIES_ENABLE_SINGLE_REPLICA_COMPACTION);
+        int enableSingleCompaction = -1; // < 0 means don't update
+        if (singleCompaction != null) {
+            enableSingleCompaction = Boolean.parseBoolean(singleCompaction) ? 1 : 0;
+        }
+
+        String skipWriteIndexOnLoad = properties.get(PropertyAnalyzer.PROPERTIES_SKIP_WRITE_INDEX_ON_LOAD);
+        int skip = -1; // < 0 means don't update
+        if (skipWriteIndexOnLoad != null) {
+            skip = Boolean.parseBoolean(skipWriteIndexOnLoad) ? 1 : 0;
+        }
+
         for (Partition partition : partitions) {
             updatePartitionProperties(db, olapTable.getName(), partition.getName(), storagePolicyId, isInMemory,
-                                        null, compactionPolicy, timeSeriesCompactionConfig);
+                                    null, compactionPolicy, timeSeriesCompactionConfig, enableSingleCompaction, skip);
         }
 
         olapTable.writeLockOrDdlException();
@@ -2222,7 +2236,7 @@ public class SchemaChangeHandler extends AlterHandler {
         for (String partitionName : partitionNames) {
             try {
                 updatePartitionProperties(db, olapTable.getName(), partitionName, storagePolicyId,
-                                                                                    isInMemory, null, null, null);
+                                                                                isInMemory, null, null, null, -1, -1);
             } catch (Exception e) {
                 String errMsg = "Failed to update partition[" + partitionName + "]'s 'in_memory' property. "
                         + "The reason is [" + e.getMessage() + "]";
@@ -2237,7 +2251,8 @@ public class SchemaChangeHandler extends AlterHandler {
      */
     public void updatePartitionProperties(Database db, String tableName, String partitionName, long storagePolicyId,
                                           int isInMemory, BinlogConfig binlogConfig, String compactionPolicy,
-                                          Map<String, Long> timeSeriesCompactionConfig) throws UserException {
+                                          Map<String, Long> timeSeriesCompactionConfig,
+                                          int enableSingleCompaction, int skipWriteIndexOnLoad) throws UserException {
         // be id -> <tablet id,schemaHash>
         Map<Long, Set<Pair<Long, Integer>>> beIdToTabletIdWithHash = Maps.newHashMap();
         OlapTable olapTable = (OlapTable) db.getTableOrMetaException(tableName, Table.TableType.OLAP);
@@ -2269,7 +2284,8 @@ public class SchemaChangeHandler extends AlterHandler {
         for (Map.Entry<Long, Set<Pair<Long, Integer>>> kv : beIdToTabletIdWithHash.entrySet()) {
             countDownLatch.addMark(kv.getKey(), kv.getValue());
             UpdateTabletMetaInfoTask task = new UpdateTabletMetaInfoTask(kv.getKey(), kv.getValue(), isInMemory,
-                    storagePolicyId, binlogConfig, countDownLatch, compactionPolicy, timeSeriesCompactionConfig);
+                                            storagePolicyId, binlogConfig, countDownLatch, compactionPolicy,
+                                            timeSeriesCompactionConfig, enableSingleCompaction, skipWriteIndexOnLoad);
             batchTask.addTask(task);
         }
         if (!FeConstants.runningUnitTest) {
@@ -2914,7 +2930,7 @@ public class SchemaChangeHandler extends AlterHandler {
 
         for (Partition partition : partitions) {
             updatePartitionProperties(db, olapTable.getName(), partition.getName(), -1, -1,
-                                                newBinlogConfig, null, null);
+                                                newBinlogConfig, null, null, -1, -1);
         }
 
         olapTable.writeLockOrDdlException();

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyTablePropertiesClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyTablePropertiesClause.java
@@ -54,46 +54,6 @@ public class ModifyTablePropertiesClause extends AlterTableClause {
         return isBeingSynced;
     }
 
-    private String compactionPolicy;
-
-    private long timeSeriesCompactionGoalSizeMbytes;
-
-    private long timeSeriesCompactionFileCountThreshold;
-
-    private long timeSeriesCompactionTimeThresholdSeconds;
-
-    public void setCompactionPolicy(String compactionPolicy) {
-        this.compactionPolicy = compactionPolicy;
-    }
-
-    public String compactionPolicy() {
-        return compactionPolicy;
-    }
-
-    public void setTimeSeriesCompactionGoalSizeMbytes(long timeSeriesCompactionGoalSizeMbytes) {
-        this.timeSeriesCompactionGoalSizeMbytes = timeSeriesCompactionGoalSizeMbytes;
-    }
-
-    public long timeSeriesCompactionGoalSizeMbytes() {
-        return timeSeriesCompactionGoalSizeMbytes;
-    }
-
-    public void setTimeSeriesCompactionFileCountThreshold(long timeSeriesCompactionFileCountThreshold) {
-        this.timeSeriesCompactionFileCountThreshold = timeSeriesCompactionFileCountThreshold;
-    }
-
-    public Long timeSeriesCompactionFileCountThreshold() {
-        return timeSeriesCompactionFileCountThreshold;
-    }
-
-    public void setTimeSeriesCompactionTimeThresholdSeconds(long timeSeriesCompactionTimeThresholdSeconds) {
-        this.timeSeriesCompactionTimeThresholdSeconds = timeSeriesCompactionTimeThresholdSeconds;
-    }
-
-    public Long timeSeriesCompactionTimeThresholdSeconds() {
-        return timeSeriesCompactionTimeThresholdSeconds;
-    }
-
     public ModifyTablePropertiesClause(Map<String, String> properties) {
         super(AlterOpType.MODIFY_TABLE_PROPERTY);
         this.properties = properties;
@@ -192,7 +152,7 @@ public class ModifyTablePropertiesClause extends AlterTableClause {
                         + " or " + PropertyAnalyzer.SIZE_BASED_COMPACTION_POLICY);
             }
             this.needTableStable = false;
-            setCompactionPolicy(compactionPolicy);
+            this.opType = AlterOpType.MODIFY_TABLE_PROPERTY_SYNC;
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_GOAL_SIZE_MBYTES)) {
             long goalSizeMbytes;
             String goalSizeMbytesStr = properties
@@ -208,7 +168,7 @@ public class ModifyTablePropertiesClause extends AlterTableClause {
                         + goalSizeMbytesStr);
             }
             this.needTableStable = false;
-            setTimeSeriesCompactionGoalSizeMbytes(goalSizeMbytes);
+            this.opType = AlterOpType.MODIFY_TABLE_PROPERTY_SYNC;
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_FILE_COUNT_THRESHOLD)) {
             long fileCountThreshold;
             String fileCountThresholdStr = properties
@@ -224,7 +184,7 @@ public class ModifyTablePropertiesClause extends AlterTableClause {
                                                                                 + fileCountThresholdStr);
             }
             this.needTableStable = false;
-            setTimeSeriesCompactionFileCountThreshold(fileCountThreshold);
+            this.opType = AlterOpType.MODIFY_TABLE_PROPERTY_SYNC;
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_TIME_SERIES_COMPACTION_TIME_THRESHOLD_SECONDS)) {
             long timeThresholdSeconds;
             String timeThresholdSecondsStr = properties
@@ -240,7 +200,27 @@ public class ModifyTablePropertiesClause extends AlterTableClause {
                                                                                         + timeThresholdSecondsStr);
             }
             this.needTableStable = false;
-            setTimeSeriesCompactionTimeThresholdSeconds(timeThresholdSeconds);
+            this.opType = AlterOpType.MODIFY_TABLE_PROPERTY_SYNC;
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_SKIP_WRITE_INDEX_ON_LOAD)) {
+            if (!properties.get(PropertyAnalyzer.PROPERTIES_SKIP_WRITE_INDEX_ON_LOAD).equalsIgnoreCase("true")
+                    && !properties.get(PropertyAnalyzer
+                                                .PROPERTIES_SKIP_WRITE_INDEX_ON_LOAD).equalsIgnoreCase("false")) {
+                throw new AnalysisException(
+                    "Property "
+                    + PropertyAnalyzer.PROPERTIES_SKIP_WRITE_INDEX_ON_LOAD + " should be set to true or false");
+            }
+            this.needTableStable = false;
+            this.opType = AlterOpType.MODIFY_TABLE_PROPERTY_SYNC;
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_SINGLE_REPLICA_COMPACTION)) {
+            if (!properties.get(PropertyAnalyzer.PROPERTIES_ENABLE_SINGLE_REPLICA_COMPACTION).equalsIgnoreCase("true")
+                    && !properties.get(PropertyAnalyzer
+                                            .PROPERTIES_ENABLE_SINGLE_REPLICA_COMPACTION).equalsIgnoreCase("false")) {
+                throw new AnalysisException(
+                    "Property "
+                    + PropertyAnalyzer.PROPERTIES_ENABLE_SINGLE_REPLICA_COMPACTION + " should be set to true or false");
+            }
+            this.needTableStable = false;
+            this.opType = AlterOpType.MODIFY_TABLE_PROPERTY_SYNC;
         } else {
             throw new AnalysisException("Unknown table property: " + properties.keySet());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -4575,7 +4575,9 @@ public class Env {
                 .buildCompactionPolicy()
                 .buildTimeSeriesCompactionGoalSizeMbytes()
                 .buildTimeSeriesCompactionFileCountThreshold()
-                .buildTimeSeriesCompactionTimeThresholdSeconds();
+                .buildTimeSeriesCompactionTimeThresholdSeconds()
+                .buildSkipWriteIndexOnLoad()
+                .buildEnableSingleReplicaCompaction();
 
         // need to update partition info meta
         for (Partition partition : table.getPartitions()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
@@ -127,6 +127,8 @@ public class TableProperty implements Writable {
                 buildTimeSeriesCompactionGoalSizeMbytes();
                 buildTimeSeriesCompactionFileCountThreshold();
                 buildTimeSeriesCompactionTimeThresholdSeconds();
+                buildSkipWriteIndexOnLoad();
+                buildEnableSingleReplicaCompaction();
                 break;
             default:
                 break;

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
@@ -215,7 +215,11 @@ public class OperationType {
 
     // set table replication_num config 266
     public static final short OP_MODIFY_REPLICATION_NUM = 266;
-    // set table in memory
+    // set table in memory (confusion)
+    // The actual opcode now represents
+    // modify table properties: inMemory, StoragePolicy, IsBeingSynced, CompactionPolicy,
+    // TimeSeriesCompactionFileCountThreshold, SeriesCompactionTimeThresholdSeconds,
+    // SkipWriteIndexOnLoad, EnableSingleReplicaCompaction.
     public static final short OP_MODIFY_IN_MEMORY = 267;
 
     // set table default distribution bucket num

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -412,6 +412,8 @@ struct TTabletMetaInfo {
     11: optional i64 time_series_compaction_goal_size_mbytes
     12: optional i64 time_series_compaction_file_count_threshold
     13: optional i64 time_series_compaction_time_threshold_seconds
+    14: optional bool enable_single_replica_compaction
+    15: optional bool skip_write_index_on_load
 }
 
 struct TUpdateTabletMetaInfoReq {

--- a/regression-test/suites/schema_change/test_alter_table_property.groovy
+++ b/regression-test/suites/schema_change/test_alter_table_property.groovy
@@ -1,0 +1,48 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+suite("test_alter_table_property") {
+    def tableName = "test_table"
+    sql """ DROP TABLE IF EXISTS ${tableName} """
+
+    sql """
+            CREATE TABLE ${tableName} (
+                    `c_custkey` int(11) NOT NULL COMMENT "",
+                    `c_name` varchar(26) NOT NULL COMMENT "",
+                    `c_address` varchar(41) NOT NULL COMMENT "",
+                    `c_city` varchar(11) NOT NULL COMMENT ""
+            )
+            DUPLICATE KEY (`c_custkey`)
+            DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 1
+            PROPERTIES (
+                    "replication_num" = "1"
+             );
+        """
+    sql """sync"""
+
+    def showResult1 = sql """show create table ${tableName}"""
+    logger.info("${showResult1}")
+    assertTrue(showResult1.toString().containsIgnoreCase('"enable_single_replica_compaction" = "false"'))
+
+    sql """
+        alter table ${tableName} set ("enable_single_replica_compaction" = "true")
+        """
+    sql """sync"""
+
+    def showResult2 = sql """show create table ${tableName}"""
+    logger.info("${showResult2}")
+    assertTrue(showResult2.toString().containsIgnoreCase('"enable_single_replica_compaction" = "true"'))
+}

--- a/regression-test/suites/schema_change/test_alter_table_property.groovy
+++ b/regression-test/suites/schema_change/test_alter_table_property.groovy
@@ -45,4 +45,7 @@ suite("test_alter_table_property") {
     def showResult2 = sql """show create table ${tableName}"""
     logger.info("${showResult2}")
     assertTrue(showResult2.toString().containsIgnoreCase('"enable_single_replica_compaction" = "true"'))
+
+    sql """ DROP TABLE IF EXISTS ${tableName} """
+    sql """sync"""
 }


### PR DESCRIPTION
## Proposed changes

```
CREATE TABLE IF NOT EXISTS example_db.example_tbl
(
    `user_id` LARGEINT NOT NULL,
    `date` DATE NOT NULL,
    `city` VARCHAR(20),
    `age` SMALLINT,
)
DUPLICATE KEY(`user_id`)
DISTRIBUTED BY HASH(`user_id`) BUCKETS 1
PROPERTIES (
"replication_allocation" = "tag.location.default: 1"
);

alter table  example_db.example_tbl set ("enable_single_replica_compaction"="true");
alter table  example_db.example_tbl set ("skip_write_index_on_load"="true");
```

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

