### PR TITLE
[fix](Nereids) fix row count unconsistent when join ordering

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/DeriveStatsJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/DeriveStatsJob.java
@@ -28,6 +28,7 @@ import org.apache.doris.nereids.metrics.consumer.LogConsumer;
 import org.apache.doris.nereids.metrics.event.StatsStateEvent;
 import org.apache.doris.nereids.stats.StatsCalculator;
 import org.apache.doris.nereids.trees.expressions.CTEId;
+import org.apache.doris.nereids.trees.plans.algebra.Project;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.statistics.Statistics;
 
@@ -115,6 +116,17 @@ public class DeriveStatsJob extends Job {
                     .putAll(statsCalculator.getTotalColumnStatisticMap());
                 context.getCascadesContext().getConnectContext().getTotalHistogramMap()
                     .putAll(statsCalculator.getTotalHistogramMap());
+            }
+
+            if (groupExpression.getPlan() instanceof Project) {
+                // In the context of reorder join, when a new plan is generated, it may include a project operation.
+                // In this case, the newly generated join root and the original join root will no longer be in the
+                // same group. To avoid inconsistencies in the statistics between these two groups, we keep the
+                // child group's row count unchanged when the parent group expression is a project operation.
+                double parentRowCount = groupExpression.getOwnerGroup().getStatistics().getRowCount();
+                groupExpression.children().forEach(g -> g.setStatistics(
+                        g.getStatistics().updateRowCountOnly(parentRowCount))
+                );
             }
         }
     }

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query18.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query18.out
@@ -10,15 +10,15 @@ PhysicalResultSink
 --------------hashAgg[LOCAL]
 ----------------PhysicalRepeat
 ------------------PhysicalProject
---------------------hashJoin[INNER_JOIN](customer.c_current_cdemo_sk = cd2.cd_demo_sk)
+--------------------hashJoin[INNER_JOIN](catalog_sales.cs_item_sk = item.i_item_sk)
+----------------------PhysicalProject
+------------------------PhysicalOlapScan[item]
 ----------------------PhysicalDistribute
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[customer_demographics]
-----------------------PhysicalDistribute
-------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN](catalog_sales.cs_item_sk = item.i_item_sk)
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[item]
+--------------------------hashJoin[INNER_JOIN](customer.c_current_cdemo_sk = cd2.cd_demo_sk)
+----------------------------PhysicalDistribute
+------------------------------PhysicalProject
+--------------------------------PhysicalOlapScan[customer_demographics]
 ----------------------------PhysicalDistribute
 ------------------------------PhysicalProject
 --------------------------------hashJoin[INNER_JOIN](customer.c_current_addr_sk = customer_address.ca_address_sk)

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query59.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query59.out
@@ -17,33 +17,36 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------PhysicalDistribute
 --------PhysicalTopN
 ----------PhysicalProject
-------------hashJoin[INNER_JOIN](y.s_store_id1 = x.s_store_id2)(wss.ss_store_sk = store.s_store_sk)
---------------hashJoin[INNER_JOIN](expr_cast(d_week_seq1 as BIGINT) = expr_(d_week_seq2 - 52))
-----------------PhysicalDistribute
-------------------PhysicalProject
---------------------hashJoin[INNER_JOIN](wss.ss_store_sk = store.s_store_sk)
-----------------------PhysicalDistribute
-------------------------hashJoin[INNER_JOIN](d.d_week_seq = d_week_seq1)
+------------hashJoin[INNER_JOIN](y.s_store_id1 = x.s_store_id2)(expr_cast(d_week_seq1 as BIGINT) = expr_(d_week_seq2 - 52))
+--------------PhysicalDistribute
+----------------PhysicalProject
+------------------hashJoin[INNER_JOIN](wss.ss_store_sk = store.s_store_sk)
+--------------------PhysicalDistribute
+----------------------hashJoin[INNER_JOIN](d.d_week_seq = d_week_seq1)
+------------------------PhysicalDistribute
+--------------------------PhysicalProject
+----------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+------------------------PhysicalDistribute
+--------------------------PhysicalProject
+----------------------------filter((d.d_month_seq <= 1207)(d.d_month_seq >= 1196))
+------------------------------PhysicalOlapScan[date_dim]
+--------------------PhysicalDistribute
+----------------------PhysicalProject
+------------------------PhysicalOlapScan[store]
+--------------PhysicalDistribute
+----------------PhysicalProject
+------------------hashJoin[INNER_JOIN](wss.ss_store_sk = store.s_store_sk)
+--------------------PhysicalDistribute
+----------------------PhysicalProject
+------------------------hashJoin[INNER_JOIN](d.d_week_seq = d_week_seq2)
 --------------------------PhysicalDistribute
 ----------------------------PhysicalProject
 ------------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 --------------------------PhysicalDistribute
 ----------------------------PhysicalProject
