### PR TITLE
[fix](regression-test)Fix test insert from tvf with common user

### DIFF
--- a/regression-test/suites/external_table_p0/tvf/test_insert_from_tvf_with_common_user.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_insert_from_tvf_with_common_user.groovy
@@ -97,11 +97,12 @@ suite("test_insert_from_tvf_with_common_user", "p0") {
                     "ACCESS_KEY"= "${ak}",
                     "SECRET_KEY" = "${sk}",
                     "format" = "csv",
+                    "column_separator" = "\t",
                     "region" = "${region}"
                 );
             """
 
-        order_qt_select_base """ SELECT * FROM ${export_table_name} t ORDER BY id; """
+        order_qt_select_base """ SELECT * FROM ${load_table_name} t ORDER BY id; """
     }
 
     sql """drop user ${common_user}"""


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
caused by #24706 
Because this PR has changed the default `column_separator` of TVF to '\t'

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

