### PR TITLE
[Fix](merge-on-write) Check the returned filtered rows from different replicas

### DIFF
--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -281,8 +281,8 @@ public:
         _num_rows_load_unselected.fetch_add(num_rows);
     }
 
-    void update_num_rows_filtered_in_strict_mode_partial_update(int64_t num_rows) {
-        _num_rows_filtered_in_strict_mode_partial_update += num_rows;
+    void set_num_rows_filtered_in_strict_mode_partial_update(int64_t num_rows) {
+        _num_rows_filtered_in_strict_mode_partial_update = num_rows;
     }
 
     void set_per_fragment_instance_idx(int idx) { _per_fragment_instance_idx = idx; }

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -47,6 +47,7 @@
 #include <iterator>
 #include <memory>
 #include <mutex>
+#include <numeric>
 #include <sstream>
 #include <string>
 #include <type_traits>
@@ -165,9 +166,20 @@ public:
 
     void set_tablets_received_rows(
             const std::vector<std::pair<int64_t, int64_t>>& tablets_received_rows, int64_t node_id);
+    void set_tablets_filtered_rows(
+            const std::vector<std::pair<int64_t, int64_t>>& tablets_filtered_rows, int64_t node_id);
+    int64_t num_rows_filtered() {
+        CHECK(!_tablets_filtered_rows.empty());
+        // the Unique table has no roll up or materilized view
+        // we just add up filtered rows from all partitions
+        return std::accumulate(_tablets_filtered_rows.cbegin(), _tablets_filtered_rows.cend(), 0,
+                               [](int64_t sum, const auto& a) { return sum + a.second[0].second; });
+    }
 
     // check whether the rows num written by different replicas is consistent
     Status check_tablet_received_rows_consistency();
+    // check whether the rows num filtered by different replicas is consistent
+    Status check_tablet_filtered_rows_consistency();
 
     vectorized::VExprContextSPtr get_where_clause() { return _where_clause; }
 
@@ -203,6 +215,9 @@ private:
     // rows num received by DeltaWriter per tablet, tablet_id -> <node_Id, rows_num>
     // used to verify whether the rows num received by different replicas is consistent
     std::map<int64_t, std::vector<std::pair<int64_t, int64_t>>> _tablets_received_rows;
+    // rows num filtered by DeltaWriter per tablet, tablet_id -> <node_Id, filtered_rows_num>
+    // used to verify whether the rows num filtered by different replicas is consistent
+    std::map<int64_t, std::vector<std::pair<int64_t, int64_t>>> _tablets_filtered_rows;
 };
 
 Status IndexChannel::init(RuntimeState* state, const std::vector<TTabletWithPartition>& tablets) {
@@ -308,6 +323,13 @@ void IndexChannel::set_tablets_received_rows(
     }
 }
 
