### PR TITLE
[improvement](start script) start script can not set http proxy

### DIFF
--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -209,7 +209,7 @@ if [[ -z "${JAVA_HOME}" ]]; then
     exit 1
 fi
 
-for var in http_proxy HTTP_PROXY https_proxy  HTTPS_PROXY ; do
+for var in http_proxy HTTP_PROXY https_proxy HTTPS_PROXY; do
     if [[ -n ${!var} ]]; then
         echo "env '${var}' = '${!var}', need unset it using 'unset ${var}'"
         exit 1

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -209,6 +209,13 @@ if [[ -z "${JAVA_HOME}" ]]; then
     exit 1
 fi
 
+for var in http_proxy HTTP_PROXY https_proxy  HTTPS_PROXY ; do
+    if [[ -n ${!var} ]]; then
+        echo "env '${var}' = '${!var}', need unset it using 'unset ${var}'"
+        exit 1
+    fi
+done
+
 if [[ ! -d "${LOG_DIR}" ]]; then
     mkdir -p "${LOG_DIR}"
 fi

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -138,6 +138,13 @@ if [[ ! -x "${JAVA}" ]]; then
     exit 1
 fi
 
+for var in http_proxy HTTP_PROXY https_proxy  HTTPS_PROXY ; do
+    if [[ -n ${!var} ]]; then
+        echo "env '${var}' = '${!var}', need unset it using 'unset ${var}'"
+        exit 1
+    fi
+done
+
 # get jdk version, return version as an Integer.
 # 1.8 => 8, 13.0 => 13
 jdk_version() {

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -138,7 +138,7 @@ if [[ ! -x "${JAVA}" ]]; then
     exit 1
 fi
 
-for var in http_proxy HTTP_PROXY https_proxy  HTTPS_PROXY ; do
+for var in http_proxy HTTP_PROXY https_proxy HTTPS_PROXY; do
     if [[ -n ${!var} ]]; then
         echo "env '${var}' = '${!var}', need unset it using 'unset ${var}'"
         exit 1


### PR DESCRIPTION
## Proposed changes

be clone snapshot using http,  if set http proxy, then be clone snapshot will failed.  so the start script forbit set env http proxy.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

