### PR TITLE
[fix](merge-on-write) fix dead lock when publish (#21339)

### DIFF
--- a/be/src/olap/task/engine_publish_version_task.h
+++ b/be/src/olap/task/engine_publish_version_task.h
@@ -57,20 +57,13 @@ public:
     void add_error_tablet_id(int64_t tablet_id);
     void add_succ_tablet_id(int64_t tablet_id);
 
-    void notify();
-    void wait();
-
     int64_t finish_task();
 
 private:
-    std::atomic<int64_t> _total_task_num;
     const TPublishVersionRequest& _publish_version_req;
     std::mutex _tablet_ids_mutex;
     vector<TTabletId>* _error_tablet_ids;
     vector<TTabletId>* _succ_tablet_ids;
-
-    std::mutex _tablet_finish_mutex;
-    std::condition_variable _tablet_finish_cond;
 };
 
 } // namespace doris


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
cherry-pick from：#21339

Using ThreadPoolToken for publish instead of condition_variable. The use of conditional variables here may cause a lost wakeup.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

