### PR TITLE
[Bug](function) fix heap-use-after-free on map_agg

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_map.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_map.h
@@ -58,13 +58,13 @@ struct AggregateFunctionMapAggData {
         _value_column->clear();
     }
 
-    void add(const StringRef& key, const Field& value) {
+    void add(StringRef key, const Field& value) {
         DCHECK(key.data != nullptr);
         if (UNLIKELY(_map.find(key) != _map.end())) {
             return;
         }
 
-        _arena.insert(key.data, key.size);
+        key.data = _arena.insert(key.data, key.size);
 
         _map.emplace(key, _key_column->size());
         _key_column->insert_data(key.data, key.size);
@@ -95,7 +95,7 @@ struct AggregateFunctionMapAggData {
                 return;
             }
 
-            _arena.insert(key.data, key.size);
+            key.data = _arena.insert(key.data, key.size);
 
             _map.emplace(key, _key_column->size());
             _key_column->insert_data(key.data, key.size);
@@ -116,7 +116,7 @@ struct AggregateFunctionMapAggData {
             if (_map.find(key) != _map.cend()) {
                 continue;
             }
-            _arena.insert(key.data, key.size);
+            key.data = _arena.insert(key.data, key.size);
 
             _map.emplace(key, _key_column->size());
             static_cast<KeyColumnType&>(*_key_column).insert_data(key.data, key.size);

--- a/be/src/vec/common/arena.h
+++ b/be/src/vec/common/arena.h
@@ -197,8 +197,8 @@ public:
       * NOTE This method is usable only for the last allocation made on this
       * Arena. For earlier allocations, see 'realloc' method.
       */
-    char* alloc_continue(size_t additional_bytes, char const*& range_start,
-                         size_t start_alignment = 0) {
+    [[nodiscard]] char* alloc_continue(size_t additional_bytes, char const*& range_start,
+                                       size_t start_alignment = 0) {
         if (!range_start) {
             // Start a new memory range.
             char* result = start_alignment ? aligned_alloc(additional_bytes, start_alignment)
@@ -245,7 +245,7 @@ public:
     }
 
     /// NOTE Old memory region is wasted.
-    char* realloc(const char* old_data, size_t old_size, size_t new_size) {
+    [[nodiscard]] char* realloc(const char* old_data, size_t old_size, size_t new_size) {
         char* res = alloc(new_size);
         if (old_data) {
             memcpy(res, old_data, old_size);
@@ -254,8 +254,8 @@ public:
         return res;
     }
 
-    char* aligned_realloc(const char* old_data, size_t old_size, size_t new_size,
-                          size_t alignment) {
+    [[nodiscard]] char* aligned_realloc(const char* old_data, size_t old_size, size_t new_size,
+                                        size_t alignment) {
         char* res = aligned_alloc(new_size, alignment);
         if (old_data) {
             memcpy(res, old_data, old_size);
@@ -265,13 +265,13 @@ public:
     }
 
     /// Insert string without alignment.
-    const char* insert(const char* data, size_t size) {
+    [[nodiscard]] const char* insert(const char* data, size_t size) {
         char* res = alloc(size);
         memcpy(res, data, size);
         return res;
     }
 
-    const char* aligned_insert(const char* data, size_t size, size_t alignment) {
+    [[nodiscard]] const char* aligned_insert(const char* data, size_t size, size_t alignment) {
         char* res = aligned_alloc(size, alignment);
         memcpy(res, data, size);
         return res;

--- a/regression-test/suites/query_p0/aggregate/map_agg.groovy
+++ b/regression-test/suites/query_p0/aggregate/map_agg.groovy
@@ -275,10 +275,4 @@ suite("map_agg") {
             select userid, map_agg(subject,score) as map from test_map_agg_score group by userid
         ) a order by userid;
     """
-
-    sql "DROP TABLE IF EXISTS `test_map_agg`"
-    sql "DROP TABLE IF EXISTS `test_map_agg_nullable`"
-    sql "DROP TABLE IF EXISTS `test_map_agg_numeric_key`"
-    sql "DROP TABLE IF EXISTS `test_map_agg_decimal`"
-    sql "DROP TABLE IF EXISTS `test_map_agg_score`"
  }


### PR DESCRIPTION
## Proposed changes
fix heap-use-after-free on map_agg

```cpp
disabled stack guard. The VM will try to fix the stack guard now.
It's highly recommended that you fix the library with 'execstack -c <libfile>', or link it with '-z noexecstack'.
=================================================================
==8358==ERROR: AddressSanitizer: heap-use-after-free on address 0x608002c319b0 at pc 0x55778c831c4d bp 0x7fa85a63b390 sp 0x7fa85a63b388
READ of size 4 at 0x608002c319b0 thread T278 (WithoutGroupTas)
    #0 0x55778c831c4c in doris::HashUtil::crc_hash(void const*, int, unsigned int) /root/doris/be/src/util/hash_util.hpp:80:40
    #1 0x55778d864183 in doris::HashUtil::hash(void const*, int, unsigned int) /root/doris/be/src/util/hash_util.hpp:299:20
    #2 0x5577986ff725 in doris::hash_value(doris::StringRef const&) /root/doris/be/src/vec/common/string_ref.h:309:12
    #3 0x5577986ff725 in unsigned long phmap::Hash<doris::StringRef>::_hash<doris::StringRef, 0>(doris::StringRef const&) const /var/local/thirdparty/installed/include/parallel_hashmap/phmap_utils.h:153:16
    #4 0x5577986ff725 in phmap::Hash<doris::StringRef>::operator()(doris::StringRef const&) const /var/local/thirdparty/installed/include/parallel_hashmap/phmap_utils.h:164:16
    #5 0x5577986ff725 in unsigned long phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::HashElement::operator()<doris::StringRef, std::piecewise_construct_t const&, std::tuple<doris::StringRef const&>, std::tuple<long const&> >(doris::StringRef const&, std::piecewise_construct_t const&, std::tuple<doris::StringRef const&>&&, std::tuple<long const&>&&) const /var/local/thirdparty/installed/include/parallel_hashmap/phmap.h:1867:48
    #6 0x5577986ff725 in decltype(std::declval<phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::HashElement>()(std::declval<doris::StringRef const& const&>(), std::piecewise_construct, std::declval<std::tuple<doris::StringRef const&> >(), std::declval<std::tuple<long const&> >())) phmap::priv::memory_internal::DecomposePairImpl<phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::HashElement, doris::StringRef const&, std::tuple<long const&> >(phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::HashElement&&, std::pair<std::tuple<doris::StringRef const&>, std::tuple<long const&> >) /var/local/thirdparty/installed/include/parallel_hashmap/phmap.h:751:12
    #7 0x5577986ff725 in decltype(memory_internal::DecomposePairImpl(std::forward<phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::HashElement>(fp), PairArgs(std::forward<std::pair<doris::StringRef const, long>&>(fp0)))) phmap::priv::DecomposePair<phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::HashElement, std::pair<doris::StringRef const, long>&>(phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::HashElement&&, std::pair<doris::StringRef const, long>&) /var/local/thirdparty/installed/include/parallel_hashmap/phmap.h:4119:12
    #8 0x5577986ff725 in decltype(phmap::priv::DecomposePair(std::declval<phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::HashElement>(), std::declval<std::pair<doris::StringRef const, long>&>())) phmap::priv::FlatHashMapPolicy<doris::StringRef, long>::apply<phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::HashElement, std::pair<doris::StringRef const, long>&>(phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::HashElement&&, std::pair<doris::StringRef const, long>&) /var/local/thirdparty/installed/include/parallel_hashmap/phmap.h:4222:16
    #9 0x5577986ff725 in decltype(phmap::priv::FlatHashMapPolicy<doris::StringRef, long>::apply(std::forward<phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::HashElement>(fp), std::forward<std::pair<doris::StringRef const, long>&>(fp0))) phmap::priv::hash_policy_traits<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, void>::apply<phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::HashElement, std::pair<doris::StringRef const, long>&, phmap::priv::FlatHashMapPolicy<doris::StringRef, long> >(phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::HashElement&&, std::pair<doris::StringRef const, long>&) /var/local/thirdparty/installed/include/parallel_hashmap/phmap_base.h:548:16
    #10 0x5577986ff725 in phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::resize(unsigned long) /var/local/thirdparty/installed/include/parallel_hashmap/phmap.h:2019:34
    #11 0x5577986ff153 in phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::prepare_insert(unsigned long) /var/local/thirdparty/installed/include/parallel_hashmap/phmap.h:2198:13
    #12 0x5577986feb54 in std::pair<unsigned long, bool> phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::find_or_prepare_insert<doris::StringRef>(doris::StringRef const&, unsigned long) /var/local/thirdparty/installed/include/parallel_hashmap/phmap.h:2186:17
    #13 0x5577987011bf in std::pair<phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::iterator, bool> phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::emplace_decomposable<doris::StringRef, std::piecewise_construct_t const&, std::tuple<doris::StringRef&>, std::tuple<unsigned long&&> >(doris::StringRef const&, unsigned long, std::piecewise_construct_t const&, std::tuple<doris::StringRef&>&&, std::tuple<unsigned long&&>&&) /var/local/thirdparty/installed/include/parallel_hashmap/phmap.h:1887:20
    #14 0x55779878b4fb in std::pair<phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::iterator, bool> phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::EmplaceDecomposable::operator()<doris::StringRef, std::piecewise_construct_t const&, std::tuple<doris::StringRef&>, std::tuple<unsigned long&&> >(doris::StringRef const&, std::piecewise_construct_t const&, std::tuple<doris::StringRef&>&&, std::tuple<unsigned long&&>&&) const /var/local/thirdparty/installed/include/parallel_hashmap/phmap.h:1898:22
    #15 0x55779878b4fb in decltype(std::declval<phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::EmplaceDecomposable>()(std::declval<doris::StringRef& const&>(), std::piecewise_construct, std::declval<std::tuple<doris::StringRef&> >(), std::declval<std::tuple<unsigned long&&> >())) phmap::priv::memory_internal::DecomposePairImpl<phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::EmplaceDecomposable, doris::StringRef&, std::tuple<unsigned long&&> >(phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::EmplaceDecomposable&&, std::pair<std::tuple<doris::StringRef&>, std::tuple<unsigned long&&> >) /var/local/thirdparty/installed/include/parallel_hashmap/phmap.h:751:12
    #16 0x55779878b4fb in decltype(memory_internal::DecomposePairImpl(std::forward<phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::EmplaceDecomposable>(fp), PairArgs(std::forward<doris::StringRef&>(fp0), std::forward<unsigned long>(fp0)))) phmap::priv::DecomposePair<phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::EmplaceDecomposable, doris::StringRef&, unsigned long>(phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::EmplaceDecomposable&&, doris::StringRef&, unsigned long&&) /var/local/thirdparty/installed/include/parallel_hashmap/phmap.h:4119:12
    #17 0x55779878b4fb in decltype(phmap::priv::DecomposePair(std::declval<phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::EmplaceDecomposable>(), std::declval<doris::StringRef&>(), std::declval<unsigned long>())) phmap::priv::FlatHashMapPolicy<doris::StringRef, long>::apply<phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::EmplaceDecomposable, doris::StringRef&, unsigned long>(phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::EmplaceDecomposable&&, doris::StringRef&, unsigned long&&) /var/local/thirdparty/installed/include/parallel_hashmap/phmap.h:4222:16
    #18 0x55779878b4fb in decltype(phmap::priv::FlatHashMapPolicy<doris::StringRef, long>::apply(std::forward<phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::EmplaceDecomposable>(fp), std::forward<doris::StringRef&>(fp0), std::forward<unsigned long>(fp0))) phmap::priv::hash_policy_traits<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, void>::apply<phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::EmplaceDecomposable, doris::StringRef&, unsigned long, phmap::priv::FlatHashMapPolicy<doris::StringRef, long> >(phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::EmplaceDecomposable&&, doris::StringRef&, unsigned long&&) /var/local/thirdparty/installed/include/parallel_hashmap/phmap_base.h:548:16
    #19 0x55779878b4fb in std::pair<phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::iterator, bool> phmap::priv::raw_hash_set<phmap::priv::FlatHashMapPolicy<doris::StringRef, long>, phmap::Hash<doris::StringRef>, phmap::EqualTo<doris::StringRef>, std::allocator<std::pair<doris::StringRef const, long> > >::emplace<doris::StringRef&, unsigned long, 0>(doris::StringRef&, unsigned long&&) /var/local/thirdparty/installed/include/parallel_hashmap/phmap.h:1438:16
    #20 0x55779878b4fb in doris::vectorized::AggregateFunctionMapAggData<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::add(doris::vectorized::Field const&, doris::vectorized::Field const&) /root/doris/be/src/vec/aggregate_functions/aggregate_function_map.h:100:18
    #21 0x557798783cac in doris::vectorized::AggregateFunctionMapAgg<doris::vectorized::AggregateFunctionMapAggData<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::deserialize_and_merge_vec(char* const*, unsigned long, char*, doris::vectorized::ColumnString const*, doris::vectorized::Arena*, unsigned long) const /root/doris/be/src/vec/aggregate_functions/aggregate_function_map.h:281:35
    #22 0x55779ec8b28b in doris::Status doris::vectorized::AggregationNode::_merge_with_serialized_key_helper<false, false>(doris::vectorized::Block*) /root/doris/be/src/vec/exec/vaggregation_node.h:693:63
    #23 0x55779eb0ae08 in doris::vectorized::AggregationNode::_merge_with_serialized_key(doris::vectorized::Block*) /root/doris/be/src/vec/exec/vaggregation_node.cpp:1535:16
    #24 0x55779edf3816 in doris::Status std::__invoke_impl<doris::Status, doris::Status (doris::vectorized::AggregationNode::*&)(doris::vectorized::Block*), doris::vectorized::AggregationNode*&, doris::vectorized::Block*>(std::__invoke_memfun_deref, doris::Status (doris::vectorized::AggregationNode::*&)(doris::vectorized::Block*), doris::vectorized::AggregationNode*&, doris::vectorized::Block*&&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74:14
    #25 0x55779edf3816 in std::enable_if<is_invocable_r_v<doris::Status, doris::Status (doris::vectorized::AggregationNode::*&)(doris::vectorized::Block*), doris::vectorized::AggregationNode*&, doris::vectorized::Block*>, doris::Status>::type std::__invoke_r<doris::Status, doris::Status (doris::vectorized::AggregationNode::*&)(doris::vectorized::Block*), doris::vectorized::AggregationNode*&, doris::vectorized::Block*>(doris::Status (doris::vectorized::AggregationNode::*&)(doris::vectorized::Block*), doris::vectorized::AggregationNode*&, doris::vectorized::Block*&&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:114:9
    #26 0x55779edf3816 in doris::Status std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::* (doris::vectorized::AggregationNode*, std::_Placeholder<1>))(doris::vectorized::Block*)>::__call<doris::Status, doris::vectorized::Block*&&, 0ul, 1ul>(std::tuple<doris::vectorized::Block*&&>&&, std::_Index_tuple<0ul, 1ul>) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:570:11
    #27 0x55779edf3816 in doris::Status std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::* (doris::vectorized::AggregationNode*, std::_Placeholder<1>))(doris::vectorized::Block*)>::operator()<doris::vectorized::Block*>(doris::vectorized::Block*&&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:629:17
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

