### PR TITLE
[opt](Nereids) use correct column label when execute query in FE

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/BuiltinScalarFunctions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/BuiltinScalarFunctions.java
@@ -510,7 +510,7 @@ public class BuiltinScalarFunctions implements FunctionHelper {
             scalar(CurrentDate.class, "curdate", "current_date"),
             scalar(CurrentTime.class, "curtime", "current_time"),
             scalar(CurrentUser.class, "current_user"),
-            scalar(Database.class, "database"),
+            scalar(Database.class, "database", "schema"),
             scalar(Date.class, "date"),
             scalar(DateDiff.class, "datediff"),
             scalar(DateFormat.class, "date_format"),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -450,10 +450,11 @@ public class NereidsPlanner extends Planner {
         List<String> data = Lists.newArrayList();
         for (int i = 0; i < physicalOneRowRelation.getProjects().size(); i++) {
             NamedExpression item = physicalOneRowRelation.getProjects().get(i);
+            NamedExpression output = physicalPlan.getOutput().get(i);
             Expression expr = item.child(0);
             if (expr instanceof Literal) {
                 LiteralExpr legacyExpr = ((Literal) expr).toLegacyLiteral();
-                columns.add(new Column(item.getName(), item.getDataType().toCatalogDataType()));
+                columns.add(new Column(output.getName(), output.getDataType().toCatalogDataType()));
                 super.handleLiteralInFe(legacyExpr, data);
             } else {
                 return Optional.empty();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/CurrentUser.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/CurrentUser.java
@@ -22,7 +22,7 @@ import org.apache.doris.nereids.trees.expressions.functions.AlwaysNotNullable;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
 import org.apache.doris.nereids.trees.expressions.shape.LeafExpression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
-import org.apache.doris.nereids.types.BigIntType;
+import org.apache.doris.nereids.types.StringType;
 
 import com.google.common.collect.ImmutableList;
 
@@ -35,7 +35,7 @@ public class CurrentUser extends ScalarFunction
         implements LeafExpression, ExplicitlyCastableSignature, AlwaysNotNullable {
 
     public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
-            FunctionSignature.ret(BigIntType.INSTANCE).args()
+            FunctionSignature.ret(StringType.INSTANCE).args()
     );
 
     public CurrentUser() {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

```sql
SET @a = '4';
SELECT @a;
```

previous:
```
+-----+
| '4' |
+-----+
| 4   |
+-----+
```

current:
```
+----+
| @a |
+----+
| 4  |
+----+
```



## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

