### PR TITLE
[fix](grace exit) Fix daemon stop before static variables are destructed 

### DIFF
--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -63,10 +63,6 @@
 
 namespace doris {
 
-Daemon::~Daemon() {
-    stop();
-}
-
 void Daemon::tcmalloc_gc_thread() {
     // TODO All cache GC wish to be supported
 #if !defined(ADDRESS_SANITIZER) && !defined(LEAK_SANITIZER) && !defined(THREAD_SANITIZER) && \

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -178,6 +178,7 @@ void Daemon::tcmalloc_gc_thread() {
             last_ms = 0;
         }
     }
+    LOG(INFO) << "Daemon tcmalloc_gc_thread End";
 #endif
 }
 
@@ -213,6 +214,7 @@ void Daemon::memory_maintenance_thread() {
                             process_mem_log_str(); // print mem log when memory state by 256M
         }
     }
+    LOG(INFO) << "Daemon memory_maintenance_thread End";
 }
 
 void Daemon::memory_gc_thread() {
@@ -266,6 +268,7 @@ void Daemon::memory_gc_thread() {
             }
         }
     }
+    LOG(INFO) << "Daemon memory_gc_thread End";
 }
 
 void Daemon::memtable_memory_limiter_tracker_refresh_thread() {
@@ -275,6 +278,7 @@ void Daemon::memtable_memory_limiter_tracker_refresh_thread() {
             std::chrono::milliseconds(config::memtable_mem_tracker_refresh_interval_ms))) {
         doris::ExecEnv::GetInstance()->memtable_memory_limiter()->refresh_mem_tracker();
     }
