### PR TITLE
[improvement](type) modify the inner type display of the Array/Map/Struct type

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/ArrayType.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/ArrayType.java
@@ -203,7 +203,7 @@ public class ArrayType extends Type {
 
     @Override
     public String toString() {
-        return toSql(0).toUpperCase();
+        return String.format("ARRAY<%s>", itemType.toString()).toUpperCase();
     }
 
     @Override

--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/MapType.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/MapType.java
@@ -174,7 +174,8 @@ public class MapType extends Type {
 
     @Override
     public String toString() {
-        return  toSql(0).toUpperCase();
+        return String.format("MAP<%s,%s>",
+                keyType.toString(), valueType.toString());
     }
 
     @Override

--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/StructField.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/StructField.java
@@ -158,4 +158,16 @@ public class StructField {
         return otherStructField.name.equals(name) && otherStructField.type.equals(type)
                 && otherStructField.containsNull == containsNull;
     }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder(name);
+        if (type != null) {
+            sb.append(":").append(type);
+        }
+        if (StringUtils.isNotBlank(comment)) {
+            sb.append(String.format(" COMMENT '%s'", comment));
+        }
+        return sb.toString();
+    }
 }

--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/StructType.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/StructType.java
@@ -303,7 +303,11 @@ public class StructType extends Type {
 
     @Override
     public String toString() {
-        return toSql(0);
+        ArrayList<String> fieldsSql = Lists.newArrayList();
+        for (StructField f : fields) {
+            fieldsSql.add(f.toString());
+        }
+        return String.format("STRUCT<%s>", Joiner.on(",").join(fieldsSql));
     }
 
     @Override

--- a/regression-test/data/schema_change_p0/test_alter_table_column.out
+++ b/regression-test/data/schema_change_p0/test_alter_table_column.out
@@ -21,9 +21,9 @@ value2	INT	Yes	false	\N	SUM
 -- !sql --
 k1	INT	Yes	true	\N	
 value1	INT	Yes	false	\N	NONE
-value2	ARRAY<INT(11)>	Yes	false	[]	NONE
-value3	ARRAY<INT(11)>	Yes	false	\N	NONE
-value4	ARRAY<INT(11)>	No	false	[]	NONE
+value2	ARRAY<INT>	Yes	false	[]	NONE
+value3	ARRAY<INT>	Yes	false	\N	NONE
+value4	ARRAY<INT>	No	false	[]	NONE
 
 -- !sql --
 1	2	[]	\N	[]


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

In the old code, when using desc command to view the table schema
It will display as follows
```
ARRAY<TINYINT(4)>
ARRAY<SMALLINT(6)>
ARRAY<INT(11)>
ARRAY<BIGINT(20)>
ARRAY<LARGEINT(40)>
```
However, for normal integer type displays, the width is not displayed
So, I changed it to the following
```
ARRAY<TINYINT>
ARRAY<SMALLINT>
ARRAY<INT>
ARRAY<BIGINT>
ARRAY<LARGEINT>
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

