### PR TITLE
[fix](Nereids) make TVF's distribution spec always be RANDOM

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/table/Numbers.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/table/Numbers.java
@@ -90,10 +90,11 @@ public class Numbers extends TableValuedFunction {
 
     @Override
     public PhysicalProperties getPhysicalProperties() {
-        String backendNum = getTVFProperties().getMap().getOrDefault(NumbersTableValuedFunction.BACKEND_NUM, "1");
-        if (backendNum.trim().equals("1")) {
-            return PhysicalProperties.GATHER;
-        }
+        // TODO: use gather after coordinator support plan gather scan
+        // String backendNum = getTVFProperties().getMap().getOrDefault(NumbersTableValuedFunction.BACKEND_NUM, "1");
+        // if (backendNum.trim().equals("1")) {
+        //     return PhysicalProperties.GATHER;
+        // }
         return PhysicalProperties.ANY;
     }
 

--- a/regression-test/suites/nereids_function_p0/tvf/tvf.groovy
+++ b/regression-test/suites/nereids_function_p0/tvf/tvf.groovy
@@ -20,5 +20,12 @@ suite("nereids_tvf") {
     sql 'set enable_nereids_planner=true'
     sql 'set enable_fallback_to_original_planner=false'
     qt_sql_number '''
-        select * from numbers("number" = "10")'''
+        select * from numbers("number" = "10")
+    '''
+
+    // when we set numbers to gather, coordinator could not process and set none scan range in thrift
+    // so we add this test case to ensure this sql do not core dump
+    sql """
+        select * from numbers("number"="10") a right join numbers("number"="10") b on true;
+    """
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

Nereids make TVF number as Gather distribution if backend num = 1.
But coordinator could not process gather fragment with scan node.
In the long run, we need to get coordinators to support this scenario.
But it is need a lot of refactor. So, we just forbid Gather
distribution for ScanNode now.


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

