### PR TITLE
[enhancement](Nereids) remove deriveStats jobs for some groupExpression 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/ApplyRuleJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/ApplyRuleJob.java
@@ -30,6 +30,7 @@ import org.apache.doris.nereids.metrics.event.TransformEvent;
 import org.apache.doris.nereids.minidump.NereidsTracer;
 import org.apache.doris.nereids.pattern.GroupExpressionMatching;
 import org.apache.doris.nereids.rules.Rule;
+import org.apache.doris.nereids.rules.RuleType;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 
@@ -82,11 +83,20 @@ public class ApplyRuleJob extends Job {
                 newGroupExpression.setFromRule(rule);
                 if (newPlan instanceof LogicalPlan) {
                     pushJob(new OptimizeGroupExpressionJob(newGroupExpression, context));
+                    if (!rule.getRuleType().equals(RuleType.LOGICAL_JOIN_COMMUTE)) {
+                        pushJob(new DeriveStatsJob(newGroupExpression, context));
+                    } else {
+                        groupExpression.setStatDerived(true);
+                    }
                 } else {
                     pushJob(new CostAndEnforcerJob(newGroupExpression, context));
+                    if (newGroupExpression.children().stream().anyMatch(g -> g.getLogicalExpressions().isEmpty())) {
+                        pushJob(new DeriveStatsJob(newGroupExpression, context));
+                    } else {
+                        groupExpression.setStatDerived(true);
+                    }
                 }
-                // we should derive stats for new logical/physical plan if the plan missing the stats
-                pushJob(new DeriveStatsJob(newGroupExpression, context));
+
                 NereidsTracer.logApplyRuleEvent(rule.toString(), plan, newGroupExpression.getPlan());
                 APPLY_RULE_TRACER.log(TransformEvent.of(groupExpression, plan, newPlans, rule.getRuleType()),
                         rule::isRewrite);


### PR DESCRIPTION
## Proposed changes
Don't call DeriveStatJob for follow group expressions:
1. the group expression that is generated by the joinCommute rule
2. the group expression that is generated by the implementation rule without creating a new group
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

