### PR TITLE
[opt](cache) Support segment cache dynamic opening and closing

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -300,6 +300,7 @@ DEFINE_mInt32(trash_file_expire_time_sec, "259200");
 // minimum file descriptor number
 // modify them upon necessity
 DEFINE_Int32(min_file_descriptor_number, "60000");
+DEFINE_mBool(disable_segment_cache, "false");
 DEFINE_Int64(index_stream_cache_capacity, "10737418240");
 DEFINE_String(row_cache_mem_limit, "20%");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -347,6 +347,7 @@ DECLARE_mInt32(trash_file_expire_time_sec);
 // minimum file descriptor number
 // modify them upon necessity
 DECLARE_Int32(min_file_descriptor_number);
+DECLARE_mBool(disable_segment_cache);
 DECLARE_Int64(index_stream_cache_capacity);
 DECLARE_String(row_cache_mem_limit);
 
@@ -359,6 +360,7 @@ DECLARE_Int32(storage_page_cache_shard_size);
 // all storage page cache will be divided into data_page_cache and index_page_cache
 DECLARE_Int32(index_page_cache_percentage);
 // whether to disable page cache feature in storage
+// TODO delete it. Divided into Data page, Index page, pk index page
 DECLARE_Bool(disable_storage_page_cache);
 // whether to disable row cache feature in storage
 DECLARE_Bool(disable_storage_row_cache);

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -259,6 +259,17 @@ void StorageEngine::_cache_clean_callback() {
         }
 
         CacheManager::instance()->for_each_cache_prune_stale();
