### PR TITLE
[fix](export) BufferWritable must be committed before deconstruct

### DIFF
--- a/be/src/vec/runtime/vcsv_transformer.cpp
+++ b/be/src/vec/runtime/vcsv_transformer.cpp
@@ -97,8 +97,14 @@ Status VCSVTransformer::write(const Block& block) {
             if (col_id != 0) {
                 buffer_writer.write(_column_separator.data(), _column_separator.size());
             }
-            RETURN_IF_ERROR(_serdes[col_id]->serialize_one_cell_to_json(
-                    *(block.get_by_position(col_id).column), i, buffer_writer, _options));
+            Status st = _serdes[col_id]->serialize_one_cell_to_json(
+                    *(block.get_by_position(col_id).column), i, buffer_writer, _options);
+            if (!st.ok()) {
+                // VectorBufferWriter must do commit before deconstruct,
+                // or it may throw DCHECK failure.
+                buffer_writer.commit();
+                return st;
+            }
         }
         buffer_writer.write(_line_delimiter.data(), _line_delimiter.size());
         buffer_writer.commit();


### PR DESCRIPTION
## Proposed changes

F20231009 16:03:47.659968 3342535 string_buffer.hpp:48] Check failed: _now_offset == 0
*** Check failure stack trace: ***
    @     0x561a6f8e21e6  google::LogMessage::SendToLog()
    @     0x561a6f8de7b0  google::LogMessage::Flush()
    @     0x561a6f8e2a29  google::LogMessageFatal::~LogMessageFatal()
    @     0x561a4a409233  doris::vectorized::BufferWritable::~BufferWritable()
    @     0x561a6e202853  doris::vectorized::VCSVTransformer::write()
    @     0x561a6e1f19ba  doris::vectorized::VFileResultWriter::_write_file()
    @     0x561a6e1f1522  doris::vectorized::VFileResultWriter::append_block()
    @     0x561a6e121bed 

The error will occur in DEBUG mode, and doing export will invalid data.
It has been covered by baidu case.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

