### PR TITLE
[opt](index compaction) optimize checks before index compaction

### DIFF
--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -556,7 +556,8 @@ Status Compaction::construct_output_rowset_writer(RowsetWriterContext& ctx, bool
                             auto index_meta =
                                     rowset->tablet_schema()->get_inverted_index(unique_id);
                             if (index_meta == nullptr) {
-                                LOG(WARNING) << "tablet[" << _tablet->tablet_id() << "] index_unique_id[" << unique_id
+                                LOG(WARNING) << "tablet[" << _tablet->tablet_id()
+                                             << "] index_unique_id[" << unique_id
                                              << "] index meta is null, will skip index compaction";
                                 return false;
                             }
@@ -572,8 +573,9 @@ Status Compaction::construct_output_rowset_writer(RowsetWriterContext& ctx, bool
                                     return false;
                                 }
                                 if (!exists) {
-                                    LOG(WARNING) << "tablet[" << _tablet->tablet_id() << "] index_unique_id["
-                                                 << unique_id << "]," << inverted_index_src_file_path
+                                    LOG(WARNING) << "tablet[" << _tablet->tablet_id()
+                                                 << "] index_unique_id[" << unique_id << "],"
+                                                 << inverted_index_src_file_path
                                                  << " is not exists, will skip index compaction";
                                     return false;
                                 }
@@ -582,13 +584,14 @@ Status Compaction::construct_output_rowset_writer(RowsetWriterContext& ctx, bool
                                 int64_t file_size = 0;
                                 if (fs->file_size(inverted_index_src_file_path, &file_size) !=
                                     Status::OK()) {
-                                    LOG(ERROR)
-                                            << inverted_index_src_file_path << " fs->file_size error";
+                                    LOG(ERROR) << inverted_index_src_file_path
+                                               << " fs->file_size error";
                                     return false;
                                 }
                                 if (file_size == 0) {
-                                    LOG(WARNING) << "tablet[" << _tablet->tablet_id() << "] index_unique_id["
-                                                 << unique_id << "]," << inverted_index_src_file_path
+                                    LOG(WARNING) << "tablet[" << _tablet->tablet_id()
+                                                 << "] index_unique_id[" << unique_id << "],"
+                                                 << inverted_index_src_file_path
                                                  << " is empty file, will skip index compaction";
                                     return false;
                                 }
@@ -606,8 +609,9 @@ Status Compaction::construct_output_rowset_writer(RowsetWriterContext& ctx, bool
                                 // why is 3?
                                 // bkd index will write at least 3 files
                                 if (files.size() < 3) {
-                                    LOG(WARNING) << "tablet[" << _tablet->tablet_id() << "] index_unique_id["
-                                                 << unique_id << "]," << inverted_index_src_file_path
+                                    LOG(WARNING) << "tablet[" << _tablet->tablet_id()
+                                                 << "] index_unique_id[" << unique_id << "],"
+                                                 << inverted_index_src_file_path
                                                  << " is corrupted, will skip index compaction";
                                     return false;
                                 }


### PR DESCRIPTION
## Proposed changes

If inverted index file is empty or corrupted, the index compaction will crash.
So we add more checks before apply index compaction.

<!--Describe your changes.-->

### index file count tests
```sql
CREATE TABLE t1
(
    k1 int ,
    k2 string,
    k3 char(50),
    k4 varchar(200),
    k5 int,
    index index_int (k1) using inverted,
    index index_str_k2 (k2) using inverted properties("parser"="english"),
    index index_str_k4 (k4) using inverted,
    index index_k5 (k5) using inverted
)
DISTRIBUTED BY RANDOM BUCKETS 1
PROPERTIES("replication_num" = "1");
-- q1
insert into t1 values(1, "json love anny", "json", "anny",1);
-- q2
insert into t1 values(1, "", "", "",null);
-- q3
insert into t1 values(1, null, null, null,null);
```
#### index file list
![image](https://github.com/apache/doris/assets/26450235/6124902b-dc44-48a2-aa0b-b0e5d387116d)

1. q1
![image](https://github.com/apache/doris/assets/26450235/07bc23f0-1f4a-4bff-a868-fd7137b3290a)

2. q2
![image](https://github.com/apache/doris/assets/26450235/d209085a-3500-44c2-8613-54ebbec7cab3)

3. q3
![image](https://github.com/apache/doris/assets/26450235/e4519bd4-41ed-4e99-89c4-c4cc107f3c57)


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

