### PR TITLE
[fix](nereids)left outer join estimation

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/JoinEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/JoinEstimation.java
@@ -137,7 +137,7 @@ public class JoinEstimation {
             outputRowCount = outputRowCount * Math.pow(0.9, unTrustableCondition.size());
         } else {
             outputRowCount = Math.max(leftStats.getRowCount(), rightStats.getRowCount());
-            Optional<Double> ratio = unTrustEqualRatio.stream().max(Double::compareTo);
+            Optional<Double> ratio = unTrustEqualRatio.stream().min(Double::compareTo);
             if (ratio.isPresent()) {
                 outputRowCount = Math.max(1, outputRowCount * ratio.get());
             }

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query17.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query17.out
@@ -14,36 +14,35 @@ PhysicalResultSink
 ----------------------hashJoin[INNER_JOIN](store_returns.sr_item_sk = catalog_sales.cs_item_sk)(store_returns.sr_customer_sk = catalog_sales.cs_bill_customer_sk)
 ------------------------PhysicalDistribute
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN](store_returns.sr_returned_date_sk = d2.d_date_sk)
-------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN](store_sales.ss_item_sk = store_returns.sr_item_sk)(store_sales.ss_ticket_number = store_returns.sr_ticket_number)(store_sales.ss_customer_sk = store_returns.sr_customer_sk)
-----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[store_returns]
-----------------------------------PhysicalDistribute
-------------------------------------PhysicalProject
---------------------------------------hashJoin[INNER_JOIN](store.s_store_sk = store_sales.ss_store_sk)
-----------------------------------------hashJoin[INNER_JOIN](item.i_item_sk = store_sales.ss_item_sk)
-------------------------------------------PhysicalDistribute
---------------------------------------------hashJoin[INNER_JOIN](d1.d_date_sk = store_sales.ss_sold_date_sk)
-----------------------------------------------PhysicalProject
-------------------------------------------------PhysicalOlapScan[store_sales]
-----------------------------------------------PhysicalDistribute
-------------------------------------------------PhysicalProject
---------------------------------------------------filter((cast(d_quarter_name as VARCHAR(*)) = '2001Q1'))
-----------------------------------------------------PhysicalOlapScan[date_dim]
-------------------------------------------PhysicalDistribute
---------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[item]
-----------------------------------------PhysicalDistribute
-------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[store]
-------------------------------PhysicalDistribute
---------------------------------PhysicalProject
-----------------------------------filter(d_quarter_name IN ('2001Q1', '2001Q2', '2001Q3'))
-------------------------------------PhysicalOlapScan[date_dim]
-------------------------PhysicalDistribute
---------------------------PhysicalProject
 ----------------------------PhysicalOlapScan[catalog_sales]
+------------------------PhysicalDistribute
+--------------------------hashJoin[INNER_JOIN](store.s_store_sk = store_sales.ss_store_sk)
+----------------------------PhysicalProject
+------------------------------hashJoin[INNER_JOIN](item.i_item_sk = store_sales.ss_item_sk)
+--------------------------------PhysicalDistribute
+----------------------------------PhysicalProject
+------------------------------------hashJoin[INNER_JOIN](store_returns.sr_returned_date_sk = d2.d_date_sk)
+--------------------------------------PhysicalProject
+----------------------------------------hashJoin[INNER_JOIN](store_sales.ss_item_sk = store_returns.sr_item_sk)(store_sales.ss_ticket_number = store_returns.sr_ticket_number)(store_sales.ss_customer_sk = store_returns.sr_customer_sk)
+------------------------------------------PhysicalProject
+--------------------------------------------PhysicalOlapScan[store_returns]
+------------------------------------------hashJoin[INNER_JOIN](d1.d_date_sk = store_sales.ss_sold_date_sk)
+--------------------------------------------PhysicalProject
+----------------------------------------------PhysicalOlapScan[store_sales]
+--------------------------------------------PhysicalDistribute
+----------------------------------------------PhysicalProject
+------------------------------------------------filter((cast(d_quarter_name as VARCHAR(*)) = '2001Q1'))
+--------------------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------------PhysicalDistribute
+----------------------------------------PhysicalProject
+------------------------------------------filter(d_quarter_name IN ('2001Q1', '2001Q2', '2001Q3'))
+--------------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------PhysicalDistribute
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[item]
+----------------------------PhysicalDistribute
+------------------------------PhysicalProject
+--------------------------------PhysicalOlapScan[store]
 --------------------PhysicalDistribute
 ----------------------PhysicalProject
 ------------------------filter(d_quarter_name IN ('2001Q1', '2001Q2', '2001Q3'))

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query25.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query25.out
@@ -15,34 +15,33 @@ PhysicalResultSink
 ------------------------PhysicalProject
 --------------------------PhysicalOlapScan[catalog_sales]
 ----------------------PhysicalDistribute
