### PR TITLE
[Fix](cache) fix query cache returns wrong result after deleting partitions.

### DIFF
--- a/be/src/runtime/cache/result_node.h
+++ b/be/src/runtime/cache/result_node.h
@@ -63,6 +63,9 @@ private:
         if (req_param.last_version_time() > _cache_value->param().last_version_time()) {
             return false;
         }
+        if (req_param.partition_num() != _cache_value->param().partition_num()) {
+            return false;
+        }
         return true;
     }
 
@@ -74,7 +77,15 @@ private:
         if (up_param.last_version_time() > _cache_value->param().last_version_time()) {
             return true;
         }
+        if (up_param.last_version_time() == _cache_value->param().last_version_time()
+            && up_param.partition_num() != _cache_value->param().partition_num()) {
+            return true;
+        }
         if (up_param.last_version() > _cache_value->param().last_version()) {
+            return true;
+        }
+        if (up_param.last_version() == _cache_value->param().last_version()
+            && up_param.partition_num() != _cache_value->param().partition_num()) {
             return true;
         }
         return false;

--- a/be/src/runtime/cache/result_node.h
+++ b/be/src/runtime/cache/result_node.h
@@ -77,15 +77,15 @@ private:
         if (up_param.last_version_time() > _cache_value->param().last_version_time()) {
             return true;
         }
