### PR TITLE
[WIP][Fix](Table)Fix create table like error, the converted table field COMMENT contains extra characters

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/io/DiskUtils.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/io/DiskUtils.java
@@ -23,18 +23,16 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 
 @Slf4j
 public class DiskUtils {
 
     public static class Df {
         public String fileSystem = "";
-        public long blocks;
-        public long used;
-        public long available;
-        public int useRate;
+        public long blocks = 0L;
+        public long used = 0L;
+        public long available = 0L;
+        public int useRate = 0;
         public String mountedOn = "";
     }
 
@@ -46,52 +44,83 @@ public class DiskUtils {
             return df;
         }
 
+
         Process process;
         try {
-            process = Runtime.getRuntime().exec("df " + dir);
+            process = Runtime.getRuntime().exec("df -k" + dir);
             InputStream inputStream = process.getInputStream();
             BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
-
+            Df df = new Df();
             // Filesystem      1K-blocks       Used Available Use% Mounted on
             // /dev/sdc       5814186096 5814169712         0 100% /home/spy-sd/sdc
             String titleLine = reader.readLine();
             String dataLine = reader.readLine();
             if (titleLine == null || dataLine == null) {
-                return null;
+                return df;
             }
-            String[] values = dataLine.split("\\s+");
-            if (values.length != 6) {
-                return null;
+            String[] dfValues = dataLine.split("\\s+");
+            if (os.startsWith("Mac")) {
+                parseMacOSDiskInfo(dfValues, df);
+            } else {
+                parseLinuxDiskInfo(dfValues, df);
             }
-
-            Df df = new Df();
-            df.fileSystem = values[0];
-            df.blocks = Long.parseLong(values[1]);
-            df.used = Long.parseLong(values[2]);
-            df.available = Long.parseLong(values[3]);
-            df.useRate = Integer.parseInt(values[4].replace("%", ""));
-            df.mountedOn = values[5];
             return df;
         } catch (IOException e) {
             log.info("failed to obtain disk information", e);
-            return null;
+            return new Df();
         }
     }
 
-    private static List<String> getTitles(String titlesLine) {
-        List<String> titles = new ArrayList<>();
-        String[] titleArray = titlesLine.split("\\s+");
-        for (String title : titleArray) {
-            if (title.equalsIgnoreCase("on")) {
-                if (!titles.isEmpty()) {
-                    int lastIdx = titles.size() - 1;
-                    titles.set(lastIdx, titles.get(lastIdx) + "On");
-                }
-            } else {
-                titles.add(title);
-            }
+    /**
+     * Linux df -k output
+     * Filesystem     1K-blocks     Used Available Use% Mounted on
+     * /dev/sda1       8256952  2094712   5742232  27% /
+     */
+    private static void parseLinuxDiskInfo(String[] dfValues, Df df) {
+        if (dfValues.length != 6) {
+            return;
         }
-        return titles;
+        df.fileSystem = dfValues[0];
+        df.blocks = parseLongValue(dfValues[1]);
+        df.used = parseLongValue(dfValues[2]);
+        df.available = parseLongValue(dfValues[3]);
+        df.useRate = parseIntegerValue(dfValues[4].replace("%", ""));
+        df.mountedOn = dfValues[5];
+    }
+
+    /**
+     * MacOS df -k output
+     * Filesystem    1024-blocks      Used Available Capacity iused      ifree %iused  Mounted on
+     * /dev/disk1s1   488555536  97511104  390044432    20%  121655 4884849711    0%   /
+     */
+    private static void parseMacOSDiskInfo(String[] dfValues, Df df) {
+        if (dfValues.length != 9) {
+            return;
+        }
+        df.fileSystem = dfValues[0];
+        df.blocks = Long.parseLong(dfValues[1]);
+        df.used = parseLongValue(dfValues[2]);
+        df.available = parseLongValue(dfValues[3]);
+        df.useRate = parseIntegerValue(dfValues[4].replace("%", ""));
+        df.mountedOn = dfValues[8];
+    }
+
+    private static long parseLongValue(String value) {
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            e.printStackTrace();
+            return 0L;
+        }
+    }
+
+    private static int parseIntegerValue(String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            e.printStackTrace();
+            return 0;
+        }
     }
 
     private static String[] units = new String[]{"", "K", "M", "G", "T", "P"};

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Column.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Column.java
@@ -767,7 +767,7 @@ public class Column implements Writable, GsonPostProcessable {
             }
         }
         if (StringUtils.isNotBlank(comment)) {
-            sb.append(" COMMENT '").append(getComment(true)).append("'");
+            sb.append(" COMMENT ").append(addQuotesIfNeeded(getComment(true)));
         }
         return sb.toString();
     }
