### PR TITLE
[log](load) PUBLISH_TIMEOUT should not print stacktrace

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -292,6 +292,7 @@ constexpr bool capture_stacktrace(int code) {
         && code != ErrorCode::CUMULATIVE_NO_SUITABLE_VERSION
         && code != ErrorCode::FULL_NO_SUITABLE_VERSION
         && code != ErrorCode::PUBLISH_VERSION_NOT_CONTINUOUS
+        && code != ErrorCode::PUBLISH_TIMEOUT
         && code != ErrorCode::ROWSET_RENAME_FILE_FAILED
         && code != ErrorCode::SEGCOMPACTION_INIT_READER
         && code != ErrorCode::SEGCOMPACTION_INIT_WRITER


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

PUBLISH_TIMEOUT is a very comment error code, should not print stack trace

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

