### PR TITLE
[bug](schema change)fix schema change cause load failed due to err -215

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
@@ -105,6 +105,10 @@ public abstract class AlterJobV2 implements Writable {
     @SerializedName(value = "failedTabletBackends")
     protected Map<Long, List<Long>> failedTabletBackends = Maps.newHashMap();
 
+    // used for delete decommission tablet
+    @SerializedName(value = "deleteTabletWatermarkTxnId")
+    protected long deleteTabletWatermarkTxnId = -1;
+
     public AlterJobV2(String rawSql, long jobId, JobType jobType, long dbId, long tableId, String tableName,
                       long timeoutMs) {
         this.rawSql = rawSql;

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
@@ -24,6 +24,7 @@ import org.apache.doris.catalog.OlapTable.OlapTableState;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.MetaNotFoundException;
+import org.apache.doris.common.UserException;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.DebugPointUtil;
@@ -322,5 +323,13 @@ public abstract class AlterJobV2 implements Writable {
 
     public String toJson() {
         return GsonUtils.GSON.toJson(this);
+    }
+
+    protected void assignDeleteTabletWatermarkTxnId() {
+        try {
+            this.deleteTabletWatermarkTxnId = Env.getCurrentGlobalTransactionMgr().getNextTransactionId();
+        } catch (UserException e) {
+            LOG.warn("get next transaction id failed");
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
@@ -646,13 +646,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
             return false;
         }
 
-        try {
-            this.deleteTabletWatermarkTxnId =
-                    Env.getCurrentGlobalTransactionMgr().getNextTransactionId();
-        } catch (UserException e) {
-            LOG.warn("get next transaction id failed");
-        }
-
+        assignDeleteTabletWatermarkTxnId();
         cancelInternal();
 
         jobState = JobState.CANCELLED;

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
@@ -661,11 +661,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
             } // end for partitions
             commitShadowIndex();
             // all partitions are good
-            try {
-                this.deleteTabletWatermarkTxnId = Env.getCurrentGlobalTransactionMgr().getNextTransactionId();
-            } catch (UserException e) {
-                LOG.warn("get next transaction id failed");
-            }
+            assignDeleteTabletWatermarkTxnId();
             onFinished(tbl);
         } finally {
             tbl.writeUnlock();
@@ -792,12 +788,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         if (jobState.isFinalState()) {
             return false;
         }
-        try {
-            this.deleteTabletWatermarkTxnId =
-                    Env.getCurrentGlobalTransactionMgr().getNextTransactionId();
-        } catch (Exception e) {
-            LOG.warn("get next transaction id failed");
-        }
+        assignDeleteTabletWatermarkTxnId();
         cancelInternal();
 
         pruneMeta();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
@@ -152,7 +152,7 @@ public class TabletInvertedIndex {
             for (Map.Entry<Long, Long> entry : decommissionTabletMap.entrySet()) {
                 long tabletId = entry.getKey();
                 long watermarkId = entry.getValue();
-                TabletMeta tabletMeta = tabletMetaMap.get(tabletId);
+                TabletMeta tabletMeta = getTabletMeta(tabletId);
                 if (Env.getCurrentGlobalTransactionMgr().isPreviousTransactionsFinished(
                         watermarkId, tabletMeta.getDbId(), tabletMeta.getTableId(),
                         tabletMeta.getPartitionId())) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -1001,7 +1001,10 @@ public class InternalCatalog implements CatalogIf<Database> {
 
         Env.getCurrentEnv().getQueryStats().clear(Env.getCurrentEnv().getCurrentCatalog().getId(),
                 db.getId(), table.getId());
-        DropInfo info = new DropInfo(db.getId(), table.getId(), tableName, -1L, forceDrop, recycleTime);
+
+        Env.getCurrentEnv().getAnalysisManager().removeTableStats(table.getId());
+
+        DropInfo info = new DropInfo(db.getId(), table.getId(), tableName, -1L, forceDrop, recycleTime, -1);
         Env.getCurrentEnv().getEditLog().logDropTable(info);
         Env.getCurrentEnv().getMtmvService().dropTable(table);
     }
@@ -3229,7 +3232,7 @@ public class InternalCatalog implements CatalogIf<Database> {
             try {
                 dropTable(db, tableId, true, false, 0L);
                 if (hadLogEditCreateTable) {
-                    DropInfo info = new DropInfo(db.getId(), tableId, olapTable.getName(), -1L, true, 0L);
+                    DropInfo info = new DropInfo(db.getId(), tableId, olapTable.getName(), -1L, true, 0L, -1);
                     Env.getCurrentEnv().getEditLog().logDropTable(info);
                 }
             } catch (Exception ex) {

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
@@ -83,6 +83,7 @@ import org.apache.doris.persist.ColocatePersistInfo;
 import org.apache.doris.persist.ConsistencyCheckInfo;
 import org.apache.doris.persist.CreateTableInfo;
 import org.apache.doris.persist.DatabaseInfo;
+import org.apache.doris.persist.DeleteTabletInfo;
 import org.apache.doris.persist.DropDbInfo;
 import org.apache.doris.persist.DropInfo;
 import org.apache.doris.persist.DropPartitionInfo;
@@ -952,6 +953,11 @@ public class JournalEntity implements Writable {
             // FIXME: support cloud related operation types.
             case OperationType.OP_UPDATE_CLOUD_REPLICA: {
                 data = UpdateCloudReplicaInfo.read(in);
+                isRead = true;
+                break;
+            }
+            case OperationType.OP_DELETE_DECOMMISSION_TABLET: {
+                data = DeleteTabletInfo.read(in);
                 isRead = true;
                 break;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/BatchDropInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/BatchDropInfo.java
@@ -44,11 +44,17 @@ public class BatchDropInfo implements Writable {
     @SerializedName(value = "indexIdSet")
     private Set<Long> indexIdSet;
 
-    public BatchDropInfo(long dbId, long tableId, String tableName, Set<Long> indexIdSet) {
+    // used for delete decommission tablet
+    @SerializedName(value = "deleteTabletWatermarkTxnId")
+    private long deleteTabletWatermarkTxnId = -1;
+
+    public BatchDropInfo(long dbId, long tableId, String tableName, Set<Long> indexIdSet,
+            long deleteTabletWatermarkTxnId) {
         this.dbId = dbId;
         this.tableId = tableId;
         this.tableName = tableName;
         this.indexIdSet = indexIdSet;
+        this.deleteTabletWatermarkTxnId = deleteTabletWatermarkTxnId;
     }
 
     @Override
@@ -65,7 +71,8 @@ public class BatchDropInfo implements Writable {
         }
         BatchDropInfo otherBatchDropInfo = (BatchDropInfo) other;
         return this.dbId == otherBatchDropInfo.dbId && this.tableId == otherBatchDropInfo.tableId
-                && this.indexIdSet.equals(otherBatchDropInfo.indexIdSet);
+                && this.indexIdSet.equals(otherBatchDropInfo.indexIdSet)
+                && this.deleteTabletWatermarkTxnId == otherBatchDropInfo.deleteTabletWatermarkTxnId;
     }
 
     @Override
@@ -92,6 +99,10 @@ public class BatchDropInfo implements Writable {
 
     public String getTableName() {
         return tableName;
+    }
+
+    public long getDeleteTabletWatermarkTxnId() {
+        return deleteTabletWatermarkTxnId;
     }
 
     public String toJson() {

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/DeleteTabletInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/DeleteTabletInfo.java
@@ -1,0 +1,56 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.persist;
+
+import org.apache.doris.common.io.Text;
+import org.apache.doris.common.io.Writable;
+import org.apache.doris.persist.gson.GsonUtils;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+public class DeleteTabletInfo implements Writable {
+
+    @SerializedName(value = "tabletId")
+    private long tabletId;
+
+    public DeleteTabletInfo(long tabletId) {
+        this.tabletId = tabletId;
+    }
+
+    public long getTabletId() {
+        return tabletId;
+    }
+
+    public void setTabletId(long tabletId) {
+        this.tabletId = tabletId;
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        Text.writeString(out, GsonUtils.GSON.toJson(this));
+    }
+
+    public static DeleteTabletInfo read(DataInput in) throws IOException {
+        String json = Text.readString(in);
+        return GsonUtils.GSON.fromJson(json, DeleteTabletInfo.class);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/DropInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/DropInfo.java
@@ -42,17 +42,21 @@ public class DropInfo implements Writable {
     private boolean forceDrop = false;
     @SerializedName(value = "recycleTime")
     private long recycleTime = 0;
+    @SerializedName(value = "deleteTabletWatermarkTxnId")
+    private long deleteTabletWatermarkTxnId = -1;
 
     public DropInfo() {
     }
 
-    public DropInfo(long dbId, long tableId, String tableName, long indexId, boolean forceDrop, long recycleTime) {
+    public DropInfo(long dbId, long tableId, String tableName, long indexId, boolean forceDrop, long recycleTime,
+            long deleteTabletWatermarkTxnId) {
         this.dbId = dbId;
         this.tableId = tableId;
         this.tableName = tableName;
         this.indexId = indexId;
         this.forceDrop = forceDrop;
         this.recycleTime = recycleTime;
+        this.deleteTabletWatermarkTxnId = deleteTabletWatermarkTxnId;
     }
 
     public long getDbId() {
@@ -77,6 +81,10 @@ public class DropInfo implements Writable {
 
     public Long getRecycleTime() {
         return recycleTime;
+    }
+
+    public long getDeleteTabletWatermarkTxnId() {
+        return deleteTabletWatermarkTxnId;
     }
 
     @Override
@@ -119,7 +127,8 @@ public class DropInfo implements Writable {
         DropInfo info = (DropInfo) obj;
 
         return (dbId == info.dbId) && (tableId == info.tableId) && (indexId == info.indexId)
-                && (forceDrop == info.forceDrop) && (recycleTime == info.recycleTime);
+                && (forceDrop == info.forceDrop) && (recycleTime == info.recycleTime)
+                && (deleteTabletWatermarkTxnId == info.deleteTabletWatermarkTxnId);
     }
 
     public String toJson() {

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
@@ -419,6 +419,8 @@ public class OperationType {
     public static final short OP_MODIFY_TTL_SECONDS = 1001;
     public static final short OP_MODIFY_CLOUD_WARM_UP_JOB = 1002;
 
+    public static final short OP_DELETE_DECOMMISSION_TABLET = 1003;
+
     /**
      * Get opcode name by op code.
      **/

--- a/fe/fe-core/src/test/java/org/apache/doris/persist/DropAndRecoverInfoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/persist/DropAndRecoverInfoTest.java
@@ -44,7 +44,7 @@ public class DropAndRecoverInfoTest {
         DropInfo info1 = new DropInfo();
         info1.write(dos);
 
-        DropInfo info2 = new DropInfo(1, 2, "t2", -1, true, 0);
+        DropInfo info2 = new DropInfo(1, 2, "t2", -1, true, 0, -1);
         info2.write(dos);
 
         dos.flush();
@@ -65,10 +65,10 @@ public class DropAndRecoverInfoTest {
 
         Assert.assertEquals(rInfo2, rInfo2);
         Assert.assertNotEquals(rInfo2, this);
-        Assert.assertNotEquals(info2, new DropInfo(0, 2, "t2", -1L, true, 0));
-        Assert.assertNotEquals(info2, new DropInfo(1, 0, "t0", -1L, true, 0));
-        Assert.assertNotEquals(info2, new DropInfo(1, 2, "t2", -1L, false, 0));
-        Assert.assertEquals(info2, new DropInfo(1, 2, "t2", -1L, true, 0));
+        Assert.assertNotEquals(info2, new DropInfo(0, 2, "t2", -1L, true, 0, -1));
+        Assert.assertNotEquals(info2, new DropInfo(1, 0, "t0", -1L, true, 0, -1));
+        Assert.assertNotEquals(info2, new DropInfo(1, 2, "t2", -1L, false, 0, -1));
+        Assert.assertEquals(info2, new DropInfo(1, 2, "t2", -1L, true, 0, -1));
 
         // 3. delete files
         dis.close();


### PR DESCRIPTION
## Proposed changes

If Doris schema change job and load job execute in parallel, load job may be failed after schema change job finished.

Schema change job will generate a new shadow index for loading new data stream and convert history data. After schema change job finished, FE will delete the origin index and its' tablet in fe's meta, and then sends drop tablet task to BE to drop origin tablet meta and data in BE. But if a load job has not finished, which is loading data to both origin tablet and new tablet, it will fail due to OLAP_ERR_TABLE_NOT_FOUND.

This PR implements that Doris will not delete tablets of origin index immediately when schema change job is finished, but set the tablets' state  to DECOMMISSION, Doris will delete those tablets later after all transactions on those tablets are finished.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

