### PR TITLE
[fix](union) should open/alloc_resource in sink operator instead of source

### DIFF
--- a/be/src/pipeline/exec/union_sink_operator.h
+++ b/be/src/pipeline/exec/union_sink_operator.h
@@ -56,8 +56,6 @@ public:
 
     Status sink(RuntimeState* state, vectorized::Block* in_block,
                 SourceState source_state) override;
-    // this operator in sink open directly return, do this work in source
-    Status open(RuntimeState* /*state*/) override { return Status::OK(); }
 
     Status close(RuntimeState* state) override;
 

--- a/be/src/pipeline/exec/union_source_operator.h
+++ b/be/src/pipeline/exec/union_source_operator.h
@@ -52,6 +52,9 @@ public:
     UnionSourceOperator(OperatorBuilderBase* operator_builder, ExecNode* node,
                         std::shared_ptr<DataQueue>);
 
+    // this operator in source open directly return, do this work in sink
+    Status open(RuntimeState* /*state*/) override { return Status::OK(); }
+
     Status get_block(RuntimeState* state, vectorized::Block* block,
                      SourceState& source_state) override;
     bool can_read() override;

--- a/be/src/vec/exec/vunion_node.h
+++ b/be/src/vec/exec/vunion_node.h
@@ -91,6 +91,9 @@ private:
     /// to -1 if no child needs to be closed.
     int _to_close_child_idx;
 
+    std::mutex _resource_lock;
+    bool _resource_allocated {false};
+
     // Time spent to evaluates exprs and materializes the results
     RuntimeProfile::Counter* _materialize_exprs_evaluate_timer = nullptr;
     /// GetNext() for the passthrough case. We pass 'block' directly into the GetNext()


### PR DESCRIPTION
## Proposed changes

The sink operator processes the data before the source operator, therefore the expressions need to be opened in the sink operator.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

