### PR TITLE
[improvement](column_reader) move load once to index reader to reduce

### DIFF
--- a/be/src/olap/rowset/segment_v2/bitmap_index_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/bitmap_index_reader.cpp
@@ -32,14 +32,16 @@
 namespace doris {
 namespace segment_v2 {
 
-Status BitmapIndexReader::load(bool use_page_cache, bool kept_in_memory, const BitmapIndexPB* index_meta) {
+Status BitmapIndexReader::load(bool use_page_cache, bool kept_in_memory,
+                               const BitmapIndexPB* index_meta) {
     // TODO yyq: implement a new once flag to avoid status construct.
     return _load_once.call([this, use_page_cache, kept_in_memory, index_meta] {
         return _load(use_page_cache, kept_in_memory, index_meta);
     });
 }
 
-Status BitmapIndexReader::_load(bool use_page_cache, bool kept_in_memory, const BitmapIndexPB* index_meta) {
+Status BitmapIndexReader::_load(bool use_page_cache, bool kept_in_memory,
+                                const BitmapIndexPB* index_meta) {
     const IndexedColumnMetaPB& dict_meta = index_meta->dict_column();
     const IndexedColumnMetaPB& bitmap_meta = index_meta->bitmap_column();
     _has_null = index_meta->has_null();

--- a/be/src/olap/rowset/segment_v2/bitmap_index_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/bitmap_index_reader.cpp
@@ -32,10 +32,17 @@
 namespace doris {
 namespace segment_v2 {
 
-Status BitmapIndexReader::load(bool use_page_cache, bool kept_in_memory) {
-    const IndexedColumnMetaPB& dict_meta = _bitmap_index_meta->dict_column();
-    const IndexedColumnMetaPB& bitmap_meta = _bitmap_index_meta->bitmap_column();
-    _has_null = _bitmap_index_meta->has_null();
+Status BitmapIndexReader::load(bool use_page_cache, bool kept_in_memory, const BitmapIndexPB* index_meta) {
+    // TODO yyq: implement a new once flag to avoid status construct.
+    return _load_once.call([this, use_page_cache, kept_in_memory, index_meta] {
+        return _load(use_page_cache, kept_in_memory, index_meta);
+    });
+}
+
+Status BitmapIndexReader::_load(bool use_page_cache, bool kept_in_memory, const BitmapIndexPB* index_meta) {
+    const IndexedColumnMetaPB& dict_meta = index_meta->dict_column();
+    const IndexedColumnMetaPB& bitmap_meta = index_meta->bitmap_column();
+    _has_null = index_meta->has_null();
 
     _dict_column_reader.reset(new IndexedColumnReader(_file_reader, dict_meta));
     _bitmap_column_reader.reset(new IndexedColumnReader(_file_reader, bitmap_meta));

--- a/be/src/olap/rowset/segment_v2/bitmap_index_reader.h
+++ b/be/src/olap/rowset/segment_v2/bitmap_index_reader.h
@@ -28,6 +28,7 @@
 #include "olap/rowset/segment_v2/common.h"
 #include "olap/rowset/segment_v2/indexed_column_reader.h"
 #include "olap/types.h"
+#include "util/once.h"
 
 namespace roaring {
 class Roaring;
@@ -45,10 +46,9 @@ public:
     explicit BitmapIndexReader(io::FileReaderSPtr file_reader,
                                const BitmapIndexPB* bitmap_index_meta)
             : _file_reader(std::move(file_reader)),
-              _type_info(get_scalar_type_info<FieldType::OLAP_FIELD_TYPE_VARCHAR>()),
-              _bitmap_index_meta(bitmap_index_meta) {}
+              _type_info(get_scalar_type_info<FieldType::OLAP_FIELD_TYPE_VARCHAR>()) {}
 
-    Status load(bool use_page_cache, bool kept_in_memory);
+    Status load(bool use_page_cache, bool kept_in_memory, const BitmapIndexPB*);
 
     // create a new column iterator. Client should delete returned iterator
     Status new_iterator(BitmapIndexIterator** iterator);
@@ -58,12 +58,15 @@ public:
     const TypeInfo* type_info() { return _type_info; }
 
 private:
+    Status _load(bool use_page_cache, bool kept_in_memory, const BitmapIndexPB*);
+
+private:
     friend class BitmapIndexIterator;
 
     io::FileReaderSPtr _file_reader;
     const TypeInfo* _type_info;
-    const BitmapIndexPB* _bitmap_index_meta;
     bool _has_null = false;
+    DorisCallOnce<Status> _load_once;
     std::unique_ptr<IndexedColumnReader> _dict_column_reader;
     std::unique_ptr<IndexedColumnReader> _bitmap_column_reader;
 };

--- a/be/src/olap/rowset/segment_v2/bitmap_index_reader.h
+++ b/be/src/olap/rowset/segment_v2/bitmap_index_reader.h
@@ -43,8 +43,7 @@ class BitmapIndexPB;
 
 class BitmapIndexReader {
 public:
-    explicit BitmapIndexReader(io::FileReaderSPtr file_reader,
-                               const BitmapIndexPB* bitmap_index_meta)
+    explicit BitmapIndexReader(io::FileReaderSPtr file_reader)
             : _file_reader(std::move(file_reader)),
               _type_info(get_scalar_type_info<FieldType::OLAP_FIELD_TYPE_VARCHAR>()) {}
 

--- a/be/src/olap/rowset/segment_v2/bloom_filter_index_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/bloom_filter_index_reader.cpp
@@ -31,6 +31,13 @@ namespace doris {
 namespace segment_v2 {
 
 Status BloomFilterIndexReader::load(bool use_page_cache, bool kept_in_memory) {
+    // TODO yyq: implement a new once flag to avoid status construct.
+    return _load_once.call([this, use_page_cache, kept_in_memory] {
+        return _load(use_page_cache, kept_in_memory);
+    });
+}
+
+Status BloomFilterIndexReader::_load(bool use_page_cache, bool kept_in_memory) {
     const IndexedColumnMetaPB& bf_index_meta = _bloom_filter_index_meta->bloom_filter();
 
     _bloom_filter_reader.reset(new IndexedColumnReader(_file_reader, bf_index_meta));

--- a/be/src/olap/rowset/segment_v2/bloom_filter_index_reader.h
+++ b/be/src/olap/rowset/segment_v2/bloom_filter_index_reader.h
@@ -28,6 +28,7 @@
 #include "olap/rowset/segment_v2/common.h"
 #include "olap/rowset/segment_v2/indexed_column_reader.h"
 #include "olap/types.h"
+#include "util/once.h"
 
 namespace doris {
 
@@ -53,9 +54,13 @@ public:
     const TypeInfo* type_info() const { return _type_info; }
 
 private:
+    Status _load(bool use_page_cache, bool kept_in_memory);
+
+private:
     friend class BloomFilterIndexIterator;
 
     io::FileReaderSPtr _file_reader;
+    DorisCallOnce<Status> _load_once;
     const TypeInfo* _type_info;
     const BloomFilterIndexPB* _bloom_filter_index_meta;
     std::unique_ptr<IndexedColumnReader> _bloom_filter_reader;

--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -207,8 +207,7 @@ Status ColumnReader::init(const ColumnMetaPB* meta) {
         switch (index_meta.type()) {
         case ORDINAL_INDEX:
             _ordinal_index_meta = &index_meta.ordinal_index();
-            _ordinal_index.reset(
-                    new OrdinalIndexReader(_file_reader, _num_rows));
+            _ordinal_index.reset(new OrdinalIndexReader(_file_reader, _num_rows));
             break;
         case ZONE_MAP_INDEX:
             _zone_map_index_meta = &index_meta.zone_map_index();

--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -208,15 +208,15 @@ Status ColumnReader::init(const ColumnMetaPB* meta) {
         case ORDINAL_INDEX:
             _ordinal_index_meta = &index_meta.ordinal_index();
             _ordinal_index.reset(
-                    new OrdinalIndexReader(_file_reader, _ordinal_index_meta, _num_rows));
+                    new OrdinalIndexReader(_file_reader, _num_rows));
             break;
         case ZONE_MAP_INDEX:
             _zone_map_index_meta = &index_meta.zone_map_index();
-            _zone_map_index.reset(new ZoneMapIndexReader(_file_reader, _zone_map_index_meta));
+            _zone_map_index.reset(new ZoneMapIndexReader(_file_reader));
             break;
         case BITMAP_INDEX:
             _bitmap_index_meta = &index_meta.bitmap_index();
-            _bitmap_index.reset(new BitmapIndexReader(_file_reader, _bitmap_index_meta));
+            _bitmap_index.reset(new BitmapIndexReader(_file_reader));
             break;
         case BLOOM_FILTER_INDEX:
             _bf_index_meta = &index_meta.bloom_filter_index();

--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -473,25 +473,19 @@ Status ColumnReader::get_row_ranges_by_bloom_filter(const AndBlockColumnPredicat
 
 Status ColumnReader::_load_ordinal_index(bool use_page_cache, bool kept_in_memory) {
     DCHECK(_ordinal_index_meta != nullptr);
-    return _load_ordinal_index_once.call([this, use_page_cache, kept_in_memory] {
-        return _ordinal_index->load(use_page_cache, kept_in_memory);
-    });
+    return _ordinal_index->load(use_page_cache, kept_in_memory, _ordinal_index_meta);
 }
 
 Status ColumnReader::_load_zone_map_index(bool use_page_cache, bool kept_in_memory) {
     if (_zone_map_index_meta != nullptr) {
-        return _load_zone_map_index_once.call([this, use_page_cache, kept_in_memory] {
-            return _zone_map_index->load(use_page_cache, kept_in_memory);
-        });
+        return _zone_map_index->load(use_page_cache, kept_in_memory, _zone_map_index_meta);
     }
     return Status::OK();
 }
 
 Status ColumnReader::_load_bitmap_index(bool use_page_cache, bool kept_in_memory) {
     if (_bitmap_index_meta != nullptr) {
-        return _load_bitmap_index_once.call([this, use_page_cache, kept_in_memory] {
-            return _bitmap_index->load(use_page_cache, kept_in_memory);
-        });
+        return _bitmap_index->load(use_page_cache, kept_in_memory, _bitmap_index_meta);
     }
     return Status::OK();
 }
@@ -534,9 +528,7 @@ Status ColumnReader::_load_inverted_index_index(const TabletIndex* index_meta) {
 
 Status ColumnReader::_load_bloom_filter_index(bool use_page_cache, bool kept_in_memory) {
     if (_bf_index_meta != nullptr) {
-        return _load_bloom_filter_index_once.call([this, use_page_cache, kept_in_memory] {
-            return _bloom_filter_index->load(use_page_cache, kept_in_memory);
-        });
+        return _bloom_filter_index->load(use_page_cache, kept_in_memory);
     }
     return Status::OK();
 }

--- a/be/src/olap/rowset/segment_v2/column_reader.h
+++ b/be/src/olap/rowset/segment_v2/column_reader.h
@@ -253,15 +253,9 @@ private:
     std::unique_ptr<BitmapIndexReader> _bitmap_index;
     std::shared_ptr<InvertedIndexReader> _inverted_index;
     std::unique_ptr<BloomFilterIndexReader> _bloom_filter_index;
-    DorisCallOnce<Status> _load_zone_map_index_once;
-    DorisCallOnce<Status> _load_ordinal_index_once;
-    DorisCallOnce<Status> _load_bitmap_index_once;
-    DorisCallOnce<Status> _load_bloom_filter_index_once;
-    DorisCallOnce<Status> _load_inverted_index_once;
 
     std::vector<std::unique_ptr<ColumnReader>> _sub_readers;
 
-    std::once_flag _set_dict_encoding_type_flag;
     DorisCallOnce<Status> _set_dict_encoding_type_once;
 };
 

--- a/be/src/olap/rowset/segment_v2/ordinal_page_index.cpp
+++ b/be/src/olap/rowset/segment_v2/ordinal_page_index.cpp
@@ -67,19 +67,26 @@ Status OrdinalIndexWriter::finish(io::FileWriter* file_writer, ColumnIndexMetaPB
     return Status::OK();
 }
 
-Status OrdinalIndexReader::load(bool use_page_cache, bool kept_in_memory) {
-    if (_index_meta->root_page().is_root_data_page()) {
+Status OrdinalIndexReader::load(bool use_page_cache, bool kept_in_memory, const OrdinalIndexPB* index_meta) {
+    // TODO yyq: implement a new once flag to avoid status construct.
+    return _load_once.call([this, use_page_cache, kept_in_memory, index_meta] {
+        return _load(use_page_cache, kept_in_memory, index_meta);
+    });
+}
+
+Status OrdinalIndexReader::_load(bool use_page_cache, bool kept_in_memory, const OrdinalIndexPB* index_meta) {
+    if (index_meta->root_page().is_root_data_page()) {
         // only one data page, no index page
         _num_pages = 1;
         _ordinals.push_back(0);
         _ordinals.push_back(_num_values);
-        _pages.emplace_back(_index_meta->root_page().root_page());
+        _pages.emplace_back(index_meta->root_page().root_page());
         return Status::OK();
     }
     // need to read index page
     PageReadOptions opts;
     opts.file_reader = _file_reader.get();
-    opts.page_pointer = PagePointer(_index_meta->root_page().root_page());
+    opts.page_pointer = PagePointer(index_meta->root_page().root_page());
     opts.codec = nullptr; // ordinal index page uses NO_COMPRESSION right now
     OlapReaderStatistics tmp_stats;
     opts.stats = &tmp_stats;

--- a/be/src/olap/rowset/segment_v2/ordinal_page_index.cpp
+++ b/be/src/olap/rowset/segment_v2/ordinal_page_index.cpp
@@ -67,14 +67,16 @@ Status OrdinalIndexWriter::finish(io::FileWriter* file_writer, ColumnIndexMetaPB
     return Status::OK();
 }
 
-Status OrdinalIndexReader::load(bool use_page_cache, bool kept_in_memory, const OrdinalIndexPB* index_meta) {
+Status OrdinalIndexReader::load(bool use_page_cache, bool kept_in_memory,
+                                const OrdinalIndexPB* index_meta) {
     // TODO yyq: implement a new once flag to avoid status construct.
     return _load_once.call([this, use_page_cache, kept_in_memory, index_meta] {
         return _load(use_page_cache, kept_in_memory, index_meta);
     });
 }
 
-Status OrdinalIndexReader::_load(bool use_page_cache, bool kept_in_memory, const OrdinalIndexPB* index_meta) {
+Status OrdinalIndexReader::_load(bool use_page_cache, bool kept_in_memory,
+                                 const OrdinalIndexPB* index_meta) {
     if (index_meta->root_page().is_root_data_page()) {
         // only one data page, no index page
         _num_pages = 1;

--- a/be/src/olap/rowset/segment_v2/ordinal_page_index.h
+++ b/be/src/olap/rowset/segment_v2/ordinal_page_index.h
@@ -68,8 +68,7 @@ class OrdinalIndexReader {
 public:
     explicit OrdinalIndexReader(io::FileReaderSPtr file_reader, const OrdinalIndexPB* index_meta,
                                 ordinal_t num_values)
-            : _file_reader(std::move(file_reader)),
-              _num_values(num_values) {}
+            : _file_reader(std::move(file_reader)), _num_values(num_values) {}
 
     // load and parse the index page into memory
     Status load(bool use_page_cache, bool kept_in_memory, const OrdinalIndexPB* index_meta);

--- a/be/src/olap/rowset/segment_v2/ordinal_page_index.h
+++ b/be/src/olap/rowset/segment_v2/ordinal_page_index.h
@@ -66,8 +66,7 @@ class OrdinalPageIndexIterator;
 
 class OrdinalIndexReader {
 public:
-    explicit OrdinalIndexReader(io::FileReaderSPtr file_reader, const OrdinalIndexPB* index_meta,
-                                ordinal_t num_values)
+    explicit OrdinalIndexReader(io::FileReaderSPtr file_reader, ordinal_t num_values)
             : _file_reader(std::move(file_reader)), _num_values(num_values) {}
 
     // load and parse the index page into memory

--- a/be/src/olap/rowset/segment_v2/ordinal_page_index.h
+++ b/be/src/olap/rowset/segment_v2/ordinal_page_index.h
@@ -30,6 +30,7 @@
 #include "olap/rowset/segment_v2/common.h"
 #include "olap/rowset/segment_v2/index_page.h"
 #include "olap/rowset/segment_v2/page_pointer.h"
+#include "util/once.h"
 
 namespace doris {
 
@@ -68,11 +69,10 @@ public:
     explicit OrdinalIndexReader(io::FileReaderSPtr file_reader, const OrdinalIndexPB* index_meta,
                                 ordinal_t num_values)
             : _file_reader(std::move(file_reader)),
-              _index_meta(index_meta),
               _num_values(num_values) {}
 
     // load and parse the index page into memory
-    Status load(bool use_page_cache, bool kept_in_memory);
+    Status load(bool use_page_cache, bool kept_in_memory, const OrdinalIndexPB* index_meta);
 
     // the returned iter points to the largest element which is less than `ordinal`,
     // or points to the first element if all elements are greater than `ordinal`,
@@ -90,10 +90,14 @@ public:
     int32_t num_data_pages() const { return _num_pages; }
 
 private:
+    Status _load(bool use_page_cache, bool kept_in_memory, const OrdinalIndexPB* index_meta);
+
+private:
     friend OrdinalPageIndexIterator;
 
     io::FileReaderSPtr _file_reader;
-    const OrdinalIndexPB* _index_meta;
+    DorisCallOnce<Status> _load_once;
+
     // total number of values (including NULLs) in the indexed column,
     // equals to 1 + 'last ordinal of last data pages'
     ordinal_t _num_values;

--- a/be/src/olap/rowset/segment_v2/zone_map_index.cpp
+++ b/be/src/olap/rowset/segment_v2/zone_map_index.cpp
@@ -145,8 +145,15 @@ Status TypedZoneMapIndexWriter<Type>::finish(io::FileWriter* file_writer,
     return writer.finish(meta->mutable_page_zone_maps());
 }
 
-Status ZoneMapIndexReader::load(bool use_page_cache, bool kept_in_memory) {
-    IndexedColumnReader reader(_file_reader, _index_meta->page_zone_maps());
+Status ZoneMapIndexReader::load(bool use_page_cache, bool kept_in_memory, const ZoneMapIndexPB* index_meta) {
+    // TODO yyq: implement a new once flag to avoid status construct.
+    return _load_once.call([this, use_page_cache, kept_in_memory, index_meta] {
+        return _load(use_page_cache, kept_in_memory, index_meta);
+    });
+}
+
+Status ZoneMapIndexReader::_load(bool use_page_cache, bool kept_in_memory, const ZoneMapIndexPB* index_meta) {
+    IndexedColumnReader reader(_file_reader, index_meta->page_zone_maps());
     RETURN_IF_ERROR(reader.load(use_page_cache, kept_in_memory));
     IndexedColumnIterator iter(&reader);
 

--- a/be/src/olap/rowset/segment_v2/zone_map_index.cpp
+++ b/be/src/olap/rowset/segment_v2/zone_map_index.cpp
@@ -145,14 +145,16 @@ Status TypedZoneMapIndexWriter<Type>::finish(io::FileWriter* file_writer,
     return writer.finish(meta->mutable_page_zone_maps());
 }
 
-Status ZoneMapIndexReader::load(bool use_page_cache, bool kept_in_memory, const ZoneMapIndexPB* index_meta) {
+Status ZoneMapIndexReader::load(bool use_page_cache, bool kept_in_memory,
+                                const ZoneMapIndexPB* index_meta) {
     // TODO yyq: implement a new once flag to avoid status construct.
     return _load_once.call([this, use_page_cache, kept_in_memory, index_meta] {
         return _load(use_page_cache, kept_in_memory, index_meta);
     });
 }
 
-Status ZoneMapIndexReader::_load(bool use_page_cache, bool kept_in_memory, const ZoneMapIndexPB* index_meta) {
+Status ZoneMapIndexReader::_load(bool use_page_cache, bool kept_in_memory,
+                                 const ZoneMapIndexPB* index_meta) {
     IndexedColumnReader reader(_file_reader, index_meta->page_zone_maps());
     RETURN_IF_ERROR(reader.load(use_page_cache, kept_in_memory));
     IndexedColumnIterator iter(&reader);

--- a/be/src/olap/rowset/segment_v2/zone_map_index.h
+++ b/be/src/olap/rowset/segment_v2/zone_map_index.h
@@ -30,6 +30,7 @@
 #include "io/fs/file_reader_writer_fwd.h"
 #include "olap/field.h"
 #include "runtime/define_primitive_type.h"
+#include "util/once.h"
 #include "vec/common/arena.h"
 
 namespace doris {
@@ -147,19 +148,23 @@ private:
 class ZoneMapIndexReader {
 public:
     explicit ZoneMapIndexReader(io::FileReaderSPtr file_reader, const ZoneMapIndexPB* index_meta)
-            : _file_reader(std::move(file_reader)), _index_meta(index_meta) {}
+            : _file_reader(std::move(file_reader)) {}
 
     // load all page zone maps into memory
-    Status load(bool use_page_cache, bool kept_in_memory);
+    Status load(bool use_page_cache, bool kept_in_memory, const ZoneMapIndexPB*);
 
     const std::vector<ZoneMapPB>& page_zone_maps() const { return _page_zone_maps; }
 
     int32_t num_pages() const { return _page_zone_maps.size(); }
 
 private:
-    io::FileReaderSPtr _file_reader;
-    const ZoneMapIndexPB* _index_meta;
+    Status _load(bool use_page_cache, bool kept_in_memory, const ZoneMapIndexPB*);
 
+private:
+
+    DorisCallOnce<Status> _load_once;
+    // TODO: yyq, we shoud remove file_reader from here.
+    io::FileReaderSPtr _file_reader;
     std::vector<ZoneMapPB> _page_zone_maps;
 };
 

--- a/be/src/olap/rowset/segment_v2/zone_map_index.h
+++ b/be/src/olap/rowset/segment_v2/zone_map_index.h
@@ -161,7 +161,6 @@ private:
     Status _load(bool use_page_cache, bool kept_in_memory, const ZoneMapIndexPB*);
 
 private:
-
     DorisCallOnce<Status> _load_once;
     // TODO: yyq, we shoud remove file_reader from here.
     io::FileReaderSPtr _file_reader;

--- a/be/src/olap/rowset/segment_v2/zone_map_index.h
+++ b/be/src/olap/rowset/segment_v2/zone_map_index.h
@@ -147,7 +147,7 @@ private:
 
 class ZoneMapIndexReader {
 public:
-    explicit ZoneMapIndexReader(io::FileReaderSPtr file_reader, const ZoneMapIndexPB* index_meta)
+    explicit ZoneMapIndexReader(io::FileReaderSPtr file_reader)
             : _file_reader(std::move(file_reader)) {}
 
     // load all page zone maps into memory

--- a/be/test/olap/rowset/segment_v2/bitmap_index_test.cpp
+++ b/be/test/olap/rowset/segment_v2/bitmap_index_test.cpp
@@ -80,8 +80,8 @@ void get_bitmap_reader_iter(const std::string& file_name, const ColumnIndexMetaP
                             BitmapIndexReader** reader, BitmapIndexIterator** iter) {
     io::FileReaderSPtr file_reader;
     ASSERT_EQ(io::global_local_filesystem()->open_file(file_name, &file_reader), Status::OK());
-    *reader = new BitmapIndexReader(std::move(file_reader), &meta.bitmap_index());
-    auto st = (*reader)->load(true, false);
+    *reader = new BitmapIndexReader(std::move(file_reader));
+    auto st = (*reader)->load(true, false, &meta.bitmap_index());
     EXPECT_TRUE(st.ok());
 
     st = (*reader)->new_iterator(iter);

--- a/be/test/olap/rowset/segment_v2/ordinal_page_index_test.cpp
+++ b/be/test/olap/rowset/segment_v2/ordinal_page_index_test.cpp
@@ -70,8 +70,8 @@ TEST_F(OrdinalPageIndexTest, normal) {
 
     io::FileReaderSPtr file_reader;
     EXPECT_TRUE(fs->open_file(filename, &file_reader).ok());
-    OrdinalIndexReader index(file_reader, &index_meta.ordinal_index(), 16 * 1024 * 4096 + 1);
-    EXPECT_TRUE(index.load(true, false).ok());
+    OrdinalIndexReader index(file_reader, 16 * 1024 * 4096 + 1);
+    EXPECT_TRUE(index.load(true, false, &index_meta.ordinal_index()).ok());
     EXPECT_EQ(16 * 1024, index.num_data_pages());
     EXPECT_EQ(1, index.get_first_ordinal(0));
     EXPECT_EQ(4096, index.get_last_ordinal(0));
@@ -124,8 +124,8 @@ TEST_F(OrdinalPageIndexTest, one_data_page) {
         EXPECT_EQ(data_page_pointer, root_page_pointer);
     }
 
-    OrdinalIndexReader index(nullptr, &index_meta.ordinal_index(), num_values);
-    EXPECT_TRUE(index.load(true, false).ok());
+    OrdinalIndexReader index(nullptr, num_values);
+    EXPECT_TRUE(index.load(true, false, &index_meta.ordinal_index()).ok());
     EXPECT_EQ(1, index.num_data_pages());
     EXPECT_EQ(0, index.get_first_ordinal(0));
     EXPECT_EQ(num_values - 1, index.get_last_ordinal(0));

--- a/be/test/olap/rowset/segment_v2/zone_map_index_test.cpp
+++ b/be/test/olap/rowset/segment_v2/zone_map_index_test.cpp
@@ -81,8 +81,8 @@ public:
 
         io::FileReaderSPtr file_reader;
         EXPECT_TRUE(fs->open_file(filename, &file_reader).ok());
-        ZoneMapIndexReader column_zone_map(file_reader, &index_meta.zone_map_index());
-        Status status = column_zone_map.load(true, false);
+        ZoneMapIndexReader column_zone_map(file_reader);
+        Status status = column_zone_map.load(true, false, &index_meta.zone_map_index());
         EXPECT_TRUE(status.ok());
         EXPECT_EQ(3, column_zone_map.num_pages());
         const std::vector<ZoneMapPB>& zone_maps = column_zone_map.page_zone_maps();
@@ -128,8 +128,8 @@ public:
 
         io::FileReaderSPtr file_reader;
         EXPECT_TRUE(fs->open_file(filename, &file_reader).ok());
-        ZoneMapIndexReader column_zone_map(file_reader, &index_meta.zone_map_index());
-        Status status = column_zone_map.load(true, false);
+        ZoneMapIndexReader column_zone_map(file_reader);
+        Status status = column_zone_map.load(true, false, &index_meta.zone_map_index());
         EXPECT_TRUE(status.ok());
         EXPECT_EQ(1, column_zone_map.num_pages());
         const std::vector<ZoneMapPB>& zone_maps = column_zone_map.page_zone_maps();
@@ -181,8 +181,8 @@ TEST_F(ColumnZoneMapTest, NormalTestIntPage) {
 
     io::FileReaderSPtr file_reader;
     EXPECT_TRUE(fs->open_file(filename, &file_reader).ok());
-    ZoneMapIndexReader column_zone_map(file_reader, &index_meta.zone_map_index());
-    Status status = column_zone_map.load(true, false);
+    ZoneMapIndexReader column_zone_map(file_reader);
+    Status status = column_zone_map.load(true, false, &index_meta.zone_map_index());
     EXPECT_TRUE(status.ok());
     EXPECT_EQ(3, column_zone_map.num_pages());
     const std::vector<ZoneMapPB>& zone_maps = column_zone_map.page_zone_maps();


### PR DESCRIPTION
memory footprint of column reader

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

