### PR TITLE
[feature](nereids)support unnest subquery in LogicalOneRowRelation

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleType.java
@@ -122,6 +122,7 @@ public enum RuleType {
     // subquery analyze
     FILTER_SUBQUERY_TO_APPLY(RuleTypeClass.REWRITE),
     PROJECT_SUBQUERY_TO_APPLY(RuleTypeClass.REWRITE),
+    ONE_ROW_RELATION_SUBQUERY_TO_APPLY(RuleTypeClass.REWRITE),
     // subquery rewrite rule
     ELIMINATE_LIMIT_UNDER_APPLY(RuleTypeClass.REWRITE),
     ELIMINATE_SORT_UNDER_APPLY(RuleTypeClass.REWRITE),

--- a/regression-test/data/nereids_p0/subquery/test_subquery.out
+++ b/regression-test/data/nereids_p0/subquery/test_subquery.out
@@ -20,3 +20,6 @@
 -- !uncorrelated_scalar_with_sort_and_limit --
 true	15	1992	3021	11011920	0.000	true	9999-12-12	2015-04-02T00:00		3.141592653	20.456	string12345	701411834604692317
 
+-- !sql_one_row_relation --
+1
+

--- a/regression-test/data/nereids_p0/subquery/test_subquery.out
+++ b/regression-test/data/nereids_p0/subquery/test_subquery.out
@@ -20,6 +20,6 @@
 -- !uncorrelated_scalar_with_sort_and_limit --
 true	15	1992	3021	11011920	0.000	true	9999-12-12	2015-04-02T00:00		3.141592653	20.456	string12345	701411834604692317
 
--- !sql_one_row_relation --
+-- !sql_subquery_one_row_relation --
 1
 

--- a/regression-test/suites/nereids_p0/subquery/test_subquery.groovy
+++ b/regression-test/suites/nereids_p0/subquery/test_subquery.groovy
@@ -64,4 +64,6 @@ suite("test_subquery") {
     qt_uncorrelated_scalar_with_sort_and_limit """
             select * from nereids_test_query_db.baseall where k1 = (select k1 from nereids_test_query_db.baseall order by k1 desc limit 1)
         """
+    
+    qt_sql_one_row_relation """select (select 1);"""
 }

--- a/regression-test/suites/nereids_p0/subquery/test_subquery.groovy
+++ b/regression-test/suites/nereids_p0/subquery/test_subquery.groovy
@@ -64,6 +64,25 @@ suite("test_subquery") {
     qt_uncorrelated_scalar_with_sort_and_limit """
             select * from nereids_test_query_db.baseall where k1 = (select k1 from nereids_test_query_db.baseall order by k1 desc limit 1)
         """
+
+    sql """drop table if exists test_one_row_relation;"""
+    sql """
+        CREATE TABLE `test_one_row_relation` (
+        `user_id` int(11) NULL 
+        )
+        UNIQUE KEY(`user_id`)
+        COMMENT 'test'
+        DISTRIBUTED BY HASH(`user_id`) BUCKETS 1
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1"
+        );
+    """
+
+    sql """ set enable_nereids_dml=true; """
     
-    qt_sql_one_row_relation """select (select 1);"""
+    sql """insert into test_one_row_relation select (select 1);"""
+
+    qt_sql_subquery_one_row_relation """select * from test_one_row_relation;"""
+
+    sql """drop table if exists test_one_row_relation;"""
 }


### PR DESCRIPTION
select (select 1);
before : 
ERROR 1105 (HY000): errCode = 2, detailMessage = Subquery is not supported in the select list.
after:
mysql> select (select 1);
+---------------------------------------------------------------------+
|  (SCALARSUBQUERY) (LogicalOneRowRelation ( projects=[1 AS `1`#0] )) |
+---------------------------------------------------------------------+
|                                                                   1 |
+---------------------------------------------------------------------+
1 row in set (0.61 sec)


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

