### PR TITLE
[fix](Nereids) could not prune datev1 partition column

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/HiveDefaultPartitionEvaluator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/HiveDefaultPartitionEvaluator.java
@@ -32,8 +32,8 @@ import java.util.Map;
  * For any partition predicate, the evaluate() will always return true.
  */
 public class HiveDefaultPartitionEvaluator implements OnePartitionEvaluator {
-    private long id;
-    private List<Slot> partitionSlots;
+    private final long id;
+    private final List<Slot> partitionSlots;
 
     public HiveDefaultPartitionEvaluator(long id, List<Slot> partitionSlots) {
         this.id = id;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/OneRangePartitionEvaluator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/OneRangePartitionEvaluator.java
@@ -76,15 +76,15 @@ public class OneRangePartitionEvaluator
         extends ExpressionVisitor<EvaluateRangeResult, EvaluateRangeInput>
         implements OnePartitionEvaluator {
     private final long partitionId;
-    private List<Slot> partitionSlots;
-    private RangePartitionItem partitionItem;
-    private ExpressionRewriteContext expressionRewriteContext;
-    private List<PartitionSlotType> partitionSlotTypes;
-    private List<Literal> lowers;
-    private List<Literal> uppers;
-    private List<List<Expression>> inputs;
-    private Map<Slot, Boolean> partitionSlotContainsNull;
-    private Map<Slot, PartitionSlotType> slotToType;
+    private final List<Slot> partitionSlots;
+    private final RangePartitionItem partitionItem;
+    private final ExpressionRewriteContext expressionRewriteContext;
+    private final List<PartitionSlotType> partitionSlotTypes;
+    private final List<Literal> lowers;
+    private final List<Literal> uppers;
+    private final List<List<Expression>> inputs;
+    private final Map<Slot, Boolean> partitionSlotContainsNull;
+    private final Map<Slot, PartitionSlotType> slotToType;
 
     /** OneRangePartitionEvaluator */
     public OneRangePartitionEvaluator(long partitionId, List<Slot> partitionSlots,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeLiteral.java
@@ -93,6 +93,10 @@ public class DateTimeLiteral extends DateLiteral {
         this.day = day;
     }
 
+    public boolean isMidnight() {
+        return hour == 0 && minute == 0 && second == 0 && microSecond == 0;
+    }
+
     /**
      * determine scale by datetime string
      */


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

because storage engine could not process date comparison predicates.
we convert it to datetime comparison predicates.
however, partition prunner could not process cast(slot) cp literal.
so, we convert back in partition pruner to let it work well.

TODO:
move convert date to datetime in translate stage
and only convert predicates for storage engine.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

