### PR TITLE
[chore](format) fix tablet_meta.cpp

### DIFF
--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -448,7 +448,7 @@ Status TabletMeta::_save_meta(DataDir* data_dir) {
                    << ", schema_hash=" << schema_hash();
     }
     auto t3 = MonotonicMicros();
-    auto cost =  t3 - t1;
+    auto cost = t3 - t1;
     if (cost > 1 * 1000 * 1000) {
         LOG(INFO) << "save tablet(" << full_name() << ") meta too slow. serialize cost " << t2 - t1
                   << "(us), serialized binary size: " << meta_binary.length()


### PR DESCRIPTION
fix format error introduced by #25124 

The clang format check had a bug before, so PR 25124 can pass the check at that time.
