### PR TITLE
[improvement](compaction) output tablet_id when be core dumped.

### DIFF
--- a/be/src/common/signal_handler.h
+++ b/be/src/common/signal_handler.h
@@ -53,7 +53,7 @@ namespace doris::signal {
 
 inline thread_local uint64 query_id_hi;
 inline thread_local uint64 query_id_lo;
-inline thread_local uint64 tablet_id = -1;
+inline thread_local uint64 tablet_id = 0;
 
 namespace {
 

--- a/be/src/common/signal_handler.h
+++ b/be/src/common/signal_handler.h
@@ -53,6 +53,7 @@ namespace doris::signal {
 
 inline thread_local uint64 query_id_hi;
 inline thread_local uint64 query_id_lo;
+inline thread_local uint64 tablet_id = -1;
 
 namespace {
 
@@ -242,6 +243,9 @@ void DumpTimeInfo() {
     formatter.AppendUint64(query_id_hi, 16);
     formatter.AppendString("-");
     formatter.AppendUint64(query_id_lo, 16);
+    formatter.AppendString(" ***\n");
+    formatter.AppendString("*** tablet id: ");
+    formatter.AppendUint64(tablet_id, 10);
     formatter.AppendString(" ***\n");
     formatter.AppendString("*** Aborted at ");
     formatter.AppendUint64(static_cast<uint64>(time_in_sec), 10);

--- a/be/src/common/signal_handler.h
+++ b/be/src/common/signal_handler.h
@@ -53,7 +53,7 @@ namespace doris::signal {
 
 inline thread_local uint64 query_id_hi;
 inline thread_local uint64 query_id_lo;
-inline thread_local uint64 tablet_id = 0;
+inline thread_local int64_t tablet_id = 0;
 
 namespace {
 

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -29,6 +29,7 @@
 #include <tuple>
 
 #include "common/logging.h"
+#include "common/signal_handler.h"
 #include "common/status.h"
 #include "gutil/hash/hash.h"
 #include "gutil/integral_types.h"
@@ -680,6 +681,8 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletReqV2&
         return Status::Error<TABLE_NOT_FOUND>("fail to find base tablet. base_tablet={}",
                                               request.base_tablet_id);
     }
+
+    signal::tablet_id = base_tablet->get_table_id();
 
     // new tablet has to exist
     TabletSharedPtr new_tablet =

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -62,6 +62,7 @@
 #include "common/config.h"
 #include "common/consts.h"
 #include "common/logging.h"
+#include "common/signal_handler.h"
 #include "common/status.h"
 #include "gutil/ref_counted.h"
 #include "gutil/strings/stringpiece.h"
@@ -1844,6 +1845,7 @@ std::vector<Version> Tablet::get_all_versions() {
 }
 
 void Tablet::execute_compaction(CompactionType compaction_type) {
+    signal::tablet_id = tablet_id();
     if (compaction_type == CompactionType::CUMULATIVE_COMPACTION) {
         MonotonicStopWatch watch;
         watch.start();


### PR DESCRIPTION
## Proposed changes
when be compaction core,  be.out will print tablet_id like this:

start time: Wed 27 Sep 2023 02:12:36 PM CST
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/root/huanghaibin/new/be/lib/java_extensions/preload-extensions/preload-extensions-jar-with-dependencies.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/root/huanghaibin/new/be/lib/java_extensions/java-udf/java-udf-jar-with-dependencies.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/root/huanghaibin/new/be/lib/hadoop_hdfs/common/lib/slf4j-reload4j-1.7.36.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.Reload4jLoggerFactory]
Java HotSpot(TM) 64-Bit Server VM warning: You have loaded library /root/huanghaibin/new/be/lib/hadoop_hdfs/native/libhadoop.so.1.0.0 which might have disabled stack guard. The VM will try to fix the stack guard now.
It's highly recommended that you fix the library with 'execstack -c <libfile>', or link it with '-z noexecstack'.
*** Query id: 0-0 ***
*** tablet id: 10346 ***
*** Aborted at 1695795175 (unix time) try "date -d @1695795175" if you are using GNU date ***
*** Current BE git commitID: 05ac530e34 ***
*** SIGSEGV address not mapped to object (@0x28) received by PID 2156884 (TID 2157536 OR 0x7ff70bdd8700) from PID 40; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk1/huanghaibin/hhb/tmp2/doris/be/src/common/signal_handler.h:417
 1# os::Linux::chained_handler(int, siginfo*, void*) in /root/huanghaibin/jdk1.8.0_131/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /root/huanghaibin/jdk1.8.0_131/jre/lib/amd64/server/libjvm.so
 3# signalHandler(int, siginfo*, void*) in /root/huanghaibin/jdk1.8.0_131/jre/lib/amd64/server/libjvm.so
 4# 0x00007FF888798090 in /lib/x86_64-linux-gnu/libc.so.6
 5# doris::SegmentLoader::load_segments(std::shared_ptr<doris::BetaRowset> const&, doris::SegmentCacheHandle*, bool) at /mnt/disk1/huanghaibin/hhb/tmp2/doris/be/src/olap/segment_loader.cpp:63
 6# doris::Compaction::_load_segment_to_cache() at /mnt/disk1/huanghaibin/hhb/tmp2/doris/be/src/olap/compaction.cpp:839
 7# doris::Compaction::do_compaction(long) at /mnt/disk1/huanghaibin/hhb/tmp2/doris/be/src/olap/compaction.cpp:142
 8# doris::BaseCompaction::execute_compact_impl() at /mnt/disk1/huanghaibin/hhb/tmp2/doris/be/src/olap/base_compaction.cpp:87
 9# doris::Compaction::execute_compact() at /mnt/disk1/huanghaibin/hhb/tmp2/doris/be/src/olap/compaction.cpp:106
10# doris::Tablet::execute_compaction(doris::CompactionType) at /mnt/disk1/huanghaibin/hhb/tmp2/doris/be/src/olap/tablet.cpp:1884
11# std::_Function_handler<void (), doris::StorageEngine::_submit_compaction_task(std::shared_ptr<doris::Tablet>, doris::CompactionType, bool)::$_0>::_M_invoke(std::_Any_data const&) at /mnt/disk1/huanghaibin/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
12# doris::ThreadPool::dispatch_thread() in /root/huanghaibin/new/be/lib/doris_be
13# doris::Thread::supervise_thread(void*) at /mnt/disk1/huanghaibin/hhb/tmp2/doris/be/src/util/thread.cpp:495
14# start_thread in /lib/x86_64-linux-gnu/libpthread.so.0
15# __clone in /lib/x86_64-linux-gnu/libc.so.6 
Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

