### PR TITLE
[test](nereids) add ut for UnCorrelatedApplyProjectFilter

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/UnCorrelatedApplyProjectFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/UnCorrelatedApplyProjectFilter.java
@@ -63,7 +63,7 @@ public class UnCorrelatedApplyProjectFilter extends OneRewriteRuleFactory {
     public Rule build() {
         return logicalApply(any(), logicalProject(logicalFilter()))
                 .when(LogicalApply::isCorrelated)
-                .when(LogicalApply::isIn)
+                //.when(LogicalApply::isIn)
                 .then(apply -> {
                     LogicalProject<LogicalFilter<Plan>> project = apply.right();
                     LogicalFilter<Plan> filter = project.child();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/UnCorrelatedApplyProjectFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/UnCorrelatedApplyProjectFilter.java
@@ -63,7 +63,6 @@ public class UnCorrelatedApplyProjectFilter extends OneRewriteRuleFactory {
     public Rule build() {
         return logicalApply(any(), logicalProject(logicalFilter()))
                 .when(LogicalApply::isCorrelated)
-                //.when(LogicalApply::isIn)
                 .then(apply -> {
                     LogicalProject<LogicalFilter<Plan>> project = apply.right();
                     LogicalFilter<Plan> filter = project.child();

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/UnCorrelatedApplyProjectFilterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/UnCorrelatedApplyProjectFilterTest.java
@@ -1,0 +1,89 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.rewrite;
+
+import org.apache.doris.nereids.pattern.GeneratedPlanPatterns;
+import org.apache.doris.nereids.rules.RulePromise;
+import org.apache.doris.nereids.util.PlanChecker;
+import org.apache.doris.utframe.TestWithFeService;
+
+import org.junit.jupiter.api.Test;
+
+class UnCorrelatedApplyProjectFilterTest extends TestWithFeService implements GeneratedPlanPatterns {
+
+    @Override
+    protected void runBeforeAll() throws Exception {
+        createDatabase("testApplyProjectFilter");
+        connectContext.setDatabase("default_cluster:testApplyProjectFilter");
+        createTables(
+                "CREATE TABLE t1 (c1 int, c2 int) DISTRIBUTED BY HASH(c1)\n" + "BUCKETS 1\n" + "PROPERTIES(\n"
+                        + "    \"replication_num\"=\"1\"\n" + ");",
+                "CREATE TABLE t2 (c1 int, c2 int) DISTRIBUTED BY HASH(c1)\n" + "BUCKETS 1\n" + "PROPERTIES(\n"
+                        + "    \"replication_num\"=\"1\"\n" + ");"
+        );
+    }
+
+    @Test
+    void testCorrelatedExistsProjectFilter1() {
+        String sql = "select * from t1 where exists (select * from t2 where t2.c2 > t1.c2)";
+        PlanChecker.from(connectContext)
+                .parse(sql)
+                .analyze()
+                .applyBottomUp(new UnCorrelatedApplyProjectFilter())
+                .matchesFromRoot(logicalResultSink(logicalProject(logicalFilter(
+                        logicalProject(logicalApply(logicalOlapScan(), logicalProject(logicalOlapScan())))))));
+    }
+
+    @Test
+    void testCorrelatedExistsProjectFilter2() {
+        String sql = "select * from t1 where exists (select * from t2 where t2.c2 > t1.c2 and t2.c1 > 0)";
+        PlanChecker.from(connectContext)
+                .parse(sql)
+                .analyze()
+                .applyBottomUp(new UnCorrelatedApplyProjectFilter())
+                .matchesFromRoot(logicalResultSink(logicalProject(logicalFilter(
+                        logicalProject(logicalApply(logicalOlapScan(), logicalProject(logicalFilter(logicalOlapScan()))))))));
+    }
+
+    @Test
+    void testCorrelatedInProjectFilter1() {
+        String sql = "select * from t1 where t1.c2 in (select t2.c2 from t2 where t2.c1 > t1.c1)";
+        PlanChecker.from(connectContext)
+                .parse(sql)
+                .analyze()
+                .applyBottomUp(new UnCorrelatedApplyProjectFilter())
+                .matchesFromRoot(logicalResultSink(logicalProject(logicalFilter(
+                        logicalProject(logicalApply(logicalOlapScan(), logicalProject(logicalOlapScan())))))));
+    }
+
+    @Test
+    void testCorrelatedInProjectFilter2() {
+        String sql = "select * from t1 where t1.c2 in (select t2.c2 from t2 where t2.c1 > t1.c1 and t2.c2 > 0)";
+        PlanChecker.from(connectContext)
+                .parse(sql)
+                .analyze()
+                .applyBottomUp(new UnCorrelatedApplyProjectFilter())
+                .matchesFromRoot(logicalResultSink(logicalProject(logicalFilter(
+                        logicalProject(logicalApply(logicalOlapScan(), logicalProject(logicalFilter(logicalOlapScan()))))))));
+    }
+
+    @Override
+    public RulePromise defaultPromise() {
+        return RulePromise.REWRITE;
+    }
+}


### PR DESCRIPTION
## Proposed changes

1. remove UnCorrelatedApplyProjectFilter LogicalApply::isIn restriction.
2. add ut.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

