### PR TITLE
[fix](security): non-static inner class should not implement serialized interface, or when it is serialized it will contain outer class info, which is not safe

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/DppScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/DppScheduler.java
@@ -552,7 +552,7 @@ public class DppScheduler {
         return String.format(ETL_OUTPUT_PATH, fsDefaultName, outputPath, dbId, loadLabel, etlOutputDir);
     }
 
-    private class InputSizeInvalidException extends LoadException {
+    private static class InputSizeInvalidException extends LoadException {
         public InputSizeInvalidException(String msg) {
             super(msg);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -2519,12 +2519,12 @@ public class Coordinator {
 
     // map from a BE host address to the per-node assigned scan ranges;
     // records scan range assignment for a single fragment
-    class FragmentScanRangeAssignment
+    static class FragmentScanRangeAssignment
             extends HashMap<TNetworkAddress, Map<Integer, List<TScanRangeParams>>> {
     }
 
     // Bucket sequence -> (scan node id -> list of TScanRangeParams)
-    class BucketSeqToScanRange extends HashMap<Integer, Map<Integer, List<TScanRangeParams>>> {
+    static class BucketSeqToScanRange extends HashMap<Integer, Map<Integer, List<TScanRangeParams>>> {
 
     }
 


### PR DESCRIPTION
[fix](*): non-static inner class should not implement serialized interface, or when it is serialized it will contain outer class info, which is not safe

And in this scenario, the class does not use info of outer class, which should use static class instead