### PR TITLE
[enhancement](Nereids) avoiding broadcast join heuristically and pruning more in CostAndEnforceJob

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
@@ -207,15 +207,6 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
 
         // replicate
         if (spec instanceof DistributionSpecReplicated) {
-            double dataSize = childStatistics.computeSize();
-            double memLimit = ConnectContext.get().getSessionVariable().getMaxExecMemByte();
-            //if build side is big, avoid use broadcast join
-            double rowsLimit = ConnectContext.get().getSessionVariable().getBroadcastRowCountLimit();
-            double brMemlimit = ConnectContext.get().getSessionVariable().getBroadcastHashtableMemLimitPercentage();
-            if (dataSize > memLimit * brMemlimit
-                    || childStatistics.getRowCount() > rowsLimit) {
-                return CostV1.of(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
-            }
             // estimate broadcast cost by an experience formula: beNumber^0.5 * rowCount
             // - sender number and receiver number is not available at RBO stage now, so we use beNumber
             // - senders and receivers work in parallel, that why we use square of beNumber

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/CostAndEnforcerJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/CostAndEnforcerJob.java
@@ -188,19 +188,17 @@ public class CostAndEnforcerJob extends Job implements Cloneable {
                         curNodeCost,
                         lowestCostExpr.getCostValueByProperties(requestChildProperty),
                         curChildIndex);
-                if (curTotalCost.getValue() > context.getCostUpperBound()) {
-                    // TODO: remove it for pruning
-                    // setting it to infinity instead of exiting directly is to avoid repeatedly
-                    // optimizing the children. For example:
-                    //      Group1 : betterExpr, currentExpr(child: Group2)
-                    //      steps
-                    //          1. CostAndEnforce(currentExpr) with upperBound betterExpr.cost
-                    //          2. OptimzeGroup(Group2) with upperBound bestExpr.cost - currentExpr.nodeCost
-                    //          3. CostAndEnforce(Expr in Group2) trigger here and exit
-                    //              ...
-                    //          n.  CostAndEnforce(Group2) and then optimize group2 again for the same requireProp
-                    curTotalCost = Cost.infinite();
-                }
+
+                // Not performing lower bound group pruning here is to avoid redundant optimization of children.
+                // For example:
+                //      Group1 : betterExpr, currentExpr(child: Group2), otherExpr(child: Group)
+                //      steps
+                //          1. CostAndEnforce(currentExpr) with upperBound betterExpr.cost
+                //          2. OptimzeGroup(Group2) with upperBound bestExpr.cost - currentExpr.nodeCost
+                //          3. CostAndEnforce(Expr in Group2) trigger here and exit
+                //              ...
+                //          n.  CostAndEnforce(otherExpr) can trigger optimize group2 again for the same requireProp
+
                 // the request child properties will be covered by the output properties
                 // that corresponding to the request properties. so if we run a costAndEnforceJob of the same
                 // group expression, that request child properties will be different of this.
@@ -286,7 +284,7 @@ public class CostAndEnforcerJob extends Job implements Cloneable {
             return;
         }
 
-        if (context.getRequiredProperties().isDistributorProperties()) {
+        if (context.getRequiredProperties().isDistributionOnlyProperties()) {
             // For properties without an orderSpec, enforceMissingPropertiesHelper always adds a distributor
             // above this group expression. The cost of the distributor is equal to the cost of the groupExpression
             // plus the cost of the distributor. The distributor remains unchanged for different groupExpressions.

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/PhysicalProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/PhysicalProperties.java
@@ -106,6 +106,10 @@ public class PhysicalProperties {
         return distributionSpec;
     }
 
+    public boolean isDistributorProperties() {
+        return orderSpec.getOrderKeys().isEmpty();
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/PhysicalProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/PhysicalProperties.java
@@ -106,7 +106,7 @@ public class PhysicalProperties {
         return distributionSpec;
     }
 
-    public boolean isDistributorProperties() {
+    public boolean isDistributionOnlyProperties() {
         return orderSpec.getOrderKeys().isEmpty();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
@@ -165,10 +165,14 @@ public class RequestPropertyDeriver extends PlanVisitor<Void, PlanContext> {
         if (JoinUtils.couldShuffle(hashJoin)) {
             addShuffleJoinRequestProperty(hashJoin);
         }
+
         // for broadcast join
-        if (JoinUtils.couldBroadcast(hashJoin)
-                && hashJoin.getGroupExpression().get().child(1).getStatistics().getRowCount()
-                <= ConnectContext.get().getSessionVariable().getBroadcastRowCountLimit()) {
+        double memLimit = ConnectContext.get().getSessionVariable().getMaxExecMemByte();
+        double rowsLimit = ConnectContext.get().getSessionVariable().getBroadcastRowCountLimit();
+        double brMemlimit = ConnectContext.get().getSessionVariable().getBroadcastHashtableMemLimitPercentage();
+        double datasize = hashJoin.getGroupExpression().get().child(1).getStatistics().computeSize();
+        double rowCount = hashJoin.getGroupExpression().get().child(1).getStatistics().getRowCount();
+        if (JoinUtils.couldBroadcast(hashJoin) && rowCount <= rowsLimit && datasize <= memLimit * brMemlimit) {
             addBroadcastJoinRequestProperty();
         }
         return null;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
@@ -166,7 +166,9 @@ public class RequestPropertyDeriver extends PlanVisitor<Void, PlanContext> {
             addShuffleJoinRequestProperty(hashJoin);
         }
         // for broadcast join
-        if (JoinUtils.couldBroadcast(hashJoin)) {
+        if (JoinUtils.couldBroadcast(hashJoin)
+                && hashJoin.getGroupExpression().get().child(1).getStatistics().getRowCount()
+                < ConnectContext.get().getSessionVariable().getBroadcastRowCountLimit()) {
             addBroadcastJoinRequestProperty();
         }
         return null;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
@@ -168,7 +168,7 @@ public class RequestPropertyDeriver extends PlanVisitor<Void, PlanContext> {
         // for broadcast join
         if (JoinUtils.couldBroadcast(hashJoin)
                 && hashJoin.getGroupExpression().get().child(1).getStatistics().getRowCount()
-                < ConnectContext.get().getSessionVariable().getBroadcastRowCountLimit()) {
+                <= ConnectContext.get().getSessionVariable().getBroadcastRowCountLimit()) {
             addBroadcastJoinRequestProperty();
         }
         return null;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/RequestPropertyDeriverTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/RequestPropertyDeriverTest.java
@@ -37,6 +37,7 @@ import org.apache.doris.nereids.trees.plans.physical.PhysicalHashJoin;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalNestedLoopJoin;
 import org.apache.doris.nereids.types.IntegerType;
 import org.apache.doris.nereids.util.ExpressionUtils;
+import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -59,6 +60,12 @@ class RequestPropertyDeriverTest {
 
     @Mocked
     LogicalProperties logicalProperties;
+
+    @Mocked
+    ConnectContext connectContext;
+
+    @Injectable
+    Group group;
 
     @Injectable
     JobContext jobContext;
@@ -130,11 +137,18 @@ class RequestPropertyDeriverTest {
             }
         };
 
+        new MockUp<ConnectContext>() {
+            @Mock
+            ConnectContext get() {
+                return connectContext;
+            }
+        };
+
         PhysicalHashJoin<GroupPlan, GroupPlan> join = new PhysicalHashJoin<>(JoinType.INNER_JOIN,
                 ExpressionUtils.EMPTY_CONDITION, ExpressionUtils.EMPTY_CONDITION, JoinHint.NONE, Optional.empty(),
                 logicalProperties,
                 groupPlan, groupPlan);
-        GroupExpression groupExpression = new GroupExpression(join);
+        GroupExpression groupExpression = new GroupExpression(join, Lists.newArrayList(group, group));
         new Group(null, groupExpression, null);
 
         RequestPropertyDeriver requestPropertyDeriver = new RequestPropertyDeriver(jobContext);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/RequestPropertyDeriverTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/RequestPropertyDeriverTest.java
@@ -112,7 +112,7 @@ class RequestPropertyDeriverTest {
                 ExpressionUtils.EMPTY_CONDITION, ExpressionUtils.EMPTY_CONDITION, JoinHint.NONE, Optional.empty(),
                 logicalProperties,
                 groupPlan, groupPlan);
-        GroupExpression groupExpression = new GroupExpression(join);
+        GroupExpression groupExpression = new GroupExpression(join, Lists.newArrayList(group, group));
         new Group(null, groupExpression, null);
 
         RequestPropertyDeriver requestPropertyDeriver = new RequestPropertyDeriver(jobContext);


### PR DESCRIPTION
## Proposed changes

1. When the rowCount exceeds a certain threshold, refrain from generating a broadcast join.
2. Only enforce the best expression in CostAndEnforce Job, rather than enforcing every expression.
3. Remove lower bound group pruning

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