+    LOG(INFO) << "Daemon memtable_memory_limiter_tracker_refresh_thread End";
 }
 
 /*
@@ -343,6 +347,7 @@ void Daemon::calculate_metrics_thread() {
                     StorageEngine::instance()->tablet_manager()->get_segment_nums());
         }
     } while (!_stop_background_threads_latch.wait_for(std::chrono::seconds(15)));
+    LOG(INFO) << "Daemon calculate_metrics_thread End";
 }
 
 // clean up stale spilled files
@@ -350,6 +355,7 @@ void Daemon::block_spill_gc_thread() {
     while (!_stop_background_threads_latch.wait_for(std::chrono::seconds(60))) {
         ExecEnv::GetInstance()->block_spill_mgr()->gc(200);
     }
+    LOG(INFO) << "Daemon block_spill_gc_thread End";
 }
 
 void Daemon::start() {
@@ -394,6 +400,7 @@ void Daemon::stop() {
             t->join();
         }
     }
+    LOG(INFO) << "Daemon stop End";
 }
 
 } // namespace doris

--- a/be/src/common/daemon.h
+++ b/be/src/common/daemon.h
@@ -28,7 +28,7 @@ namespace doris {
 class Daemon {
 public:
     Daemon() : _stop_background_threads_latch(1) {}
-    ~Daemon();
+    ~Daemon() = default;
 
     // Start background threads
     void start();

--- a/be/src/common/stack_trace.cpp
+++ b/be/src/common/stack_trace.cpp
@@ -477,7 +477,9 @@ std::string StackTrace::toString(void** frame_pointers_raw, size_t offset, size_
 void StackTrace::createCache() {
     std::lock_guard lock {stacktrace_cache_mutex};
     cacheInstance();
+#if defined(__ELF__) && !defined(__FreeBSD__)
     doris::SymbolIndex::instance();
+#endif
 }
 
 void StackTrace::dropCache() {

--- a/be/src/common/stack_trace.cpp
+++ b/be/src/common/stack_trace.cpp
@@ -477,6 +477,7 @@ std::string StackTrace::toString(void** frame_pointers_raw, size_t offset, size_
 void StackTrace::createCache() {
     std::lock_guard lock {stacktrace_cache_mutex};
     cacheInstance();
+    doris::SymbolIndex::instance();
 }
 
 void StackTrace::dropCache() {

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -453,6 +453,8 @@ void ExecEnv::_destroy() {
     _page_no_cache_mem_tracker.reset();
     _brpc_iobuf_block_memory_tracker.reset();
     InvertedIndexSearcherCache::reset_global_instance();
+
+    LOG(INFO) << "ExecEnv destroy end";
 }
 
 void ExecEnv::destroy(ExecEnv* env) {

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -411,6 +411,7 @@ void ExecEnv::_destroy() {
     if (!ready()) {
         return;
     }
+    LOG(INFO) << "ExecEnv destroy start";
     // Memory barrier to prevent other threads from accessing destructed resources
     _s_ready = false;
     _deregister_metrics();

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -411,7 +411,7 @@ void ExecEnv::_destroy() {
     if (!ready()) {
         return;
     }
-    LOG(INFO) << "ExecEnv destroy start";
+    LOG(INFO) << "ExecEnv Destroy Start";
     // Memory barrier to prevent other threads from accessing destructed resources
     _s_ready = false;
     _deregister_metrics();
@@ -455,7 +455,7 @@ void ExecEnv::_destroy() {
     _brpc_iobuf_block_memory_tracker.reset();
     InvertedIndexSearcherCache::reset_global_instance();
 
-    LOG(INFO) << "ExecEnv destroy end";
+    LOG(INFO) << "ExecEnv Destroy End";
 }
 
 void ExecEnv::destroy(ExecEnv* env) {

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -92,7 +92,9 @@ void __lsan_do_leak_check();
 namespace doris {
 
 void signal_handler(int signal) {
+    LOG(INFO) << "receive signal handler";
     if (signal == SIGINT || signal == SIGTERM) {
+        LOG(INFO) << "signal handler exit";
         k_doris_exit = true;
     }
 }

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -612,6 +612,9 @@ int main(int argc, char** argv) {
         sleep(3);
     }
 
+    // Stop before static variables are destructed
+    daemon.stop();
+
     // For graceful shutdown, need to wait for all running queries to stop
     exec_env->wait_for_all_tasks_done();
 


### PR DESCRIPTION
## Proposed changes

```
It's highly recommended that you fix the library with 'execstack -c <libfile>', or link it with '-z noexecstack'.
=================================================================
==15848==ERROR: AddressSanitizer: heap-use-after-free on address 0x60e000084b28 at pc 0x5641b20e5196 bp 0x7f91f8973a70 sp 0x7f91f8973a68
READ of size 8 at 0x60e000084b28 thread T799 (memory_maintena)
    #0 0x5641b20e5195 in std::_shared_ptr<doris::MemTracker::MemCounter, (_gnu_cxx::_Lock_policy)2>::get() const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1291:16
    #1 0x5641b20e5195 in std::_shared_ptr_access<doris::MemTracker::MemCounter, (_gnu_cxx::_Lock_policy)2, false, false>::_M_get() const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:990:66
    #2 0x5641b20e5195 in std::_shared_ptr_access<doris::MemTracker::MemCounter, (_gnu_cxx::_Lock_policy)2, false, false>::operator->() const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:984:9
    #3 0x5641b20e5195 in doris::MemTracker::consumption() const /root/doris/be/src/runtime/memory/mem_tracker.h:132:42
    #4 0x5641b20e5195 in doris::MemTrackerLimiter::refresh_global_counter() /root/doris/be/src/runtime/memory/mem_tracker_limiter.cpp:121:55
    #5 0x5641b005b7cb in doris::Daemon::memory_maintenance_thread() /root/doris/be/src/common/daemon.cpp:204:13
    #6 0x5641b2704523 in std::function<void ()>::operator()() const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #7 0x5641b2704523 in doris::Thread::supervise_thread(void*) /root/doris/be/src/util/thread.cpp:465:5
    #8 0x7f961d3e3608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477:8
    #9 0x7f961d672132 in __clone /build/glibc-SzIz7B/glibc-2.31/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95

0x60e000084b28 is located 40 bytes inside of 152-byte region [0x60e000084b00,0x60e000084b98)
freed by thread T27 here:
    #0 0x5641affe880d in operator delete(void*) (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be+0xe21c80d) (BuildId: f297d32e874f38f9)
    #1 0x5641b17077a6 in std::default_delete<doris::MemTrackerLimiter>::operator()(doris::MemTrackerLimiter*) const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:85:2
    #2 0x5641b17077a6 in std::unique_ptr<doris::MemTrackerLimiter, std::default_delete<doris::MemTrackerLimiter> >::~unique_ptr() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../i
nclude/c++/11/bits/unique_ptr.h:361:4
    #3 0x5641b17077a6 in doris::ShardedLRUCache::~ShardedLRUCache() /root/doris/be/src/olap/lru_cache.cpp:581:1
    #4 0x5641b17079ed in doris::ShardedLRUCache::~ShardedLRUCache() /root/doris/be/src/olap/lru_cache.cpp:572:37
    #5 0x5641b177701c in std::default_delete<doris::Cache>::operator()(doris::Cache*) const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:85:2
    #6 0x5641b177701c in std::unique_ptr<doris::Cache, std::default_delete<doris::Cache> >::~unique_ptr() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/uniqu
e_ptr.h:361:4
    #7 0x5641b177701c in doris::LRUCachePolicy::~LRUCachePolicy() /root/doris/be/src/runtime/memory/lru_cache_policy.h:49:40
    #8 0x5641b177701c in doris::StoragePageCache::DataPageCache::~DataPageCache() /root/doris/be/src/olap/page_cache.h:103:11
    #9 0x5641b1776582 in std::default_delete<doris::StoragePageCache::DataPageCache>::operator()(doris::StoragePageCache::DataPageCache*) const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11
/../../../../include/c++/11/bits/unique_ptr.h:85:2
    #10 0x5641b1776582 in std::unique_ptr<doris::StoragePageCache::DataPageCache, std::default_delete<doris::StoragePageCache::DataPageCache> >::~unique_ptr() /var/local/ldb-toolchain/bin/../lib/gcc/x86_
64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:361:4
    #11 0x5641b1776582 in doris::StoragePageCache::~StoragePageCache() /root/doris/be/src/olap/page_cache.h:79:7
    #12 0x7f961d5998a6 in __run_exit_handlers /build/glibc-SzIz7B/glibc-2.31/stdlib/exit.c:108:8
```

```
==49616==ERROR: AddressSanitizer: heap-use-after-free on address 0x60e000084ce8 at pc 0x55f62f77c4b6 bp 0x7f2ec18d7a70 sp 0x7f2ec18d7a68
READ of size 8 at 0x60e000084ce8 thread T799 (memory_maintena)
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:413
 1# os::Linux::chained_handler(int, siginfo*, void*) in /usr/local/software/jdk1.8.0_131/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/local/software/jdk1.8.0_131/jre/lib/amd64/server/libjvm.so
 3# signalHandler(int, siginfo*, void*) in /usr/local/software/jdk1.8.0_131/jre/lib/amd64/server/libjvm.so
 4# 0x00007F33A8EEA090 in /lib/x86_64-linux-gnu/libc.so.6
 5# __pthread_rwlock_rdlock at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_rwlock_rdlock.c:27
 6# doris::taskgroup::TaskGroupManager::get_resource_groups(std::function<bool (std::shared_ptr<doris::taskgroup::TaskGroup> const&)> const&, std::vector<std::shared_ptr<doris::taskgroup::TaskGroup>, std::allocator<std::shared_ptr<doris::taskgroup::TaskGroup> > >*) at /root/doris/be/src/runtime/task_group/task_group_manager.cpp:57
 7# doris::MemInfo::tg_hard_memory_limit_gc() at /root/doris/be/src/util/mem_info.cpp:247
 8# doris::Daemon::memory_gc_thread() at /root/doris/be/src/common/daemon.cpp:233
 9# doris::Thread::supervise_thread(void*) at /root/doris/be/src/util/thread.cpp:466
10# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
11# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97
```

```
=48366==ERROR: AddressSanitizer: heap-use-after-free on address 0x603001cb3e28 at pc 0x55b552396074 bp 0x7fb72652b170 sp 0x7fb72652b168
WRITE of size 4 at 0x603001cb3e28 thread T27
    #0 0x55b552396073 in __gnu_cxx::__atomic_add(int volatile*, int) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/ext/atomicity.h:71:5
    #1 0x55b552396073 in __gnu_cxx::__atomic_add_dispatch(int*, int) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/ext/atomicity.h:111:7
    #2 0x55b552396073 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_add_ref_copy() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:148:9
    #3 0x55b552396073 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count(std::__shared_count<(__gnu_cxx::_Lock_policy)2> const&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:709:11
    #4 0x55b552396073 in std::__shared_ptr<doris::SymbolIndex const, (__gnu_cxx::_Lock_policy)2>::__shared_ptr(std::__shared_ptr<doris::SymbolIndex const, (__gnu_cxx::_Lock_policy)2> const&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1147:7
    #5 0x55b552396073 in std::shared_ptr<doris::SymbolIndex const>::shared_ptr(std::shared_ptr<doris::SymbolIndex const> const&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr.h:150:7
    #6 0x55b552396073 in std::shared_ptr<doris::SymbolIndex const> std::atomic_load_explicit<doris::SymbolIndex const>(std::shared_ptr<doris::SymbolIndex const> const*, std::memory_order) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_atomic.h:106:14
    #7 0x55b552396073 in std::shared_ptr<doris::SymbolIndex const> std::atomic_load<doris::SymbolIndex const>(std::shared_ptr<doris::SymbolIndex const> const*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_atomic.h:112:14
    #8 0x55b552396073 in MultiVersion<doris::SymbolIndex>::get() const /root/doris/be/src/common/multi_version.h:54:34
    #9 0x55b552396073 in doris::SymbolIndex::instance() /root/doris/be/src/common/symbol_index.cpp:548:27
    #10 0x55b5523585ab in toStringEveryLineImpl(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, StackTraceRefTriple const&, std::function<void (std::basic_string_view<char, std::char_traits<char> >)>) /root/doris/be/src/common/stack_trace.cpp:371:29
    #11 0x55b55235b858 in toStringCached[abi:cxx11](std::array<void*, 45ul> const&, unsigned long, unsigned long) /root/doris/be/src/common/stack_trace.cpp:454:9
    #12 0x55b55235c542 in StackTrace::toString[abi:cxx11]() const /root/doris/be/src/common/stack_trace.cpp:465:12
    #13 0x55b554984b22 in doris::get_stack_trace_by_libunwind[abi:cxx11]() /root/doris/be/src/util/stack_util.cpp:84:32
    #14 0x55b554983c8d in doris::get_stack_trace[abi:cxx11]() /root/doris/be/src/util/stack_util.cpp:51:16
    #15 0x55b554a1c73b in doris::Status doris::Status::Error<41, true, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>(std::basic_string_view<char, std::char_trai
...skipping...
    #3 0x7fb7cf5d5ce3 in JNI_CreateJavaVM (/usr/local/software/jdk1.8.0_131/jre/lib/amd64/server/libjvm.so+0x6d2ce3) (BuildId: 78b091327a0bf6d146f8881f285955b4f7f2b712)
    #4 0x55b575d45cd7 in getGlobalJNIEnv /var/local/doris/thirdparty/src/doris-thirdparty-hadoop-3.3.4.5-for-doris/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/jni_helper.c:734:14
    #5 0x55b575d45cd7 in getJNIEnv /var/local/doris/thirdparty/src/doris-thirdparty-hadoop-3.3.4.5-for-doris/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/jni_helper.c:823:18

Thread T799 (memory_maintena) created by T0 here:
    #0 0x55b55227ecaa in pthread_create (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be+0xe1c9caa) (BuildId: a8f8e4d2c7b27e80)
    #1 0x55b5549ec3a9 in doris::Thread::start_thread(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::function<void ()> const&, unsigned long, scoped_refptr<doris::Thread>*) /root/doris/be/src/util/thread.cpp:419:15
    #2 0x55b552347720 in doris::Status doris::Thread::create<doris::Daemon::start()::$_1>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, doris::Daemon::start()::$_1 const&, scoped_refptr<doris::Thread>*) /root/doris/be/src/util/thread.h:50:16
    #3 0x55b552347720 in doris::Daemon::start() /root/doris/be/src/common/daemon.cpp:361:10
    #4 0x55b5522d87ee in main /root/doris/be/src/service/doris_main.cpp:541:12
    #5 0x7fb7d8046082 in __libc_start_main /build/glibc-SzIz7B/glibc-2.31/csu/../csu/libc-start.c:308:16

```
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

