### PR TITLE
[fix](stacktrace) Fix StackTraceCache initialized before ExecEnv

### DIFF
--- a/be/src/common/stack_trace.cpp
+++ b/be/src/common/stack_trace.cpp
@@ -474,6 +474,11 @@ std::string StackTrace::toString(void** frame_pointers_raw, size_t offset, size_
     return toStringCached(frame_pointers, offset, size);
 }
 
+void StackTrace::createCache() {
+    std::lock_guard lock {stacktrace_cache_mutex};
+    cacheInstance();
+}
+
 void StackTrace::dropCache() {
     std::lock_guard lock {stacktrace_cache_mutex};
     cacheInstance().clear();

--- a/be/src/common/stack_trace.cpp
+++ b/be/src/common/stack_trace.cpp
@@ -331,9 +331,14 @@ struct StackTraceRefTriple {
     size_t size;
 };
 
+struct StackTraceTriple {
+    StackTrace::FramePointers pointers;
+    size_t offset;
+    size_t size;
+};
+
 template <class T>
-concept MaybeRef =
-        std::is_same_v<T, StackTrace::StackTraceTriple> || std::is_same_v<T, StackTraceRefTriple>;
+concept MaybeRef = std::is_same_v<T, StackTraceTriple> || std::is_same_v<T, StackTraceRefTriple>;
 
 constexpr bool operator<(const MaybeRef auto& left, const MaybeRef auto& right) {
     return std::tuple {left.pointers, left.size, left.offset} <
@@ -424,6 +429,13 @@ void StackTrace::toStringEveryLine(std::function<void(std::string_view)> callbac
     toStringEveryLineImpl("FULL_WITH_INLINE", {frame_pointers, offset, size}, std::move(callback));
 }
 
+using StackTraceCache = std::map<StackTraceTriple, std::string, std::less<>>;
+
+static StackTraceCache& cacheInstance() {
+    static StackTraceCache cache;
+    return cache;
+}
+
 static std::mutex stacktrace_cache_mutex;
 
 std::string toStringCached(const StackTrace::FramePointers& pointers, size_t offset, size_t size) {
@@ -432,7 +444,7 @@ std::string toStringCached(const StackTrace::FramePointers& pointers, size_t off
     /// Note that this cache can grow unconditionally, but practically it should be small.
     std::lock_guard lock {stacktrace_cache_mutex};
 
-    StackTrace::StackTraceCache& cache = StackTrace::cacheInstance();
+    StackTraceCache& cache = cacheInstance();
     const StackTraceRefTriple key {pointers, offset, size};
 
     if (auto it = cache.find(key); it != cache.end()) {
@@ -442,8 +454,7 @@ std::string toStringCached(const StackTrace::FramePointers& pointers, size_t off
         toStringEveryLineImpl(doris::config::dwarf_location_info_mode, key,
                               [&](std::string_view str) { out << str << '\n'; });
 
-        return cache.emplace(StackTrace::StackTraceTriple {pointers, offset, size}, out.str())
-                .first->second;
+        return cache.emplace(StackTraceTriple {pointers, offset, size}, out.str()).first->second;
     }
 }
 
@@ -465,5 +476,5 @@ std::string StackTrace::toString(void** frame_pointers_raw, size_t offset, size_
 
 void StackTrace::dropCache() {
     std::lock_guard lock {stacktrace_cache_mutex};
-    StackTrace::cacheInstance().clear();
+    cacheInstance().clear();
 }

--- a/be/src/common/stack_trace.h
+++ b/be/src/common/stack_trace.h
@@ -76,6 +76,7 @@ public:
     [[nodiscard]] std::string toString() const;
 
     static std::string toString(void** frame_pointers, size_t offset, size_t size);
+    static void createCache();
     static void dropCache();
     static void symbolize(const FramePointers& frame_pointers, size_t offset, size_t size,
                           StackTrace::Frames& frames);

--- a/be/src/common/stack_trace.h
+++ b/be/src/common/stack_trace.h
@@ -60,19 +60,6 @@ public:
     using FramePointers = std::array<void*, capacity>;
     using Frames = std::array<Frame, capacity>;
 
-    struct StackTraceTriple {
-        StackTrace::FramePointers pointers;
-        size_t offset;
-        size_t size;
-    };
-
-    using StackTraceCache = std::map<StackTraceTriple, std::string, std::less<>>;
-
-    static StackTraceCache& cacheInstance() {
-        static StackTraceCache cache;
-        return cache;
-    }
-
     /// Tries to capture stack trace
     inline StackTrace() { tryCapture(); }
 

--- a/be/src/common/stack_trace.h
+++ b/be/src/common/stack_trace.h
@@ -60,6 +60,19 @@ public:
     using FramePointers = std::array<void*, capacity>;
     using Frames = std::array<Frame, capacity>;
 
+    struct StackTraceTriple {
+        StackTrace::FramePointers pointers;
+        size_t offset;
+        size_t size;
+    };
+
+    using StackTraceCache = std::map<StackTraceTriple, std::string, std::less<>>;
+
+    static StackTraceCache& cacheInstance() {
+        static StackTraceCache cache;
+        return cache;
+    }
+
     /// Tries to capture stack trace
     inline StackTrace() { tryCapture(); }
 

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -34,6 +34,7 @@
 #include <tuple>
 #include <vector>
 
+#include "common/stack_trace.h"
 #include "olap/tablet_schema_cache.h"
 #include "olap/utils.h"
 #include "runtime/memory/mem_tracker_limiter.h"
@@ -301,6 +302,7 @@ struct Checker {
 int main(int argc, char** argv) {
     doris::signal::InstallFailureSignalHandler();
     doris::init_signals();
+    StackTrace::cacheInstance(); // At the beginning, other static destructors may use.
 
     // check if print version or help
     if (argc > 1) {

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -34,7 +34,6 @@
 #include <tuple>
 #include <vector>
 
-#include "common/stack_trace.h"
 #include "olap/tablet_schema_cache.h"
 #include "olap/utils.h"
 #include "runtime/memory/mem_tracker_limiter.h"
@@ -302,7 +301,6 @@ struct Checker {
 int main(int argc, char** argv) {
     doris::signal::InstallFailureSignalHandler();
     doris::init_signals();
-    StackTrace::cacheInstance(); // At the beginning, other static destructors may use.
 
     // check if print version or help
     if (argc > 1) {

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -34,6 +34,7 @@
 #include <tuple>
 #include <vector>
 
+#include "common/stack_trace.h"
 #include "olap/tablet_schema_cache.h"
 #include "olap/utils.h"
 #include "runtime/memory/mem_tracker_limiter.h"
@@ -301,6 +302,8 @@ struct Checker {
 int main(int argc, char** argv) {
     doris::signal::InstallFailureSignalHandler();
     doris::init_signals();
+    // create StackTraceCache Instance, at the beginning, other static destructors may use.
+    StackTrace::createCache();
 
     // check if print version or help
     if (argc > 1) {


### PR DESCRIPTION
## Proposed changes

Fix BE grace exit
```
==45195==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x614000432bc8 at pc 0x5584e269579b bp 0x7f473f491410 sp 0x7f473f491408
READ of size 8 at 0x614000432bc8 thread T12
    #0 0x5584e269579a in std::_Head_base<2ul, unsigned long, false>::_Head_base(unsigned long const&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/tuple:183:22
    #1 0x5584e269579a in std::_Tuple_impl<2ul, unsigned long>::_Tuple_impl(unsigned long const&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/tuple:426:9
    #2 0x5584e269579a in std::_Tuple_impl<1ul, unsigned long, unsigned long>::_Tuple_impl(unsigned long const&, unsigned long const&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../
../include/c++/11/tuple:270:9
    #3 0x5584e269579a in std::_Tuple_impl<0ul, std::array<void*, 45ul>, unsigned long, unsigned long>::_Tuple_impl(std::array<void*, 45ul> const&, unsigned long const&, unsigned long const&) /var/local/l
db-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/tuple:270:9
    #4 0x5584e269579a in std::tuple<std::array<void*, 45ul>, unsigned long, unsigned long>::tuple<true, true>(std::array<void*, 45ul> const&, unsigned long const&, unsigned long const&) /var/local/ldb-to
olchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/tuple:719:4
    #5 0x5584e269579a in bool operator<<StackTraceTriple, StackTraceRefTriple>(StackTraceTriple const&, StackTraceRefTriple const&) /src/common/stack_trace.cpp:344:12
    #6 0x5584e269579a in decltype(auto) std::less<void>::_S_cmp<StackTraceTriple const&, StackTraceRefTriple const&>(StackTraceTriple const&, StackTraceRefTriple const&, std::integral_constant<bool, fals
e>) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_function.h:601:34
    #7 0x5584e269579a in decltype((std::forward<StackTraceTriple const&>(fp)) < (std::forward<StackTraceRefTriple const&>(fp0))) std::less<void>::operator()<StackTraceTriple const&, StackTraceRefTriple c
onst&>(StackTraceTriple const&, StackTraceRefTriple const&) const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_function.h:586:11
    #8 0x5584e269579a in std::Rb_tree_const_iterator<std::pair<StackTraceTriple const, std::_cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > std::_Rb_tree<StackTraceTriple,
 std::pair<StackTraceTriple const, std::_cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::_Select1st<std::pair<StackTraceTriple const, std::_cxx11::basic_string<char, st
d::char_traits<char>, std::allocator<char> > > >, std::less<void>, std::allocator<std::pair<StackTraceTriple const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >::
_M_lower_bound_tr<StackTraceRefTriple, void>(StackTraceRefTriple const&) const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:1337:11
    #9 0x5584e269579a in std::Rb_tree_const_iterator<std::pair<StackTraceTriple const, std::_cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > std::_Rb_tree<StackTraceTriple,
 std::pair<StackTraceTriple const, std::_cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::_Select1st<std::pair<StackTraceTriple const, std::_cxx11::basic_string<char, st
d::char_traits<char>, std::allocator<char> > > >, std::less<void>, std::allocator<std::pair<StackTraceTriple const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >::
_M_find_tr<StackTraceRefTriple, void>(StackTraceRefTriple const&) const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:1305:15
    #10 0x5584e268f66f in std::Rb_tree_iterator<std::pair<StackTraceTriple const, std::cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > std::_Rb_tree<StackTraceTriple, std::pair<StackTraceTriple const, std::cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::_Select1st<std::pair<StackTraceTriple const, std::cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, std::less<void>, std::allocator<std::pair<StackTraceTriple const, std::_cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >::_M_find_tr<StackTraceRefTriple, void>(StackTraceRefTriple const&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:1297:25
    #11 0x5584e268f66f in decltype(*(this)._M_t._M_find_tr(fp)) std::map<StackTraceTriple, std::_cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<void>, std::allocator<std::pair<StackTraceTriple const, std::_cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >::find<StackTraceRefTriple>(StackTraceRefTriple const&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_map.h:1176:16
    #12 0x5584e268f66f in toStringCached[abi:cxx11](std::array<void*, 45ul> const&, unsigned long, unsigned long) /src/common/stack_trace.cpp:450:25
    #13 0x5584e2690712 in StackTrace::toString[abi:cxx11]() const /src/common/stack_trace.cpp:465:12
    #14 0x5584e2686972 in doris::get_stack_trace_by_libunwind[abi:cxx11]() /src/util/stack_util.cpp:84:32
    #15 0x5584e2685add in doris::get_stack_trace[abi:cxx11]() /src/util/stack_util.cpp:51:16
    #16 0x5584e276defb in doris::Status doris::Status::Error<41, true, std::_cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>(std::basic_string_view<char, std::char_traits<char> >, std::_cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /src/common/status.h:368:39
    #17 0x5584e275f23d in doris::Status doris::Status::ServiceUnavailable<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>(std::basic_string_view<char, std::char_tr
aits<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /src/common/status.h:422:5
    #18 0x5584e275f23d in doris::ThreadPool::shutdown() /src/util/threadpool.cpp:277:20
    #19 0x55850163da21 in doris::pipeline::TaskScheduler::shutdown() /src/pipeline/task_scheduler.cpp:361:31
    #20 0x55850163da21 in doris::pipeline::TaskScheduler::~TaskScheduler() /src/pipeline/task_scheduler.cpp:199:5
    #21 0x5584e1f94859 in doris::ExecEnv::_destroy() /src/runtime/exec_env_init.cpp:423:5
    #22 0x5584e1f80d38 in doris::ExecEnv::~ExecEnv() /src/runtime/exec_env.cpp:36:5
    #23 0x7f47e2c598a6 in __run_exit_handlers /build/glibc-SzIz7B/glibc-2.31/stdlib/exit.c:108:8
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

