### PR TITLE
[feature](pipelineX) add node id and profilev2 in pipelineX 

### DIFF
--- a/be/src/pipeline/exec/multi_cast_data_stream_sink.cpp
+++ b/be/src/pipeline/exec/multi_cast_data_stream_sink.cpp
@@ -23,27 +23,14 @@ OperatorPtr MultiCastDataStreamSinkOperatorBuilder::build_operator() {
     return std::make_shared<MultiCastDataStreamSinkOperator>(this, _sink);
 }
 
-Status MultiCastDataStreamSinkLocalState::init(RuntimeState* state, LocalSinkStateInfo& info) {
+std::string MultiCastDataStreamSinkLocalState::id_name() {
     auto& sinks = static_cast<MultiCastDataStreamSinkOperatorX*>(_parent)->sink_node().sinks;
     std::string id_name = " (dst id : ";
     for (auto& sink : sinks) {
         id_name += std::to_string(sink.dest_node_id) + ",";
     }
     id_name += ")";
-    // create profile
-    _profile = state->obj_pool()->add(new RuntimeProfile(_parent->get_name() + id_name));
-    _dependency = (MultiCastDependency*)info.dependency;
-    if (_dependency) {
-        _shared_state = (typename MultiCastDependency::SharedState*)_dependency->shared_state();
-        _wait_for_dependency_timer =
-                ADD_TIMER(_profile, "WaitForDependency[" + _dependency->name() + "]Time");
-    }
-    _rows_input_counter = ADD_COUNTER(_profile, "InputRows", TUnit::UNIT);
-    _open_timer = ADD_TIMER(_profile, "OpenTime");
-    _close_timer = ADD_TIMER(_profile, "CloseTime");
-    info.parent_profile->add_child(_profile, true, nullptr);
-    _mem_tracker = std::make_unique<MemTracker>(_parent->get_name());
-    return Status::OK();
+    return id_name;
 }
 
 } // namespace doris::pipeline

--- a/be/src/pipeline/exec/multi_cast_data_stream_sink.cpp
+++ b/be/src/pipeline/exec/multi_cast_data_stream_sink.cpp
@@ -23,12 +23,4 @@ OperatorPtr MultiCastDataStreamSinkOperatorBuilder::build_operator() {
     return std::make_shared<MultiCastDataStreamSinkOperator>(this, _sink);
 }
 
-Status MultiCastDataStreamSinkLocalState::init(RuntimeState* state, LocalSinkStateInfo& info) {
-    RETURN_IF_ERROR(Base::init(state, info));
-    auto& p = _parent->cast<MultiCastDataStreamSinkOperatorX>();
-    _shared_state->multi_cast_data_streamer = std::make_shared<pipeline::MultiCastDataStreamer>(
-            p._row_desc, p._pool, p._cast_sender_count);
-    return Status::OK();
-}
-
 } // namespace doris::pipeline

--- a/be/src/pipeline/exec/multi_cast_data_stream_sink.cpp
+++ b/be/src/pipeline/exec/multi_cast_data_stream_sink.cpp
@@ -23,4 +23,27 @@ OperatorPtr MultiCastDataStreamSinkOperatorBuilder::build_operator() {
     return std::make_shared<MultiCastDataStreamSinkOperator>(this, _sink);
 }
 
