### PR TITLE
[feature](AuditLog) add scanRows scanBytes in auditlog

### DIFF
--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -1233,7 +1233,8 @@ Status ScanLocalState<Derived>::clone_conjunct_ctxs(vectorized::VExprContextSPtr
 template <typename Derived>
 Status ScanLocalState<Derived>::_init_profile() {
     // 1. counters for scan node
-    _rows_read_counter = ADD_COUNTER(_runtime_profile, "RowsRead", TUnit::UNIT);
+    _rows_read_counter = ADD_COUNTER(_runtime_profile, "ScanRowsRead", TUnit::UNIT);
+    _byte_read_counter = ADD_COUNTER(_runtime_profile, "ScanByteRead", TUnit::BYTES);
     _total_throughput_counter =
             profile()->add_rate_counter("TotalReadThroughput", _rows_read_counter);
     _num_scanners = ADD_COUNTER(_runtime_profile, "NumScanners", TUnit::UNIT);

--- a/be/src/pipeline/exec/scan_operator.h
+++ b/be/src/pipeline/exec/scan_operator.h
@@ -180,6 +180,7 @@ protected:
     RuntimeProfile::HighWaterMarkCounter* _free_blocks_memory_usage;
     // rows read from the scanner (including those discarded by (pre)filters)
     RuntimeProfile::Counter* _rows_read_counter;
+    RuntimeProfile::Counter* _byte_read_counter;
 
     // Wall based aggregate read throughput [rows/sec]
     RuntimeProfile::Counter* _total_throughput_counter;

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -279,7 +279,8 @@ Status VScanNode::get_next(RuntimeState* state, vectorized::Block* block, bool* 
 
 Status VScanNode::_init_profile() {
     // 1. counters for scan node
-    _rows_read_counter = ADD_COUNTER(_runtime_profile, "RowsRead", TUnit::UNIT);
+    _rows_read_counter = ADD_COUNTER(_runtime_profile, "ScanRowsRead", TUnit::UNIT);
+    _byte_read_counter = ADD_COUNTER(_runtime_profile, "ScanByteRead", TUnit::BYTES);
     _total_throughput_counter =
             runtime_profile()->add_rate_counter("TotalReadThroughput", _rows_read_counter);
     _num_scanners = ADD_COUNTER(_runtime_profile, "NumScanners", TUnit::UNIT);

--- a/be/src/vec/exec/scan/vscan_node.h
+++ b/be/src/vec/exec/scan/vscan_node.h
@@ -319,6 +319,7 @@ protected:
 
     // rows read from the scanner (including those discarded by (pre)filters)
     RuntimeProfile::Counter* _rows_read_counter;
+    RuntimeProfile::Counter* _byte_read_counter;
     // Wall based aggregate read throughput [rows/sec]
     RuntimeProfile::Counter* _total_throughput_counter;
     RuntimeProfile::Counter* _num_scanners;

--- a/be/src/vec/exec/scan/vscanner.cpp
+++ b/be/src/vec/exec/scan/vscanner.cpp
@@ -95,6 +95,7 @@ Status VScanner::get_block(RuntimeState* state, Block* block, bool* eof) {
                     break;
                 }
                 _num_rows_read += block->rows();
+                _num_byte_read += block->allocated_bytes();
             }
 
             // 2. Filter the output block finally.
@@ -191,9 +192,11 @@ void VScanner::_update_counters_before_close() {
     if (_parent) {
         COUNTER_UPDATE(_parent->_scan_cpu_timer, _scan_cpu_timer);
         COUNTER_UPDATE(_parent->_rows_read_counter, _num_rows_read);
+        COUNTER_UPDATE(_parent->_byte_read_counter, _num_byte_read);
     } else {
         COUNTER_UPDATE(_local_state->_scan_cpu_timer, _scan_cpu_timer);
         COUNTER_UPDATE(_local_state->_rows_read_counter, _num_rows_read);
+        COUNTER_UPDATE(_local_state->_byte_read_counter, _num_byte_read);
     }
     if (!_state->enable_profile() && !_is_load) return;
     // Update stats for load

--- a/be/src/vec/exec/scan/vscanner.h
+++ b/be/src/vec/exec/scan/vscanner.h
@@ -196,6 +196,8 @@ protected:
     // num of rows read from scanner
     int64_t _num_rows_read = 0;
 
+    int64_t _num_byte_read = 0;
+
     // num of rows return from scanner, after filter block
     int64_t _num_rows_return = 0;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
@@ -85,6 +85,9 @@ public class Profile {
     }
 
     public ProfileStatistics getStatisticsFromProfile() {
+        if (rootProfile == null) {
+            return null;
+        }
         return rootProfile.getStatisticsFromProfile();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
@@ -18,6 +18,7 @@
 package org.apache.doris.common.profile;
 
 import org.apache.doris.common.util.ProfileManager;
+import org.apache.doris.common.util.ProfileStatistics;
 import org.apache.doris.common.util.RuntimeProfile;
 import org.apache.doris.planner.Planner;
 
@@ -81,5 +82,9 @@ public class Profile {
 
     public SummaryProfile getSummaryProfile() {
         return summaryProfile;
+    }
+
+    public ProfileStatistics getStatisticsFromProfile() {
+        return rootProfile.getStatisticsFromProfile();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileStatistics.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileStatistics.java
@@ -38,12 +38,26 @@ public class ProfileStatistics {
 
     private boolean isPipelineX;
 
+    private long scanRows;
+
+    private long scanBytes;
+
+    public static ProfileStatistics create() {
+        // statistical scanRow and scanByte
+        ProfileStatistics statistics = new ProfileStatistics(false);
+        statistics.statisticalInfo = null;
+        statistics.fragmentInfo = null;
+        return statistics;
+    }
+
     public ProfileStatistics(boolean isPipelineX) {
         statisticalInfo = new HashMap<Integer, ArrayList<String>>();
         fragmentInfo = new HashMap<Integer, ArrayList<String>>();
         fragmentId = 0;
         isDataSink = false;
         this.isPipelineX = isPipelineX;
+        scanRows = 0;
+        scanBytes = 0;
     }
 
     private void addPlanNodeInfo(int id, String info) {
@@ -109,6 +123,23 @@ public class ProfileStatistics {
 
     public void setIsDataSink(boolean dataSink) {
         this.isDataSink = dataSink;
+    }
+
+    public void statisticalInfoFromCounter(String name, Counter counter) {
+        if (name.equals("ScanRowsRead")) {
+            scanRows += counter.getValue();
+        }
+        if (name.equals("ScanByteRead")) {
+            scanBytes += counter.getValue();
+        }
+    }
+
+    public long getScanRows() {
+        return this.scanRows;
+    }
+
+    public long getScanBytes() {
+        return this.scanBytes;
     }
 
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
@@ -539,6 +539,34 @@ public class RuntimeProfile {
         return "Simple profile \n \n " + planerStr + "\n \n \n" + builder.toString();
     }
 
+    public ProfileStatistics getStatisticsFromProfile() {
+        ProfileStatistics statistics = ProfileStatistics.create();
+        iterateProfile(this, statistics);
+        return statistics;
+    }
+
+    static void iterateProfile(RuntimeProfile src, ProfileStatistics statistics) {
+        for (int i = 0; i < src.childList.size(); i++) {
+            Pair<RuntimeProfile, Boolean> pair = src.childList.get(i);
+            RuntimeProfile childProfile = pair.first;
+            iterateProfile(childProfile, statistics);
+        }
+        iterateCounter(src, ROOT_COUNTER, statistics);
+    }
+
+    static void iterateCounter(RuntimeProfile src, String counterName, ProfileStatistics statistics) {
+        Set<String> childCounterSet = src.childCounterMap.get(counterName);
+        if (childCounterSet == null) {
+            return;
+        }
+        List<String> childCounterList = new LinkedList<>(childCounterSet);
+        for (String childCounterName : childCounterList) {
+            Counter counter = src.counterMap.get(childCounterName);
+            iterateCounter(src, childCounterName, statistics);
+            statistics.statisticalInfoFromCounter(childCounterName, counter);
+        }
+    }
+
     private void printChildCounters(String prefix, String counterName, StringBuilder builder) {
         Set<String> childCounterSet = childCounterMap.get(counterName);
         if (childCounterSet == null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/AuditLogHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/AuditLogHelper.java
@@ -44,7 +44,10 @@ public class AuditLogHelper {
         long endTime = System.currentTimeMillis();
         long elapseMs = endTime - ctx.getStartTime();
         SpanContext spanContext = Span.fromContext(Context.current()).getSpanContext();
-        ProfileStatistics statisticsFromProfile = ctx.executor.getProfile().getStatisticsFromProfile();
+        ProfileStatistics statisticsFromProfile = null;
+        if (ctx.executor != null) {
+            statisticsFromProfile = ctx.executor.getProfile().getStatisticsFromProfile();
+        }
         ctx.getAuditEventBuilder().setEventType(EventType.AFTER_QUERY)
                 .setDb(ClusterNamespace.getNameFromFullName(ctx.getDatabase()))
                 .setState(ctx.getState().toString())
@@ -53,8 +56,8 @@ public class AuditLogHelper {
                 .setErrorMessage((ctx.getState().getErrorMessage() == null ? ""
                         : ctx.getState().getErrorMessage().replace("\n", " ").replace("\t", " ")))
                 .setQueryTime(elapseMs)
-                .setScanBytes(statistics == null ? 0 : statisticsFromProfile.getScanBytes())
-                .setScanRows(statistics == null ? 0 : statisticsFromProfile.getScanRows())
+                .setScanBytes(statisticsFromProfile == null ? 0 : statisticsFromProfile.getScanBytes())
+                .setScanRows(statisticsFromProfile == null ? 0 : statisticsFromProfile.getScanRows())
                 .setCpuTimeMs(statistics == null ? 0 : elapseMs)
                 .setPeakMemoryBytes(statistics == null ? 0 : statistics.getMaxPeakMemoryBytes())
                 .setReturnRows(ctx.getReturnRows())


### PR DESCRIPTION
## Proposed changes

info from profile

sql

```
select count(*) from web_sales;
+----------+
| count(*) |
+----------+
|   719384 |
+----------+
```

profile
```
-  ScanByteRead:  6.56  MB
-  ScanRowsRead:  719.384K  (719384)
```

auditlog
```
State=EOF|ErrorCode=0|ErrorMessage=|Time(ms)=49|ScanBytes=6881280|ScanRows=719384|ReturnRows=1|StmtId=16|QueryId=d93ad95d62484a3f-a81acb47b7835a9c|IsQuery=true|isNereids=true|feIp=127.0.0.1|Stmt=select count(*) from web_sales|CpuTimeMS=49
```


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

