### PR TITLE
[fix](stack trace) Optimize stack trace output

### DIFF
--- a/be/src/common/stack_trace.cpp
+++ b/be/src/common/stack_trace.cpp
@@ -380,9 +380,15 @@ static void toStringEveryLineImpl([[maybe_unused]] const std::string dwarf_locat
                 reinterpret_cast<const void*>(uintptr_t(virtual_addr) - virtual_offset);
 
         std::stringstream out;
-        out << "\t" << i << ". ";
+        out << "\t" << i << "# ";
         if (i < 10) { // for alignment
             out << " ";
+        }
+
+        if (const auto* const symbol = symbol_index.findSymbol(virtual_addr)) {
+            out << collapseNames(demangle(symbol->name));
+        } else {
+            out << "?";
         }
 
         if (std::error_code ec; object && std::filesystem::exists(object->name, ec) && !ec) {
@@ -392,14 +398,8 @@ static void toStringEveryLineImpl([[maybe_unused]] const std::string dwarf_locat
 
             if (dwarf_it->second.findAddress(uintptr_t(physical_addr), location, mode,
                                              inline_frames)) {
-                out << location.file.toString() << ":" << location.line;
+                out << " at " << location.file.toString() << ":" << location.line;
             }
-        }
-
-        if (const auto* const symbol = symbol_index.findSymbol(virtual_addr)) {
-            out << "  " << collapseNames(demangle(symbol->name));
-        } else {
-            out << " ?";
         }
 
         // Do not display the stack address and file name, it is not important.

--- a/be/src/common/stack_trace.h
+++ b/be/src/common/stack_trace.h
@@ -73,7 +73,7 @@ public:
     [[nodiscard]] constexpr size_t getSize() const { return size; }
     [[nodiscard]] constexpr size_t getOffset() const { return offset; }
     [[nodiscard]] const FramePointers& getFramePointers() const { return frame_pointers; }
-    [[nodiscard]] std::string toString() const;
+    [[nodiscard]] std::string toString(int start_pointers_index = 0) const;
 
     static std::string toString(void** frame_pointers, size_t offset, size_t size);
     static void createCache();

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -377,7 +377,8 @@ public:
         }
 #ifdef ENABLE_STACKTRACE
         if constexpr (stacktrace && capture_stacktrace(code)) {
-            status._err_msg->_stack = get_stack_trace();
+            // Delete the first four frame pointers, which are inside the StackTrace and Status.
+            status._err_msg->_stack = get_stack_trace(4);
             LOG(WARNING) << "meet error status: " << status; // may print too many stacks.
         }
 #endif
@@ -396,7 +397,7 @@ public:
         }
 #ifdef ENABLE_STACKTRACE
         if (stacktrace && capture_stacktrace(code)) {
-            status._err_msg->_stack = get_stack_trace();
+            status._err_msg->_stack = get_stack_trace(4);
             LOG(WARNING) << "meet error status: " << status; // may print too many stacks.
         }
 #endif

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -397,7 +397,7 @@ public:
         }
 #ifdef ENABLE_STACKTRACE
         if (stacktrace && capture_stacktrace(code)) {
-            status._err_msg->_stack = get_stack_trace(4);
+            status._err_msg->_stack = get_stack_trace(1);
             LOG(WARNING) << "meet error status: " << status; // may print too many stacks.
         }
 #endif

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -377,8 +377,8 @@ public:
         }
 #ifdef ENABLE_STACKTRACE
         if constexpr (stacktrace && capture_stacktrace(code)) {
-            // Delete the first four frame pointers, which are inside the StackTrace and Status.
-            status._err_msg->_stack = get_stack_trace(4);
+            // Delete the first one frame pointers, which are inside the status.h
+            status._err_msg->_stack = get_stack_trace(1);
             LOG(WARNING) << "meet error status: " << status; // may print too many stacks.
         }
 #endif

