### PR TITLE
[bugfix](topn) fix topn do not work because Field == Null always return true

### DIFF
--- a/be/src/vec/exec/vsort_node.cpp
+++ b/be/src/vec/exec/vsort_node.cpp
@@ -144,7 +144,7 @@ Status VSortNode::sink(RuntimeState* state, vectorized::Block* input_block, bool
         // update runtime predicate
         if (_use_topn_opt) {
             Field new_top = _sorter->get_top_value();
-            if (!new_top.is_null() && new_top != old_top) {
+            if (!new_top.is_null() && (old_top.is_null() || new_top != old_top)) {
                 auto& sort_description = _sorter->get_sort_description();
                 auto col = input_block->get_by_position(sort_description[0].column_number);
                 bool is_reverse = sort_description[0].direction < 0;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

`if (!new_top.is_null() && new_top != old_top)` is always false since old_top is Null when init and `Field == Null` always return true.

We add old_top.is_null() check first to avoid the problem and then issue more carefull discussion about `Field == Null` semantics.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

