### PR TITLE
[Fix](Nereids) fix create table as select of view with unknown length character type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateTableCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateTableCommand.java
@@ -108,8 +108,8 @@ public class CreateTableCommand extends Command implements ForwardWithSync {
             } else if (i == 0 && dataType.isStringType()) {
                 dataType = VarcharType.createVarcharType(ScalarType.MAX_VARCHAR_LENGTH);
             } else if (dataType instanceof CharacterType) {
-                // if column is not come from column, we should set varchar length to max
-                if (((CharacterType) dataType).getLen() > 0 && !s.isColumnFromTable()) {
+                // if column is not come from table, we should set varchar length to max
+                if (!s.isColumnFromTable()) {
                     dataType = VarcharType.createVarcharType(ScalarType.MAX_VARCHAR_LENGTH);
                 }
             }

--- a/regression-test/suites/ddl_p0/test_ctas.groovy
+++ b/regression-test/suites/ddl_p0/test_ctas.groovy
@@ -252,5 +252,43 @@ suite("test_ctas") {
         sql 'drop table c'
         sql 'drop table test_date_v2'
     }
+
+    try {
+        sql '''set enable_nereids_planner=true;'''
+        sql'''CREATE TABLE `test_ctas_of_view` (
+            `l_varchar` varchar(65533) NULL
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`l_varchar`)
+        COMMENT 'OLAP\'
+        DISTRIBUTED BY HASH(`l_varchar`) BUCKETS 10
+        PROPERTIES (
+                "replication_allocation" = "tag.location.default: 1",
+                "is_being_synced" = "false",
+                "storage_format" = "V2",
+                "light_schema_change" = "true",
+                "disable_auto_compaction" = "false",
+                "enable_single_replica_compaction" = "false"
+        );'''
+
+        sql '''insert into test_ctas_of_view values ('a');'''
+
+        sql '''CREATE VIEW `ctas_view` COMMENT 'VIEW' 
+        AS SELECT `l_varchar` AS `l_varchar_1`, 
+        CAST(row_number() OVER (ORDER BY `l_varchar` ASC NULLS FIRST) AS CHARACTER) AS `l_varchar_2` 
+        FROM test_ctas_of_view;'''
+
+        sql '''create table test_ctas 
+        PROPERTIES ( "replication_allocation" = "tag.location.default: 1") 
+        as select  l_varchar_1 
+        from ctas_view;'''
+
+        String desc = sql 'desc test_ctas'
+        assertTrue(desc.contains('Yes'))
+
+    } finally {
+        sql 'drop table test_ctas'
+        sql 'drop table test_ctas_of_view'
+        sql 'drop view ctas_view'
+    }
 }
 


### PR DESCRIPTION
Problem:
when create table as select from a view with unknown length character type, be would return an error of inserting data failed
Example:
doris/regression-test/suites/ddl_p0/test_ctas.groovy
Reason & Solved:
BE can not derive varchar length automaticly so FE should tell BE to maximize the size of varchar type

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