-------------------------------filter((d.d_month_seq <= 1207)(d.d_month_seq >= 1196))
+------------------------------filter((d.d_month_seq <= 1219)(d.d_month_seq >= 1208))
 --------------------------------PhysicalOlapScan[date_dim]
-----------------------PhysicalDistribute
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[store]
-----------------PhysicalDistribute
-------------------hashJoin[INNER_JOIN](d.d_week_seq = d_week_seq2)
 --------------------PhysicalDistribute
 ----------------------PhysicalProject
-------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
---------------------PhysicalDistribute
-----------------------PhysicalProject
-------------------------filter((d.d_month_seq <= 1219)(d.d_month_seq >= 1208))
---------------------------PhysicalOlapScan[date_dim]
---------------PhysicalDistribute
-----------------PhysicalProject
-------------------PhysicalOlapScan[store]
+------------------------PhysicalOlapScan[store]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query61.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query61.out
@@ -27,9 +27,9 @@ PhysicalResultSink
 ------------------------------------PhysicalOlapScan[customer]
 --------------------------------PhysicalDistribute
 ----------------------------------PhysicalProject
-------------------------------------hashJoin[INNER_JOIN](store_sales.ss_promo_sk = promotion.p_promo_sk)
---------------------------------------PhysicalDistribute
-----------------------------------------hashJoin[INNER_JOIN](store_sales.ss_sold_date_sk = date_dim.d_date_sk)
+------------------------------------hashJoin[INNER_JOIN](store_sales.ss_sold_date_sk = date_dim.d_date_sk)
+--------------------------------------PhysicalProject
+----------------------------------------hashJoin[INNER_JOIN](store_sales.ss_promo_sk = promotion.p_promo_sk)
 ------------------------------------------PhysicalProject
 --------------------------------------------hashJoin[INNER_JOIN](store_sales.ss_store_sk = store.s_store_sk)
 ----------------------------------------------PhysicalProject
@@ -40,12 +40,12 @@ PhysicalResultSink
 ----------------------------------------------------PhysicalOlapScan[store]
 ------------------------------------------PhysicalDistribute
 --------------------------------------------PhysicalProject
-----------------------------------------------filter((date_dim.d_moy = 11)(date_dim.d_year = 1999))
-------------------------------------------------PhysicalOlapScan[date_dim]
+----------------------------------------------filter((((cast(p_channel_dmail as VARCHAR(*)) = 'Y') OR (cast(p_channel_email as VARCHAR(*)) = 'Y')) OR (cast(p_channel_tv as VARCHAR(*)) = 'Y')))
+------------------------------------------------PhysicalOlapScan[promotion]
 --------------------------------------PhysicalDistribute
 ----------------------------------------PhysicalProject
