### PR TITLE
[Hotfix](merge-on-write) Fix when `DeltaWriter` don't report `num_filtered_rows` in `TTabletCommitInfo`

### DIFF
--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -1859,7 +1859,7 @@ Status VOlapTableSink::close(RuntimeState* state, Status exec_status) {
             // Due to the non-determinism of compaction, the rowsets of each replica may be different from each other on different
             // BE nodes. The number of rows filtered in SegmentWriter depends on the historical rowsets located in the correspoding
             // BE node. So we check the number of rows filtered on each succeccful BE to ensure the consistency of the current load
-            if (!_write_single_replica && _schema->is_strict_mode() &&
+            if (status.ok() && !_write_single_replica && _schema->is_strict_mode() &&
                 _schema->is_partial_update()) {
                 if (Status st = index_channel->check_tablet_filtered_rows_consistency(); !st.ok()) {
                     status = st;

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -169,7 +169,6 @@ public:
     void set_tablets_filtered_rows(
             const std::vector<std::pair<int64_t, int64_t>>& tablets_filtered_rows, int64_t node_id);
     int64_t num_rows_filtered() {
-        CHECK(!_tablets_filtered_rows.empty());
         // the Unique table has no roll up or materilized view
         // we just add up filtered rows from all partitions
         return std::accumulate(_tablets_filtered_rows.cbegin(), _tablets_filtered_rows.cend(), 0,

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -169,6 +169,7 @@ public:
     void set_tablets_filtered_rows(
             const std::vector<std::pair<int64_t, int64_t>>& tablets_filtered_rows, int64_t node_id);
     int64_t num_rows_filtered() {
+        DCHECK(!_tablets_filtered_rows.empty());
         // the Unique table has no roll up or materilized view
         // we just add up filtered rows from all partitions
         return std::accumulate(_tablets_filtered_rows.cbegin(), _tablets_filtered_rows.cend(), 0,


### PR DESCRIPTION
## Proposed changes

This is a fix for https://github.com/apache/doris/pull/24191

When `DeltaWriter::commit_txn` failed, `TabletsChannel::_commit_txn` will not set `num_rows_filtered` in `TTabletCommitInfo` and `_tablets_filtered_rows .empty()` can be true.

```
F20230914 11:09:57.605302 27805 vtablet_sink.cpp:172] Check failed: !_tablets_filtered_rows.empty()
11:13:24   *** Check failure stack trace: ***
11:13:24       @     0x56043a7394d6  google::LogMessageFatal::~LogMessageFatal()
11:13:24       @     0x560439a2d83e  doris::stream_load::IndexChannel::num_rows_filtered()
11:13:24       @     0x560439a1f19b  doris::stream_load::VOlapTableSink::close()
11:13:24       @     0x56041b014850  doris::PlanFragmentExecutor::open_vectorized_internal()
11:13:24       @     0x56041b0130b1  doris::PlanFragmentExecutor::open()
11:13:24       @     0x56041b01834e  doris::PlanFragmentExecutor::execute()
11:13:24       @     0x56041ae5846e  doris::FragmentMgr::_exec_actual()
11:13:24       @     0x56041ae835ae  std::_Function_handler<>::_M_invoke()
11:13:24       @     0x56041b607acd  doris::ThreadPool::dispatch_thread()
11:13:24       @     0x56041b5e3f34  doris::Thread::supervise_thread()
11:13:24       @     0x7f1759812609  start_thread
11:13:24       @     0x7f1759aa1133  clone
11:13:24       @              (nil)  (unknown)
11:13:24   *** Query id: e573ec8eb25a4d69-ab40283c09543b23 ***
11:13:24   *** Aborted at 1694660997 (unix time) try "date -d @1694660997" if you are using GNU date ***
11:13:24   *** Current BE git commitID: 8204679 ***
11:13:24   *** SIGABRT unknown detail explain (@0x6b14) received by PID 27412 (TID 27805 OR 0x7f1517244700) from PID 27412; stack trace: ***
11:13:24    0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:413
11:13:24    1# 0x00007F17599C5090 in /lib/x86_64-linux-gnu/libc.so.6
11:13:24    2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
11:13:24    3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
11:13:24    4# 0x000056043A7403DD in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
11:13:24    5# google::LogMessage::SendToLog() in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
11:13:24    6# google::LogMessage::Flush() in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
11:13:24    7# google::LogMessageFatal::~LogMessageFatal() in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
11:13:24    8# 0x0000560439A2D83E in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
11:13:24    9# doris::stream_load::VOlapTableSink::close(doris::RuntimeState*, doris::Status) at /root/doris/be/src/vec/sink/vtablet_sink.cpp:1868
11:13:24   10# doris::PlanFragmentExecutor::open_vectorized_internal() at /root/doris/be/src/runtime/plan_fragment_executor.cpp:369
11:13:24   11# doris::PlanFragmentExecutor::open() at /root/doris/be/src/runtime/plan_fragment_executor.cpp:278
11:13:24   12# doris::PlanFragmentExecutor::execute() in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
11:13:24   13# doris::FragmentMgr::_exec_actual(std::shared_ptr<doris::PlanFragmentExecutor>, std::function<void (doris::RuntimeState*, doris::Status*)> const&) at /root/doris/be/src/runtime/fragment_mgr.cpp:340
11:13:24   14# std::_Function_handler<void (), doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_0>::_M_invoke(std::_Any_data const&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
11:13:24   15# doris::ThreadPool::dispatch_thread() at /root/doris/be/src/util/threadpool.cpp:541
11:13:24   16# doris::Thread::supervise_thread(void*) at /root/doris/be/src/util/thread.cpp:466
11:13:24   17# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
11:13:24   18# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97
```
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

