### PR TITLE
[fix](filter) fix error id in bloomfilter 

### DIFF
--- a/be/src/exprs/bitmapfilter_predicate.h
+++ b/be/src/exprs/bitmapfilter_predicate.h
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 
+#include "exprs/runtime_filter.h"
 #include "gutil/integral_types.h"
 #include "runtime/define_primitive_type.h"
 #include "runtime/primitive_type.h"
@@ -27,7 +28,7 @@
 namespace doris {
 
 // only used in Runtime Filter
-class BitmapFilterFuncBase {
+class BitmapFilterFuncBase : public FilterFuncBase {
 public:
     virtual void insert(const void* data) = 0;
     virtual void insert_many(const std::vector<const BitmapValue*> bitmaps) = 0;
@@ -43,13 +44,9 @@ public:
     void set_not_in(bool not_in) { _not_in = not_in; }
     virtual ~BitmapFilterFuncBase() = default;
 
-    void set_filter_id(int filter_id) { _filter_id = filter_id; }
-    int get_filter_id() const { return _filter_id; }
-
 protected:
     // true -> not in bitmap, false -> in bitmap
     bool _not_in {false};
-    int _filter_id = -1;
 };
 
 template <PrimitiveType type>

--- a/be/src/exprs/bloom_filter_func.h
+++ b/be/src/exprs/bloom_filter_func.h
@@ -218,7 +218,11 @@ public:
         set_filter_id(other_func->_filter_id);
     }
 
-    void set_filter_id(int filter_id) { _filter_id = filter_id; }
+    void set_filter_id(int filter_id) {
+        if (_filter_id == -1) {
+            _filter_id = filter_id;
+        }
+    }
 
     int get_filter_id() const { return _filter_id; }
 

--- a/be/src/exprs/bloom_filter_func.h
+++ b/be/src/exprs/bloom_filter_func.h
@@ -225,7 +225,7 @@ public:
     }
 
     int get_filter_id() const {
-        DCHECK(_filter_id!=-1);
+        DCHECK(_filter_id != -1);
         return _filter_id;
     }
 

--- a/be/src/exprs/bloom_filter_func.h
+++ b/be/src/exprs/bloom_filter_func.h
@@ -94,7 +94,7 @@ private:
 };
 
 // Only Used In RuntimeFilter
-class BloomFilterFuncBase {
+class BloomFilterFuncBase : public FilterFuncBase {
 public:
     BloomFilterFuncBase() : _inited(false) {}
 

--- a/be/src/exprs/bloom_filter_func.h
+++ b/be/src/exprs/bloom_filter_func.h
@@ -164,7 +164,6 @@ public:
                              << other_func->_bloom_filter_alloced;
                 return Status::InvalidArgument("bloom filter size invalid");
             }
-            set_filter_id(other_func->_filter_id);
             return _bloom_filter->merge(other_func->_bloom_filter.get());
         }
         {
@@ -176,7 +175,6 @@ public:
                 _bloom_filter = bloomfilter_func->_bloom_filter;
                 _bloom_filter_alloced = other_func->_bloom_filter_alloced;
                 _inited = true;
-                set_filter_id(other_func->_filter_id);
                 return Status::OK();
             } else {
                 DCHECK(bloomfilter_func != nullptr);
@@ -187,7 +185,6 @@ public:
                                  << other_func->_bloom_filter_alloced;
                     return Status::InvalidArgument("bloom filter size invalid");
                 }
-                set_filter_id(other_func->_filter_id);
                 return _bloom_filter->merge(other_func->_bloom_filter.get());
             }
         }
@@ -215,18 +212,6 @@ public:
         _bloom_filter_alloced = other_func->_bloom_filter_alloced;
         _bloom_filter = other_func->_bloom_filter;
         _inited = other_func->_inited;
-        set_filter_id(other_func->_filter_id);
-    }
-
-    void set_filter_id(int filter_id) {
-        if (_filter_id == -1) {
-            _filter_id = filter_id;
-        }
-    }
-
-    int get_filter_id() const {
-        DCHECK(_filter_id != -1);
-        return _filter_id;
     }
 
     virtual void insert(const void* data) = 0;

--- a/be/src/exprs/bloom_filter_func.h
+++ b/be/src/exprs/bloom_filter_func.h
@@ -262,7 +262,6 @@ protected:
     std::mutex _lock;
     int64_t _bloom_filter_length;
     bool _build_bf_exactly = false;
-    int _filter_id = -1;
 };
 
 template <class T>

--- a/be/src/exprs/bloom_filter_func.h
+++ b/be/src/exprs/bloom_filter_func.h
@@ -224,7 +224,10 @@ public:
         }
     }
 
