### PR TITLE
[improvement](jdbc catalog) Remove useless mysql jdbc connection parameters

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcResource.java
@@ -300,11 +300,8 @@ public class JdbcResource extends Resource {
             newJdbcUrl = checkAndSetJdbcBoolParam(newJdbcUrl, "yearIsDateType", "true", "false");
             // MySQL Types and Return Values for GetColumnTypeName and GetColumnClassName
             // are presented in https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-type-conversions.html
-            // However when tinyInt1isBit=false, GetColumnClassName of MySQL returns java.lang.Boolean,
-            // while that of Doris returns java.lang.Integer. In order to be compatible with both MySQL and Doris,
-            // Jdbc params should set tinyInt1isBit=true&transformedBitIsBoolean=true
+            // When mysql's tinyint stores non-0 or 1, we need to read the data correctly, so we need tinyInt1isBit=false
             newJdbcUrl = checkAndSetJdbcBoolParam(newJdbcUrl, "tinyInt1isBit", "true", "false");
-            newJdbcUrl = checkAndSetJdbcBoolParam(newJdbcUrl, "transformedBitIsBoolean", "false", "true");
             // set useUnicode and characterEncoding to false and utf-8
             newJdbcUrl = checkAndSetJdbcBoolParam(newJdbcUrl, "useUnicode", "false", "true");
             newJdbcUrl = checkAndSetJdbcBoolParam(newJdbcUrl, "rewriteBatchedStatements", "false", "true");

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcResource.java
@@ -300,7 +300,8 @@ public class JdbcResource extends Resource {
             newJdbcUrl = checkAndSetJdbcBoolParam(newJdbcUrl, "yearIsDateType", "true", "false");
             // MySQL Types and Return Values for GetColumnTypeName and GetColumnClassName
             // are presented in https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-type-conversions.html
-            // When mysql's tinyint stores non-0 or 1, we need to read the data correctly, so we need tinyInt1isBit=false
+            // When mysql's tinyint stores non-0 or 1, we need to read the data correctly,
+            // so we need tinyInt1isBit=false
             newJdbcUrl = checkAndSetJdbcBoolParam(newJdbcUrl, "tinyInt1isBit", "true", "false");
             // set useUnicode and characterEncoding to false and utf-8
             newJdbcUrl = checkAndSetJdbcBoolParam(newJdbcUrl, "useUnicode", "false", "true");


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

When tinyInt1isBit forced to false transformedBitIsBoolean doesn't work, so I deleted it

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