-------------------------------------------filter((((cast(p_channel_dmail as VARCHAR(*)) = 'Y') OR (cast(p_channel_email as VARCHAR(*)) = 'Y')) OR (cast(p_channel_tv as VARCHAR(*)) = 'Y')))
---------------------------------------------PhysicalOlapScan[promotion]
+------------------------------------------filter((date_dim.d_moy = 11)(date_dim.d_year = 1999))
+--------------------------------------------PhysicalOlapScan[date_dim]
 ----------PhysicalDistribute
 ------------hashAgg[GLOBAL]
 --------------PhysicalDistribute

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query71.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query71.out
@@ -10,40 +10,41 @@ PhysicalResultSink
 --------------PhysicalProject
 ----------------hashJoin[INNER_JOIN](tmp.time_sk = time_dim.t_time_sk)
 ------------------PhysicalDistribute
---------------------hashJoin[INNER_JOIN](tmp.sold_item_sk = item.i_item_sk)
-----------------------PhysicalDistribute
-------------------------PhysicalUnion
---------------------------PhysicalDistribute
-----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN](date_dim.d_date_sk = web_sales.ws_sold_date_sk)
---------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[web_sales]
---------------------------------PhysicalDistribute
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN](tmp.sold_item_sk = item.i_item_sk)
+------------------------PhysicalDistribute
+--------------------------PhysicalUnion
+----------------------------PhysicalDistribute
+------------------------------PhysicalProject
+--------------------------------hashJoin[INNER_JOIN](date_dim.d_date_sk = web_sales.ws_sold_date_sk)
 ----------------------------------PhysicalProject
-------------------------------------filter((date_dim.d_moy = 12)(date_dim.d_year = 1998))
---------------------------------------PhysicalOlapScan[date_dim]
---------------------------PhysicalDistribute
-----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN](date_dim.d_date_sk = catalog_sales.cs_sold_date_sk)
---------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[catalog_sales]
---------------------------------PhysicalDistribute
+------------------------------------PhysicalOlapScan[web_sales]
+----------------------------------PhysicalDistribute
+------------------------------------PhysicalProject
+--------------------------------------filter((date_dim.d_moy = 12)(date_dim.d_year = 1998))
+----------------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalDistribute
+------------------------------PhysicalProject
+--------------------------------hashJoin[INNER_JOIN](date_dim.d_date_sk = catalog_sales.cs_sold_date_sk)
 ----------------------------------PhysicalProject
-------------------------------------filter((date_dim.d_moy = 12)(date_dim.d_year = 1998))
---------------------------------------PhysicalOlapScan[date_dim]
---------------------------PhysicalDistribute
-----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN](date_dim.d_date_sk = store_sales.ss_sold_date_sk)
---------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[store_sales]
---------------------------------PhysicalDistribute
+------------------------------------PhysicalOlapScan[catalog_sales]
+----------------------------------PhysicalDistribute
+------------------------------------PhysicalProject
+--------------------------------------filter((date_dim.d_moy = 12)(date_dim.d_year = 1998))
+----------------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalDistribute
+------------------------------PhysicalProject
+--------------------------------hashJoin[INNER_JOIN](date_dim.d_date_sk = store_sales.ss_sold_date_sk)
 ----------------------------------PhysicalProject
