### PR TITLE
[fix](pipeline) Fix cancel_query locks nothing

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -849,7 +849,7 @@ void FragmentMgr::_set_scan_concurrency(const Param& params, QueryContext* query
 
 void FragmentMgr::cancel_query(const TUniqueId& query_id, const PPlanFragmentCancelReason& reason,
                                const std::string& msg) {
-    std::unique_lock<std::mutex> state_lock;
+    std::unique_lock<std::mutex> state_lock(_lock);
     return cancel_query_unlocked(query_id, reason, state_lock, msg);
 }
 


### PR DESCRIPTION
Bug fix,  FragmentMgr::cancel_query should get lock of _lock

Fix of issue #23816 