### PR TITLE
[enhance](cooldown) Improve cooldown logs

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -718,7 +718,8 @@ DEFINE_mInt32(zone_map_row_num_threshold, "20");
 //    Info = 4,
 //    Debug = 5,
 //    Trace = 6
-DEFINE_Int32(aws_log_level, "3");
+// Default to turn off aws sdk log, because aws sdk errors that need to be cared will be output through Doris logs
+DEFINE_Int32(aws_log_level, "0");
 
 // the buffer size when read data from remote storage like s3
 DEFINE_mInt32(remote_storage_read_buffer_mb, "16");

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -407,10 +407,10 @@ public:
 
     static Status OK() { return Status(); }
 
-#define ERROR_CTOR(name, code)                                                 \
-    template <typename... Args>                                                \
-    static Status name(std::string_view msg, Args&&... args) {                 \
-        return Error<ErrorCode::code, true>(msg, std::forward<Args>(args)...); \
+#define ERROR_CTOR(name, code)                                                       \
+    template <bool stacktrace = true, typename... Args>                              \
+    static Status name(std::string_view msg, Args&&... args) {                       \
+        return Error<ErrorCode::code, stacktrace>(msg, std::forward<Args>(args)...); \
     }
 
     ERROR_CTOR(PublishTimeout, PUBLISH_TIMEOUT)

--- a/be/src/olap/cold_data_compaction.cpp
+++ b/be/src/olap/cold_data_compaction.cpp
@@ -63,7 +63,7 @@ Status ColdDataCompaction::execute_compact_impl() {
     int64_t permits = get_compaction_permits();
     std::shared_lock cooldown_conf_rlock(_tablet->get_cooldown_conf_lock());
     if (_tablet->cooldown_conf_unlocked().first != _tablet->replica_id()) {
-        return Status::Aborted("this replica is not cooldown replica");
+        return Status::Aborted<false>("this replica is not cooldown replica");
     }
     RETURN_IF_ERROR(do_compaction(permits));
     _state = CompactionState::SUCCESS;

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2088,7 +2088,8 @@ Status Tablet::_cooldown_data() {
     RETURN_IF_ERROR(get_remote_file_system(storage_policy_id(), &dest_fs));
     auto old_rowset = pick_cooldown_rowset();
     if (!old_rowset) {
-        return Status::InternalError("cannot pick cooldown rowset in tablet {}", tablet_id());
+        LOG(INFO) << "cannot pick cooldown rowset in tablet " << tablet_id();
+        return Status::OK();
     }
     if (old_rowset->num_segments() < 1) {
         // Empty rowset, just reset rowset's resource_id
@@ -2217,8 +2218,9 @@ bool Tablet::update_cooldown_conf(int64_t cooldown_term, int64_t cooldown_replic
 Status Tablet::write_cooldown_meta() {
     std::shared_lock rlock(_cooldown_conf_lock);
     if (_cooldown_replica_id != _tablet_meta->replica_id()) {
-        return Status::Aborted("not cooldown replcia({} vs {}) tablet_id={}",
-                               _tablet_meta->replica_id(), _cooldown_replica_id, tablet_id());
+        return Status::Aborted<false>("not cooldown replica({} vs {}) tablet_id={}",
+                                      _tablet_meta->replica_id(), _cooldown_replica_id,
+                                      tablet_id());
     }
 
     std::shared_ptr<io::RemoteFileSystem> fs;
@@ -2283,7 +2285,11 @@ Status Tablet::_follow_cooldowned_data() {
     }
 
     TabletMetaPB cooldown_meta_pb;
-    RETURN_IF_ERROR(_read_cooldown_meta(fs, &cooldown_meta_pb));
+    auto st = _read_cooldown_meta(fs, &cooldown_meta_pb);
+    if (!st.ok()) {
+        LOG(INFO) << "cannot read cooldown meta: " << st;
+        return Status::InternalError<false>("cannot read cooldown meta");
+    }
     DCHECK(cooldown_meta_pb.rs_metas_size() > 0);
     if (_tablet_meta->cooldown_meta_id() == cooldown_meta_pb.cooldown_meta_id()) {
         // cooldowned rowsets are same, no need to follow
@@ -2299,7 +2305,7 @@ Status Tablet::_follow_cooldowned_data() {
         std::lock_guard wlock(_meta_lock);
         SCOPED_SIMPLE_TRACE_IF_TIMEOUT(TRACE_TABLET_LOCK_THRESHOLD);
         if (tablet_state() != TABLET_RUNNING) {
-            return Status::InternalError("tablet not running");
+            return Status::InternalError<false>("tablet not running");
         }
 
         for (auto& [v, rs] : _rs_version_map) {
@@ -2309,13 +2315,14 @@ Status Tablet::_follow_cooldowned_data() {
             }
         }
         if (!version_aligned) {
-            return Status::InternalError("cooldowned version is not aligned");
+            return Status::InternalError<false>("cooldowned version is not aligned");
         }
         for (auto& [v, rs] : _rs_version_map) {
             if (v.second <= cooldowned_version) {
                 overlap_rowsets.push_back(rs);
             } else if (!rs->is_local()) {
-                return Status::InternalError("cooldowned version larger than that to follow");
+                return Status::InternalError<false>(
+                        "cooldowned version larger than that to follow");
             }
         }
         std::sort(overlap_rowsets.begin(), overlap_rowsets.end(), Rowset::comparator);

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -448,7 +448,7 @@ Status TabletMeta::_save_meta(DataDir* data_dir) {
                    << ", schema_hash=" << schema_hash();
     }
     auto t3 = MonotonicMicros();
-    auto cost =  t3 - t1;
+    auto cost = t3 - t1;
     if (cost > 1 * 1000 * 1000) {
         LOG(INFO) << "save tablet(" << full_name() << ") meta too slow. serialize cost " << t2 - t1
                   << "(us), serialized binary size: " << meta_binary.length()


### PR DESCRIPTION
## Proposed changes

Cooldown meta not found  in `_follow_cooldowned_data` is usually an expected phenomenon rather than data loss, because cooldown replica may not complete uploading yet. This PR reduces log level to `INFO` to avoid misleading users.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