-------------------------------------filter((date_dim.d_moy = 12)(date_dim.d_year = 1998))
---------------------------------------PhysicalOlapScan[date_dim]
-----------------------PhysicalDistribute
-------------------------PhysicalProject
---------------------------filter((item.i_manager_id = 1))
-----------------------------PhysicalOlapScan[item]
+------------------------------------PhysicalOlapScan[store_sales]
+----------------------------------PhysicalDistribute
+------------------------------------PhysicalProject
+--------------------------------------filter((date_dim.d_moy = 12)(date_dim.d_year = 1998))
+----------------------------------------PhysicalOlapScan[date_dim]
+------------------------PhysicalDistribute
+--------------------------PhysicalProject
+----------------------------filter((item.i_manager_id = 1))
+------------------------------PhysicalOlapScan[item]
 ------------------PhysicalDistribute
 --------------------PhysicalProject
 ----------------------filter(((cast(t_meal_time as VARCHAR(*)) = 'breakfast') OR (cast(t_meal_time as VARCHAR(*)) = 'dinner')))

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query72.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query72.out
@@ -13,49 +13,51 @@ PhysicalResultSink
 --------------------PhysicalProject
 ----------------------hashJoin[INNER_JOIN](warehouse.w_warehouse_sk = inventory.inv_warehouse_sk)
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN](inventory.inv_date_sk = d2.d_date_sk)(d1.d_week_seq = d2.d_week_seq)
-----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_item_sk = inventory.inv_item_sk)(inventory.inv_quantity_on_hand < catalog_sales.cs_quantity)
---------------------------------PhysicalOlapScan[inventory]
---------------------------------PhysicalDistribute
-----------------------------------PhysicalProject
-------------------------------------hashJoin[LEFT_OUTER_JOIN](catalog_sales.cs_promo_sk = promotion.p_promo_sk)
---------------------------------------PhysicalProject
-----------------------------------------hashJoin[INNER_JOIN](item.i_item_sk = catalog_sales.cs_item_sk)
-------------------------------------------PhysicalDistribute
---------------------------------------------PhysicalProject
-----------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_ship_date_sk = d3.d_date_sk)(d3.d_date > cast((cast(d_date as BIGINT) + 5) as DATEV2))
-------------------------------------------------PhysicalDistribute
---------------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_bill_cdemo_sk = customer_demographics.cd_demo_sk)
-----------------------------------------------------PhysicalDistribute
-------------------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_sold_date_sk = d1.d_date_sk)
---------------------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_bill_hdemo_sk = household_demographics.hd_demo_sk)
-----------------------------------------------------------PhysicalProject
-------------------------------------------------------------PhysicalOlapScan[catalog_sales]
-----------------------------------------------------------PhysicalDistribute
-------------------------------------------------------------PhysicalProject
---------------------------------------------------------------filter((cast(hd_buy_potential as VARCHAR(*)) = '501-1000'))
-----------------------------------------------------------------PhysicalOlapScan[household_demographics]
---------------------------------------------------------PhysicalDistribute
-----------------------------------------------------------PhysicalProject
-------------------------------------------------------------filter((d1.d_year = 2002))
---------------------------------------------------------------PhysicalOlapScan[date_dim]
-----------------------------------------------------PhysicalDistribute
-------------------------------------------------------PhysicalProject
---------------------------------------------------------filter((cast(cd_marital_status as VARCHAR(*)) = 'W'))
-----------------------------------------------------------PhysicalOlapScan[customer_demographics]
-------------------------------------------------PhysicalDistribute
---------------------------------------------------PhysicalProject
-----------------------------------------------------PhysicalOlapScan[date_dim]
-------------------------------------------PhysicalDistribute
---------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[item]
---------------------------------------PhysicalDistribute
-----------------------------------------PhysicalProject
-------------------------------------------PhysicalOlapScan[promotion]
+--------------------------hashJoin[INNER_JOIN](catalog_sales.cs_item_sk = inventory.inv_item_sk)(inventory.inv_date_sk = d2.d_date_sk)(inventory.inv_quantity_on_hand < catalog_sales.cs_quantity)
+----------------------------PhysicalDistribute
+------------------------------PhysicalOlapScan[inventory]
 ----------------------------PhysicalDistribute
 ------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[date_dim]
