### PR TITLE
[Bug](ScanNode) Fix potential incorrect query result caused by concurrent NewOlapScanNode initialization and Compaction

### DIFF
--- a/be/src/olap/reader.h
+++ b/be/src/olap/reader.h
@@ -90,6 +90,12 @@ class TabletReader {
     };
 
 public:
+    struct ReadSource {
+        std::vector<RowSetSplits> rs_splits;
+        std::vector<RowsetMetaSharedPtr> delete_predicates;
+        // Fill delete predicates with `rs_splits`
+        void fill_delete_predicates();
+    };
     // Params for Reader,
     // mainly include tablet, data version and fetch range.
     struct ReaderParams {
@@ -103,7 +109,10 @@ public:
                     !rs_splits[1].rs_reader->rowset()->rowset_meta()->is_segments_overlapping());
         }
 
-        void fill_delete_predicates_with_rs_splits();
+        void set_read_source(ReadSource read_source) {
+            rs_splits = std::move(read_source.rs_splits);
+            delete_predicates = std::move(read_source.delete_predicates);
+        }
 
         TabletSharedPtr tablet;
         TabletSchemaSPtr tablet_schema;
@@ -128,9 +137,9 @@ public:
         std::vector<FunctionFilter> function_filters;
         std::vector<RowsetMetaSharedPtr> delete_predicates;
 
+        std::vector<RowSetSplits> rs_splits;
         // For unique key table with merge-on-write
         DeleteBitmap* delete_bitmap {nullptr};
-        std::vector<RowSetSplits> rs_splits;
 
         // return_columns is init from query schema
         std::vector<uint32_t> return_columns;

--- a/be/src/olap/reader.h
+++ b/be/src/olap/reader.h
@@ -103,6 +103,8 @@ public:
                     !rs_splits[1].rs_reader->rowset()->rowset_meta()->is_segments_overlapping());
         }
 
+        void fill_delete_predicates_with_rs_splits();
+
         TabletSharedPtr tablet;
         TabletSchemaSPtr tablet_schema;
         ReaderType reader_type = ReaderType::READER_QUERY;

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -819,15 +819,16 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletReqV2&
                         versions_to_be_changed.size(), rs_splits.size());
                 break;
             }
