### PR TITLE
[opt](Nereids): GroupExpressionMatching don't need withGroupExpression

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundOlapTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundOlapTableSink.java
@@ -110,7 +110,7 @@ public class UnboundOlapTableSink<CHILD_TYPE extends Plan> extends LogicalSink<C
     public Plan withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1, "UnboundOlapTableSink only accepts one child");
         return new UnboundOlapTableSink<>(nameParts, colNames, hints, partitions, isPartialUpdate,
-                isFromNativeInsertStmt, groupExpression, Optional.of(getLogicalProperties()), children.get(0));
+                isFromNativeInsertStmt, groupExpression, Optional.empty(), children.get(0));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundResultSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundResultSink.java
@@ -52,7 +52,7 @@ public class UnboundResultSink<CHILD_TYPE extends Plan> extends LogicalSink<CHIL
     @Override
     public Plan withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1, "UnboundResultSink only accepts one child");
-        return new UnboundResultSink<>(groupExpression, Optional.of(getLogicalProperties()), children.get(0));
+        return new UnboundResultSink<>(groupExpression, Optional.empty(), children.get(0));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
@@ -257,11 +257,6 @@ public class GroupExpression {
         this.requestPropertiesMap.put(requiredProperties, outputProperties);
     }
 
-    public void putOutputPropertiesMapIfAbsent(PhysicalProperties outputProperties,
-            PhysicalProperties requiredProperties) {
-        this.requestPropertiesMap.putIfAbsent(requiredProperties, outputProperties);
-    }
-
     /**
      * Merge GroupExpression.
      */

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/pattern/GroupExpressionMatching.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/pattern/GroupExpressionMatching.java
@@ -98,7 +98,7 @@ public class GroupExpressionMatching implements Iterable<Plan> {
                 if (pattern.matchPredicates(root)) {
                     // if no children pattern, we treat all children as GROUP. e.g. Pattern.ANY.
                     // leaf plan will enter this branch too, e.g. logicalRelation().
-                    results.add(root.withGroupExpression(Optional.of(groupExpression)));
+                    results.add(root);
                 }
             } else if (childrenGroupArity > 0) {
                 // matching children group, one List<Plan> per child


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

