### PR TITLE
[Fix](S3 tvf) fix that S3 tvf can not run properly 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/S3TableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/S3TableValuedFunction.java
@@ -25,6 +25,7 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.S3URI;
 import org.apache.doris.datasource.credentials.CloudCredentialWithEndpoint;
 import org.apache.doris.datasource.property.PropertyConverter;
+import org.apache.doris.datasource.property.S3ClientBEProperties;
 import org.apache.doris.datasource.property.constants.S3Properties;
 import org.apache.doris.fs.FileSystemFactory;
 import org.apache.doris.thrift.TFileType;
@@ -110,6 +111,7 @@ public class S3TableValuedFunction extends ExternalFileTableValuedFunction {
         locationProperties = S3Properties.credentialToMap(credential);
         String usePathStyle = fileParams.getOrDefault(PropertyConverter.USE_PATH_STYLE, "false");
         locationProperties.put(PropertyConverter.USE_PATH_STYLE, usePathStyle);
+        this.locationProperties.putAll(S3ClientBEProperties.getBeFSProperties(this.locationProperties));
 
         super.parseProperties(fileParams);
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

# bug describe
There will be an error  althouth when we use correctness S3 properties:
```sql
select * from s3(     
"uri" = "https://xxx.com/bucket/exp_f123b8def7854e52-909204d211935e70_0.orc",     
"s3.secret_key"="sk",     
"s3.access_key" = "ak",     
"format" = "orc" );

ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[INVALID_ARGUMENT]S3 properties are incorrect, please check properties.
```

# Reson
This bug is caused by this PR: #23635 

Because the `Broker constructor` will change the incoming parameters——`properties` before #23635 :
```
public BrokerDesc(String name, Map<String, String> properties) {
        this.name = name;
        this.properties = properties;
        if (this.properties == null) {
            this.properties = Maps.newHashMap();
        }
        if (isMultiLoadBroker()) {
            this.storageType = StorageBackend.StorageType.LOCAL;
        } else {
            this.storageType = StorageBackend.StorageType.BROKER;
        }
        this.properties.putAll(S3ClientBEProperties.getBeFSProperties(this.properties));
        this.convertedToS3 = BosProperties.tryConvertBosToS3(this.properties, this.storageType);
        if (this.convertedToS3) {
            this.storageType = StorageBackend.StorageType.S3;
        }
    }
```
The parameter  `properties` will be changed at `this.properties.putAll(S3ClientBEProperties.getBeFSProperties(this.properties));` because `this.properties`  and `properties` are point to the same reference.
But `properties` will not be changed in PR  #23635 

Howerver, the member`locationProperties` of `S3TableValuedFunction` rely on this change. So we get this bug

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

