### PR TITLE
[doc](thirdparty) correct the full path of build-thirdparty.sh

### DIFF
--- a/docs/en/docs/install/source-install/compilation-general.md
+++ b/docs/en/docs/install/source-install/compilation-general.md
@@ -249,7 +249,7 @@ You can compile Doris directly in your own Linux environment.
 
          ```
          export REPOSITORY_URL=https://doris-thirdparty-repo.bj.bcebos.com/thirdparty
-         sh build-thirdparty.sh
+         sh thirdparty/build-thirdparty.sh
          ```
 
          REPOSITORY_URL contains all third-party library source code packages and their historical versions.

--- a/docs/zh-CN/docs/install/source-install/compilation-general.md
+++ b/docs/zh-CN/docs/install/source-install/compilation-general.md
@@ -241,7 +241,7 @@ under the License.
 
         ```
         export REPOSITORY_URL=https://doris-thirdparty-repo.bj.bcebos.com/thirdparty
-        sh build-thirdparty.sh
+        sh thirdparty/build-thirdparty.sh
         ```
 
        REPOSITORY_URL 中包含所有第三方库源码包和他们的历史版本。


### PR DESCRIPTION
## Proposed changes

Correct the full path of build-thirdparty.sh in docs: `thirdparty/build-thirdparty.sh`.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

