### PR TITLE
[fix](mysqldb) Fix mysqldb upgrade 

### DIFF
--- a/docs/en/docs/admin-manual/config/fe-config.md
+++ b/docs/en/docs/admin-manual/config/fe-config.md
@@ -2771,6 +2771,7 @@ Temporary configuration option. After it is enabled, a background thread will be
 Default：true
 
 Forbid LocalDeployManager drop nodes to prevent errors in the cluster.info file from causing nodes to be dropped.
+
 #### `mysqldb_replace_name`
 
 Default: mysql

--- a/docs/en/docs/admin-manual/config/fe-config.md
+++ b/docs/en/docs/admin-manual/config/fe-config.md
@@ -2771,3 +2771,8 @@ Temporary configuration option. After it is enabled, a background thread will be
 Default：true
 
 Forbid LocalDeployManager drop nodes to prevent errors in the cluster.info file from causing nodes to be dropped.
+#### `mysqldb_replace_name`
+
+Default: mysql
+
+To ensure compatibility with the MySQL ecosystem, Doris includes a built-in database called mysql. If this database conflicts with a user's own database, please modify this field to replace the name of the Doris built-in MySQL database with a different name.

--- a/docs/zh-CN/docs/admin-manual/config/fe-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/fe-config.md
@@ -2774,6 +2774,7 @@ show data （其他用法：HELP SHOW DATA）
 默认值：true
 
 禁止LocalDeployManager删除节点，防止cluster.info文件有误导致节点被删除。
+
 #### `mysqldb_replace_name`
 
 Default: mysql

--- a/docs/zh-CN/docs/admin-manual/config/fe-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/fe-config.md
@@ -2774,3 +2774,8 @@ show data （其他用法：HELP SHOW DATA）
 默认值：true
 
 禁止LocalDeployManager删除节点，防止cluster.info文件有误导致节点被删除。
+#### `mysqldb_replace_name`
+
+Default: mysql
+
+Doris 为了兼用 mysql 周边工具生态，会内置一个名为 mysql 的数据库，如果该数据库与用户自建数据库冲突，请修改这个字段，为 doris 内置的 mysql database 更换一个名字

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2210,4 +2210,9 @@ public class Config extends ConfigBase {
             + "the default value is 4320, which is 3 days"})
     public static int arrow_flight_token_alive_time = 4320;
 
+    @ConfField(mutable = true, description = {
+            "To ensure compatibility with the MySQL ecosystem, Doris includes a built-in database called mysql. "
+            + "If this database conflicts with a user's own database, please modify this field to replace "
+            + "the name of the Doris built-in MySQL database with a different name."})
+    public static String mysqldb_replace_name = "mysql";
 }

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2211,6 +2211,8 @@ public class Config extends ConfigBase {
     public static int arrow_flight_token_alive_time = 4320;
 
     @ConfField(mutable = true, description = {
+            "Doris 为了兼用 mysql 周边工具生态，会内置一个名为 mysql 的数据库，如果该数据库与用户自建数据库冲突，"
+            + "请修改这个字段，为 doris 内置的 mysql database 更换一个名字",
             "To ensure compatibility with the MySQL ecosystem, Doris includes a built-in database called mysql. "
             + "If this database conflicts with a user's own database, please modify this field to replace "
             + "the name of the Doris built-in MySQL database with a different name."})

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DropDbStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DropDbStmt.java
@@ -18,6 +18,7 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.ErrorCode;
@@ -27,8 +28,6 @@ import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.base.Strings;
-
-import java.util.Optional;
 
 // DROP DB表达式
 public class DropDbStmt extends DdlStmt {
@@ -62,9 +61,9 @@ public class DropDbStmt extends DdlStmt {
         }
         dbName = ClusterNamespace.getFullName(getClusterName(), dbName);
 
-        // Don't allowed to drop mysql compatible databases
-        Optional<Database> dbTmp = Env.getCurrentEnv().getInternalCatalog().getDb(dbName);
-        if (dbTmp != null && dbTmp.get().isMysqlCompatibleDatabase()) {
+        // Don't allow to drop mysql compatible databases
+        DatabaseIf db = Env.getCurrentInternalCatalog().getDbNullable(dbName);
+        if (db != null && (db instanceof Database) && ((Database) db).isMysqlCompatibleDatabase()) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_DBACCESS_DENIED_ERROR,
                     analyzer.getQualifiedUser(), dbName);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MysqlDb.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MysqlDb.java
@@ -18,6 +18,7 @@
 package org.apache.doris.catalog;
 
 import org.apache.doris.cluster.ClusterNamespace;
+import org.apache.doris.common.Config;
 
 /**
  *  This class is used for MySQL compatibility.
@@ -33,7 +34,7 @@ import org.apache.doris.cluster.ClusterNamespace;
  *  We will add useful system tables in the future.
 */
 public class MysqlDb extends MysqlCompatibleDatabase {
-    public static final String DATABASE_NAME = "mysql";
+    public static final String DATABASE_NAME = Config.mysqldb_replace_name;
     /**
      * Database created by user will have database id starting from 10000 {@link Env#NEXT_ID_INIT_VALUE}.
      * InfoSchemaDb takes id 0, so we assign id 1 to MysqlDb.

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -3178,6 +3178,21 @@ public class InternalCatalog implements CatalogIf<Database> {
             Database db = new Database();
             db.readFields(dis);
             newChecksum ^= db.getId();
+
+            Database dbPrev = fullNameToDb.get(db.getFullName());
+            if (dbPrev != null) {
+                String errMsg;
+                if (dbPrev.isMysqlCompatibleDatabase() || db.isMysqlCompatibleDatabase()) {
+                    errMsg = String.format(
+                        "Mysql compatibility problem, previous checkpoint already has a database with full name "
+                        + "%s. If its name is mysql, try to add mysqldb_replace_name=\"mysql_comp\" in fe.conf.",
+                        db.getFullName());
+                } else {
+                    errMsg = String.format("Logical error, duplicated database fullname: %s, id: %d %d.",
+                                    db.getFullName(), db.getId(), fullNameToDb.get(db.getFullName()).getId());
+                }
+                throw new IOException(errMsg);
+            }
             idToDb.put(db.getId(), db);
             fullNameToDb.put(db.getFullName(), db);
             Env.getCurrentGlobalTransactionMgr().addDatabaseTransactionMgr(db.getId());


### PR DESCRIPTION
If user has database with same name mysql, will introduce problem when doing checkpoint.

Solution:
1. Add check for this situation, if duplicate, exit and print log info to prevent damage of metadata;
2. Add fe config field: mysqldb_replace_name to make things correct if user already has mysql db.

Related pr: https://github.com/apache/doris/pull/23087  https://github.com/apache/doris/pull/22868