### PR TITLE
[feature-wip](arrow-flight) BE not start Arrow Flight Service by default

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -60,7 +60,7 @@ DEFINE_Int32(be_port, "9060");
 // port for brpc
 DEFINE_Int32(brpc_port, "8060");
 
-DEFINE_Int32(arrow_flight_port, "8070");
+DEFINE_Int32(arrow_flight_port, "-1");
 
 // the number of bthreads for brpc, the default value is set to -1,
 // which means the number of bthreads is #cpu-cores

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -97,6 +97,7 @@ DECLARE_Int32(be_port);
 DECLARE_Int32(brpc_port);
 
 // port for arrow flight
+// Default -1, do not start arrow flight server.
 DECLARE_Int32(arrow_flight_port);
 
 // the number of bthreads for brpc, the default value is set to -1,

--- a/be/src/service/arrow_flight/flight_sql_service.cpp
+++ b/be/src/service/arrow_flight/flight_sql_service.cpp
@@ -98,6 +98,10 @@ arrow::Result<std::unique_ptr<arrow::flight::FlightDataStream>> FlightSqlServer:
 }
 
 Status FlightSqlServer::init(int port) {
+    if (port == -1) {
+        LOG(INFO) << "Arrow Flight Service not start";
+        return Status::OK();
+    }
     arrow::flight::Location bind_location;
     RETURN_DORIS_STATUS_IF_ERROR(
             arrow::flight::Location::ForGrpcTcp(BackendOptions::get_service_bind_address(), port)

--- a/conf/be.conf
+++ b/conf/be.conf
@@ -40,7 +40,7 @@ be_port = 9060
 webserver_port = 8040
 heartbeat_service_port = 9050
 brpc_port = 8060
-arrow_flight_port = 8070
+arrow_flight_port = -1
 
 # HTTPS configures
 enable_https = false


### PR DESCRIPTION
## Proposed changes

arrow_flight_port default -1, do not start arrow flight server.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