+
+        // Dynamically modify the config to clear the cache, each time the disable cache will only be cleared once.
+        // TODO, Support page cache and other caches.
+        if (config::disable_segment_cache) {
+            if (!_clear_segment_cache) {
+                CacheManager::instance()->clear_once("SegmentCache");
+                _clear_segment_cache = true;
+            }
+        } else {
+            _clear_segment_cache = false;
+        }
     }
 }
 

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -264,7 +264,7 @@ void StorageEngine::_cache_clean_callback() {
         // TODO, Support page cache and other caches.
         if (config::disable_segment_cache) {
             if (!_clear_segment_cache) {
-                CacheManager::instance()->clear_once(CachePolicy::Type::SEGMENT_CACHE);
+                CacheManager::instance()->clear_once(CachePolicy::CacheType::SEGMENT_CACHE);
                 _clear_segment_cache = true;
             }
         } else {

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -264,7 +264,7 @@ void StorageEngine::_cache_clean_callback() {
         // TODO, Support page cache and other caches.
         if (config::disable_segment_cache) {
             if (!_clear_segment_cache) {
-                CacheManager::instance()->clear_once("SegmentCache");
+                CacheManager::instance()->clear_once(CachePolicy::Type::SEGMENT_CACHE);
                 _clear_segment_cache = true;
             }
         } else {

--- a/be/src/olap/page_cache.h
+++ b/be/src/olap/page_cache.h
@@ -103,21 +103,23 @@ public:
     class DataPageCache : public LRUCachePolicy {
     public:
         DataPageCache(size_t capacity, uint32_t num_shards)
-                : LRUCachePolicy(CachePolicy::Type::DATA_PAGE_CACHE, capacity, LRUCacheType::SIZE,
-                                 config::data_page_cache_stale_sweep_time_sec, num_shards) {}
+                : LRUCachePolicy(CachePolicy::CacheType::DATA_PAGE_CACHE, capacity,
+                                 LRUCacheType::SIZE, config::data_page_cache_stale_sweep_time_sec,
+                                 num_shards) {}
     };
 
     class IndexPageCache : public LRUCachePolicy {
     public:
         IndexPageCache(size_t capacity, uint32_t num_shards)
-                : LRUCachePolicy(CachePolicy::Type::INDEXPAGE_CACHE, capacity, LRUCacheType::SIZE,
-                                 config::index_page_cache_stale_sweep_time_sec, num_shards) {}
+                : LRUCachePolicy(CachePolicy::CacheType::INDEXPAGE_CACHE, capacity,
+                                 LRUCacheType::SIZE, config::index_page_cache_stale_sweep_time_sec,
+                                 num_shards) {}
     };
 
     class PKIndexPageCache : public LRUCachePolicy {
     public:
         PKIndexPageCache(size_t capacity, uint32_t num_shards)
-                : LRUCachePolicy(CachePolicy::Type::PK_INDEX_PAGE_CACHE, capacity,
+                : LRUCachePolicy(CachePolicy::CacheType::PK_INDEX_PAGE_CACHE, capacity,
                                  LRUCacheType::SIZE,
                                  config::pk_index_page_cache_stale_sweep_time_sec, num_shards) {}
     };

--- a/be/src/olap/page_cache.h
+++ b/be/src/olap/page_cache.h
@@ -103,21 +103,22 @@ public:
     class DataPageCache : public LRUCachePolicy {
     public:
         DataPageCache(size_t capacity, uint32_t num_shards)
-                : LRUCachePolicy("DataPageCache", capacity, LRUCacheType::SIZE,
+                : LRUCachePolicy(CachePolicy::Type::DATA_PAGE_CACHE, capacity, LRUCacheType::SIZE,
                                  config::data_page_cache_stale_sweep_time_sec, num_shards) {}
     };
 
     class IndexPageCache : public LRUCachePolicy {
     public:
         IndexPageCache(size_t capacity, uint32_t num_shards)
-                : LRUCachePolicy("IndexPageCache", capacity, LRUCacheType::SIZE,
+                : LRUCachePolicy(CachePolicy::Type::INDEXPAGE_CACHE, capacity, LRUCacheType::SIZE,
                                  config::index_page_cache_stale_sweep_time_sec, num_shards) {}
     };
 
     class PKIndexPageCache : public LRUCachePolicy {
     public:
         PKIndexPageCache(size_t capacity, uint32_t num_shards)
-                : LRUCachePolicy("PKIndexPageCache", capacity, LRUCacheType::SIZE,
+                : LRUCachePolicy(CachePolicy::Type::PK_INDEX_PAGE_CACHE, capacity,
+                                 LRUCacheType::SIZE,
                                  config::pk_index_page_cache_stale_sweep_time_sec, num_shards) {}
     };
 

--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
@@ -62,7 +62,7 @@ void InvertedIndexSearcherCache::create_global_instance(size_t capacity, uint32_
 }
 
 InvertedIndexSearcherCache::InvertedIndexSearcherCache(size_t capacity, uint32_t num_shards)
-        : LRUCachePolicy("InvertedIndexSearcherCache",
+        : LRUCachePolicy(CachePolicy::Type::INVERTEDINDEX_SEARCHER_CACHE,
                          config::inverted_index_cache_stale_sweep_time_sec),
           _mem_tracker(std::make_unique<MemTracker>("InvertedIndexSearcherCache")) {
     SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());

--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
@@ -62,7 +62,7 @@ void InvertedIndexSearcherCache::create_global_instance(size_t capacity, uint32_
 }
 
 InvertedIndexSearcherCache::InvertedIndexSearcherCache(size_t capacity, uint32_t num_shards)
-        : LRUCachePolicy(CachePolicy::Type::INVERTEDINDEX_SEARCHER_CACHE,
+        : LRUCachePolicy(CachePolicy::CacheType::INVERTEDINDEX_SEARCHER_CACHE,
                          config::inverted_index_cache_stale_sweep_time_sec),
           _mem_tracker(std::make_unique<MemTracker>("InvertedIndexSearcherCache")) {
     SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());

--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.h
@@ -237,8 +237,9 @@ public:
     InvertedIndexQueryCache() = delete;
 
     InvertedIndexQueryCache(size_t capacity, uint32_t num_shards)
-            : LRUCachePolicy("InvertedIndexQueryCache", capacity, LRUCacheType::SIZE,
-                             config::inverted_index_cache_stale_sweep_time_sec, num_shards) {}
+            : LRUCachePolicy(CachePolicy::Type::INVERTEDINDEX_QUERY_CACHE, capacity,
+                             LRUCacheType::SIZE, config::inverted_index_cache_stale_sweep_time_sec,
+                             num_shards) {}
 
     bool lookup(const CacheKey& key, InvertedIndexQueryCacheHandle* handle);
 

--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.h
@@ -237,7 +237,7 @@ public:
     InvertedIndexQueryCache() = delete;
 
     InvertedIndexQueryCache(size_t capacity, uint32_t num_shards)
-            : LRUCachePolicy(CachePolicy::Type::INVERTEDINDEX_QUERY_CACHE, capacity,
+            : LRUCachePolicy(CachePolicy::CacheType::INVERTEDINDEX_QUERY_CACHE, capacity,
                              LRUCacheType::SIZE, config::inverted_index_cache_stale_sweep_time_sec,
                              num_shards) {}
 

--- a/be/src/olap/schema_cache.h
+++ b/be/src/olap/schema_cache.h
@@ -117,7 +117,7 @@ public:
 
 private:
     SchemaCache(size_t capacity)
-            : LRUCachePolicy(CachePolicy::Type::SCHEMA_CACHE, capacity, LRUCacheType::NUMBER,
+            : LRUCachePolicy(CachePolicy::CacheType::SCHEMA_CACHE, capacity, LRUCacheType::NUMBER,
                              config::schema_cache_sweep_time_sec) {}
     static constexpr char SCHEMA_DELIMITER = '-';
     static SchemaCache* _s_instance;

--- a/be/src/olap/schema_cache.h
+++ b/be/src/olap/schema_cache.h
@@ -117,7 +117,7 @@ public:
 
 private:
     SchemaCache(size_t capacity)
-            : LRUCachePolicy("SchemaCache", capacity, LRUCacheType::NUMBER,
+            : LRUCachePolicy(CachePolicy::Type::SCHEMA_CACHE, capacity, LRUCacheType::NUMBER,
                              config::schema_cache_sweep_time_sec) {}
     static constexpr char SCHEMA_DELIMITER = '-';
     static SchemaCache* _s_instance;

--- a/be/src/olap/segment_loader.cpp
+++ b/be/src/olap/segment_loader.cpp
@@ -70,14 +70,14 @@ Status SegmentLoader::load_segments(const BetaRowsetSharedPtr& rowset,
     }
 
     SegmentCache::CacheKey cache_key(rowset->rowset_id());
-    if (_segment_cache->lookup(cache_key, cache_handle)) {
+    if (!config::disable_segment_cache && _segment_cache->lookup(cache_key, cache_handle)) {
         return Status::OK();
     }
 
     std::vector<segment_v2::SegmentSharedPtr> segments;
     RETURN_IF_ERROR(rowset->load_segments(&segments));
 
-    if (use_cache) {
+    if (use_cache && !config::disable_segment_cache) {
         // memory of SegmentCache::CacheValue will be handled by SegmentCache
         SegmentCache::CacheValue* cache_value = new SegmentCache::CacheValue();
         cache_value->segments = std::move(segments);

--- a/be/src/olap/segment_loader.h
+++ b/be/src/olap/segment_loader.h
@@ -73,7 +73,7 @@ public:
     };
 
     SegmentCache(size_t capacity)
-            : LRUCachePolicy(CachePolicy::Type::SEGMENT_CACHE, capacity, LRUCacheType::NUMBER,
+            : LRUCachePolicy(CachePolicy::CacheType::SEGMENT_CACHE, capacity, LRUCacheType::NUMBER,
                              config::tablet_rowset_stale_sweep_time_sec) {}
 
     // Lookup the given rowset in the cache.

--- a/be/src/olap/segment_loader.h
+++ b/be/src/olap/segment_loader.h
@@ -73,7 +73,7 @@ public:
     };
 
     SegmentCache(size_t capacity)
-            : LRUCachePolicy("SegmentCache", capacity, LRUCacheType::NUMBER,
+            : LRUCachePolicy(CachePolicy::Type::SEGMENT_CACHE, capacity, LRUCacheType::NUMBER,
                              config::tablet_rowset_stale_sweep_time_sec) {}
 
     // Lookup the given rowset in the cache.

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -483,6 +483,8 @@ private:
     scoped_refptr<Thread> _async_publish_thread;
     std::mutex _async_publish_mutex;
 
+    bool _clear_segment_cache = false;
+
     DISALLOW_COPY_AND_ASSIGN(StorageEngine);
 };
 

--- a/be/src/runtime/memory/cache_manager.cpp
+++ b/be/src/runtime/memory/cache_manager.cpp
@@ -46,10 +46,10 @@ int64_t CacheManager::for_each_cache_prune_all(RuntimeProfile* profile) {
             [](CachePolicy* cache_policy) { cache_policy->prune_all(false); }, profile);
 }
 
-void CacheManager::clear_once(const std::string& name) {
+void CacheManager::clear_once(CachePolicy::Type type) {
     std::lock_guard<std::mutex> l(_caches_lock);
     for (auto cache_policy : _caches) {
-        if (cache_policy->name() == name) {
+        if (cache_policy->type() == type) {
             cache_policy->prune_all(true); // will print log
         }
     }

--- a/be/src/runtime/memory/cache_manager.cpp
+++ b/be/src/runtime/memory/cache_manager.cpp
@@ -43,7 +43,16 @@ int64_t CacheManager::for_each_cache_prune_stale(RuntimeProfile* profile) {
 
 int64_t CacheManager::for_each_cache_prune_all(RuntimeProfile* profile) {
     return for_each_cache_prune_stale_wrap(
-            [](CachePolicy* cache_policy) { cache_policy->prune_all(); }, profile);
+            [](CachePolicy* cache_policy) { cache_policy->prune_all(false); }, profile);
+}
+
+void CacheManager::clear_once(const std::string& name) {
+    std::lock_guard<std::mutex> l(_caches_lock);
+    for (auto cache_policy : _caches) {
+        if (cache_policy->name() == name) {
+            cache_policy->prune_all(true); // will print log
+        }
+    }
 }
 
 } // namespace doris

--- a/be/src/runtime/memory/cache_manager.cpp
+++ b/be/src/runtime/memory/cache_manager.cpp
@@ -46,7 +46,7 @@ int64_t CacheManager::for_each_cache_prune_all(RuntimeProfile* profile) {
             [](CachePolicy* cache_policy) { cache_policy->prune_all(false); }, profile);
 }
 
-void CacheManager::clear_once(CachePolicy::Type type) {
+void CacheManager::clear_once(CachePolicy::CacheType type) {
     std::lock_guard<std::mutex> l(_caches_lock);
     for (auto cache_policy : _caches) {
         if (cache_policy->type() == type) {

--- a/be/src/runtime/memory/cache_manager.h
+++ b/be/src/runtime/memory/cache_manager.h
@@ -17,11 +17,10 @@
 
 #pragma once
 
+#include "runtime/memory/cache_policy.h"
 #include "util/runtime_profile.h"
 
 namespace doris {
-
-class CachePolicy;
 
 // Hold the list of all caches, for prune when memory not enough or timing.
 class CacheManager {
@@ -53,7 +52,7 @@ public:
 
     int64_t for_each_cache_prune_all(RuntimeProfile* profile = nullptr);
 
-    void clear_once(const std::string& name);
+    void clear_once(CachePolicy::Type type);
 
 private:
     static inline CacheManager* _s_instance = nullptr;

--- a/be/src/runtime/memory/cache_manager.h
+++ b/be/src/runtime/memory/cache_manager.h
@@ -53,6 +53,8 @@ public:
 
     int64_t for_each_cache_prune_all(RuntimeProfile* profile = nullptr);
 
+    void clear_once(const std::string& name);
+
 private:
     static inline CacheManager* _s_instance = nullptr;
 

--- a/be/src/runtime/memory/cache_manager.h
+++ b/be/src/runtime/memory/cache_manager.h
@@ -52,7 +52,7 @@ public:
 
     int64_t for_each_cache_prune_all(RuntimeProfile* profile = nullptr);
 
-    void clear_once(CachePolicy::Type type);
+    void clear_once(CachePolicy::CacheType type);
 
 private:
     static inline CacheManager* _s_instance = nullptr;

--- a/be/src/runtime/memory/cache_policy.cpp
+++ b/be/src/runtime/memory/cache_policy.cpp
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "runtime/memory/cache_policy.h"
+
+#include "runtime/memory/cache_manager.h"
+
+namespace doris {
+
+CachePolicy::CachePolicy(Type type, uint32_t stale_sweep_time_s)
+        : _type(type), _stale_sweep_time_s(stale_sweep_time_s) {
+    _it = CacheManager::instance()->register_cache(this);
+    init_profile();
+}
+
+CachePolicy::~CachePolicy() {
+    CacheManager::instance()->unregister_cache(_it);
+}
+
+} // namespace doris

--- a/be/src/runtime/memory/cache_policy.cpp
+++ b/be/src/runtime/memory/cache_policy.cpp
@@ -21,7 +21,7 @@
 
 namespace doris {
 
-CachePolicy::CachePolicy(Type type, uint32_t stale_sweep_time_s)
+CachePolicy::CachePolicy(CacheType type, uint32_t stale_sweep_time_s)
         : _type(type), _stale_sweep_time_s(stale_sweep_time_s) {
     _it = CacheManager::instance()->register_cache(this);
     init_profile();

--- a/be/src/runtime/memory/cache_policy.h
+++ b/be/src/runtime/memory/cache_policy.h
@@ -26,7 +26,7 @@ static constexpr int32_t CACHE_MIN_FREE_SIZE = 67108864; // 64M
 // Base of all caches. register to CacheManager when cache is constructed.
 class CachePolicy {
 public:
-    enum class Type {
+    enum class CacheType {
         DATA_PAGE_CACHE = 0,
         INDEXPAGE_CACHE = 1,
         PK_INDEX_PAGE_CACHE = 2,
@@ -37,23 +37,23 @@ public:
         LOOKUP_CONNECTION_CACHE = 7
     };
 
-    static std::string type_string(Type type) {
+    static std::string type_string(CacheType type) {
         switch (type) {
-        case Type::DATA_PAGE_CACHE:
+        case CacheType::DATA_PAGE_CACHE:
             return "DataPageCache";
-        case Type::INDEXPAGE_CACHE:
+        case CacheType::INDEXPAGE_CACHE:
             return "IndexPageCache";
-        case Type::PK_INDEX_PAGE_CACHE:
+        case CacheType::PK_INDEX_PAGE_CACHE:
             return "PKIndexPageCache";
-        case Type::SCHEMA_CACHE:
+        case CacheType::SCHEMA_CACHE:
             return "SchemaCache";
-        case Type::SEGMENT_CACHE:
+        case CacheType::SEGMENT_CACHE:
             return "SegmentCache";
-        case Type::INVERTEDINDEX_SEARCHER_CACHE:
+        case CacheType::INVERTEDINDEX_SEARCHER_CACHE:
             return "InvertedIndexSearcherCache";
-        case Type::INVERTEDINDEX_QUERY_CACHE:
+        case CacheType::INVERTEDINDEX_QUERY_CACHE:
             return "InvertedIndexQueryCache";
-        case Type::LOOKUP_CONNECTION_CACHE:
+        case CacheType::LOOKUP_CONNECTION_CACHE:
             return "LookupConnectionCache";
         default:
             LOG(FATAL) << "not match type of cache policy :" << static_cast<int>(type);
@@ -61,13 +61,13 @@ public:
         __builtin_unreachable();
     }
 
-    CachePolicy(Type type, uint32_t stale_sweep_time_s);
+    CachePolicy(CacheType type, uint32_t stale_sweep_time_s);
     virtual ~CachePolicy();
 
     virtual void prune_stale() = 0;
     virtual void prune_all(bool clear) = 0;
 
-    Type type() { return _type; }
+    CacheType type() { return _type; }
     RuntimeProfile* profile() { return _profile.get(); }
 
 protected:
@@ -81,7 +81,7 @@ protected:
         _cost_timer = ADD_TIMER(_profile, "CostTime");
     }
 
-    Type _type;
+    CacheType _type;
     std::list<CachePolicy*>::iterator _it;
 
     std::unique_ptr<RuntimeProfile> _profile;

--- a/be/src/runtime/memory/cache_policy.h
+++ b/be/src/runtime/memory/cache_policy.h
@@ -35,8 +35,9 @@ public:
 
     virtual ~CachePolicy() { CacheManager::instance()->unregister_cache(_it); };
     virtual void prune_stale() = 0;
-    virtual void prune_all() = 0;
+    virtual void prune_all(bool clear) = 0;
 
+    std::string name() { return _name; }
     RuntimeProfile* profile() { return _profile.get(); }
 
 protected:

--- a/be/src/runtime/memory/lru_cache_policy.h
+++ b/be/src/runtime/memory/lru_cache_policy.h
@@ -34,9 +34,9 @@ struct LRUCacheValueBase {
 // Base of lru cache, allow prune stale entry and prune all entry.
 class LRUCachePolicy : public CachePolicy {
 public:
-    LRUCachePolicy(Type type, uint32_t stale_sweep_time_s)
+    LRUCachePolicy(CacheType type, uint32_t stale_sweep_time_s)
             : CachePolicy(type, stale_sweep_time_s) {};
-    LRUCachePolicy(Type type, size_t capacity, LRUCacheType lru_cache_type,
+    LRUCachePolicy(CacheType type, size_t capacity, LRUCacheType lru_cache_type,
                    uint32_t stale_sweep_time_s, uint32_t num_shards = -1)
             : CachePolicy(type, stale_sweep_time_s) {
         _cache = num_shards == -1

--- a/be/src/runtime/memory/lru_cache_policy.h
+++ b/be/src/runtime/memory/lru_cache_policy.h
@@ -34,14 +34,16 @@ struct LRUCacheValueBase {
 // Base of lru cache, allow prune stale entry and prune all entry.
 class LRUCachePolicy : public CachePolicy {
 public:
-    LRUCachePolicy(const std::string& name, uint32_t stale_sweep_time_s)
-            : CachePolicy(name, stale_sweep_time_s) {};
-    LRUCachePolicy(const std::string& name, size_t capacity, LRUCacheType type,
+    LRUCachePolicy(Type type, uint32_t stale_sweep_time_s)
+            : CachePolicy(type, stale_sweep_time_s) {};
+    LRUCachePolicy(Type type, size_t capacity, LRUCacheType lru_cache_type,
                    uint32_t stale_sweep_time_s, uint32_t num_shards = -1)
-            : CachePolicy(name, stale_sweep_time_s) {
+            : CachePolicy(type, stale_sweep_time_s) {
         _cache = num_shards == -1
-                         ? std::unique_ptr<Cache>(new_lru_cache(name, capacity, type))
-                         : std::unique_ptr<Cache>(new_lru_cache(name, capacity, type, num_shards));
+                         ? std::unique_ptr<Cache>(
+                                   new_lru_cache(type_string(type), capacity, lru_cache_type))
+                         : std::unique_ptr<Cache>(new_lru_cache(type_string(type), capacity,
+                                                                lru_cache_type, num_shards));
     }
 
     ~LRUCachePolicy() override = default;
@@ -66,8 +68,9 @@ public:
             COUNTER_SET(_freed_entrys_counter, _cache->prune_if(pred, true));
             COUNTER_SET(_freed_memory_counter, byte_size);
             COUNTER_UPDATE(_prune_stale_number_counter, 1);
-            LOG(INFO) << fmt::format("{} prune stale {} entries, {} bytes, {} times prune", _name,
-                                     _freed_entrys_counter->value(), _freed_memory_counter->value(),
+            LOG(INFO) << fmt::format("{} prune stale {} entries, {} bytes, {} times prune",
+                                     type_string(_type), _freed_entrys_counter->value(),
+                                     _freed_memory_counter->value(),
                                      _prune_stale_number_counter->value());
         }
     }
@@ -82,9 +85,9 @@ public:
             COUNTER_SET(_freed_memory_counter, size);
             COUNTER_UPDATE(_prune_all_number_counter, 1);
             LOG(INFO) << fmt::format(
-                    "{} prune all {} entries, {} bytes, {} times prune, is clear: {}", _name,
-                    _freed_entrys_counter->value(), _freed_memory_counter->value(),
-                    _prune_stale_number_counter->value(), clear);
+                    "{} prune all {} entries, {} bytes, {} times prune, is clear: {}",
+                    type_string(_type), _freed_entrys_counter->value(),
+                    _freed_memory_counter->value(), _prune_stale_number_counter->value(), clear);
         }
     }
 

--- a/be/src/runtime/memory/lru_cache_policy.h
+++ b/be/src/runtime/memory/lru_cache_policy.h
@@ -72,17 +72,19 @@ public:
         }
     }
 
-    void prune_all() override {
-        if (_cache->mem_consumption() > CACHE_MIN_FREE_SIZE) {
+    void prune_all(bool clear) override {
+        if ((clear && _cache->mem_consumption() != 0) ||
+            _cache->mem_consumption() > CACHE_MIN_FREE_SIZE) {
             COUNTER_SET(_cost_timer, (int64_t)0);
             SCOPED_TIMER(_cost_timer);
             auto size = _cache->mem_consumption();
             COUNTER_SET(_freed_entrys_counter, _cache->prune());
             COUNTER_SET(_freed_memory_counter, size);
             COUNTER_UPDATE(_prune_all_number_counter, 1);
-            LOG(INFO) << fmt::format("{} prune all {} entries, {} bytes, {} times prune", _name,
-                                     _freed_entrys_counter->value(), _freed_memory_counter->value(),
-                                     _prune_stale_number_counter->value());
+            LOG(INFO) << fmt::format(
+                    "{} prune all {} entries, {} bytes, {} times prune, is clear: {}", _name,
+                    _freed_entrys_counter->value(), _freed_memory_counter->value(),
+                    _prune_stale_number_counter->value(), clear);
         }
     }
 

--- a/be/src/service/point_query_executor.h
+++ b/be/src/service/point_query_executor.h
@@ -198,8 +198,8 @@ public:
 private:
     friend class PointQueryExecutor;
     LookupConnectionCache(size_t capacity)
-            : LRUCachePolicy("LookupConnectionCache", capacity, LRUCacheType::SIZE,
-                             config::tablet_lookup_cache_clean_interval) {}
+            : LRUCachePolicy(CachePolicy::Type::LOOKUP_CONNECTION_CACHE, capacity,
+                             LRUCacheType::SIZE, config::tablet_lookup_cache_clean_interval) {}
 
     std::string encode_key(__int128_t cache_id) {
         fmt::memory_buffer buffer;

--- a/be/src/service/point_query_executor.h
+++ b/be/src/service/point_query_executor.h
@@ -198,7 +198,7 @@ public:
 private:
     friend class PointQueryExecutor;
     LookupConnectionCache(size_t capacity)
-            : LRUCachePolicy(CachePolicy::Type::LOOKUP_CONNECTION_CACHE, capacity,
+            : LRUCachePolicy(CachePolicy::CacheType::LOOKUP_CONNECTION_CACHE, capacity,
                              LRUCacheType::SIZE, config::tablet_lookup_cache_clean_interval) {}
 
     std::string encode_key(__int128_t cache_id) {

--- a/be/test/testutil/run_all_tests.cpp
+++ b/be/test/testutil/run_all_tests.cpp
@@ -28,6 +28,7 @@
 #include "olap/segment_loader.h"
 #include "olap/tablet_schema_cache.h"
 #include "runtime/exec_env.h"
+#include "runtime/memory/cache_manager.h"
 #include "runtime/memory/thread_mem_tracker_mgr.h"
 #include "runtime/thread_context.h"
 #include "service/backend_options.h"


### PR DESCRIPTION
## Proposed changes

Dynamically modify the config to clear the cache, each time the disable cache will only be cleared once.
TODO, Support page cache and other caches.

`curl -X POST http://xxxx:8040/api/update_config?disable_segment_cache=true`

![image](https://github.com/apache/doris/assets/13197424/0a759f02-a1c9-4a73-b6d6-dfa6cd6d1852)


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

