### PR TITLE
[Opt](parquet reader) Optimize the performance of reading decimal in parquet reader.

### DIFF
--- a/be/src/util/bit_util.h
+++ b/be/src/util/bit_util.h
@@ -27,6 +27,7 @@
 // IWYU pragma: no_include <opentelemetry/common/threadlocal.h>
 #include "common/compiler_util.h" // IWYU pragma: keep
 #include "gutil/bits.h"
+#include "gutil/endian.h"
 #include "util/cpu_info.h"
 #include "util/sse_util.hpp"
 
@@ -184,6 +185,35 @@ public:
     static inline int16_t big_endian(int16_t val) { return val; }
     static inline uint16_t big_endian(uint16_t val) { return val; }
 #endif
+
+    template <typename T>
+    static T big_endian_to_host(T value) {
+        if constexpr (std::is_same_v<T, __int128>) {
+            return BigEndian::ToHost128(value);
+        } else if constexpr (std::is_same_v<T, unsigned __int128>) {
+            return BigEndian::ToHost128(value);
+        } else if constexpr (std::is_same_v<T, int64_t>) {
+            return BigEndian::ToHost64(value);
+        } else if constexpr (std::is_same_v<T, uint64_t>) {
+            return BigEndian::ToHost64(value);
+        } else if constexpr (std::is_same_v<T, int32_t>) {
+            return BigEndian::ToHost32(value);
+        } else if constexpr (std::is_same_v<T, uint32_t>) {
+            return BigEndian::ToHost32(value);
+        } else if constexpr (std::is_same_v<T, int16_t>) {
+            return BigEndian::ToHost16(value);
+        } else if constexpr (std::is_same_v<T, uint16_t>) {
+            return BigEndian::ToHost16(value);
+        } else if constexpr (std::is_same_v<T, int8_t>) {
+            return value;
+        } else if constexpr (std::is_same_v<T, uint8_t>) {
+            return value;
+        } else {
+            __builtin_unreachable();
+            LOG(FATAL) << "__builtin_unreachable";
+            return value;
+        }
+    }
 
     /// Returns the smallest power of two that contains v. If v is a power of two, v is
     /// returned. Taken from

--- a/be/src/vec/exec/format/parquet/fix_length_dict_decoder.hpp
+++ b/be/src/vec/exec/format/parquet/fix_length_dict_decoder.hpp
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "util/bit_util.h"
 #include "vec/columns/column_dictionary.h"
 #include "vec/columns/column_nullable.h"
 #include "vec/data_types/data_type_nullable.h"
