### PR TITLE
[fix](trash) fix clean trash not working

### DIFF
--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -296,6 +296,10 @@ void StorageEngine::_garbage_sweeper_thread_callback() {
 
         // start clean trash and update usage.
         Status res = start_trash_sweep(&usage);
+        if (res.ok() && _need_clean_trash.exchange(false, std::memory_order_relaxed)) {
+            res = start_trash_sweep(&usage, true);
+        }
+
         if (!res.ok()) {
             LOG(WARNING) << "one or more errors occur when sweep trash."
                          << "see previous message for detail. err code=" << res;

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -634,10 +634,17 @@ Status StorageEngine::start_trash_sweep(double* usage, bool ignore_guard) {
     std::unique_lock<std::mutex> l(_trash_sweep_lock, std::defer_lock);
     if (!l.try_lock()) {
         LOG(INFO) << "trash and snapshot sweep is running.";
+        if (ignore_guard) {
+            _need_clean_trash.store(true, std::memory_order_relaxed);
+        }
         return res;
     }
 
-    LOG(INFO) << "start trash and snapshot sweep.";
+    if (_need_clean_trash.exchange(false, std::memory_order_relaxed)) {
+        ignore_guard = true;
+    }
+
+    LOG(INFO) << "start trash and snapshot sweep. is_clean=" << ignore_guard;
 
     const int32_t snapshot_expire = config::snapshot_expire_time_sec;
     const int32_t trash_expire = config::trash_file_expire_time_sec;

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -640,10 +640,6 @@ Status StorageEngine::start_trash_sweep(double* usage, bool ignore_guard) {
         return res;
     }
 
-    if (_need_clean_trash.exchange(false, std::memory_order_relaxed)) {
-        ignore_guard = true;
-    }
-
     LOG(INFO) << "start trash and snapshot sweep. is_clean=" << ignore_guard;
 
     const int32_t snapshot_expire = config::snapshot_expire_time_sec;

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -484,6 +484,8 @@ private:
 
     bool _clear_segment_cache = false;
 
+    std::atomic<bool> _need_clean_trash {false};
+
     DISALLOW_COPY_AND_ASSIGN(StorageEngine);
 };
 


### PR DESCRIPTION
## Proposed changes

When executing `admin clean trash`,  if the backend daemon clean thread is cleaning trash,  then SQL command will return immediately. But for the backend daemon thread,  it doesn't clean all the trashes,  it clean only the expired trashes.
Also if there's lots of trashes, the daemon clean thread will  busy handling trashes for a long time. 

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

