### PR TITLE
[bugfix](topn) fix miss-use of unique_id causing vector buffer overflow

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -472,7 +472,8 @@ Status SegmentIterator::_get_row_ranges_from_conditions(RowRanges* condition_row
         auto query_ctx = _opts.runtime_state->get_query_ctx();
         runtime_predicate = query_ctx->get_runtime_predicate().get_predictate();
         if (runtime_predicate) {
-            int32_t unique_id = _opts.tablet_schema->column(runtime_predicate->column_id()).unique_id();
+            int32_t unique_id =
+                    _opts.tablet_schema->column(runtime_predicate->column_id()).unique_id();
             AndBlockColumnPredicate and_predicate;
             auto single_predicate = new SingleColumnBlockPredicate(runtime_predicate.get());
             and_predicate.add_column_predicate(single_predicate);

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -472,13 +472,13 @@ Status SegmentIterator::_get_row_ranges_from_conditions(RowRanges* condition_row
         auto query_ctx = _opts.runtime_state->get_query_ctx();
         runtime_predicate = query_ctx->get_runtime_predicate().get_predictate();
         if (runtime_predicate) {
-            int32_t cid = _opts.tablet_schema->column(runtime_predicate->column_id()).unique_id();
+            int32_t unique_id = _opts.tablet_schema->column(runtime_predicate->column_id()).unique_id();
             AndBlockColumnPredicate and_predicate;
             auto single_predicate = new SingleColumnBlockPredicate(runtime_predicate.get());
             and_predicate.add_column_predicate(single_predicate);
 
             RowRanges column_rp_row_ranges = RowRanges::create_single(num_rows());
-            RETURN_IF_ERROR(_column_iterators[_schema->unique_id(cid)]->get_row_ranges_by_zone_map(
+            RETURN_IF_ERROR(_column_iterators[unique_id]->get_row_ranges_by_zone_map(
                     &and_predicate, nullptr, &column_rp_row_ranges));
 
             // intersect different columns's row ranges to get final row ranges by zone map

--- a/regression-test/suites/datatype_p0/scalar_types/load.groovy
+++ b/regression-test/suites/datatype_p0/scalar_types/load.groovy
@@ -51,6 +51,9 @@ suite("test_scalar_types_load", "p0") {
         PROPERTIES("replication_num" = "1", "store_row_column" = "true");
         """
 
+    sql """ ALTER TABLE ${testTable} DROP COLUMN c_bigint """
+    sql """ ALTER TABLE ${testTable}  ADD COLUMN c_bigint bigint AFTER c_int """
+
     // load data
     streamLoad {
         table testTable

--- a/regression-test/suites/datatype_p2/scalar_types/load.groovy
+++ b/regression-test/suites/datatype_p2/scalar_types/load.groovy
@@ -51,6 +51,9 @@ suite("test_scalar_types_load_p2", "p2") {
         PROPERTIES("replication_num" = "1");
         """
 
+    sql """ ALTER TABLE ${testTable} DROP COLUMN c_bigint """
+    sql """ ALTER TABLE ${testTable}  ADD COLUMN c_bigint bigint AFTER c_int """
+
     // load data
     streamLoad {
         table testTable


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

miss-use: the original cid is actually unique_id and `_schema->unique_id(cid)` is wrong.

BTW, there is no problem in master branch, since it's refactored by #23505.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

