### PR TITLE
[fix](nereids) external scan use STORAGE_ANY instead of ANY as distibution

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriver.java
@@ -125,17 +125,27 @@ public class ChildOutputPropertyDeriver extends PlanVisitor<PhysicalProperties, 
 
     @Override
     public PhysicalProperties visitPhysicalEsScan(PhysicalEsScan esScan, PlanContext context) {
-        return PhysicalProperties.ANY;
+        return PhysicalProperties.STORAGE_ANY;
     }
 
     @Override
     public PhysicalProperties visitPhysicalFileScan(PhysicalFileScan fileScan, PlanContext context) {
-        return PhysicalProperties.ANY;
+        return PhysicalProperties.STORAGE_ANY;
     }
 
+    /**
+     * TODO return ANY after refactor coordinator
+     * return STORAGE_ANY not ANY, in order to generate distribute on jdbc scan.
+     * select * from (select * from external.T) as A union all (select * from external.T)
+     * if visitPhysicalJdbcScan returns ANY, the plan is
+     * union
+     *  |--- JDBCSCAN
+     *  +--- JDBCSCAN
+     *  this breaks coordinator assumption that one fragment has at most only one scan.
+     */
     @Override
     public PhysicalProperties visitPhysicalJdbcScan(PhysicalJdbcScan jdbcScan, PlanContext context) {
-        return PhysicalProperties.ANY;
+        return PhysicalProperties.STORAGE_ANY;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalJdbcScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalJdbcScan.java
@@ -49,7 +49,7 @@ public class PhysicalJdbcScan extends PhysicalCatalogRelation {
     public PhysicalJdbcScan(RelationId id, TableIf table, List<String> qualifier,
             Optional<GroupExpression> groupExpression, LogicalProperties logicalProperties, Set<Expression> conjuncts) {
         this(id, table, qualifier, groupExpression, logicalProperties,
-                PhysicalProperties.STORAGE_ANY, null, conjuncts);
+                null, null, conjuncts);
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalJdbcScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalJdbcScan.java
@@ -48,8 +48,8 @@ public class PhysicalJdbcScan extends PhysicalCatalogRelation {
      */
     public PhysicalJdbcScan(RelationId id, TableIf table, List<String> qualifier,
             Optional<GroupExpression> groupExpression, LogicalProperties logicalProperties, Set<Expression> conjuncts) {
-        super(id, PlanType.PHYSICAL_JDBC_SCAN, table, qualifier, groupExpression, logicalProperties);
-        this.conjuncts = ImmutableSet.copyOf(Objects.requireNonNull(conjuncts, "conjuncts should not be null"));
+        this(id, table, qualifier, groupExpression, logicalProperties,
+                PhysicalProperties.STORAGE_ANY, null, conjuncts);
     }
 
     /**


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

