### PR TITLE
[fix](multicatalog)fix jdbc catalog current_timestamp default

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcMySQLClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcMySQLClient.java
@@ -178,9 +178,13 @@ public class JdbcMySQLClient extends JdbcClient {
             DefaultValueExprDef defaultValueExprDef = null;
             if (field.getDefaultValue() != null
                     && field.getDefaultValue().toLowerCase().startsWith("current_timestamp")) {
-                long precision = field.getDefaultValue().toLowerCase().contains("(")
-                        ? Long.parseLong(field.getDefaultValue().toLowerCase()
-                        .split("\\(")[1].split("\\)")[0]) : 0;
+                // current_timestamp()
+                String colDefaultValue = field.getDefaultValue().toLowerCase();
+                long precision = 0;
+                if (colDefaultValue.contains("(")) {
+                    String substring = colDefaultValue.substring(18, colDefaultValue.length() - 1).trim();
+                    precision = substring.isEmpty() ? 0 : Long.parseLong(substring);
+                }
                 defaultValueExprDef = new DefaultValueExprDef("now", precision);
             }
             dorisTableSchema.add(new Column(field.getColumnName(),

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcMySQLClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/client/JdbcMySQLClient.java
@@ -176,16 +176,17 @@ public class JdbcMySQLClient extends JdbcClient {
         List<Column> dorisTableSchema = Lists.newArrayListWithCapacity(jdbcTableSchema.size());
         for (JdbcFieldSchema field : jdbcTableSchema) {
             DefaultValueExprDef defaultValueExprDef = null;
-            if (field.getDefaultValue() != null
-                    && field.getDefaultValue().toLowerCase().startsWith("current_timestamp")) {
-                // current_timestamp()
+            if (field.getDefaultValue() != null) {
                 String colDefaultValue = field.getDefaultValue().toLowerCase();
-                long precision = 0;
-                if (colDefaultValue.contains("(")) {
-                    String substring = colDefaultValue.substring(18, colDefaultValue.length() - 1).trim();
-                    precision = substring.isEmpty() ? 0 : Long.parseLong(substring);
+                // current_timestamp()
+                if (colDefaultValue.startsWith("current_timestamp")) {
+                    long precision = 0;
+                    if (colDefaultValue.contains("(")) {
+                        String substring = colDefaultValue.substring(18, colDefaultValue.length() - 1).trim();
+                        precision = substring.isEmpty() ? 0 : Long.parseLong(substring);
+                    }
+                    defaultValueExprDef = new DefaultValueExprDef("now", precision);
                 }
-                defaultValueExprDef = new DefaultValueExprDef("now", precision);
             }
             dorisTableSchema.add(new Column(field.getColumnName(),
                     jdbcTypeToDoris(field), field.isKey(), null,


### PR DESCRIPTION
## Proposed changes
![image](https://github.com/apache/doris/assets/31833513/ad62f834-001a-4d49-ad21-42c54f7cb28a)

This problem is caused when you read table data from Mariadb where the datatime type default value is set to current_timestamp().




## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

