### PR TITLE
[bugfix](Coordinator) The error msg hide host info exclude localhost

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -1247,7 +1247,10 @@ public class Coordinator implements CoordInterface {
                 String errMsg = copyStatus.getErrorMsg();
                 LOG.warn("query failed: {}", errMsg);
 
-                // hide host info
+                // hide host info exclude localhost
+                if (errMsg.contains("localhost")) {
+                    throw new UserException(errMsg);
+                }
                 int hostIndex = errMsg.indexOf("host");
                 if (hostIndex != -1) {
                     errMsg = errMsg.substring(0, hostIndex);


### PR DESCRIPTION
## Proposed changes

Exception information is incomplete when localhost exists in the log.


<img width="572" alt="image" src="https://github.com/apache/doris/assets/48236177/136e5890-545e-43e3-bfd5-66a00f631417">


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

