### PR TITLE
[FIX](regresstest) fix cases for test_nested_types_insert_into_with_s3

### DIFF
--- a/regression-test/suites/datatype_p0/nested_types/query/test_nested_types_insert_into_with_s3.groovy
+++ b/regression-test/suites/datatype_p0/nested_types/query/test_nested_types_insert_into_with_s3.groovy
@@ -216,7 +216,12 @@ suite("test_nested_types_insert_into_with_s3", "p0") {
              """
 
         qt_sql_arr_orc_doris """ select * from ${table_names[i]} order by k1 limit 1; """
+        sql "sync"
+        sql "truncate table ${table_names[i]} "
     }
+
+    // here need truncate table for insert into same table with parquet file which data is not same with orc file,
+    // so select from parquet will fail
 
     
     for (int i = 0; i < 2; ++i) {
@@ -256,6 +261,8 @@ suite("test_nested_types_insert_into_with_s3", "p0") {
                 "format" = "orc");"""
 
         qt_sql_arr_orc_doris """ select c_bool,c_bigint,c_decimalv3,c_datetimev2 from ${table_names[i]} order by k1 limit 1; """
+        sql "sync"
+        sql "truncate table ${table_names[i]} "
     }
 
     for (int i = 2; i < parquetFiles.size(); ++i) {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
here need truncate table for insert into same table with parquet file which data is not same with orc file,
so  next select from parquet may has 50% chance to fail 
we can truncate table first.
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

