### PR TITLE
[Bug](pipelineX) init runtime filter profile at first

### DIFF
--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -1084,7 +1084,7 @@ private:
 Status IRuntimeFilter::create(RuntimeState* state, ObjectPool* pool, const TRuntimeFilterDesc* desc,
                               const TQueryOptions* query_options, const RuntimeFilterRole role,
                               int node_id, IRuntimeFilter** res, bool build_bf_exactly) {
-    *res = pool->add(new IRuntimeFilter(state, pool));
+    *res = pool->add(new IRuntimeFilter(state, pool, desc));
     (*res)->set_role(role);
     return (*res)->init_with_desc(desc, query_options, node_id, build_bf_exactly);
 }
@@ -1093,7 +1093,7 @@ Status IRuntimeFilter::create(QueryContext* query_ctx, ObjectPool* pool,
                               const TRuntimeFilterDesc* desc, const TQueryOptions* query_options,
                               const RuntimeFilterRole role, int node_id, IRuntimeFilter** res,
                               bool build_bf_exactly) {
-    *res = pool->add(new IRuntimeFilter(query_ctx, pool));
+    *res = pool->add(new IRuntimeFilter(query_ctx, pool, desc));
     (*res)->set_role(role);
     return (*res)->init_with_desc(desc, query_options, node_id, build_bf_exactly);
 }
