### PR TITLE
[improvement](tablet clone) impr further repair tablet sched priority

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
@@ -1221,7 +1221,11 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
 
         // repair tasks always prior than balance
         if (type == Type.BALANCE) {
-            value += 10 * 24 * 3600L;
+            value += 5 * 3600 * 1000L;  // 5 hour
+        }
+
+        if (tabletStatus == TabletStatus.NEED_FURTHER_REPAIR) {
+            value -= 30 * 60 * 1000L;  // 30 min
         }
 
         return value;

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
@@ -1225,7 +1225,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         }
 
         if (tabletStatus == TabletStatus.NEED_FURTHER_REPAIR) {
-            value -= 30 * 60 * 1000L;  // 30 min
+            value -= 3600 * 1000L;  // 1 hour
         }
 
         return value;


### PR DESCRIPTION
## Proposed changes

If there are many tablets waiting for sched,  the need further repair replica will wait long to sched,  it will have two bad effects:
1) Other replicas may compact the versions which this replica miss,  then a increment clone between them is impossible;
2) This replica couldn't compact because it miss some versions;

So we need impr the further repair replica sched priority,  and complete their versions as soon as possible.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

