### PR TITLE
[fix](transaction) fix publish txn fake succ

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -306,6 +306,7 @@ constexpr bool capture_stacktrace(int code) {
         && code != ErrorCode::INVERTED_INDEX_BUILD_WAITTING
         && code != ErrorCode::META_KEY_NOT_FOUND
         && code != ErrorCode::PUSH_VERSION_ALREADY_EXIST
+        && code != ErrorCode::VERSION_NOT_EXIST
         && code != ErrorCode::TABLE_ALREADY_DELETED_ERROR
         && code != ErrorCode::TRANSACTION_NOT_EXIST
         && code != ErrorCode::TRANSACTION_ALREADY_VISIBLE

--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -490,7 +490,7 @@ Status DataDir::load() {
         PendingPublishInfoPB pending_publish_info_pb;
         bool parsed = pending_publish_info_pb.ParseFromString(info);
         if (!parsed) {
-            LOG(WARNING) << "parse pending publish info failed, tablt_id: " << tablet_id
+            LOG(WARNING) << "parse pending publish info failed, tablet_id: " << tablet_id
                          << " publish_version: " << publish_version;
         }
         StorageEngine::instance()->add_async_publish_task(

--- a/be/src/olap/task/engine_publish_version_task.cpp
+++ b/be/src/olap/task/engine_publish_version_task.cpp
@@ -69,22 +69,17 @@ void TabletPublishStatistics::record_in_bvar() {
 }
 
 EnginePublishVersionTask::EnginePublishVersionTask(
-        const TPublishVersionRequest& publish_version_req, std::vector<TTabletId>* error_tablet_ids,
-        std::vector<TTabletId>* succ_tablet_ids,
+        const TPublishVersionRequest& publish_version_req, std::set<TTabletId>* error_tablet_ids,
+        std::map<TTabletId, TVersion>* succ_tablets,
         std::vector<std::tuple<int64_t, int64_t, int64_t>>* discontinuous_version_tablets)
         : _publish_version_req(publish_version_req),
           _error_tablet_ids(error_tablet_ids),
-          _succ_tablet_ids(succ_tablet_ids),
+          _succ_tablets(succ_tablets),
           _discontinuous_version_tablets(discontinuous_version_tablets) {}
 
 void EnginePublishVersionTask::add_error_tablet_id(int64_t tablet_id) {
     std::lock_guard<std::mutex> lck(_tablet_ids_mutex);
-    _error_tablet_ids->push_back(tablet_id);
-}
-
-void EnginePublishVersionTask::add_succ_tablet_id(int64_t tablet_id) {
-    std::lock_guard<std::mutex> lck(_tablet_ids_mutex);
-    _succ_tablet_ids->push_back(tablet_id);
+    _error_tablet_ids->insert(tablet_id);
 }
 
 Status EnginePublishVersionTask::finish() {
@@ -126,7 +121,7 @@ Status EnginePublishVersionTask::finish() {
             // and receive fe's publish version task
             // this be must return as an error tablet
             if (rowset == nullptr) {
-                _error_tablet_ids->push_back(tablet_info.tablet_id);
+                add_error_tablet_id(tablet_info.tablet_id);
                 res = Status::Error<PUSH_ROWSET_NOT_FOUND>(
                         "could not find related rowset for tablet {}, txn id {}",
                         tablet_info.tablet_id, transaction_id);
@@ -135,7 +130,7 @@ Status EnginePublishVersionTask::finish() {
             TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(
                     tablet_info.tablet_id, tablet_info.tablet_uid);
             if (tablet == nullptr) {
-                _error_tablet_ids->push_back(tablet_info.tablet_id);
+                add_error_tablet_id(tablet_info.tablet_id);
                 res = Status::Error<PUSH_TABLE_NOT_EXIST>(
                         "can't get tablet when publish version. tablet_id={}",
                         tablet_info.tablet_id);
@@ -199,6 +194,7 @@ Status EnginePublishVersionTask::finish() {
     }
     token->wait();
 
+    _succ_tablets->clear();
     // check if the related tablet remained all have the version
     for (auto& par_ver_info : _publish_version_req.partition_version_infos) {
         int64_t partition_id = par_ver_info.partition_id;
@@ -209,18 +205,31 @@ Status EnginePublishVersionTask::finish() {
 
         Version version(par_ver_info.version, par_ver_info.version);
         for (auto& tablet_info : partition_related_tablet_infos) {
-            // has to use strict mode to check if check all tablets
-            if (!_publish_version_req.strict_mode) {
-                break;
-            }
             TabletSharedPtr tablet =
                     StorageEngine::instance()->tablet_manager()->get_tablet(tablet_info.tablet_id);
+            auto tablet_id = tablet_info.tablet_id;
             if (tablet == nullptr) {
-                add_error_tablet_id(tablet_info.tablet_id);
+                add_error_tablet_id(tablet_id);
+                _succ_tablets->erase(tablet_id);
+                LOG(WARNING) << "publish version failed on transaction, not found tablet. "
+                             << "transaction_id=" << transaction_id << ", tablet_id=" << tablet_id
+                             << ", version=" << par_ver_info.version;
             } else {
                 // check if the version exist, if not exist, then set publish failed
-                if (!tablet->check_version_exist(version)) {
-                    add_error_tablet_id(tablet_info.tablet_id);
+                if (_error_tablet_ids->find(tablet_id) == _error_tablet_ids->end()) {
+                    if (tablet->check_version_exist(version)) {
+                        // it's better to report the max continous succ version,
+                        // but it maybe time cost now.
+                        // current just report 0
+                        (*_succ_tablets)[tablet_id] = 0;
+                    } else {
+                        add_error_tablet_id(tablet_id);
+                        LOG(WARNING) << "publish version failed on transaction, tablet version not "
+                                        "exists. "
+                                     << "transaction_id=" << transaction_id
+                                     << ", tablet_id=" << tablet_id
+                                     << ", version=" << par_ver_info.version;
+                    }
                 }
             }
         }
@@ -280,9 +289,7 @@ void TabletPublishTxnTask::handle() {
         _engine_publish_version_task->add_error_tablet_id(_tablet_info.tablet_id);
         return;
     }
-    _engine_publish_version_task->add_succ_tablet_id(_tablet_info.tablet_id);
     int64_t cost_us = MonotonicMicros() - _stats.submit_time_us;
-    // print stats if publish cost > 500ms
     g_tablet_publish_latency << cost_us;
     _stats.record_in_bvar();
     LOG(INFO) << "publish version successfully on tablet"

--- a/be/src/olap/task/engine_publish_version_task.cpp
+++ b/be/src/olap/task/engine_publish_version_task.cpp
@@ -224,6 +224,11 @@ Status EnginePublishVersionTask::finish() {
                         (*_succ_tablets)[tablet_id] = 0;
                     } else {
                         add_error_tablet_id(tablet_id);
+                        if (res.ok()) {
+                            res = Status::Error<VERSION_NOT_EXIST>(
+                                    "tablet {} not exists version {}", tablet_id,
+                                    par_ver_info.version);
+                        }
                         LOG(WARNING) << "publish version failed on transaction, tablet version not "
                                         "exists. "
                                      << "transaction_id=" << transaction_id

--- a/be/src/olap/task/engine_publish_version_task.h
+++ b/be/src/olap/task/engine_publish_version_task.h
@@ -23,7 +23,9 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <map>
 #include <mutex>
+#include <set>
 #include <vector>
 
 #include "common/status.h"
@@ -83,23 +85,22 @@ private:
 class EnginePublishVersionTask : public EngineTask {
 public:
     EnginePublishVersionTask(
-            const TPublishVersionRequest& publish_version_req, vector<TTabletId>* error_tablet_ids,
-            std::vector<TTabletId>* succ_tablet_ids,
+            const TPublishVersionRequest& publish_version_req,
+            std::set<TTabletId>* error_tablet_ids, std::map<TTabletId, TVersion>* succ_tablets,
             std::vector<std::tuple<int64_t, int64_t, int64_t>>* discontinous_version_tablets);
     ~EnginePublishVersionTask() {}
 
     virtual Status finish() override;
 
     void add_error_tablet_id(int64_t tablet_id);
-    void add_succ_tablet_id(int64_t tablet_id);
 
     int64_t finish_task();
 
 private:
     const TPublishVersionRequest& _publish_version_req;
     std::mutex _tablet_ids_mutex;
-    vector<TTabletId>* _error_tablet_ids;
-    vector<TTabletId>* _succ_tablet_ids;
+    std::set<TTabletId>* _error_tablet_ids;
+    std::map<TTabletId, TVersion>* _succ_tablets;
     std::vector<std::tuple<int64_t, int64_t, int64_t>>* _discontinuous_version_tablets;
 };
 

--- a/fe/fe-core/src/main/java/org/apache/doris/master/MasterImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/MasterImpl.java
@@ -67,6 +67,7 @@ import org.apache.thrift.TException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class MasterImpl {
@@ -465,6 +466,10 @@ public class MasterImpl {
     }
 
     private void finishPublishVersion(AgentTask task, TFinishTaskRequest request) {
+        Map<Long, Long> succTablets = null;
+        if (request.isSetSuccTablets()) {
+            succTablets = request.getSuccTablets();
+        }
         List<Long> errorTabletIds = null;
         if (request.isSetErrorTabletIds()) {
             errorTabletIds = request.getErrorTabletIds();
@@ -478,6 +483,7 @@ public class MasterImpl {
         }
 
         PublishVersionTask publishVersionTask = (PublishVersionTask) task;
+        publishVersionTask.setSuccTablets(succTablets);
         publishVersionTask.addErrorTablets(errorTabletIds);
         publishVersionTask.setFinished(true);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/task/PublishVersionTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/PublishVersionTask.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class PublishVersionTask extends AgentTask {
     private static final Logger LOG = LogManager.getLogger(PublishVersionTask.class);
@@ -34,11 +35,15 @@ public class PublishVersionTask extends AgentTask {
     private List<TPartitionVersionInfo> partitionVersionInfos;
     private List<Long> errorTablets;
 
+    // tabletId => version, current version = 0
+    private Map<Long, Long> succTablets;
+
     public PublishVersionTask(long backendId, long transactionId, long dbId,
             List<TPartitionVersionInfo> partitionVersionInfos, long createTime) {
         super(null, backendId, TTaskType.PUBLISH_VERSION, dbId, -1L, -1L, -1L, -1L, transactionId, createTime);
         this.transactionId = transactionId;
         this.partitionVersionInfos = partitionVersionInfos;
+        this.succTablets = null;
         this.errorTablets = new ArrayList<Long>();
         this.isFinished = false;
     }
@@ -55,6 +60,14 @@ public class PublishVersionTask extends AgentTask {
 
     public List<TPartitionVersionInfo> getPartitionVersionInfos() {
         return partitionVersionInfos;
+    }
+
+    public Map<Long, Long> getSuccTablets() {
+        return succTablets;
+    }
+
+    public void setSuccTablets(Map<Long, Long> succTablets) {
+        this.succTablets = succTablets;
     }
 
     public synchronized List<Long> getErrorTablets() {

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -54,6 +54,7 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.task.AgentBatchTask;
 import org.apache.doris.task.AgentTaskExecutor;
 import org.apache.doris.task.ClearTransactionTask;
+import org.apache.doris.task.PublishVersionTask;
 import org.apache.doris.thrift.TUniqueId;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -868,7 +869,7 @@ public class DatabaseTransactionMgr {
         }
     }
 
-    public void finishTransaction(long transactionId, Set<Long> errorReplicaIds) throws UserException {
+    public void finishTransaction(long transactionId) throws UserException {
         TransactionState transactionState = null;
         readLock();
         try {
@@ -876,14 +877,10 @@ public class DatabaseTransactionMgr {
         } finally {
             readUnlock();
         }
+
         // add all commit errors and publish errors to a single set
-        if (errorReplicaIds == null) {
-            errorReplicaIds = Sets.newHashSet();
-        }
-        Set<Long> originalErrorReplicas = transactionState.getErrorReplicas();
-        if (originalErrorReplicas != null) {
-            errorReplicaIds.addAll(originalErrorReplicas);
-        }
+        Set<Long> errorReplicaIds = transactionState.getErrorReplicas();
+        Map<Long, PublishVersionTask> publishTasks = transactionState.getPublishVersionTasks();
 
         long now = System.currentTimeMillis();
         long firstPublishOneSuccTime = transactionState.getFirstPublishOneSuccTime();
@@ -980,21 +977,10 @@ public class DatabaseTransactionMgr {
                             tabletWriteFailedReplicas.clear();
                             tabletVersionFailedReplicas.clear();
                             for (Replica replica : tablet.getReplicas()) {
-                                if (!errorReplicaIds.contains(replica.getId())) {
-                                    if (replica.checkVersionCatchUp(partition.getVisibleVersion(), true)) {
-                                        tabletSuccReplicas.add(replica);
-                                    } else {
-                                        tabletVersionFailedReplicas.add(replica);
-                                    }
-                                } else if (replica.getVersion() >= partitionCommitInfo.getVersion()) {
-                                    // the replica's version is larger than or equal to current transaction
-                                    // partition's version the replica is normal, then remove it from error replica ids
-                                    // TODO(cmy): actually I have no idea why we need this check
-                                    tabletSuccReplicas.add(replica);
-                                    errorReplicaIds.remove(replica.getId());
-                                } else {
-                                    tabletWriteFailedReplicas.add(replica);
-                                }
+                                checkReplicaContinuousVersionSucc(tablet.getId(), replica,
+                                        partitionCommitInfo.getVersion(), publishTasks.get(replica.getBackendId()),
+                                        errorReplicaIds, tabletSuccReplicas, tabletWriteFailedReplicas,
+                                        tabletVersionFailedReplicas);
                             }
 
                             int healthReplicaNum = tabletSuccReplicas.size();
@@ -1005,7 +991,7 @@ public class DatabaseTransactionMgr {
                                     LOG.info("publish version quorum succ for transaction {} on tablet {} with version"
                                             + " {}, and has failed replicas, quorum num {}. table {}, partition {},"
                                             + " tablet detail: {}",
-                                            transactionState, tablet, partitionCommitInfo.getVersion(),
+                                            transactionState, tablet.getId(), partitionCommitInfo.getVersion(),
                                             quorumReplicaNum, tableId, partitionId, writeDetail);
                                 }
                                 continue;
@@ -1033,8 +1019,8 @@ public class DatabaseTransactionMgr {
                                 LOG.info("publish version timeout succ for transaction {} on tablet {} with version"
                                         + " {}, and has failed replicas, quorum num {}. table {}, partition {},"
                                         + " tablet detail: {}",
-                                        transactionState, tablet, partitionCommitInfo.getVersion(), quorumReplicaNum,
-                                        tableId, partitionId, writeDetail);
+                                        transactionState, tablet.getId(), partitionCommitInfo.getVersion(),
+                                        quorumReplicaNum, tableId, partitionId, writeDetail);
                             } else {
                                 publishResult = PublishResult.FAILED;
                                 String errMsg = String.format("publish on tablet %d failed."
@@ -1046,8 +1032,8 @@ public class DatabaseTransactionMgr {
                                 LOG.info("publish version failed for transaction {} on tablet {} with version"
                                         + " {}, and has failed replicas, quorum num {}. table {}, partition {},"
                                         + " tablet detail: {}",
-                                        transactionState, tablet, partitionCommitInfo.getVersion(), quorumReplicaNum,
-                                        tableId, partitionId, writeDetail);
+                                        transactionState, tablet.getId(), partitionCommitInfo.getVersion(),
+                                        quorumReplicaNum, tableId, partitionId, writeDetail);
                             }
                         }
                     }
@@ -1091,6 +1077,43 @@ public class DatabaseTransactionMgr {
         // even if we call "sync" before querying.
         transactionState.countdownVisibleLatch();
         LOG.info("finish transaction {} successfully, publish result: {}", transactionState, publishResult.name());
+    }
+
+    private void checkReplicaContinuousVersionSucc(long tabletId, Replica replica, long version,
+            PublishVersionTask backendPublishTask, Set<Long> errorReplicaIds, List<Replica> tabletSuccReplicas,
+            List<Replica> tabletWriteFailedReplicas, List<Replica> tabletVersionFailedReplicas) {
+        if (backendPublishTask == null || !backendPublishTask.isFinished()) {
+            errorReplicaIds.add(replica.getId());
+        } else {
+            Map<Long, Long> backendSuccTablets = backendPublishTask.getSuccTablets();
+            // new doris BE will report succ tablets
+            if (backendSuccTablets != null) {
+                if (backendSuccTablets.containsKey(tabletId)) {
+                    errorReplicaIds.remove(replica.getId());
+                } else {
+                    errorReplicaIds.add(replica.getId());
+                }
+            } else {
+                // for compatibility, old doris BE report only error tablets
+                List<Long> backendErrorTablets = backendPublishTask.getErrorTablets();
+                if (backendErrorTablets != null && backendErrorTablets.contains(tabletId)) {
+                    errorReplicaIds.add(replica.getId());
+                }
+            }
+        }
+
+        if (!errorReplicaIds.contains(replica.getId())) {
+            if (replica.checkVersionCatchUp(version - 1, true)) {
+                tabletSuccReplicas.add(replica);
+            } else {
+                tabletVersionFailedReplicas.add(replica);
+            }
+        } else if (replica.getVersion() >= version) {
+            tabletSuccReplicas.add(replica);
+            errorReplicaIds.remove(replica.getId());
+        } else {
+            tabletWriteFailedReplicas.add(replica);
+        }
     }
 
     protected void unprotectedPreCommitTransaction2PC(TransactionState transactionState, Set<Long> errorReplicaIds,

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
@@ -402,13 +402,13 @@ public class GlobalTransactionMgr implements Writable {
     /**
      * if the table is deleted between commit and publish version, then should ignore the partition
      *
+     * @param dbId
      * @param transactionId
-     * @param errorReplicaIds
      * @return
      */
-    public void finishTransaction(long dbId, long transactionId, Set<Long> errorReplicaIds) throws UserException {
+    public void finishTransaction(long dbId, long transactionId) throws UserException {
         DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(dbId);
-        dbTransactionMgr.finishTransaction(transactionId, errorReplicaIds);
+        dbTransactionMgr.finishTransaction(transactionId);
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
@@ -17,15 +17,7 @@
 
 package org.apache.doris.transaction;
 
-import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
-import org.apache.doris.catalog.MaterializedIndex;
-import org.apache.doris.catalog.OlapTable;
-import org.apache.doris.catalog.Partition;
-import org.apache.doris.catalog.Replica;
-import org.apache.doris.catalog.Table;
-import org.apache.doris.catalog.Tablet;
-import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.util.MasterDaemon;
 import org.apache.doris.metric.MetricRepo;
@@ -138,109 +130,23 @@ public class PublishVersionDaemon extends MasterDaemon {
             AgentTaskExecutor.submit(batchTask);
         }
 
-        TabletInvertedIndex tabletInvertedIndex = Env.getCurrentInvertedIndex();
         // try to finish the transaction, if failed just retry in next loop
         for (TransactionState transactionState : readyTransactionStates) {
             Map<Long, PublishVersionTask> transTasks = transactionState.getPublishVersionTasks();
-            Set<Long> publishErrorReplicaIds = Sets.newHashSet();
             List<PublishVersionTask> unfinishedTasks = Lists.newArrayList();
             for (PublishVersionTask publishVersionTask : transTasks.values()) {
-                if (publishVersionTask.isFinished()) {
-                    // sometimes backend finish publish version task,
-                    // but it maybe failed to change transactionid to version for some tablets
-                    // and it will upload the failed tabletinfo to fe and fe will deal with them
-                    List<Long> errorTablets = publishVersionTask.getErrorTablets();
-                    if (errorTablets == null || errorTablets.isEmpty()) {
-                        continue;
-                    } else {
-                        for (long tabletId : errorTablets) {
-                            // tablet inverted index also contains rollingup index
-                            // if tablet meta not contains the tablet, skip this tablet because this tablet is dropped
-                            // from fe
-                            if (tabletInvertedIndex.getTabletMeta(tabletId) == null) {
-                                continue;
-                            }
-                            Replica replica = tabletInvertedIndex.getReplica(
-                                    tabletId, publishVersionTask.getBackendId());
-                            if (replica != null) {
-                                publishErrorReplicaIds.add(replica.getId());
-                            } else {
-                                LOG.info("could not find related replica with tabletid={}, backendid={}",
-                                        tabletId, publishVersionTask.getBackendId());
-                            }
-                        }
-                    }
-                } else {
+                if (!publishVersionTask.isFinished()) {
                     unfinishedTasks.add(publishVersionTask);
                 }
             }
 
-            boolean shouldFinishTxn = false;
-            if (!unfinishedTasks.isEmpty()) {
-                shouldFinishTxn = isAllBackendsOfUnfinishedTasksDead(unfinishedTasks);
-                if (transactionState.isPublishTimeout() || shouldFinishTxn) {
-                    // transaction's publish is timeout, but there still has unfinished tasks.
-                    // we need to collect all error replicas, and try to finish this txn.
-                    for (PublishVersionTask unfinishedTask : unfinishedTasks) {
-                        // set all replicas in the backend to error state
-                        List<TPartitionVersionInfo> versionInfos = unfinishedTask.getPartitionVersionInfos();
-                        Set<Long> errorPartitionIds = Sets.newHashSet();
-                        for (TPartitionVersionInfo versionInfo : versionInfos) {
-                            errorPartitionIds.add(versionInfo.getPartitionId());
-                        }
-                        if (errorPartitionIds.isEmpty()) {
-                            continue;
-                        }
-
-                        Database db = Env.getCurrentInternalCatalog()
-                                .getDbNullable(transactionState.getDbId());
-                        if (db == null) {
-                            LOG.warn("Database [{}] has been dropped.", transactionState.getDbId());
-                            continue;
-                        }
-
-                        for (long tableId : transactionState.getTableIdList()) {
-                            Table table = db.getTableNullable(tableId);
-                            if (table == null || table.getType() != Table.TableType.OLAP) {
-                                LOG.warn("Table [{}] in database [{}] has been dropped.", tableId, db.getFullName());
-                                continue;
-                            }
-                            OlapTable olapTable = (OlapTable) table;
-                            olapTable.readLock();
-                            try {
-                                for (Long errorPartitionId : errorPartitionIds) {
-                                    Partition partition = olapTable.getPartition(errorPartitionId);
-                                    if (partition != null) {
-                                        List<MaterializedIndex> materializedIndexList
-                                                = partition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL);
-                                        for (MaterializedIndex materializedIndex : materializedIndexList) {
-                                            for (Tablet tablet : materializedIndex.getTablets()) {
-                                                Replica replica = tablet.getReplicaByBackendId(
-                                                        unfinishedTask.getBackendId());
-                                                if (replica != null) {
-                                                    publishErrorReplicaIds.add(replica.getId());
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            } finally {
-                                olapTable.readUnlock();
-                            }
-                        }
-                    }
-                    shouldFinishTxn = true;
-                }
-            } else {
-                // all publish tasks are finished, try to finish this txn.
-                shouldFinishTxn = true;
-            }
-
+            boolean shouldFinishTxn = isAllBackendsOfUnfinishedTasksDead(unfinishedTasks)
+                    || transactionState.isPublishTimeout();
             if (shouldFinishTxn) {
                 try {
                     // one transaction exception should not affect other transaction
                     globalTransactionMgr.finishTransaction(transactionState.getDbId(),
-                            transactionState.getTransactionId(), publishErrorReplicaIds);
+                            transactionState.getTransactionId());
                 } catch (Exception e) {
                     LOG.warn("error happens when finish transaction {}", transactionState.getTransactionId(), e);
                 }
@@ -248,8 +154,7 @@ public class PublishVersionDaemon extends MasterDaemon {
                     // if finish transaction state failed, then update publish version time, should check
                     // to finish after some interval
                     transactionState.updateSendTaskTime();
-                    LOG.debug("publish version for transaction {} failed, has {} error replicas during publish",
-                            transactionState, publishErrorReplicaIds.size());
+                    LOG.debug("publish version for transaction {} failed", transactionState);
                 }
             }
 

--- a/gensrc/thrift/MasterService.thrift
+++ b/gensrc/thrift/MasterService.thrift
@@ -65,6 +65,7 @@ struct TFinishTaskRequest {
     14: optional list<Types.TTabletId> downloaded_tablet_ids
     15: optional i64 copy_size
     16: optional i64 copy_time_ms
+    17: optional map<Types.TTabletId, Types.TVersion> succ_tablets
 }
 
 struct TTablet {


### PR DESCRIPTION
## Proposed changes

**BUG**

There is a bug in publishing transaction, which may cause FE replica contains a certain version, but tablet in BE actually does not contain that version data. An example is as follows：
1.  Suppose  partition current visible version = V,   has a replica A.   And a committed txn T whose version is V + 1,   T is not published yet;
2. Clone a new replica B from A.  After cloning,   B's version = V;
3. Publish txn T,  after publishing,  the txn will fininsh and increase replica's version. For B,  its version catchup with T's version - 1 = (V+1) - 1 = V,   and B is not in T's error replica ids,  so FE will treat B as succ, and update B's new version = V + 1.  But  B's BE actually not contains txn T's data.  

**FIX**
1. when publish,  BE  will check if the tablet contains this txn's related version data. If this tablet contains the version, BE will report this tablet as succ;
2. FE will check BE's succ tablets,  if a replica is not in the BE' s report succ tablets,  it will treat this replica as failed for this version.

**TEST**

FE send a test txn publish task to the BEs,  the test txn is not exists in BE,  BE will report tablets as failed. Finally FE will publish failed.

BE log:

```
W20230912 15:28:41.339694  1623 engine_publish_version_task.cpp:227] publish version failed on transaction, tablet version not exists. transaction_id=9999999, tablet_id=10268, version=4
W20230912 15:28:41.339735  1623 engine_publish_version_task.cpp:227] publish version failed on transaction, tablet version not exists. transaction_id=9999999, tablet_id=10272, version=4
W20230912 15:28:41.339742  1623 engine_publish_version_task.cpp:227] publish version failed on transaction, tablet version not exists. transaction_id=9999999, tablet_id=10276, version=4
W20230912 15:28:41.339751  1623 engine_publish_version_task.cpp:227] publish version failed on transaction, tablet version not exists. transaction_id=9999999, tablet_id=10280, version=4
W20230912 15:28:41.339762  1623 engine_publish_version_task.cpp:227] publish version failed on transaction, tablet version not exists. transaction_id=9999999, tablet_id=10284, version=4
``` 

FE log:

```
2023-09-12 15:29:55,082 INFO (PUBLISH_VERSION|36) [DatabaseTransactionMgr.finishTransaction():1032] publish version failed for transaction TransactionState. transaction id: 1002, label: insert_d50da1383dcd4f4d_8b9c3cfe227dd56d, db id: 10256, table id list: 10258, callback id: -1, coordinator: FE: 128.0.1.1, transaction status: COMMITTED, error replicas num: 30, replica ids: 10261,10262,10263,10265,10266, prepare
time: 1694532521141, commit time: 1694532521285, finish time: -1, reason:  on tablet 10292 with version 4, and has failed replicas, quorum num 2. table 10258, partition 10257, tablet detail: 3 replicas write
data failed: { [replicaId=10293, backendId=10003, backendAlive=true, version=3, state=NORMAL], [replicaId=10294, backendId=10002, backendAlive=true, version=3, state=NORMAL], [replicaId=10295, backendId=10004, backendAlive=true, version=3, state=NORMAL] };
```


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

