### PR TITLE
[fix](planner)fix bug of resolve column

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -927,7 +927,8 @@ public class Analyzer {
             // ===================================================
             // Someone may concern that if t2 is not alias of t, this fix will cause incorrect resolve. In fact,
             // this does not happen, since we push t2.a in (1.2) down to this inline view, t2 must be alias of t.
-            if (d == null && isInlineView && newTblName.getTbl().equals(explicitViewAlias)) {
+            if (d == null && isInlineView && newTblName.getTbl().equals(explicitViewAlias)
+                    && !tupleByAlias.containsKey(newTblName.getTbl())) {
                 d = resolveColumnRef(colName);
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -927,6 +927,32 @@ public class Analyzer {
             // ===================================================
             // Someone may concern that if t2 is not alias of t, this fix will cause incorrect resolve. In fact,
             // this does not happen, since we push t2.a in (1.2) down to this inline view, t2 must be alias of t.
+            // create table tmp_can_drop_t1 (
+            //     cust_id varchar(96),
+            //     user_id varchar(96)
+            // )
+            // create table tmp_can_drop_t2 (
+            //     cust_id varchar(96),
+            //     usr_id varchar(96)
+            // )
+            // select
+            // a.cust_id,
+            // a.usr_id
+            // from (
+            // select
+            //     a.cust_id,
+            //     a.usr_id, --------->(report error, because there is no user_id column in tmp_can_drop_t1)
+            //     a.user_id
+            // from tmp_can_drop_t1 a
+            // full join (
+            //     select
+            //     cust_id,
+            //     usr_id
+            //     from
+            //     tmp_can_drop_t2
+            // ) b
+            // on b.cust_id = a.cust_id
+            // ) a;
             if (d == null && isInlineView && newTblName.getTbl().equals(explicitViewAlias)
                     && !tupleByAlias.containsKey(newTblName.getTbl())) {
                 d = resolveColumnRef(colName);

--- a/regression-test/suites/correctness_p0/test_inlineview_error_msg.groovy
+++ b/regression-test/suites/correctness_p0/test_inlineview_error_msg.groovy
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_inlineview_error_msg") {
+    sql "set enable_nereids_planner=false"
+    sql """
+        drop table if exists tmp_can_drop_t1;
+    """
+
+    sql """
+        drop table if exists tmp_can_drop_t2;
+    """
+
+    sql """
+        create table tmp_can_drop_t1 (
+            cust_id varchar(96),
+            user_id varchar(96)
+        )
+        DISTRIBUTED by random BUCKETS 1
+        PROPERTIES(
+            "replication_num" = "1"
+        );
+    """
+
+    sql """
+        create table tmp_can_drop_t2 (
+            cust_id varchar(96),
+            usr_id varchar(96)
+        )
+        DISTRIBUTED by random BUCKETS 1
+        PROPERTIES(
+            "replication_num" = "1"
+        );
+    """
+    test {
+            sql """
+            select
+            a.cust_id,
+            a.usr_id
+            from (
+            select
+                a.cust_id,
+                a.usr_id,
+                a.user_id
+            from tmp_can_drop_t1 a
+            full join (
+                select
+                cust_id,
+                usr_id
+                from
+                tmp_can_drop_t2
+            ) b
+            on b.cust_id = a.cust_id
+            ) a;
+        """
+        exception "Unknown column 'usr_id' in 'a'"
+    }
+    
+    sql """
+        drop table if exists tmp_can_drop_t1;
+    """
+
+    sql """
+        drop table if exists tmp_can_drop_t2;
+    """
+}


### PR DESCRIPTION
## Proposed changes
if resolve a inline view column failed, we try to resolve it again by removing the  table name. But it's wrong if the table name(may be the inlineview's alias) is same as some table name inside inlineview. So this pr check the table name, and only remove it when there is no table inside the inlineview has the same name with the column's table name

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

