### PR TITLE
[feature](cache) 2q LRU cache

### DIFF
--- a/be/src/olap/lru_cache.cpp
+++ b/be/src/olap/lru_cache.cpp
@@ -672,6 +672,7 @@ Cache* new_lru_cache(const std::string& name, size_t capacity, LRUCacheType type
 }
 
 void TwoQueueLRUCache::_evict_from_lru(size_t total_size, LRUHandle** to_remove_head) {
+    // TODO(tsy): try to encapsule public logic
     for (size_t total_usage = _usage + total_size; total_usage > _capacity;
          total_usage = _usage + total_size) {
         if (_in_size > _kin && _recent_queue_normal.next != &_recent_queue_normal) {
@@ -701,7 +702,7 @@ void TwoQueueLRUCache::_evict_from_lru(size_t total_size, LRUHandle** to_remove_
         if (_in_size > _kin && _recent_queue_normal.next != &_recent_queue_normal) {
             // evict from a1in and record to a1out
             LRUHandle* old = _recent_queue_durable.next;
-            DCHECK(old->priority == CachePriority::NORMAL);
+            DCHECK(old->priority == CachePriority::DURABLE);
             _evict_one_entry(old);
             old->next = *to_remove_head;
             *to_remove_head = old;
@@ -709,7 +710,7 @@ void TwoQueueLRUCache::_evict_from_lru(size_t total_size, LRUHandle** to_remove_
         } else if (_am_size > _km && _lru_normal.next != &_lru_normal) {
             // evict from am
             LRUHandle* old = _lru_durable.next;
-            DCHECK(old->priority == CachePriority::NORMAL);
+            DCHECK(old->priority == CachePriority::DURABLE);
             _evict_one_entry(old);
             old->next = *to_remove_head;
             *to_remove_head = old;

--- a/be/src/olap/lru_cache.h
+++ b/be/src/olap/lru_cache.h
@@ -450,6 +450,12 @@ private:
     std::unique_ptr<bvar::PerSecond<bvar::Adder<uint64_t>>> _lookup_count_per_second;
 };
 
+enum class QueueType { AM, A1In, A1Out };
+
+struct TwoQueueLRUHandle : LRUHandle {
+    QueueType queue_type;
+};
+
 /// refer to https://www.vldb.org/conf/1994/P439.PDF
 class TwoQueueLRUCache : LRUCache {
 public:
@@ -468,6 +474,7 @@ protected:
     // TODO(tsy): mod interface name
     void _evict_from_lru(size_t total_size, LRUHandle** to_remove_head) override;
     void _evict_one_entry(LRUHandle* e) override;
+
 private:
     /// note: the `A1out` in paper consists from history_table and history_queue
     HandleTable _history_table;

--- a/be/src/olap/lru_cache.h
+++ b/be/src/olap/lru_cache.h
@@ -13,6 +13,7 @@
 #include <string.h>
 
 #include <atomic>
+#include <cstddef>
 #include <functional>
 #include <memory>
 #include <set>
@@ -327,7 +328,7 @@ using LRUHandleSortedSet = std::set<std::pair<int64_t, LRUHandle*>>;
 class LRUCache {
 public:
     LRUCache(LRUCacheType type);
-    ~LRUCache();
+    virtual ~LRUCache();
 
     // Separate from constructor so caller can easily make an array of LRUCache
     void set_capacity(size_t capacity) { _capacity = capacity; }
@@ -336,15 +337,16 @@ public:
     }
 
     // Like Cache methods, but with an extra "hash" parameter.
-    Cache::Handle* insert(const CacheKey& key, uint32_t hash, void* value, size_t charge,
-                          void (*deleter)(const CacheKey& key, void* value),
-                          MemTrackerLimiter* tracker,
-                          CachePriority priority = CachePriority::NORMAL, size_t bytes = -1);
-    Cache::Handle* lookup(const CacheKey& key, uint32_t hash);
-    void release(Cache::Handle* handle);
-    void erase(const CacheKey& key, uint32_t hash);
-    int64_t prune();
-    int64_t prune_if(CacheValuePredicate pred, bool lazy_mode = false);
+    virtual Cache::Handle* insert(const CacheKey& key, uint32_t hash, void* value, size_t charge,
+                                  void (*deleter)(const CacheKey& key, void* value),
+                                  MemTrackerLimiter* tracker,
+                                  CachePriority priority = CachePriority::NORMAL,
+                                  size_t bytes = -1);
+    virtual Cache::Handle* lookup(const CacheKey& key, uint32_t hash);
+    virtual void release(Cache::Handle* handle);
+    virtual void erase(const CacheKey& key, uint32_t hash);
+    virtual int64_t prune();
+    virtual int64_t prune_if(CacheValuePredicate pred, bool lazy_mode = false);
 
     void set_cache_value_time_extractor(CacheValueTimeExtractor cache_value_time_extractor);
     void set_cache_value_check_timestamp(bool cache_value_check_timestamp);
@@ -354,16 +356,15 @@ public:
     [[nodiscard]] size_t get_usage() const { return _usage; }
     [[nodiscard]] size_t get_capacity() const { return _capacity; }
 
-private:
+protected:
     void _lru_remove(LRUHandle* e);
     void _lru_append(LRUHandle* list, LRUHandle* e);
     bool _unref(LRUHandle* e);
-    void _evict_from_lru(size_t total_size, LRUHandle** to_remove_head);
+    virtual void _evict_from_lru(size_t total_size, LRUHandle** to_remove_head);
     void _evict_from_lru_with_time(size_t total_size, LRUHandle** to_remove_head);
-    void _evict_one_entry(LRUHandle* e);
+    virtual void _evict_one_entry(LRUHandle* e);
     bool _check_element_count_limit();
 
-private:
     LRUCacheType _type;
 
     // Initialized before use.
@@ -402,18 +403,17 @@ public:
                              CacheValueTimeExtractor cache_value_time_extractor,
                              bool cache_value_check_timestamp, uint32_t element_count_capacity = 0);
     // TODO(fdy): 析构时清除所有cache元素
-     ~ShardedLRUCache() override;
+    ~ShardedLRUCache() override;
     Handle* insert(const CacheKey& key, void* value, size_t charge,
-                           void (*deleter)(const CacheKey& key, void* value),
-                           CachePriority priority = CachePriority::NORMAL,
-                           size_t bytes = -1) override;
-     Handle* lookup(const CacheKey& key) override;
-     void release(Handle* handle) override;
-     void erase(const CacheKey& key) override;
-     void* value(Handle* handle) override;
+                   void (*deleter)(const CacheKey& key, void* value),
+                   CachePriority priority = CachePriority::NORMAL, size_t bytes = -1) override;
+    Handle* lookup(const CacheKey& key) override;
+    void release(Handle* handle) override;
+    void erase(const CacheKey& key) override;
+    void* value(Handle* handle) override;
     Slice value_slice(Handle* handle) override;
-     uint64_t new_id() override;
-     int64_t prune() override;
+    uint64_t new_id() override;
+    int64_t prune() override;
     int64_t prune_if(CacheValuePredicate pred, bool lazy_mode = false) override;
     int64_t mem_consumption() override;
     int64_t get_usage() override;
@@ -450,8 +450,42 @@ private:
     std::unique_ptr<bvar::PerSecond<bvar::Adder<uint64_t>>> _lookup_count_per_second;
 };
 
-class TwoQueueLRUCache {
+/// refer to https://www.vldb.org/conf/1994/P439.PDF
+class TwoQueueLRUCache : LRUCache {
+public:
+    Cache::Handle* insert(const CacheKey& key, uint32_t hash, void* value, size_t charge,
+                          void (*deleter)(const CacheKey& key, void* value),
+                          MemTrackerLimiter* tracker,
+                          CachePriority priority = CachePriority::NORMAL,
+                          size_t bytes = -1) override;
+    Cache::Handle* lookup(const CacheKey& key, uint32_t hash) override;
+    void release(Cache::Handle* handle) override;
+    void erase(const CacheKey& key, uint32_t hash) override;
+    int64_t prune() override;
+    int64_t prune_if(CacheValuePredicate pred, bool lazy_mode = false) override;
+
+protected:
+    // TODO(tsy): mod interface name
+    void _evict_from_lru(size_t total_size, LRUHandle** to_remove_head) override;
+    void _evict_one_entry(LRUHandle* e) override;
 private:
+    /// note: the `A1out` in paper consists from history_table and history_queue
+    HandleTable _history_table;
+    LRUHandle _history_normal;
+    LRUHandle _history_durable;
+
+    // the `A1in` in paper
+    LRUHandle _recent_queue_normal;
+    LRUHandle _recent_queue_durable;
+
+    // size limit
+    size_t _kin;
+    size_t _kout;
+    size_t _km;
+    // real size
+    size_t _in_size;
+    size_t _out_size;
+    size_t _am_size;
 };
 
 } // namespace doris

--- a/be/src/olap/page_cache.h
+++ b/be/src/olap/page_cache.h
@@ -92,7 +92,7 @@ public:
         int64_t offset;
 
         // Encode to a flat binary which can be used as LRUCache's key
-        std::string encode() const {
+        [[nodiscard]] std::string encode() const {
             std::string key_buf(fname);
             key_buf.append((char*)&fsize, sizeof(fsize));
             key_buf.append((char*)&offset, sizeof(offset));
@@ -205,7 +205,7 @@ private:
 // class will release the cache entry when it is destroyed.
 class PageCacheHandle {
 public:
-    PageCacheHandle() {}
+    PageCacheHandle() = default;
     PageCacheHandle(Cache* cache, Cache::Handle* handle) : _cache(cache), _handle(handle) {}
     ~PageCacheHandle() {
         if (_handle != nullptr) {
@@ -225,8 +225,8 @@ public:
         return *this;
     }
 
-    Cache* cache() const { return _cache; }
-    Slice data() const {
+    [[nodiscard]] Cache* cache() const { return _cache; }
+    [[nodiscard]] Slice data() const {
         DataPage* cache_value = (DataPage*)_cache->value(_handle);
         return Slice(cache_value->data(), cache_value->size());
     }

--- a/be/src/olap/rowset/segment_v2/page_handle.h
+++ b/be/src/olap/rowset/segment_v2/page_handle.h
@@ -72,7 +72,7 @@ public:
     }
 
     // the return slice contains uncompressed page body, page footer, and footer size
-    Slice data() const {
+    [[nodiscard]] Slice data() const {
         if (_is_data_owner) {
             return Slice(_data->data(), _data->size());
         } else {

--- a/be/src/olap/rowset/segment_v2/page_io.cpp
+++ b/be/src/olap/rowset/segment_v2/page_io.cpp
@@ -44,8 +44,6 @@
 namespace doris {
 namespace segment_v2 {
 
-using strings::Substitute;
-
 Status PageIO::compress_page_body(BlockCompressionCodec* codec, double min_space_saving,
                                   const std::vector<Slice>& body, OwnedSlice* compressed_body) {
     size_t uncompressed_size = Slice::compute_total_size(body);


### PR DESCRIPTION
## Proposed changes

This PR aims to support 2q LRU cache, which is more adaptive to the query scenario, that big query should not phase out the hot data in cache.

The implementation is based on the [paper](https://www.vldb.org/conf/1994/P439.PDF) of 2q LRU algorithm.

Keypoints: 
1. 2q LRU cache, with the same interface of the original LRU cache. To be different, our A1out will simply record the key, because data pointer has been stored in meta and used during page IO. Therefore, data recorded in A1out will shared the reading path of non-cached data, but insert to Am queue. 
2. 2q LRU policy for page cache memory management. Page cache now implements LRU policy to process GC during.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

