### PR TITLE
[bug](explode) fix table node not implement alloc_resource function

### DIFF
--- a/be/src/vec/exec/vtable_function_node.h
+++ b/be/src/vec/exec/vtable_function_node.h
@@ -54,11 +54,13 @@ public:
 
     Status init(const TPlanNode& tnode, RuntimeState* state = nullptr) override;
     Status prepare(RuntimeState* state) override;
-    Status open(RuntimeState* state) override { return alloc_resource(state); }
+    Status open(RuntimeState* state) override {
+        RETURN_IF_ERROR(alloc_resource(state));
+        return _children[0]->open(state);
+    }
     Status alloc_resource(RuntimeState* state) override {
         RETURN_IF_ERROR(ExecNode::alloc_resource(state));
-        RETURN_IF_ERROR(VExpr::open(_vfn_ctxs, state));
-        return _children[0]->open(state);
+        return VExpr::open(_vfn_ctxs, state);
     }
     Status get_next(RuntimeState* state, Block* block, bool* eos) override;
     bool need_more_input_data() const { return !_child_block.rows() && !_child_eos; }

--- a/be/src/vec/exec/vtable_function_node.h
+++ b/be/src/vec/exec/vtable_function_node.h
@@ -54,8 +54,9 @@ public:
 
     Status init(const TPlanNode& tnode, RuntimeState* state = nullptr) override;
     Status prepare(RuntimeState* state) override;
-    Status open(RuntimeState* state) override {
-        RETURN_IF_ERROR(alloc_resource(state));
+    Status open(RuntimeState* state) override { return alloc_resource(state); }
+    Status alloc_resource(RuntimeState* state) override {
+        RETURN_IF_ERROR(ExecNode::alloc_resource(state));
         RETURN_IF_ERROR(VExpr::open(_vfn_ctxs, state));
         return _children[0]->open(state);
     }


### PR DESCRIPTION
## Proposed changes
if we open pipeline mode, the node will call alloc_resource function rather than open function.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

