### PR TITLE
[opt](nereids) enable runtime filter prune by default

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/MergeProjectPostProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/MergeProjectPostProcessor.java
@@ -37,8 +37,12 @@ public class MergeProjectPostProcessor extends PlanPostProcessor {
         Plan newChild = child.accept(this, ctx);
         if (newChild instanceof PhysicalProject) {
             List<NamedExpression> projections = project.mergeProjections((PhysicalProject) newChild);
-            return project.withProjectionsAndChild(projections, newChild.child(0));
+            return (PhysicalProject) project
+                    .withProjectionsAndChild(projections, newChild.child(0))
+                    .copyStatsAndGroupIdFrom(project);
         }
-        return child != newChild ? project.withChildren(Lists.newArrayList(newChild)) : project;
+        return child != newChild
+                ? (PhysicalProject) project.withChildren(Lists.newArrayList(newChild)).copyStatsAndGroupIdFrom(project)
+                : project;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/PlanPostProcessors.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/PlanPostProcessors.java
@@ -61,6 +61,7 @@ public class PlanPostProcessors {
         builder.add(new PushdownFilterThroughProject());
         builder.add(new MergeProjectPostProcessor());
         builder.add(new RecomputeLogicalPropertiesProcessor());
+        builder.add(new TopNScanOpt());
         // after generate rf, DO NOT replace PLAN NODE
         builder.add(new FragmentProcessor());
         if (!cascadesContext.getConnectContext().getSessionVariable().getRuntimeFilterMode()
@@ -71,7 +72,6 @@ public class PlanPostProcessors {
             }
         }
         builder.add(new Validator());
-        builder.add(new TopNScanOpt());
         return builder.build();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/PushdownFilterThroughProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/PushdownFilterThroughProject.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids.processor.post;
 
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.physical.AbstractPhysicalPlan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalFilter;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalProject;
 import org.apache.doris.nereids.util.ExpressionUtils;
@@ -31,14 +32,20 @@ public class PushdownFilterThroughProject extends PlanPostProcessor {
     public Plan visitPhysicalFilter(PhysicalFilter<? extends Plan> filter, CascadesContext context) {
         Plan child = filter.child();
         if (!(child instanceof PhysicalProject)) {
-            return filter.withChildren(child.accept(this, context));
+            Plan newChild = child.accept(this, context);
+            if (newChild == child) {
+                return filter;
+            } else {
+                return ((AbstractPhysicalPlan) filter.withChildren(child.accept(this, context)))
+                        .copyStatsAndGroupIdFrom(filter);
+            }
         }
 
         PhysicalProject<? extends Plan> project = (PhysicalProject<? extends Plan>) child;
         PhysicalFilter<? extends Plan> newFilter = filter.withConjunctsAndChild(
                 ExpressionUtils.replace(filter.getConjuncts(), project.getAliasToProducer()),
                 project.child());
-
-        return project.withChildren(newFilter.accept(this, context));
+        return ((PhysicalProject) project.withChildren(newFilter.accept(this, context)))
+                .copyStatsAndGroupIdFrom(project);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RecomputeLogicalPropertiesProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RecomputeLogicalPropertiesProcessor.java
@@ -18,10 +18,8 @@
 package org.apache.doris.nereids.processor.post;
 
 import org.apache.doris.nereids.CascadesContext;
-import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
-import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
-import org.apache.doris.nereids.util.MutableState;
+import org.apache.doris.nereids.trees.plans.physical.AbstractPhysicalPlan;
 
 /**
  * merge consecutive projects
@@ -29,11 +27,8 @@ import org.apache.doris.nereids.util.MutableState;
 public class RecomputeLogicalPropertiesProcessor extends PlanPostProcessor {
     @Override
     public Plan visit(Plan plan, CascadesContext ctx) {
-        PhysicalPlan physicalPlan = (PhysicalPlan) visitChildren(this, plan, ctx);
-        physicalPlan = physicalPlan.resetLogicalProperties();
-        physicalPlan = physicalPlan.withPhysicalPropertiesAndStats(physicalPlan.getPhysicalProperties(),
-                ((AbstractPlan) plan).getStats());
-        physicalPlan.setMutableState(MutableState.KEY_GROUP, plan.getGroupIdAsString());
-        return physicalPlan;
+        AbstractPhysicalPlan newPlan = (AbstractPhysicalPlan) visitChildren(this, plan, ctx);
+        return ((AbstractPhysicalPlan) newPlan.resetLogicalProperties())
+                .copyStatsAndGroupIdFrom((AbstractPhysicalPlan) plan);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/TopNScanOpt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/TopNScanOpt.java
@@ -44,7 +44,7 @@ public class TopNScanOpt extends PlanPostProcessor {
         Plan child = topN.child().accept(this, ctx);
         topN = rewriteTopN(topN);
         if (child != topN.child()) {
-            topN.withChildren(child);
+            topN = ((PhysicalTopN) topN.withChildren(child)).copyStatsAndGroupIdFrom(topN);
         }
         return topN;
     }
@@ -54,11 +54,11 @@ public class TopNScanOpt extends PlanPostProcessor {
             CascadesContext context) {
         Plan child = topN.child().accept(this, context);
         if (child != topN.child()) {
-            topN = topN.withChildren(ImmutableList.of(child));
+            topN = topN.withChildren(ImmutableList.of(child)).copyStatsAndGroupIdFrom(topN);
         }
         PhysicalTopN<? extends Plan> rewrittenTopN = rewriteTopN(topN.getPhysicalTopN());
         if (topN.getPhysicalTopN() != rewrittenTopN) {
-            topN = topN.withPhysicalTopN(rewrittenTopN);
+            topN = topN.withPhysicalTopN(rewrittenTopN).copyStatsAndGroupIdFrom(topN);
         }
         return topN;
     }
@@ -103,7 +103,7 @@ public class TopNScanOpt extends PlanPostProcessor {
         olapScan = (OlapScan) child;
 
         if (olapScan.getTable().isDupKeysOrMergeOnWrite()) {
-            return topN.withEnableRuntimeFilter(true);
+            return topN.withEnableRuntimeFilter(true).copyStatsAndGroupIdFrom(topN);
         }
 
         return topN;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/AbstractPhysicalPlan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/AbstractPhysicalPlan.java
@@ -32,6 +32,7 @@ import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.Explainable;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
+import org.apache.doris.nereids.util.MutableState;
 import org.apache.doris.planner.RuntimeFilterId;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.statistics.Statistics;
@@ -135,5 +136,12 @@ public abstract class AbstractPhysicalPlan extends AbstractPlan implements Physi
     @Override
     public Plan getExplainPlan(ConnectContext ctx) {
         return this;
+    }
+
+    public <T extends AbstractPhysicalPlan> T copyStatsAndGroupIdFrom(T from) {
+        T newPlan = (T) withPhysicalPropertiesAndStats(
+                from.getPhysicalProperties(), from.getStats());
+        newPlan.setMutableState(MutableState.KEY_GROUP, from.getGroupIdAsString());
+        return newPlan;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -904,7 +904,7 @@ public class SessionVariable implements Serializable, Writable {
     private double broadcastHashtableMemLimitPercentage = 0.2;
 
     @VariableMgr.VarAttr(name = ENABLE_RUNTIME_FILTER_PRUNE, needForward = true)
-    public boolean enableRuntimeFilterPrune = false;
+    public boolean enableRuntimeFilterPrune = true;
 
     /**
      * The client can pass some special information by setting this session variable in the format: "k1:v1;k2:v2".

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/RuntimeFilterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/RuntimeFilterTest.java
@@ -45,6 +45,8 @@ public class RuntimeFilterTest extends SSBTestBase {
         super.runBeforeAll();
         connectContext.getSessionVariable().setRuntimeFilterMode("Global");
         connectContext.getSessionVariable().setRuntimeFilterType(8);
+        connectContext.getSessionVariable().setEnableRuntimeFilterPrune(false);
+        connectContext.getSessionVariable().expandRuntimeFilterByInnerJoin = false;
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -63,7 +63,7 @@ public class QueryPlanTest extends TestWithFeService {
     protected void runBeforeAll() throws Exception {
         // disable bucket shuffle join
         Deencapsulation.setField(connectContext.getSessionVariable(), "enableBucketShuffleJoin", false);
-
+        connectContext.getSessionVariable().setEnableRuntimeFilterPrune(false);
         // create database
         createDatabase("test");
         connectContext.getSessionVariable().setEnableNereidsPlanner(false);

--- a/regression-test/suites/correctness_p0/test_runtimefilter_with_window.groovy
+++ b/regression-test/suites/correctness_p0/test_runtimefilter_with_window.groovy
@@ -16,7 +16,8 @@
  // under the License.
 
 suite("test_runtimefilter_with_window") {
- sql """ set enable_nereids_planner=false"""
+ sql """ set enable_nereids_planner=true"""
+ sql """ set disable_join_reorder=true"""
  sql """ DROP TABLE IF EXISTS `test_runtimefilter_with_window_table1` """
  sql """ DROP TABLE IF EXISTS `test_runtimefilter_with_window_table2` """
  sql """
@@ -82,9 +83,42 @@ suite("test_runtimefilter_with_window") {
                 on      a.channel_param = b.param; """)
         contains "runtime filters"
     }
-    
- sql """ DROP TABLE IF EXISTS `test_runtimefilter_with_window_table1` """
- sql """ DROP TABLE IF EXISTS `test_runtimefilter_with_window_table2` """
 
+ sql """ set enable_nereids_planner=false"""
+ sql """ set disable_join_reorder=true"""
+ sql """ set enable_runtime_filter_prune=false"""
+ log.info("======origin planner1=================")
+ explain {
+        sql("""select  a.phone
+                        ,a.channel_param
+                        ,a.createtime
+                        ,rn
+                        ,if(rn = 1,1,0) as liuzi_status
+                from    (
+                            select a.phone,a.channel_param,a.createtime
+                            ,row_number() over(partition by phone order by createtime asc) as rn
+                            from test_runtimefilter_with_window_table2 a
+                        ) a join    (
+                            select  param
+                            from    test_runtimefilter_with_window_table1
+                        ) b
+                on      a.channel_param = b.param; """)
+        notContains "runtime filters"
+    }
+log.info("======origin planner2=================")
+  explain {
+        sql("""select  a.phone
+                        ,a.channel_param
+                        ,a.createtime
+                from    (
+                            select a.phone,a.channel_param,a.createtime
+                            from test_runtimefilter_with_window_table2 a
+                        ) a join    (
+                            select  param
+                            from    test_runtimefilter_with_window_table1
+                        ) b
+                on      a.channel_param = b.param; """)
+        contains "runtime filters"
+    }
 }
 

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/ddl/rf.tmpl
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/ddl/rf.tmpl
@@ -30,6 +30,7 @@ suite("ds_rf{--}") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
     String stmt = '''
     explain physical plan
     {query}

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf1.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf1.groovy
@@ -30,6 +30,8 @@ suite("ds_rf1") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     with customer_total_return as

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf10.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf10.groovy
@@ -30,6 +30,8 @@ suite("ds_rf10") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf11.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf11.groovy
@@ -30,6 +30,8 @@ suite("ds_rf11") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     with year_total as (

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf12.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf12.groovy
@@ -30,6 +30,8 @@ suite("ds_rf12") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  i_item_id

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf13.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf13.groovy
@@ -30,6 +30,8 @@ suite("ds_rf13") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select avg(ss_quantity)

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf14.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf14.groovy
@@ -30,6 +30,8 @@ suite("ds_rf14") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     with  cross_items as

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf15.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf15.groovy
@@ -30,6 +30,8 @@ suite("ds_rf15") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  ca_zip

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf16.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf16.groovy
@@ -30,6 +30,8 @@ suite("ds_rf16") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf17.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf17.groovy
@@ -30,6 +30,8 @@ suite("ds_rf17") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  i_item_id

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf18.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf18.groovy
@@ -30,6 +30,8 @@ suite("ds_rf18") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  i_item_id,

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf19.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf19.groovy
@@ -30,6 +30,8 @@ suite("ds_rf19") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  i_brand_id brand_id, i_brand brand, i_manufact_id, i_manufact,

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf2.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf2.groovy
@@ -30,6 +30,8 @@ suite("ds_rf2") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     with wscs as

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf20.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf20.groovy
@@ -30,6 +30,8 @@ suite("ds_rf20") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  i_item_id

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf21.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf21.groovy
@@ -30,6 +30,8 @@ suite("ds_rf21") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  *

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf22.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf22.groovy
@@ -30,6 +30,8 @@ suite("ds_rf22") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  i_product_name

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf23.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf23.groovy
@@ -30,6 +30,8 @@ suite("ds_rf23") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     with frequent_ss_items as 

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf24.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf24.groovy
@@ -30,6 +30,8 @@ suite("ds_rf24") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     with ssales as

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf25.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf25.groovy
@@ -30,6 +30,8 @@ suite("ds_rf25") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf26.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf26.groovy
@@ -30,6 +30,8 @@ suite("ds_rf26") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  i_item_id, 

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf27.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf27.groovy
@@ -30,6 +30,8 @@ suite("ds_rf27") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  i_item_id,

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf28.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf28.groovy
@@ -30,6 +30,8 @@ suite("ds_rf28") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  *

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf29.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf29.groovy
@@ -30,6 +30,8 @@ suite("ds_rf29") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select   

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf3.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf3.groovy
@@ -30,6 +30,8 @@ suite("ds_rf3") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  dt.d_year 

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf30.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf30.groovy
@@ -30,6 +30,8 @@ suite("ds_rf30") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     with customer_total_return as

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf31.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf31.groovy
@@ -30,6 +30,8 @@ suite("ds_rf31") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     with ss as

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf32.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf32.groovy
@@ -30,6 +30,8 @@ suite("ds_rf32") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  sum(cs_ext_discount_amt)  as "excess discount amount" 

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf33.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf33.groovy
@@ -30,6 +30,8 @@ suite("ds_rf33") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     with ss as (

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf34.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf34.groovy
@@ -30,6 +30,8 @@ suite("ds_rf34") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select c_last_name

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf35.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf35.groovy
@@ -30,6 +30,8 @@ suite("ds_rf35") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select   

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf36.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf36.groovy
@@ -30,6 +30,8 @@ suite("ds_rf36") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf37.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf37.groovy
@@ -30,6 +30,8 @@ suite("ds_rf37") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  i_item_id

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf38.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf38.groovy
@@ -30,6 +30,8 @@ suite("ds_rf38") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  count(*) from (

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf39.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf39.groovy
@@ -30,6 +30,8 @@ suite("ds_rf39") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     with inv as

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf4.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf4.groovy
@@ -30,6 +30,8 @@ suite("ds_rf4") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     with year_total as (

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf40.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf40.groovy
@@ -30,6 +30,8 @@ suite("ds_rf40") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf41.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf41.groovy
@@ -30,6 +30,8 @@ suite("ds_rf41") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  distinct(i_product_name)

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf42.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf42.groovy
@@ -30,6 +30,8 @@ suite("ds_rf42") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  dt.d_year

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf43.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf43.groovy
@@ -30,6 +30,8 @@ suite("ds_rf43") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  s_store_name, s_store_id,

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf44.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf44.groovy
@@ -30,6 +30,8 @@ suite("ds_rf44") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  asceding.rnk, i1.i_product_name best_performing, i2.i_product_name worst_performing

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf45.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf45.groovy
@@ -30,6 +30,8 @@ suite("ds_rf45") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  ca_zip, ca_city, sum(ws_sales_price)

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf46.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf46.groovy
@@ -30,6 +30,8 @@ suite("ds_rf46") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  c_last_name

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf47.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf47.groovy
@@ -30,6 +30,8 @@ suite("ds_rf47") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     with v1 as(

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf48.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf48.groovy
@@ -30,6 +30,8 @@ suite("ds_rf48") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select sum (ss_quantity)

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf49.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf49.groovy
@@ -30,6 +30,8 @@ suite("ds_rf49") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  channel, item, return_ratio, return_rank, currency_rank from

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf5.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf5.groovy
@@ -30,6 +30,8 @@ suite("ds_rf5") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     with ssr as

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf50.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf50.groovy
@@ -30,6 +30,8 @@ suite("ds_rf50") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf51.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf51.groovy
@@ -30,6 +30,8 @@ suite("ds_rf51") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     WITH web_v1 as (

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf52.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf52.groovy
@@ -30,6 +30,8 @@ suite("ds_rf52") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  dt.d_year

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf53.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf53.groovy
@@ -30,6 +30,8 @@ suite("ds_rf53") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  * from 

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf54.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf54.groovy
@@ -30,6 +30,8 @@ suite("ds_rf54") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     with my_customers as (

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf55.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf55.groovy
@@ -30,6 +30,8 @@ suite("ds_rf55") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  i_brand_id brand_id, i_brand brand,

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf56.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf56.groovy
@@ -30,6 +30,8 @@ suite("ds_rf56") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     with ss as (

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf57.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf57.groovy
@@ -30,6 +30,8 @@ suite("ds_rf57") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     with v1 as(

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf58.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf58.groovy
@@ -30,6 +30,8 @@ suite("ds_rf58") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     with ss_items as

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf59.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf59.groovy
@@ -30,6 +30,8 @@ suite("ds_rf59") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     with wss as 

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf6.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf6.groovy
@@ -30,6 +30,8 @@ suite("ds_rf6") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  a.ca_state state, count(*) cnt

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf60.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf60.groovy
@@ -30,6 +30,8 @@ suite("ds_rf60") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     with ss as (

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf61.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf61.groovy
@@ -30,6 +30,8 @@ suite("ds_rf61") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  promotions,total,cast(promotions as decimal(15,4))/cast(total as decimal(15,4))*100

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf62.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf62.groovy
@@ -30,6 +30,8 @@ suite("ds_rf62") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf63.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf63.groovy
@@ -30,6 +30,8 @@ suite("ds_rf63") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  * 

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf64.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf64.groovy
@@ -30,6 +30,8 @@ suite("ds_rf64") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     with cs_ui as

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf65.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf65.groovy
@@ -30,6 +30,8 @@ suite("ds_rf65") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select 

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf66.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf66.groovy
@@ -30,6 +30,8 @@ suite("ds_rf66") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select   

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf67.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf67.groovy
@@ -30,6 +30,8 @@ suite("ds_rf67") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  *

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf68.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf68.groovy
@@ -30,6 +30,8 @@ suite("ds_rf68") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  c_last_name

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf69.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf69.groovy
@@ -30,6 +30,8 @@ suite("ds_rf69") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf7.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf7.groovy
@@ -30,6 +30,8 @@ suite("ds_rf7") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  i_item_id, 

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf70.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf70.groovy
@@ -30,6 +30,8 @@ suite("ds_rf70") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf71.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf71.groovy
@@ -30,6 +30,8 @@ suite("ds_rf71") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select i_brand_id brand_id, i_brand brand,t_hour,t_minute,

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf72.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf72.groovy
@@ -30,6 +30,8 @@ suite("ds_rf72") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  i_item_desc

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf73.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf73.groovy
@@ -30,6 +30,8 @@ suite("ds_rf73") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select c_last_name

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf74.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf74.groovy
@@ -30,6 +30,8 @@ suite("ds_rf74") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     with year_total as (

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf75.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf75.groovy
@@ -30,6 +30,8 @@ suite("ds_rf75") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     WITH all_sales AS (

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf76.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf76.groovy
@@ -30,6 +30,8 @@ suite("ds_rf76") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  channel, col_name, d_year, d_qoy, i_category, COUNT(*) sales_cnt, SUM(ext_sales_price) sales_amt FROM (

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf77.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf77.groovy
@@ -30,6 +30,8 @@ suite("ds_rf77") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     with ss as

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf78.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf78.groovy
@@ -30,6 +30,8 @@ suite("ds_rf78") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     with ws as

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf79.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf79.groovy
@@ -30,6 +30,8 @@ suite("ds_rf79") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select 

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf8.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf8.groovy
@@ -30,6 +30,8 @@ suite("ds_rf8") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  s_store_name

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf80.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf80.groovy
@@ -30,6 +30,8 @@ suite("ds_rf80") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     with ssr as

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf81.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf81.groovy
@@ -30,6 +30,8 @@ suite("ds_rf81") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     with customer_total_return as

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf82.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf82.groovy
@@ -30,6 +30,8 @@ suite("ds_rf82") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  i_item_id

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf83.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf83.groovy
@@ -30,6 +30,8 @@ suite("ds_rf83") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     with sr_items as

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf84.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf84.groovy
@@ -30,6 +30,8 @@ suite("ds_rf84") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  c_customer_id as customer_id

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf85.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf85.groovy
@@ -30,6 +30,8 @@ suite("ds_rf85") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  substr(r_reason_desc,1,20)

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf86.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf86.groovy
@@ -30,6 +30,8 @@ suite("ds_rf86") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select   

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf87.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf87.groovy
@@ -30,6 +30,8 @@ suite("ds_rf87") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select count(*) 

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf88.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf88.groovy
@@ -30,6 +30,8 @@ suite("ds_rf88") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  *

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf89.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf89.groovy
@@ -30,6 +30,8 @@ suite("ds_rf89") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  *

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf9.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf9.groovy
@@ -30,6 +30,8 @@ suite("ds_rf9") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select case when (select count(*) 

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf90.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf90.groovy
@@ -30,6 +30,8 @@ suite("ds_rf90") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  cast(amc as decimal(15,4))/cast(pmc as decimal(15,4)) am_pm_ratio

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf91.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf91.groovy
@@ -30,6 +30,8 @@ suite("ds_rf91") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf92.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf92.groovy
@@ -30,6 +30,8 @@ suite("ds_rf92") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf93.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf93.groovy
@@ -30,6 +30,8 @@ suite("ds_rf93") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  ss_customer_sk

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf94.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf94.groovy
@@ -30,6 +30,8 @@ suite("ds_rf94") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf95.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf95.groovy
@@ -30,6 +30,8 @@ suite("ds_rf95") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     with ws_wh as

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf96.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf96.groovy
@@ -30,6 +30,8 @@ suite("ds_rf96") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  count(*) 

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf97.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf97.groovy
@@ -30,6 +30,8 @@ suite("ds_rf97") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     with ssci as (

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf98.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf98.groovy
@@ -30,6 +30,8 @@ suite("ds_rf98") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select i_item_id

--- a/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf99.groovy
+++ b/regression-test/suites/nereids_tpcds_shape_sf100_p0/rf/ds_rf99.groovy
@@ -30,6 +30,8 @@ suite("ds_rf99") {
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
     sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
     String stmt = '''
     explain physical plan
     select  

--- a/regression-test/suites/nereids_tpch_shape_sf1000_p0/ddl/rf.tmpl
+++ b/regression-test/suites/nereids_tpch_shape_sf1000_p0/ddl/rf.tmpl
@@ -29,6 +29,9 @@ suite("h_rf{--}") {
     sql 'set forbid_unknown_col_stats=true'
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
+    sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
 
     String stmt = '''
     explain physical plan

--- a/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf1.groovy
+++ b/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf1.groovy
@@ -29,6 +29,9 @@ suite("h_rf1") {
     sql 'set forbid_unknown_col_stats=true'
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
+    sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
 
     String stmt = '''
     explain physical plan

--- a/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf10.groovy
+++ b/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf10.groovy
@@ -29,6 +29,9 @@ suite("h_rf10") {
     sql 'set forbid_unknown_col_stats=true'
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
+    sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
 
     String stmt = '''
     explain physical plan

--- a/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf11.groovy
+++ b/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf11.groovy
@@ -29,6 +29,9 @@ suite("h_rf11") {
     sql 'set forbid_unknown_col_stats=true'
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
+    sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
 
     String stmt = '''
     explain physical plan

--- a/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf12.groovy
+++ b/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf12.groovy
@@ -29,6 +29,9 @@ suite("h_rf12") {
     sql 'set forbid_unknown_col_stats=true'
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
+    sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
 
     String stmt = '''
     explain physical plan

--- a/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf13.groovy
+++ b/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf13.groovy
@@ -29,6 +29,9 @@ suite("h_rf13") {
     sql 'set forbid_unknown_col_stats=true'
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
+    sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
 
     String stmt = '''
     explain physical plan

--- a/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf14.groovy
+++ b/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf14.groovy
@@ -29,6 +29,9 @@ suite("h_rf14") {
     sql 'set forbid_unknown_col_stats=true'
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
+    sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
 
     String stmt = '''
     explain physical plan

--- a/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf15.groovy
+++ b/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf15.groovy
@@ -29,6 +29,9 @@ suite("h_rf15") {
     sql 'set forbid_unknown_col_stats=true'
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
+    sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
 
     String stmt = '''
     explain physical plan

--- a/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf16.groovy
+++ b/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf16.groovy
@@ -29,6 +29,9 @@ suite("h_rf16") {
     sql 'set forbid_unknown_col_stats=true'
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
+    sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
 
     String stmt = '''
     explain physical plan

--- a/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf17.groovy
+++ b/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf17.groovy
@@ -29,6 +29,9 @@ suite("h_rf17") {
     sql 'set forbid_unknown_col_stats=true'
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
+    sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
 
     String stmt = '''
     explain physical plan

--- a/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf18.groovy
+++ b/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf18.groovy
@@ -29,6 +29,9 @@ suite("h_rf18") {
     sql 'set forbid_unknown_col_stats=true'
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
+    sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
 
     String stmt = '''
     explain physical plan

--- a/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf19.groovy
+++ b/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf19.groovy
@@ -29,6 +29,9 @@ suite("h_rf19") {
     sql 'set forbid_unknown_col_stats=true'
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
+    sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
 
     String stmt = '''
     explain physical plan

--- a/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf2.groovy
+++ b/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf2.groovy
@@ -29,6 +29,9 @@ suite("h_rf2") {
     sql 'set forbid_unknown_col_stats=true'
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
+    sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
 
     String stmt = '''
     explain physical plan

--- a/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf20.groovy
+++ b/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf20.groovy
@@ -29,6 +29,9 @@ suite("h_rf20") {
     sql 'set forbid_unknown_col_stats=true'
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
+    sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
 
     String stmt = '''
     explain physical plan

--- a/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf21.groovy
+++ b/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf21.groovy
@@ -29,6 +29,9 @@ suite("h_rf21") {
     sql 'set forbid_unknown_col_stats=true'
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
+    sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
 
     String stmt = '''
     explain physical plan

--- a/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf22.groovy
+++ b/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf22.groovy
@@ -29,6 +29,9 @@ suite("h_rf22") {
     sql 'set forbid_unknown_col_stats=true'
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
+    sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
 
     String stmt = '''
     explain physical plan

--- a/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf3.groovy
+++ b/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf3.groovy
@@ -29,6 +29,9 @@ suite("h_rf3") {
     sql 'set forbid_unknown_col_stats=true'
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
+    sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
 
     String stmt = '''
     explain physical plan

--- a/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf4.groovy
+++ b/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf4.groovy
@@ -29,6 +29,9 @@ suite("h_rf4") {
     sql 'set forbid_unknown_col_stats=true'
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
+    sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
 
     String stmt = '''
     explain physical plan

--- a/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf5.groovy
+++ b/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf5.groovy
@@ -29,6 +29,9 @@ suite("h_rf5") {
     sql 'set forbid_unknown_col_stats=true'
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
+    sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
 
     String stmt = '''
     explain physical plan

--- a/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf6.groovy
+++ b/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf6.groovy
@@ -29,6 +29,9 @@ suite("h_rf6") {
     sql 'set forbid_unknown_col_stats=true'
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
+    sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
 
     String stmt = '''
     explain physical plan

--- a/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf7.groovy
+++ b/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf7.groovy
@@ -29,6 +29,9 @@ suite("h_rf7") {
     sql 'set forbid_unknown_col_stats=true'
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
+    sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
 
     String stmt = '''
     explain physical plan

--- a/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf8.groovy
+++ b/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf8.groovy
@@ -29,6 +29,9 @@ suite("h_rf8") {
     sql 'set forbid_unknown_col_stats=true'
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
+    sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
 
     String stmt = '''
     explain physical plan

--- a/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf9.groovy
+++ b/regression-test/suites/nereids_tpch_shape_sf1000_p0/rf/h_rf9.groovy
@@ -29,6 +29,9 @@ suite("h_rf9") {
     sql 'set forbid_unknown_col_stats=true'
     sql 'set broadcast_row_count_limit = 30000000'
     sql 'set enable_nereids_timeout = false'
+    sql 'set enable_pipeline_engine=true'
+    sql 'set enable_runtime_filter_prune=false'
+    sql 'set expand_runtime_filter_by_inner_join=false'
 
     String stmt = '''
     explain physical plan


### PR DESCRIPTION
## Proposed changes
1. add stats back to physical plan in post processors. stats are used by rf-prune
2. set enable_runtime_filter_prune true by default

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

