### PR TITLE
[fix](insert) Make insert group commit regression stable

### DIFF
--- a/regression-test/suites/insert_p0/insert_group_commit_into_duplicate.groovy
+++ b/regression-test/suites/insert_p0/insert_group_commit_into_duplicate.groovy
@@ -20,7 +20,7 @@ suite("insert_group_commit_into_duplicate") {
 
     def getRowCount = { expectedRowCount ->
         def retry = 0
-        while (retry < 10) {
+        while (retry < 30) {
             sleep(2000)
             def rowCount = sql "select count(*) from ${table}"
             logger.info("rowCount: " + rowCount + ", retry: " + retry)

--- a/regression-test/suites/insert_p0/insert_group_commit_with_exception.groovy
+++ b/regression-test/suites/insert_p0/insert_group_commit_with_exception.groovy
@@ -25,7 +25,7 @@ suite("insert_group_commit_with_exception") {
 
     def getRowCount = { expectedRowCount ->
         def retry = 0
-        while (retry < 10) {
+        while (retry < 30) {
             sleep(2000)
             def rowCount = sql "select count(*) from ${table}"
             logger.info("rowCount: " + rowCount + ", retry: " + retry)

--- a/regression-test/suites/insert_p0/insert_group_commit_with_large_data.groovy
+++ b/regression-test/suites/insert_p0/insert_group_commit_with_large_data.groovy
@@ -20,7 +20,7 @@ suite("insert_group_commit_with_large_data") {
 
     def getRowCount = { expectedRowCount ->
         def retry = 0
-        while (retry < 10) {
+        while (retry < 30) {
             sleep(2000)
             def rowCount = sql "select count(*) from ${table}"
             logger.info("rowCount: " + rowCount + ", retry: " + retry)

--- a/regression-test/suites/insert_p0/insert_group_commit_with_prepare_stmt.groovy
+++ b/regression-test/suites/insert_p0/insert_group_commit_with_prepare_stmt.groovy
@@ -25,7 +25,7 @@ suite("insert_group_commit_with_prepare_stmt") {
 
     def getRowCount = { expectedRowCount ->
         def retry = 0
-        while (retry < 10) {
+        while (retry < 30) {
             sleep(4000)
             def rowCount = sql "select count(*) from ${table}"
             logger.info("rowCount: " + rowCount + ", retry: " + retry)


### PR DESCRIPTION
## Proposed changes

`insert_group_commit_into_duplicate` is unstable,  because flush memtable cost 15s sometimes.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

