### PR TITLE
[Enhancement](Schema hash) Remove schema hash in tablet info

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1384,7 +1384,7 @@ void DropTableTaskPool::_drop_tablet_worker_thread_callback() {
             // if tablet is dropped by fe, then the related txn should also be removed
             StorageEngine::instance()->txn_manager()->force_rollback_tablet_related_txns(
                     dropped_tablet->data_dir()->get_meta(), drop_tablet_req.tablet_id,
-                    drop_tablet_req.schema_hash, dropped_tablet->tablet_uid());
+                    dropped_tablet->tablet_uid());
             LOG_INFO("successfully drop tablet")
                     .tag("signature", agent_task_req.signature)
                     .tag("tablet_id", drop_tablet_req.tablet_id);

--- a/be/src/http/action/tablets_distribution_action.cpp
+++ b/be/src/http/action/tablets_distribution_action.cpp
@@ -116,9 +116,6 @@ EasyJson TabletsDistributionAction::get_tablets_distribution_group_by_partition(
                     tablet["tablet_id"] =
                             tablets_info_on_disk[partition_iter->first][disk_iter->first][i]
                                     .tablet_id;
-                    tablet["schema_hash"] =
-                            tablets_info_on_disk[partition_iter->first][disk_iter->first][i]
-                                    .schema_hash;
                     tablet["tablet_size"] =
                             tablets_info_on_disk[partition_iter->first][disk_iter->first][i]
                                     .tablet_size;

--- a/be/src/http/action/tablets_info_action.cpp
+++ b/be/src/http/action/tablets_info_action.cpp
@@ -79,7 +79,6 @@ EasyJson TabletsInfoAction::get_tablets_info(string tablet_num_to_return) {
     for (TabletInfo tablet_info : tablets_info) {
         EasyJson tablet = tablets.PushBack(EasyJson::kObject);
         tablet["tablet_id"] = tablet_info.tablet_id;
-        tablet["schema_hash"] = tablet_info.schema_hash;
     }
     tablets_info_ej["count"] = tablets_info.size();
     return tablets_info_ej;

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -668,8 +668,7 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
                     it.rowset_ids.insert(_output_rowset->rowset_id());
                     StorageEngine::instance()->txn_manager()->set_txn_related_delete_bitmap(
                             it.partition_id, it.transaction_id, _tablet->tablet_id(),
-                            _tablet->schema_hash(), _tablet->tablet_uid(), true, it.delete_bitmap,
-                            it.rowset_ids);
+                            _tablet->tablet_uid(), true, it.delete_bitmap, it.rowset_ids);
                 }
             }
 

