### PR TITLE
[fix](spill) avoid printing too much status stack trace if gc dir does not exist

### DIFF
--- a/be/src/runtime/block_spill_manager.cpp
+++ b/be/src/runtime/block_spill_manager.cpp
@@ -70,6 +70,11 @@ void BlockSpillManager::gc(int64_t max_file_count) {
     for (const auto& path : _store_paths) {
         std::string gc_root_dir = fmt::format("{}/{}", path.path, BLOCK_SPILL_GC_DIR);
 
+        std::error_code ec;
+        exists = std::filesystem::exists(gc_root_dir, ec);
+        if (ec || !exists) {
+            continue;
+        }
         std::vector<io::FileInfo> dirs;
         auto st = io::global_local_filesystem()->list(gc_root_dir, false, &dirs, &exists);
         if (!st.ok()) {


### PR DESCRIPTION

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

