### PR TITLE
[Fix](Planner) fix create table as select failed

### DIFF
--- a/regression-test/suites/ddl_p0/test_ctas.groovy
+++ b/regression-test/suites/ddl_p0/test_ctas.groovy
@@ -234,10 +234,18 @@ suite("test_ctas") {
         
         String desc = sql 'desc c'
         assertTrue(desc.contains('Yes'))
+        sql '''create table test_date_v2 
+        properties (
+                "replication_num"="1"
+        ) as select to_date('20250829');
+        '''
+        desc = sql 'desc test_date_v2'
+        assertTrue(desc.contains('Yes'))
     } finally {
         sql 'drop table a'
         sql 'drop table b'
         sql 'drop table c'
+        sql 'drop table test_date_v2'
     }
 }
 


### PR DESCRIPTION
## Proposed changes

Problem: 
when create table as select using to_date function, it would failed

Example: 
create table test_to_date properties('replication_num' = '1') as select to_date('20230816') as datev2;

Reason:
after release version 2.0, datev1 is disabled, but to_date function signature does not upgrade, so it failed when checking return type of to_date

Solved:
when getfunction, forbidden to_date with return type date_v1， datetime v1 also changed to datetime v2 and decimal v2 changed to decimal v3

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

