### PR TITLE
[fix](load) fix MemTableWriter::active_memtable_mem_consumption

### DIFF
--- a/be/src/olap/delta_writer_v2.cpp
+++ b/be/src/olap/delta_writer_v2.cpp
@@ -196,10 +196,6 @@ int64_t DeltaWriterV2::mem_consumption(MemType mem) {
     return _memtable_writer->mem_consumption(mem);
 }
 
-int64_t DeltaWriterV2::active_memtable_mem_consumption() {
-    return _memtable_writer->active_memtable_mem_consumption();
-}
-
 int64_t DeltaWriterV2::partition_id() const {
     return _req.partition_id;
 }

--- a/be/src/olap/delta_writer_v2.h
+++ b/be/src/olap/delta_writer_v2.h
@@ -89,7 +89,6 @@ public:
     int64_t partition_id() const;
 
     int64_t mem_consumption(MemType mem);
-    int64_t active_memtable_mem_consumption();
 
     int64_t tablet_id() { return _req.tablet_id; }
 

--- a/be/src/olap/memtable_writer.cpp
+++ b/be/src/olap/memtable_writer.cpp
@@ -354,20 +354,7 @@ int64_t MemTableWriter::mem_consumption(MemType mem) {
 }
 
 int64_t MemTableWriter::active_memtable_mem_consumption() {
-    if (_flush_token == nullptr) {
-        // This method may be called before this writer is initialized.
-        // So _flush_token may be null.
-        return 0;
-    }
-    int64_t mem_usage = 0;
-    {
-        std::lock_guard<SpinLock> l(_mem_table_tracker_lock);
-        if (_mem_table_insert_trackers.size() > 0) {
-            mem_usage += (*_mem_table_insert_trackers.rbegin())->consumption();
-            mem_usage += (*_mem_table_flush_trackers.rbegin())->consumption();
-        }
-    }
-    return mem_usage;
+    return _mem_table != nullptr ? _mem_table->memory_usage() : 0;
 }
 
 } // namespace doris


### PR DESCRIPTION
## Proposed changes

Active memtable should be the memtable currently being writing.
Fix active_memtable_mem_consumption for use in memtable memory limiter.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

