### PR TITLE
[improve](segment-cache) Change the segment cache granularity from rowset_id to rowset_id+segment_id

### DIFF
--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -141,7 +141,7 @@ Status BetaRowset::load_segments(int64_t seg_id_begin, int64_t seg_id_end,
     int64_t seg_id = seg_id_begin;
     while (seg_id < seg_id_end) {
         std::shared_ptr<segment_v2::Segment> segment;
-        load_segment(seg_id, &segment);
+        RETURN_IF_ERROR(load_segment(seg_id, &segment));
         segments->push_back(std::move(segment));
         seg_id++;
     }

--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -181,7 +181,8 @@ Status BetaRowset::remove() {
                 << ", version:" << start_version() << "-" << end_version()
                 << ", tabletid:" << _rowset_meta->tablet_id();
     // If the rowset was removed, it need to remove the fds in segment cache directly
-    SegmentLoader::instance()->erase_segments(rowset->rowset_id(), rowset->num_segments());
+    SegmentLoader::instance()->erase_segments(_rowset_meta->rowset_id(),
+                                              _rowset_meta->num_segments());
     auto fs = _rowset_meta->fs();
     if (!fs) {
         return Status::Error<INIT_FAILED>("get fs failed");

--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -138,28 +138,33 @@ Status BetaRowset::load_segments(std::vector<segment_v2::SegmentSharedPtr>* segm
 
 Status BetaRowset::load_segments(int64_t seg_id_begin, int64_t seg_id_end,
                                  std::vector<segment_v2::SegmentSharedPtr>* segments) {
+    int64_t seg_id = seg_id_begin;
+    while (seg_id < seg_id_end) {
+        std::shared_ptr<segment_v2::Segment> segment;
+        load_segment(seg_id, &segment);
+        segments->push_back(std::move(segment));
+        seg_id++;
+    }
+    return Status::OK();
+}
+
+Status BetaRowset::load_segment(int64_t seg_id, segment_v2::SegmentSharedPtr* segment) {
     auto fs = _rowset_meta->fs();
     if (!fs || _schema == nullptr) {
         return Status::Error<INIT_FAILED>("get fs failed");
     }
-    int64_t seg_id = seg_id_begin;
-    while (seg_id < seg_id_end) {
-        DCHECK(seg_id >= 0);
-        auto seg_path = segment_file_path(seg_id);
-        std::shared_ptr<segment_v2::Segment> segment;
-        io::SegmentCachePathPolicy cache_policy;
-        cache_policy.set_cache_path(segment_cache_path(seg_id));
-        auto type = config::enable_file_cache ? config::file_cache_type : "";
-        io::FileReaderOptions reader_options(io::cache_type_from_string(type), cache_policy);
-        auto s = segment_v2::Segment::open(fs, seg_path, seg_id, rowset_id(), _schema,
-                                           reader_options, &segment);
-        if (!s.ok()) {
-            LOG(WARNING) << "failed to open segment. " << seg_path << " under rowset "
-                         << unique_id() << " : " << s.to_string();
-            return s;
-        }
-        segments->push_back(std::move(segment));
-        seg_id++;
+    DCHECK(seg_id >= 0);
+    auto seg_path = segment_file_path(seg_id);
+    io::SegmentCachePathPolicy cache_policy;
+    cache_policy.set_cache_path(segment_cache_path(seg_id));
+    auto type = config::enable_file_cache ? config::file_cache_type : "";
+    io::FileReaderOptions reader_options(io::cache_type_from_string(type), cache_policy);
+    auto s = segment_v2::Segment::open(fs, seg_path, seg_id, rowset_id(), _schema, reader_options,
+                                       segment);
+    if (!s.ok()) {
+        LOG(WARNING) << "failed to open segment. " << seg_path << " under rowset " << unique_id()
+                     << " : " << s.to_string();
+        return s;
     }
     return Status::OK();
 }
@@ -176,7 +181,7 @@ Status BetaRowset::remove() {
                 << ", version:" << start_version() << "-" << end_version()
                 << ", tabletid:" << _rowset_meta->tablet_id();
     // If the rowset was removed, it need to remove the fds in segment cache directly
-    SegmentLoader::instance()->erase_segments(SegmentCache::CacheKey(rowset_id()));
+    SegmentLoader::instance()->erase_segments(rowset->rowset_id(), rowset->num_segments());
     auto fs = _rowset_meta->fs();
     if (!fs) {
         return Status::Error<INIT_FAILED>("get fs failed");

--- a/be/src/olap/rowset/beta_rowset.h
+++ b/be/src/olap/rowset/beta_rowset.h
@@ -92,6 +92,8 @@ public:
     Status load_segments(int64_t seg_id_begin, int64_t seg_id_end,
                          std::vector<segment_v2::SegmentSharedPtr>* segments);
 
+    Status load_segment(int64_t seg_id, segment_v2::SegmentSharedPtr* segment);
+
     Status get_segments_size(std::vector<size_t>* segments_size);
 
     [[nodiscard]] virtual Status add_to_binlog() override;

--- a/be/src/olap/segment_loader.cpp
+++ b/be/src/olap/segment_loader.cpp
@@ -37,7 +37,7 @@ bool SegmentCache::lookup(const SegmentCache::CacheKey& key, SegmentCacheHandle*
     if (lru_handle == nullptr) {
         return false;
     }
-    handle->init(_cache.get(), lru_handle);
+    handle->push_segment(_cache.get(), lru_handle);
     return true;
 }
 
@@ -45,18 +45,14 @@ void SegmentCache::insert(const SegmentCache::CacheKey& key, SegmentCache::Cache
                           SegmentCacheHandle* handle) {
     auto deleter = [](const doris::CacheKey& key, void* value) {
         SegmentCache::CacheValue* cache_value = (SegmentCache::CacheValue*)value;
-        cache_value->segments.clear();
+        cache_value->segment.reset();
         delete cache_value;
     };
 
-    int64_t meta_mem_usage = 0;
-    for (auto segment : value.segments) {
-        meta_mem_usage += segment->meta_mem_usage();
-    }
-
-    auto lru_handle = _cache->insert(key.encode(), &value, sizeof(SegmentCache::CacheValue),
-                                     deleter, CachePriority::NORMAL, meta_mem_usage);
-    handle->init(_cache.get(), lru_handle);
+    auto lru_handle =
+            _cache->insert(key.encode(), &value, sizeof(SegmentCache::CacheValue), deleter,
+                           CachePriority::NORMAL, value.segment->meta_mem_usage());
+    handle->push_segment(_cache.get(), lru_handle);
 }
 
 void SegmentCache::erase(const SegmentCache::CacheKey& key) {
@@ -68,28 +64,34 @@ Status SegmentLoader::load_segments(const BetaRowsetSharedPtr& rowset,
     if (cache_handle->is_inited()) {
         return Status::OK();
     }
-
-    SegmentCache::CacheKey cache_key(rowset->rowset_id());
-    if (!config::disable_segment_cache && _segment_cache->lookup(cache_key, cache_handle)) {
-        return Status::OK();
+    for (int64_t i = 0; i < rowset->num_segments(); i++) {
+        SegmentCache::CacheKey cache_key(rowset->rowset_id(), i);
+        if (_segment_cache->lookup(cache_key, cache_handle)) {
+            continue;
+        }
+        segment_v2::SegmentSharedPtr segment;
+        RETURN_IF_ERROR(rowset->load_segment(i, &segment));
+        if (use_cache && !config::disable_segment_cache) {
+            // memory of SegmentCache::CacheValue will be handled by SegmentCache
+            SegmentCache::CacheValue* cache_value = new SegmentCache::CacheValue();
+            cache_value->segment = std::move(segment);
+            _segment_cache->insert(cache_key, *cache_value, cache_handle);
+        } else {
+            cache_handle->push_segment(std::move(segment));
+        }
     }
-
-    std::vector<segment_v2::SegmentSharedPtr> segments;
-    RETURN_IF_ERROR(rowset->load_segments(&segments));
-
-    if (use_cache && !config::disable_segment_cache) {
-        // memory of SegmentCache::CacheValue will be handled by SegmentCache
-        SegmentCache::CacheValue* cache_value = new SegmentCache::CacheValue();
-        cache_value->segments = std::move(segments);
-        _segment_cache->insert(cache_key, *cache_value, cache_handle);
-    } else {
-        cache_handle->init(std::move(segments));
-    }
+    cache_handle->set_inited();
     return Status::OK();
 }
 
-void SegmentLoader::erase_segments(const SegmentCache::CacheKey& key) {
+void SegmentLoader::erase_segment(const SegmentCache::CacheKey& key) {
     _segment_cache->erase(key);
+}
+
+void SegmentLoader::erase_segments(const RowsetId& rowset_id, int64_t num_segments) {
+    for (int64_t i = 0; i < num_segments; i++) {
+        erase_segment(SegmentCache::CacheKey(rowset_id, num_segments));
+    }
 }
 
 } // namespace doris

--- a/be/src/olap/segment_loader.cpp
+++ b/be/src/olap/segment_loader.cpp
@@ -90,7 +90,7 @@ void SegmentLoader::erase_segment(const SegmentCache::CacheKey& key) {
 
 void SegmentLoader::erase_segments(const RowsetId& rowset_id, int64_t num_segments) {
     for (int64_t i = 0; i < num_segments; i++) {
-        erase_segment(SegmentCache::CacheKey(rowset_id, num_segments));
+        erase_segment(SegmentCache::CacheKey(rowset_id, i));
     }
 }
 

--- a/be/src/olap/segment_loader.h
+++ b/be/src/olap/segment_loader.h
@@ -59,25 +59,29 @@ class SegmentCache : public LRUCachePolicy {
 public:
     // The cache key or segment lru cache
     struct CacheKey {
-        CacheKey(RowsetId rowset_id_) : rowset_id(rowset_id_) {}
+        CacheKey(RowsetId rowset_id_, int64_t segment_id_)
+                : rowset_id(rowset_id_), segment_id(segment_id_) {}
         RowsetId rowset_id;
+        int64_t segment_id;
 
         // Encode to a flat binary which can be used as LRUCache's key
-        [[nodiscard]] std::string encode() const { return rowset_id.to_string(); }
+        [[nodiscard]] std::string encode() const {
+            return rowset_id.to_string() + std::to_string(segment_id);
+        }
     };
 
     // The cache value of segment lru cache.
     // Holding all opened segments of a rowset.
     struct CacheValue : public LRUCacheValueBase {
-        std::vector<segment_v2::SegmentSharedPtr> segments;
+        segment_v2::SegmentSharedPtr segment;
     };
 
     SegmentCache(size_t capacity)
             : LRUCachePolicy(CachePolicy::CacheType::SEGMENT_CACHE, capacity, LRUCacheType::NUMBER,
                              config::tablet_rowset_stale_sweep_time_sec) {}
 
-    // Lookup the given rowset in the cache.
-    // If the rowset is found, the cache entry will be written into handle.
+    // Lookup the given segment in the cache.
+    // If the segment is found, the cache entry will be written into handle.
     // Return true if entry is found, otherwise return false.
     bool lookup(const SegmentCache::CacheKey& key, SegmentCacheHandle* handle);
 
@@ -111,7 +115,9 @@ public:
     Status load_segments(const BetaRowsetSharedPtr& rowset, SegmentCacheHandle* cache_handle,
                          bool use_cache = false);
 
-    void erase_segments(const SegmentCache::CacheKey& key);
+    void erase_segment(const SegmentCache::CacheKey& key);
+
+    void erase_segments(const RowsetId& rowset_id, int64_t num_segments);
 
 private:
     SegmentLoader();
@@ -128,50 +134,30 @@ private:
 class SegmentCacheHandle {
 public:
     SegmentCacheHandle() = default;
+    ~SegmentCacheHandle() = default;
 
-    ~SegmentCacheHandle() {
-        if (_handle != nullptr) {
-            CHECK(_cache != nullptr);
-            CHECK(_segments.empty()) << _segments.size();
-            CHECK(!_owned);
-            // last_visit_time is set when release.
-            // because it only be needed when pruning.
-            ((SegmentCache::CacheValue*)_cache->value(_handle))->last_visit_time = UnixMillis();
-            _cache->release(_handle);
-        }
+    void push_segment(Cache* cache, Cache::Handle* handle) {
+        segments.push_back(((SegmentCache::CacheValue*)cache->value(handle))->segment);
+        ((SegmentCache::CacheValue*)cache->value(handle))->last_visit_time = UnixMillis();
+        cache->release(handle);
     }
+
+    void push_segment(segment_v2::SegmentSharedPtr segment) {
+        segments.push_back(std::move(segment));
+    }
+
+    std::vector<segment_v2::SegmentSharedPtr>& get_segments() { return segments; }
 
     [[nodiscard]] bool is_inited() const { return _init; }
 
-    void init(std::vector<segment_v2::SegmentSharedPtr> segments) {
+    void set_inited() {
         DCHECK(!_init);
-        _owned = true;
-        _segments = std::move(segments);
         _init = true;
-    }
-
-    void init(Cache* cache, Cache::Handle* handle) {
-        DCHECK(!_init);
-        _owned = false;
-        _cache = cache;
-        _handle = handle;
-        _init = true;
-    }
-
-    std::vector<segment_v2::SegmentSharedPtr>& get_segments() {
-        if (_owned) {
-            return _segments;
-        } else {
-            return ((SegmentCache::CacheValue*)_cache->value(_handle))->segments;
-        }
     }
 
 private:
+    std::vector<segment_v2::SegmentSharedPtr> segments;
     bool _init {false};
-    bool _owned {false};
-    std::vector<segment_v2::SegmentSharedPtr> _segments;
-    Cache* _cache = nullptr;
-    Cache::Handle* _handle = nullptr;
 
     // Don't allow copy and assign
     DISALLOW_COPY_AND_ASSIGN(SegmentCacheHandle);

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -554,8 +554,8 @@ Status TabletManager::_drop_tablet_unlocked(TTabletId tablet_id, TReplicaId repl
         static auto recycle_segment_cache = [](const auto& rowset_map) {
             for (auto& [_, rowset] : rowset_map) {
                 // If the tablet was deleted, it need to remove all rowsets fds directly
-                SegmentLoader::instance()->erase_segments(
-                        SegmentCache::CacheKey(rowset->rowset_id()));
+                SegmentLoader::instance()->erase_segments(rowset->rowset_id(),
+                                                          rowset->num_segments());
             }
         };
         recycle_segment_cache(to_drop_tablet->rowset_map());

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -371,7 +371,7 @@ Status TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id,
             rowset->merge_rowset_meta(transient_rowset->rowset_meta());
 
             // erase segment cache cause we will add a segment to rowset
-            SegmentLoader::instance()->erase_segments(rowset->rowset_id());
+            SegmentLoader::instance()->erase_segments(rowset->rowset_id(), rowset->num_segments());
         }
         stats->partial_update_write_segment_us = MonotonicMicros() - t3;
         int64_t t4 = MonotonicMicros();

--- a/be/src/vec/olap/vertical_block_reader.cpp
+++ b/be/src/vec/olap/vertical_block_reader.cpp
@@ -66,6 +66,7 @@ Status VerticalBlockReader::_get_segment_iterators(const ReaderParams& read_para
     }
     _reader_context.is_vertical_compaction = true;
     for (auto& rs_split : read_params.rs_splits) {
+        // segment iterator will be inited here
         // In vertical compaction, every group will load segment so we should cache
         // segment to avoid tot many s3 head request
         bool use_cache = !rs_split.rs_reader->rowset()->is_local();
@@ -106,8 +107,7 @@ Status VerticalBlockReader::_init_collect_iter(const ReaderParams& read_params) 
     if (!segment_iters_ptr) {
         RETURN_IF_ERROR(_get_segment_iterators(read_params, &iter_ptr_vector, &iterator_init_flag,
                                                &rowset_ids));
-        CHECK(iter_ptr_vector.size() == iterator_init_flag.size())
-                << iter_ptr_vector.size() << "???" << iterator_init_flag.size();
+        CHECK(iter_ptr_vector.size() == iterator_init_flag.size());
         segment_iters_ptr = &iter_ptr_vector;
     } else {
         for (int i = 0; i < segment_iters_ptr->size(); ++i) {

--- a/be/src/vec/olap/vertical_block_reader.cpp
+++ b/be/src/vec/olap/vertical_block_reader.cpp
@@ -66,7 +66,6 @@ Status VerticalBlockReader::_get_segment_iterators(const ReaderParams& read_para
     }
     _reader_context.is_vertical_compaction = true;
     for (auto& rs_split : read_params.rs_splits) {
-        // segment iterator will be inited here
         // In vertical compaction, every group will load segment so we should cache
         // segment to avoid tot many s3 head request
         bool use_cache = !rs_split.rs_reader->rowset()->is_local();
@@ -107,7 +106,8 @@ Status VerticalBlockReader::_init_collect_iter(const ReaderParams& read_params) 
     if (!segment_iters_ptr) {
         RETURN_IF_ERROR(_get_segment_iterators(read_params, &iter_ptr_vector, &iterator_init_flag,
                                                &rowset_ids));
-        CHECK(iter_ptr_vector.size() == iterator_init_flag.size());
+        CHECK(iter_ptr_vector.size() == iterator_init_flag.size())
+                << iter_ptr_vector.size() << "???" << iterator_init_flag.size();
         segment_iters_ptr = &iter_ptr_vector;
     } else {
         for (int i = 0; i < segment_iters_ptr->size(); ++i) {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
In current segment cache, the key is rowset_id and the value is the vector of segments. And the segment cache size comes from be/src/runtime/exec_env_init.cpp.
```
uint64_t fd_number = config::min_file_descriptor_number;
struct rlimit l;
int ret = getrlimit(RLIMIT_NOFILE, &l);
fd_number = static_cast<uint64_t>(l.rlim_cur);
uint64_t segment_cache_capacity = fd_number * 2 / 5;
SegmentLoader::create_global_instance(segment_cache_capacity);
```
Even the segment cache capacity is calculated by fd_number * 2 / 5. There's still some probability that the problem 'too many open file' will trigger. So we need more granular statistics.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

