### PR TITLE
[improvement](tablet schedule) disk balance skip cooldown storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # ignore file with wildcard anywhere
+*.swo
 *.swp
 *.pyc
 *.class

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DiskRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DiskRebalancer.java
@@ -17,6 +17,10 @@
 
 package org.apache.doris.clone;
 
+import org.apache.doris.catalog.DataProperty;
+import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.catalog.TabletMeta;
@@ -27,6 +31,7 @@ import org.apache.doris.clone.TabletScheduler.PathSlot;
 import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TStorageMedium;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -147,6 +152,7 @@ public class DiskRebalancer extends Rebalancer {
             return alternativeTablets;
         }
 
+        Set<Long> alternativeTabletIds = Sets.newHashSet();
         Set<Long> unbalancedBEs = Sets.newHashSet();
         // choose tablets from backends randomly.
         Collections.shuffle(midBEs);
@@ -182,11 +188,14 @@ public class DiskRebalancer extends Rebalancer {
             }
 
             if (remainingPaths.isEmpty()) {
-                return alternativeTablets;
+                continue;
             }
 
             // select tablet from shuffled tablets
             for (Long tabletId : tabletIds) {
+                if (alternativeTabletIds.contains(tabletId)) {
+                    continue;
+                }
                 Replica replica = invertedIndex.getReplica(tabletId, beStat.getBeId());
                 if (replica == null) {
                     continue;
@@ -224,6 +233,7 @@ public class DiskRebalancer extends Rebalancer {
                     tabletCtx.setBalanceType(BalanceType.DISK_BALANCE);
 
                     alternativeTablets.add(tabletCtx);
+                    alternativeTabletIds.add(tabletId);
                     unbalancedBEs.add(beStat.getBeId());
                     // update remaining paths
                     int remaining = remainingPaths.get(replicaPathHash) - 1;
@@ -272,6 +282,19 @@ public class DiskRebalancer extends Rebalancer {
         if (replica.getDataSize() == 0) {
             throw new SchedException(Status.UNRECOVERABLE, "size of src replica is zero");
         }
+        Database db = Env.getCurrentInternalCatalog().getDbOrException(tabletCtx.getDbId(),
+                s -> new SchedException(Status.UNRECOVERABLE, "db " + tabletCtx.getDbId() + " does not exist"));
+        OlapTable tbl = (OlapTable) db.getTableOrException(tabletCtx.getTblId(),
+                s -> new SchedException(Status.UNRECOVERABLE, "tbl " + tabletCtx.getTblId() + " does not exist"));
+        DataProperty dataProperty = tbl.getPartitionInfo().getDataProperty(tabletCtx.getPartitionId());
+        if (dataProperty == null) {
+            throw new SchedException(Status.UNRECOVERABLE, "data property is null");
+        }
+        String storagePolicy = dataProperty.getStoragePolicy();
+        if (!Strings.isNullOrEmpty(storagePolicy)) {
+            throw new SchedException(Status.UNRECOVERABLE, "disk balance not support for cooldown storage");
+        }
+
         // check src slot
         PathSlot slot = backendsWorkingSlots.get(replica.getBackendId());
         if (slot == null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -248,7 +248,7 @@ public class TabletScheduler extends MasterDaemon {
             return AddResult.ALREADY_IN;
         }
 
-        // if this is not a BALANCE task, and not a force add,
+        // if this is not a force add,
         // and number of scheduling tablets exceed the limit,
         // refuse to add.
         if (!force && (pendingTablets.size() > Config.max_scheduling_tablets

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -251,8 +251,7 @@ public class TabletScheduler extends MasterDaemon {
         // if this is not a BALANCE task, and not a force add,
         // and number of scheduling tablets exceed the limit,
         // refuse to add.
-        if (tablet.getType() != TabletSchedCtx.Type.BALANCE && !force
-                && (pendingTablets.size() > Config.max_scheduling_tablets
+        if (!force && (pendingTablets.size() > Config.max_scheduling_tablets
                 || runningTablets.size() > Config.max_scheduling_tablets)) {
             return AddResult.LIMIT_EXCEED;
         }


### PR DESCRIPTION
## Proposed changes

BE not support storage medium migration for cooldown tablets.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

