### PR TITLE
[feature](nereids) eliminate cascading outer join

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateOuterJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateOuterJoin.java
@@ -68,8 +68,12 @@ public class EliminateOuterJoin extends OneRewriteRuleFactory {
             Set<Expression> conjuncts = new HashSet<>();
             join.getHashJoinConjuncts().forEach(expression -> {
                 EqualTo equalTo = (EqualTo) expression;
-                JoinUtils.addIsNotNullIfNullableToCollection(equalTo.left(), conjuncts);
-                JoinUtils.addIsNotNullIfNullableToCollection(equalTo.right(), conjuncts);
+                if (canFilterLeftNull) {
+                    JoinUtils.addIsNotNullIfNullableToCollection(equalTo.left(), conjuncts);
+                }
+                if (canFilterRightNull) {
+                    JoinUtils.addIsNotNullIfNullableToCollection(equalTo.right(), conjuncts);
+                }
             });
             JoinUtils.JoinSlotCoverageChecker checker = new JoinUtils.JoinSlotCoverageChecker(
                     join.left().getOutput(),
@@ -77,8 +81,12 @@ public class EliminateOuterJoin extends OneRewriteRuleFactory {
             join.getOtherJoinConjuncts().stream().filter(EqualTo.class::isInstance).forEach(expr -> {
                 EqualTo equalTo = (EqualTo) expr;
                 if (checker.isHashJoinCondition(equalTo)) {
-                    JoinUtils.addIsNotNullIfNullableToCollection(equalTo.left(), conjuncts);
-                    JoinUtils.addIsNotNullIfNullableToCollection(equalTo.right(), conjuncts);
+                    if (canFilterLeftNull) {
+                        JoinUtils.addIsNotNullIfNullableToCollection(equalTo.left(), conjuncts);
+                    }
+                    if (canFilterRightNull) {
+                        JoinUtils.addIsNotNullIfNullableToCollection(equalTo.right(), conjuncts);
+                    }
                 }
             });
             conjuncts.addAll(filter.getConjuncts());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateOuterJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateOuterJoin.java
@@ -19,11 +19,13 @@ package org.apache.doris.nereids.rules.rewrite;
 
 import org.apache.doris.nereids.rules.Rule;
 import org.apache.doris.nereids.rules.RuleType;
+import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
+import org.apache.doris.nereids.util.JoinUtils;
 import org.apache.doris.nereids.util.TypeUtils;
 import org.apache.doris.nereids.util.Utils;
 
@@ -63,7 +65,24 @@ public class EliminateOuterJoin extends OneRewriteRuleFactory {
             }
 
             JoinType newJoinType = tryEliminateOuterJoin(join.getJoinType(), canFilterLeftNull, canFilterRightNull);
-            return filter.withChildren(join.withJoinType(newJoinType));
+            Set<Expression> conjuncts = new HashSet<>();
+            join.getHashJoinConjuncts().forEach(expression -> {
+                EqualTo equalTo = (EqualTo) expression;
+                JoinUtils.addIsNotNullIfNullableToCollection(equalTo.left(), conjuncts);
+                JoinUtils.addIsNotNullIfNullableToCollection(equalTo.right(), conjuncts);
+            });
+            JoinUtils.JoinSlotCoverageChecker checker = new JoinUtils.JoinSlotCoverageChecker(
+                    join.left().getOutput(),
+                    join.right().getOutput());
+            join.getOtherJoinConjuncts().stream().filter(EqualTo.class::isInstance).forEach(expr -> {
+                EqualTo equalTo = (EqualTo) expr;
+                if (checker.isHashJoinCondition(equalTo)) {
+                    JoinUtils.addIsNotNullIfNullableToCollection(equalTo.left(), conjuncts);
+                    JoinUtils.addIsNotNullIfNullableToCollection(equalTo.right(), conjuncts);
+                }
+            });
+            conjuncts.addAll(filter.getConjuncts());
+            return filter.withConjuncts(conjuncts).withChildren(join.withJoinType(newJoinType));
         }).toRule(RuleType.ELIMINATE_OUTER_JOIN);
     }
 


### PR DESCRIPTION
## Proposed changes
 after eliminate outer join, create is-not-null predicate, and then this is-not-null predicate can be used to eliminate descendant outer join. the newly created is-not-null predicate will be eliminated in EliminateNotNull rule.



Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