-        if (up_param.last_version_time() == _cache_value->param().last_version_time()
-            && up_param.partition_num() != _cache_value->param().partition_num()) {
+        if (up_param.last_version_time() == _cache_value->param().last_version_time() &&
+            up_param.partition_num() != _cache_value->param().partition_num()) {
             return true;
         }
         if (up_param.last_version() > _cache_value->param().last_version()) {
             return true;
         }
-        if (up_param.last_version() == _cache_value->param().last_version()
-            && up_param.partition_num() != _cache_value->param().partition_num()) {
+        if (up_param.last_version() == _cache_value->param().last_version() &&
+            up_param.partition_num() != _cache_value->param().partition_num()) {
             return true;
         }
         return false;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
@@ -220,7 +220,7 @@ public class CacheAnalyzer {
             }
             if (enablePartitionCache() && ((OlapScanNode) node).getSelectedPartitionNum() > 1
                     && selectStmt.hasGroupByClause()) {
-                LOG.debug("more than one partition scanned when qeury has agg, partition cache cannot use, queryid {}",
+                LOG.debug("more than one partition scanned when query has agg, partition cache cannot use, queryid {}",
                         DebugUtil.printId(queryId));
                 return CacheMode.None;
             }
@@ -583,13 +583,13 @@ public class CacheAnalyzer {
         CacheTable cacheTable = new CacheTable();
         OlapTable olapTable = node.getOlapTable();
         cacheTable.olapTable = olapTable;
+        cacheTable.partitionNum = node.getSelectedPartitionIds().size();
         for (Long partitionId : node.getSelectedPartitionIds()) {
             Partition partition = olapTable.getPartition(partitionId);
             if (partition.getVisibleVersionTime() >= cacheTable.latestTime) {
                 cacheTable.latestPartitionId = partition.getId();
                 cacheTable.latestTime = partition.getVisibleVersionTime();
                 cacheTable.latestVersion = partition.getVisibleVersion();
-                cacheTable.partitionNum = node.getSelectedPartitionNum();
             }
         }
         return cacheTable;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
@@ -157,7 +157,7 @@ public class CacheAnalyzer {
         }
 
         public void debug() {
-            LOG.debug("table {}, partition id {}, ver {}, time {}, partition num: {}", olapTable.getName(),
+            LOG.debug("table {}, partition id {}, ver {}, time {}, partition num {}", olapTable.getName(),
                     latestPartitionId, latestVersion, latestTime, partitionNum);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
@@ -141,12 +141,14 @@ public class CacheAnalyzer {
         public long latestPartitionId;
         public long latestVersion;
         public long latestTime;
+        public long partitionNum;
 
         public CacheTable() {
             olapTable = null;
             latestPartitionId = 0;
             latestVersion = 0;
             latestTime = 0;
+            partitionNum = 0;
         }
 
         @Override
@@ -155,8 +157,8 @@ public class CacheAnalyzer {
         }
 
         public void debug() {
-            LOG.debug("table {}, partition id {}, ver {}, time {}", olapTable.getName(),
-                    latestPartitionId, latestVersion, latestTime);
+            LOG.debug("table {}, partition id {}, ver {}, time {}, partition num: {}", olapTable.getName(),
+                    latestPartitionId, latestVersion, latestTime, partitionNum);
         }
     }
 
@@ -584,6 +586,7 @@ public class CacheAnalyzer {
                 cacheTable.latestVersion = partition.getVisibleVersion();
             }
         }
+        cacheTable.partitionNum = node.getSelectedPartitionNum();
         return cacheTable;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/RowBatchBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/RowBatchBuilder.java
@@ -112,7 +112,7 @@ public class RowBatchBuilder {
     }
 
     public InternalService.PUpdateCacheRequest buildSqlUpdateRequest(
-            String sql, long partitionKey, long lastVersion, long lastestTime) {
+            String sql, long partitionKey, long lastVersion, long lastestTime, long partitionNum) {
         if (updateRequest == null) {
             updateRequest = InternalService.PUpdateCacheRequest.newBuilder()
                     .setSqlKey(CacheProxy.getMd5(sql))
@@ -124,6 +124,7 @@ public class RowBatchBuilder {
                                 .setPartitionKey(partitionKey)
                                 .setLastVersion(lastVersion)
                                 .setLastVersionTime(lastestTime)
+                                .setPartitionNum(partitionNum)
                                 .build()).setDataSize(dataSize).addAllRows(
                                 rowList.stream().map(row -> ByteString.copyFrom(row))
                                         .collect(Collectors.toList()))).build();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/SqlCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/SqlCache.java
@@ -61,7 +61,8 @@ public class SqlCache extends Cache {
                 .addParams(InternalService.PCacheParam.newBuilder()
                         .setPartitionKey(latestTable.latestPartitionId)
                         .setLastVersion(latestTable.latestVersion)
-                        .setLastVersionTime(latestTable.latestTime))
+                        .setLastVersionTime(latestTable.latestTime)
+                        .setPartitionNum(latestTable.partitionNum))
                 .build();
 
         InternalService.PFetchCacheResult cacheResult = proxy.fetchCache(request, 10000, status);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/SqlCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/SqlCache.java
@@ -62,7 +62,7 @@ public class SqlCache extends Cache {
                         .setPartitionKey(latestTable.latestPartitionId)
                         .setLastVersion(latestTable.latestVersion)
                         .setLastVersionTime(latestTable.latestTime)
-                        .setPartitionNum(latestTable.partitionNum))
+                        .setPartitionNum(latestTable.sumOfPartitionNum))
                 .build();
 
         InternalService.PFetchCacheResult cacheResult = proxy.fetchCache(request, 10000, status);
@@ -95,7 +95,7 @@ public class SqlCache extends Cache {
 
         InternalService.PUpdateCacheRequest updateRequest =
                 rowBatchBuilder.buildSqlUpdateRequest(getSqlWithViewStmt(), latestTable.latestPartitionId,
-                        latestTable.latestVersion, latestTable.latestTime);
+                        latestTable.latestVersion, latestTable.latestTime, latestTable.sumOfPartitionNum);
         if (updateRequest.getValuesCount() > 0) {
             CacheBeProxy proxy = new CacheBeProxy();
             Status status = new Status();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/SqlCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/SqlCache.java
@@ -55,6 +55,10 @@ public class SqlCache extends Cache {
         return cacheKey;
     }
 
+    public long getSumOfPartitionNum() {
+        return latestTable.sumOfPartitionNum;
+    }
+
     public InternalService.PFetchCacheResult getCacheData(Status status) {
         InternalService.PFetchCacheRequest request = InternalService.PFetchCacheRequest.newBuilder()
                 .setSqlKey(CacheProxy.getMd5(getSqlWithViewStmt()))

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -301,6 +301,7 @@ message PCacheParam {
     required int64 partition_key = 1;
     optional int64 last_version = 2;
     optional int64 last_version_time = 3;
+    optional int64 partition_num = 4;
 };
 
 message PCacheValue {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #23548

The reason is that sql cache just use `partitionKey` , `latestVersion` and `latestTime` to check if the cache should be returned, if we delete some partition(s) which is not the latest updated partition, all above values are not changed, so the cache will hit.
Use a field to save the partition num of these tables and sum the partition nums and send it to `BE`,  there are two situations which contains delete-partition ops:

1.  just delete some partition(s), so the sum of partition num will be lower than before.
2. delete some partition(s) coexists with add some partition(s), so the latest time or latest version will be higher than before.


![image](https://github.com/apache/doris/assets/5926365/f0e605e6-62cb-46fb-985c-86b83c20553e)

![image](https://github.com/apache/doris/assets/5926365/09e758da-ca19-40f1-bdac-93d6c5f27cb2)

![image](https://github.com/apache/doris/assets/5926365/53f033e6-fcf8-407c-ba45-183a75b4dd21)


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