+--------------------------------hashJoin[INNER_JOIN](d1.d_week_seq = d2.d_week_seq)
+----------------------------------PhysicalDistribute
+------------------------------------PhysicalProject
+--------------------------------------hashJoin[LEFT_OUTER_JOIN](catalog_sales.cs_promo_sk = promotion.p_promo_sk)
+----------------------------------------PhysicalProject
+------------------------------------------hashJoin[INNER_JOIN](item.i_item_sk = catalog_sales.cs_item_sk)
+--------------------------------------------PhysicalDistribute
+----------------------------------------------PhysicalProject
+------------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_ship_date_sk = d3.d_date_sk)(d3.d_date > cast((cast(d_date as BIGINT) + 5) as DATEV2))
+--------------------------------------------------PhysicalDistribute
+----------------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_bill_cdemo_sk = customer_demographics.cd_demo_sk)
+------------------------------------------------------PhysicalDistribute
+--------------------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_sold_date_sk = d1.d_date_sk)
+----------------------------------------------------------hashJoin[INNER_JOIN](catalog_sales.cs_bill_hdemo_sk = household_demographics.hd_demo_sk)
+------------------------------------------------------------PhysicalProject
+--------------------------------------------------------------PhysicalOlapScan[catalog_sales]
+------------------------------------------------------------PhysicalDistribute
+--------------------------------------------------------------PhysicalProject
+----------------------------------------------------------------filter((cast(hd_buy_potential as VARCHAR(*)) = '501-1000'))
+------------------------------------------------------------------PhysicalOlapScan[household_demographics]
+----------------------------------------------------------PhysicalDistribute
+------------------------------------------------------------PhysicalProject
+--------------------------------------------------------------filter((d1.d_year = 2002))
+----------------------------------------------------------------PhysicalOlapScan[date_dim]
+------------------------------------------------------PhysicalDistribute
+--------------------------------------------------------PhysicalProject
+----------------------------------------------------------filter((cast(cd_marital_status as VARCHAR(*)) = 'W'))
+------------------------------------------------------------PhysicalOlapScan[customer_demographics]
+--------------------------------------------------PhysicalDistribute
+----------------------------------------------------PhysicalProject
+------------------------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------------------PhysicalDistribute
+----------------------------------------------PhysicalProject
+------------------------------------------------PhysicalOlapScan[item]
+----------------------------------------PhysicalDistribute
+------------------------------------------PhysicalProject
+--------------------------------------------PhysicalOlapScan[promotion]
+----------------------------------PhysicalDistribute
+------------------------------------PhysicalProject
+--------------------------------------PhysicalOlapScan[date_dim]
 ------------------------PhysicalDistribute
 --------------------------PhysicalProject
 ----------------------------PhysicalOlapScan[warehouse]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query81.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query81.out
@@ -25,11 +25,11 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 --------PhysicalTopN
 ----------PhysicalProject
 ------------hashJoin[INNER_JOIN](ctr1.ctr_state = ctr2.ctr_state)(cast(ctr_total_return as DOUBLE) > cast((avg(cast(ctr_total_return as DECIMALV3(38, 4))) * 1.2) as DOUBLE))
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN](ctr1.ctr_customer_sk = customer.c_customer_sk)
-------------------PhysicalDistribute
---------------------PhysicalCteConsumer ( cteId=CTEId#0 )
-------------------PhysicalDistribute
+--------------hashJoin[INNER_JOIN](ctr1.ctr_customer_sk = customer.c_customer_sk)
+----------------PhysicalDistribute
+------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+----------------PhysicalDistribute
+------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN](customer_address.ca_address_sk = customer.c_current_addr_sk)
 ----------------------PhysicalProject
 ------------------------PhysicalOlapScan[customer]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query99.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query99.out
@@ -8,10 +8,10 @@ PhysicalResultSink
 ----------PhysicalDistribute
 ------------hashAgg[LOCAL]
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN](catalog_sales.cs_warehouse_sk = warehouse.w_warehouse_sk)
+----------------hashJoin[INNER_JOIN](catalog_sales.cs_call_center_sk = call_center.cc_call_center_sk)
 ------------------PhysicalProject
 --------------------hashJoin[INNER_JOIN](catalog_sales.cs_ship_mode_sk = ship_mode.sm_ship_mode_sk)
