### PR TITLE
[config](log) disable StreamLoad log default and enable in regression pipeline

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -479,9 +479,9 @@ DEFINE_Int32(tablet_writer_open_rpc_timeout_sec, "60");
 DEFINE_mBool(tablet_writer_ignore_eovercrowded, "true");
 DEFINE_mBool(exchange_sink_ignore_eovercrowded, "true");
 DEFINE_mInt32(slave_replica_writer_rpc_timeout_sec, "60");
-// Whether to enable stream load record function, the default is true.
+// Whether to enable stream load record function, the default is false.
 // False: disable stream load record
-DEFINE_mBool(enable_stream_load_record, "true");
+DEFINE_mBool(enable_stream_load_record, "false");
 // batch size of stream load record reported to FE
 DEFINE_mInt32(stream_load_record_batch_size, "50");
 // expire time of stream load record in rocksdb.

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -113,7 +113,7 @@ void StreamLoadAction::handle(HttpRequest* req) {
             _exec_env->stream_load_executor()->rollback_txn(ctx.get());
             ctx->need_rollback = false;
         }
-        if (ctx->body_sink != nullptr) {
+        if (ctx->body_sink.get() != nullptr) {
             ctx->body_sink->cancel(ctx->status.to_string());
         }
     }
@@ -194,7 +194,7 @@ int StreamLoadAction::on_header(HttpRequest* req) {
             _exec_env->stream_load_executor()->rollback_txn(ctx.get());
             ctx->need_rollback = false;
         }
-        if (ctx->body_sink != nullptr) {
+        if (ctx->body_sink.get() != nullptr) {
             ctx->body_sink->cancel(ctx->status.to_string());
         }
         auto str = ctx->to_json();

--- a/docs/en/docs/admin-manual/config/be-config.md
+++ b/docs/en/docs/admin-manual/config/be-config.md
@@ -694,8 +694,8 @@ BaseCompaction:546859:
 #### `enable_stream_load_record`
 
 * Type: bool
-* Description: Whether to enable stream load record function, the default is true.
-* Default value: true
+* Description:Whether to enable stream load record function, the default is false.
+* Default value: false
 
 #### `load_data_reserve_hours`
 

--- a/docs/zh-CN/docs/admin-manual/config/be-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/be-config.md
@@ -720,8 +720,8 @@ BaseCompaction:546859:
 #### `enable_stream_load_record`
 
 * 类型: bool
-* 描述: 是否开启 stream load 操作记录，默认开启
-* 默认值: true
+* 描述: 是否开启 stream load 操作记录，默认是不启用
+* 默认值: false
 
 #### `load_data_reserve_hours`
 

--- a/regression-test/pipeline/external/conf/be.conf
+++ b/regression-test/pipeline/external/conf/be.conf
@@ -61,6 +61,7 @@ priority_networks=172.19.0.0/24
 # sys_log_roll_num = 10
 # sys_log_verbose_modules = *
 # log_buffer_level = -1
+enable_stream_load_record = true
 # palo_cgroups 
 
 disable_auto_compaction=true

--- a/regression-test/pipeline/p0/conf/be.conf
+++ b/regression-test/pipeline/p0/conf/be.conf
@@ -60,6 +60,7 @@ chunk_reserved_bytes_limit = 134217728
 # sys_log_roll_num = 10
 # sys_log_verbose_modules = *
 log_buffer_level = -1
+enable_stream_load_record = true
 # palo_cgroups 
 #storage_root_path=/mnt/hdd01/doris.SSD/NON_VEC_RELEASE;/mnt/hdd01/doris.HDD/NON_VEC_RELEASE;/mnt/hdd02/doris.SSD/NON_VEC_RELEASE;/mnt/hdd02/doris.HDD/NON_VEC_RELEASE;/mnt/hdd03/doris.SSD/NON_VEC_RELEASE;/mnt/hdd03/doris.HDD/NON_VEC_RELEASE;/mnt/hdd04/doris.SSD/NON_VEC_RELEASE;/mnt/hdd04/doris.HDD/NON_VEC_RELEASE;/mnt/hdd05/doris.SSD/NON_VEC_RELEASE;/mnt/hdd05/doris.HDD/NON_VEC_RELEASE;/mnt/hdd06/doris.SSD/NON_VEC_RELEASE;/mnt/hdd06/doris.HDD/NON_VEC_RELEASE;
 

--- a/regression-test/pipeline/p1/conf/be.conf
+++ b/regression-test/pipeline/p1/conf/be.conf
@@ -61,6 +61,7 @@ priority_networks=172.19.0.0/24
 # sys_log_roll_num = 10
 # sys_log_verbose_modules = *
 # log_buffer_level = -1
+enable_stream_load_record = true
 # palo_cgroups 
 
 disable_auto_compaction=true


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

rollback streamload_log default to disable. enable it on regression-test pipeline.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

