### PR TITLE
[fix](Nereids) bind sink should use full base schema

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSink.java
@@ -268,7 +268,7 @@ public class BindSink implements AnalysisRuleFactory {
     private List<Column> bindTargetColumns(OlapTable table, List<String> colsName, boolean isNeedSequenceCol) {
         // if the table set sequence column in stream load phase, the sequence map column is null, we query it.
         return colsName.isEmpty()
-                ? table.getFullSchema().stream()
+                ? table.getBaseSchema(true).stream()
                 .filter(c -> validColumn(c, isNeedSequenceCol))
                 .collect(ImmutableList.toImmutableList())
                 : colsName.stream().map(cn -> {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

fullschema contians some column should not be see for base index after schema change

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

