### PR TITLE
[feature](insert) Support group commit insert use new syntax like insert into table_id(xxx)

### DIFF
--- a/be/src/runtime/group_commit_mgr.cpp
+++ b/be/src/runtime/group_commit_mgr.cpp
@@ -194,7 +194,7 @@ Status GroupCommitTable::_create_group_commit_load(
     std::regex reg("-");
     std::string label = "group_commit_" + std::regex_replace(load_id.to_string(), reg, "_");
     std::stringstream ss;
-    ss << "insert into " << table_id << " WITH LABEL " << label
+    ss << "insert into table_id(" << table_id << ") WITH LABEL " << label
        << " select * from group_commit(\"table_id\"=\"" << table_id << "\")";
     request.__set_load_sql(ss.str());
     request.__set_loadId(tload_id);

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -594,6 +594,7 @@ terminal String
     KW_SYNC,
     KW_SYSTEM,
     KW_TABLE,
+    KW_TABLE_ID,
     KW_TABLES,
     KW_TABLESAMPLE,
     KW_TABLET,
@@ -4840,7 +4841,7 @@ insert_stmt ::=
     // TODO(zc) add default value for SQL-2003
     // | KW_INSERT KW_INTO insert_target:target KW_DEFAULT KW_VALUES
     | /* used for group commit */
-    KW_INSERT KW_INTO INTEGER_LITERAL:table_id opt_with_label:label opt_col_list:cols opt_plan_hints:hints insert_source:source
+    KW_INSERT KW_INTO KW_TABLE_ID LPAREN INTEGER_LITERAL:table_id RPAREN opt_with_label:label opt_col_list:cols opt_plan_hints:hints insert_source:source
     {:
         RESULT = new NativeInsertStmt(table_id, label, cols, source, hints);
     :}

--- a/fe/fe-core/src/main/jflex/sql_scanner.flex
+++ b/fe/fe-core/src/main/jflex/sql_scanner.flex
@@ -447,6 +447,7 @@ import org.apache.doris.qe.SqlModeHelper;
         keywordMap.put("sync", new Integer(SqlParserSymbols.KW_SYNC));
         keywordMap.put("system", new Integer(SqlParserSymbols.KW_SYSTEM));
         keywordMap.put("table", new Integer(SqlParserSymbols.KW_TABLE));
+        keywordMap.put("table_id", new Integer(SqlParserSymbols.KW_TABLE_ID));
         keywordMap.put("tables", new Integer(SqlParserSymbols.KW_TABLES));
         keywordMap.put("tablesample", new Integer(SqlParserSymbols.KW_TABLESAMPLE));
         keywordMap.put("tablet", new Integer(SqlParserSymbols.KW_TABLET));


### PR DESCRIPTION
## Proposed changes

Support group commit insert use new syntax like insert into table_id(xxx)

``` sql
insert into  table_id(12121) values('1111', 'a') , ('2222', 'b');
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

