### PR TITLE
[Fix](regression) Fix `test_partial_update_schema_change`

### DIFF
--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_schema_change.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_schema_change.groovy
@@ -70,7 +70,7 @@ suite("test_partial_update_schema_change", "p0") {
     def try_times=100
     while(true){
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1000)
+        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
             break;
         }
@@ -192,7 +192,7 @@ suite("test_partial_update_schema_change", "p0") {
     try_times=100
     while(true){
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1000)
+        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
             break;
         }
@@ -314,7 +314,7 @@ suite("test_partial_update_schema_change", "p0") {
     try_times=100
     while(true){
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1000)
+        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
             break;
         }
@@ -398,7 +398,7 @@ suite("test_partial_update_schema_change", "p0") {
     try_times=100
     while(true){
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1000)
+        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
             break;
         }
@@ -410,7 +410,7 @@ suite("test_partial_update_schema_change", "p0") {
     try_times=100
     while(true){
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1000)
+        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
             break;
         }
@@ -501,7 +501,7 @@ suite("test_partial_update_schema_change", "p0") {
     try_times=100
     while(true){
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1000)
+        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
             break;
         }
@@ -670,7 +670,7 @@ suite("test_partial_update_schema_change", "p0") {
     try_times=100
     while(true){
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1000)
+        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
             break;
         }
@@ -791,7 +791,7 @@ suite("test_partial_update_schema_change", "p0") {
     try_times=100
     while(true){
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1000)
+        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
             break;
         }
@@ -908,7 +908,7 @@ suite("test_partial_update_schema_change", "p0") {
     try_times=100
     while(true){
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1000)
+        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
             break;
         }
@@ -991,7 +991,7 @@ suite("test_partial_update_schema_change", "p0") {
     try_times=100
     while(true){
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1000)
+        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
             break;
         }
@@ -1002,7 +1002,7 @@ suite("test_partial_update_schema_change", "p0") {
     try_times=100
     while(true){
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1000)
+        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
             break;
         }
@@ -1088,7 +1088,7 @@ suite("test_partial_update_schema_change", "p0") {
     try_times=100
     while(true){
         def res = sql " SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1 "
-        Thread.sleep(1000)
+        Thread.sleep(1200)
         if(res[0][9].toString() == "FINISHED"){
             break;
         }


### PR DESCRIPTION
## Proposed changes
When the regression test `test_partial_update_schema_change` try to wait for the current schema change to finish. It use `SHOW ALTER TABLE COLUMN WHERE TableName = '${tableName}' ORDER BY CreateTime DESC LIMIT 1;` to get the status of the current schema change job. Although the field `CreateTime` has precision up to millisecond, before sorting the results, it will first serialize the fields to string and the default string presentation of `CreateTime` only has precision up to seconds. So in order to ensure that the waiting job is the newest schema change job, the time interval between two alter jobs should have at least one second.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

