### PR TITLE
[branch-2.0](fix) compile error when compiler opens -Werror and -Wunused-result

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -729,7 +729,7 @@ void DeltaWriter::_request_slave_tablet_pull_rowset(PNodeInfo node_info) {
     closure->cntl.set_timeout_ms(config::slave_replica_writer_rpc_timeout_sec * 1000);
     closure->cntl.ignore_eovercrowded();
     stub->request_slave_tablet_pull_rowset(&closure->cntl, &request, &closure->result, closure);
-    request.release_rowset_meta();
+    static_cast<void>(request.release_rowset_meta());
 
     closure->join();
     if (closure->cntl.Failed()) {

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -48,13 +48,6 @@ PipelineTask::PipelineTask(PipelinePtr& pipeline, uint32_t index, RuntimeState* 
                            RuntimeProfile* parent_profile)
         : _index(index),
           _pipeline(pipeline),
-          _prepared(false),
-          _opened(false),
-          _state(state),
-          _cur_state(PipelineTaskState::NOT_READY),
-          _data_state(SourceState::DEPEND_ON_SOURCE),
-          _fragment_context(fragment_context),
-          _parent_profile(parent_profile),
           _operators(pipeline->_operators),
           _source(_operators.front()),
           _root(_operators.back()),

--- a/be/src/vec/sink/vdata_stream_sender.h
+++ b/be/src/vec/sink/vdata_stream_sender.h
@@ -239,8 +239,8 @@ public:
             delete _closure;
         }
         // release this before request desctruct
-        _brpc_request.release_finst_id();
-        _brpc_request.release_query_id();
+        static_cast<void>(_brpc_request.release_finst_id());
+        static_cast<void>(_brpc_request.release_query_id());
     }
 
     // Initialize channel.


### PR DESCRIPTION
## Proposed changes

If the compiler opens -Werror,-Wunused-result, discard non-discard function return values will be treated as compile error.
Cast unused return value.