-------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN](store_returns.sr_returned_date_sk = d2.d_date_sk)
-----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN](store_sales.ss_item_sk = store_returns.sr_item_sk)(store_sales.ss_ticket_number = store_returns.sr_ticket_number)(store_sales.ss_customer_sk = store_returns.sr_customer_sk)
+------------------------hashJoin[INNER_JOIN](store.s_store_sk = store_sales.ss_store_sk)
+--------------------------PhysicalProject
+----------------------------hashJoin[INNER_JOIN](item.i_item_sk = store_sales.ss_item_sk)
+------------------------------PhysicalDistribute
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[store_returns]
---------------------------------PhysicalDistribute
-----------------------------------PhysicalProject
-------------------------------------hashJoin[INNER_JOIN](store.s_store_sk = store_sales.ss_store_sk)
---------------------------------------hashJoin[INNER_JOIN](item.i_item_sk = store_sales.ss_item_sk)
-----------------------------------------PhysicalDistribute
-------------------------------------------hashJoin[INNER_JOIN](d1.d_date_sk = store_sales.ss_sold_date_sk)
---------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[store_sales]
---------------------------------------------PhysicalDistribute
-----------------------------------------------PhysicalProject
-------------------------------------------------filter((d1.d_year = 2000)(d1.d_moy = 4))
---------------------------------------------------PhysicalOlapScan[date_dim]
-----------------------------------------PhysicalDistribute
-------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[item]
---------------------------------------PhysicalDistribute
+----------------------------------hashJoin[INNER_JOIN](store_returns.sr_returned_date_sk = d2.d_date_sk)
+------------------------------------PhysicalProject
+--------------------------------------hashJoin[INNER_JOIN](store_sales.ss_item_sk = store_returns.sr_item_sk)(store_sales.ss_ticket_number = store_returns.sr_ticket_number)(store_sales.ss_customer_sk = store_returns.sr_customer_sk)
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[store]
-----------------------------PhysicalDistribute
-------------------------------PhysicalProject
---------------------------------filter((d2.d_moy <= 10)(d2.d_moy >= 4)(d2.d_year = 2000))
-----------------------------------PhysicalOlapScan[date_dim]
+------------------------------------------PhysicalOlapScan[store_returns]
+----------------------------------------hashJoin[INNER_JOIN](d1.d_date_sk = store_sales.ss_sold_date_sk)
+------------------------------------------PhysicalProject
+--------------------------------------------PhysicalOlapScan[store_sales]
+------------------------------------------PhysicalDistribute
+--------------------------------------------PhysicalProject
+----------------------------------------------filter((d1.d_year = 2000)(d1.d_moy = 4))
+------------------------------------------------PhysicalOlapScan[date_dim]
+------------------------------------PhysicalDistribute
+--------------------------------------PhysicalProject
+----------------------------------------filter((d2.d_moy <= 10)(d2.d_moy >= 4)(d2.d_year = 2000))
+------------------------------------------PhysicalOlapScan[date_dim]
+------------------------------PhysicalDistribute
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[item]
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[store]
 ------------------PhysicalDistribute
 --------------------PhysicalProject
 ----------------------filter((d3.d_year = 2000)(d3.d_moy <= 10)(d3.d_moy >= 4))

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query29.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query29.out
@@ -11,38 +11,36 @@ PhysicalResultSink
 ----------------hashJoin[INNER_JOIN](catalog_sales.cs_sold_date_sk = d3.d_date_sk)
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN](store_returns.sr_item_sk = catalog_sales.cs_item_sk)(store_returns.sr_customer_sk = catalog_sales.cs_bill_customer_sk)
+----------------------PhysicalProject
+------------------------PhysicalOlapScan[catalog_sales]
 ----------------------PhysicalDistribute
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[catalog_sales]
-----------------------PhysicalDistribute
-------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN](store_returns.sr_returned_date_sk = d2.d_date_sk)
-----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN](store_sales.ss_item_sk = store_returns.sr_item_sk)(store_sales.ss_ticket_number = store_returns.sr_ticket_number)(store_sales.ss_customer_sk = store_returns.sr_customer_sk)
+------------------------hashJoin[INNER_JOIN](store.s_store_sk = store_sales.ss_store_sk)
+--------------------------PhysicalProject
+----------------------------hashJoin[INNER_JOIN](item.i_item_sk = store_sales.ss_item_sk)
+------------------------------PhysicalDistribute
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[store_returns]
---------------------------------PhysicalDistribute
-----------------------------------PhysicalProject
-------------------------------------hashJoin[INNER_JOIN](store.s_store_sk = store_sales.ss_store_sk)
---------------------------------------hashJoin[INNER_JOIN](item.i_item_sk = store_sales.ss_item_sk)
-----------------------------------------PhysicalDistribute
-------------------------------------------hashJoin[INNER_JOIN](d1.d_date_sk = store_sales.ss_sold_date_sk)
---------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[store_sales]
---------------------------------------------PhysicalDistribute
-----------------------------------------------PhysicalProject
-------------------------------------------------filter((d1.d_year = 1999)(d1.d_moy = 4))
---------------------------------------------------PhysicalOlapScan[date_dim]
-----------------------------------------PhysicalDistribute
-------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[item]
---------------------------------------PhysicalDistribute
+----------------------------------hashJoin[INNER_JOIN](d1.d_date_sk = store_sales.ss_sold_date_sk)
+------------------------------------PhysicalProject
+--------------------------------------hashJoin[INNER_JOIN](store_sales.ss_item_sk = store_returns.sr_item_sk)(store_sales.ss_ticket_number = store_returns.sr_ticket_number)(store_sales.ss_customer_sk = store_returns.sr_customer_sk)
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[store]
-----------------------------PhysicalDistribute
-------------------------------PhysicalProject
---------------------------------filter((d2.d_moy <= 7)(d2.d_moy >= 4)(d2.d_year = 1999))
-----------------------------------PhysicalOlapScan[date_dim]
+------------------------------------------PhysicalOlapScan[store_sales]
+----------------------------------------hashJoin[INNER_JOIN](store_returns.sr_returned_date_sk = d2.d_date_sk)
+------------------------------------------PhysicalProject
+--------------------------------------------PhysicalOlapScan[store_returns]
+------------------------------------------PhysicalDistribute
+--------------------------------------------PhysicalProject
+----------------------------------------------filter((d2.d_moy <= 7)(d2.d_moy >= 4)(d2.d_year = 1999))
+------------------------------------------------PhysicalOlapScan[date_dim]
+------------------------------------PhysicalDistribute
+--------------------------------------PhysicalProject
+----------------------------------------filter((d1.d_year = 1999)(d1.d_moy = 4))
+------------------------------------------PhysicalOlapScan[date_dim]
+------------------------------PhysicalDistribute
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[item]
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[store]
 ------------------PhysicalDistribute
 --------------------PhysicalProject
 ----------------------filter(d_year IN (1999, 2000, 2001))

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query29.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query29.out
@@ -19,21 +19,21 @@ PhysicalResultSink
 ----------------------------hashJoin[INNER_JOIN](item.i_item_sk = store_sales.ss_item_sk)
 ------------------------------PhysicalDistribute
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN](d1.d_date_sk = store_sales.ss_sold_date_sk)
+----------------------------------hashJoin[INNER_JOIN](store_returns.sr_returned_date_sk = d2.d_date_sk)
 ------------------------------------PhysicalProject
 --------------------------------------hashJoin[INNER_JOIN](store_sales.ss_item_sk = store_returns.sr_item_sk)(store_sales.ss_ticket_number = store_returns.sr_ticket_number)(store_sales.ss_customer_sk = store_returns.sr_customer_sk)
 ----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[store_sales]
