### PR TITLE
[supplement](regression-test) Pass CCR cases when Fe enable_feature_binlog=false

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Syncer.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Syncer.groovy
@@ -63,6 +63,14 @@ class Syncer {
         TARGET
     }
 
+    Boolean checkEnableFeatureBinlog() {
+        List<List<Object>> rows = suite.sql("ADMIN SHOW FRONTEND CONFIG LIKE \"%%enable_feature_binlog%%\"")
+        if (rows.size() >= 1 && (rows[0][0] as String).contains("enable_feature_binlog")) {
+            return (rows[0][1] as String) == "true"
+        }
+        return false
+    }
+
     private Boolean checkBinlog(TBinlog binlog, String table, Boolean update) {
 
         // step 1: check binlog availability

--- a/regression-test/suites/ccr_mow_syncer_p0/test_binlog_config_change.groovy
+++ b/regression-test/suites/ccr_mow_syncer_p0/test_binlog_config_change.groovy
@@ -18,6 +18,10 @@
 suite("test_mow_binlog_config_change") {
 
     def syncer = getSyncer()
+    if (!syncer.checkEnableFeatureBinlog()) {
+        logger.info("fe enable_feature_binlog is false, skip case test_mow_binlog_config_change")
+        return
+    }
     def tableName = "tbl_binlog_config_change"
     def test_num = 0
     def insert_num = 5

--- a/regression-test/suites/ccr_mow_syncer_p0/test_create_table_with_binlog_config.groovy
+++ b/regression-test/suites/ccr_mow_syncer_p0/test_create_table_with_binlog_config.groovy
@@ -16,6 +16,11 @@
 // under the License.
 
 suite("test_mow_create_table_with_binlog_config") {
+    def syncer = getSyncer()
+    if (!syncer.checkEnableFeatureBinlog()) {
+        logger.info("fe enable_feature_binlog is false, skip case test_mow_create_table_with_binlog_config")
+        return
+    }
     sql "drop database if exists test_table_binlog"
 
     sql """

--- a/regression-test/suites/ccr_mow_syncer_p0/test_get_binlog.groovy
+++ b/regression-test/suites/ccr_mow_syncer_p0/test_get_binlog.groovy
@@ -36,6 +36,10 @@ suite("test_mow_get_binlog_case") {
     }
     
     def syncer = getSyncer()
+    if (!syncer.checkEnableFeatureBinlog()) {
+        logger.info("fe enable_feature_binlog is false, skip case test_mow_get_binlog_case")
+        return
+    }
     def seqTableName = "tbl_get_binlog_case"
     def test_num = 0
     def insert_num = 5

--- a/regression-test/suites/ccr_mow_syncer_p0/test_ingest_binlog.groovy
+++ b/regression-test/suites/ccr_mow_syncer_p0/test_ingest_binlog.groovy
@@ -18,6 +18,10 @@
 suite("test_mow_ingest_binlog") {
 
     def syncer = getSyncer()
+    if (!syncer.checkEnableFeatureBinlog()) {
+        logger.info("fe enable_feature_binlog is false, skip case test_mow_ingest_binlog")
+        return
+    }
     def tableName = "tbl_ingest_binlog"
     def insert_num = 5
     def test_num = 0

--- a/regression-test/suites/ccr_mow_syncer_p0/test_multi_buckets.groovy
+++ b/regression-test/suites/ccr_mow_syncer_p0/test_multi_buckets.groovy
@@ -18,6 +18,10 @@
 suite("test_mow_multi_buckets") {
 
     def syncer = getSyncer()
+    if (!syncer.checkEnableFeatureBinlog()) {
+        logger.info("fe enable_feature_binlog is false, skip case test_mow_multi_buckets")
+        return
+    }
     def tableName = "tbl_multi_buckets"
     def test_num = 0
     def insert_num = 5

--- a/regression-test/suites/ccr_mow_syncer_p0/test_txn_case.groovy
+++ b/regression-test/suites/ccr_mow_syncer_p0/test_txn_case.groovy
@@ -39,6 +39,10 @@ suite("test_mow_txn_case") {
     }
 
     def syncer = getSyncer()
+    if (!syncer.checkEnableFeatureBinlog()) {
+        logger.info("fe enable_feature_binlog is false, skip case test_mow_txn_case")
+        return
+    }
     def txnTableName = "tbl_txn_case"
     def test_num = 0
     sql "DROP TABLE IF EXISTS ${txnTableName}"

--- a/regression-test/suites/ccr_mow_syncer_p1/test_backup_restore.groovy
+++ b/regression-test/suites/ccr_mow_syncer_p1/test_backup_restore.groovy
@@ -18,6 +18,10 @@
 suite("test_mow_backup_restore") {
 
     def syncer = getSyncer()
+    if (!syncer.checkEnableFeatureBinlog()) {
+        logger.info("fe enable_feature_binlog is false, skip case test_mow_backup_restore")
+        return
+    }
     def tableName = "tbl_backup_restore"
     def test_num = 0
     def insert_num = 5

--- a/regression-test/suites/ccr_syncer_p0/test_binlog_config_change.groovy
+++ b/regression-test/suites/ccr_syncer_p0/test_binlog_config_change.groovy
@@ -18,6 +18,10 @@
 suite("test_binlog_config_change") {
 
     def syncer = getSyncer()
+    if (!syncer.checkEnableFeatureBinlog()) {
+        logger.info("fe enable_feature_binlog is false, skip case test_binlog_config_change")
+        return
+    }
     def tableName = "tbl_binlog_config_change"
     def test_num = 0
     def insert_num = 5

--- a/regression-test/suites/ccr_syncer_p0/test_create_table_with_binlog_config.groovy
+++ b/regression-test/suites/ccr_syncer_p0/test_create_table_with_binlog_config.groovy
@@ -16,6 +16,11 @@
 // under the License.
 
 suite("test_create_table_with_binlog_config") {
+    def syncer = getSyncer()
+    if (!syncer.checkEnableFeatureBinlog()) {
+        logger.info("fe enable_feature_binlog is false, skip case test_create_table_with_binlog_config")
+        return
+    }
     sql "drop database if exists test_table_binlog"
 
     sql """

--- a/regression-test/suites/ccr_syncer_p0/test_get_binlog.groovy
+++ b/regression-test/suites/ccr_syncer_p0/test_get_binlog.groovy
@@ -35,6 +35,10 @@ suite("test_get_binlog_case") {
     }
     
     def syncer = getSyncer()
+    if (!syncer.checkEnableFeatureBinlog()) {
+        logger.info("fe enable_feature_binlog is false, skip case test_get_binlog_case")
+        return
+    }
     def seqTableName = "tbl_get_binlog_case"
     def test_num = 0
     def insert_num = 5

--- a/regression-test/suites/ccr_syncer_p0/test_ingest_binlog.groovy
+++ b/regression-test/suites/ccr_syncer_p0/test_ingest_binlog.groovy
@@ -18,6 +18,10 @@
 suite("test_ingest_binlog") {
 
     def syncer = getSyncer()
+    if (!syncer.checkEnableFeatureBinlog()) {
+        logger.info("fe enable_feature_binlog is false, skip case test_ingest_binlog")
+        return
+    }
     def tableName = "tbl_ingest_binlog"
     def insert_num = 5
     def test_num = 0

--- a/regression-test/suites/ccr_syncer_p0/test_multi_buckets.groovy
+++ b/regression-test/suites/ccr_syncer_p0/test_multi_buckets.groovy
@@ -18,6 +18,10 @@
 suite("test_multi_buckets") {
 
     def syncer = getSyncer()
+    if (!syncer.checkEnableFeatureBinlog()) {
+        logger.info("fe enable_feature_binlog is false, skip case test_multi_buckets")
+        return
+    }
     def tableName = "tbl_multi_buckets"
     def test_num = 0
     def insert_num = 5

--- a/regression-test/suites/ccr_syncer_p0/test_txn_case.groovy
+++ b/regression-test/suites/ccr_syncer_p0/test_txn_case.groovy
@@ -39,6 +39,10 @@ suite("test_txn_case") {
     }
 
     def syncer = getSyncer()
+    if (!syncer.checkEnableFeatureBinlog()) {
+        logger.info("fe enable_feature_binlog is false, skip case test_txn_case")
+        return
+    }
     def txnTableName = "tbl_txn_case"
     def test_num = 0
     sql "DROP TABLE IF EXISTS ${txnTableName}"

--- a/regression-test/suites/ccr_syncer_p1/test_backup_restore.groovy
+++ b/regression-test/suites/ccr_syncer_p1/test_backup_restore.groovy
@@ -18,6 +18,10 @@
 suite("test_backup_restore") {
 
     def syncer = getSyncer()
+    if (!syncer.checkEnableFeatureBinlog()) {
+        logger.info("fe enable_feature_binlog is false, skip case test_backup_restore")
+        return
+    }
     def tableName = "tbl_backup_restore"
     def test_num = 0
     def insert_num = 5


### PR DESCRIPTION
## Proposed changes

Before starting the CCR case test, use syncer.checkEnableFeatureBinlog() to determine whether enable_feature_binlog is true. If true, skip this case.
