### PR TITLE
[Bugfix](regression-test) Fix a naming conflict in ccr regression test

### DIFF
--- a/regression-test/suites/ccr_mow_syncer_p0/test_create_table_with_binlog_config.groovy
+++ b/regression-test/suites/ccr_mow_syncer_p0/test_create_table_with_binlog_config.groovy
@@ -21,73 +21,73 @@ suite("test_mow_create_table_with_binlog_config") {
         logger.info("fe enable_feature_binlog is false, skip case test_mow_create_table_with_binlog_config")
         return
     }
-    sql "drop database if exists test_table_binlog"
+    sql "drop database if exists test_mow_table_binlog"
 
     sql """
-        create database test_table_binlog
+        create database test_mow_table_binlog
         """
-    result = sql "show create database test_table_binlog"
+    def result = sql "show create database test_mow_table_binlog"
     logger.info("${result}")
 
     // Case 1: database disable binlog, create table with binlog disable
     sql """
-        CREATE TABLE test_table_binlog.t1 ( k1 INT ) ENGINE = olap UNIQUE KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 3 PROPERTIES ( "enable_unique_key_merge_on_write" = "true", "replication_num" = "1", "binlog.enable" = "false" );
+        CREATE TABLE test_mow_table_binlog.t1 ( k1 INT ) ENGINE = olap UNIQUE KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 3 PROPERTIES ( "enable_unique_key_merge_on_write" = "true", "replication_num" = "1", "binlog.enable" = "false" );
         """
-    result = sql "show create table test_table_binlog.t1"
+    result = sql "show create table test_mow_table_binlog.t1"
     logger.info("${result}")
     assertTrue(result.toString().containsIgnoreCase('"binlog.enable" = "false"'))
     sql """
-        drop table if exists test_table_binlog.t1
+        drop table if exists test_mow_table_binlog.t1
         """
 
     // Case 2: database disable binlog, create table with binlog enable
     sql """
-        CREATE TABLE test_table_binlog.t1 ( k1 INT ) ENGINE = olap UNIQUE KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 3 PROPERTIES ( "enable_unique_key_merge_on_write" = "true", "replication_num" = "1", "binlog.enable" = "true" );
+        CREATE TABLE test_mow_table_binlog.t1 ( k1 INT ) ENGINE = olap UNIQUE KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 3 PROPERTIES ( "enable_unique_key_merge_on_write" = "true", "replication_num" = "1", "binlog.enable" = "true" );
         """
-    result = sql "show create table test_table_binlog.t1"
+    result = sql "show create table test_mow_table_binlog.t1"
     logger.info("${result}")
     assertTrue(result.toString().containsIgnoreCase('"binlog.enable" = "true"'))
     sql """
-        drop table if exists test_table_binlog.t1
+        drop table if exists test_mow_table_binlog.t1
         """
 
     // Case 3: database enable binlog, create table with binlog disable
     sql """
-        alter database test_table_binlog set properties ("binlog.enable" = "true")
+        alter database test_mow_table_binlog set properties ("binlog.enable" = "true")
         """
     assertThrows(Exception.class, {
         sql """
-            CREATE TABLE test_table_binlog.t1 ( k1 INT ) ENGINE = olap UNIQUE KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 3 PROPERTIES ( "enable_unique_key_merge_on_write" = "true", "replication_num" = "1", "binlog.enable" = "false" );
+            CREATE TABLE test_mow_table_binlog.t1 ( k1 INT ) ENGINE = olap UNIQUE KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 3 PROPERTIES ( "enable_unique_key_merge_on_write" = "true", "replication_num" = "1", "binlog.enable" = "false" );
             """
     })
     sql """
-        drop table if exists test_table_binlog.t1
+        drop table if exists test_mow_table_binlog.t1
         """
 
     // Case 4: database enable binlog, create table with binlog enable
     sql """
-        alter database test_table_binlog set properties ("binlog.enable" = "true")
+        alter database test_mow_table_binlog set properties ("binlog.enable" = "true")
         """
     sql """
-        CREATE TABLE test_table_binlog.t1 ( k1 INT ) ENGINE = olap UNIQUE KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 3 PROPERTIES ( "enable_unique_key_merge_on_write" = "true", "replication_num" = "1", "binlog.enable" = "true" );
+        CREATE TABLE test_mow_table_binlog.t1 ( k1 INT ) ENGINE = olap UNIQUE KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 3 PROPERTIES ( "enable_unique_key_merge_on_write" = "true", "replication_num" = "1", "binlog.enable" = "true" );
         """
