### PR TITLE
[fix](profile) move probe time to pull and add LoopGenerateJoin time

### DIFF
--- a/be/src/vec/exec/join/vnested_loop_join_node.cpp
+++ b/be/src/vec/exec/join/vnested_loop_join_node.cpp
@@ -149,7 +149,7 @@ Status VNestedLoopJoinNode::prepare(RuntimeState* state) {
     _num_build_side_columns = child(1)->row_desc().num_materialized_slots();
     RETURN_IF_ERROR(VExpr::prepare(_output_expr_ctxs, state, *_intermediate_row_desc));
     RETURN_IF_ERROR(VExpr::prepare(_filter_src_expr_ctxs, state, child(1)->row_desc()));
-
+    _loop_join_timer = ADD_CHILD_TIMER(_probe_phase_profile, "LoopGenerateJoin", "ProbeTime");
     _construct_mutable_join_block();
     return Status::OK();
 }
@@ -264,9 +264,7 @@ Status VNestedLoopJoinNode::_fresh_left_block(doris::RuntimeState* state) {
 
 Status VNestedLoopJoinNode::get_next(RuntimeState* state, Block* block, bool* eos) {
     SCOPED_TIMER(_runtime_profile->total_time_counter());
-    SCOPED_TIMER(_probe_timer);
     RETURN_IF_CANCELLED(state);
-
     while (need_more_input_data()) {
         RETURN_IF_ERROR(_fresh_left_block(state));
         push(state, &_left_block, _left_side_eos);
@@ -666,6 +664,7 @@ void VNestedLoopJoinNode::_release_mem() {
 }
 
 Status VNestedLoopJoinNode::pull(RuntimeState* state, vectorized::Block* block, bool* eos) {
+    SCOPED_TIMER(_probe_timer);
     if (_is_output_left_side_only) {
         RETURN_IF_ERROR(_build_output_block(&_left_block, block));
         *eos = _left_side_eos;
@@ -699,6 +698,7 @@ Status VNestedLoopJoinNode::pull(RuntimeState* state, vectorized::Block* block, 
                                                  set_build_side_flag, set_probe_side_flag>(
                         state, join_op_variants);
             };
+            SCOPED_TIMER(_loop_join_timer);
             RETURN_IF_ERROR(std::visit(func, _join_op_variants,
                                        make_bool_variant(_match_all_build || _is_right_semi_anti),
                                        make_bool_variant(_match_all_probe || _is_left_semi_anti)));

--- a/be/src/vec/exec/join/vnested_loop_join_node.h
+++ b/be/src/vec/exec/join/vnested_loop_join_node.h
@@ -274,7 +274,7 @@ private:
     std::stack<uint16_t> _build_offset_stack;
     std::stack<uint16_t> _probe_offset_stack;
     VExprContextSPtrs _join_conjuncts;
-
+    RuntimeProfile::Counter* _loop_join_timer;
     template <typename Parent>
     friend struct RuntimeFilterBuild;
 };


### PR DESCRIPTION
## Proposed changes
beforce
```
                                  -  ProbeTime:  0ns
                                      -  BuildOutputBlock:  338.796ms
                                      -  JoinFilterTimer:  21s182ms
```

now

```
                                  -  ProbeTime:  2s530ms
                                      -  BuildOutputBlock:  84.810ms
                                      -  JoinFilterTimer:  1.921ms
                                      -  LoopGenerateJoin:  2s380ms
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

