### PR TITLE
[branch-2.0][fix](jdbc catalog) Use String to map Json types

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcMySQLClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcMySQLClient.java
@@ -296,8 +296,9 @@ public class JdbcMySQLClient extends JdbcClient {
                 } else {
                     return ScalarType.createStringType();
                 }
+            // For Json Type in Doris 2.0,
+            // we need to use a String mapping because the new optimizer doesn't support Json
             case "JSON":
-                return ScalarType.createJsonbType();
             case "TIME":
             case "TINYTEXT":
             case "TEXT":
@@ -415,9 +416,10 @@ public class JdbcMySQLClient extends JdbcClient {
             }
             case "STRING":
             case "TEXT":
-                return ScalarType.createStringType();
+            // For Json Type in Doris 2.0,
+            // we need to use a String mapping because the new optimizer doesn't support Json
             case "JSON":
-                return ScalarType.createJsonbType();
+                return ScalarType.createStringType();
             case "HLL":
                 return ScalarType.createHllType();
             case "BITMAP":

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcPostgreSQLClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcPostgreSQLClient.java
@@ -101,10 +101,11 @@ public class JdbcPostgreSQLClient extends JdbcClient {
             case "varbit":
             case "uuid":
             case "bytea":
-                return ScalarType.createStringType();
+            // For Json Type in Doris 2.0,
+            // we need to use a String mapping because the new optimizer doesn't support Json
             case "json":
             case "jsonb":
-                return ScalarType.createJsonbType();
+                return ScalarType.createStringType();
             default:
                 return Type.UNSUPPORTED;
         }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

For Json Type in Doris 2.0, we need to use a String mapping because the new optimizer doesn't support Json

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

