### PR TITLE
[fix](UT)fix coverage compute fail if run string cmd directly

### DIFF
--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -390,11 +390,15 @@ if [[ -f "${test}" ]]; then
         if [[ -d "${DORIS_TEST_BINARY_DIR}"/report ]]; then
             rm -rf "${DORIS_TEST_BINARY_DIR}"/report
         fi
-        "${LLVM_PROFDATA} merge -o ${profdata} ${profraw}"
-        "${LLVM_COV} show -output-dir=${DORIS_TEST_BINARY_DIR}/report -format=html \
+        cmd1="${LLVM_PROFDATA} merge -o ${profdata} ${profraw}"
+        echo "${cmd1}"
+        eval "${cmd1}"
+        cmd2="${LLVM_COV} show -output-dir=${DORIS_TEST_BINARY_DIR}/report -format=html \
             -ignore-filename-regex='(.*gensrc/.*)|(.*_test\.cpp$)|(.*be/test.*)|(.*apache-orc/.*)|(.*clucene/.*)' \
             -instr-profile=${profdata} \
             -object=${test}"
+        echo "${cmd2}"
+        eval "${cmd2}"
     else
         "${test}" --gtest_output="xml:${GTEST_OUTPUT_DIR}/${file_name}.xml" --gtest_print_time=true "${FILTER}"
     fi


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
if run coverage directly in docker, it will fail that cannot find file, so change cmd exec way

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

