### PR TITLE
[fix](agg) Add the unimplemented functions in AggregateFunctionOldSum

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_sum_old.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_sum_old.h
@@ -141,6 +141,22 @@ public:
         }
     }
 
+    void deserialize_and_merge_vec(const AggregateDataPtr* places, size_t offset,
+                                   AggregateDataPtr rhs, const ColumnString* column, Arena* arena,
+                                   const size_t num_rows) const override {
+        this->deserialize_from_column(rhs, *column, arena, num_rows);
+        DEFER({ this->destroy_vec(rhs, num_rows); });
+        this->merge_vec(places, offset, rhs, arena, num_rows);
+    }
+
+    void deserialize_and_merge_vec_selected(const AggregateDataPtr* places, size_t offset,
+                                            AggregateDataPtr rhs, const ColumnString* column,
+                                            Arena* arena, const size_t num_rows) const override {
+        this->deserialize_from_column(rhs, *column, arena, num_rows);
+        DEFER({ this->destroy_vec(rhs, num_rows); });
+        this->merge_vec_selected(places, offset, rhs, arena, num_rows);
+    }
+
     void deserialize_and_merge_from_column(AggregateDataPtr __restrict place, const IColumn& column,
                                            Arena* arena) const override {
         auto data = assert_cast<const ColVecResult&>(column).get_data().data();


### PR DESCRIPTION
## Proposed changes

```
*** Current BE git commitID: 30d35c4 ***
*** SIGSEGV address not mapped to object (@0x0) received by PID 203833 (TID 204268 OR 0x7fa69c06d700) from PID 0; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/src/doris-2.0/be/src/common/signal_handler.h:413
 1# os::Linux::chained_handler(int, siginfo*, void*) in /opt/java/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /opt/java/jre/lib/amd64/server/libjvm.so
 3# signalHandler(int, siginfo*, void*) in /opt/java/jre/lib/amd64/server/libjvm.so
 4# 0x00007FA7A1778400 in /lib64/libc.so.6
 5# doris::vectorized::IAggregateFunctionHelper<doris::vectorized::AggregateFunctionOldSum<double, double, doris::vectorized::AggregateFunctionSumData<double> > >::deserialize_and_merge_vec(char* const*, unsigned long, char*, doris::vectorized::ColumnString const*, doris::vectorized::Arena*, unsigned long) const at /root/src/doris-2.0/be/src/vec/aggregate_functions/aggregate_function.h:386
 6# doris::Status doris::vectorized::AggregationNode::_merge_with_serialized_key_helper<false, false>(doris::vectorized::Block*) at /root/src/doris-2.0/be/src/vec/exec/vaggregation_node.h:1119
 7# doris::vectorized::AggregationNode::_merge_with_serialized_key(doris::vectorized::Block*) at /root/src/doris-2.0/be/src/vec/exec/vaggregation_node.cpp:1656
 8# std::_Function_handler<doris::Status (doris::vectorized::Block*), std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::*(doris::vectorized::AggregationNode*, std::_Placeholder<1>))(doris::vectorized::Block*)> >::_M_invoke(std::_Any_data const&, doris::vectorized::Block*&&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
 9# doris::vectorized::AggregationNode::sink(doris::RuntimeState*, doris::vectorized::Block*, bool) at /root/src/doris-2.0/be/src/vec/exec/vaggregation_node.cpp:599
10# doris::vectorized::AggregationNode::open(doris::RuntimeState*) at /root/src/doris-2.0/be/src/vec/exec/vaggregation_node.cpp:541
11# doris::vectorized::AggregationNode::open(doris::RuntimeState*) at /root/src/doris-2.0/be/src/vec/exec/vaggregation_node.cpp:526
12# doris::PlanFragmentExecutor::open_vectorized_internal() in /moji/be/lib/doris_be
13# doris::PlanFragmentExecutor::open() at /root/src/doris-2.0/be/src/runtime/plan_fragment_executor.cpp:271
14# doris::FragmentExecState::execute() at /root/src/doris-2.0/be/src/runtime/fragment_mgr.cpp:265
15# doris::FragmentMgr::_exec_actual(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::RuntimeState*, doris::Status*)> const&) at /root/src/doris-2.0/be/src/runtime/fragment_mgr.cpp:534
16# std::_Function_handler<void (), doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_0>::_M_invoke(std::_Any_data const&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
17# doris::ThreadPool::dispatch_thread() in /moji/be/lib/doris_be
18# doris::Thread::supervise_thread(void*) at /root/src/doris-2.0/be/src/util/thread.cpp:466
19# start_thread in /lib64/libpthread.so.0
20# __clone in /lib64/libc.so.6 
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

