### PR TITLE
[regression-test](topn opt) fix case that explain with wrong result

### DIFF
--- a/regression-test/suites/query_p0/sort/topn_2pr_rule.groovy
+++ b/regression-test/suites/query_p0/sort/topn_2pr_rule.groovy
@@ -42,7 +42,7 @@ suite("topn_2pr_rule") {
                 contains "OPT TWO PHASE"
             } 
             explain {
-                sql("select * from ${table_name}  where k = 1 order by k limit 1;")
+                sql("select * from ${table_name}  where k > 1 order by k limit 1;")
                 contains "OPT TWO PHASE"
             } 
             explain {


### PR DESCRIPTION
`select * from tbl where k = 1 order by k limit 1` will eliminate sort in original planner

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

