### PR TITLE
[fix](merge-on-write) MergeIndexDeleteBitmapCalculator stack overflow

### DIFF
--- a/be/src/olap/delete_bitmap_calculator.cpp
+++ b/be/src/olap/delete_bitmap_calculator.cpp
@@ -120,8 +120,8 @@ bool MergeIndexDeleteBitmapCalculatorContext::Comparator::operator()(
 
 bool MergeIndexDeleteBitmapCalculatorContext::Comparator::is_key_same(Slice const& lhs,
                                                                       Slice const& rhs) const {
-    DCHECK(lhs.get_size() > _sequence_length);
-    DCHECK(rhs.get_size() > _sequence_length);
+    DCHECK(lhs.get_size() >= _sequence_length);
+    DCHECK(rhs.get_size() >= _sequence_length);
     auto lhs_without_seq = Slice(lhs.get_data(), lhs.get_size() - _sequence_length);
     auto rhs_without_seq = Slice(rhs.get_data(), rhs.get_size() - _sequence_length);
     return lhs_without_seq.compare(rhs_without_seq) == 0;

--- a/be/src/olap/delete_bitmap_calculator.cpp
+++ b/be/src/olap/delete_bitmap_calculator.cpp
@@ -120,6 +120,8 @@ bool MergeIndexDeleteBitmapCalculatorContext::Comparator::operator()(
 
 bool MergeIndexDeleteBitmapCalculatorContext::Comparator::is_key_same(Slice const& lhs,
                                                                       Slice const& rhs) const {
+    DCHECK(lhs.get_size() > _sequence_length);
+    DCHECK(rhs.get_size() > _sequence_length);
     auto lhs_without_seq = Slice(lhs.get_data(), lhs.get_size() - _sequence_length);
     auto rhs_without_seq = Slice(rhs.get_data(), rhs.get_size() - _sequence_length);
     return lhs_without_seq.compare(rhs_without_seq) == 0;
@@ -154,7 +156,7 @@ Status MergeIndexDeleteBitmapCalculator::calculate_one(RowLocation& loc) {
         _heap->pop();
         Slice cur_key;
         RETURN_IF_ERROR(cur_ctx->get_current_key(cur_key));
-        if (_comparator.is_key_same(cur_key, _last_key)) {
+        if (!_last_key.empty() && _comparator.is_key_same(cur_key, _last_key)) {
             loc.segment_id = cur_ctx->segment_id();
             loc.row_id = cur_ctx->row_id();
             auto st = cur_ctx->advance();


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

ASAN reports stack overflow
```
==1283508==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7f6ecab749c0 at pc 0x56131f8a81f5 bp 0x7f6ecd84d090 sp 0x7f6ecd84c838
READ of size 107 at 0x7f6ecab749c0 thread T880 (brpc_heavy)
==1283508==WARNING: invalid path to external symbolizer!
==1283508==WARNING: Failed to use and restart external symbolizer!
    #0 0x56131f8a81f4 in MemcmpInterceptorCommon(void*, int (*)(void const*, void const*, unsigned long), void const*, void const*, unsigned long) crtstuff.c:?
    #1 0x56131f8a85f9 in __interceptor_memcmp ??:?
    #2 0x56131fe932c4 in doris::Slice::mem_compare(void const*, void const*, unsigned long) ??:?
    #3 0x56131fe8aadb in doris::Slice::compare(doris::Slice const&) const ??:?
    #4 0x561321f618df in doris::MergeIndexDeleteBitmapCalculatorContext::Comparator::is_key_same(doris::Slice const&, doris::Slice const&) const ??:?
    #5 0x561321f62914 in doris::MergeIndexDeleteBitmapCalculator::calculate_one(doris::RowLocation&) ??:?
    #6 0x561321f63383 in doris::MergeIndexDeleteBitmapCalculator::calculate_all(std::shared_ptr<doris::DeleteBitmap>) ??:?
    #7 0x561321ec815d in doris::Tablet::calc_delete_bitmap_between_segments(std::shared_ptr<doris::Rowset>, std::vector<std::shared_ptr<doris::segment_v2::Segment>, std::allocator<std::shared_ptr<doris::segment_v2::Segment> > > const&, std::shared_ptr<doris::DeleteBitmap>) ??:? 
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

