### PR TITLE
[fix](join) avoid DCHECK failed in '_filter_data_and_build_output'

### DIFF
--- a/be/src/vec/exec/join/vhash_join_node.cpp
+++ b/be/src/vec/exec/join/vhash_join_node.cpp
@@ -524,7 +524,11 @@ Status HashJoinNode::pull(doris::RuntimeState* state, vectorized::Block* output_
                     ->get_data()
                     .resize_fill(block_rows, 1);
         }
-        RETURN_IF_ERROR(_filter_data_and_build_output(state, output_block, eos, &temp_block));
+
+        /// No need to check the block size in `_filter_data_and_build_output` because here dose not
+        /// increase the output rows count(just same as `_probe_block`'s rows count).
+        RETURN_IF_ERROR(
+                _filter_data_and_build_output(state, output_block, eos, &temp_block, false));
         temp_block.clear();
         release_block_memory(_probe_block);
         return Status::OK();
@@ -612,12 +616,14 @@ Status HashJoinNode::pull(doris::RuntimeState* state, vectorized::Block* output_
 
 Status HashJoinNode::_filter_data_and_build_output(RuntimeState* state,
                                                    vectorized::Block* output_block, bool* eos,
-                                                   Block* temp_block) {
+                                                   Block* temp_block, bool check_rows_count) {
     if (_is_outer_join) {
         _add_tuple_is_null_column(temp_block);
     }
     auto output_rows = temp_block->rows();
-    DCHECK(output_rows <= state->batch_size());
+    if (check_rows_count) { // If the join node does not increase the number of output rows, no need to check.
+        DCHECK(output_rows <= state->batch_size());
+    }
     {
         SCOPED_TIMER(_join_filter_timer);
         RETURN_IF_ERROR(VExprContext::filter_block(_conjuncts, temp_block, temp_block->columns()));

--- a/be/src/vec/exec/join/vhash_join_node.h
+++ b/be/src/vec/exec/join/vhash_join_node.h
@@ -703,7 +703,8 @@ private:
     void _add_tuple_is_null_column(Block* block) override;
 
     Status _filter_data_and_build_output(RuntimeState* state, vectorized::Block* output_block,
-                                         bool* eos, Block* temp_block);
+                                         bool* eos, Block* temp_block,
+                                         bool check_rows_count = true);
 
     template <class HashTableContext>
     friend struct ProcessHashTableBuild;


### PR DESCRIPTION
## Proposed changes

```
Check failure stack trace: ***
F20230910 13:58:28.553936  8958 vhash_join_node.cpp:620] Check failed: output_rows <= state->batch_size()
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

