### PR TITLE
[chore](exception) Add config item 'exit_on_exception'

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1090,6 +1090,9 @@ DEFINE_Int32(group_commit_insert_threads, "10");
 
 DEFINE_mInt32(scan_thread_nice_value, "0");
 
+DEFINE_Bool(exit_on_exception, "false")
+
+// clang-format off
 #ifdef BE_TEST
 // test s3
 DEFINE_String(test_s3_resource, "resource");
@@ -1100,6 +1103,7 @@ DEFINE_String(test_s3_region, "region");
 DEFINE_String(test_s3_bucket, "bucket");
 DEFINE_String(test_s3_prefix, "prefix");
 #endif
+// clang-format on
 
 std::map<std::string, Register::Field>* Register::_s_field_map = nullptr;
 std::map<std::string, std::function<bool()>>* RegisterConfValidator::_s_field_validator = nullptr;

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1165,6 +1165,9 @@ DECLARE_mInt32(group_commit_insert_threads);
 // to lower the priority of scan threads
 DECLARE_Int32(scan_thread_nice_value);
 
+// Use `LOG(FATAL)` to replace `throw` when true
+DECLARE_mBool(exit_on_exception);
+
 #ifdef BE_TEST
 // test s3
 DECLARE_String(test_s3_resource);

--- a/be/src/common/exception.cpp
+++ b/be/src/common/exception.cpp
@@ -17,6 +17,7 @@
 
 #include "common/exception.h"
 
+#include "common/config.h"
 #include "util/stack_util.h"
 namespace doris {
 
@@ -25,7 +26,11 @@ Exception::Exception(int code, const std::string_view msg) {
     _err_msg = std::make_unique<ErrMsg>();
     _err_msg->_msg = msg;
     _err_msg->_stack = get_stack_trace();
+    if (config::exit_on_exception) {
+        LOG(FATAL) << "[ExitOnException] error code: " << code << ", message: " << msg;
+    }
 }
+
 Exception::Exception(const Exception& nested, int code, const std::string_view msg) {
     _code = code;
     _err_msg = std::make_unique<ErrMsg>();
@@ -36,6 +41,10 @@ Exception::Exception(const Exception& nested, int code, const std::string_view m
     _nested_excption->_err_msg = std::make_unique<ErrMsg>();
     _nested_excption->_err_msg->_msg = nested._err_msg->_msg;
     _nested_excption->_err_msg->_stack = nested._err_msg->_stack;
+
+    if (config::exit_on_exception) {
+        LOG(FATAL) << "[ExitOnException] error code: " << code << ", message: " << msg;
+    }
 }
 
 } // namespace doris


### PR DESCRIPTION
## Proposed changes

Add one configuration item: 'exit_on_exception'.
If  'exit_on_exception' is set to true, the process of the BE will crash instead of throwing an exception.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

