### PR TITLE
[fix](nereids) Mistaken stats when analyzing table incrementally and partition number less than 512

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -2670,7 +2670,12 @@ public class ShowExecutor {
                     LocalDateTime.ofInstant(Instant.ofEpochMilli(analysisInfo.lastExecTimeInMs),
                             ZoneId.systemDefault())));
             row.add(analysisInfo.state.toString());
-            row.add(Env.getCurrentEnv().getAnalysisManager().getJobProgress(analysisInfo.jobId));
+            try {
+                row.add(Env.getCurrentEnv().getAnalysisManager().getJobProgress(analysisInfo.jobId));
+            } catch (Exception e) {
+                row.add("N/A");
+                LOG.warn("Failed to get progress for job: {}", analysisInfo, e);
+            }
             row.add(analysisInfo.scheduleType.toString());
             resultRows.add(row);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -2438,6 +2438,7 @@ public class StmtExecutor {
     }
 
     public List<ResultRow> executeInternalQuery() {
+        LOG.debug("INTERNAL QUERY: " + originStmt.toString());
         try {
             List<ResultRow> resultRows = new ArrayList<>();
             try {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfo.java
@@ -200,6 +200,9 @@ public class AnalysisInfo implements Writable {
         this.partitionOnly = partitionOnly;
         this.samplingPartition = samplingPartition;
         this.cronExpression = cronExpression;
+        if (cronExpression != null) {
+            this.cronExprStr = cronExpression.getCronExpression();
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfoBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfoBuilder.java
@@ -89,6 +89,7 @@ public class AnalysisInfoBuilder {
         externalTableLevelTask = info.externalTableLevelTask;
         partitionOnly = info.partitionOnly;
         samplingPartition = info.samplingPartition;
+        cronExpression = info.cronExpression;
     }
 
     public AnalysisInfoBuilder setJobId(long jobId) {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisState.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisState.java
@@ -18,7 +18,9 @@
 package org.apache.doris.statistics;
 
 public enum AnalysisState {
+    // When analyze job/task created, but never run
     PENDING,
+    // When analyze job/task is in running queue
     RUNNING,
     FINISHED,
     FAILED;

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
@@ -236,6 +236,7 @@ public abstract class BaseAnalysisTask {
         if (killed) {
             return;
         }
+        LOG.debug("execute internal sql: {}", stmtExecutor.getOriginStmt());
         stmtExecutor.execute();
         QueryState queryState = stmtExecutor.getContext().getState();
         if (queryState.getStateType().equals(MysqlStateType.ERR)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticConstants.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticConstants.java
@@ -28,14 +28,11 @@ import java.util.concurrent.TimeUnit;
 public class StatisticConstants {
 
     public static final String STATISTIC_TBL_NAME = "column_statistics";
-
     public static final String HISTOGRAM_TBL_NAME = "histogram_statistics";
 
     public static final int MAX_NAME_LEN = 64;
 
     public static final int ID_LEN = 4096;
-
-    public static final int STATISTICS_CACHE_VALID_DURATION_IN_HOURS = 24 * 2;
 
     public static final int STATISTICS_CACHE_REFRESH_INTERVAL = 24 * 2;
 
@@ -75,6 +72,8 @@ public class StatisticConstants {
     public static int ANALYZE_TASK_RETRY_TIMES = 5;
 
     public static final String DB_NAME = SystemInfoService.DEFAULT_CLUSTER + ":" + FeConstants.INTERNAL_DB_NAME;
+
+    public static final String FULL_QUALIFIED_STATS_TBL_NAME = FeConstants.INTERNAL_DB_NAME + "." + STATISTIC_TBL_NAME;
 
     public static final int STATISTIC_INTERNAL_TABLE_REPLICA_NUM = 3;
 

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisJobTest.java
@@ -135,6 +135,7 @@ public class AnalysisJobTest extends TestWithFeService {
                 .setAnalysisMethod(AnalysisMethod.FULL)
                 .setAnalysisType(AnalysisType.FUNDAMENTALS)
                 .setColToPartitions(colToPartitions)
+                .setState(AnalysisState.RUNNING)
                 .build();
         new OlapAnalysisTask(analysisJobInfo).doExecute();
         new Expectations() {

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisManagerTest.java
@@ -24,6 +24,7 @@ import org.apache.doris.analysis.TableName;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.statistics.AnalysisInfo.AnalysisType;
 import org.apache.doris.statistics.AnalysisInfo.JobType;
+import org.apache.doris.statistics.AnalysisInfo.ScheduleType;
 import org.apache.doris.statistics.util.StatisticsUtil;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -182,7 +183,9 @@ public class AnalysisManagerTest {
     // test build async job
     @Test
     public void testBuildAndAssignJob2(@Injectable OlapAnalysisTask analysisTask) throws Exception {
-        AnalysisInfo analysisInfo = new AnalysisInfoBuilder().setColToPartitions(new HashMap<>()).build();
+        AnalysisInfo analysisInfo = new AnalysisInfoBuilder().setColToPartitions(new HashMap<>())
+                .setScheduleType(ScheduleType.PERIOD)
+                .build();
         new MockUp<StatisticsUtil>() {
 
             @Mock
@@ -240,9 +243,9 @@ public class AnalysisManagerTest {
         }, new AnalyzeProperties(new HashMap<String, String>() {
             {
                 put(AnalyzeProperties.PROPERTY_SYNC, "false");
+                put(AnalyzeProperties.PROPERTY_PERIOD_SECONDS, "100");
             }
         }));
-
         AnalysisManager analysisManager = new AnalysisManager();
         analysisInfo.colToPartitions.put("c1", new HashSet<String>() {
             {

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisTaskExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisTaskExecutorTest.java
@@ -113,6 +113,7 @@ public class AnalysisTaskExecutorTest extends TestWithFeService {
                 .setAnalysisMode(AnalysisMode.FULL)
                 .setAnalysisMethod(AnalysisMethod.FULL)
                 .setAnalysisType(AnalysisType.FUNDAMENTALS)
+                .setState(AnalysisState.RUNNING)
                 .setColToPartitions(colToPartitions)
                 .build();
         OlapAnalysisTask task = new OlapAnalysisTask(analysisInfo);

--- a/regression-test/suites/statistics/analyze_stats.groovy
+++ b/regression-test/suites/statistics/analyze_stats.groovy
@@ -143,99 +143,99 @@ suite("test_analyze") {
         ANALYZE DATABASE ${db} WITH SYNC WITH SAMPLE PERCENT 10
     """
 
-//    a_result_2 = sql """
-//        ANALYZE DATABASE ${db} WITH SYNC WITH SAMPLE PERCENT 5
-//    """
-//
-//    a_result_3 = sql """
-//        ANALYZE DATABASE ${db} WITH SAMPLE PERCENT 5
-//    """
-//
-//    show_result = sql """
-//        SHOW ANALYZE
-//    """
-//
-//    def contains_expected_table = { r ->
-//        for (int i = 0; i < r.size; i++) {
-//            if (r[i][3] == "${tbl}") {
-//                return true
-//            }
-//        }
-//        return false
-//    }
-//
-//    def stats_job_removed = { r, id ->
-//        for (int i = 0; i < r.size; i++) {
-//            if (r[i][0] == id) {
-//                return false
-//            }
-//        }
-//        return true
-//    }
-//
-//    assert contains_expected_table(show_result)
-//
-//    sql """
-//        DROP ANALYZE JOB ${a_result_3[0][4]}
-//    """
-//
-//    show_result = sql """
-//        SHOW ANALYZE
-//    """
-//
-//    assert stats_job_removed(show_result, a_result_3[0][4])
-//
-//    sql """
-//        ANALYZE DATABASE ${db} WITH SAMPLE ROWS 5 WITH PERIOD 100000
-//    """
-//
-//    sql """
-//        DROP TABLE IF EXISTS analyze_partitioned_tbl_test
-//    """
+    a_result_2 = sql """
+        ANALYZE DATABASE ${db} WITH SYNC WITH SAMPLE PERCENT 5
+    """
 
-//    sql """
-//        CREATE TABLE analyze_partitioned_tbl_test (col1 int, col2 int, col3 int)
-//        PARTITION BY RANGE(`col2`) (
-//            PARTITION `p1` VALUES LESS THAN ('5'),
-//            PARTITION `p2` VALUES LESS THAN ('10'),
-//            PARTITION `P3` VALUES LESS THAN ('15'),
-//            PARTITION `P4` VALUES LESS THAN ('20'),
-//            PARTITION `P5` VALUES LESS THAN ('25'),
-//            PARTITION `P6` VALUES LESS THAN ('30'))
-//        DISTRIBUTED BY HASH(col3)
-//        BUCKETS 3
-//        PROPERTIES(
-//            "replication_num"="1"
-//        )
-//    """
-//
-//    sql """insert into analyze_partitioned_tbl_test values(1,3,1) """
-//    sql """insert into analyze_partitioned_tbl_test values(6,6,6) """
-//    sql """insert into analyze_partitioned_tbl_test values(11,6,6) """
-//    sql """insert into analyze_partitioned_tbl_test values(16,6,6) """
-//    sql """insert into analyze_partitioned_tbl_test values(21,6,6) """
-//    sql """insert into analyze_partitioned_tbl_test values(26,6,6) """
-//
-//    sql """
-//        ANALYZE TABLE analyze_partitioned_tbl_test WITH SYNC
-//    """
-//
-//    part_tbl_analyze_result = sql """
-//        SHOW COLUMN CACHED STATS analyze_partitioned_tbl_test(col1)
-//    """
-//
-//    def expected_result = { r ->
-//        for (int i = 0; i < r.size; i++) {
-//            if ((int) Double.parseDouble(r[i][1]) == 6) {
-//                return true
-//            } else {
-//                return false
-//            }
-//        }
-//        return false
-//    }
-//
-//    assert expected_result(part_tbl_analyze_result)
+    a_result_3 = sql """
+        ANALYZE DATABASE ${db} WITH SAMPLE PERCENT 5
+    """
+
+    show_result = sql """
+        SHOW ANALYZE
+    """
+
+    def contains_expected_table = { r ->
+        for (int i = 0; i < r.size; i++) {
+            if (r[i][3] == "${tbl}") {
+                return true
+            }
+        }
+        return false
+    }
+
+    def stats_job_removed = { r, id ->
+        for (int i = 0; i < r.size; i++) {
+            if (r[i][0] == id) {
+                return false
+            }
+        }
+        return true
+    }
+
+    assert contains_expected_table(show_result)
+
+    sql """
+        DROP ANALYZE JOB ${a_result_3[0][4]}
+    """
+
+    show_result = sql """
+        SHOW ANALYZE
+    """
+
+    assert stats_job_removed(show_result, a_result_3[0][4])
+
+    sql """
+        ANALYZE DATABASE ${db} WITH SAMPLE ROWS 5 WITH PERIOD 100000
+    """
+
+    sql """
+        DROP TABLE IF EXISTS analyze_partitioned_tbl_test
+    """
+
+    sql """
+        CREATE TABLE analyze_partitioned_tbl_test (col1 int, col2 int, col3 int)
+        PARTITION BY RANGE(`col2`) (
+            PARTITION `p1` VALUES LESS THAN ('5'),
+            PARTITION `p2` VALUES LESS THAN ('10'),
+            PARTITION `P3` VALUES LESS THAN ('15'),
+            PARTITION `P4` VALUES LESS THAN ('20'),
+            PARTITION `P5` VALUES LESS THAN ('25'),
+            PARTITION `P6` VALUES LESS THAN ('30'))
+        DISTRIBUTED BY HASH(col3)
+        BUCKETS 3
+        PROPERTIES(
+            "replication_num"="1"
+        )
+    """
+
+    sql """insert into analyze_partitioned_tbl_test values(1,3,1) """
+    sql """insert into analyze_partitioned_tbl_test values(6,6,6) """
+    sql """insert into analyze_partitioned_tbl_test values(11,6,6) """
+    sql """insert into analyze_partitioned_tbl_test values(16,6,6) """
+    sql """insert into analyze_partitioned_tbl_test values(21,6,6) """
+    sql """insert into analyze_partitioned_tbl_test values(26,6,6) """
+
+    sql """
+        ANALYZE TABLE analyze_partitioned_tbl_test WITH SYNC
+    """
+
+    part_tbl_analyze_result = sql """
+        SHOW COLUMN CACHED STATS analyze_partitioned_tbl_test(col1)
+    """
+
+    def expected_result = { r ->
+        for (int i = 0; i < r.size; i++) {
+            if ((int) Double.parseDouble(r[i][1]) == 6) {
+                return true
+            } else {
+                return false
+            }
+        }
+        return false
+    }
+
+    assert expected_result(part_tbl_analyze_result)
 
     sql """
         DROP TABLE IF EXISTS test_600_partition_table_analyze;
@@ -877,4 +877,31 @@ PARTITION `p599` VALUES IN (599)
     assert expected_id_col_stats(id_col_stats, 600, 1)
     assert expected_id_col_stats(id_col_stats, 599, 7)
     assert expected_id_col_stats(id_col_stats, 0, 6)
+
+    sql """DROP TABLE IF EXISTS increment_analyze_test"""
+    sql """
+        CREATE TABLE increment_analyze_test (
+            id BIGINT
+        ) DUPLICATE KEY(`id`)
+        PARTITION BY RANGE(`id`)
+        (
+            PARTITION `p1` VALUES LESS THAN ('5')
+        )
+        
+        DISTRIBUTED BY HASH(`id`) BUCKETS 3
+        PROPERTIES (
+            "replication_num"="1"
+        );
+    """
+
+    sql """INSERT INTO increment_analyze_test VALUES(1),(2),(3)"""
+    sql """ANALYZE TABLE increment_analyze_test WITH SYNC"""
+    sql """ALTER TABLE increment_analyze_test ADD PARTITION p2 VALUES LESS THAN('10')"""
+
+    sql """INSERT INTO increment_analyze_test VALUES(6),(7),(8)"""
+    sql """ANALYZE TABLE increment_analyze_test WITH SYNC WITH INCREMENTAL"""
+    def inc_res = sql """
+        SHOW COLUMN CACHED STATS increment_analyze_test(id)
+    """
+    expected_id_col_stats(inc_res, 6, 1)
 }


### PR DESCRIPTION
## Proposed changes

1. Fix bug that mistaken stats when analyzing table incrementally and partition number less than 512
2. Fix bug that cron expression lost during analyzing
3. Mark system job as running after registered to AnalysisManager to avoid submit same jobs if previous one take long time

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

