### PR TITLE
[Enhancement](inverted index) accelerate match tokenzier for english without index

### DIFF
--- a/be/src/olap/itoken_extractor.cpp
+++ b/be/src/olap/itoken_extractor.cpp
@@ -20,6 +20,7 @@
 #include <stdint.h>
 
 #include "util/simd/vstring_function.h"
+#include "vec/common/string_utils/string_utils.h"
 
 namespace doris {
 
@@ -75,5 +76,59 @@ bool NgramTokenExtractor::next_in_string_like(const char* data, size_t length, s
     }
 
     return false;
+}
+
+bool AlphaNumTokenExtractor::next_in_string(const char* data, size_t length, size_t* __restrict pos,
+                                            size_t* __restrict token_start,
+                                            size_t* __restrict token_length) const {
+    *token_start = *pos;
+    *token_length = 0;
+    while (*pos < length) {
+        if (is_ascii(data[*pos]) && !is_alpha_numeric_ascii(data[*pos])) {
+            /// Finish current token if any
+            if (*token_length > 0) {
+                return true;
+            }
+            *token_start = ++*pos;
+        } else {
+            /// Note that UTF-8 sequence is completely consisted of non-ASCII bytes.
+            ++*pos;
+            ++*token_length;
+        }
+    }
+    return *token_length > 0;
+}
+
+bool AlphaNumTokenExtractor::next_in_string_like(const char* data, size_t length, size_t* pos,
+                                                 std::string& token) const {
+    token.clear();
+    bool bad_token = false; // % or _ before token
+    bool escaped = false;
+    while (*pos < length) {
+        if (!escaped && (data[*pos] == '%' || data[*pos] == '_')) {
+            token.clear();
+            bad_token = true;
+            ++*pos;
+        } else if (!escaped && data[*pos] == '\\') {
+            escaped = true;
+            ++*pos;
+        } else if (is_ascii(data[*pos]) && !is_alpha_numeric_ascii(data[*pos])) {
+            if (!bad_token && !token.empty()) {
+                return true;
+            }
+            token.clear();
+            bad_token = false;
+            escaped = false;
+            ++*pos;
+        } else {
+            const size_t sz = get_utf8_byte_length(static_cast<uint8_t>(data[*pos]));
+            for (size_t j = 0; j < sz; ++j) {
+                token += data[*pos];
+                ++*pos;
+            }
+            escaped = false;
+        }
+    }
+    return !bad_token && !token.empty();
 }
 } // namespace doris

--- a/be/src/olap/itoken_extractor.h
+++ b/be/src/olap/itoken_extractor.h
@@ -93,6 +93,17 @@ public:
 private:
     size_t n;
 };
+
+struct AlphaNumTokenExtractor final : public ITokenExtractorHelper<AlphaNumTokenExtractor> {
+public:
+    AlphaNumTokenExtractor() = default;
+    bool next_in_string(const char* data, size_t length, size_t* __restrict pos,
+                        size_t* __restrict token_start,
+                        size_t* __restrict token_length) const override;
+
+    bool next_in_string_like(const char* data, size_t length, size_t* pos,
+                             std::string& token) const override;
+};
 } // namespace doris
 
 #endif //DORIS_ITOKEN_EXTRACTOR_H

--- a/be/src/vec/common/string_ref.h
+++ b/be/src/vec/common/string_ref.h
@@ -195,6 +195,10 @@ struct StringRef {
 
     StringRef(const std::string& s) : data(s.data()), size(s.size()) {}
     explicit StringRef(const char* str) : data(str), size(strlen(str)) {}
+    void init(const char* data_, size_t size_) {
+        data = data_;
+        size = size_;
+    }
 
     std::string to_string() const { return std::string(data, size); }
     std::string debug_string() const { return to_string(); }
@@ -235,6 +239,19 @@ struct StringRef {
     bool end_with(char) const;
     bool start_with(const StringRef& search_string) const;
     bool end_with(const StringRef& search_string) const;
+    [[nodiscard]] bool equals_ignore_case(const StringRef& other) const {
+        if (size != other.size) {
+            return false;
+        }
+
+        for (size_t i = 0; i < size; ++i) {
+            if (std::tolower(data[i]) != std::tolower(other.data[i])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 
     // Byte-by-byte comparison. Returns:
     // this < other: -1


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
```
before:

mysql> select COUNT() from wc_httplogs_without_index where request match "GET";                                                                 +-----------+
| count(*)  |
+-----------+
| 245552656 |
+-----------+
1 row in set (9.16 sec)

after:
mysql> select COUNT() from wc_httplogs_without_index where request match "GET";
+-----------+
| count(*)  |
+-----------+
| 245552656 |
+-----------+
1 row in set (0.60 sec)
```
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

