### PR TITLE
[fix](nereids)some nodes missing stats in physical plan

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RecomputeLogicalPropertiesProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RecomputeLogicalPropertiesProcessor.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.processor.post;
 
 import org.apache.doris.nereids.CascadesContext;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
 import org.apache.doris.nereids.util.MutableState;
@@ -30,6 +31,8 @@ public class RecomputeLogicalPropertiesProcessor extends PlanPostProcessor {
     public Plan visit(Plan plan, CascadesContext ctx) {
         PhysicalPlan physicalPlan = (PhysicalPlan) visitChildren(this, plan, ctx);
         physicalPlan = physicalPlan.resetLogicalProperties();
+        physicalPlan = physicalPlan.withPhysicalPropertiesAndStats(physicalPlan.getPhysicalProperties(),
+                ((AbstractPlan) plan).getStats());
         physicalPlan.setMutableState(MutableState.KEY_GROUP, plan.getGroupIdAsString());
         return physicalPlan;
     }


### PR DESCRIPTION
## Proposed changes
Postprocessor RecomputeLogicalPropertiesProcessor clears some stats in physical plan. This blocks runtime filter prune

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

