### PR TITLE
[fix](fs) fix remove error log failed

### DIFF
--- a/be/src/runtime/load_path_mgr.cpp
+++ b/be/src/runtime/load_path_mgr.cpp
@@ -171,7 +171,7 @@ void LoadPathMgr::process_path(time_t now, const std::string& path, int64_t rese
         return;
     }
     LOG(INFO) << "Going to remove path. path=" << path;
-    Status status = io::global_local_filesystem()->delete_directory(path);
+    Status status = io::global_local_filesystem()->delete_directory_or_file(path);
     if (status.ok()) {
         LOG(INFO) << "Remove path success. path=" << path;
     } else {


### PR DESCRIPTION
## Proposed changes

Warning log:
failed to delete /data/doris/doris_data/storage/error_log/__shard_16/error_log_insert_stmt_32406c24c096c352-9cc0a99e1b586f98_32406c24c096c352_9cc0a99e1b586f98, not a directory

Error log is file but not dir, using delete_directory() will cause error.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

