### PR TITLE
[Improvement](statistics)Show column stats even when error occurred.

### DIFF
--- a/regression-test/suites/external_table_p2/hive/test_hive_statistic.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_hive_statistic.groovy
@@ -243,6 +243,53 @@ suite("test_hive_statistic", "p2,external,hive,external_remote,external_remote_h
         sql """drop stats statistics"""
         result = sql """show column cached stats statistics"""
         assertTrue(result.size() == 0)
+
+        sql """use multi_catalog"""
+        sql """analyze table logs1_parquet (log_time) with sync"""
+        def ctlId
+        def dbId
+        def tblId
+        result = sql """show proc '/catalogs'"""
+
+        for (int i = 0; i < result.size(); i++) {
+            if (result[i][1] == catalog_name) {
+                ctlId = result[i][0]
+            }
+        }
+        result = sql """show proc '/catalogs/$ctlId'"""
+        for (int i = 0; i < result.size(); i++) {
+            if (result[i][1] == 'multi_catalog') {
+                dbId = result[i][0]
+            }
+        }
+        result = sql """show proc '/catalogs/$ctlId/$dbId'"""
+        for (int i = 0; i < result.size(); i++) {
+            if (result[i][1] == 'logs1_parquet') {
+                tblId = result[i][0]
+            }
+        }
+
+        result = sql """select * from internal.__internal_schema.column_statistics where id = '${tblId}--1-log_time'"""
+        assertTrue(result.size() == 1)
+        def id = result[0][0]
+        def catalog_id = result[0][1]
+        def db_id = result[0][2]
+        def tbl_id = result[0][3]
+        def idx_id = result[0][4]
+        def col_id = result[0][5]
+        def count = result[0][7]
+        def ndv = result[0][8]
+        def null_count = result[0][9]
+        def data_size_in_bytes = result[0][12]
+        def update_time = result[0][13]
+
+        sql """insert into internal.__internal_schema.column_statistics values ('$id', '$catalog_id', '$db_id', '$tbl_id', '$idx_id', '$col_id', NULL, $count, $ndv, $null_count, '', '', '$data_size_in_bytes', '$update_time')"""
+
+        result = sql """show column stats logs1_parquet (log_time)"""
+        assertTrue(result.size() == 1)
+        assertTrue(result[0][6] == "N/A")
+        assertTrue(result[0][7] == "N/A")
+        sql """drop catalog ${catalog_name}"""
     }
 }
 


### PR DESCRIPTION
Before, show column stats will ignore column with error.
In this pr, when min or max value failed to deserialize, show column stats will use N/A as value of min or max, and still show the rest stats. (count, null_count, ndv and so on).

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

