### PR TITLE
[fix](transaction) fix profile null exception cause txn stuck

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
@@ -61,7 +61,8 @@ public class Profile {
         executionProfile.addToProfileAsChild(rootProfile);
     }
 
-    public synchronized void update(long startTime, Map<String, String> summaryInfo, boolean isFinished) {
+    public synchronized void update(long startTime, Map<String, String> summaryInfo, boolean isFinished,
+            boolean isSimpleProfile) {
         if (this.isFinished) {
             return;
         }
@@ -70,7 +71,7 @@ public class Profile {
             executionProfile.update(startTime, isFinished);
         }
         rootProfile.computeTimeInProfile();
-        rootProfile.setProfileLevel();
+        rootProfile.setProfileLevel(isSimpleProfile);
         ProfileManager.getInstance().pushProfile(rootProfile);
         this.isFinished = isFinished;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
@@ -20,7 +20,6 @@ package org.apache.doris.common.util;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.Reference;
 import org.apache.doris.common.profile.SummaryProfile;
-import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.thrift.TCounter;
 import org.apache.doris.thrift.TRuntimeProfileNode;
 import org.apache.doris.thrift.TRuntimeProfileTree;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
@@ -689,8 +689,8 @@ public class RuntimeProfile {
         computeTimeInProfile(this.counterTotalTime.getValue());
     }
 
-    public void setProfileLevel() {
-        this.enableSimplyProfile = ConnectContext.get().getSessionVariable().getEnableSimplyProfile();
+    public void setProfileLevel(boolean isSimpleProfile) {
+        this.enableSimplyProfile = isSimpleProfile;
     }
 
     private void computeTimeInProfile(long total) {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -48,6 +48,7 @@ import org.apache.doris.load.EtlJobType;
 import org.apache.doris.load.FailMsg;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.OriginStatement;
+import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.service.FrontendOptions;
 import org.apache.doris.thrift.TUniqueId;
 import org.apache.doris.transaction.BeginTransactionException;
@@ -55,6 +56,7 @@ import org.apache.doris.transaction.TransactionState;
 import org.apache.doris.transaction.TransactionState.TxnCoordinator;
 import org.apache.doris.transaction.TransactionState.TxnSourceType;
 
+import com.amazonaws.services.paymentcryptographydata.model.SessionKeyVisa;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import org.apache.logging.log4j.LogManager;
@@ -321,7 +323,8 @@ public class BrokerLoadJob extends BulkLoadJob {
         if (!enableProfile) {
             return;
         }
-        jobProfile.update(createTimestamp, getSummaryInfo(true), true);
+        jobProfile.update(createTimestamp, getSummaryInfo(true), true,
+                Boolean.valueOf(sessionVariables.getOrDefault(SessionVariable.ENABLE_SIMPLY_PROFILE, "true")));
     }
 
     private Map<String, String> getSummaryInfo(boolean isFinished) {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -56,7 +56,6 @@ import org.apache.doris.transaction.TransactionState;
 import org.apache.doris.transaction.TransactionState.TxnCoordinator;
 import org.apache.doris.transaction.TransactionState.TxnSourceType;
 
-import com.amazonaws.services.paymentcryptographydata.model.SessionKeyVisa;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import org.apache.logging.log4j.LogManager;

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BulkLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BulkLoadJob.java
@@ -88,7 +88,7 @@ public abstract class BulkLoadJob extends LoadJob {
 
     // sessionVariable's name -> sessionVariable's value
     // we persist these sessionVariables due to the session is not available when replaying the job.
-    private Map<String, String> sessionVariables = Maps.newHashMap();
+    protected Map<String, String> sessionVariables = Maps.newHashMap();
 
     public BulkLoadJob(EtlJobType jobType) {
         super(jobType);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -885,7 +885,8 @@ public class StmtExecutor {
         if (!context.getSessionVariable().enableProfile()) {
             return;
         }
-        profile.update(context.startTime, getSummaryInfo(isFinished), isFinished);
+        profile.update(context.startTime, getSummaryInfo(isFinished), isFinished,
+                context.getSessionVariable().enableSimplyProfile);
     }
 
     // Analyze one statement to structure in memory.

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -1065,7 +1065,7 @@ public class DatabaseTransactionMgr {
                 try {
                     transactionState.afterStateTransform(TransactionStatus.VISIBLE, txnOperated);
                 } catch (Exception e) {
-                    LOG.warn("afterStateTransform txn {} failed. msg: {}", transactionId, e.getMessage());
+                    LOG.warn("afterStateTransform txn {} failed. exception: ", transactionState, e);
                 }
             }
             updateCatalogAfterVisible(transactionState, db);

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -699,7 +699,11 @@ public class DatabaseTransactionMgr {
         } finally {
             writeUnlock();
             // after state transform
-            transactionState.afterStateTransform(TransactionStatus.COMMITTED, txnOperated);
+            try {
+                transactionState.afterStateTransform(TransactionStatus.COMMITTED, txnOperated);
+            } catch (Throwable e) {
+                LOG.warn("afterStateTransform txn {} failed. exception: ", transactionState, e);
+            }
         }
 
         // update nextVersion because of the failure of persistent transaction resulting in error version
@@ -1064,7 +1068,7 @@ public class DatabaseTransactionMgr {
                 writeUnlock();
                 try {
                     transactionState.afterStateTransform(TransactionStatus.VISIBLE, txnOperated);
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     LOG.warn("afterStateTransform txn {} failed. exception: ", transactionState, e);
                 }
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -1064,7 +1064,7 @@ public class DatabaseTransactionMgr {
                 writeUnlock();
                 try {
                     transactionState.afterStateTransform(TransactionStatus.VISIBLE, txnOperated);
-                } catch (UserException e) {
+                } catch (Exception e) {
                     LOG.warn("afterStateTransform txn {} failed. msg: {}", transactionId, e.getMessage());
                 }
             }


### PR DESCRIPTION
Fix runtime profile null exception @morningman

When finishing a txn,  state transfer cb may raise an exception. It will cause the replicas and partitions' version couldn't update. Then later txn will be stucked. Fix this. 

test case will be covered by cases from Baidu, which is under dev.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

