### PR TITLE
[improvement](disk balancer) reduce disk balance sensitivity

### DIFF
--- a/be/src/olap/task/engine_storage_migration_task.cpp
+++ b/be/src/olap/task/engine_storage_migration_task.cpp
@@ -105,7 +105,8 @@ Status EngineStorageMigrationTask::_check_running_txns() {
     StorageEngine::instance()->txn_manager()->get_tablet_related_txns(
             _tablet->tablet_id(), _tablet->tablet_uid(), &partition_id, &transaction_ids);
     if (transaction_ids.size() > 0) {
-        return Status::InternalError("tablet {} has unfinished txns", _tablet->tablet_id());
+        return Status::Error<ErrorCode::INTERNAL_ERROR, false>("tablet {} has unfinished txns",
+                                                               _tablet->tablet_id());
     }
     return Status::OK();
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/BackendLoadStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/BackendLoadStatistic.java
@@ -291,8 +291,9 @@ public class BackendLoadStatistic {
                 continue;
             }
 
+            // ensure: HIGH - LOW >= 2.5% * 2 = 5%
             if (Math.abs(pathStat.getUsedPercent() - avgUsedPercent)
-                    / avgUsedPercent > Config.balance_load_score_threshold) {
+                    > Math.max(avgUsedPercent * Config.balance_load_score_threshold, 0.025)) {
                 if (pathStat.getUsedPercent() > avgUsedPercent) {
                     pathStat.setClazz(Classification.HIGH);
                     highCounter++;


### PR DESCRIPTION
impr:  
1. When disk usage < 1%,  it's very easy to trigger disk balance even disks usage diff is little. Fix this;
2. BE disk balance error do not print error code stack.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