-            auto& all_del_preds = base_tablet->delete_predicates();
-            for (auto& delete_pred : all_del_preds) {
-                if (delete_pred->version().first > end_version) {
+            std::vector<RowsetMetaSharedPtr> del_preds;
+            for (auto&& split : rs_splits) {
+                auto& rs_meta = split.rs_reader->rowset()->rowset_meta();
+                if (!rs_meta->has_delete_predicate() || rs_meta->start_version() > end_version) {
                     continue;
                 }
-                base_tablet_schema->merge_dropped_columns(
-                        base_tablet->tablet_schema(delete_pred->version()));
+                base_tablet_schema->merge_dropped_columns(*rs_meta->tablet_schema());
+                del_preds.push_back(rs_meta);
             }
-            res = delete_handler.init(base_tablet_schema, all_del_preds, end_version);
+            res = delete_handler.init(base_tablet_schema, del_preds, end_version);
             if (!res) {
                 LOG(WARNING) << "init delete handler failed. base_tablet="
                              << base_tablet->full_name() << ", end_version=" << end_version;

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -964,10 +964,6 @@ Status Tablet::capture_rs_readers(const std::vector<Version>& version_path,
     return Status::OK();
 }
 
-bool Tablet::version_for_delete_predicate(const Version& version) {
-    return _tablet_meta->version_for_delete_predicate(version);
-}
-
 bool Tablet::can_do_compaction(size_t path_hash, CompactionType compaction_type) {
     if (compaction_type == CompactionType::BASE_COMPACTION && tablet_state() != TABLET_RUNNING) {
         // base compaction can only be done for tablet in TABLET_RUNNING state.

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -191,11 +191,6 @@ public:
     Status capture_rs_readers(const std::vector<Version>& version_path,
                               std::vector<RowSetSplits>* rs_splits) const;
 
-    const std::vector<RowsetMetaSharedPtr> delete_predicates() {
-        return _tablet_meta->delete_predicates();
-    }
-    bool version_for_delete_predicate(const Version& version);
-
     // meta lock
     std::shared_mutex& get_header_lock() { return _meta_lock; }
     std::mutex& get_rowset_update_lock() { return _rowset_update_lock; }

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -828,30 +828,6 @@ RowsetMetaSharedPtr TabletMeta::acquire_stale_rs_meta_by_version(const Version& 
     return nullptr;
 }
 
-const std::vector<RowsetMetaSharedPtr> TabletMeta::delete_predicates() const {
-    std::vector<RowsetMetaSharedPtr> res;
-    for (auto& del_pred : _rs_metas) {
-        if (del_pred->has_delete_predicate()) {
-            res.push_back(del_pred);
-        }
-    }
-    return res;
-}
-
-bool TabletMeta::version_for_delete_predicate(const Version& version) {
-    if (version.first != version.second) {
-        return false;
-    }
-
-    for (auto& del_pred : _rs_metas) {
-        if (del_pred->version().first == version.first && del_pred->has_delete_predicate()) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
 std::string TabletMeta::full_name() const {
     std::stringstream ss;
     ss << _tablet_id << "." << _schema_hash << "." << _tablet_uid.to_string();

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -191,8 +191,6 @@ public:
     RowsetMetaSharedPtr acquire_rs_meta_by_version(const Version& version) const;
     void delete_stale_rs_meta_by_version(const Version& version);
     RowsetMetaSharedPtr acquire_stale_rs_meta_by_version(const Version& version) const;
-    const std::vector<RowsetMetaSharedPtr> delete_predicates() const;
-    bool version_for_delete_predicate(const Version& version);
 
     std::string full_name() const;
 

--- a/be/src/olap/tablet_schema.cpp
+++ b/be/src/olap/tablet_schema.cpp
@@ -859,12 +859,12 @@ void TabletSchema::build_current_tablet_schema(int64_t index_id, int32_t version
     }
 }
 
-void TabletSchema::merge_dropped_columns(TabletSchemaSPtr src_schema) {
+void TabletSchema::merge_dropped_columns(const TabletSchema& src_schema) {
     // If they are the same tablet schema object, then just return
-    if (this == src_schema.get()) {
+    if (this == &src_schema) {
         return;
     }
-    for (const auto& src_col : src_schema->columns()) {
+    for (const auto& src_col : src_schema.columns()) {
         if (_field_id_to_index.find(src_col.unique_id()) == _field_id_to_index.end()) {
             CHECK(!src_col.is_key()) << src_col.name() << " is key column, should not be dropped.";
             ColumnPB src_col_pb;

--- a/be/src/olap/tablet_schema.h
+++ b/be/src/olap/tablet_schema.h
@@ -315,7 +315,7 @@ public:
     // 7. insert value  4, 5
     // Then the read schema should be ColA, ColB, ColB' because the delete predicate need ColB to remove related data.
     // Because they have same name, so that the dropped column should not be added to the map, only with unique id.
-    void merge_dropped_columns(std::shared_ptr<TabletSchema> src_schema);
+    void merge_dropped_columns(const TabletSchema& src_schema);
 
     bool is_dropped_column(const TabletColumn& col) const;
 

--- a/be/src/vec/exec/scan/new_olap_scan_node.cpp
+++ b/be/src/vec/exec/scan/new_olap_scan_node.cpp
@@ -38,6 +38,7 @@
 #include "common/object_pool.h"
 #include "common/status.h"
 #include "exec/exec_node.h"
+#include "olap/reader.h"
 #include "olap/rowset/rowset.h"
 #include "olap/rowset/rowset_reader.h"
 #include "olap/storage_engine.h"
@@ -446,15 +447,16 @@ Status NewOlapScanNode::_init_scanners(std::list<VScannerSPtr>* scanners) {
 
     bool is_dup_mow_key = false;
     size_t segment_count = 0;
-    std::vector<std::vector<RowSetSplits>> rowset_splits_vector(_scan_ranges.size());
-    std::vector<std::vector<size_t>> tablet_rs_seg_count(_scan_ranges.size());
+    std::vector<TabletReader::ReadSource> tablets_read_source;
+    tablets_read_source.reserve(_scan_ranges.size());
+    std::vector<std::vector<size_t>> tablet_rs_seg_count;
+    tablet_rs_seg_count.reserve(_scan_ranges.size());
 
     // Split tablet segment by scanner, only use in pipeline in duplicate key
     // 1. if tablet count lower than scanner thread num, count segment num of all tablet ready for scan
     // TODO: some tablet may do not have segment, may need split segment all case
     if (_shared_scan_opt && _scan_ranges.size() < config::doris_scanner_thread_pool_thread_num) {
-        for (int i = 0; i < _scan_ranges.size(); ++i) {
-            auto& scan_range = _scan_ranges[i];
+        for (auto&& scan_range : _scan_ranges) {
             auto tablet_id = scan_range->tablet_id;
             auto [tablet, status] =
                     StorageEngine::instance()->tablet_manager()->get_tablet_and_status(tablet_id,
@@ -472,24 +474,25 @@ Status NewOlapScanNode::_init_scanners(std::list<VScannerSPtr>* scanners) {
             std::from_chars(scan_range->version.c_str(),
                             scan_range->version.c_str() + scan_range->version.size(), version);
 
-            std::shared_lock rdlock(tablet->get_header_lock());
-            // acquire tablet rowset readers at the beginning of the scan node
-            // to prevent this case: when there are lots of olap scanners to run for example 10000
-            // the rowsets maybe compacted when the last olap scanner starts
-            Status acquire_reader_st =
-                    tablet->capture_rs_readers({0, version}, &rowset_splits_vector[i]);
-            if (!acquire_reader_st.ok()) {
-                LOG(WARNING) << "fail to init reader.res=" << acquire_reader_st;
-                std::stringstream ss;
-                ss << "failed to initialize storage reader. tablet=" << tablet->full_name()
-                   << ", res=" << acquire_reader_st
-                   << ", backend=" << BackendOptions::get_localhost();
-                return Status::InternalError(ss.str());
+            auto& read_source = tablets_read_source.emplace_back();
+            {
+                std::shared_lock rdlock(tablet->get_header_lock());
+                auto st = tablet->capture_rs_readers({0, version}, &read_source.rs_splits);
+                if (!st.ok()) {
+                    LOG(WARNING) << "fail to init reader.res=" << st;
+                    return Status::InternalError(
+                            "failed to initialize storage reader. tablet_id={} : {}",
+                            tablet->tablet_id(), st.to_string());
+                }
+            }
+            if (!_state->skip_delete_predicate()) {
+                read_source.fill_delete_predicates();
             }
 
-            for (const auto& rowset_splits : rowset_splits_vector[i]) {
+            auto& rs_seg_count = tablet_rs_seg_count.emplace_back();
+            for (const auto& rowset_splits : read_source.rs_splits) {
                 auto num_segments = rowset_splits.rs_reader->rowset()->num_segments();
-                tablet_rs_seg_count[i].emplace_back(num_segments);
+                rs_seg_count.emplace_back(num_segments);
                 segment_count += num_segments;
             }
         }
@@ -498,14 +501,14 @@ Status NewOlapScanNode::_init_scanners(std::list<VScannerSPtr>* scanners) {
     if (is_dup_mow_key) {
         auto build_new_scanner = [&](const TPaloScanRange& scan_range,
                                      const std::vector<OlapScanRange*>& key_ranges,
-                                     const std::vector<RowSetSplits>& rs_splits) {
+                                     TabletReader::ReadSource read_source) {
             std::shared_ptr<NewOlapScanner> scanner = NewOlapScanner::create_shared(
                     _state, this, _limit_per_scanner, _olap_scan_node.is_preaggregation, scan_range,
-                    key_ranges, rs_splits, _scanner_profile.get());
+                    key_ranges, std::move(read_source), _scanner_profile.get());
 
             RETURN_IF_ERROR(scanner->prepare(_state, _conjuncts));
             scanner->set_compound_filters(_compound_filters);
-            scanners->push_back(scanner);
+            scanners->push_back(std::move(scanner));
             return Status::OK();
         };
         // 2. Split segment evenly to each scanner (e.g. each scanner need to scan `avg_segment_count_per_scanner` segments)
@@ -527,6 +530,7 @@ Status NewOlapScanNode::_init_scanners(std::list<VScannerSPtr>* scanners) {
             size_t segment_idx_to_scan = 0;
             size_t num_segments_assigned = 0;
 
+            auto& read_source = tablets_read_source[i];
             std::vector<RowSetSplits> rs_splits;
 
             while (rowset_idx < rs_seg_count.size()) {
@@ -538,35 +542,35 @@ Status NewOlapScanNode::_init_scanners(std::list<VScannerSPtr>* scanners) {
                 }
 
                 const auto max_add_seg_nums = rs_seg_count[rowset_idx] - segment_idx_to_scan;
-                rs_splits.emplace_back(RowSetSplits());
-                rs_splits.back().rs_reader = rowset_splits_vector[i][rowset_idx].rs_reader->clone();
+                auto& split = rs_splits.emplace_back();
+                split.rs_reader = read_source.rs_splits[rowset_idx].rs_reader->clone();
 
                 // if segments assigned to current scanner are already more than the average count,
                 // this scanner will just scan segments equal to the average count
                 if (num_segments_assigned + max_add_seg_nums > avg_segment_count_by_scanner) {
                     auto need_add_seg_nums = avg_segment_count_by_scanner - num_segments_assigned;
-                    rs_splits.back().segment_offsets = {
+                    split.segment_offsets = {
                             segment_idx_to_scan,
                             segment_idx_to_scan + need_add_seg_nums}; // only scan need_add_seg_nums
 
-                    RETURN_IF_ERROR(build_new_scanner(*scan_range, scanner_ranges, rs_splits));
+                    RETURN_IF_ERROR(build_new_scanner(
+                            *scan_range, scanner_ranges,
+                            {std::move(rs_splits), read_source.delete_predicates}));
 
                     segment_idx_to_scan += need_add_seg_nums;
                     num_segments_assigned = 0;
-                    rs_splits.clear();
                 } else if (num_segments_assigned + max_add_seg_nums ==
                            avg_segment_count_by_scanner) {
-                    rs_splits.back().segment_offsets = {segment_idx_to_scan,
-                                                        rs_seg_count[rowset_idx]};
-                    RETURN_IF_ERROR(build_new_scanner(*scan_range, scanner_ranges, rs_splits));
+                    split.segment_offsets = {segment_idx_to_scan, rs_seg_count[rowset_idx]};
+                    RETURN_IF_ERROR(build_new_scanner(
+                            *scan_range, scanner_ranges,
+                            {std::move(rs_splits), read_source.delete_predicates}));
 
                     segment_idx_to_scan = 0;
                     num_segments_assigned = 0;
-                    rs_splits.clear();
                     rowset_idx++;
                 } else {
-                    rs_splits.back().segment_offsets = {segment_idx_to_scan,
-                                                        rs_seg_count[rowset_idx]};
+                    split.segment_offsets = {segment_idx_to_scan, rs_seg_count[rowset_idx]};
 
                     segment_idx_to_scan = 0;
                     num_segments_assigned += max_add_seg_nums;
@@ -583,7 +587,8 @@ Status NewOlapScanNode::_init_scanners(std::list<VScannerSPtr>* scanners) {
 
             // dispose some segment tail
             if (!rs_splits.empty()) {
-                build_new_scanner(*scan_range, scanner_ranges, rs_splits);
+                build_new_scanner(*scan_range, scanner_ranges,
+                                  {std::move(rs_splits), read_source.delete_predicates});
             }
         }
     } else {

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -61,6 +61,8 @@
 
 namespace doris::vectorized {
 
+using ReadSource = TabletReader::ReadSource;
+
 NewOlapScanner::NewOlapScanner(RuntimeState* state, NewOlapScanNode* parent, int64_t limit,
                                bool aggregation, const TPaloScanRange& scan_range,
                                const std::vector<OlapScanRange*>& key_ranges,
@@ -77,13 +79,13 @@ NewOlapScanner::NewOlapScanner(RuntimeState* state, NewOlapScanNode* parent, int
 NewOlapScanner::NewOlapScanner(RuntimeState* state, NewOlapScanNode* parent, int64_t limit,
                                bool aggregation, const TPaloScanRange& scan_range,
                                const std::vector<OlapScanRange*>& key_ranges,
-                               const std::vector<RowSetSplits>& rs_splits, RuntimeProfile* profile)
+                               ReadSource read_source, RuntimeProfile* profile)
         : VScanner(state, static_cast<VScanNode*>(parent), limit, profile),
           _aggregation(aggregation),
           _version(-1),
           _scan_range(scan_range),
           _key_ranges(key_ranges) {
-    _tablet_reader_params.rs_splits = rs_splits;
+    _tablet_reader_params.set_read_source(std::move(read_source));
     _tablet_schema = std::make_shared<TabletSchema>();
     _is_init = false;
 }
@@ -104,13 +106,13 @@ NewOlapScanner::NewOlapScanner(RuntimeState* state, pipeline::ScanLocalStateBase
 NewOlapScanner::NewOlapScanner(RuntimeState* state, pipeline::ScanLocalStateBase* local_state,
                                int64_t limit, bool aggregation, const TPaloScanRange& scan_range,
                                const std::vector<OlapScanRange*>& key_ranges,
-                               const std::vector<RowSetSplits>& rs_splits, RuntimeProfile* profile)
+                               ReadSource read_source, RuntimeProfile* profile)
         : VScanner(state, local_state, limit, profile),
           _aggregation(aggregation),
           _version(-1),
           _scan_range(scan_range),
           _key_ranges(key_ranges) {
-    _tablet_reader_params.rs_splits = rs_splits;
+    _tablet_reader_params.set_read_source(std::move(read_source));
     _tablet_schema = std::make_shared<TabletSchema>();
     _is_init = false;
 }
@@ -212,39 +214,34 @@ Status NewOlapScanner::init() {
             }
         }
 
-        {
-            std::shared_lock rdlock(_tablet->get_header_lock());
-            if (_tablet_reader_params.rs_splits.empty()) {
-                const RowsetSharedPtr rowset = _tablet->rowset_with_max_version();
-                if (rowset == nullptr) {
-                    std::stringstream ss;
-                    ss << "fail to get latest version of tablet: " << tablet_id;
-                    LOG(WARNING) << ss.str();
-                    return Status::InternalError(ss.str());
-                }
-
-                // acquire tablet rowset readers at the beginning of the scan node
-                // to prevent this case: when there are lots of olap scanners to run for example 10000
-                // the rowsets maybe compacted when the last olap scanner starts
-                Version rd_version(0, _version);
-                Status acquire_reader_st =
-                        _tablet->capture_rs_readers(rd_version, &_tablet_reader_params.rs_splits);
-                if (!acquire_reader_st.ok()) {
-                    LOG(WARNING) << "fail to init reader.res=" << acquire_reader_st;
-                    std::stringstream ss;
-                    ss << "failed to initialize storage reader. tablet=" << _tablet->full_name()
-                       << ", res=" << acquire_reader_st
-                       << ", backend=" << BackendOptions::get_localhost();
-                    return Status::InternalError(ss.str());
+        if (_tablet_reader_params.rs_splits.empty()) {
+            // Non-pipeline mode, Tablet : Scanner = 1 : 1
+            // acquire tablet rowset readers at the beginning of the scan node
+            // to prevent this case: when there are lots of olap scanners to run for example 10000
+            // the rowsets maybe compacted when the last olap scanner starts
+            Version rd_version(0, _version);
+            ReadSource read_source;
+            {
+                std::shared_lock rdlock(_tablet->get_header_lock());
+                auto st = _tablet->capture_rs_readers(rd_version, &read_source.rs_splits);
+                if (!st.ok()) {
+                    LOG(WARNING) << "fail to init reader.res=" << st;
+                    return Status::InternalError(
+                            "failed to initialize storage reader. tablet_id={} : {}",
+                            _tablet->tablet_id(), st.to_string());
                 }
             }
-
-            // Initialize tablet_reader_params
-            RETURN_IF_ERROR(_init_tablet_reader_params(
-                    _key_ranges, parent ? parent->_olap_filters : local_state->_olap_filters,
-                    parent ? parent->_filter_predicates : local_state->_filter_predicates,
-                    parent ? parent->_push_down_functions : local_state->_push_down_functions));
+            if (!_state->skip_delete_predicate()) {
+                read_source.fill_delete_predicates();
+            }
+            _tablet_reader_params.set_read_source(std::move(read_source));
         }
+
+        // Initialize tablet_reader_params
+        RETURN_IF_ERROR(_init_tablet_reader_params(
+                _key_ranges, parent ? parent->_olap_filters : local_state->_olap_filters,
+                parent ? parent->_filter_predicates : local_state->_filter_predicates,
+                parent ? parent->_push_down_functions : local_state->_push_down_functions));
     }
 
     // add read columns in profile
@@ -350,10 +347,6 @@ Status NewOlapScanner::_init_tablet_reader_params(
     std::copy(function_filters.cbegin(), function_filters.cend(),
               std::inserter(_tablet_reader_params.function_filters,
                             _tablet_reader_params.function_filters.begin()));
-
-    if (!_state->skip_delete_predicate()) {
-        _tablet_reader_params.fill_delete_predicates_with_rs_splits();
-    }
 
     // Merge the columns in delete predicate that not in latest schema in to current tablet schema
     for (auto& del_pred : _tablet_reader_params.delete_predicates) {

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -352,15 +352,12 @@ Status NewOlapScanner::_init_tablet_reader_params(
                             _tablet_reader_params.function_filters.begin()));
 
     if (!_state->skip_delete_predicate()) {
-        auto& delete_preds = _tablet->delete_predicates();
-        std::copy(delete_preds.cbegin(), delete_preds.cend(),
-                  std::inserter(_tablet_reader_params.delete_predicates,
-                                _tablet_reader_params.delete_predicates.begin()));
+        _tablet_reader_params.fill_delete_predicates_with_rs_splits();
     }
 
     // Merge the columns in delete predicate that not in latest schema in to current tablet schema
-    for (auto& del_pred_pb : _tablet_reader_params.delete_predicates) {
-        _tablet_schema->merge_dropped_columns(_tablet->tablet_schema(del_pred_pb->version()));
+    for (auto& del_pred : _tablet_reader_params.delete_predicates) {
+        _tablet_schema->merge_dropped_columns(*del_pred->tablet_schema());
     }
 
     // Range

--- a/be/src/vec/exec/scan/new_olap_scanner.h
+++ b/be/src/vec/exec/scan/new_olap_scanner.h
@@ -30,6 +30,7 @@
 #include "common/status.h"
 #include "olap/data_dir.h"
 #include "olap/reader.h"
+#include "olap/rowset/rowset_meta.h"
 #include "olap/rowset/rowset_reader.h"
 #include "olap/tablet.h"
 #include "olap/tablet_schema.h"
@@ -59,7 +60,7 @@ public:
 
     NewOlapScanner(RuntimeState* state, NewOlapScanNode* parent, int64_t limit, bool aggregation,
                    const TPaloScanRange& scan_range, const std::vector<OlapScanRange*>& key_ranges,
-                   const std::vector<RowSetSplits>& rs_splits, RuntimeProfile* profile);
+                   TabletReader::ReadSource read_source, RuntimeProfile* profile);
 
     NewOlapScanner(RuntimeState* state, pipeline::ScanLocalStateBase* parent, int64_t limit,
                    bool aggregation, const TPaloScanRange& scan_range,
@@ -68,7 +69,7 @@ public:
     NewOlapScanner(RuntimeState* state, pipeline::ScanLocalStateBase* parent, int64_t limit,
                    bool aggregation, const TPaloScanRange& scan_range,
                    const std::vector<OlapScanRange*>& key_ranges,
-                   const std::vector<RowSetSplits>& rs_splits, RuntimeProfile* profile);
+                   TabletReader::ReadSource read_source, RuntimeProfile* profile);
 
     Status init() override;
 

--- a/be/src/vec/sink/writer/vtablet_writer.h
+++ b/be/src/vec/sink/writer/vtablet_writer.h
@@ -71,7 +71,7 @@
 #include "vec/core/block.h"
 #include "vec/data_types/data_type.h"
 #include "vec/exprs/vexpr_fwd.h"
-#include "vec/runtime/vfile_writer_wrapper.h"
+#include "vec/runtime/vfile_format_transformer.h"
 #include "vec/sink/vtablet_block_convertor.h"
 #include "vec/sink/vtablet_finder.h"
 #include "vec/sink/writer/async_result_writer.h"

--- a/be/test/olap/delete_handler_test.cpp
+++ b/be/test/olap/delete_handler_test.cpp
@@ -937,6 +937,16 @@ protected:
         tablet->add_rowset(rowset);
     }
 
+    std::vector<RowsetMetaSharedPtr> get_delete_predicates() {
+        std::vector<RowsetMetaSharedPtr> delete_preds;
+        for (auto&& rs_meta : tablet->tablet_meta()->_rs_metas) {
+            if (rs_meta->has_delete_predicate()) {
+                delete_preds.push_back(rs_meta);
+            }
+        }
+        return delete_preds;
+    }
+
     std::string _tablet_path;
     RowCursor _data_row_cursor;
     TabletSharedPtr tablet;
@@ -957,7 +967,7 @@ TEST_F(TestDeleteHandler, ValueWithQuote) {
 
     add_delete_predicate(del_predicate, 2);
 
-    auto res = _delete_handler.init(tablet->tablet_schema(), tablet->delete_predicates(), 5);
+    auto res = _delete_handler.init(tablet->tablet_schema(), get_delete_predicates(), 5);
     EXPECT_EQ(Status::OK(), res);
     _delete_handler.finalize();
 }
@@ -970,7 +980,7 @@ TEST_F(TestDeleteHandler, ValueWithoutQuote) {
 
     add_delete_predicate(del_predicate, 2);
 
-    auto res = _delete_handler.init(tablet->tablet_schema(), tablet->delete_predicates(), 5);
+    auto res = _delete_handler.init(tablet->tablet_schema(), get_delete_predicates(), 5);
     EXPECT_EQ(Status::OK(), res);
     _delete_handler.finalize();
 }
@@ -1044,7 +1054,7 @@ TEST_F(TestDeleteHandler, InitSuccess) {
     add_delete_predicate(del_pred_4, 5);
 
     // Get delete conditions which version <= 5
-    res = _delete_handler.init(tablet->tablet_schema(), tablet->delete_predicates(), 5);
+    res = _delete_handler.init(tablet->tablet_schema(), get_delete_predicates(), 5);
     EXPECT_EQ(Status::OK(), res);
     _delete_handler.finalize();
 }
@@ -1076,7 +1086,7 @@ TEST_F(TestDeleteHandler, FilterDataSubconditions) {
     add_delete_predicate(del_pred, 2);
 
     // 指定版本号为10以载入Header中的所有过滤条件(在这个case中，只有过滤条件1)
-    res = _delete_handler.init(tablet->tablet_schema(), tablet->delete_predicates(), 4);
+    res = _delete_handler.init(tablet->tablet_schema(), get_delete_predicates(), 4);
     EXPECT_EQ(Status::OK(), res);
 
     // 构造一行测试数据
@@ -1161,7 +1171,7 @@ TEST_F(TestDeleteHandler, FilterDataConditions) {
     add_delete_predicate(del_pred_3, 4);
 
     // 指定版本号为4以载入meta中的所有过滤条件(在这个case中，只有过滤条件1)
-    res = _delete_handler.init(tablet->tablet_schema(), tablet->delete_predicates(), 4);
+    res = _delete_handler.init(tablet->tablet_schema(), get_delete_predicates(), 4);
     EXPECT_EQ(Status::OK(), res);
 
     std::vector<string> data_str;
@@ -1224,7 +1234,7 @@ TEST_F(TestDeleteHandler, FilterDataVersion) {
     add_delete_predicate(del_pred_2, 4);
 
     // 指定版本号为4以载入meta中的所有过滤条件(过滤条件1，过滤条件2)
-    res = _delete_handler.init(tablet->tablet_schema(), tablet->delete_predicates(), 4);
+    res = _delete_handler.init(tablet->tablet_schema(), get_delete_predicates(), 4);
     EXPECT_EQ(Status::OK(), res);
 
     // 构造一行测试数据

--- a/be/test/olap/rowid_conversion_test.cpp
+++ b/be/test/olap/rowid_conversion_test.cpp
@@ -143,7 +143,9 @@ protected:
                                                      const SegmentsOverlapPB& overlap,
                                                      uint32_t max_rows_per_segment,
                                                      Version version) {
-        static int64_t inc_id = 1000;
+        // FIXME(plat1ko): If `inc_id` set to 1000, and run `VerticalCompactionTest` before `TestRowIdConversion`,
+        //  will `TestRowIdConversion` will fail. There may be some strange global states here.
+        static int64_t inc_id = 0;
         RowsetWriterContext rowset_writer_context;
         RowsetId rowset_id;
         rowset_id.init(inc_id);
@@ -217,33 +219,20 @@ protected:
         return rowset;
     }
 
-    void init_rs_meta(RowsetMetaSharedPtr& pb1, int64_t start, int64_t end) {
+    void init_rs_meta(RowsetMetaSharedPtr& rs_meta, int64_t start, int64_t end) {
         std::string json_rowset_meta = R"({
             "rowset_id": 540081,
             "tablet_id": 15673,
-            "txn_id": 4042,
             "tablet_schema_hash": 567997577,
             "rowset_type": "BETA_ROWSET",
             "rowset_state": "VISIBLE",
-            "start_version": 2,
-            "end_version": 2,
-            "num_rows": 3929,
-            "total_disk_size": 84699,
-            "data_disk_size": 84464,
-            "index_disk_size": 235,
-            "empty": false,
-            "load_id": {
-                "hi": -5350970832824939812,
-                "lo": -6717994719194512122
-            },
-            "creation_time": 1553765670
+            "empty": false
         })";
         RowsetMetaPB rowset_meta_pb;
         json2pb::JsonToProtoMessage(json_rowset_meta, &rowset_meta_pb);
         rowset_meta_pb.set_start_version(start);
         rowset_meta_pb.set_end_version(end);
-        rowset_meta_pb.set_creation_time(10000);
-        pb1->init_from_pb(rowset_meta_pb);
+        rs_meta->init_from_pb(rowset_meta_pb);
     }
 
     RowsetSharedPtr create_delete_predicate(const TabletSchemaSPtr& schema,
@@ -251,7 +240,7 @@ protected:
         RowsetMetaSharedPtr rsm(new RowsetMeta());
         init_rs_meta(rsm, version, version);
         RowsetId id;
-        id.init(version * 1000);
+        id.init(version);
         rsm->set_rowset_id(id);
         rsm->set_delete_predicate(std::move(del_pred));
         rsm->set_tablet_schema(schema);
@@ -315,19 +304,23 @@ protected:
             RowsetSharedPtr rowset = create_rowset(tablet_schema, new_overlap, input_data[i], i);
             input_rowsets.push_back(rowset);
         }
-        // delete data with key < 1000
-        std::vector<TCondition> conditions;
-        TCondition condition;
-        condition.column_name = tablet_schema->column(0).name();
-        condition.condition_op = "<";
-        condition.condition_values.clear();
-        condition.condition_values.push_back("1000");
-        conditions.push_back(condition);
+        if (has_delete_handler) {
+            // delete data with key < 1000
+            std::vector<TCondition> conditions;
+            TCondition condition;
+            condition.column_name = tablet_schema->column(0).name();
+            condition.condition_op = "<";
+            condition.condition_values.clear();
+            condition.condition_values.push_back("1000");
+            conditions.push_back(condition);
 
-        DeletePredicatePB del_pred;
-        Status st = DeleteHandler::generate_delete_predicate(*tablet_schema, conditions, &del_pred);
-        ASSERT_TRUE(st.ok()) << st;
-        input_rowsets.push_back(create_delete_predicate(tablet_schema, del_pred, num_input_rowset));
+            DeletePredicatePB del_pred;
+            Status st =
+                    DeleteHandler::generate_delete_predicate(*tablet_schema, conditions, &del_pred);
+            ASSERT_TRUE(st.ok()) << st;
+            input_rowsets.push_back(
+                    create_delete_predicate(tablet_schema, del_pred, num_input_rowset));
+        }
 
         // create output rowset writer
         auto writer_context = create_rowset_writer_context(
@@ -386,8 +379,8 @@ protected:
                 output_data.emplace_back(columns[0].column->get_int(i),
                                          columns[1].column->get_int(i));
             }
-        } while (s == Status::OK());
-        EXPECT_EQ(Status::Error<END_OF_FILE>(""), s);
+        } while (s.ok());
+        EXPECT_TRUE(s.is<END_OF_FILE>()) << s;
         EXPECT_EQ(out_rowset->rowset_meta()->num_rows(), output_data.size());
         std::vector<uint32_t> segment_num_rows;
         EXPECT_TRUE(output_rs_reader->get_segment_num_rows(&segment_num_rows).ok());
@@ -575,7 +568,6 @@ TEST_P(TestRowIdConversion, Conversion) {
         {
             uint32_t num_segments = 1;
             SegmentsOverlapPB overlap = NONOVERLAPPING;
-            std::vector<std::vector<std::vector<std::tuple<int64_t, int64_t>>>> input_data;
             check_rowid_conversion(keys_type, enable_unique_key_merge_on_write, num_input_rowset,
                                    num_segments, rows_per_segment, overlap, has_delete_handler,
                                    is_vertical_merger);
@@ -584,7 +576,6 @@ TEST_P(TestRowIdConversion, Conversion) {
         {
             uint32_t num_segments = 2;
             SegmentsOverlapPB overlap = OVERLAPPING;
-            std::vector<std::vector<std::vector<std::tuple<int64_t, int64_t>>>> input_data;
             check_rowid_conversion(keys_type, enable_unique_key_merge_on_write, num_input_rowset,
                                    num_segments, rows_per_segment, overlap, has_delete_handler,
                                    is_vertical_merger);
@@ -593,7 +584,6 @@ TEST_P(TestRowIdConversion, Conversion) {
         {
             uint32_t num_segments = 2;
             SegmentsOverlapPB overlap = NONOVERLAPPING;
-            std::vector<std::vector<std::vector<std::tuple<int64_t, int64_t>>>> input_data;
             check_rowid_conversion(keys_type, enable_unique_key_merge_on_write, num_input_rowset,
                                    num_segments, rows_per_segment, overlap, has_delete_handler,
                                    is_vertical_merger);
@@ -602,7 +592,6 @@ TEST_P(TestRowIdConversion, Conversion) {
         {
             uint32_t num_segments = 2;
             SegmentsOverlapPB overlap = OVERLAP_UNKNOWN;
-            std::vector<std::vector<std::vector<std::tuple<int64_t, int64_t>>>> input_data;
             check_rowid_conversion(keys_type, enable_unique_key_merge_on_write, num_input_rowset,
                                    num_segments, rows_per_segment, overlap, has_delete_handler,
                                    is_vertical_merger);

--- a/be/test/olap/rowid_conversion_test.cpp
+++ b/be/test/olap/rowid_conversion_test.cpp
@@ -139,22 +139,24 @@ protected:
         return tablet_schema;
     }
 
-    void create_rowset_writer_context(TabletSchemaSPtr tablet_schema,
-                                      const SegmentsOverlapPB& overlap,
-                                      uint32_t max_rows_per_segment,
-                                      RowsetWriterContext* rowset_writer_context) {
-        static int64_t inc_id = 0;
+    RowsetWriterContext create_rowset_writer_context(TabletSchemaSPtr tablet_schema,
+                                                     const SegmentsOverlapPB& overlap,
+                                                     uint32_t max_rows_per_segment,
+                                                     Version version) {
+        static int64_t inc_id = 1000;
+        RowsetWriterContext rowset_writer_context;
         RowsetId rowset_id;
         rowset_id.init(inc_id);
-        rowset_writer_context->rowset_id = rowset_id;
-        rowset_writer_context->rowset_type = BETA_ROWSET;
-        rowset_writer_context->rowset_state = VISIBLE;
-        rowset_writer_context->tablet_schema = tablet_schema;
-        rowset_writer_context->rowset_dir = absolute_dir + "/tablet_path";
-        rowset_writer_context->version = Version(inc_id, inc_id);
-        rowset_writer_context->segments_overlap = overlap;
-        rowset_writer_context->max_rows_per_segment = max_rows_per_segment;
+        rowset_writer_context.rowset_id = rowset_id;
+        rowset_writer_context.rowset_type = BETA_ROWSET;
+        rowset_writer_context.rowset_state = VISIBLE;
+        rowset_writer_context.tablet_schema = tablet_schema;
+        rowset_writer_context.rowset_dir = absolute_dir + "/tablet_path";
+        rowset_writer_context.version = version;
+        rowset_writer_context.segments_overlap = overlap;
+        rowset_writer_context.max_rows_per_segment = max_rows_per_segment;
         inc_id++;
+        return rowset_writer_context;
     }
 
     void create_and_init_rowset_reader(Rowset* rowset, RowsetReaderContext& context,
@@ -169,8 +171,7 @@ protected:
 
     RowsetSharedPtr create_rowset(
             TabletSchemaSPtr tablet_schema, const SegmentsOverlapPB& overlap,
-            std::vector<std::vector<std::tuple<int64_t, int64_t>>> rowset_data) {
-        RowsetWriterContext writer_context;
+            std::vector<std::vector<std::tuple<int64_t, int64_t>>> rowset_data, int64_t version) {
         if (overlap == NONOVERLAPPING) {
             for (auto i = 1; i < rowset_data.size(); i++) {
                 auto& last_seg_data = rowset_data[i - 1];
@@ -180,8 +181,8 @@ protected:
                 EXPECT_LT(last_seg_max, cur_seg_min);
             }
         }
-        create_rowset_writer_context(tablet_schema, overlap, UINT32_MAX, &writer_context);
-
+        auto writer_context = create_rowset_writer_context(tablet_schema, overlap, UINT32_MAX,
+                                                           {version, version});
         std::unique_ptr<RowsetWriter> rowset_writer;
         Status s = RowsetFactory::create_rowset_writer(writer_context, false, &rowset_writer);
         EXPECT_TRUE(s.ok());
@@ -245,22 +246,20 @@ protected:
         pb1->init_from_pb(rowset_meta_pb);
     }
 
-    void add_delete_predicate(TabletSharedPtr tablet, DeletePredicatePB& del_pred,
-                              int64_t version) {
+    RowsetSharedPtr create_delete_predicate(const TabletSchemaSPtr& schema,
+                                            DeletePredicatePB del_pred, int64_t version) {
         RowsetMetaSharedPtr rsm(new RowsetMeta());
         init_rs_meta(rsm, version, version);
         RowsetId id;
         id.init(version * 1000);
         rsm->set_rowset_id(id);
-        rsm->set_delete_predicate(del_pred);
-        rsm->set_tablet_schema(tablet->tablet_schema());
-        RowsetSharedPtr rowset = std::make_shared<BetaRowset>(tablet->tablet_schema(), "", rsm);
-        tablet->add_rowset(rowset);
+        rsm->set_delete_predicate(std::move(del_pred));
+        rsm->set_tablet_schema(schema);
+        return std::make_shared<BetaRowset>(schema, "", rsm);
     }
 
     TabletSharedPtr create_tablet(const TabletSchema& tablet_schema,
-                                  bool enable_unique_key_merge_on_write, int64_t version,
-                                  bool has_delete_handler) {
+                                  bool enable_unique_key_merge_on_write) {
         std::vector<TColumn> cols;
         std::unordered_map<uint32_t, uint32_t> col_ordinal_to_unique_id;
         for (auto i = 0; i < tablet_schema.num_columns(); i++) {
@@ -290,22 +289,6 @@ protected:
 
         TabletSharedPtr tablet(new Tablet(tablet_meta, nullptr));
         tablet->init();
-        if (has_delete_handler) {
-            // delete data with key < 1000
-            std::vector<TCondition> conditions;
-            TCondition condition;
-            condition.column_name = tablet_schema.column(0).name();
-            condition.condition_op = "<";
-            condition.condition_values.clear();
-            condition.condition_values.push_back("1000");
-            conditions.push_back(condition);
-
-            DeletePredicatePB del_pred;
-            Status st =
-                    DeleteHandler::generate_delete_predicate(tablet_schema, conditions, &del_pred);
-            EXPECT_EQ(Status::OK(), st);
-            add_delete_predicate(tablet, del_pred, version);
-        }
         return tablet;
     }
 
@@ -329,13 +312,26 @@ protected:
                     new_overlap = OVERLAPPING;
                 }
             }
-            RowsetSharedPtr rowset = create_rowset(tablet_schema, new_overlap, input_data[i]);
+            RowsetSharedPtr rowset = create_rowset(tablet_schema, new_overlap, input_data[i], i);
             input_rowsets.push_back(rowset);
         }
+        // delete data with key < 1000
+        std::vector<TCondition> conditions;
+        TCondition condition;
+        condition.column_name = tablet_schema->column(0).name();
+        condition.condition_op = "<";
+        condition.condition_values.clear();
+        condition.condition_values.push_back("1000");
+        conditions.push_back(condition);
+
+        DeletePredicatePB del_pred;
+        Status st = DeleteHandler::generate_delete_predicate(*tablet_schema, conditions, &del_pred);
+        ASSERT_TRUE(st.ok()) << st;
+        input_rowsets.push_back(create_delete_predicate(tablet_schema, del_pred, num_input_rowset));
 
         // create output rowset writer
-        RowsetWriterContext writer_context;
-        create_rowset_writer_context(tablet_schema, NONOVERLAPPING, 3456, &writer_context);
+        auto writer_context = create_rowset_writer_context(
+                tablet_schema, NONOVERLAPPING, 3456, {0, input_rowsets.back()->end_version()});
         std::unique_ptr<RowsetWriter> output_rs_writer;
         Status s;
         if (is_vertical_merger) {
@@ -343,12 +339,10 @@ protected:
         } else {
             s = RowsetFactory::create_rowset_writer(writer_context, false, &output_rs_writer);
         }
-        EXPECT_TRUE(s.ok());
+        ASSERT_TRUE(s.ok()) << s;
 
         // merge input rowset
-        TabletSharedPtr tablet =
-                create_tablet(*tablet_schema, enable_unique_key_merge_on_write,
-                              output_rs_writer->version().first - 1, has_delete_handler);
+        TabletSharedPtr tablet = create_tablet(*tablet_schema, enable_unique_key_merge_on_write);
 
         // create input rowset reader
         vector<RowsetReaderSharedPtr> input_rs_readers;
@@ -400,7 +394,7 @@ protected:
         if (has_delete_handler) {
             // All keys less than 1000 are deleted by delete handler
             for (auto& item : output_data) {
-                EXPECT_GE(std::get<0>(item), 1000);
+                ASSERT_GE(std::get<0>(item), 1000);
             }
         }
 

--- a/be/test/vec/olap/vertical_compaction_test.cpp
+++ b/be/test/vec/olap/vertical_compaction_test.cpp
@@ -190,22 +190,24 @@ protected:
         return tablet_schema;
     }
 
-    void create_rowset_writer_context(TabletSchemaSPtr tablet_schema,
-                                      const SegmentsOverlapPB& overlap,
-                                      uint32_t max_rows_per_segment,
-                                      RowsetWriterContext* rowset_writer_context) {
+    RowsetWriterContext create_rowset_writer_context(TabletSchemaSPtr tablet_schema,
+                                                     const SegmentsOverlapPB& overlap,
+                                                     uint32_t max_rows_per_segment,
+                                                     Version version) {
         static int64_t inc_id = 1000;
+        RowsetWriterContext rowset_writer_context;
         RowsetId rowset_id;
         rowset_id.init(inc_id);
-        rowset_writer_context->rowset_id = rowset_id;
-        rowset_writer_context->rowset_type = BETA_ROWSET;
-        rowset_writer_context->rowset_state = VISIBLE;
-        rowset_writer_context->tablet_schema = tablet_schema;
-        rowset_writer_context->rowset_dir = absolute_dir + "/tablet_path";
-        rowset_writer_context->version = Version(inc_id, inc_id);
-        rowset_writer_context->segments_overlap = overlap;
-        rowset_writer_context->max_rows_per_segment = max_rows_per_segment;
+        rowset_writer_context.rowset_id = rowset_id;
+        rowset_writer_context.rowset_type = BETA_ROWSET;
+        rowset_writer_context.rowset_state = VISIBLE;
+        rowset_writer_context.tablet_schema = tablet_schema;
+        rowset_writer_context.rowset_dir = absolute_dir + "/tablet_path";
+        rowset_writer_context.version = version;
+        rowset_writer_context.segments_overlap = overlap;
+        rowset_writer_context.max_rows_per_segment = max_rows_per_segment;
         inc_id++;
+        return rowset_writer_context;
     }
 
     void create_and_init_rowset_reader(Rowset* rowset, RowsetReaderContext& context,
@@ -220,8 +222,7 @@ protected:
 
     RowsetSharedPtr create_rowset(
             TabletSchemaSPtr tablet_schema, const SegmentsOverlapPB& overlap,
-            std::vector<std::vector<std::tuple<int64_t, int64_t>>> rowset_data) {
-        RowsetWriterContext writer_context;
+            std::vector<std::vector<std::tuple<int64_t, int64_t>>> rowset_data, int64_t version) {
         if (overlap == NONOVERLAPPING) {
             for (auto i = 1; i < rowset_data.size(); i++) {
                 auto& last_seg_data = rowset_data[i - 1];
@@ -231,7 +232,8 @@ protected:
                 EXPECT_LT(last_seg_max, cur_seg_min);
             }
         }
-        create_rowset_writer_context(tablet_schema, overlap, UINT32_MAX, &writer_context);
+        auto writer_context = create_rowset_writer_context(tablet_schema, overlap, UINT32_MAX,
+                                                           {version, version});
 
         std::unique_ptr<RowsetWriter> rowset_writer;
         Status s = RowsetFactory::create_rowset_writer(writer_context, false, &rowset_writer);
@@ -296,22 +298,20 @@ protected:
         pb1->init_from_pb(rowset_meta_pb);
     }
 
-    void add_delete_predicate(TabletSharedPtr tablet, DeletePredicatePB& del_pred,
-                              int64_t version) {
+    RowsetSharedPtr create_delete_predicate(const TabletSchemaSPtr& schema,
+                                            DeletePredicatePB del_pred, int64_t version) {
         RowsetMetaSharedPtr rsm(new RowsetMeta());
         init_rs_meta(rsm, version, version);
         RowsetId id;
         id.init(version * 1000);
         rsm->set_rowset_id(id);
-        rsm->set_delete_predicate(del_pred);
-        rsm->set_tablet_schema(tablet->tablet_schema());
-        RowsetSharedPtr rowset = std::make_shared<BetaRowset>(tablet->tablet_schema(), "", rsm);
-        tablet->add_rowset(rowset);
+        rsm->set_delete_predicate(std::move(del_pred));
+        rsm->set_tablet_schema(schema);
+        return std::make_shared<BetaRowset>(schema, "", rsm);
     }
 
     TabletSharedPtr create_tablet(const TabletSchema& tablet_schema,
-                                  bool enable_unique_key_merge_on_write, int64_t version,
-                                  bool has_delete_handler) {
+                                  bool enable_unique_key_merge_on_write) {
         std::vector<TColumn> cols;
         std::unordered_map<uint32_t, uint32_t> col_ordinal_to_unique_id;
         for (auto i = 0; i < tablet_schema.num_columns(); i++) {
@@ -348,23 +348,6 @@ protected:
         EXPECT_TRUE(res.ok() && !exists);
         res = io::global_local_filesystem()->create_directory(tablet->tablet_path());
         EXPECT_TRUE(res.ok());
-
-        if (has_delete_handler) {
-            // delete data with key < 1000
-            std::vector<TCondition> conditions;
-            TCondition condition;
-            condition.column_name = tablet_schema.column(0).name();
-            condition.condition_op = "<";
-            condition.condition_values.clear();
-            condition.condition_values.push_back("100");
-            conditions.push_back(condition);
-
-            DeletePredicatePB del_pred;
-            Status st =
-                    DeleteHandler::generate_delete_predicate(tablet_schema, conditions, &del_pred);
-            EXPECT_EQ(Status::OK(), st);
-            add_delete_predicate(tablet, del_pred, version);
-        }
         return tablet;
     }
 
@@ -493,35 +476,34 @@ TEST_F(VerticalCompactionTest, TestDupKeyVerticalMerge) {
                 new_overlap = OVERLAPPING;
             }
         }
-        RowsetSharedPtr rowset = create_rowset(tablet_schema, new_overlap, input_data[i]);
+        RowsetSharedPtr rowset = create_rowset(tablet_schema, new_overlap, input_data[i], i);
         input_rowsets.push_back(rowset);
     }
     // create input rowset reader
     vector<RowsetReaderSharedPtr> input_rs_readers;
     for (auto& rowset : input_rowsets) {
         RowsetReaderSharedPtr rs_reader;
-        EXPECT_TRUE(rowset->create_reader(&rs_reader).ok());
+        ASSERT_TRUE(rowset->create_reader(&rs_reader).ok());
         input_rs_readers.push_back(std::move(rs_reader));
     }
 
     // create output rowset writer
-    RowsetWriterContext writer_context;
-    create_rowset_writer_context(tablet_schema, NONOVERLAPPING, 3456, &writer_context);
+    auto writer_context = create_rowset_writer_context(tablet_schema, NONOVERLAPPING, 3456,
+                                                       {0, input_rowsets.back()->end_version()});
     std::unique_ptr<RowsetWriter> output_rs_writer;
     Status s = RowsetFactory::create_rowset_writer(writer_context, true, &output_rs_writer);
-    EXPECT_TRUE(s.ok());
+    ASSERT_TRUE(s.ok()) << s;
 
     // merge input rowset
-    bool has_delete_handler = false;
-    TabletSharedPtr tablet = create_tablet(
-            *tablet_schema, false, output_rs_writer->version().first - 1, has_delete_handler);
+    TabletSharedPtr tablet = create_tablet(*tablet_schema, false);
     Merger::Statistics stats;
     RowIdConversion rowid_conversion;
     stats.rowid_conversion = &rowid_conversion;
     s = Merger::vertical_merge_rowsets(tablet, ReaderType::READER_BASE_COMPACTION, tablet_schema,
                                        input_rs_readers, output_rs_writer.get(), 100, &stats);
-    EXPECT_TRUE(s.ok());
+    ASSERT_TRUE(s.ok()) << s;
     RowsetSharedPtr out_rowset = output_rs_writer->build();
+    ASSERT_TRUE(out_rowset);
 
     // create output rowset reader
     RowsetReaderContext reader_context;
@@ -600,7 +582,7 @@ TEST_F(VerticalCompactionTest, TestDupWithoutKeyVerticalMerge) {
                 new_overlap = OVERLAPPING;
             }
         }
-        RowsetSharedPtr rowset = create_rowset(tablet_schema, new_overlap, input_data[i]);
+        RowsetSharedPtr rowset = create_rowset(tablet_schema, new_overlap, input_data[i], i);
         input_rowsets.push_back(rowset);
     }
     // create input rowset reader
@@ -612,22 +594,20 @@ TEST_F(VerticalCompactionTest, TestDupWithoutKeyVerticalMerge) {
     }
 
     // create output rowset writer
-    RowsetWriterContext writer_context;
-    create_rowset_writer_context(tablet_schema, NONOVERLAPPING, 3456, &writer_context);
+    auto writer_context = create_rowset_writer_context(tablet_schema, NONOVERLAPPING, 3456,
+                                                       {0, input_rowsets.back()->end_version()});
     std::unique_ptr<RowsetWriter> output_rs_writer;
     Status s = RowsetFactory::create_rowset_writer(writer_context, true, &output_rs_writer);
     EXPECT_TRUE(s.ok());
 
     // merge input rowset
-    bool has_delete_handler = false;
-    TabletSharedPtr tablet = create_tablet(
-            *tablet_schema, false, output_rs_writer->version().first - 1, has_delete_handler);
+    TabletSharedPtr tablet = create_tablet(*tablet_schema, false);
     Merger::Statistics stats;
     RowIdConversion rowid_conversion;
     stats.rowid_conversion = &rowid_conversion;
     s = Merger::vertical_merge_rowsets(tablet, ReaderType::READER_BASE_COMPACTION, tablet_schema,
                                        input_rs_readers, output_rs_writer.get(), 100, &stats);
-    EXPECT_TRUE(s.ok());
+    ASSERT_TRUE(s.ok()) << s;
     RowsetSharedPtr out_rowset = output_rs_writer->build();
 
     // create output rowset reader
@@ -708,7 +688,7 @@ TEST_F(VerticalCompactionTest, TestUniqueKeyVerticalMerge) {
                 new_overlap = OVERLAPPING;
             }
         }
-        RowsetSharedPtr rowset = create_rowset(tablet_schema, new_overlap, input_data[i]);
+        RowsetSharedPtr rowset = create_rowset(tablet_schema, new_overlap, input_data[i], i);
         input_rowsets.push_back(rowset);
     }
     // create input rowset reader
@@ -720,16 +700,14 @@ TEST_F(VerticalCompactionTest, TestUniqueKeyVerticalMerge) {
     }
 
     // create output rowset writer
-    RowsetWriterContext writer_context;
-    create_rowset_writer_context(tablet_schema, NONOVERLAPPING, 3456, &writer_context);
+    auto writer_context = create_rowset_writer_context(tablet_schema, NONOVERLAPPING, 3456,
+                                                       {0, input_rowsets.back()->end_version()});
     std::unique_ptr<RowsetWriter> output_rs_writer;
     Status s = RowsetFactory::create_rowset_writer(writer_context, true, &output_rs_writer);
     EXPECT_TRUE(s.ok());
 
     // merge input rowset
-    bool has_delete_handler = false;
-    TabletSharedPtr tablet = create_tablet(
-            *tablet_schema, false, output_rs_writer->version().first - 1, has_delete_handler);
+    TabletSharedPtr tablet = create_tablet(*tablet_schema, false);
     Merger::Statistics stats;
     RowIdConversion rowid_conversion;
     stats.rowid_conversion = &rowid_conversion;
@@ -797,46 +775,55 @@ TEST_F(VerticalCompactionTest, TestDupKeyVerticalMergeWithDelete) {
     }
 
     TabletSchemaSPtr tablet_schema = create_schema(DUP_KEYS);
+    TabletSharedPtr tablet = create_tablet(*tablet_schema, false);
     // create input rowset
-    vector<RowsetSharedPtr> input_rowsets;
     SegmentsOverlapPB new_overlap = overlap;
+    std::vector<RowsetSharedPtr> input_rowsets;
     for (auto i = 0; i < num_input_rowset; i++) {
         if (overlap == OVERLAP_UNKNOWN) {
-            if (i == 0) {
-                new_overlap = NONOVERLAPPING;
-            } else {
-                new_overlap = OVERLAPPING;
-            }
+            new_overlap = (i == 0) ? NONOVERLAPPING : OVERLAPPING;
         }
-        RowsetSharedPtr rowset = create_rowset(tablet_schema, new_overlap, input_data[i]);
-        input_rowsets.push_back(rowset);
+        input_rowsets.push_back(create_rowset(tablet_schema, new_overlap, input_data[i], i));
     }
+
+    // delete data with key < 100
+    std::vector<TCondition> conditions;
+    TCondition condition;
+    condition.column_name = tablet->tablet_schema()->column(0).name();
+    condition.condition_op = "<";
+    condition.condition_values.clear();
+    condition.condition_values.push_back("100");
+    conditions.push_back(condition);
+    DeletePredicatePB del_pred;
+    auto st = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
+                                                       &del_pred);
+    ASSERT_TRUE(st.ok()) << st;
+    input_rowsets.push_back(create_delete_predicate(tablet->tablet_schema(), std::move(del_pred),
+                                                    num_input_rowset));
+
     // create input rowset reader
     vector<RowsetReaderSharedPtr> input_rs_readers;
     for (auto& rowset : input_rowsets) {
         RowsetReaderSharedPtr rs_reader;
-        EXPECT_TRUE(rowset->create_reader(&rs_reader).ok());
+        ASSERT_TRUE(rowset->create_reader(&rs_reader).ok());
         input_rs_readers.push_back(std::move(rs_reader));
     }
 
     // create output rowset writer
-    RowsetWriterContext writer_context;
-    create_rowset_writer_context(tablet_schema, NONOVERLAPPING, 3456, &writer_context);
+    auto writer_context = create_rowset_writer_context(tablet_schema, NONOVERLAPPING, 3456,
+                                                       {0, input_rowsets.back()->end_version()});
     std::unique_ptr<RowsetWriter> output_rs_writer;
-    Status s = RowsetFactory::create_rowset_writer(writer_context, true, &output_rs_writer);
-    EXPECT_TRUE(s.ok());
-
+    st = RowsetFactory::create_rowset_writer(writer_context, true, &output_rs_writer);
+    ASSERT_TRUE(st.ok()) << st;
     // merge input rowset
-    bool has_delete_handler = true;
-    TabletSharedPtr tablet = create_tablet(*tablet_schema, false, output_rs_writer->version().first,
-                                           has_delete_handler);
     Merger::Statistics stats;
     RowIdConversion rowid_conversion;
     stats.rowid_conversion = &rowid_conversion;
-    s = Merger::vertical_merge_rowsets(tablet, ReaderType::READER_BASE_COMPACTION, tablet_schema,
-                                       input_rs_readers, output_rs_writer.get(), 100, &stats);
-    EXPECT_TRUE(s.ok());
+    st = Merger::vertical_merge_rowsets(tablet, ReaderType::READER_BASE_COMPACTION, tablet_schema,
+                                        input_rs_readers, output_rs_writer.get(), 100, &stats);
+    ASSERT_TRUE(st.ok()) << st;
     RowsetSharedPtr out_rowset = output_rs_writer->build();
+    ASSERT_TRUE(out_rowset);
 
     // create output rowset reader
     RowsetReaderContext reader_context;
@@ -853,24 +840,22 @@ TEST_F(VerticalCompactionTest, TestDupKeyVerticalMergeWithDelete) {
     std::vector<std::tuple<int64_t, int64_t>> output_data;
     do {
         block_create(tablet_schema, &output_block);
-        s = output_rs_reader->next_block(&output_block);
+        st = output_rs_reader->next_block(&output_block);
         auto columns = output_block.get_columns_with_type_and_name();
         EXPECT_EQ(columns.size(), 2);
         for (auto i = 0; i < output_block.rows(); i++) {
             output_data.emplace_back(columns[0].column->get_int(i), columns[1].column->get_int(i));
         }
-    } while (s == Status::OK());
-    EXPECT_EQ(Status::Error<END_OF_FILE>(""), s);
+    } while (st.ok());
+    EXPECT_TRUE(st.is<END_OF_FILE>()) << st;
     EXPECT_EQ(out_rowset->rowset_meta()->num_rows(), output_data.size());
     EXPECT_EQ(output_data.size(),
               num_input_rowset * num_segments * rows_per_segment - num_input_rowset * 100);
     std::vector<uint32_t> segment_num_rows;
     EXPECT_TRUE(output_rs_reader->get_segment_num_rows(&segment_num_rows).ok());
-    if (has_delete_handler) {
-        // All keys less than 1000 are deleted by delete handler
-        for (auto& item : output_data) {
-            EXPECT_GE(std::get<0>(item), 100);
-        }
+    // All keys less than 1000 are deleted by delete handler
+    for (auto& item : output_data) {
+        ASSERT_GE(std::get<0>(item), 100);
     }
 }
 
@@ -891,46 +876,55 @@ TEST_F(VerticalCompactionTest, TestDupWithoutKeyVerticalMergeWithDelete) {
     }
 
     TabletSchemaSPtr tablet_schema = create_schema(DUP_KEYS, true);
+    TabletSharedPtr tablet = create_tablet(*tablet_schema, false);
     // create input rowset
-    vector<RowsetSharedPtr> input_rowsets;
     SegmentsOverlapPB new_overlap = overlap;
+    std::vector<RowsetSharedPtr> input_rowsets;
     for (auto i = 0; i < num_input_rowset; i++) {
         if (overlap == OVERLAP_UNKNOWN) {
-            if (i == 0) {
-                new_overlap = NONOVERLAPPING;
-            } else {
-                new_overlap = OVERLAPPING;
-            }
+            new_overlap = (i == 0) ? NONOVERLAPPING : OVERLAPPING;
         }
-        RowsetSharedPtr rowset = create_rowset(tablet_schema, new_overlap, input_data[i]);
-        input_rowsets.push_back(rowset);
+        input_rowsets.push_back(create_rowset(tablet_schema, new_overlap, input_data[i], i));
     }
+
+    // delete data with key < 100
+    std::vector<TCondition> conditions;
+    TCondition condition;
+    condition.column_name = tablet->tablet_schema()->column(0).name();
+    condition.condition_op = "<";
+    condition.condition_values.clear();
+    condition.condition_values.push_back("100");
+    conditions.push_back(condition);
+    DeletePredicatePB del_pred;
+    auto st = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
+                                                       &del_pred);
+    ASSERT_TRUE(st.ok()) << st;
+    input_rowsets.push_back(create_delete_predicate(tablet->tablet_schema(), std::move(del_pred),
+                                                    num_input_rowset));
+
     // create input rowset reader
     vector<RowsetReaderSharedPtr> input_rs_readers;
     for (auto& rowset : input_rowsets) {
         RowsetReaderSharedPtr rs_reader;
-        EXPECT_TRUE(rowset->create_reader(&rs_reader).ok());
+        ASSERT_TRUE(rowset->create_reader(&rs_reader).ok());
         input_rs_readers.push_back(std::move(rs_reader));
     }
 
     // create output rowset writer
-    RowsetWriterContext writer_context;
-    create_rowset_writer_context(tablet_schema, NONOVERLAPPING, 3456, &writer_context);
+    auto writer_context = create_rowset_writer_context(tablet_schema, NONOVERLAPPING, 3456,
+                                                       {0, input_rowsets.back()->end_version()});
     std::unique_ptr<RowsetWriter> output_rs_writer;
-    Status s = RowsetFactory::create_rowset_writer(writer_context, true, &output_rs_writer);
-    EXPECT_TRUE(s.ok());
-
+    st = RowsetFactory::create_rowset_writer(writer_context, true, &output_rs_writer);
+    ASSERT_TRUE(st.ok()) << st;
     // merge input rowset
-    bool has_delete_handler = true;
-    TabletSharedPtr tablet = create_tablet(*tablet_schema, false, output_rs_writer->version().first,
-                                           has_delete_handler);
     Merger::Statistics stats;
     RowIdConversion rowid_conversion;
     stats.rowid_conversion = &rowid_conversion;
-    s = Merger::vertical_merge_rowsets(tablet, ReaderType::READER_BASE_COMPACTION, tablet_schema,
-                                       input_rs_readers, output_rs_writer.get(), 100, &stats);
-    EXPECT_TRUE(s.ok());
+    st = Merger::vertical_merge_rowsets(tablet, ReaderType::READER_BASE_COMPACTION, tablet_schema,
+                                        input_rs_readers, output_rs_writer.get(), 100, &stats);
+    ASSERT_TRUE(st.ok()) << st;
     RowsetSharedPtr out_rowset = output_rs_writer->build();
+    ASSERT_TRUE(out_rowset);
 
     // create output rowset reader
     RowsetReaderContext reader_context;
@@ -947,24 +941,22 @@ TEST_F(VerticalCompactionTest, TestDupWithoutKeyVerticalMergeWithDelete) {
     std::vector<std::tuple<int64_t, int64_t>> output_data;
     do {
         block_create(tablet_schema, &output_block);
-        s = output_rs_reader->next_block(&output_block);
+        st = output_rs_reader->next_block(&output_block);
         auto columns = output_block.get_columns_with_type_and_name();
         EXPECT_EQ(columns.size(), 2);
         for (auto i = 0; i < output_block.rows(); i++) {
             output_data.emplace_back(columns[0].column->get_int(i), columns[1].column->get_int(i));
         }
-    } while (s == Status::OK());
-    EXPECT_EQ(Status::Error<END_OF_FILE>(""), s);
+    } while (st.ok());
+    EXPECT_TRUE(st.is<END_OF_FILE>()) << st;
     EXPECT_EQ(out_rowset->rowset_meta()->num_rows(), output_data.size());
     EXPECT_EQ(output_data.size(),
               num_input_rowset * num_segments * rows_per_segment - num_input_rowset * 100);
     std::vector<uint32_t> segment_num_rows;
     EXPECT_TRUE(output_rs_reader->get_segment_num_rows(&segment_num_rows).ok());
-    if (has_delete_handler) {
-        // All keys less than 1000 are deleted by delete handler
-        for (auto& item : output_data) {
-            EXPECT_GE(std::get<0>(item), 100);
-        }
+    // All keys less than 1000 are deleted by delete handler
+    for (auto& item : output_data) {
+        ASSERT_GE(std::get<0>(item), 100);
     }
 }
 
@@ -996,7 +988,7 @@ TEST_F(VerticalCompactionTest, TestAggKeyVerticalMerge) {
                 new_overlap = OVERLAPPING;
             }
         }
-        RowsetSharedPtr rowset = create_rowset(tablet_schema, new_overlap, input_data[i]);
+        RowsetSharedPtr rowset = create_rowset(tablet_schema, new_overlap, input_data[i], i);
         input_rowsets.push_back(rowset);
     }
     // create input rowset reader
@@ -1008,16 +1000,14 @@ TEST_F(VerticalCompactionTest, TestAggKeyVerticalMerge) {
     }
 
     // create output rowset writer
-    RowsetWriterContext writer_context;
-    create_rowset_writer_context(tablet_schema, NONOVERLAPPING, 3456, &writer_context);
+    auto writer_context = create_rowset_writer_context(tablet_schema, NONOVERLAPPING, 3456,
+                                                       {0, input_rowsets.back()->end_version()});
     std::unique_ptr<RowsetWriter> output_rs_writer;
     Status s = RowsetFactory::create_rowset_writer(writer_context, true, &output_rs_writer);
     EXPECT_TRUE(s.ok());
 
     // merge input rowset
-    bool has_delete_handler = false;
-    TabletSharedPtr tablet = create_tablet(
-            *tablet_schema, false, output_rs_writer->version().first - 1, has_delete_handler);
+    TabletSharedPtr tablet = create_tablet(*tablet_schema, false);
     Merger::Statistics stats;
     RowIdConversion rowid_conversion;
     stats.rowid_conversion = &rowid_conversion;

--- a/be/test/vec/olap/vertical_compaction_test.cpp
+++ b/be/test/vec/olap/vertical_compaction_test.cpp
@@ -269,33 +269,21 @@ protected:
         return rowset;
     }
 
-    void init_rs_meta(RowsetMetaSharedPtr& pb1, int64_t start, int64_t end) {
+    void init_rs_meta(RowsetMetaSharedPtr& rs_meta, int64_t start, int64_t end) {
         std::string json_rowset_meta = R"({
-            "rowset_id": 540085,
-            "tablet_id": 15674,
-            "txn_id": 4045,
-            "tablet_schema_hash": 567997588,
+            "rowset_id": 540081,
+            "tablet_id": 15673,
+            "tablet_schema_hash": 567997577,
             "rowset_type": "BETA_ROWSET",
             "rowset_state": "VISIBLE",
-            "start_version": 2,
-            "end_version": 2,
-            "num_rows": 3929,
-            "total_disk_size": 84699,
-            "data_disk_size": 84464,
-            "index_disk_size": 235,
-            "empty": false,
-            "load_id": {
-                "hi": -5350970832824939812,
-                "lo": -6717994719194512122
-            },
-            "creation_time": 1553765670
+            "empty": false
         })";
         RowsetMetaPB rowset_meta_pb;
         json2pb::JsonToProtoMessage(json_rowset_meta, &rowset_meta_pb);
         rowset_meta_pb.set_start_version(start);
         rowset_meta_pb.set_end_version(end);
         rowset_meta_pb.set_creation_time(10000);
-        pb1->init_from_pb(rowset_meta_pb);
+        rs_meta->init_from_pb(rowset_meta_pb);
     }
 
     RowsetSharedPtr create_delete_predicate(const TabletSchemaSPtr& schema,


### PR DESCRIPTION
## Proposed changes

1. Optimize fetching delete predicates code:
  - Avoid traversing rowsets of tablet to  get specified version schema.
  - Get delete predicates directly from captured consistent rowsets instead of tablet to get rid of holding meta lock.

2. Fix incorrect query result when compaction eliminate delete predicates between `NewOlapScanNode::_init_scanners` and `NewOlapScanner::init`.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

