### PR TITLE
[opt](nereids) prune filters after partition pruning

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/PartitionPruner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/PartitionPruner.java
@@ -119,7 +119,7 @@ public class PartitionPruner extends DefaultExpressionRewriter<Void> {
         List<OnePartitionEvaluator> evaluators = idToPartitions.entrySet()
                 .stream()
                 .map(kv -> toPartitionEvaluator(kv.getKey(), kv.getValue(), partitionSlots, cascadesContext,
-                        partitionTableType))
+                        partitionTableType, false))
                 .collect(ImmutableList.toImmutableList());
 
         PartitionPruner partitionPruner = new PartitionPruner(evaluators, partitionPredicate);
@@ -131,7 +131,8 @@ public class PartitionPruner extends DefaultExpressionRewriter<Void> {
      * convert partition item to partition evaluator
      */
     public static final OnePartitionEvaluator toPartitionEvaluator(long id, PartitionItem partitionItem,
-            List<Slot> partitionSlots, CascadesContext cascadesContext, PartitionTableType partitionTableType) {
+            List<Slot> partitionSlots, CascadesContext cascadesContext, PartitionTableType partitionTableType,
+            boolean allowMerged) {
         if (partitionItem instanceof ListPartitionItem) {
             if (partitionTableType == PartitionTableType.HIVE
                     && ((ListPartitionItem) partitionItem).isHiveDefaultPartition()) {
@@ -142,7 +143,7 @@ public class PartitionPruner extends DefaultExpressionRewriter<Void> {
             }
         } else if (partitionItem instanceof RangePartitionItem) {
             return new OneRangePartitionEvaluator(
-                    id, partitionSlots, (RangePartitionItem) partitionItem, cascadesContext);
+                    id, partitionSlots, (RangePartitionItem) partitionItem, cascadesContext, allowMerged);
         } else {
             return new UnknownPartitionEvaluator(id, partitionItem);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/PartitionRangeExpander.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/PartitionRangeExpander.java
@@ -76,7 +76,7 @@ public class PartitionRangeExpander {
     /** expandRangeLiterals */
     public final List<List<Expression>> tryExpandRange(
             List<Slot> partitionSlots, List<Literal> lowers, List<Literal> uppers,
-            List<PartitionSlotType> partitionSlotTypes, int expandThreshold) {
+            List<PartitionSlotType> partitionSlotTypes, int expandThreshold, boolean allowMerged) {
 
         long expandedCount = 1;
         List<List<Expression>> expandedLists = Lists.newArrayListWithCapacity(lowers.size());
@@ -97,7 +97,7 @@ public class PartitionRangeExpander {
                     Literal upper = uppers.get(i);
                     try {
                         boolean isLastColumn = i + 1 == partitionSlots.size();
-                        if (canExpandRange(slot, lower, upper, expandedCount, expandThreshold)) {
+                        if (!allowMerged && canExpandRange(slot, lower, upper, expandedCount, expandThreshold)) {
                             expandedList.addAll(ImmutableList.copyOf(
                                     enumerableIterator(slot, lower, upper, isLastColumn))
                             );

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PruneOlapScanPartition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PruneOlapScanPartition.java
@@ -17,21 +17,37 @@
 
 package org.apache.doris.nereids.rules.rewrite;
 
+import org.apache.doris.analysis.PartitionValue;
+import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.PartitionInfo;
+import org.apache.doris.catalog.PartitionItem;
+import org.apache.doris.catalog.PartitionKey;
+import org.apache.doris.catalog.RangePartitionItem;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.rules.Rule;
 import org.apache.doris.nereids.rules.RuleType;
+import org.apache.doris.nereids.rules.expression.rules.OneRangePartitionEvaluator;
 import org.apache.doris.nereids.rules.expression.rules.PartitionPruner;
 import org.apache.doris.nereids.rules.expression.rules.PartitionPruner.PartitionTableType;
+import org.apache.doris.nereids.rules.expression.rules.PartitionSlotInput;
+import org.apache.doris.nereids.rules.expression.rules.TryEliminateUninterestedPredicates;
+import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
 import org.apache.doris.nereids.util.Utils;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Range;
 import org.apache.commons.collections.CollectionUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -74,7 +90,132 @@ public class PruneOlapScanPartition extends OneRewriteRuleFactory {
                 prunedPartitions.retainAll(manuallySpecifiedPartitions);
             }
             LogicalOlapScan rewrittenScan = scan.withSelectedPartitionIds(ImmutableList.copyOf(prunedPartitions));
-            return new LogicalFilter<>(filter.getConjuncts(), rewrittenScan);
+            Set<PartitionItem> prunedPartitionItems = new HashSet<>();
+            for (Long partitionId : prunedPartitions) {
+                PartitionItem item = partitionInfo.getItem(partitionId);
+                prunedPartitionItems.add(item);
+            }
+            boolean canPrunedFilterConjuncts = false;
+            if (partitionInfo.getPartitionColumns().size() == 1) {
+                // NOT support multi-partition key cases
+                canPrunedFilterConjuncts = canPruneFilterConjuncts(filter, prunedPartitions,
+                        partitionInfo.getIdToItem(false),
+                        partitionSlots, ctx.cascadesContext, prunedPartitionItems);
+            }
+            if (canPrunedFilterConjuncts) {
+                return rewrittenScan;
+            } else {
+                return new LogicalFilter<>(filter.getConjuncts(), rewrittenScan);
+            }
         }).toRule(RuleType.OLAP_SCAN_PARTITION_PRUNE);
+    }
+
+    private boolean canPruneFilterConjuncts(LogicalFilter<LogicalOlapScan> filter, List<Long> prunedPartitions,
+            Map<Long, PartitionItem> idToPartitions,
+            List<Slot> partitionSlots, CascadesContext cascadesContext,
+            Set<PartitionItem> prunedPartitionItems) {
+        if (prunedPartitionItems.isEmpty() || filter.getConjuncts().isEmpty()) {
+            return true;
+        } else {
+            boolean isRangePartItem = prunedPartitionItems.iterator().next() instanceof RangePartitionItem;
+            if (isRangePartItem) {
+                Expression prunedExpression = TryEliminateUninterestedPredicates.rewrite(
+                        filter.getPredicate(), ImmutableSet.copyOf(partitionSlots), cascadesContext);
+                // prunedConjuncts = ExpressionUtils.extractConjunctionToSet(prunedExpression);
+                Set<RangePartitionItem> itemSet = idToPartitions.entrySet()
+                        .stream()
+                        .filter(f -> prunedPartitions.contains(f.getKey()))
+                        .map(kv -> (RangePartitionItem) kv.getValue())
+                        .collect(ImmutableSet.toImmutableSet());
+                RangePartitionItem mergedPartitionItem = mergePartitionItem(itemSet,
+                        ((SlotReference) partitionSlots.get(0)).getColumn().get());
+                if (mergedPartitionItem == null) {
+                    return false;
+                } else {
+                    OneRangePartitionEvaluator evaluator = (OneRangePartitionEvaluator) PartitionPruner
+                            .toPartitionEvaluator(-1, mergedPartitionItem, partitionSlots, cascadesContext,
+                                    PartitionTableType.OLAP, true);
+
+                    Map<Slot, PartitionSlotInput> onePartitionInput = evaluator.getOnePartitionInputs().get(0);
+
+                    return evaluator.checkEqualRange(prunedExpression, onePartitionInput);
+                }
+            } else {
+                // TODO: support list partition
+                return false;
+            }
+        }
+    }
+
+    private RangePartitionItem mergePartitionItem(Set<RangePartitionItem> partitionItemSet, Column partitionColumn) {
+        List<RangePartitionItem> newPartitionItemList = new ArrayList<>(partitionItemSet);
+        List<Boolean> visited = new ArrayList<>();
+        for (int i = 0; i < newPartitionItemList.size(); i++) {
+            visited.add(false);
+        }
+        RangePartitionItem mergedPartitionItem = newPartitionItemList.get(0);
+        boolean matched = true;
+        for (int i = 1; i < newPartitionItemList.size(); i++) {
+            RangePartitionItem tempPartitionItem = null;
+            int matchIndex = -1;
+            for (int j = 1; j < newPartitionItemList.size(); j++) {
+                if (!visited.get(j)) {
+                    RangePartitionItem otherItm = newPartitionItemList.get(j);
+                    tempPartitionItem = mergeTwoPartitionItem(mergedPartitionItem, otherItm, partitionColumn);
+                    if (tempPartitionItem != null) {
+                        matchIndex = j;
+                        break;
+                    }
+                }
+            }
+            if (tempPartitionItem != null) {
+                visited.set(matchIndex, true);
+                mergedPartitionItem = tempPartitionItem;
+            } else {
+                matched = false;
+                break;
+            }
+        }
+        if (matched) {
+            return mergedPartitionItem;
+        } else {
+            return null;
+        }
+    }
+
+    private RangePartitionItem mergeTwoPartitionItem(RangePartitionItem item, RangePartitionItem other,
+            Column partitionColumn) {
+        String itemLowerBorder = item.getItems().lowerEndpoint().getKeys().get(0).getStringValue();
+        String itemUpperBorder = item.getItems().upperEndpoint().getKeys().get(0).getStringValue();
+        String otherLowerBorder = other.getItems().lowerEndpoint().getKeys().get(0).getStringValue();
+        String otherUpperBorder = other.getItems().upperEndpoint().getKeys().get(0).getStringValue();
+
+        RangePartitionItem newPartitionItem;
+        PartitionValue newLowerPartValue;
+        PartitionValue newUpperPartValue;
+        Range<PartitionKey> newPartitionKeyRange;
+
+        if (itemUpperBorder.equals(otherLowerBorder)) {
+            newLowerPartValue = new PartitionValue(itemLowerBorder);
+            newUpperPartValue = new PartitionValue(otherUpperBorder);
+        } else if (otherUpperBorder.equals(itemLowerBorder)) {
+            newLowerPartValue = new PartitionValue(otherLowerBorder);
+            newUpperPartValue = new PartitionValue(itemUpperBorder);
+        } else {
+            return null;
+        }
+
+        try {
+            PartitionKey lowerBound = PartitionKey.createPartitionKey(Collections.singletonList(newLowerPartValue),
+                    Collections.singletonList(partitionColumn));
+            PartitionKey upperBound = PartitionKey.createPartitionKey(Collections.singletonList(newUpperPartValue),
+                    Collections.singletonList(partitionColumn));
+            newPartitionKeyRange = Range.closedOpen(lowerBound, upperBound);
+            newPartitionItem = new RangePartitionItem(newPartitionKeyRange);
+        } catch (AnalysisException | IllegalArgumentException e) {
+            newPartitionItem = null;
+        }
+
+        return newPartitionItem;
     }
 }


### PR DESCRIPTION
## Proposed changes

Prune partition pruning filters if the filters can prune partitions out accurately, and no need the additional filters operations again for saving computing effort. As shown the following cases, the filter operator is optimized since it has been applied to partition prune and no need to do filter again.

case:
```
mysql> explain shape plan select * from td_main where date >= 20230801 and date < 20230807;
+---------------------------------+
| Explain String(Nereids Planner) |
+---------------------------------+
| PhysicalResultSink              |
| --PhysicalDistribute            |
| ----PhysicalOlapScan[td_main]   |
+---------------------------------+
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

