### PR TITLE
[Bug](table-function) insert default when json array parse failed

### DIFF
--- a/be/src/vec/exprs/table_function/vexplode_json_array.cpp
+++ b/be/src/vec/exprs/table_function/vexplode_json_array.cpp
@@ -215,7 +215,7 @@ Status VExplodeJsonArrayTableFunction::process_close() {
 }
 
 void VExplodeJsonArrayTableFunction::get_value(MutableColumnPtr& column) {
-    if (current_empty()) {
+    if (current_empty() || _parsed_data.get_value(_type, _cur_offset, true) == nullptr) {
         column->insert_default();
     } else {
         column->insert_data((char*)_parsed_data.get_value(_type, _cur_offset, true),

--- a/regression-test/data/query_p0/sql_functions/table_function/explode_json_array.out
+++ b/regression-test/data/query_p0/sql_functions/table_function/explode_json_array.out
@@ -21,6 +21,10 @@
 30	8
 60	8
 
+-- !explode_json_array_8_invalid --
+0	8
+60	8
+
 -- !explode_json_array9 --
 
 -- !explode_json_array10 --

--- a/regression-test/suites/query_p0/sql_functions/table_function/explode_json_array.groovy
+++ b/regression-test/suites/query_p0/sql_functions/table_function/explode_json_array.groovy
@@ -45,6 +45,11 @@ suite("explode_json_array") {
                         LATERAL VIEW EXPLODE_JSON_ARRAY_INT('[40, 80]') t2 as d_age 
                         GROUP BY c_age ORDER BY c_age """
 
+    qt_explode_json_array_8_invalid """ SELECT c_age, COUNT(1) FROM ${tableName}
+                        LATERAL VIEW EXPLODE_JSON_ARRAY_INT('["1", 60]') t1 as c_age 
+                        LATERAL VIEW EXPLODE_JSON_ARRAY_INT('["b", "c"]') t2 as d_age 
+                        GROUP BY c_age ORDER BY c_age """
+
     qt_explode_json_array9 """ SELECT * FROM ${tableName}
                             LATERAL VIEW EXPLODE_JSON_ARRAY_INT('[]') t1 AS c_age 
                             ORDER BY id, c_age """


### PR DESCRIPTION
## Proposed changes
```cpp
 7# long unaligned_load(void const*) at /home/zcp/repo_center/doris_master/doris/be/src/vec/common/unaligned.h:30
 8# doris::vectorized::ColumnVector::insert_data(char const*, unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/vec/columns/column_vector.h:189
 9# doris::vectorized::VExplodeJsonArrayTableFunction::get_value(COW::mutable_ptr&) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exprs/table_function/vexplode_json_array.cpp:224
10# doris::vectorized::TableFunction::get_value(COW::mutable_ptr&, int) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exprs/table_function/table_function.h:63
11# doris::vectorized::VTableFunctionNode::_get_expanded_block(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exec/vtable_function_node.cpp:199
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