@@ -337,6 +338,65 @@ protected:
     Status _decode_primitive_decimal(MutableColumnPtr& doris_column, DataTypePtr& data_type,
                                      ColumnSelectVector& select_vector) {
         init_decimal_converter<DecimalPrimitiveType>(data_type);
+        DecimalScaleParams& scale_params = _decode_params->decimal_scale;
+#define M(FixedTypeLength, ValueCopyType, ScaleType)                                          \
+    case FixedTypeLength:                                                                     \
+        return _decode_primitive_decimal_internal<DecimalPrimitiveType, DecimalPhysicalType,  \
+                                                  has_filter, FixedTypeLength, ValueCopyType, \
+                                                  ScaleType>(doris_column, data_type,         \
+                                                             select_vector);
+
+#define APPLY_FOR_DECIMALS(ScaleType) \
+    M(1, int64_t, ScaleType)          \
+    M(2, int64_t, ScaleType)          \
+    M(3, int64_t, ScaleType)          \
+    M(4, int64_t, ScaleType)          \
+    M(5, int64_t, ScaleType)          \
+    M(6, int64_t, ScaleType)          \
+    M(7, int64_t, ScaleType)          \
+    M(8, int64_t, ScaleType)          \
+    M(9, int128_t, ScaleType)         \
+    M(10, int128_t, ScaleType)        \
+    M(11, int128_t, ScaleType)        \
+    M(12, int128_t, ScaleType)        \
+    M(13, int128_t, ScaleType)        \
+    M(14, int128_t, ScaleType)        \
+    M(15, int128_t, ScaleType)        \
+    M(16, int128_t, ScaleType)
+
+        if (scale_params.scale_type == DecimalScaleParams::SCALE_UP) {
+            switch (_type_length) {
+                APPLY_FOR_DECIMALS(DecimalScaleParams::SCALE_UP)
+            default:
+                LOG(FATAL) << "__builtin_unreachable";
+                __builtin_unreachable();
+            }
+        } else if (scale_params.scale_type == DecimalScaleParams::SCALE_DOWN) {
+            switch (_type_length) {
+                APPLY_FOR_DECIMALS(DecimalScaleParams::SCALE_DOWN)
+            default:
+                LOG(FATAL) << "__builtin_unreachable";
+                __builtin_unreachable();
+            }
+        } else {
+            switch (_type_length) {
+                APPLY_FOR_DECIMALS(DecimalScaleParams::NO_SCALE)
+            default:
+                LOG(FATAL) << "__builtin_unreachable";
+                __builtin_unreachable();
+            }
+        }
+        return Status::OK();
+#undef APPLY_FOR_DECIMALS
+#undef M
+    }
+
+    template <typename DecimalPrimitiveType, typename DecimalPhysicalType, bool has_filter,
+              int fixed_type_length, typename ValueCopyType,
+              DecimalScaleParams::ScaleType ScaleType>
+    Status _decode_primitive_decimal_internal(MutableColumnPtr& doris_column,
+                                              DataTypePtr& data_type,
+                                              ColumnSelectVector& select_vector) {
         auto& column_data =
                 static_cast<ColumnDecimal<Decimal<DecimalPrimitiveType>>&>(*doris_column)
                         .get_data();
@@ -350,12 +410,16 @@ protected:
             switch (read_type) {
             case ColumnSelectVector::CONTENT: {
                 for (size_t i = 0; i < run_length; ++i) {
-                    // we should use decimal128 to scale up/down
-                    Int128 value = static_cast<Int128>(_dict_items[_indexes[dict_index++]]);
-                    if (scale_params.scale_type == DecimalScaleParams::SCALE_UP) {
+                    ValueCopyType value = static_cast<T>(_dict_items[_indexes[dict_index++]]);
+                    if constexpr (ScaleType == DecimalScaleParams::SCALE_UP) {
                         value *= scale_params.scale_factor;
-                    } else if (scale_params.scale_type == DecimalScaleParams::SCALE_DOWN) {
+                    } else if constexpr (ScaleType == DecimalScaleParams::SCALE_DOWN) {
                         value /= scale_params.scale_factor;
+                    } else if constexpr (ScaleType == DecimalScaleParams::NO_SCALE) {
+                        // do nothing
+                    } else {
+                        LOG(FATAL) << "__builtin_unreachable";
+                        __builtin_unreachable();
                     }
                     auto& v = reinterpret_cast<DecimalPrimitiveType&>(column_data[data_index++]);
                     v = (DecimalPrimitiveType)value;
@@ -523,51 +587,56 @@ protected:
     Status _decode_binary_decimal(MutableColumnPtr& doris_column, DataTypePtr& data_type,
                                   ColumnSelectVector& select_vector) {
         init_decimal_converter<DecimalPrimitiveType>(data_type);
-        auto& column_data =
-                static_cast<ColumnDecimal<Decimal<DecimalPrimitiveType>>&>(*doris_column)
-                        .get_data();
-        size_t data_index = column_data.size();
-        column_data.resize(data_index + select_vector.num_values() - select_vector.num_filtered());
-        size_t dict_index = 0;
         DecimalScaleParams& scale_params = _decode_params->decimal_scale;
+#define M(FixedTypeLength, ValueCopyType, ScaleType)                                              \
+    case FixedTypeLength:                                                                         \
+        return _decode_binary_decimal_internal<DecimalPrimitiveType, has_filter, FixedTypeLength, \
+                                               ValueCopyType, ScaleType>(doris_column, data_type, \
+                                                                         select_vector);
 
-        ColumnSelectVector::DataReadType read_type;
-        while (size_t run_length = select_vector.get_next_run<has_filter>(&read_type)) {
-            switch (read_type) {
-            case ColumnSelectVector::CONTENT: {
-                for (size_t i = 0; i < run_length; ++i) {
-                    char* buf_start = _dict_items[_indexes[dict_index++]];
-                    // When Decimal in parquet is stored in byte arrays, binary and fixed,
-                    // the unscaled number must be encoded as two's complement using big-endian byte order.
-                    Int128 value = buf_start[0] & 0x80 ? -1 : 0;
-                    memcpy(reinterpret_cast<char*>(&value) + sizeof(Int128) - _type_length,
-                           buf_start, _type_length);
-                    value = BigEndian::ToHost128(value);
-                    if (scale_params.scale_type == DecimalScaleParams::SCALE_UP) {
-                        value *= scale_params.scale_factor;
-                    } else if (scale_params.scale_type == DecimalScaleParams::SCALE_DOWN) {
-                        value /= scale_params.scale_factor;
-                    }
-                    auto& v = reinterpret_cast<DecimalPrimitiveType&>(column_data[data_index++]);
-                    v = (DecimalPrimitiveType)value;
-                }
-                break;
+#define APPLY_FOR_DECIMALS(ScaleType) \
+    M(1, int64_t, ScaleType)          \
+    M(2, int64_t, ScaleType)          \
+    M(3, int64_t, ScaleType)          \
+    M(4, int64_t, ScaleType)          \
+    M(5, int64_t, ScaleType)          \
+    M(6, int64_t, ScaleType)          \
+    M(7, int64_t, ScaleType)          \
+    M(8, int64_t, ScaleType)          \
+    M(9, int128_t, ScaleType)         \
+    M(10, int128_t, ScaleType)        \
+    M(11, int128_t, ScaleType)        \
+    M(12, int128_t, ScaleType)        \
+    M(13, int128_t, ScaleType)        \
+    M(14, int128_t, ScaleType)        \
+    M(15, int128_t, ScaleType)        \
+    M(16, int128_t, ScaleType)
+
+        if (scale_params.scale_type == DecimalScaleParams::SCALE_UP) {
+            switch (_type_length) {
+                APPLY_FOR_DECIMALS(DecimalScaleParams::SCALE_UP)
+            default:
+                LOG(FATAL) << "__builtin_unreachable";
+                __builtin_unreachable();
             }
-            case ColumnSelectVector::NULL_DATA: {
-                data_index += run_length;
-                break;
+        } else if (scale_params.scale_type == DecimalScaleParams::SCALE_DOWN) {
+            switch (_type_length) {
+                APPLY_FOR_DECIMALS(DecimalScaleParams::SCALE_DOWN)
+            default:
+                LOG(FATAL) << "__builtin_unreachable";
+                __builtin_unreachable();
             }
-            case ColumnSelectVector::FILTERED_CONTENT: {
-                dict_index += run_length;
-                break;
-            }
-            case ColumnSelectVector::FILTERED_NULL: {
-                // do nothing
-                break;
-            }
+        } else {
+            switch (_type_length) {
+                APPLY_FOR_DECIMALS(DecimalScaleParams::NO_SCALE)
+            default:
+                LOG(FATAL) << "__builtin_unreachable";
+                __builtin_unreachable();
             }
         }
         return Status::OK();
+#undef APPLY_FOR_DECIMALS
+#undef M
     }
 
     template <bool has_filter>
@@ -607,6 +676,65 @@ protected:
     // For dictionary encoding
     std::vector<char*> _dict_items;
     std::unordered_map<StringRef, int32_t> _dict_value_to_code;
+
+private:
+    template <typename DecimalPrimitiveType, bool has_filter, int fixed_type_length,
+              typename ValueCopyType, DecimalScaleParams::ScaleType ScaleType>
+    Status _decode_binary_decimal_internal(MutableColumnPtr& doris_column, DataTypePtr& data_type,
+                                           ColumnSelectVector& select_vector) {
+        auto& column_data =
+                static_cast<ColumnDecimal<Decimal<DecimalPrimitiveType>>&>(*doris_column)
+                        .get_data();
+        size_t data_index = column_data.size();
+        column_data.resize(data_index + select_vector.num_values() - select_vector.num_filtered());
+        size_t dict_index = 0;
+        DecimalScaleParams& scale_params = _decode_params->decimal_scale;
+
+        ColumnSelectVector::DataReadType read_type;
+        while (size_t run_length = select_vector.get_next_run<has_filter>(&read_type)) {
+            switch (read_type) {
+            case ColumnSelectVector::CONTENT: {
+                for (size_t i = 0; i < run_length; ++i) {
+                    char* buf_start = _dict_items[_indexes[dict_index++]];
+                    // When Decimal in parquet is stored in byte arrays, binary and fixed,
+                    // the unscaled number must be encoded as two's complement using big-endian byte order.
+                    DecimalPrimitiveType result_value = 0;
+                    ValueCopyType value = 0;
+                    memcpy(reinterpret_cast<char*>(&value), buf_start, fixed_type_length);
+                    value = BitUtil::big_endian_to_host(value);
+                    value = value >> ((sizeof(value) - fixed_type_length) * 8);
+                    result_value = value;
+                    if constexpr (ScaleType == DecimalScaleParams::SCALE_UP) {
+                        result_value *= scale_params.scale_factor;
+                    } else if constexpr (ScaleType == DecimalScaleParams::SCALE_DOWN) {
+                        result_value /= scale_params.scale_factor;
+                    } else if constexpr (ScaleType == DecimalScaleParams::NO_SCALE) {
+                        // do nothing
+                    } else {
+                        LOG(FATAL) << "__builtin_unreachable";
+                        __builtin_unreachable();
+                    }
+                    auto& v = reinterpret_cast<DecimalPrimitiveType&>(column_data[data_index++]);
+                    v = (DecimalPrimitiveType)result_value;
+                }
+                break;
+            }
+            case ColumnSelectVector::NULL_DATA: {
+                data_index += run_length;
+                break;
+            }
+            case ColumnSelectVector::FILTERED_CONTENT: {
+                dict_index += run_length;
+                break;
+            }
+            case ColumnSelectVector::FILTERED_NULL: {
+                // do nothing
+                break;
+            }
+            }
+        }
+        return Status::OK();
+    }
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/exec/format/parquet/fix_length_plain_decoder.cpp
+++ b/be/src/vec/exec/format/parquet/fix_length_plain_decoder.cpp
@@ -26,7 +26,7 @@
 
 // IWYU pragma: no_include <opentelemetry/common/threadlocal.h>
 #include "common/compiler_util.h" // IWYU pragma: keep
-#include "gutil/endian.h"
+#include "util/bit_util.h"
 #include "util/slice.h"
 #include "vec/columns/column.h"
 #include "vec/common/string_ref.h"
@@ -389,6 +389,63 @@ Status FixLengthPlainDecoder::_decode_binary_decimal(MutableColumnPtr& doris_col
                                                      DataTypePtr& data_type,
                                                      ColumnSelectVector& select_vector) {
     init_decimal_converter<DecimalPrimitiveType>(data_type);
+    DecimalScaleParams& scale_params = _decode_params->decimal_scale;
+#define M(FixedTypeLength, ValueCopyType, ScaleType)                                              \
+    case FixedTypeLength:                                                                         \
+        return _decode_binary_decimal_internal<DecimalPrimitiveType, has_filter, FixedTypeLength, \
+                                               ValueCopyType, ScaleType>(doris_column, data_type, \
+                                                                         select_vector);
+
+#define APPLY_FOR_DECIMALS(ScaleType) \
+    M(1, int64_t, ScaleType)          \
+    M(2, int64_t, ScaleType)          \
+    M(3, int64_t, ScaleType)          \
+    M(4, int64_t, ScaleType)          \
+    M(5, int64_t, ScaleType)          \
+    M(6, int64_t, ScaleType)          \
+    M(7, int64_t, ScaleType)          \
+    M(8, int64_t, ScaleType)          \
+    M(9, int128_t, ScaleType)         \
+    M(10, int128_t, ScaleType)        \
+    M(11, int128_t, ScaleType)        \
+    M(12, int128_t, ScaleType)        \
+    M(13, int128_t, ScaleType)        \
+    M(14, int128_t, ScaleType)        \
+    M(15, int128_t, ScaleType)        \
+    M(16, int128_t, ScaleType)
+
+    if (scale_params.scale_type == DecimalScaleParams::SCALE_UP) {
+        switch (_type_length) {
+            APPLY_FOR_DECIMALS(DecimalScaleParams::SCALE_UP)
+        default:
+            LOG(FATAL) << "__builtin_unreachable";
+            __builtin_unreachable();
+        }
+    } else if (scale_params.scale_type == DecimalScaleParams::SCALE_DOWN) {
+        switch (_type_length) {
+            APPLY_FOR_DECIMALS(DecimalScaleParams::SCALE_DOWN)
+        default:
+            LOG(FATAL) << "__builtin_unreachable";
+            __builtin_unreachable();
+        }
+    } else {
+        switch (_type_length) {
+            APPLY_FOR_DECIMALS(DecimalScaleParams::NO_SCALE)
+        default:
+            LOG(FATAL) << "__builtin_unreachable";
+            __builtin_unreachable();
+        }
+    }
+    return Status::OK();
+#undef APPLY_FOR_DECIMALS
+#undef M
+}
+
+template <typename DecimalPrimitiveType, bool has_filter, int fixed_type_length,
+          typename ValueCopyType, DecimalScaleParams::ScaleType ScaleType>
+Status FixLengthPlainDecoder::_decode_binary_decimal_internal(MutableColumnPtr& doris_column,
+                                                              DataTypePtr& data_type,
+                                                              ColumnSelectVector& select_vector) {
     auto& column_data =
             static_cast<ColumnDecimal<Decimal<DecimalPrimitiveType>>&>(*doris_column).get_data();
     size_t data_index = column_data.size();
@@ -403,18 +460,25 @@ Status FixLengthPlainDecoder::_decode_binary_decimal(MutableColumnPtr& doris_col
                 char* buf_start = _data->data + _offset;
                 // When Decimal in parquet is stored in byte arrays, binary and fixed,
                 // the unscaled number must be encoded as two's complement using big-endian byte order.
-                Int128 value = buf_start[0] & 0x80 ? -1 : 0;
-                memcpy(reinterpret_cast<char*>(&value) + sizeof(Int128) - _type_length, buf_start,
-                       _type_length);
-                value = BigEndian::ToHost128(value);
-                if (scale_params.scale_type == DecimalScaleParams::SCALE_UP) {
-                    value *= scale_params.scale_factor;
-                } else if (scale_params.scale_type == DecimalScaleParams::SCALE_DOWN) {
-                    value /= scale_params.scale_factor;
+                DecimalPrimitiveType result_value = 0;
+                ValueCopyType value = 0;
+                memcpy(reinterpret_cast<char*>(&value), buf_start, fixed_type_length);
+                value = BitUtil::big_endian_to_host(value);
+                value = value >> ((sizeof(value) - fixed_type_length) * 8);
+                result_value = value;
+                if constexpr (ScaleType == DecimalScaleParams::SCALE_UP) {
+                    result_value *= scale_params.scale_factor;
+                } else if constexpr (ScaleType == DecimalScaleParams::SCALE_DOWN) {
+                    result_value /= scale_params.scale_factor;
+                } else if constexpr (ScaleType == DecimalScaleParams::NO_SCALE) {
+                    // do nothing
+                } else {
+                    LOG(FATAL) << "__builtin_unreachable";
+                    __builtin_unreachable();
                 }
                 auto& v = reinterpret_cast<DecimalPrimitiveType&>(column_data[data_index++]);
-                v = (DecimalPrimitiveType)value;
-                _offset += _type_length;
+                v = (DecimalPrimitiveType)result_value;
+                _offset += fixed_type_length;
             }
             break;
         }
@@ -440,6 +504,62 @@ Status FixLengthPlainDecoder::_decode_primitive_decimal(MutableColumnPtr& doris_
                                                         DataTypePtr& data_type,
                                                         ColumnSelectVector& select_vector) {
     init_decimal_converter<DecimalPrimitiveType>(data_type);
+    DecimalScaleParams& scale_params = _decode_params->decimal_scale;
+#define M(FixedTypeLength, T, ScaleType)                                                      \
+    case FixedTypeLength:                                                                     \
+        return _decode_primitive_decimal_internal<DecimalPrimitiveType, DecimalPhysicalType,  \
+                                                  has_filter, FixedTypeLength, T, ScaleType>( \
+                doris_column, data_type, select_vector);
+
+#define APPLY_FOR_DECIMALS(ScaleType) \
+    M(1, int64_t, ScaleType)          \
+    M(2, int64_t, ScaleType)          \
+    M(3, int64_t, ScaleType)          \
+    M(4, int64_t, ScaleType)          \
+    M(5, int64_t, ScaleType)          \
+    M(6, int64_t, ScaleType)          \
+    M(7, int64_t, ScaleType)          \
+    M(8, int64_t, ScaleType)          \
+    M(9, int128_t, ScaleType)         \
+    M(10, int128_t, ScaleType)        \
+    M(11, int128_t, ScaleType)        \
+    M(12, int128_t, ScaleType)        \
+    M(13, int128_t, ScaleType)        \
+    M(14, int128_t, ScaleType)        \
+    M(15, int128_t, ScaleType)        \
+    M(16, int128_t, ScaleType)
+
+    if (scale_params.scale_type == DecimalScaleParams::SCALE_UP) {
+        switch (_type_length) {
+            APPLY_FOR_DECIMALS(DecimalScaleParams::SCALE_UP)
+        default:
+            LOG(FATAL) << "__builtin_unreachable";
+            __builtin_unreachable();
+        }
+    } else if (scale_params.scale_type == DecimalScaleParams::SCALE_DOWN) {
+        switch (_type_length) {
+            APPLY_FOR_DECIMALS(DecimalScaleParams::SCALE_DOWN)
+        default:
+            LOG(FATAL) << "__builtin_unreachable";
+            __builtin_unreachable();
+        }
+    } else {
+        switch (_type_length) {
+            APPLY_FOR_DECIMALS(DecimalScaleParams::NO_SCALE)
+        default:
+            LOG(FATAL) << "__builtin_unreachable";
+            __builtin_unreachable();
+        }
+    }
+    return Status::OK();
+#undef APPLY_FOR_DECIMALS
+#undef M
+}
+
+template <typename DecimalPrimitiveType, typename DecimalPhysicalType, bool has_filter,
+          int fixed_type_length, typename ValueCopyType, DecimalScaleParams::ScaleType ScaleType>
+Status FixLengthPlainDecoder::_decode_primitive_decimal_internal(
+        MutableColumnPtr& doris_column, DataTypePtr& data_type, ColumnSelectVector& select_vector) {
     auto& column_data =
             static_cast<ColumnDecimal<Decimal<DecimalPrimitiveType>>&>(*doris_column).get_data();
     size_t data_index = column_data.size();
@@ -452,12 +572,16 @@ Status FixLengthPlainDecoder::_decode_primitive_decimal(MutableColumnPtr& doris_
         case ColumnSelectVector::CONTENT: {
             for (size_t i = 0; i < run_length; ++i) {
                 char* buf_start = _data->data + _offset;
-                // we should use decimal128 to scale up/down
-                Int128 value = *reinterpret_cast<DecimalPhysicalType*>(buf_start);
-                if (scale_params.scale_type == DecimalScaleParams::SCALE_UP) {
+                ValueCopyType value = *reinterpret_cast<DecimalPhysicalType*>(buf_start);
+                if constexpr (ScaleType == DecimalScaleParams::SCALE_UP) {
                     value *= scale_params.scale_factor;
-                } else if (scale_params.scale_type == DecimalScaleParams::SCALE_DOWN) {
+                } else if constexpr (ScaleType == DecimalScaleParams::SCALE_DOWN) {
                     value /= scale_params.scale_factor;
+                } else if constexpr (ScaleType == DecimalScaleParams::NO_SCALE) {
+                    // do nothing
+                } else {
+                    LOG(FATAL) << "__builtin_unreachable";
+                    __builtin_unreachable();
                 }
                 auto& v = reinterpret_cast<DecimalPrimitiveType&>(column_data[data_index++]);
                 v = (DecimalPrimitiveType)value;

--- a/be/src/vec/exec/format/parquet/fix_length_plain_decoder.h
+++ b/be/src/vec/exec/format/parquet/fix_length_plain_decoder.h
@@ -71,5 +71,17 @@ protected:
     Status _decode_string(MutableColumnPtr& doris_column, ColumnSelectVector& select_vector);
 
     tparquet::Type::type _physical_type;
+
+private:
+    template <typename DecimalPrimitiveType, bool has_filter, int fixed_type_length,
+              typename ValueCopyType, DecimalScaleParams::ScaleType ScaleType>
+    Status _decode_binary_decimal_internal(MutableColumnPtr& doris_column, DataTypePtr& data_type,
+                                           ColumnSelectVector& select_vector);
+    template <typename DecimalPrimitiveType, typename DecimalPhysicalType, bool has_filter,
+              int fixed_type_length, typename ValueCopyType,
+              DecimalScaleParams::ScaleType ScaleType>
+    Status _decode_primitive_decimal_internal(MutableColumnPtr& doris_column,
+                                              DataTypePtr& data_type,
+                                              ColumnSelectVector& select_vector);
 };
 } // namespace doris::vectorized


### PR DESCRIPTION
## Proposed changes

Optimize the performance of reading decimal in parquet reader.

- Static dispatch `DecimalScaleParams`.
- Optimize `memcpy`, static dispatch copy size in fixed length cases.
- Use right shift bit operator to convert decimals.

## Optimize Result:

TPCDS Q28 (3 be * 16 cores * 64G): 3.5 s->2.6 s.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

