### PR TITLE
fix: no need to compress further when using bitshuffle encode

### DIFF
--- a/be/src/olap/rowset/segment_v2/bitshuffle_page.h
+++ b/be/src/olap/rowset/segment_v2/bitshuffle_page.h
@@ -194,14 +194,11 @@ private:
             _data.push_back(0);
         }
 
-        // reserve enough place for compression
-        _buffer.resize(
-                BITSHUFFLE_PAGE_HEADER_SIZE +
-                bitshuffle::compress_lz4_bound(num_elems_after_padding, final_size_of_type, 0));
+        // reserve enough place for bitshuffle output
+        _buffer.resize(BITSHUFFLE_PAGE_HEADER_SIZE + _data.size());
 
-        int64_t bytes =
-                bitshuffle::compress_lz4(_data.data(), &_buffer[BITSHUFFLE_PAGE_HEADER_SIZE],
-                                         num_elems_after_padding, final_size_of_type, 0);
+        int64_t bytes = bitshuffle::bitshuffle(_data.data(), &_buffer[BITSHUFFLE_PAGE_HEADER_SIZE],
+                                               num_elems_after_padding, final_size_of_type, 0);
         if (PREDICT_FALSE(bytes < 0)) {
             // This means the bitshuffle function fails.
             // Ideally, this should not happen.

--- a/be/src/olap/rowset/segment_v2/bitshuffle_page_pre_decoder.h
+++ b/be/src/olap/rowset/segment_v2/bitshuffle_page_pre_decoder.h
@@ -20,6 +20,7 @@
 #include "olap/page_cache.h"
 #include "olap/rowset/segment_v2/binary_dict_page.h"
 #include "olap/rowset/segment_v2/bitshuffle_page.h"
+#include "olap/rowset/segment_v2/bitshuffle_wrapper.h"
 #include "olap/rowset/segment_v2/encoding_info.h"
 
 namespace doris {
@@ -75,7 +76,7 @@ struct BitShufflePagePreDecoder : public DataPagePreDecoder {
 
         memcpy(decoded_slice.data + size_of_dict_header, data.data, BITSHUFFLE_PAGE_HEADER_SIZE);
 
-        auto bytes = bitshuffle::decompress_lz4(
+        auto bytes = bitshuffle::bitunshuffle(
                 &data.data[BITSHUFFLE_PAGE_HEADER_SIZE],
                 decoded_slice.data + BITSHUFFLE_PAGE_HEADER_SIZE + size_of_dict_header,
                 num_element_after_padding, size_of_element, 0);

--- a/be/src/olap/rowset/segment_v2/bitshuffle_wrapper.cpp
+++ b/be/src/olap/rowset/segment_v2/bitshuffle_wrapper.cpp
@@ -95,5 +95,15 @@ size_t compress_lz4_bound(size_t size, size_t elem_size, size_t block_size) {
     return g_bshuf_compress_lz4_bound(size, elem_size, block_size);
 }
 
+int64_t bitshuffle(const void* in, void* out, const size_t size, const size_t elem_size,
+                   size_t block_size) {
+    return bshuf_bitshuffle(in, out, size, elem_size, block_size);
+}
+
+int64_t bitunshuffle(const void* in, void* out, const size_t size, const size_t elem_size,
+                     size_t block_size) {
+    return bshuf_bitunshuffle(in, out, size, elem_size, block_size);
+}
+
 } // namespace bitshuffle
 } // namespace doris

--- a/be/src/olap/rowset/segment_v2/bitshuffle_wrapper.h
+++ b/be/src/olap/rowset/segment_v2/bitshuffle_wrapper.h
@@ -29,6 +29,11 @@ namespace bitshuffle {
 size_t compress_lz4_bound(size_t size, size_t elem_size, size_t block_size);
 int64_t compress_lz4(void* in, void* out, size_t size, size_t elem_size, size_t block_size);
 int64_t decompress_lz4(void* in, void* out, size_t size, size_t elem_size, size_t block_size);
+// See <bitshuffle_core.h> for documentation on these functions.
+int64_t bitshuffle(const void* in, void* out, const size_t size, const size_t elem_size,
+                   size_t block_size);
+int64_t bitunshuffle(const void* in, void* out, const size_t size, const size_t elem_size,
+                     size_t block_size);
 
 } // namespace bitshuffle
 } // namespace doris

--- a/be/src/olap/rowset/segment_v2/column_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/column_writer.cpp
@@ -708,6 +708,7 @@ Status ScalarColumnWriter::finish_current_page() {
     data_page_footer->set_first_ordinal(_first_rowid);
     data_page_footer->set_num_values(_next_rowid - _first_rowid);
     data_page_footer->set_nullmap_size(nullmap.slice().size);
+    data_page_footer->set_is_bitshuffle_not_compressed(true);
     if (_new_page_callback != nullptr) {
         _new_page_callback->put_extra_info_in_page(data_page_footer);
     }

--- a/be/src/olap/rowset/segment_v2/encoding_info.h
+++ b/be/src/olap/rowset/segment_v2/encoding_info.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <gen_cpp/segment_v2.pb.h>
 #include <stddef.h>
 
 #include <functional>
@@ -42,8 +43,8 @@ enum EncodingTypePB : int;
 // For better performance, some encodings (like BitShuffle) need to be decoded before being added to the PageCache.
 class DataPagePreDecoder {
 public:
-    virtual Status decode(std::unique_ptr<DataPage>* page, Slice* page_slice,
-                          size_t size_of_tail) = 0;
+    virtual Status decode(std::unique_ptr<DataPage>* page, Slice* page_slice, size_t size_of_tail,
+                          const DataPageFooterPB& footer) = 0;
     virtual ~DataPagePreDecoder() = default;
 };
 

--- a/be/src/olap/rowset/segment_v2/page_io.cpp
+++ b/be/src/olap/rowset/segment_v2/page_io.cpp
@@ -205,7 +205,7 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
         if (pre_decoder) {
             RETURN_IF_ERROR(pre_decoder->decode(
                     &page, &page_slice,
-                    footer->data_page_footer().nullmap_size() + footer_size + 4));
+                    footer->data_page_footer().nullmap_size() + footer_size + 4, footer->data_page_footer()));
         }
     }
 

--- a/be/src/olap/rowset/segment_v2/page_io.cpp
+++ b/be/src/olap/rowset/segment_v2/page_io.cpp
@@ -204,8 +204,8 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
         auto* pre_decoder = opts.encoding_info->get_data_page_pre_decoder();
         if (pre_decoder) {
             RETURN_IF_ERROR(pre_decoder->decode(
-                    &page, &page_slice,
-                    footer->data_page_footer().nullmap_size() + footer_size + 4, footer->data_page_footer()));
+                    &page, &page_slice, footer->data_page_footer().nullmap_size() + footer_size + 4,
+                    footer->data_page_footer()));
         }
     }
 

--- a/gensrc/proto/segment_v2.proto
+++ b/gensrc/proto/segment_v2.proto
@@ -73,6 +73,7 @@ message DataPageFooterPB {
     // only for array column
     // Save the offset of next page 
     optional uint64 next_array_item_ordinal = 4;
+    optional bool is_bitshuffle_not_compressed = 5 [default = false];
 }
 
 message IndexPageFooterPB {


### PR DESCRIPTION
## Proposed changes

As title

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

