### PR TITLE
[fix](Outfile) fix bug that the fileSize is not correct when outfile is completed

### DIFF
--- a/be/src/vec/runtime/vfile_result_writer.cpp
+++ b/be/src/vec/runtime/vfile_result_writer.cpp
@@ -426,7 +426,11 @@ Status VFileResultWriter::_create_new_file_if_exceed_size() {
 Status VFileResultWriter::_close_file_writer(bool done, bool only_close) {
     if (_vfile_writer) {
         _vfile_writer->close();
-        COUNTER_UPDATE(_written_data_bytes, _current_written_bytes);
+        // we can not use _current_written_bytes to COUNTER_UPDATE(_written_data_bytes, _current_written_bytes)
+        // because it will call `write()` function of orc/parquet function in `_vfile_writer->close()`
+        // and the real written_len will increase
+        // and _current_written_bytes will less than _vfile_writer->written_len()
+        COUNTER_UPDATE(_written_data_bytes, _vfile_writer->written_len());
         _vfile_writer.reset(nullptr);
     } else if (_file_writer_impl) {
         _file_writer_impl->close();


### PR DESCRIPTION
## Proposed changes

From pr: #22951

1. fix that the fileSize is not correct when outfile parquet/orc file format is completed.
2. max_file_size of orc file format must be multiple of 64MB:
The function add(RowBatch) of orc::Writer would not flush any pending data to the output stream until the strip data is filled. And the defult of strip size of orc file format is 64MB, so we can not get the correct _written_len from orcOutputStream until 64MB data has been writen.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

