### PR TITLE
[FIX](decimal)fix decimal precision  (#22364)

### DIFF
--- a/be/test/runtime/decimalv2_value_test.cpp
+++ b/be/test/runtime/decimalv2_value_test.cpp
@@ -53,8 +53,12 @@ TEST_F(DecimalV2ValueTest, string_to_decimal) {
     len = value1.to_buffer(buffer, -1);
     EXPECT_EQ("-0.23", std::string(buffer, len));
 
+    // overflow value, decimalv2 will ignore precision and scale limit
     DecimalV2Value value2(std::string("1234567890123456789.0"));
+    EXPECT_EQ(9, value2.scale());
+    EXPECT_EQ(27, value2.precision());
     EXPECT_EQ("1234567890123456789.000", value2.to_string(3));
+    // overflow value
     EXPECT_EQ("1234567890123456789", value2.to_string());
     len = value2.to_buffer(buffer, 3);
     EXPECT_EQ("1234567890123456789.000", std::string(buffer, len));


### PR DESCRIPTION
Now we make wrong for decimal parse from string
if given string precision is bigger than defined decimal precision, we will return a overflow error, but only digit part is bigger than typed digit length , we should return overflow error when we traverse given string to decimal value

## Proposed changes

~~Issue Number: close #xxx~~

Cherry pick #22364

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

