### PR TITLE
[Improvement](inverted index) return status error when create inverted index reader throwing error

### DIFF
--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -511,16 +511,31 @@ Status ColumnReader::_load_inverted_index_index(const TabletIndex* index_meta) {
 
     if (is_string_type(type)) {
         if (parser_type != InvertedIndexParserType::PARSER_NONE) {
-            _inverted_index = FullTextIndexReader::create_shared(
-                    _file_reader->fs(), _file_reader->path().native(), index_meta);
-            return Status::OK();
+            try {
+                _inverted_index = FullTextIndexReader::create_shared(
+                        _file_reader->fs(), _file_reader->path().native(), index_meta);
+                return Status::OK();
+            } catch (const CLuceneError& e) {
+                return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
+                        "create FullTextIndexReader error: {}", e.what());
+            }
         } else {
-            _inverted_index = StringTypeInvertedIndexReader::create_shared(
-                    _file_reader->fs(), _file_reader->path().native(), index_meta);
+            try {
+                _inverted_index = StringTypeInvertedIndexReader::create_shared(
+                        _file_reader->fs(), _file_reader->path().native(), index_meta);
+            } catch (const CLuceneError& e) {
+                return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
+                        "create StringTypeInvertedIndexReader error: {}", e.what());
+            }
         }
     } else if (is_numeric_type(type)) {
-        _inverted_index = BkdIndexReader::create_shared(_file_reader->fs(),
-                                                        _file_reader->path().native(), index_meta);
+        try {
+            _inverted_index = BkdIndexReader::create_shared(
+                    _file_reader->fs(), _file_reader->path().native(), index_meta);
+        } catch (const CLuceneError& e) {
+            return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
+                    "create BkdIndexReader error: {}", e.what());
+        }
     } else {
         _inverted_index.reset();
     }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

doris will be core when index file error when initialize column reader's index reader, try to catch throwing error and return error status.
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

