### PR TITLE
[fix](load) add lock for serialize profile

### DIFF
--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -167,10 +167,11 @@ void LoadChannel::_report_profile(PTabletWriterAddBlockResult* response) {
     }
 
     TRuntimeProfileTree tprofile;
-    _profile->to_thrift(&tprofile);
     ThriftSerializer ser(false, 4096);
     uint8_t* buf = nullptr;
     uint32_t len = 0;
+    std::lock_guard<SpinLock> l(_profile_serialize_lock);
+    _profile->to_thrift(&tprofile);
     auto st = ser.serialize(&tprofile, &len, &buf);
     if (st.ok()) {
         response->set_load_channel_profile(std::string((const char*)buf, len));

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -120,6 +120,7 @@ protected:
 private:
     UniqueId _load_id;
 
+    SpinLock _profile_serialize_lock;
     std::unique_ptr<RuntimeProfile> _profile;
     RuntimeProfile* _self_profile;
     RuntimeProfile::Counter* _add_batch_number_counter = nullptr;


### PR DESCRIPTION
## Proposed changes

The following error may be caused by concurrent to_thrift operations, add a lock for serialize profile.

```
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/zcp/repo_center/doris_master/doris/be/src/vec/common/columns_hashing_impl.h:172:76 in 
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:413
 1# 0x00007FA62BC1A090 in /lib/x86_64-linux-gnu/libc.so.6
 2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
 3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
 4# __gnu_cxx::__verbose_terminate_handler() [clone .cold] at ../../../../libstdc++-v3/libsupc++/vterminate.cc:75
 5# __cxxabiv1::__terminate(void (*)()) at ../../../../libstdc++-v3/libsupc++/eh_terminate.cc:48
 6# 0x000055C43B3ECD21 in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 7# 0x000055C43B3ECE74 in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 8# std::__throw_length_error(char const*) at ../../../../../libstdc++-v3/src/c++11/functexcept.cc:82
 9# std::vector >::reserve(unsigned long) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/vector.tcc:70
10# doris::RuntimeProfile::to_thrift(std::vector >*) at /home/zcp/repo_center/doris_master/doris/be/src/util/runtime_profile.cpp:627
11# doris::RuntimeProfile::to_thrift(std::vector >*) at /home/zcp/repo_center/doris_master/doris/be/src/util/runtime_profile.cpp:666
12# doris::RuntimeProfile::to_thrift(std::vector >*) at /home/zcp/repo_center/doris_master/doris/be/src/util/runtime_profile.cpp:666
13# doris::RuntimeProfile::to_thrift(std::vector >*) at /home/zcp/repo_center/doris_master/doris/be/src/util/runtime_profile.cpp:666
14# doris::RuntimeProfile::to_thrift(doris::TRuntimeProfileTree*) at /home/zcp/repo_center/doris_master/doris/be/src/util/runtime_profile.cpp:622
15# doris::LoadChannel::_report_profile(doris::PTabletWriterAddBlockResult*) at /home/zcp/repo_center/doris_master/doris/be/src/runtime/load_channel.cpp:170
16# doris::LoadChannel::add_batch(doris::PTabletWriterAddBlockRequest const&, doris::PTabletWriterAddBlockResult*) at /home/zcp/repo_center/doris_master/doris/be/src/runtime/load_channel.cpp:138
17# doris::LoadChannelMgr::add_batch(doris::PTabletWriterAddBlockRequest const&, doris::PTabletWriterAddBlockResult*) at /home/zcp/repo_center/doris_master/doris/be/src/runtime/load_channel_mgr.cpp:166
18# doris::PInternalServiceImpl::_tablet_writer_add_block(google::protobuf::RpcController*, doris::PTabletWriterAddBlockRequest const*, doris::PTabletWriterAddBlockResult*, google::protobuf::Closure*)::$_0::operator()() const at /home/zcp/repo_center/doris_master/doris/be/src/service/internal_service.cpp:458
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