@@ -967,5 +967,28 @@ public class Column implements Writable, GsonPostProcessable {
     public boolean isMaterializedViewColumn() {
         return getName().startsWith(CreateMaterializedViewStmt.MATERIALIZED_VIEW_NAME_PREFIX)
                 || getName().startsWith(CreateMaterializedViewStmt.MATERIALIZED_VIEW_AGGREGATE_NAME_PREFIX);
+    }
+
+    /**
+     * Adds single quote characters at the beginning and end of a string if necessary.
+     *
+     * @param str The original string.
+     * @return The modified string with single quotes added if needed.
+     */
+    public static String addQuotesIfNeeded(String str) {
+        if (str.isEmpty()) {
+            // If the original string is empty, return two single quote characters
+            return "''";
+        }
+        StringBuilder sb = new StringBuilder(str);
+        // Check if the beginning needs to add a single quote
+        if (str.charAt(0) != '\'') {
+            sb.insert(0, '\'');
+        }
+        // Check if the end needs to add a single quote
+        if (str.charAt(str.length() - 1) != '\'') {
+            sb.append('\'');
+        }
+        return sb.toString();
     }
 }

--- a/regression-test/suites/table_p0/crete_table_like_p0.groovy
+++ b/regression-test/suites/table_p0/crete_table_like_p0.groovy
@@ -1,0 +1,32 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("crete_table_like_p0") {
+    sql """DROP TABLE IF EXISTS test_create_table"""
+    sql """ 
+            CREATE TABLE test_create_table (
+              a DATEV2 NOT NULL COMMENT "a",
+              b VARCHAR(96) NOT NULL COMMENT 'b',
+              c VARCHAR(96) NOT NULL COMMENT 'c',
+              d VARCHAR(96) COMMENT '',
+              e bigint NOT NULL  )
+            DISTRIBUTED BY HASH(e) BUCKETS 1
+            PROPERTIES( 'replication_num' = '1');
+    """
+    sql """DROP TABLE IF EXISTS test_create_table_like"""
+    sql """create table test_create_table_like like test_create_table"""
+}


### PR DESCRIPTION
### Error Context
```sql
CREATE TABLE test_create_table (
  a DATEV2 NOT NULL COMMENT "a",
  b VARCHAR(96) NOT NULL COMMENT 'b',
  c VARCHAR(96) NOT NULL COMMENT 'c',
  d VARCHAR(96) COMMENT '',
  e bigint NOT NULL  )
DISTRIBUTED BY HASH(e) BUCKETS 1
PROPERTIES( 'replication_num' = '1');

create table test_create_table_like like test_create_table

show create table test_create_table_like
```

``` error log
2023-10-16 11:46:39,422 WARN (mysql-nio-pool-1|298) [StmtExecutor.handleDdlStmt():2321] DDL statement(/* ApplicationName=DataGrip 2023.1.1 */ create table test_create_table_like like test_create_table) process failed.
org.apache.doris.common.DdlException: errCode = 2, detailMessage = Failed to execute CREATE TABLE LIKE test_create_table. Reason: errCode = 2, detailMessage = Syntax error in line 3:
  `b` varchar(96) NOT NULL COMMENT ''b'',
                                     ^
Encountered: IDENTIFIER
Expected: COMMA

        at org.apache.doris.datasource.InternalCatalog.createTableLike(InternalCatalog.java:1187) ~[classes/:?]
        at org.apache.doris.catalog.Env.createTableLike(Env.java:2878) ~[classes/:?]
        at org.apache.doris.qe.DdlExecutor.execute(DdlExecutor.java:163) ~[classes/:?]
        at org.apache.doris.qe.StmtExecutor.handleDdlStmt(StmtExecutor.java:2312) ~[classes/:?]
        at org.apache.doris.qe.StmtExecutor.executeByLegacy(StmtExecutor.java:772) ~[classes/:?]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:468) ~[classes/:?]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:438) ~[classes/:?]
        at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:353) ~[classes/:?]

```

### Affected version
master 
### Changes

Considering that our `Comment` currently contains single quote characters, this change will
When encapsulating `Comment`, it will be judged. If `Comment` itself already contains single quotes, there is no need to add '.
In this way, if we directly use the `Comment` field later, we can remove the single quotes without any impact. It is compatible with both old and new versions.