-----------------------------------------hashJoin[INNER_JOIN](store_returns.sr_returned_date_sk = d2.d_date_sk)
+------------------------------------------PhysicalOlapScan[store_returns]
+----------------------------------------hashJoin[INNER_JOIN](d1.d_date_sk = store_sales.ss_sold_date_sk)
 ------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[store_returns]
+--------------------------------------------PhysicalOlapScan[store_sales]
 ------------------------------------------PhysicalDistribute
 --------------------------------------------PhysicalProject
-----------------------------------------------filter((d2.d_moy <= 7)(d2.d_moy >= 4)(d2.d_year = 1999))
+----------------------------------------------filter((d1.d_year = 1999)(d1.d_moy = 4))
 ------------------------------------------------PhysicalOlapScan[date_dim]
 ------------------------------------PhysicalDistribute
 --------------------------------------PhysicalProject
-----------------------------------------filter((d1.d_year = 1999)(d1.d_moy = 4))
+----------------------------------------filter((d2.d_moy <= 7)(d2.d_moy >= 4)(d2.d_year = 1999))
 ------------------------------------------PhysicalOlapScan[date_dim]
 ------------------------------PhysicalDistribute
 --------------------------------PhysicalProject

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query40.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query40.out
@@ -8,25 +8,24 @@ PhysicalResultSink
 ----------PhysicalDistribute
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[RIGHT_OUTER_JOIN](catalog_sales.cs_item_sk = catalog_returns.cr_item_sk)(catalog_sales.cs_order_number = catalog_returns.cr_order_number)
+----------------hashJoin[INNER_JOIN](catalog_sales.cs_warehouse_sk = warehouse.w_warehouse_sk)
 ------------------PhysicalProject
---------------------PhysicalOlapScan[catalog_returns]
+--------------------hashJoin[RIGHT_OUTER_JOIN](catalog_sales.cs_item_sk = catalog_returns.cr_item_sk)(catalog_sales.cs_order_number = catalog_returns.cr_order_number)
+----------------------PhysicalProject
+------------------------PhysicalOlapScan[catalog_returns]
+----------------------hashJoin[INNER_JOIN](catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)
+------------------------hashJoin[INNER_JOIN](item.i_item_sk = catalog_sales.cs_item_sk)
+--------------------------PhysicalProject
+----------------------------PhysicalOlapScan[catalog_sales]
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------filter((item.i_current_price >= 0.99)(item.i_current_price <= 1.49))
+--------------------------------PhysicalOlapScan[item]
+------------------------PhysicalDistribute
+--------------------------PhysicalProject
+----------------------------filter((date_dim.d_date >= 2001-03-03)(date_dim.d_date <= 2001-05-02))
+------------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalDistribute
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN](catalog_sales.cs_warehouse_sk = warehouse.w_warehouse_sk)
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[warehouse]
-------------------------PhysicalDistribute
---------------------------hashJoin[INNER_JOIN](catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)
-----------------------------hashJoin[INNER_JOIN](item.i_item_sk = catalog_sales.cs_item_sk)
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[catalog_sales]
-------------------------------PhysicalDistribute
---------------------------------PhysicalProject
-----------------------------------filter((item.i_current_price >= 0.99)(item.i_current_price <= 1.49))
-------------------------------------PhysicalOlapScan[item]
-----------------------------PhysicalDistribute
-------------------------------PhysicalProject
---------------------------------filter((date_dim.d_date >= 2001-03-03)(date_dim.d_date <= 2001-05-02))
-----------------------------------PhysicalOlapScan[date_dim]
+----------------------PhysicalOlapScan[warehouse]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query47.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query47.out
@@ -35,16 +35,15 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --------PhysicalDistribute
 ----------PhysicalTopN
 ------------PhysicalProject