--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -259,14 +259,14 @@ Status DataDir::get_shard(uint64_t* shard) {
 }
 
 void DataDir::register_tablet(Tablet* tablet) {
-    TabletInfo tablet_info(tablet->tablet_id(), tablet->schema_hash(), tablet->tablet_uid());
+    TabletInfo tablet_info(tablet->tablet_id(), tablet->tablet_uid());
 
     std::lock_guard<std::mutex> l(_mutex);
     _tablet_set.emplace(std::move(tablet_info));
 }
 
 void DataDir::deregister_tablet(Tablet* tablet) {
-    TabletInfo tablet_info(tablet->tablet_id(), tablet->schema_hash(), tablet->tablet_uid());
+    TabletInfo tablet_info(tablet->tablet_id(), tablet->tablet_uid());
 
     std::lock_guard<std::mutex> l(_mutex);
     _tablet_set.erase(tablet_info);
@@ -500,8 +500,8 @@ Status DataDir::load() {
             }
             Status commit_txn_status = _txn_manager->commit_txn(
                     _meta, rowset_meta->partition_id(), rowset_meta->txn_id(),
-                    rowset_meta->tablet_id(), rowset_meta->tablet_schema_hash(),
-                    rowset_meta->tablet_uid(), rowset_meta->load_id(), rowset, true);
+                    rowset_meta->tablet_id(), rowset_meta->tablet_uid(), rowset_meta->load_id(),
+                    rowset, true);
             if (!commit_txn_status && !commit_txn_status.is<PUSH_TRANSACTION_ALREADY_EXIST>()) {
                 LOG(WARNING) << "failed to add committed rowset: " << rowset_meta->rowset_id()
                              << " to tablet: " << rowset_meta->tablet_id()

--- a/be/src/olap/olap_common.h
+++ b/be/src/olap/olap_common.h
@@ -73,14 +73,12 @@ struct DataDirInfoLessAvailability {
 };
 
 struct TabletInfo {
-    TabletInfo(TTabletId in_tablet_id, TSchemaHash in_schema_hash, UniqueId in_uid)
-            : tablet_id(in_tablet_id), schema_hash(in_schema_hash), tablet_uid(in_uid) {}
+    TabletInfo(TTabletId in_tablet_id, UniqueId in_uid)
+            : tablet_id(in_tablet_id), tablet_uid(in_uid) {}
 
     bool operator<(const TabletInfo& right) const {
         if (tablet_id != right.tablet_id) {
             return tablet_id < right.tablet_id;
-        } else if (schema_hash != right.schema_hash) {
-            return schema_hash < right.schema_hash;
         } else {
             return tablet_uid < right.tablet_uid;
         }
@@ -88,21 +86,19 @@ struct TabletInfo {
 
     std::string to_string() const {
         std::stringstream ss;
-        ss << tablet_id << "." << schema_hash << "." << tablet_uid.to_string();
+        ss << tablet_id << "." << tablet_uid.to_string();
         return ss.str();
     }
 
     TTabletId tablet_id;
-    TSchemaHash schema_hash;
     UniqueId tablet_uid;
 };
 
 struct TabletSize {
-    TabletSize(TTabletId in_tablet_id, TSchemaHash in_schema_hash, size_t in_tablet_size)
-            : tablet_id(in_tablet_id), schema_hash(in_schema_hash), tablet_size(in_tablet_size) {}
+    TabletSize(TTabletId in_tablet_id, size_t in_tablet_size)
+            : tablet_id(in_tablet_id), tablet_size(in_tablet_size) {}
 
     TTabletId tablet_id;
-    TSchemaHash schema_hash;
     size_t tablet_size;
 };
 

--- a/be/src/olap/rowset_builder.cpp
+++ b/be/src/olap/rowset_builder.cpp
@@ -261,8 +261,8 @@ Status RowsetBuilder::commit_txn() {
     }
     if (_tablet->enable_unique_key_merge_on_write()) {
         _storage_engine->txn_manager()->set_txn_related_delete_bitmap(
-                _req.partition_id, _req.txn_id, _tablet->tablet_id(), _tablet->schema_hash(),
-                _tablet->tablet_uid(), true, _delete_bitmap, _rowset_ids);
+                _req.partition_id, _req.txn_id, _tablet->tablet_id(), _tablet->tablet_uid(), true,
+                _delete_bitmap, _rowset_ids);
     }
 
     _is_committed = true;

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -882,7 +882,6 @@ void StorageEngine::_clean_unused_txns() {
             // currently just remove them from memory
             // nullptr to indicate not remove them from meta store
             _txn_manager->force_rollback_tablet_related_txns(nullptr, tablet_info.tablet_id,
-                                                             tablet_info.schema_hash,
                                                              tablet_info.tablet_uid);
         }
     }

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1270,7 +1270,7 @@ Status Tablet::_contains_version(const Version& version) {
 }
 
 TabletInfo Tablet::get_tablet_info() const {
-    return TabletInfo(tablet_id(), schema_hash(), tablet_uid());
+    return TabletInfo(tablet_id(), tablet_uid());
 }
 
 std::vector<RowsetSharedPtr> Tablet::pick_candidate_rowsets_to_cumulative_compaction() {

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -1045,7 +1045,7 @@ Status TabletManager::build_all_report_tablets_info(std::map<TTabletId, TTablet>
         TTabletInfo& tablet_info = t_tablet.tablet_infos.emplace_back();
         tablet->build_tablet_report_info(&tablet_info, true, true);
         // find expired transaction corresponding to this tablet
-        TabletInfo tinfo(tablet->tablet_id(), tablet->schema_hash(), tablet->tablet_uid());
+        TabletInfo tinfo(tablet->tablet_id(), tablet->tablet_uid());
         auto find = expire_txn_map.find(tinfo);
         if (find != expire_txn_map.end()) {
             tablet_info.__set_transaction_ids(find->second);
@@ -1429,8 +1429,7 @@ void TabletManager::get_tablets_distribution_on_different_disks(
             DataDir* data_dir = tablet->data_dir();
             size_t tablet_footprint = tablet->tablet_footprint();
             tablets_num[data_dir]++;
-            TabletSize tablet_size(tablet_info_iter->tablet_id, tablet_info_iter->schema_hash,
-                                   tablet_footprint);
+            TabletSize tablet_size(tablet_info_iter->tablet_id, tablet_footprint);
             tablets_info[data_dir].push_back(tablet_size);
         }
         tablets_num_on_disk[partition_id] = tablets_num;

--- a/be/src/olap/task/engine_publish_version_task.cpp
+++ b/be/src/olap/task/engine_publish_version_task.cpp
@@ -120,9 +120,8 @@ Status EnginePublishVersionTask::finish() {
             TabletInfo tablet_info = tablet_rs.first;
             RowsetSharedPtr rowset = tablet_rs.second;
             VLOG_CRITICAL << "begin to publish version on tablet. "
-                          << "tablet_id=" << tablet_info.tablet_id
-                          << ", schema_hash=" << tablet_info.schema_hash
-                          << ", version=" << version.first << ", transaction_id=" << transaction_id;
+                          << "tablet_id=" << tablet_info.tablet_id << ", version=" << version.first
+                          << ", transaction_id=" << transaction_id;
             // if rowset is null, it means this be received write task, but failed during write
             // and receive fe's publish version task
             // this be must return as an error tablet
@@ -138,8 +137,8 @@ Status EnginePublishVersionTask::finish() {
             if (tablet == nullptr) {
                 _error_tablet_ids->push_back(tablet_info.tablet_id);
                 res = Status::Error<PUSH_TABLE_NOT_EXIST>(
-                        "can't get tablet when publish version. tablet_id={}, schema_hash={}",
-                        tablet_info.tablet_id, tablet_info.schema_hash);
+                        "can't get tablet when publish version. tablet_id={}",
+                        tablet_info.tablet_id);
                 continue;
             }
             // in uniq key model with merge-on-write, we should see all
@@ -299,8 +298,7 @@ void AsyncTabletPublishTask::handle() {
     std::map<TabletInfo, RowsetSharedPtr> tablet_related_rs;
     StorageEngine::instance()->txn_manager()->get_txn_related_tablets(
             _transaction_id, _partition_id, &tablet_related_rs);
-    auto iter = tablet_related_rs.find(
-            TabletInfo(_tablet->tablet_id(), _tablet->schema_hash(), _tablet->tablet_uid()));
+    auto iter = tablet_related_rs.find(TabletInfo(_tablet->tablet_id(), _tablet->tablet_uid()));
     if (iter == tablet_related_rs.end()) {
         return;
     }

--- a/be/src/olap/task/engine_storage_migration_task.cpp
+++ b/be/src/olap/task/engine_storage_migration_task.cpp
@@ -103,8 +103,7 @@ Status EngineStorageMigrationTask::_check_running_txns() {
     std::set<int64_t> transaction_ids;
     // check if this tablet has related running txns. if yes, can not do migration.
     StorageEngine::instance()->txn_manager()->get_tablet_related_txns(
-            _tablet->tablet_id(), _tablet->schema_hash(), _tablet->tablet_uid(), &partition_id,
-            &transaction_ids);
+            _tablet->tablet_id(), _tablet->tablet_uid(), &partition_id, &transaction_ids);
     if (transaction_ids.size() > 0) {
         return Status::InternalError("tablet {} has unfinished txns", _tablet->tablet_id());
     }

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -115,8 +115,8 @@ public:
                        bool is_ingest = false);
     // most used for ut
     Status prepare_txn(TPartitionId partition_id, TTransactionId transaction_id,
-                       TTabletId tablet_id, SchemaHash schema_hash, TabletUid tablet_uid,
-                       const PUniqueId& load_id, bool is_ingest = false);
+                       TTabletId tablet_id, TabletUid tablet_uid, const PUniqueId& load_id,
+                       bool is_ingest = false);
 
     Status commit_txn(TPartitionId partition_id, const TabletSharedPtr& tablet,
                       TTransactionId transaction_id, const PUniqueId& load_id,
@@ -134,28 +134,27 @@ public:
                       TTransactionId transaction_id);
 
     Status commit_txn(OlapMeta* meta, TPartitionId partition_id, TTransactionId transaction_id,
-                      TTabletId tablet_id, SchemaHash schema_hash, TabletUid tablet_uid,
-                      const PUniqueId& load_id, const RowsetSharedPtr& rowset_ptr,
-                      bool is_recovery);
+                      TTabletId tablet_id, TabletUid tablet_uid, const PUniqueId& load_id,
+                      const RowsetSharedPtr& rowset_ptr, bool is_recovery);
 
     // remove a txn from txn manager
     // not persist rowset meta because
     Status publish_txn(OlapMeta* meta, TPartitionId partition_id, TTransactionId transaction_id,
-                       TTabletId tablet_id, SchemaHash schema_hash, TabletUid tablet_uid,
-                       const Version& version, TabletPublishStatistics* stats);
+                       TTabletId tablet_id, TabletUid tablet_uid, const Version& version,
+                       TabletPublishStatistics* stats);
 
     // delete the txn from manager if it is not committed(not have a valid rowset)
     Status rollback_txn(TPartitionId partition_id, TTransactionId transaction_id,
-                        TTabletId tablet_id, SchemaHash schema_hash, TabletUid tablet_uid);
+                        TTabletId tablet_id, TabletUid tablet_uid);
 
     // remove the txn from txn manager
     // delete the related rowset if it is not null
     // delete rowset related data if it is not null
     Status delete_txn(OlapMeta* meta, TPartitionId partition_id, TTransactionId transaction_id,
-                      TTabletId tablet_id, SchemaHash schema_hash, TabletUid tablet_uid);
+                      TTabletId tablet_id, TabletUid tablet_uid);
 
