### PR TITLE
[fix](rest)query_info returns empty rows

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/QueryProfileAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/QueryProfileAction.java
@@ -171,7 +171,7 @@ public class QueryProfileAction extends RestBaseController {
         }
 
         Stream<List<String>> queryStream = ProfileManager.getInstance().getAllQueries().stream()
-                .filter(profile -> profile.get(4).equals("Query"));
+                .filter(profile -> profile.get(1).equalsIgnoreCase("Query"));
         queryStream = filterQueriesByUserAndQueryId(queryStream, queryId);
         queries = queryStream.collect(Collectors.toList());
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

