### PR TITLE
 [bug](profile) query profile api of fe cann't get result if non-root user query on the other fe 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/QueryProfileAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/QueryProfileAction.java
@@ -268,10 +268,12 @@ public class QueryProfileAction extends RestBaseController {
             @RequestParam(value = IS_ALL_NODE_PARA, required = false, defaultValue = "true") boolean isAllNode) {
         executeCheckPassword(request, response);
 
-        try {
-            checkAuthByUserAndQueryId(queryId);
-        } catch (AuthenticationException e) {
-            return ResponseEntityBuilder.badRequest(e.getMessage());
+        if (!isAllNode) {
+            try {
+                checkAuthByUserAndQueryId(queryId);
+            } catch (AuthenticationException e) {
+                return ResponseEntityBuilder.badRequest(e.getMessage());
+            }
         }
 
         if (format.equals("text")) {


### PR DESCRIPTION
## Proposed changes

Issue Number: #24858

If isAllNode is true, the api should only distribute the query to all fe and do not run checkAuthByUserAndQueryId.
If isAllNode is false, the api queries profile on the fe, at this time the api should  run checkAuthByUserAndQueryId. 

## Further comments