-    void get_tablet_related_txns(TTabletId tablet_id, SchemaHash schema_hash, TabletUid tablet_uid,
-                                 int64_t* partition_id, std::set<int64_t>* transaction_ids);
+    void get_tablet_related_txns(TTabletId tablet_id, TabletUid tablet_uid, int64_t* partition_id,
+                                 std::set<int64_t>* transaction_ids);
 
     void get_txn_related_tablets(const TTransactionId transaction_id, TPartitionId partition_ids,
                                  std::map<TabletInfo, RowsetSharedPtr>* tablet_infos);
@@ -164,14 +163,14 @@ public:
 
     // Just check if the txn exists.
     bool has_txn(TPartitionId partition_id, TTransactionId transaction_id, TTabletId tablet_id,
-                 SchemaHash schema_hash, TabletUid tablet_uid);
+                 TabletUid tablet_uid);
 
     // Get all expired txns and save them in expire_txn_map.
     // This is currently called before reporting all tablet info, to avoid iterating txn map for every tablets.
     void build_expire_txn_map(std::map<TabletInfo, std::vector<int64_t>>* expire_txn_map);
 
     void force_rollback_tablet_related_txns(OlapMeta* meta, TTabletId tablet_id,
-                                            SchemaHash schema_hash, TabletUid tablet_uid);
+                                            TabletUid tablet_uid);
 
     void get_partition_ids(const TTransactionId transaction_id,
                            std::vector<TPartitionId>* partition_ids);
