### PR TITLE
[fix](compile) fix mac compile sort failed

### DIFF
--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -449,7 +449,7 @@ std::vector<DataDir*> StorageEngine::get_stores_for_create_tablet(
 
         int tablet_num;
 
-        bool operator<(const DirInfo& other) {
+        bool operator<(const DirInfo& other) const {
             if (available_level != other.available_level) {
                 return available_level < other.available_level;
             }


### PR DESCRIPTION
## Proposed changes

<!--Describe your changes.-->

fix mac compile err:

```
/Users/runner/work/doris/doris/be/src/olap/storage_engine.cpp:515:10: note: in instantiation of function template specialization 'std::sort<std::__wrap_iter<DirInfo *>>' requested here
    std::sort(dir_infos.begin(), dir_infos.end());
         ^
/Users/runner/work/doris/doris/be/src/olap/storage_engine.cpp:452:14: note: candidate function not viable: 'this' argument has type 'const DirInfo', but method is not marked const
        bool operator<(const DirInfo& other) {
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

