### PR TITLE
[fix](bitmap) fix coredump of bitmap_from_array caused by null array literal

### DIFF
--- a/be/src/vec/functions/function_bitmap.cpp
+++ b/be/src/vec/functions/function_bitmap.cpp
@@ -292,6 +292,9 @@ public:
             if (check_column<ColumnInt8>(nested_column)) {
                 Impl::template vector<ColumnInt8>(offset_column_data, nested_column,
                                                   nested_null_map, res, null_map);
+            } else if (check_column<ColumnUInt8>(nested_column)) {
+                Impl::template vector<ColumnInt8>(offset_column_data, nested_column,
+                                                  nested_null_map, res, null_map);
             } else if (check_column<ColumnInt16>(nested_column)) {
                 Impl::template vector<ColumnInt16>(offset_column_data, nested_column,
                                                    nested_null_map, res, null_map);
@@ -301,6 +304,10 @@ public:
             } else if (check_column<ColumnInt64>(nested_column)) {
                 Impl::template vector<ColumnInt64>(offset_column_data, nested_column,
                                                    nested_null_map, res, null_map);
+            } else {
+                return Status::RuntimeError("Illegal column {} of argument of function {}",
+                                            block.get_by_position(arguments[0]).column->get_name(),
+                                            get_name());
             }
         } else {
             return Status::RuntimeError("Illegal column {} of argument of function {}",

--- a/regression-test/data/query_p0/sql_functions/bitmap_functions/test_bitmap_function.out
+++ b/regression-test/data/query_p0/sql_functions/bitmap_functions/test_bitmap_function.out
@@ -510,3 +510,6 @@ true
 -- !sql_orthogonal_bitmap_intersect_count --
 1	1
 
+-- !sql --
+
+

--- a/regression-test/suites/query_p0/sql_functions/bitmap_functions/test_bitmap_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/bitmap_functions/test_bitmap_function.groovy
@@ -762,4 +762,7 @@ suite("test_bitmap_function") {
         select count(distinct tag) as count1,
             orthogonal_bitmap_intersect_count(id_bitmap, tag, 0) as count2_bitmap from test_orthog_bitmap_intersect;
     """
+
+     // BITMAP_FROM_ARRAY
+    qt_sql """ select bitmap_to_string(BITMAP_FROM_ARRAY([]));"""
 }


### PR DESCRIPTION

## Proposed changes

Pick from master #24404

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

