### PR TITLE
[fix](stacktrace) Temporary fix ARM and MacOS stacktrace

### DIFF
--- a/be/src/common/stack_trace.cpp
+++ b/be/src/common/stack_trace.cpp
@@ -299,7 +299,7 @@ StackTrace::StackTrace(const ucontext_t& signal_context) {
 void StackTrace::tryCapture() {
     // When unw_backtrace is not available, fall back on the standard
     // `backtrace` function from execinfo.h.
-#if USE_UNWIND
+#if USE_UNWIND && defined(__x86_64__) // TODO
     size = unw_backtrace(frame_pointers.data(), capacity);
 #else
     size = backtrace(frame_pointers.data(), capacity);

--- a/be/src/util/stack_util.cpp
+++ b/be/src/util/stack_util.cpp
@@ -45,6 +45,9 @@ std::string get_stack_trace() {
     } else if (tool == "glibc") {
         return get_stack_trace_by_glibc();
     } else if (tool == "libunwind") {
+#if defined(__APPLE__) // TODO
+        return get_stack_trace_by_glog();
+#endif
         return get_stack_trace_by_libunwind();
     } else {
         return "no stack";


### PR DESCRIPTION
## Proposed changes

Issue Number: #23633

Temporary ARM use glibc backtrace, compared to libunwind will have no line numbers
Temporary MacOS use glog, will be slower and have no line numbers compared to libunwind, but does not affect debugging

I will do more tests on ARM and MacOS later

![img_v2_514f4233-ea46-4860-b214-17a7478d31bg](https://github.com/apache/doris/assets/13197424/26f3d24b-96d1-4b11-88c7-8df3b76655da)
![img_v2_1c0b29e6-267f-4757-891f-83529978559g](https://github.com/apache/doris/assets/13197424/3b54a93b-9433-441b-98c4-c1e2923a2b10)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