+void IndexChannel::set_tablets_filtered_rows(
+        const std::vector<std::pair<int64_t, int64_t>>& tablets_filtered_rows, int64_t node_id) {
+    for (const auto& [tablet_id, rows_num] : tablets_filtered_rows) {
+        _tablets_filtered_rows[tablet_id].emplace_back(node_id, rows_num);
+    }
+}
+
 Status IndexChannel::check_tablet_received_rows_consistency() {
     for (auto& tablet : _tablets_received_rows) {
         for (size_t i = 0; i < tablet.second.size(); i++) {
@@ -322,6 +344,30 @@ Status IndexChannel::check_tablet_received_rows_consistency() {
             if (tablet.second[i].second != tablet.second[0].second) {
                 return Status::InternalError(
                         "rows num written by multi replicas doest't match, load_id={}, txn_id={}, "
+                        "tablt_id={}, node_id={}, rows_num={}, node_id={}, rows_num={}",
+                        print_id(_parent->_load_id), _parent->_txn_id, tablet.first,
+                        tablet.second[i].first, tablet.second[i].second, tablet.second[0].first,
+                        tablet.second[0].second);
+            }
+        }
+    }
+    return Status::OK();
+}
+
+Status IndexChannel::check_tablet_filtered_rows_consistency() {
+    for (auto& tablet : _tablets_filtered_rows) {
+        for (size_t i = 0; i < tablet.second.size(); i++) {
+            VLOG_NOTICE << "check_tablet_filtered_rows_consistency, load_id: " << _parent->_load_id
+                        << ", txn_id: " << std::to_string(_parent->_txn_id)
+                        << ", tablet_id: " << tablet.first
+                        << ", node_id: " << tablet.second[i].first
+                        << ", rows_num: " << tablet.second[i].second;
+            if (i == 0) {
+                continue;
+            }
+            if (tablet.second[i].second != tablet.second[0].second) {
+                return Status::InternalError(
+                        "rows num filtered by multi replicas doest't match, load_id={}, txn_id={}, "
                         "tablt_id={}, node_id={}, rows_num={}, node_id={}, rows_num={}",
                         print_id(_parent->_load_id), _parent->_txn_id, tablet.first,
                         tablet.second[i].first, tablet.second[i].second, tablet.second[0].first,
@@ -860,8 +906,8 @@ void VNodeChannel::_add_block_success_callback(const PTabletWriterAddBlockResult
                     _tablets_received_rows.emplace_back(tablet.tablet_id(), tablet.received_rows());
                 }
                 if (tablet.has_num_rows_filtered()) {
-                    _state->update_num_rows_filtered_in_strict_mode_partial_update(
-                            tablet.num_rows_filtered());
+                    _tablets_filtered_rows.emplace_back(tablet.tablet_id(),
+                                                        tablet.num_rows_filtered());
                 }
                 VLOG_CRITICAL << "master replica commit info: tabletId=" << tablet.tablet_id()
                               << ", backendId=" << _node_id
@@ -1005,6 +1051,7 @@ Status VNodeChannel::close_wait(RuntimeState* state) {
 
         _index_channel->set_error_tablet_in_state(state);
         _index_channel->set_tablets_received_rows(_tablets_received_rows, _node_id);
+        _index_channel->set_tablets_filtered_rows(_tablets_filtered_rows, _node_id);
         return Status::OK();
     }
 
@@ -1683,6 +1730,8 @@ Status VOlapTableSink::_cancel_channel_and_check_intolerable_failure(
         status = index_st;
     } else if (Status st = ich->check_tablet_received_rows_consistency(); !st.ok()) {
         status = st;
+    } else if (Status st = ich->check_tablet_filtered_rows_consistency(); !st.ok()) {
+        status = st;
     }
     return status;
 }
@@ -1807,6 +1856,20 @@ Status VOlapTableSink::close(RuntimeState* state, Status exec_status) {
                                         &total_wait_exec_time_ns, &wait_exec_time,
                                         &total_add_batch_num);
                     });
+
+            // Due to the non-determinism of compaction, the rowsets of each replica may be different from each other on different
+            // BE nodes. The number of rows filtered in SegmentWriter depends on the historical rowsets located in the correspoding
+            // BE node. So we check the number of rows filtered on each succeccful BE to ensure the consistency of the current load
+            if (!_write_single_replica && _schema->is_strict_mode() &&
+                _schema->is_partial_update()) {
+                if (Status st = index_channel->check_tablet_filtered_rows_consistency(); !st.ok()) {
+                    status = st;
+                } else {
+                    state->set_num_rows_filtered_in_strict_mode_partial_update(
+                            index_channel->num_rows_filtered());
+                }
+            }
+
             num_node_channels += index_channel->num_node_channels();
             if (add_batch_exec_time > max_add_batch_exec_time_ns) {
                 max_add_batch_exec_time_ns = add_batch_exec_time;

--- a/be/src/vec/sink/vtablet_sink.h
+++ b/be/src/vec/sink/vtablet_sink.h
@@ -404,6 +404,8 @@ protected:
     RuntimeState* _state;
     // rows number received per tablet, tablet_id -> rows_num
     std::vector<std::pair<int64_t, int64_t>> _tablets_received_rows;
+    // rows number filtered per tablet, tablet_id -> filtered_rows_num
+    std::vector<std::pair<int64_t, int64_t>> _tablets_filtered_rows;
 
     // build a _cur_mutable_block and push into _pending_blocks. when not building, this block is empty.
     std::unique_ptr<vectorized::MutableBlock> _cur_mutable_block;

--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_strict_mode.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_strict_mode.groovy
@@ -30,7 +30,7 @@ suite("test_partial_update_strict_mode", "p0") {
                 `last_access_time` datetime NULL 
             ) ENGINE = OLAP UNIQUE KEY(`id`) 
             COMMENT 'OLAP' DISTRIBUTED BY HASH(`id`) 
-            BUCKETS AUTO PROPERTIES ( 
+            BUCKETS 4 PROPERTIES ( 
                 "replication_allocation" = "tag.location.default: 1", 
                 "storage_format" = "V2", 
                 "enable_unique_key_merge_on_write" = "true", 
@@ -65,7 +65,7 @@ suite("test_partial_update_strict_mode", "p0") {
     }
     sql "sync"
     qt_sql """select * from ${tableName} order by id;"""
-    sql """ DROP TABLE IF EXISTS ${tableName} """
+    sql """ DROP TABLE IF EXISTS ${tableName}; """
 
 
     def tableName2 = "test_partial_update_strict_mode2"
@@ -80,7 +80,7 @@ suite("test_partial_update_strict_mode", "p0") {
                 `last_access_time` datetime NULL 
             ) ENGINE = OLAP UNIQUE KEY(`id`) 
             COMMENT 'OLAP' DISTRIBUTED BY HASH(`id`) 
-            BUCKETS AUTO PROPERTIES ( 
+            BUCKETS 4 PROPERTIES ( 
                 "replication_allocation" = "tag.location.default: 1", 
                 "storage_format" = "V2", 
                 "enable_unique_key_merge_on_write" = "true", 
@@ -116,6 +116,7 @@ suite("test_partial_update_strict_mode", "p0") {
     }
     sql "sync"
     qt_sql """select * from ${tableName2} order by id;"""
+    sql """ DROP TABLE IF EXISTS ${tableName2}; """
 
     def tableName3 = "test_partial_update_strict_mode3";
     sql """ DROP TABLE IF EXISTS ${tableName3} """
@@ -129,7 +130,7 @@ suite("test_partial_update_strict_mode", "p0") {
                 `last_access_time` datetime NULL 
             ) ENGINE = OLAP UNIQUE KEY(`id`) 
             COMMENT 'OLAP' DISTRIBUTED BY HASH(`id`) 
-            BUCKETS AUTO PROPERTIES ( 
+            BUCKETS 4 PROPERTIES ( 
                 "replication_allocation" = "tag.location.default: 1", 
                 "storage_format" = "V2", 
                 "enable_unique_key_merge_on_write" = "true", 
@@ -165,6 +166,7 @@ suite("test_partial_update_strict_mode", "p0") {
     }
     sql "sync"
     qt_sql """select * from ${tableName3} order by id;"""
+    sql """ DROP TABLE IF EXISTS ${tableName3}; """
 
     // all columns valid, partial columns do not exist in file
     def tableName4 = "test_partial_update_strict_mode4"
@@ -179,7 +181,7 @@ suite("test_partial_update_strict_mode", "p0") {
                 `last_access_time` datetime NULL 
             ) ENGINE = OLAP UNIQUE KEY(`id`) 
             COMMENT 'OLAP' DISTRIBUTED BY HASH(`id`) 
-            BUCKETS AUTO PROPERTIES ( 
+            BUCKETS 4 PROPERTIES ( 
                 "replication_allocation" = "tag.location.default: 1", 
                 "storage_format" = "V2", 
                 "enable_unique_key_merge_on_write" = "true", 
@@ -211,4 +213,5 @@ suite("test_partial_update_strict_mode", "p0") {
 
     sql "sync"
     qt_sql """select * from ${tableName4} order by id;"""
+    sql """ DROP TABLE IF EXISTS ${tableName4}; """
 }


### PR DESCRIPTION
## Proposed changes

In https://github.com/apache/doris/pull/21746, we just add up all filtered rows reported up by the executor BEs. When the table has replicas, it will get the wrong number of rows filtered. This PR adds consistency check for reported filtered rows and correct the calculation of the number of filtered rows in partial update.
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

