### PR TITLE
[opt](Nereids) remove canEliminate flag on LogicalProject

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateUnnecessaryProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateUnnecessaryProject.java
@@ -23,8 +23,6 @@ import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalEmptyRelation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
-import org.apache.doris.nereids.trees.plans.logical.LogicalSetOperation;
-import org.apache.doris.nereids.trees.plans.logical.OutputSavePoint;
 import org.apache.doris.nereids.trees.plans.visitor.CustomRewriter;
 
 import java.util.ArrayList;
@@ -39,71 +37,39 @@ public class EliminateUnnecessaryProject implements CustomRewriter {
 
     @Override
     public Plan rewriteRoot(Plan plan, JobContext jobContext) {
-        return rewrite(plan, false);
+        return rewrite(plan);
     }
 
-    private Plan rewrite(Plan plan, boolean outputSavePoint) {
-        if (plan instanceof LogicalSetOperation) {
-            return rewriteLogicalSetOperation((LogicalSetOperation) plan, outputSavePoint);
-        } else if (plan instanceof LogicalProject) {
-            return rewriteProject((LogicalProject) plan, outputSavePoint);
-        } else if (plan instanceof OutputSavePoint) {
-            return rewriteChildren(plan, true);
+    private Plan rewrite(Plan plan) {
+        if (plan instanceof LogicalProject) {
+            return rewriteProject((LogicalProject<?>) plan);
         } else {
-            return rewriteChildren(plan, outputSavePoint);
+            return rewriteChildren(plan);
         }
     }
 
-    private Plan rewriteProject(LogicalProject<Plan> project, boolean outputSavePoint) {
+    private Plan rewriteProject(LogicalProject<?> project) {
         if (project.child() instanceof LogicalEmptyRelation) {
             // eliminate unnecessary project
             return new LogicalEmptyRelation(StatementScopeIdGenerator.newRelationId(), project.getProjects());
-        } else if (project.canEliminate() && outputSavePoint
-                && project.getOutputSet().equals(project.child().getOutputSet())) {
+        } else if (project.getOutputSet().equals(project.child().getOutputSet())) {
             // eliminate unnecessary project
-            return rewrite(project.child(), outputSavePoint);
-        } else if (project.canEliminate() && project.getOutput().equals(project.child().getOutput())) {
-            // eliminate unnecessary project
-            return rewrite(project.child(), outputSavePoint);
+            return rewrite(project.child());
         } else {
-            return rewriteChildren(project, true);
+            return rewriteChildren(project);
         }
     }
 
-    private Plan rewriteLogicalSetOperation(LogicalSetOperation set, boolean outputSavePoint) {
-        if (set.arity() == 2) {
-            Plan left = set.child(0);
-            Plan right = set.child(1);
-            boolean changed = false;
-            if (isCanEliminateProject(left)) {
-                changed = true;
-                left = ((LogicalProject) left).withEliminate(false);
-            }
-            if (isCanEliminateProject(right)) {
-                changed = true;
-                right = ((LogicalProject) right).withEliminate(false);
-            }
-            if (changed) {
-                set = (LogicalSetOperation) set.withChildren(left, right);
-            }
-        }
-        return rewriteChildren(set, outputSavePoint);
-    }
-
-    private Plan rewriteChildren(Plan plan, boolean outputSavePoint) {
+    private Plan rewriteChildren(Plan plan) {
         List<Plan> newChildren = new ArrayList<>();
         boolean hasNewChildren = false;
         for (Plan child : plan.children()) {
-            Plan newChild = rewrite(child, outputSavePoint);
+            Plan newChild = rewrite(child);
             if (newChild != child) {
                 hasNewChildren = true;
             }
             newChildren.add(newChild);
         }
         return hasNewChildren ? plan.withChildren(newChildren) : plan;
-    }
-
-    private static boolean isCanEliminateProject(Plan plan) {
-        return plan instanceof LogicalProject && ((LogicalProject<?>) plan).canEliminate();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/MergeProjects.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/MergeProjects.java
@@ -45,14 +45,13 @@ public class MergeProjects extends OneRewriteRuleFactory {
         return logicalProject(logicalProject())
                 .whenNot(project -> containsWindowExpression(project.getProjects())
                         && containsWindowExpression(project.child().getProjects()))
-                .then(project -> mergeProjects(project)).toRule(RuleType.MERGE_PROJECTS);
+                .then(MergeProjects::mergeProjects).toRule(RuleType.MERGE_PROJECTS);
     }
 
-    public static Plan mergeProjects(LogicalProject project) {
-        LogicalProject<? extends Plan> childProject = (LogicalProject) project.child();
+    public static Plan mergeProjects(LogicalProject<?> project) {
+        LogicalProject<? extends Plan> childProject = (LogicalProject<?>) project.child();
         List<NamedExpression> projectExpressions = project.mergeProjections(childProject);
-        LogicalProject newProject = childProject.canEliminate() ? project : childProject;
-        return newProject.withProjectsAndChild(projectExpressions, childProject.child(0));
+        return project.withProjectsAndChild(projectExpressions, childProject.child(0));
     }
 
     private boolean containsWindowExpression(List<NamedExpression> expressions) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalProject.java
@@ -49,37 +49,30 @@ public class LogicalProject<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_
     private final List<NamedExpression> projects;
     private final List<NamedExpression> excepts;
     private final boolean isDistinct;
-    // For project nodes under union, erasure cannot be configured, so add this flag.
-    private final boolean canEliminate;
 
     public LogicalProject(List<NamedExpression> projects, CHILD_TYPE child) {
-        this(projects, ImmutableList.of(), false, true, child);
+        this(projects, ImmutableList.of(), false, child);
     }
 
     /**
      * only for test.
      */
     public LogicalProject(List<NamedExpression> projects, List<NamedExpression> excepts, CHILD_TYPE child) {
-        this(projects, excepts, false, true, child);
+        this(projects, excepts, false, child);
     }
 
     public LogicalProject(List<NamedExpression> projects, boolean isDistinct, CHILD_TYPE child) {
-        this(projects, ImmutableList.of(), isDistinct, true, child);
+        this(projects, ImmutableList.of(), isDistinct, child);
     }
 
     public LogicalProject(List<NamedExpression> projects, List<NamedExpression> excepts,
             boolean isDistinct, CHILD_TYPE child) {
-        this(projects, excepts, isDistinct, true, child);
-    }
-
-    private LogicalProject(List<NamedExpression> projects, List<NamedExpression> excepts,
-            boolean isDistinct, boolean canEliminate, CHILD_TYPE child) {
-        this(projects, excepts, isDistinct, canEliminate, Optional.empty(), Optional.empty(), child);
+        this(projects, excepts, isDistinct, Optional.empty(), Optional.empty(), child);
     }
 
     private LogicalProject(List<NamedExpression> projects, List<NamedExpression> excepts, boolean isDistinct,
-            boolean canEliminate, Optional<GroupExpression> groupExpression,
-            Optional<LogicalProperties> logicalProperties, CHILD_TYPE child) {
+            Optional<GroupExpression> groupExpression, Optional<LogicalProperties> logicalProperties,
+            CHILD_TYPE child) {
         super(PlanType.LOGICAL_PROJECT, groupExpression, logicalProperties, child);
         Preconditions.checkArgument(projects != null, "projects can not be null");
         // only ColumnPrune rule may produce empty projects, this happens in rewrite phase
@@ -91,7 +84,6 @@ public class LogicalProject<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_
                 : projects;
         this.excepts = ImmutableList.copyOf(excepts);
         this.isDistinct = isDistinct;
-        this.canEliminate = canEliminate;
     }
 
     /**
@@ -124,8 +116,7 @@ public class LogicalProject<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_
         return Utils.toSqlString("LogicalProject[" + id.asInt() + "]",
                 "distinct", isDistinct,
                 "projects", projects,
-                "excepts", excepts,
-                "canEliminate", canEliminate
+                "excepts", excepts
         );
     }
 
@@ -150,7 +141,6 @@ public class LogicalProject<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_
         LogicalProject<?> that = (LogicalProject<?>) o;
         boolean equal = projects.equals(that.projects)
                 && excepts.equals(that.excepts)
-                && canEliminate == that.canEliminate
                 && isDistinct == that.isDistinct;
         // TODO: should add exprId for UnBoundStar and BoundStar for equality comparison
         if (!projects.isEmpty() && (projects.get(0) instanceof UnboundStar || projects.get(0) instanceof BoundStar)) {
@@ -161,18 +151,18 @@ public class LogicalProject<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_
 
     @Override
     public int hashCode() {
-        return Objects.hash(projects, canEliminate);
+        return Objects.hash(projects);
     }
 
     @Override
     public LogicalProject<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalProject<>(projects, excepts, isDistinct, canEliminate, children.get(0));
+        return new LogicalProject<>(projects, excepts, isDistinct, children.get(0));
     }
 
     @Override
     public LogicalProject<Plan> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalProject<>(projects, excepts, isDistinct, canEliminate,
+        return new LogicalProject<>(projects, excepts, isDistinct,
                 groupExpression, Optional.of(getLogicalProperties()), child());
     }
 
@@ -180,28 +170,20 @@ public class LogicalProject<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalProject<>(projects, excepts, isDistinct, canEliminate,
+        return new LogicalProject<>(projects, excepts, isDistinct,
                 groupExpression, logicalProperties, children.get(0));
     }
 
-    public LogicalProject<Plan> withEliminate(boolean isEliminate) {
-        return new LogicalProject<>(projects, excepts, isDistinct, isEliminate, child());
-    }
-
     public LogicalProject<Plan> withProjects(List<NamedExpression> projects) {
-        return new LogicalProject<>(projects, excepts, isDistinct, canEliminate, child());
+        return new LogicalProject<>(projects, excepts, isDistinct, child());
     }
 
     public LogicalProject<Plan> withProjectsAndChild(List<NamedExpression> projects, Plan child) {
-        return new LogicalProject<>(projects, excepts, isDistinct, canEliminate, child);
+        return new LogicalProject<>(projects, excepts, isDistinct, child);
     }
 
     public boolean isDistinct() {
         return isDistinct;
-    }
-
-    public boolean canEliminate() {
-        return canEliminate;
     }
 
     @Override
@@ -220,7 +202,6 @@ public class LogicalProject<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_
         JSONObject properties = new JSONObject();
         properties.put("Projects", projects.toString());
         properties.put("Excepts", excepts.toString());
-        properties.put("CanEliminate", canEliminate);
         properties.put("IsDistinct", isDistinct);
         logicalProject.put("Properties", properties);
         return logicalProject;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateUnnecessaryProjectTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateUnnecessaryProjectTest.java
@@ -61,7 +61,7 @@ class EliminateUnnecessaryProjectTest extends TestWithFeService implements MemoP
 
         PlanChecker.from(MemoTestUtils.createConnectContext(), unnecessaryProject)
                 .customRewrite(new EliminateUnnecessaryProject())
-                .matchesFromRoot(logicalFilter(logicalProject()));
+                .matchesFromRoot(logicalFilter(logicalOlapScan()));
     }
 
     @Test
@@ -76,14 +76,14 @@ class EliminateUnnecessaryProjectTest extends TestWithFeService implements MemoP
     }
 
     @Test
-    void testNotEliminateTopProjectWhenOutputNotEquals() {
+    void testEliminateTopProjectWhenOutputNotEquals() {
         LogicalPlan necessaryProject = new LogicalPlanBuilder(PlanConstructor.newLogicalOlapScan(0, "t1", 0))
                 .project(ImmutableList.of(1, 0))
                 .build();
 
         PlanChecker.from(MemoTestUtils.createConnectContext(), necessaryProject)
                 .customRewrite(new EliminateUnnecessaryProject())
-                .matchesFromRoot(logicalProject());
+                .notMatchesFromRoot(logicalProject());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanToStringTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanToStringTest.java
@@ -91,7 +91,7 @@ public class PlanToStringTest {
         LogicalProject<Plan> plan = new LogicalProject<>(ImmutableList.of(
                 new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList())), child);
 
-        Assertions.assertTrue(plan.toString().matches("LogicalProject\\[\\d+\\] \\( distinct=false, projects=\\[a#\\d+], excepts=\\[], canEliminate=true \\)"));
+        Assertions.assertTrue(plan.toString().matches("LogicalProject\\[\\d+\\] \\( distinct=false, projects=\\[a#\\d+], excepts=\\[] \\)"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/PlanChecker.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/PlanChecker.java
@@ -457,6 +457,13 @@ public class PlanChecker {
         return this;
     }
 
+    public PlanChecker notMatchesFromRoot(PatternDescriptor<? extends Plan> patternDesc) {
+        Memo memo = cascadesContext.getMemo();
+        assertMatches(memo, () -> !(new GroupExpressionMatching(patternDesc.pattern,
+                memo.getRoot().getLogicalExpression()).iterator().hasNext()));
+        return this;
+    }
+
     public PlanChecker matches(PatternDescriptor<? extends Plan> patternDesc) {
         Memo memo = cascadesContext.getMemo();
         checkSlotFromChildren(memo);

--- a/regression-test/data/nereids_ssb_shape_sf100_p0/shape/q2.1.out
+++ b/regression-test/data/nereids_ssb_shape_sf100_p0/shape/q2.1.out
@@ -4,25 +4,24 @@ PhysicalResultSink
 --PhysicalQuickSort
 ----PhysicalDistribute
 ------PhysicalQuickSort
---------PhysicalProject
-----------hashAgg[GLOBAL]
-------------PhysicalDistribute
---------------hashAgg[LOCAL]
-----------------PhysicalProject
-------------------hashJoin[INNER_JOIN](lineorder.lo_orderdate = dates.d_datekey)
---------------------hashJoin[INNER_JOIN](lineorder.lo_suppkey = supplier.s_suppkey)
-----------------------hashJoin[INNER_JOIN](lineorder.lo_partkey = part.p_partkey)
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[lineorder]
-------------------------PhysicalDistribute
---------------------------PhysicalProject
-----------------------------filter((part.p_category = 'MFGR#12'))
-------------------------------PhysicalOlapScan[part]
+--------hashAgg[GLOBAL]
+----------PhysicalDistribute
+------------hashAgg[LOCAL]
+--------------PhysicalProject
+----------------hashJoin[INNER_JOIN](lineorder.lo_orderdate = dates.d_datekey)
+------------------hashJoin[INNER_JOIN](lineorder.lo_suppkey = supplier.s_suppkey)
+--------------------hashJoin[INNER_JOIN](lineorder.lo_partkey = part.p_partkey)
+----------------------PhysicalProject
+------------------------PhysicalOlapScan[lineorder]
 ----------------------PhysicalDistribute
 ------------------------PhysicalProject
---------------------------filter((supplier.s_region = 'AMERICA'))
-----------------------------PhysicalOlapScan[supplier]
+--------------------------filter((part.p_category = 'MFGR#12'))
+----------------------------PhysicalOlapScan[part]
 --------------------PhysicalDistribute
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[dates]
+------------------------filter((supplier.s_region = 'AMERICA'))
+--------------------------PhysicalOlapScan[supplier]
+------------------PhysicalDistribute
+--------------------PhysicalProject
+----------------------PhysicalOlapScan[dates]
 

--- a/regression-test/data/nereids_ssb_shape_sf100_p0/shape/q2.2.out
+++ b/regression-test/data/nereids_ssb_shape_sf100_p0/shape/q2.2.out
@@ -4,28 +4,27 @@ PhysicalResultSink
 --PhysicalQuickSort
 ----PhysicalDistribute
 ------PhysicalQuickSort
---------PhysicalProject
-----------hashAgg[GLOBAL]
-------------PhysicalDistribute
---------------hashAgg[LOCAL]
-----------------PhysicalProject
-------------------hashJoin[INNER_JOIN](lineorder.lo_orderdate = dates.d_datekey)
---------------------PhysicalDistribute
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN](lineorder.lo_suppkey = supplier.s_suppkey)
---------------------------PhysicalDistribute
-----------------------------hashJoin[INNER_JOIN](lineorder.lo_partkey = part.p_partkey)
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[lineorder]
-------------------------------PhysicalDistribute
---------------------------------PhysicalProject
-----------------------------------filter((part.p_brand >= 'MFGR#2221')(part.p_brand <= 'MFGR#2228'))
-------------------------------------PhysicalOlapScan[part]
---------------------------PhysicalDistribute
+--------hashAgg[GLOBAL]
+----------PhysicalDistribute
+------------hashAgg[LOCAL]
+--------------PhysicalProject
+----------------hashJoin[INNER_JOIN](lineorder.lo_orderdate = dates.d_datekey)
+------------------PhysicalDistribute
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN](lineorder.lo_suppkey = supplier.s_suppkey)
+------------------------PhysicalDistribute
+--------------------------hashJoin[INNER_JOIN](lineorder.lo_partkey = part.p_partkey)
 ----------------------------PhysicalProject
-------------------------------filter((supplier.s_region = 'ASIA'))
---------------------------------PhysicalOlapScan[supplier]
---------------------PhysicalDistribute
-----------------------PhysicalProject
-------------------------PhysicalOlapScan[dates]
+------------------------------PhysicalOlapScan[lineorder]
+----------------------------PhysicalDistribute
+------------------------------PhysicalProject
+--------------------------------filter((part.p_brand >= 'MFGR#2221')(part.p_brand <= 'MFGR#2228'))
+----------------------------------PhysicalOlapScan[part]
+------------------------PhysicalDistribute
+--------------------------PhysicalProject
+----------------------------filter((supplier.s_region = 'ASIA'))
+------------------------------PhysicalOlapScan[supplier]
+------------------PhysicalDistribute
+--------------------PhysicalProject
+----------------------PhysicalOlapScan[dates]
 

--- a/regression-test/data/nereids_ssb_shape_sf100_p0/shape/q2.3.out
+++ b/regression-test/data/nereids_ssb_shape_sf100_p0/shape/q2.3.out
@@ -4,28 +4,27 @@ PhysicalResultSink
 --PhysicalQuickSort
 ----PhysicalDistribute
 ------PhysicalQuickSort
---------PhysicalProject
-----------hashAgg[GLOBAL]
-------------PhysicalDistribute
---------------hashAgg[LOCAL]
-----------------PhysicalProject
-------------------hashJoin[INNER_JOIN](lineorder.lo_orderdate = dates.d_datekey)
---------------------PhysicalDistribute
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN](lineorder.lo_suppkey = supplier.s_suppkey)
---------------------------PhysicalDistribute
-----------------------------hashJoin[INNER_JOIN](lineorder.lo_partkey = part.p_partkey)
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[lineorder]
-------------------------------PhysicalDistribute
---------------------------------PhysicalProject
-----------------------------------filter((part.p_brand = 'MFGR#2239'))
-------------------------------------PhysicalOlapScan[part]
---------------------------PhysicalDistribute
+--------hashAgg[GLOBAL]
+----------PhysicalDistribute
+------------hashAgg[LOCAL]
+--------------PhysicalProject
+----------------hashJoin[INNER_JOIN](lineorder.lo_orderdate = dates.d_datekey)
+------------------PhysicalDistribute
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN](lineorder.lo_suppkey = supplier.s_suppkey)
+------------------------PhysicalDistribute
+--------------------------hashJoin[INNER_JOIN](lineorder.lo_partkey = part.p_partkey)
 ----------------------------PhysicalProject
-------------------------------filter((supplier.s_region = 'EUROPE'))
---------------------------------PhysicalOlapScan[supplier]
---------------------PhysicalDistribute
-----------------------PhysicalProject
-------------------------PhysicalOlapScan[dates]
+------------------------------PhysicalOlapScan[lineorder]
+----------------------------PhysicalDistribute
+------------------------------PhysicalProject
+--------------------------------filter((part.p_brand = 'MFGR#2239'))
+----------------------------------PhysicalOlapScan[part]
+------------------------PhysicalDistribute
+--------------------------PhysicalProject
+----------------------------filter((supplier.s_region = 'EUROPE'))
+------------------------------PhysicalOlapScan[supplier]
+------------------PhysicalDistribute
+--------------------PhysicalProject
+----------------------PhysicalOlapScan[dates]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query10.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query10.out
@@ -9,26 +9,26 @@ PhysicalResultSink
 ------------PhysicalDistribute
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------filter(($c$1 OR $c$2))
---------------------hashJoin[LEFT_SEMI_JOIN](c.c_customer_sk = catalog_sales.cs_ship_customer_sk)
-----------------------hashJoin[LEFT_SEMI_JOIN](c.c_customer_sk = web_sales.ws_bill_customer_sk)
-------------------------PhysicalDistribute
+------------------hashJoin[RIGHT_SEMI_JOIN](c.c_customer_sk = store_sales.ss_customer_sk)
+--------------------PhysicalDistribute
+----------------------PhysicalProject
+------------------------hashJoin[INNER_JOIN](store_sales.ss_sold_date_sk = date_dim.d_date_sk)
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN](customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)
-------------------------------PhysicalOlapScan[customer_demographics]
-------------------------------PhysicalDistribute
---------------------------------PhysicalProject
-----------------------------------hashJoin[RIGHT_SEMI_JOIN](c.c_customer_sk = store_sales.ss_customer_sk)
-------------------------------------PhysicalDistribute
---------------------------------------PhysicalProject
-----------------------------------------hashJoin[INNER_JOIN](store_sales.ss_sold_date_sk = date_dim.d_date_sk)
-------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[store_sales]
-------------------------------------------PhysicalDistribute
---------------------------------------------PhysicalProject
-----------------------------------------------filter((date_dim.d_moy <= 4)(date_dim.d_moy >= 1)(date_dim.d_year = 2001))
-------------------------------------------------PhysicalOlapScan[date_dim]
-------------------------------------PhysicalDistribute
+----------------------------PhysicalOlapScan[store_sales]
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy >= 1)(date_dim.d_moy <= 4)(date_dim.d_year = 2001))
+--------------------------------PhysicalOlapScan[date_dim]
+--------------------PhysicalProject
+----------------------filter(($c$1 OR $c$2))
+------------------------hashJoin[LEFT_SEMI_JOIN](c.c_customer_sk = catalog_sales.cs_ship_customer_sk)
+--------------------------hashJoin[LEFT_SEMI_JOIN](c.c_customer_sk = web_sales.ws_bill_customer_sk)
+----------------------------PhysicalDistribute
+------------------------------PhysicalProject
+--------------------------------hashJoin[INNER_JOIN](customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)
+----------------------------------PhysicalOlapScan[customer_demographics]
+----------------------------------PhysicalDistribute
+------------------------------------PhysicalProject
 --------------------------------------hashJoin[INNER_JOIN](c.c_current_addr_sk = ca.ca_address_sk)
 ----------------------------------------PhysicalProject
 ------------------------------------------PhysicalOlapScan[customer]
@@ -36,22 +36,22 @@ PhysicalResultSink
 ------------------------------------------PhysicalProject
 --------------------------------------------filter(ca_county IN ('Storey County', 'Marquette County', 'Warren County', 'Cochran County', 'Kandiyohi County'))
 ----------------------------------------------PhysicalOlapScan[customer_address]
-------------------------PhysicalDistribute
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN](web_sales.ws_sold_date_sk = date_dim.d_date_sk)
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[web_sales]
-------------------------------PhysicalDistribute
---------------------------------PhysicalProject
-----------------------------------filter((date_dim.d_moy <= 4)(date_dim.d_moy >= 1)(date_dim.d_year = 2001))
-------------------------------------PhysicalOlapScan[date_dim]
-----------------------PhysicalDistribute
-------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN](catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[catalog_sales]
 ----------------------------PhysicalDistribute
 ------------------------------PhysicalProject
---------------------------------filter((date_dim.d_moy >= 1)(date_dim.d_moy <= 4)(date_dim.d_year = 2001))
-----------------------------------PhysicalOlapScan[date_dim]
+--------------------------------hashJoin[INNER_JOIN](web_sales.ws_sold_date_sk = date_dim.d_date_sk)
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[web_sales]
+----------------------------------PhysicalDistribute
+------------------------------------PhysicalProject
+--------------------------------------filter((date_dim.d_moy >= 1)(date_dim.d_year = 2001)(date_dim.d_moy <= 4))
+----------------------------------------PhysicalOlapScan[date_dim]
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[catalog_sales]
+--------------------------------PhysicalDistribute
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_moy >= 1)(date_dim.d_moy <= 4)(date_dim.d_year = 2001))
+--------------------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query16.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query16.out
@@ -3,37 +3,36 @@
 PhysicalResultSink
 --PhysicalTopN
 ----PhysicalTopN
-------PhysicalProject
---------hashAgg[DISTINCT_GLOBAL]
-----------PhysicalDistribute
-------------hashAgg[DISTINCT_LOCAL]
---------------hashAgg[GLOBAL]
-----------------hashAgg[LOCAL]
-------------------PhysicalProject
---------------------hashJoin[RIGHT_SEMI_JOIN](cs1.cs_order_number = cs2.cs_order_number)( not (cs_warehouse_sk = cs_warehouse_sk))
-----------------------PhysicalDistribute
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[catalog_sales]
-----------------------hashJoin[INNER_JOIN](cs1.cs_call_center_sk = call_center.cc_call_center_sk)
-------------------------hashJoin[RIGHT_ANTI_JOIN](cs1.cs_order_number = cr1.cr_order_number)
---------------------------PhysicalDistribute
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[catalog_returns]
---------------------------PhysicalDistribute
-----------------------------hashJoin[INNER_JOIN](cs1.cs_ship_date_sk = date_dim.d_date_sk)
-------------------------------hashJoin[INNER_JOIN](cs1.cs_ship_addr_sk = customer_address.ca_address_sk)
---------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[catalog_sales]
---------------------------------PhysicalDistribute
-----------------------------------PhysicalProject
-------------------------------------filter((cast(ca_state as VARCHAR(*)) = 'WV'))
---------------------------------------PhysicalOlapScan[customer_address]
-------------------------------PhysicalDistribute
---------------------------------PhysicalProject
-----------------------------------filter((date_dim.d_date <= 2002-05-31)(date_dim.d_date >= 2002-04-01))
-------------------------------------PhysicalOlapScan[date_dim]
+------hashAgg[DISTINCT_GLOBAL]
+--------PhysicalDistribute
+----------hashAgg[DISTINCT_LOCAL]
+------------hashAgg[GLOBAL]
+--------------hashAgg[LOCAL]
+----------------PhysicalProject
+------------------hashJoin[RIGHT_SEMI_JOIN](cs1.cs_order_number = cs2.cs_order_number)( not (cs_warehouse_sk = cs_warehouse_sk))
+--------------------PhysicalDistribute
+----------------------PhysicalProject
+------------------------PhysicalOlapScan[catalog_sales]
+--------------------hashJoin[INNER_JOIN](cs1.cs_call_center_sk = call_center.cc_call_center_sk)
+----------------------hashJoin[RIGHT_ANTI_JOIN](cs1.cs_order_number = cr1.cr_order_number)
 ------------------------PhysicalDistribute
 --------------------------PhysicalProject
-----------------------------filter(cc_county IN ('Ziebach County', 'Luce County', 'Richland County', 'Daviess County', 'Barrow County'))
-------------------------------PhysicalOlapScan[call_center]
+----------------------------PhysicalOlapScan[catalog_returns]
+------------------------PhysicalDistribute
+--------------------------hashJoin[INNER_JOIN](cs1.cs_ship_date_sk = date_dim.d_date_sk)
+----------------------------hashJoin[INNER_JOIN](cs1.cs_ship_addr_sk = customer_address.ca_address_sk)
+------------------------------PhysicalProject
+--------------------------------PhysicalOlapScan[catalog_sales]
+------------------------------PhysicalDistribute
+--------------------------------PhysicalProject
+----------------------------------filter((cast(ca_state as VARCHAR(*)) = 'WV'))
+------------------------------------PhysicalOlapScan[customer_address]
+----------------------------PhysicalDistribute
+------------------------------PhysicalProject
+--------------------------------filter((date_dim.d_date <= 2002-05-31)(date_dim.d_date >= 2002-04-01))
+----------------------------------PhysicalOlapScan[date_dim]
+----------------------PhysicalDistribute
+------------------------PhysicalProject
+--------------------------filter(cc_county IN ('Ziebach County', 'Luce County', 'Richland County', 'Daviess County', 'Barrow County'))
+----------------------------PhysicalOlapScan[call_center]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query19.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query19.out
@@ -4,37 +4,36 @@ PhysicalResultSink
 --PhysicalTopN
 ----PhysicalDistribute
 ------PhysicalTopN
---------PhysicalProject
-----------hashAgg[GLOBAL]
-------------PhysicalDistribute
---------------hashAgg[LOCAL]
-----------------PhysicalProject
-------------------hashJoin[INNER_JOIN](store_sales.ss_store_sk = store.s_store_sk)( not (substring(ca_zip, 1, 5) = substring(s_zip, 1, 5)))
---------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN](customer.c_current_addr_sk = customer_address.ca_address_sk)
+--------hashAgg[GLOBAL]
+----------PhysicalDistribute
+------------hashAgg[LOCAL]
+--------------PhysicalProject
+----------------hashJoin[INNER_JOIN](store_sales.ss_store_sk = store.s_store_sk)( not (substring(ca_zip, 1, 5) = substring(s_zip, 1, 5)))
+------------------PhysicalProject
+--------------------hashJoin[INNER_JOIN](customer.c_current_addr_sk = customer_address.ca_address_sk)
+----------------------PhysicalProject
+------------------------PhysicalOlapScan[customer_address]
+----------------------PhysicalDistribute
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[customer_address]
-------------------------PhysicalDistribute
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN](store_sales.ss_customer_sk = customer.c_customer_sk)
-------------------------------PhysicalDistribute
---------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[customer]
-------------------------------PhysicalDistribute
---------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN](date_dim.d_date_sk = store_sales.ss_sold_date_sk)
-------------------------------------hashJoin[INNER_JOIN](store_sales.ss_item_sk = item.i_item_sk)
---------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[store_sales]
---------------------------------------PhysicalDistribute
-----------------------------------------PhysicalProject
-------------------------------------------filter((item.i_manager_id = 2))
---------------------------------------------PhysicalOlapScan[item]
+--------------------------hashJoin[INNER_JOIN](store_sales.ss_customer_sk = customer.c_customer_sk)
+----------------------------PhysicalDistribute
+------------------------------PhysicalProject
+--------------------------------PhysicalOlapScan[customer]
+----------------------------PhysicalDistribute
+------------------------------PhysicalProject
+--------------------------------hashJoin[INNER_JOIN](date_dim.d_date_sk = store_sales.ss_sold_date_sk)
+----------------------------------hashJoin[INNER_JOIN](store_sales.ss_item_sk = item.i_item_sk)
+------------------------------------PhysicalProject
+--------------------------------------PhysicalOlapScan[store_sales]
 ------------------------------------PhysicalDistribute
 --------------------------------------PhysicalProject
-----------------------------------------filter((date_dim.d_moy = 12)(date_dim.d_year = 1999))
-------------------------------------------PhysicalOlapScan[date_dim]
---------------------PhysicalDistribute
-----------------------PhysicalProject
-------------------------PhysicalOlapScan[store]
+----------------------------------------filter((item.i_manager_id = 2))
+------------------------------------------PhysicalOlapScan[item]
+----------------------------------PhysicalDistribute
+------------------------------------PhysicalProject
+--------------------------------------filter((date_dim.d_moy = 12)(date_dim.d_year = 1999))
+----------------------------------------PhysicalOlapScan[date_dim]
+------------------PhysicalDistribute
+--------------------PhysicalProject
+----------------------PhysicalOlapScan[store]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query3.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query3.out
@@ -4,22 +4,21 @@ PhysicalResultSink
 --PhysicalTopN
 ----PhysicalDistribute
 ------PhysicalTopN
---------PhysicalProject
-----------hashAgg[GLOBAL]
-------------PhysicalDistribute
---------------hashAgg[LOCAL]
-----------------PhysicalProject
-------------------hashJoin[INNER_JOIN](dt.d_date_sk = store_sales.ss_sold_date_sk)
---------------------PhysicalDistribute
-----------------------hashJoin[INNER_JOIN](store_sales.ss_item_sk = item.i_item_sk)
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[store_sales]
-------------------------PhysicalDistribute
---------------------------PhysicalProject
-----------------------------filter((item.i_manufact_id = 816))
-------------------------------PhysicalOlapScan[item]
---------------------PhysicalDistribute
+--------hashAgg[GLOBAL]
+----------PhysicalDistribute
+------------hashAgg[LOCAL]
+--------------PhysicalProject
+----------------hashJoin[INNER_JOIN](dt.d_date_sk = store_sales.ss_sold_date_sk)
+------------------PhysicalDistribute
+--------------------hashJoin[INNER_JOIN](store_sales.ss_item_sk = item.i_item_sk)
 ----------------------PhysicalProject
-------------------------filter((dt.d_moy = 11))
---------------------------PhysicalOlapScan[date_dim]
+------------------------PhysicalOlapScan[store_sales]
+----------------------PhysicalDistribute
+------------------------PhysicalProject
+--------------------------filter((item.i_manufact_id = 816))
+----------------------------PhysicalOlapScan[item]
+------------------PhysicalDistribute
+--------------------PhysicalProject
+----------------------filter((dt.d_moy = 11))
+------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query31.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query31.out
@@ -2,44 +2,42 @@
 -- !ds_shape_31 --
 PhysicalCteAnchor ( cteId=CTEId#0 )
 --PhysicalCteProducer ( cteId=CTEId#0 )
-----PhysicalProject
+----hashAgg[GLOBAL]
+------PhysicalDistribute
+--------hashAgg[LOCAL]
+----------PhysicalProject
+------------hashJoin[INNER_JOIN](store_sales.ss_addr_sk = customer_address.ca_address_sk)
+--------------PhysicalDistribute
+----------------PhysicalProject
+------------------hashJoin[INNER_JOIN](store_sales.ss_sold_date_sk = date_dim.d_date_sk)
+--------------------PhysicalProject
+----------------------PhysicalOlapScan[store_sales]
+--------------------PhysicalDistribute
+----------------------PhysicalProject
+------------------------filter(d_qoy IN (1, 2, 3)(ss.d_year = 2000))
+--------------------------PhysicalOlapScan[date_dim]
+--------------PhysicalDistribute
+----------------PhysicalProject
+------------------PhysicalOlapScan[customer_address]
+--PhysicalCteAnchor ( cteId=CTEId#1 )
+----PhysicalCteProducer ( cteId=CTEId#1 )
 ------hashAgg[GLOBAL]
 --------PhysicalDistribute
 ----------hashAgg[LOCAL]
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN](store_sales.ss_addr_sk = customer_address.ca_address_sk)
+--------------hashJoin[INNER_JOIN](web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)
 ----------------PhysicalDistribute
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN](store_sales.ss_sold_date_sk = date_dim.d_date_sk)
+--------------------hashJoin[INNER_JOIN](web_sales.ws_sold_date_sk = date_dim.d_date_sk)
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[store_sales]
+------------------------PhysicalOlapScan[web_sales]
 ----------------------PhysicalDistribute
 ------------------------PhysicalProject
---------------------------filter(d_qoy IN (1, 2, 3)(ss.d_year = 2000))
+--------------------------filter((ws.d_year = 2000)d_qoy IN (1, 2, 3))
 ----------------------------PhysicalOlapScan[date_dim]
 ----------------PhysicalDistribute
 ------------------PhysicalProject
 --------------------PhysicalOlapScan[customer_address]
---PhysicalCteAnchor ( cteId=CTEId#1 )
-----PhysicalCteProducer ( cteId=CTEId#1 )
-------PhysicalProject
---------hashAgg[GLOBAL]
-----------PhysicalDistribute
-------------hashAgg[LOCAL]
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN](web_sales.ws_bill_addr_sk = customer_address.ca_address_sk)
-------------------PhysicalDistribute
---------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN](web_sales.ws_sold_date_sk = date_dim.d_date_sk)
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[web_sales]
-------------------------PhysicalDistribute
---------------------------PhysicalProject
-----------------------------filter((ws.d_year = 2000)d_qoy IN (1, 2, 3))
-------------------------------PhysicalOlapScan[date_dim]
-------------------PhysicalDistribute
---------------------PhysicalProject
-----------------------PhysicalOlapScan[customer_address]
 ----PhysicalResultSink
 ------PhysicalQuickSort
 --------PhysicalDistribute

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query35.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query35.out
@@ -9,51 +9,51 @@ PhysicalResultSink
 ------------PhysicalDistribute
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------filter(($c$1 OR $c$2))
---------------------hashJoin[LEFT_SEMI_JOIN](c.c_customer_sk = catalog_sales.cs_ship_customer_sk)
-----------------------hashJoin[LEFT_SEMI_JOIN](c.c_customer_sk = web_sales.ws_bill_customer_sk)
-------------------------PhysicalDistribute
+------------------hashJoin[RIGHT_SEMI_JOIN](c.c_customer_sk = store_sales.ss_customer_sk)
+--------------------PhysicalDistribute
+----------------------PhysicalProject
+------------------------hashJoin[INNER_JOIN](store_sales.ss_sold_date_sk = date_dim.d_date_sk)
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN](customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)
-------------------------------PhysicalDistribute
---------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN](c.c_current_addr_sk = ca.ca_address_sk)
-------------------------------------PhysicalDistribute
---------------------------------------hashJoin[RIGHT_SEMI_JOIN](c.c_customer_sk = store_sales.ss_customer_sk)
-----------------------------------------PhysicalDistribute
-------------------------------------------PhysicalProject
---------------------------------------------hashJoin[INNER_JOIN](store_sales.ss_sold_date_sk = date_dim.d_date_sk)
-----------------------------------------------PhysicalProject
-------------------------------------------------PhysicalOlapScan[store_sales]
-----------------------------------------------PhysicalDistribute
-------------------------------------------------PhysicalProject
---------------------------------------------------filter((date_dim.d_qoy < 4)(date_dim.d_year = 2001))
-----------------------------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalOlapScan[store_sales]
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_qoy < 4)(date_dim.d_year = 2001))
+--------------------------------PhysicalOlapScan[date_dim]
+--------------------PhysicalProject
+----------------------filter(($c$1 OR $c$2))
+------------------------hashJoin[LEFT_SEMI_JOIN](c.c_customer_sk = catalog_sales.cs_ship_customer_sk)
+--------------------------hashJoin[LEFT_SEMI_JOIN](c.c_customer_sk = web_sales.ws_bill_customer_sk)
+----------------------------PhysicalDistribute
+------------------------------PhysicalProject
+--------------------------------hashJoin[INNER_JOIN](customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)
+----------------------------------PhysicalDistribute
+------------------------------------PhysicalProject
+--------------------------------------hashJoin[INNER_JOIN](c.c_current_addr_sk = ca.ca_address_sk)
 ----------------------------------------PhysicalDistribute
 ------------------------------------------PhysicalProject
 --------------------------------------------PhysicalOlapScan[customer]
-------------------------------------PhysicalDistribute
---------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[customer_address]
-------------------------------PhysicalDistribute
---------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[customer_demographics]
-------------------------PhysicalDistribute
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN](web_sales.ws_sold_date_sk = date_dim.d_date_sk)
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[web_sales]
-------------------------------PhysicalDistribute
---------------------------------PhysicalProject
-----------------------------------filter((date_dim.d_qoy < 4)(date_dim.d_year = 2001))
-------------------------------------PhysicalOlapScan[date_dim]
-----------------------PhysicalDistribute
-------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN](catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[catalog_sales]
+----------------------------------------PhysicalDistribute
+------------------------------------------PhysicalProject
+--------------------------------------------PhysicalOlapScan[customer_address]
+----------------------------------PhysicalDistribute
+------------------------------------PhysicalProject
+--------------------------------------PhysicalOlapScan[customer_demographics]
 ----------------------------PhysicalDistribute
 ------------------------------PhysicalProject
---------------------------------filter((date_dim.d_qoy < 4)(date_dim.d_year = 2001))
-----------------------------------PhysicalOlapScan[date_dim]
+--------------------------------hashJoin[INNER_JOIN](web_sales.ws_sold_date_sk = date_dim.d_date_sk)
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[web_sales]
+----------------------------------PhysicalDistribute
+------------------------------------PhysicalProject
+--------------------------------------filter((date_dim.d_qoy < 4)(date_dim.d_year = 2001))
+----------------------------------------PhysicalOlapScan[date_dim]
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[catalog_sales]
+--------------------------------PhysicalDistribute
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_qoy < 4)(date_dim.d_year = 2001))
+--------------------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query38.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query38.out
@@ -8,58 +8,55 @@ PhysicalResultSink
 ----------hashAgg[LOCAL]
 ------------PhysicalProject
 --------------PhysicalIntersect
-----------------PhysicalProject
-------------------hashAgg[GLOBAL]
---------------------PhysicalDistribute
-----------------------hashAgg[LOCAL]
-------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN](store_sales.ss_customer_sk = customer.c_customer_sk)
-----------------------------PhysicalDistribute
-------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN](store_sales.ss_sold_date_sk = date_dim.d_date_sk)
+----------------hashAgg[GLOBAL]
+------------------PhysicalDistribute
+--------------------hashAgg[LOCAL]
+----------------------PhysicalProject
+------------------------hashJoin[INNER_JOIN](store_sales.ss_customer_sk = customer.c_customer_sk)
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------hashJoin[INNER_JOIN](store_sales.ss_sold_date_sk = date_dim.d_date_sk)
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[store_sales]
+--------------------------------PhysicalDistribute
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[store_sales]
-----------------------------------PhysicalDistribute
-------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_month_seq <= 1194)(date_dim.d_month_seq >= 1183))
-----------------------------------------PhysicalOlapScan[date_dim]
-----------------------------PhysicalDistribute
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[customer]
-----------------PhysicalProject
-------------------hashAgg[GLOBAL]
---------------------PhysicalDistribute
-----------------------hashAgg[LOCAL]
-------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN](catalog_sales.cs_bill_customer_sk = customer.c_customer_sk)
-----------------------------PhysicalDistribute
-------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)
+------------------------------------filter((date_dim.d_month_seq <= 1194)(date_dim.d_month_seq >= 1183))
+--------------------------------------PhysicalOlapScan[date_dim]
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[customer]
+----------------hashAgg[GLOBAL]
+------------------PhysicalDistribute
+--------------------hashAgg[LOCAL]
+----------------------PhysicalProject
+------------------------hashJoin[INNER_JOIN](catalog_sales.cs_bill_customer_sk = customer.c_customer_sk)
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[catalog_sales]
+--------------------------------PhysicalDistribute
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[catalog_sales]
-----------------------------------PhysicalDistribute
-------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_month_seq <= 1194)(date_dim.d_month_seq >= 1183))
-----------------------------------------PhysicalOlapScan[date_dim]
-----------------------------PhysicalDistribute
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[customer]
-----------------PhysicalProject
-------------------hashAgg[GLOBAL]
---------------------PhysicalDistribute
-----------------------hashAgg[LOCAL]
-------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN](web_sales.ws_bill_customer_sk = customer.c_customer_sk)
-----------------------------PhysicalDistribute
-------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN](web_sales.ws_sold_date_sk = date_dim.d_date_sk)
+------------------------------------filter((date_dim.d_month_seq <= 1194)(date_dim.d_month_seq >= 1183))
+--------------------------------------PhysicalOlapScan[date_dim]
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[customer]
+----------------hashAgg[GLOBAL]
+------------------PhysicalDistribute
+--------------------hashAgg[LOCAL]
+----------------------PhysicalProject
+------------------------hashJoin[INNER_JOIN](web_sales.ws_bill_customer_sk = customer.c_customer_sk)
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------hashJoin[INNER_JOIN](web_sales.ws_sold_date_sk = date_dim.d_date_sk)
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[web_sales]
+--------------------------------PhysicalDistribute
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[web_sales]
-----------------------------------PhysicalDistribute
-------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_month_seq <= 1194)(date_dim.d_month_seq >= 1183))
-----------------------------------------PhysicalOlapScan[date_dim]
-----------------------------PhysicalDistribute
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[customer]
+------------------------------------filter((date_dim.d_month_seq <= 1194)(date_dim.d_month_seq >= 1183))
+--------------------------------------PhysicalOlapScan[date_dim]
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[customer]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query52.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query52.out
@@ -4,21 +4,20 @@ PhysicalResultSink
 --PhysicalTopN
 ----PhysicalDistribute
 ------PhysicalTopN
---------PhysicalProject
-----------hashAgg[GLOBAL]
-------------PhysicalDistribute
---------------hashAgg[LOCAL]
-----------------PhysicalProject
-------------------hashJoin[INNER_JOIN](dt.d_date_sk = store_sales.ss_sold_date_sk)
---------------------hashJoin[INNER_JOIN](store_sales.ss_item_sk = item.i_item_sk)
-----------------------PhysicalProject
-------------------------PhysicalOlapScan[store_sales]
-----------------------PhysicalDistribute
-------------------------PhysicalProject
---------------------------filter((item.i_manager_id = 1))
-----------------------------PhysicalOlapScan[item]
+--------hashAgg[GLOBAL]
+----------PhysicalDistribute
+------------hashAgg[LOCAL]
+--------------PhysicalProject
+----------------hashJoin[INNER_JOIN](dt.d_date_sk = store_sales.ss_sold_date_sk)
+------------------hashJoin[INNER_JOIN](store_sales.ss_item_sk = item.i_item_sk)
+--------------------PhysicalProject
+----------------------PhysicalOlapScan[store_sales]
 --------------------PhysicalDistribute
 ----------------------PhysicalProject
-------------------------filter((dt.d_moy = 12)(dt.d_year = 2002))
---------------------------PhysicalOlapScan[date_dim]
+------------------------filter((item.i_manager_id = 1))
+--------------------------PhysicalOlapScan[item]
+------------------PhysicalDistribute
+--------------------PhysicalProject
+----------------------filter((dt.d_moy = 12)(dt.d_year = 2002))
+------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query55.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query55.out
@@ -4,21 +4,20 @@ PhysicalResultSink
 --PhysicalTopN
 ----PhysicalDistribute
 ------PhysicalTopN
---------PhysicalProject
-----------hashAgg[GLOBAL]
-------------PhysicalDistribute
---------------hashAgg[LOCAL]
-----------------PhysicalProject
-------------------hashJoin[INNER_JOIN](date_dim.d_date_sk = store_sales.ss_sold_date_sk)
---------------------hashJoin[INNER_JOIN](store_sales.ss_item_sk = item.i_item_sk)
-----------------------PhysicalProject
-------------------------PhysicalOlapScan[store_sales]
-----------------------PhysicalDistribute
-------------------------PhysicalProject
---------------------------filter((item.i_manager_id = 100))
-----------------------------PhysicalOlapScan[item]
+--------hashAgg[GLOBAL]
+----------PhysicalDistribute
+------------hashAgg[LOCAL]
+--------------PhysicalProject
+----------------hashJoin[INNER_JOIN](date_dim.d_date_sk = store_sales.ss_sold_date_sk)
+------------------hashJoin[INNER_JOIN](store_sales.ss_item_sk = item.i_item_sk)
+--------------------PhysicalProject
+----------------------PhysicalOlapScan[store_sales]
 --------------------PhysicalDistribute
 ----------------------PhysicalProject
-------------------------filter((date_dim.d_moy = 12)(date_dim.d_year = 2000))
---------------------------PhysicalOlapScan[date_dim]
+------------------------filter((item.i_manager_id = 100))
+--------------------------PhysicalOlapScan[item]
+------------------PhysicalDistribute
+--------------------PhysicalProject
+----------------------filter((date_dim.d_moy = 12)(date_dim.d_year = 2000))
+------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query59.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query59.out
@@ -2,17 +2,16 @@
 -- !ds_shape_59 --
 PhysicalCteAnchor ( cteId=CTEId#0 )
 --PhysicalCteProducer ( cteId=CTEId#0 )
-----PhysicalProject
-------hashAgg[GLOBAL]
---------PhysicalDistribute
-----------hashAgg[LOCAL]
-------------PhysicalProject
---------------hashJoin[INNER_JOIN](date_dim.d_date_sk = store_sales.ss_sold_date_sk)
+----hashAgg[GLOBAL]
+------PhysicalDistribute
+--------hashAgg[LOCAL]
+----------PhysicalProject
+------------hashJoin[INNER_JOIN](date_dim.d_date_sk = store_sales.ss_sold_date_sk)
+--------------PhysicalProject
+----------------PhysicalOlapScan[store_sales]
+--------------PhysicalDistribute
 ----------------PhysicalProject
-------------------PhysicalOlapScan[store_sales]
-----------------PhysicalDistribute
-------------------PhysicalProject
---------------------PhysicalOlapScan[date_dim]
+------------------PhysicalOlapScan[date_dim]
 --PhysicalResultSink
 ----PhysicalTopN
 ------PhysicalDistribute

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query71.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query71.out
@@ -4,49 +4,48 @@ PhysicalResultSink
 --PhysicalQuickSort
 ----PhysicalDistribute
 ------PhysicalQuickSort
---------PhysicalProject
-----------hashAgg[GLOBAL]
-------------PhysicalDistribute
---------------hashAgg[LOCAL]
-----------------PhysicalProject
-------------------hashJoin[INNER_JOIN](tmp.time_sk = time_dim.t_time_sk)
---------------------PhysicalDistribute
-----------------------hashJoin[INNER_JOIN](tmp.sold_item_sk = item.i_item_sk)
-------------------------PhysicalDistribute
---------------------------PhysicalUnion
-----------------------------PhysicalDistribute
-------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN](date_dim.d_date_sk = web_sales.ws_sold_date_sk)
+--------hashAgg[GLOBAL]
+----------PhysicalDistribute
+------------hashAgg[LOCAL]
+--------------PhysicalProject
+----------------hashJoin[INNER_JOIN](tmp.time_sk = time_dim.t_time_sk)
+------------------PhysicalDistribute
+--------------------hashJoin[INNER_JOIN](tmp.sold_item_sk = item.i_item_sk)
+----------------------PhysicalDistribute
+------------------------PhysicalUnion
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------hashJoin[INNER_JOIN](date_dim.d_date_sk = web_sales.ws_sold_date_sk)
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[web_sales]
+--------------------------------PhysicalDistribute
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[web_sales]
-----------------------------------PhysicalDistribute
-------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 12)(date_dim.d_year = 1998))
-----------------------------------------PhysicalOlapScan[date_dim]
-----------------------------PhysicalDistribute
-------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN](date_dim.d_date_sk = catalog_sales.cs_sold_date_sk)
+------------------------------------filter((date_dim.d_moy = 12)(date_dim.d_year = 1998))
+--------------------------------------PhysicalOlapScan[date_dim]
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------hashJoin[INNER_JOIN](date_dim.d_date_sk = catalog_sales.cs_sold_date_sk)
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[catalog_sales]
+--------------------------------PhysicalDistribute
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[catalog_sales]
-----------------------------------PhysicalDistribute
-------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 12)(date_dim.d_year = 1998))
-----------------------------------------PhysicalOlapScan[date_dim]
-----------------------------PhysicalDistribute
-------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN](date_dim.d_date_sk = store_sales.ss_sold_date_sk)
+------------------------------------filter((date_dim.d_moy = 12)(date_dim.d_year = 1998))
+--------------------------------------PhysicalOlapScan[date_dim]
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------hashJoin[INNER_JOIN](date_dim.d_date_sk = store_sales.ss_sold_date_sk)
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[store_sales]
+--------------------------------PhysicalDistribute
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[store_sales]
-----------------------------------PhysicalDistribute
-------------------------------------PhysicalProject
---------------------------------------filter((date_dim.d_moy = 12)(date_dim.d_year = 1998))
-----------------------------------------PhysicalOlapScan[date_dim]
-------------------------PhysicalDistribute
---------------------------PhysicalProject
-----------------------------filter((item.i_manager_id = 1))
-------------------------------PhysicalOlapScan[item]
---------------------PhysicalDistribute
-----------------------PhysicalProject
-------------------------filter(((cast(t_meal_time as VARCHAR(*)) = 'breakfast') OR (cast(t_meal_time as VARCHAR(*)) = 'dinner')))
---------------------------PhysicalOlapScan[time_dim]
+------------------------------------filter((date_dim.d_moy = 12)(date_dim.d_year = 1998))
+--------------------------------------PhysicalOlapScan[date_dim]
+----------------------PhysicalDistribute
+------------------------PhysicalProject
+--------------------------filter((item.i_manager_id = 1))
+----------------------------PhysicalOlapScan[item]
+------------------PhysicalDistribute
+--------------------PhysicalProject
+----------------------filter(((cast(t_meal_time as VARCHAR(*)) = 'breakfast') OR (cast(t_meal_time as VARCHAR(*)) = 'dinner')))
+------------------------PhysicalOlapScan[time_dim]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query87.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query87.out
@@ -6,58 +6,55 @@ PhysicalResultSink
 ------hashAgg[LOCAL]
 --------PhysicalProject
 ----------PhysicalExcept
-------------PhysicalProject
---------------hashAgg[GLOBAL]
-----------------PhysicalDistribute
-------------------hashAgg[LOCAL]
---------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN](store_sales.ss_customer_sk = customer.c_customer_sk)
-------------------------PhysicalDistribute
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN](store_sales.ss_sold_date_sk = date_dim.d_date_sk)
+------------hashAgg[GLOBAL]
+--------------PhysicalDistribute
+----------------hashAgg[LOCAL]
+------------------PhysicalProject
+--------------------hashJoin[INNER_JOIN](store_sales.ss_customer_sk = customer.c_customer_sk)
+----------------------PhysicalDistribute
+------------------------PhysicalProject
+--------------------------hashJoin[INNER_JOIN](store_sales.ss_sold_date_sk = date_dim.d_date_sk)
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[store_sales]
+----------------------------PhysicalDistribute
 ------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[store_sales]
-------------------------------PhysicalDistribute
---------------------------------PhysicalProject
-----------------------------------filter((date_dim.d_month_seq >= 1184)(date_dim.d_month_seq <= 1195))
-------------------------------------PhysicalOlapScan[date_dim]
-------------------------PhysicalDistribute
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[customer]
-------------PhysicalProject
---------------hashAgg[GLOBAL]
-----------------PhysicalDistribute
-------------------hashAgg[LOCAL]
---------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN](catalog_sales.cs_bill_customer_sk = customer.c_customer_sk)
-------------------------PhysicalDistribute
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN](catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)
+--------------------------------filter((date_dim.d_month_seq >= 1184)(date_dim.d_month_seq <= 1195))
+----------------------------------PhysicalOlapScan[date_dim]
+----------------------PhysicalDistribute
+------------------------PhysicalProject
+--------------------------PhysicalOlapScan[customer]
+------------hashAgg[GLOBAL]
+--------------PhysicalDistribute
+----------------hashAgg[LOCAL]
+------------------PhysicalProject
+--------------------hashJoin[INNER_JOIN](catalog_sales.cs_bill_customer_sk = customer.c_customer_sk)
+----------------------PhysicalDistribute
+------------------------PhysicalProject
+--------------------------hashJoin[INNER_JOIN](catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[catalog_sales]
+----------------------------PhysicalDistribute
 ------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[catalog_sales]
-------------------------------PhysicalDistribute
---------------------------------PhysicalProject
-----------------------------------filter((date_dim.d_month_seq >= 1184)(date_dim.d_month_seq <= 1195))
-------------------------------------PhysicalOlapScan[date_dim]
-------------------------PhysicalDistribute
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[customer]
-------------PhysicalProject
---------------hashAgg[GLOBAL]
-----------------PhysicalDistribute
-------------------hashAgg[LOCAL]
---------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN](web_sales.ws_bill_customer_sk = customer.c_customer_sk)
-------------------------PhysicalDistribute
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN](web_sales.ws_sold_date_sk = date_dim.d_date_sk)
+--------------------------------filter((date_dim.d_month_seq >= 1184)(date_dim.d_month_seq <= 1195))
+----------------------------------PhysicalOlapScan[date_dim]
+----------------------PhysicalDistribute
+------------------------PhysicalProject
+--------------------------PhysicalOlapScan[customer]
+------------hashAgg[GLOBAL]
+--------------PhysicalDistribute
+----------------hashAgg[LOCAL]
+------------------PhysicalProject
+--------------------hashJoin[INNER_JOIN](web_sales.ws_bill_customer_sk = customer.c_customer_sk)
+----------------------PhysicalDistribute
+------------------------PhysicalProject
+--------------------------hashJoin[INNER_JOIN](web_sales.ws_sold_date_sk = date_dim.d_date_sk)
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[web_sales]
+----------------------------PhysicalDistribute
 ------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[web_sales]
-------------------------------PhysicalDistribute
---------------------------------PhysicalProject
-----------------------------------filter((date_dim.d_month_seq <= 1195)(date_dim.d_month_seq >= 1184))
-------------------------------------PhysicalOlapScan[date_dim]
-------------------------PhysicalDistribute
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[customer]
+--------------------------------filter((date_dim.d_month_seq <= 1195)(date_dim.d_month_seq >= 1184))
+----------------------------------PhysicalOlapScan[date_dim]
+----------------------PhysicalDistribute
+------------------------PhysicalProject
+--------------------------PhysicalOlapScan[customer]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query94.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query94.out
@@ -3,37 +3,36 @@
 PhysicalResultSink
 --PhysicalTopN
 ----PhysicalTopN
-------PhysicalProject
---------hashAgg[DISTINCT_GLOBAL]
-----------PhysicalDistribute
-------------hashAgg[DISTINCT_LOCAL]
---------------hashAgg[GLOBAL]
-----------------hashAgg[LOCAL]
-------------------PhysicalProject
---------------------hashJoin[RIGHT_SEMI_JOIN](ws1.ws_order_number = ws2.ws_order_number)( not (ws_warehouse_sk = ws_warehouse_sk))
+------hashAgg[DISTINCT_GLOBAL]
+--------PhysicalDistribute
+----------hashAgg[DISTINCT_LOCAL]
+------------hashAgg[GLOBAL]
+--------------hashAgg[LOCAL]
+----------------PhysicalProject
+------------------hashJoin[RIGHT_SEMI_JOIN](ws1.ws_order_number = ws2.ws_order_number)( not (ws_warehouse_sk = ws_warehouse_sk))
+--------------------PhysicalDistribute
+----------------------PhysicalProject
+------------------------PhysicalOlapScan[web_sales]
+--------------------hashJoin[RIGHT_ANTI_JOIN](ws1.ws_order_number = wr1.wr_order_number)
 ----------------------PhysicalDistribute
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[web_sales]
-----------------------hashJoin[RIGHT_ANTI_JOIN](ws1.ws_order_number = wr1.wr_order_number)
-------------------------PhysicalDistribute
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[web_returns]
-------------------------PhysicalDistribute
---------------------------hashJoin[INNER_JOIN](ws1.ws_web_site_sk = web_site.web_site_sk)
-----------------------------hashJoin[INNER_JOIN](ws1.ws_ship_date_sk = date_dim.d_date_sk)
-------------------------------hashJoin[INNER_JOIN](ws1.ws_ship_addr_sk = customer_address.ca_address_sk)
---------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[web_sales]
---------------------------------PhysicalDistribute
-----------------------------------PhysicalProject
-------------------------------------filter((cast(ca_state as VARCHAR(*)) = 'OK'))
---------------------------------------PhysicalOlapScan[customer_address]
+--------------------------PhysicalOlapScan[web_returns]
+----------------------PhysicalDistribute
+------------------------hashJoin[INNER_JOIN](ws1.ws_web_site_sk = web_site.web_site_sk)
+--------------------------hashJoin[INNER_JOIN](ws1.ws_ship_date_sk = date_dim.d_date_sk)
+----------------------------hashJoin[INNER_JOIN](ws1.ws_ship_addr_sk = customer_address.ca_address_sk)
+------------------------------PhysicalProject
+--------------------------------PhysicalOlapScan[web_sales]
 ------------------------------PhysicalDistribute
 --------------------------------PhysicalProject
-----------------------------------filter((date_dim.d_date <= 2000-04-01)(date_dim.d_date >= 2000-02-01))
-------------------------------------PhysicalOlapScan[date_dim]
+----------------------------------filter((cast(ca_state as VARCHAR(*)) = 'OK'))
+------------------------------------PhysicalOlapScan[customer_address]
 ----------------------------PhysicalDistribute
 ------------------------------PhysicalProject
---------------------------------filter((cast(web_company_name as VARCHAR(*)) = 'pri'))
-----------------------------------PhysicalOlapScan[web_site]
+--------------------------------filter((date_dim.d_date <= 2000-04-01)(date_dim.d_date >= 2000-02-01))
+----------------------------------PhysicalOlapScan[date_dim]
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------filter((cast(web_company_name as VARCHAR(*)) = 'pri'))
+--------------------------------PhysicalOlapScan[web_site]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query95.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query95.out
@@ -13,13 +13,16 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --PhysicalResultSink
 ----PhysicalTopN
 ------PhysicalTopN
---------PhysicalProject
-----------hashAgg[DISTINCT_GLOBAL]
-------------PhysicalDistribute
---------------hashAgg[DISTINCT_LOCAL]
-----------------hashAgg[GLOBAL]
-------------------hashAgg[LOCAL]
---------------------PhysicalProject
+--------hashAgg[DISTINCT_GLOBAL]
+----------PhysicalDistribute
+------------hashAgg[DISTINCT_LOCAL]
+--------------hashAgg[GLOBAL]
+----------------hashAgg[LOCAL]
+------------------PhysicalProject
+--------------------hashJoin[RIGHT_SEMI_JOIN](ws1.ws_order_number = ws_wh.ws_order_number)
+----------------------PhysicalDistribute
+------------------------PhysicalProject
+--------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 ----------------------hashJoin[RIGHT_SEMI_JOIN](ws1.ws_order_number = web_returns.wr_order_number)
 ------------------------PhysicalProject
 --------------------------hashJoin[INNER_JOIN](web_returns.wr_order_number = ws_wh.ws_order_number)
@@ -29,26 +32,22 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ----------------------------PhysicalDistribute
 ------------------------------PhysicalProject
 --------------------------------PhysicalOlapScan[web_returns]
-------------------------hashJoin[RIGHT_SEMI_JOIN](ws1.ws_order_number = ws_wh.ws_order_number)
---------------------------PhysicalDistribute
-----------------------------PhysicalProject
-------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
---------------------------PhysicalDistribute
-----------------------------hashJoin[INNER_JOIN](ws1.ws_web_site_sk = web_site.web_site_sk)
-------------------------------hashJoin[INNER_JOIN](ws1.ws_ship_date_sk = date_dim.d_date_sk)
---------------------------------hashJoin[INNER_JOIN](ws1.ws_ship_addr_sk = customer_address.ca_address_sk)
-----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[web_sales]
-----------------------------------PhysicalDistribute
-------------------------------------PhysicalProject
---------------------------------------filter((cast(ca_state as VARCHAR(*)) = 'NC'))
-----------------------------------------PhysicalOlapScan[customer_address]
+------------------------PhysicalDistribute
+--------------------------hashJoin[INNER_JOIN](ws1.ws_web_site_sk = web_site.web_site_sk)
+----------------------------hashJoin[INNER_JOIN](ws1.ws_ship_date_sk = date_dim.d_date_sk)
+------------------------------hashJoin[INNER_JOIN](ws1.ws_ship_addr_sk = customer_address.ca_address_sk)
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[web_sales]
 --------------------------------PhysicalDistribute
 ----------------------------------PhysicalProject
-------------------------------------filter((date_dim.d_date >= 1999-02-01)(date_dim.d_date <= 1999-04-02))
---------------------------------------PhysicalOlapScan[date_dim]
+------------------------------------filter((cast(ca_state as VARCHAR(*)) = 'NC'))
+--------------------------------------PhysicalOlapScan[customer_address]
 ------------------------------PhysicalDistribute
 --------------------------------PhysicalProject
-----------------------------------filter((cast(web_company_name as VARCHAR(*)) = 'pri'))
-------------------------------------PhysicalOlapScan[web_site]
+----------------------------------filter((date_dim.d_date >= 1999-02-01)(date_dim.d_date <= 1999-04-02))
+------------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalDistribute
+------------------------------PhysicalProject
+--------------------------------filter((cast(web_company_name as VARCHAR(*)) = 'pri'))
+----------------------------------PhysicalOlapScan[web_site]
 

--- a/regression-test/data/nereids_tpch_shape_sf1000_p0/shape/q10.out
+++ b/regression-test/data/nereids_tpch_shape_sf1000_p0/shape/q10.out
@@ -4,26 +4,25 @@ PhysicalResultSink
 --PhysicalTopN
 ----PhysicalDistribute
 ------PhysicalTopN
---------PhysicalProject
-----------hashAgg[GLOBAL]
-------------PhysicalDistribute
---------------hashAgg[LOCAL]
-----------------PhysicalProject
-------------------hashJoin[INNER_JOIN](lineitem.l_orderkey = orders.o_orderkey)
---------------------PhysicalProject
-----------------------filter((lineitem.l_returnflag = 'R'))
-------------------------PhysicalOlapScan[lineitem]
---------------------PhysicalDistribute
-----------------------hashJoin[INNER_JOIN](customer.c_nationkey = nation.n_nationkey)
-------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN](customer.c_custkey = orders.o_custkey)
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[customer]
-----------------------------PhysicalDistribute
-------------------------------PhysicalProject
---------------------------------filter((orders.o_orderdate < 1994-01-01)(orders.o_orderdate >= 1993-10-01))
-----------------------------------PhysicalOlapScan[orders]
-------------------------PhysicalDistribute
+--------hashAgg[GLOBAL]
+----------PhysicalDistribute
+------------hashAgg[LOCAL]
+--------------PhysicalProject
+----------------hashJoin[INNER_JOIN](lineitem.l_orderkey = orders.o_orderkey)
+------------------PhysicalProject
+--------------------filter((lineitem.l_returnflag = 'R'))
+----------------------PhysicalOlapScan[lineitem]
+------------------PhysicalDistribute
+--------------------hashJoin[INNER_JOIN](customer.c_nationkey = nation.n_nationkey)
+----------------------PhysicalProject
+------------------------hashJoin[INNER_JOIN](customer.c_custkey = orders.o_custkey)
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[nation]
+----------------------------PhysicalOlapScan[customer]
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------filter((orders.o_orderdate < 1994-01-01)(orders.o_orderdate >= 1993-10-01))
+--------------------------------PhysicalOlapScan[orders]
+----------------------PhysicalDistribute
+------------------------PhysicalProject
+--------------------------PhysicalOlapScan[nation]
 

--- a/regression-test/data/nereids_tpch_shape_sf1000_p0/shape/q3.out
+++ b/regression-test/data/nereids_tpch_shape_sf1000_p0/shape/q3.out
@@ -4,22 +4,21 @@ PhysicalResultSink
 --PhysicalTopN
 ----PhysicalDistribute
 ------PhysicalTopN
---------PhysicalProject
-----------hashAgg[LOCAL]
-------------PhysicalProject
---------------hashJoin[INNER_JOIN](lineitem.l_orderkey = orders.o_orderkey)
+--------hashAgg[LOCAL]
+----------PhysicalProject
+------------hashJoin[INNER_JOIN](lineitem.l_orderkey = orders.o_orderkey)
+--------------PhysicalProject
+----------------filter((lineitem.l_shipdate > 1995-03-15))
+------------------PhysicalOlapScan[lineitem]
+--------------PhysicalDistribute
 ----------------PhysicalProject
-------------------filter((lineitem.l_shipdate > 1995-03-15))
---------------------PhysicalOlapScan[lineitem]
-----------------PhysicalDistribute
-------------------PhysicalProject
---------------------hashJoin[INNER_JOIN](customer.c_custkey = orders.o_custkey)
-----------------------PhysicalDistribute
-------------------------PhysicalProject
---------------------------filter((orders.o_orderdate < 1995-03-15))
-----------------------------PhysicalOlapScan[orders]
-----------------------PhysicalDistribute
-------------------------PhysicalProject
---------------------------filter((customer.c_mktsegment = 'BUILDING'))
-----------------------------PhysicalOlapScan[customer]
+------------------hashJoin[INNER_JOIN](customer.c_custkey = orders.o_custkey)
+--------------------PhysicalDistribute
+----------------------PhysicalProject
+------------------------filter((orders.o_orderdate < 1995-03-15))
+--------------------------PhysicalOlapScan[orders]
+--------------------PhysicalDistribute
+----------------------PhysicalProject
+------------------------filter((customer.c_mktsegment = 'BUILDING'))
+--------------------------PhysicalOlapScan[customer]
 

--- a/regression-test/data/nereids_tpch_shape_sf500_p0/shape/q10.out
+++ b/regression-test/data/nereids_tpch_shape_sf500_p0/shape/q10.out
@@ -4,26 +4,25 @@ PhysicalResultSink
 --PhysicalTopN
 ----PhysicalDistribute
 ------PhysicalTopN
---------PhysicalProject
-----------hashAgg[GLOBAL]
-------------PhysicalDistribute
---------------hashAgg[LOCAL]
-----------------PhysicalProject
-------------------hashJoin[INNER_JOIN](lineitem.l_orderkey = orders.o_orderkey)
---------------------PhysicalProject
-----------------------filter((lineitem.l_returnflag = 'R'))
-------------------------PhysicalOlapScan[lineitem]
---------------------PhysicalDistribute
-----------------------hashJoin[INNER_JOIN](customer.c_nationkey = nation.n_nationkey)
-------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN](customer.c_custkey = orders.o_custkey)
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[customer]
-----------------------------PhysicalDistribute
-------------------------------PhysicalProject
---------------------------------filter((orders.o_orderdate < 1994-01-01)(orders.o_orderdate >= 1993-10-01))
-----------------------------------PhysicalOlapScan[orders]
-------------------------PhysicalDistribute
+--------hashAgg[GLOBAL]
+----------PhysicalDistribute
+------------hashAgg[LOCAL]
+--------------PhysicalProject
+----------------hashJoin[INNER_JOIN](lineitem.l_orderkey = orders.o_orderkey)
+------------------PhysicalProject
+--------------------filter((lineitem.l_returnflag = 'R'))
+----------------------PhysicalOlapScan[lineitem]
+------------------PhysicalDistribute
+--------------------hashJoin[INNER_JOIN](customer.c_nationkey = nation.n_nationkey)
+----------------------PhysicalProject
+------------------------hashJoin[INNER_JOIN](customer.c_custkey = orders.o_custkey)
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[nation]
+----------------------------PhysicalOlapScan[customer]
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------filter((orders.o_orderdate < 1994-01-01)(orders.o_orderdate >= 1993-10-01))
+--------------------------------PhysicalOlapScan[orders]
+----------------------PhysicalDistribute
+------------------------PhysicalProject
+--------------------------PhysicalOlapScan[nation]
 

--- a/regression-test/data/nereids_tpch_shape_sf500_p0/shape/q3.out
+++ b/regression-test/data/nereids_tpch_shape_sf500_p0/shape/q3.out
@@ -4,22 +4,21 @@ PhysicalResultSink
 --PhysicalTopN
 ----PhysicalDistribute
 ------PhysicalTopN
---------PhysicalProject
-----------hashAgg[LOCAL]
-------------PhysicalProject
---------------hashJoin[INNER_JOIN](lineitem.l_orderkey = orders.o_orderkey)
+--------hashAgg[LOCAL]
+----------PhysicalProject
+------------hashJoin[INNER_JOIN](lineitem.l_orderkey = orders.o_orderkey)
+--------------PhysicalProject
+----------------filter((lineitem.l_shipdate > 1995-03-15))
+------------------PhysicalOlapScan[lineitem]
+--------------PhysicalDistribute
 ----------------PhysicalProject
-------------------filter((lineitem.l_shipdate > 1995-03-15))
---------------------PhysicalOlapScan[lineitem]
-----------------PhysicalDistribute
-------------------PhysicalProject
---------------------hashJoin[INNER_JOIN](customer.c_custkey = orders.o_custkey)
-----------------------PhysicalDistribute
-------------------------PhysicalProject
---------------------------filter((orders.o_orderdate < 1995-03-15))
-----------------------------PhysicalOlapScan[orders]
-----------------------PhysicalDistribute
-------------------------PhysicalProject
---------------------------filter((customer.c_mktsegment = 'BUILDING'))
-----------------------------PhysicalOlapScan[customer]
+------------------hashJoin[INNER_JOIN](customer.c_custkey = orders.o_custkey)
+--------------------PhysicalDistribute
+----------------------PhysicalProject
+------------------------filter((orders.o_orderdate < 1995-03-15))
+--------------------------PhysicalOlapScan[orders]
+--------------------PhysicalDistribute
+----------------------PhysicalProject
+------------------------filter((customer.c_mktsegment = 'BUILDING'))
+--------------------------PhysicalOlapScan[customer]
 

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf10.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf10.groovy
@@ -109,5 +109,5 @@ limit 100;
     // File file = new File(outFile)
     // file.write(getRuntimeFilters(plan))
     
-     assertEquals("RF5[c_current_cdemo_sk->[cd_demo_sk],RF4[c_customer_sk->[ss_customer_sk],RF3[d_date_sk->[ss_sold_date_sk],RF2[ca_address_sk->[c_current_addr_sk],RF1[d_date_sk->[ws_sold_date_sk],RF0[d_date_sk->[cs_sold_date_sk]", getRuntimeFilters(plan))
+     assertEquals("RF5[c_customer_sk->[ss_customer_sk],RF4[d_date_sk->[ss_sold_date_sk],RF3[c_current_cdemo_sk->[cd_demo_sk],RF2[ca_address_sk->[c_current_addr_sk],RF1[d_date_sk->[ws_sold_date_sk],RF0[d_date_sk->[cs_sold_date_sk]", getRuntimeFilters(plan))
 }

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf35.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf35.groovy
@@ -108,5 +108,5 @@ suite("ds_rf35") {
     // File file = new File(outFile)
     // file.write(getRuntimeFilters(plan))
     
-     assertEquals("RF5[cd_demo_sk->[c_current_cdemo_sk],RF4[ca_address_sk->[c_current_addr_sk],RF3[c_customer_sk->[ss_customer_sk],RF2[d_date_sk->[ss_sold_date_sk],RF1[d_date_sk->[ws_sold_date_sk],RF0[d_date_sk->[cs_sold_date_sk]", getRuntimeFilters(plan))
+     assertEquals("RF5[c_customer_sk->[ss_customer_sk],RF4[d_date_sk->[ss_sold_date_sk],RF3[cd_demo_sk->[c_current_cdemo_sk],RF2[ca_address_sk->[c_current_addr_sk],RF1[d_date_sk->[ws_sold_date_sk],RF0[d_date_sk->[cs_sold_date_sk]", getRuntimeFilters(plan))
 }

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf95.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf95.groovy
@@ -82,5 +82,5 @@ limit 100;
     // File file = new File(outFile)
     // file.write(getRuntimeFilters(plan))
 
-     assertEquals("RF0[ws_order_number->[ws_order_number],RF5[wr_order_number->[ws_order_number],RF7[wr_order_number->[ws_order_number, ws_order_number],RF4[ws_order_number->[ws_order_number],RF6[ws_order_number->[ws_order_number, ws_order_number],RF3[web_site_sk->[ws_web_site_sk],RF2[d_date_sk->[ws_ship_date_sk],RF1[ca_address_sk->[ws_ship_addr_sk]", getRuntimeFilters(plan))
+     assertEquals("RF0[ws_order_number->[ws_order_number],RF5[ws_order_number->[wr_order_number],RF4[wr_order_number->[ws_order_number],RF3[web_site_sk->[ws_web_site_sk],RF2[d_date_sk->[ws_ship_date_sk],RF1[ca_address_sk->[ws_ship_addr_sk]", getRuntimeFilters(plan))
 }


### PR DESCRIPTION
since we have three infrastructure to ensure changing input column order not lead to wrong result, we could remove this flag on LogicalProject to eliminate project as mush as possible and let code clear.

1. output list in ResultSink node
2. regular children output in SetOperation node
3. producer to consumer slot id map in CteConsumer

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

