### PR TITLE
[fix](env)mock env.isCheckpointThread

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/AccessTestUtil.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/AccessTestUtil.java
@@ -418,6 +418,10 @@ public class AccessTestUtil {
                     env.getCatalogMgr();
                     minTimes = 0;
                     result = ctlMgr;
+
+                    env.isCheckpointThread();
+                    minTimes = 0;
+                    result = false;
                 }
             };
             return env;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

`ShowTableStmtTest.testNoDb` and `DropDbStmtTest.testNoPriv`  are unstable cases，error msg is:
```
java.lang.Exception: Unexpected exception, expected<org.apache.doris.common.AnalysisException> but was<mockit.internal.expectations.invocation.MissingInvocation>
```
reason is missing mock env.isCheckpointThread

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

