### PR TITLE
[feature](Nereids): date/datetime parser support many complex case

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteral.java
@@ -170,6 +170,13 @@ public class DateLiteral extends Literal {
             }
         }
 
+        len = sb.length();
+        int signIdx = sb.indexOf("+", 10); // from index:10, skip date part (it contains '-')
+        signIdx = signIdx == -1 ? sb.indexOf("-", 10) : signIdx;
+        if (signIdx != -1 && len - signIdx == 3) {
+            sb.append(":00");
+        }
+
         return sb.toString();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteral.java
@@ -103,7 +103,7 @@ public class DateLiteral extends Literal {
 
         // handle two digit year
         if (s.charAt(2) != '-' && s.charAt(4) != '-') {
-            throw new AnalysisException("datetime literal [" + s + "] is invalid");
+            throw new AnalysisException("date/datetime literal [" + s + "] is invalid");
         }
         if (s.charAt(2) == '-') {
             String yy = s.substring(0, 2);
@@ -146,7 +146,7 @@ public class DateLiteral extends Literal {
                     sb.append('0');
                     sb.append(c);
                 } else {
-                    throw new AnalysisException("datetime literal [" + s + "] is invalid");
+                    throw new AnalysisException("date/datetime literal [" + s + "] is invalid");
                 }
                 i = j;
             } else {
@@ -180,20 +180,6 @@ public class DateLiteral extends Literal {
         return sb.toString();
     }
 
-    // replace 'T' with ' '
-    private static String replaceDelimiterT(String s) {
-        if (s.length() <= 10) {
-            return s;
-        }
-        if (s.charAt(10) == 'T') {
-            return s.substring(0, 10) + " " + s.substring(11);
-        } else if (s.charAt(8) == 'T') {
-            return s.substring(0, 8) + " " + s.substring(9);
-        } else {
-            return s;
-        }
-    }
-
     protected static TemporalAccessor parse(String s) {
         String originalString = s;
         try {
@@ -224,12 +210,12 @@ public class DateLiteral extends Literal {
 
             // if Year is not present, throw exception
             if (!dateTime.isSupported(ChronoField.YEAR)) {
-                throw new AnalysisException("datetime literal [" + originalString + "] is invalid");
+                throw new AnalysisException("date/datetime literal [" + originalString + "] is invalid");
             }
 
             return dateTime;
         } catch (Exception ex) {
-            throw new AnalysisException("datetime literal [" + originalString + "] is invalid");
+            throw new AnalysisException("date/datetime literal [" + originalString + "] is invalid");
         }
     }
 
@@ -240,7 +226,7 @@ public class DateLiteral extends Literal {
         day = DateUtils.getOrDefault(dateTime, ChronoField.DAY_OF_MONTH);
 
         if (checkRange() || checkDate()) {
-            throw new AnalysisException("datetime literal [" + s + "] is out of range");
+            throw new AnalysisException("date/datetime literal [" + s + "] is out of range");
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/DateTimeFormatterUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/DateTimeFormatterUtils.java
@@ -56,29 +56,17 @@ public class DateTimeFormatterUtils {
             .toFormatter().withResolverStyle(ResolverStyle.STRICT);
     // yyyy-mm-dd
     public static final DateTimeFormatter DATE_FORMATTER = new DateTimeFormatterBuilder()
-            .appendOptional(
-                    new DateTimeFormatterBuilder().appendValue(ChronoField.YEAR, 4).toFormatter())
-            .appendOptional(
-                    new DateTimeFormatterBuilder().appendValueReduced(ChronoField.YEAR, 2, 2, 1970).toFormatter())
+            .appendValue(ChronoField.YEAR, 4)
             .appendLiteral('-').appendValue(ChronoField.MONTH_OF_YEAR, 2)
             .appendLiteral('-').appendValue(ChronoField.DAY_OF_MONTH, 2)
             .toFormatter().withResolverStyle(ResolverStyle.STRICT);
     // HH[:mm][:ss][.microsecond]
     public static final DateTimeFormatter TIME_FORMATTER = new DateTimeFormatterBuilder()
             .appendValue(ChronoField.HOUR_OF_DAY, 2)
-            .appendOptional(
-                    new DateTimeFormatterBuilder()
-                            .appendLiteral(':').appendValue(ChronoField.MINUTE_OF_HOUR, 2)
-                            .appendOptional(
-                                    new DateTimeFormatterBuilder()
-                                            .appendLiteral(':').appendValue(ChronoField.SECOND_OF_MINUTE, 2)
-                                            .appendOptional(new DateTimeFormatterBuilder()
-                                                    .appendFraction(ChronoField.MICRO_OF_SECOND, 1, 6, true)
-                                                    .toFormatter())
-                                            .toFormatter()
-                            )
-                            .toFormatter()
-            )
+            .appendLiteral(':').appendValue(ChronoField.MINUTE_OF_HOUR, 2)
+            .appendLiteral(':').appendValue(ChronoField.SECOND_OF_MINUTE, 2)
+            .appendOptional(new DateTimeFormatterBuilder()
+                    .appendFraction(ChronoField.MICRO_OF_SECOND, 1, 6, true).toFormatter())
             .toFormatter().withResolverStyle(ResolverStyle.STRICT);
     // Time without delimiter: HHmmss[.microsecond]
     private static final DateTimeFormatter BASIC_TIME_FORMATTER = new DateTimeFormatterBuilder()
@@ -114,10 +102,7 @@ public class DateTimeFormatterUtils {
             .append(TIME_FORMATTER)
             .toFormatter().withResolverStyle(ResolverStyle.STRICT);
     public static final DateTimeFormatter ZONE_DATE_FORMATTER = new DateTimeFormatterBuilder()
-            .appendOptional(
-                    new DateTimeFormatterBuilder().appendValue(ChronoField.YEAR, 4).toFormatter())
-            .appendOptional(
-                    new DateTimeFormatterBuilder().appendValueReduced(ChronoField.YEAR, 2, 2, 1970).toFormatter())
+            .appendValue(ChronoField.YEAR, 4)
             .appendLiteral('-').appendValue(ChronoField.MONTH_OF_YEAR, 2)
             .appendLiteral('-').appendValue(ChronoField.DAY_OF_MONTH, 2)
             // .optionalStart()

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/DateTimeFormatterUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/DateTimeFormatterUtils.java
@@ -44,8 +44,8 @@ public class DateTimeFormatterUtils {
             // .appendZoneText(TextStyle.FULL)
             .appendZoneOrOffsetId()
             .optionalEnd()
-            // .appendOptional(
-            //         new DateTimeFormatterBuilder().appendOffset("+HH", "").toFormatter())
+            .appendOptional(
+                    new DateTimeFormatterBuilder().appendOffset("+HH", "").toFormatter())
             .toFormatter()
             .withResolverStyle(ResolverStyle.STRICT);
     // yymmdd

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/DateTimeFormatterUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/DateTimeFormatterUtils.java
@@ -44,8 +44,6 @@ public class DateTimeFormatterUtils {
             // .appendZoneText(TextStyle.FULL)
             .appendZoneOrOffsetId()
             .optionalEnd()
-            .appendOptional(
-                    new DateTimeFormatterBuilder().appendOffset("+HH", "").toFormatter())
             .toFormatter()
             .withResolverStyle(ResolverStyle.STRICT);
     // yymmdd

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/DateTimeFormatterUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/DateTimeFormatterUtils.java
@@ -46,10 +46,6 @@ public class DateTimeFormatterUtils {
             .optionalEnd()
             // .appendOptional(
             //         new DateTimeFormatterBuilder().appendOffset("+HH", "").toFormatter())
-            // .appendOptional(
-            //         new DateTimeFormatterBuilder().appendOffset("+HH:MM", "").toFormatter())
-            // .appendOptional(
-            //         new DateTimeFormatterBuilder().appendOffset("+HH:MM:SS", "").toFormatter())
             .toFormatter()
             .withResolverStyle(ResolverStyle.STRICT);
     // yymmdd

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/LiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/LiteralTest.java
@@ -17,29 +17,24 @@
 
 package org.apache.doris.nereids.trees.expressions;
 
-import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
-import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
-import org.apache.doris.nereids.trees.expressions.literal.Literal;
-import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
-import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.DateLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.DateTimeV2Literal;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class LiteralTest {
-
-    @Test
-    public void testEqual() {
-        IntegerLiteral one = new IntegerLiteral(1);
-        IntegerLiteral anotherOne = new IntegerLiteral(1);
-        IntegerLiteral two = new IntegerLiteral(2);
-        Assertions.assertNotEquals(one, two);
-        Assertions.assertEquals(one, anotherOne);
-        StringLiteral str1 = new StringLiteral("hello");
-        Assertions.assertNotEquals(str1, one);
-        Assertions.assertTrue(Literal.of("world") instanceof StringLiteral);
-        Assertions.assertTrue(Literal.of(null) instanceof NullLiteral);
-        Assertions.assertTrue(Literal.of(1) instanceof IntegerLiteral);
-        Assertions.assertTrue(Literal.of(false) instanceof BooleanLiteral);
-    }
+    // MySQL Date的组成
+    // 1. 没有任何分隔符 eg: 20220801, 20220801010101
+    //    MySQL 支持 20220801T010101 但是不支持 20220801 010101
+    //    MySQL 这种情况下不支持 zone / offset
+    // 2. 有分隔符
+    //    分隔符可以为 ' '/ 'T'
+    //    组成为 Date + delimiter + Time + Zone + Offset
+    //    其中 Zone 和 Offset 是 Optional
+    //    Date 需要注意 two-digit year https://dev.mysql.com/doc/refman/8.0/en/datetime.html
+    //      Dates containing 2-digit year values are ambiguous because the century is unknown. MySQL interprets 2-digit year values using these rules:
+    //          Year values in the range 00-69 become 2000-2069.
+    //          Year values in the range 70-99 become 1970-1999.
+    //    Time 需要注意 microsecond
+    //      需要注意 不完全time 'hh:mm:ss', 'hh:mm', 'D hh:mm', 'D hh', or 'ss'
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/LiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/LiteralTest.java
@@ -17,24 +17,29 @@
 
 package org.apache.doris.nereids.trees.expressions;
 
-import org.apache.doris.nereids.trees.expressions.literal.DateLiteral;
-import org.apache.doris.nereids.trees.expressions.literal.DateTimeV2Literal;
+import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.Literal;
+import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class LiteralTest {
-    // MySQL Date的组成
-    // 1. 没有任何分隔符 eg: 20220801, 20220801010101
-    //    MySQL 支持 20220801T010101 但是不支持 20220801 010101
-    //    MySQL 这种情况下不支持 zone / offset
-    // 2. 有分隔符
-    //    分隔符可以为 ' '/ 'T'
-    //    组成为 Date + delimiter + Time + Zone + Offset
-    //    其中 Zone 和 Offset 是 Optional
-    //    Date 需要注意 two-digit year https://dev.mysql.com/doc/refman/8.0/en/datetime.html
-    //      Dates containing 2-digit year values are ambiguous because the century is unknown. MySQL interprets 2-digit year values using these rules:
-    //          Year values in the range 00-69 become 2000-2069.
-    //          Year values in the range 70-99 become 1970-1999.
-    //    Time 需要注意 microsecond
-    //      需要注意 不完全time 'hh:mm:ss', 'hh:mm', 'D hh:mm', 'D hh', or 'ss'
+
+    @Test
+    public void testEqual() {
+        IntegerLiteral one = new IntegerLiteral(1);
+        IntegerLiteral anotherOne = new IntegerLiteral(1);
+        IntegerLiteral two = new IntegerLiteral(2);
+        Assertions.assertNotEquals(one, two);
+        Assertions.assertEquals(one, anotherOne);
+        StringLiteral str1 = new StringLiteral("hello");
+        Assertions.assertNotEquals(str1, one);
+        Assertions.assertTrue(Literal.of("world") instanceof StringLiteral);
+        Assertions.assertTrue(Literal.of(null) instanceof NullLiteral);
+        Assertions.assertTrue(Literal.of(1) instanceof IntegerLiteral);
+        Assertions.assertTrue(Literal.of(false) instanceof BooleanLiteral);
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteralTest.java
@@ -20,7 +20,6 @@ package org.apache.doris.nereids.trees.expressions.literal;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.function.Consumer;
@@ -80,7 +79,6 @@ class DateLiteralTest {
     }
 
     @Test
-    @Disabled
     void testOffset() {
         new DateLiteral("2022-01-01+01:00:00");
         new DateLiteral("2022-01-01+01:00");
@@ -94,8 +92,8 @@ class DateLiteralTest {
         new DateLiteral("2022-01-01-1:0:0");
         new DateLiteral("2022-01-01-1:0");
 
-        Assertions.assertThrows(AnalysisException.class, () -> new DateLiteral("2022-01-01-01"));
-        Assertions.assertThrows(AnalysisException.class, () -> new DateLiteral("2022-01-01-1"));
+        // Assertions.assertThrows(AnalysisException.class, () -> new DateLiteral("2022-01-01-01"));
+        // Assertions.assertThrows(AnalysisException.class, () -> new DateLiteral("2022-01-01-1"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteralTest.java
@@ -72,8 +72,8 @@ class DateLiteralTest {
         new DateLiteral("2022-01-01Z");
         new DateLiteral("2022-01-01UTC");
         new DateLiteral("2022-01-01GMT");
-        // new DateLiteral("2022-01-01UTC+08");
-        // new DateLiteral("2022-01-01UTC-06");
+        new DateLiteral("2022-01-01UTC+08");
+        new DateLiteral("2022-01-01UTC-06");
         new DateLiteral("2022-01-01UTC+08:00");
         new DateLiteral("2022-01-01UTC-06:00");
         new DateLiteral("2022-01-01Europe/London");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteralTest.java
@@ -26,6 +26,16 @@ import java.util.function.Consumer;
 
 class DateLiteralTest {
     @Test
+    void reject() {
+        // TODO: reject them.
+        // Now parse them as date + offset.
+        // PG parse them as date + offset, MySQL parse them as date + time (rubbish behavior!)
+        // So strange! reject these strange case.
+        // Assertions.assertThrows(AnalysisException.class, () -> new DateLiteral("2022-01-01-01"));
+        // Assertions.assertThrows(AnalysisException.class, () -> new DateLiteral("2022-01-01-1"));
+    }
+
+    @Test
     void testNormalize() {
         String s = DateLiteral.normalize("2021-5");
         Assertions.assertEquals("2021-05", s);
@@ -91,9 +101,6 @@ class DateLiteralTest {
         new DateLiteral("2022-01-01-01:00");
         new DateLiteral("2022-01-01-1:0:0");
         new DateLiteral("2022-01-01-1:0");
-
-        // Assertions.assertThrows(AnalysisException.class, () -> new DateLiteral("2022-01-01-01"));
-        // Assertions.assertThrows(AnalysisException.class, () -> new DateLiteral("2022-01-01-1"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteralTest.java
@@ -23,13 +23,45 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import java.util.function.Consumer;
+
 class DateLiteralTest {
+    @Test
+    void testNormalize() {
+        String s = DateLiteral.normalize("2021-5");
+        Assertions.assertEquals("2021-05", s);
+        s = DateLiteral.normalize("2021-5-1");
+        Assertions.assertEquals("2021-05-01", s);
+        s = DateLiteral.normalize("2021-5-01");
+        Assertions.assertEquals("2021-05-01", s);
+
+        s = DateLiteral.normalize("2021-5-01 0:0:0");
+        Assertions.assertEquals("2021-05-01 00:00:00", s);
+        s = DateLiteral.normalize("2021-5-01 0:0:0.001");
+        Assertions.assertEquals("2021-05-01 00:00:00.001", s);
+
+        s = DateLiteral.normalize("2021-5-01 0:0:0.001+8:0");
+        Assertions.assertEquals("2021-05-01 00:00:00.001+08:00", s);
+        s = DateLiteral.normalize("2021-5-01 0:0:0.001+8:0:0");
+        Assertions.assertEquals("2021-05-01 00:00:00.001+08:00:00", s);
+
+        s = DateLiteral.normalize("2021-5-01 0:0:0.001UTC+8:0");
+        Assertions.assertEquals("2021-05-01 00:00:00.001UTC+08:00", s);
+        s = DateLiteral.normalize("2021-5-01 0:0:0.001UTC+8:0:0");
+        Assertions.assertEquals("2021-05-01 00:00:00.001UTC+08:00:00", s);
+
+    }
+
     @Test
     void testDate() {
         new DateLiteral("220101");
         new DateLiteral("22-01-01");
+        new DateLiteral("22-01-1");
+        new DateLiteral("22-1-1");
 
         new DateLiteral("2022-01-01");
+        new DateLiteral("2022-01-1");
+        new DateLiteral("2022-1-1");
         new DateLiteral("20220101");
 
         Assertions.assertThrows(AnalysisException.class, () -> new DateLiteral("-01-01"));
@@ -66,18 +98,30 @@ class DateLiteralTest {
         Assertions.assertThrows(AnalysisException.class, () -> new DateLiteral("2022-01-01-1"));
     }
 
-    @Disabled
     @Test
     void testIrregularDate() {
-        new DateLiteral("2016-07-02");
+        Consumer<DateLiteral> assertFunc = (DateLiteral dateLiteral) -> {
+            Assertions.assertEquals("2016-07-02", dateLiteral.toString());
+        };
+        DateLiteral dateLiteral;
 
-        new DateLiteral("2016-7-02");
-        new DateLiteral("2016-07-2");
-        new DateLiteral("2016-7-2");
+        dateLiteral = new DateLiteral("2016-07-02");
+        assertFunc.accept(dateLiteral);
 
-        new DateLiteral("2016-07-02");
-        new DateLiteral("2016-07-2");
-        new DateLiteral("2016-7-02");
-        new DateLiteral("2016-7-2");
+        dateLiteral = new DateLiteral("2016-7-02");
+        assertFunc.accept(dateLiteral);
+        dateLiteral = new DateLiteral("2016-07-2");
+        assertFunc.accept(dateLiteral);
+        dateLiteral = new DateLiteral("2016-7-2");
+        assertFunc.accept(dateLiteral);
+
+        dateLiteral = new DateLiteral("2016-07-02");
+        assertFunc.accept(dateLiteral);
+        dateLiteral = new DateLiteral("2016-07-2");
+        assertFunc.accept(dateLiteral);
+        dateLiteral = new DateLiteral("2016-7-02");
+        assertFunc.accept(dateLiteral);
+        dateLiteral = new DateLiteral("2016-7-2");
+        assertFunc.accept(dateLiteral);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteralTest.java
@@ -33,6 +33,8 @@ class DateLiteralTest {
         // So strange! reject these strange case.
         // Assertions.assertThrows(AnalysisException.class, () -> new DateLiteral("2022-01-01-01"));
         // Assertions.assertThrows(AnalysisException.class, () -> new DateLiteral("2022-01-01-1"));
+        // Assertions.assertThrows(AnalysisException.class, () -> new DateLiteral("2022-01-01+01"));
+        // Assertions.assertThrows(AnalysisException.class, () -> new DateLiteral("2022-01-01+1"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeLiteralTest.java
@@ -18,10 +18,16 @@
 package org.apache.doris.nereids.trees.expressions.literal;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class DateTimeLiteralTest {
+    @Test
+    void reject() {
+        // Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        //     new DateTimeV2Literal("2022-08-01T01:01:01-00:00");
+        // });
+    }
+
     @Test
     void testWithoutZoneOrOffset() {
         new DateTimeV2Literal("2022-08-01");
@@ -91,7 +97,7 @@ class DateTimeLiteralTest {
     @Test
     void testZoneOrOffsetRight() {
         java.util.function.BiConsumer<DateTimeV2Literal, Long> assertHour = (dateTimeV2Literal, expectHour) -> {
-            Assertions.assertSame(dateTimeV2Literal.hour, expectHour);
+            Assertions.assertEquals(dateTimeV2Literal.hour, expectHour);
         };
         DateTimeV2Literal dateTimeV2Literal;
         dateTimeV2Literal = new DateTimeV2Literal("2022-08-01 00:00:00Europe/London"); // +01:00
@@ -123,7 +129,7 @@ class DateTimeLiteralTest {
     @Test
     void testZoneOffset() {
         new DateTimeV2Literal("2022-08-01 01:01:01UTC+01:01:01");
-        // new DateTimeV2Literal("2022-08-01 01:01:01UTC+1:1:1");
+        new DateTimeV2Literal("2022-08-01 01:01:01UTC+1:1:1");
 
         new DateTimeV2Literal("2022-08-01 01:01:01UTC+01:01");
 
@@ -147,11 +153,11 @@ class DateTimeLiteralTest {
         new DateTimeV2Literal("2022-08-01 01:01:01+01:01:01");
         new DateTimeV2Literal("2022-08-01 01:01:01+01:01");
         // new DateTimeV2Literal("2022-08-01 01:01:01+01");
-        // new DateTimeV2Literal("2022-08-01 01:01:01+01:1:01");
-        // new DateTimeV2Literal("2022-08-01 01:01:01+01:1");
-        // new DateTimeV2Literal("2022-08-01 01:01:01+01:01:1");
-        // new DateTimeV2Literal("2022-08-01 01:01:01+1:1:1");
-        // new DateTimeV2Literal("2022-08-01 01:01:01+1:1");
+        new DateTimeV2Literal("2022-08-01 01:01:01+01:1:01");
+        new DateTimeV2Literal("2022-08-01 01:01:01+01:1");
+        new DateTimeV2Literal("2022-08-01 01:01:01+01:01:1");
+        new DateTimeV2Literal("2022-08-01 01:01:01+1:1:1");
+        new DateTimeV2Literal("2022-08-01 01:01:01+1:1");
         // new DateTimeV2Literal("2022-08-01 01:01:01+1");
 
         new DateTimeV2Literal("2022-05-01 01:02:55+02:30");
@@ -171,8 +177,8 @@ class DateTimeLiteralTest {
 
     @Test
     void testDateTime() {
-        // new DateTimeV2Literal("2022-08-01 01:01:01UTC+1:1:1");
-        // new DateTimeV2Literal("2022-08-01 01:01:01UTC+1:1");
+        new DateTimeV2Literal("2022-08-01 01:01:01UTC+1:1:1");
+        new DateTimeV2Literal("2022-08-01 01:01:01UTC+1:1");
         // new DateTimeV2Literal("2022-08-01 01:01:01UTC+1");
 
         new DateTimeV2Literal("0001-01-01 00:01:01");
@@ -203,7 +209,6 @@ class DateTimeLiteralTest {
         // new DateTimeV2Literal("20220801GMT-3");
     }
 
-    @Disabled
     @Test
     void testIrregularDateTime() {
         new DateLiteral("2016-07-02 01:01:00");
@@ -227,7 +232,6 @@ class DateTimeLiteralTest {
         new DateLiteral("2016-7-2 01:1:0");
     }
 
-    @Disabled
     @Test
     void testIrregularDateTimeHour() {
         new DateTimeV2Literal("2016-07-02 01");
@@ -243,7 +247,6 @@ class DateTimeLiteralTest {
         new DateTimeV2Literal("2016-7-2 01");
     }
 
-    @Disabled
     @Test
     void testIrregularDateTimeHourMinute() {
         new DateTimeV2Literal("2016-07-02 01:01");
@@ -267,7 +270,6 @@ class DateTimeLiteralTest {
         new DateTimeV2Literal("2016-7-2 1:1");
     }
 
-    @Disabled
     @Test
     void testIrregularDateTimeHourMinuteSecond() {
         new DateTimeV2Literal("2016-07-02 01:01:01");
@@ -307,7 +309,6 @@ class DateTimeLiteralTest {
         new DateTimeV2Literal("2016-7-2 1:1:1");
     }
 
-    @Disabled
     @Test
     void testIrregularDateTimeHourMinuteSecondMicrosecond() {
         new DateTimeV2Literal("2016-07-02 01:01:01.1");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeLiteralTest.java
@@ -164,8 +164,6 @@ class DateTimeLiteralTest {
         new DateTimeV2Literal("2022-05-01 01:02:55.123-02:30");
         new DateTimeV2Literal("2022-06-01T01:02:55+04:30");
         new DateTimeV2Literal("2022-06-01 01:02:55.123-07:30");
-        // new DateTimeV2Literal("20220701010255+07:00");
-        // new DateTimeV2Literal("20220701010255-05:00");
         new DateTimeV2Literal("2022-05-01 01:02:55+02:30");
 
         new DateTimeV2Literal("2022-05-01 01:02:55.123-02:30");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeLiteralTest.java
@@ -133,32 +133,32 @@ class DateTimeLiteralTest {
 
         new DateTimeV2Literal("2022-08-01 01:01:01UTC+01:01");
 
-        // new DateTimeV2Literal("2022-08-01 01:01:01UTC+01");
-        // new DateTimeV2Literal("2022-08-01 01:01:01UTC+1");
+        new DateTimeV2Literal("2022-08-01 01:01:01UTC+01");
+        new DateTimeV2Literal("2022-08-01 01:01:01UTC+1");
     }
 
     @Test
     void testTwoDigitalYearZoneOffset() {
         new DateTimeV2Literal("22-08-01 01:01:01UTC+01:01:01");
-        // new DateTimeV2Literal("22-08-01 01:01:01UTC+1:1:1");
+        new DateTimeV2Literal("22-08-01 01:01:01UTC+1:1:1");
 
         new DateTimeV2Literal("22-08-01 01:01:01UTC+01:01");
 
-        // new DateTimeV2Literal("22-08-01 01:01:01UTC+01");
-        // new DateTimeV2Literal("22-08-01 01:01:01UTC+1");
+        new DateTimeV2Literal("22-08-01 01:01:01UTC+01");
+        new DateTimeV2Literal("22-08-01 01:01:01UTC+1");
     }
 
     @Test
     void testOffset() {
         new DateTimeV2Literal("2022-08-01 01:01:01+01:01:01");
         new DateTimeV2Literal("2022-08-01 01:01:01+01:01");
-        // new DateTimeV2Literal("2022-08-01 01:01:01+01");
+        new DateTimeV2Literal("2022-08-01 01:01:01+01");
         new DateTimeV2Literal("2022-08-01 01:01:01+01:1:01");
         new DateTimeV2Literal("2022-08-01 01:01:01+01:1");
         new DateTimeV2Literal("2022-08-01 01:01:01+01:01:1");
         new DateTimeV2Literal("2022-08-01 01:01:01+1:1:1");
         new DateTimeV2Literal("2022-08-01 01:01:01+1:1");
-        // new DateTimeV2Literal("2022-08-01 01:01:01+1");
+        new DateTimeV2Literal("2022-08-01 01:01:01+1");
 
         new DateTimeV2Literal("2022-05-01 01:02:55+02:30");
         new DateTimeV2Literal("2022-05-01 01:02:55.123-02:30");
@@ -179,7 +179,7 @@ class DateTimeLiteralTest {
     void testDateTime() {
         new DateTimeV2Literal("2022-08-01 01:01:01UTC+1:1:1");
         new DateTimeV2Literal("2022-08-01 01:01:01UTC+1:1");
-        // new DateTimeV2Literal("2022-08-01 01:01:01UTC+1");
+        new DateTimeV2Literal("2022-08-01 01:01:01UTC+1");
 
         new DateTimeV2Literal("0001-01-01 00:01:01");
         new DateTimeV2Literal("0001-01-01 00:01:01.001");
@@ -189,20 +189,20 @@ class DateTimeLiteralTest {
         new DateTimeV2Literal("2022-01-01 01:02:55.123");
         new DateTimeV2Literal("2022-02-01 01:02:55Z");
         new DateTimeV2Literal("2022-02-01 01:02:55.123Z");
-        // new DateTimeV2Literal("2022-03-01 01:02:55UTC+8");
+        new DateTimeV2Literal("2022-03-01 01:02:55UTC+8");
         new DateTimeV2Literal("2022-03-01 01:02:55.123UTC");
-        // new DateTimeV2Literal("2022-04-01 01:02:55UTC-6");
-        // new DateTimeV2Literal("2022-04-01T01:02:55UTC-6");
-        // new DateTimeV2Literal("2022-04-01T01:02:55.123UTC+6");
+        new DateTimeV2Literal("2022-04-01 01:02:55UTC-6");
+        new DateTimeV2Literal("2022-04-01T01:02:55UTC-6");
+        new DateTimeV2Literal("2022-04-01T01:02:55.123UTC+6");
 
         new DateTimeV2Literal("2022-01-01 01:02:55");
         new DateTimeV2Literal("2022-01-01 01:02:55.123");
         new DateTimeV2Literal("2022-02-01 01:02:55Z");
         new DateTimeV2Literal("2022-02-01 01:02:55.123Z");
-        // new DateTimeV2Literal("2022-03-01 01:02:55UTC+8");
+        new DateTimeV2Literal("2022-03-01 01:02:55UTC+8");
         new DateTimeV2Literal("2022-03-01 01:02:55.123UTC");
-        // new DateTimeV2Literal("2022-04-01T01:02:55UTC-6");
-        // new DateTimeV2Literal("2022-04-01T01:02:55.123UTC+6");
+        new DateTimeV2Literal("2022-04-01T01:02:55UTC-6");
+        new DateTimeV2Literal("2022-04-01T01:02:55.123UTC+6");
 
         new DateTimeV2Literal("0001-01-01");
         // new DateTimeV2Literal("20220801GMT+5");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/DateTimeFormatterUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/DateTimeFormatterUtilsTest.java
@@ -33,11 +33,9 @@ class DateTimeFormatterUtilsTest {
 
         formatter.parse("");
 
-        // formatter.parse("UTC+01");
         formatter.parse("UTC+01:00");
         formatter.parse("UTC+01:00:00");
 
-        // formatter.parse("GMT+01");
         formatter.parse("GMT+01:00");
         formatter.parse("Asia/Shanghai");
         formatter.parse("Z");
@@ -89,27 +87,6 @@ class DateTimeFormatterUtilsTest {
     }
 
     @Test
-    void testTwoDigitalDate() {
-        DateTimeFormatter formatter = DateTimeFormatterUtils.DATE_FORMATTER;
-        // Year values in the range 00-69 become 2000-2069.
-        // Year values in the range 70-99 become 1970-199
-        for (int i = 0; i < 100; i++) {
-            String str;
-            if (i < 10) {
-                str = "0" + i + "-02-19";
-            } else {
-                str = i + "-02-19";
-            }
-            TemporalAccessor dateTime = formatter.parse(str);
-            if (i < 70) {
-                Assertions.assertEquals(2000 + i, dateTime.get(ChronoField.YEAR));
-            } else {
-                Assertions.assertEquals(1900 + i, dateTime.get(ChronoField.YEAR));
-            }
-        }
-    }
-
-    @Test
     void testDateTimeFormatter() {
         DateTimeFormatter formatter = DateTimeFormatterUtils.DATE_TIME_FORMATTER;
         TemporalAccessor dateTime = formatter.parse("2020-02-19 01:01:01");
@@ -131,9 +108,7 @@ class DateTimeFormatterUtilsTest {
         assertTime.accept(dateTime);
         dateTime = timeFormatter.parse("01:01:01");
         assertTime.accept(dateTime);
-        dateTime = timeFormatter.parse("01:01");
-        assertTime.accept(dateTime);
-        dateTime = timeFormatter.parse("01");
-        assertTime.accept(dateTime);
+        Assertions.assertThrows(DateTimeParseException.class, () -> timeFormatter.parse("01:01"));
+        Assertions.assertThrows(DateTimeParseException.class, () -> timeFormatter.parse("01"));
     }
 }


### PR DESCRIPTION
## Proposed changes

- feature: normalize date/datetime with leading 0
- feature: support 'HH' offset in date/datetime
- feature: normalize() add missing Minute/Second in Time part
- feature: normalize offset HH to HH:MM
- correct DateTimeFormatterUtilsTest

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

