### PR TITLE
[improvement](deploy) Forbid LocalDeployManager drop node

### DIFF
--- a/docs/en/docs/admin-manual/config/fe-config.md
+++ b/docs/en/docs/admin-manual/config/fe-config.md
@@ -2768,3 +2768,8 @@ Default：true
 
 Temporary configuration option. After it is enabled, a background thread will be started to automatically modify all olap tables to light schema change. The modification results can be viewed through the command `show convert_light_schema_change [from db]`, and the conversion results of all non-light schema change tables will be displayed.
 
+#### `disable_local_deploy_manager_drop_node`
+
+Default：true
+
+Forbid LocalDeployManager drop nodes to prevent errors in the cluster.info file from causing nodes to be dropped.

--- a/docs/zh-CN/docs/admin-manual/config/fe-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/fe-config.md
@@ -2770,3 +2770,9 @@ show data （其他用法：HELP SHOW DATA）
 默认值：true
 
 暂时性配置项，开启后会启动后台线程自动将所有的olap表修改为可light schema change，修改结果可通过命令`show convert_light_schema_change [from db]` 来查看，将会展示所有非light schema change表的转换结果
+
+#### `disable_local_deploy_manager_drop_node`
+
+默认值：true
+
+禁止LocalDeployManager删除节点，防止cluster.info文件有误导致节点被删除。

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2153,4 +2153,8 @@ public class Config extends ConfigBase {
     })
     public static long query_metadata_name_ids_timeout = 3;
 
+    @ConfField(mutable = true, masterOnly = true, description = {
+            "是否禁止LocalDeployManager删除节点",
+            "Whether to disable LocalDeployManager drop node"})
+    public static boolean disable_local_deploy_manager_drop_node = true;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/deploy/DeployManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/deploy/DeployManager.java
@@ -25,6 +25,7 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.MasterDaemon;
+import org.apache.doris.deploy.impl.LocalFileDeployManager;
 import org.apache.doris.ha.FrontendNodeType;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.Frontend;
@@ -480,6 +481,10 @@ public class DeployManager extends MasterDaemon {
             HostInfo foundHostInfo = getFromHostInfos(remoteHostInfos, localHostInfo);
             boolean needDrop = needDrop(foundHostInfo != null, localHostInfo);
             if (needDrop) {
+                if (this instanceof LocalFileDeployManager && Config.disable_local_deploy_manager_drop_node) {
+                    LOG.warn("For now, Local File Deploy Manager dose not handle shrinking operations");
+                    continue;
+                }
                 dealDropLocal(localHostInfo, nodeType);
             }
         }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
Forbid LocalDeployManager drop nodes to prevent errors in the cluster.info file from causing nodes to be dropped.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

