### PR TITLE
[optimize](Nereids): speedup analyze

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/PlanContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/PlanContext.java
@@ -22,7 +22,6 @@ import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.statistics.Statistics;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -33,7 +32,7 @@ import java.util.List;
  */
 public class PlanContext {
 
-    private List<Statistics> childrenStats = new ArrayList<>();
+    private final List<Statistics> childrenStats;
     private Statistics planStats;
     private final int arity;
     private boolean isBroadcastJoin = false;
@@ -43,19 +42,16 @@ public class PlanContext {
      */
     public PlanContext(GroupExpression groupExpression) {
         this.arity = groupExpression.arity();
-        if (groupExpression.getOwnerGroup() == null) {
-            return;
-        }
-        planStats = groupExpression.getOwnerGroup().getStatistics();
-        childrenStats = new ArrayList<>(groupExpression.arity());
+        this.planStats = groupExpression.getOwnerGroup().getStatistics();
+        this.childrenStats = new ArrayList<>(groupExpression.arity());
         for (int i = 0; i < groupExpression.arity(); i++) {
             childrenStats.add(groupExpression.childStatistics(i));
         }
     }
 
-    public PlanContext(Statistics planStats, Statistics... childrenStats) {
+    public PlanContext(Statistics planStats, List<Statistics> childrenStats) {
         this.planStats = planStats;
-        this.childrenStats = Arrays.asList(childrenStats);
+        this.childrenStats = childrenStats;
         this.arity = this.childrenStats.size();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
@@ -149,14 +149,14 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
         // TODO: consider two-phase sort and enforcer.
         Statistics statistics = context.getStatisticsWithCheck();
         Statistics childStatistics = context.getChildStatistics(0);
+
+        double childRowCount = childStatistics.getRowCount();
+        double rowCount = statistics.getRowCount();
         if (physicalQuickSort.getSortPhase().isGather()) {
             // Now we do more like two-phase sort, so penalise one-phase sort
-            statistics = statistics.withRowCount(statistics.getRowCount() * 100);
+            rowCount *= 100;
         }
-        return CostV1.of(
-                childStatistics.getRowCount(),
-                statistics.getRowCount(),
-                childStatistics.getRowCount());
+        return CostV1.of(childRowCount, rowCount, childRowCount);
     }
 
     @Override
@@ -164,14 +164,14 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
         // TODO: consider two-phase sort and enforcer.
         Statistics statistics = context.getStatisticsWithCheck();
         Statistics childStatistics = context.getChildStatistics(0);
+
+        double childRowCount = childStatistics.getRowCount();
+        double rowCount = statistics.getRowCount();
         if (topN.getSortPhase().isGather()) {
             // Now we do more like two-phase sort, so penalise one-phase sort
-            statistics = statistics.withRowCount(statistics.getRowCount() * 100);
+            rowCount *= 100;
         }
-        return CostV1.of(
-                childStatistics.getRowCount(),
-                statistics.getRowCount(),
-                childStatistics.getRowCount());
+        return CostV1.of(childRowCount, rowCount, childRowCount);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/GraphSimplifier.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/GraphSimplifier.java
@@ -31,6 +31,7 @@ import org.apache.doris.nereids.util.JoinUtils;
 import org.apache.doris.statistics.Statistics;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -432,7 +433,7 @@ public class GraphSimplifier {
     private Cost calCost(Edge edge, Statistics stats,
             Statistics leftStats, Statistics rightStats) {
         LogicalJoin join = edge.getJoin();
-        PlanContext planContext = new PlanContext(stats, leftStats, rightStats);
+        PlanContext planContext = new PlanContext(stats, ImmutableList.of(leftStats, rightStats));
         Cost cost;
         if (JoinUtils.shouldNestedLoopJoin(join)) {
             PhysicalNestedLoopJoin nestedLoopJoin = new PhysicalNestedLoopJoin<>(

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindExpression.java
@@ -613,7 +613,7 @@ public class BindExpression implements AnalysisRuleFactory {
 
     private <E extends Expression> List<E> bindSlot(
             List<E> exprList, List<Plan> inputs, CascadesContext cascadesContext) {
-        List<E> slots = new ArrayList<>();
+        List<E> slots = new ArrayList<>(exprList.size());
         for (E expr : exprList) {
             E result = bindSlot(expr, inputs, cascadesContext);
             slots.add(result);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
@@ -31,6 +31,7 @@ import org.apache.doris.nereids.types.ArrayType;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.MapType;
 import org.apache.doris.nereids.types.StructType;
+import org.apache.doris.nereids.types.coercion.AnyDataType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -105,6 +106,10 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
     }
 
     private boolean checkPrimitiveInputDataTypesWithExpectType(DataType input, DataType expected) {
+        // These type will throw exception when invoke toCatalogDataType()
+        if (expected instanceof AnyDataType) {
+            return expected.acceptsType(input);
+        }
         // TODO: complete the cast logic like FunctionCallExpr.analyzeImpl
         boolean legacyCastCompatible = false;
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/DefaultExpressionRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/DefaultExpressionRewriter.java
@@ -35,7 +35,7 @@ public abstract class DefaultExpressionRewriter<C> extends ExpressionVisitor<Exp
 
     /** rewrite */
     public static final <C> Expression rewrite(ExpressionVisitor<Expression, C> rewriter, Expression expr, C context) {
-        List<Expression> newChildren = new ArrayList<>();
+        List<Expression> newChildren = new ArrayList<>(expr.arity());
         boolean hasNewChildren = false;
         for (Expression child : expr.children()) {
             Expression newChild = child.accept(rewriter, context);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriverTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriverTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.properties;
 import org.apache.doris.catalog.ColocateTableIndex;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Pair;
+import org.apache.doris.nereids.memo.Group;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.DistributionSpecHash.ShuffleType;
 import org.apache.doris.nereids.trees.expressions.AssertNumRowsElement;
@@ -67,8 +68,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-@SuppressWarnings("unused")
-public class ChildOutputPropertyDeriverTest {
+class ChildOutputPropertyDeriverTest {
 
     @Mocked
     GroupPlan groupPlan;
@@ -97,11 +97,12 @@ public class ChildOutputPropertyDeriverTest {
     }
 
     @Test
-    public void testInnerJoin() {
+    void testInnerJoin() {
         PhysicalHashJoin<GroupPlan, GroupPlan> join = new PhysicalHashJoin<>(JoinType.INNER_JOIN,
                 ExpressionUtils.EMPTY_CONDITION, ExpressionUtils.EMPTY_CONDITION, JoinHint.NONE, Optional.empty(), logicalProperties,
                 groupPlan, groupPlan);
         GroupExpression groupExpression = new GroupExpression(join);
+        new Group(null, groupExpression, null);
 
         PhysicalProperties left = new PhysicalProperties(
                 new DistributionSpecHash(
@@ -135,11 +136,12 @@ public class ChildOutputPropertyDeriverTest {
     }
 
     @Test
-    public void testCrossJoin() {
+    void testCrossJoin() {
         PhysicalHashJoin<GroupPlan, GroupPlan> join = new PhysicalHashJoin<>(JoinType.CROSS_JOIN,
                 ExpressionUtils.EMPTY_CONDITION, ExpressionUtils.EMPTY_CONDITION, JoinHint.NONE, Optional.empty(), logicalProperties,
                 groupPlan, groupPlan);
         GroupExpression groupExpression = new GroupExpression(join);
+        new Group(null, groupExpression, null);
 
         PhysicalProperties left = new PhysicalProperties(
                 new DistributionSpecHash(
@@ -173,11 +175,12 @@ public class ChildOutputPropertyDeriverTest {
     }
 
     @Test
-    public void testLeftOuterJoin() {
+    void testLeftOuterJoin() {
         PhysicalHashJoin<GroupPlan, GroupPlan> join = new PhysicalHashJoin<>(JoinType.LEFT_OUTER_JOIN,
                 ExpressionUtils.EMPTY_CONDITION, ExpressionUtils.EMPTY_CONDITION, JoinHint.NONE, Optional.empty(), logicalProperties,
                 groupPlan, groupPlan);
         GroupExpression groupExpression = new GroupExpression(join);
+        new Group(null, groupExpression, null);
 
         PhysicalProperties left = new PhysicalProperties(
                 new DistributionSpecHash(
@@ -212,11 +215,12 @@ public class ChildOutputPropertyDeriverTest {
     }
 
     @Test
-    public void testLeftSemiJoin() {
+    void testLeftSemiJoin() {
         PhysicalHashJoin<GroupPlan, GroupPlan> join = new PhysicalHashJoin<>(JoinType.LEFT_SEMI_JOIN,
                 ExpressionUtils.EMPTY_CONDITION, ExpressionUtils.EMPTY_CONDITION, JoinHint.NONE, Optional.empty(), logicalProperties,
                 groupPlan, groupPlan);
         GroupExpression groupExpression = new GroupExpression(join);
+        new Group(null, groupExpression, null);
 
         PhysicalProperties left = new PhysicalProperties(
                 new DistributionSpecHash(
@@ -251,11 +255,12 @@ public class ChildOutputPropertyDeriverTest {
     }
 
     @Test
-    public void testLeftAntiJoin() {
+    void testLeftAntiJoin() {
         PhysicalHashJoin<GroupPlan, GroupPlan> join = new PhysicalHashJoin<>(JoinType.LEFT_ANTI_JOIN,
                 ExpressionUtils.EMPTY_CONDITION, ExpressionUtils.EMPTY_CONDITION, JoinHint.NONE, Optional.empty(), logicalProperties,
                 groupPlan, groupPlan);
         GroupExpression groupExpression = new GroupExpression(join);
+        new Group(null, groupExpression, null);
 
         PhysicalProperties left = new PhysicalProperties(
                 new DistributionSpecHash(
@@ -290,11 +295,12 @@ public class ChildOutputPropertyDeriverTest {
     }
 
     @Test
-    public void testNullAwareLeftAntiJoin() {
+    void testNullAwareLeftAntiJoin() {
         PhysicalHashJoin<GroupPlan, GroupPlan> join = new PhysicalHashJoin<>(JoinType.NULL_AWARE_LEFT_ANTI_JOIN,
                 ExpressionUtils.EMPTY_CONDITION, ExpressionUtils.EMPTY_CONDITION, JoinHint.NONE, Optional.empty(), logicalProperties,
                 groupPlan, groupPlan);
         GroupExpression groupExpression = new GroupExpression(join);
+        new Group(null, groupExpression, null);
 
         PhysicalProperties left = new PhysicalProperties(
                 new DistributionSpecHash(
@@ -329,11 +335,12 @@ public class ChildOutputPropertyDeriverTest {
     }
 
     @Test
-    public void testRightSemiJoin() {
+    void testRightSemiJoin() {
         PhysicalHashJoin<GroupPlan, GroupPlan> join = new PhysicalHashJoin<>(JoinType.RIGHT_SEMI_JOIN,
                 ExpressionUtils.EMPTY_CONDITION, ExpressionUtils.EMPTY_CONDITION, JoinHint.NONE, Optional.empty(), logicalProperties,
                 groupPlan, groupPlan);
         GroupExpression groupExpression = new GroupExpression(join);
+        new Group(null, groupExpression, null);
 
         PhysicalProperties left = new PhysicalProperties(
                 new DistributionSpecHash(
@@ -369,11 +376,12 @@ public class ChildOutputPropertyDeriverTest {
     }
 
     @Test
-    public void testRightAntiJoin() {
+    void testRightAntiJoin() {
         PhysicalHashJoin<GroupPlan, GroupPlan> join = new PhysicalHashJoin<>(JoinType.RIGHT_ANTI_JOIN,
                 ExpressionUtils.EMPTY_CONDITION, ExpressionUtils.EMPTY_CONDITION, JoinHint.NONE, Optional.empty(), logicalProperties,
                 groupPlan, groupPlan);
         GroupExpression groupExpression = new GroupExpression(join);
+        new Group(null, groupExpression, null);
 
         PhysicalProperties left = new PhysicalProperties(
                 new DistributionSpecHash(
@@ -409,11 +417,12 @@ public class ChildOutputPropertyDeriverTest {
     }
 
     @Test
-    public void testRightOuterJoin() {
+    void testRightOuterJoin() {
         PhysicalHashJoin<GroupPlan, GroupPlan> join = new PhysicalHashJoin<>(JoinType.RIGHT_OUTER_JOIN,
                 ExpressionUtils.EMPTY_CONDITION, ExpressionUtils.EMPTY_CONDITION, JoinHint.NONE, Optional.empty(), logicalProperties,
                 groupPlan, groupPlan);
         GroupExpression groupExpression = new GroupExpression(join);
+        new Group(null, groupExpression, null);
 
         PhysicalProperties left = new PhysicalProperties(
                 new DistributionSpecHash(
@@ -449,11 +458,12 @@ public class ChildOutputPropertyDeriverTest {
     }
 
     @Test
-    public void testFullOuterJoin() {
+    void testFullOuterJoin() {
         PhysicalHashJoin<GroupPlan, GroupPlan> join = new PhysicalHashJoin<>(JoinType.FULL_OUTER_JOIN,
                 ExpressionUtils.EMPTY_CONDITION, ExpressionUtils.EMPTY_CONDITION, JoinHint.NONE, Optional.empty(), logicalProperties,
                 groupPlan, groupPlan);
         GroupExpression groupExpression = new GroupExpression(join);
+        new Group(null, groupExpression, null);
 
         PhysicalProperties left = new PhysicalProperties(
                 new DistributionSpecHash(
@@ -483,7 +493,7 @@ public class ChildOutputPropertyDeriverTest {
     }
 
     @Test
-    public void testBroadcastJoin() {
+    void testBroadcastJoin() {
         new MockUp<JoinUtils>() {
             @Mock
             Pair<List<ExprId>, List<ExprId>> getOnClauseUsedSlots(
@@ -499,6 +509,7 @@ public class ChildOutputPropertyDeriverTest {
                                 Collections.emptyList()))),
                 ExpressionUtils.EMPTY_CONDITION, JoinHint.NONE, Optional.empty(), logicalProperties, groupPlan, groupPlan);
         GroupExpression groupExpression = new GroupExpression(join);
+        new Group(null, groupExpression, null);
 
         Map<ExprId, Integer> leftMap = Maps.newHashMap();
         leftMap.put(new ExprId(0), 0);
@@ -529,7 +540,7 @@ public class ChildOutputPropertyDeriverTest {
     }
 
     @Test
-    public void testShuffleJoin() {
+    void testShuffleJoin() {
         new MockUp<JoinUtils>() {
             @Mock
             Pair<List<ExprId>, List<ExprId>> getOnClauseUsedSlots(
@@ -545,6 +556,7 @@ public class ChildOutputPropertyDeriverTest {
                                 Collections.emptyList()))),
                 ExpressionUtils.EMPTY_CONDITION, JoinHint.NONE, Optional.empty(), logicalProperties, groupPlan, groupPlan);
         GroupExpression groupExpression = new GroupExpression(join);
+        new Group(null, groupExpression, null);
 
         Map<ExprId, Integer> leftMap = Maps.newHashMap();
         leftMap.put(new ExprId(0), 0);
@@ -578,11 +590,12 @@ public class ChildOutputPropertyDeriverTest {
     }
 
     @Test
-    public void testNestedLoopJoin() {
+    void testNestedLoopJoin() {
         PhysicalNestedLoopJoin<GroupPlan, GroupPlan> join = new PhysicalNestedLoopJoin<>(JoinType.CROSS_JOIN,
                 ExpressionUtils.EMPTY_CONDITION, ExpressionUtils.EMPTY_CONDITION, Optional.empty(), logicalProperties, groupPlan,
                 groupPlan);
         GroupExpression groupExpression = new GroupExpression(join);
+        new Group(null, groupExpression, null);
 
         Map<ExprId, Integer> leftMap = Maps.newHashMap();
         leftMap.put(new ExprId(0), 0);
@@ -608,7 +621,7 @@ public class ChildOutputPropertyDeriverTest {
     }
 
     @Test
-    public void testLocalPhaseAggregate() {
+    void testLocalPhaseAggregate() {
         SlotReference key = new SlotReference("col1", IntegerType.INSTANCE);
         PhysicalHashAggregate<GroupPlan> aggregate = new PhysicalHashAggregate<>(
                 Lists.newArrayList(key),
@@ -620,6 +633,7 @@ public class ChildOutputPropertyDeriverTest {
                 groupPlan
         );
         GroupExpression groupExpression = new GroupExpression(aggregate);
+        new Group(null, groupExpression, null);
         PhysicalProperties child = new PhysicalProperties(DistributionSpecReplicated.INSTANCE,
                 new OrderSpec(Lists.newArrayList(
                         new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE), true, true))));
@@ -631,7 +645,7 @@ public class ChildOutputPropertyDeriverTest {
     }
 
     @Test
-    public void testGlobalPhaseAggregate() {
+    void testGlobalPhaseAggregate() {
         SlotReference key = new SlotReference("col1", IntegerType.INSTANCE);
         SlotReference partition = new SlotReference("col2", BigIntType.INSTANCE);
         PhysicalHashAggregate<GroupPlan> aggregate = new PhysicalHashAggregate<>(
@@ -644,6 +658,7 @@ public class ChildOutputPropertyDeriverTest {
                 groupPlan
         );
         GroupExpression groupExpression = new GroupExpression(aggregate);
+        new Group(null, groupExpression, null);
         DistributionSpecHash childHash = new DistributionSpecHash(Lists.newArrayList(partition.getExprId()),
                 ShuffleType.EXECUTION_BUCKETED);
         PhysicalProperties child = new PhysicalProperties(childHash,
@@ -662,7 +677,7 @@ public class ChildOutputPropertyDeriverTest {
     }
 
     @Test
-    public void testAggregateWithoutGroupBy() {
+    void testAggregateWithoutGroupBy() {
         PhysicalHashAggregate<GroupPlan> aggregate = new PhysicalHashAggregate<>(
                 Lists.newArrayList(),
                 Lists.newArrayList(),
@@ -674,6 +689,7 @@ public class ChildOutputPropertyDeriverTest {
         );
 
         GroupExpression groupExpression = new GroupExpression(aggregate);
+        new Group(null, groupExpression, null);
         PhysicalProperties child = new PhysicalProperties(DistributionSpecGather.INSTANCE,
                 new OrderSpec(Lists.newArrayList(
                         new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE), true, true))));
@@ -684,11 +700,12 @@ public class ChildOutputPropertyDeriverTest {
     }
 
     @Test
-    public void testLocalQuickSort() {
+    void testLocalQuickSort() {
         SlotReference key = new SlotReference("col1", IntegerType.INSTANCE);
         List<OrderKey> orderKeys = Lists.newArrayList(new OrderKey(key, true, true));
         PhysicalQuickSort<GroupPlan> sort = new PhysicalQuickSort<>(orderKeys, SortPhase.LOCAL_SORT, logicalProperties, groupPlan);
         GroupExpression groupExpression = new GroupExpression(sort);
+        new Group(null, groupExpression, null);
         PhysicalProperties child = new PhysicalProperties(DistributionSpecReplicated.INSTANCE,
                 new OrderSpec(Lists.newArrayList(
                         new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE), true, true))));
@@ -700,11 +717,12 @@ public class ChildOutputPropertyDeriverTest {
     }
 
     @Test
-    public void testQuickSort() {
+    void testQuickSort() {
         SlotReference key = new SlotReference("col1", IntegerType.INSTANCE);
         List<OrderKey> orderKeys = Lists.newArrayList(new OrderKey(key, true, true));
         PhysicalQuickSort<GroupPlan> sort = new PhysicalQuickSort<>(orderKeys, SortPhase.MERGE_SORT, logicalProperties, groupPlan);
         GroupExpression groupExpression = new GroupExpression(sort);
+        new Group(null, groupExpression, null);
         PhysicalProperties child = new PhysicalProperties(DistributionSpecReplicated.INSTANCE,
                 new OrderSpec(Lists.newArrayList(
                         new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE), true, true))));
@@ -716,12 +734,13 @@ public class ChildOutputPropertyDeriverTest {
     }
 
     @Test
-    public void testTopN() {
+    void testTopN() {
         SlotReference key = new SlotReference("col1", IntegerType.INSTANCE);
         List<OrderKey> orderKeys = Lists.newArrayList(new OrderKey(key, true, true));
         // localSort require any
         PhysicalTopN<GroupPlan> sort = new PhysicalTopN<>(orderKeys, 10, 10, SortPhase.LOCAL_SORT, logicalProperties, groupPlan);
         GroupExpression groupExpression = new GroupExpression(sort);
+        new Group(null, groupExpression, null);
         PhysicalProperties child = new PhysicalProperties(DistributionSpecReplicated.INSTANCE,
                 new OrderSpec(Lists.newArrayList(
                         new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE), true, true))));
@@ -733,6 +752,7 @@ public class ChildOutputPropertyDeriverTest {
         // merge/gather sort requires gather
         sort = new PhysicalTopN<>(orderKeys, 10, 10, SortPhase.MERGE_SORT, logicalProperties, groupPlan);
         groupExpression = new GroupExpression(sort);
+        new Group(null, groupExpression, null);
         child = new PhysicalProperties(DistributionSpecReplicated.INSTANCE,
                 new OrderSpec(Lists.newArrayList(
                         new OrderKey(new SlotReference("ignored", IntegerType.INSTANCE), true, true))));
@@ -744,11 +764,12 @@ public class ChildOutputPropertyDeriverTest {
     }
 
     @Test
-    public void testLimit() {
+    void testLimit() {
         SlotReference key = new SlotReference("col1", IntegerType.INSTANCE);
         List<OrderKey> orderKeys = Lists.newArrayList(new OrderKey(key, true, true));
         PhysicalLimit<GroupPlan> limit = new PhysicalLimit<>(10, 10, LimitPhase.ORIGIN, logicalProperties, groupPlan);
         GroupExpression groupExpression = new GroupExpression(limit);
+        new Group(null, groupExpression, null);
         PhysicalProperties child = new PhysicalProperties(DistributionSpecGather.INSTANCE,
                 new OrderSpec(orderKeys));
 
@@ -759,13 +780,14 @@ public class ChildOutputPropertyDeriverTest {
     }
 
     @Test
-    public void testAssertNumRows() {
+    void testAssertNumRows() {
         PhysicalAssertNumRows<GroupPlan> assertNumRows = new PhysicalAssertNumRows<>(
                 new AssertNumRowsElement(1, "", AssertNumRowsElement.Assertion.EQ),
                 logicalProperties,
                 groupPlan
         );
         GroupExpression groupExpression = new GroupExpression(assertNumRows);
+        new Group(null, groupExpression, null);
         PhysicalProperties child = new PhysicalProperties(DistributionSpecGather.INSTANCE, new OrderSpec());
         ChildOutputPropertyDeriver deriver = new ChildOutputPropertyDeriver(Lists.newArrayList(child));
         PhysicalProperties result = deriver.getOutputProperties(groupExpression);


### PR DESCRIPTION
## Proposed changes

- avoid some `withRowCount`
- ArrayList with size
- checkPrimitiveInputDataTypesWithExpectType avoid to check AnyDataType

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

