### PR TITLE
[Fix](IndexColumnWriter) Add logic for `IndexedColumnWriter::add`  when the current page is full

### DIFF
--- a/be/src/olap/rowset/segment_v2/indexed_column_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/indexed_column_writer.cpp
@@ -91,6 +91,15 @@ Status IndexedColumnWriter::add(const void* value) {
     size_t num_to_write = 1;
     RETURN_IF_ERROR(
             _data_page_builder->add(reinterpret_cast<const uint8_t*>(value), &num_to_write));
+    CHECK(num_to_write == 1 || num_to_write == 0);
+    if (num_to_write == 0) {
+        CHECK(_data_page_builder->is_page_full());
+        // current page is already full, we need to first flush the current page,
+        // and then add the value to the new page
+        size_t num_val;
+        RETURN_IF_ERROR(_finish_current_data_page(num_val));
+        return add(value);
+    }
     _num_values++;
     size_t num_val;
     if (_data_page_builder->is_page_full()) {


### PR DESCRIPTION
## Proposed changes

`_data_page_builder->add` in `IndexedColumnWriter::add` may fail to add the value if the current page is already full. In this occasion, we should first finish the current page and then add the value to the new page

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

