### PR TITLE
[Improvement] (pipeline) Cancel related query if backend restarts or dead

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -212,6 +212,7 @@ import org.apache.doris.qe.AuditEventProcessor;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.GlobalVariable;
 import org.apache.doris.qe.JournalObservable;
+import org.apache.doris.qe.QueryCancelWorker;
 import org.apache.doris.qe.VariableMgr;
 import org.apache.doris.resource.Tag;
 import org.apache.doris.resource.workloadgroup.WorkloadGroupMgr;
@@ -474,6 +475,8 @@ public class Env {
 
     private BinlogGcer binlogGcer;
 
+    private QueryCancelWorker queryCancelWorker;
+
     /**
      * TODO(tsy): to be removed after load refactor
      */
@@ -717,6 +720,7 @@ public class Env {
         this.binlogManager = new BinlogManager();
         this.binlogGcer = new BinlogGcer();
         this.columnIdFlusher = new ColumnIdFlushDaemon();
+        this.queryCancelWorker = new QueryCancelWorker(systemInfo);
     }
 
     public static void destroyCheckpoint() {
@@ -961,6 +965,8 @@ public class Env {
         if (statisticsPeriodCollector != null) {
             statisticsPeriodCollector.start();
         }
+
+        queryCancelWorker.start();
     }
 
     // wait until FE is ready.

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/ExecutionProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/ExecutionProfile.java
@@ -63,6 +63,8 @@ public class ExecutionProfile {
     // instance id -> dummy value
     private MarkedCountDownLatch<TUniqueId, Long> profileDoneSignal;
 
+    private TUniqueId queryId;
+
     public ExecutionProfile(TUniqueId queryId, int fragmentNum) {
         executionProfile = new RuntimeProfile("Execution Profile " + DebugUtil.printId(queryId));
         RuntimeProfile fragmentsProfile = new RuntimeProfile("Fragments");
@@ -74,6 +76,7 @@ public class ExecutionProfile {
         }
         loadChannelProfile = new RuntimeProfile("LoadChannels");
         executionProfile.addChild(loadChannelProfile);
+        this.queryId = queryId;
     }
 
     public RuntimeProfile getExecutionProfile() {
@@ -117,7 +120,7 @@ public class ExecutionProfile {
         if (profileDoneSignal != null) {
             // count down to zero to notify all objects waiting for this
             profileDoneSignal.countDownToZero(new Status());
-            LOG.info("unfinished instance: {}", profileDoneSignal.getLeftMarks()
+            LOG.info("Query {} unfinished instance: {}", DebugUtil.printId(queryId),  profileDoneSignal.getLeftMarks()
                     .stream().map(e -> DebugUtil.printId(e.getKey())).toArray());
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -528,11 +528,12 @@ public class Coordinator {
 
         this.idToBackend = Env.getCurrentSystemInfo().getIdToBackend();
         if (LOG.isDebugEnabled()) {
-            LOG.debug("idToBackend size={}", idToBackend.size());
+            LOG.debug("Query {} idToBackend size={}", DebugUtil.printId(queryId), idToBackend.size());
             for (Map.Entry<Long, Backend> entry : idToBackend.entrySet()) {
                 Long backendID = entry.getKey();
                 Backend backend = entry.getValue();
-                LOG.debug("backend: {}-{}-{}", backendID, backend.getHost(), backend.getBePort());
+                LOG.debug("Query {}, backend: {}-{}-{}-{}", DebugUtil.printId(queryId),
+                                    backendID, backend.getHost(), backend.getBePort(), backend.getProcessEpoch());
             }
         }
     }
@@ -761,7 +762,7 @@ public class Coordinator {
                     BackendExecStates states = beToExecStates.get(execState.backend.getId());
                     if (states == null) {
                         states = new BackendExecStates(execState.backend.getId(), execState.brpcAddress,
-                                twoPhaseExecution);
+                                twoPhaseExecution, execState.backend.getProcessEpoch());
                         beToExecStates.putIfAbsent(execState.backend.getId(), states);
                     }
                     states.addState(execState);
@@ -1252,6 +1253,92 @@ public class Coordinator {
         return resultBatch;
     }
 
+
+    // We use a very conservative cancel strategy.
+    // 0. If backends has zero process epoch, do not cancel. Zero process epoch usually arises in cluster upgrading.
+    // 1. If process epoch is same, do not cancel. Means backends does not restart or die.
+    public boolean shouldCancel(List<Backend> currentBackends) {
+        Map<Long, Backend> curBeMap = Maps.newHashMap();
+        for (Backend be : currentBackends) {
+            curBeMap.put(be.getId(), be);
+        }
+        lock();
+
+        for (Long id : idToBackend.keySet()) {
+            Backend be = curBeMap.get(id);
+
+            if (be == null) {
+                // Be not exists in latest be snapshot
+                unlock();
+                LOG.warn("Backend {} not exists, query {} should be cancelled",
+                         id, DebugUtil.printId(queryId));
+                return true;
+            } else if (!be.isAlive()) {
+                unlock();
+                LOG.warn("Backend {} dead, coordinator {} should be cancelled.",
+                         be.getId(), DebugUtil.printId(queryId));
+                return true;
+            }
+        }
+
+        // Usually, if any be dead or restarted, this function should have returned true
+        // in above for loop.
+        // But there is a situation where a backend has finished restart, and hb has already
+        // updated before this function is involved, so we need to compare the backend process epoch
+        // still.
+        if (queryOptions.isEnablePipelineEngine()) {
+            for (PipelineExecContext pipelineExecContext : pipelineExecContexts.values()) {
+                // Here we have an implicit consumption that pipelineExecContexts and idToBackend
+                // are logical correct, so be could not be null.
+                Backend be = curBeMap.get(pipelineExecContext.backend.getId());
+                if (be == null || !be.isAlive()) {
+                    // Should not happen.
+                    unlock();
+                    LOG.error("Logical error in Coordinator, backend: {}", pipelineExecContext.backend.toString());
+                    return true;
+                }
+
+                // Backend process epoch changed, indicates that this be restarts, query should be cancelled.
+                // Check zero since during upgrading, older version oplog will not persistent be start time
+                // so newer version follower will get zero epoch when replaying oplog or snapshot
+                if (pipelineExecContext.beProcessEpoch != be.getProcessEpoch() && be.getProcessEpoch() != 0) {
+                    unlock();
+                    LOG.warn("Backend process epoch changed, previous {} now {}, means this be has already restarted, "
+                                    + "should cancel this coordinator, query id {}",
+                            pipelineExecContext.beProcessEpoch, be.getProcessEpoch(), DebugUtil.printId(queryId));
+                    return true;
+                } else if (be.getProcessEpoch() == 0) {
+                    LOG.warn("Backend {} has zero process epoch, maybe we are upgrading cluster?", be.toString());
+                }
+            }
+        } else {
+            // beToExecStates will be updated only in non-pipeline query.
+            for (BackendExecStates beExecState : beToExecStates.values()) {
+                Backend be = curBeMap.get(beExecState.beId);
+                if (be == null || !be.isAlive()) {
+                    // Should not happen.
+                    unlock();
+                    LOG.error("Logical error in Coordinator, backendId: {}, beProcessEpoch: {}",
+                                        beExecState.beId, beExecState.beProcessEpoch);
+                    return true;
+                }
+
+                if (beExecState.beProcessEpoch != be.getProcessEpoch() && be.getProcessEpoch() != 0) {
+                    unlock();
+                    LOG.warn("Process epoch changed, previous {} now {}, means this be has already restarted, "
+                                    + "should cancel this coordinator, query id {}",
+                            beExecState.beProcessEpoch, be.getProcessEpoch(), DebugUtil.printId(queryId));
+                    return true;
+                } else if (be.getProcessEpoch() == 0) {
+                    LOG.warn("Backend {} has zero process epoch, maybe we are upgrading cluster?", be.toString());
+                }
+            }
+        }
+
+        unlock();
+        return false;
+    }
+
     // Cancel execution of query. This includes the execution of the local plan
     // fragment,
     // if any, as well as all plan fragments on remote nodes.
@@ -1268,7 +1355,7 @@ public class Coordinator {
             } else {
                 queryStatus.setStatus(Status.CANCELLED);
             }
-            LOG.warn("cancel execution of query, this is outside invoke");
+            LOG.warn("Cancel execution of query {}, this is a outside invoke", DebugUtil.printId(queryId));
             cancelInternal(cancelReason);
         } finally {
             unlock();
@@ -1307,8 +1394,9 @@ public class Coordinator {
         instanceIds.clear();
         for (FragmentExecParams params : fragmentExecParamsMap.values()) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("fragment {} has instances {}",
-                        params.fragment.getFragmentId(), params.instanceExecParams.size());
+                LOG.debug("Query {} fragment {} has {} instances.",
+                        DebugUtil.printId(queryId), params.fragment.getFragmentId(),
+                        params.instanceExecParams.size());
             }
 
             for (int j = 0; j < params.instanceExecParams.size(); ++j) {
@@ -2823,6 +2911,7 @@ public class Coordinator {
         Backend backend;
         long lastMissingHeartbeatTime = -1;
         long profileReportProgress = 0;
+        long beProcessEpoch = 0;
         private final int numInstances;
 
         public PipelineExecContext(PlanFragmentId fragmentId, int profileFragmentId,
@@ -2842,6 +2931,7 @@ public class Coordinator {
             this.backend = idToBackend.get(backendId);
             this.address = new TNetworkAddress(backend.getHost(), backend.getBePort());
             this.brpcAddress = new TNetworkAddress(backend.getHost(), backend.getBrpcPort());
+            this.beProcessEpoch = backend.getProcessEpoch();
 
             this.hasCanceled = false;
             this.lastMissingHeartbeatTime = backend.getLastMissingHeartbeatTime();
@@ -2898,13 +2988,16 @@ public class Coordinator {
         // return true if cancel success. Otherwise, return false
         public synchronized boolean cancelFragmentInstance(Types.PPlanFragmentCancelReason cancelReason) {
             if (!this.initiated) {
+                LOG.warn("Query {}, ccancel before initiated", DebugUtil.printId(queryId));
                 return false;
             }
             // don't cancel if it is already finished
             if (this.done) {
+                LOG.warn("Query {}, cancel after finished", DebugUtil.printId(queryId));
                 return false;
             }
             if (this.hasCanceled) {
+                LOG.warn("Query {}, cancel after cancelled", DebugUtil.printId(queryId));
                 return false;
             }
             for (TPipelineInstanceParams localParam : rpcParams.local_params) {
@@ -2987,11 +3080,13 @@ public class Coordinator {
         List<BackendExecState> states = Lists.newArrayList();
         boolean twoPhaseExecution = false;
         ScopedSpan scopedSpan = new ScopedSpan();
+        long beProcessEpoch = 0;
 
-        public BackendExecStates(long beId, TNetworkAddress brpcAddr, boolean twoPhaseExecution) {
+        public BackendExecStates(long beId, TNetworkAddress brpcAddr, boolean twoPhaseExecution, long beProcessEpoch) {
             this.beId = beId;
             this.brpcAddr = brpcAddr;
             this.twoPhaseExecution = twoPhaseExecution;
+            this.beProcessEpoch = beProcessEpoch;
         }
 
         public void addState(BackendExecState state) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/QeProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/QeProcessor.java
@@ -23,6 +23,7 @@ import org.apache.doris.thrift.TReportExecStatusParams;
 import org.apache.doris.thrift.TReportExecStatusResult;
 import org.apache.doris.thrift.TUniqueId;
 
+import java.util.List;
 import java.util.Map;
 
 public interface QeProcessor {
@@ -42,4 +43,6 @@ public interface QeProcessor {
     String getCurrentQueryByQueryId(TUniqueId queryId);
 
     Coordinator getCoordinator(TUniqueId queryId);
+
+    List<Coordinator> getAllCoordinators();
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/QeProcessorImpl.java
@@ -37,6 +37,8 @@ import com.google.common.collect.Maps;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -74,6 +76,16 @@ public final class QeProcessorImpl implements QeProcessor {
             return queryInfo.getCoord();
         }
         return null;
+    }
+
+    @Override
+    public List<Coordinator> getAllCoordinators() {
+        List<Coordinator> res = new ArrayList<>();
+
+        for (QueryInfo co : coordinatorMap.values()) {
+            res.add(co.coord);
+        }
+        return res;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/QueryCancelWorker.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/QueryCancelWorker.java
@@ -1,0 +1,47 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.qe;
+
+import org.apache.doris.common.util.MasterDaemon;
+import org.apache.doris.proto.Types;
+import org.apache.doris.system.Backend;
+import org.apache.doris.system.SystemInfoService;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+
+public class QueryCancelWorker extends MasterDaemon {
+    private SystemInfoService systemInfoService;
+
+    public QueryCancelWorker(SystemInfoService systemInfoService) {
+        this.systemInfoService = systemInfoService;
+    }
+
+    @Override
+    protected void runAfterCatalogReady() {
+        List<Backend> allBackends = systemInfoService.getAllBackends();
+
+        for (Coordinator co : QeProcessorImpl.INSTANCE.getAllCoordinators()) {
+            if (co.shouldCancel(allBackends)) {
+                co.cancel(Types.PPlanFragmentCancelReason.INTERNAL_ERROR);
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/QueryCancelWorker.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/QueryCancelWorker.java
@@ -22,9 +22,6 @@ import org.apache.doris.proto.Types;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.util.List;
 
 public class QueryCancelWorker extends MasterDaemon {
@@ -40,6 +37,8 @@ public class QueryCancelWorker extends MasterDaemon {
 
         for (Coordinator co : QeProcessorImpl.INSTANCE.getAllCoordinators()) {
             if (co.shouldCancel(allBackends)) {
+                // TODO(zhiqiang): We need more clear cancel message, so that user can figure out what happened
+                //  by searching log.
                 co.cancel(Types.PPlanFragmentCancelReason.INTERNAL_ERROR);
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/system/BackendHbResponse.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/BackendHbResponse.java
@@ -41,6 +41,7 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
     private String nodeRole = Tag.VALUE_MIX;
     // We need to broadcast be start time to all frontends,
     // it will be used to check if query on this backend should be canceled.
+
     @SerializedName(value = "beStartTime")
     private long beStartTime = 0;
     private String host;
@@ -113,8 +114,6 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
     public boolean isShutDown() {
         return isShutDown;
     }
-
-    public long getBeProcessEpoch() { return beStartTime; }
 
     @Override
     protected void readFields(DataInput in) throws IOException {

--- a/fe/fe-core/src/main/java/org/apache/doris/system/BackendHbResponse.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/BackendHbResponse.java
@@ -39,7 +39,10 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
     private int brpcPort;
     @SerializedName(value = "nodeRole")
     private String nodeRole = Tag.VALUE_MIX;
-    private long beStartTime;
+    // We need to broadcast be start time to all frontends,
+    // it will be used to check if query on this backend should be canceled.
+    @SerializedName(value = "beStartTime")
+    private long beStartTime = 0;
     private String host;
     private String version = "";
     @SerializedName(value = "isShutDown")
@@ -110,6 +113,8 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
     public boolean isShutDown() {
         return isShutDown;
     }
+
+    public long getBeProcessEpoch() { return beStartTime; }
 
     @Override
     protected void readFields(DataInput in) throws IOException {

--- a/fe/fe-core/src/main/java/org/apache/doris/system/BackendHbResponse.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/BackendHbResponse.java
@@ -39,9 +39,9 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
     private int brpcPort;
     @SerializedName(value = "nodeRole")
     private String nodeRole = Tag.VALUE_MIX;
+
     // We need to broadcast be start time to all frontends,
     // it will be used to check if query on this backend should be canceled.
-
     @SerializedName(value = "beStartTime")
     private long beStartTime = 0;
     private String host;

--- a/gensrc/thrift/HeartbeatService.thrift
+++ b/gensrc/thrift/HeartbeatService.thrift
@@ -47,7 +47,7 @@ struct TBackendInfo {
     3: optional Types.TPort be_rpc_port
     4: optional Types.TPort brpc_port
     5: optional string version
-    6: optional i64 be_start_time
+    6: optional i64 be_start_time // This field will also be uesd to identify a be process
     7: optional string be_node_role
     8: optional bool is_shutdown
 }


### PR DESCRIPTION
## Proposed changes

This is the 2nd pr of #23704  , now we can cancel query if related backend restarts or dead. Privious pr is #23582 
