### PR TITLE
[chore](build) Fix issues with GLIBC dependency

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -510,6 +510,7 @@ if (absl_FOUND)
         absl::flags_reflection
         absl::random_internal_pool_urbg
         absl::random_internal_randen
+        absl::random_internal_seed_material
         absl::spinlock_wait
         absl::status
         absl::statusor


### PR DESCRIPTION
## Proposed changes

Issue Number: close #24838

Linking with `libabsl_random_internal_seed_material.a` instead of glibc to fix this issue.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

