### PR TITLE
[Fix](catalog) Doris datetime type conversion failed

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcMySQLClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcMySQLClient.java
@@ -400,7 +400,7 @@ public class JdbcMySQLClient extends JdbcClient {
                 return ScalarType.createDateV2Type();
             case "DATETIME":
             case "DATETIMEV2": {
-                int scale = Integer.parseInt(upperType.substring(openParen + 1, upperType.length() - 1));
+                int scale = (openParen == -1) ? 6 : Integer.parseInt(upperType.substring(openParen + 1, upperType.length() - 1));
                 if (scale > 6) {
                     scale = 6;
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcMySQLClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcMySQLClient.java
@@ -400,7 +400,8 @@ public class JdbcMySQLClient extends JdbcClient {
                 return ScalarType.createDateV2Type();
             case "DATETIME":
             case "DATETIMEV2": {
-                int scale = (openParen == -1) ? 6 : Integer.parseInt(upperType.substring(openParen + 1, upperType.length() - 1));
+                int scale = (openParen == -1) ? 6
+                        : Integer.parseInt(upperType.substring(openParen + 1, upperType.length() - 1));
                 if (scale > 6) {
                     scale = 6;
                 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx


1. The catalog is connected to an old version of Doris, and an error is reported when using the datetime field type on the Doris surface .
2. error message [fe]:
  Caused by: java.lang.NumberFormatException: For input string: "DATETIM"
  at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65) ~[?:1.8.0_291]
  at java.lang.Integer.parseInt(Integer.java:580) ~[?:1.8.0_291]
  at java.lang.Integer.parseInt(Integer.java:615) ~[?:1.8.0_291]
  at org.apache.doris.datasource.jdbc.client.JdbcMySQLClient.dorisTypeToDoris(JdbcMySQLClient.java:401) ~[doris-fe.jar:1.2- 
 SNAPSHOT]

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