-----------------------hashJoin[INNER_JOIN](catalog_sales.cs_call_center_sk = call_center.cc_call_center_sk)
+----------------------hashJoin[INNER_JOIN](catalog_sales.cs_warehouse_sk = warehouse.w_warehouse_sk)
 ------------------------hashJoin[INNER_JOIN](catalog_sales.cs_ship_date_sk = date_dim.d_date_sk)
 --------------------------PhysicalProject
 ----------------------------PhysicalOlapScan[catalog_sales]
@@ -21,11 +21,11 @@ PhysicalResultSink
 --------------------------------PhysicalOlapScan[date_dim]
 ------------------------PhysicalDistribute
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[call_center]
+----------------------------PhysicalOlapScan[warehouse]
 ----------------------PhysicalDistribute
 ------------------------PhysicalProject
 --------------------------PhysicalOlapScan[ship_mode]
 ------------------PhysicalDistribute
 --------------------PhysicalProject
-----------------------PhysicalOlapScan[warehouse]
+----------------------PhysicalOlapScan[call_center]
 

--- a/regression-test/data/nereids_tpch_shape_sf1000_p0/shape/q8.out
+++ b/regression-test/data/nereids_tpch_shape_sf1000_p0/shape/q8.out
@@ -16,33 +16,36 @@ PhysicalResultSink
 --------------------------PhysicalOlapScan[supplier]
 ------------------------PhysicalDistribute
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN](n1.n_regionkey = region.r_regionkey)
-------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN](customer.c_nationkey = n1.n_nationkey)
-----------------------------------PhysicalProject
-------------------------------------hashJoin[INNER_JOIN](orders.o_custkey = customer.c_custkey)
---------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[customer]
---------------------------------------PhysicalDistribute
-----------------------------------------hashJoin[INNER_JOIN](lineitem.l_orderkey = orders.o_orderkey)
-------------------------------------------PhysicalProject
---------------------------------------------filter((orders.o_orderdate <= 1996-12-31)(orders.o_orderdate >= 1995-01-01))
-----------------------------------------------PhysicalOlapScan[orders]
-------------------------------------------PhysicalProject
---------------------------------------------hashJoin[INNER_JOIN](part.p_partkey = lineitem.l_partkey)
-----------------------------------------------PhysicalProject
-------------------------------------------------PhysicalOlapScan[lineitem]
-----------------------------------------------PhysicalDistribute
-------------------------------------------------PhysicalProject
---------------------------------------------------filter((part.p_type = 'ECONOMY ANODIZED STEEL'))
-----------------------------------------------------PhysicalOlapScan[part]
-----------------------------------PhysicalDistribute
-------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[nation]
+----------------------------hashJoin[INNER_JOIN](lineitem.l_orderkey = orders.o_orderkey)
 ------------------------------PhysicalDistribute
 --------------------------------PhysicalProject