-    int get_filter_id() const { return _filter_id; }
+    int get_filter_id() const {
+        DCHECK(_filter_id!=-1);
+        return _filter_id;
+    }
 
     virtual void insert(const void* data) = 0;
 

--- a/be/src/exprs/hybrid_set.h
+++ b/be/src/exprs/hybrid_set.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "common/object_pool.h"
+#include "exprs/runtime_filter.h"
 #include "runtime/decimalv2_value.h"
 #include "runtime/define_primitive_type.h"
 #include "runtime/primitive_type.h"
@@ -174,7 +175,7 @@ private:
 };
 
 // TODO Maybe change void* parameter to template parameter better.
-class HybridSetBase {
+class HybridSetBase : public FilterFuncBase {
 public:
     HybridSetBase() = default;
     virtual ~HybridSetBase() = default;
@@ -225,9 +226,6 @@ public:
         LOG(FATAL) << "HybridSetBase not support find_batch_nullable_negative";
     }
 
-    void set_filter_id(int filter_id) { _filter_id = filter_id; }
-    int get_filter_id() const { return _filter_id; }
-    int _filter_id = -1;
     class IteratorBase {
     public:
         IteratorBase() = default;

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -47,7 +47,6 @@
 #include "runtime/primitive_type.h"
 #include "runtime/runtime_filter_mgr.h"
 #include "util/bitmap_value.h"
-#include "util/defer_op.h"
 #include "util/runtime_profile.h"
 #include "util/string_parser.hpp"
 #include "vec/columns/column.h"

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -400,7 +400,6 @@ public:
     // init runtime filter wrapper
     // alloc memory to init runtime filter function
     Status init(const RuntimeFilterParams* params) {
-        Defer([&]() { set_filter_id(_filter_id); });
         _max_in_num = params->max_in_num;
         switch (_filter_type) {
         case RuntimeFilterType::IN_FILTER: {
@@ -443,16 +442,8 @@ public:
         _is_bloomfilter = true;
         BloomFilterFuncBase* bf = _context.bloom_filter_func.get();
         // BloomFilter may be not init
-        set_filter_id(_filter_id);
         bf->init_with_fixed_length();
         insert_to_bloom_filter(bf);
-        if (_context.bloom_filter_func) {
-            bf->set_filter_id(_context.bloom_filter_func->get_filter_id());
-        }
-        if (_context.hybrid_set) {
-            bf->set_filter_id(_context.hybrid_set->get_filter_id());
-        }
-
         // release in filter
         _context.hybrid_set.reset(create_set(_column_return_type));
     }
@@ -460,7 +451,6 @@ public:
     Status init_bloom_filter(const size_t build_bf_cardinality) {
         DCHECK(_filter_type == RuntimeFilterType::BLOOM_FILTER ||
                _filter_type == RuntimeFilterType::IN_OR_BLOOM_FILTER);
-        set_filter_id(_filter_id);
         return _context.bloom_filter_func->init_with_cardinality(build_bf_cardinality);
     }
 
@@ -1493,7 +1483,6 @@ void IRuntimeFilter::init_profile(RuntimeProfile* parent_profile) {
     }
     parent_profile->add_child(_profile.get(), true, nullptr);
     _profile->add_info_string("Info", _format_status());
-    _wrapper->set_filter_id(_filter_id);
     if (_runtime_filter_type == RuntimeFilterType::IN_OR_BLOOM_FILTER) {
         update_runtime_filter_type_to_profile();
     }
@@ -1856,7 +1845,7 @@ Status RuntimePredicateWrapper::get_push_exprs(std::list<vectorized::VExprContex
     vectorized::VExprContextSPtr probe_ctx;
     RETURN_IF_ERROR(vectorized::VExpr::create_expr_tree(probe_expr, probe_ctx));
     probe_ctxs.push_back(probe_ctx);
-
+    set_filter_id(_filter_id);
     DCHECK(probe_ctx->root()->type().type == _column_return_type ||
            (is_string_type(probe_ctx->root()->type().type) &&
             is_string_type(_column_return_type)) ||

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -1482,6 +1482,7 @@ void IRuntimeFilter::init_profile(RuntimeProfile* parent_profile) {
     }
     parent_profile->add_child(_profile.get(), true, nullptr);
     _profile->add_info_string("Info", _format_status());
+    _wrapper->set_filter_id(_filter_id);
     if (_runtime_filter_type == RuntimeFilterType::IN_OR_BLOOM_FILTER) {
         update_runtime_filter_type_to_profile();
     }
@@ -1490,7 +1491,6 @@ void IRuntimeFilter::init_profile(RuntimeProfile* parent_profile) {
 void IRuntimeFilter::update_runtime_filter_type_to_profile() {
     if (_profile != nullptr) {
         _profile->add_info_string("RealRuntimeFilterType", to_string(_wrapper->get_real_type()));
-        _wrapper->set_filter_id(_filter_id);
     }
 }
 

--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -97,7 +97,19 @@ struct RuntimeFilterParams {
     bool bitmap_filter_not_in;
     bool build_bf_exactly;
 };
+struct FilterFuncBase {
+public:
+    void set_filter_id(int filter_id) {
+        if (_filter_id == -1) {
+            _filter_id = filter_id;
+        }
+    }
 
+    [[nodiscard]] int get_filter_id() const { return _filter_id; }
+
+private:
+    int _filter_id = -1;
+};
 struct UpdateRuntimeFilterParams {
     UpdateRuntimeFilterParams(const PPublishFilterRequest* req,
                               butil::IOBufAsZeroCopyInputStream* data_stream, ObjectPool* obj_pool)

--- a/be/src/olap/bitmap_filter_predicate.h
+++ b/be/src/olap/bitmap_filter_predicate.h
@@ -101,6 +101,7 @@ private:
     SpecificFilter* _specific_filter; // owned by _filter
 
     int get_filter_id() const override { return _filter->get_filter_id(); }
+    bool is_filter() const override { return true; }
 };
 
 template <PrimitiveType T>

--- a/be/src/olap/bloom_filter_predicate.h
+++ b/be/src/olap/bloom_filter_predicate.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include "common/logging.h"
 #include "exprs/bloom_filter_func.h"
 #include "exprs/runtime_filter.h"
 #include "olap/column_predicate.h"

--- a/be/src/olap/bloom_filter_predicate.h
+++ b/be/src/olap/bloom_filter_predicate.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "common/logging.h"
 #include "exprs/bloom_filter_func.h"
 #include "exprs/runtime_filter.h"
 #include "olap/column_predicate.h"
@@ -155,7 +156,11 @@ private:
         return info;
     }
 
-    int get_filter_id() const override { return _filter->get_filter_id(); }
+    int get_filter_id() const override {
+        int filter_id = _filter->get_filter_id();
+        DCHECK(filter_id != -1);
+        return filter_id;
+    }
     bool is_filter() const override { return true; }
 
     std::shared_ptr<BloomFilterFuncBase> _filter;

--- a/be/src/olap/bloom_filter_predicate.h
+++ b/be/src/olap/bloom_filter_predicate.h
@@ -156,6 +156,7 @@ private:
     }
 
     int get_filter_id() const override { return _filter->get_filter_id(); }
+    bool is_filter() const override { return true; }
 
     std::shared_ptr<BloomFilterFuncBase> _filter;
     SpecificFilter* _specific_filter; // owned by _filter

--- a/be/src/olap/column_predicate.h
+++ b/be/src/olap/column_predicate.h
@@ -219,7 +219,8 @@ public:
     virtual void clone(ColumnPredicate** to) const { LOG(FATAL) << "clone not supported"; }
 
     virtual int get_filter_id() const { return -1; }
-
+    // now InListPredicateBase BloomFilterColumnPredicate BitmapFilterColumnPredicate  = true
+    virtual bool is_filter() const { return false; }
     PredicateFilterInfo get_filtered_info() const {
         return PredicateFilterInfo {static_cast<int>(type()), _evaluated_rows - 1,
                                     _evaluated_rows - 1 - _passed_rows};

--- a/be/src/olap/in_list_predicate.h
+++ b/be/src/olap/in_list_predicate.h
@@ -287,6 +287,8 @@ public:
         return new_size;
     }
     int get_filter_id() const override { return _values->get_filter_id(); }
+    bool is_filter() const override { return true; }
+
     template <bool is_and>
     void _evaluate_bit(const vectorized::IColumn& column, const uint16_t* sel, uint16_t size,
                        bool* flags) const {

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -1328,7 +1328,9 @@ Status SegmentIterator::_vec_init_lazy_materialization() {
             } else {
                 short_cir_pred_col_id_set.insert(cid);
                 _short_cir_eval_predicate.push_back(predicate);
-                _filter_info_id.push_back(predicate);
+                if (predicate->is_filter()) {
+                    _filter_info_id.push_back(predicate);
+                }
             }
         }
 


### PR DESCRIPTION
## Proposed changes

1. "set" may overwrite the original ID.
2.A bloom filter may not necessarily be an IN_OR_BLOOM_FILTER.

before may be
RuntimeFilterInfo  id  -1:  [type  =  BF,  input  =  25,  filtered  =  0]
now 
 RuntimeFilterInfo  id  0:  [type  =  BF,  input  =  25,  filtered  =  0]

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

