### PR TITLE
[Fix](Plan)StreamLoad cannot be parsed correctly when it contains complex where conditions

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
@@ -212,6 +212,9 @@ public class StreamLoadPlanner {
             }
         }
 
+        scanTupleDesc.setTable(destTable);
+        analyzer.registerTupleDescriptor(scanTupleDesc);
+        taskInfo.getWhereExpr().analyze(analyzer);
         // create scan node
         FileLoadScanNode fileScanNode = new FileLoadScanNode(new PlanNodeId(0), scanTupleDesc);
         // 1. create file group


### PR DESCRIPTION
Steps to reproduce：
``` sql
 curl --location-trusted  -H "Expect: 100-continue" -X PUT  -u root:  -H "format:json" -H "where:d = 'doris' or d = 'nb'"  -d '{"a":"3","b":"2","c":"389","d":"nb"}' http://localhost:8030/api/kris/test/_stream_load

```

``` error
java.lang.IllegalStateException: null
        at com.google.common.base.Preconditions.checkState(Preconditions.java:492) ~[guava-30.0-jre.jar:?]
        at org.apache.doris.analysis.SlotRef.getTableName(SlotRef.java:264) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.rewrite.ExtractCommonFactorsRule.rewriteOrToIn(ExtractCommonFactorsRule.java:532) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.rewrite.ExtractCommonFactorsRule.makeCompoundRemaining(ExtractCommonFactorsRule.java:455) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.rewrite.ExtractCommonFactorsRule.extractCommonFactors(ExtractCommonFactorsRule.java:205) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.rewrite.ExtractCommonFactorsRule.apply(ExtractCommonFactorsRule.java:80) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.rewrite.ExprRewriter.applyRuleOnce(ExprRewriter.java:146) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.rewrite.ExprRewriter.rewrite(ExprRewriter.java:139) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.external.ExternalFileScanNode.initWhereExpr(ExternalFileScanNode.java:312) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.external.ExternalFileScanNode.initAndSetWhereExpr(ExternalFileScanNode.java:293) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.external.ExternalFileScanNode.initParamCreateContexts(ExternalFileScanNode.java:274) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.external.ExternalFileScanNode.init(ExternalFileScanNode.java:207) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.StreamLoadPlanner.plan(StreamLoadPlanner.java:201) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.load.routineload.RoutineLoadJob.plan(RoutineLoadJob.java:804) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.load.routineload.KafkaTaskInfo.rePlan(KafkaTaskInfo.java:117) ~[doris-fe.jar:1.2-SNAPSHOT]
```