### PR TITLE
[enhancement](serialize) add dcheck to ensure pb type is set

### DIFF
--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -827,6 +827,7 @@ Status Block::serialize(int be_exec_version, PBlock* pblock,
     for (const auto& c : *this) {
         PColumnMeta* pcm = pblock->add_column_metas();
         c.to_pb_column_meta(pcm);
+        DCHECK(pcm->type != PGenericType::UNKNOWN) << " forget to set pb type";
         // get serialized size
         content_uncompressed_size +=
                 c.type->get_uncompressed_serialized_bytes(*(c.column), pblock->be_exec_version());

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -827,7 +827,7 @@ Status Block::serialize(int be_exec_version, PBlock* pblock,
     for (const auto& c : *this) {
         PColumnMeta* pcm = pblock->add_column_metas();
         c.to_pb_column_meta(pcm);
-        DCHECK(pcm->type != PGenericType::UNKNOWN) << " forget to set pb type";
+        DCHECK(pcm->type() != PGenericType::UNKNOWN) << " forget to set pb type";
         // get serialized size
         content_uncompressed_size +=
                 c.type->get_uncompressed_serialized_bytes(*(c.column), pblock->be_exec_version());

--- a/be/src/vec/data_types/data_type.cpp
+++ b/be/src/vec/data_types/data_type.cpp
@@ -174,6 +174,7 @@ PGenericType_TypeId IDataType::get_pdata_type(const IDataType* data_type) {
     case TypeIndex::TimeV2:
         return PGenericType::TIMEV2;
     default:
+        LOG(FATAL) << "could not mapping type " << data_type->get_type_id() << " to pb type";
         return PGenericType::UNKNOWN;
     }
 }

--- a/be/src/vec/data_types/data_type.cpp
+++ b/be/src/vec/data_types/data_type.cpp
@@ -174,7 +174,7 @@ PGenericType_TypeId IDataType::get_pdata_type(const IDataType* data_type) {
     case TypeIndex::TimeV2:
         return PGenericType::TIMEV2;
     default:
-        LOG(FATAL) << "could not mapping type " << data_type->get_type_id() << " to pb type";
+        LOG(FATAL) << fmt::format("could not mapping type {} to pb type", data_type->get_type_id());
         return PGenericType::UNKNOWN;
     }
 }


### PR DESCRIPTION
## Proposed changes

1. should check the pb's type is set, or the deserialize will core.
2. should not return unknown type because deserialize will core.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

