### PR TITLE
[Fix](HttpServer)  creating this cookie without the "secure" flag and enabling cross-origin resource safe

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2195,5 +2195,5 @@ public class Config extends ConfigBase {
         "Set the specific domain name that allows cross-domain access. "
             + "By default, any domain name is allowed cross-domain access"
     })
-    public static String http_access_control_allowed_origin_domain = "*";
+    public static String access_control_allowed_origin_domain = "*";
 }

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2190,4 +2190,10 @@ public class Config extends ConfigBase {
     })
     public static long auto_analyze_job_record_count = 20000;
 
+    @ConfField(description = {
+        "设置允许跨域访问的特定域名,默认允许任何域名跨域访问",
+        "Set the specific domain name that allows cross-domain access. "
+            + "By default, any domain name is allowed cross-domain access"
+    })
+    public static String http_access_control_allowed_origin_domain = "*";
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcMySQLClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcMySQLClient.java
@@ -178,9 +178,13 @@ public class JdbcMySQLClient extends JdbcClient {
             DefaultValueExprDef defaultValueExprDef = null;
             if (field.getDefaultValue() != null
                     && field.getDefaultValue().toLowerCase().startsWith("current_timestamp")) {
-                long precision = field.getDefaultValue().toLowerCase().contains("(")
-                        ? Long.parseLong(field.getDefaultValue().toLowerCase()
-                        .split("\\(")[1].split("\\)")[0]) : 0;
+                // current_timestamp（)
+                String colDefaultValue = field.getDefaultValue().toLowerCase();
+                long precision = 0;
+                if (colDefaultValue.contains("(")) {
+                    String substring = colDefaultValue.substring(18, colDefaultValue.length() - 1).trim();
+                    precision = substring.isEmpty() ? 0 : Long.parseLong(substring);
+                }
                 defaultValueExprDef = new DefaultValueExprDef("now", precision);
             }
             dorisTableSchema.add(new Column(field.getColumnName(),

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/config/WebConfigurer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/config/WebConfigurer.java
@@ -46,6 +46,7 @@ public class WebConfigurer implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
+                .allowCredentials(false)
                 .allowedMethods("*")
                 .allowedOrigins(Config.access_control_allowed_origin_domain)
                 .allowedHeaders("*")

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/config/WebConfigurer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/config/WebConfigurer.java
@@ -46,9 +46,8 @@ public class WebConfigurer implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowCredentials(false)
                 .allowedMethods("*")
-                .allowedOrigins("*")
+                .allowedOrigins(Config.http_access_control_allowed_origin_domain)
                 .allowedHeaders("*")
                 .maxAge(3600);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/config/WebConfigurer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/config/WebConfigurer.java
@@ -47,7 +47,7 @@ public class WebConfigurer implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedMethods("*")
-                .allowedOrigins(Config.http_access_control_allowed_origin_domain)
+                .allowedOrigins(Config.access_control_allowed_origin_domain)
                 .allowedHeaders("*")
                 .maxAge(3600);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/BaseController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/BaseController.java
@@ -103,6 +103,7 @@ public class BaseController {
     protected void addSession(HttpServletRequest request, HttpServletResponse response, SessionValue value) {
         String key = UUID.randomUUID().toString();
         Cookie cookie = new Cookie(PALO_SESSION_ID, key);
+        cookie.setSecure(true);
         cookie.setMaxAge(PALO_SESSION_EXPIRED_TIME);
         cookie.setPath("/");
         cookie.setHttpOnly(true);


### PR DESCRIPTION
## Proposed changes
1. creating this cookie without the "secure" flag
2. enabling CORS is safe：The Access-Control-Allow-Origin header should be set only for a trusted origin and for specific resources. Thus, you can set `access_control_allowed_origin_domain="trustedwebsite.com"`. By default, any domain name is allowed cross-domain access,`tring access_control_allowed_origin_domain = "*"`


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

