### PR TITLE
[chore](vec) Make the copy constructor of StringRef explicit

### DIFF
--- a/be/src/vec/columns/column_object.cpp
+++ b/be/src/vec/columns/column_object.cpp
@@ -610,7 +610,7 @@ void ColumnObject::try_insert_from(const IColumn& src, size_t n) {
 
 void ColumnObject::try_insert(const Field& field) {
     const auto& object = field.get<const VariantMap&>();
-    phmap::flat_hash_set<StringRef, StringRefHash> inserted;
+    phmap::flat_hash_set<std::string> inserted;
     size_t old_size = size();
     for (const auto& [key_str, value] : object) {
         PathInData key(key_str);

--- a/be/src/vec/common/string_ref.h
+++ b/be/src/vec/common/string_ref.h
@@ -193,7 +193,8 @@ struct StringRef {
     StringRef(const unsigned char* data_, size_t size_)
             : StringRef(reinterpret_cast<const char*>(data_), size_) {}
 
-    StringRef(const std::string& s) : data(s.data()), size(s.size()) {}
+    /// Make this copy constructor explicit to prevent inadvertently constructing a StringRef from a temporary std::string variable.
+    explicit StringRef(const std::string& s) : data(s.data()), size(s.size()) {}
     explicit StringRef(const char* str) : data(str), size(strlen(str)) {}
 
     std::string to_string() const { return std::string(data, size); }

--- a/be/src/vec/exec/format/json/new_json_reader.cpp
+++ b/be/src/vec/exec/format/json/new_json_reader.cpp
@@ -192,7 +192,7 @@ Status NewJsonReader::init_reader(
         }
     }
     for (int i = 0; i < _file_slot_descs.size(); ++i) {
-        _slot_desc_index[_file_slot_descs[i]->col_name()] = i;
+        _slot_desc_index[StringRef {_file_slot_descs[i]->col_name()}] = i;
     }
     return Status::OK();
 }
@@ -1003,7 +1003,7 @@ Status NewJsonReader::_simdjson_init_reader() {
     }
     _ondemand_json_parser = std::make_unique<simdjson::ondemand::parser>();
     for (int i = 0; i < _file_slot_descs.size(); ++i) {
-        _slot_desc_index[_file_slot_descs[i]->col_name()] = i;
+        _slot_desc_index[StringRef {_file_slot_descs[i]->col_name()}] = i;
     }
     _simdjson_ondemand_padding_buffer.resize(_padded_size);
     _simdjson_ondemand_unscape_padding_buffer.resize(_padded_size);

--- a/be/src/vec/json/parse2column.cpp
+++ b/be/src/vec/json/parse2column.cpp
@@ -210,7 +210,7 @@ void parse_json_to_variant(IColumn& column, const char* src, size_t length,
     }
     auto& [paths, values] = *result;
     assert(paths.size() == values.size());
-    phmap::flat_hash_set<StringRef, StringRefHash> paths_set;
+    phmap::flat_hash_set<std::string> paths_set;
     size_t num_rows = column_object.size();
     for (size_t i = 0; i < paths.size(); ++i) {
         FieldInfo field_info;


### PR DESCRIPTION
## Proposed changes

Make this copy constructor explicit to prevent inadvertently constructing a StringRef from a temporary std::string variable.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

