### PR TITLE
[fix](publish) publish go ahead even if quorum is not met

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -444,7 +444,7 @@ public class Config extends ConfigBase {
             "Waiting time for one transaction changing to \"at least one replica success\", in seconds."
             + "If time exceeds this, and for each tablet it has at least one replica publish successful, "
             + "then the load task will be successful." })
-    public static int publish_wait_time_second = 600;
+    public static int publish_wait_time_second = 300;
 
     @ConfField(mutable = true, masterOnly = true, description = {"提交事务的最大超时时间，单位是秒。"
             + "该参数仅用于事务型 insert 操作中。",

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -439,6 +439,13 @@ public class Config extends ConfigBase {
             "Maximal waiting time for all publish version tasks of one transaction to be finished, in seconds."})
     public static int publish_version_timeout_second = 30; // 30 seconds
 
+    @ConfField(mutable = true, masterOnly = true, description = {"导入 Publish 阶段的等待时间，单位是秒。超过此时间，"
+            + "则只需每个tablet包含一个成功副本，则导入成功。值为 -1 时，表示无限等待。",
+            "Waiting time for one transaction changing to \"at least one replica success\", in seconds."
+            + "If time exceeds this, and for each tablet it has at least one replica publish successful, "
+            + "then the load task will be successful." })
+    public static int publish_wait_time_second = 600;
+
     @ConfField(mutable = true, masterOnly = true, description = {"提交事务的最大超时时间，单位是秒。"
             + "该参数仅用于事务型 insert 操作中。",
             "Maximal waiting time for all data inserted before one transaction to be committed, in seconds. "

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Replica.java
@@ -487,6 +487,32 @@ public class Replica implements Writable {
         return strBuffer.toString();
     }
 
+    public String toStringSimple(boolean checkBeAlive) {
+        StringBuilder strBuffer = new StringBuilder("[replicaId=");
+        strBuffer.append(id);
+        strBuffer.append(", backendId=");
+        strBuffer.append(backendId);
+        if (checkBeAlive) {
+            strBuffer.append(", backendAlive=");
+            strBuffer.append(Env.getCurrentSystemInfo().checkBackendAlive(backendId));
+        }
+        strBuffer.append(", version=");
+        strBuffer.append(version);
+        if (lastFailedVersion > 0) {
+            strBuffer.append(", lastFailedVersion=");
+            strBuffer.append(lastFailedVersion);
+            strBuffer.append(", lastSuccessVersion=");
+            strBuffer.append(lastSuccessVersion);
+            strBuffer.append(", lastFailedTimestamp=");
+            strBuffer.append(lastFailedTimestamp);
+        }
+        strBuffer.append(", state=");
+        strBuffer.append(state.name());
+        strBuffer.append("]");
+
+        return strBuffer.toString();
+    }
+
     @Override
     public void write(DataOutput out) throws IOException {
         out.writeLong(id);

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionState.java
@@ -219,8 +219,14 @@ public class TransactionState implements Writable {
     private long publishVersionTime = -1;
     private TransactionStatus preStatus = null;
 
+    // When publish txn, if every tablet has at least 1 replica published succ, but not quorum replicas succ,
+    // and time since firstPublishOneSuccTime has exceeds Config.publish_wait_time_second,
+    // then this transaction will become visible.
+    private long firstPublishOneSuccTime = -1;
+
     @SerializedName(value = "callbackId")
     private long callbackId = -1;
+
     // In the beforeStateTransform() phase, we will get the callback object through the callbackId,
     // and if we get it, we will save it in this variable.
     // The main function of this variable is to retain a reference to this callback object.
@@ -385,6 +391,14 @@ public class TransactionState implements Writable {
 
     public String getErrorLogUrl() {
         return errorLogUrl;
+    }
+
+    public long getFirstPublishOneSuccTime() {
+        return firstPublishOneSuccTime;
+    }
+
+    public void setFirstPublishOneSuccTime(long firstPublishOneSuccTime) {
+        this.firstPublishOneSuccTime = firstPublishOneSuccTime;
     }
 
     public void setTransactionStatus(TransactionStatus transactionStatus) {


### PR DESCRIPTION
## Proposed changes

pick: #18696

If publish txn is not quorum met, writes will be stucked. Let publish go ahead if each tablet contains at least one succ replica and time exceeds 5 min.

 This PR also change some hints.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

