### PR TITLE
[fix](agg) The offset value was added twice in 'pack_fixed'

### DIFF
--- a/be/src/vec/common/aggregation_common.h
+++ b/be/src/vec/common/aggregation_common.h
@@ -95,7 +95,6 @@ T pack_fixed(size_t i, size_t keys_size, const ColumnRawPtrs& key_columns, const
                    static_cast<const ColumnVectorHelper*>(key_columns[j])->get_raw_data_begin<1>() +
                            i * key_sizes[j],
                    key_sizes[j]);
-            offset += key_sizes[j];
         }
 
         offset += key_sizes[j];


### PR DESCRIPTION
## Proposed changes

```
==2164125==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fa3c1c3a4c4 at pc 0x5654d0b6ee66 bp 0x7fa3c5b8e4f0 sp 0x7fa3c5b8dcb8
WRITE of size 8 at 0x7fa3c1c3a4c4 thread T254 (WithoutGroupTas)
    #0 0x5654d0b6ee65 in __asan_memcpy (/root/doris/be/lib/doris_be+0x18847e65) (BuildId: 1a6d1dfc76924ca2)
    #1 0x5654e2bb5c9e in doris::vectorized::UInt256 doris::vectorized::pack_fixed(unsigned long, unsigned long, std::vector> const&, std::vector> const&, std::array()> const&) /root/doris/be/src/vec/common/aggregation_common.h:202:13
    #2 0x5654e81ac516 in doris::vectorized::ColumnsHashing::HashMethodKeysFixed, doris::vectorized::UInt256, char*, true, false>::get_key_holder(unsigned long, doris::vectorized::Arena&) const /root/doris/be/src/vec/common/columns_hashing.h:199:20
    #3 0x5654e81ac516 in void doris::vectorized::AggregationNode::_emplace_into_hash_table(char**, std::vector>&, unsigned long)::$_0::operator(), false>, true>&>(doris::vectorized::AggregationMethodKeysFixed, false>, true>&) const /root/doris/be/src/vec/exec/vaggregation_node.cpp:944:64
    #4 0x5654e81abc2e in void std::__invoke_impl>&, unsigned long)::$_0, doris::vectorized::AggregationMethodKeysFixed, false>, true>&>(std::__invoke_other, doris::vectorized::AggregationNode::_emplace_into_hash_table(char**, std::vector>&, unsigned long)::$_0&&, doris::vectorized::AggregationMethodKeysFixed, false>, true>&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #5 0x5654e81abbae in std::__invoke_result>&, unsigned long)::$_0, doris::vectorized::AggregationMethodKeysFixed, false>, true>&>::type std::__invoke>&, unsigned long)::$_0, doris::vectorized::AggregationMethodKeysFixed, false>, true>&>(doris::vectorized::AggregationNode::_emplace_into_hash_table(char**, std::vector>&, unsigned long)::$_0&&, doris::vectorized::AggregationMethodKeysFixed, false>, true>&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96:14
    #6 0x5654e8174c90 in std::__detail::__variant::__gen_vtable_impl (*)(doris::vectorized::AggregationNode::_emplace_into_hash_table(char**, std::vector>&, unsigned long)::$_0&&, std::variant, false>>, doris::vectorized::AggregationMethodOneNumber, FixedHashTableCalculatedSize>, Allocator>, false>, doris::vectorized::AggregationMethodOneNumber, FixedHashTableStoredSize>, Allocator>, false>, doris::vectorized::AggregationMethodOneNumber, false>, false>, doris::vectorized::AggregationMethodOneNumber, false>, false>, doris::vectorized::AggregationMethodStringNoCache>>, doris::vectorized::AggregationMethodOneNumber, false>, false>, doris::vectorized::AggregationMethodOneNumber>, false>, false>, doris::vectorized::AggregationMethodOneNumber>, false>, false>, doris::vectorized::AggregationMethodOneNumber>, false>, false>, doris::vectorized::AggregationMethodSingleNullableColumn, FixedHashTableCalculatedSize>, Allocator>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn, FixedHashTableStoredSize>, Allocator>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn>, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn>, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn>, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn>>>>, doris::vectorized::AggregationMethodKeysFixed, false>, false>, doris::vectorized::AggregationMethodKeysFixed, false>, true>, doris::vectorized::AggregationMethodKeysFixed, false>, false>, doris::vectorized::AggregationMethodKeysFixed, false>, true>, doris::vectorized::AggregationMethodKeysFixed, false>, false>, doris::vectorized::AggregationMethodKeysFixed, false>, true>, doris::vectorized::AggregationMethodKeysFixed>, false>, false>, doris::vectorized::AggregationMethodKeysFixed>, false>, true>, doris::vectorized::AggregationMethodKeysFixed>, false>, false>, doris::vectorized::AggregationMethodKeysFixed>, false>, true>, doris::vectorized::AggregationMethodKeysFixed>, false>, false>, doris::vectorized::AggregationMethodKeysFixed>, false>, true>>&)>, std::integer_sequence>::__visit_invoke(doris::vectorized::AggregationNode::_emplace_into_hash_table(char**, std::vector>&, unsigned long)::$_0&&, std::variant, false>>, doris::vectorized::AggregationMethodOneNumber, FixedHashTableCalculatedSize>, Allocator>, false>, doris::vectorized::AggregationMethodOneNumber, FixedHashTableStoredSize>, Allocator>, false>, doris::vectorized::AggregationMethodOneNumber, false>, false>, doris::vectorized::AggregationMethodOneNumber, false>, false>, doris::vectorized::AggregationMethodStringNoCache>>, doris::vectorized::AggregationMethodOneNumber, false>, false>, doris::vectorized::AggregationMethodOneNumber>, false>, false>, doris::vectorized::AggregationMethodOneNumber>, false>, false>, doris::vectorized::AggregationMethodOneNumber>, false>, false>, doris::vectorized::AggregationMethodSingleNullableColumn, FixedHashTableCalculatedSize>, Allocator>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn, FixedHashTableStoredSize>, Allocator>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn>, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn>, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn>, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn>>>>, doris::vectorized::AggregationMethodKeysFixed, false>, false>, doris::vectorized::AggregationMethodKeysFixed, false>, true>, doris::vectorized::AggregationMethodKeysFixed, false>, false>, doris::vectorized::AggregationMethodKeysFixed, false>, true>, doris::vectorized::AggregationMethodKeysFixed, false>, false>, doris::vectorized::AggregationMethodKeysFixed, false>, true>, doris::vectorized::AggregationMethodKeysFixed>, false>, false>, doris::vectorized::AggregationMethodKeysFixed>, false>, true>, doris::vectorized::AggregationMethodKeysFixed>, false>, false>, doris::vectorized::AggregationMethodKeysFixed>, false>, true>, doris::vectorized::AggregationMethodKeysFixed>, false>, false>, doris::vectorized::AggregationMethodKeysFixed>, false>, true>>&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1013:11
    #7 0x5654e81742eb in decltype(auto) std::__do_visit, doris::vectorized::AggregationNode::_emplace_into_hash_table(char**, std::vector>&, unsigned long)::$_0, std::variant, false>>, doris::vectorized::AggregationMethodOneNumber, FixedHashTableCalculatedSize>, Allocator>, false>, doris::vectorized::AggregationMethodOneNumber, FixedHashTableStoredSize>, Allocator>, false>, doris::vectorized::AggregationMethodOneNumber, false>, false>, doris::vectorized::AggregationMethodOneNumber, false>, false>, doris::vectorized::AggregationMethodStringNoCache>>, doris::vectorized::AggregationMethodOneNumber, false>, false>, doris::vectorized::AggregationMethodOneNumber>, false>, false>, doris::vectorized::AggregationMethodOneNumber>, false>, false>, doris::vectorized::AggregationMethodOneNumber>, false>, false>, doris::vectorized::AggregationMethodSingleNullableColumn, FixedHashTableCalculatedSize>, Allocator>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn, FixedHashTableStoredSize>, Allocator>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn>, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn>, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn>, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn>>>>, doris::vectorized::AggregationMethodKeysFixed, false>, false>, doris::vectorized::AggregationMethodKeysFixed, false>, true>, doris::vectorized::AggregationMethodKeysFixed, false>, false>, doris::vectorized::AggregationMethodKeysFixed, false>, true>, doris::vectorized::AggregationMethodKeysFixed, false>, false>, doris::vectorized::AggregationMethodKeysFixed, false>, true>, doris::vectorized::AggregationMethodKeysFixed>, false>, false>, doris::vectorized::AggregationMethodKeysFixed>, false>, true>, doris::vectorized::AggregationMethodKeysFixed>, false>, false>, doris::vectorized::AggregationMethodKeysFixed>, false>, true>, doris::vectorized::AggregationMethodKeysFixed>, false>, false>, doris::vectorized::AggregationMethodKeysFixed>, false>, true>>&>(doris::vectorized::AggregationNode::_emplace_into_hash_table(char**, std::vector>&, unsigned long)::$_0&&, std::variant, false>>, doris::vectorized::AggregationMethodOneNumber, FixedHashTableCalculatedSize>, Allocator>, false>, doris::vectorized::AggregationMethodOneNumber, FixedHashTableStoredSize>, Allocator>, false>, doris::vectorized::AggregationMethodOneNumber, false>, false>, doris::vectorized::AggregationMethodOneNumber, false>, false>, doris::vectorized::AggregationMethodStringNoCache>>, doris::vectorized::AggregationMethodOneNumber, false>, false>, doris::vectorized::AggregationMethodOneNumber>, false>, false>, doris::vectorized::AggregationMethodOneNumber>, false>, false>, doris::vectorized::AggregationMethodOneNumber>, false>, false>, doris::vectorized::AggregationMethodSingleNullableColumn, FixedHashTableCalculatedSize>, Allocator>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn, FixedHashTableStoredSize>, Allocator>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn>, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn>, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn>, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn>>>>, doris::vectorized::AggregationMethodKeysFixed, false>, false>, doris::vectorized::AggregationMethodKeysFixed, false>, true>, doris::vectorized::AggregationMethodKeysFixed, false>, false>, doris::vectorized::AggregationMethodKeysFixed, false>, true>, doris::vectorized::AggregationMethodKeysFixed, false>, false>, doris::vectorized::AggregationMethodKeysFixed, false>, true>, doris::vectorized::AggregationMethodKeysFixed>, false>, false>, doris::vectorized::AggregationMethodKeysFixed>, false>, true>, doris::vectorized::AggregationMethodKeysFixed>, false>, false>, doris::vectorized::AggregationMethodKeysFixed>, false>, true>, doris::vectorized::AggregationMethodKeysFixed>, false>, false>, doris::vectorized::AggregationMethodKeysFixed>, false>, true>>&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1714:14
    #8 0x5654e8136818 in decltype(auto) std::visit>&, unsigned long)::$_0, std::variant, false>>, doris::vectorized::AggregationMethodOneNumber, FixedHashTableCalculatedSize>, Allocator>, false>, doris::vectorized::AggregationMethodOneNumber, FixedHashTableStoredSize>, Allocator>, false>, doris::vectorized::AggregationMethodOneNumber, false>, false>, doris::vectorized::AggregationMethodOneNumber, false>, false>, doris::vectorized::AggregationMethodStringNoCache>>, doris::vectorized::AggregationMethodOneNumber, false>, false>, doris::vectorized::AggregationMethodOneNumber>, false>, false>, doris::vectorized::AggregationMethodOneNumber>, false>, false>, doris::vectorized::AggregationMethodOneNumber>, false>, false>, doris::vectorized::AggregationMethodSingleNullableColumn, FixedHashTableCalculatedSize>, Allocator>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn, FixedHashTableStoredSize>, Allocator>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn>, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn>, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn>, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn>>>>, doris::vectorized::AggregationMethodKeysFixed, false>, false>, doris::vectorized::AggregationMethodKeysFixed, false>, true>, doris::vectorized::AggregationMethodKeysFixed, false>, false>, doris::vectorized::AggregationMethodKeysFixed, false>, true>, doris::vectorized::AggregationMethodKeysFixed, false>, false>, doris::vectorized::AggregationMethodKeysFixed, false>, true>, doris::vectorized::AggregationMethodKeysFixed>, false>, false>, doris::vectorized::AggregationMethodKeysFixed>, false>, true>, doris::vectorized::AggregationMethodKeysFixed>, false>, false>, doris::vectorized::AggregationMethodKeysFixed>, false>, true>, doris::vectorized::AggregationMethodKeysFixed>, false>, false>, doris::vectorized::AggregationMethodKeysFixed>, false>, true>>&>(doris::vectorized::AggregationNode::_emplace_into_hash_table(char**, std::vector>&, unsigned long)::$_0&&, std::variant, false>>, doris::vectorized::AggregationMethodOneNumber, FixedHashTableCalculatedSize>, Allocator>, false>, doris::vectorized::AggregationMethodOneNumber, FixedHashTableStoredSize>, Allocator>, false>, doris::vectorized::AggregationMethodOneNumber, false>, false>, doris::vectorized::AggregationMethodOneNumber, false>, false>, doris::vectorized::AggregationMethodStringNoCache>>, doris::vectorized::AggregationMethodOneNumber, false>, false>, doris::vectorized::AggregationMethodOneNumber>, false>, false>, doris::vectorized::AggregationMethodOneNumber>, false>, false>, doris::vectorized::AggregationMethodOneNumber>, false>, false>, doris::vectorized::AggregationMethodSingleNullableColumn, FixedHashTableCalculatedSize>, Allocator>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn, FixedHashTableStoredSize>, Allocator>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn>, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn>, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn>, false>>, false>>, doris::vectorized::AggregationMethodSingleNullableColumn>>>>, doris::vectorized::AggregationMethodKeysFixed, false>, false>, doris::vectorized::AggregationMethodKeysFixed, false>, true>, doris::vectorized::AggregationMethodKeysFixed, false>, false>, doris::vectorized::AggregationMethodKeysFixed, false>, true>, doris::vectorized::AggregationMethodKeysFixed, false>, false>, doris::vectorized::AggregationMethodKeysFixed, false>, true>, doris::vectorized::AggregationMethodKeysFixed>, false>, false>, doris::vectorized::AggregationMethodKeysFixed>, false>, true>, doris::vectorized::AggregationMethodKeysFixed>, false>, false>, doris::vectorized::AggregationMethodKeysFixed>, false>, true>, doris::vectorized::AggregationMethodKeysFixed>, false>, false>, doris::vectorized::AggregationMethodKeysFixed>, false>, true>>&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1764:13
    #9 0x5654e8136705 in doris::vectorized::AggregationNode::_emplace_into_hash_table(char**, std::vector>&, unsigned long) /root/doris/be/src/vec/exec/vaggregation_node.cpp:922:5
    #10 0x5654e82be2ee in doris::Status doris::vectorized::AggregationNode::_execute_with_serialized_key_helper(doris::vectorized::Block*) /root/doris/be/src/vec/exec/vaggregation_node.h:1007:13
    #11 0x5654e812e229 in doris::vectorized::AggregationNode::_execute_with_serialized_key(doris::vectorized::Block*) /root/doris/be/src/vec/exec/vaggregation_node.cpp:1358:16
    #12 0x5654e83adc60 in doris::Status std::__invoke_impl(std::__invoke_memfun_deref, doris::Status (doris::vectorized::AggregationNode::*&)(doris::vectorized::Block*), doris::vectorized::AggregationNode*&, doris::vectorized::Block*&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74:14
    #13 0x5654e83ada51 in std::enable_if, doris::Status>::type std::__invoke_r(doris::Status (doris::vectorized::AggregationNode::*&)(doris::vectorized::Block*), doris::vectorized::AggregationNode*&, doris::vectorized::Block*&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:114:9
    #14 0x5654e83ad96a in doris::Status std::_Bind_result))(doris::vectorized::Block*)>::__call(std::tuple&&, std::_Index_tuple<0ul, 1ul>) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:570:11
    #15 0x5654e83ad7ae in doris::Status std::_Bind_result))(doris::vectorized::Block*)>::operator()(doris::vectorized::Block*&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:629:17
    #16 0x5654e83ad689 in doris::Status std::__invoke_impl))(doris::vectorized::Block*)>&, doris::vectorized::Block*>(std::__invoke_other, std::_Bind_result))(doris::vectorized::Block*)>&, doris::vectorized::Block*&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #17 0x5654e83ad5d9 in std::enable_if))(doris::vectorized::Block*)>&, doris::vectorized::Block*>, doris::Status>::type std::__invoke_r))(doris::vectorized::Block*)>&, doris::vectorized::Block*>(std::_Bind_result))(doris::vectorized::Block*)>&, doris::vectorized::Block*&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:114:9
    #18 0x5654e83ad3a9 in std::_Function_handler))(doris::vectorized::Block*)>>::_M_invoke(std::_Any_data const&, doris::vectorized::Block*&&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #19 0x5654e82bbab7 in std::function::operator()(doris::vectorized::Block*) const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #20 0x5654e8134671 in doris::vectorized::AggregationNode::sink(doris::RuntimeState*, doris::vectorized::Block*, bool) /root/doris/be/src/vec/exec/vaggregation_node.cpp:599:9
    #21 0x5654f588d64d in doris::pipeline::StreamingOperator::sink(doris::RuntimeState*, doris::vectorized::Block*, doris::pipeline::SourceState) /root/doris/be/src/pipeline/exec/operator.h:341:23
    #22 0x5654f595921e in doris::pipeline::PipelineTask::execute(bool*) /root/doris/be/src/pipeline/pipeline_task.cpp:259:34
    #23 0x5654f59824d6 in doris::pipeline::TaskScheduler::_do_work(unsigned long) /root/doris/be/src/pipeline/task_scheduler.cpp:267:28
    #24 0x5654f599195a in void std::__invoke_impl(std::__invoke_memfun_deref, void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74:14
    #25 0x5654f5991776 in std::__invoke_result::type std::__invoke(void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96:14
    #26 0x5654f59916d5 in void std::_Bind::__call(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420:11
    #27 0x5654f599152f in void std::_Bind::operator()() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503:17
    #28 0x5654f5991436 in void std::__invoke_impl&>(std::__invoke_other, std::_Bind&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #29 0x5654f59913a8 in std::enable_if&>, void>::type std::__invoke_r&>(std::_Bind&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #30 0x5654f5990f9e in std::_Function_handler>::_M_invoke(std::_Any_data const&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #31 0x5654d0d8c3e6 in std::function::operator()() const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #32 0x5654d43f05da in doris::FunctionRunnable::run() /root/doris/be/src/util/threadpool.cpp:48:27
    #33 0x5654d43db5af in doris::ThreadPool::dispatch_thread() /root/doris/be/src/util/threadpool.cpp:533:24
    #34 0x5654d4405975 in void std::__invoke_impl(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74:14
    #35 0x5654d440581e in std::__invoke_result::type std::__invoke(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96:14
    #36 0x5654d4405796 in void std::_Bind::__call(std::tuple<>&&, std::_Index_tuple<0ul>) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420:11
    #37 0x5654d440562f in void std::_Bind::operator()() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503:17
    #38 0x5654d4405536 in void std::__invoke_impl&>(std::__invoke_other, std::_Bind&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #39 0x5654d44054a8 in std::enable_if&>, void>::type std::__invoke_r&>(std::_Bind&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #40 0x5654d44050fe in std::_Function_handler>::_M_invoke(std::_Any_data const&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #41 0x5654d0d8c3e6 in std::function::operator()() const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #42 0x5654d43a462f in doris::Thread::supervise_thread(void*) /root/doris/be/src/util/thread.cpp:465:5
    #43 0x7fa587da8608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477:8
    #44 0x7fa588055132 in __clone /build/glibc-SzIz7B/glibc-2.31/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

