### PR TITLE
[fix](ut) fix ut of stats test #22325

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisTaskExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisTaskExecutorTest.java
@@ -28,7 +28,6 @@ import org.apache.doris.statistics.util.InternalQueryResult.ResultRow;
 import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.Maps;
-import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
@@ -130,12 +129,6 @@ public class AnalysisTaskExecutorTest extends TestWithFeService {
         new MockUp<AnalysisManager>() {
             @Mock
             public void updateTaskStatus(AnalysisInfo info, AnalysisState jobState, String message, long time) {}
-        };
-        new Expectations() {
-            {
-                task.doExecute();
-                times = 1;
-            }
         };
         Deencapsulation.invoke(analysisTaskExecutor, "doFetchAndExecute");
     }


### PR DESCRIPTION
After auto retry merged, it's hard to determine the execute times of doExecute method in compile time, and if the expected execute times in the expectation block is missed, unexpected invocation  exception would be thrown, so just remove the expected execute times

## Proposed changes

~~Issue Number: close #xxx~~

Cherry pick #22325

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

