### PR TITLE
[Fix](nereids) Fix Runtime Filter is not pushed down into CTE producer when using external table.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/algebra/CatalogRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/algebra/CatalogRelation.java
@@ -27,4 +27,6 @@ public interface CatalogRelation extends Relation {
     TableIf getTable();
 
     DatabaseIf getDatabase() throws AnalysisException;
+
+    boolean canPushDownRuntimeFilter();
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCatalogRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCatalogRelation.java
@@ -113,4 +113,9 @@ public abstract class LogicalCatalogRelation extends LogicalRelation implements 
         }
         return Utils.qualifiedName(qualifier, table.getName());
     }
+
+    @Override
+    public boolean canPushDownRuntimeFilter() {
+        return false;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalCatalogRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalCatalogRelation.java
@@ -123,4 +123,9 @@ public abstract class PhysicalCatalogRelation extends PhysicalRelation implement
         return Utils.qualifiedName(qualifier, table.getName());
     }
 
+    @Override
+    public boolean canPushDownRuntimeFilter() {
+        return true;
+    }
+
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalSchemaScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalSchemaScan.java
@@ -78,6 +78,14 @@ public class PhysicalSchemaScan extends PhysicalCatalogRelation {
                 groupExpression, getLogicalProperties(), physicalProperties, statistics);
     }
 
+    /**
+     * Currently the be side does not support.
+     */
+    @Override
+    public boolean canPushDownRuntimeFilter() {
+        return false;
+    }
+
     @Override
     public String toString() {
         return Utils.toSqlString("PhysicalSchemaScan");


### PR DESCRIPTION

## Proposed changes

Fix Runtime Filter is not pushed down into CTE producer when using external table.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