@@ -1297,25 +1297,10 @@ Status IRuntimeFilter::init_with_desc(const TRuntimeFilterDesc* desc, const TQue
     // if node_id == -1 , it shouldn't be a consumer
     DCHECK(node_id >= 0 || (node_id == -1 && !is_consumer()));
 
-    if (desc->type == TRuntimeFilterType::BLOOM) {
-        _runtime_filter_type = RuntimeFilterType::BLOOM_FILTER;
-    } else if (desc->type == TRuntimeFilterType::MIN_MAX) {
-        _runtime_filter_type = RuntimeFilterType::MINMAX_FILTER;
-    } else if (desc->type == TRuntimeFilterType::IN) {
-        _runtime_filter_type = RuntimeFilterType::IN_FILTER;
-    } else if (desc->type == TRuntimeFilterType::IN_OR_BLOOM) {
-        _runtime_filter_type = RuntimeFilterType::IN_OR_BLOOM_FILTER;
-    } else if (desc->type == TRuntimeFilterType::BITMAP) {
-        _runtime_filter_type = RuntimeFilterType::BITMAP_FILTER;
-    } else {
-        return Status::InvalidArgument("unknown filter type");
-    }
-
     _is_broadcast_join = desc->is_broadcast_join;
     _has_local_target = desc->has_local_targets;
     _has_remote_target = desc->has_remote_targets;
     _expr_order = desc->expr_order;
-    _filter_id = desc->filter_id;
     _opt_remote_rf = desc->__isset.opt_remote_rf && desc->opt_remote_rf;
     vectorized::VExprContextSPtr build_ctx;
     RETURN_IF_ERROR(vectorized::VExpr::create_expr_tree(desc->src_expr, build_ctx));
@@ -1469,17 +1454,7 @@ void IRuntimeFilter::init_profile(RuntimeProfile* parent_profile) {
         parent_profile->add_child(_profile.get(), true, nullptr);
         return;
     }
-    {
-        std::lock_guard guard(_profile_mutex);
-        if (_profile_init) {
-            return;
-        }
-        DCHECK(parent_profile != nullptr);
-        _name = fmt::format("RuntimeFilter: (id = {}, type = {})", _filter_id,
-                            to_string(_runtime_filter_type));
-        _profile.reset(new RuntimeProfile(_name));
-        _profile_init = true;
-    }
+    _profile_init = true;
     parent_profile->add_child(_profile.get(), true, nullptr);
     _profile->add_info_string("Info", _format_status());
     if (_runtime_filter_type == RuntimeFilterType::IN_OR_BLOOM_FILTER) {

--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -78,6 +78,29 @@ enum class RuntimeFilterType {
     BITMAP_FILTER = 4
 };
 
+static RuntimeFilterType get_runtime_filter_type(TRuntimeFilterType::type ttype) {
+    switch (ttype) {
+    case TRuntimeFilterType::BLOOM: {
+        return RuntimeFilterType::BLOOM_FILTER;
+    }
+    case TRuntimeFilterType::MIN_MAX: {
+        return RuntimeFilterType::MINMAX_FILTER;
+    }
+    case TRuntimeFilterType::IN: {
+        return RuntimeFilterType::IN_FILTER;
+    }
+    case TRuntimeFilterType::IN_OR_BLOOM: {
+        return RuntimeFilterType::IN_OR_BLOOM_FILTER;
+    }
+    case TRuntimeFilterType::BITMAP: {
+        return RuntimeFilterType::BITMAP_FILTER;
+    }
+    default: {
+        throw doris::Exception(doris::ErrorCode::INTERNAL_ERROR, "Invalid runtime filter type!");
+    }
+    }
+}
+
 enum class RuntimeFilterRole { PRODUCER = 0, CONSUMER = 1 };
 
 struct RuntimeFilterParams {
@@ -150,11 +173,10 @@ enum RuntimeFilterState {
 /// that can be pushed down to node based on the results of the right table.
 class IRuntimeFilter {
 public:
-    IRuntimeFilter(RuntimeState* state, ObjectPool* pool)
+    IRuntimeFilter(RuntimeState* state, ObjectPool* pool, const TRuntimeFilterDesc* desc)
             : _state(state),
               _pool(pool),
-              _runtime_filter_type(RuntimeFilterType::UNKNOWN_FILTER),
-              _filter_id(-1),
+              _filter_id(desc->filter_id),
               _is_broadcast_join(true),
               _has_remote_target(false),
               _has_local_target(false),
@@ -165,13 +187,16 @@ public:
               _always_true(false),
               _is_ignored(false),
               registration_time_(MonotonicMillis()),
-              _enable_pipeline_exec(_state->enable_pipeline_exec()) {}
+              _enable_pipeline_exec(_state->enable_pipeline_exec()),
+              _runtime_filter_type(get_runtime_filter_type(desc->type)),
+              _name(fmt::format("RuntimeFilter: (id = {}, type = {})", _filter_id,
+                                to_string(_runtime_filter_type))),
+              _profile(new RuntimeProfile(_name)) {}
 
-    IRuntimeFilter(QueryContext* query_ctx, ObjectPool* pool)
+    IRuntimeFilter(QueryContext* query_ctx, ObjectPool* pool, const TRuntimeFilterDesc* desc)
             : _query_ctx(query_ctx),
               _pool(pool),
-              _runtime_filter_type(RuntimeFilterType::UNKNOWN_FILTER),
-              _filter_id(-1),
+              _filter_id(desc->filter_id),
               _is_broadcast_join(true),
               _has_remote_target(false),
               _has_local_target(false),
@@ -182,7 +207,11 @@ public:
               _always_true(false),
               _is_ignored(false),
               registration_time_(MonotonicMillis()),
-              _enable_pipeline_exec(query_ctx->enable_pipeline_exec()) {}
+              _enable_pipeline_exec(query_ctx->enable_pipeline_exec()),
+              _runtime_filter_type(get_runtime_filter_type(desc->type)),
+              _name(fmt::format("RuntimeFilter: (id = {}, type = {})", _filter_id,
+                                to_string(_runtime_filter_type))),
+              _profile(new RuntimeProfile(_name)) {}
 
     ~IRuntimeFilter() = default;
 
@@ -362,8 +391,6 @@ protected:
     // _wrapper is a runtime filter function wrapper
     // _wrapper should alloc from _pool
     RuntimePredicateWrapper* _wrapper;
-    // runtime filter type
-    RuntimeFilterType _runtime_filter_type;
     // runtime filter id
     int _filter_id;
     // Specific types BoardCast or Shuffle
@@ -399,18 +426,18 @@ protected:
 
     std::shared_ptr<RPCContext> _rpc_context;
 
-    // parent profile
-    // only effect on consumer
-    std::unique_ptr<RuntimeProfile> _profile;
-
     /// Time in ms (from MonotonicMillis()), that the filter was registered.
     const int64_t registration_time_;
 
     const bool _enable_pipeline_exec;
 
-    bool _profile_init = false;
-    std::mutex _profile_mutex;
+    std::atomic<bool> _profile_init = false;
+    // runtime filter type
+    RuntimeFilterType _runtime_filter_type;
     std::string _name;
+    // parent profile
+    // only effect on consumer
+    std::unique_ptr<RuntimeProfile> _profile;
     bool _opt_remote_rf;
 };
 

--- a/be/src/runtime/runtime_filter_mgr.cpp
+++ b/be/src/runtime/runtime_filter_mgr.cpp
@@ -218,8 +218,8 @@ Status RuntimeFilterMergeControllerEntity::_init_with_desc(
     cntVal->runtime_filter_desc = *runtime_filter_desc;
     cntVal->target_info = *target_info;
     cntVal->pool.reset(new ObjectPool());
-    cntVal->filter =
-            cntVal->pool->add(new IRuntimeFilter(_state, &_state->get_query_ctx()->obj_pool));
+    cntVal->filter = cntVal->pool->add(
+            new IRuntimeFilter(_state, &_state->get_query_ctx()->obj_pool, runtime_filter_desc));
 
     auto filter_id = runtime_filter_desc->filter_id;
     // LOG(INFO) << "entity filter id:" << filter_id;
@@ -240,8 +240,8 @@ Status RuntimeFilterMergeControllerEntity::_init_with_desc(
     cntVal->runtime_filter_desc = *runtime_filter_desc;
     cntVal->targetv2_info = *targetv2_info;
     cntVal->pool.reset(new ObjectPool());
-    cntVal->filter =
-            cntVal->pool->add(new IRuntimeFilter(_state, &_state->get_query_ctx()->obj_pool));
+    cntVal->filter = cntVal->pool->add(
+            new IRuntimeFilter(_state, &_state->get_query_ctx()->obj_pool, runtime_filter_desc));
 
     auto filter_id = runtime_filter_desc->filter_id;
     // LOG(INFO) << "entity filter id:" << filter_id;


### PR DESCRIPTION
## Proposed changes

*** Current BE git commitID: eea0a33 ***
15:31:00   *** SIGSEGV address not mapped to object (@0x1f0) received by PID 30487 (TID 30812 OR 0x7ff5bf110700) from PID 496; stack trace: ***
15:31:00    0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:413
15:31:00    1# os::Linux::chained_handler(int, siginfo*, void*) in /usr/local/software/jdk1.8.0_131/jre/lib/amd64/server/libjvm.so
15:31:00    2# JVM_handle_linux_signal in /usr/local/software/jdk1.8.0_131/jre/lib/amd64/server/libjvm.so
15:31:00    3# signalHandler(int, siginfo*, void*) in /usr/local/software/jdk1.8.0_131/jre/lib/amd64/server/libjvm.so
15:31:00    4# 0x00007FF79D7A3090 in /lib/x86_64-linux-gnu/libc.so.6
15:31:00    5# __pthread_mutex_lock at ../nptl/pthread_mutex_lock.c:67
15:31:00    6# pthread_mutex_lock in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P1/Cluster0/be/lib/doris_be
15:31:00    7# doris::RuntimeProfile::add_info_string(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at /root/doris/be/src/util/runtime_profile.cpp:340
15:31:00    8# doris::IRuntimeFilter::signal() at /root/doris/be/src/exprs/runtime_filter.cpp:1278
15:31:00    9# doris::IRuntimeFilter::publish() at /root/doris/be/src/exprs/runtime_filter.cpp:1140
15:31:00   10# doris::VRuntimeFilterSlots::publish() at /root/doris/be/src/exprs/runtime_filter_slots.h:223
15:31:00   11# doris::vectorized::ProcessRuntimeFilterBuild<doris::vectorized::PrimaryTypeHashTableContext<unsigned int, doris::vectorized::RowRefList> >::operator()(doris::RuntimeState*, doris::vectorized::PrimaryTypeHashTableContext<unsigned int, doris::vectorized::RowRefList>&) in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P1/Cluster0/be/lib/doris_be
15:31:00   12# _ZNSt8__detail9__variant17__gen_vtable_implINS0_12_Multi_arrayIPFNS0_21__deduce_visit_resultIN5doris6StatusEEEONS4_8pipeline8OverloadIJZNS7_26HashJoinBuildSinkOperatorX4sinkEPNS4_12RuntimeStateEPNS4_10vectorized5BlockENS7_11SourceStateEE3$_0ZNS9_4sinkESB_SE_SF_E3$_1EEERSt7variantIJSt9monostateNSC_26SerializedHashTableContextINSC_10RowRefListEEENSC_27PrimaryTypeHashTableContextIhSN_EENSP_ItSN_EENSP_IjSN_EENSP_ImSN_EENSP_INSC_7UInt128ESN_EENSP_INSC_7UInt256ESN_EENSC_24FixedKeyHashTableContextImLb1ESN_EENSY_ImLb0ESN_EENSY_ISU_Lb1ESN_EENSY_ISU_Lb0ESN_EENSY_ISW_Lb1ESN_EENSY_ISW_Lb0ESN_EENSM_INSC_18RowRefListWithFlagEEENSP_IhS15_EENSP_ItS15_EENSP_IjS15_EENSP_ImS15_EENSP_ISU_S15_EENSP_ISW_S15_EENSY_ImLb1ES15_EENSY_ImLb0ES15_EENSY_ISU_Lb1ES15_EENSY_ISU_Lb0ES15_EENSY_ISW_Lb1ES15_EENSY_ISW_Lb0ES15_EENSM_INSC_19RowRefListWithFlagsEEENSP_IhS1J_EENSP_ItS1J_EENSP_IjS1J_EENSP_ImS1J_EENSP_ISU_S1J_EENSP_ISW_S1J_EENSY_ImLb1ES1J_EENSY_ImLb0ES1J_EENSY_ISU_Lb1ES1J_EENSY_ISU_Lb0ES1J_EENSY_ISW_Lb1ES1J_EENSY_ISW_Lb0ES1J_EEEEEJEEESt16integer_sequenceImJLm4EEEE14__visit_invokeESJ_S1Y_ at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1013
15:31:00   13# doris::pipeline::HashJoinBuildSinkOperatorX::sink(doris::RuntimeState*, doris::vectorized::Block*, doris::pipeline::SourceState) at /root/doris/be/src/pipeline/exec/hashjoin_build_sink.cpp:497
15:31:00   14# doris::pipeline::PipelineXTask::execute(bool*) at /root/doris/be/src/pipeline/pipeline_x/pipeline_x_task.cpp:198
15:31:00   15# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /root/doris/be/src/pipeline/task_scheduler.cpp:265
15:31:00   16# doris::ThreadPool::dispatch_thread() at /root/doris/be/src/util/threadpool.cpp:539
15:31:00   17# doris::Thread::supervise_thread(void*) at /root/doris/be/src/util/thread.cpp:466
15:31:00   18# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
15:31:00   19# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

