### PR TITLE
[Bug](migration) Enhance invalid behavior handling in `copy_files_to`

### DIFF
--- a/be/src/io/fs/local_file_system.cpp
+++ b/be/src/io/fs/local_file_system.cpp
@@ -360,13 +360,13 @@ Status LocalFileSystem::get_space_info_impl(const Path& path, size_t* capacity, 
     return Status::OK();
 }
 
-Status LocalFileSystem::copy_dirs(const Path& src, const Path& dest) {
+Status LocalFileSystem::copy_path(const Path& src, const Path& dest) {
     auto src_path = absolute_path(src);
     auto dest_path = absolute_path(dest);
-    FILESYSTEM_M(copy_dirs_impl(src_path, dest_path));
+    FILESYSTEM_M(copy_path_impl(src_path, dest_path));
 }
 
-Status LocalFileSystem::copy_dirs_impl(const Path& src, const Path& dest) {
+Status LocalFileSystem::copy_path_impl(const Path& src, const Path& dest) {
     std::error_code ec;
     std::filesystem::copy(src, dest, std::filesystem::copy_options::recursive, ec);
     if (ec) {

--- a/be/src/io/fs/local_file_system.h
+++ b/be/src/io/fs/local_file_system.h
@@ -62,8 +62,8 @@ public:
     Status delete_and_create_directory(const Path& dir);
     // return disk available space where the given path is.
     Status get_space_info(const Path& path, size_t* capacity, size_t* available);
-    // copy src dir to dest dir, recursivly
-    Status copy_dirs(const Path& src, const Path& dest);
+    // Copy src path to dest path. If `src` is a directory, this method will call recursively for each directory entry.
+    Status copy_path(const Path& src, const Path& dest);
     // return true if parent path contain sub path
     static bool contain_path(const Path& parent, const Path& sub);
     // delete dir or file
@@ -102,7 +102,7 @@ protected:
     Status mtime_impl(const Path& file, time_t* m_time);
     Status delete_and_create_directory_impl(const Path& dir);
     Status get_space_info_impl(const Path& path, size_t* capacity, size_t* available);
-    Status copy_dirs_impl(const Path& src, const Path& dest);
+    Status copy_path_impl(const Path& src, const Path& dest);
     Status delete_directory_or_file_impl(const Path& path);
 
 private:

--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -286,7 +286,11 @@ Status BetaRowset::link_files_to(const std::string& dir, RowsetId new_rowset_id,
 }
 
 Status BetaRowset::copy_files_to(const std::string& dir, const RowsetId& new_rowset_id) {
-    DCHECK(is_local());
+    if (is_local() && num_segments() > 0) [[unlikely]] {
+        DCHECK(false) << rowset_id();
+        return Status::NotSupported("cannot copy remote files, rowset_id={}",
+                                    rowset_id().to_string());
+    }
     bool exists = false;
     for (int i = 0; i < num_segments(); ++i) {
         auto dst_path = segment_file_path(dir, new_rowset_id, i);
@@ -295,7 +299,7 @@ Status BetaRowset::copy_files_to(const std::string& dir, const RowsetId& new_row
             return Status::Error<FILE_ALREADY_EXIST>("file already exist: {}", dst_path);
         }
         auto src_path = segment_file_path(i);
-        RETURN_IF_ERROR(io::global_local_filesystem()->copy_dirs(src_path, dst_path));
+        RETURN_IF_ERROR(io::global_local_filesystem()->copy_path(src_path, dst_path));
         for (auto& column : _schema->columns()) {
             // if (column.has_inverted_index()) {
             const TabletIndex* index_meta = _schema->get_inverted_index(column.unique_id());
@@ -306,7 +310,7 @@ Status BetaRowset::copy_files_to(const std::string& dir, const RowsetId& new_row
                 std::string inverted_index_dst_file_path =
                         InvertedIndexDescriptor::get_index_file_name(dst_path,
                                                                      index_meta->index_id());
-                RETURN_IF_ERROR(io::global_local_filesystem()->copy_dirs(
+                RETURN_IF_ERROR(io::global_local_filesystem()->copy_path(
                         inverted_index_src_file_path, inverted_index_dst_file_path));
                 LOG(INFO) << "success to copy file. from=" << inverted_index_src_file_path << ", "
                           << "to=" << inverted_index_dst_file_path;


### PR DESCRIPTION
## Proposed changes

Return error when trying to copy rowsets which have remote data.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

