### PR TITLE
[fix](move-memtable) exclude rpc memory in flush mem-tracker

### DIFF
--- a/be/src/vec/sink/load_stream_stub.cpp
+++ b/be/src/vec/sink/load_stream_stub.cpp
@@ -234,7 +234,11 @@ Status LoadStreamStub::_send_with_buffer(butil::IOBuf& buf, bool eos) {
 
 Status LoadStreamStub::_send_with_retry(butil::IOBuf& buf) {
     for (;;) {
-        int ret = brpc::StreamWrite(_stream_id, buf);
+        int ret;
+        {
+            SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->orphan_mem_tracker());
+            ret = brpc::StreamWrite(_stream_id, buf);
+        }
         switch (ret) {
         case 0:
             return Status::OK();


### PR DESCRIPTION
## Proposed changes

Exclude rpc memory in flush MemTracker for OlapTableSinkV2.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

