### PR TITLE
[fix](optimizer): Fix health calculation

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -1132,7 +1132,8 @@ public class OlapTable extends Table {
         if (rowCount == 0) {
             return false;
         }
-        long updateRows = tblStats.updatedRows.get();
+        // long updateRows = tblStats.updatedRows.get();
+        long updateRows = Math.abs(tblStats.rowCount - rowCount);
         int tblHealth = StatisticsUtil.getTableHealth(rowCount, updateRows);
         return tblHealth < Config.table_stats_health_threshold;
     }


### PR DESCRIPTION
## Proposed changes

Stats health calculation shouldn't use TableStats::updatedRows since it doesn't get ready yet

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