---------------hashJoin[INNER_JOIN](v1.i_category = v1_lead.i_category)(v1.i_brand = v1_lead.i_brand)(v1.s_store_name = v1_lead.s_store_name)(v1.s_company_name = v1_lead.s_company_name)(v1.rn = expr_(rn - 1))
-----------------PhysicalProject
-------------------hashJoin[INNER_JOIN](v1.i_category = v1_lag.i_category)(v1.i_brand = v1_lag.i_brand)(v1.s_store_name = v1_lag.s_store_name)(v1.s_company_name = v1_lag.s_company_name)(v1.rn = expr_(rn + 1))
---------------------PhysicalDistribute
-----------------------PhysicalProject
+--------------hashJoin[INNER_JOIN](v1.i_category = v1_lag.i_category)(v1.i_brand = v1_lag.i_brand)(v1.s_store_name = v1_lag.s_store_name)(v1.s_company_name = v1_lag.s_company_name)(v1.rn = expr_(rn + 1))
+----------------hashJoin[INNER_JOIN](v1.i_category = v1_lead.i_category)(v1.i_brand = v1_lead.i_brand)(v1.s_store_name = v1_lead.s_store_name)(v1.s_company_name = v1_lead.s_company_name)(v1.rn = expr_(rn - 1))
+------------------PhysicalDistribute
+--------------------PhysicalProject
+----------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+------------------PhysicalDistribute
+--------------------PhysicalProject
+----------------------filter((if((avg_monthly_sales > 0.0000), (abs((cast(sum_sales as DOUBLE) - cast(avg_monthly_sales as DOUBLE))) / cast(avg_monthly_sales as DOUBLE)), NULL) > 0.1)(v2.d_year = 2001)(v2.avg_monthly_sales > 0.0000))
 ------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
---------------------PhysicalDistribute
-----------------------PhysicalProject
-------------------------filter((if((avg_monthly_sales > 0.0000), (abs((cast(sum_sales as DOUBLE) - cast(avg_monthly_sales as DOUBLE))) / cast(avg_monthly_sales as DOUBLE)), NULL) > 0.1)(v2.d_year = 2001)(v2.avg_monthly_sales > 0.0000))
---------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 ----------------PhysicalDistribute
 ------------------PhysicalProject
 --------------------PhysicalCteConsumer ( cteId=CTEId#0 )

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query54.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query54.out
@@ -13,72 +13,73 @@ PhysicalResultSink
 --------------------PhysicalDistribute
 ----------------------hashAgg[LOCAL]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN](customer_address.ca_county = store.s_county)(customer_address.ca_state = store.s_state)
-----------------------------PhysicalProject
-------------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) <= (d_month_seq + 3))
---------------------------------PhysicalProject
-----------------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) >= (d_month_seq + 1))
-------------------------------------hashJoin[INNER_JOIN](store_sales.ss_sold_date_sk = date_dim.d_date_sk)
---------------------------------------PhysicalDistribute
-----------------------------------------PhysicalProject
-------------------------------------------hashJoin[INNER_JOIN](my_customers.c_customer_sk = store_sales.ss_customer_sk)
---------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[store_sales]
---------------------------------------------PhysicalDistribute
-----------------------------------------------hashJoin[INNER_JOIN](my_customers.c_current_addr_sk = customer_address.ca_address_sk)
-------------------------------------------------PhysicalProject
---------------------------------------------------PhysicalOlapScan[customer_address]
-------------------------------------------------PhysicalDistribute
---------------------------------------------------PhysicalProject
-----------------------------------------------------hashAgg[GLOBAL]
-------------------------------------------------------PhysicalDistribute
---------------------------------------------------------hashAgg[LOCAL]
-----------------------------------------------------------PhysicalProject
-------------------------------------------------------------hashJoin[INNER_JOIN](customer.c_customer_sk = cs_or_ws_sales.customer_sk)
---------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------PhysicalOlapScan[customer]
---------------------------------------------------------------PhysicalDistribute
-----------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------hashJoin[INNER_JOIN](cs_or_ws_sales.sold_date_sk = date_dim.d_date_sk)
---------------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------------hashJoin[INNER_JOIN](cs_or_ws_sales.item_sk = item.i_item_sk)
-------------------------------------------------------------------------PhysicalUnion
---------------------------------------------------------------------------PhysicalDistribute
-----------------------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------------------PhysicalOlapScan[catalog_sales]
---------------------------------------------------------------------------PhysicalDistribute
-----------------------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------------------PhysicalOlapScan[web_sales]
-------------------------------------------------------------------------PhysicalDistribute
---------------------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------------------filter((cast(i_class as VARCHAR(*)) = 'maternity')(cast(i_category as VARCHAR(*)) = 'Women'))
-------------------------------------------------------------------------------PhysicalOlapScan[item]
---------------------------------------------------------------------PhysicalDistribute
-----------------------------------------------------------------------PhysicalProject
-------------------------------------------------------------------------filter((date_dim.d_year = 1998)(date_dim.d_moy = 5))
---------------------------------------------------------------------------PhysicalOlapScan[date_dim]
---------------------------------------PhysicalDistribute
-----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[date_dim]
-------------------------------------PhysicalDistribute
---------------------------------------PhysicalAssertNumRows
-----------------------------------------PhysicalDistribute
-------------------------------------------hashAgg[GLOBAL]
---------------------------------------------PhysicalDistribute
-----------------------------------------------hashAgg[LOCAL]
-------------------------------------------------PhysicalProject
---------------------------------------------------filter((date_dim.d_year = 1998)(date_dim.d_moy = 5))
-----------------------------------------------------PhysicalOlapScan[date_dim]
---------------------------------PhysicalDistribute
-----------------------------------PhysicalAssertNumRows
-------------------------------------PhysicalDistribute
---------------------------------------hashAgg[GLOBAL]
-----------------------------------------PhysicalDistribute
-------------------------------------------hashAgg[LOCAL]
---------------------------------------------PhysicalProject
-----------------------------------------------filter((date_dim.d_year = 1998)(date_dim.d_moy = 5))
-------------------------------------------------PhysicalOlapScan[date_dim]
-----------------------------PhysicalDistribute
+--------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) <= (d_month_seq + 3))
+----------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) >= (d_month_seq + 1))
 ------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[store]
