### PR TITLE
[Improve](Load)Change the response label prefix of Update and Delete …

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DeleteStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DeleteStmt.java
@@ -201,7 +201,8 @@ public class DeleteStmt extends DdlStmt {
                 cols,
                 new InsertSource(selectStmt),
                 null,
-                isPartialUpdate);
+                isPartialUpdate,
+                NativeInsertStmt.InsertType.DELETE);
         ((NativeInsertStmt) insertStmt).setIsFromDeleteOrUpdateStmt(true);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/NativeInsertStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/NativeInsertStmt.java
@@ -168,6 +168,19 @@ public class NativeInsertStmt extends InsertStmt {
 
     private boolean isFromDeleteOrUpdateStmt = false;
 
+    private InsertType insertType = InsertType.NATIVE_INSERT;
+
+    enum InsertType {
+        NATIVE_INSERT("insert_"),
+        UPDATE("update_"),
+        DELETE("delete_");
+        private String labePrefix;
+
+        InsertType(String labePrefix) {
+            this.labePrefix = labePrefix;
+        }
+    }
+
     public NativeInsertStmt(InsertTarget target, String label, List<String> cols, InsertSource source,
             List<String> hints) {
         super(new LabelName(null, label), null, null);
@@ -201,10 +214,11 @@ public class NativeInsertStmt extends InsertStmt {
     }
 
     public NativeInsertStmt(InsertTarget target, String label, List<String> cols, InsertSource source,
-             List<String> hints, boolean isPartialUpdate) {
+                            List<String> hints, boolean isPartialUpdate, InsertType insertType) {
         this(target, label, cols, source, hints);
         this.isPartialUpdate = isPartialUpdate;
         this.partialUpdateCols.addAll(cols);
+        this.insertType = insertType;
     }
 
     public boolean isValuesOrConstantSelect() {
@@ -366,7 +380,7 @@ public class NativeInsertStmt extends InsertStmt {
         long timeoutSecond = ConnectContext.get().getExecTimeout();
         if (label == null || Strings.isNullOrEmpty(label.getLabelName())) {
             label = new LabelName(db.getFullName(),
-                    "insert_" + DebugUtil.printId(analyzer.getContext().queryId()).replace("-", "_"));
+                    insertType.labePrefix + DebugUtil.printId(analyzer.getContext().queryId()).replace("-", "_"));
         }
         if (!isExplain() && !isTransactionBegin) {
             if (targetTable instanceof OlapTable) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/UpdateStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/UpdateStmt.java
@@ -125,7 +125,7 @@ public class UpdateStmt extends DdlStmt {
                 cols,
                 new InsertSource(selectStmt),
                 null,
-                isPartialUpdate);
+                isPartialUpdate, NativeInsertStmt.InsertType.UPDATE);
         ((NativeInsertStmt) insertStmt).setIsFromDeleteOrUpdateStmt(true);
     }
 


### PR DESCRIPTION
### Backend
Doris Whether it is insert, delete, or update, the label prefix is insert, which may confuse users.
### Change
Add Update and Delete label prefix
### Test

```

mysql>  insert into t2 (id,id_str) values (2,'test2');
Query OK, 1 row affected (0.09 sec)
{'label':'insert_b16405a387f14bfa_947dc9b2217ee3df', 'status':'VISIBLE', 'txnId':'17023'}

mysql>  insert into t1 (id,id_str) values (2,'test2');
Query OK, 1 row affected (0.09 sec)
{'label':'insert_c3acdf63bf94e87_ad65a2dca88f5576', 'status':'VISIBLE', 'txnId':'17025'}

mysql> update t2 set id_str='update2';
Query OK, 2 rows affected (5.27 sec)
{'label':'update_903a88c8defe41d5_a7fca85159c84e50', 'status':'VISIBLE', 'txnId':'17026'}


mysql> delete from  t2  where id =2;
Query OK, 0 rows affected (5.56 sec)
{'label':'delete_1ca419aa-b7a2-41f6-9cbd-e14f4c7517f4', 'status':'VISIBLE', 'txnId':'17028'}

mysql> delete from t1 where t1.id in (select id from t2);
Query OK, 1 row affected (4.41 sec)
{'label':'delete_7e2ae75fee9a42b7_9322d4ae8b80a28b', 'status':'VISIBLE', 'txnId':'17034'}


```

