### PR TITLE
[Chore](checks) change SonarCloud Scan projectBaseDir to be to avoid include .java file

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -151,11 +151,12 @@ jobs:
         if: ${{ steps.filter.outputs.be_changes == 'true' }}
         uses: sonarsource/sonarcloud-github-action@master
         with:
+          projectBaseDir: be
           args: >
             -Dsonar.host.url=https://sonarcloud.io 
             -Dsonar.organization=apache 
             -Dsonar.projectKey=apache_incubator-doris
-            -Dsonar.cfamily.compile-commands=be/build_Release/compile_commands.json
+            -Dsonar.cfamily.compile-commands=build_Release/compile_commands.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Proposed changes
change SonarCloud Scan projectBaseDir to be to avoid include .java file

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

