### PR TITLE
[Fix](status) fix printing too many logs in `VNodeChannel::try_send_and_fetch_status`

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -309,7 +309,9 @@ constexpr bool capture_stacktrace(int code) {
         && code != ErrorCode::TOO_MANY_TRANSACTIONS
         && code != ErrorCode::TRANSACTION_ALREADY_COMMITTED
         && code != ErrorCode::KEY_NOT_FOUND
-        && code != ErrorCode::KEY_ALREADY_EXISTS;
+        && code != ErrorCode::KEY_ALREADY_EXISTS
+        && code != ErrorCode::CANCELLED
+        && code != ErrorCode::UNINITIALIZED;
 }
 // clang-format on
 

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -730,7 +730,7 @@ Status VNodeChannel::none_of(std::initializer_list<bool> vars) {
         if (!vars_str.empty()) {
             vars_str.pop_back(); // 0/1/0/ -> 0/1/0
         }
-        st = Status::InternalError(vars_str);
+        st = Status::Uninitialized(vars_str);
     }
 
     return st;


### PR DESCRIPTION
## Proposed changes

after #23425, `Status::InternalError(...)` will print stacktrace and warning logs, so we can't use it in `VNodeChannel::try_send_and_fetch_status`

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

