### PR TITLE
[community](collaborator) add collaborator shuke987 for issue/pr label

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -80,15 +80,14 @@ github:
         required_approving_review_count: 1
   collaborators:
     - LemonLiTree
-    - zy-kkk
     - Yukang-Lian
-    - xiaokang
     - TangSiyang2001
     - platoneko
     - Lchangliang
     - freemandealer
     - nanfeng1999
     - gitccl
+    - shuke987
 
 notifications:
     pullrequests_status:  commits@doris.apache.org


### PR DESCRIPTION
## Proposed changes

1. add collaborator shuke987 for issue/pr label
2. remove collaborators xiaokang and zy-kkk since they are committer


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

