### PR TITLE
[Bug](compare) fix core dump on decimal128 when be is build by debug mode

### DIFF
--- a/be/src/vec/core/types.h
+++ b/be/src/vec/core/types.h
@@ -502,8 +502,6 @@ struct Decimal {
 };
 
 struct Decimal128I : public Decimal<Int128> {
-    using NativeType = Int128;
-
     Decimal128I() = default;
 
 #define DECLARE_NUMERIC_CTOR(TYPE) \


### PR DESCRIPTION
## Proposed changes
fix core dump on decimal128 when be is build by debug mode

```cpp
*** SIGSEGV unknown detail explain (@0x0) received by PID 3100534 (TID 3101134 OR 0x7f5966fe9700) from PID 0; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk1/xiaolei/incubator-doris/be/src/common/signal_handler.h:413
 1# 0x00007F5AA35AF400 in /lib64/libc.so.6
 2# doris::vectorized::Decimal<__int128>::operator<=>(doris::vectorized::Decimal<__int128> const&) const at /mnt/disk1/xiaolei/incubator-doris/be/src/vec/core/types.h:381
 3# bool doris::ComparisonPredicateBase<(doris::PrimitiveType)30, (doris::PredicateType)6>::_operator<doris::vectorized::Decimal128I, doris::vectorized::Decimal128I>(doris::vectorized::Decimal128I const&, doris::vectorized::Decimal128I const&) const at /mnt/disk1/xiaolei/incubator-doris/be/src/olap/comparison_predicate.h:393
 4# doris::ComparisonPredicateBase<(doris::PrimitiveType)30, (doris::PredicateType)6>::compare(void*) const at /mnt/disk1/xiaolei/incubator-doris/be/src/olap/comparison_predicate.h:158
 5# doris::ComparisonPredicateBase<(doris::PrimitiveType)30, (doris::PredicateType)6>::evaluate_and(std::pair<doris::WrapperField*, doris::WrapperField*> const&) const at /mnt/disk1/xiaolei/incubator-doris/be/src/olap/comparison_predicate.h:203
 6# doris::SingleColumnBlockPredicate::evaluate_and(std::pair<doris::WrapperField*, doris::WrapperField*> const&) const at /mnt/disk1/xiaolei/incubator-doris/be/src/olap/block_column_predicate.cpp:48
 7# doris::AndBlockColumnPredicate::evaluate_and(std::pair<doris::WrapperField*, doris::WrapperField*> const&) const at /mnt/disk1/xiaolei/incubator-doris/be/src/olap/block_column_predicate.cpp:150
 8# doris::segment_v2::ColumnReader::_zone_map_match_condition(doris::segment_v2::ZoneMapPB const&, doris::WrapperField*, doris::WrapperField*, doris::AndBlockColumnPredicate const*) const at /mnt/disk1/xiaolei/incubator-doris/be/src/olap/rowset/segment_v2/column_reader.cpp:383
 9# doris::segment_v2::ColumnReader::match_condition(doris::AndBlockColumnPredicate const*) const at /mnt/disk1/xiaolei/incubator-doris/be/src/olap/rowset/segment_v2/column_reader.cpp:334
10# doris::segment_v2::Segment::new_iterator(std::shared_ptr<doris::Schema const>, doris::StorageReadOptions const&, std::unique_ptr<doris::RowwiseIterator, std::default_delete<doris::RowwiseIterator> >*) at /mnt/disk1/xiaolei/incubator-doris/be/src/olap/rowset/segment_v2/segment.cpp:134
11# doris::BetaRowsetReader::get_segment_iterators(doris::RowsetReaderContext*, std::vector<std::unique_ptr<doris::RowwiseIterator, std::default_delete<doris::RowwiseIterator> >, std::allocator<std::unique_ptr<doris::RowwiseIterator, std::default_delete<doris::RowwiseIterator> > > >*, doris::RowSetSplits const&, bool) at /mnt/disk1/xiaolei/incubator-doris/be/src/olap/rowset/beta_rowset_reader.cpp:228
12# doris::BetaRowsetReader::init(doris::RowsetReaderContext*, doris::RowSetSplits const&) at /mnt/disk1/xiaolei/incubator-doris/be/src/olap/rowset/beta_rowset_reader.cpp:246
13# doris::vectorized::BlockReader::_init_collect_iter(doris::TabletReader::ReaderParams const&) at /mnt/disk1/xiaolei/incubator-doris/be/src/vec/olap/block_reader.cpp:134
14# doris::vectorized::BlockReader::init(doris::TabletReader::ReaderParams const&) at /mnt/disk1/xiaolei/incubator-doris/be/src/vec/olap/block_reader.cpp:215
15# doris::vectorized::NewOlapScanner::open(doris::RuntimeState*) at /mnt/disk1/xiaolei/incubator-doris/be/src/vec/exec/scan/new_olap_scanner.cpp:266
16# doris::vectorized::ScannerScheduler::_scanner_scan(doris::vectorized::ScannerScheduler*, doris::vectorized::ScannerContext*, std::shared_ptr<doris::vectorized::VScanner>) at /mnt/disk1/xiaolei/incubator-doris/be/src/vec/exec/scan/scanner_scheduler.cpp:354
```
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

