### PR TITLE
[fix](view) The parameter positions of timestamp diff function to sql are reversed

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -557,8 +557,8 @@ public class FunctionCallExpr extends Expr {
                 || fnName.getFunction().equalsIgnoreCase("hours_diff")
                 || fnName.getFunction().equalsIgnoreCase("minutes_diff")
                 || fnName.getFunction().equalsIgnoreCase("seconds_diff")) {
-            sb.append(children.get(1).toSql()).append(", ");
-            sb.append(children.get(0).toSql()).append(")");
+            sb.append(children.get(0).toSql()).append(", ");
+            sb.append(children.get(1).toSql()).append(")");
             return sb.toString();
         }
         // used by nereids END

--- a/regression-test/data/view_p0/view_p0.out
+++ b/regression-test/data/view_p0/view_p0.out
@@ -12,3 +12,6 @@
 1	2023-08-01	DORID_FIELD1	DORID_FIELD2	["cat", "dog"]	cat
 1	2023-08-01	DORID_FIELD1	DORID_FIELD2	["cat", "dog"]	dog
 
+-- !sql --
+960
+

--- a/regression-test/suites/view_p0/view_p0.groovy
+++ b/regression-test/suites/view_p0/view_p0.groovy
@@ -112,5 +112,15 @@ suite("view_p0") {
         ) c;
     """
     qt_sql "select * from test_element_at_view;"
+
+    sql "drop view if exists test_element_at_view"
+
+    sql "drop view if exists test_time_diff"
+
+    sql "create view test_time_diff as select minutes_diff('2023-01-16 10:05:04', '2023-01-15 18:05:04')"
+
+    qt_sql "select * from test_time_diff"
+
+    sql "drop view if exists test_time_diff"
     
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

