### PR TITLE
[Fix](merge-on-write) Skip to check delete bitmap correctness in commit phase if the current tablet is converting

### DIFF
--- a/be/src/olap/rowset_builder.cpp
+++ b/be/src/olap/rowset_builder.cpp
@@ -251,7 +251,9 @@ Status RowsetBuilder::wait_calc_delete_bitmap() {
 
 Status RowsetBuilder::commit_txn() {
     if (_tablet->enable_unique_key_merge_on_write() &&
-        config::enable_merge_on_write_correctness_check && _rowset->num_rows() != 0) {
+        config::enable_merge_on_write_correctness_check && _rowset->num_rows() != 0 &&
+        !(_tablet->tablet_state() == TABLET_NOTREADY &&
+          SchemaChangeHandler::tablet_in_converting(_tablet->tablet_id()))) {
         auto st = _tablet->check_delete_bitmap_correctness(
                 _delete_bitmap, _rowset->end_version() - 1, _req.txn_id, _rowset_ids);
         if (!st.ok()) {

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -3771,7 +3771,7 @@ Status Tablet::check_delete_bitmap_correctness(DeleteBitmapPtr delete_bitmap, in
             missing_rowsets_arr.PushBack(miss_value, missing_rowsets_arr.GetAllocator());
         }
 
-        root.AddMember("requied_rowsets", required_rowsets_arr, root.GetAllocator());
+        root.AddMember("required_rowsets", required_rowsets_arr, root.GetAllocator());
         root.AddMember("missing_rowsets", missing_rowsets_arr, root.GetAllocator());
         rapidjson::StringBuffer strbuf;
         rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(strbuf);


### PR DESCRIPTION
## Proposed changes
If the tablet is in converting, the calculation of delete bitmap will be skipped and the delete bitmap will be calculated after the conversion is done. So we don't need to check delete bitmap correctness in this situation 


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

