### PR TITLE
[enhancement](baddisk) record bad disk in be_custom.conf to handle

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -274,7 +274,7 @@ DEFINE_mInt32(tablet_lookup_cache_clean_interval, "30");
 DEFINE_mInt32(disk_stat_monitor_interval, "5");
 DEFINE_mInt32(unused_rowset_monitor_interval, "30");
 DEFINE_String(storage_root_path, "${DORIS_HOME}/storage");
-DEFINE_String(broken_storage_path, "");
+DEFINE_mString(broken_storage_path, "");
 
 // Config is used to check incompatible old format hdr_ format
 // whether doris uses strict way. When config is true, process will log fatal

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -274,6 +274,7 @@ DEFINE_mInt32(tablet_lookup_cache_clean_interval, "30");
 DEFINE_mInt32(disk_stat_monitor_interval, "5");
 DEFINE_mInt32(unused_rowset_monitor_interval, "30");
 DEFINE_String(storage_root_path, "${DORIS_HOME}/storage");
+DEFINE_String(broken_storage_path, "");
 
 // Config is used to check incompatible old format hdr_ format
 // whether doris uses strict way. When config is true, process will log fatal
@@ -1326,9 +1327,9 @@ void Properties::set_force(const std::string& key, const std::string& val) {
 }
 
 Status Properties::dump(const std::string& conffile) {
-    RETURN_IF_ERROR(io::global_local_filesystem()->delete_file(conffile));
+    std::string conffile_tmp = conffile + ".tmp";
     io::FileWriterPtr file_writer;
-    RETURN_IF_ERROR(io::global_local_filesystem()->create_file(conffile, &file_writer));
+    RETURN_IF_ERROR(io::global_local_filesystem()->create_file(conffile_tmp, &file_writer));
     RETURN_IF_ERROR(file_writer->append("# THIS IS AN AUTO GENERATED CONFIG FILE.\n"));
     RETURN_IF_ERROR(file_writer->append(
             "# You can modify this file manually, and the configurations in this file\n"));
@@ -1341,7 +1342,9 @@ Status Properties::dump(const std::string& conffile) {
         RETURN_IF_ERROR(file_writer->append("\n"));
     }
 
-    return file_writer->close();
+    RETURN_IF_ERROR(file_writer->close());
+
+    return io::global_local_filesystem()->rename(conffile_tmp, conffile);
 }
 
 template <typename T>

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -323,6 +323,7 @@ DECLARE_mInt32(tablet_lookup_cache_clean_interval);
 DECLARE_mInt32(disk_stat_monitor_interval);
 DECLARE_mInt32(unused_rowset_monitor_interval);
 DECLARE_String(storage_root_path);
+DECLARE_mString(broken_storage_path);
 
 // Config is used to check incompatible old format hdr_ format
 // whether doris uses strict way. When config is true, process will log fatal

--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -242,6 +242,7 @@ void DataDir::health_check() {
         if (!res) {
             LOG(WARNING) << "store read/write test file occur IO Error. path=" << _path
                          << ", err: " << res;
+            StorageEngine::instance()->add_broken_path(_path);
             _is_used = !res.is<IO_ERROR>();
         }
     }

