### PR TITLE
[feature](statistics) collect loaded rows on table level after txn published

### DIFF
--- a/be/src/olap/task/engine_publish_version_task.cpp
+++ b/be/src/olap/task/engine_publish_version_task.cpp
@@ -71,11 +71,13 @@ void TabletPublishStatistics::record_in_bvar() {
 EnginePublishVersionTask::EnginePublishVersionTask(
         const TPublishVersionRequest& publish_version_req, std::set<TTabletId>* error_tablet_ids,
         std::map<TTabletId, TVersion>* succ_tablets,
-        std::vector<std::tuple<int64_t, int64_t, int64_t>>* discontinuous_version_tablets)
+        std::vector<std::tuple<int64_t, int64_t, int64_t>>* discontinuous_version_tablets,
+        std::map<TTabletId, int64_t>* tablet_id_to_num_delta_rows)
         : _publish_version_req(publish_version_req),
           _error_tablet_ids(error_tablet_ids),
           _succ_tablets(succ_tablets),
-          _discontinuous_version_tablets(discontinuous_version_tablets) {}
+          _discontinuous_version_tablets(discontinuous_version_tablets),
+          _tablet_id_to_num_delta_rows(tablet_id_to_num_delta_rows) {}
 
 void EnginePublishVersionTask::add_error_tablet_id(int64_t tablet_id) {
     std::lock_guard<std::mutex> lck(_tablet_ids_mutex);
@@ -186,6 +188,9 @@ Status EnginePublishVersionTask::finish() {
                     continue;
                 }
             }
+            auto rowset_meta_ptr = rowset->rowset_meta();
+            _tablet_id_to_num_delta_rows->insert(
+                    {rowset_meta_ptr->tablet_id(), rowset_meta_ptr->num_rows()});
             auto tablet_publish_txn_ptr = std::make_shared<TabletPublishTxnTask>(
                     this, tablet, rowset, partition_id, transaction_id, version, tablet_info);
             auto submit_st = token->submit_func([=]() { tablet_publish_txn_ptr->handle(); });

--- a/be/src/olap/task/engine_publish_version_task.h
+++ b/be/src/olap/task/engine_publish_version_task.h
@@ -87,10 +87,11 @@ public:
     EnginePublishVersionTask(
             const TPublishVersionRequest& publish_version_req,
             std::set<TTabletId>* error_tablet_ids, std::map<TTabletId, TVersion>* succ_tablets,
-            std::vector<std::tuple<int64_t, int64_t, int64_t>>* discontinous_version_tablets);
-    ~EnginePublishVersionTask() {}
+            std::vector<std::tuple<int64_t, int64_t, int64_t>>* discontinous_version_tablets,
+            std::map<TTabletId, int64_t>* tablet_id_to_num_delta_rows);
+    ~EnginePublishVersionTask() override = default;
 
-    virtual Status finish() override;
+    Status finish() override;
 
     void add_error_tablet_id(int64_t tablet_id);
 
@@ -102,6 +103,7 @@ private:
     std::set<TTabletId>* _error_tablet_ids;
     std::map<TTabletId, TVersion>* _succ_tablets;
     std::vector<std::tuple<int64_t, int64_t, int64_t>>* _discontinuous_version_tablets;
