### PR TITLE
[fix](datetime) Fix multithread races of timezone cache

### DIFF
--- a/be/src/vec/runtime/vdatetime_value.cpp
+++ b/be/src/vec/runtime/vdatetime_value.cpp
@@ -176,8 +176,6 @@ bool VecDateTimeValue::from_date_str_base(const char* date_str, int len,
                         time_zone_cache->erase(str_tz);
                         throw Exception {ErrorCode::INVALID_ARGUMENT, ""};
                     }
-                } else {
-                    cache_lock->unlock_shared();
                 }
                 auto given = cctz::convert(cctz::civil_second {}, (*time_zone_cache)[str_tz]);
                 auto local = cctz::convert(cctz::civil_second {}, *local_time_zone);
@@ -2076,8 +2074,6 @@ bool DateV2Value<T>::from_date_str_base(const char* date_str, int len, int scale
                         time_zone_cache->erase(str_tz);
                         throw Exception {ErrorCode::INVALID_ARGUMENT, ""};
                     }
-                } else {
-                    cache_lock->unlock_shared();
                 }
                 auto given = cctz::convert(cctz::civil_second {}, (*time_zone_cache)[str_tz]);
                 auto local = cctz::convert(cctz::civil_second {}, *local_time_zone);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

```
==3556474==ERROR: AddressSanitizer: heap-use-after-free on address 0x60600e13a700 at pc 0x556f32fc7f16 bp 0x7fe4c05979b0 sp 0x7fe4c05979a8
READ of size 8 at 0x60600e13a700 thread T465 (_scanner_scan)
    #0 0x556f32fc7f15 in std::_Hashtable, std::allocator>, std::pair, std::allocator> const, cctz::time_zone>, std::allocator, std::allocator> const, cctz::time_zone>>, std::__detail::_Select1st, std::equal_to, std::allocator>>, std::hash, std::allocator>>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits>::_M_find_before_node(unsigned long, std::__cxx11::basic_string, std::allocator> const&, unsigned long) const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/hashtable.h:1814:63
    #1 0x556f32fc721c in std::_Hashtable, std::allocator>, std::pair, std::allocator> const, cctz::time_zone>, std::allocator, std::allocator> const, cctz::time_zone>>, std::__detail::_Select1st, std::equal_to, std::allocator>>, std::hash, std::allocator>>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits>::_M_find_node(unsigned long, std::__cxx11::basic_string, std::allocator> const&, unsigned long) const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/hashtable.h:791:31
    #2 0x556f4a5dec8f in std::__detail::_Map_base, std::allocator>, std::pair, std::allocator> const, cctz::time_zone>, std::allocator, std::allocator> const, cctz::time_zone>>, std::__detail::_Select1st, std::equal_to, std::allocator>>, std::hash, std::allocator>>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits, true>::operator[](std::__cxx11::basic_string, std::allocator> const&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/hashtable_policy.h:703:30
    #3 0x556f4a5de80c in std::unordered_map, std::allocator>, cctz::time_zone, std::hash, std::allocator>>, std::equal_to, std::allocator>>, std::allocator, std::allocator> const, cctz::time_zone>>>::operator[](std::__cxx11::basic_string, std::allocator> const&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unordered_map.h:980:16
    #4 0x556f524357c7 in doris::vectorized::DateV2Value::from_date_str_base(char const*, int, int, cctz::time_zone const*, std::unordered_map, std::allocator>, cctz::time_zone, std::hash, std::allocator>>, std::equal_to, std::allocator>>, std::allocator, std::allocator> const, cctz::time_zone>>>*, std::shared_mutex*)::'lambda'(std::__cxx11::basic_string, std::allocator> const&, cctz::time_zone const*)::operator()(std::__cxx11::basic_string, std::allocator> const&, cctz::time_zone const*) const /home/zcp/repo_center/doris_master/doris/be/src/vec/runtime/vdatetime_value.cpp:2082:67
    #5 0x556f5242d14f in doris::vectorized::DateV2Value::from_date_str_base(char const*, int, int, cctz::time_zone const*, std::unordered_map, std::allocator>, cctz::time_zone, std::hash, std::allocator>>, std::equal_to, std::allocator>>, std::allocator, std::allocator> const, cctz::time_zone>>>*, std::shared_mutex*) /home/zcp/repo_center/doris_master/doris/be/src/vec/runtime/vdatetime_value.cpp:2088:30
    #6 0x556f5242df74 in doris::vectorized::DateV2Value::from_date_str(char const*, int, cctz::time_zone const&, std::unordered_map, std::allocator>, cctz::time_zone, std::hash, std::allocator>>, std::equal_to, std::allocator>>, std::allocator, std::allocator> const, cctz::time_zone>>>&, std::shared_mutex*, int) /home/zcp/repo_center/doris_master/doris/be/src/vec/runtime/vdatetime_value.cpp:1968:12
    #7 0x556f4a5513cb in bool doris::vectorized::read_datetime_v2_text_impl(unsigned long&, doris::vectorized::ReadBuffer&, cctz::time_zone const&, std::unordered_map, std::allocator>, cctz::time_zone, std::hash, std::allocator>>, std::equal_to, std::allocator>>, std::allocator, std::allocator> const, cctz::time_zone>>>&, std::shared_mutex&, unsigned int) /home/zcp/repo_center/doris_master/doris/be/src/vec/io/io_helper.h:372:19
    #8 0x556f4a55120c in bool doris::vectorized::try_read_datetime_v2_text(unsigned long&, doris::vectorized::ReadBuffer&, cctz::time_zone const&, std::unordered_map, std::allocator>, cctz::time_zone, std::hash, std::allocator>>, std::equal_to, std::allocator>>, std::allocator, std::allocator> const, cctz::time_zone>>>&, std::shared_mutex&, unsigned int) /home/zcp/repo_center/doris_master/doris/be/src/vec/io/io_helper.h:478:12
    #9 0x556f4a5511a2 in bool doris::vectorized::try_parse_impl(doris::vectorized::DataTypeDateTimeV2::FieldType&, doris::vectorized::ReadBuffer&, cctz::time_zone const&, std::unordered_map, std::allocator>, cctz::time_zone, std::hash, std::allocator>>, std::equal_to, std::allocator>>, std::allocator, std::allocator> const, cctz::time_zone>>>&, std::shared_mutex&, unsigned int) /home/zcp/repo_center/doris_master/doris/be/src/vec/functions/function_cast.h:872:16
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

