### PR TITLE
[fix](sql block) If you use a space at the end of the SQL statement in the interception rule, there will be a problem of mismatching.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterSqlBlockRuleStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterSqlBlockRuleStmt.java
@@ -72,7 +72,8 @@ public class AlterSqlBlockRuleStmt extends DdlStmt {
     }
 
     private void setProperties(Map<String, String> properties) throws AnalysisException {
-        this.sql = properties.getOrDefault(CreateSqlBlockRuleStmt.SQL_PROPERTY, CreateSqlBlockRuleStmt.STRING_NOT_SET).trim();
+        this.sql = properties.getOrDefault(CreateSqlBlockRuleStmt.SQL_PROPERTY, CreateSqlBlockRuleStmt.STRING_NOT_SET);
+        this.sql = this.sql.trim();
         this.sqlHash = properties.getOrDefault(CreateSqlBlockRuleStmt.SQL_HASH_PROPERTY,
                 CreateSqlBlockRuleStmt.STRING_NOT_SET);
         String partitionNumString = properties.get(CreateSqlBlockRuleStmt.SCANNED_PARTITION_NUM);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterSqlBlockRuleStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterSqlBlockRuleStmt.java
@@ -72,7 +72,7 @@ public class AlterSqlBlockRuleStmt extends DdlStmt {
     }
 
     private void setProperties(Map<String, String> properties) throws AnalysisException {
-        this.sql = properties.getOrDefault(CreateSqlBlockRuleStmt.SQL_PROPERTY, CreateSqlBlockRuleStmt.STRING_NOT_SET);
+        this.sql = properties.getOrDefault(CreateSqlBlockRuleStmt.SQL_PROPERTY, CreateSqlBlockRuleStmt.STRING_NOT_SET).trim();
         this.sqlHash = properties.getOrDefault(CreateSqlBlockRuleStmt.SQL_HASH_PROPERTY,
                 CreateSqlBlockRuleStmt.STRING_NOT_SET);
         String partitionNumString = properties.get(CreateSqlBlockRuleStmt.SCANNED_PARTITION_NUM);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateSqlBlockRuleStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateSqlBlockRuleStmt.java
@@ -126,7 +126,8 @@ public class CreateSqlBlockRuleStmt extends DdlStmt {
     }
 
     private void setProperties(Map<String, String> properties) throws UserException {
-        this.sql = properties.getOrDefault(SQL_PROPERTY, STRING_NOT_SET);
+        //Here the SQL must go to the last space, otherwise there will be no match.
+        this.sql = properties.getOrDefault(SQL_PROPERTY, STRING_NOT_SET).trim();
         this.sqlHash = properties.getOrDefault(SQL_HASH_PROPERTY, STRING_NOT_SET);
         String partitionNumString = properties.get(SCANNED_PARTITION_NUM);
         String tabletNumString = properties.get(SCANNED_TABLET_NUM);


### PR DESCRIPTION
## Proposed changes
I defined the rule. This SQL has an extra space at the end.
```
mysql> CREATE SQL_BLOCK_RULE select_all_block_rule PROPERTIES(
     -> "sql"="select * from .+ ",
     -> "global"="true",
     -> "enable"="true"
     -> );
Query OK, 0 rows affected (0.01 sec)

--Not intercepted when executing SQL
mysql> select * from test_load_001;
+---------------------+--------+-------------+--- -------+-------------+
| day_time | app_id | mid_pv_count | uv_count | ip_pv_count |
+---------------------+--------+-------------+--- -------+-------------+
| 2023-07-16 12:12:34 | 1 | NULL | 2002 | NULL |
| 2023-07-15 12:12:34 | 1 | NULL | 2002 | NULL |
+---------------------+--------+-------------+--- -------+-------------+
2 rows in set (0.02 sec)
```
You can intercept it by removing the space at the end of the sql above.
```
mysql> CREATE SQL_BLOCK_RULE select_all_block_rule PROPERTIES(
     -> "sql"="select \\* from .+",
     -> "global"="true",
     -> "enable"="true"
     -> );
Query OK, 0 rows affected (0.00 sec)

mysql> select * from test_load_001;
ERROR 1105 (HY000): errCode = 2, detailMessage = sql match regex sql block rule: select_all_block_rule
```

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

