### PR TITLE
[fix](build) aarch64 compilation fix #

### DIFF
--- a/be/src/common/stack_trace.cpp
+++ b/be/src/common/stack_trace.cpp
@@ -38,7 +38,7 @@
 #include "vec/common/demangle.h"
 #include "vec/common/hex.h"
 
-#if USE_UNWIND
+#if USE_UNWIND && defined(__x86_64__)
 #include <libunwind.h>
 #else
 #include <execinfo.h>


### PR DESCRIPTION
## Proposed changes
Compilation to include execinfo when building on aarch64


Issue Number: close #25442

<!--Describe your changes.-->

synchronized the include and usage of backtrace/unwind lib usage, for ccompilation fix

![image](https://github.com/apache/doris/assets/66766227/e323d1a7-783c-4eec-8362-1f3ce28eee17)
