### PR TITLE
[Fix](autoinc) skip to fill the auto increment column when the input column is not nullable

### DIFF
--- a/be/src/vec/sink/vtablet_block_convertor.cpp
+++ b/be/src/vec/sink/vtablet_block_convertor.cpp
@@ -507,7 +507,6 @@ Status OlapTableBlockConvertor::_fill_auto_inc_cols(vectorized::Block* block, si
     } else {
         return Status::OK();
     }
-
     block->get_by_position(idx).column = std::move(dst_column);
     block->get_by_position(idx).type =
             vectorized::DataTypeFactory::instance().create_data_type(slot->type(), false);

--- a/be/src/vec/sink/vtablet_block_convertor.cpp
+++ b/be/src/vec/sink/vtablet_block_convertor.cpp
@@ -462,7 +462,6 @@ Status OlapTableBlockConvertor::_fill_auto_inc_cols(vectorized::Block* block, si
     vectorized::ColumnInt64::Container& dst_values = dst_column->get_data();
 
     vectorized::ColumnPtr src_column_ptr = block->get_by_position(idx).column;
-    DCHECK(vectorized::is_column_const(*src_column_ptr) || src_column_ptr->is_nullable());
     if (const vectorized::ColumnConst* const_column =
                 check_and_get_column<vectorized::ColumnConst>(src_column_ptr)) {
         // for insert stmt like "insert into tbl1 select null,col1,col2,... from tbl2" or
@@ -487,11 +486,10 @@ Status OlapTableBlockConvertor::_fill_auto_inc_cols(vectorized::Block* block, si
             int64_t value = const_column->get_int(0);
             dst_values.resize_fill(rows, value);
         }
-    } else {
-        const auto& src_nullable_column =
-                assert_cast<const vectorized::ColumnNullable&>(*src_column_ptr);
-        auto src_nested_column_ptr = src_nullable_column.get_nested_column_ptr();
-        const auto& null_map_data = src_nullable_column.get_null_map_data();
+    } else if (const vectorized::ColumnNullable* src_nullable_column =
+                       check_and_get_column<vectorized::ColumnNullable>(src_column_ptr)) {
+        auto src_nested_column_ptr = src_nullable_column->get_nested_column_ptr();
+        const auto& null_map_data = src_nullable_column->get_null_map_data();
         dst_values.reserve(rows);
         for (size_t i = 0; i < rows; i++) {
             null_value_count += null_map_data[i];
@@ -506,7 +504,10 @@ Status OlapTableBlockConvertor::_fill_auto_inc_cols(vectorized::Block* block, si
             dst_values.emplace_back((null_map_data[i] != 0) ? _auto_inc_id_allocator.next_id()
                                                             : src_nested_column_ptr->get_int(i));
         }
+    } else {
+        return Status::OK();
     }
+
     block->get_by_position(idx).column = std::move(dst_column);
     block->get_by_position(idx).type =
             vectorized::DataTypeFactory::instance().create_data_type(slot->type(), false);

--- a/regression-test/data/data_model_p0/unique/test_unique_table_auto_inc.out
+++ b/regression-test/data/data_model_p0/unique/test_unique_table_auto_inc.out
@@ -153,3 +153,45 @@ Nereids	9998	8
 1	b	20
 2	c	30
 
+-- !sql --
+0	AFRICA	lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to
+1	AMERICA	hs use ironic, even requests. s
+2	ASIA	ges. thinly even pinto beans ca
+3	EUROPE	ly final courts cajole furiously final excuse
+4	MIDDLE EAST	uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl
+
+-- !sql --
+0	AFRICA	foobar
+1	AMERICA	foobar
+2	ASIA	foobar
+3	EUROPE	foobar
+4	MIDDLE EAST	foobar
+
+-- !sql --
+0	AFRICA	barfoo
+1	AMERICA	barfoo
+2	ASIA	barfoo
+3	EUROPE	barfoo
+4	MIDDLE EAST	barfoo
+
+-- !sql --
+0	AFRICA	lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to
+1	AMERICA	hs use ironic, even requests. s
+2	ASIA	ges. thinly even pinto beans ca
+3	EUROPE	ly final courts cajole furiously final excuse
+4	MIDDLE EAST	uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl
+
+-- !sql --
+0	AFRICA	lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to
+1	AMERICA	hs use ironic, even requests. s
+2	ASIA	ges. thinly even pinto beans ca
+3	test1	test2
+4	MIDDLE EAST	uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl
+
+-- !sql --
+0	AFRICA	lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to
+1	AMERICA	hs use ironic, even requests. s
+2	ASIA	ges. thinly even pinto beans ca
+3	test1	test2
+4	test3	test4
+

--- a/regression-test/suites/data_model_p0/unique/test_unique_table_auto_inc.groovy
+++ b/regression-test/suites/data_model_p0/unique/test_unique_table_auto_inc.groovy
@@ -342,5 +342,72 @@ suite("test_unique_table_auto_inc") {
     sql "drop table if exists ${table8};"
     sql "drop table if exists ${table9};"
     sql "drop table if exists ${table10};"
+
+
+    def table11 = "test_unique_tab_auto_inc_col_insert_select"
+    sql "drop table if exists ${table11}"
+    sql """CREATE TABLE ${table11} (
+        `r_regionkey` bigint(20) NOT NULL AUTO_INCREMENT,
+        `r_name` varchar(25) NOT NULL,
+        `r_comment` varchar(152) NULL
+        ) ENGINE=OLAP
+        UNIQUE KEY(`r_regionkey`)
+        COMMENT 'OLAP'
+        DISTRIBUTED BY HASH(`r_regionkey`) BUCKETS 10
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1"
+        ); """
+    sql """ INSERT INTO ${table11} values 
+ (0,'AFRICA','lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to')
+,(1,'AMERICA','hs use ironic, even requests. s')
+,(2,'ASIA','ges. thinly even pinto beans ca')
+,(3,'EUROPE','ly final courts cajole furiously final excuse')
+,(4,'MIDDLE EAST','uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl');"""
+    qt_sql "select * from ${table11} order by r_regionkey;"
+    sql 'set enable_nereids_planner=true'
+    sql "set experimental_enable_nereids_planner=true;"
+    sql 'set enable_nereids_dml=true'
+    sql "update ${table11} set r_comment = 'foobar' where  r_regionkey <= 10;"
+    qt_sql "select * from ${table11} order by r_regionkey;"
+
+    sql 'set enable_nereids_planner=false'
+    sql "set experimental_enable_nereids_planner=false;"
+    sql 'set enable_nereids_dml=false'
+    sql "update ${table11} set r_comment = 'barfoo' where  r_regionkey <= 10;"
+    qt_sql "select * from ${table11} order by r_regionkey;"
+    sql "drop table if exists ${table11};"
+
+
+    def table12 = "test_unique_tab_auto_inc_col_insert_select2"
+    sql "drop table if exists ${table12}"
+    sql """CREATE TABLE ${table12} (
+        `r_regionkey` bigint(20) NOT NULL AUTO_INCREMENT,
+        `r_name` varchar(25) NOT NULL,
+        `r_comment` varchar(152) NULL
+        ) ENGINE=OLAP
+        UNIQUE KEY(`r_regionkey`)
+        COMMENT 'OLAP'
+        DISTRIBUTED BY HASH(`r_regionkey`) BUCKETS 10
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1"
+        ); """
+    sql """ INSERT INTO ${table12} values 
+ (0,'AFRICA','lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to')
+,(1,'AMERICA','hs use ironic, even requests. s')
+,(2,'ASIA','ges. thinly even pinto beans ca')
+,(3,'EUROPE','ly final courts cajole furiously final excuse')
+,(4,'MIDDLE EAST','uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl');"""
+    qt_sql "select * from ${table12} order by r_regionkey;"
+    sql 'set enable_nereids_planner=true'
+    sql "set experimental_enable_nereids_planner=true;"
+    sql 'set enable_nereids_dml=true'
+    sql """insert into ${table12} select r_regionkey, "test1", "test2" from ${table12} where r_regionkey=3;"""
+    qt_sql "select * from ${table12} order by r_regionkey;"
+    sql 'set enable_nereids_planner=false'
+    sql "set experimental_enable_nereids_planner=false;"
+    sql 'set enable_nereids_dml=false'
+    sql """insert into ${table12} select r_regionkey, "test3", "test4" from ${table12} where r_regionkey=4;"""
+    qt_sql "select * from ${table12} order by r_regionkey;"
+    sql "drop table if exists ${table12};"
 }
 


### PR DESCRIPTION
## Proposed changes
For insert statement like `insert into tbl select ... from tbl`, the input column of an auto-increment column may be not nullabe. In this case, we just skip the filling process.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