+Status MultiCastDataStreamSinkLocalState::init(RuntimeState* state, LocalSinkStateInfo& info) {
+    auto& sinks = static_cast<MultiCastDataStreamSinkOperatorX*>(_parent)->sink_node().sinks;
+    std::string id_name = " (dst id : ";
+    for (auto& sink : sinks) {
+        id_name += std::to_string(sink.dest_node_id) + ",";
+    }
+    id_name += ")";
+    // create profile
+    _profile = state->obj_pool()->add(new RuntimeProfile(_parent->get_name() + id_name));
+    _dependency = (MultiCastDependency*)info.dependency;
+    if (_dependency) {
+        _shared_state = (typename MultiCastDependency::SharedState*)_dependency->shared_state();
+        _wait_for_dependency_timer =
+                ADD_TIMER(_profile, "WaitForDependency[" + _dependency->name() + "]Time");
+    }
+    _rows_input_counter = ADD_COUNTER(_profile, "InputRows", TUnit::UNIT);
+    _open_timer = ADD_TIMER(_profile, "OpenTime");
+    _close_timer = ADD_TIMER(_profile, "CloseTime");
+    info.parent_profile->add_child(_profile, true, nullptr);
+    _mem_tracker = std::make_unique<MemTracker>(_parent->get_name());
+    return Status::OK();
+}
+
 } // namespace doris::pipeline

--- a/be/src/pipeline/exec/multi_cast_data_stream_sink.h
+++ b/be/src/pipeline/exec/multi_cast_data_stream_sink.h
@@ -51,6 +51,7 @@ class MultiCastDataStreamSinkLocalState final
     friend class DataSinkOperatorX<MultiCastDataStreamSinkLocalState>;
     using Base = PipelineXSinkLocalState<MultiCastDependency>;
     using Parent = MultiCastDataStreamSinkOperatorX;
+    Status init(RuntimeState* state, LocalSinkStateInfo& info) override;
 
 private:
     std::shared_ptr<pipeline::MultiCastDataStreamer> _multi_cast_data_streamer;
@@ -65,10 +66,11 @@ public:
                                      const int cast_sender_count, ObjectPool* pool,
                                      const TMultiCastDataStreamSink& sink,
                                      const RowDescriptor& row_desc)
-            : Base(sink_id, sources),
+            : Base(sink_id, -1, sources),
               _pool(pool),
               _row_desc(row_desc),
-              _cast_sender_count(cast_sender_count) {}
+              _cast_sender_count(cast_sender_count),
+              _sink(sink) {}
     ~MultiCastDataStreamSinkOperatorX() override = default;
 
     Status sink(RuntimeState* state, vectorized::Block* in_block,
@@ -96,12 +98,14 @@ public:
                 _row_desc, _pool, _cast_sender_count);
         return multi_cast_data_streamer;
     }
+    const TMultiCastDataStreamSink& sink_node() { return _sink; }
 
 private:
     friend class MultiCastDataStreamSinkLocalState;
     ObjectPool* _pool;
     RowDescriptor _row_desc;
     int _cast_sender_count;
+    const TMultiCastDataStreamSink& _sink;
     friend class MultiCastDataStreamSinkLocalState;
 };
 

--- a/be/src/pipeline/exec/multi_cast_data_stream_sink.h
+++ b/be/src/pipeline/exec/multi_cast_data_stream_sink.h
@@ -51,7 +51,7 @@ class MultiCastDataStreamSinkLocalState final
     friend class DataSinkOperatorX<MultiCastDataStreamSinkLocalState>;
     using Base = PipelineXSinkLocalState<MultiCastDependency>;
     using Parent = MultiCastDataStreamSinkOperatorX;
-    Status init(RuntimeState* state, LocalSinkStateInfo& info) override;
+    std::string id_name() override;
 
 private:
     std::shared_ptr<pipeline::MultiCastDataStreamer> _multi_cast_data_streamer;

--- a/be/src/pipeline/exec/multi_cast_data_stream_sink.h
+++ b/be/src/pipeline/exec/multi_cast_data_stream_sink.h
@@ -47,8 +47,6 @@ class MultiCastDataStreamSinkLocalState final
     ENABLE_FACTORY_CREATOR(MultiCastDataStreamSinkLocalState);
     MultiCastDataStreamSinkLocalState(DataSinkOperatorXBase* parent, RuntimeState* state)
             : Base(parent, state) {}
