### PR TITLE
[fix](Nereids): avoid Exception to cause analyze time too long

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/IdenticalSignature.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/IdenticalSignature.java
@@ -18,7 +18,9 @@
 package org.apache.doris.nereids.trees.expressions.functions;
 
 import org.apache.doris.catalog.FunctionSignature;
+import org.apache.doris.nereids.types.ArrayType;
 import org.apache.doris.nereids.types.DataType;
+import org.apache.doris.nereids.types.coercion.AnyDataType;
 
 import java.util.List;
 
@@ -33,6 +35,12 @@ public interface IdenticalSignature extends ComputeSignature {
     static boolean isIdentical(DataType signatureType, DataType realType) {
         try {
             // TODO: copy matchesType to DataType
+            // TODO: resolve AnyDataType invoke toCatalogDataType
+            if (signatureType instanceof ArrayType) {
+                if (((ArrayType) signatureType).getItemType() instanceof AnyDataType) {
+                    return false;
+                }
+            }
             return realType.toCatalogDataType().matchesType(signatureType.toCatalogDataType());
         } catch (Throwable t) {
             // the signatureType maybe DataType and can not cast to catalog data type.

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ImplicitlyCastableSignature.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ImplicitlyCastableSignature.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids.trees.expressions.functions;
 
 import org.apache.doris.catalog.FunctionSignature;
 import org.apache.doris.catalog.Type;
+import org.apache.doris.nereids.types.ArrayType;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.NullType;
 import org.apache.doris.nereids.types.coercion.AnyDataType;
@@ -51,6 +52,12 @@ public interface ImplicitlyCastableSignature extends ComputeSignature {
         }
         try {
             // TODO: copy isImplicitlyCastable method to DataType
+            // TODO: resolve AnyDataType invoke toCatalogDataType
+            if (signatureType instanceof ArrayType) {
+                if (((ArrayType) signatureType).getItemType() instanceof AnyDataType) {
+                    return false;
+                }
+            }
             if (Type.isImplicitlyCastable(realType.toCatalogDataType(), signatureType.toCatalogDataType(), true)) {
                 return true;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/NullOrIdenticalSignature.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/NullOrIdenticalSignature.java
@@ -18,8 +18,10 @@
 package org.apache.doris.nereids.trees.expressions.functions;
 
 import org.apache.doris.catalog.FunctionSignature;
+import org.apache.doris.nereids.types.ArrayType;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.NullType;
+import org.apache.doris.nereids.types.coercion.AnyDataType;
 
 import java.util.List;
 
@@ -34,6 +36,12 @@ public interface NullOrIdenticalSignature extends ComputeSignature {
     static boolean isNullOrIdentical(DataType signatureType, DataType realType) {
         try {
             // TODO: copy matchesType to DataType
+            // TODO: resolve AnyDataType invoke toCatalogDataType
+            if (signatureType instanceof ArrayType) {
+                if (((ArrayType) signatureType).getItemType() instanceof AnyDataType) {
+                    return false;
+                }
+            }
             return realType instanceof NullType
                     || realType.toCatalogDataType().matchesType(signatureType.toCatalogDataType());
         } catch (Throwable t) {


### PR DESCRIPTION
## Proposed changes

AnyDataType will cause toCatalogDataType throw Exception, it will cost much time.

Avoid to throw Exception in Analyzer.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

