### PR TITLE
[fix](Nereids) init Date/DateV2Literal should check non-zero time fields

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/coercion/DateLikeType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/coercion/DateLikeType.java
@@ -61,9 +61,11 @@ public abstract class DateLikeType extends PrimitiveType {
      */
     public DateLiteral fromString(String s) {
         if (this instanceof DateType) {
-            return new DateLiteral(s);
+            DateTimeV2Literal l = new DateTimeV2Literal(DateTimeV2Type.MAX, s);
+            return new DateLiteral(l.getYear(), l.getMonth(), l.getDay());
         } else if (this instanceof DateV2Type) {
-            return new DateV2Literal(s);
+            DateTimeV2Literal l = new DateTimeV2Literal(DateTimeV2Type.MAX, s);
+            return new DateV2Literal(l.getYear(), l.getMonth(), l.getDay());
         } else if (this instanceof DateTimeType) {
             return new DateTimeLiteral(s);
         } else if (this instanceof DateTimeV2Type) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
@@ -488,10 +488,10 @@ class FoldConstantTest extends ExpressionRewriteTestHelper {
         Assertions.assertEquals(DateTimeExtractAndTransform.dateV2(dateLiteral).toSql(), answer[answerIdx]);
 
         Assertions.assertEquals("'2021 52 2022 01'", DateTimeExtractAndTransform.dateFormat(
-                new DateLiteral("2022-01-01 00:12:42"),
+                new DateTimeLiteral("2022-01-01 00:12:42"),
                 new VarcharLiteral("%x %v %X %V")).toSql());
         Assertions.assertEquals("'2023 18 2023 19'", DateTimeExtractAndTransform.dateFormat(
-                new DateLiteral("2023-05-07 02:41:42"),
+                new DateTimeLiteral("2023-05-07 02:41:42"),
                 new VarcharLiteral("%x %v %X %V")).toSql());
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteralTest.java
@@ -35,6 +35,10 @@ class DateLiteralTest {
         // Assertions.assertThrows(AnalysisException.class, () -> new DateLiteral("2022-01-01-1"));
         // Assertions.assertThrows(AnalysisException.class, () -> new DateLiteral("2022-01-01+01"));
         // Assertions.assertThrows(AnalysisException.class, () -> new DateLiteral("2022-01-01+1"));
+        Assertions.assertThrows(AnalysisException.class, () -> new DateLiteral("2022-01-01 01:00:00.000000"));
+        Assertions.assertThrows(AnalysisException.class, () -> new DateLiteral("2022-01-01 00:01:00.000000"));
+        Assertions.assertThrows(AnalysisException.class, () -> new DateLiteral("2022-01-01 00:00:01.000000"));
+        Assertions.assertThrows(AnalysisException.class, () -> new DateLiteral("2022-01-01 00:00:00.000001"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeLiteralTest.java
@@ -245,25 +245,24 @@ class DateTimeLiteralTest {
 
     @Test
     void testIrregularDateTime() {
-        new DateLiteral("2016-07-02 01:01:00");
 
-        new DateLiteral("2016-7-02 01:01:00");
-        new DateLiteral("2016-07-2 01:01:00");
-        new DateLiteral("2016-7-2 01:01:00");
+        new DateTimeV2Literal("2016-7-02 01:01:00");
+        new DateTimeV2Literal("2016-07-2 01:01:00");
+        new DateTimeV2Literal("2016-7-2 01:01:00");
 
-        new DateLiteral("2016-07-02 1:01:00");
-        new DateLiteral("2016-07-02 01:1:00");
-        new DateLiteral("2016-07-02 01:01:0");
-        new DateLiteral("2016-07-02 1:1:00");
-        new DateLiteral("2016-07-02 1:01:0");
-        new DateLiteral("2016-07-02 10:1:0");
-        new DateLiteral("2016-07-02 1:1:0");
+        new DateTimeV2Literal("2016-07-02 1:01:00");
+        new DateTimeV2Literal("2016-07-02 01:1:00");
+        new DateTimeV2Literal("2016-07-02 01:01:0");
+        new DateTimeV2Literal("2016-07-02 1:1:00");
+        new DateTimeV2Literal("2016-07-02 1:01:0");
+        new DateTimeV2Literal("2016-07-02 10:1:0");
+        new DateTimeV2Literal("2016-07-02 1:1:0");
 
-        new DateLiteral("2016-7-2 1:1:0");
-        new DateLiteral("2016-7-02 1:01:0");
-        new DateLiteral("2016-07-2 1:1:0");
-        new DateLiteral("2016-7-02 01:01:0");
-        new DateLiteral("2016-7-2 01:1:0");
+        new DateTimeV2Literal("2016-7-2 1:1:0");
+        new DateTimeV2Literal("2016-7-02 1:01:0");
+        new DateTimeV2Literal("2016-07-2 1:1:0");
+        new DateTimeV2Literal("2016-7-02 01:01:0");
+        new DateTimeV2Literal("2016-7-2 01:1:0");
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

