### PR TITLE
[fix](move-memtable) handle error in LoadStreamWriter::close

### DIFF
--- a/be/src/runtime/load_stream_writer.cpp
+++ b/be/src/runtime/load_stream_writer.cpp
@@ -151,10 +151,10 @@ Status LoadStreamWriter::close() {
         }
     }
 
-    static_cast<void>(_rowset_builder.build_rowset());
-    static_cast<void>(_rowset_builder.submit_calc_delete_bitmap_task());
-    static_cast<void>(_rowset_builder.wait_calc_delete_bitmap());
-    static_cast<void>(_rowset_builder.commit_txn());
+    RETURN_IF_ERROR(_rowset_builder.build_rowset());
+    RETURN_IF_ERROR(_rowset_builder.submit_calc_delete_bitmap_task());
+    RETURN_IF_ERROR(_rowset_builder.wait_calc_delete_bitmap());
+    RETURN_IF_ERROR(_rowset_builder.commit_txn());
 
     return Status::OK();
 }


### PR DESCRIPTION
## Proposed changes

Do not ignore status in `LoadStreamWriter::close()`

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

