### PR TITLE
[branch-2.0](fix) compile error when compiler opens -Werror and -Wunused-result

### DIFF
--- a/be/src/pipeline/exec/exchange_sink_buffer.cpp
+++ b/be/src/pipeline/exec/exchange_sink_buffer.cpp
@@ -229,7 +229,7 @@ Status ExchangeSinkBuffer::_send_rpc(InstanceLoId id) {
             }
         }
         if (request.block) {
-            brpc_request->release_block();
+            static_cast<void>(brpc_request->release_block());
         }
         q.pop();
     } else if (!broadcast_q.empty()) {
@@ -282,7 +282,7 @@ Status ExchangeSinkBuffer::_send_rpc(InstanceLoId id) {
             }
         }
         if (request.block_holder->get_block()) {
-            brpc_request->release_block();
+            static_cast<void>(brpc_request->release_block());
         }
         broadcast_q.pop();
     } else {

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -192,7 +192,7 @@ Status Channel::send_block(PBlock* block, bool eos) {
     }
 
     if (block != nullptr) {
-        _brpc_request.release_block();
+        static_cast<void>(_brpc_request.release_block());
     }
     return Status::OK();
 }

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -243,7 +243,7 @@ VNodeChannel::~VNodeChannel() {
     if (_open_closure != nullptr) {
         delete _open_closure;
     }
-    _cur_add_block_request.release_id();
+    static_cast<void>(_cur_add_block_request.release_id());
 }
 
 void VNodeChannel::clear_all_blocks() {
@@ -336,8 +336,8 @@ void VNodeChannel::open() {
     }
     _stub->tablet_writer_open(&_open_closure->cntl, &request, &_open_closure->result,
                               _open_closure);
-    request.release_id();
-    request.release_schema();
+    static_cast<void>(request.release_id());
+    static_cast<void>(request.release_schema());
 }
 
 Status VNodeChannel::open_wait() {
@@ -821,7 +821,7 @@ void VNodeChannel::cancel(const std::string& cancel_msg) {
         closure->cntl.ignore_eovercrowded();
     }
     _stub->tablet_writer_cancel(&closure->cntl, &request, &closure->result, closure);
-    request.release_id();
+    static_cast<void>(request.release_id());
 }
 
 bool VNodeChannel::is_send_data_rpc_done() const {


### PR DESCRIPTION
## Proposed changes


If the compiler opens -Werror,-Wunused-result, discard non-discard function return values will be treated as compile error.
Cast unused return value.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

