### PR TITLE
[fix](compile) fix GHA mac ut compile failure

### DIFF
--- a/be/src/util/timezone_utils.cpp
+++ b/be/src/util/timezone_utils.cpp
@@ -266,7 +266,7 @@ void TimezoneUtils::load_timezones_to_cache() {
 
 bool TimezoneUtils::find_cctz_time_zone(const std::string& timezone, cctz::time_zone& ctz) {
     zone_cache_rw_lock.lock_shared();
-    if (auto it = zone_cache->find(timezone); it != nullptr) {
+    if (auto it = zone_cache->find(timezone); it != zone_cache->end()) {
         ctz = it->second;
         zone_cache_rw_lock.unlock_shared();
         return true;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

fix:
```
/Users/runner/work/doris/doris/be/src/util/timezone_utils.cpp:269:50: error: invalid operands to binary expression ('iterator' (aka '__hash_map_iterator<__hash_iterator<std::__hash_node<std::__hash_value_type<std::string, cctz::time_zone>, void *> *>>') and 'std::nullptr_t')
    if (auto it = zone_cache->find(timezone); it != nullptr) {
                                              ~~ ^  ~~~~~~~
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

