### PR TITLE
[fix](Nereids) When col stats is Unknow, not expression should return the stats with selectivity of 1

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
@@ -348,8 +348,16 @@ public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationCo
         return estimated;
     }
 
+    // Right Now, we just assume the selectivity is 1 when stats is Unknown
+    private Statistics handleUnknownCase(EstimationContext context) {
+        return context.statistics;
+    }
+
     @Override
     public Statistics visitNot(Not not, EstimationContext context) {
+        if (context.statistics.isInputSlotsUnknown(not.getInputSlots())) {
+            return handleUnknownCase(context);
+        }
         Statistics childStats = new FilterEstimation().estimate(not.child(), context.statistics);
         //if estimated rowCount is 0, adjust to 1 to make upper join reorder reasonable.
         double rowCount = Math.max(context.statistics.getRowCount() - childStats.getRowCount(), 1);

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
@@ -19,11 +19,13 @@ package org.apache.doris.statistics;
 
 import org.apache.doris.nereids.stats.StatsMathUtil;
 import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.Slot;
 
 import java.text.DecimalFormat;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 public class Statistics {
     private static final int K_BYTES = 1024;
@@ -129,6 +131,12 @@ public class Statistics {
     public Statistics addColumnStats(Expression expression, ColumnStatistic columnStatistic) {
         expressionToColumnStats.put(expression, columnStatistic);
         return this;
+    }
+
+    public boolean isInputSlotsUnknown(Set<Slot> inputs) {
+        return inputs.stream()
+                .allMatch(s -> expressionToColumnStats.containsKey(s)
+                        && expressionToColumnStats.get(s).isUnKnown);
     }
 
     public Statistics merge(Statistics statistics) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/FilterEstimationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/FilterEstimationTest.java
@@ -133,12 +133,12 @@ class FilterEstimationTest {
         Map<Expression, ColumnStatistic> slotToColumnStat = new HashMap<>();
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder()
                 .setNdv(500)
-                .setIsUnknown(true);
+                .setIsUnknown(false);
         slotToColumnStat.put(a, builder.build());
         Statistics stat = new Statistics(1000, slotToColumnStat);
         FilterEstimation filterEstimation = new FilterEstimation();
         Statistics expected = filterEstimation.estimate(notIn, stat);
-        Assertions.assertTrue(Precision.equals(666.666, expected.getRowCount(), 0.01));
+        Assertions.assertTrue(Precision.equals(1000, expected.getRowCount(), 0.01));
     }
 
     /**


### PR DESCRIPTION
## Proposed changes

When col stats is Unknow, not expression should return the stats with selectivity of 1

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

