### PR TITLE
[Fix](Status) Disable printing stacktrace for `InvalidArgument` in `BitShufflePageDecoder::seek_to_position_in_page`

### DIFF
--- a/be/src/olap/rowset/segment_v2/bitshuffle_page.h
+++ b/be/src/olap/rowset/segment_v2/bitshuffle_page.h
@@ -320,7 +320,7 @@ public:
         DCHECK(_parsed) << "Must call init()";
         if (PREDICT_FALSE(_num_elements == 0)) {
             DCHECK_EQ(0, pos);
-            return Status::InvalidArgument("invalid pos");
+            return Status::Error<ErrorCode::INVALID_ARGUMENT, false>("invalid pos");
         }
 
         DCHECK_LE(pos, _num_elements);


### PR DESCRIPTION
## Proposed changes



## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

