### PR TITLE
[improvement](config) add a specific be config for segment_cache_capacity

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1030,8 +1030,8 @@ DEFINE_Bool(enable_shrink_memory, "false");
 DEFINE_mInt32(schema_cache_capacity, "1024");
 DEFINE_mInt32(schema_cache_sweep_time_sec, "100");
 
-// max number of segment cache
-DEFINE_mInt32(segment_cache_capacity, "10000");
+// max number of segment cache, default -1 for backward compatibility
+DEFINE_mInt32(segment_cache_capacity, "-1");
 
 // enable feature binlog, default false
 DEFINE_Bool(enable_feature_binlog, "false");

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1030,6 +1030,9 @@ DEFINE_Bool(enable_shrink_memory, "false");
 DEFINE_mInt32(schema_cache_capacity, "1024");
 DEFINE_mInt32(schema_cache_sweep_time_sec, "100");
 
+// max number of segment cache
+DEFINE_mInt32(segment_cache_capacity, "10000");
+
 // enable feature binlog, default false
 DEFINE_Bool(enable_feature_binlog, "false");
 

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1030,7 +1030,7 @@ DEFINE_Bool(enable_shrink_memory, "false");
 DEFINE_mInt32(schema_cache_capacity, "1024");
 DEFINE_mInt32(schema_cache_sweep_time_sec, "100");
 
-// max number of segment cache, default -1 for backward compatibility
+// max number of segment cache, default -1 for backward compatibility fd_number*2/5
 DEFINE_mInt32(segment_cache_capacity, "-1");
 
 // enable feature binlog, default false

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1069,6 +1069,9 @@ DECLARE_Bool(enable_shrink_memory);
 DECLARE_mInt32(schema_cache_capacity);
 DECLARE_mInt32(schema_cache_sweep_time_sec);
 
+// max number of segment cache
+DECLARE_mInt32(segment_cache_capacity);
+
 // enable binlog
 DECLARE_Bool(enable_feature_binlog);
 

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -286,8 +286,8 @@ Status ExecEnv::_init_mem_env() {
     }
     // SegmentLoader caches segments in rowset granularity. So the size of
     // opened files will greater than segment_cache_capacity.
-    uint64_t segment_cache_capacity = config::segment_cache_capacity;
-    if (segment_cache_capacity > fd_number * 2 / 5) {
+    int64_t segment_cache_capacity = config::segment_cache_capacity;
+    if (segment_cache_capacity < 0 || segment_cache_capacity > fd_number * 2 / 5) {
         segment_cache_capacity = fd_number * 2 / 5;
     }
     LOG(INFO) << "segment_cache_capacity <= fd_number * 2 / 5, fd_number: " << fd_number

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -286,8 +286,11 @@ Status ExecEnv::_init_mem_env() {
     }
     // SegmentLoader caches segments in rowset granularity. So the size of
     // opened files will greater than segment_cache_capacity.
-    uint64_t segment_cache_capacity = fd_number * 2 / 5;
-    LOG(INFO) << "segment_cache_capacity = fd_number * 2 / 5, fd_number: " << fd_number
+    uint64_t segment_cache_capacity = config::segment_cache_capacity;
+    if (segment_cache_capacity > fd_number * 2 / 5) {
+        segment_cache_capacity = fd_number * 2 / 5;
+    }
+    LOG(INFO) << "segment_cache_capacity <= fd_number * 2 / 5, fd_number: " << fd_number
               << " segment_cache_capacity: " << segment_cache_capacity;
     SegmentLoader::create_global_instance(segment_cache_capacity);
 

--- a/docs/en/docs/admin-manual/config/be-config.md
+++ b/docs/en/docs/admin-manual/config/be-config.md
@@ -1197,6 +1197,11 @@ BaseCompaction:546859:
 * Description: Index page cache as a percentage of total storage page cache, value range is [0, 100]
 * Default value: 10
 
+#### `segment_cache_capacity`
+* Type: int32
+* Description: Max number of segment cache (the key is rowset id) entries
+* Default value: 10000
+
 #### `storage_strict_check_incompatible_old_format`
 
 * Type: bool

--- a/docs/en/docs/admin-manual/config/be-config.md
+++ b/docs/en/docs/admin-manual/config/be-config.md
@@ -1028,13 +1028,6 @@ BaseCompaction:546859:
   - Increasing this value can reduce the number of calls to read remote data, but it will increase memory overhead.
 * Default value: 16 (MB)
 
-#### `segment_cache_capacity`
-
-* Type: int32
-* Description: The maximum number of Segments cached by Segment Cache.
-  - The default value is currently only an empirical value, and may need to be modified according to actual scenarios. Increasing this value can cache more segments and avoid some IO. Decreasing this value will reduce memory usage.
-* Default value: 1000000
-
 #### `file_cache_type`
 
 * Type: string
@@ -1199,8 +1192,8 @@ BaseCompaction:546859:
 
 #### `segment_cache_capacity`
 * Type: int32
-* Description: Max number of segment cache (the key is rowset id) entries
-* Default value: 10000
+* Description: Max number of segment cache (the key is rowset id) entries. -1 is for backward compatibility as fd_number * 2/5.
+* Default value: -1
 
 #### `storage_strict_check_incompatible_old_format`
 

--- a/docs/zh-CN/docs/admin-manual/config/be-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/be-config.md
@@ -1053,13 +1053,6 @@ BaseCompaction:546859:
   - 增大这个值，可以减少远端数据读取的调用次数，但会增加内存开销。
 * 默认值: 16MB
 
-#### `segment_cache_capacity`
-
-* 类型: int32
-* 描述: Segment Cache 缓存的 Segment 最大数量
-  - 默认值目前只是一个经验值，可能需要根据实际场景修改。增大该值可以缓存更多的segment从而避免一些IO。减少该值则会降低内存使用。
-* 默认值: 1000000
-
 #### `file_cache_type`
 
 * 类型：string
@@ -1224,8 +1217,8 @@ BaseCompaction:546859:
 
 #### `segment_cache_capacity`
 * Type: int32
-* Description: segment元数据缓存（以rowset id为key）的最大rowset个数
-* Default value: 10000
+* Description: segment元数据缓存（以rowset id为key）的最大rowset个数. -1代表向后兼容取值为fd_number * 2/5
+* Default value: -1
 
 #### `storage_strict_check_incompatible_old_format`
 

--- a/docs/zh-CN/docs/admin-manual/config/be-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/be-config.md
@@ -1222,6 +1222,11 @@ BaseCompaction:546859:
 * 描述：索引页缓存占总页面缓存的百分比，取值为[0, 100]。
 * 默认值：10
 
+#### `segment_cache_capacity`
+* Type: int32
+* Description: segment元数据缓存（以rowset id为key）的最大rowset个数
+* Default value: 10000
+
 #### `storage_strict_check_incompatible_old_format`
 
 * 类型：bool


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Currently, segment cache capacity is caculated by `fd limit * 2/5`. It's not flexible to change it since changing fd limit affects others.

Add a specific be config for segment_cache_capacity. If the config >= `fd limit * 2/5`, set it back to `fd limit * 2/5` to avoid open too many files.


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

