### PR TITLE
[fix](planner): do not use == to compare encapsulate type, use equals instead.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
@@ -584,7 +584,7 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
             C obj = (C) it.next();
             Integer count1 = (Integer) cMap1.get(obj);
             Integer count2 = (Integer) cMap2.get(obj);
-            if (count2 == null || count1 != count2) {
+            if (count2 == null || !count1.equals(count2)) {
                 return false;
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/SqlBlockUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/SqlBlockUtil.java
@@ -67,7 +67,7 @@ public class SqlBlockUtil {
     }
 
     public static Boolean isSqlBlockLimitationsDefault(Long partitionNum, Long tabletNum, Long cardinality) {
-        return partitionNum == LONG_ZERO && tabletNum == LONG_ZERO && cardinality == LONG_ZERO;
+        return partitionNum.equals(LONG_ZERO) && tabletNum.equals(LONG_ZERO) && cardinality.equals(LONG_ZERO);
     }
 
     public static Boolean isSqlBlockLimitationsNull(Long partitionNum, Long tabletNum, Long cardinality) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/JournalObserver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/JournalObserver.java
@@ -124,7 +124,7 @@ public class JournalObserver implements Comparable<JournalObserver> {
         }
 
         JournalObserver obs = ((JournalObserver) obj);
-        return this.targetJournalVersion == obs.targetJournalVersion && this.id == obs.id;
+        return this.targetJournalVersion.equals(obs.targetJournalVersion) && this.id.equals(obs.id);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/HyperGraphBuilder.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/HyperGraphBuilder.java
@@ -687,7 +687,7 @@ public class HyperGraphBuilder {
             } else {
                 rv = left.get(slots.get(1)).get(leftIndex);
             }
-            Boolean res = (lv == rv) && (lv != null) && (rv != null);
+            Boolean res = lv.equals(rv) && (lv != null) && (rv != null);
             if (joinType.isNullAwareLeftAntiJoin()) {
                 res |= (lv == null);
             }


### PR DESCRIPTION
[fix](*): do not use == to compare encapsulate type, use equals instead.

for example, the following sample will lead to hard-to-find bugs

public class Wrapper {
public static void main(String[] args){
Integer i1 = 100;
Integer i2 = 100;
Integer i3 = 1000;
Integer i4 = 1000;
System.out.println(i1 == i2);
System.out.println(i1 != i2);
System.out.println(i3 == i4);
System.out.println(i3 != i4);
}
}

true
false
false
true