+--------------------------------hashJoin[INNER_JOIN](store_sales.ss_sold_date_sk = date_dim.d_date_sk)
+----------------------------------PhysicalDistribute
+------------------------------------PhysicalProject
+--------------------------------------hashJoin[INNER_JOIN](my_customers.c_customer_sk = store_sales.ss_customer_sk)
+----------------------------------------PhysicalProject
+------------------------------------------PhysicalOlapScan[store_sales]
+----------------------------------------PhysicalDistribute
+------------------------------------------PhysicalProject
+--------------------------------------------hashJoin[INNER_JOIN](customer_address.ca_county = store.s_county)(customer_address.ca_state = store.s_state)
+----------------------------------------------PhysicalDistribute
+------------------------------------------------hashJoin[INNER_JOIN](my_customers.c_current_addr_sk = customer_address.ca_address_sk)
+--------------------------------------------------PhysicalProject
+----------------------------------------------------PhysicalOlapScan[customer_address]
+--------------------------------------------------PhysicalDistribute
+----------------------------------------------------PhysicalProject
+------------------------------------------------------hashAgg[GLOBAL]
+--------------------------------------------------------PhysicalDistribute
+----------------------------------------------------------hashAgg[LOCAL]
+------------------------------------------------------------PhysicalProject
+--------------------------------------------------------------hashJoin[INNER_JOIN](customer.c_customer_sk = cs_or_ws_sales.customer_sk)
+----------------------------------------------------------------PhysicalProject
+------------------------------------------------------------------PhysicalOlapScan[customer]
+----------------------------------------------------------------PhysicalDistribute
+------------------------------------------------------------------PhysicalProject
+--------------------------------------------------------------------hashJoin[INNER_JOIN](cs_or_ws_sales.sold_date_sk = date_dim.d_date_sk)
+----------------------------------------------------------------------PhysicalProject
+------------------------------------------------------------------------hashJoin[INNER_JOIN](cs_or_ws_sales.item_sk = item.i_item_sk)
+--------------------------------------------------------------------------PhysicalUnion
+----------------------------------------------------------------------------PhysicalDistribute
+------------------------------------------------------------------------------PhysicalProject
+--------------------------------------------------------------------------------PhysicalOlapScan[catalog_sales]
+----------------------------------------------------------------------------PhysicalDistribute
+------------------------------------------------------------------------------PhysicalProject
+--------------------------------------------------------------------------------PhysicalOlapScan[web_sales]
+--------------------------------------------------------------------------PhysicalDistribute
+----------------------------------------------------------------------------PhysicalProject
+------------------------------------------------------------------------------filter((cast(i_class as VARCHAR(*)) = 'maternity')(cast(i_category as VARCHAR(*)) = 'Women'))
+--------------------------------------------------------------------------------PhysicalOlapScan[item]
+----------------------------------------------------------------------PhysicalDistribute
+------------------------------------------------------------------------PhysicalProject
+--------------------------------------------------------------------------filter((date_dim.d_year = 1998)(date_dim.d_moy = 5))
+----------------------------------------------------------------------------PhysicalOlapScan[date_dim]
+----------------------------------------------PhysicalDistribute
+------------------------------------------------PhysicalProject
+--------------------------------------------------PhysicalOlapScan[store]
+----------------------------------PhysicalDistribute
+------------------------------------PhysicalProject
+--------------------------------------PhysicalOlapScan[date_dim]
+------------------------------PhysicalDistribute
+--------------------------------PhysicalAssertNumRows
+----------------------------------PhysicalDistribute
+------------------------------------hashAgg[GLOBAL]
+--------------------------------------PhysicalDistribute
+----------------------------------------hashAgg[LOCAL]
+------------------------------------------PhysicalProject
+--------------------------------------------filter((date_dim.d_year = 1998)(date_dim.d_moy = 5))
+----------------------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalDistribute
+------------------------------PhysicalAssertNumRows
+--------------------------------PhysicalDistribute
+----------------------------------hashAgg[GLOBAL]
+------------------------------------PhysicalDistribute
+--------------------------------------hashAgg[LOCAL]
+----------------------------------------PhysicalProject
+------------------------------------------filter((date_dim.d_year = 1998)(date_dim.d_moy = 5))
+--------------------------------------------PhysicalOlapScan[date_dim]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query72.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query72.out
@@ -8,60 +8,58 @@ PhysicalResultSink
 ----------PhysicalDistribute
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[LEFT_OUTER_JOIN](catalog_returns.cr_item_sk = catalog_sales.cs_item_sk)(catalog_returns.cr_order_number = catalog_sales.cs_order_number)
-------------------PhysicalDistribute
---------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN](warehouse.w_warehouse_sk = inventory.inv_warehouse_sk)
+----------------hashJoin[INNER_JOIN](warehouse.w_warehouse_sk = inventory.inv_warehouse_sk)
+------------------PhysicalProject
+--------------------hashJoin[INNER_JOIN](catalog_sales.cs_item_sk = inventory.inv_item_sk)(inventory.inv_date_sk = d2.d_date_sk)(inventory.inv_quantity_on_hand < catalog_sales.cs_quantity)
+----------------------PhysicalDistribute
+------------------------PhysicalOlapScan[inventory]
+----------------------PhysicalDistribute
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN](catalog_sales.cs_item_sk = inventory.inv_item_sk)(inventory.inv_date_sk = d2.d_date_sk)(inventory.inv_quantity_on_hand < catalog_sales.cs_quantity)
+--------------------------hashJoin[INNER_JOIN](d1.d_week_seq = d2.d_week_seq)
 ----------------------------PhysicalDistribute