@@ -183,8 +182,8 @@ public:
                                          bool is_succeed);
 
     void set_txn_related_delete_bitmap(TPartitionId partition_id, TTransactionId transaction_id,
-                                       TTabletId tablet_id, SchemaHash schema_hash,
-                                       TabletUid tablet_uid, bool unique_key_merge_on_write,
+                                       TTabletId tablet_id, TabletUid tablet_uid,
+                                       bool unique_key_merge_on_write,
                                        DeleteBitmapPtr delete_bitmap,
                                        const RowsetIdUnorderedSet& rowset_ids);
     void get_all_commit_tablet_txn_info_by_tablet(

--- a/be/src/service/backend_service.cpp
+++ b/be/src/service/backend_service.cpp
@@ -648,8 +648,8 @@ void BackendService::ingest_binlog(TIngestBinlogResult& result,
     // Step 6.2: commit txn
     Status commit_txn_status = StorageEngine::instance()->txn_manager()->commit_txn(
             local_tablet->data_dir()->get_meta(), rowset_meta->partition_id(),
-            rowset_meta->txn_id(), rowset_meta->tablet_id(), rowset_meta->tablet_schema_hash(),
-            local_tablet->tablet_uid(), rowset_meta->load_id(), rowset, true);
+            rowset_meta->txn_id(), rowset_meta->tablet_id(), local_tablet->tablet_uid(),
+            rowset_meta->load_id(), rowset, true);
     if (!commit_txn_status && !commit_txn_status.is<ErrorCode::PUSH_TRANSACTION_ALREADY_EXIST>()) {
         auto err_msg = fmt::format(
                 "failed to commit txn for remote tablet. rowset_id: {}, remote_tablet_id={}, "

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -1450,8 +1450,8 @@ void PInternalServiceImpl::request_slave_tablet_pull_rowset(
         }
         Status commit_txn_status = StorageEngine::instance()->txn_manager()->commit_txn(
                 tablet->data_dir()->get_meta(), rowset_meta->partition_id(), rowset_meta->txn_id(),
-                rowset_meta->tablet_id(), rowset_meta->tablet_schema_hash(), tablet->tablet_uid(),
-                rowset_meta->load_id(), rowset, true);
+                rowset_meta->tablet_id(), tablet->tablet_uid(), rowset_meta->load_id(), rowset,
+                true);
         if (!commit_txn_status && !commit_txn_status.is<PUSH_TRANSACTION_ALREADY_EXIST>()) {
             LOG(WARNING) << "failed to add committed rowset for slave replica. rowset_id="
                          << rowset_meta->rowset_id() << ", tablet_id=" << rowset_meta->tablet_id()

--- a/be/test/olap/delta_writer_test.cpp
+++ b/be/test/olap/delta_writer_test.cpp
@@ -668,8 +668,8 @@ TEST_F(TestDeltaWriter, vec_write) {
         RowsetSharedPtr rowset = tablet_rs.second;
         TabletPublishStatistics stats;
         res = k_engine->txn_manager()->publish_txn(meta, write_req.partition_id, write_req.txn_id,
-                                                   write_req.tablet_id, write_req.schema_hash,
-                                                   tablet_rs.first.tablet_uid, version, &stats);
+                                                   write_req.tablet_id, tablet_rs.first.tablet_uid,
+                                                   version, &stats);
         ASSERT_TRUE(res.ok());
         std::cout << "start to add inc rowset:" << rowset->rowset_id()
                   << ", num rows:" << rowset->num_rows() << ", version:" << rowset->version().first
@@ -765,7 +765,7 @@ TEST_F(TestDeltaWriter, vec_sequence_col) {
     TabletPublishStatistics pstats;
     res = k_engine->txn_manager()->publish_txn(
             meta, write_req.partition_id, write_req.txn_id, write_req.tablet_id,
-            write_req.schema_hash, tablet_related_rs.begin()->first.tablet_uid, version, &pstats);
+            tablet_related_rs.begin()->first.tablet_uid, version, &pstats);
     ASSERT_TRUE(res.ok());
     std::cout << "start to add inc rowset:" << rowset->rowset_id()
               << ", num rows:" << rowset->num_rows() << ", version:" << rowset->version().first
@@ -914,10 +914,9 @@ TEST_F(TestDeltaWriter, vec_sequence_col_concurrent_write) {
         std::cout << "start to publish txn" << std::endl;
         rowset1 = tablet_related_rs.begin()->second;
         TabletPublishStatistics pstats;
-        res = k_engine->txn_manager()->publish_txn(meta, write_req.partition_id, write_req.txn_id,
-                                                   write_req.tablet_id, write_req.schema_hash,
-                                                   tablet_related_rs.begin()->first.tablet_uid,
-                                                   version, &pstats);
+        res = k_engine->txn_manager()->publish_txn(
+                meta, write_req.partition_id, write_req.txn_id, write_req.tablet_id,
+                tablet_related_rs.begin()->first.tablet_uid, version, &pstats);
         ASSERT_TRUE(res.ok());
         std::cout << "start to add inc rowset:" << rowset1->rowset_id()
                   << ", num rows:" << rowset1->num_rows()
@@ -968,10 +967,9 @@ TEST_F(TestDeltaWriter, vec_sequence_col_concurrent_write) {
         ASSERT_TRUE(delete_bitmap->contains({rowset2->rowset_id(), 0, 0}, 1));
 
         TabletPublishStatistics pstats;
-        res = k_engine->txn_manager()->publish_txn(meta, write_req.partition_id, write_req.txn_id,
-                                                   write_req.tablet_id, write_req.schema_hash,
-                                                   tablet_related_rs.begin()->first.tablet_uid,
-                                                   version, &pstats);
+        res = k_engine->txn_manager()->publish_txn(
+                meta, write_req.partition_id, write_req.txn_id, write_req.tablet_id,
+                tablet_related_rs.begin()->first.tablet_uid, version, &pstats);
         ASSERT_TRUE(res.ok());
         std::cout << "start to add inc rowset:" << rowset2->rowset_id()
                   << ", num rows:" << rowset2->num_rows()

--- a/be/test/olap/engine_storage_migration_task_test.cpp
+++ b/be/test/olap/engine_storage_migration_task_test.cpp
@@ -224,8 +224,8 @@ TEST_F(TestEngineStorageMigrationTask, write_and_migration) {
         RowsetSharedPtr rowset = tablet_rs.second;
         TabletPublishStatistics stats;
         res = k_engine->txn_manager()->publish_txn(meta, write_req.partition_id, write_req.txn_id,
-                                                   tablet->tablet_id(), tablet->schema_hash(),
-                                                   tablet->tablet_uid(), version, &stats);
+                                                   tablet->tablet_id(), tablet->tablet_uid(),
+                                                   version, &stats);
         EXPECT_EQ(Status::OK(), res);
         res = tablet->add_inc_rowset(rowset);
         EXPECT_EQ(Status::OK(), res);

--- a/be/test/olap/tablet_cooldown_test.cpp
+++ b/be/test/olap/tablet_cooldown_test.cpp
@@ -426,8 +426,8 @@ void createTablet(StorageEngine* engine, TabletSharedPtr* tablet, int64_t replic
         RowsetSharedPtr rowset = tablet_rs.second;
         TabletPublishStatistics stats;
         st = engine->txn_manager()->publish_txn(meta, write_req.partition_id, write_req.txn_id,
-                                                (*tablet)->tablet_id(), (*tablet)->schema_hash(),
-                                                (*tablet)->tablet_uid(), version, &stats);
+                                                (*tablet)->tablet_id(), (*tablet)->tablet_uid(),
+                                                version, &stats);
         ASSERT_EQ(Status::OK(), st);
         st = (*tablet)->add_inc_rowset(rowset);
         ASSERT_EQ(Status::OK(), st);

--- a/be/test/olap/txn_manager_test.cpp
+++ b/be/test/olap/txn_manager_test.cpp
@@ -175,7 +175,6 @@ private:
     TPartitionId partition_id = 1123;
     TTransactionId transaction_id = 111;
     TTabletId tablet_id = 222;
-    SchemaHash schema_hash = 333;
     TabletUid _tablet_uid {0, 0};
     PUniqueId load_id;
     TabletSchemaSPtr _schema;
@@ -185,8 +184,8 @@ private:
 };
 
 TEST_F(TxnManagerTest, PrepareNewTxn) {
-    Status status = _txn_mgr->prepare_txn(partition_id, transaction_id, tablet_id, schema_hash,
-                                          _tablet_uid, load_id);
+    Status status =
+            _txn_mgr->prepare_txn(partition_id, transaction_id, tablet_id, _tablet_uid, load_id);
     EXPECT_TRUE(status == Status::OK());
 }
 
@@ -194,10 +193,10 @@ TEST_F(TxnManagerTest, PrepareNewTxn) {
 // 2. commit txn
 // 3. should be success
 TEST_F(TxnManagerTest, CommitTxnWithPrepare) {
-    Status status = _txn_mgr->prepare_txn(partition_id, transaction_id, tablet_id, schema_hash,
-                                          _tablet_uid, load_id);
-    _txn_mgr->commit_txn(_meta, partition_id, transaction_id, tablet_id, schema_hash, _tablet_uid,
-                         load_id, _rowset, false);
+    Status status =
+            _txn_mgr->prepare_txn(partition_id, transaction_id, tablet_id, _tablet_uid, load_id);
+    _txn_mgr->commit_txn(_meta, partition_id, transaction_id, tablet_id, _tablet_uid, load_id,
+                         _rowset, false);
     EXPECT_TRUE(status == Status::OK());
     RowsetMetaSharedPtr rowset_meta(new RowsetMeta());
     status = RowsetMetaManager::get_rowset_meta(_meta, _tablet_uid, _rowset->rowset_id(),
@@ -210,7 +209,7 @@ TEST_F(TxnManagerTest, CommitTxnWithPrepare) {
 // 2. should success
 TEST_F(TxnManagerTest, CommitTxnWithNoPrepare) {
     Status status = _txn_mgr->commit_txn(_meta, partition_id, transaction_id, tablet_id,
-                                         schema_hash, _tablet_uid, load_id, _rowset, false);
+                                         _tablet_uid, load_id, _rowset, false);
     EXPECT_TRUE(status == Status::OK());
 }
 
@@ -218,10 +217,10 @@ TEST_F(TxnManagerTest, CommitTxnWithNoPrepare) {
 // 2. should failed
 TEST_F(TxnManagerTest, CommitTxnTwiceWithDiffRowsetId) {
     Status status = _txn_mgr->commit_txn(_meta, partition_id, transaction_id, tablet_id,
-                                         schema_hash, _tablet_uid, load_id, _rowset, false);
+                                         _tablet_uid, load_id, _rowset, false);
     EXPECT_TRUE(status == Status::OK());
-    status = _txn_mgr->commit_txn(_meta, partition_id, transaction_id, tablet_id, schema_hash,
-                                  _tablet_uid, load_id, _rowset_diff_id, false);
+    status = _txn_mgr->commit_txn(_meta, partition_id, transaction_id, tablet_id, _tablet_uid,
+                                  load_id, _rowset_diff_id, false);
     EXPECT_TRUE(status != Status::OK());
 }
 
@@ -229,30 +228,28 @@ TEST_F(TxnManagerTest, CommitTxnTwiceWithDiffRowsetId) {
 // 2. should success
 TEST_F(TxnManagerTest, CommitTxnTwiceWithSameRowsetId) {
     Status status = _txn_mgr->commit_txn(_meta, partition_id, transaction_id, tablet_id,
-                                         schema_hash, _tablet_uid, load_id, _rowset, false);
+                                         _tablet_uid, load_id, _rowset, false);
     EXPECT_TRUE(status == Status::OK());
-    status = _txn_mgr->commit_txn(_meta, partition_id, transaction_id, tablet_id, schema_hash,
-                                  _tablet_uid, load_id, _rowset_same_id, false);
+    status = _txn_mgr->commit_txn(_meta, partition_id, transaction_id, tablet_id, _tablet_uid,
+                                  load_id, _rowset_same_id, false);
     EXPECT_TRUE(status == Status::OK());
 }
 
 // 1. prepare twice should be success
 TEST_F(TxnManagerTest, PrepareNewTxnTwice) {
-    Status status = _txn_mgr->prepare_txn(partition_id, transaction_id, tablet_id, schema_hash,
-                                          _tablet_uid, load_id);
+    Status status =
+            _txn_mgr->prepare_txn(partition_id, transaction_id, tablet_id, _tablet_uid, load_id);
     EXPECT_TRUE(status == Status::OK());
-    status = _txn_mgr->prepare_txn(partition_id, transaction_id, tablet_id, schema_hash,
-                                   _tablet_uid, load_id);
+    status = _txn_mgr->prepare_txn(partition_id, transaction_id, tablet_id, _tablet_uid, load_id);
     EXPECT_TRUE(status == Status::OK());
 }
 
 // 1. txn could be rollbacked if it is not committed
 TEST_F(TxnManagerTest, RollbackNotCommittedTxn) {
-    Status status = _txn_mgr->prepare_txn(partition_id, transaction_id, tablet_id, schema_hash,
-                                          _tablet_uid, load_id);
+    Status status =
+            _txn_mgr->prepare_txn(partition_id, transaction_id, tablet_id, _tablet_uid, load_id);
     EXPECT_TRUE(status == Status::OK());
-    status = _txn_mgr->rollback_txn(partition_id, transaction_id, tablet_id, schema_hash,
-                                    _tablet_uid);
+    status = _txn_mgr->rollback_txn(partition_id, transaction_id, tablet_id, _tablet_uid);
     EXPECT_TRUE(status == Status::OK());
     RowsetMetaSharedPtr rowset_meta(new RowsetMeta());
     status = RowsetMetaManager::get_rowset_meta(_meta, _tablet_uid, _rowset->rowset_id(),
@@ -263,10 +260,9 @@ TEST_F(TxnManagerTest, RollbackNotCommittedTxn) {
 // 1. txn could not be rollbacked if it is committed
 TEST_F(TxnManagerTest, RollbackCommittedTxn) {
     Status status = _txn_mgr->commit_txn(_meta, partition_id, transaction_id, tablet_id,
-                                         schema_hash, _tablet_uid, load_id, _rowset, false);
+                                         _tablet_uid, load_id, _rowset, false);
     EXPECT_TRUE(status == Status::OK());
-    status = _txn_mgr->rollback_txn(partition_id, transaction_id, tablet_id, schema_hash,
-                                    _tablet_uid);
+    status = _txn_mgr->rollback_txn(partition_id, transaction_id, tablet_id, _tablet_uid);
     EXPECT_FALSE(status == Status::OK());
     RowsetMetaSharedPtr rowset_meta(new RowsetMeta());
     status = RowsetMetaManager::get_rowset_meta(_meta, _tablet_uid, _rowset->rowset_id(),
@@ -278,12 +274,12 @@ TEST_F(TxnManagerTest, RollbackCommittedTxn) {
 // 1. publish version success
 TEST_F(TxnManagerTest, PublishVersionSuccessful) {
     Status status = _txn_mgr->commit_txn(_meta, partition_id, transaction_id, tablet_id,
-                                         schema_hash, _tablet_uid, load_id, _rowset, false);
+                                         _tablet_uid, load_id, _rowset, false);
     EXPECT_TRUE(status == Status::OK());
     Version new_version(10, 11);
     TabletPublishStatistics stats;
-    status = _txn_mgr->publish_txn(_meta, partition_id, transaction_id, tablet_id, schema_hash,
-                                   _tablet_uid, new_version, &stats);
+    status = _txn_mgr->publish_txn(_meta, partition_id, transaction_id, tablet_id, _tablet_uid,
+                                   new_version, &stats);
     EXPECT_TRUE(status == Status::OK());
 
     RowsetMetaSharedPtr rowset_meta(new RowsetMeta());
@@ -302,29 +298,27 @@ TEST_F(TxnManagerTest, PublishNotExistedTxn) {
     auto not_exist_txn = transaction_id + 1000;
     TabletPublishStatistics stats;
     Status status = _txn_mgr->publish_txn(_meta, partition_id, not_exist_txn, tablet_id,
-                                          schema_hash, _tablet_uid, new_version, &stats);
+                                          _tablet_uid, new_version, &stats);
     EXPECT_EQ(status, Status::OK());
 }
 
 TEST_F(TxnManagerTest, DeletePreparedTxn) {
-    Status status = _txn_mgr->prepare_txn(partition_id, transaction_id, tablet_id, schema_hash,
-                                          _tablet_uid, load_id);
+    Status status =
+            _txn_mgr->prepare_txn(partition_id, transaction_id, tablet_id, _tablet_uid, load_id);
     EXPECT_TRUE(status == Status::OK());
-    status = _txn_mgr->delete_txn(_meta, partition_id, transaction_id, tablet_id, schema_hash,
-                                  _tablet_uid);
+    status = _txn_mgr->delete_txn(_meta, partition_id, transaction_id, tablet_id, _tablet_uid);
     EXPECT_TRUE(status == Status::OK());
 }
 
 TEST_F(TxnManagerTest, DeleteCommittedTxn) {
     Status status = _txn_mgr->commit_txn(_meta, partition_id, transaction_id, tablet_id,
-                                         schema_hash, _tablet_uid, load_id, _rowset, false);
+                                         _tablet_uid, load_id, _rowset, false);
     EXPECT_TRUE(status == Status::OK());
     RowsetMetaSharedPtr rowset_meta(new RowsetMeta());
     status = RowsetMetaManager::get_rowset_meta(_meta, _tablet_uid, _rowset->rowset_id(),
                                                 rowset_meta);
     EXPECT_TRUE(status == Status::OK());
-    status = _txn_mgr->delete_txn(_meta, partition_id, transaction_id, tablet_id, schema_hash,
-                                  _tablet_uid);
+    status = _txn_mgr->delete_txn(_meta, partition_id, transaction_id, tablet_id, _tablet_uid);
     EXPECT_TRUE(status == Status::OK());
     RowsetMetaSharedPtr rowset_meta2(new RowsetMeta());
     status = RowsetMetaManager::get_rowset_meta(_meta, _tablet_uid, _rowset->rowset_id(),


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

Due to schema changes, the txn map may contain two sets of keys with the same txnid, namely tablet_id + schema_hash + tablet_uid. This can cause txn publish to be blocked. This PR removes the schema hash to resolve this issue.


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

