### PR TITLE
[fix](function) add arraySubTypes with  DECIMALV3 

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/Type.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/Type.java
@@ -168,6 +168,9 @@ public abstract class Type {
         arraySubTypes.add(CHAR);
         arraySubTypes.add(VARCHAR);
         arraySubTypes.add(STRING);
+        arraySubTypes.add(DECIMAL32);
+        arraySubTypes.add(DECIMAL64);
+        arraySubTypes.add(DECIMAL128);
     }
 
     public static final Set<Class> DATE_SUPPORTED_JAVA_TYPE = Sets.newHashSet(LocalDate.class, java.util.Date.class,


### PR DESCRIPTION
## Proposed changes

close #23606 

For example, in the collect_list function, the return value is of type 'array'. If the arraySubTypes does not include the 'decimalv3' type, a type conversion will be performed. This will result in casting 'decimalv3' as 'char', causing a type error and potentially leading to a core issue.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