-------------------------------PhysicalOlapScan[inventory]
-----------------------------PhysicalDistribute
-------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN](d1.d_week_seq = d2.d_week_seq)
-----------------------------------PhysicalDistribute
-------------------------------------PhysicalProject
---------------------------------------hashJoin[LEFT_OUTER_JOIN](catalog_sales.cs_promo_sk = promotion.p_promo_sk)
-----------------------------------------PhysicalProject
-------------------------------------------hashJoin[INNER_JOIN](item.i_item_sk = catalog_sales.cs_item_sk)
---------------------------------------------PhysicalDistribute
-----------------------------------------------PhysicalProject
-------------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_ship_date_sk = d3.d_date_sk)(d3.d_date > cast((cast(d_date as BIGINT) + 5) as DATEV2))
---------------------------------------------------PhysicalDistribute
-----------------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_bill_cdemo_sk = customer_demographics.cd_demo_sk)
-------------------------------------------------------PhysicalDistribute
---------------------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_sold_date_sk = d1.d_date_sk)
-----------------------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_bill_hdemo_sk = household_demographics.hd_demo_sk)
-------------------------------------------------------------PhysicalProject
---------------------------------------------------------------PhysicalOlapScan[catalog_sales]
-------------------------------------------------------------PhysicalDistribute
---------------------------------------------------------------PhysicalProject
-----------------------------------------------------------------filter((cast(hd_buy_potential as VARCHAR(*)) = '501-1000'))
-------------------------------------------------------------------PhysicalOlapScan[household_demographics]
+------------------------------hashJoin[RIGHT_OUTER_JOIN](catalog_returns.cr_item_sk = catalog_sales.cs_item_sk)(catalog_returns.cr_order_number = catalog_sales.cs_order_number)
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[catalog_returns]
+--------------------------------PhysicalDistribute
+----------------------------------PhysicalProject
+------------------------------------hashJoin[LEFT_OUTER_JOIN](catalog_sales.cs_promo_sk = promotion.p_promo_sk)
+--------------------------------------PhysicalProject
+----------------------------------------hashJoin[INNER_JOIN](item.i_item_sk = catalog_sales.cs_item_sk)
+------------------------------------------PhysicalDistribute
+--------------------------------------------PhysicalProject
+----------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_ship_date_sk = d3.d_date_sk)(d3.d_date > cast((cast(d_date as BIGINT) + 5) as DATEV2))
+------------------------------------------------PhysicalDistribute
+--------------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_bill_cdemo_sk = customer_demographics.cd_demo_sk)
+----------------------------------------------------PhysicalDistribute
+------------------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_sold_date_sk = d1.d_date_sk)
+--------------------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_bill_hdemo_sk = household_demographics.hd_demo_sk)
+----------------------------------------------------------PhysicalProject
+------------------------------------------------------------PhysicalOlapScan[catalog_sales]
 ----------------------------------------------------------PhysicalDistribute
 ------------------------------------------------------------PhysicalProject
---------------------------------------------------------------filter((d1.d_year = 2002))
-----------------------------------------------------------------PhysicalOlapScan[date_dim]
-------------------------------------------------------PhysicalDistribute
---------------------------------------------------------PhysicalProject
-----------------------------------------------------------filter((cast(cd_marital_status as VARCHAR(*)) = 'W'))
-------------------------------------------------------------PhysicalOlapScan[customer_demographics]
---------------------------------------------------PhysicalDistribute
-----------------------------------------------------PhysicalProject
-------------------------------------------------------PhysicalOlapScan[date_dim]
---------------------------------------------PhysicalDistribute
-----------------------------------------------PhysicalProject
-------------------------------------------------PhysicalOlapScan[item]
-----------------------------------------PhysicalDistribute
-------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[promotion]
-----------------------------------PhysicalDistribute
-------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[date_dim]
-------------------------PhysicalDistribute
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[warehouse]
+--------------------------------------------------------------filter((cast(hd_buy_potential as VARCHAR(*)) = '501-1000'))
+----------------------------------------------------------------PhysicalOlapScan[household_demographics]
+--------------------------------------------------------PhysicalDistribute
+----------------------------------------------------------PhysicalProject
+------------------------------------------------------------filter((d1.d_year = 2002))
+--------------------------------------------------------------PhysicalOlapScan[date_dim]
+----------------------------------------------------PhysicalDistribute
+------------------------------------------------------PhysicalProject
+--------------------------------------------------------filter((cast(cd_marital_status as VARCHAR(*)) = 'W'))
+----------------------------------------------------------PhysicalOlapScan[customer_demographics]
+------------------------------------------------PhysicalDistribute
+--------------------------------------------------PhysicalProject
+----------------------------------------------------PhysicalOlapScan[date_dim]
+------------------------------------------PhysicalDistribute
+--------------------------------------------PhysicalProject
+----------------------------------------------PhysicalOlapScan[item]
+--------------------------------------PhysicalDistribute
+----------------------------------------PhysicalProject
+------------------------------------------PhysicalOlapScan[promotion]
+----------------------------PhysicalDistribute
+------------------------------PhysicalProject
+--------------------------------PhysicalOlapScan[date_dim]
 ------------------PhysicalDistribute
 --------------------PhysicalProject
