### PR TITLE
[enhancement](compaction) record base compaction schedule time and status

### DIFF
--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -625,6 +625,9 @@ void StorageEngine::_compaction_tasks_producer_callback() {
             /// If it is not cleaned up, the reference count of the tablet will always be greater than 1,
             /// thus cannot be collected by the garbage collector. (TabletManager::start_trash_sweep)
             for (const auto& tablet : tablets_compaction) {
+                if (compaction_type == CompactionType::BASE_COMPACTION) {
+                    tablet->set_last_base_compaction_schedule_time(UnixMillis());
+                }
                 Status st = _submit_compaction_task(tablet, compaction_type, false);
                 if (!st.ok()) {
                     LOG(WARNING) << "failed to submit compaction task for tablet: "

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1907,6 +1907,7 @@ void Tablet::execute_compaction(CompactionType compaction_type) {
         });
 
         Status res = _base_compaction->execute_compact();
+        set_last_base_compaction_status(res.to_string());
         if (!res.ok()) {
             set_last_base_compaction_failure_time(UnixMillis());
             DorisMetrics::instance()->base_compaction_request_failed->increment(1);

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -253,6 +253,11 @@ public:
         _last_full_compaction_success_millis = millis;
     }
 
+    int64_t last_base_compaction_schedule_time() { return _last_base_compaction_schedule_millis; }
+    void set_last_base_compaction_schedule_time(int64_t millis) {
+        _last_base_compaction_schedule_millis = millis;
+    }
+
     void delete_all_files();
 
     void check_tablet_path_exists();
@@ -321,6 +326,12 @@ public:
     std::shared_ptr<CumulativeCompactionPolicy> get_cumulative_compaction_policy() {
         return _cumulative_compaction_policy;
     }
+
+    void set_last_base_compaction_status(std::string status) {
+        _last_base_compaction_status = status;
+    }
+
+    std::string get_last_base_compaction_status() { return _last_base_compaction_status; }
 
     inline bool all_beta() const {
         std::shared_lock rdlock(_meta_lock);
@@ -656,10 +667,13 @@ private:
     std::atomic<int64_t> _last_base_compaction_success_millis;
     // timestamp of last full compaction success
     std::atomic<int64_t> _last_full_compaction_success_millis;
+    // timestamp of last base compaction schedule time
+    std::atomic<int64_t> _last_base_compaction_schedule_millis;
     std::atomic<int64_t> _cumulative_point;
     std::atomic<int64_t> _cumulative_promotion_size;
     std::atomic<int32_t> _newly_created_rowset_num;
     std::atomic<int64_t> _last_checkpoint_time;
+    std::string _last_base_compaction_status;
 
     // cumulative compaction policy
     std::shared_ptr<CumulativeCompactionPolicy> _cumulative_compaction_policy;

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -448,7 +448,7 @@ Status TabletMeta::_save_meta(DataDir* data_dir) {
                    << ", schema_hash=" << schema_hash();
     }
     auto t3 = MonotonicMicros();
-    auto cost =  t3 - t1;
+    auto cost = t3 - t1;
     if (cost > 1 * 1000 * 1000) {
         LOG(INFO) << "save tablet(" << full_name() << ") meta too slow. serialize cost " << t2 - t1
                   << "(us), serialized binary size: " << meta_binary.length()


### PR DESCRIPTION
now base compaction thread may be not triger, so we need to record  base compaction schedule time and status.
after apply this pr, show compaction status will be like this:
{
cumulative policy type: "size_based",
cumulative point: 11,
last cumulative failure time: "1970-01-01 08:00:00.000",
last base failure time: "2023-10-11 11:39:10.923",
last full failure time: null,
last cumulative success time: "2023-10-11 11:39:17.734",
last base success time: "1970-01-01 08:00:00.000",
last full success time: "1970-01-01 08:00:00.000",
last base schedule time: "2023-10-11 11:39:10.923",
last base status: "[E-808]_input_rowsets.size() is 1",
rowsets: [
"[0-9] 5 DATA NONOVERLAPPING 0200000000000009ae4bea23a0e26fc2f5d039e8fba682ad 1.02 GB",
"[10-10] 5 DATA NONOVERLAPPING 02000000000000022c4baaea7c085cd49ab59f894c35fa90 1.02 GB"
],
missing_rowsets: [ ],
stale_rowsets: [ ],
stale version path: [ ]
}

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

