### PR TITLE
[fix](statistics)Set default database while forwarding stmt to master.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -748,6 +748,9 @@ public class ConnectProcessor {
             if (request.isSetDefaultCatalog()) {
                 ctx.getEnv().changeCatalog(ctx, request.getDefaultCatalog());
             }
+            if (request.isSetDefaultDatabase() && !request.getDefaultDatabase().isEmpty()) {
+                ctx.getEnv().changeDb(ctx, request.getDefaultDatabase());
+            }
             TUniqueId queryId; // This query id will be set in ctx
             if (request.isSetQueryId()) {
                 queryId = request.getQueryId();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
@@ -168,6 +168,7 @@ public class MasterOpExecutor {
         params.setStmtIdx(originStmt.idx);
         params.setUser(ctx.getQualifiedUser());
         params.setDefaultCatalog(ctx.getDefaultCatalog());
+        params.setDefaultDatabase(ctx.getDatabase());
         params.setDb(ctx.getDatabase());
         params.setUserIp(ctx.getRemoteIP());
         params.setStmtId(ctx.getStmtId());

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -482,6 +482,7 @@ struct TMasterOpRequest {
     23: optional i32 clientNodePort
     24: optional bool syncJournalOnly // if set to true, this request means to do nothing but just sync max journal id of master
     25: optional string defaultCatalog
+    26: optional string defaultDatabase
 }
 
 struct TColumnDefinition {


### PR DESCRIPTION
Set default database while forwarding request to master. Avoid `No database selected` error.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