-----------------------------------filter((region.r_name = 'AMERICA'))
-------------------------------------PhysicalOlapScan[region]
+----------------------------------hashJoin[INNER_JOIN](orders.o_custkey = customer.c_custkey)
+------------------------------------PhysicalDistribute
+--------------------------------------PhysicalProject
+----------------------------------------filter((orders.o_orderdate <= 1996-12-31)(orders.o_orderdate >= 1995-01-01))
+------------------------------------------PhysicalOlapScan[orders]
+------------------------------------PhysicalDistribute
+--------------------------------------hashJoin[INNER_JOIN](customer.c_nationkey = n1.n_nationkey)
+----------------------------------------PhysicalProject
+------------------------------------------PhysicalOlapScan[customer]
+----------------------------------------PhysicalDistribute
+------------------------------------------hashJoin[INNER_JOIN](n1.n_regionkey = region.r_regionkey)
+--------------------------------------------PhysicalDistribute
+----------------------------------------------PhysicalProject
+------------------------------------------------PhysicalOlapScan[nation]
+--------------------------------------------PhysicalDistribute
+----------------------------------------------PhysicalProject
+------------------------------------------------filter((region.r_name = 'AMERICA'))
+--------------------------------------------------PhysicalOlapScan[region]
+------------------------------PhysicalDistribute
+--------------------------------PhysicalProject
+----------------------------------hashJoin[INNER_JOIN](part.p_partkey = lineitem.l_partkey)
+------------------------------------PhysicalProject
+--------------------------------------PhysicalOlapScan[lineitem]
+------------------------------------PhysicalDistribute
+--------------------------------------PhysicalProject
+----------------------------------------filter((part.p_type = 'ECONOMY ANODIZED STEEL'))
+------------------------------------------PhysicalOlapScan[part]
 --------------------PhysicalDistribute
 ----------------------PhysicalProject
 ------------------------PhysicalOlapScan[nation]

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf18.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf18.groovy
@@ -84,5 +84,5 @@ suite("ds_rf18") {
     // File file = new File(outFile)
     // file.write(getRuntimeFilters(plan))
     
-     assertEquals("RF5[c_current_cdemo_sk->[cd_demo_sk],RF4[cs_item_sk->[i_item_sk],RF3[ca_address_sk->[c_current_addr_sk],RF2[c_customer_sk->[cs_bill_customer_sk],RF1[d_date_sk->[cs_sold_date_sk],RF0[cd_demo_sk->[cs_bill_cdemo_sk]", getRuntimeFilters(plan))
+     assertEquals("RF5[cs_item_sk->[i_item_sk],RF4[c_current_cdemo_sk->[cd_demo_sk],RF3[ca_address_sk->[c_current_addr_sk],RF2[c_customer_sk->[cs_bill_customer_sk],RF1[d_date_sk->[cs_sold_date_sk],RF0[cd_demo_sk->[cs_bill_cdemo_sk]", getRuntimeFilters(plan))
 }

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf59.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf59.groovy
@@ -93,5 +93,5 @@ limit 100;
     // def outFile = "regression-test/suites/nereids_tpcds_shape_sf100_p0/ddl/rf/rf.59"
     // File file = new File(outFile)
     // file.write(getRuntimeFilters(plan))
-     assertEquals("RF0[d_date_sk->[ss_sold_date_sk],RF4[s_store_id2->[s_store_id],RF5[s_store_sk->[ss_store_sk],RF3[s_store_sk->[ss_store_sk],RF2[d_week_seq->[d_week_seq],RF1[d_week_seq->[d_week_seq]", getRuntimeFilters(plan))
+     assertEquals("RF0[d_date_sk->[ss_sold_date_sk],RF4[s_store_sk->[ss_store_sk],RF3[d_week_seq->[d_week_seq],RF2[s_store_sk->[ss_store_sk],RF1[d_week_seq->[d_week_seq]", getRuntimeFilters(plan))
 }

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf61.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf61.groovy
@@ -94,5 +94,5 @@ limit 100;
     // File file = new File(outFile)
     // file.write(getRuntimeFilters(plan))
 
-     assertEquals("RF10[ss_item_sk->[i_item_sk],RF9[c_current_addr_sk->[ca_address_sk],RF8[ss_customer_sk->[c_customer_sk],RF7[p_promo_sk->[ss_promo_sk],RF6[d_date_sk->[ss_sold_date_sk],RF5[s_store_sk->[ss_store_sk],RF4[ss_item_sk->[i_item_sk],RF3[c_current_addr_sk->[ca_address_sk],RF2[ss_customer_sk->[c_customer_sk],RF1[d_date_sk->[ss_sold_date_sk],RF0[s_store_sk->[ss_store_sk]", getRuntimeFilters(plan))
+     assertEquals("RF10[ss_item_sk->[i_item_sk],RF9[c_current_addr_sk->[ca_address_sk],RF8[ss_customer_sk->[c_customer_sk],RF7[d_date_sk->[ss_sold_date_sk],RF6[p_promo_sk->[ss_promo_sk],RF5[s_store_sk->[ss_store_sk],RF4[ss_item_sk->[i_item_sk],RF3[c_current_addr_sk->[ca_address_sk],RF2[ss_customer_sk->[c_customer_sk],RF1[d_date_sk->[ss_sold_date_sk],RF0[s_store_sk->[ss_store_sk]", getRuntimeFilters(plan))
 }

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf72.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf72.groovy
@@ -79,5 +79,5 @@ limit 100;
     // File file = new File(outFile)
     // file.write(getRuntimeFilters(plan))
 
