### PR TITLE
[minor](optimizer): SUPPORT COLLATE GRAMMAR

### DIFF
--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -389,6 +389,7 @@ primaryExpression
     | KEY (dbName=identifier DOT)? keyName=identifier                                          #encryptKey
     | EXTRACT LEFT_PAREN field=identifier FROM (DATE | TIMESTAMP)?
       source=valueExpression RIGHT_PAREN                                                       #extract
+    | primaryExpression COLLATE (identifier | STRING_LITERAL | DEFAULT)                        #collate
     ;
 
 functionIdentifier 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -33,6 +33,7 @@ import org.apache.doris.nereids.DorisParser.BooleanExpressionContext;
 import org.apache.doris.nereids.DorisParser.BooleanLiteralContext;
 import org.apache.doris.nereids.DorisParser.BracketJoinHintContext;
 import org.apache.doris.nereids.DorisParser.BracketRelationHintContext;
+import org.apache.doris.nereids.DorisParser.CollateContext;
 import org.apache.doris.nereids.DorisParser.ColumnReferenceContext;
 import org.apache.doris.nereids.DorisParser.CommentJoinHintContext;
 import org.apache.doris.nereids.DorisParser.CommentRelationHintContext;
@@ -2053,5 +2054,10 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
             return ((Literal) constant).getStringValue();
         }
         return context.getText();
+    }
+
+    @Override
+    public Object visitCollate(CollateContext ctx) {
+        return visit(ctx.primaryExpression());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/NereidsParserTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/NereidsParserTest.java
@@ -348,6 +348,7 @@ public class NereidsParserTest extends ParserTestBase {
     }
 
     @Test
+
     void testParseExprDepthWidth() {
         String sql = "SELECT 1+2 = 3 from t";
         NereidsParser nereidsParser = new NereidsParser();
@@ -356,5 +357,12 @@ public class NereidsParserTest extends ParserTestBase {
         // alias (1 + 2 = 3)
         Assertions.assertEquals(4, logicalPlan.getExpressions().get(0).getDepth());
         Assertions.assertEquals(3, logicalPlan.getExpressions().get(0).getWidth());
+    }
+
+    @Test
+    public void testParseCollate() {
+        String sql = "SELECT * FROM t1 WHERE col COLLATE utf8 = 'test'";
+        NereidsParser nereidsParser = new NereidsParser();
+        nereidsParser.parseSingle(sql);
     }
 }

--- a/regression-test/suites/nereids_syntax_p0/collate.groovy
+++ b/regression-test/suites/nereids_syntax_p0/collate.groovy
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("collate_grammar_test") {
+    sql "set enable_nereids_planner=true;"
+    sql "set enable_fallback_to_original_planner=false;"
+    sql """
+        select table_name from information_schema.tables         where table_schema collate utf8_general_ci = 'information_schema'           and table_name collate utf8_general_ci = 'parameters';
+    """
+
+}


### PR DESCRIPTION
## Proposed changes

Support such sql grammar, Just for compatibility

```sql
select table_name
from information_schema.tables
where table_schema collate utf8_general_ci = 'information_schema'
  and table_name collate utf8_general_ci = 'parameters';
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

