### PR TITLE
[Fix](RoutineLoad)Query the transaction status NPE when the task has not yet started scheduling

### DIFF
--- a/docs/en/docs/sql-manual/sql-reference/Show-Statements/SHOW-ROUTINE-LOAD-TASK.md
+++ b/docs/en/docs/sql-manual/sql-reference/Show-Statements/SHOW-ROUTINE-LOAD-TASK.md
@@ -57,7 +57,7 @@ DataSourceProperties: {"0":19}
 
 - `TaskId`: The unique ID of the subtask.
 - `TxnId`: The import transaction ID corresponding to the subtask.
-- `TxnStatus`: The import transaction status corresponding to the subtask. Usually UNKNOWN. No real meaning.
+- `TxnStatus`: The import transaction status corresponding to the subtask. When TxnStatus is null, it means that the subtask has not yet started scheduling.
 - `JobId`: The job ID corresponding to the subtask.
 - `CreateTime`: The creation time of the subtask.
 - `ExecuteStartTime`: The time when the subtask is scheduled to be executed, usually later than the creation time.

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Show-Statements/SHOW-ROUTINE-LOAD-TASK.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Show-Statements/SHOW-ROUTINE-LOAD-TASK.md
@@ -55,7 +55,7 @@ DataSourceProperties: {"0":19}
 
 - `TaskId`：子任务的唯一 ID。
 - `TxnId`：子任务对应的导入事务 ID。
-- `TxnStatus`：子任务对应的导入事务状态。通常为 UNKNOWN。并无实际意思。
+- `TxnStatus`：子任务对应的导入事务状态。为 null 时表示子任务还未开始调度。
 - `JobId`：子任务对应的作业 ID。
 - `CreateTime`：子任务的创建时间。
 - `ExecuteStartTime`：子任务被调度执行的时间，通常晚于创建时间。

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadTaskInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadTaskInfo.java
@@ -54,7 +54,8 @@ public abstract class RoutineLoadTaskInfo {
     private RoutineLoadManager routineLoadManager = Env.getCurrentEnv().getRoutineLoadManager();
 
     protected UUID id;
-    protected long txnId = -1L;
+    protected static final long INIT_TXN_ID = -1L;
+    protected long txnId = INIT_TXN_ID;
     protected long jobId;
     protected String clusterName;
 
@@ -198,7 +199,11 @@ public abstract class RoutineLoadTaskInfo {
         List<String> row = Lists.newArrayList();
         row.add(DebugUtil.printId(id));
         row.add(String.valueOf(txnId));
-        row.add(txnStatus.name());
+        if (INIT_TXN_ID != txnId) {
+            row.add(txnStatus.name());
+        } else {
+            row.add(null);
+        }
         row.add(String.valueOf(jobId));
         row.add(String.valueOf(TimeUtils.longToTimeString(createTimeMs)));
         row.add(String.valueOf(TimeUtils.longToTimeString(executeStartTimeMs)));


### PR DESCRIPTION
### error log

When the task has not yet started scheduling, there is no transaction status at this time. Therefore the query will cause an NPE exception
```
show routine load task where JobName="npe"
```
```
2023-10-07 13:52:16,883 WARN (mysql-nio-pool-3|1310) [StmtExecutor.executeByLegacy():807] execute Exception. stmt[1368, fc075cfd62aa4459-a8014ca6b5f574fa]
java.lang.NullPointerException: null
	at org.apache.doris.load.routineload.RoutineLoadJob.lambda$getTasksShowInfo$6(RoutineLoadJob.java:1452) ~[classes/:?]
	at java.util.ArrayList.forEach(ArrayList.java:1259) ~[?:1.8.0_362]
	at org.apache.doris.load.routineload.RoutineLoadJob.getTasksShowInfo(RoutineLoadJob.java:1450) ~[classes/:?]
	at org.apache.doris.qe.ShowExecutor.handleShowRoutineLoadTask(ShowExecutor.java:1605) ~[classes/:?]
	at org.apache.doris.qe.ShowExecutor.execute(ShowExecutor.java:316) ~[classes/:?]
	at org.apache.doris.qe.StmtExecutor.handleShow(StmtExecutor.java:2208) ~[classes/:?]
	at org.apache.doris.qe.StmtExecutor.executeByLegacy(StmtExecutor.java:775) ~[classes/:?]
	at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:468) ~[classes/:?]
	at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:438) ~[classes/:?]
	at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:353) ~[classes/:?]
	at org.apache.doris.qe.ConnectProcessor.dispatch(ConnectProcessor.java:501) ~[classes/:?]
	at org.apache.doris.qe.ConnectProcessor.processOnce(ConnectProcessor.java:752) ~[classes/:?]
	at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52) ~[classes/:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_362]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_362]

```
### Changes
When the task has not yet started scheduling, that is, when txn_id is -1, the transaction status is set to null

### Test

<img width="1096" alt="image" src="https://github.com/apache/doris/assets/16631152/55d6d97f-c8df-4b8b-82ea-a9661387aefe">
