### PR TITLE
[feat](stats) Support analyze with sample automatically

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.common;
 
+import java.util.concurrent.TimeUnit;
+
 public class Config extends ConfigBase {
 
     @ConfField(description = {"用户自定义配置文件的路径，用于存放 fe_custom.conf。该文件中的配置会覆盖 fe.conf 中的配置",
@@ -1516,8 +1518,12 @@ public class Config extends ConfigBase {
     /*
      * the system automatically checks the time interval for statistics
      */
-    @ConfField(mutable = true, masterOnly = true)
-    public static int auto_check_statistics_in_minutes = 1;
+    @ConfField(mutable = true, masterOnly = true, description = {
+            "该参数控制自动收集作业检查库表统计信息健康度并触发自动收集的时间间隔",
+            "This parameter controls the time interval for automatic collection jobs to check the health of table"
+                    + "statistics and trigger automatic collection"
+    })
+    public static int auto_check_statistics_in_minutes = 10;
 
     /**
      * If this configuration is enabled, you should also specify the trace_export_url.
@@ -2172,4 +2178,26 @@ public class Config extends ConfigBase {
                     + "The larger the value, the more uniform the distribution of the hash algorithm, "
                     + "but it will increase the memory overhead."})
     public static int virtual_node_number = 2048;
+
+    @ConfField(description = {"控制对大表的自动ANALYZE的最小时间间隔，"
+            + "在该时间间隔内大小超过huge_table_lower_bound_size_in_bytes的表仅ANALYZE一次",
+            "This controls the minimum time interval for automatic ANALYZE on large tables. Within this interval,"
+                    + "tables larger than huge_table_lower_bound_size_in_bytes are analyzed only once."})
+    public static long huge_table_auto_analyze_interval_in_millis = TimeUnit.HOURS.toMillis(12);
+
+    @ConfField(description = {"定义大表的大小下界，在开启enable_auto_sample的情况下，"
+            + "大小超过该值的表将会自动通过采样收集统计信息", "This defines the lower size bound for large tables. "
+            + "When enable_auto_sample is enabled, tables larger than this value will automatically collect "
+            + "statistics through sampling"})
+    public static long huge_table_lower_bound_size_in_bytes = 5L * 1024 * 1024 * 1024;
+
+    @ConfField(description = {"定义开启开启大表自动sample后，对大表的采样行数",
+            "This defines the number of sample rows for large tables when automatic sampling for"
+                    + "large tables is enabled"})
+    public static int huge_table_default_sample_rows = 20_0000;
+
+    @ConfField(description = {"是否开启大表自动sample，开启后对于大小超过huge_table_lower_bound_size_in_bytes会自动通过采样收集"
+            + "统计信息", "Whether to enable automatic sampling for large tables, which, when enabled, automatically"
+            + "collects statistics through sampling for tables larger than 'huge_table_lower_bound_size_in_bytes'"})
+    public static boolean enable_auto_sample = false;
 }

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -6074,6 +6074,13 @@ with_analysis_properties ::=
             put("period.cron", cron_expr);
         }};
     :}
+    | KW_FULL
+    {:
+        RESULT = new HashMap<String, String>() {{
+             put(AnalyzeProperties.PROPERTY_FORCE_FULL, "true");
+        }};
+    :}
+
     ;
 
 opt_with_analysis_properties ::=

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AnalyzeProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AnalyzeProperties.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+// TODO: Remove map
 public class AnalyzeProperties {
 
     public static final String PROPERTY_SYNC = "sync";
@@ -41,6 +42,8 @@ public class AnalyzeProperties {
     public static final String PROPERTY_NUM_BUCKETS = "num.buckets";
     public static final String PROPERTY_ANALYSIS_TYPE = "analysis.type";
     public static final String PROPERTY_PERIOD_SECONDS = "period.seconds";
+
+    public static final String PROPERTY_FORCE_FULL = "force.full";
 
     public static final AnalyzeProperties DEFAULT_PROP = new AnalyzeProperties(new HashMap<String, String>() {
         {
@@ -67,6 +70,7 @@ public class AnalyzeProperties {
             .add(PROPERTY_ANALYSIS_TYPE)
             .add(PROPERTY_PERIOD_SECONDS)
             .add(PROPERTY_PERIOD_CRON)
+            .add(PROPERTY_FORCE_FULL)
             .build();
 
     public AnalyzeProperties(Map<String, String> properties) {
@@ -262,6 +266,10 @@ public class AnalyzeProperties {
     public boolean isSample() {
         return properties.containsKey(PROPERTY_SAMPLE_PERCENT)
                 || properties.containsKey(PROPERTY_SAMPLE_ROWS);
+    }
+
+    public boolean forceFull() {
+        return properties.containsKey(PROPERTY_FORCE_FULL);
     }
 
     public String toSQL() {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AnalyzeStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AnalyzeStmt.java
@@ -93,4 +93,8 @@ public class AnalyzeStmt extends StatementBase {
     public CronExpression getCron() {
         return analyzeProperties.getCron();
     }
+
+    public boolean forceFull() {
+        return analyzeProperties.forceFull();
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AnalyzeTblStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AnalyzeTblStmt.java
@@ -181,6 +181,9 @@ public class AnalyzeTblStmt extends AnalyzeStmt {
             throw new AnalysisException("Automatic collection "
                     + "and period statistics collection cannot be set at same time");
         }
+        if (analyzeProperties.isSample() && analyzeProperties.forceFull()) {
+            throw new AnalysisException("Impossible to analyze with sample and full simultaneously");
+        }
     }
 
     private void checkColumn() throws AnalysisException {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowTableStatsStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowTableStatsStmt.java
@@ -144,7 +144,7 @@ public class ShowTableStatsStmt extends ShowStmt {
         row.add(tableStatistic.analysisMethod.toString());
         row.add(tableStatistic.analysisType.toString());
         row.add(new Date(tableStatistic.updatedTime).toString());
-        row.add(tableStatistic.columns);
+        row.add(tableStatistic.analyzeColumns().toString());
         row.add(tableStatistic.jobType.toString());
         result.add(row);
         return new ShowResultSet(getMetaData(), result);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -1132,24 +1132,39 @@ public class OlapTable extends Table {
         if (rowCount == 0) {
             return false;
         }
-        long updateRows = tblStats.updatedRows.get();
+        if (!tblStats.analyzeColumns().containsAll(getBaseSchema()
+                .stream()
+                .map(Column::getName)
+                .collect(Collectors.toSet()))) {
+            return true;
+        }
+        // long updateRows = tblStats.updatedRows.get();
+        long updateRows = Math.abs(tblStats.rowCount - rowCount);
         int tblHealth = StatisticsUtil.getTableHealth(rowCount, updateRows);
         return tblHealth < Config.table_stats_health_threshold;
     }
 
     @Override
-    public Set<String> findReAnalyzeNeededPartitions() {
-        TableStats tableStats = Env.getCurrentEnv().getAnalysisManager().findTableStatsStatus(getId());
-        if (tableStats == null) {
-            return getPartitionNames().stream().map(this::getPartition)
+    public Map<String, Set<String>> findReAnalyzeNeededPartitions() {
+        TableIf table = this;
+        TableStats tableStats = Env.getCurrentEnv().getAnalysisManager().findTableStatsStatus(table.getId());
+        Set<String> allPartitions = table.getPartitionNames().stream().map(table::getPartition)
                 .filter(Partition::hasData).map(Partition::getName).collect(Collectors.toSet());
+        if (tableStats == null) {
+            return table.getBaseSchema().stream().collect(Collectors.toMap(Column::getName, v -> allPartitions));
         }
-        return getPartitionNames().stream()
-            .map(this::getPartition)
-            .filter(Partition::hasData)
-            .filter(partition ->
-                partition.getVisibleVersionTime() >= tableStats.updatedTime).map(Partition::getName)
-            .collect(Collectors.toSet());
+        Map<String, Set<String>> colToPart = new HashMap<>();
+        for (Column col : table.getBaseSchema()) {
+            long lastUpdateTime = tableStats.findColumnLastUpdateTime(col.getName());
+            Set<String> partitions = table.getPartitionNames().stream()
+                    .map(table::getPartition)
+                    .filter(Partition::hasData)
+                    .filter(partition ->
+                            partition.getVisibleVersionTime() >= lastUpdateTime).map(Partition::getName)
+                    .collect(Collectors.toSet());
+            colToPart.put(col.getName(), partitions);
+        }
+        return colToPart;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Table.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Table.java
@@ -580,7 +580,7 @@ public abstract class Table extends MetaObject implements Writable, TableIf {
     }
 
     @Override
-    public Set<String> findReAnalyzeNeededPartitions() {
-        return Collections.emptySet();
+    public Map<String, Set<String>> findReAnalyzeNeededPartitions() {
+        return Collections.emptyMap();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
@@ -34,6 +34,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -139,7 +140,7 @@ public interface TableIf {
 
     boolean needReAnalyzeTable(TableStats tblStats);
 
-    Set<String> findReAnalyzeNeededPartitions();
+    Map<String, Set<String>> findReAnalyzeNeededPartitions();
 
     void write(DataOutput out) throws IOException;
 
@@ -243,6 +244,11 @@ public interface TableIf {
 
     default long getLastUpdateTime() {
         return -1L;
+    }
+
+    default long getDataSize() {
+        // TODO: Each tableIf should impl it by itself.
+        return 0;
     }
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
@@ -50,10 +50,12 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
 
 /**
  * External table represent tables that are not self-managed by Doris.
@@ -388,10 +390,10 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
     }
 
     @Override
-    public Set<String> findReAnalyzeNeededPartitions() {
+    public Map<String, Set<String>> findReAnalyzeNeededPartitions() {
         HashSet<String> partitions = Sets.newHashSet();
         // TODO: Find a way to collect external table partitions that need to be analyzed.
         partitions.add("Dummy Partition");
-        return partitions;
+        return getBaseSchema().stream().collect(Collectors.toMap(Column::getName, k -> partitions));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfo.java
@@ -27,6 +27,7 @@ import org.apache.doris.statistics.util.StatisticsUtil;
 import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.quartz.CronExpression;
@@ -167,13 +168,16 @@ public class AnalysisInfo implements Writable {
 
     public CronExpression cronExpression;
 
+    @SerializedName("forceFull")
+    public final boolean forceFull;
+
     public AnalysisInfo(long jobId, long taskId, List<Long> taskIds, String catalogName, String dbName, String tblName,
             Map<String, Set<String>> colToPartitions, Set<String> partitionNames, String colName, Long indexId,
             JobType jobType, AnalysisMode analysisMode, AnalysisMethod analysisMethod, AnalysisType analysisType,
             int samplePercent, int sampleRows, int maxBucketNum, long periodTimeInMs, String message,
             long lastExecTimeInMs, long timeCostInMs, AnalysisState state, ScheduleType scheduleType,
             boolean isExternalTableLevelTask, boolean partitionOnly, boolean samplingPartition,
-            CronExpression cronExpression) {
+            CronExpression cronExpression, boolean forceFull) {
         this.jobId = jobId;
         this.taskId = taskId;
         this.taskIds = taskIds;
@@ -204,6 +208,7 @@ public class AnalysisInfo implements Writable {
         if (cronExpression != null) {
             this.cronExprStr = cronExpression.getCronExpression();
         }
+        this.forceFull = forceFull;
     }
 
     @Override
@@ -214,11 +219,11 @@ public class AnalysisInfo implements Writable {
         sj.add("DBName: " + dbName);
         sj.add("TableName: " + tblName);
         sj.add("ColumnName: " + colName);
-        sj.add("TaskType: " + analysisType.toString());
-        sj.add("TaskMode: " + analysisMode.toString());
-        sj.add("TaskMethod: " + analysisMethod.toString());
+        sj.add("TaskType: " + analysisType);
+        sj.add("TaskMode: " + analysisMode);
+        sj.add("TaskMethod: " + analysisMethod);
         sj.add("Message: " + message);
-        sj.add("CurrentState: " + state.toString());
+        sj.add("CurrentState: " + state);
         if (samplePercent > 0) {
             sj.add("SamplePercent: " + samplePercent);
         }
@@ -240,6 +245,10 @@ public class AnalysisInfo implements Writable {
         if (periodTimeInMs > 0) {
             sj.add("periodTimeInMs: " + StatisticsUtil.getReadableTime(periodTimeInMs));
         }
+        if (StringUtils.isNotEmpty(cronExprStr)) {
+            sj.add("cronExpr: " + cronExprStr);
+        }
+        sj.add("forceFull: " + forceFull);
         return sj.toString();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfoBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfoBuilder.java
@@ -59,6 +59,8 @@ public class AnalysisInfoBuilder {
 
     private CronExpression cronExpression;
 
+    private boolean forceFull;
+
     public AnalysisInfoBuilder() {
     }
 
@@ -90,6 +92,7 @@ public class AnalysisInfoBuilder {
         partitionOnly = info.partitionOnly;
         samplingPartition = info.samplingPartition;
         cronExpression = info.cronExpression;
+        forceFull = info.forceFull;
     }
 
     public AnalysisInfoBuilder setJobId(long jobId) {
@@ -226,37 +229,14 @@ public class AnalysisInfoBuilder {
         this.cronExpression = cronExpression;
     }
 
+    public void setForceFull(boolean forceFull) {
+        this.forceFull = forceFull;
+    }
+
     public AnalysisInfo build() {
         return new AnalysisInfo(jobId, taskId, taskIds, catalogName, dbName, tblName, colToPartitions, partitionNames,
                 colName, indexId, jobType, analysisMode, analysisMethod, analysisType, samplePercent,
                 sampleRows, maxBucketNum, periodTimeInMs, message, lastExecTimeInMs, timeCostInMs, state, scheduleType,
-                externalTableLevelTask, partitionOnly, samplingPartition, cronExpression);
-    }
-
-    public AnalysisInfoBuilder copy() {
-        return new AnalysisInfoBuilder()
-                .setJobId(jobId)
-                .setTaskId(taskId)
-                .setTaskIds(taskIds)
-                .setCatalogName(catalogName)
-                .setDbName(dbName)
-                .setTblName(tblName)
-                .setColToPartitions(colToPartitions)
-                .setColName(colName)
-                .setIndexId(indexId)
-                .setJobType(jobType)
-                .setAnalysisMode(analysisMode)
-                .setAnalysisMethod(analysisMethod)
-                .setAnalysisType(analysisType)
-                .setSamplePercent(samplePercent)
-                .setSampleRows(sampleRows)
-                .setPeriodTimeInMs(periodTimeInMs)
-                .setMaxBucketNum(maxBucketNum)
-                .setMessage(message)
-                .setLastExecTimeInMs(lastExecTimeInMs)
-                .setTimeCostInMs(timeCostInMs)
-                .setState(state)
-                .setScheduleType(scheduleType)
-                .setExternalTableLevelTask(externalTableLevelTask);
+                externalTableLevelTask, partitionOnly, samplingPartition, cronExpression, forceFull);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
@@ -23,6 +23,7 @@ import org.apache.doris.qe.AutoCloseConnectContext;
 import org.apache.doris.qe.QueryState;
 import org.apache.doris.qe.QueryState.MysqlStateType;
 import org.apache.doris.qe.StmtExecutor;
+import org.apache.doris.statistics.AnalysisInfo.JobType;
 import org.apache.doris.statistics.util.StatisticsUtil;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -64,10 +65,14 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
                     + "MIN(`${colName}`) AS min, "
                     + "MAX(`${colName}`) AS max, "
                     + "${dataSizeFunction} AS data_size, "
-                    + "NOW() FROM `${dbName}`.`${tblName}` PARTITION ${partitionName}";
+                    + "NOW() FROM `${dbName}`.`${tblName}` PARTITION ${partitionName}  ${sampleExpr}";
 
     // cache stats for each partition, it would be inserted into column_statistics in a batch.
     private final List<List<ColStatsData>> buf = new ArrayList<>();
+
+    @VisibleForTesting
+    public OlapAnalysisTask() {
+    }
 
     public OlapAnalysisTask(AnalysisInfo info) {
         super(info);
@@ -116,7 +121,7 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
     public void execSQLs(List<String> partitionAnalysisSQLs, Map<String, String> params) throws Exception {
         long startTime = System.currentTimeMillis();
         LOG.debug("analyze task {} start at {}", info.toString(), new Date());
-        try (AutoCloseConnectContext r = StatisticsUtil.buildConnectContext()) {
+        try (AutoCloseConnectContext r = StatisticsUtil.buildConnectContext(info.jobType.equals(JobType.SYSTEM))) {
             List<List<String>> sqlGroups = Lists.partition(partitionAnalysisSQLs, StatisticConstants.UNION_ALL_LIMIT);
             for (List<String> group : sqlGroups) {
                 if (killed) {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsAutoCollector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsAutoCollector.java
@@ -23,18 +23,19 @@ import org.apache.doris.analysis.VariableExpr;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.TableIf;
-import org.apache.doris.catalog.View;
+import org.apache.doris.catalog.external.ExternalTable;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.qe.VariableMgr;
+import org.apache.doris.statistics.AnalysisInfo.AnalysisMethod;
 import org.apache.doris.statistics.AnalysisInfo.JobType;
 import org.apache.doris.statistics.util.StatisticsUtil;
 
-import com.google.common.collect.Maps;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.logging.log4j.LogManager;
@@ -57,7 +58,7 @@ public class StatisticsAutoCollector extends StatisticsCollector {
 
     public StatisticsAutoCollector() {
         super("Automatic Analyzer",
-                TimeUnit.MINUTES.toMillis(Config.auto_check_statistics_in_minutes) / 2,
+                TimeUnit.MINUTES.toMillis(Config.auto_check_statistics_in_minutes),
                 new AnalysisTaskExecutor(Config.full_auto_analyze_simultaneously_running_task_num));
     }
 
@@ -103,34 +104,55 @@ public class StatisticsAutoCollector extends StatisticsCollector {
         }
     }
 
-    public List<AnalysisInfo> constructAnalysisInfo(DatabaseIf<? extends TableIf> db) {
+    protected List<AnalysisInfo> constructAnalysisInfo(DatabaseIf<? extends TableIf> db) {
         List<AnalysisInfo> analysisInfos = new ArrayList<>();
         for (TableIf table : db.getTables()) {
-            if (table instanceof View) {
+            if (skip(table)) {
                 continue;
             }
-            TableName tableName = new TableName(db.getCatalog().getName(), db.getFullName(),
-                    table.getName());
-            AnalysisInfo jobInfo = new AnalysisInfoBuilder()
-                    .setJobId(Env.getCurrentEnv().getNextId())
-                    .setCatalogName(db.getCatalog().getName())
-                    .setDbName(db.getFullName())
-                    .setTblName(tableName.getTbl())
-                    .setColName(
-                            table.getBaseSchema().stream().filter(c -> !StatisticsUtil.isUnsupportedType(c.getType()))
-                                    .map(
-                                            Column::getName).collect(Collectors.joining(","))
-                    )
-                    .setAnalysisType(AnalysisInfo.AnalysisType.FUNDAMENTALS)
-                    .setAnalysisMode(AnalysisInfo.AnalysisMode.INCREMENTAL)
-                    .setAnalysisMethod(AnalysisInfo.AnalysisMethod.FULL)
-                    .setScheduleType(AnalysisInfo.ScheduleType.ONCE)
-                    .setState(AnalysisState.PENDING)
-                    .setTaskIds(new ArrayList<>())
-                    .setJobType(JobType.SYSTEM).build();
-            analysisInfos.add(jobInfo);
+            createAnalyzeJobForTbl(db, analysisInfos, table);
         }
         return analysisInfos;
+    }
+
+    // return true if skip auto analyze this time.
+    protected boolean skip(TableIf table) {
+        if (!(table instanceof OlapTable || table instanceof ExternalTable)) {
+            return true;
+        }
+        if (table.getDataSize() < Config.huge_table_lower_bound_size_in_bytes) {
+            return false;
+        }
+        TableStats tableStats = Env.getCurrentEnv().getAnalysisManager().findTableStatsStatus(table.getId());
+        return System.currentTimeMillis() - tableStats.updatedTime < Config.huge_table_auto_analyze_interval_in_millis;
+    }
+
+    protected void createAnalyzeJobForTbl(DatabaseIf<? extends TableIf> db,
+            List<AnalysisInfo> analysisInfos, TableIf table) {
+        AnalysisMethod analysisMethod = table.getDataSize() > Config.huge_table_lower_bound_size_in_bytes
+                ? AnalysisMethod.SAMPLE : AnalysisMethod.FULL;
+        TableName tableName = new TableName(db.getCatalog().getName(), db.getFullName(),
+                table.getName());
+        AnalysisInfo jobInfo = new AnalysisInfoBuilder()
+                .setJobId(Env.getCurrentEnv().getNextId())
+                .setCatalogName(db.getCatalog().getName())
+                .setDbName(db.getFullName())
+                .setTblName(tableName.getTbl())
+                .setColName(
+                        table.getBaseSchema().stream().filter(c -> !StatisticsUtil.isUnsupportedType(c.getType()))
+                                .map(
+                                        Column::getName).collect(Collectors.joining(","))
+                )
+                .setAnalysisType(AnalysisInfo.AnalysisType.FUNDAMENTALS)
+                .setAnalysisMode(AnalysisInfo.AnalysisMode.INCREMENTAL)
+                .setAnalysisMethod(analysisMethod)
+                .setSamplePercent(Config.huge_table_default_sample_rows)
+                .setScheduleType(AnalysisInfo.ScheduleType.ONCE)
+                .setState(AnalysisState.PENDING)
+                .setTaskIds(new ArrayList<>())
+                .setLastExecTimeInMs(System.currentTimeMillis())
+                .setJobType(JobType.SYSTEM).build();
+        analysisInfos.add(jobInfo);
     }
 
     @VisibleForTesting
@@ -144,35 +166,15 @@ public class StatisticsAutoCollector extends StatisticsCollector {
             return null;
         }
 
-        Set<String> needRunPartitions = table.findReAnalyzeNeededPartitions();
+        Map<String, Set<String>> needRunPartitions = table.findReAnalyzeNeededPartitions();
 
         if (needRunPartitions.isEmpty()) {
             return null;
         }
 
-        return getAnalysisJobInfo(jobInfo, table, needRunPartitions);
+        return new AnalysisInfoBuilder(jobInfo).setColToPartitions(needRunPartitions).build();
     }
 
-    @VisibleForTesting
-    protected AnalysisInfo getAnalysisJobInfo(AnalysisInfo jobInfo, TableIf table,
-            Set<String> needRunPartitions) {
-        Map<String, Set<String>> newColToPartitions = Maps.newHashMap();
-        Map<String, Set<String>> colToPartitions = jobInfo.colToPartitions;
-        if (colToPartitions == null) {
-            for (Column c : table.getColumns()) {
-                newColToPartitions.put(c.getName(), needRunPartitions);
-            }
-        } else {
-            colToPartitions.keySet().forEach(colName -> {
-                Column column = table.getColumn(colName);
-                if (column != null) {
-                    newColToPartitions.put(colName, needRunPartitions);
-                }
-            });
-        }
-        return new AnalysisInfoBuilder(jobInfo)
-                .setColToPartitions(newColToPartitions).build();
-    }
 
     private boolean checkAnalyzeTime(LocalTime now) {
         try {
@@ -215,7 +217,7 @@ public class StatisticsAutoCollector extends StatisticsCollector {
     }
 
     private SessionVariable findRangeFromGlobalSessionVar(String varName) throws Exception {
-        SessionVariable sessionVariable =  VariableMgr.newSessionVariable();
+        SessionVariable sessionVariable = VariableMgr.newSessionVariable();
         VariableExpr variableExpr = new VariableExpr(varName, SetType.GLOBAL);
         VariableMgr.getValue(sessionVariable, variableExpr);
         return sessionVariable;

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -158,6 +158,10 @@ public class StatisticsUtil {
     }
 
     public static AutoCloseConnectContext buildConnectContext() {
+        return buildConnectContext(false);
+    }
+
+    public static AutoCloseConnectContext buildConnectContext(boolean limitScan) {
         ConnectContext connectContext = new ConnectContext();
         SessionVariable sessionVariable = connectContext.getSessionVariable();
         sessionVariable.internalSession = true;
@@ -168,6 +172,7 @@ public class StatisticsUtil {
         sessionVariable.parallelPipelineTaskNum = Config.statistics_sql_parallel_exec_instance_num;
         sessionVariable.setEnableNereidsPlanner(false);
         sessionVariable.enableProfile = false;
+        sessionVariable.enableScanRunSerial = limitScan;
         sessionVariable.queryTimeoutS = Config.analyze_task_timeout_in_hours * 60 * 60;
         sessionVariable.insertTimeoutS = Config.analyze_task_timeout_in_hours * 60 * 60;
         sessionVariable.enableFileCache = false;

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/OlapAnalysisTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/OlapAnalysisTaskTest.java
@@ -1,0 +1,68 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.statistics;
+
+import org.apache.doris.catalog.DatabaseIf;
+import org.apache.doris.catalog.TableIf;
+import org.apache.doris.common.Config;
+import org.apache.doris.datasource.CatalogIf;
+import org.apache.doris.statistics.AnalysisInfo.AnalysisMethod;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class OlapAnalysisTaskTest {
+
+    @Test
+    public void testAutoSample(@Mocked CatalogIf catalogIf, @Mocked DatabaseIf databaseIf, @Mocked TableIf tableIf) {
+        new Expectations() {
+            {
+                tableIf.getDataSize();
+                result = 60_0000_0000L;
+            }
+        };
+
+        AnalysisInfoBuilder analysisInfoBuilder = new AnalysisInfoBuilder()
+                .setAnalysisMethod(AnalysisMethod.FULL);
+        OlapAnalysisTask olapAnalysisTask = new OlapAnalysisTask();
+        olapAnalysisTask.info = analysisInfoBuilder.build();
+        olapAnalysisTask.tbl = tableIf;
+        Config.enable_auto_sample = true;
+        String sampleExpr = olapAnalysisTask.getSampleExpression();
+        Assertions.assertEquals("TABLESAMPLE(200000 ROWS)", sampleExpr);
+
+        new Expectations() {
+            {
+                tableIf.getDataSize();
+                result = 1_0000_0000L;
+            }
+        };
+        sampleExpr = olapAnalysisTask.getSampleExpression();
+        Assertions.assertEquals("", sampleExpr);
+
+        analysisInfoBuilder.setSampleRows(10);
+        analysisInfoBuilder.setAnalysisMethod(AnalysisMethod.SAMPLE);
+        olapAnalysisTask.info = analysisInfoBuilder.build();
+        sampleExpr = olapAnalysisTask.getSampleExpression();
+        Assertions.assertEquals("TABLESAMPLE(10 ROWS)", sampleExpr);
+
+    }
+
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/StatisticsAutoCollectorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/StatisticsAutoCollectorTest.java
@@ -24,6 +24,7 @@ import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.TableIf;
+import org.apache.doris.catalog.Type;
 import org.apache.doris.catalog.View;
 import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.DdlException;
@@ -39,14 +40,17 @@ import mockit.Expectations;
 import mockit.Injectable;
 import mockit.Mock;
 import mockit.MockUp;
+import org.apache.hadoop.util.Lists;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class StatisticsAutoCollectorTest {
@@ -145,16 +149,23 @@ public class StatisticsAutoCollectorTest {
 
         new MockUp<OlapTable>() {
             @Mock
-            protected Set<String> findReAnalyzeNeededPartitions() {
+            protected Map<String, Set<String>> findReAnalyzeNeededPartitions() {
                 Set<String> partitionNames = new HashSet<>();
                 partitionNames.add("p1");
                 partitionNames.add("p2");
-                return partitionNames;
+                Map<String, Set<String>> map = new HashMap<>();
+                map.put("col1", partitionNames);
+                return map;
             }
 
             @Mock
             public long getRowCount() {
                 return 100;
+            }
+
+            @Mock
+            public List<Column> getBaseSchema() {
+                return Lists.newArrayList(new Column("col1", Type.INT), new Column("col2", Type.INT));
             }
         };
 
@@ -198,7 +209,8 @@ public class StatisticsAutoCollectorTest {
                 .setDbName("db")
                 .setTblName("tbl").build();
         Assertions.assertNotNull(statisticsAutoCollector.getReAnalyzeRequiredPart(analysisInfo2));
-        Assertions.assertNull(statisticsAutoCollector.getReAnalyzeRequiredPart(analysisInfo2));
+        // uncomment it when updatedRows get ready
+        // Assertions.assertNull(statisticsAutoCollector.getReAnalyzeRequiredPart(analysisInfo2));
         Assertions.assertNotNull(statisticsAutoCollector.getReAnalyzeRequiredPart(analysisInfo2));
     }
 }


### PR DESCRIPTION
## Proposed changes

1. Analyze with sample automatically when table size is greater than huge_table_lower_bound_size_in_bytes(5G by default). User can disable this feature by fe option enable_auto_sample
2. Support grammer like `ANALYZE TABLE test WITH FULL` to force do full analyze whatever table size is
3. Fix bugs that tables stats doesn't get updated properly when stats is dropped, or only few column is analyzed

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

