### PR TITLE
[feature](nereids)push runtime filter to right child of left outer join

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
@@ -74,7 +74,7 @@ import java.util.stream.Collectors;
  */
 public class RuntimeFilterGenerator extends PlanPostProcessor {
 
-    private static final ImmutableSet<JoinType> DENIED_JOIN_TYPES = ImmutableSet.of(
+    public static final ImmutableSet<JoinType> DENIED_JOIN_TYPES = ImmutableSet.of(
             JoinType.LEFT_ANTI_JOIN,
             JoinType.FULL_OUTER_JOIN,
             JoinType.LEFT_OUTER_JOIN,
@@ -110,33 +110,13 @@ public class RuntimeFilterGenerator extends PlanPostProcessor {
     public PhysicalPlan visitPhysicalHashJoin(PhysicalHashJoin<? extends Plan, ? extends Plan> join,
             CascadesContext context) {
         RuntimeFilterContext ctx = context.getRuntimeFilterContext();
-        Map<NamedExpression, Pair<PhysicalRelation, Slot>> aliasTransferMap = ctx.getAliasTransferMap();
         join.right().accept(this, context);
         join.left().accept(this, context);
-        if (DENIED_JOIN_TYPES.contains(join.getJoinType()) || join.isMarkJoin()) {
-            // aliasTransMap is also used for judging whether the slot can be as rf target.
-            // for denied join type, the forbidden slots will be removed from the map.
-            // for example: a full outer join b on a.id = b.id, all slots will be removed out.
-            // for left outer join, only remove the right side slots and leave the left side.
-            // in later visit, the additional checking for the join type will be invoked for different cases:
-            // case 1: a left join b on a.id = b.id, checking whether rf on b.id can be pushed to a, the answer is no,
-            //         since current join type is left outer join which is in denied list;
-            // case 2: (a left join b on a.id = b.id) inner join c on a.id2 = c.id2, checking whether rf on c.id2 can
-            //         be pushed to a, the answer is yes, since the current join is inner join which is permitted.
-            if (join.getJoinType() == JoinType.LEFT_OUTER_JOIN) {
-                Set<Slot> slots = join.right().getOutputSet();
-                slots.forEach(aliasTransferMap::remove);
-            } else {
-                Set<Slot> slots = join.getOutputSet();
-                slots.forEach(aliasTransferMap::remove);
-            }
+        collectPushDownCTEInfos(join, context);
+        if (!getPushDownCTECandidates(ctx).isEmpty()) {
+            pushDownRuntimeFilterIntoCTE(ctx);
         } else {
-            collectPushDownCTEInfos(join, context);
-            if (!getPushDownCTECandidates(ctx).isEmpty()) {
-                pushDownRuntimeFilterIntoCTE(ctx);
-            } else {
-                pushDownRuntimeFilterCommon(join, context);
-            }
+            pushDownRuntimeFilterCommon(join, context);
         }
         return join;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
@@ -204,6 +204,14 @@ public class PhysicalHashJoin<
     public boolean pushDownRuntimeFilter(CascadesContext context, IdGenerator<RuntimeFilterId> generator,
                                          AbstractPhysicalJoin builderNode, Expression srcExpr, Expression probeExpr,
                                          TRuntimeFilterType type, long buildSideNdv, int exprOrder) {
+        if (RuntimeFilterGenerator.DENIED_JOIN_TYPES.contains(getJoinType()) || isMarkJoin()) {
+            if (builderNode instanceof PhysicalHashJoin) {
+                PhysicalHashJoin builderJion = (PhysicalHashJoin) builderNode;
+                if (builderJion.id.asInt() == id.asInt()) {
+                    return false;
+                }
+            }
+        }
         RuntimeFilterContext ctx = context.getRuntimeFilterContext();
         Map<NamedExpression, Pair<PhysicalRelation, Slot>> aliasTransferMap = ctx.getAliasTransferMap();
 


### PR DESCRIPTION
## Proposed changes

A inner join (B left outer join C)

runtimer filter A->C is valid, and can be pushed to C.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

