### PR TITLE
[fix](move-memtable) lock when send data in load stream stub

### DIFF
--- a/be/src/vec/sink/load_stream_stub.h
+++ b/be/src/vec/sink/load_stream_stub.h
@@ -176,6 +176,7 @@ protected:
     bthread::ConditionVariable _close_cv;
 
     bthread::Mutex _buffer_mutex;
+    bthread::Mutex _send_mutex;
     butil::IOBuf _buffer;
 
     PUniqueId _load_id;

--- a/be/src/vec/sink/load_stream_stub.h
+++ b/be/src/vec/sink/load_stream_stub.h
@@ -175,8 +175,8 @@ protected:
     bthread::Mutex _mutex;
     bthread::ConditionVariable _close_cv;
 
-    bthread::Mutex _buffer_mutex;
-    bthread::Mutex _send_mutex;
+    std::mutex _buffer_mutex;
+    std::mutex _send_mutex;
     butil::IOBuf _buffer;
 
     PUniqueId _load_id;


### PR DESCRIPTION
## Proposed changes

Add a lock to ensure message order when send data in load stream stub.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

