### PR TITLE
[fix](schema) Table column order is changed if add a column and do truncate

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -1615,17 +1615,19 @@ public class InternalCatalog implements CatalogIf<Database> {
 
                         List<Column> oldSchema = indexIdToMeta.get(indexId).getSchema();
                         List<Column> newSchema = entry.getValue().getSchema();
-                        oldSchema.sort((Column a, Column b) -> a.getUniqueId() - b.getUniqueId());
-                        newSchema.sort((Column a, Column b) -> a.getUniqueId() - b.getUniqueId());
                         if (oldSchema.size() != newSchema.size()) {
                             LOG.warn("schema column size diff, old schema {}, new schema {}", oldSchema, newSchema);
                             metaChanged = true;
                             break;
                         } else {
-                            for (int i = 0; i < oldSchema.size(); ++i) {
-                                if (!oldSchema.get(i).equals(newSchema.get(i))) {
-                                    LOG.warn("schema diff, old schema {}, new schema {}",
-                                            oldSchema.get(i), newSchema.get(i));
+                            List<Column> oldSchemaCopy = Lists.newArrayList(oldSchema);
+                            List<Column> newSchemaCopy = Lists.newArrayList(newSchema);
+                            oldSchemaCopy.sort((Column a, Column b) -> a.getUniqueId() - b.getUniqueId());
+                            newSchemaCopy.sort((Column a, Column b) -> a.getUniqueId() - b.getUniqueId());
+                            for (int i = 0; i < oldSchemaCopy.size(); ++i) {
+                                if (!oldSchemaCopy.get(i).equals(newSchemaCopy.get(i))) {
+                                    LOG.warn("schema diff, old schema {}, new schema {}", oldSchemaCopy.get(i),
+                                            newSchemaCopy.get(i));
                                     metaChanged = true;
                                     break;
                                 }
@@ -3014,15 +3016,18 @@ public class InternalCatalog implements CatalogIf<Database> {
 
                 List<Column> oldSchema = copiedTbl.getFullSchema();
                 List<Column> newSchema = olapTable.getFullSchema();
-                oldSchema.sort((Column a, Column b) -> a.getUniqueId() - b.getUniqueId());
-                newSchema.sort((Column a, Column b) -> a.getUniqueId() - b.getUniqueId());
                 if (oldSchema.size() != newSchema.size()) {
                     LOG.warn("schema column size diff, old schema {}, new schema {}", oldSchema, newSchema);
                     metaChanged = true;
                 } else {
-                    for (int i = 0; i < oldSchema.size(); ++i) {
-                        if (!oldSchema.get(i).equals(newSchema.get(i))) {
-                            LOG.warn("schema diff, old schema {}, new schema {}", oldSchema.get(i), newSchema.get(i));
+                    List<Column> oldSchemaCopy = Lists.newArrayList(oldSchema);
+                    List<Column> newSchemaCopy = Lists.newArrayList(newSchema);
+                    oldSchemaCopy.sort((Column a, Column b) -> a.getUniqueId() - b.getUniqueId());
+                    newSchemaCopy.sort((Column a, Column b) -> a.getUniqueId() - b.getUniqueId());
+                    for (int i = 0; i < oldSchemaCopy.size(); ++i) {
+                        if (!oldSchemaCopy.get(i).equals(newSchemaCopy.get(i))) {
+                            LOG.warn("schema diff, old schema {}, new schema {}", oldSchemaCopy.get(i),
+                                    newSchemaCopy.get(i));
                             metaChanged = true;
                             break;
                         }


### PR DESCRIPTION
https://github.com/apache/doris/pull/24707 introduces this bug.

The table column order is changed if add a column in the middle of all columns and then truncate, since the new added column has the max column_unique_id.

This bug lead to `insert_group_commit_into_duplicate` fail.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

