### PR TITLE
[Enhancement](multi-catalog) do not serialize external databases/tables/hms events.

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1870,19 +1870,19 @@ public class Config extends ConfigBase {
     /**
      * If set to true, doris will automatically synchronize hms metadata to the cache in fe.
      */
-    @ConfField(masterOnly = true)
+    @ConfField(masterOnly = false)
     public static boolean enable_hms_events_incremental_sync = false;
 
     /**
      * Maximum number of events to poll in each RPC.
      */
-    @ConfField(mutable = true, masterOnly = true)
+    @ConfField(mutable = true, masterOnly = false)
     public static int hms_events_batch_size_per_rpc = 500;
 
     /**
      * HMS polling interval in milliseconds.
      */
-    @ConfField(masterOnly = true)
+    @ConfField(masterOnly = false)
     public static int hms_events_polling_interval_ms = 10000;
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -467,6 +467,8 @@ public class Env {
 
     private AtomicLong stmtIdCounter;
 
+    private AtomicLong externalCtlIdCounter;
+
     private WorkloadGroupMgr workloadGroupMgr;
 
     private QueryStats queryStats;
@@ -631,6 +633,7 @@ public class Env {
         this.exportTaskRegister = new ExportTaskRegister(transientTaskManager);
         this.replayedJournalId = new AtomicLong(0L);
         this.stmtIdCounter = new AtomicLong(0L);
+        this.externalCtlIdCounter = new AtomicLong(0L);
         this.isElectable = false;
         this.synchronizedTimeMs = 0;
         this.feType = FrontendNodeType.INIT;
@@ -1558,9 +1561,6 @@ public class Env {
         streamLoadRecordMgr.start();
         getInternalCatalog().getIcebergTableCreationRecordMgr().start();
         new InternalSchemaInitializer().start();
-        if (Config.enable_hms_events_incremental_sync) {
-            metastoreEventsProcessor.start();
-        }
         // start mtmv jobManager
         mtmvJobManager.start();
         getRefreshManager().start();
@@ -1581,6 +1581,10 @@ public class Env {
         domainResolver.start();
         // fe disk updater
         feDiskUpdater.start();
+        // hms event processor
+        if (Config.enable_hms_events_incremental_sync) {
+            metastoreEventsProcessor.start();
+        }
     }
 
     private void transferToNonMaster(FrontendNodeType newType) {
@@ -3608,6 +3612,11 @@ public class Env {
     // counter for prepared statement id
     public long getNextStmtId() {
         return this.stmtIdCounter.getAndIncrement();
+    }
+
+    // counter for external catalog meta
+    public long getNextExtCtlId() {
+        return this.externalCtlIdCounter.getAndIncrement();
     }
 
     public IdGeneratorBuffer getIdGeneratorBuffer(long bufferSize) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
@@ -132,7 +132,7 @@ public class RefreshManager {
         ((ExternalDatabase) db).setUnInitialized(invalidCache);
         ExternalObjectLog log = new ExternalObjectLog();
         log.setCatalogId(catalog.getId());
-        log.setDbId(db.getId());
+        log.setDbName(db.getFullName());
         log.setInvalidCache(invalidCache);
         Env.getCurrentEnv().getEditLog().logRefreshExternalDb(log);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
@@ -69,7 +69,7 @@ public class RefreshManager {
             refreshInternalCtlIcebergTable(stmt, env);
         } else {
             // Process external catalog table refresh
-            env.getCatalogMgr().refreshExternalTable(dbName, tableName, catalogName, false);
+            env.getCatalogMgr().refreshExternalTable(dbName, tableName, catalogName, false, true);
         }
         LOG.info("Successfully refresh table: {} from db: {}", tableName, dbName);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalDatabase.java
@@ -152,10 +152,6 @@ public abstract class ExternalDatabase<T extends ExternalTable>
 
     protected abstract T getExternalTable(String tableName, long tblId, ExternalCatalog catalog);
 
-    public T getTableForReplay(long tableId) {
-        return idToTbl.get(tableId);
-    }
-
     @Override
     public void readLock() {
         this.rwLock.readLock().lock();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalDatabase.java
@@ -35,7 +35,6 @@ import org.apache.doris.qe.ConnectContext;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.google.gson.annotations.SerializedName;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -61,19 +60,13 @@ public abstract class ExternalDatabase<T extends ExternalTable>
 
     protected ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock(true);
 
-    @SerializedName(value = "id")
     protected long id;
-    @SerializedName(value = "name")
     protected String name;
-    @SerializedName(value = "dbProperties")
     protected DatabaseProperty dbProperties = new DatabaseProperty();
-    @SerializedName(value = "initialized")
     protected boolean initialized = false;
     // Cache of table name to table id.
     protected Map<String, Long> tableNameToId = Maps.newConcurrentMap();
-    @SerializedName(value = "idToTbl")
     protected Map<Long, T> idToTbl = Maps.newConcurrentMap();
-    @SerializedName(value = "lastUpdateTime")
     protected long lastUpdateTime;
     protected final InitDatabaseLog.Type dbLogType;
     protected ExternalCatalog extCatalog;
@@ -128,19 +121,10 @@ public abstract class ExternalDatabase<T extends ExternalTable>
             Map<String, Long> tmpTableNameToId = Maps.newConcurrentMap();
             Map<Long, T> tmpIdToTbl = Maps.newHashMap();
             for (String tableName : tableNames) {
-                long tblId;
-                if (tableNameToId != null && tableNameToId.containsKey(tableName)) {
-                    tblId = tableNameToId.get(tableName);
-                    tmpTableNameToId.put(tableName, tblId);
-                    T table = idToTbl.get(tblId);
-                    table.unsetObjectCreated();
-                    tmpIdToTbl.put(tblId, table);
-                } else {
-                    tblId = Env.getCurrentEnv().getNextExtCtlId();
-                    tmpTableNameToId.put(tableName, tblId);
-                    T table = getExternalTable(tableName, tblId, extCatalog);
-                    tmpIdToTbl.put(tblId, table);
-                }
+                long tblId = Env.getCurrentEnv().getNextExtCtlId();
+                tmpTableNameToId.put(tableName, tblId);
+                T table = getExternalTable(tableName, tblId, extCatalog);
+                tmpIdToTbl.put(tblId, table);
             }
             tableNameToId = tmpTableNameToId;
             idToTbl = tmpIdToTbl;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
@@ -39,7 +39,6 @@ import org.apache.doris.statistics.TableStatsMeta;
 import org.apache.doris.thrift.TTableDescriptor;
 
 import com.google.common.collect.Sets;
-import com.google.gson.annotations.SerializedName;
 import lombok.Getter;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.logging.log4j.LogManager;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
@@ -65,17 +65,11 @@ import java.util.stream.Collectors;
 public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
     private static final Logger LOG = LogManager.getLogger(ExternalTable.class);
 
-    @SerializedName(value = "id")
     protected long id;
-    @SerializedName(value = "name")
     protected String name;
-    @SerializedName(value = "type")
     protected TableType type = null;
-    @SerializedName(value = "timestamp")
     protected long timestamp;
-    @SerializedName(value = "dbName")
     protected String dbName;
-    @SerializedName(value = "lastUpdateTime")
     protected long lastUpdateTime;
 
     protected long dbId;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalDatabase.java
@@ -78,8 +78,8 @@ public class HMSExternalDatabase extends ExternalDatabase<HMSExternalTable> {
     }
 
     @Override
-    public void dropTableForReplay(String tableName) {
-        LOG.debug("replayDropTableFromEvent [{}]", tableName);
+    public void dropTableWithoutInit(String tableName) {
+        LOG.debug("dropTableWithoutInit [{}]", tableName);
         Long tableId = tableNameToId.remove(tableName);
         if (tableId == null) {
             LOG.warn("replayDropTableFromEvent [{}] failed", tableName);
@@ -89,7 +89,7 @@ public class HMSExternalDatabase extends ExternalDatabase<HMSExternalTable> {
     }
 
     @Override
-    public void createTableForReplay(String tableName, long tableId) {
+    public void createTable(String tableName, long tableId) {
         LOG.debug("create table [{}]", tableName);
         tableNameToId.put(tableName, tableId);
         HMSExternalTable table = getExternalTable(tableName, tableId, extCatalog);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/IcebergExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/IcebergExternalDatabase.java
@@ -49,7 +49,7 @@ public class IcebergExternalDatabase extends ExternalDatabase<IcebergExternalTab
     }
 
     @Override
-    public void dropTableForReplay(String tableName) {
+    public void dropTableWithoutInit(String tableName) {
         LOG.debug("drop table [{}]", tableName);
         Long tableId = tableNameToId.remove(tableName);
         if (tableId == null) {
@@ -59,7 +59,7 @@ public class IcebergExternalDatabase extends ExternalDatabase<IcebergExternalTab
     }
 
     @Override
-    public void createTableForReplay(String tableName, long tableId) {
+    public void createTable(String tableName, long tableId) {
         LOG.debug("create table [{}]", tableName);
         tableNameToId.put(tableName, tableId);
         IcebergExternalTable table = new IcebergExternalTable(tableId, tableName, name,

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/PaimonExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/PaimonExternalDatabase.java
@@ -49,7 +49,7 @@ public class PaimonExternalDatabase extends ExternalDatabase<PaimonExternalTable
     }
 
     @Override
-    public void dropTableForReplay(String tableName) {
+    public void dropTableWithoutInit(String tableName) {
         LOG.debug("drop table [{}]", tableName);
         Long tableId = tableNameToId.remove(tableName);
         if (tableId == null) {
@@ -59,7 +59,7 @@ public class PaimonExternalDatabase extends ExternalDatabase<PaimonExternalTable
     }
 
     @Override
-    public void createTableForReplay(String tableName, long tableId) {
+    public void createTable(String tableName, long tableId) {
         LOG.debug("create table [{}]", tableName);
         tableNameToId.put(tableName, tableId);
         PaimonExternalTable table = new PaimonExternalTable(tableId, tableName, name,

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
@@ -595,30 +595,6 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
         }
     }
 
-    // init catalog and init db can happen at any time,
-    // even after catalog or db is dropped.
-    // Because it may already hold the catalog or db object before they are being dropped.
-    // So just skip the edit log if object does not exist.
-    public void replayInitCatalog(InitCatalogLog log) {
-        ExternalCatalog catalog = (ExternalCatalog) idToCatalog.get(log.getCatalogId());
-        if (catalog == null) {
-            return;
-        }
-        catalog.replayInitCatalog(log);
-    }
-
-    public void replayInitExternalDb(InitDatabaseLog log) {
-        ExternalCatalog catalog = (ExternalCatalog) idToCatalog.get(log.getCatalogId());
-        if (catalog == null) {
-            return;
-        }
-        ExternalDatabase db = catalog.getDbForReplay(log.getDbId());
-        if (db == null) {
-            return;
-        }
-        db.replayInitDb(log, catalog);
-    }
-
     public void replayRefreshExternalDb(ExternalObjectLog log) {
         writeLock();
         try {
@@ -630,7 +606,8 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
         }
     }
 
-    public void refreshExternalTable(String dbName, String tableName, String catalogName, boolean ignoreIfNotExists)
+    public void refreshExternalTable(String dbName, String tableName, String catalogName,
+                                     boolean ignoreIfNotExists, boolean needLog)
             throws DdlException {
         CatalogIf catalog = nameToCatalog.get(catalogName);
         if (catalog == null) {
@@ -658,11 +635,13 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
             ((ExternalTable) table).unsetObjectCreated();
         }
         Env.getCurrentEnv().getExtMetaCacheMgr().invalidateTableCache(catalog.getId(), dbName, tableName);
-        ExternalObjectLog log = new ExternalObjectLog();
-        log.setCatalogId(catalog.getId());
-        log.setDbId(db.getId());
-        log.setTableId(table.getId());
-        Env.getCurrentEnv().getEditLog().logRefreshExternalTable(log);
+        if (needLog) {
+            ExternalObjectLog log = new ExternalObjectLog();
+            log.setCatalogId(catalog.getId());
+            log.setDbId(db.getId());
+            log.setTableId(table.getId());
+            Env.getCurrentEnv().getEditLog().logRefreshExternalTable(log);
+        }
     }
 
     public void replayRefreshExternalTable(ExternalObjectLog log) {
@@ -710,37 +689,11 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
             }
             return;
         }
-        ExternalObjectLog log = new ExternalObjectLog();
-        log.setCatalogId(catalog.getId());
-        log.setDbId(db.getId());
-        log.setTableId(table.getId());
-        log.setLastUpdateTime(System.currentTimeMillis());
-        replayDropExternalTable(log);
-        Env.getCurrentEnv().getEditLog().logDropExternalTable(log);
-    }
 
-    public void replayDropExternalTable(ExternalObjectLog log) {
-        LOG.debug("ReplayDropExternalTable,catalogId:[{}],dbId:[{}],tableId:[{}]", log.getCatalogId(), log.getDbId(),
-                log.getTableId());
-        ExternalCatalog catalog = (ExternalCatalog) idToCatalog.get(log.getCatalogId());
-        if (catalog == null) {
-            LOG.warn("No catalog found with id:[{}], it may have been dropped.", log.getCatalogId());
-            return;
-        }
-        ExternalDatabase db = catalog.getDbForReplay(log.getDbId());
-        if (db == null) {
-            LOG.warn("No db found with id:[{}], it may have been dropped.", log.getDbId());
-            return;
-        }
-        ExternalTable table = db.getTableForReplay(log.getTableId());
-        if (table == null) {
-            LOG.warn("No table found with id:[{}], it may have been dropped.", log.getTableId());
-            return;
-        }
         db.writeLock();
         try {
-            db.dropTableForReplay(table.getName());
-            db.setLastUpdateTime(log.getLastUpdateTime());
+            ((ExternalDatabase) db).dropTableWithoutInit(table.getName());
+            ((ExternalDatabase) db).setLastUpdateTime(System.currentTimeMillis());
         } finally {
             db.writeUnlock();
         }
@@ -760,8 +713,8 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
         return ((ExternalCatalog) catalog).tableExistInLocal(dbName, tableName);
     }
 
-    public void createExternalTableFromEvent(String dbName, String tableName, String catalogName,
-            boolean ignoreIfExists)
+    public void createExternalTable(String dbName, String tableName, String catalogName,
+                                    boolean ignoreIfExists)
             throws DdlException {
         CatalogIf catalog = nameToCatalog.get(catalogName);
         if (catalog == null) {
@@ -785,33 +738,11 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
             }
             return;
         }
-        ExternalObjectLog log = new ExternalObjectLog();
-        log.setCatalogId(catalog.getId());
-        log.setDbId(db.getId());
-        log.setTableName(tableName);
-        log.setTableId(Env.getCurrentEnv().getNextId());
-        log.setLastUpdateTime(System.currentTimeMillis());
-        replayCreateExternalTableFromEvent(log);
-        Env.getCurrentEnv().getEditLog().logCreateExternalTable(log);
-    }
 
-    public void replayCreateExternalTableFromEvent(ExternalObjectLog log) {
-        LOG.debug("ReplayCreateExternalTable,catalogId:[{}],dbId:[{}],tableId:[{}],tableName:[{}]", log.getCatalogId(),
-                log.getDbId(), log.getTableId(), log.getTableName());
-        ExternalCatalog catalog = (ExternalCatalog) idToCatalog.get(log.getCatalogId());
-        if (catalog == null) {
-            LOG.warn("No catalog found with id:[{}], it may have been dropped.", log.getCatalogId());
-            return;
-        }
-        ExternalDatabase db = catalog.getDbForReplay(log.getDbId());
-        if (db == null) {
-            LOG.warn("No db found with id:[{}], it may have been dropped.", log.getDbId());
-            return;
-        }
         db.writeLock();
         try {
-            db.createTableForReplay(log.getTableName(), log.getTableId());
-            db.setLastUpdateTime(log.getLastUpdateTime());
+            ((ExternalDatabase) db).createTable(tableName, Env.getCurrentEnv().getNextExtCtlId());
+            ((ExternalDatabase) db).setLastUpdateTime(System.currentTimeMillis());
         } finally {
             db.writeUnlock();
         }
@@ -833,34 +764,15 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
             return;
         }
 
-        ExternalObjectLog log = new ExternalObjectLog();
-        log.setCatalogId(catalog.getId());
-        log.setDbId(db.getId());
-        log.setInvalidCache(true);
-        replayDropExternalDatabase(log);
-        Env.getCurrentEnv().getEditLog().logDropExternalDatabase(log);
-    }
-
-    public void replayDropExternalDatabase(ExternalObjectLog log) {
         writeLock();
         try {
-            LOG.debug("ReplayDropExternalTable,catalogId:[{}],dbId:[{}],tableId:[{}]", log.getCatalogId(),
-                    log.getDbId(), log.getTableId());
-            ExternalCatalog catalog = (ExternalCatalog) idToCatalog.get(log.getCatalogId());
-            if (catalog == null) {
-                LOG.warn("No catalog found with id:[{}], it may have been dropped.", log.getCatalogId());
-                return;
-            }
-            ExternalDatabase db = catalog.getDbForReplay(log.getDbId());
-            if (db == null) {
-                LOG.warn("No db found with id:[{}], it may have been dropped.", log.getDbId());
-                return;
-            }
-            catalog.dropDatabaseForReplay(db.getFullName());
+            LOG.debug("DropExternalTable,catalogId:[{}],dbId:[{}],tableId:[{}]", catalog.getId(), db.getId(), -1);
+            ((ExternalCatalog) catalog).dropDatabase(db.getFullName());
             Env.getCurrentEnv().getExtMetaCacheMgr().invalidateDbCache(catalog.getId(), db.getFullName());
         } finally {
             writeUnlock();
         }
+
     }
 
     public void createExternalDatabase(String dbName, String catalogName, boolean ignoreIfExists) throws DdlException {
@@ -879,25 +791,12 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
             return;
         }
 
-        ExternalObjectLog log = new ExternalObjectLog();
-        log.setCatalogId(catalog.getId());
-        log.setDbId(Env.getCurrentEnv().getNextId());
-        log.setDbName(dbName);
-        replayCreateExternalDatabase(log);
-        Env.getCurrentEnv().getEditLog().logCreateExternalDatabase(log);
-    }
-
-    public void replayCreateExternalDatabase(ExternalObjectLog log) {
         writeLock();
         try {
-            LOG.debug("ReplayCreateExternalDatabase,catalogId:[{}],dbId:[{}],dbName:[{}]", log.getCatalogId(),
-                    log.getDbId(), log.getDbName());
-            ExternalCatalog catalog = (ExternalCatalog) idToCatalog.get(log.getCatalogId());
-            if (catalog == null) {
-                LOG.warn("No catalog found with id:[{}], it may have been dropped.", log.getCatalogId());
-                return;
-            }
-            catalog.createDatabaseForReplay(log.getDbId(), log.getDbName());
+            long dbId = Env.getCurrentEnv().getNextExtCtlId();
+            LOG.debug("CreateExternalDatabase,catalogId:[{}],dbId:[{}],dbName:[{}]",
+                    catalog.getId(), dbId, dbName);
+            ((ExternalCatalog) catalog).createDatabase(dbId, dbName);
         } finally {
             writeUnlock();
         }
@@ -931,40 +830,6 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
 
         Env.getCurrentEnv().getExtMetaCacheMgr().addPartitionsCache(catalog.getId(),
                 (ExternalTable) table, partitionNames);
-        ExternalObjectLog log = new ExternalObjectLog();
-        log.setCatalogId(catalog.getId());
-        log.setDbId(db.getId());
-        log.setTableId(table.getId());
-        log.setPartitionNames(partitionNames);
-        Env.getCurrentEnv().getEditLog().logAddExternalPartitions(log);
-    }
-
-    public void replayAddExternalPartitions(ExternalObjectLog log) {
-        LOG.debug("ReplayAddExternalPartitions,catalogId:[{}],dbId:[{}],tableId:[{}]", log.getCatalogId(),
-                log.getDbId(), log.getTableId());
-        ExternalCatalog catalog = (ExternalCatalog) idToCatalog.get(log.getCatalogId());
-        if (catalog == null) {
-            LOG.warn("No catalog found with id:[{}], it may have been dropped.", log.getCatalogId());
-            return;
-        }
-        ExternalDatabase db = catalog.getDbForReplay(log.getDbId());
-        if (db == null) {
-            LOG.warn("No db found with id:[{}], it may have been dropped.", log.getDbId());
-            return;
-        }
-        ExternalTable table = db.getTableForReplay(log.getTableId());
-        if (table == null) {
-            LOG.warn("No table found with id:[{}], it may have been dropped.", log.getTableId());
-            return;
-        }
-        try {
-            Env.getCurrentEnv().getExtMetaCacheMgr()
-                .addPartitionsCache(catalog.getId(), table, log.getPartitionNames());
-        } catch (HMSClientException e) {
-            LOG.warn("Network problem occurs or hms table has been deleted, fallback to invalidate table cache", e);
-            Env.getCurrentEnv().getExtMetaCacheMgr().invalidateTableCache(catalog.getId(),
-                    db.getFullName(), table.getName());
-        }
     }
 
     public void dropExternalPartitions(String catalogName, String dbName, String tableName, List<String> partitionNames,
@@ -993,35 +858,11 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
             return;
         }
 
-        ExternalObjectLog log = new ExternalObjectLog();
-        log.setCatalogId(catalog.getId());
-        log.setDbId(db.getId());
-        log.setTableId(table.getId());
-        log.setPartitionNames(partitionNames);
-        replayDropExternalPartitions(log);
-        Env.getCurrentEnv().getEditLog().logDropExternalPartitions(log);
-    }
+        LOG.debug("DropExternalPartitions,catalogId:[{}],dbId:[{}],tableId:[{}]",
+                    catalog.getId(), db.getId(), table.getId());
+        Env.getCurrentEnv().getExtMetaCacheMgr().dropPartitionsCache(
+                    catalog.getId(), (ExternalTable) table, partitionNames);
 
-    public void replayDropExternalPartitions(ExternalObjectLog log) {
-        LOG.debug("ReplayDropExternalPartitions,catalogId:[{}],dbId:[{}],tableId:[{}]", log.getCatalogId(),
-                log.getDbId(), log.getTableId());
-        ExternalCatalog catalog = (ExternalCatalog) idToCatalog.get(log.getCatalogId());
-        if (catalog == null) {
-            LOG.warn("No catalog found with id:[{}], it may have been dropped.", log.getCatalogId());
-            return;
-        }
-        ExternalDatabase db = catalog.getDbForReplay(log.getDbId());
-        if (db == null) {
-            LOG.warn("No db found with id:[{}], it may have been dropped.", log.getDbId());
-            return;
-        }
-        ExternalTable table = db.getTableForReplay(log.getTableId());
-        if (table == null) {
-            LOG.warn("No table found with id:[{}], it may have been dropped.", log.getTableId());
-            return;
-        }
-        Env.getCurrentEnv().getExtMetaCacheMgr()
-                .dropPartitionsCache(catalog.getId(), table, log.getPartitionNames());
     }
 
     public void refreshExternalPartitions(String catalogName, String dbName, String tableName,
@@ -1053,36 +894,11 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
             return;
         }
 
-        ExternalObjectLog log = new ExternalObjectLog();
-        log.setCatalogId(catalog.getId());
-        log.setDbId(db.getId());
-        log.setTableId(table.getId());
-        log.setPartitionNames(partitionNames);
-        replayRefreshExternalPartitions(log);
-        Env.getCurrentEnv().getEditLog().logInvalidateExternalPartitions(log);
-    }
+        LOG.debug("RefreshExternalPartitions,catalogId:[{}],dbId:[{}],tableId:[{}]",
+                    catalog.getId(), db.getId(), table.getId());
 
-    public void replayRefreshExternalPartitions(ExternalObjectLog log) {
-        LOG.debug("replayRefreshExternalPartitions,catalogId:[{}],dbId:[{}],tableId:[{}]", log.getCatalogId(),
-                log.getDbId(), log.getTableId());
-        ExternalCatalog catalog = (ExternalCatalog) idToCatalog.get(log.getCatalogId());
-        if (catalog == null) {
-            LOG.warn("No catalog found with id:[{}], it may have been dropped.", log.getCatalogId());
-            return;
-        }
-        ExternalDatabase db = catalog.getDbForReplay(log.getDbId());
-        if (db == null) {
-            LOG.warn("No db found with id:[{}], it may have been dropped.", log.getDbId());
-            return;
-        }
-        ExternalTable table = db.getTableForReplay(log.getTableId());
-        if (table == null) {
-            LOG.warn("No table found with id:[{}], it may have been dropped.", log.getTableId());
-            return;
-        }
-        Env.getCurrentEnv().getExtMetaCacheMgr()
-                .invalidatePartitionsCache(catalog.getId(), db.getFullName(), table.getName(),
-                        log.getPartitionNames());
+        Env.getCurrentEnv().getExtMetaCacheMgr().invalidatePartitionsCache(
+                    catalog.getId(), db.getFullName(), table.getName(), partitionNames);
     }
 
     public void registerCatalogRefreshListener(Env env) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -432,33 +432,6 @@ public abstract class ExternalCatalog
         Env.getCurrentEnv().getAccessManager().removeAccessController(name);
     }
 
-    public void replayInitCatalog(InitCatalogLog log) {
-        Map<String, Long> tmpDbNameToId = Maps.newConcurrentMap();
-        Map<Long,  ExternalDatabase<? extends ExternalTable>> tmpIdToDb = Maps.newConcurrentMap();
-        for (int i = 0; i < log.getRefreshCount(); i++) {
-            ExternalDatabase<? extends ExternalTable> db = getDbForReplay(log.getRefreshDbIds().get(i));
-            db.setUnInitialized(invalidCacheInInit);
-            tmpDbNameToId.put(db.getFullName(), db.getId());
-            tmpIdToDb.put(db.getId(), db);
-        }
-        for (int i = 0; i < log.getCreateCount(); i++) {
-            ExternalDatabase<? extends ExternalTable> db =
-                    getDbForInit(log.getCreateDbNames().get(i), log.getCreateDbIds().get(i), log.getType());
-            if (db != null) {
-                tmpDbNameToId.put(db.getFullName(), db.getId());
-                tmpIdToDb.put(db.getId(), db);
-            }
-        }
-        dbNameToId = tmpDbNameToId;
-        idToDb = tmpIdToDb;
-        lastUpdateTime = log.getLastUpdateTime();
-        initialized = true;
-    }
-
-    public  ExternalDatabase<? extends ExternalTable> getDbForReplay(long dbId) {
-        return idToDb.get(dbId);
-    }
-
     protected ExternalDatabase<? extends ExternalTable> getDbForInit(String dbName, long dbId,
                                                                      InitCatalogLog.Type logType) {
         switch (logType) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -87,9 +87,7 @@ public abstract class ExternalCatalog
     // save properties of this catalog, such as hive meta store url.
     @SerializedName(value = "catalogProperty")
     protected CatalogProperty catalogProperty;
-    @SerializedName(value = "initialized")
     private boolean initialized = false;
-    @SerializedName(value = "idToDb")
     protected Map<Long, ExternalDatabase<? extends ExternalTable>> idToDb = Maps.newConcurrentMap();
     @SerializedName(value = "lastUpdateTime")
     protected long lastUpdateTime;
@@ -244,19 +242,10 @@ public abstract class ExternalCatalog
             if (!includeDatabaseMap.isEmpty() && !includeDatabaseMap.containsKey(dbName)) {
                 continue;
             }
-            long dbId;
-            if (dbNameToId != null && dbNameToId.containsKey(dbName)) {
-                dbId = dbNameToId.get(dbName);
-                tmpDbNameToId.put(dbName, dbId);
-                ExternalDatabase<? extends ExternalTable> db = idToDb.get(dbId);
-                db.setUnInitialized(invalidCacheInInit);
-                tmpIdToDb.put(dbId, db);
-            } else {
-                dbId = Env.getCurrentEnv().getNextExtCtlId();
-                tmpDbNameToId.put(dbName, dbId);
-                ExternalDatabase<? extends ExternalTable> db = getDbForInit(dbName, dbId, logType);
-                tmpIdToDb.put(dbId, db);
-            }
+            long dbId = Env.getCurrentEnv().getNextExtCtlId();
+            tmpDbNameToId.put(dbName, dbId);
+            ExternalDatabase<? extends ExternalTable> db = getDbForInit(dbName, dbId, logType);
+            tmpIdToDb.put(dbId, db);
         }
         dbNameToId = tmpDbNameToId;
         idToDb = tmpIdToDb;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalObjectLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalObjectLog.java
@@ -29,7 +29,6 @@ import lombok.NoArgsConstructor;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.util.List;
 
 @NoArgsConstructor
 @Getter
@@ -38,26 +37,14 @@ public class ExternalObjectLog implements Writable {
     @SerializedName(value = "catalogId")
     private long catalogId;
 
-    @SerializedName(value = "dbId")
-    private long dbId;
-
     @SerializedName(value = "dbName")
     private String dbName;
-
-    @SerializedName(value = "tableId")
-    private long tableId;
 
     @SerializedName(value = "tableName")
     private String tableName;
 
     @SerializedName(value = "invalidCache")
     private boolean invalidCache;
-
-    @SerializedName(value = "partitionNames")
-    private List<String> partitionNames;
-
-    @SerializedName(value = "lastUpdateTime")
-    private long lastUpdateTime;
 
     @Override
     public void write(DataOutput out) throws IOException {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
@@ -255,7 +255,7 @@ public class HMSExternalCatalog extends ExternalCatalog {
         CatalogLog log = new CatalogLog();
         log.setCatalogId(hmsExternalCatalog.getId());
         log.setInvalidCache(true);
-        Env.getCurrentEnv().getCatalogMgr().refreshCatalog(log);
+        Env.getCurrentEnv().getCatalogMgr().replayRefreshCatalog(log);
     }
 
     private long getCurrentEventId() {
@@ -269,7 +269,7 @@ public class HMSExternalCatalog extends ExternalCatalog {
     }
 
     @Override
-    public void dropDatabaseForReplay(String dbName) {
+    public void dropDatabase(String dbName) {
         LOG.debug("drop database [{}]", dbName);
         Long dbId = dbNameToId.remove(dbName);
         if (dbId == null) {
@@ -279,7 +279,7 @@ public class HMSExternalCatalog extends ExternalCatalog {
     }
 
     @Override
-    public void createDatabaseForReplay(long dbId, String dbName) {
+    public void createDatabase(long dbId, String dbName) {
         LOG.debug("create database [{}]", dbName);
         dbNameToId.put(dbName, dbId);
         ExternalDatabase<? extends ExternalTable> db = getDbForInit(dbName, dbId, logType);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterTableEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/AlterTableEvent.java
@@ -99,7 +99,7 @@ public class AlterTableEvent extends MetastoreTableEvent {
         Env.getCurrentEnv().getCatalogMgr()
                 .dropExternalTable(tableBefore.getDbName(), tableBefore.getTableName(), catalogName, true);
         Env.getCurrentEnv().getCatalogMgr()
-                .createExternalTableFromEvent(tableAfter.getDbName(), tableAfter.getTableName(), catalogName, true);
+                .createExternalTable(tableAfter.getDbName(), tableAfter.getTableName(), catalogName, true);
     }
 
     private void processRename() throws DdlException {
@@ -117,7 +117,7 @@ public class AlterTableEvent extends MetastoreTableEvent {
         Env.getCurrentEnv().getCatalogMgr()
                 .dropExternalTable(tableBefore.getDbName(), tableBefore.getTableName(), catalogName, true);
         Env.getCurrentEnv().getCatalogMgr()
-                .createExternalTableFromEvent(tableAfter.getDbName(), tableAfter.getTableName(), catalogName, true);
+                .createExternalTable(tableAfter.getDbName(), tableAfter.getTableName(), catalogName, true);
 
     }
 
@@ -154,7 +154,8 @@ public class AlterTableEvent extends MetastoreTableEvent {
             }
             //The scope of refresh can be narrowed in the future
             Env.getCurrentEnv().getCatalogMgr()
-                    .refreshExternalTable(tableBefore.getDbName(), tableBefore.getTableName(), catalogName, true);
+                    .refreshExternalTable(
+                                tableBefore.getDbName(), tableBefore.getTableName(), catalogName, true, false);
         } catch (Exception e) {
             throw new MetastoreNotificationException(
                     debugString("Failed to process event"), e);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/CreateTableEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/CreateTableEvent.java
@@ -76,7 +76,7 @@ public class CreateTableEvent extends MetastoreTableEvent {
         try {
             infoLog("catalogName:[{}],dbName:[{}],tableName:[{}]", catalogName, dbName, tblName);
             Env.getCurrentEnv().getCatalogMgr()
-                    .createExternalTableFromEvent(dbName, hmsTbl.getTableName(), catalogName, true);
+                    .createExternalTable(dbName, hmsTbl.getTableName(), catalogName, true);
         } catch (DdlException e) {
             throw new MetastoreNotificationException(
                     debugString("Failed to process event"), e);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/InsertEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/InsertEvent.java
@@ -83,7 +83,7 @@ public class InsertEvent extends MetastoreTableEvent {
              *  the file cache of this table,
              *  but <a href="https://github.com/apache/doris/pull/17932">this PR</a> has fixed it.
              */
-            Env.getCurrentEnv().getCatalogMgr().refreshExternalTable(dbName, tblName, catalogName, true);
+            Env.getCurrentEnv().getCatalogMgr().refreshExternalTable(dbName, tblName, catalogName, true, false);
         } catch (DdlException e) {
             throw new MetastoreNotificationException(
                     debugString("Failed to process event"), e);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreEventsProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/event/MetastoreEventsProcessor.java
@@ -140,9 +140,8 @@ public class MetastoreEventsProcessor extends MasterDaemon {
             CatalogIf catalog = Env.getCurrentEnv().getCatalogMgr().getCatalog(catalogId);
             if (catalog instanceof HMSExternalCatalog) {
                 HMSExternalCatalog hmsExternalCatalog = (HMSExternalCatalog) catalog;
-                List<NotificationEvent> events = Collections.emptyList();
                 try {
-                    events = getNextHMSEvents(hmsExternalCatalog);
+                    List<NotificationEvent> events = getNextHMSEvents(hmsExternalCatalog);
                     if (!events.isEmpty()) {
                         LOG.info("Events size are {} on catalog [{}]", events.size(),
                                 hmsExternalCatalog.getName());

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/paimon/PaimonExternalCatalog.java
@@ -53,11 +53,6 @@ public abstract class PaimonExternalCatalog extends ExternalCatalog {
         super(catalogId, name, InitCatalogLog.Type.PAIMON, comment);
     }
 
-    @Override
-    protected void init() {
-        super.init();
-    }
-
     public Catalog getCatalog() {
         makeSureInitialized();
         return catalog;

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -49,8 +49,6 @@ import org.apache.doris.cooldown.CooldownConfList;
 import org.apache.doris.cooldown.CooldownDelete;
 import org.apache.doris.datasource.CatalogLog;
 import org.apache.doris.datasource.ExternalObjectLog;
-import org.apache.doris.datasource.InitCatalogLog;
-import org.apache.doris.datasource.InitDatabaseLog;
 import org.apache.doris.ha.MasterInfo;
 import org.apache.doris.journal.Journal;
 import org.apache.doris.journal.JournalCursor;
@@ -1002,8 +1000,6 @@ public class EditLog {
                     break;
                 }
                 case OperationType.OP_INIT_CATALOG: {
-                    final InitCatalogLog log = (InitCatalogLog) journal.getData();
-                    env.getCatalogMgr().replayInitCatalog(log);
                     break;
                 }
                 case OperationType.OP_REFRESH_EXTERNAL_DB: {
@@ -1012,8 +1008,6 @@ public class EditLog {
                     break;
                 }
                 case OperationType.OP_INIT_EXTERNAL_DB: {
-                    final InitDatabaseLog log = (InitDatabaseLog) journal.getData();
-                    env.getCatalogMgr().replayInitExternalDb(log);
                     break;
                 }
                 case OperationType.OP_REFRESH_EXTERNAL_TABLE: {
@@ -1021,39 +1015,13 @@ public class EditLog {
                     env.getCatalogMgr().replayRefreshExternalTable(log);
                     break;
                 }
-                case OperationType.OP_DROP_EXTERNAL_TABLE: {
-                    final ExternalObjectLog log = (ExternalObjectLog) journal.getData();
-                    env.getCatalogMgr().replayDropExternalTable(log);
-                    break;
-                }
-                case OperationType.OP_CREATE_EXTERNAL_TABLE: {
-                    final ExternalObjectLog log = (ExternalObjectLog) journal.getData();
-                    env.getCatalogMgr().replayCreateExternalTableFromEvent(log);
-                    break;
-                }
-                case OperationType.OP_DROP_EXTERNAL_DB: {
-                    final ExternalObjectLog log = (ExternalObjectLog) journal.getData();
-                    env.getCatalogMgr().replayDropExternalDatabase(log);
-                    break;
-                }
-                case OperationType.OP_CREATE_EXTERNAL_DB: {
-                    final ExternalObjectLog log = (ExternalObjectLog) journal.getData();
-                    env.getCatalogMgr().replayCreateExternalDatabase(log);
-                    break;
-                }
-                case OperationType.OP_ADD_EXTERNAL_PARTITIONS: {
-                    final ExternalObjectLog log = (ExternalObjectLog) journal.getData();
-                    env.getCatalogMgr().replayAddExternalPartitions(log);
-                    break;
-                }
-                case OperationType.OP_DROP_EXTERNAL_PARTITIONS: {
-                    final ExternalObjectLog log = (ExternalObjectLog) journal.getData();
-                    env.getCatalogMgr().replayDropExternalPartitions(log);
-                    break;
-                }
+                case OperationType.OP_DROP_EXTERNAL_TABLE:
+                case OperationType.OP_CREATE_EXTERNAL_TABLE:
+                case OperationType.OP_DROP_EXTERNAL_DB:
+                case OperationType.OP_CREATE_EXTERNAL_DB:
+                case OperationType.OP_ADD_EXTERNAL_PARTITIONS:
+                case OperationType.OP_DROP_EXTERNAL_PARTITIONS:
                 case OperationType.OP_REFRESH_EXTERNAL_PARTITIONS: {
-                    final ExternalObjectLog log = (ExternalObjectLog) journal.getData();
-                    env.getCatalogMgr().replayRefreshExternalPartitions(log);
                     break;
                 }
                 case OperationType.OP_CREATE_WORKLOAD_GROUP: {
@@ -1867,48 +1835,12 @@ public class EditLog {
         logEdit(OperationType.OP_DROP_MTMV_TASK, new DropMTMVTask(taskIds));
     }
 
-    public void logInitCatalog(InitCatalogLog log) {
-        logEdit(OperationType.OP_INIT_CATALOG, log);
-    }
-
     public void logRefreshExternalDb(ExternalObjectLog log) {
         logEdit(OperationType.OP_REFRESH_EXTERNAL_DB, log);
     }
 
-    public void logInitExternalDb(InitDatabaseLog log) {
-        logEdit(OperationType.OP_INIT_EXTERNAL_DB, log);
-    }
-
     public void logRefreshExternalTable(ExternalObjectLog log) {
         logEdit(OperationType.OP_REFRESH_EXTERNAL_TABLE, log);
-    }
-
-    public void logDropExternalTable(ExternalObjectLog log) {
-        logEdit(OperationType.OP_DROP_EXTERNAL_TABLE, log);
-    }
-
-    public void logCreateExternalTable(ExternalObjectLog log) {
-        logEdit(OperationType.OP_CREATE_EXTERNAL_TABLE, log);
-    }
-
-    public void logDropExternalDatabase(ExternalObjectLog log) {
-        logEdit(OperationType.OP_DROP_EXTERNAL_DB, log);
-    }
-
-    public void logCreateExternalDatabase(ExternalObjectLog log) {
-        logEdit(OperationType.OP_CREATE_EXTERNAL_DB, log);
-    }
-
-    public void logAddExternalPartitions(ExternalObjectLog log) {
-        logEdit(OperationType.OP_ADD_EXTERNAL_PARTITIONS, log);
-    }
-
-    public void logDropExternalPartitions(ExternalObjectLog log) {
-        logEdit(OperationType.OP_DROP_EXTERNAL_PARTITIONS, log);
-    }
-
-    public void logInvalidateExternalPartitions(ExternalObjectLog log) {
-        logEdit(OperationType.OP_REFRESH_EXTERNAL_PARTITIONS, log);
     }
 
     public Journal getJournal() {

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
@@ -264,8 +264,10 @@ public class OperationType {
     public static final short OP_ALTER_CATALOG_NAME = 322;
     public static final short OP_ALTER_CATALOG_PROPS = 323;
     public static final short OP_REFRESH_CATALOG = 324;
+    @Deprecated
     public static final short OP_INIT_CATALOG = 325;
     public static final short OP_REFRESH_EXTERNAL_DB = 326;
+    @Deprecated
     public static final short OP_INIT_EXTERNAL_DB = 327;
     public static final short OP_REFRESH_EXTERNAL_TABLE = 328;
     @Deprecated
@@ -283,12 +285,19 @@ public class OperationType {
 
     public static final short OP_ALTER_MTMV_STMT = 345;
 
+    @Deprecated
     public static final short OP_DROP_EXTERNAL_TABLE = 350;
+    @Deprecated
     public static final short OP_DROP_EXTERNAL_DB = 351;
+    @Deprecated
     public static final short OP_CREATE_EXTERNAL_TABLE = 352;
+    @Deprecated
     public static final short OP_CREATE_EXTERNAL_DB = 353;
+    @Deprecated
     public static final short OP_ADD_EXTERNAL_PARTITIONS = 354;
+    @Deprecated
     public static final short OP_DROP_EXTERNAL_PARTITIONS = 355;
+    @Deprecated
     public static final short OP_REFRESH_EXTERNAL_PARTITIONS = 356;
 
     public static final short OP_ALTER_USER = 400;

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/RefreshCatalogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/RefreshCatalogTest.java
@@ -88,8 +88,8 @@ public class RefreshCatalogTest extends TestWithFeService {
         long l3 = test1.getLastUpdateTime();
         Assertions.assertTrue(l3 == l2);
         Assertions.assertTrue(table.isObjectCreated());
-        test1.getDbNullable("db1").getTables();
-        Assertions.assertFalse(table.isObjectCreated());
+        TestExternalTable table1 = (TestExternalTable) test1.getDbNullable("db1").getTableNullable("tbl11");
+        Assertions.assertFalse(table1.isObjectCreated());
         try {
             DdlExecutor.execute(Env.getCurrentEnv(), refreshCatalogStmt);
         } catch (Exception e) {

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/RefreshDbTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/RefreshDbTest.java
@@ -86,8 +86,8 @@ public class RefreshDbTest extends TestWithFeService {
         long l3 = db1.getLastUpdateTime();
         Assertions.assertTrue(l3 == l2);
         Assertions.assertTrue(table.isObjectCreated());
-        test1.getDbNullable("db1").getTables();
-        Assertions.assertFalse(table.isObjectCreated());
+        TestExternalTable table1 = (TestExternalTable) test1.getDbNullable("db1").getTableNullable("tbl11");
+        Assertions.assertFalse(table1.isObjectCreated());
         try {
             DdlExecutor.execute(Env.getCurrentEnv(), refreshDbStmt);
         } catch (Exception e) {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

The current implement will persist all `databases/tables` of external catalogs, and only the master FE can handle hms events and then persist these events, **this will bring some problems**:

1. The hms event processor ( `MetastoreEventsProcessor` ) can not consume the events **in time**. (Add journal log is a **synchronized** method, we can not speed up the consume rate by using concurrent processing) So the hive meta maybe **out of date**.
2. Slave FE nodes maybe crashed if FE replays the journal logs of hms events failed.  (In fact we have fixed some issues about this, but we can not make sure all the issues have been resolved)
3. There are many journal logs which are produced by hms events, but in fact these logs are not used anymore after FE restart. **It makes the start time of all `FE` nodes very long**.

Now doris try to persis all `databases/tables` of external catalogs just to make sure that the `dbId/tableId` of `databases/tables` are the same through all `FE` nodes, it will be used by analysis jobs. Maybe we should not rely on 
`dbId/tableId` ?  Maybe we can use `dbName/tableName` instead of `dbId/tableId`?

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

