### PR TITLE
[fix](profile) add projection time in total time

### DIFF
--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -519,6 +519,7 @@ std::string ExecNode::get_name() {
 
 Status ExecNode::do_projections(vectorized::Block* origin_block, vectorized::Block* output_block) {
     SCOPED_TIMER(_projection_timer);
+    SCOPED_TIMER(_runtime_profile->total_time_counter());
     using namespace vectorized;
     MutableBlock mutable_block =
             VectorizedUtils::build_mutable_mem_reuse_block(output_block, *_output_row_descriptor);

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -97,6 +97,8 @@ public:
 
         virtual void update(int64_t delta) { _value.fetch_add(delta, std::memory_order_relaxed); }
 
+        void sub_value(int64_t delta) { _value.fetch_sub(delta, std::memory_order_relaxed); }
+
         void bit_or(int64_t delta) { _value.fetch_or(delta, std::memory_order_relaxed); }
 
         virtual void set(int64_t value) { _value.store(value, std::memory_order_relaxed); }
@@ -341,6 +343,8 @@ public:
     // Does not hold locks when it makes any function calls.
     void to_thrift(TRuntimeProfileTree* tree);
     void to_thrift(std::vector<TRuntimeProfileNode>* nodes);
+
+    void sub_projection();
 
     // Divides all counters by n
     void divide(int n);


### PR DESCRIPTION
## Proposed changes



before
```

                    VAGGREGATION_NODE  (id=276):_(Active:  6s210ms,_  %  non-child:  0.00%)
                          -  BuildTime:  912.566ms
                          -  ExecTime:  911.374ms
                          -  ExprTime:  377.651us
                          -  ProjectionTime:  0ns
                          -  RowsReturned:  1
                        VNewOlapScanNode(dbtime)  (id=269):(Active:  18.529ms,  %  non-child:  0.00%)
                              -  ProjectionTime:  5s254ms
```
now


```
                    VAGGREGATION_NODE  (id=276):(Active:  953.243ms,  %  non-child:  0.00%)
                          -  BuildTime:  879.855ms
                          -  DeserializeAndMergeTime:  0ns
                          -  ExecTime:  878.27ms
                          -  ExprTime:  652.465us
                        VNewOlapScanNode(dbtime)  (id=269):(Active:  5s485ms,  %  non-child:  0.00%)
                              -  ProjectionTime:  5s450ms


```
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