+    std::map<TTabletId, int64_t>* _tablet_id_to_num_delta_rows;
 };
 
 class AsyncTabletPublishTask {

--- a/fe/fe-core/src/main/java/org/apache/doris/master/MasterImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/MasterImpl.java
@@ -491,6 +491,9 @@ public class MasterImpl {
             // not remove the task from queue and be will retry
             return;
         }
+        if (request.isSetTabletIdToDeltaNumRows()) {
+            publishVersionTask.setTabletIdToDeltaNumRows(request.getTabletIdToDeltaNumRows());
+        }
         AgentTaskQueue.removeTask(publishVersionTask.getBackendId(),
                                   publishVersionTask.getTaskType(),
                                   publishVersionTask.getSignature());

--- a/fe/fe-core/src/main/java/org/apache/doris/task/PublishVersionTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/PublishVersionTask.java
@@ -21,6 +21,7 @@ import org.apache.doris.thrift.TPartitionVersionInfo;
 import org.apache.doris.thrift.TPublishVersionRequest;
 import org.apache.doris.thrift.TTaskType;
 
+import com.google.common.collect.Maps;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -37,6 +38,11 @@ public class PublishVersionTask extends AgentTask {
 
     // tabletId => version, current version = 0
     private Map<Long, Long> succTablets;
+
+    /**
+     * To collect loaded rows for each tablet from each BE
+     */
+    private final Map<Long, Long> tabletIdToDeltaNumRows = Maps.newHashMap();
 
     public PublishVersionTask(long backendId, long transactionId, long dbId,
             List<TPartitionVersionInfo> partitionVersionInfos, long createTime) {
@@ -80,5 +86,13 @@ public class PublishVersionTask extends AgentTask {
             return;
         }
         this.errorTablets.addAll(errorTablets);
+    }
+
+    public void setTabletIdToDeltaNumRows(Map<Long, Long> tabletIdToDeltaNumRows) {
+        this.tabletIdToDeltaNumRows.putAll(tabletIdToDeltaNumRows);
+    }
+
+    public Map<Long, Long> getTabletIdToDeltaNumRows() {
+        return tabletIdToDeltaNumRows;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -51,6 +51,7 @@ import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.persist.BatchRemoveTransactionsOperationV2;
 import org.apache.doris.persist.EditLog;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.statistics.AnalysisManager;
 import org.apache.doris.task.AgentBatchTask;
 import org.apache.doris.task.AgentTaskExecutor;
 import org.apache.doris.task.ClearTransactionTask;
@@ -1787,6 +1788,9 @@ public class DatabaseTransactionMgr {
                 }
             }
         }
+        AnalysisManager analysisManager = Env.getCurrentEnv().getAnalysisManager();
+        LOG.debug("table id to loaded rows:{}", transactionState.getTableIdToNumDeltaRows());
+        transactionState.getTableIdToNumDeltaRows().forEach(analysisManager::updateUpdatedRows);
         return true;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
@@ -147,7 +147,9 @@ public class PublishVersionDaemon extends MasterDaemon {
                                     return;
                                 }
                                 TabletMeta tabletMeta = tabletInvertedIndex.getTabletMeta(tabletId);
-                                Preconditions.checkNotNull(tabletMeta, "tablet id: %s, doesn't match a table", tabletId);
+                                if (tabletMeta == null) {
+                                    return;
+                                }
                                 long tableId = tabletMeta.getTableId();
                                 tableIdToNumDeltaRows.computeIfPresent(tableId, (tblId, orgNum) -> orgNum + numRows);
                                 tableIdToNumDeltaRows.putIfAbsent(tableId, numRows);

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
@@ -31,7 +31,6 @@ import org.apache.doris.task.PublishVersionTask;
 import org.apache.doris.thrift.TPartitionVersionInfo;
 import org.apache.doris.thrift.TTaskType;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.commons.collections.CollectionUtils;

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.transaction;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.catalog.TabletMeta;
@@ -35,6 +34,7 @@ import org.apache.doris.thrift.TTaskType;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -133,7 +133,6 @@ public class PublishVersionDaemon extends MasterDaemon {
         Map<Long, Long> tableIdToNumDeltaRows = Maps.newHashMap();
         // try to finish the transaction, if failed just retry in next loop
         for (TransactionState transactionState : readyTransactionStates) {
-<<<<<<< HEAD
             Stream<PublishVersionTask> publishVersionTaskStream = transactionState
                     .getPublishVersionTasks()
                     .values()
@@ -146,109 +145,6 @@ public class PublishVersionDaemon extends MasterDaemon {
                                 if (!tabletIdFilter.add(tabletId)) {
                                     // means the delta num rows for this tablet id has been collected
                                     return;
-=======
-            Map<Long, PublishVersionTask> transTasks = transactionState.getPublishVersionTasks();
-            Set<Long> publishErrorReplicaIds = Sets.newHashSet();
-            List<PublishVersionTask> unfinishedTasks = Lists.newArrayList();
-            Map<Long, Long> tableIdToNumDeltaRows = Maps.newHashMap();
-            Set<Long> tabletIdFilter = Sets.newHashSet();
-            for (PublishVersionTask publishVersionTask : transTasks.values()) {
-                if (publishVersionTask.isFinished()) {
-                    // sometimes backend finish publish version task,
-                    // but it maybe failed to change transactionid to version for some tablets
-                    // and it will upload the failed tabletinfo to fe and fe will deal with them
-                    List<Long> errorTablets = publishVersionTask.getErrorTablets();
-                    if (errorTablets == null || errorTablets.isEmpty()) {
-                        Map<Long, Long> tabletIdToDeltaNumRows =
-                                publishVersionTask.getTabletIdToDeltaNumRows();
-                        tabletIdToDeltaNumRows.forEach((tabletId, numRows) -> {
-                            if (!tabletIdFilter.add(tabletId)) {
-                                // means the delta num rows for this tablet id has been collected
-                                return;
-                            }
-                            TabletMeta tabletMeta = tabletInvertedIndex.getTabletMeta(tabletId);
-                            if (tabletMeta == null) {
-                                // for delete, here may be a null value
-                                return;
-                            }
-                            long tableId = tabletMeta.getTableId();
-                            tableIdToNumDeltaRows.computeIfPresent(tableId, (tblId, orgNum) -> orgNum + numRows);
-                            tableIdToNumDeltaRows.putIfAbsent(tableId, numRows);
-                        });
-                        continue;
-                    } else {
-                        for (long tabletId : errorTablets) {
-                            // tablet inverted index also contains rollingup index
-                            // if tablet meta not contains the tablet, skip this tablet because this tablet is dropped
-                            // from fe
-                            if (tabletInvertedIndex.getTabletMeta(tabletId) == null) {
-                                continue;
-                            }
-                            Replica replica = tabletInvertedIndex.getReplica(
-                                    tabletId, publishVersionTask.getBackendId());
-                            if (replica != null) {
-                                publishErrorReplicaIds.add(replica.getId());
-                            } else {
-                                LOG.info("could not find related replica with tabletid={}, backendid={}",
-                                        tabletId, publishVersionTask.getBackendId());
-                            }
-                        }
-                    }
-                } else {
-                    unfinishedTasks.add(publishVersionTask);
-                }
-            }
-            transactionState.setTableIdToNumDeltaRows(tableIdToNumDeltaRows);
-
-            boolean shouldFinishTxn = false;
-            if (!unfinishedTasks.isEmpty()) {
-                shouldFinishTxn = isAllBackendsOfUnfinishedTasksDead(unfinishedTasks);
-                if (transactionState.isPublishTimeout() || shouldFinishTxn) {
-                    // transaction's publish is timeout, but there still has unfinished tasks.
-                    // we need to collect all error replicas, and try to finish this txn.
-                    for (PublishVersionTask unfinishedTask : unfinishedTasks) {
-                        // set all replicas in the backend to error state
-                        List<TPartitionVersionInfo> versionInfos = unfinishedTask.getPartitionVersionInfos();
-                        Set<Long> errorPartitionIds = Sets.newHashSet();
-                        for (TPartitionVersionInfo versionInfo : versionInfos) {
-                            errorPartitionIds.add(versionInfo.getPartitionId());
-                        }
-                        if (errorPartitionIds.isEmpty()) {
-                            continue;
-                        }
-
-                        Database db = Env.getCurrentInternalCatalog()
-                                .getDbNullable(transactionState.getDbId());
-                        if (db == null) {
-                            LOG.warn("Database [{}] has been dropped.", transactionState.getDbId());
-                            continue;
-                        }
-
-                        for (long tableId : transactionState.getTableIdList()) {
-                            Table table = db.getTableNullable(tableId);
-                            if (table == null || table.getType() != Table.TableType.OLAP) {
-                                LOG.warn("Table [{}] in database [{}] has been dropped.", tableId, db.getFullName());
-                                continue;
-                            }
-                            OlapTable olapTable = (OlapTable) table;
-                            olapTable.readLock();
-                            try {
-                                for (Long errorPartitionId : errorPartitionIds) {
-                                    Partition partition = olapTable.getPartition(errorPartitionId);
-                                    if (partition != null) {
-                                        List<MaterializedIndex> materializedIndexList
-                                                = partition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL);
-                                        for (MaterializedIndex materializedIndex : materializedIndexList) {
-                                            for (Tablet tablet : materializedIndex.getTablets()) {
-                                                Replica replica = tablet.getReplicaByBackendId(
-                                                        unfinishedTask.getBackendId());
-                                                if (replica != null) {
-                                                    publishErrorReplicaIds.add(replica.getId());
-                                                }
-                                            }
-                                        }
-                                    }
->>>>>>> d4517cf722 (fix table not found in tablet inverted index)
                                 }
                                 TabletMeta tabletMeta = tabletInvertedIndex.getTabletMeta(tabletId);
                                 Preconditions.checkNotNull(tabletMeta, "tablet id: %s, doesn't match a table", tabletId);

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
@@ -133,6 +133,7 @@ public class PublishVersionDaemon extends MasterDaemon {
         Map<Long, Long> tableIdToNumDeltaRows = Maps.newHashMap();
         // try to finish the transaction, if failed just retry in next loop
         for (TransactionState transactionState : readyTransactionStates) {
+<<<<<<< HEAD
             Stream<PublishVersionTask> publishVersionTaskStream = transactionState
                     .getPublishVersionTasks()
                     .values()
@@ -145,6 +146,109 @@ public class PublishVersionDaemon extends MasterDaemon {
                                 if (!tabletIdFilter.add(tabletId)) {
                                     // means the delta num rows for this tablet id has been collected
                                     return;
+=======
+            Map<Long, PublishVersionTask> transTasks = transactionState.getPublishVersionTasks();
+            Set<Long> publishErrorReplicaIds = Sets.newHashSet();
+            List<PublishVersionTask> unfinishedTasks = Lists.newArrayList();
+            Map<Long, Long> tableIdToNumDeltaRows = Maps.newHashMap();
+            Set<Long> tabletIdFilter = Sets.newHashSet();
+            for (PublishVersionTask publishVersionTask : transTasks.values()) {
+                if (publishVersionTask.isFinished()) {
+                    // sometimes backend finish publish version task,
+                    // but it maybe failed to change transactionid to version for some tablets
+                    // and it will upload the failed tabletinfo to fe and fe will deal with them
+                    List<Long> errorTablets = publishVersionTask.getErrorTablets();
+                    if (errorTablets == null || errorTablets.isEmpty()) {
+                        Map<Long, Long> tabletIdToDeltaNumRows =
+                                publishVersionTask.getTabletIdToDeltaNumRows();
+                        tabletIdToDeltaNumRows.forEach((tabletId, numRows) -> {
+                            if (!tabletIdFilter.add(tabletId)) {
+                                // means the delta num rows for this tablet id has been collected
+                                return;
+                            }
+                            TabletMeta tabletMeta = tabletInvertedIndex.getTabletMeta(tabletId);
+                            if (tabletMeta == null) {
+                                // for delete, here may be a null value
+                                return;
+                            }
+                            long tableId = tabletMeta.getTableId();
+                            tableIdToNumDeltaRows.computeIfPresent(tableId, (tblId, orgNum) -> orgNum + numRows);
+                            tableIdToNumDeltaRows.putIfAbsent(tableId, numRows);
+                        });
+                        continue;
+                    } else {
+                        for (long tabletId : errorTablets) {
+                            // tablet inverted index also contains rollingup index
+                            // if tablet meta not contains the tablet, skip this tablet because this tablet is dropped
+                            // from fe
+                            if (tabletInvertedIndex.getTabletMeta(tabletId) == null) {
+                                continue;
+                            }
+                            Replica replica = tabletInvertedIndex.getReplica(
+                                    tabletId, publishVersionTask.getBackendId());
+                            if (replica != null) {
+                                publishErrorReplicaIds.add(replica.getId());
+                            } else {
+                                LOG.info("could not find related replica with tabletid={}, backendid={}",
+                                        tabletId, publishVersionTask.getBackendId());
+                            }
+                        }
+                    }
+                } else {
+                    unfinishedTasks.add(publishVersionTask);
+                }
+            }
+            transactionState.setTableIdToNumDeltaRows(tableIdToNumDeltaRows);
+
+            boolean shouldFinishTxn = false;
+            if (!unfinishedTasks.isEmpty()) {
+                shouldFinishTxn = isAllBackendsOfUnfinishedTasksDead(unfinishedTasks);
+                if (transactionState.isPublishTimeout() || shouldFinishTxn) {
+                    // transaction's publish is timeout, but there still has unfinished tasks.
+                    // we need to collect all error replicas, and try to finish this txn.
+                    for (PublishVersionTask unfinishedTask : unfinishedTasks) {
+                        // set all replicas in the backend to error state
+                        List<TPartitionVersionInfo> versionInfos = unfinishedTask.getPartitionVersionInfos();
+                        Set<Long> errorPartitionIds = Sets.newHashSet();
+                        for (TPartitionVersionInfo versionInfo : versionInfos) {
+                            errorPartitionIds.add(versionInfo.getPartitionId());
+                        }
+                        if (errorPartitionIds.isEmpty()) {
+                            continue;
+                        }
+
+                        Database db = Env.getCurrentInternalCatalog()
+                                .getDbNullable(transactionState.getDbId());
+                        if (db == null) {
+                            LOG.warn("Database [{}] has been dropped.", transactionState.getDbId());
+                            continue;
+                        }
+
+                        for (long tableId : transactionState.getTableIdList()) {
+                            Table table = db.getTableNullable(tableId);
+                            if (table == null || table.getType() != Table.TableType.OLAP) {
+                                LOG.warn("Table [{}] in database [{}] has been dropped.", tableId, db.getFullName());
+                                continue;
+                            }
+                            OlapTable olapTable = (OlapTable) table;
+                            olapTable.readLock();
+                            try {
+                                for (Long errorPartitionId : errorPartitionIds) {
+                                    Partition partition = olapTable.getPartition(errorPartitionId);
+                                    if (partition != null) {
+                                        List<MaterializedIndex> materializedIndexList
+                                                = partition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL);
+                                        for (MaterializedIndex materializedIndex : materializedIndexList) {
+                                            for (Tablet tablet : materializedIndex.getTablets()) {
+                                                Replica replica = tablet.getReplicaByBackendId(
+                                                        unfinishedTask.getBackendId());
+                                                if (replica != null) {
+                                                    publishErrorReplicaIds.add(replica.getId());
+                                                }
+                                            }
+                                        }
+                                    }
+>>>>>>> d4517cf722 (fix table not found in tablet inverted index)
                                 }
                                 TabletMeta tabletMeta = tabletInvertedIndex.getTabletMeta(tabletId);
                                 Preconditions.checkNotNull(tabletMeta, "tablet id: %s, doesn't match a table", tabletId);

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
@@ -148,6 +148,7 @@ public class PublishVersionDaemon extends MasterDaemon {
                                 }
                                 TabletMeta tabletMeta = tabletInvertedIndex.getTabletMeta(tabletId);
                                 if (tabletMeta == null) {
+                                    // for delete, drop, schema change etc. here may be a null value
                                     return;
                                 }
                                 long tableId = tabletMeta.getTableId();

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
@@ -17,7 +17,10 @@
 
 package org.apache.doris.transaction;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.TabletInvertedIndex;
+import org.apache.doris.catalog.TabletMeta;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.util.MasterDaemon;
 import org.apache.doris.metric.MetricRepo;
@@ -29,13 +32,17 @@ import org.apache.doris.task.PublishVersionTask;
 import org.apache.doris.thrift.TPartitionVersionInfo;
 import org.apache.doris.thrift.TTaskType;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 public class PublishVersionDaemon extends MasterDaemon {
 
@@ -121,12 +128,36 @@ public class PublishVersionDaemon extends MasterDaemon {
             AgentTaskExecutor.submit(batchTask);
         }
 
+        TabletInvertedIndex tabletInvertedIndex = Env.getCurrentEnv().getTabletInvertedIndex();
+        Set<Long> tabletIdFilter = Sets.newHashSet();
+        Map<Long, Long> tableIdToNumDeltaRows = Maps.newHashMap();
         // try to finish the transaction, if failed just retry in next loop
         for (TransactionState transactionState : readyTransactionStates) {
-            boolean hasBackendAliveAndUnfinishTask = transactionState.getPublishVersionTasks().values().stream()
+            Stream<PublishVersionTask> publishVersionTaskStream = transactionState
+                    .getPublishVersionTasks()
+                    .values()
+                    .stream()
+                    .peek(task -> {
+                        if (task.isFinished() && CollectionUtils.isEmpty(task.getErrorTablets())) {
+                            Map<Long, Long> tabletIdToDeltaNumRows =
+                                    task.getTabletIdToDeltaNumRows();
+                            tabletIdToDeltaNumRows.forEach((tabletId, numRows) -> {
+                                if (!tabletIdFilter.add(tabletId)) {
+                                    // means the delta num rows for this tablet id has been collected
+                                    return;
+                                }
+                                TabletMeta tabletMeta = tabletInvertedIndex.getTabletMeta(tabletId);
+                                Preconditions.checkNotNull(tabletMeta, "tablet id: %s, doesn't match a table", tabletId);
+                                long tableId = tabletMeta.getTableId();
+                                tableIdToNumDeltaRows.computeIfPresent(tableId, (tblId, orgNum) -> orgNum + numRows);
+                                tableIdToNumDeltaRows.putIfAbsent(tableId, numRows);
+                            });
+                        }
+                    });
+            boolean hasBackendAliveAndUnfinishedTask = publishVersionTaskStream
                     .anyMatch(task -> !task.isFinished() && infoService.checkBackendAlive(task.getBackendId()));
 
-            boolean shouldFinishTxn = !hasBackendAliveAndUnfinishTask || transactionState.isPublishTimeout();
+            boolean shouldFinishTxn = !hasBackendAliveAndUnfinishedTask || transactionState.isPublishTimeout();
             if (shouldFinishTxn) {
                 try {
                     // one transaction exception should not affect other transaction

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionState.java
@@ -253,6 +253,8 @@ public class TransactionState implements Writable {
     // tbl id -> (index ids)
     private Map<Long, Set<Long>> loadedTblIndexes = Maps.newHashMap();
 
+    private Map<Long, Long> tableIdToNumDeltaRows = Maps.newHashMap();
+
     private String errorLogUrl = null;
 
     // record some error msgs during the transaction operation.
@@ -699,6 +701,14 @@ public class TransactionState implements Writable {
         for (int i = 0; i < tableListSize; i++) {
             tableIdList.add(in.readLong());
         }
+    }
+
+    public Map<Long, Long> getTableIdToNumDeltaRows() {
+        return tableIdToNumDeltaRows;
+    }
+
+    public void setTableIdToNumDeltaRows(Map<Long, Long> tableIdToNumDeltaRows) {
+        this.tableIdToNumDeltaRows.putAll(tableIdToNumDeltaRows);
     }
 
     public void setErrorMsg(String errMsg) {

--- a/gensrc/thrift/MasterService.thrift
+++ b/gensrc/thrift/MasterService.thrift
@@ -66,6 +66,7 @@ struct TFinishTaskRequest {
     15: optional i64 copy_size
     16: optional i64 copy_time_ms
     17: optional map<Types.TTabletId, Types.TVersion> succ_tablets
+    18: optional map<i64, i64> tablet_id_to_delta_num_rows
 }
 
 struct TTablet {


### PR DESCRIPTION
## Proposed changes

As title.

Stream load 20 lines

```
2023-09-14 11:40:04,186 DEBUG (PUBLISH_VERSION|23) [DatabaseTransactionMgr.updateCatalogAfterVisible():1769] table id to loaded rows:{51016=20}
```

```
mysql> select count(*) from dup_tbl_basic;
+----------+
| count(*) |
+----------+
|       20 |
+----------+
1 row in set (0.05 sec)
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

