### PR TITLE
[fix](Nereids) some expression not cast in InPredicate

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyInPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyInPredicate.java
@@ -24,8 +24,9 @@ import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.InPredicate;
 import org.apache.doris.nereids.trees.expressions.literal.DateTimeV2Literal;
 import org.apache.doris.nereids.trees.expressions.literal.DateV2Literal;
+import org.apache.doris.nereids.types.DateTimeV2Type;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 
@@ -46,11 +47,23 @@ public class SimplifyInPredicate extends AbstractExpressionRewriteRule {
                     List<Expression> literals = expr.children().subList(1, expr.children().size());
                     if (literals.stream().allMatch(literal -> literal instanceof DateTimeV2Literal
                             && canLosslessConvertToDateV2Literal((DateTimeV2Literal) literal))) {
-                        List<Expression> children = Lists.newArrayList();
+                        ImmutableList.Builder<Expression> children = ImmutableList.builder();
                         children.add(cast.child());
-                        literals.stream().forEach(
-                                l -> children.add(convertToDateV2Literal((DateTimeV2Literal) l)));
-                        return expr.withChildren(children);
+                        literals.forEach(l -> children.add(convertToDateV2Literal((DateTimeV2Literal) l)));
+                        return expr.withChildren(children.build());
+                    }
+                } else if (cast.child().getDataType().isDateTimeV2Type()
+                        && expr.child(1) instanceof DateTimeV2Literal) {
+                    List<Expression> literals = expr.children().subList(1, expr.children().size());
+                    DateTimeV2Type compareType = (DateTimeV2Type) cast.child().getDataType();
+                    if (literals.stream().allMatch(literal -> literal instanceof DateTimeV2Literal
+                            && canLosslessConvertToLowScaleLiteral(
+                            (DateTimeV2Literal) literal, compareType.getScale()))) {
+                        ImmutableList.Builder<Expression> children = ImmutableList.builder();
+                        children.add(cast.child());
+                        literals.forEach(l -> children.add(new DateTimeV2Literal(compareType,
+                                ((DateTimeV2Literal) l).getStringValue())));
+                        return expr.withChildren(children.build());
                     }
                 }
             }
