### PR TITLE
[runtimeFilter](thrift) define min max runtime filter type

### DIFF
--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -1064,6 +1064,18 @@ enum TRuntimeFilterType {
   BITMAP = 16
 }
 
+// generate min-max runtime filter for non-equal condition or equal condition. 
+enum TMinMaxRuntimeFilterType {
+  // only min is valid, RF generated according to condition: n < col_A
+  MIN = 1
+  // only max is valid, RF generated according to condition: m > col_A
+  MAX = 2
+  // both min/max are valid, 
+  // support hash join condition: col_A = col_B
+  // support other join condition: n < col_A and col_A < m
+  MIN_MAX = 4
+}
+
 // Specification of a runtime filter.
 struct TRuntimeFilterDesc {
   // Filter unique id (within a query)
@@ -1104,7 +1116,12 @@ struct TRuntimeFilterDesc {
   11: optional bool bitmap_filter_not_in
 
   12: optional bool opt_remote_rf;
+  
+  // for min/max rf
+  13: optional TMinMaxRuntimeFilterType min_max_type;
 }
+
+
 
 struct TDataGenScanNode {
 	1: optional Types.TTupleId tuple_id


### PR DESCRIPTION
## Proposed changes
extend min-max rf to support 3 types:
1. n<A
2. m>A
3. n<A<m,
in which m/n are constants and A is column.
this pr only contains thrift definition.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

