### PR TITLE
[Bug](check) add column number check for  vsorted_run_merger

### DIFF
--- a/be/src/vec/runtime/vsorted_run_merger.cpp
+++ b/be/src/vec/runtime/vsorted_run_merger.cpp
@@ -20,6 +20,8 @@
 #include <utility>
 #include <vector>
 
+#include "common/exception.h"
+#include "common/status.h"
 #include "util/runtime_profile.h"
 #include "util/stopwatch.hpp"
 #include "vec/columns/column.h"
@@ -161,6 +163,13 @@ Status VSortedRunMerger::get_next(Block* output_block, bool* eos) {
                 VectorizedUtils::build_mutable_mem_reuse_block(output_block, _empty_block);
         MutableColumns& merged_columns = m_block.mutable_columns();
 
+        if (num_columns != merged_columns.size()) {
+            throw Exception(
+                    ErrorCode::INTERNAL_ERROR,
+                    "num_columns!=merged_columns.size(), num_columns={}, merged_columns.size()={}",
+                    num_columns, merged_columns.size());
+        }
+
         /// Take rows from queue in right order and push to 'merged'.
         size_t merged_rows = 0;
         while (!_priority_queue.empty()) {
@@ -170,8 +179,9 @@ Status VSortedRunMerger::get_next(Block* output_block, bool* eos) {
             if (_offset > 0) {
                 _offset--;
             } else {
-                for (size_t i = 0; i < num_columns; ++i)
+                for (size_t i = 0; i < num_columns; ++i) {
                     merged_columns[i]->insert_from(*current->all_columns[i], current->pos);
+                }
                 ++merged_rows;
             }
 


### PR DESCRIPTION
## Proposed changes
```cpp
==3978669==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x602006446400 at pc 0x559259c8dc1e bp 0x7f6b0495b430 sp 0x7f6b0495b428
READ of size 8 at 0x602006446400 thread T259 (TaskSchedulerTh)
    #0 0x559259c8dc1d in COW::intrusive_ptr::operator->() const /home/zcp/repo_center/doris_master/doris/be/src/vec/common/cow.h:198:40
    #1 0x55927c327377 in doris::vectorized::VSortedRunMerger::get_next(doris::vectorized::Block*, bool*) /home/zcp/repo_center/doris_master/doris/be/src/vec/runtime/vsorted_run_merger.cpp:174:21
    #2 0x55927c2bceb9 in doris::vectorized::VDataStreamRecvr::get_next(doris::vectorized::Block*, bool*) /home/zcp/repo_center/doris_master/doris/be/src/vec/runtime/vdata_stream_recvr.cpp:411:25
    #3 0x55927015d095 in doris::vectorized::VExchangeNode::get_next(doris::RuntimeState*, doris::vectorized::Block*, bool*) /home/zcp/repo_center/doris_master/doris/be/src/vec/exec/vexchange_node.cpp:107:34
    #4 0x55925c547be3 in doris::ExecNode::pull(doris::RuntimeState*, doris::vectorized::Block*, bool*) /home/zcp/repo_center/doris_master/doris/be/src/exec/exec_node.h:127:16
    #5 0x55927c812c4c in doris::Status std::__invoke_impl(std::__invoke_memfun_deref, doris::Status (doris::ExecNode::*&)(doris::RuntimeState*, doris::vectorized::Block*, bool*), doris::vectorized::VExchangeNode*&, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74:14
    #6 0x55927c8129ef in std::__invoke_result::type std::__invoke(doris::Status (doris::ExecNode::*&)(doris::RuntimeState*, doris::vectorized::Block*, bool*), doris::vectorized::VExchangeNode*&, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96:14
    #7 0x55927c812926 in doris::Status std::_Bind, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>::__call(std::tuple&&, std::_Index_tuple<0ul, 1ul, 2ul, 3ul>) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420:11
    #8 0x55927c8126b7 in doris::Status std::_Bind, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>::operator()(doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503:17
    #9 0x55927c812567 in doris::Status std::__invoke_impl, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>&, doris::RuntimeState*, doris::vectorized::Block*, bool*>(std::__invoke_other, std::_Bind, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>&, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #10 0x55927c8124d7 in std::enable_if, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>&, doris::RuntimeState*, doris::vectorized::Block*, bool*>, doris::Status>::type std::__invoke_r, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>&, doris::RuntimeState*, doris::vectorized::Block*, bool*>(std::_Bind, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>&, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:114:9
    #11 0x55927c812127 in std::_Function_handler, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>>::_M_invoke(std::_Any_data const&, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #12 0x55925c547ace in std::function::operator()(doris::RuntimeState*, doris::vectorized::Block*, bool*) const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #13 0x55925c53ad73 in doris::ExecNode::get_next_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*, std::function const&, bool) /home/zcp/repo_center/doris_master/doris/be/src/exec/exec_node.cpp:584:12
    #14 0x55927c80f60c in doris::pipeline::SourceOperator::get_block(doris::RuntimeState*, doris::vectorized::Block*, doris::pipeline::SourceState&) /home/zcp/repo_center/doris_master/doris/be/src/pipeline/exec/operator.h:416:9
    #15 0x55927cbaa87b in doris::pipeline::PipelineTask::execute(bool*) /home/zcp/repo_center/doris_master/doris/be/src/pipeline/pipeline_task.cpp:274:13
    #16 0x55927cc381e7 in doris::pipeline::TaskScheduler::_do_work(unsigned long) /home/zcp/repo_center/doris_master/doris/be/src/pipeline/task_scheduler.cpp:265:28
    #17 0x55927cc48a28 in void std::__invoke_impl(std::__invoke_memfun_deref, void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74:14
    #18 0x55927cc48894 in std::__invoke_result::type std::__invoke(void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96:14
    #19 0x55927cc48803 in void std::_Bind::__call(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420:11
    #20 0x55927cc4866d in void std::_Bind::operator()() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503:17
    #21 0x55927cc48584 in void std::__invoke_impl&>(std::__invoke_other, std::_Bind&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #22 0x55927cc48524 in std::enable_if&>, void>::type std::__invoke_r&>(std::_Bind&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #23 0x55927cc4821c in std::_Function_handler>::_M_invoke(std::_Any_data const&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #24 0x559259bb05e2 in std::function::operator()() const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #25 0x55925ce6ca68 in doris::FunctionRunnable::run() /home/zcp/repo_center/doris_master/doris/be/src/util/threadpool.cpp:48:27
    #26 0x55925ce5a006 in doris::ThreadPool::dispatch_thread() /home/zcp/repo_center/doris_master/doris/be/src/util/threadpool.cpp:531:24
    #27 0x55925ce7fb13 in void std::__invoke_impl(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74:14
    #28 0x55925ce7f9ec in std::__invoke_result::type std::__invoke(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96:14
    #29 0x55925ce7f974 in void std::_Bind::__call(std::tuple<>&&, std::_Index_tuple<0ul>) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420:11
    #30 0x55925ce7f81d in void std::_Bind::operator()() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503:17
    #31 0x55925ce7f734 in void std::__invoke_impl&>(std::__invoke_other, std::_Bind&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #32 0x55925ce7f6d4 in std::enable_if&>, void>::type std::__invoke_r&>(std::_Bind&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #33 0x55925ce7f3fc in std::_Function_handler>::_M_invoke(std::_Any_data const&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #34 0x559259bb05e2 in std::function::operator()() const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #35 0x55925ce27306 in doris::Thread::supervise_thread(void*) /home/zcp/repo_center/doris_master/doris/be/src/util/thread.cpp:465:5
    #36 0x7f6cca293608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477:8
    #37 0x7f6cca522132 in __clone /build/glibc-SzIz7B/glibc-2.31/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95

```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

