### PR TITLE
[feat](stats) calculate stats health based on real updated rows count

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -1127,19 +1127,17 @@ public class OlapTable extends Table {
 
     @Override
     public boolean needReAnalyzeTable(TableStats tblStats) {
-        long rowCount = getRowCount();
-        // TODO: Do we need to analyze an empty table?
-        if (rowCount == 0) {
-            return false;
+        if (tblStats == null) {
+            return true;
         }
+        long rowCount = getRowCount();
         if (!tblStats.analyzeColumns().containsAll(getBaseSchema()
                 .stream()
                 .map(Column::getName)
                 .collect(Collectors.toSet()))) {
             return true;
         }
-        // long updateRows = tblStats.updatedRows.get();
-        long updateRows = Math.abs(tblStats.rowCount - rowCount);
+        long updateRows = tblStats.updatedRows.get();
         int tblHealth = StatisticsUtil.getTableHealth(rowCount, updateRows);
         return tblHealth < Config.table_stats_health_threshold;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
@@ -987,6 +987,7 @@ public class AnalysisManager extends Daemon implements Writable {
         TableStats statsStatus = idToTblStats.get(tblId);
         if (statsStatus != null) {
             statsStatus.updatedRows.addAndGet(rows);
+            logCreateTableStats(statsStatus);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsAutoCollector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsAutoCollector.java
@@ -157,7 +157,7 @@ public class StatisticsAutoCollector extends StatisticsCollector {
         AnalysisManager analysisManager = Env.getServingEnv().getAnalysisManager();
         TableStats tblStats = analysisManager.findTableStatsStatus(table.getId());
 
-        if (!(tblStats == null || table.needReAnalyzeTable(tblStats))) {
+        if (!table.needReAnalyzeTable(tblStats)) {
             return null;
         }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisManagerTest.java
@@ -340,8 +340,10 @@ public class AnalysisManagerTest {
         };
         OlapTable olapTable = new OlapTable();
         TableStats stats1 = new TableStats(0, 50, new AnalysisInfoBuilder().setColName("col1").build());
+        stats1.updatedRows.addAndGet(30);
         Assertions.assertTrue(olapTable.needReAnalyzeTable(stats1));
         TableStats stats2 = new TableStats(0, 190, new AnalysisInfoBuilder().setColName("col1").build());
+        stats2.updatedRows.addAndGet(20);
         Assertions.assertFalse(olapTable.needReAnalyzeTable(stats2));
 
     }


### PR DESCRIPTION
## Proposed changes

Use actual load rows since last analyze rather than delta of total row count.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