--- a/be/src/util/stack_util.cpp
+++ b/be/src/util/stack_util.cpp
@@ -35,7 +35,7 @@ void DumpStackTraceToString(std::string* stacktrace);
 
 namespace doris {
 
-std::string get_stack_trace() {
+std::string get_stack_trace(int start_pointers_index) {
 #ifdef ENABLE_STACKTRACE
     auto tool = config::get_stack_trace_tool;
     if (tool == "glog") {
@@ -48,7 +48,7 @@ std::string get_stack_trace() {
 #if defined(__APPLE__) // TODO
         return get_stack_trace_by_glog();
 #endif
-        return get_stack_trace_by_libunwind();
+        return get_stack_trace_by_libunwind(start_pointers_index);
     } else {
         return "no stack";
     }
@@ -80,8 +80,8 @@ std::string get_stack_trace_by_glibc() {
     return out.str();
 }
 
-std::string get_stack_trace_by_libunwind() {
-    return "\n" + StackTrace().toString();
+std::string get_stack_trace_by_libunwind(int start_pointers_index) {
+    return "\n" + StackTrace().toString(start_pointers_index);
 }
 
 } // namespace doris

--- a/be/src/util/stack_util.h
+++ b/be/src/util/stack_util.h
@@ -29,8 +29,7 @@ namespace doris {
 // boost: 1000 times cost 1min, has line numbers, but has memory leak.
 // glibc: 1000 times cost 1min, no line numbers, unresolved backtrace symbol.
 // libunwind: cost is negligible, has line numbers.
-// Delete the first three frame pointers, which are inside the StackTrace.
-std::string get_stack_trace(int start_pointers_index = 3);
+std::string get_stack_trace(int start_pointers_index = 0);
 
 // Note: there is a libc bug that causes this not to work on 64 bit machines
 // for recursive calls.

--- a/be/src/util/stack_util.h
+++ b/be/src/util/stack_util.h
@@ -29,7 +29,8 @@ namespace doris {
 // boost: 1000 times cost 1min, has line numbers, but has memory leak.
 // glibc: 1000 times cost 1min, no line numbers, unresolved backtrace symbol.
 // libunwind: cost is negligible, has line numbers.
-std::string get_stack_trace();
+// Delete the first three frame pointers, which are inside the StackTrace.
+std::string get_stack_trace(int start_pointers_index = 3);
 
 // Note: there is a libc bug that causes this not to work on 64 bit machines
 // for recursive calls.
@@ -53,6 +54,6 @@ std::string get_stack_trace_by_glibc();
 //  2. Support signal handle
 //  3. libunwid support unw_backtrace for jemalloc
 //  4. Use of undefined compile option USE_MUSL for later
-std::string get_stack_trace_by_libunwind();
+std::string get_stack_trace_by_libunwind(int start_pointers_index);
 
 } // namespace doris


### PR DESCRIPTION
## Proposed changes

1. Status prints the stack trace, the first four frame pointers are removed, it doesn't make sense.
2. Optimize stack trace field order.

example:
```
  0#  doris::PlanFragmentExecutor::cancel(doris::PPlanFragmentCancelReason const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at doris/core/be/src/common/status.h:0
  1#  doris::FragmentMgr::cancel_query_unlocked(doris::TUniqueId const&, doris::PPlanFragmentCancelReason const&, std::unique_lock<std::mutex> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at doris/cor
e/be/src/runtime/fragment_mgr.cpp:984
  2#  doris::FragmentMgr::cancel_query(doris::TUniqueId const&, doris::PPlanFragmentCancelReason const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at doris/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/
../../../../include/x86_64-linux-gnu/c++/11/bits/gthr-default.h:778
  3#  long doris::MemTrackerLimiter::free_top_memory_query<doris::MemTrackerLimiter::TrackerLimiterGroup>(long, doris::MemTrackerLimiter::Type, std::vector<doris::MemTrackerLimiter::TrackerLimiterGroup, std::allocator<doris::MemTrackerLimiter::TrackerLimiterGroup> >&, s
td::function<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > (long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)> const&, doris::RuntimeProfile*) at doris/ldb_toolchain/bin/../
lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:187
  4#  doris::MemTrackerLimiter::free_top_memory_query(long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, doris::RuntimeProfile*, doris::Mem
TrackerLimiter::Type) at doris/core/be/src/runtime/memory/mem_tracker_limiter.cpp:362
  5#  doris::MemInfo::process_full_gc() at doris/core/be/src/util/mem_info.cpp:198
  6#  doris::Daemon::memory_gc_thread() at doris/core/be/src/common/daemon.cpp:0
  7#  doris::Thread::supervise_thread(void*) at doris/ldb_toolchain/bin/../usr/include/pthread.h:562
  8#  start_thread
  9#  __clone
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