@@ -74,5 +87,9 @@ public class SimplifyInPredicate extends AbstractExpressionRewriteRule {
 
     private DateV2Literal convertToDateV2Literal(DateTimeV2Literal literal) {
         return new DateV2Literal(literal.getYear(), literal.getMonth(), literal.getDay());
+    }
+
+    private static boolean canLosslessConvertToLowScaleLiteral(DateTimeV2Literal literal, int targetScale) {
+        return literal.getMicroSecond() % (1L << (DateTimeV2Type.MAX_SCALE - targetScale)) == 0;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/StringLikeLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/StringLikeLiteral.java
@@ -19,6 +19,8 @@ package org.apache.doris.nereids.trees.expressions.literal;
 
 import org.apache.doris.nereids.types.DataType;
 
+import java.util.Objects;
+
 /** StringLikeLiteral. */
 public abstract class StringLikeLiteral extends Literal {
     public final String value;
@@ -42,5 +44,22 @@ public abstract class StringLikeLiteral extends Literal {
             pos++;
         }
         return (double) v;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof StringLikeLiteral)) {
+            return false;
+        }
+        StringLikeLiteral that = (StringLikeLiteral) o;
+        return Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/CharType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/CharType.java
@@ -19,7 +19,6 @@ package org.apache.doris.nereids.types;
 
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
-import org.apache.doris.nereids.types.coercion.AbstractDataType;
 import org.apache.doris.nereids.types.coercion.CharacterType;
 
 import java.util.Objects;
@@ -50,11 +49,6 @@ public class CharType extends CharacterType {
     @Override
     public Type toCatalogDataType() {
         return ScalarType.createChar(len);
-    }
-
-    @Override
-    public boolean acceptsType(AbstractDataType other) {
-        return other instanceof CharType;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/StringType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/StringType.java
@@ -18,7 +18,6 @@
 package org.apache.doris.nereids.types;
 
 import org.apache.doris.catalog.Type;
-import org.apache.doris.nereids.types.coercion.AbstractDataType;
 import org.apache.doris.nereids.types.coercion.CharacterType;
 
 /**
@@ -40,11 +39,6 @@ public class StringType extends CharacterType {
     @Override
     public Type toCatalogDataType() {
         return Type.STRING;
-    }
-
-    @Override
-    public boolean acceptsType(AbstractDataType other) {
-        return other instanceof StringType || other instanceof VarcharType;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/VarcharType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/VarcharType.java
@@ -19,7 +19,6 @@ package org.apache.doris.nereids.types;
 
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
-import org.apache.doris.nereids.types.coercion.AbstractDataType;
 import org.apache.doris.nereids.types.coercion.CharacterType;
 
 import java.util.Objects;
@@ -52,11 +51,6 @@ public class VarcharType extends CharacterType {
         ScalarType catalogDataType = ScalarType.createVarcharType(len);
         catalogDataType.setByteSize(len);
         return catalogDataType;
-    }
-
-    @Override
-    public boolean acceptsType(AbstractDataType other) {
-        return other instanceof VarcharType || other instanceof StringType;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
@@ -243,8 +243,7 @@ public class TypeCoercionUtils {
         if (input.isNullLiteral()) {
             return new NullLiteral(targetType);
         } else if (input.getDataType().equals(targetType) || isSubqueryAndDataTypeIsBitmap(input)
-                || (isVarCharOrStringType(input.getDataType())
-                        && isVarCharOrStringType(targetType))) {
+                || (input.getDataType().isStringLikeType() && targetType.isStringLikeType())) {
             return input;
         } else {
             checkCanCastTo(input.getDataType(), targetType);
@@ -254,10 +253,6 @@ public class TypeCoercionUtils {
 
     private static boolean isSubqueryAndDataTypeIsBitmap(Expression input) {
         return input instanceof SubqueryExpr && input.getDataType().isBitmapType();
-    }
-
-    private static boolean isVarCharOrStringType(DataType dataType) {
-        return dataType instanceof VarcharType || dataType instanceof StringType;
     }
 
     private static boolean canCastTo(DataType input, DataType target) {
@@ -709,7 +704,7 @@ public class TypeCoercionUtils {
         return optionalCommonType
                 .map(commonType -> {
                     List<Expression> newChildren = inPredicate.children().stream()
-                            .map(e -> TypeCoercionUtils.castIfNotMatchType(e, commonType))
+                            .map(e -> TypeCoercionUtils.castIfNotSameType(e, commonType))
                             .collect(Collectors.toList());
                     return inPredicate.withChildren(newChildren);
                 })
@@ -735,7 +730,7 @@ public class TypeCoercionUtils {
                     List<Expression> newChildren
                             = caseWhen.getWhenClauses().stream()
                             .map(wc -> {
-                                Expression valueExpr = TypeCoercionUtils.castIfNotMatchType(
+                                Expression valueExpr = TypeCoercionUtils.castIfNotSameType(
                                         wc.getResult(), commonType);
                                 // we must cast every child to the common type, and then
                                 // FoldConstantRuleOnFe can eliminate some branches and direct
@@ -748,7 +743,7 @@ public class TypeCoercionUtils {
                             .collect(Collectors.toList());
                     caseWhen.getDefaultValue()
                             .map(dv -> {
-                                Expression defaultExpr = TypeCoercionUtils.castIfNotMatchType(dv, commonType);
+                                Expression defaultExpr = TypeCoercionUtils.castIfNotSameType(dv, commonType);
                                 if (!defaultExpr.getDataType().equals(commonType)) {
                                     defaultExpr = new Cast(defaultExpr, commonType);
                                 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/datasets/ssb/SSBJoinReorderTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/datasets/ssb/SSBJoinReorderTest.java
@@ -39,7 +39,7 @@ public class SSBJoinReorderTest extends SSBTestBase implements MemoPatternMatchS
                 ImmutableList.of(
                         "(c_region = 'AMERICA')",
                         "(s_region = 'AMERICA')",
-                        "p_mfgr IN ('MFGR#2', 'MFGR#1')"
+                        "p_mfgr IN ('MFGR#1', 'MFGR#2')"
                 )
         );
     }
@@ -58,7 +58,7 @@ public class SSBJoinReorderTest extends SSBTestBase implements MemoPatternMatchS
                         "d_year IN (1997, 1998)",
                         "(c_region = 'AMERICA')",
                         "(s_region = 'AMERICA')",
-                        "p_mfgr IN ('MFGR#2', 'MFGR#1')"
+                        "p_mfgr IN ('MFGR#1', 'MFGR#2')"
                 )
         );
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/SimplifyInPredicateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/SimplifyInPredicateTest.java
@@ -39,7 +39,11 @@ public class SimplifyInPredicateTest extends ExpressionRewriteTestHelper {
         ));
         Map<String, Slot> mem = Maps.newHashMap();
         Expression rewrittenExpression = PARSER.parseExpression("cast(CA as DATETIME) in ('1992-01-31 00:00:00', '1992-02-01 00:00:00')");
+        // after parse and type coercion: CAST(CAST(CA AS DATETIMEV2(0)) AS DATETIMEV2(6)) IN ('1992-01-31 00:00:00.000000', '1992-02-01 00:00:00.000000')
         rewrittenExpression = typeCoercion(replaceUnboundSlot(rewrittenExpression, mem));
+        // after first rewrite: CAST(CA AS DATETIMEV2(0)) IN ('1992-01-31 00:00:00', '1992-02-01 00:00:00')
+        rewrittenExpression = executor.rewrite(rewrittenExpression, context);
+        // after second rewrite: CA IN ('1992-01-31', '1992-02-01')
         rewrittenExpression = executor.rewrite(rewrittenExpression, context);
         Expression expectedExpression = PARSER.parseExpression("CA in (cast('1992-01-31' as date), cast('1992-02-01' as date))");
         expectedExpression = replaceUnboundSlot(expectedExpression, mem);
@@ -47,7 +51,6 @@ public class SimplifyInPredicateTest extends ExpressionRewriteTestHelper {
                 FoldConstantRule.INSTANCE
         ));
         expectedExpression = executor.rewrite(expectedExpression, context);
-        Assertions.assertEquals(expectedExpression.toSql(), rewrittenExpression.toSql());
+        Assertions.assertEquals(expectedExpression, rewrittenExpression);
     }
-
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/TypeCoercionUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/TypeCoercionUtilsTest.java
@@ -23,9 +23,12 @@ import org.apache.doris.nereids.trees.expressions.Divide;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Multiply;
 import org.apache.doris.nereids.trees.expressions.Subtract;
+import org.apache.doris.nereids.trees.expressions.literal.CharLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.DecimalLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.DecimalV3Literal;
 import org.apache.doris.nereids.trees.expressions.literal.DoubleLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
 import org.apache.doris.nereids.types.ArrayType;
 import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.types.BitmapType;
@@ -692,9 +695,17 @@ public class TypeCoercionUtilsTest {
     @Test
     public void testCastIfNotSameType() {
         Assertions.assertEquals(new DoubleLiteral(5L),
-                TypeCoercionUtils.castIfNotMatchType(new DoubleLiteral(5L), DoubleType.INSTANCE));
+                TypeCoercionUtils.castIfNotSameType(new DoubleLiteral(5L), DoubleType.INSTANCE));
         Assertions.assertEquals(new Cast(new DoubleLiteral(5L), BooleanType.INSTANCE),
-                TypeCoercionUtils.castIfNotMatchType(new DoubleLiteral(5L), BooleanType.INSTANCE));
+                TypeCoercionUtils.castIfNotSameType(new DoubleLiteral(5L), BooleanType.INSTANCE));
+        Assertions.assertEquals(new StringLiteral("varchar"),
+                TypeCoercionUtils.castIfNotSameType(new VarcharLiteral("varchar"), StringType.INSTANCE));
+        Assertions.assertEquals(new StringLiteral("char"),
+                TypeCoercionUtils.castIfNotSameType(new CharLiteral("char", 4), StringType.INSTANCE));
+        Assertions.assertEquals(new CharLiteral("char", 4),
+                TypeCoercionUtils.castIfNotSameType(new CharLiteral("char", 4), VarcharType.createVarcharType(100)));
+        Assertions.assertEquals(new StringLiteral("string"),
+                TypeCoercionUtils.castIfNotSameType(new StringLiteral("string"), VarcharType.createVarcharType(100)));
     }
 
     @Test

--- a/regression-test/suites/nereids_p0/join/bucket_shuffle_join.groovy
+++ b/regression-test/suites/nereids_p0/join/bucket_shuffle_join.groovy
@@ -72,7 +72,7 @@ suite("bucket-shuffle-join") {
     explain {
         sql("select * from shuffle_join_t1 t1 left join shuffle_join_t2 t2 on t1.a = t2.c;")
         contains "BUCKET_SHUFFLE"
-        contains "BUCKET_SHFFULE_HASH_PARTITIONED: expr_cast(c as VARCHAR(*))"
+        contains "BUCKET_SHFFULE_HASH_PARTITIONED: c"
     }
 
     sql """ DROP TABLE IF EXISTS shuffle_join_t1 """


### PR DESCRIPTION
1. should use castIfNotSameType in InPredicate and CaseWhen
2. castIfNotSameType should cast all type if two side is not exactly same

picked from master
PR: #24680
commit id: 320fc1481acbdc521961e74d0b23e321d66cce63

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

