### PR TITLE
[improve](Status) Add new status code`KEY_NOT_FOUND` and `KEY_ALREADY_EXISTS` for merge on write

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -268,6 +268,8 @@ E(INVERTED_INDEX_NO_TERMS, -6005);
 E(INVERTED_INDEX_RENAME_FILE_FAILED, -6006);
 E(INVERTED_INDEX_EVALUATE_SKIPPED, -6007);
 E(INVERTED_INDEX_BUILD_WAITTING, -6008);
+E(KEY_NOT_FOUND, -6009);
+E(KEY_ALREADY_EXISTS, -6010);
 #undef E
 } // namespace ErrorCode
 
@@ -305,7 +307,9 @@ constexpr bool capture_stacktrace(int code) {
         && code != ErrorCode::TRANSACTION_NOT_EXIST
         && code != ErrorCode::TRANSACTION_ALREADY_VISIBLE
         && code != ErrorCode::TOO_MANY_TRANSACTIONS
-        && code != ErrorCode::TRANSACTION_ALREADY_COMMITTED;
+        && code != ErrorCode::TRANSACTION_ALREADY_COMMITTED
+        && code != ErrorCode::KEY_NOT_FOUND
+        && code != ErrorCode::KEY_ALREADY_EXISTS;
 }
 // clang-format on
 

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -367,14 +367,14 @@ Status Segment::lookup_row_key(const Slice& key, bool with_seq_col, RowLocation*
 
     DCHECK(_pk_index_reader != nullptr);
     if (!_pk_index_reader->check_present(key_without_seq)) {
-        return Status::NotFound("Can't find key in the segment");
+        return Status::Error<ErrorCode::KEY_NOT_FOUND>("Can't find key in the segment");
     }
     bool exact_match = false;
     std::unique_ptr<segment_v2::IndexedColumnIterator> index_iterator;
     RETURN_IF_ERROR(_pk_index_reader->new_iterator(&index_iterator));
     RETURN_IF_ERROR(index_iterator->seek_at_or_after(&key_without_seq, &exact_match));
     if (!has_seq_col && !exact_match) {
-        return Status::NotFound("Can't find key in the segment");
+        return Status::Error<ErrorCode::KEY_NOT_FOUND>("Can't find key in the segment");
     }
     row_location->row_id = index_iterator->get_current_ordinal();
     row_location->segment_id = _segment_id;
@@ -396,7 +396,7 @@ Status Segment::lookup_row_key(const Slice& key, bool with_seq_col, RowLocation*
 
         // compare key
         if (key_without_seq.compare(sought_key_without_seq) != 0) {
-            return Status::NotFound("Can't find key in the segment");
+            return Status::Error<ErrorCode::KEY_NOT_FOUND>("Can't find key in the segment");
         }
 
         if (!with_seq_col) {
@@ -409,7 +409,8 @@ Status Segment::lookup_row_key(const Slice& key, bool with_seq_col, RowLocation*
         Slice previous_sequence_id = Slice(
                 sought_key.get_data() + sought_key_without_seq.get_size() + 1, seq_col_length - 1);
         if (sequence_id.compare(previous_sequence_id) < 0) {
-            return Status::AlreadyExist("key with higher sequence id exists");
+            return Status::Error<ErrorCode::KEY_ALREADY_EXISTS>(
+                    "key with higher sequence id exists");
         }
     }
 

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -419,7 +419,7 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
         RowsetSharedPtr rowset;
         auto st = _tablet->lookup_row_key(key, have_input_seq_column, specified_rowsets, &loc,
                                           _mow_context->max_version, segment_caches, &rowset);
-        if (st.is<NOT_FOUND>()) {
+        if (st.is<KEY_NOT_FOUND>()) {
             if (_tablet_schema->is_strict_mode()) {
                 ++num_rows_filtered;
                 // delete the invalid newly inserted row
@@ -436,7 +436,7 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
             use_default_or_null_flag.emplace_back(true);
             continue;
         }
-        if (!st.ok() && !st.is<ALREADY_EXIST>()) {
+        if (!st.ok() && !st.is<KEY_ALREADY_EXISTS>()) {
             LOG(WARNING) << "failed to lookup row key, error: " << st;
             return st;
         }
@@ -454,7 +454,7 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
             _tablet->prepare_to_read(loc, segment_pos, &_rssid_to_rid);
         }
 
-        if (st.is<ALREADY_EXIST>()) {
+        if (st.is<KEY_ALREADY_EXISTS>()) {
             // although we need to mark delete current row, we still need to read missing columns
             // for this row, we need to ensure that each column is aligned
             _mow_context->delete_bitmap->add({_opts.rowset_ctx->rowset_id, _segment_id, 0},

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -580,10 +580,6 @@ private:
     bool _reconstruct_version_tracker_if_necessary();
     void _init_context_common_fields(RowsetWriterContext& context);
 
-    Status _check_pk_in_pre_segments(RowsetId rowset_id,
-                                     const std::vector<segment_v2::SegmentSharedPtr>& pre_segments,
-                                     const Slice& key, DeleteBitmapPtr delete_bitmap,
-                                     RowLocation* loc);
     void _rowset_ids_difference(const RowsetIdUnorderedSet& cur, const RowsetIdUnorderedSet& pre,
                                 RowsetIdUnorderedSet* to_add, RowsetIdUnorderedSet* to_del);
     Status _load_rowset_segments(const RowsetSharedPtr& rowset,

--- a/be/src/service/point_query_executor.cpp
+++ b/be/src/service/point_query_executor.cpp
@@ -287,7 +287,7 @@ Status PointQueryExecutor::_lookup_row_key() {
         st = (_tablet->lookup_row_key(_row_read_ctxs[i]._primary_key, true, specified_rowsets,
                                       &location, INT32_MAX /*rethink?*/, segment_caches,
                                       rowset_ptr.get()));
-        if (st.is<ErrorCode::NOT_FOUND>()) {
+        if (st.is<ErrorCode::KEY_NOT_FOUND>()) {
             continue;
         }
         RETURN_IF_ERROR(st);


### PR DESCRIPTION
## Proposed changes

For merge on write table, when loading data, it will call `lookup_row_key` to find if there exists a row with the same key as the inserted row. The return value of `lookup_row_key` can be one of `Status::NotFound`/`Status::AlreadyExist`/`Status::OK`.  Currently, call to `Status::NotFound`/`Status::AlreadyExist` will lead to printing stacktrace info. However, the number of call to `Status::NotFound`/`Status::AlreadyExist` can be up to **the number of rows inserted times the number segments of the tablet** in the worst case. So it may print lots of useless stacktrace info when loading data. So this PR add two new status code for this scenarios to eliminate printing these useless stacktrace info.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

