### PR TITLE
[Fix](func numbers) Remove backend_nums argument of numbers function

### DIFF
--- a/be/src/vec/exec/data_gen_functions/vnumbers_tvf.cpp
+++ b/be/src/vec/exec/data_gen_functions/vnumbers_tvf.cpp
@@ -80,6 +80,9 @@ Status VNumbersTVF::get_next(RuntimeState* state, vectorized::Block* block, bool
 }
 
 Status VNumbersTVF::set_scan_ranges(const std::vector<TScanRangeParams>& scan_range_params) {
+    // Currently we do not support multi-threads numbers function, so there is no need to
+    // use more than one scan_range_param.
+    DCHECK(scan_range_params.size() == 1);
     _total_numbers =
             scan_range_params[0].scan_range.data_gen_scan_range.numbers_params.totalNumbers;
     return Status::OK();

--- a/docs/en/docs/sql-manual/sql-functions/table-functions/numbers.md
+++ b/docs/en/docs/sql-manual/sql-functions/table-functions/numbers.md
@@ -36,14 +36,12 @@ This function is used in FROM clauses.
 
 ```sql
 numbers(
-  "number" = "n",
-  "backend_num" = "m"
+  "number" = "n"
   );
 ```
 
 parameter：
 - `number`: It means to generate rows [0, n).
-- `backend_num`: Optional parameters. It means this function is executed simultaneously on `m` be nodes (multiple BEs need to be deployed).
 
 ### example
 ```

--- a/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/numbers.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/table-functions/numbers.md
@@ -35,14 +35,12 @@ under the License.
 #### syntax
 ```sql
 numbers(
-  "number" = "n",
-  "backend_num" = "m"
+  "number" = "n"
   );
 ```
 
 参数：
 - `number`: 代表生成[0,n)的行。
-- `backend_num`: 可选参数,代表`m`个be节点同时执行该函数（需要部署多个be）。
 
 ### example
 ```

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/DataGenScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/DataGenScanNode.java
@@ -107,4 +107,14 @@ public class DataGenScanNode extends ExternalScanNode {
     public boolean needToCheckColumnPriv() {
         return false;
     }
+
+    // Currently DataGenScanNode is only used by DataGenTableValuedFunction, which is
+    // inherited by NumbersTableValuedFunction.
+    // NumbersTableValuedFunction is not a complete implementation for now, since its
+    // function signature do not support us to split total numbers, so it can not be executed
+    // by multi-processes or multi-threads. So we assign instance number to 1.
+    @Override
+    public int getNumInstances() {
+        return 1;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -703,8 +703,9 @@ public class Coordinator implements CoordInterface {
             // else use exec_plan_fragments directly.
             // we choose #fragments >=2 because in some cases
             // we need ensure that A fragment is already prepared to receive data before B fragment sends data.
-            // For example: select * from numbers("number"="10") will generate ExchangeNode and TableValuedFunctionScanNode,
-            // we should ensure TableValuedFunctionScanNode does not send data until ExchangeNode is ready to receive.
+            // For example: select * from numbers("number"="10") will generate ExchangeNode and
+            // TableValuedFunctionScanNode, we should ensure TableValuedFunctionScanNode does
+            // not send data until ExchangeNode is ready to receive.
             boolean twoPhaseExecution = fragments.size() >= 2;
             for (PlanFragment fragment : fragments) {
                 FragmentExecParams params = fragmentExecParamsMap.get(fragment.getFragmentId());
@@ -825,8 +826,9 @@ public class Coordinator implements CoordInterface {
             // else use exec_plan_fragments directly.
             // we choose #fragments >=2 because in some cases
             // we need ensure that A fragment is already prepared to receive data before B fragment sends data.
-            // For example: select * from numbers("number"="10") will generate ExchangeNode and TableValuedFunctionScanNode,
-            // we should ensure TableValuedFunctionScanNode does not send data until ExchangeNode is ready to receive.
+            // For example: select * from numbers("number"="10") will generate ExchangeNode and
+            // TableValuedFunctionScanNode, we should ensure TableValuedFunctionScanNode does not
+            // send data until ExchangeNode is ready to receive.
             boolean twoPhaseExecution = fragments.size() >= 2;
             for (PlanFragment fragment : fragments) {
                 FragmentExecParams params = fragmentExecParamsMap.get(fragment.getFragmentId());

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -703,7 +703,7 @@ public class Coordinator implements CoordInterface {
             // else use exec_plan_fragments directly.
             // we choose #fragments >=2 because in some cases
             // we need ensure that A fragment is already prepared to receive data before B fragment sends data.
-            // For example: select * from numbers("10","w") will generate ExchangeNode and TableValuedFunctionScanNode,
+            // For example: select * from numbers("number"="10") will generate ExchangeNode and TableValuedFunctionScanNode,
             // we should ensure TableValuedFunctionScanNode does not send data until ExchangeNode is ready to receive.
             boolean twoPhaseExecution = fragments.size() >= 2;
             for (PlanFragment fragment : fragments) {
@@ -825,7 +825,7 @@ public class Coordinator implements CoordInterface {
             // else use exec_plan_fragments directly.
             // we choose #fragments >=2 because in some cases
             // we need ensure that A fragment is already prepared to receive data before B fragment sends data.
-            // For example: select * from numbers("10","w") will generate ExchangeNode and TableValuedFunctionScanNode,
+            // For example: select * from numbers("number"="10") will generate ExchangeNode and TableValuedFunctionScanNode,
             // we should ensure TableValuedFunctionScanNode does not send data until ExchangeNode is ready to receive.
             boolean twoPhaseExecution = fragments.size() >= 2;
             for (PlanFragment fragment : fragments) {
@@ -2315,6 +2315,11 @@ public class Coordinator implements CoordInterface {
             FragmentScanRangeAssignment assignment,
             Map<TNetworkAddress, Long> assignedBytesPerHost,
             Map<TNetworkAddress, Long> replicaNumPerHost) throws Exception {
+        // Type of locations is List, it could have elements that have same "location"
+        // and we do have this situation for some scan node.
+        // The duplicate "location" will NOT be filtered by FragmentScanRangeAssignment,
+        // since FragmentScanRangeAssignment use List<TScanRangeParams> as its value type,
+        // duplicate "locations" will be converted to list.
         for (TScanRangeLocations scanRangeLocations : locations) {
             Reference<Long> backendIdRef = new Reference<Long>();
             TScanRangeLocation minLocation = selectBackendsByRoundRobin(scanRangeLocations,

--- a/regression-test/suites/http_rest_api/post/test_query_stmt.groovy
+++ b/regression-test/suites/http_rest_api/post/test_query_stmt.groovy
@@ -49,7 +49,7 @@ suite("test_query_stmt") {
     def url= "/api/query/default_cluster/" + context.config.defaultDb
 
     // test select
-    def stmt1 = """ select * from numbers('number' = '10', 'backend_num' = '1') """ 
+    def stmt1 = """ select * from numbers('number' = '10') """ 
     def stmt1_json = JsonOutput.toJson(new Stmt(stmt: stmt1));
 
     def resJson = http_post(url, stmt1_json)

--- a/regression-test/suites/nereids_syntax_p0/aggregate_strategies.groovy
+++ b/regression-test/suites/nereids_syntax_p0/aggregate_strategies.groovy
@@ -170,7 +170,7 @@ suite("aggregate_strategies") {
         sql """select
                 /*+SET_VAR(disable_nereids_rules='TWO_PHASE_AGGREGATE_WITH_DISTINCT')*/
                 count(distinct number)
-                from numbers('number' = '10000', 'backend_num'='10')"""
+                from numbers('number' = '10000')"""
         result([[10000L]])
     }
 
@@ -178,7 +178,7 @@ suite("aggregate_strategies") {
         sql """select
                 /*+SET_VAR(disable_nereids_rules='THREE_PHASE_AGGREGATE_WITH_DISTINCT')*/
                 count(distinct number)
-                from numbers('number' = '10000', 'backend_num'='10')"""
+                from numbers('number' = '10000')"""
         result([[10000L]])
     }
 
@@ -186,7 +186,7 @@ suite("aggregate_strategies") {
         sql """select
                 /*+SET_VAR(disable_nereids_rules='TWO_PHASE_AGGREGATE_WITH_DISTINCT')*/
                 count(distinct number)
-                from numbers('number' = '10000', 'backend_num'='1')"""
+                from numbers('number' = '10000')"""
         result([[10000L]])
     }
 
@@ -194,7 +194,7 @@ suite("aggregate_strategies") {
         sql """select
                 /*+SET_VAR(disable_nereids_rules='THREE_PHASE_AGGREGATE_WITH_DISTINCT')*/
                 count(distinct number)
-                from numbers('number' = '10000', 'backend_num'='1')"""
+                from numbers('number' = '10000')"""
         result([[10000L]])
     }
 

--- a/regression-test/suites/nereids_syntax_p0/function.groovy
+++ b/regression-test/suites/nereids_syntax_p0/function.groovy
@@ -91,7 +91,7 @@ suite("nereids_function") {
     qt_subquery3 """ select a.number from numbers("number" = "10") a where number in (select number from numbers("number" = "10") b where a.number=b.number); """
 
     test {
-        sql """select `number` from numbers("number" = -1, 'backend_num' = `1`)"""
+        sql """select `number` from numbers("number" = "-1")"""
         result([])
     }
 

--- a/regression-test/suites/nereids_syntax_p0/function.groovy
+++ b/regression-test/suites/nereids_syntax_p0/function.groovy
@@ -70,7 +70,7 @@ suite("nereids_function") {
 
     // numbers: table valued function
     test {
-        sql "select `number` from numbers(number = 10, backend_num = 1)"
+        sql "select `number` from numbers(number = 10)"
         result([[0L], [1L], [2L], [3L], [4L], [5L], [6L], [7L], [8L], [9L]])
     }
 

--- a/regression-test/suites/nereids_syntax_p2/aggregate_strategies.groovy
+++ b/regression-test/suites/nereids_syntax_p2/aggregate_strategies.groovy
@@ -20,7 +20,7 @@ suite("aggregate_strategies") {
         sql """select
                 /*+SET_VAR(disable_nereids_rules='TWO_PHASE_AGGREGATE_WITH_DISTINCT')*/
                 count(distinct number)
-                from numbers('number' = '10000000', 'backend_num'='10')"""
+                from numbers('number' = '10000000')"""
         result([[10000000L]])
     }
 
@@ -28,7 +28,7 @@ suite("aggregate_strategies") {
         sql """select
                 /*+SET_VAR(disable_nereids_rules='THREE_PHASE_AGGREGATE_WITH_DISTINCT')*/
                 count(distinct number)
-                from numbers('number' = '10000000', 'backend_num'='10')"""
+                from numbers('number' = '10000000')"""
         result([[10000000L]])
     }
 
@@ -36,7 +36,7 @@ suite("aggregate_strategies") {
         sql """select
                 /*+SET_VAR(disable_nereids_rules='TWO_PHASE_AGGREGATE_WITH_DISTINCT')*/
                 count(distinct number)
-                from numbers('number' = '10000000', 'backend_num'='1')"""
+                from numbers('number' = '10000000')"""
         result([[10000000L]])
     }
 
@@ -44,7 +44,7 @@ suite("aggregate_strategies") {
         sql """select
                 /*+SET_VAR(disable_nereids_rules='THREE_PHASE_AGGREGATE_WITH_DISTINCT')*/
                 count(distinct number)
-                from numbers('number' = '10000000', 'backend_num'='1')"""
+                from numbers('number' = '10000000')"""
         result([[10000000L]])
     }
 }


### PR DESCRIPTION
We have some bugs in function numbers:

1. When we have real backends less than requested backend_nums, we do not throw exception.
2. Current thrift definition of function numbers do not support number partition between multiple backends or multiple threads, since we just have total_numbers without range parameter.
3. Computation of execution parallelism is wrong.  

And we do not have requests for parallel execute of function numbers. So we remove backend_num argument.