### PR TITLE
[fix](analysis) MessageDigest Algorithms is used SHA-256 in CreateFunctionStmt to  replace MD5

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateFunctionStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateFunctionStmt.java
@@ -281,7 +281,7 @@ public class CreateFunctionStmt extends DdlStmt {
         }
 
         try (InputStream inputStream = Util.getInputStreamFromUrl(userFile, null, HTTP_TIMEOUT_MS, HTTP_TIMEOUT_MS)) {
-            MessageDigest digest = MessageDigest.getInstance("MD5");
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
             byte[] buf = new byte[4096];
             int bytesRead = 0;
             do {


### PR DESCRIPTION
…ctionStmt to  replace MD5

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

