### PR TITLE
[docs](developer-guide) Improve the be-vscode-gdb document

### DIFF
--- a/docs/en/community/developer-guide/be-vscode-dev.md
+++ b/docs/en/community/developer-guide/be-vscode-dev.md
@@ -164,6 +164,7 @@ mkdir -p /soft/be/storage
                            ],
             "externalConsole": true,
             "MIMode": "gdb",
+            "miDebuggerPath": "/path/to/gdb",
             "setupCommands": [
                 {
                     "description": "Enable pretty-printing for gdb",
@@ -178,6 +179,8 @@ mkdir -p /soft/be/storage
 
 Among them, environment defines several environment variables DORIS_HOME UDF_RUNTIME_DIR LOG_DIR PID_DIR, which are the environment variables needed when doris_be is running. If it is not set, the startup will fail
 
+MiDebuggerPath specifies the path of the debugger (such as gdb). If miDebuggerPath is not specified, it will search for gdb path in the PATH variable of the os. The gdb version that comes with the system can be too low, you may need to manually specify the new version of gdb path.
+
 **Note: If you want attach (additional process) debugging, the configuration code is as follows:**
 
 ```
@@ -191,6 +194,7 @@ Among them, environment defines several environment variables DORIS_HOME UDF_RUN
           "program": "/home/workspace/doris/output/lib/doris_be",
           "processId":,
           "MIMode": "gdb",
+          "miDebuggerPath": "/path/to/gdb",
           "internalConsoleOptions":"openOnSessionStart",
           "setupCommands": [
                 {
@@ -231,6 +235,7 @@ An example of a complete launch.json is as follows:
             "program": "/home/workspace/doris/output/be/lib/doris_be",
             "processId": 17016,
             "MIMode": "gdb",
+            "miDebuggerPath": "/path/to/gdb",
             "setupCommands": [
                 {
                     "description": "Enable pretty-printing for gdb",
@@ -267,6 +272,7 @@ An example of a complete launch.json is as follows:
             ],
             "externalConsole": false,
             "MIMode": "gdb",
+            "miDebuggerPath": "/path/to/gdb",
             "setupCommands": [
                 {
                     "description": "Enable pretty-printing for gdb",

--- a/docs/zh-CN/community/developer-guide/be-vscode-dev.md
+++ b/docs/zh-CN/community/developer-guide/be-vscode-dev.md
@@ -163,6 +163,7 @@ mkdir -p /soft/be/storage
                            ],
             "externalConsole": true,
             "MIMode": "gdb",
+            "miDebuggerPath": "/path/to/gdb",
             "setupCommands": [
                 {
                     "description": "Enable pretty-printing for gdb",
@@ -177,6 +178,8 @@ mkdir -p /soft/be/storage
 
 其中，environment 定义了几个环境变量 DORIS_HOME UDF_RUNTIME_DIR LOG_DIR PID_DIR，这是 doris_be 运行时需要的环境变量，如果没有设置，启动会失败。
 
+miDebuggerPath 指定了调试器的路径（如gdb），如果不指定 miDebuggerPath ，它将在操作系统的 PATH 变量中搜索调试器。系统自带的 gdb 版本有可能过低，这时就需要手动去指定新版本的 gdb 路径。
+
 **注意：如果希望是 attach(附加进程）调试，配置代码如下：**
 
 ```
@@ -190,6 +193,7 @@ mkdir -p /soft/be/storage
           "program": "/home/workspace/doris/output/lib/doris_be",
           "processId":,
           "MIMode": "gdb",
+          "miDebuggerPath": "/path/to/gdb",
           "internalConsoleOptions":"openOnSessionStart",
           "setupCommands": [
                 {
@@ -230,6 +234,7 @@ lsof -i | grep -m 1 doris_be | awk "{print $2}"
             "program": "/home/workspace/doris/output/be/lib/doris_be",
             "processId": 17016,
             "MIMode": "gdb",
+            "miDebuggerPath": "/path/to/gdb",
             "setupCommands": [
                 {
                     "description": "Enable pretty-printing for gdb",
@@ -266,6 +271,7 @@ lsof -i | grep -m 1 doris_be | awk "{print $2}"
             ],
             "externalConsole": false,
             "MIMode": "gdb",
+            "miDebuggerPath": "/path/to/gdb",
             "setupCommands": [
                 {
                     "description": "Enable pretty-printing for gdb",


### PR DESCRIPTION
## Proposed changes

Add miDebuggerPath into document to allow user set the gdb path.
If miDebuggerPath is not set, vscode may choose the gdb with low version.

ref: https://code.visualstudio.com/docs/cpp/launch-json-reference#_midebuggerpath

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