-
-    Status init(RuntimeState* state, LocalSinkStateInfo& info) override;
     friend class MultiCastDataStreamSinkOperatorX;
     friend class DataSinkOperatorX<MultiCastDataStreamSinkLocalState>;
     using Base = PipelineXSinkLocalState<MultiCastDependency>;
@@ -72,11 +70,6 @@ public:
               _row_desc(row_desc),
               _cast_sender_count(cast_sender_count) {}
     ~MultiCastDataStreamSinkOperatorX() override = default;
-    Status init(const TDataSink& tsink) override { return Status::OK(); }
-
-    Status open(doris::RuntimeState* state) override { return Status::OK(); };
-
-    Status prepare(RuntimeState* state) override { return Status::OK(); }
 
     Status sink(RuntimeState* state, vectorized::Block* in_block,
                 SourceState source_state) override {

--- a/be/src/pipeline/exec/multi_cast_data_stream_source.h
+++ b/be/src/pipeline/exec/multi_cast_data_stream_source.h
@@ -116,7 +116,7 @@ public:
     MultiCastDataStreamerSourceOperatorX(const int consumer_id, ObjectPool* pool,
                                          const TDataStreamSink& sink,
                                          const RowDescriptor& row_descriptor, int id)
-            : Base(pool, id),
+            : Base(pool, sink.dest_node_id, id),
               _consumer_id(consumer_id),
               _t_data_stream_sink(sink),
               _row_descriptor(row_descriptor) {

--- a/be/src/pipeline/exec/multi_cast_data_stream_source.h
+++ b/be/src/pipeline/exec/multi_cast_data_stream_source.h
@@ -119,7 +119,9 @@ public:
             : Base(pool, id),
               _consumer_id(consumer_id),
               _t_data_stream_sink(sink),
-              _row_descriptor(row_descriptor) {};
+              _row_descriptor(row_descriptor) {
+        _op_name = "MULTI_CAST_DATA_STREAM_SOURCE_OPERATOR";
+    };
     ~MultiCastDataStreamerSourceOperatorX() override = default;
     Dependency* wait_for_dependency(RuntimeState* state) override {
         CREATE_LOCAL_STATE_RETURN_NULL_IF_ERROR(local_state);

--- a/be/src/pipeline/exec/multi_cast_data_stream_source.h
+++ b/be/src/pipeline/exec/multi_cast_data_stream_source.h
@@ -116,7 +116,7 @@ public:
     MultiCastDataStreamerSourceOperatorX(const int consumer_id, ObjectPool* pool,
                                          const TDataStreamSink& sink,
                                          const RowDescriptor& row_descriptor, int id)
-            : Base(pool, sink.dest_node_id, id),
+            : Base(pool, -1, id),
               _consumer_id(consumer_id),
               _t_data_stream_sink(sink),
               _row_descriptor(row_descriptor) {

--- a/be/src/pipeline/exec/union_sink_operator.cpp
+++ b/be/src/pipeline/exec/union_sink_operator.cpp
@@ -108,7 +108,7 @@ Status UnionSinkLocalState::init(RuntimeState* state, LocalSinkStateInfo& info) 
 
 UnionSinkOperatorX::UnionSinkOperatorX(int child_id, int sink_id, ObjectPool* pool,
                                        const TPlanNode& tnode, const DescriptorTbl& descs)
-        : Base(sink_id, tnode.node_id),
+        : Base(sink_id, tnode.node_id, tnode.node_id),
           _first_materialized_child_idx(tnode.union_node.first_materialized_child_idx),
           _row_descriptor(descs, tnode.row_tuples, tnode.nullable_tuples),
           _cur_child_id(child_id),

--- a/be/src/pipeline/pipeline_x/operator.cpp
+++ b/be/src/pipeline/pipeline_x/operator.cpp
@@ -417,8 +417,7 @@ template <typename DependencyType>
 Status PipelineXSinkLocalState<DependencyType>::init(RuntimeState* state,
                                                      LocalSinkStateInfo& info) {
     // create profile
-    _profile = state->obj_pool()->add(new RuntimeProfile(
-            _parent->get_name() + " (id=" + std::to_string(_parent->node_id()) + ")"));
+    _profile = state->obj_pool()->add(new RuntimeProfile(_parent->get_name() + id_name()));
     _profile->set_metadata(_parent->node_id());
     _profile->set_is_sink(true);
     if constexpr (!std::is_same_v<FakeDependency, Dependency>) {

--- a/be/src/pipeline/pipeline_x/operator.h
+++ b/be/src/pipeline/pipeline_x/operator.h
@@ -154,6 +154,7 @@ public:
     OperatorXBase(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs)
             : OperatorBase(nullptr),
               _id(tnode.node_id),
+              _node_id(tnode.node_id),
               _type(tnode.node_type),
               _pool(pool),
               _tuple_ids(tnode.row_tuples),
@@ -165,7 +166,8 @@ public:
         }
     }
 
-    OperatorXBase(ObjectPool* pool, int id) : OperatorBase(nullptr), _id(id), _pool(pool) {};
+    OperatorXBase(ObjectPool* pool, int node_id, int id)
+            : OperatorBase(nullptr), _id(id), _node_id(node_id), _pool(pool) {};
     virtual Status init(const TPlanNode& tnode, RuntimeState* state);
     Status init(const TDataSink& tsink) override {
         LOG(FATAL) << "should not reach here!";
@@ -259,6 +261,7 @@ public:
     [[nodiscard]] RowDescriptor& row_descriptor() { return _row_descriptor; }
 
     [[nodiscard]] int id() const override { return _id; }
+    [[nodiscard]] int node_id() const { return _node_id; }
 
     [[nodiscard]] int64_t limit() const { return _limit; }
 
@@ -279,7 +282,8 @@ protected:
     template <typename Dependency>
     friend class PipelineXLocalState;
     friend class PipelineXLocalStateBase;
-    int _id; // unique w/in single plan tree
+    int _id;
+    const int _node_id; // unique w/in single plan tree
     TPlanNodeType::type _type;
     ObjectPool* _pool;
     std::vector<TupleId> _tuple_ids;
@@ -304,7 +308,7 @@ class OperatorX : public OperatorXBase {
 public:
     OperatorX(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs)
             : OperatorXBase(pool, tnode, descs) {}
-    OperatorX(ObjectPool* pool, int id) : OperatorXBase(pool, id) {};
+    OperatorX(ObjectPool* pool, int node_id, int id) : OperatorXBase(pool, node_id, id) {};
     ~OperatorX() override = default;
 
     Status setup_local_state(RuntimeState* state, LocalStateInfo& info) override;
@@ -401,13 +405,14 @@ protected:
 
 class DataSinkOperatorXBase : public OperatorBase {
 public:
-    DataSinkOperatorXBase(const int id) : OperatorBase(nullptr), _id(id), _dests_id({id}) {}
+    DataSinkOperatorXBase(const int id)
+            : OperatorBase(nullptr), _id(id), _node_id(id), _dests_id({id}) {}
 
-    DataSinkOperatorXBase(const int id, const int dest_id)
-            : OperatorBase(nullptr), _id(id), _dests_id({dest_id}) {}
+    DataSinkOperatorXBase(const int id, const int node_id, const int dest_id)
+            : OperatorBase(nullptr), _id(id), _node_id(node_id), _dests_id({dest_id}) {}
 
-    DataSinkOperatorXBase(const int id, std::vector<int>& sources)
-            : OperatorBase(nullptr), _id(id), _dests_id(sources) {}
+    DataSinkOperatorXBase(const int id, const int node_id, std::vector<int>& sources)
+            : OperatorBase(nullptr), _id(id), _node_id(node_id), _dests_id(sources) {}
 
     ~DataSinkOperatorXBase() override = default;
 
@@ -495,6 +500,8 @@ public:
 
     [[nodiscard]] const std::vector<int>& dests_id() const { return _dests_id; }
 
+    [[nodiscard]] int node_id() const { return _node_id; }
+
     [[nodiscard]] std::string get_name() const override { return _name; }
 
     Status finalize(RuntimeState* state) override { return Status::OK(); }
@@ -504,9 +511,11 @@ public:
 protected:
     template <typename Writer, typename Parent>
     friend class AsyncWriterSink;
-
+    // _id : the current Operator's ID, which is not visible to the user.
+    // _node_id : the plan node ID corresponding to the Operator, which is visible on the profile.
+    // _dests_id : the target ID of the sink, for example, in the case of a multi-sink, there are multiple targets.
     const int _id;
-
+    const int _node_id;
     std::vector<int> _dests_id;
     std::string _name;
 
@@ -521,10 +530,11 @@ class DataSinkOperatorX : public DataSinkOperatorXBase {
 public:
     DataSinkOperatorX(const int id) : DataSinkOperatorXBase(id) {}
 
-    DataSinkOperatorX(const int id, const int source_id) : DataSinkOperatorXBase(id, source_id) {}
+    DataSinkOperatorX(const int id, const int node_id, const int source_id)
+            : DataSinkOperatorXBase(id, node_id, source_id) {}
 
-    DataSinkOperatorX(const int id, std::vector<int> sources)
-            : DataSinkOperatorXBase(id, sources) {}
+    DataSinkOperatorX(const int id, const int node_id, std::vector<int> sources)
+            : DataSinkOperatorXBase(id, node_id, sources) {}
     ~DataSinkOperatorX() override = default;
 
     Status setup_local_states(RuntimeState* state, std::vector<LocalSinkStateInfo>& infos) override;

--- a/be/src/pipeline/pipeline_x/operator.h
+++ b/be/src/pipeline/pipeline_x/operator.h
@@ -104,7 +104,7 @@ public:
     RuntimeProfile::Counter* memory_used_counter() { return _memory_used_counter; }
     RuntimeProfile::Counter* projection_timer() { return _projection_timer; }
     RuntimeProfile::Counter* wait_for_dependency_timer() { return _wait_for_dependency_timer; }
-    RuntimeProfile::Counter* blocks_returned_counter() { return _rows_returned_counter; }
+    RuntimeProfile::Counter* blocks_returned_counter() { return _blocks_returned_counter; }
 
     OperatorXBase* parent() { return _parent; }
     RuntimeState* state() { return _state; }

--- a/be/src/pipeline/pipeline_x/operator.h
+++ b/be/src/pipeline/pipeline_x/operator.h
@@ -562,6 +562,8 @@ public:
     [[nodiscard]] std::string debug_string(int indentation_level) const override;
     typename DependencyType::SharedState*& get_shared_state() { return _shared_state; }
 
+    virtual std::string id_name() { return " (id=" + std::to_string(_parent->node_id()) + ")"; }
+
 protected:
     DependencyType* _dependency = nullptr;
     typename DependencyType::SharedState* _shared_state;

--- a/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
@@ -297,14 +297,12 @@ Status PipelineXFragmentContext::_create_data_sink(ObjectPool* pool, const TData
         DCHECK(thrift_sink.__isset.multi_cast_stream_sink);
         DCHECK_GT(thrift_sink.multi_cast_stream_sink.sinks.size(), 0);
         // TODO: figure out good buffer size based on size of output row
-        /// TODO: Here is a magic number, and we will refactor this part later.
-        static int sink_count = 120000;
-        auto sink_id = sink_count++;
+        auto sink_id = next_operator_id();
         auto sender_size = thrift_sink.multi_cast_stream_sink.sinks.size();
         // one sink has multiple sources.
         std::vector<int> sources;
         for (int i = 0; i < sender_size; ++i) {
-            auto source_id = sink_count++;
+            auto source_id = next_operator_id();
             sources.push_back(source_id);
         }
 
@@ -657,7 +655,7 @@ Status PipelineXFragmentContext::_create_operator(ObjectPool* pool, const TPlanN
             PipelinePtr build_side_pipe = add_pipeline();
             _dag[downstream_pipeline_id].push_back(build_side_pipe->id());
             DataSinkOperatorXPtr sink;
-            sink.reset(new UnionSinkOperatorX(i, father_id + 1000 * (i + 1), pool, tnode, descs));
+            sink.reset(new UnionSinkOperatorX(i, next_operator_id(), pool, tnode, descs));
             RETURN_IF_ERROR(build_side_pipe->set_sink(sink));
             RETURN_IF_ERROR(build_side_pipe->sink_x()->init(tnode, _runtime_state.get()));
             if (_union_child_pipelines.find(father_id) == _union_child_pipelines.end()) {

--- a/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.h
+++ b/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.h
@@ -111,6 +111,8 @@ public:
         }
     }
 
+    int next_operator_id() { return _operator_id++; }
+
 private:
     void _close_action() override;
     Status _build_pipeline_tasks(const doris::TPipelineFragmentParams& request) override;
@@ -162,6 +164,9 @@ private:
     std::map<UniqueId, RuntimeState*> _instance_id_to_runtime_state;
     std::mutex _state_map_lock;
     std::map<int, std::vector<PipelinePtr>> _union_child_pipelines;
+    // The number of operators is generally greater than the number of plan nodes,
+    // so we need additional ID and cannot rely solely on plan node ID.
+    int _operator_id = {1000000};
 };
 
 } // namespace pipeline

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -281,6 +281,9 @@ RuntimeProfile* RuntimeProfile::create_child(const std::string& name, bool inden
     if (this->is_set_metadata()) {
         child->set_metadata(this->metadata());
     }
+    if (this->is_set_sink()) {
+        child->set_is_sink(this->is_sink());
+    }
     if (_children.empty()) {
         add_child_unlock(child, indent, nullptr);
     } else {
@@ -635,6 +638,9 @@ void RuntimeProfile::to_thrift(std::vector<TRuntimeProfileNode>* nodes) {
     node.metadata = _metadata;
     node.timestamp = _timestamp;
     node.indent = true;
+    if (this->is_set_sink()) {
+        node.__set_is_sink(this->is_sink());
+    }
     CounterMap counter_map;
     {
         std::lock_guard<std::mutex> l(_counter_map_lock);

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -368,6 +368,15 @@ public:
 
     bool is_set_metadata() const { return _is_set_metadata; }
 
+    void set_is_sink(bool is_sink) {
+        _is_set_sink = true;
+        _is_sink = is_sink;
+    }
+
+    bool is_sink() const { return _is_sink; }
+
+    bool is_set_sink() const { return _is_set_sink; }
+
     time_t timestamp() const { return _timestamp; }
     void set_timestamp(time_t ss) { _timestamp = ss; }
 
@@ -429,6 +438,9 @@ private:
     // user-supplied, uninterpreted metadata.
     int64_t _metadata;
     bool _is_set_metadata = false;
+
+    bool _is_sink = false;
+    bool _is_set_sink = false;
 
     // The timestamp when the profile was modified, make sure the update is up to date.
     time_t _timestamp;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
@@ -63,7 +63,7 @@ public class Profile {
     }
 
     public synchronized void update(long startTime, Map<String, String> summaryInfo, boolean isFinished,
-            int profileLevel, Planner planner) {
+            int profileLevel, Planner planner, boolean isPipelineX) {
         if (this.isFinished) {
             return;
         }
@@ -74,6 +74,7 @@ public class Profile {
         rootProfile.computeTimeInProfile();
         rootProfile.setPlaner(planner);
         rootProfile.setProfileLevel(profileLevel);
+        rootProfile.setIsPipelineX(isPipelineX);
         ProfileManager.getInstance().pushProfile(rootProfile);
         this.isFinished = isFinished;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileStatistics.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileStatistics.java
@@ -63,7 +63,9 @@ public class ProfileStatistics {
     public void addInfoFromProfile(RuntimeProfile profile, String name, String info) {
         if (isPipelineX) {
             if (profile.sinkOperator()) {
-                name = name + "Sink";
+                name = name + "(Sink)";
+            } else {
+                name = name + "(Operator)";
             }
             addPlanNodeInfo(profile.nodeId(), name + ": " + info);
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileStatistics.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileStatistics.java
@@ -18,6 +18,7 @@
 package org.apache.doris.common.util;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 
 /**
@@ -35,11 +36,14 @@ public class ProfileStatistics {
 
     private boolean isDataSink;
 
-    public ProfileStatistics() {
+    private boolean isPipelineX;
+
+    public ProfileStatistics(boolean isPipelineX) {
         statisticalInfo = new HashMap<Integer, ArrayList<String>>();
         fragmentInfo = new HashMap<Integer, ArrayList<String>>();
         fragmentId = 0;
         isDataSink = false;
+        this.isPipelineX = isPipelineX;
     }
 
     private void addPlanNodeInfo(int id, String info) {
@@ -56,11 +60,18 @@ public class ProfileStatistics {
         fragmentInfo.get(fragmentId).add(info);
     }
 
-    public void addInfoFromProfile(RuntimeProfile profile, String info) {
-        if (isDataSink) {
-            addDataSinkInfo(info);
+    public void addInfoFromProfile(RuntimeProfile profile, String name, String info) {
+        if (isPipelineX) {
+            if (profile.sinkOperator()) {
+                name = name + "Sink";
+            }
+            addPlanNodeInfo(profile.nodeId(), name + ": " + info);
         } else {
-            addPlanNodeInfo(profile.nodeId(), info);
+            if (isDataSink) {
+                addDataSinkInfo(name + ": " + info);
+            } else {
+                addPlanNodeInfo(profile.nodeId(), name + ": " + info);
+            }
         }
     }
 
@@ -73,6 +84,7 @@ public class ProfileStatistics {
             return;
         }
         ArrayList<String> infos = statisticalInfo.get(id);
+        Collections.sort(infos);
         for (String info : infos) {
             str.append(prefix + info + "\n");
         }
@@ -83,6 +95,7 @@ public class ProfileStatistics {
             return;
         }
         ArrayList<String> infos = fragmentInfo.get(fragmentIdx);
+        Collections.sort(infos);
         for (String info : infos) {
             str.append(prefix + info + "\n");
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -323,7 +323,7 @@ public class BrokerLoadJob extends BulkLoadJob {
             return;
         }
         jobProfile.update(createTimestamp, getSummaryInfo(true), true,
-                Integer.valueOf(sessionVariables.getOrDefault(SessionVariable.PROFILE_LEVEL, "3")), null);
+                Integer.valueOf(sessionVariables.getOrDefault(SessionVariable.PROFILE_LEVEL, "3")), null, false);
     }
 
     private Map<String, String> getSummaryInfo(boolean isFinished) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -887,7 +887,8 @@ public class StmtExecutor {
         }
 
         profile.update(context.startTime, getSummaryInfo(isFinished), isFinished,
-                context.getSessionVariable().profileLevel, this.planner);
+                context.getSessionVariable().profileLevel, this.planner,
+                context.getSessionVariable().getEnablePipelineXEngine());
     }
 
     // Analyze one statement to structure in memory.

--- a/gensrc/thrift/RuntimeProfile.thrift
+++ b/gensrc/thrift/RuntimeProfile.thrift
@@ -52,6 +52,8 @@ struct TRuntimeProfileNode {
   8: required map<string, set<string>> child_counters_map
 
   9: required i64 timestamp
+
+  10: optional bool is_sink
 }
 
 // A flattened tree of runtime profiles, obtained by an


### PR DESCRIPTION
## Proposed changes

```
    // _id : the current Operator's ID, which is not visible to the user.
    // _node_id : the plan node ID corresponding to the Operator, which is visible on the profile.
    // _dests_id : the target ID of the sink, for example, in the case of a multi-sink, there are multiple targets.
```



```
set experimental_enable_pipeline_x_engine=true;
set profile_level = 1;

    12:VAGGREGATE  (update  serialize)
    |    output:  partial_count(*)[#156]
    |    group  by:  
    |    cardinality=1
    |    BlocksReturned(Operator):  2
    |    CloseTime(Operator):  avg  11.888us,  max  12.275us,  min  11.501us
    |    CloseTime(Sink):  avg  3.482us,  max  4.136us,  min  2.828us
    |    InputRows(Sink):  365
    |    OpenTime(Operator):  avg  29.840us,  max  30.88us,  min  29.593us
    |    OpenTime(Sink):  avg  100.519us,  max  108.254us,  min  92.785us
    |    RowsReturned(Operator):  2
    |    TotalTime(Operator):  avg  76.980us,  max  85.433us,  min  68.527us
    |    TotalTime(Sink):  avg  118.219us,  max  123.314us,  min  113.124us
    |    
    11:VHASH  JOIN
    |    join  op:  INNER  JOIN(PARTITIONED)[]
    |    equal  join  conjunct:  d_week_seq  =  d_week_seq
    |    cardinality=361
    |    vec  output  tuple  id:  10
    |    vIntermediate  tuple  ids:  9  
    |    hash  output  slot  ids:  68  69  70  71  72  73  74  75  76  77  78  79  80  81  82  83  84  85  86  87  88  89  90  91  92  93  94  95  97  
    |    BlocksReturned(Operator):  2
    |    CloseTime(Operator):  avg  66.144us,  max  72.1us,  min  60.287us
    |    InputRows(Sink):  365
    |    OpenTime(Operator):  avg  237.765us,  max  240.342us,  min  235.189us
    |    OpenTime(Sink):  avg  142.224us,  max  146.703us,  min  137.745us
    |    ProjectionTime(Operator):  avg  47.241us,  max  51.388us,  min  43.95us
    |    RowsReturned(Operator):  365
    |    TotalTime(Operator):  avg  304.453us,  max  313.8us,  min  295.898us
    |    TotalTime(Sink):  avg  1.174ms,  max  1.525ms,  min  822.330us
    |    
    |----9:VEXCHANGE
    |              offset:  0
    |              BlocksReturned(Operator):  4
    |              BlocksSent(Sink):  4
    |              CloseTime(Operator):  avg  12.967us,  max  13.190us,  min  12.744us
    |              CloseTime(Sink):  avg  39.87us,  max  40.649us,  min  37.526us
    |              InputRows(Sink):  365
    |              OpenTime(Operator):  avg  96.541us,  max  100.337us,  min  92.746us
    |              OpenTime(Sink):  avg  217.801us,  max  223.514us,  min  212.89us
    |              RowsReturned(Operator):  365
    |              TotalTime(Operator):  avg  323.564us,  max  351.401us,  min  295.728us
    |              TotalTime(Sink):  avg  1.769ms,  max  1.979ms,  min  1.559ms
    |        
    10:VEXCHANGE
          offset:  0
          BlocksReturned(Operator):  2
          BlocksSent(Sink):  4
          CloseTime(Operator):  avg  14.176us,  max  16.294us,  min  12.58us
          CloseTime(Sink):  avg  41.566us,  max  48.724us,  min  34.409us
          InputRows(Sink):  262
          OpenTime(Operator):  avg  104.390us,  max  114.84us,  min  94.697us
          OpenTime(Sink):  avg  201.631us,  max  201.769us,  min  201.493us
          RowsReturned(Operator):  262
          TotalTime(Operator):  avg  194.406us,  max  195.162us,  min  193.651us
          TotalTime(Sink):  avg  400.11us,  max  444.302us,  min  355.720us
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

