### PR TITLE
[fix](scanner) fix load cannot end when set exec_mem_limit

### DIFF
--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -55,6 +55,7 @@ ScannerContext::ScannerContext(doris::RuntimeState* state_, doris::vectorized::V
           _process_status(Status::OK()),
           _batch_size(state_->batch_size()),
           limit(limit_),
+          _max_bytes_in_queue(std::max(max_bytes_in_blocks_queue_, (int64_t)1024) * num_parallel_instances),
           _scanner_scheduler(state_->exec_env()->scanner_scheduler()),
           _scanners(scanners_),
           _num_parallel_instances(num_parallel_instances) {
@@ -65,9 +66,6 @@ ScannerContext::ScannerContext(doris::RuntimeState* state_, doris::vectorized::V
     if (limit < 0) {
         limit = -1;
     }
-    max_bytes_in_blocks_queue_ =
-            max_bytes_in_blocks_queue_ < 1024 ? 1024 : max_bytes_in_blocks_queue_;
-    _max_bytes_in_queue = max_bytes_in_blocks_queue_ * num_parallel_instances;
     _max_thread_num = config::doris_scanner_thread_pool_thread_num / 4;
     _max_thread_num *= num_parallel_instances;
     _max_thread_num = _max_thread_num == 0 ? 1 : _max_thread_num;

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -55,7 +55,6 @@ ScannerContext::ScannerContext(doris::RuntimeState* state_, doris::vectorized::V
           _process_status(Status::OK()),
           _batch_size(state_->batch_size()),
           limit(limit_),
-          _max_bytes_in_queue(max_bytes_in_blocks_queue_ * num_parallel_instances),
           _scanner_scheduler(state_->exec_env()->scanner_scheduler()),
           _scanners(scanners_),
           _num_parallel_instances(num_parallel_instances) {

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -66,6 +66,9 @@ ScannerContext::ScannerContext(doris::RuntimeState* state_, doris::vectorized::V
     if (limit < 0) {
         limit = -1;
     }
+    max_bytes_in_blocks_queue_ =
+            max_bytes_in_blocks_queue_ < 1024 ? 1024 : max_bytes_in_blocks_queue_;
+    _max_bytes_in_queue = max_bytes_in_blocks_queue_ * num_parallel_instances;
     _max_thread_num = config::doris_scanner_thread_pool_thread_num / 4;
     _max_thread_num *= num_parallel_instances;
     _max_thread_num = _max_thread_num == 0 ? 1 : _max_thread_num;

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -55,7 +55,8 @@ ScannerContext::ScannerContext(doris::RuntimeState* state_, doris::vectorized::V
           _process_status(Status::OK()),
           _batch_size(state_->batch_size()),
           limit(limit_),
-          _max_bytes_in_queue(std::max(max_bytes_in_blocks_queue_, (int64_t)1024) * num_parallel_instances),
+          _max_bytes_in_queue(std::max(max_bytes_in_blocks_queue_, (int64_t)1024) *
+                              num_parallel_instances),
           _scanner_scheduler(state_->exec_env()->scanner_scheduler()),
           _scanners(scanners_),
           _num_parallel_instances(num_parallel_instances) {

--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -253,7 +253,7 @@ protected:
     // The current bytes of blocks in blocks queue
     int64_t _cur_bytes_in_queue = 0;
     // The max limit bytes of blocks in blocks queue
-    int64_t _max_bytes_in_queue = 0;
+    const int64_t _max_bytes_in_queue;
 
     doris::vectorized::ScannerScheduler* _scanner_scheduler;
     // List "scanners" saves all "unfinished" scanners.

--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -253,7 +253,7 @@ protected:
     // The current bytes of blocks in blocks queue
     int64_t _cur_bytes_in_queue = 0;
     // The max limit bytes of blocks in blocks queue
-    const int64_t _max_bytes_in_queue;
+    int64_t _max_bytes_in_queue = 0;
 
     doris::vectorized::ScannerScheduler* _scanner_scheduler;
     // List "scanners" saves all "unfinished" scanners.

--- a/regression-test/suites/load_p0/stream_load/test_stream_load_properties.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_stream_load_properties.groovy
@@ -136,7 +136,7 @@ suite("test_stream_load_properties", "p0") {
                 table "stream_load_" + tableName
                 set 'column_separator', '|'
                 set 'columns', columns[i]
-                //set 'exec_mem_limit', '1'
+                set 'exec_mem_limit', '1'
                 file files[i]
                 time 10000 // limit inflight 10s
 


### PR DESCRIPTION
## Proposed changes

When value of exec_mem_limit is too small(like 1 byte), the load cannot be completed.
```
int get_available_thread_slot_num() {
        int thread_slot_num = 0;
        thread_slot_num = (allowed_blocks_num() + _block_per_scanner - 1) / _block_per_scanner;
        thread_slot_num = std::min(thread_slot_num, _max_thread_num - _num_running_scanners);
        return thread_slot_num;
}

int32_t allowed_blocks_num() const {
        int32_t blocks_num = std::min(_free_blocks_capacity,
                                      int32_t((_max_bytes_in_queue + _estimated_block_bytes - 1) /
                                              _estimated_block_bytes));
        return blocks_num;
}
```
When exec_mem_limit = 1, _max_bytes_in_queue = 1/20 * num_parallel_instances = 0，and the value of get_available_thread_slot_num() is 0, which none thread will add block to queue and make sender in vtablet_sink endless loop.

Solving it by set minimum max_bytes_in_blocks_queue threshold to optimize get_available_thread_slot_num() logic.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

