### PR TITLE
[chore](workflow) 1/2, remove required checks ("License Check", "Clan…

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -48,8 +48,6 @@ github:
         # if strict is true, means "Require branches to be up to date before merging".
         strict: false
         contexts:
-          - License Check
-          - Clang Formatter
           - CheckStyle
           - P0 Regression (Doris Regression)
           - P1 Regression (Doris Regression)


### PR DESCRIPTION
…g Formatter") temporally

In order to change the two checks, "License Check" and "Clang Formatter",  to auto trigger instead of after approval， 
that pr #25101 is blocked by these required checks。
So, It should remove these required checks first, merge this PR, and then add back these required checks in PR  #25101

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

