### PR TITLE
[bugfix](map) fix map offset column DCHECK nullptr

### DIFF
--- a/be/src/olap/rowset/segment_v2/column_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/column_writer.cpp
@@ -739,7 +739,7 @@ OffsetColumnWriter::OffsetColumnWriter(const ColumnWriterOptions& opts,
                                        std::unique_ptr<Field> field, io::FileWriter* file_writer)
         : ScalarColumnWriter(opts, std::move(field), file_writer) {
     // now we only explain data in offset column as uint64
-    DCHECK(field->type() == FieldType::OLAP_FIELD_TYPE_UNSIGNED_BIGINT);
+    DCHECK(get_field()->type() == FieldType::OLAP_FIELD_TYPE_UNSIGNED_BIGINT);
 }
 
 OffsetColumnWriter::~OffsetColumnWriter() = default;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

fix using unique_ptr after std::move.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

