### PR TITLE
[Bug](function) fix explode_json_array_int can't handle min/max values

### DIFF
--- a/be/src/vec/exprs/table_function/vexplode_json_array.cpp
+++ b/be/src/vec/exprs/table_function/vexplode_json_array.cpp
@@ -22,6 +22,7 @@
 #include <stdio.h>
 
 #include <algorithm>
+#include <limits>
 
 #include "common/status.h"
 #include "rapidjson/stringbuffer.h"
@@ -36,6 +37,8 @@ namespace doris::vectorized {
 
 std::string ParsedData::true_value = "true";
 std::string ParsedData::false_value = "false";
+auto max_value = std::numeric_limits<int64_t>::max(); //9223372036854775807
+auto min_value = std::numeric_limits<int64_t>::min(); //-9223372036854775808
 
 int ParsedData::set_output(ExplodeJsonArrayType type, rapidjson::Document& document) {
     int size = document.GetArray().Size();
@@ -47,6 +50,24 @@ int ParsedData::set_output(ExplodeJsonArrayType type, rapidjson::Document& docum
         for (auto& v : document.GetArray()) {
             if (v.IsInt64()) {
                 _backup_int[i] = v.GetInt64();
+                _data[i] = &_backup_int[i];
+            } else if (v.IsUint64()) {
+                auto value = v.GetUint64();
+                if (value > max_value) {
+                    _backup_int[i] = max_value;
+                } else {
+                    _backup_int[i] = value;
+                }
+                _data[i] = &_backup_int[i];
+            } else if (v.IsDouble()) {
+                auto value = v.GetDouble();
+                if (value > max_value) {
+                    _backup_int[i] = max_value;
+                } else if (value < min_value) {
+                    _backup_int[i] = min_value;
+                } else {
+                    _backup_int[i] = value;
+                }
                 _data[i] = &_backup_int[i];
             } else {
                 _data[i] = nullptr;

--- a/regression-test/data/query_p0/sql_functions/table_function/explode_json_array.out
+++ b/regression-test/data/query_p0/sql_functions/table_function/explode_json_array.out
@@ -89,3 +89,9 @@
 \N	80	{"id":2,"name":"Mary"}
 \N	80	{"id":3,"name":"Bob"}
 
+-- !explode_json_array12 --
+9223372036854775807	8
+
+-- !explode_json_array13 --
+-9223372036854775808	8
+

--- a/regression-test/suites/query_p0/sql_functions/table_function/explode_json_array.groovy
+++ b/regression-test/suites/query_p0/sql_functions/table_function/explode_json_array.groovy
@@ -60,4 +60,13 @@ suite("explode_json_array") {
     qt_outer_join_explode_json_array11 """SELECT id, age, e1 FROM (SELECT id, age, e1 FROM (SELECT b.id, a.age FROM
                                         ${tableName} a LEFT JOIN ${tableName} b ON a.id=b.age)T LATERAL VIEW EXPLODE_JSON_ARRAY_JSON('[{"id":1,"name":"John"},{"id":2,"name":"Mary"},{"id":3,"name":"Bob"}]')
                                         TMP AS e1) AS T ORDER BY age, e1"""
+
+    qt_explode_json_array12 """ SELECT c_age, COUNT(1) FROM ${tableName}
+                        LATERAL VIEW EXPLODE_JSON_ARRAY_INT('[9223372036854775807,9223372036854775808]') t1 as c_age 
+                        GROUP BY c_age ORDER BY c_age """
+
+    qt_explode_json_array13 """ SELECT c_age, COUNT(1) FROM ${tableName}
+                        LATERAL VIEW EXPLODE_JSON_ARRAY_INT('[-92233720368547758071,-92233720368547758081]') t1 as c_age 
+                        GROUP BY c_age ORDER BY c_age """
+
 }


### PR DESCRIPTION
## Proposed changes
the json str get value maybe beyond max/min of Int64,
so add some check to limit the value, and return the max/min of Int64

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

