### PR TITLE
[fix](Nereids) function implict cast for json is not work well

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/JsonType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/JsonType.java
@@ -19,7 +19,6 @@ package org.apache.doris.nereids.types;
 
 import org.apache.doris.catalog.Type;
 import org.apache.doris.nereids.annotation.Developing;
-import org.apache.doris.nereids.types.coercion.CharacterType;
 
 /**
  * Json type in Nereids.
@@ -41,7 +40,7 @@ public class JsonType extends DataType {
 
     @Override
     public boolean acceptsType(DataType other) {
-        return other instanceof JsonType || other instanceof CharacterType;
+        return other instanceof JsonType;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
@@ -83,6 +83,7 @@ import org.apache.doris.nereids.types.DecimalV3Type;
 import org.apache.doris.nereids.types.DoubleType;
 import org.apache.doris.nereids.types.FloatType;
 import org.apache.doris.nereids.types.IntegerType;
+import org.apache.doris.nereids.types.JsonType;
 import org.apache.doris.nereids.types.LargeIntType;
 import org.apache.doris.nereids.types.MapType;
 import org.apache.doris.nereids.types.NullType;
@@ -236,6 +237,8 @@ public class TypeCoercionUtils {
                 returnType = expected.defaultConcreteType();
             } else if (expected instanceof DateTimeType) {
                 returnType = DateTimeType.INSTANCE;
+            } else if (expected instanceof JsonType) {
+                returnType = JsonType.INSTANCE;
             }
         } else if (input.isDateType()) {
             if (expected instanceof DateTimeType) {

--- a/regression-test/data/nereids_function_p0/scalar_function/J.out
+++ b/regression-test/data/nereids_function_p0/scalar_function/J.out
@@ -7461,3 +7461,6 @@ false
 30	-9223372036854775808	[null,null,null]
 31	18446744073709551615	[null,null,null]
 
+-- !json_extract_string --
+"v31"
+

--- a/regression-test/suites/nereids_function_p0/scalar_function/J.groovy
+++ b/regression-test/suites/nereids_function_p0/scalar_function/J.groovy
@@ -532,4 +532,7 @@ suite("nereids_scalar_fn_J") {
     qt_select """SELECT id, j, JSON_EXTRACT(j, '\$.k2', '\$.x.y') FROM ${testTable} ORDER BY id"""
     qt_select """SELECT id, j, JSON_EXTRACT(j, '\$.k2', null) FROM ${testTable} ORDER BY id"""
     qt_select """SELECT id, j, JSON_EXTRACT(j, '\$.a1[0].k1', '\$.a1[0].k2', '\$.a1[2]') FROM ${testTable} ORDER BY id"""
+
+    qt_json_extract_string """select jsonb_extract('{"k1":"v31","k2":300}','\$.k1');"""
+
 }


### PR DESCRIPTION
for sql like:

SELECT JSONB_EXTRACT('{"k1":"v31","k2":300}','$.k1');

the result should be

+------------------------------------------------+
| jsonb_extract('{"k1":"v31","k2":300}', '$.k1') |
+------------------------------------------------+
| "v31"                                          |
+------------------------------------------------+

but curent result is

+------------------------------------------------+
| jsonb_extract('{"k1":"v31","k2":300}', '$.k1') |
+------------------------------------------------+
| <null>                                         |
+------------------------------------------------+

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

