### PR TITLE
[fix](es-catalog) If the returned data is incorrect, it will be directly unified as the index was not found.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/external/elasticsearch/EsRestClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/elasticsearch/EsRestClient.java
@@ -266,7 +266,8 @@ public class EsRestClient {
                 if (response.isSuccessful()) {
                     return response.body().string();
                 } else {
-                    LOG.warn("request response code: {}, body: {}", response.code(), response.body().string());
+                    LOG.warn("request response code: {}, body: {}", response.code(), response.message());
+                    scratchExceptionForThrow = new DorisEsException(response.message());
                 }
             } catch (IOException e) {
                 LOG.warn("request node [{}] [{}] failures {}, try next nodes", currentNode, path, e);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<img width="1297" alt="image" src="https://github.com/apache/doris/assets/48236177/6c26c893-12e9-4bcb-a6a6-eb10ac4ad6ef">


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

