### PR TITLE
fix(sec): upgrade org.apache.spark:spark-core_2.12 to 3.4.0

### DIFF
--- a/fe/be-java-extensions/hudi-scanner/pom.xml
+++ b/fe/be-java-extensions/hudi-scanner/pom.xml
@@ -32,7 +32,7 @@ under the License.
         <fe_ut_parallel>1</fe_ut_parallel>
         <scala.version>2.12.15</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
-        <spark.version>3.2.0</spark.version>
+        <spark.version>3.4.0</spark.version>
         <sparkbundle.version>3.2</sparkbundle.version>
         <janino.version>3.0.16</janino.version>
     </properties>

--- a/fe/be-java-extensions/preload-extensions/pom.xml
+++ b/fe/be-java-extensions/preload-extensions/pom.xml
@@ -33,7 +33,7 @@ under the License.
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
         <scala.binary.version>2.12</scala.binary.version>
-        <spark.version>3.2.0</spark.version>
+        <spark.version>3.4.0</spark.version>
         <janino.version>3.0.16</janino.version>
     </properties>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.spark:spark-core_2.12 3.2.0
- [MPS-2022-13519](https://www.oscs1024.com/hd/MPS-2022-13519)


### What did I do？
Upgrade org.apache.spark:spark-core_2.12 from 3.2.0 to 3.4.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS