### PR TITLE
[fix][branch-2.0](memory) Fix memory daemon thread grace exit

### DIFF
--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -198,7 +198,7 @@ void Daemon::memory_maintenance_thread() {
         doris::MemInfo::refresh_proc_mem_no_allocator_cache();
 
         // Update and print memory stat when the memory changes by 256M.
-        if (abs(last_print_proc_mem - PerfCounters::get_vm_rss()) > 268435456) {
+        if (abs(last_print_proc_mem - PerfCounters::get_vm_rss()) > 268435456 && !k_doris_exit) {
             last_print_proc_mem = PerfCounters::get_vm_rss();
             doris::MemTrackerLimiter::enable_print_log_process_usage();
 


### PR DESCRIPTION
## Proposed changes

master rewrite static vairables construction & destructor order, in https://github.com/apache/doris/pull/24029, which is expected to solve this problem.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

