### PR TITLE
[fix](jdbc catalog) fix jdbc driver cache load error

### DIFF
--- a/be/src/runtime/user_function_cache.cpp
+++ b/be/src/runtime/user_function_cache.cpp
@@ -151,7 +151,7 @@ Status UserFunctionCache::_load_entry_from_lib(const std::string& dir, const std
                 file);
     }
 
-    std::vector<std::string> split_parts = strings::Split(file, ".");
+    std::vector<std::string> split_parts = _split_string_by_checksum(file);
     if (split_parts.size() != 3 && split_parts.size() != 4) {
         return Status::InternalError(
                 "user function's name should be function_id.checksum[.file_name].file_type, now "
@@ -379,4 +379,27 @@ Status UserFunctionCache::get_jarpath(int64_t fid, const std::string& url,
     return Status::OK();
 }
 
+std::vector<std::string> UserFunctionCache::_split_string_by_checksum(const std::string& file) {
+    std::vector<std::string> result;
+
+    // Find the first dot from the start
+    size_t firstDot = file.find('.');
+    if (firstDot == std::string::npos) return {};
+
+    // Find the second dot starting from the first dot's position
+    size_t secondDot = file.find('.', firstDot + 1);
+    if (secondDot == std::string::npos) return {};
+
+    // Find the last dot from the end
+    size_t lastDot = file.rfind('.');
+    if (lastDot == std::string::npos || lastDot <= secondDot) return {};
+
+    // Split based on these dots
+    result.push_back(file.substr(0, firstDot));
+    result.push_back(file.substr(firstDot + 1, secondDot - firstDot - 1));
+    result.push_back(file.substr(secondDot + 1, lastDot - secondDot - 1));
+    result.push_back(file.substr(lastDot + 1));
+
+    return result;
+}
 } // namespace doris

--- a/be/src/runtime/user_function_cache.h
+++ b/be/src/runtime/user_function_cache.h
@@ -74,6 +74,7 @@ private:
 
     std::string _get_real_url(const std::string& url);
     std::string _get_file_name_from_url(const std::string& url) const;
+    std::vector<std::string> _split_string_by_checksum(const std::string& file);
 
 private:
     std::string _lib_dir;

--- a/be/test/runtime/user_function_cache_test.cpp
+++ b/be/test/runtime/user_function_cache_test.cpp
@@ -16,3 +16,31 @@
 // under the License.
 
 #include "runtime/user_function_cache.h"
+
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+
+#include <string>
+
+#include "gtest/gtest.h"
+
+namespace doris {
+
+class UserFunctionCacheTest : public ::testing::Test {
+protected:
+    UserFunctionCache ufc;
+};
+
+TEST_F(UserFunctionCacheTest, SplitStringByChecksumTest) {
+    // Test valid string format
+    std::string valid_str =
+            "7119053928154065546.20c8228267b6c9ce620fddb39467d3eb.postgresql-42.5.0.jar";
+    auto result = ufc._split_string_by_checksum(valid_str);
+    ASSERT_EQ(result.size(), 4);
+    EXPECT_EQ(result[0], "7119053928154065546");
+    EXPECT_EQ(result[1], "20c8228267b6c9ce620fddb39467d3eb");
+    EXPECT_EQ(result[2], "postgresql-42.5.0");
+    EXPECT_EQ(result[3], "jar");
+}
+
+} // namespace doris


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

log error:
`W20230830 11:19:47.495721 3046231 status.h:363] meet error status: [INTERNAL_ERROR]user function's name should be function_id.checksum[.file_name].file_type, now the all split parts are by delimiter(.): 7119053928154065546.20c8228267b6c9ce620fddb39467d3eb.postgresql-42.5.0.jar`

When the jdbc driver had `.` in its name we failed to split it properly

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

