### PR TITLE
[Enhancement](Nereids)support skip prune default partition for Nereids

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/HiveDefaultPartitionEvaluator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/HiveDefaultPartitionEvaluator.java
@@ -60,4 +60,9 @@ public class HiveDefaultPartitionEvaluator implements OnePartitionEvaluator {
     public Expression evaluate(Expression expression, Map<Slot, PartitionSlotInput> currentInputs) {
         return BooleanLiteral.TRUE;
     }
+
+    @Override
+    public boolean isDefaultPartition() {
+        return true;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/OneListPartitionEvaluator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/OneListPartitionEvaluator.java
@@ -98,4 +98,9 @@ public class OneListPartitionEvaluator
     public Expression evaluate(Expression expression, Map<Slot, PartitionSlotInput> currentInputs) {
         return expression.accept(this, currentInputs);
     }
+
+    @Override
+    public boolean isDefaultPartition() {
+        return partitionItem.isDefaultPartition();
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/OnePartitionEvaluator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/OnePartitionEvaluator.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids.rules.expression.rules;
 
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
 
 import java.util.List;
 import java.util.Map;
@@ -45,6 +46,13 @@ public interface OnePartitionEvaluator {
      * we will return a context which result expression is BooleanLiteral.FALSE
      */
     Expression evaluate(Expression expression, Map<Slot, PartitionSlotInput> currentInputs);
+
+    default Expression evaluateWithDefaultPartition(Expression expression, Map<Slot, PartitionSlotInput> inputs) {
+        if (isDefaultPartition()) {
+            return BooleanLiteral.TRUE;
+        }
+        return evaluate(expression, inputs);
+    }
 
     boolean isDefaultPartition();
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/OnePartitionEvaluator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/OnePartitionEvaluator.java
@@ -45,4 +45,6 @@ public interface OnePartitionEvaluator {
      * we will return a context which result expression is BooleanLiteral.FALSE
      */
     Expression evaluate(Expression expression, Map<Slot, PartitionSlotInput> currentInputs);
+
+    boolean isDefaultPartition();
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/OneRangePartitionEvaluator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/OneRangePartitionEvaluator.java
@@ -665,4 +665,9 @@ public class OneRangePartitionEvaluator
             this.childrenResult = childrenResult;
         }
     }
+
+    @Override
+    public boolean isDefaultPartition() {
+        return partitionItem.isDefaultPartition();
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/PartitionPruner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/PartitionPruner.java
@@ -109,12 +109,9 @@ public class PartitionPruner {
     }
 
     private boolean canPrune(OnePartitionEvaluator evaluator) {
-        if (evaluator.isDefaultPartition()) {
-            return false;
-        }
         List<Map<Slot, PartitionSlotInput>> onePartitionInputs = evaluator.getOnePartitionInputs();
         for (Map<Slot, PartitionSlotInput> currentInputs : onePartitionInputs) {
-            Expression result = evaluator.evaluate(partitionPredicate, currentInputs);
+            Expression result = evaluator.evaluateWithDefaultPartition(partitionPredicate, currentInputs);
             if (!result.equals(BooleanLiteral.FALSE)) {
                 return false;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/UnknownPartitionEvaluator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/UnknownPartitionEvaluator.java
@@ -52,4 +52,9 @@ public class UnknownPartitionEvaluator implements OnePartitionEvaluator {
         // do not prune
         return expression;
     }
+
+    @Override
+    public boolean isDefaultPartition() {
+        return partitionItem.isDefaultPartition();
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PruneOlapScanPartition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PruneOlapScanPartition.java
@@ -70,13 +70,6 @@ public class PruneOlapScanPartition extends OneRewriteRuleFactory {
             List<Long> prunedPartitions = new ArrayList<>(PartitionPruner.prune(
                     partitionSlots, filter.getPredicate(), partitionInfo, ctx.cascadesContext,
                     PartitionTableType.OLAP));
-            // if prunedPartitions is empty, we select the default partition if exists.
-            prunedPartitions.addAll(
-                    Streams.concat(
-                            partitionInfo.getIdToItem(true).entrySet().stream(),
-                            partitionInfo.getIdToItem(false).entrySet().stream())
-                            .filter(p -> p.getValue().isDefaultPartition())
-                            .map(Entry::getKey).collect(Collectors.toList()));
 
             List<Long> manuallySpecifiedPartitions = scan.getManuallySpecifiedPartitions();
             if (!CollectionUtils.isEmpty(manuallySpecifiedPartitions)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PruneOlapScanPartition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PruneOlapScanPartition.java
@@ -29,13 +29,11 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
 import org.apache.doris.nereids.util.Utils;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Streams;
 import org.apache.commons.collections.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PruneOlapScanPartitionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PruneOlapScanPartitionTest.java
@@ -213,6 +213,9 @@ class PruneOlapScanPartitionTest extends TestWithFeService implements MemoPatter
                 + "            PARTITION p3 ) \n"
                 + "        DISTRIBUTED BY HASH(k1) BUCKETS 5 properties(\"replication_num\" = \"1\")");
         test("test_default_parts", "k1 = 10", 1);
+        test("test_default_parts", "k1 > 5", 2);
+        test("test_default_parts", "k1 > 2", 3);
+        test("test_default_parts", "(k1 > 1 and k1 < 8)", 2);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PruneOlapScanPartitionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PruneOlapScanPartitionTest.java
@@ -197,6 +197,25 @@ class PruneOlapScanPartitionTest extends TestWithFeService implements MemoPatter
     }
 
     @Test
+    public void prunePartitionWithDefaultPartition() throws Exception {
+        createTable("CREATE TABLE IF NOT EXISTS test_default_parts ( \n"
+                + "            k1 tinyint NOT NULL, \n"
+                + "            k2 smallint NOT NULL, \n"
+                + "            k3 int NOT NULL, \n"
+                + "            k4 bigint NOT NULL, \n"
+                + "            k5 decimal(9, 3) NOT NULL,\n"
+                + "            k8 double max NOT NULL, \n"
+                + "            k9 float sum NOT NULL ) \n"
+                + "        AGGREGATE KEY(k1,k2,k3,k4,k5)\n"
+                + "        PARTITION BY LIST(k1) ( \n"
+                + "            PARTITION p1 VALUES IN (\"1\",\"2\",\"3\",\"4\"), \n"
+                + "            PARTITION p2 VALUES IN (\"5\",\"6\",\"7\",\"8\"), \n"
+                + "            PARTITION p3 ) \n"
+                + "        DISTRIBUTED BY HASH(k1) BUCKETS 5 properties(\"replication_num\" = \"1\")");
+        test("test_default_parts", "k1 = 10", 1);
+    }
+
+    @Test
     public void prunePartitionWithOrPredicate() {
         test("test_list_parts", "(part = 9 and id <= 500) or (part = 3)", 1);
         test("test_range_parts", "(part = 1 and id <= 500) or (part = 3)", 2);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PruneOlapScanPartitionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PruneOlapScanPartitionTest.java
@@ -198,7 +198,7 @@ class PruneOlapScanPartitionTest extends TestWithFeService implements MemoPatter
 
     @Test
     public void prunePartitionWithDefaultPartition() throws Exception {
-        createTable("CREATE TABLE IF NOT EXISTS test_default_parts ( \n"
+        createTable("CREATE TABLE IF NOT EXISTS test_default_in_parts (\n"
                 + "            k1 tinyint NOT NULL, \n"
                 + "            k2 smallint NOT NULL, \n"
                 + "            k3 int NOT NULL, \n"
@@ -212,10 +212,10 @@ class PruneOlapScanPartitionTest extends TestWithFeService implements MemoPatter
                 + "            PARTITION p2 VALUES IN (\"5\",\"6\",\"7\",\"8\"), \n"
                 + "            PARTITION p3 ) \n"
                 + "        DISTRIBUTED BY HASH(k1) BUCKETS 5 properties(\"replication_num\" = \"1\")");
-        test("test_default_parts", "k1 = 10", 1);
-        test("test_default_parts", "k1 > 5", 2);
-        test("test_default_parts", "k1 > 2", 3);
-        test("test_default_parts", "(k1 > 1 and k1 < 8)", 2);
+        test("test_default_in_parts", "k1 = 10", 1);
+        test("test_default_in_parts", "k1 > 5", 2);
+        test("test_default_in_parts", "k1 > 2", 3);
+        test("test_default_in_parts", "(k1 > 1 and k1 < 8)", 3);
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

```sql
CREATE TABLE IF NOT EXISTS t ( 
            k1 tinyint NOT NULL, 
            k2 smallint NOT NULL, 
            k3 int NOT NULL, 
            k4 bigint NOT NULL, 
            k5 decimal(9, 3) NOT NULL,
            k8 double max NOT NULL, 
            k9 float sum NOT NULL ) 
        AGGREGATE KEY(k1,k2,k3,k4,k5)
        PARTITION BY LIST(k1) ( 
            PARTITION p1 VALUES IN ("1","2","3","4"), 
            PARTITION p2 VALUES IN ("5","6","7","8"), 
            PARTITION p3 ) 
        DISTRIBUTED BY HASH(k1) BUCKETS 5 properties("replication_num" = "1")

select * from t where k1=10
```
The query will return 0 rows because p3 is pruned, we fix it by skip prune default partitions.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

