### PR TITLE
[fix](catalog)hive catalog do not support array type to avoid BE coredump or lose mysql connection

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
@@ -700,10 +700,7 @@ public class HiveMetaStoreClientHelper {
                 break;
         }
         if (lowerCaseType.startsWith("array")) {
-            if (lowerCaseType.indexOf("<") == 5 && lowerCaseType.lastIndexOf(">") == lowerCaseType.length() - 1) {
-                Type innerType = hiveTypeToDorisType(lowerCaseType.substring(6, lowerCaseType.length() - 1));
-                return ArrayType.create(innerType, true);
-            }
+            return Type.UNSUPPORTED;
         }
         if (lowerCaseType.startsWith("char")) {
             ScalarType type = ScalarType.createType(PrimitiveType.CHAR);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #25103

<!--Describe your changes.-->

Do not support query column with array type in hms table


