### PR TITLE
[fix](planner)isnull predicate can't be safely constant folded in inlineview

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/IsNullPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/IsNullPredicate.java
@@ -160,7 +160,7 @@ public class IsNullPredicate extends Predicate {
         // after outer join
         recursiveResetChildrenResult(!forPushDownPredicatesToView);
         final Expr childValue = getChild(0);
-        if (!(childValue instanceof LiteralExpr)) {
+        if (forPushDownPredicatesToView || !(childValue instanceof LiteralExpr)) {
             return this;
         }
         return childValue instanceof NullLiteral ? new BoolLiteral(!isNotNull) : new BoolLiteral(isNotNull);

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/FoldConstantsRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/FoldConstantsRule.java
@@ -29,6 +29,7 @@ import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.InformationFunction;
 import org.apache.doris.analysis.LiteralExpr;
 import org.apache.doris.analysis.NullLiteral;
+import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.analysis.VariableExpr;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.PrimitiveType;
@@ -127,7 +128,7 @@ public class FoldConstantsRule implements ExprRewriteRule {
         // it may be wrong to fold constant value in inline view
         // so pass the info to getResultValue method to let predicate itself
         // to decide if it can fold constant value safely
-        return expr.getResultValue(analyzer.isInlineViewAnalyzer());
+        return expr.getResultValue(expr instanceof SlotRef ? false : analyzer.isInlineViewAnalyzer());
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/FoldConstantsRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/FoldConstantsRule.java
@@ -124,7 +124,10 @@ public class FoldConstantsRule implements ExprRewriteRule {
                 return expr;
             }
         }
-        return expr.getResultValue(false);
+        // it may be wrong to fold constant value in inline view
+        // so pass the info to getResultValue method to let predicate itself
+        // to decide if it can fold constant value safely
+        return expr.getResultValue(analyzer.isInlineViewAnalyzer());
     }
 
     /**

--- a/regression-test/suites/query_p0/literal_view/lietral_test.groovy
+++ b/regression-test/suites/query_p0/literal_view/lietral_test.groovy
@@ -140,4 +140,10 @@ suite("literal_view_test") {
         sql "select * from (select null as top) t where top = 5"
         result ([])
     }
+
+    sql """set enable_nereids_planner=false;"""
+    explain {
+        sql """ select c.* from ( select a.*, '' x from test_insert a left join test_insert b on true ) c where c.x is null; """
+        notContains("VEMPTYSET")
+    }
 }


### PR DESCRIPTION
## Proposed changes
disable is null predicate constant fold rule for inline view
consider sql 
select c.* 
from ( 
     select a.*, b.x
     from test_insert a left join 
               (select 'some_const_str' x from test_insert) b on true 
      ) c 
where **c.x is null**;

when push “c.x is null” into c, after folding constant rule, it will get empty result. Because x is 'some_const_str' and "x is null" will be evaluated to false. This is wrong. 


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

