### PR TITLE
[opt](nereids) enable two phase partition topn opt

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriver.java
@@ -348,8 +348,21 @@ public class ChildOutputPropertyDeriver extends PlanVisitor<PhysicalProperties, 
     public PhysicalProperties visitPhysicalPartitionTopN(PhysicalPartitionTopN<? extends Plan> partitionTopN,
             PlanContext context) {
         Preconditions.checkState(childrenOutputProperties.size() == 1);
-        PhysicalProperties childOutputProperty = childrenOutputProperties.get(0);
-        return new PhysicalProperties(childOutputProperty.getDistributionSpec());
+        DistributionSpec childDistSpec = childrenOutputProperties.get(0).getDistributionSpec();
+
+        if (partitionTopN.getPhase().isTwoPhaseLocal() || partitionTopN.getPhase().isOnePhaseGlobal()) {
+            return new PhysicalProperties(childDistSpec);
+        } else {
+            Preconditions.checkState(partitionTopN.getPhase().isTwoPhaseGlobal(),
+                    "partition topn phase is not two phase global");
+            Preconditions.checkState(childDistSpec instanceof DistributionSpecHash,
+                    "child dist spec is not hash spec");
+
+            DistributionSpec distributionSpec = PhysicalProperties.createHash(partitionTopN.getPartitionKeys(),
+                    ((DistributionSpecHash) childDistSpec).getShuffleType()).getDistributionSpec();
+
+            return new PhysicalProperties(distributionSpec, new OrderSpec(partitionTopN.getOrderKeys()));
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriver.java
@@ -358,10 +358,7 @@ public class ChildOutputPropertyDeriver extends PlanVisitor<PhysicalProperties, 
             Preconditions.checkState(childDistSpec instanceof DistributionSpecHash,
                     "child dist spec is not hash spec");
 
-            DistributionSpec distributionSpec = PhysicalProperties.createHash(partitionTopN.getPartitionKeys(),
-                    ((DistributionSpecHash) childDistSpec).getShuffleType()).getDistributionSpec();
-
-            return new PhysicalProperties(distributionSpec, new OrderSpec(partitionTopN.getOrderKeys()));
+            return new PhysicalProperties(childDistSpec, new OrderSpec(partitionTopN.getOrderKeys()));
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
@@ -45,8 +45,8 @@ import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.util.JoinUtils;
 import org.apache.doris.qe.ConnectContext;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import java.util.List;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/implementation/LogicalPartitionTopNToPhysicalPartitionTopN.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/implementation/LogicalPartitionTopNToPhysicalPartitionTopN.java
@@ -27,7 +27,6 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalPartitionTopN;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalPartitionTopN;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 import java.util.List;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/implementation/LogicalPartitionTopNToPhysicalPartitionTopN.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/implementation/LogicalPartitionTopNToPhysicalPartitionTopN.java
@@ -21,9 +21,13 @@ import org.apache.doris.nereids.properties.OrderKey;
 import org.apache.doris.nereids.rules.Rule;
 import org.apache.doris.nereids.rules.RuleType;
 import org.apache.doris.nereids.trees.expressions.OrderExpression;
+import org.apache.doris.nereids.trees.plans.PartitionTopnPhase;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalPartitionTopN;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalPartitionTopN;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
 import java.util.List;
 
@@ -33,21 +37,85 @@ import java.util.List;
 public class LogicalPartitionTopNToPhysicalPartitionTopN extends OneImplementationRuleFactory {
     @Override
     public Rule build() {
-        return logicalPartitionTopN().then(partitionTopN -> {
-            List<OrderKey> orderKeys = !partitionTopN.getOrderKeys().isEmpty()
-                    ? partitionTopN.getOrderKeys().stream()
-                        .map(OrderExpression::getOrderKey)
-                        .collect(ImmutableList.toImmutableList()) :
+        return logicalPartitionTopN().thenApplyMulti(ctx -> generatePhysicalPartitionTopn(ctx.root))
+                .toRule(RuleType.LOGICAL_PARTITION_TOP_N_TO_PHYSICAL_PARTITION_TOP_N_RULE);
+    }
+
+    private List<PhysicalPartitionTopN<? extends Plan>> generatePhysicalPartitionTopn(
+            LogicalPartitionTopN<? extends Plan> logicalPartitionTopN) {
+        if (logicalPartitionTopN.getPartitionKeys().isEmpty()) {
+            // if no partition by keys, use local partition topn combined with further full sort
+            List<OrderKey> orderKeys = !logicalPartitionTopN.getOrderKeys().isEmpty()
+                    ? logicalPartitionTopN.getOrderKeys().stream()
+                    .map(OrderExpression::getOrderKey)
+                    .collect(ImmutableList.toImmutableList()) :
                     ImmutableList.of();
 
-            return new PhysicalPartitionTopN<>(
-                    partitionTopN.getFunction(),
-                    partitionTopN.getPartitionKeys(),
+            PhysicalPartitionTopN<Plan> onePhaseLocalPartitionTopN = new PhysicalPartitionTopN<>(
+                    logicalPartitionTopN.getFunction(),
+                    logicalPartitionTopN.getPartitionKeys(),
                     orderKeys,
-                    partitionTopN.hasGlobalLimit(),
-                    partitionTopN.getPartitionLimit(),
-                    partitionTopN.getLogicalProperties(),
-                    partitionTopN.child());
-        }).toRule(RuleType.LOGICAL_PARTITION_TOP_N_TO_PHYSICAL_PARTITION_TOP_N_RULE);
+                    logicalPartitionTopN.hasGlobalLimit(),
+                    logicalPartitionTopN.getPartitionLimit(),
+                    PartitionTopnPhase.TWO_PHASE_LOCAL_PTOPN,
+                    logicalPartitionTopN.getLogicalProperties(),
+                    logicalPartitionTopN.child(0));
+
+            return ImmutableList.of(onePhaseLocalPartitionTopN);
+        } else {
+            // if partition by keys exist, the order keys will be set as original partition keys combined with
+            // orderby keys, to meet upper window operator's order requirement.
+            ImmutableList<OrderKey> fullOrderKeys = getAllOrderKeys(logicalPartitionTopN);
+            PhysicalPartitionTopN<Plan> onePhaseGlobalPartitionTopN = new PhysicalPartitionTopN<>(
+                    logicalPartitionTopN.getFunction(),
+                    logicalPartitionTopN.getPartitionKeys(),
+                    fullOrderKeys,
+                    logicalPartitionTopN.hasGlobalLimit(),
+                    logicalPartitionTopN.getPartitionLimit(),
+                    PartitionTopnPhase.ONE_PHASE_GLOBAL_PTOPN,
+                    logicalPartitionTopN.getLogicalProperties(),
+                    logicalPartitionTopN.child(0));
+
+            PhysicalPartitionTopN<Plan> twoPhaseLocalPartitionTopN = new PhysicalPartitionTopN<>(
+                    logicalPartitionTopN.getFunction(),
+                    logicalPartitionTopN.getPartitionKeys(),
+                    fullOrderKeys,
+                    logicalPartitionTopN.hasGlobalLimit(),
+                    logicalPartitionTopN.getPartitionLimit(),
+                    PartitionTopnPhase.TWO_PHASE_LOCAL_PTOPN,
+                    logicalPartitionTopN.getLogicalProperties(),
+                    logicalPartitionTopN.child(0));
+
+            PhysicalPartitionTopN<Plan> twoPhaseGlobalPartitionTopN = new PhysicalPartitionTopN<>(
+                    logicalPartitionTopN.getFunction(),
+                    logicalPartitionTopN.getPartitionKeys(),
+                    fullOrderKeys,
+                    logicalPartitionTopN.hasGlobalLimit(),
+                    logicalPartitionTopN.getPartitionLimit(),
+                    PartitionTopnPhase.TWO_PHASE_GLOBAL_PTOPN,
+                    logicalPartitionTopN.getLogicalProperties(),
+                    twoPhaseLocalPartitionTopN);
+
+            return ImmutableList.of(onePhaseGlobalPartitionTopN, twoPhaseGlobalPartitionTopN);
+        }
+    }
+
+    private ImmutableList<OrderKey> getAllOrderKeys(LogicalPartitionTopN<? extends Plan> logicalPartitionTopN) {
+        ImmutableList.Builder<OrderKey> builder = ImmutableList.builder();
+
+        if (!logicalPartitionTopN.getPartitionKeys().isEmpty()) {
+            builder.addAll(logicalPartitionTopN.getPartitionKeys().stream().map(partitionKey -> {
+                return new OrderKey(partitionKey, true, false);
+            }).collect(ImmutableList.toImmutableList()));
+        }
+
+        if (!logicalPartitionTopN.getOrderKeys().isEmpty()) {
+            builder.addAll(logicalPartitionTopN.getOrderKeys().stream()
+                    .map(OrderExpression::getOrderKey)
+                    .collect(ImmutableList.toImmutableList())
+            );
+        }
+
+        return builder.build();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/PartitionTopnPhase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/PartitionTopnPhase.java
@@ -18,28 +18,27 @@
 package org.apache.doris.nereids.trees.plans;
 
 /**
- * Represents different phase of sort and map it to the
- * enum of sort phase definition of stale optimizer.
+ * Represents different phase of partition topn and map it to the
+ * enum of partition topn phase definition of stale optimizer.
  */
-public enum SortPhase {
-    MERGE_SORT("MergeSort"),
-    GATHER_SORT("GatherSort"),
-    LOCAL_SORT("LocalSort");
+public enum PartitionTopnPhase {
+    ONE_PHASE_GLOBAL_PTOPN("OnePhaseGlobalPartitionTopn"),
+    TWO_PHASE_LOCAL_PTOPN("TwoPhaseLocalPartitionTopn"),
+    TWO_PHASE_GLOBAL_PTOPN("TwoPhaseGlobalPartitionTopn");
     private final String name;
-
-    SortPhase(String name) {
+    PartitionTopnPhase(String name) {
         this.name = name;
     }
 
-    public boolean isLocal() {
-        return this == LOCAL_SORT;
+    public boolean isOnePhaseGlobal() {
+        return this == ONE_PHASE_GLOBAL_PTOPN;
     }
 
-    public boolean isMerge() {
-        return this == MERGE_SORT;
+    public boolean isTwoPhaseLocal() {
+        return this == TWO_PHASE_LOCAL_PTOPN;
     }
 
-    public boolean isGather() {
-        return this == GATHER_SORT;
+    public boolean isTwoPhaseGlobal() {
+        return this == TWO_PHASE_GLOBAL_PTOPN;
     }
 }

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query67.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query67.out
@@ -6,7 +6,7 @@ PhysicalResultSink
 ------PhysicalTopN
 --------filter((rk <= 100))
 ----------PhysicalWindow
-------------PhysicalQuickSort
+------------PhysicalPartitionTopN
 --------------PhysicalDistribute
 ----------------PhysicalPartitionTopN
 ------------------PhysicalProject


### PR DESCRIPTION
## Proposed changes

Enable two phase partition topn optimization, instead of original full sort at the second phase. 
E.g, partial plan of tpcds q67 is as following and a full sort after exchange will have performance impact, especially if the window column's ndv is very high and the number of window is huge. 

------PhysicalTopN
--------filter((rk <= 100))
----------PhysicalWindow
------------PhysicalQuickSort
--------------PhysicalDistribute
----------------PhysicalPartitionTopN
------------------PhysicalProject

Under this scenario, the second phase full sort can be transformed to a global PhysicalPartitionTopN and reduce the cost from full sort. The plan will be optimized to the following:

------PhysicalTopN
--------filter((rk <= 100))
----------PhysicalWindow
------------PhysicalPartitionTopN
--------------PhysicalDistribute
----------------PhysicalPartitionTopN
------------------PhysicalProject


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

