### PR TITLE
[fix](planner)should set preserveRootTypes to true when call substituteList method in ExprSubstitutionMap's compose method

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ExprSubstitutionMap.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ExprSubstitutionMap.java
@@ -149,7 +149,7 @@ public final class ExprSubstitutionMap {
         ExprSubstitutionMap result = new ExprSubstitutionMap();
         // f's substitution targets need to be substituted via g
         result.lhs = Expr.cloneList(f.lhs);
-        result.rhs = Expr.substituteList(f.rhs, g, analyzer, false);
+        result.rhs = Expr.substituteList(f.rhs, g, analyzer, true);
 
         // substitution maps are cumulative: the combined map contains all
         // substitutions from f and g.


### PR DESCRIPTION

pick from master https://github.com/apache/doris/pull/24392

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

