### PR TITLE
[Enhancement](MultiCatalog) support iceberg cumstom serde

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
@@ -403,7 +403,7 @@ public class HMSExternalTable extends ExternalTable {
     public List<Column> initSchema() {
         makeSureInitialized();
         List<Column> columns;
-        // getSchema will fail when the iceberg customized deser not in hive metastore service
+        // getSchema will fail when the iceberg customized serde not in hive metastore service
         if (dlaType.equals(DLAType.ICEBERG)) {
             columns = getIcebergSchema();
         } else {
@@ -414,8 +414,8 @@ public class HMSExternalTable extends ExternalTable {
                 List<Column> tmpSchema = Lists.newArrayListWithCapacity(schema.size());
                 for (FieldSchema field : schema) {
                     tmpSchema.add(new Column(field.getName(),
-                        HiveMetaStoreClientHelper.hiveTypeToDorisType(field.getType()), true, null,
-                        true, field.getComment(), true, -1));
+                            HiveMetaStoreClientHelper.hiveTypeToDorisType(field.getType()), true, null,
+                            true, field.getComment(), true, -1));
                 }
                 columns = tmpSchema;
             }
@@ -459,14 +459,14 @@ public class HMSExternalTable extends ExternalTable {
     }
 
     private List<Column> getIcebergSchema() {
-        Schema schema  = Env.getCurrentEnv().getExtMetaCacheMgr().getIcebergMetadataCache().getIcebergTable(this).schema();
-        List<Types.NestedField> iceberg_columns = schema.columns();
-        List<Column> tmpSchema = Lists.newArrayListWithCapacity(iceberg_columns.size());
-        for (Types.NestedField field : iceberg_columns) {
+        Schema schema  = Env.getCurrentEnv().getExtMetaCacheMgr().getIcebergMetadataCache()
+                            .getIcebergTable(this).schema();
+        List<Types.NestedField> icebergColumns = schema.columns();
+        List<Column> tmpSchema = Lists.newArrayListWithCapacity(icebergColumns.size());
+        for (Types.NestedField field : icebergColumns) {
             tmpSchema.add(new Column(field.name(),
-                IcebergExternalTable.icebergTypeToDorisType(field.type()), true, null,
-                true, field.doc(), true,
-                schema.caseInsensitiveFindField(field.name()).fieldId()));
+                    IcebergExternalTable.icebergTypeToDorisType(field.type()), true, null,
+                    true, field.doc(), true, schema.caseInsensitiveFindField(field.name()).fieldId()));
         }
         return tmpSchema;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/IcebergExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/IcebergExternalTable.java
@@ -65,13 +65,13 @@ public class IcebergExternalTable extends ExternalTable {
         List<Column> tmpSchema = Lists.newArrayListWithCapacity(columns.size());
         for (Types.NestedField field : columns) {
             tmpSchema.add(new Column(field.name(),
-                    icebergTypeToDorisType(field.type()), true, null, true, field.doc(), true,
+                    IcebergExternalTable.icebergTypeToDorisType(field.type()), true, null, true, field.doc(), true,
                     schema.caseInsensitiveFindField(field.name()).fieldId()));
         }
         return tmpSchema;
     }
 
-    private Type icebergPrimitiveTypeToDorisType(org.apache.iceberg.types.Type.PrimitiveType primitive) {
+    private static Type icebergPrimitiveTypeToDorisType(org.apache.iceberg.types.Type.PrimitiveType primitive) {
         switch (primitive.typeId()) {
             case BOOLEAN:
                 return Type.BOOLEAN;
@@ -104,14 +104,14 @@ public class IcebergExternalTable extends ExternalTable {
         }
     }
 
-    protected Type icebergTypeToDorisType(org.apache.iceberg.types.Type type) {
+    public static Type icebergTypeToDorisType(org.apache.iceberg.types.Type type) {
         if (type.isPrimitiveType()) {
             return icebergPrimitiveTypeToDorisType((org.apache.iceberg.types.Type.PrimitiveType) type);
         }
         switch (type.typeId()) {
             case LIST:
                 Types.ListType list = (Types.ListType) type;
-                return ArrayType.create(icebergTypeToDorisType(list.elementType()), true);
+                return ArrayType.create(IcebergExternalTable.icebergTypeToDorisType(list.elementType()), true);
             case MAP:
             case STRUCT:
                 return Type.UNSUPPORTED;


### PR DESCRIPTION
## Proposed changes

create iceberg table in hive catalog with below:
CREATE TABLE `report.test`(
  `pin_id` bigint COMMENT '',
  `business_type` int COMMENT '',
  `day` date COMMENT '')
ROW FORMAT SERDE
  'org.apache.iceberg.mr.hive.HiveIcebergSerDe'
STORED BY
  'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler'


as the ROW FORMAT SERDE 'org.apache.iceberg.mr.hive.HiveIcebergSerDe' is not in hive metastore by default, we need to
put the iceberg-mr.jar to hive classpath.

this pr give us another solution to use iceberg-mr.jar in doris side. 

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

