### PR TITLE
[Fix](core) Fix segment cache core when output rowset is nullptr

### DIFF
--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -832,14 +832,16 @@ int64_t Compaction::get_compaction_permits() {
     return permits;
 }
 
-Status Compaction::_load_segment_to_cache() {
-    if (_output_rowset != nullptr) {
-        // Load new rowset's segments to cache.
-        SegmentCacheHandle handle;
-        RETURN_IF_ERROR(SegmentLoader::instance()->load_segments(
-                std::static_pointer_cast<BetaRowset>(_output_rowset), &handle, true));
+void Compaction::_load_segment_to_cache() {
+    // Load new rowset's segments to cache.
+    SegmentCacheHandle handle;
+    auto st = SegmentLoader::instance()->load_segments(
+            std::static_pointer_cast<BetaRowset>(_output_rowset), &handle, true);
+    if (!st.ok()) {
+        LOG(WARNING) << "failed to load segment to cache! output rowset version="
+                     << _output_rowset->start_version() << "-" << _output_rowset->end_version()
+                     << ".";
     }
-    return Status::OK();
 }
 
 #ifdef BE_TEST

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -134,7 +134,7 @@ Status Compaction::do_compaction(int64_t permits) {
                          << ", before=" << checksum_before << ", checksum_after=" << checksum_after;
         }
     }
-    _load_segment_to_cache();
+    RETURN_IF_ERROR(_load_segment_to_cache());
     return st;
 }
 
@@ -831,10 +831,12 @@ int64_t Compaction::get_compaction_permits() {
 }
 
 Status Compaction::_load_segment_to_cache() {
-    // Load new rowset's segments to cache.
-    SegmentCacheHandle handle;
-    RETURN_IF_ERROR(SegmentLoader::instance()->load_segments(
-            std::static_pointer_cast<BetaRowset>(_output_rowset), &handle, true));
+    if (_output_rowset != nullptr) {
+        // Load new rowset's segments to cache.
+        SegmentCacheHandle handle;
+        RETURN_IF_ERROR(SegmentLoader::instance()->load_segments(
+                std::static_pointer_cast<BetaRowset>(_output_rowset), &handle, true));
+    }
     return Status::OK();
 }
 

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -134,7 +134,9 @@ Status Compaction::do_compaction(int64_t permits) {
                          << ", before=" << checksum_before << ", checksum_after=" << checksum_after;
         }
     }
-    RETURN_IF_ERROR(_load_segment_to_cache());
+    if (st.ok()) {
+        _load_segment_to_cache();
+    }
     return st;
 }
 

--- a/be/src/olap/compaction.h
+++ b/be/src/olap/compaction.h
@@ -99,7 +99,7 @@ protected:
 
 private:
     bool _check_if_includes_input_rowsets(const RowsetIdUnorderedSet& commit_rowset_ids_set) const;
-    Status _load_segment_to_cache();
+    void _load_segment_to_cache();
 
 protected:
     // the root tracker for this compaction


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

1# 0x00007EFF7DC770A7 in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 3# 0x00007EFF7DC7002C in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 4# 0x00007EFF8681A090 in /lib/x86_64-linux-gnu/libc.so.6
 5# std::__shared_ptr::get() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1291
 6# std::__shared_ptr_access::_M_get() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:990
 7# std::__shared_ptr_access::operator->() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:984
 8# doris::Rowset::rowset_id() const at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/olap/rowset/rowset.h:153
 9# doris::SegmentLoader::load_segments(std::shared_ptr const&, doris::SegmentCacheHandle*, bool) at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/olap/segment_loader.cpp:72
10# doris::Compaction::_load_segment_to_cache() at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/olap/compaction.cpp:837
11# doris::Compaction::do_compaction(long) at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/olap/compaction.cpp:137
12# doris::CumulativeCompaction::execute_compact_impl() at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/olap/cumulative_compaction.cpp:87
13# doris::Compaction::execute_compact() at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/olap/compaction.cpp:105
14# doris::Tablet::execute_compaction(doris::CompactionType) at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/olap/tablet.cpp:1856
15# doris::StorageEngine::_submit_compaction_task(std::shared_ptr, doris::CompactionType, bool)::$_0::operator()() const at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/olap/olap_server.cpp:962
16# void std::__invoke_impl, doris::CompactionType, bool)::$_0&>(std::__invoke_other, doris::StorageEngine::_submit_compaction_task(std::shared_ptr, doris::CompactionType, bool)::$_0&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
17# std::enable_if, doris::CompactionType, bool)::$_0&>, void>::type std::__invoke_r, doris::CompactionType, bool)::$_0&>(doris::StorageEngine::_submit_compaction_task(std::shared_ptr, doris::CompactionType, bool)::$_0&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
18# std::_Function_handler, doris::CompactionType, bool)::$_0>::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
19# std::function::operator()() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
20# doris::FunctionRunnable::run() at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/util/threadpool.cpp:48
21# doris::ThreadPool::dispatch_thread() at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/util/threadpool.cpp:533
22# void std::__invoke_impl(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
23# std::__invoke_result::type std::__invoke(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
24# void std::_Bind::__call(std::tuple<>&&, std::_Index_tuple<0ul>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420
25# void std::_Bind::operator()<, void>() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503
26# void std::__invoke_impl&>(std::__invoke_other, std::_Bind&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
27# std::enable_if&>, void>::type std::__invoke_r&>(std::_Bind&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
28# std::_Function_handler >::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
29# std::function::operator()() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
30# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/util/thread.cpp:465
31# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
32# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

