### PR TITLE
[fix](planner)fix bug of pushing conjunct through agg node

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -2762,7 +2762,7 @@ public class SingleNodePlanner {
                 while (sourceExpr instanceof SlotRef) {
                     SlotRef slotRef = (SlotRef) sourceExpr;
                     SlotDescriptor slotDesc = slotRef.getDesc();
-                    if (slotDesc.getSourceExprs().isEmpty()) {
+                    if (slotDesc.getSourceExprs().size() != 1) {
                         break;
                     }
                     sourceExpr = slotDesc.getSourceExprs().get(0);

--- a/regression-test/suites/correctness_p0/test_push_conjuncts_inlineview.groovy
+++ b/regression-test/suites/correctness_p0/test_push_conjuncts_inlineview.groovy
@@ -128,6 +128,28 @@ sql """
     WHERE dd.d1 IN ('-1');
 """
 
+explain {
+        sql("""SELECT max(b_key)
+            FROM 
+                (SELECT a_key,
+                    max(b_key) AS b_key
+                FROM 
+                    (SELECT a_key,
+                    max(b_key) AS b_key
+                    FROM push_conjunct_table
+                    GROUP BY  a_key
+                    UNION all 
+                    SELECT a_key,
+                    max(b_key) AS b_key
+                    FROM push_conjunct_table
+                    GROUP BY  a_key) t2
+                    GROUP BY  t2.a_key ) t
+                WHERE t.a_key = "abcd"
+            GROUP BY  t.a_key;""")
+        notContains "having"
+        contains "= 'abcd'"
+    }
+
  sql """ DROP TABLE IF EXISTS `push_conjunct_table` """
 }
 


### PR DESCRIPTION
## Proposed changes

When searching for source slot of SlotRef, the search process should stop when there are more than 1 source exprs and return  the currect expr where the search process stops.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

