### PR TITLE
[fix](nereids)NormalizeAggregate may push redundant expr to child project node

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/NormalizeAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/NormalizeAggregate.java
@@ -39,6 +39,7 @@ import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 
 import java.util.List;
 import java.util.Map;
@@ -119,7 +120,7 @@ public class NormalizeAggregate extends OneRewriteRuleFactory implements Normali
             // agg(output: sum(alias(a + 1)[#1])[#2], group_by: alias(a + 1)[#1])
             // +-- project((a[#0] + 1)[#1])
             List<AggregateFunction> normalizedAggFuncs = groupByToSlotContext.normalizeToUseSlotRef(aggFuncs);
-            List<NamedExpression> bottomProjects = Lists.newArrayList(bottomGroupByProjects);
+            Set<NamedExpression> bottomProjects = Sets.newHashSet(bottomGroupByProjects);
             // TODO: if we have distinct agg, we must push down its children,
             //   because need use it to generate distribution enforce
             // step 1: split agg functions into 2 parts: distinct and not distinct

--- a/regression-test/suites/correctness_p0/test_avg.groovy
+++ b/regression-test/suites/correctness_p0/test_avg.groovy
@@ -64,6 +64,7 @@ suite("test_avg") {
             );
         """
     sql "set enable_nereids_planner=true"
+    sql "set enable_fallback_to_original_planner=false;"
     qt_select2 """select avg(distinct k2), avg(distinct cast(k4 as largeint)) from avg_test;"""
     sql "set enable_nereids_planner=false"
     qt_select3 """select avg(distinct k2), avg(distinct cast(k4 as largeint)) from avg_test;"""


### PR DESCRIPTION
NormalizeAggregate may push exprs to child project node. We need make sure there is no redundant expr in the pushed down expr list. This pr use 'Set' to make sure of that.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

