### PR TITLE
[fix](jni) the offset in map type is int64

### DIFF
--- a/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/vec/VectorColumn.java
+++ b/fe/be-java-extensions/java-common/src/main/java/org/apache/doris/common/jni/vec/VectorColumn.java
@@ -605,7 +605,7 @@ public class VectorColumn {
             childColumns[1].appendValue(v);
         }
         reserve(appendIndex + 1);
-        OffHeap.putInt(null, offsets + 8L * appendIndex, startOffset + length);
+        OffHeap.putLong(null, offsets + 8L * appendIndex, startOffset + length);
         return appendIndex++;
     }
 


### PR DESCRIPTION
## Proposed changes

The offset in map type column is int64, but https://github.com/apache/doris/pull/24810 has put as int32, causing error like:
```
  what():  [E11] Allocator: Cannot realloc from 4096 to 140737488355328.
	1.  @ 0x000000000eb3d670  Allocator<false, false, false>::throw_bad_alloc(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const  in .../doris/output/be/lib/doris_be
	2.  @ 0x000000000eb3da0a  Allocator<false, false, false>::realloc_impl(void*, unsigned long, unsigned long, unsigned long)  in .../doris/output/be/lib/doris_be
	3.  @ 0x000000000ee28301  doris::vectorized::JniConnector::_fill_column(doris::vectorized::JniConnector::TableMetaAddress&, COW<doris::vectorized::IColumn>::immutable_ptr<doris::vectorized::IColumn>&, std::shared_ptr<doris::vectorized::IDataType const>&, unsigned long)  in .../doris/output/be/lib/doris_be
	4.  @ 0x000000000ee292f5  doris::vectorized::JniConnector::_fill_map_column(doris::vectorized::JniConnector::TableMetaAddress&, COW<doris::vectorized::IColumn>::mutable_ptr<doris::vectorized::IColumn>&, std::shared_ptr<doris::vectorized::IDataType const>&, unsigned long)  in .../doris/output/be/lib/doris_be
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

