### PR TITLE
[fix](planner)implicit cast should use type member variable instead of targetTypeDef

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CastExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CastExpr.java
@@ -210,7 +210,8 @@ public class CastExpr extends Expr {
         if (isAnalyzed) {
             return "CAST(" + getChild(0).toSql() + " AS " + type.toString() + ")";
         } else {
-            return "CAST(" + getChild(0).toSql() + " AS " + targetTypeDef.toSql() + ")";
+            return "CAST(" + getChild(0).toSql() + " AS "
+                    + (isImplicit ? type.toString() : targetTypeDef.toSql()) + ")";
         }
     }
 

--- a/regression-test/suites/correctness_p0/test_implict_cast.groovy
+++ b/regression-test/suites/correctness_p0/test_implict_cast.groovy
@@ -56,4 +56,51 @@ suite("test_implict_cast") {
     sql """
         drop table if exists cast_test_table;
     """
+
+    sql """drop table if exists test_orders_t"""
+    sql """drop table if exists test_servers_t"""
+
+    sql """CREATE TABLE `test_orders_t` (
+            `a1` date NOT NULL,
+            `a2` varchar(50) NOT NULL,
+            `a3` int(11) NULL,
+            `a4` int(11) NULL,
+            `a5` varchar(128) NULL,
+            `a6` int(11) NULL,
+            `a7` varchar(50) NULL,
+            `a8` DECIMAL(8, 2) NULL,
+            `a9` int(11) NULL
+            ) ENGINE=OLAP
+            UNIQUE KEY(`a1`, `a2`, `a3`)
+            DISTRIBUTED BY HASH(`a2`) BUCKETS 2
+            PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1"
+            );"""
+
+    sql """CREATE TABLE `test_servers_t` (
+            `b1` bigint(20) NULL,
+            `b2` text NULL,
+            `b3` text NULL
+            ) ENGINE=OLAP
+            UNIQUE KEY(`b1`)
+            COMMENT 'OLAP'
+            DISTRIBUTED BY HASH(`b1`) BUCKETS 10
+            PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1"
+            ); """
+
+    sql """set enable_nereids_planner=false;"""
+    sql """SELECT  a5 AS account_id
+                ,a4 AS a4
+                ,CASE WHEN a7 = 'MC' THEN a8*0.034
+                        ELSE a8 END AS total_top_up
+                ,from_unixtime(cast(a9 AS BIGINT) - 5*3600) AS pay_date
+            FROM test_orders_t
+            WHERE a6 IN ( 2 , 5)
+            AND a4 IN ( SELECT b1 FROM test_servers_t WHERE b2 = 'yes' AND (b1 = 22101 or b3 = 'UTC-5'))
+            AND a9 >= 1672930800
+            AND a1 = current_date();"""
+
+    sql """drop table if exists test_orders_t"""
+    sql """drop table if exists test_servers_t"""
 }


### PR DESCRIPTION
## Proposed changes

for implicit cast, only type member variable is set and targetTypeDef is null. So we should not access targetTypeDef member if it's an implicit cast

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

