### PR TITLE
[enhancement](delete) avoid null txn state after delete jobs committed

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/DeleteHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/DeleteHandler.java
@@ -497,23 +497,16 @@ public class DeleteHandler implements Writable {
 
     private void commitJob(DeleteJob job, Database db, Table table, long timeoutMs)
             throws DdlException, QueryStateException {
-        TransactionStatus status = null;
+        TransactionStatus status = TransactionStatus.UNKNOWN;
         try {
-            unprotectedCommitJob(job, db, table, timeoutMs);
-            GlobalTransactionMgr transactionMgr = Env.getCurrentGlobalTransactionMgr();
-            long dbId = db.getId();
-            long transactionId = job.getTransactionId();
-            TransactionState transactionState = transactionMgr.getTransactionState(dbId, transactionId);
-            Preconditions.checkNotNull(transactionState,
-                    "got null txn state with: dbId=%s, txnId=%s", dbId, transactionId);
-            status = transactionState.getTransactionStatus();
+            boolean isVisible = unprotectedCommitJob(job, db, table, timeoutMs);
+            status = isVisible ? TransactionStatus.VISIBLE : TransactionStatus.COMMITTED;
         } catch (UserException e) {
             if (cancelJob(job, CancelType.COMMIT_FAIL, e.getMessage())) {
                 throw new DdlException(e.getMessage(), e);
             }
         }
 
-        Preconditions.checkNotNull(status, "got null txn status, jobId=%s", job.getId());
         StringBuilder sb = new StringBuilder();
         sb.append("{'label':'").append(job.getLabel()).append("', 'status':'").append(status.name());
         sb.append("', 'txnId':'").append(job.getTransactionId()).append("'");


### PR DESCRIPTION
## Proposed changes

CI raised the problem occasionally that delete handler tried to get txn state but got a null one, resulted in cleaning a label (finished txn will be removed) concurrently when a delete job committed and tried to get the txn state.

```
2023-09-20 22:27:21.321 ERROR [suite-thread-9] (ScriptContext.groovy:121) - Run nereids_insert_random in/home/work/pipline/OpenSourceDoris/clusterRegressionCenter/P0/Clu
iava.sql.SOLException: Unexpected exception: got null txn state with: dbId=233582. txnid=7070
```
```
2023-09-20 22:27:21.317 INFO [suite-thread-14] (Suite.groovy:217) - Execute sql: clean label from nereids_insert_into_table_test
2023-09-20 22:27:21.323 INFO [suite-thread-14] (Suite.groovv:217) - Execute ssgl: set enable nereids planner=true
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

