### PR TITLE
[Enhance](ip)optimize priority_ network matching logic

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendOptions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendOptions.java
@@ -58,36 +58,43 @@ public class FrontendOptions {
         }
     }
 
-
+    // 1. If priority_networks is configured . Obtain the IP that complies with the rules,
+    // and stop the process if it is not obtained
+    // 2. If the priority_networks is not configured, priority should be given to obtaining non loopback IPv4 addresses.
+    // If not, use loopback
     static void initAddrUseIp(List<InetAddress> hosts) {
         useFqdn = false;
         analyzePriorityCidrs();
-        // if not set frontend_address, get a non-loopback ip
-        InetAddress loopBack = null;
         boolean hasMatchedIp = false;
-        for (InetAddress addr : hosts) {
-            LOG.debug("check ip address: {}", addr);
-            if (addr.isLoopbackAddress()) {
-                loopBack = addr;
-            } else if (!priorityCidrs.isEmpty()) {
+        if (!priorityCidrs.isEmpty()) {
+            for (InetAddress addr : hosts) {
+                LOG.debug("check ip address: {}", addr);
                 if (isInPriorNetwork(addr.getHostAddress())) {
                     localAddr = addr;
                     hasMatchedIp = true;
                     break;
                 }
-            } else if (addr instanceof Inet4Address) {
-                localAddr = addr;
-                break;
             }
-        }
-        //if all ips not match the priority_networks then print the warning log
-        if (!priorityCidrs.isEmpty() && !hasMatchedIp) {
-            LOG.error("ip address range configured for priority_networks does not include the current IP address");
-            System.exit(-1);
-        }
-        // nothing found, use loopback addr
-        if (localAddr == null) {
-            localAddr = loopBack;
+            //if all ips not match the priority_networks then print the err log and exit
+            if (!hasMatchedIp) {
+                LOG.error("ip address range configured for priority_networks does not include the current IP address");
+                System.exit(-1);
+            }
+        } else {
+            // if not set frontend_address, get a non-loopback ip
+            InetAddress loopBack = null;
+            for (InetAddress addr : hosts) {
+                if (addr.isLoopbackAddress()) {
+                    loopBack = addr;
+                } else if (addr instanceof Inet4Address) {
+                    localAddr = addr;
+                    break;
+                }
+            }
+            // nothing found, use loopback addr
+            if (localAddr == null) {
+                localAddr = loopBack;
+            }
         }
         LOG.info("local address: {}.", localAddr);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendOptions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendOptions.java
@@ -27,6 +27,7 @@ import com.google.common.net.InetAddresses;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -74,14 +75,15 @@ public class FrontendOptions {
                     hasMatchedIp = true;
                     break;
                 }
-            } else {
+            } else if (addr instanceof Inet4Address) {
                 localAddr = addr;
                 break;
             }
         }
         //if all ips not match the priority_networks then print the warning log
         if (!priorityCidrs.isEmpty() && !hasMatchedIp) {
-            LOG.warn("ip address range configured for priority_networks does not include the current IP address");
+            LOG.error("ip address range configured for priority_networks does not include the current IP address");
+            System.exit(-1);
         }
         // nothing found, use loopback addr
         if (localAddr == null) {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
- If the user has configured the wrong priority_network, direct startup failure to avoid users mistakenly assuming that the configuration is correct
- If the user has not configured p_ n. Select only the first IP from the IPv4 list, rather than selecting from all IPs, to avoid users' servers not supporting IPv4

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

