### PR TITLE
[Bug](type) coredump on get_type_as_primitive_type

### DIFF
--- a/be/src/vec/data_types/data_type_nullable.cpp
+++ b/be/src/vec/data_types/data_type_nullable.cpp
@@ -43,9 +43,12 @@ namespace doris::vectorized {
 
 DataTypeNullable::DataTypeNullable(const DataTypePtr& nested_data_type_)
         : nested_data_type {nested_data_type_} {
+    if (!nested_data_type) {
+        throw Exception(ErrorCode::INTERNAL_ERROR, "DataTypeNullable input nested type is nullptr");
+    }
     if (!nested_data_type->can_be_inside_nullable()) {
-        LOG(FATAL) << fmt::format("Nested type {} cannot be inside Nullable type",
-                                  nested_data_type->get_name());
+        throw Exception(ErrorCode::INTERNAL_ERROR, "Nested type {} cannot be inside Nullable type",
+                        nested_data_type->get_name());
     }
 }
 

--- a/be/src/vec/data_types/data_type_number_base.h
+++ b/be/src/vec/data_types/data_type_number_base.h
@@ -66,6 +66,9 @@ public:
     const char* get_family_name() const override { return TypeName<T>::get(); }
     TypeIndex get_type_id() const override { return TypeId<T>::value; }
     PrimitiveType get_type_as_primitive_type() const override {
+        if constexpr (std::is_same_v<TypeId<T>, TypeId<UInt8>>) {
+            return TYPE_BOOLEAN;
+        }
         if constexpr (std::is_same_v<TypeId<T>, TypeId<Int8>>) {
             return TYPE_TINYINT;
         }
@@ -87,7 +90,7 @@ public:
         if constexpr (std::is_same_v<TypeId<T>, TypeId<Float64>>) {
             return TYPE_DOUBLE;
         }
-        __builtin_unreachable();
+        return INVALID_TYPE;
     }
     TPrimitiveType::type get_type_as_tprimitive_type() const override {
         if constexpr (std::is_same_v<TypeId<T>, TypeId<Int8>>) {


### PR DESCRIPTION
## Proposed changes
coredump on get_type_as_primitive_type
```cpp
* thread #1, name = 'doris_be', stop reason = signal SIGTRAP
  * frame #0: 0x0000560d2979c0a9 doris_be
    frame #1: 0x0000560d38773ffa doris_be`doris::vectorized::DataTypeNullable::get_type_as_primitive_type(this=0x0000604001a1a1a0) const at data_type_nullable.h:62:34
    frame #2: 0x0000560d29e95743 doris_be`doris::TabletColumn::get_aggregate_function(this=<unavailable>, suffix=<unavailable>) const at tablet_schema.cpp:507:23
    frame #3: 0x0000560d27aea653 doris_be`doris::MemTable::_init_agg_functions(this=0x00006160002d0080, block=0x00007fa4a761d060) at memtable.cpp:108:49
    frame #4: 0x0000560d27aec788 doris_be`doris::MemTable::insert(this=0x00006160002d0080, input_block=0x00007fa4a75f5300, row_idxs=error: summary string parsing error, is_append=false) at memtable.cpp:178:13
    frame #5: 0x0000560d27ac3a71 doris_be`doris::MemTableWriter::write(this=0x0000613004dcb200, block=0x00007fa4a75f5300, row_idxs=error: summary string parsing error, is_append=false) at memtable_writer.cpp:112:17
    frame #6: 0x0000560d2a01ecc8 doris_be`doris::DeltaWriter::write(this=0x0000617002593580, block=0x00007fa4a75f5300, row_idxs=error: summary string parsing error, is_append=false) at delta_writer.cpp:123:30
    frame #7: 0x0000560d2a6a35b5 doris_be`doris::TabletsChannel::add_batch(this=0x00007fa4a75f55c0, writer=0x0000617002593580)::$_2::operator()(doris::DeltaWriter*) const at tablets_channel.cpp:556:13
    frame #8: 0x0000560d2a6a350d doris_be`doris::Status std::__invoke_impl<doris::Status, doris::TabletsChannel::add_batch(doris::PTabletWriterAddBlockRequest const&, doris::PTabletWriterAddBlockResult*)::$_2&, doris::DeltaWriter*>((null)=__invoke_other @ 0x00007fa4aa19bd00, __f=0x00007fa4a75f55c0, __args=0x00007fa4a713da20)::$_2&, doris::DeltaWriter*&&) at invoke.h:61:14
    frame #9: 0x0000560d2a6a3468 doris_be`std::enable_if<is_invocable_r_v<doris::Status, doris::TabletsChannel::add_batch(doris::PTabletWriterAddBlockRequest const&, doris::PTabletWriterAddBlockResult*)::$_2&, doris::DeltaWriter*>, doris::Status>::type std::__invoke_r<doris::Status, doris::TabletsChannel::add_batch(__fn=0x00007fa4a75f55c0, __args=0x00007fa4a713da20)::$_2&, doris::DeltaWriter*>(doris::TabletsChannel::add_batch(doris::PTabletWriterAddBlockRequest const&, doris::PTabletWriterAddBlockResult*)::$_2&, doris::DeltaWriter*&&) at invoke.h:114:9
    frame #10: 0x0000560d2a6a3318 doris_be`std::_Function_handler<doris::Status (doris::DeltaWriter*), doris::TabletsChannel::add_batch(doris::PTabletWriterAddBlockRequest const&, doris::PTabletWriterAddBlockResult*)::$_2>::_M_invoke(__functor=0x00007fa4a75f55c0, __args=0x00007fa4a713da20) at std_function.h:291:9
    frame #11: 0x0000560d2a6b0784 doris_be`std::function<doris::Status (doris::DeltaWriter*)>::operator(this=0x00007fa4a75f55c0, __args=0x0000617002593580)(doris::DeltaWriter*) const at std_function.h:560:9
    frame #12: 0x0000560d2a6a0cd0 doris_be`doris::TabletsChannel::add_batch(this=0x00007fa4a75f5460, tablet_id=301396, write_func=function<doris::Status (doris::DeltaWriter *)> @ 0x00007fa4a75f55c0)::$_0::operator()(unsigned int, std::function<doris::Status (doris::DeltaWriter*)>) const at tablets_channel.cpp:531:21
    frame #13: 0x0000560d2a6a0084 doris_be`doris::TabletsChannel::add_batch(this=0x0000616003170190, request=0x0000611000810140, response=0x00006110007cfdc0) at tablets_channel.cpp:556:13
    frame #14: 0x0000560d2a34486b doris_be`doris::LoadChannel::add_batch(this=0x0000613004dca080, request=0x0000611000810140, response=0x00006110007cfdc0) at load_channel.cpp:136:9
    frame #15: 0x0000560d2a32e811 doris_be`doris::LoadChannelMgr::add_batch(this=0x00006110001b5c00, request=0x0000611000810140, response=0x00006110007cfdc0) at load_channel_mgr.cpp:166:26
    frame #16: 0x0000560d2a845194 doris_be`doris::PInternalServiceImpl::_tablet_writer_add_block(this=0x0000604003213a50)::$_0::operator()() const at internal_service.cpp:458:54
    frame #17: 0x0000560d2a844d45 doris_be`void std::__invoke_impl<void, doris::PInternalServiceImpl::_tablet_writer_add_block(google::protobuf::RpcController*, doris::PTabletWriterAddBlockRequest const*, doris::PTabletWriterAddBlockResult*, google::protobuf::Closure*)::$_0&>((null)=__invoke_other @ 0x00007fa4aa19c9d8, __f=0x0000604003213a50)::$_0&) at invoke.h:61:14
    frame #18: 0x0000560d2a844ce5 doris_be`std::enable_if<is_invocable_r_v<void, doris::PInternalServiceImpl::_tablet_writer_add_block(google::protobuf::RpcController*, doris::PTabletWriterAddBlockRequest const*, doris::PTabletWriterAddBlockResult*, google::protobuf::Closure*)::$_0&>, void>::type std::__invoke_r<void, doris::PInternalServiceImpl::_tablet_writer_add_block(__fn=0x0000604003213a50)::$_0&>(doris::PInternalServiceImpl::_tablet_writer_add_block(google::protobuf::RpcController*, doris::PTabletWriterAddBlockRequest const*, doris::PTabletWriterAddBlockResult*, google::protobuf::Closure*)::$_0&) at invoke.h:111:2
    frame #19: 0x0000560d2a844b4d doris_be`std::_Function_handler<void (), doris::PInternalServiceImpl::_tablet_writer_add_block(google::protobuf::RpcController*, doris::PTabletWriterAddBlockRequest const*, doris::PTabletWriterAddBlockResult*, google::protobuf::Closure*)::$_0>::_M_invoke(__functor=0x00007fa4a7179028) at std_function.h:291:9
    frame #20: 0x0000560d27a54bf3 doris_be`std::function<void ()>::operator(this=0x00007fa4a7179028)() const at std_function.h:560:9
    frame #21: 0x0000560d2a88091b doris_be`doris::WorkThreadPool<false>::work_thread(this=0x000061800001f890, thread_id=266) at work_thread_pool.hpp:159:17
    frame #22: 0x0000560d2a881ca3 doris_be`void std::__invoke_impl<void, void (doris::WorkThreadPool<false>::* const&)(int), doris::WorkThreadPool<false>*&, int&>((null)=__invoke_memfun_deref @ 0x00007fa4aa19cb88, __f=0x00006040011bb718, __t=0x00006040011bb730, __args=0x00006040011bb728)(int), doris::WorkThreadPool<false>*&, int&) at invoke.h:74:14
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

