### PR TITLE
[fix](stack trace) Default StackTrace contains inline and optimize output 

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1052,7 +1052,7 @@ DEFINE_Bool(allow_invalid_decimalv2_literal, "false");
 DEFINE_mInt64(kerberos_expiration_time_seconds, "43200");
 
 DEFINE_mString(get_stack_trace_tool, "libunwind");
-DEFINE_mString(dwarf_location_info_mode, "FAST");
+DEFINE_mString(dwarf_location_info_mode, "FULL_WITH_INLINE");
 
 // the ratio of _prefetch_size/_batch_size in AutoIncIDBuffer
 DEFINE_mInt64(auto_inc_prefetch_size_ratio, "10");

--- a/be/src/common/stack_trace.h
+++ b/be/src/common/stack_trace.h
@@ -73,7 +73,7 @@ public:
     [[nodiscard]] constexpr size_t getSize() const { return size; }
     [[nodiscard]] constexpr size_t getOffset() const { return offset; }
     [[nodiscard]] const FramePointers& getFramePointers() const { return frame_pointers; }
-    [[nodiscard]] std::string toString() const;
+    [[nodiscard]] std::string toString(int start_pointers_index = 0) const;
 
     static std::string toString(void** frame_pointers, size_t offset, size_t size);
     static void createCache();

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -376,7 +376,8 @@ public:
         }
 #ifdef ENABLE_STACKTRACE
         if constexpr (stacktrace && capture_stacktrace(code)) {
-            status._err_msg->_stack = get_stack_trace();
+            // Delete the first four frame pointers, which are inside the StackTrace and Status.
+            status._err_msg->_stack = get_stack_trace(4);
             LOG(WARNING) << "meet error status: " << status; // may print too many stacks.
         }
 #endif
@@ -395,7 +396,7 @@ public:
         }
 #ifdef ENABLE_STACKTRACE
         if (stacktrace && capture_stacktrace(code)) {
-            status._err_msg->_stack = get_stack_trace();
+            status._err_msg->_stack = get_stack_trace(4);
             LOG(WARNING) << "meet error status: " << status; // may print too many stacks.
         }
 #endif

--- a/be/src/util/stack_util.cpp
+++ b/be/src/util/stack_util.cpp
@@ -35,7 +35,7 @@ void DumpStackTraceToString(std::string* stacktrace);
 
 namespace doris {
 
-std::string get_stack_trace() {
+std::string get_stack_trace(int start_pointers_index) {
 #ifdef ENABLE_STACKTRACE
     auto tool = config::get_stack_trace_tool;
     if (tool == "glog") {
@@ -48,7 +48,7 @@ std::string get_stack_trace() {
 #if defined(__APPLE__) // TODO
         return get_stack_trace_by_glog();
 #endif
-        return get_stack_trace_by_libunwind();
+        return get_stack_trace_by_libunwind(start_pointers_index);
     } else {
         return "no stack";
     }
@@ -80,8 +80,8 @@ std::string get_stack_trace_by_glibc() {
     return out.str();
 }
 
-std::string get_stack_trace_by_libunwind() {
-    return "\n" + StackTrace().toString();
+std::string get_stack_trace_by_libunwind(int start_pointers_index) {
+    return "\n" + StackTrace().toString(start_pointers_index);
 }
 
 } // namespace doris

--- a/be/src/util/stack_util.h
+++ b/be/src/util/stack_util.h
@@ -29,7 +29,8 @@ namespace doris {
 // boost: 1000 times cost 1min, has line numbers, but has memory leak.
 // glibc: 1000 times cost 1min, no line numbers, unresolved backtrace symbol.
 // libunwind: cost is negligible, has line numbers.
-std::string get_stack_trace();
+// Delete the first three frame pointers, which are inside the StackTrace.
+std::string get_stack_trace(int start_pointers_index = 3);
 
 // Note: there is a libc bug that causes this not to work on 64 bit machines
 // for recursive calls.
@@ -53,6 +54,6 @@ std::string get_stack_trace_by_glibc();
 //  2. Support signal handle
 //  3. libunwid support unw_backtrace for jemalloc
 //  4. Use of undefined compile option USE_MUSL for later
-std::string get_stack_trace_by_libunwind();
+std::string get_stack_trace_by_libunwind(int start_pointers_index);
 
 } // namespace doris


### PR DESCRIPTION
## Proposed changes

1. Modify the default value of `dwarf_location_info_mode` to `FULL_WITH_INLINE`, which will Scan .debug_info for inline functions, but this will be slower than `FAST` to scan .debug_aranges, so production environments may use `FAST`.
2. Status prints the stack trace, the first four frame pointers are removed, it doesn't make sense.
3. Optimize stack trace output.

**NOTE**
`dwarf_location_info_mode` using `FULL_WITH_INLINE` is too slow and the pipeline will fail.

TODO: 
1. StackTraceCache adds prune stale
2. Add a second layer of cache, <fast stack trace,  full stack trace>


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

