### PR TITLE
[fix](clone) fix cannot further repair clone replica which miss version data

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
@@ -451,6 +451,10 @@ public class Tablet extends MetaObject implements Writable {
 
             if (replica.getLastFailedVersion() > 0 || replica.getVersion() < visibleVersion) {
                 // this replica is alive but version incomplete
+                if (replica.needFurtherRepair() && needFurtherRepairReplica == null
+                        && backend.isScheduleAvailable()) {
+                    needFurtherRepairReplica = replica;
+                }
                 continue;
             }
             aliveAndVersionComplete++;


### PR DESCRIPTION
## Proposed changes

pick #21382 

When it's loading data task during cloning,  the cloned new replica may miss some version data.

It will cuase this replica's last failed version > 0.

After finish cloning, the dest replicas should be repaired even if their last failed version > 0

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

