### PR TITLE
[branch1.2](broker)(orc) catch exception in orc reader and fix filesystem close issue in broker

### DIFF
--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -770,10 +770,14 @@ Status OrcReader::get_next_block(Block* block, size_t* read_rows, bool* eof) {
         SCOPED_RAW_TIMER(&_statistics.get_batch_time);
         // reset decimal_scale_params_index
         _decimal_scale_params_index = 0;
-        if (!_row_reader->next(*_batch)) {
-            *eof = true;
-            *read_rows = 0;
-            return Status::OK();
+        try {
+            if (!_row_reader->next(*_batch)) {
+                *eof = true;
+                *read_rows = 0;
+                return Status::OK();
+            }
+        } catch (std::exception& e) {
+            return Status::InternalError("orc read fail. reason = {}", e.what());
         }
     }
     const auto& batch_vec = down_cast<orc::StructVectorBatch*>(_batch.get())->fields;

--- a/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/BrokerFileSystem.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/BrokerFileSystem.java
@@ -55,7 +55,8 @@ public class BrokerFileSystem {
         try {
             if (this.dfsFileSystem != null) {
                 try {
-                    this.dfsFileSystem.close();
+                    // do not close file system, it will be closed automatically.
+                    // this.dfsFileSystem.close();
                 } catch (Exception e) {
                     logger.error("errors while close file system", e);
                 } finally {


### PR DESCRIPTION
## Proposed changes

1. catch exception in orc reader, to avoid BE crash
2. Do not close filesystem in Broker, it is unnecessary and will return error and causing BE crash 

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