-     assertEquals("RF8[w_warehouse_sk->[inv_warehouse_sk],RF6[d_week_seq->[d_week_seq],RF7[d_date_sk->[inv_date_sk],RF5[cs_item_sk->[inv_item_sk],RF4[i_item_sk->[cs_item_sk],RF3[d_date_sk->[cs_ship_date_sk],RF2[cd_demo_sk->[cs_bill_cdemo_sk],RF1[d_date_sk->[cs_sold_date_sk],RF0[hd_demo_sk->[cs_bill_hdemo_sk]", getRuntimeFilters(plan))
+     assertEquals("RF8[w_warehouse_sk->[inv_warehouse_sk],RF6[d_date_sk->[inv_date_sk],RF7[cs_item_sk->[inv_item_sk],RF5[d_week_seq->[d_week_seq],RF4[i_item_sk->[cs_item_sk],RF3[d_date_sk->[cs_ship_date_sk],RF2[cd_demo_sk->[cs_bill_cdemo_sk],RF1[d_date_sk->[cs_sold_date_sk],RF0[hd_demo_sk->[cs_bill_hdemo_sk]", getRuntimeFilters(plan))
 }

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf99.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf99.groovy
@@ -85,5 +85,5 @@ limit 100;
     // File file = new File(outFile)
     // file.write(getRuntimeFilters(plan))
     
-     assertEquals("RF3[w_warehouse_sk->[cs_warehouse_sk],RF2[sm_ship_mode_sk->[cs_ship_mode_sk],RF1[cc_call_center_sk->[cs_call_center_sk],RF0[d_date_sk->[cs_ship_date_sk]", getRuntimeFilters(plan))
+     assertEquals("RF3[cc_call_center_sk->[cs_call_center_sk],RF2[sm_ship_mode_sk->[cs_ship_mode_sk],RF1[w_warehouse_sk->[cs_warehouse_sk],RF0[d_date_sk->[cs_ship_date_sk]", getRuntimeFilters(plan))
 }

--- a/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf8.groovy
+++ b/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf8.groovy
@@ -105,5 +105,5 @@ order by
     // def outFile = "regression-test/suites/nereids_tpch_shape_sf1000_p0/ddl/rf/rf.8"
     // File file = new File(outFile)
     // file.write(getRuntimeFilters(plan))
-    assertEquals("RF6[n_nationkey->[s_nationkey],RF5[l_suppkey->[s_suppkey],RF4[r_regionkey->[n_regionkey],RF3[n_nationkey->[c_nationkey],RF2[o_custkey->[c_custkey],RF1[l_orderkey->[o_orderkey],RF0[p_partkey->[l_partkey]", getRuntimeFilters(plan))
+    assertEquals("RF6[n_nationkey->[s_nationkey],RF5[l_suppkey->[s_suppkey],RF4[l_orderkey->[o_orderkey],RF3[c_custkey->[o_custkey],RF2[n_nationkey->[c_nationkey],RF1[r_regionkey->[n_regionkey],RF0[p_partkey->[l_partkey]", getRuntimeFilters(plan))
 }


### PR DESCRIPTION
## Proposed changes

In the context of reorder join, when a new plan is generated, it may include a project operation. In this case, the newly generated join root and the original join root will no longer be in the same group. To avoid inconsistencies in the statistics between these two groups, we keep the child group's row count unchanged when the parent group expression is a project operation.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

