### PR TITLE
[fix](compaction) block reader should check column string offset

### DIFF
--- a/be/src/vec/common/pod_array.h
+++ b/be/src/vec/common/pod_array.h
@@ -340,6 +340,7 @@ public:
     const_iterator cbegin() const { return t_start(); }
     const_iterator cend() const { return t_end(); }
 
+    void* get_begin_ptr() const { return this->c_start; }
     void* get_end_ptr() const { return this->c_end; }
     void set_end_ptr(void* ptr) { this->c_end = (char*)ptr; }
 

--- a/be/src/vec/common/pod_array.h
+++ b/be/src/vec/common/pod_array.h
@@ -340,7 +340,7 @@ public:
     const_iterator cbegin() const { return t_start(); }
     const_iterator cend() const { return t_end(); }
 
-    void* get_begin_ptr() const { return this->c_start; }
+    [[nodiscard]] void* get_begin_ptr() const { return this->c_start; }
     void* get_end_ptr() const { return this->c_end; }
     void set_end_ptr(void* ptr) { this->c_end = (char*)ptr; }
 

--- a/be/src/vec/olap/block_reader.cpp
+++ b/be/src/vec/olap/block_reader.cpp
@@ -419,11 +419,10 @@ Status BlockReader::_unique_key_next_block(Block* block, bool* eof) {
 
 Status BlockReader::_insert_data_normal(MutableColumns& columns) {
     auto block = _next_row.block.get();
-    RETURN_IF_CATCH_EXCEPTION(for (auto idx
-                                   : _normal_columns_idx) {
-        columns[_return_columns_loc[idx]]->insert_from(*block->get_by_position(idx).column,
-                                                       _next_row.row_pos);
-    });
+    for (auto idx : _normal_columns_idx) {
+        RETURN_IF_CATCH_EXCEPTION(columns[_return_columns_loc[idx]]->insert_from(
+                *block->get_by_position(idx).column, _next_row.row_pos));
+    }
     return Status::OK();
 }
 

--- a/be/src/vec/olap/block_reader.h
+++ b/be/src/vec/olap/block_reader.h
@@ -80,7 +80,7 @@ private:
 
     void _init_agg_state(const ReaderParams& read_params);
 
-    Status _insert_data_normal(MutableColumns& columns);
+    [[nodiscard]] Status _insert_data_normal(MutableColumns& columns);
 
     void _append_agg_data(MutableColumns& columns);
 

--- a/be/src/vec/olap/block_reader.h
+++ b/be/src/vec/olap/block_reader.h
@@ -80,7 +80,7 @@ private:
 
     void _init_agg_state(const ReaderParams& read_params);
 
-    void _insert_data_normal(MutableColumns& columns);
+    Status _insert_data_normal(MutableColumns& columns);
 
     void _append_agg_data(MutableColumns& columns);
 

--- a/be/src/vec/olap/vertical_block_reader.cpp
+++ b/be/src/vec/olap/vertical_block_reader.cpp
@@ -524,10 +524,10 @@ Status VerticalBlockReader::_unique_key_next_block(Block* block, bool* eof) {
         }
         const auto& src_block = _next_row.block;
         assert(src_block->columns() == column_count);
-        for (size_t i = 0; i < column_count; ++i) {
+        RETURN_IF_CATCH_EXCEPTION(for (size_t i = 0; i < column_count; ++i) {
             target_columns[i]->insert_from(*(src_block->get_by_position(i).column),
                                            _next_row.row_pos);
-        }
+        });
         ++target_block_row;
     } while (target_block_row < _reader_context.batch_size);
     return Status::OK();

--- a/be/src/vec/olap/vertical_block_reader.cpp
+++ b/be/src/vec/olap/vertical_block_reader.cpp
@@ -524,10 +524,10 @@ Status VerticalBlockReader::_unique_key_next_block(Block* block, bool* eof) {
         }
         const auto& src_block = _next_row.block;
         assert(src_block->columns() == column_count);
-        RETURN_IF_CATCH_EXCEPTION(for (size_t i = 0; i < column_count; ++i) {
-            target_columns[i]->insert_from(*(src_block->get_by_position(i).column),
-                                           _next_row.row_pos);
-        });
+        for (size_t i = 0; i < column_count; ++i) {
+            RETURN_IF_CATCH_EXCEPTION(target_columns[i]->insert_from(
+                    *(src_block->get_by_position(i).column), _next_row.row_pos));
+        }
         ++target_block_row;
     } while (target_block_row < _reader_context.batch_size);
     return Status::OK();

--- a/be/src/vec/sink/writer/vtablet_writer.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer.cpp
@@ -548,7 +548,8 @@ Status VNodeChannel::add_block(vectorized::Block* block, const Payload* payload,
         *_cur_add_block_request.mutable_tablet_ids() = {tablets.begin(), tablets.end()};
         _cur_add_block_request.set_is_single_tablet_block(true);
     } else {
-        block->append_to_block_by_selector(_cur_mutable_block.get(), *(payload->first));
+        RETURN_IF_CATCH_EXCEPTION(
+                block->append_to_block_by_selector(_cur_mutable_block.get(), *(payload->first)));
         for (auto tablet_id : payload->second) {
             _cur_add_block_request.add_tablet_ids(tablet_id);
         }


### PR DESCRIPTION
## Proposed changes
there is some bug like cats will make data wrong, compaction will core when reading wrong data, so need to add a check on column string.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

