### PR TITLE
[branch-2.0-pick] Pick "[Fix](merge-on-write) Skip to check delete bitmap correctness in commit phase if the current tablet is converting #24675"

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -511,7 +511,9 @@ Status DeltaWriter::wait_calc_delete_bitmap() {
 Status DeltaWriter::commit_txn(const PSlaveTabletNodes& slave_tablet_nodes,
                                const bool write_single_replica) {
     if (_tablet->enable_unique_key_merge_on_write() &&
-        config::enable_merge_on_write_correctness_check && _cur_rowset->num_rows() != 0) {
+        config::enable_merge_on_write_correctness_check && _cur_rowset->num_rows() != 0 &&
+        !(_tablet->tablet_state() == TABLET_NOTREADY &&
+          SchemaChangeHandler::tablet_in_converting(_tablet->tablet_id()))) {
         auto st = _tablet->check_delete_bitmap_correctness(
                 _delete_bitmap, _cur_rowset->end_version() - 1, _req.txn_id, _rowset_ids);
         if (!st.ok()) {

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -3788,7 +3788,7 @@ Status Tablet::check_delete_bitmap_correctness(DeleteBitmapPtr delete_bitmap, in
             missing_rowsets_arr.PushBack(miss_value, missing_rowsets_arr.GetAllocator());
         }
 
-        root.AddMember("requied_rowsets", required_rowsets_arr, root.GetAllocator());
+        root.AddMember("required_rowsets", required_rowsets_arr, root.GetAllocator());
         root.AddMember("missing_rowsets", missing_rowsets_arr, root.GetAllocator());
         rapidjson::StringBuffer strbuf;
         rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(strbuf);


### PR DESCRIPTION
## Proposed changes

pick https://github.com/apache/doris/pull/24675

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

