### PR TITLE
[bugfix](insert into) should not send profile during report process

### DIFF
--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -850,8 +850,9 @@ void PipelineFragmentContext::send_report(bool done) {
     }
 
     _report_status_cb(
-            {exec_status, _is_report_success ? _runtime_state->runtime_profile() : nullptr,
-             _is_report_success ? _runtime_state->load_channel_profile() : nullptr,
+            {exec_status,
+             _runtime_state->enable_profile() ? _runtime_state->runtime_profile() : nullptr,
+             _runtime_state->enable_profile() ? _runtime_state->load_channel_profile() : nullptr,
              done || !exec_status.ok(), _query_ctx->coord_addr, _query_id, _fragment_id,
              _fragment_instance_id, _backend_num, _runtime_state.get(),
              std::bind(&PipelineFragmentContext::update_status, this, std::placeholders::_1),

--- a/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
@@ -749,8 +749,10 @@ void PipelineXFragmentContext::send_report(bool done) {
     // TODO: only send rpc once
     FOR_EACH_RUNTIME_STATE(
             _report_status_cb(
-                    {exec_status, _is_report_success ? _runtime_state->runtime_profile() : nullptr,
-                     _is_report_success ? runtime_state->load_channel_profile() : nullptr,
+                    {exec_status,
+                     _runtime_state->enable_profile() ? _runtime_state->runtime_profile() : nullptr,
+                     _runtime_state->enable_profile() ? runtime_state->load_channel_profile()
+                                                      : nullptr,
                      done || !exec_status.ok(), _query_ctx->coord_addr, _query_id, _fragment_id,
                      runtime_state->fragment_instance_id(), _backend_num, runtime_state.get(),
                      std::bind(&PipelineFragmentContext::update_status, this,

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -529,8 +529,8 @@ void PlanFragmentExecutor::send_report(bool done) {
     }
     ReportStatusRequest report_req = {
             status,
-            _is_report_success ? _runtime_state->runtime_profile() : nullptr,
-            _is_report_success ? _runtime_state->load_channel_profile() : nullptr,
+            _runtime_state->enable_profile() ? _runtime_state->runtime_profile() : nullptr,
+            _runtime_state->enable_profile() ? _runtime_state->load_channel_profile() : nullptr,
             done || !status.ok(),
             _query_ctx->coord_addr,
             _query_ctx->query_id(),

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -394,7 +394,9 @@ public:
 
     void set_tracer(OpentelemetryTracer&& tracer) { _tracer = std::move(tracer); }
 
-    bool enable_profile() const { return _query_options.is_report_success; }
+    bool enable_profile() const {
+        return _query_options.__isset.enable_profile && _query_options.enable_profile;
+    }
 
     bool enable_scan_node_run_serial() const {
         return _query_options.__isset.enable_scan_node_run_serial &&

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -2181,7 +2181,13 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setBufferPoolLimit(maxExecMemByte);
 
         tResult.setQueryTimeout(queryTimeoutS);
-        tResult.setIsReportSuccess(enableProfile);
+        tResult.setEnableProfile(enableProfile);
+        if (enableProfile) {
+            // If enable profile == true, then also set report success to true
+            // be need report success to start report thread. But it is very tricky
+            // we should modify BE in the future.
+            tResult.setIsReportSuccess(true);
+        }
         tResult.setCodegenLevel(codegenLevel);
         tResult.setBeExecVersion(Config.be_exec_version);
         tResult.setEnablePipelineEngine(enablePipelineEngine);

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -242,6 +242,9 @@ struct TQueryOptions {
   82: optional i64 fe_process_uuid = 0;
 
   83: optional i32 inverted_index_conjunction_opt_threshold = 1000;
+  // A seperate flag to indicate whether to enable profile, not
+  // use is_report_success any more
+  84: optional bool enable_profile = false;
 }
 
 


### PR DESCRIPTION
## Proposed changes

Add a seperate thrift variable to indicate profile, not reuse is_report_success any more.
because insert into select will set is_report_success to true by default, it will send profile to FE and FE will OOM

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

