### PR TITLE
[bugfix](regression-test) Repeated create user during parallel testing

### DIFF
--- a/regression-test/suites/ccr_syncer_p0/test_get_binlog.groovy
+++ b/regression-test/suites/ccr_syncer_p0/test_get_binlog.groovy
@@ -124,8 +124,7 @@ suite("test_get_binlog_case") {
             "replication_allocation" = "tag.location.default: 1"
         )
     """
-    sql """DROP USER IF EXISTS ${noPrivUser}"""
-    sql """CREATE USER ${noPrivUser} IDENTIFIED BY '123456'"""
+    sql """CREATE USER IF NOT EXISTS ${noPrivUser} IDENTIFIED BY '123456'"""
     sql """GRANT ALL ON ${context.config.defaultDb}.* TO ${noPrivUser}"""
     sql """GRANT ALL ON TEST_${context.dbName}.${emptyTable} TO ${noPrivUser}"""
     syncer.context.user = "${noPrivUser}"

--- a/regression-test/suites/ccr_syncer_p0/test_txn_case.groovy
+++ b/regression-test/suites/ccr_syncer_p0/test_txn_case.groovy
@@ -141,8 +141,7 @@ suite("test_txn_case") {
                     "replication_allocation" = "tag.location.default: 1"
                 )
             """
-    target_sql """DROP USER IF EXISTS ${noPrivUser}"""
-    target_sql """CREATE USER ${noPrivUser} IDENTIFIED BY '123456'"""
+    target_sql """CREATE USER IF NOT EXISTS ${noPrivUser} IDENTIFIED BY '123456'"""
     target_sql """GRANT ALL ON ${context.config.defaultDb}.* TO ${noPrivUser}"""
     target_sql """GRANT ALL ON TEST_${context.dbName}.${emptyTable} TO ${noPrivUser}"""
     syncer.context.user = "${noPrivUser}"
@@ -154,8 +153,7 @@ suite("test_txn_case") {
     // if not all privileges are obtained, txn should not be began
     logger.info("=== Test 3.3: Begin a txn with low priv user case ===")
     def lowPrivUser = "low_priv_user"
-    target_sql """DROP USER IF EXISTS ${lowPrivUser}"""
-    target_sql """CREATE USER ${lowPrivUser} IDENTIFIED BY '123456'"""
+    target_sql """CREATE USER IF NOT EXISTS ${lowPrivUser} IDENTIFIED BY '123456'"""
     target_sql """GRANT ALL ON ${context.config.defaultDb}.* TO ${lowPrivUser}"""
     syncer.context.user = "${lowPrivUser}"
     syncer.context.passwd = "123456"
@@ -172,8 +170,7 @@ suite("test_txn_case") {
 
     logger.info("=== Test 3.4: Complete the txn with SHOW_PRIV user case ===")
     def showPrivUser = "show_priv_user"
-    target_sql """DROP USER IF EXISTS ${showPrivUser}"""
-    target_sql """CREATE USER ${showPrivUser} IDENTIFIED BY '123456'"""
+    target_sql """CREATE USER IF NOT EXISTS ${showPrivUser} IDENTIFIED BY '123456'"""
     target_sql """GRANT ALL ON ${context.config.defaultDb}.* TO ${showPrivUser}"""
     target_sql """
                   GRANT 


### PR DESCRIPTION
## BUG
Repeated create user during parallel testing
## BUGFIX
use "CREATE USER IF NOT EXISTS" instead of "DROP & CREATE"