### PR TITLE
[fix](jdbc catalog) fix jdbc catalog creating json columns when reading json data

### DIFF
--- a/be/src/vec/exec/vjdbc_connector.cpp
+++ b/be/src/vec/exec/vjdbc_connector.cpp
@@ -958,7 +958,7 @@ Status JdbcConnector::_cast_string_to_json(const SlotDescriptor* slot_desc, Bloc
     DataTypePtr _target_data_type = slot_desc->get_data_type_ptr();
     std::string _target_data_type_name = _target_data_type->get_name();
     DataTypePtr _cast_param_data_type = _target_data_type;
-    ColumnPtr _cast_param = _cast_param_data_type->create_column_const_with_default_value(1);
+    ColumnPtr _cast_param = _cast_param_data_type->create_column_const(1, "{}");
 
     ColumnsWithTypeAndName argument_template;
     argument_template.reserve(2);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

```
*** Aborted at 1694172481 (unix time) try "date -d @1694172481" if you are using GNU date ***
*** Current BE git commitID: 30d35c4140 ***
*** SIGABRT unknown detail explain (@0x34a0) received by PID 13472 (TID 13914 OR 0x7fc381f39700) from PID 13472; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk1/zyk/compile/doris-2.0/be/src/common/signal_handler.h:413
 1# 0x00007FC4900E2400 in /lib64/libc.so.6
 2# gsignal in /lib64/libc.so.6
 3# abort in /lib64/libc.so.6
 4# __gnu_cxx::__verbose_terminate_handler() [clone .cold] at ../../../../libstdc++-v3/libsupc++/vterminate.cc:75
 5# __cxxabiv1::__terminate(void (*)()) at ../../../../libstdc++-v3/libsupc++/eh_terminate.cc:48
 6# 0x0000561A0F81DF71 in /root/apache-doris-2.0.1-bin-x64/be/lib/doris_be
 7# 0x0000561A0F81E0C4 in /root/apache-doris-2.0.1-bin-x64/be/lib/doris_be
 8# doris::vectorized::ColumnString::insert(doris::vectorized::Field const&) at /mnt/disk1/zyk/compile/doris-2.0/be/src/vec/columns/column_string.h:152
 9# doris::vectorized::IDataType::create_column_const(unsigned long, doris::vectorized::Field const&) const at /mnt/disk1/zyk/compile/doris-2.0/be/src/vec/data_types/data_type.cpp:75
10# doris::vectorized::IDataType::create_column_const_with_default_value(unsigned long) const in /root/apache-doris-2.0.1-bin-x64/be/lib/doris_be
11# doris::vectorized::JdbcConnector::_cast_string_to_json(doris::SlotDescriptor const*, doris::vectorized::Block*, int, int) at /mnt/disk1/zyk/compile/doris-2.0/be/src/vec/exec/vjdbc_connector.cpp:870
12# doris::vectorized::JdbcConnector::get_next(bool*, std::vector<COW<doris::vectorized::IColumn>::mutable_ptr<doris::vectorized::IColumn>, std::allocator<COW<doris::vectorized::IColumn>::mutable_ptr<doris::vectorized::IColumn> > >&, doris::vectorized::Block*, int) at /mnt/disk1/zyk/compile/doris-2.0/be/src/vec/exec/vjdbc_connector.cpp:467
13# doris::vectorized::NewJdbcScanner::_get_block_impl(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /mnt/disk1/zyk/compile/doris-2.0/be/src/vec/exec/scan/new_jdbc_scanner.cpp:156
14# doris::vectorized::VScanner::get_block(doris::RuntimeState*, doris::vectorized::Block*, bool*) in /root/apache-doris-2.0.1-bin-x64/be/lib/doris_be
15# doris::vectorized::ScannerScheduler::_scanner_scan(doris::vectorized::ScannerScheduler*, doris::vectorized::ScannerContext*, std::shared_ptr<doris::vectorized::VScanner>) at /mnt/disk1/zyk/compile/doris-2.0/be/src/vec/exec/scan/scanner_scheduler.cpp:339
16# std::_Function_handler<void (), doris::vectorized::ScannerScheduler::_schedule_scanners(doris::vectorized::ScannerContext*)::$_1::operator()() const::{lambda()#3}>::_M_invoke(std::_Any_data const&) at /mnt/disk1/zyk/software/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
17# doris::ThreadPool::dispatch_thread() in /root/apache-doris-2.0.1-bin-x64/be/lib/doris_be
18# doris::Thread::supervise_thread(void*) at /mnt/disk1/zyk/compile/doris-2.0/be/src/util/thread.cpp:466
19# start_thread in /lib64/libpthread.so.0
20# clone in /lib64/libc.so.6
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

