### PR TITLE
[fix](timezone) fix parse timezone when include GMT or time zone short ids

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/TimeUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/TimeUtilsTest.java
@@ -164,12 +164,15 @@ public class TimeUtilsTest {
     public void testTimezone() throws AnalysisException {
         try {
             Assert.assertEquals("CST", TimeUtils.checkTimeZoneValidAndStandardize("CST"));
+            Assert.assertEquals("EST", TimeUtils.checkTimeZoneValidAndStandardize("EST"));
+            Assert.assertEquals("GMT+08:00", TimeUtils.checkTimeZoneValidAndStandardize("GMT+8:00"));
+            Assert.assertEquals("UTC+08:00", TimeUtils.checkTimeZoneValidAndStandardize("UTC+8:00"));
             Assert.assertEquals("+08:00", TimeUtils.checkTimeZoneValidAndStandardize("+08:00"));
             Assert.assertEquals("+08:00", TimeUtils.checkTimeZoneValidAndStandardize("+8:00"));
             Assert.assertEquals("-08:00", TimeUtils.checkTimeZoneValidAndStandardize("-8:00"));
             Assert.assertEquals("+08:00", TimeUtils.checkTimeZoneValidAndStandardize("8:00"));
         } catch (DdlException ex) {
-            Assert.fail();
+            Assert.assertTrue(ex.getMessage(), false);
         }
         try {
             TimeUtils.checkTimeZoneValidAndStandardize("FOO");


### PR DESCRIPTION
## Proposed changes

Fix parse timezone failed when timezone is "GMT+..." or "UTC+..." or is a short timezone id like EST, CTT, PST etc

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

