### PR TITLE
[improvement](outfile)support underscore prefix when select outfile

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
@@ -577,7 +577,7 @@ public class OutFileClause {
 
         if (properties.containsKey(PROP_SUCCESS_FILE_NAME)) {
             successFileName = properties.get(PROP_SUCCESS_FILE_NAME);
-            FeNameFormat.checkSuccessFileName("file name", successFileName);
+            FeNameFormat.checkOutfileSuccessFileName("file name", successFileName);
             processedPropKeys.add(PROP_SUCCESS_FILE_NAME);
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
@@ -577,7 +577,7 @@ public class OutFileClause {
 
         if (properties.containsKey(PROP_SUCCESS_FILE_NAME)) {
             successFileName = properties.get(PROP_SUCCESS_FILE_NAME);
-            FeNameFormat.checkCommonName("file name", successFileName);
+            FeNameFormat.checkSuccessFileName("file name", successFileName);
             processedPropKeys.add(PROP_SUCCESS_FILE_NAME);
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeNameFormat.java
@@ -141,7 +141,7 @@ public class FeNameFormat {
     }
 
     public static void checkOutfileSuccessFileName(String type, String name) throws AnalysisException {
-        if (Strings.isNullOrEmpty(name) || !name.matches(getSuccessFileNameRegex())) {
+        if (Strings.isNullOrEmpty(name) || !name.matches(getOutfileSuccessFileNameRegex())) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_WRONG_NAME_FORMAT, type, name);
         }
     }
@@ -196,7 +196,7 @@ public class FeNameFormat {
         }
     }
 
-    public static String getSuccessFileNameRegex() {
+    public static String getOutfileSuccessFileNameRegex() {
         if (FeNameFormat.isEnableUnicodeNameSupport()) {
             return UNICODE_UNDERSCORE_COMMON_NAME_REGEX;
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeNameFormat.java
@@ -30,12 +30,14 @@ import com.google.common.base.Strings;
 public class FeNameFormat {
     private static final String LABEL_REGEX = "^[-_A-Za-z0-9:]{1,128}$";
     private static final String COMMON_NAME_REGEX = "^[a-zA-Z][a-zA-Z0-9-_]{0,63}$";
+    private static final String UNDERSCORE_COMMON_NAME_REGEX = "^[_a-zA-Z][a-zA-Z0-9-_]{0,63}$";
     private static final String TABLE_NAME_REGEX = "^[a-zA-Z][a-zA-Z0-9-_]*$";
     private static final String USER_NAME_REGEX = "^[a-zA-Z][a-zA-Z0-9.-_]*$";
     private static final String COLUMN_NAME_REGEX = "^[_a-zA-Z@0-9\\s<>/][.a-zA-Z0-9_+-/><?@#$%^&*\"\\s,:]{0,255}$";
 
     private static final String UNICODE_LABEL_REGEX = "^[-_A-Za-z0-9:\\p{L}]{1,128}$";
     private static final String UNICODE_COMMON_NAME_REGEX = "^[a-zA-Z\\p{L}][a-zA-Z0-9-_\\p{L}]{0,63}$";
+    private static final String UNICODE_UNDERSCORE_COMMON_NAME_REGEX = "^[_a-zA-Z\\p{L}][a-zA-Z0-9-_\\p{L}]{0,63}$";
     private static final String UNICODE_TABLE_NAME_REGEX = "^[a-zA-Z\\p{L}][a-zA-Z0-9-_\\p{L}]*$";
     private static final String UNICODE_USER_NAME_REGEX = "^[a-zA-Z\\p{L}][a-zA-Z0-9.-_\\p{L}]*$";
     private static final String UNICODE_COLUMN_NAME_REGEX
@@ -137,6 +139,11 @@ public class FeNameFormat {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_WRONG_NAME_FORMAT, type, name);
         }
     }
+    public static void checkSuccessFileName(String type, String name) throws AnalysisException {
+        if (Strings.isNullOrEmpty(name) || !name.matches(getSuccessFileNameRegex())) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_WRONG_NAME_FORMAT, type, name);
+        }
+    }
 
     private static boolean isEnableUnicodeNameSupport() {
         boolean unicodeSupport;
@@ -186,5 +193,9 @@ public class FeNameFormat {
         } else {
             return COMMON_NAME_REGEX;
         }
+    }
+
+    public static String getSuccessFileNameRegex() {
+        return FeNameFormat.isEnableUnicodeNameSupport() ? UNICODE_UNDERSCORE_COMMON_NAME_REGEX : UNDERSCORE_COMMON_NAME_REGEX;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeNameFormat.java
@@ -140,7 +140,7 @@ public class FeNameFormat {
         }
     }
 
-    public static void checkSuccessFileName(String type, String name) throws AnalysisException {
+    public static void checkOutfileSuccessFileName(String type, String name) throws AnalysisException {
         if (Strings.isNullOrEmpty(name) || !name.matches(getSuccessFileNameRegex())) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_WRONG_NAME_FORMAT, type, name);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeNameFormat.java
@@ -196,6 +196,10 @@ public class FeNameFormat {
     }
 
     public static String getSuccessFileNameRegex() {
-        return FeNameFormat.isEnableUnicodeNameSupport() ? UNICODE_UNDERSCORE_COMMON_NAME_REGEX : UNDERSCORE_COMMON_NAME_REGEX;
+        if (FeNameFormat.isEnableUnicodeNameSupport()) {
+            return UNICODE_UNDERSCORE_COMMON_NAME_REGEX;
+        } else {
+            return UNDERSCORE_COMMON_NAME_REGEX;
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeNameFormat.java
@@ -139,6 +139,7 @@ public class FeNameFormat {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_WRONG_NAME_FORMAT, type, name);
         }
     }
+
     public static void checkSuccessFileName(String type, String name) throws AnalysisException {
         if (Strings.isNullOrEmpty(name) || !name.matches(getSuccessFileNameRegex())) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_WRONG_NAME_FORMAT, type, name);

--- a/fe/fe-core/src/test/java/org/apache/doris/common/FeNameFormatTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/FeNameFormatTest.java
@@ -55,6 +55,9 @@ public class FeNameFormatTest {
         ExceptionChecker.expectThrows(AnalysisException.class, () -> FeNameFormat.checkCommonName("fakeType", "_commonName"));
         ExceptionChecker.expectThrowsNoException(() -> FeNameFormat.checkCommonName("fakeType", "common-Name"));
         ExceptionChecker.expectThrowsNoException(() -> FeNameFormat.checkCommonName("fakeType", "commonName-"));
+
+        // check success file name prefix
+        ExceptionChecker.expectThrowsNoException(() -> FeNameFormat.checkColumnName("_success"));
     }
 
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/common/FeNameFormatTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/FeNameFormatTest.java
@@ -57,7 +57,7 @@ public class FeNameFormatTest {
         ExceptionChecker.expectThrowsNoException(() -> FeNameFormat.checkCommonName("fakeType", "commonName-"));
 
         // check success file name prefix
-        ExceptionChecker.expectThrowsNoException(() -> FeNameFormat.checkColumnName("_success"));
+        ExceptionChecker.expectThrowsNoException(() -> FeNameFormat.checkOutfileSuccessFileName("fakeType", "_success"));
     }
 
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
when execute SQL 'select * from test into outfile "file:///xxx" FORMAT AS CSV PROPERTIES("success_file_name" = "SUCCESS", "column_separator" = ","); ',  the property 'success_file_name' can not use underscore, like '_SUCCESS'.
It is not friendly, especially in hive or spark, reading files without underscore prefix may cause errors.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

