### PR TITLE
[Fix](autoinc) Ensure that `_fetch_autoinc_id_executor` is destructed after the destructions of `AutoIncIDBuffer`s

### DIFF
--- a/be/src/vec/sink/autoinc_buffer.cpp
+++ b/be/src/vec/sink/autoinc_buffer.cpp
@@ -27,20 +27,11 @@
 
 namespace doris::vectorized {
 
-FetchAutoIncIDExecutor::FetchAutoIncIDExecutor() {
-    ThreadPoolBuilder("AsyncFetchAutoIncIDExecutor")
-            .set_min_threads(config::auto_inc_fetch_thread_num)
-            .set_max_threads(config::auto_inc_fetch_thread_num)
-            .set_max_queue_size(std::numeric_limits<int>::max())
-            .build(&_pool);
-}
-
 AutoIncIDBuffer::AutoIncIDBuffer(int64_t db_id, int64_t table_id, int64_t column_id)
         : _db_id(db_id),
           _table_id(table_id),
           _column_id(column_id),
-          _rpc_token(FetchAutoIncIDExecutor::GetInstance()->_pool->new_token(
-                  ThreadPool::ExecutionMode::CONCURRENT)) {}
+          _rpc_token(GlobalAutoIncBuffers::GetInstance()->create_token()) {}
 
 void AutoIncIDBuffer::set_batch_size_at_least(size_t batch_size) {
     if (batch_size > _batch_size) {


### PR DESCRIPTION
## Proposed changes
coredump:
```
F20230922 23:50:38.137264 2503194 threadpool.cpp:253] Check failed: 1 == _tokens.size() (1 vs. 3) Threadpool AsyncFetchAutoIncIDExecutor destroyed with 3 allocated tokens
*** Check failure stack trace: ***
    @     0x5631b9949696  google::LogMessage::SendToLog()
    @     0x5631b9945c60  google::LogMessage::Flush()
    @     0x5631b9949ed9  google::LogMessageFatal::~LogMessageFatal()
    @     0x56319697e17f  doris::ThreadPool::~ThreadPool()
    @     0x56319312b83d  std::default_delete<>::operator()()
    @     0x563193289dcc  std::unique_ptr<>::~unique_ptr()
    @     0x5631b8660015  doris::vectorized::FetchAutoIncIDExecutor::~FetchAutoIncIDExecutor()
    @     0x7f586fe4e8a7  (unknown)
    @     0x7f586fe4ea60  exit
    @     0x7f586fe2c08a  __libc_start_main
    @     0x563192dea02a  _start
    @              (nil)  (unknown)
*** Query id: 0-0 ***
*** Aborted at 1695397838 (unix time) try "date -d @1695397838" if you are using GNU date ***
*** Current BE git commitID: f3062e3d74 ***
*** SIGABRT unknown detail explain (@0x26321a) received by PID 2503194 (TID 2503194 OR 0x7f586fc6f7c0) from PID 2503194; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:413
 1# 0x00007F586FE4B090 in /lib/x86_64-linux-gnu/libc.so.6
 2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
 3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
 4# 0x00005631B9953EAD in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 5# 0x00005631B99461BA in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 6# google::LogMessage::SendToLog() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 7# google::LogMessage::Flush() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 8# google::LogMessageFatal::~LogMessageFatal() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 9# doris::ThreadPool::~ThreadPool() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
10# std::default_delete::operator()(doris::ThreadPool*) const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:85
11# std::unique_ptr >::~unique_ptr() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:361
12# doris::vectorized::FetchAutoIncIDExecutor::~FetchAutoIncIDExecutor() at /home/zcp/repo_center/doris_master/doris/be/src/vec/sink/autoinc_buffer.h:30
13# __run_exit_handlers at /build/glibc-SzIz7B/glibc-2.31/stdlib/exit.c:109
14# on_exit at /build/glibc-SzIz7B/glibc-2.31/stdlib/on_exit.c:26
15# __libc_start_main at ../csu/libc-start.c:261
16# _start in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

