### PR TITLE
[improve](script) echo infos if java cmd is not valid when starting be

### DIFF
--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -142,10 +142,12 @@ jdk_version() {
     local result
     local IFS=$'\n'
 
-    if [[ -z "${java_cmd}" ]]; then
+    if ! command -v "${java_cmd}"; then
+        echo "ERROR: invalid java_cmd ${java_cmd}" >>"${LOG_DIR}/be.out"
         result=no_java
         return 1
     else
+        echo "INFO: java_cmd ${java_cmd}" >>"${LOG_DIR}/be.out"
         local version
         # remove \r for Cygwin
         version="$("${java_cmd}" -Xms32M -Xmx32M -version 2>&1 | tr '\r' '\n' | grep version | awk '{print $3}')"
@@ -155,6 +157,7 @@ jdk_version() {
         else
             result="$(echo "${version}" | awk -F '.' '{print $1}')"
         fi
+        echo "INFO: jdk_version ${result}" >>"${LOG_DIR}/be.out"
     fi
     echo "${result}"
     return 0


### PR DESCRIPTION
## Proposed changes

Now, if JAVA_HOME is invalid, start_be.sh will exit without any information, and the user doesn't know what happened.


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

