### PR TITLE
[fix](Nereids) remove PARTITIONS from non-reserved list

### DIFF
--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -789,7 +789,6 @@ nonReserved
     | OPTIMIZED
     | PARAMETER
     | PARSED
-    | PARTITIONS
     | PASSWORD
     | PASSWORD_EXPIRE
     | PASSWORD_HISTORY


### PR DESCRIPTION
according to PR #24053, it removed partitions from non-reserved list in legacy planner's parser. For consistency, remove it from Nereids' parser too.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

