### PR TITLE
[fix](hive) fix partition prune issue and some external table test cases

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalFileScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalFileScan.java
@@ -149,6 +149,13 @@ public class LogicalFileScan extends LogicalCatalogRelation {
             }
         }
 
+        /**
+         * Return true means this relation is partition prunned
+         */
+        public boolean isPartitionPruned() {
+            return this.totalPartitionNum > 0 || isPartitionPruned;
+        }
+
         @Override
         public boolean equals(Object o) {
             return isPartitionPruned == ((SelectedPartitions) o).isPartitionPruned && Objects.equals(
@@ -156,4 +163,5 @@ public class LogicalFileScan extends LogicalCatalogRelation {
         }
     }
 }
+
 

--- a/regression-test/suites/external_table_p0/tvf/test_local_tvf.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_local_tvf.groovy
@@ -26,14 +26,14 @@ suite("test_local_tvf") {
 
         List<List<Object>> doris_log = sql """ ADMIN SHOW FRONTEND CONFIG like "sys_log_dir"; """
         assertTrue(doris_log.size() > 0)
-        def doris_log_path = doris_log[0][1]
+        def doris_log_path = "log/"
 
         table = sql """
             select count(*) from local(
-                "file_path" = "${doris_log_path}/fe.out",
+                "file_path" = "${doris_log_path}/be.out",
                 "backend_id" = "${be_id}",
                 "format" = "csv")
-            where c1 like "%FE type%";"""
+            where c1 like "%start time%";"""
 
         assertTrue(table.size() > 0)
         assertTrue(Long.valueOf(table[0][0]) > 0)
@@ -43,7 +43,7 @@ suite("test_local_tvf") {
                 "file_path" = "${doris_log_path}/*.out",
                 "backend_id" = "${be_id}",
                 "format" = "csv")
-            where c1 like "%FE type%";"""
+            where c1 like "%start time%";"""
 
         assertTrue(table.size() > 0)
         assertTrue(Long.valueOf(table[0][0]) > 0)
@@ -51,7 +51,7 @@ suite("test_local_tvf") {
         test {
             sql """
             select count(*) from local(
-                "file_path" = "../fe.out",
+                "file_path" = "../be.out",
                 "backend_id" = "${be_id}",
                 "format" = "csv")
             where c1 like "%FE type%";

--- a/regression-test/suites/external_table_p2/hive/test_external_catalog_hive.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_external_catalog_hive.groovy
@@ -94,8 +94,8 @@ suite("test_external_catalog_hive", "p2") {
         qt_not_single_slot_filter_conjuncts_parquet """ select * from multi_catalog.lineitem_string_date_orc where l_commitdate < l_receiptdate and l_receiptdate = '1995-01-01'  order by l_orderkey, l_partkey, l_suppkey, l_linenumber limit 10; """
 
         // test null expr with dict filter issue
-        qt_null_expr_dict_filter_orc """ select count(*), count(distinct user_no) from multi_catalog.dict_fitler_test_orc WHERE partitions in ('2023-08-21') and actual_intf_type  =  'type1' and (REUSE_FLAG<> 'y' or REUSE_FLAG is null); """
-        qt_null_expr_dict_filter_parquet """ select count(*), count(distinct user_no) from multi_catalog.dict_fitler_test_parquet WHERE partitions in ('2023-08-21') and actual_intf_type  =  'type1' and (REUSE_FLAG<> 'y' or REUSE_FLAG is null); """
+        qt_null_expr_dict_filter_orc """ select count(*), count(distinct user_no) from multi_catalog.dict_fitler_test_orc WHERE `partitions` in ('2023-08-21') and actual_intf_type  =  'type1' and (REUSE_FLAG<> 'y' or REUSE_FLAG is null); """
+        qt_null_expr_dict_filter_parquet """ select count(*), count(distinct user_no) from multi_catalog.dict_fitler_test_parquet WHERE `partitions` in ('2023-08-21') and actual_intf_type  =  'type1' and (REUSE_FLAG<> 'y' or REUSE_FLAG is null); """
 
         // test par fields in file
         qt_par_fields_in_file_orc1 """ select * from multi_catalog.par_fields_in_file_orc where year = 2023 and month = 8 order by id; """


### PR DESCRIPTION
## Proposed changes

1. Fix hive partition prune bug, introduced from #23845, will fail `test_hive_default_partition` test case.
2. Fix `test_local_tvf.groovy` test case, the path of local tvf should be relative path.
3. Fix `test_external_catalog_hive` test case, the `partitions` is now reserve keywords

pick #24338

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

