### PR TITLE
[fix](testcase) sync load of tpcds_sf1_index testcase from tpcds_sf1_p1

### DIFF
--- a/regression-test/suites/inverted_index_p1/tpcds_sf1_index/load.groovy
+++ b/regression-test/suites/inverted_index_p1/tpcds_sf1_index/load.groovy
@@ -98,5 +98,7 @@ suite("load") {
                 assertTrue(json.NumberLoadedRows > 0 && json.LoadBytes > 0)
             }
         }
+        sql """ ANALYZE TABLE $tableName WITH SYNC """
     }
+    sql """ sync """
 }


### PR DESCRIPTION
## Proposed changes

Add analyze table in load of tpcds_sf1_index testcase just like tpcds_sf1_p1 to avoid query memory limit.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

