### PR TITLE
[fix](timezone) fix timezone parse when there is no tzfile

### DIFF
--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -94,6 +94,7 @@ public:
                 const TQueryGlobals& query_globals, ExecEnv* exec_env);
 
     // for ut and non-query.
+    void set_exec_env(ExecEnv* exec_env) { _exec_env = exec_env; }
     void init_mem_trackers(const TUniqueId& id = TUniqueId(), const std::string& name = "unknown");
 
     const TQueryOptions& query_options() const { return _query_options; }

--- a/be/src/util/timezone_utils.cpp
+++ b/be/src/util/timezone_utils.cpp
@@ -45,6 +45,11 @@ bool TimezoneUtils::inited_ = false;
 const std::string TimezoneUtils::default_time_zone = "+08:00";
 static const char* tzdir = "/usr/share/zoneinfo"; // default value, may change by TZDIR env var
 
+void TimezoneUtils::clear_timezone_names() {
+    timezone_names_map_.clear();
+    inited_ = false;
+}
+
 void TimezoneUtils::load_timezone_names() {
     if (inited_) {
         return;
@@ -301,7 +306,7 @@ bool TimezoneUtils::find_cctz_time_zone(const std::string& timezone, cctz::time_
             auto it = timezone_names_map_.find(timezone_lower);
             if (it != timezone_names_map_.end()) {
                 tz_parsed = cctz::load_time_zone(it->second, &ctz);
-            } else{
+            } else {
                 tz_parsed = cctz::load_time_zone(timezone, &ctz);
             }
         }

--- a/be/src/util/timezone_utils.h
+++ b/be/src/util/timezone_utils.h
@@ -40,6 +40,9 @@ public:
     // we support to parse lower_case timezone name iff execution environment has timezone file
     static bool find_cctz_time_zone(const std::string& timezone, cctz::time_zone& ctz);
 
+    // for ut only
+    static void clear_timezone_names();
+
     static const std::string default_time_zone;
 
 private:

--- a/be/src/util/timezone_utils.h
+++ b/be/src/util/timezone_utils.h
@@ -37,6 +37,7 @@ class TimezoneUtils {
 public:
     static void load_timezone_names();
     static void load_timezones_to_cache(vectorized::ZoneList& cache_list);
+    // we support to parse lower_case timezone name iff execution environment has timezone file
     static bool find_cctz_time_zone(const std::string& timezone, cctz::time_zone& ctz);
 
     static const std::string default_time_zone;

--- a/be/src/vec/functions/function_convert_tz.h
+++ b/be/src/vec/functions/function_convert_tz.h
@@ -139,7 +139,7 @@ struct ConvertTZImpl {
             std::unique_lock<std::shared_mutex> lock_(cache_lock);
             //TODO: the lock upgrade could be done in find_... function only when we push value into the hashmap
             if (!TimezoneUtils::find_cctz_time_zone(from_tz, time_zone_cache[from_tz])) {
-                time_zone_cache.erase(to_tz);
+                time_zone_cache.erase(from_tz);
                 result_null_map[index_now] = true;
                 result_column->insert_default();
                 return;

--- a/be/test/testutil/function_utils.cpp
+++ b/be/test/testutil/function_utils.cpp
@@ -39,13 +39,17 @@ FunctionUtils::FunctionUtils() {
 
 FunctionUtils::FunctionUtils(const doris::TypeDescriptor& return_type,
                              const std::vector<doris::TypeDescriptor>& arg_types,
-                             int varargs_buffer_size) {
+                             int varargs_buffer_size, RuntimeState* state = nullptr) {
     TQueryGlobals globals;
     globals.__set_now_string("2019-08-06 01:38:57");
     globals.__set_timestamp_ms(1565026737805);
     globals.__set_time_zone("Asia/Shanghai");
-    _state = RuntimeState::create_unique(globals).release();
-    _fn_ctx = FunctionContext::create_context(_state, return_type, arg_types);
+    if (state == nullptr) {
+        _state = RuntimeState::create_unique(globals).release();
+        _fn_ctx = FunctionContext::create_context(_state, return_type, arg_types);
+    } else {
+        _fn_ctx = FunctionContext::create_context(state, return_type, arg_types);
+    }
 }
 
 FunctionUtils::~FunctionUtils() {

--- a/be/test/testutil/function_utils.h
+++ b/be/test/testutil/function_utils.h
@@ -29,7 +29,8 @@ class FunctionUtils {
 public:
     FunctionUtils();
     FunctionUtils(const doris::TypeDescriptor& return_type,
-                  const std::vector<doris::TypeDescriptor>& arg_types, int varargs_buffer_size);
+                  const std::vector<doris::TypeDescriptor>& arg_types, int varargs_buffer_size,
+                  RuntimeState*);
     ~FunctionUtils();
 
     doris::FunctionContext* get_fn_ctx() { return _fn_ctx.get(); }

--- a/be/test/vec/function/function_test_util.h
+++ b/be/test/vec/function/function_test_util.h
@@ -29,6 +29,7 @@
 #include "gtest/gtest_pred_impl.h"
 #include "olap/olap_common.h"
 #include "runtime/define_primitive_type.h"
+#include "runtime/exec_env.h"
 #include "runtime/types.h"
 #include "testutil/any_type.h"
 #include "testutil/function_utils.h"
@@ -199,9 +200,11 @@ void check_vec_table_function(TableFunction* fn, const InputTypeSet& input_types
 // Null values are represented by Null()
 // The type of the constant column is represented as follows: Consted {TypeIndex::String}
 // A DataSet with a constant column can only have one row of data
+// If state != nullptr, should set query options you use for your own.
 template <typename ReturnType, bool nullable = false>
 Status check_function(const std::string& func_name, const InputTypeSet& input_types,
-                      const DataSet& data_set, bool expect_fail = false) {
+                      const DataSet& data_set, bool expect_fail = false,
+                      RuntimeState* state = nullptr) {
     // 1.0 create data type
     ut_type::UTDataTypeDescs descs;
     EXPECT_TRUE(parse_ut_data_type(input_types, descs));
@@ -270,7 +273,7 @@ Status check_function(const std::string& func_name, const InputTypeSet& input_ty
         fn_ctx_return.type = doris::PrimitiveType::INVALID_TYPE;
     }
 
-    FunctionUtils fn_utils(fn_ctx_return, arg_types, 0);
+    FunctionUtils fn_utils(fn_ctx_return, arg_types, 0, state);
     auto* fn_ctx = fn_utils.get_fn_ctx();
     fn_ctx->set_constant_cols(constant_cols);
     func->open(fn_ctx, FunctionContext::FRAGMENT_LOCAL);

--- a/be/test/vec/function/function_time_test.cpp
+++ b/be/test/vec/function/function_time_test.cpp
@@ -23,12 +23,12 @@
 
 #include "common/status.h"
 #include "function_test_util.h"
-#include "gtest/gtest_pred_impl.h"
+#include "runtime/runtime_state.h"
 #include "testutil/any_type.h"
+#include "util/timezone_utils.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type_date.h"
 #include "vec/data_types/data_type_date_time.h"
-#include "vec/data_types/data_type_nullable.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_string.h"
 #include "vec/data_types/data_type_time.h"
@@ -199,6 +199,62 @@ TEST(VTimestampFunctionsTest, timediff_test) {
             {{std::string("2019-07-18 12:00:00"), std::string("2019-07-00 13:01:02")}, Null()}};
 
     check_function<DataTypeTimeV2, true>(func_name, input_types, data_set);
+}
+
+TEST(VTimestampFunctionsTest, convert_tz_test) {
+    std::string func_name = "convert_tz";
+
+    ExecEnv* exec_env = ExecEnv::GetInstance();
+    exec_env->_global_zone_cache = std::make_unique<vectorized::ZoneList>();
+    auto test_state = RuntimeState::create_unique();
+    test_state->set_exec_env(exec_env);
+    TimezoneUtils::clear_timezone_names();
+
+    InputTypeSet input_types = {TypeIndex::DateTimeV2, TypeIndex::String, TypeIndex::String};
+
+    {
+        DataSet data_set = {{{std::string {"2019-08-01 02:18:27"}, std::string {"Asia/SHANGHAI"},
+                              std::string {"america/Los_angeles"}},
+                             Null()}};
+        check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set, false,
+                                                 test_state.get());
+    }
+
+    {
+        DataSet data_set = {{{std::string {"2019-08-01 02:18:27"}, std::string {"Asia/Shanghai"},
+                              std::string {"UTC"}},
+                             str_to_datetime_v2("2019-07-31 18:18:27", "%Y-%m-%d %H:%i:%s.%f")},
+                            {{std::string {"2019-08-01 02:18:27"}, std::string {"Asia/Shanghai"},
+                              std::string {"Utc"}},
+                             Null()},
+                            {{std::string {"2019-08-01 02:18:27"}, std::string {"Asia/Shanghai"},
+                              std::string {"UTC"}},
+                             str_to_datetime_v2("2019-07-31 18:18:27", "%Y-%m-%d %H:%i:%s.%f")},
+                            {{std::string {"2019-08-01 02:18:27"}, std::string {"Asia/SHANGHAI"},
+                              std::string {"america/Los_angeles"}},
+                             Null()}};
+        check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set, false,
+                                                 test_state.get());
+    }
+
+    {
+        DataSet data_set = {{{std::string {"2019-08-01 02:18:27"}, std::string {"Asia/Shanghai"},
+                              std::string {"UTC"}},
+                             str_to_datetime_v2("2019-07-31 18:18:27", "%Y-%m-%d %H:%i:%s.%f")},
+                            {{std::string {"2019-08-01 02:18:27"}, std::string {"Asia/Shanghai"},
+                              std::string {"Utc"}},
+                             str_to_datetime_v2("2019-07-31 18:18:27", "%Y-%m-%d %H:%i:%s.%f")},
+                            {{std::string {"2019-08-01 02:18:27"}, std::string {"Asia/Shanghai"},
+                              std::string {"UTC"}},
+                             str_to_datetime_v2("2019-07-31 18:18:27", "%Y-%m-%d %H:%i:%s.%f")},
+                            {{std::string {"2019-08-01 02:18:27"}, std::string {"Asia/SHANGHAI"},
+                              std::string {"america/Los_angeles"}},
+                             str_to_datetime_v2("2019-07-31 11:18:27", "%Y-%m-%d %H:%i:%s.%f")}};
+        TimezoneUtils::load_timezone_names();
+        TimezoneUtils::load_timezones_to_cache(*exec_env->_global_zone_cache);
+        check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set, false,
+                                                 test_state.get());
+    }
 }
 
 TEST(VTimestampFunctionsTest, date_format_test) {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

When there's no tzfile:
before:
```SQL
mysql [test]>select convert_tz('2020-12-12 12:00:00', 'Asia/Shanghai', 'America/Los_angeles');
+--------------------------------------------------------------------------------------------------+
| convert_tz(cast('2020-12-12 12:00:00' as DATETIMEV2(0)), 'Asia/Shanghai', 'America/Los_angeles') |
+--------------------------------------------------------------------------------------------------+
| NULL                                                                                             |
+--------------------------------------------------------------------------------------------------+
1 row in set (0.03 sec)
```
after：
```SQL
mysql [test]>select convert_tz('2020-12-12 12:00:00', 'Asia/Shanghai', 'America/Los_angeles');
+--------------------------------------------------------------------------------------------------+
| convert_tz(cast('2020-12-12 12:00:00' as DATETIMEV2(0)), 'Asia/Shanghai', 'America/Los_angeles') |
+--------------------------------------------------------------------------------------------------+
| 2020-12-11 20:00:00                                                                              |
+--------------------------------------------------------------------------------------------------+
1 row in set (0.03 sec)
```

It tested in docker.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

