### PR TITLE
[fix](planner) do not support UDF without paramter

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -740,7 +740,7 @@ nonterminal ArrayList<LiteralExpr> literal_values, args_list;
 nonterminal ArrayList<Expr> func_arg_list;
 nonterminal ArrayList<Expr> expr_pipe_list;
 nonterminal String select_alias, opt_table_alias, lock_alias, opt_alias;
-nonterminal ArrayList<String> ident_list;
+nonterminal ArrayList<String> ident_list, opt_ident_list;
 nonterminal PartitionNames opt_partition_names, partition_names;
 nonterminal ArrayList<Long> opt_tablet_list, tablet_list;
 nonterminal TableSample opt_table_sample, table_sample;
@@ -1835,7 +1835,7 @@ create_stmt ::=
         RESULT = new CreateFunctionStmt(type, ifNotExists, isAggregate, functionName, args, returnType, intermediateType, properties);
     :}
     | KW_CREATE opt_var_type:type KW_ALIAS KW_FUNCTION opt_if_not_exists:ifNotExists function_name:functionName LPAREN func_args_def:args RPAREN
-            KW_WITH KW_PARAMETER LPAREN ident_list:parameters RPAREN KW_AS expr:func
+            KW_WITH KW_PARAMETER LPAREN opt_ident_list:parameters RPAREN KW_AS expr:func
     {:
         RESULT = new CreateFunctionStmt(type, ifNotExists, functionName, args, parameters, func);
     :}
@@ -6057,6 +6057,16 @@ ident_list ::=
     :}
     ;
 
+opt_ident_list ::=
+    {:
+        RESULT = Lists.newArrayList();
+    :}
+    | ident_list:list
+    {:
+        RESULT = list;
+    :}
+    ;
+
 with_analysis_properties ::=
     KW_SYNC
     {:
@@ -6451,7 +6461,11 @@ type_def_nullable_list ::=
 
 
 func_args_def ::=
-  type_def_list:argTypes
+  /* empty */
+  {:
+    RESULT = new FunctionArgsDef(Lists.newArrayList(), false);
+  :}
+  | type_def_list:argTypes
   {:
     RESULT = new FunctionArgsDef(argTypes, false);
   :}

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ExpressionFunctions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ExpressionFunctions.java
@@ -77,6 +77,9 @@ public enum ExpressionFunctions {
                 || constExpr instanceof FunctionCallExpr
                 || constExpr instanceof TimestampArithmeticExpr) {
             Function fn = constExpr.getFn();
+            if (fn == null) {
+                return constExpr;
+            }
             if (ConnectContext.get() != null
                     && ConnectContext.get().getSessionVariable() != null
                     && !ConnectContext.get().getSessionVariable().isEnableFoldNondeterministicFn()

--- a/regression-test/suites/query_p0/sql_functions/test_alias_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/test_alias_function.groovy
@@ -16,7 +16,6 @@
 // under the License.
 
 suite('test_alias_function') {
-    sql "use test_query_db"
     sql '''
         CREATE ALIAS FUNCTION IF NOT EXISTS f1(DATETIMEV2(3), INT)
             with PARAMETER (datetime1, int1) as date_trunc(days_sub(datetime1, int1), 'day')'''
@@ -31,4 +30,28 @@ suite('test_alias_function') {
         sql '''select f2(f1('2023-03-29', 2), 3)'''
         result([['20230327:01']])
     }
+
+    sql "set enable_nereids_planner=false"
+
+    sql '''
+        DROP FUNCTION IF EXISTS legacy_f4()
+    '''
+
+    sql '''
+        CREATE ALIAS FUNCTION legacy_f4() WITH PARAMETER() AS now()
+    '''
+
+    sql '''
+        SELECT legacy_f4(), now()
+    '''
+
+    sql "set enable_nereids_planner=true"
+
+    sql '''
+        SELECT legacy_f4(), now()
+    '''
+
+    sql '''
+        DROP FUNCTION IF EXISTS legacy_f4()
+    '''
 }


### PR DESCRIPTION
for example:
```
CREATE ALIAS FUNCTION f() WITH PARAMETERS() AS now();
```

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