-----------------------PhysicalOlapScan[catalog_returns]
+----------------------PhysicalOlapScan[warehouse]
 

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf17.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf17.groovy
@@ -95,5 +95,5 @@ limit 100;
     // File file = new File(outFile)
     // file.write(getRuntimeFilters(plan))
 
-     assertEquals("RF9[d_date_sk->[cs_sold_date_sk],RF7[cs_bill_customer_sk->[sr_customer_sk],RF8[cs_item_sk->[sr_item_sk],RF6[d_date_sk->[sr_returned_date_sk],RF3[ss_customer_sk->[sr_customer_sk],RF4[ss_item_sk->[sr_item_sk],RF5[ss_ticket_number->[sr_ticket_number],RF2[s_store_sk->[ss_store_sk],RF1[i_item_sk->[ss_item_sk],RF0[d_date_sk->[ss_sold_date_sk]", getRuntimeFilters(plan))
+     assertEquals("RF9[d_date_sk->[cs_sold_date_sk],RF7[sr_customer_sk->[cs_bill_customer_sk],RF8[sr_item_sk->[cs_item_sk],RF6[s_store_sk->[ss_store_sk],RF5[i_item_sk->[ss_item_sk],RF4[d_date_sk->[sr_returned_date_sk],RF1[ss_customer_sk->[sr_customer_sk],RF2[ss_item_sk->[sr_item_sk],RF3[ss_ticket_number->[sr_ticket_number],RF0[d_date_sk->[ss_sold_date_sk]", getRuntimeFilters(plan))
 }

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf25.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf25.groovy
@@ -97,5 +97,5 @@ suite("ds_rf25") {
     // def outFile = "regression-test/suites/nereids_tpcds_shape_sf100_p0/ddl/rf/rf.25"
     // File file = new File(outFile)
     // file.write(getRuntimeFilters(plan))
-     assertEquals("RF9[d_date_sk->[cs_sold_date_sk],RF7[sr_customer_sk->[cs_bill_customer_sk],RF8[sr_item_sk->[cs_item_sk],RF6[d_date_sk->[sr_returned_date_sk],RF3[ss_customer_sk->[sr_customer_sk],RF4[ss_item_sk->[sr_item_sk],RF5[ss_ticket_number->[sr_ticket_number],RF2[s_store_sk->[ss_store_sk],RF1[i_item_sk->[ss_item_sk],RF0[d_date_sk->[ss_sold_date_sk]", getRuntimeFilters(plan))
+     assertEquals("RF9[d_date_sk->[cs_sold_date_sk],RF7[sr_customer_sk->[cs_bill_customer_sk],RF8[sr_item_sk->[cs_item_sk],RF6[s_store_sk->[ss_store_sk],RF5[i_item_sk->[ss_item_sk],RF4[d_date_sk->[sr_returned_date_sk],RF1[ss_customer_sk->[sr_customer_sk],RF2[ss_item_sk->[sr_item_sk],RF3[ss_ticket_number->[sr_ticket_number],RF0[d_date_sk->[ss_sold_date_sk]", getRuntimeFilters(plan))
 }

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf29.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf29.groovy
@@ -96,5 +96,5 @@ suite("ds_rf29") {
     // def outFile = "regression-test/suites/nereids_tpcds_shape_sf100_p0/ddl/rf/rf.29"
     // File file = new File(outFile)
     // file.write(getRuntimeFilters(plan))
-     assertEquals("RF9[d_date_sk->[cs_sold_date_sk],RF7[sr_customer_sk->[cs_bill_customer_sk],RF8[sr_item_sk->[cs_item_sk],RF6[s_store_sk->[ss_store_sk],RF5[i_item_sk->[ss_item_sk],RF4[d_date_sk->[ss_sold_date_sk],RF1[sr_customer_sk->[ss_customer_sk],RF2[sr_item_sk->[ss_item_sk],RF3[sr_ticket_number->[ss_ticket_number],RF0[d_date_sk->[sr_returned_date_sk]", getRuntimeFilters(plan))
+     assertEquals("RF9[d_date_sk->[cs_sold_date_sk],RF7[sr_customer_sk->[cs_bill_customer_sk],RF8[sr_item_sk->[cs_item_sk],RF6[s_store_sk->[ss_store_sk],RF5[i_item_sk->[ss_item_sk],RF4[d_date_sk->[sr_returned_date_sk],RF1[ss_customer_sk->[sr_customer_sk],RF2[ss_item_sk->[sr_item_sk],RF3[ss_ticket_number->[sr_ticket_number],RF0[d_date_sk->[ss_sold_date_sk]", getRuntimeFilters(plan))
 }

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf29.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf29.groovy
@@ -96,5 +96,5 @@ suite("ds_rf29") {
     // def outFile = "regression-test/suites/nereids_tpcds_shape_sf100_p0/ddl/rf/rf.29"
     // File file = new File(outFile)
     // file.write(getRuntimeFilters(plan))
-     assertEquals("RF9[d_date_sk->[cs_sold_date_sk],RF7[sr_customer_sk->[cs_bill_customer_sk],RF8[sr_item_sk->[cs_item_sk],RF6[d_date_sk->[sr_returned_date_sk],RF3[ss_customer_sk->[sr_customer_sk],RF4[ss_item_sk->[sr_item_sk],RF5[ss_ticket_number->[sr_ticket_number],RF2[s_store_sk->[ss_store_sk],RF1[i_item_sk->[ss_item_sk],RF0[d_date_sk->[ss_sold_date_sk]", getRuntimeFilters(plan))
+     assertEquals("RF9[d_date_sk->[cs_sold_date_sk],RF7[sr_customer_sk->[cs_bill_customer_sk],RF8[sr_item_sk->[cs_item_sk],RF6[s_store_sk->[ss_store_sk],RF5[i_item_sk->[ss_item_sk],RF4[d_date_sk->[ss_sold_date_sk],RF1[sr_customer_sk->[ss_customer_sk],RF2[sr_item_sk->[ss_item_sk],RF3[sr_ticket_number->[ss_ticket_number],RF0[d_date_sk->[sr_returned_date_sk]", getRuntimeFilters(plan))
 }

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf40.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf40.groovy
@@ -78,5 +78,5 @@ limit 100;
     // File file = new File(outFile)
     // file.write(getRuntimeFilters(plan))
 
