### PR TITLE
[fix](nereids) avoid throw analysis ex for unsupported type to make ext table goes nereids

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/CheckDataTypes.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/CheckDataTypes.java
@@ -30,6 +30,7 @@ import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.JsonType;
 import org.apache.doris.nereids.types.MapType;
 import org.apache.doris.nereids.types.StructType;
+import org.apache.doris.nereids.types.UnsupportedType;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -40,7 +41,8 @@ import java.util.Set;
  */
 public class CheckDataTypes implements CustomRewriter {
 
-    private static final Set<Class<? extends DataType>> UNSUPPORTED_TYPE = ImmutableSet.of(JsonType.class);
+    private static final Set<Class<? extends DataType>> UNSUPPORTED_TYPE = ImmutableSet.of(
+            JsonType.class, UnsupportedType.class);
 
     @Override
     public Plan rewriteRoot(Plan rootPlan, JobContext jobContext) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DataType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DataType.java
@@ -313,8 +313,9 @@ public abstract class DataType {
             List<DataType> types = catalogType.getSubTypes().stream().map(DataType::fromCatalogType)
                     .collect(Collectors.toList());
             return new AggStateType(catalogType.getFunctionName(), types, catalogType.getSubTypeNullables());
+        } else {
+            return UnsupportedType.INSTANCE;
         }
-        throw new AnalysisException("Nereids do not support type: " + type);
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/UnsupportedType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/UnsupportedType.java
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.types;
+
+import org.apache.doris.catalog.Type;
+import org.apache.doris.nereids.annotation.Developing;
+
+/**
+ * Unsupported type in Nereids.
+ */
+@Developing
+public class UnsupportedType extends DataType {
+
+    public static final int WIDTH = -1;
+
+    public static final UnsupportedType INSTANCE = new UnsupportedType();
+
+    private UnsupportedType() {
+    }
+
+    @Override
+    public Type toCatalogDataType() {
+        return Type.UNSUPPORTED;
+    }
+
+    @Override
+    public boolean acceptsType(DataType other) {
+        return other instanceof UnsupportedType;
+    }
+
+    @Override
+    public String simpleString() {
+        return "unsupported";
+    }
+
+    @Override
+    public int width() {
+        return WIDTH;
+    }
+
+    @Override
+    public String toSql() {
+        return "UNSUPPORTED";
+    }
+}


### PR DESCRIPTION
## Proposed changes

avoid throw analysis ex for unsupported type to make ext table goes nereids.
this will improve the nereids' availability for external table if unsupported type is in the basic table schema but not referenced in the real sql.

tested in external table env.

Consider the following case:
select pu.pk_ct_pu as id
  from fms_rd_nc65_zb.NC65P.CT_PU pu
  left join fms_rd_nc65_zb.NC65P.PUB_WF_INSTANCE pwi
    on pu.pk_ct_pu = pwi.billid 
    and pu.vtrantypecode=pwi.billtype
 left join fms_rd_nc65_zb.NC65P.SM_USER su
    on pu.creator = su.cuserid
 where pu.pk_ct_pu='1001A110000000K8XPVN'; 

PUB_WF_INSTANCE table has a BLOB type column and currently it will throw analysis exception and fallback to old optimizer, although this column is not referenced in the real sql. The old optimizer doesn't have the outer join -> inner join rule and the "pu.pk_ct_pu='1001A110000000K8XPVN'; " is not pushed down and the performance will drop down. After the pr, we add the unsupported type instead of throw exception directly, it will decide the unused case and can continue goes nereids and use all advanced optimization for the sql.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

