### PR TITLE
[Fix](replayer) Fix `FE` crash when replaying analysis logs.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
@@ -1056,7 +1056,7 @@ public class AnalysisManager extends Daemon implements Writable {
                 a -> {
                     // FE is not ready when replaying log and operations triggered by replaying
                     // shouldn't be logged again.
-                    if (Env.getCurrentEnv().isReady() && !Env.isCheckpointThread()) {
+                    if (Env.getCurrentEnv().isReady() && Env.getCurrentEnv().isMaster() && !Env.isCheckpointThread()) {
                         analysisManager.logAutoJob(a);
                     }
                     return null;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #25023

The detail of this bug has been described at the above issue. We can check if current `FE` is a master node to avoid such problems.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

