### PR TITLE
[Fix](kerberos) Fix kerberos relogin bugs when using hdfs-load.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/dfs/DFSFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/dfs/DFSFileSystem.java
@@ -92,8 +92,6 @@ public class DFSFileSystem extends RemoteFileSystem {
                 }
             });
         } catch (SecurityException e) {
-            LOG.warn("A SecurityException occurs when invoke ugi.doAs(), "
-                    + "relogin and retry immediately.", e);
             throw new UserException(e);
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/dfs/DFSFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/dfs/DFSFileSystem.java
@@ -117,8 +117,7 @@ public class DFSFileSystem extends RemoteFileSystem {
                     return ugi;
                 }
             } catch (IOException e) {
-                LOG.warn("A SecurityException occurs when invoke ugi.doAs(), "
-                        + "relogin and retry immediately.", e);
+                LOG.warn("A SecurityException occurs with kerberos, do login immediately.", e);
                 return doLogin(conf);
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/dfs/DFSFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/dfs/DFSFileSystem.java
@@ -82,47 +82,48 @@ public class DFSFileSystem extends RemoteFileSystem {
             conf.set(propEntry.getKey(), propEntry.getValue());
         }
 
-        boolean hasRelogin = false;
-        UserGroupInformation ugi;
+        UserGroupInformation ugi = login(conf);
         try {
-            // try use current ugi first to avoid relogin
-            // because it may be a time-consuming task
-            ugi = UserGroupInformation.getCurrentUser();
-        } catch (IOException e) {
-            LOG.warn("An IOException occurs when invoke "
-                    + "UserGroupInformation.getCurrentUser(), relogin immediately.", e);
-            ugi = doLogin(conf);
-            hasRelogin = true;
-        }
-
-        do {
-            try {
-                dfsFileSystem = ugi.doAs((PrivilegedAction<FileSystem>) () -> {
-                    try {
-                        String username = properties.get(HdfsResource.HADOOP_USER_NAME);
-                        return username == null
-                                    ? FileSystem.get(new Path(remotePath).toUri(), conf)
-                                    : FileSystem.get(new Path(remotePath).toUri(), conf, username);
-                    } catch (IOException | InterruptedException e) {
-                        throw new RuntimeException(e);
-                    }
-                });
-                LOG.debug("Reuse current ugi for dfs, remote path: {}", remotePath);
-                break;
-            } catch (SecurityException e) {
-                LOG.warn("A SecurityException occurs when invoke ugi.doAs(), "
-                            + "relogin and retry immediately.", e);
-                if (hasRelogin) {
-                    throw new UserException(e);
+            dfsFileSystem = ugi.doAs((PrivilegedAction<FileSystem>) () -> {
+                try {
+                    return FileSystem.get(new Path(remotePath).toUri(), conf);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
                 }
-                ugi = doLogin(conf);
-                hasRelogin = true;
-            }
-        } while (true);
+            });
+        } catch (SecurityException e) {
+            LOG.warn("A SecurityException occurs when invoke ugi.doAs(), "
+                    + "relogin and retry immediately.", e);
+            throw new UserException(e);
+        }
 
         Preconditions.checkNotNull(dfsFileSystem);
         operations = new HDFSFileOperations(dfsFileSystem);
         return dfsFileSystem;
+    }
+
+    private UserGroupInformation login(Configuration conf) throws UserException {
+        if (AuthType.KERBEROS.getDesc().equals(
+                conf.get(HdfsResource.HADOOP_SECURITY_AUTHENTICATION, null))) {
+            try {
+                UserGroupInformation ugi = UserGroupInformation.getLoginUser();
+                String principal = conf.get(HdfsResource.HADOOP_KERBEROS_PRINCIPAL);
+                LOG.debug("Current login user: {}", ugi.getUserName());
+                if (ugi.hasKerberosCredentials() && ugi.getUserName().equals(principal)) {
+                    // if the current user is logged by kerberos and is the same user
+                    // just use checkTGTAndReloginFromKeytab because this method will only relogin
+                    // when the TGT is expired or is close to expiry
+                    ugi.checkTGTAndReloginFromKeytab();
+                    return ugi;
+                }
+            } catch (IOException e) {
+                LOG.warn("A SecurityException occurs when invoke ugi.doAs(), "
+                        + "relogin and retry immediately.", e);
+                return doLogin(conf);
+            }
+        }
+
+        return doLogin(conf);
     }
 
     private UserGroupInformation doLogin(Configuration conf) throws UserException {


### PR DESCRIPTION
## Proposed changes

![image](https://github.com/apache/doris/assets/5926365/a260dd5a-8251-4122-9f6a-2821e2a783ea)

When import data by `hdfs load`, `FE` will not login until listing the hdfs files, so the reuse logic of keberos login should 
check if the current ugi has logged by kerberos and the current user name is the same with the principal of current configuration, just invoke `ugi.checkTGTAndReloginFromKeytab` (this method will only relogin when the TGT is expired or is close to expiry, otherwise it will do nothing) if it's true, do login if it's false. 

I have test with following situations and it works fine:
- hdfs load
```sql
LOAD LABEL `default_cluster:test_d`.`test_ics_tr_offer_rp` (
  APPEND DATA INFILE (
    'hdfs://xxx/user/hive/warehouse/test.db/ics_tr_offer_rp/*/*'
  ) INTO TABLE ics_tr_offer_rp FORMAT AS "ORC"
 (
    `id`
  )  
  SET (
      `id` = `id`
    )
) WITH HDFS (
  "fs.defaultFS" = "hdfs://xxx",
  "dfs.client.failover.proxy.provider" = "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider", 
  "hadoop.security.authentication" = "kerberos", 
  "hadoop.kerberos.principal" = "xxx", 
  "hadoop.kerberos.keytab" = "/etc/xxx.keytab"
) PROPERTIES (
  "max_filter_ratio" = "0", "timeout" = "30000"
);
```
- broker load
```sql
LOAD LABEL `default_cluster:test_d`.`test_ics_tr_offer_rp2` (
  APPEND DATA INFILE (
    'hdfs://xxx/user/hive/warehouse/test.db/ics_tr_offer_rp/*/*'
  ) INTO TABLE ics_tr_offer_rp FORMAT AS "ORC"
 (
    `id`
  )  
  SET (
      `id` = `id`
    )
) WITH BROKER test_doris (
  "dfs.client.failover.proxy.provider" = "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider", 
  "hadoop.security.authentication" = "kerberos", 
  "kerberos_principal" = "xxx", 
  "kerberos_keytab" = "/etc/xxx.keytab", 
  "dfs.nameservices" = "xxx",
  "dfs.namenode.rpc-address.xxx.nn2" = "xxx:8020",
  "dfs.namenode.rpc-address.xxx.nn1" = "xxx:8020",
  "dfs.ha.namenodes.xxx" = "nn1,nn2",
  "dfs.client.failover.proxy.provider.xxx" = "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider"
) PROPERTIES (
  "max_filter_ratio" = "0", "timeout" = "30000"
);
```
- query hive catalog

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