--- a/be/src/olap/options.cpp
+++ b/be/src/olap/options.cpp
@@ -167,7 +167,8 @@ Status parse_conf_store_paths(const string& config_path, std::vector<StorePath>*
                 paths->emplace_back(std::move(path));
             } else {
                 LOG(WARNING) << "a duplicated path is found " << path.path;
-                return Status::Error<INVALID_ARGUMENT>("a duplicated path is found, path={}", path.path);
+                return Status::Error<INVALID_ARGUMENT>("a duplicated path is found, path={}",
+                                                       path.path);
             }
         } else {
             LOG(WARNING) << "failed to parse store path " << item << ", res=" << res;

--- a/be/src/olap/options.cpp
+++ b/be/src/olap/options.cpp
@@ -156,11 +156,19 @@ Status parse_conf_store_paths(const string& config_path, std::vector<StorePath>*
         // deal with the case that user add `;` to the tail
         path_vec.pop_back();
     }
+
+    std::set<std::string> real_paths;
     for (auto& item : path_vec) {
         StorePath path;
         auto res = parse_root_path(item, &path);
         if (res.ok()) {
-            paths->emplace_back(std::move(path));
+            auto success = real_paths.emplace(path.path).second;
+            if (success) {
+                paths->emplace_back(std::move(path));
+            } else {
+                LOG(WARNING) << "a duplicated path is found " << path.path;
+                return Status::Error<INVALID_ARGUMENT>("a duplicated path is found, path={}", path.path);
+            }
         } else {
             LOG(WARNING) << "failed to parse store path " << item << ", res=" << res;
         }
@@ -170,6 +178,21 @@ Status parse_conf_store_paths(const string& config_path, std::vector<StorePath>*
                                                config_path);
     }
     return Status::OK();
+}
+
+void parse_conf_broken_store_paths(const string& config_path, std::set<std::string>* paths) {
+    std::vector<string> path_vec = strings::Split(config_path, ";", strings::SkipWhitespace());
+    if (path_vec.empty()) {
+        return;
+    }
+    if (path_vec.back().empty()) {
+        // deal with the case that user add `;` to the tail
+        path_vec.pop_back();
+    }
+    for (auto& item : path_vec) {
+        paths->emplace(item);
+    }
+    return;
 }
 
 /** format:   

--- a/be/src/olap/options.h
+++ b/be/src/olap/options.h
@@ -47,6 +47,8 @@ Status parse_root_path(const std::string& root_path, StorePath* path);
 
 Status parse_conf_store_paths(const std::string& config_path, std::vector<StorePath>* path);
 
+void parse_conf_broken_store_paths(const std::string& config_path, std::set<std::string>* paths);
+
 struct CachePath {
     io::FileCacheSettings init_settings() const;
     CachePath(std::string path, int64_t total_bytes, int64_t query_limit_bytes)
@@ -62,6 +64,7 @@ Status parse_conf_cache_paths(const std::string& config_path, std::vector<CacheP
 struct EngineOptions {
     // list paths that tablet will be put into.
     std::vector<StorePath> store_paths;
+    std::set<std::string> broken_paths;
     // BE's UUID. It will be reset every time BE restarts.
     UniqueId backend_uid {0, 0};
 };

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -296,7 +296,7 @@ Status BetaRowsetReader::_init_iterator() {
 
 Status BetaRowsetReader::next_block(vectorized::Block* block) {
     SCOPED_RAW_TIMER(&_stats->block_fetch_ns);
-    _init_iterator_once();
+    RETURN_IF_ERROR(_init_iterator_once());
     if (_empty) {
         return Status::Error<END_OF_FILE>("BetaRowsetReader is empty");
     }
@@ -316,7 +316,7 @@ Status BetaRowsetReader::next_block(vectorized::Block* block) {
 
 Status BetaRowsetReader::next_block_view(vectorized::BlockView* block_view) {
     SCOPED_RAW_TIMER(&_stats->block_fetch_ns);
-    _init_iterator_once();
+    RETURN_IF_ERROR(_init_iterator_once());
     do {
         auto s = _iterator->next_block_view(block_view);
         if (!s.ok()) {

--- a/be/src/olap/rowset/beta_rowset_reader.h
+++ b/be/src/olap/rowset/beta_rowset_reader.h
@@ -85,8 +85,8 @@ public:
     RowsetReaderSharedPtr clone() override;
 
 private:
-    Status _init_iterator_once();
-    Status _init_iterator();
+    [[nodiscard]] Status _init_iterator_once();
+    [[nodiscard]] Status _init_iterator();
     bool _should_push_down_value_predicates() const;
     bool _is_merge_iterator() const {
         return _read_context->need_ordered_result &&

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -1406,7 +1406,9 @@ Status StorageEngine::_persist_broken_paths() {
     }
 
     if (config_value.length() > 0) {
-        return config::set_config("broken_store_path", config_value);
+        auto st = config::set_config("broken_storage_path", config_value, true);
+        LOG(INFO) << "persist broken_store_path " << config_value << st;
+        return st;
     }
 
     return Status::OK();

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -1393,10 +1393,10 @@ bool StorageEngine::add_broken_path(std::string path) {
 bool StorageEngine::remove_broken_path(std::string path) {
     std::lock_guard<std::mutex> lock(_broken_paths_mutex);
     auto count = _broken_paths.erase(path);
-    if (count > 1) {
+    if (count > 0) {
         _persist_broken_paths();
     }
-    return count > 1;
+    return count > 0;
 }
 
 Status StorageEngine::_persist_broken_paths() {

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -1407,7 +1407,7 @@ Status StorageEngine::_persist_broken_paths() {
 
     if (config_value.length() > 0) {
         auto st = config::set_config("broken_storage_path", config_value, true);
-        LOG(INFO) << "persist broken_store_path " << config_value << st;
+        LOG(INFO) << "persist broken_storae_path " << config_value << st;
         return st;
     }
 

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -129,6 +129,8 @@ StorageEngine::StorageEngine(const EngineOptions& options)
         // std::lock_guard<std::mutex> lock(_gc_mutex);
         return _unused_rowsets.size();
     });
+
+    _broken_paths = options.broken_paths;
 }
 
 StorageEngine::~StorageEngine() {
@@ -1377,6 +1379,37 @@ RowsetSharedPtr StorageEngine::get_quering_rowset(RowsetId rs_id) {
 void StorageEngine::evict_querying_rowset(RowsetId rs_id) {
     std::lock_guard<std::mutex> lock(_quering_rowsets_mutex);
     _querying_rowsets.erase(rs_id);
+}
+
+bool StorageEngine::add_broken_path(std::string path) {
+    std::lock_guard<std::mutex> lock(_broken_paths_mutex);
+    auto success = _broken_paths.emplace(path).second;
+    if (success) {
+        _persist_broken_paths();
+    }
+    return success;
+}
+
+bool StorageEngine::remove_broken_path(std::string path) {
+    std::lock_guard<std::mutex> lock(_broken_paths_mutex);
+    auto count = _broken_paths.erase(path);
+    if (count > 1) {
+        _persist_broken_paths();
+    }
+    return count > 1;
+}
+
+Status StorageEngine::_persist_broken_paths() {
+    std::string config_value;
+    for (const std::string& path : _broken_paths) {
+        config_value += path + ";";
+    }
+
+    if (config_value.length() > 0) {
+        return config::set_config("broken_store_path", config_value);
+    }
+
+    return Status::OK();
 }
 
 } // namespace doris

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -239,6 +239,8 @@ public:
     bool add_broken_path(std::string path);
     bool remove_broken_path(std::string path);
 
+    std::set<string> get_broken_paths() { return _broken_paths; }
+
 private:
     // Instance should be inited from `static open()`
     // MUST NOT be called in other circumstances.

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -236,6 +236,9 @@ public:
 
     void evict_querying_rowset(RowsetId rs_id);
 
+    bool add_broken_path(std::string path);
+    bool remove_broken_path(std::string path);
+
 private:
     // Instance should be inited from `static open()`
     // MUST NOT be called in other circumstances.
@@ -336,6 +339,8 @@ private:
 
     void _async_publish_callback();
 
+    Status _persist_broken_paths();
+
 private:
     struct CompactionCandidate {
         CompactionCandidate(uint32_t nicumulative_compaction_, int64_t tablet_id_, uint32_t index_)
@@ -370,6 +375,9 @@ private:
     std::mutex _store_lock;
     std::mutex _trash_sweep_lock;
     std::map<std::string, DataDir*> _store_map;
+    std::set<std::string> _broken_paths;
+    std::mutex _broken_paths_mutex;
+
     uint32_t _available_storage_medium_type_count;
 
     int32_t _effective_cluster_id;

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -73,8 +73,6 @@ public:
     // If `is_drop_table_or_partition` is true, we need to remove all remote rowsets in this tablet.
     Status drop_tablet(TTabletId tablet_id, TReplicaId replica_id, bool is_drop_table_or_partition);
 
-    Status drop_tablets_on_error_root_path(const std::vector<TabletInfo>& tablet_info_vec);
-
     TabletSharedPtr find_best_tablet_to_compaction(
             CompactionType compaction_type, DataDir* data_dir,
             const std::unordered_set<TTabletId>& tablet_submitted_compaction, uint32_t* score,

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -116,7 +116,8 @@ public:
     ~ExecEnv();
 
     // Initial exec environment. must call this to init all
-    [[nodiscard]] static Status init(ExecEnv* env, const std::vector<StorePath>& store_paths);
+    [[nodiscard]] static Status init(ExecEnv* env, const std::vector<StorePath>& store_paths,
+                                     const std::set<std::string>& broken_paths);
 
     // Stop all threads and delete resources.
     void destroy();
@@ -268,7 +269,8 @@ public:
 private:
     ExecEnv();
 
-    [[nodiscard]] Status _init(const std::vector<StorePath>& store_paths);
+    [[nodiscard]] Status _init(const std::vector<StorePath>& store_paths,
+                               const std::set<std::string>& broken_paths);
     void _destroy();
 
     Status _init_mem_env();

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -138,7 +138,8 @@ Status ExecEnv::init(ExecEnv* env, const std::vector<StorePath>& store_paths,
     return env->_init(store_paths, broken_paths);
 }
 
-Status ExecEnv::_init(const std::vector<StorePath>& store_paths, const std::set<std::string>& broken_paths) {
+Status ExecEnv::_init(const std::vector<StorePath>& store_paths,
+                      const std::set<std::string>& broken_paths) {
     //Only init once before be destroyed
     if (ready()) {
         return Status::OK();

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -411,6 +411,7 @@ int main(int argc, char** argv) {
         if (broken_paths.count(it->path) > 0) {
             if (doris::config::ignore_broken_disk) {
                 LOG(WARNING) << "ignore broken disk, path = " << it->path;
+                it = paths.erase(it);
             } else {
                 LOG(FATAL) << "a broken disk is found " << it->path;
                 exit(-1);

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -403,9 +403,19 @@ int main(int argc, char** argv) {
         LOG(FATAL) << "parse config storage path failed, path=" << doris::config::storage_root_path;
         exit(-1);
     }
+    std::set<std::string> broken_paths;
+    doris::parse_conf_broken_store_paths(doris::config::broken_storage_path, &broken_paths);
+
     auto it = paths.begin();
     for (; it != paths.end();) {
-        if (!doris::check_datapath_rw(it->path)) {
+        if (broken_paths.count(it->path) > 0) {
+            if (doris::config::ignore_broken_disk) {
+                LOG(WARNING) << "ignore broken disk, path = " << it->path;
+            } else {
+                LOG(FATAL) << "a broken disk is found " << it->path;
+                exit(-1);
+            }
+        } else if (!doris::check_datapath_rw(it->path)) {
             if (doris::config::ignore_broken_disk) {
                 LOG(WARNING) << "read write test file failed, path=" << it->path;
                 it = paths.erase(it);
@@ -472,7 +482,7 @@ int main(int argc, char** argv) {
 
     // init exec env
     auto exec_env(doris::ExecEnv::GetInstance());
-    status = doris::ExecEnv::init(doris::ExecEnv::GetInstance(), paths);
+    status = doris::ExecEnv::init(doris::ExecEnv::GetInstance(), paths, broken_paths);
     if (status != Status::OK()) {
         LOG(FATAL) << "failed to init doris storage engine, res=" << status;
         exit(-1);

--- a/be/test/common/config_test.cpp
+++ b/be/test/common/config_test.cpp
@@ -33,6 +33,7 @@ using namespace config;
 
 class ConfigTest : public testing::Test {
     void SetUp() override { config::Register::_s_field_map->clear(); }
+    void TearDown() override { config::Register::_s_field_map->clear(); }
 };
 
 TEST_F(ConfigTest, DumpAllConfigs) {

--- a/be/test/olap/options_test.cpp
+++ b/be/test/olap/options_test.cpp
@@ -127,4 +127,74 @@ TEST_F(OptionsTest, parse_root_path) {
     }
 }
 
+TEST_F(OptionsTest, parse_conf_store_path) {
+    std::string path_prefix = std::filesystem::absolute("./test_run").string();
+    std::string path1 = path_prefix + "/palo";
+    std::string path2 = path_prefix + "/palo.ssd";
+
+    {
+        std::vector<StorePath> paths;
+        std::string config_path = path1;
+        auto st = parse_conf_store_paths(config_path, &paths);
+        EXPECT_EQ(Status::OK(), st);
+        EXPECT_EQ(paths.size(), 1);
+        EXPECT_STREQ(paths[0].path.c_str(), config_path.c_str());
+        EXPECT_EQ(paths[0].capacity_bytes, -1);
+        EXPECT_EQ(paths[0].storage_medium, TStorageMedium::HDD);
+    }
+    {
+        std::vector<StorePath> paths;
+        std::string config_path = path1 + ";";
+        auto st = parse_conf_store_paths(config_path, &paths);
+        EXPECT_EQ(Status::OK(), st);
+        EXPECT_EQ(paths.size(), 1);
+        EXPECT_STREQ(paths[0].path.c_str(), path1.c_str());
+        EXPECT_EQ(paths[0].capacity_bytes, -1);
+        EXPECT_EQ(paths[0].storage_medium, TStorageMedium::HDD);
+    }
+    {
+        std::vector<StorePath> paths;
+        std::string config_path = path1 + ";" + path1;
+        auto st = parse_conf_store_paths(config_path, &paths);
+        EXPECT_EQ(Status::Error<ErrorCode::INVALID_ARGUMENT>("a duplicated path is found, path={}", path1), st);
+    }
+    {
+        std::vector<StorePath> paths;
+        std::string config_path = path1 + ";" + path2 + ";";
+        auto st = parse_conf_store_paths(config_path, &paths);
+        EXPECT_EQ(Status::OK(), st);
+        EXPECT_EQ(paths.size(), 2);
+        EXPECT_STREQ(paths[0].path.c_str(), path1.c_str());
+        EXPECT_EQ(paths[0].capacity_bytes, -1);
+        EXPECT_EQ(paths[0].storage_medium, TStorageMedium::HDD);
+        EXPECT_STREQ(paths[1].path.c_str(), path2.c_str());
+        EXPECT_EQ(paths[1].capacity_bytes, -1);
+        EXPECT_EQ(paths[1].storage_medium, TStorageMedium::SSD);
+    }
+}
+
+TEST_F(OptionsTest, parse_broken_path) {
+    {
+        std::string broken_paths = "path1";
+        std::set<std::string> parsed_paths;
+        parse_conf_broken_store_paths(broken_paths, &parsed_paths);
+        EXPECT_EQ(parsed_paths.size(), 1);
+    }
+    {
+        std::string broken_paths = "path1;path1;";
+        std::set<std::string> parsed_paths;
+        parse_conf_broken_store_paths(broken_paths, &parsed_paths);
+        EXPECT_EQ(parsed_paths.size(), 1);
+        EXPECT_EQ(parsed_paths.count("path1"), 1);
+    }
+    {
+        std::string broken_paths = "path1;path2;";
+        std::set<std::string> parsed_paths;
+        parse_conf_broken_store_paths(broken_paths, &parsed_paths);
+        EXPECT_EQ(parsed_paths.size(), 2);
+        EXPECT_EQ(parsed_paths.count("path1"), 1);
+        EXPECT_EQ(parsed_paths.count("path2"), 1);
+    }
+}
+
 } // namespace doris

--- a/be/test/olap/options_test.cpp
+++ b/be/test/olap/options_test.cpp
@@ -156,7 +156,9 @@ TEST_F(OptionsTest, parse_conf_store_path) {
         std::vector<StorePath> paths;
         std::string config_path = path1 + ";" + path1;
         auto st = parse_conf_store_paths(config_path, &paths);
-        EXPECT_EQ(Status::Error<ErrorCode::INVALID_ARGUMENT>("a duplicated path is found, path={}", path1), st);
+        EXPECT_EQ(Status::Error<ErrorCode::INVALID_ARGUMENT>("a duplicated path is found, path={}",
+                                                             path1),
+                  st);
     }
     {
         std::vector<StorePath> paths;

--- a/be/test/olap/storage_engine_test.cpp
+++ b/be/test/olap/storage_engine_test.cpp
@@ -34,6 +34,7 @@ using ::testing::SetArgPointee;
 using std::string;
 
 namespace doris {
+using namespace config;
 
 class StorageEngineTest : public testing::Test {
 public:
@@ -49,13 +50,15 @@ public:
 };
 
 TEST_F(StorageEngineTest, TestBrokenDisk) {
+    DEFINE_mString(broken_storage_path, "");
     std::string path = config::custom_config_dir + "/be_custom.conf";
+
     std::error_code ec;
     {
         _storage_engine->add_broken_path("broken_path1");
         EXPECT_EQ(std::filesystem::exists(path, ec), true);
         EXPECT_EQ(_storage_engine->get_broken_paths().count("broken_path1"), 1);
-        EXPECT_EQ(config::broken_storage_path, "broken_path1;");
+        EXPECT_EQ(broken_storage_path, "broken_path1;");
     }
 
     {
@@ -63,7 +66,7 @@ TEST_F(StorageEngineTest, TestBrokenDisk) {
         EXPECT_EQ(std::filesystem::exists(path, ec), true);
         EXPECT_EQ(_storage_engine->get_broken_paths().count("broken_path1"), 1);
         EXPECT_EQ(_storage_engine->get_broken_paths().count("broken_path2"), 1);
-        EXPECT_EQ(config::broken_storage_path, "broken_path1;broken_path2;");
+        EXPECT_EQ(broken_storage_path, "broken_path1;broken_path2;");
     }
 
     {
@@ -71,7 +74,7 @@ TEST_F(StorageEngineTest, TestBrokenDisk) {
         EXPECT_EQ(std::filesystem::exists(path, ec), true);
         EXPECT_EQ(_storage_engine->get_broken_paths().count("broken_path1"), 1);
         EXPECT_EQ(_storage_engine->get_broken_paths().count("broken_path2"), 1);
-        EXPECT_EQ(config::broken_storage_path, "broken_path1;broken_path2;");
+        EXPECT_EQ(broken_storage_path, "broken_path1;broken_path2;");
     }
 
     {
@@ -79,7 +82,7 @@ TEST_F(StorageEngineTest, TestBrokenDisk) {
         EXPECT_EQ(std::filesystem::exists(path, ec), true);
         EXPECT_EQ(_storage_engine->get_broken_paths().count("broken_path1"), 1);
         EXPECT_EQ(_storage_engine->get_broken_paths().count("broken_path2"), 0);
-        EXPECT_EQ(config::broken_storage_path, "broken_path1;");
+        EXPECT_EQ(broken_storage_path, "broken_path1;");
     }
 }
 

--- a/be/test/olap/storage_engine_test.cpp
+++ b/be/test/olap/storage_engine_test.cpp
@@ -48,7 +48,6 @@ public:
     std::unique_ptr<StorageEngine> _storage_engine;
 };
 
-
 TEST_F(StorageEngineTest, TestBrokenDisk) {
     std::string path = config::custom_config_dir + "/be_custom.conf";
     std::error_code ec;

--- a/be/test/olap/storage_engine_test.cpp
+++ b/be/test/olap/storage_engine_test.cpp
@@ -1,0 +1,87 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "olap/storage_engine.h"
+
+#include <gmock/gmock-actions.h>
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+
+#include <filesystem>
+
+#include "common/status.h"
+#include "gtest/gtest_pred_impl.h"
+#include "testutil/test_util.h"
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+using std::string;
+
+namespace doris {
+
+class StorageEngineTest : public testing::Test {
+public:
+    virtual void SetUp() {
+        EngineOptions options;
+
+        _storage_engine.reset(new StorageEngine(options));
+    }
+
+    virtual void TearDown() {}
+
+    std::unique_ptr<StorageEngine> _storage_engine;
+};
+
+
+TEST_F(StorageEngineTest, TestBrokenDisk) {
+    std::string path = config::custom_config_dir + "/be_custom.conf";
+    std::error_code ec;
+    {
+        _storage_engine->add_broken_path("broken_path1");
+        EXPECT_EQ(std::filesystem::exists(path, ec), true);
+        EXPECT_EQ(_storage_engine->get_broken_paths().count("broken_path1"), 1);
+        EXPECT_EQ(config::broken_storage_path, "broken_path1;");
+    }
+
+    {
+        _storage_engine->add_broken_path("broken_path2");
+        EXPECT_EQ(std::filesystem::exists(path, ec), true);
+        EXPECT_EQ(_storage_engine->get_broken_paths().count("broken_path1"), 1);
+        EXPECT_EQ(_storage_engine->get_broken_paths().count("broken_path2"), 1);
+        EXPECT_EQ(config::broken_storage_path, "broken_path1;broken_path2;");
+    }
+
+    {
+        _storage_engine->add_broken_path("broken_path2");
+        EXPECT_EQ(std::filesystem::exists(path, ec), true);
+        EXPECT_EQ(_storage_engine->get_broken_paths().count("broken_path1"), 1);
+        EXPECT_EQ(_storage_engine->get_broken_paths().count("broken_path2"), 1);
+        EXPECT_EQ(config::broken_storage_path, "broken_path1;broken_path2;");
+    }
+
+    {
+        _storage_engine->remove_broken_path("broken_path2");
+        EXPECT_EQ(std::filesystem::exists(path, ec), true);
+        EXPECT_EQ(_storage_engine->get_broken_paths().count("broken_path1"), 1);
+        EXPECT_EQ(_storage_engine->get_broken_paths().count("broken_path2"), 0);
+        EXPECT_EQ(config::broken_storage_path, "broken_path1;");
+    }
+}
+
+}

--- a/be/test/olap/storage_engine_test.cpp
+++ b/be/test/olap/storage_engine_test.cpp
@@ -84,4 +84,4 @@ TEST_F(StorageEngineTest, TestBrokenDisk) {
     }
 }
 
-}
+} // namespace doris

--- a/be/test/testutil/run_all_tests.cpp
+++ b/be/test/testutil/run_all_tests.cpp
@@ -47,7 +47,9 @@ int main(int argc, char** argv) {
             doris::StoragePageCache::create_global_cache(1 << 30, 10, 0));
     doris::ExecEnv::GetInstance()->set_segment_loader(new doris::SegmentLoader(1000));
     std::string conf = std::string(getenv("DORIS_HOME")) + "/conf/be.conf";
-    doris::config::init(conf.c_str(), false);
+    auto st = doris::config::init(conf.c_str(), false);
+    LOG(INFO) << "init config " << st;
+
     doris::init_glog("be-test");
     ::testing::InitGoogleTest(&argc, argv);
     doris::CpuInfo::init();

--- a/be/test/testutil/run_all_tests.cpp
+++ b/be/test/testutil/run_all_tests.cpp
@@ -47,10 +47,7 @@ int main(int argc, char** argv) {
             doris::StoragePageCache::create_global_cache(1 << 30, 10, 0));
     doris::ExecEnv::GetInstance()->set_segment_loader(new doris::SegmentLoader(1000));
     std::string conf = std::string(getenv("DORIS_HOME")) + "/conf/be.conf";
-    if (!doris::config::init(conf.c_str(), false)) {
-        fprintf(stderr, "error read config file. \n");
-        return -1;
-    }
+    doris::config::init(conf.c_str(), false);
     doris::init_glog("be-test");
     ::testing::InitGoogleTest(&argc, argv);
     doris::CpuInfo::init();


### PR DESCRIPTION
reboot

## Proposed changes

When an io error happens, we mark the path as broken and record it in config, then when a disk is unplugged and be is rebooted, broken path is not used.

In the future, we can add the disk back by set broken_storage_path.

The following tests are done.
1. When a be is running, a disk is unplugged, then tablets are marked as bad.
2. When a be is running, a disk is unplugged and a query is running, then query fails due to io error, tablets are marked as bad.
3. the be is rebooted with a broken mountpoint, be starts successfully without broken disk conf.
4. the bad mount point is umounted, the be is rebooted without load the bad disk.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

