### PR TITLE
[fix](nested_loop_join) null value should be output in semi-anti join

### DIFF
--- a/be/src/vec/exec/join/vnested_loop_join_node.h
+++ b/be/src/vec/exec/join/vnested_loop_join_node.h
@@ -106,9 +106,7 @@ public:
 private:
     template <typename JoinOpType, bool set_build_side_flag, bool set_probe_side_flag>
     Status _generate_join_block_data(RuntimeState* state, JoinOpType& join_op_variants) {
-        constexpr bool ignore_null = JoinOpType::value == TJoinOp::LEFT_ANTI_JOIN ||
-                                     JoinOpType::value == TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN ||
-                                     JoinOpType::value == TJoinOp::RIGHT_ANTI_JOIN;
+        constexpr bool ignore_null = JoinOpType::value == TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN;
         _left_block_start_pos = _left_block_pos;
         _left_side_process_count = 0;
         DCHECK(!_need_more_input_data || !_matched_rows_done);

--- a/regression-test/data/nereids_p0/join/test_join_13.out
+++ b/regression-test/data/nereids_p0/join/test_join_13.out
@@ -51,6 +51,7 @@
 15
 
 -- !left_anti_join_null_3 --
+\N
 1
 2
 3
@@ -91,6 +92,7 @@
 3
 
 -- !right_anti_join_null_1 --
+\N
 1
 
 -- !right_anti_join_null_2 --

--- a/regression-test/data/query_p0/join/test_join.out
+++ b/regression-test/data/query_p0/join/test_join.out
@@ -1268,6 +1268,7 @@ false	3	1989	1002	11011905	24453.325	false	2012-03-14	2000-01-01T00:00	yunlj8@nk
 15
 
 -- !left_anti_join_null_3 --
+\N
 1
 2
 3
@@ -1308,6 +1309,7 @@ false	3	1989	1002	11011905	24453.325	false	2012-03-14	2000-01-01T00:00	yunlj8@nk
 3
 
 -- !right_anti_join_null_1 --
+\N
 1
 
 -- !right_anti_join_null_2 --


### PR DESCRIPTION
## Proposed changes

Schema:
```sql
create table t1
        (k1 bigint, k2 bigint)
        ENGINE=OLAP
DUPLICATE KEY(k1, k2)
COMMENT 'OLAP'
DISTRIBUTED BY HASH(k2) BUCKETS 1
PROPERTIES (
"replication_allocation" = "tag.location.default: 1",
"is_being_synced" = "false",
"storage_format" = "V2",
"light_schema_change" = "true",
"disable_auto_compaction" = "false",
"enable_single_replica_compaction" = "false"
);
create table t3
        (k1 bigint, k2 bigint)
        ENGINE=OLAP
DUPLICATE KEY(k1, k2)
COMMENT 'OLAP'
DISTRIBUTED BY HASH(k2) BUCKETS 1
PROPERTIES (
"replication_allocation" = "tag.location.default: 1",
"is_being_synced" = "false",
"storage_format" = "V2",
"light_schema_change" = "true",
"disable_auto_compaction" = "false",
"enable_single_replica_compaction" = "false"
);
```
Data:
```sql
insert into t1 values (1,null),(null,1),(1,2), (null,2),(1,3), (2,4), (2,5), (3,3), (3,4), (20,2), (22,3), (24,4),(null,null);
insert into t3 values (1,null),(null,1),(1,4), (1,2), (null,3), (2,4), (3,7), (3,9),(null,null),(5,1);
```
Query:
```sql
 select t1.* from t1 where not exists ( select k1 from t3 where t1.k2 < t3.k2 );
```

Result:
```
Empty set
```
Expect result:
```
+------+------+
| k1   | k2   |
+------+------+
| NULL | NULL |
|    1 | NULL |
+------+------+
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

