### PR TITLE
[Fix](BinaryPrefixPage) stop to read values when current pos reached the end of the page in `BinaryPrefixPageDecoder::next_batch`

### DIFF
--- a/be/src/olap/rowset/segment_v2/binary_prefix_page.cpp
+++ b/be/src/olap/rowset/segment_v2/binary_prefix_page.cpp
@@ -222,8 +222,8 @@ Status BinaryPrefixPageDecoder::next_batch(size_t* n, vectorized::MutableColumnP
         dst->insert_data((char*)(_current_value.data()), _current_value.size());
     }
 
-    if (_cur_pos < _num_values - 1) {
-        _cur_pos++;
+    _cur_pos++;
+    if (_cur_pos < _num_values) {
         RETURN_IF_ERROR(_read_next_value());
     }
 

--- a/be/src/olap/rowset/segment_v2/binary_prefix_page.cpp
+++ b/be/src/olap/rowset/segment_v2/binary_prefix_page.cpp
@@ -216,7 +216,7 @@ Status BinaryPrefixPageDecoder::next_batch(size_t* n, vectorized::MutableColumnP
 
     dst->insert_data((char*)(_current_value.data()), _current_value.size());
     // read and copy values
-    for (size_t i = 0; i < max_fetch - 1; ++i) {
+    for (size_t i = 1; i < max_fetch; ++i) {
         RETURN_IF_ERROR(_read_next_value());
         _cur_pos++;
         dst->insert_data((char*)(_current_value.data()), _current_value.size());

--- a/be/src/olap/rowset/segment_v2/binary_prefix_page.cpp
+++ b/be/src/olap/rowset/segment_v2/binary_prefix_page.cpp
@@ -163,8 +163,8 @@ Status BinaryPrefixPageDecoder::seek_to_position_in_page(size_t pos) {
     size_t restart_point_index = pos / _restart_point_internal;
     RETURN_IF_ERROR(_seek_to_restart_point(restart_point_index));
     while (_cur_pos < pos) {
-        RETURN_IF_ERROR(_read_next_value());
         _cur_pos++;
+        RETURN_IF_ERROR(_read_next_value());
     }
     return Status::OK();
 }
@@ -201,8 +201,8 @@ Status BinaryPrefixPageDecoder::seek_at_or_after_value(const void* value, bool* 
             *exact_match = cmp == 0;
             return Status::OK();
         }
-        RETURN_IF_ERROR(_read_next_value());
         _cur_pos++;
+        RETURN_IF_ERROR(_read_next_value());
     }
 }
 
@@ -217,14 +217,14 @@ Status BinaryPrefixPageDecoder::next_batch(size_t* n, vectorized::MutableColumnP
     dst->insert_data((char*)(_current_value.data()), _current_value.size());
     // read and copy values
     for (size_t i = 1; i < max_fetch; ++i) {
-        RETURN_IF_ERROR(_read_next_value());
         _cur_pos++;
+        RETURN_IF_ERROR(_read_next_value());
         dst->insert_data((char*)(_current_value.data()), _current_value.size());
     }
 
     if (_cur_pos < _num_values - 1) {
-        RETURN_IF_ERROR(_read_next_value());
         _cur_pos++;
+        RETURN_IF_ERROR(_read_next_value());
     }
 
     *n = max_fetch;

--- a/be/src/olap/rowset/segment_v2/binary_prefix_page.cpp
+++ b/be/src/olap/rowset/segment_v2/binary_prefix_page.cpp
@@ -121,6 +121,7 @@ Status BinaryPrefixPageDecoder::_read_next_value() {
     uint32_t non_shared_len;
     auto data_ptr = _decode_value_lengths(_next_ptr, &shared_len, &non_shared_len);
     if (data_ptr == nullptr) {
+        DCHECK(false) << "[BinaryPrefixPageDecoder::_read_next_value] corruption!";
         return Status::Corruption("Failed to decode value at position {}", _cur_pos);
     }
     _current_value.resize(shared_len);

--- a/be/test/olap/primary_key_index_test.cpp
+++ b/be/test/olap/primary_key_index_test.cpp
@@ -129,7 +129,7 @@ TEST_F(PrimaryKeyIndexTest, builder) {
         EXPECT_FALSE(exists);
         auto status = index_iterator->seek_at_or_after(&slice, &exact_match);
         EXPECT_FALSE(exact_match);
-        EXPECT_TRUE(status.is<NOT_FOUND>());
+        EXPECT_TRUE(status.is<ErrorCode::END_OF_FILE>());
     }
 
     // read all key


### PR DESCRIPTION
## Proposed changes


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

