### PR TITLE
[Fix](Nereids) fix case when to if error in function signature

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/If.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/If.java
@@ -40,6 +40,7 @@ import org.apache.doris.nereids.types.FloatType;
 import org.apache.doris.nereids.types.HllType;
 import org.apache.doris.nereids.types.IntegerType;
 import org.apache.doris.nereids.types.LargeIntType;
+import org.apache.doris.nereids.types.NullType;
 import org.apache.doris.nereids.types.SmallIntType;
 import org.apache.doris.nereids.types.StringType;
 import org.apache.doris.nereids.types.TinyIntType;
@@ -59,6 +60,8 @@ public class If extends ScalarFunction
         implements TernaryExpression, ExplicitlyCastableSignature {
 
     public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
+            FunctionSignature.ret(NullType.INSTANCE)
+                    .args(BooleanType.INSTANCE, NullType.INSTANCE, NullType.INSTANCE),
             FunctionSignature.ret(DateTimeV2Type.SYSTEM_DEFAULT)
                     .args(BooleanType.INSTANCE, DateTimeV2Type.SYSTEM_DEFAULT, DateTimeV2Type.SYSTEM_DEFAULT),
             FunctionSignature.ret(DateV2Type.INSTANCE)


### PR DESCRIPTION
## Proposed changes

Problem: 
when doing case when which can transform to if-function, datatype in if-function would be wrong to match cast outside case when

Example:
select cast (case when BITMAP_EMPTY() is NULL then null else null end as bitmap) is NULL;

Reason:
when optimizer fould case when can transform to if-function, it would transform to it with first 
matched function signature. But null can match to any signature, so the types of if-function go wrong

Solved:
add NullType prosess in if-function signature

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

