### PR TITLE
[fix](path gc) fix data dir path gc

### DIFF
--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -636,12 +636,23 @@ void DataDir::remove_pending_ids(const std::string& id) {
     _pending_path_ids.erase(id);
 }
 
-// gc unused tablet schemahash dir
-void DataDir::perform_path_gc_by_tablet() {
+void DataDir::perform_path_gc() {
     std::unique_lock<std::mutex> lck(_check_path_mutex);
-    _check_path_cv.wait(
-            lck, [this] { return _stop_bg_worker || !_all_tablet_schemahash_paths.empty(); });
+    _check_path_cv.wait(lck, [this] {
+        return _stop_bg_worker || !_all_tablet_schemahash_paths.empty() ||
+               !_all_check_paths.empty();
+    });
     if (_stop_bg_worker) {
+        return;
+    }
+
+    _perform_path_gc_by_tablet();
+    _perform_path_gc_by_rowsetid();
+}
+
+// gc unused tablet schemahash dir
+void DataDir::_perform_path_gc_by_tablet() {
+    if (_all_tablet_schemahash_paths.empty()) {
         return;
     }
     LOG(INFO) << "start to path gc by tablet schemahash.";
@@ -685,12 +696,10 @@ void DataDir::perform_path_gc_by_tablet() {
     LOG(INFO) << "finished one time path gc by tablet.";
 }
 
-void DataDir::perform_path_gc_by_rowsetid() {
+void DataDir::_perform_path_gc_by_rowsetid() {
     // init the set of valid path
     // validate the path in data dir
-    std::unique_lock<std::mutex> lck(_check_path_mutex);
-    _check_path_cv.wait(lck, [this] { return _stop_bg_worker || !_all_check_paths.empty(); });
-    if (_stop_bg_worker) {
+    if (_all_check_paths.empty()) {
         return;
     }
     LOG(INFO) << "start to path gc by rowsetid.";

--- a/be/src/olap/data_dir.h
+++ b/be/src/olap/data_dir.h
@@ -113,9 +113,7 @@ public:
     // this is a producer function. After scan, it will notify the perform_path_gc function to gc
     Status perform_path_scan();
 
-    void perform_path_gc_by_rowsetid();
-
-    void perform_path_gc_by_tablet();
+    void perform_path_gc();
 
     void perform_remote_rowset_gc();
 
@@ -169,6 +167,10 @@ private:
     void _remove_check_paths(const std::set<std::string>& paths);
 
     bool _check_pending_ids(const std::string& id);
+
+    void _perform_path_gc_by_tablet();
+
+    void _perform_path_gc_by_rowsetid();
 
 private:
     std::atomic<bool> _stop_bg_worker = false;

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -357,11 +357,8 @@ void StorageEngine::_path_gc_thread_callback(DataDir* data_dir) {
     LOG(INFO) << "try to start path gc thread!";
     int32_t interval = config::path_gc_check_interval_second;
     do {
-        LOG(INFO) << "try to perform path gc by tablet!";
-        data_dir->perform_path_gc_by_tablet();
-
-        LOG(INFO) << "try to perform path gc by rowsetid!";
-        data_dir->perform_path_gc_by_rowsetid();
+        LOG(INFO) << "try to perform path gc!";
+        data_dir->perform_path_gc();
 
         interval = config::path_gc_check_interval_second;
         if (interval <= 0) {
@@ -370,6 +367,7 @@ void StorageEngine::_path_gc_thread_callback(DataDir* data_dir) {
             interval = 1800; // 0.5 hour
         }
     } while (!_stop_background_threads_latch.wait_for(std::chrono::seconds(interval)));
+    LOG(INFO) << "stop path gc thread!";
 }
 
 void StorageEngine::_path_scan_thread_callback(DataDir* data_dir) {

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -448,7 +448,7 @@ Status TabletMeta::_save_meta(DataDir* data_dir) {
                    << ", schema_hash=" << schema_hash();
     }
     auto t3 = MonotonicMicros();
-    auto cost =  t3 - t1;
+    auto cost = t3 - t1;
     if (cost > 1 * 1000 * 1000) {
         LOG(INFO) << "save tablet(" << full_name() << ") meta too slow. serialize cost " << t2 - t1
                   << "(us), serialized binary size: " << meta_binary.length()


### PR DESCRIPTION
## Proposed changes

Data dir path gc include gc by tablet and gc by rowset,  both use the same one thread.  If notify to gc by rowset, but the gc thread is just waiting for gc by tablet, then this thread will not try to perform gc by rowset,  it's just always waiting for gc by tablet.  Vice versa.  Fix this.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

