### PR TITLE
[regression](inverted index) force nereids open for count on index

### DIFF
--- a/regression-test/suites/inverted_index_p0/test_count_on_index.groovy
+++ b/regression-test/suites/inverted_index_p0/test_count_on_index.groovy
@@ -141,7 +141,8 @@ suite("test_count_on_index_httplogs", "p0") {
         load_httplogs_data.call(testTable_unique, 'test_httplogs_load_count_on_index', 'true', 'json', 'documents-1000.json')
 
         sql "sync"
-
+        sql """set experimental_enable_nereids_planner=true;"""
+        sql """set enable_fallback_to_original_planner=false;"""
         // case1: test duplicate table
         explain {
             sql("select COUNT() from ${testTable_dup} where request match 'GET'")


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

count-on-index does not work in original planner

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