-     assertEquals("RF3[cs_order_number->[cr_order_number],RF4[cs_item_sk->[cr_item_sk],RF2[cs_warehouse_sk->[w_warehouse_sk],RF1[d_date_sk->[cs_sold_date_sk],RF0[i_item_sk->[cs_item_sk]", getRuntimeFilters(plan))
+     assertEquals("RF4[w_warehouse_sk->[cs_warehouse_sk],RF2[cs_order_number->[cr_order_number],RF3[cs_item_sk->[cr_item_sk],RF1[d_date_sk->[cs_sold_date_sk],RF0[i_item_sk->[cs_item_sk]", getRuntimeFilters(plan))
 }

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf54.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf54.groovy
@@ -106,5 +106,5 @@ suite("ds_rf54") {
     // File file = new File(outFile)
     // file.write(getRuntimeFilters(plan))
     
-     assertEquals("RF5[s_county->[ca_county],RF6[s_state->[ca_state],RF4[d_date_sk->[ss_sold_date_sk],RF3[c_customer_sk->[ss_customer_sk],RF2[c_current_addr_sk->[ca_address_sk],RF1[customer_sk->[c_customer_sk],RF0[i_item_sk->[cs_item_sk, ws_item_sk]", getRuntimeFilters(plan))
+     assertEquals("RF6[d_date_sk->[ss_sold_date_sk],RF5[c_customer_sk->[ss_customer_sk],RF3[s_county->[ca_county],RF4[s_state->[ca_state],RF2[c_current_addr_sk->[ca_address_sk],RF1[customer_sk->[c_customer_sk],RF0[i_item_sk->[cs_item_sk, ws_item_sk]", getRuntimeFilters(plan))
 }

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf72.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf72.groovy
@@ -79,5 +79,5 @@ limit 100;
     // File file = new File(outFile)
     // file.write(getRuntimeFilters(plan))
 
-     assertEquals("RF8[w_warehouse_sk->[inv_warehouse_sk],RF6[d_date_sk->[inv_date_sk],RF7[cs_item_sk->[inv_item_sk],RF5[d_week_seq->[d_week_seq],RF4[i_item_sk->[cs_item_sk],RF3[d_date_sk->[cs_ship_date_sk],RF2[cd_demo_sk->[cs_bill_cdemo_sk],RF1[d_date_sk->[cs_sold_date_sk],RF0[hd_demo_sk->[cs_bill_hdemo_sk]", getRuntimeFilters(plan))
+     assertEquals("RF10[w_warehouse_sk->[inv_warehouse_sk],RF8[d_date_sk->[inv_date_sk],RF9[cs_item_sk->[inv_item_sk],RF7[d_week_seq->[d_week_seq],RF5[cs_item_sk->[cr_item_sk],RF6[cs_order_number->[cr_order_number],RF4[i_item_sk->[cs_item_sk],RF3[d_date_sk->[cs_ship_date_sk],RF2[cd_demo_sk->[cs_bill_cdemo_sk],RF1[d_date_sk->[cs_sold_date_sk],RF0[hd_demo_sk->[cs_bill_hdemo_sk]", getRuntimeFilters(plan))
 }


### PR DESCRIPTION
## Proposed changes
A left join B on A.x=B.x and A.y=B.y
B.x and B.y make result tuple number scale out.
suppose A is scaled out by B.x N1 time, and scaled out by B.y N2 time, and N1 < N2.
we should choose N1 as the final scale out factor, not N2.

this pr impact on tpcds_sf100 59/17/29/25/47/40/54 

before
query59 77295   75279   75230   75230
query17 22642   21566   21599   21566
query29 16508   16092   16006   16006
query25 20262   20571   21171   20571
query47 23571   23264   23107   23107
query40 3305    2849    3064    2849
query54 9052    8882    8715    8715
Total cold run time: 172635 ms
Total hot run time: 168044 ms

after 
query59 56435   54717   53919   53919
query17 24167   22377   23237   22377
query29 16950   18325   16333   16333
query25 21478   22975   21358   21358
query47 24412   24611   23920   23920
query40 5491    4779    5176    4779
query54 8671    8664    8658    8658
Total cold run time: 157604 ms
Total hot run time: 151344 ms

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