-    result = sql "show create table test_table_binlog.t1"
+    result = sql "show create table test_mow_table_binlog.t1"
     logger.info("${result}")
     assertTrue(result.toString().containsIgnoreCase('"binlog.enable" = "true"'))
     sql """
-        drop table if exists test_table_binlog.t1
+        drop table if exists test_mow_table_binlog.t1
         """
 
     // Case 5: database enable binlog, create table inherit database binlog config
     sql """
-        CREATE TABLE test_table_binlog.t1 ( k1 INT ) ENGINE = olap UNIQUE KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 3 PROPERTIES ( "enable_unique_key_merge_on_write" = "true", "replication_num" = "1" );
+        CREATE TABLE test_mow_table_binlog.t1 ( k1 INT ) ENGINE = olap UNIQUE KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 3 PROPERTIES ( "enable_unique_key_merge_on_write" = "true", "replication_num" = "1" );
         """
-    result = sql "show create table test_table_binlog.t1"
+    result = sql "show create table test_mow_table_binlog.t1"
     logger.info("${result}")
     assertTrue(result.toString().containsIgnoreCase('"binlog.enable" = "true"'))
     sql """
-        drop table if exists test_table_binlog.t1
+        drop table if exists test_mow_table_binlog.t1
         """
 
-    sql "drop database if exists test_table_binlog"
+    sql "drop database if exists test_mow_table_binlog"
 }

--- a/regression-test/suites/ccr_mow_syncer_p0/test_get_binlog.groovy
+++ b/regression-test/suites/ccr_mow_syncer_p0/test_get_binlog.groovy
@@ -113,8 +113,8 @@ suite("test_mow_get_binlog_case") {
     
     logger.info("=== Test 3.2: no priv user get binlog case ===")
     syncer.context.seq = -1
-    noPrivUser = "no_priv_user0"
-    emptyTable = "tbl_empty_test"
+    def noPrivUser = "no_priv_mow_user0"
+    def emptyTable = "tbl_mow_empty_test"
     sql "DROP TABLE IF EXISTS ${emptyTable}"
     sql """
         CREATE TABLE if NOT EXISTS ${emptyTable} 

--- a/regression-test/suites/ccr_syncer_p0/test_create_table_with_binlog_config.groovy
+++ b/regression-test/suites/ccr_syncer_p0/test_create_table_with_binlog_config.groovy
@@ -26,7 +26,7 @@ suite("test_create_table_with_binlog_config") {
     sql """
         create database test_table_binlog
         """
-    result = sql "show create database test_table_binlog"
+    def result = sql "show create database test_table_binlog"
     logger.info("${result}")
 
     // Case 1: database disable binlog, create table with binlog disable

--- a/regression-test/suites/ccr_syncer_p0/test_get_binlog.groovy
+++ b/regression-test/suites/ccr_syncer_p0/test_get_binlog.groovy
@@ -112,8 +112,8 @@ suite("test_get_binlog_case") {
     
     logger.info("=== Test 3.2: no priv user get binlog case ===")
     syncer.context.seq = -1
-    noPrivUser = "no_priv_user2"
-    emptyTable = "tbl_empty_test"
+    def noPrivUser = "no_priv_user2"
+    def emptyTable = "tbl_empty_test"
     sql "DROP TABLE IF EXISTS ${emptyTable}"
     sql """
         CREATE TABLE if NOT EXISTS ${emptyTable} 


### PR DESCRIPTION
## BUG
1. Operating the same DB in the `ccr_mow_syncer_p0.test_create_table_with_binlog_config` test as in the `ccr_syncer_p0.test_create_table_with_binlog_config` test will result in the same DBs in both test to get results that are not expected when the two tests are executed at the same time
2. Created and manipulated the same username in the `ccr_mow_syncer_p0.test_get_binlog` test as in the `ccr_syncer_p0.test_get_binlog` test, which would cause the test results to not be as expected

## FIX
- Rename DB and user in `ccr_mow_syncer_p0` cases
- Replacing Global Variables with Local Variables