### PR TITLE
[improvement](tablet clone) tablet balance ignore deleted partitions

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -194,6 +194,17 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         idToRecycleTime.put(id, recycleTime);
     }
 
+    public synchronized boolean isRecyclePartition(long dbId, long tableId, long partitionId) {
+        return idToDatabase.containsKey(dbId) || idToTable.containsKey(tableId)
+                || idToPartition.containsKey(partitionId);
+    }
+
+    public synchronized void getRecycleIds(Set<Long> dbIds, Set<Long> tableIds, Set<Long> partitionIds) {
+        dbIds.addAll(idToDatabase.keySet());
+        tableIds.addAll(idToTable.keySet());
+        partitionIds.addAll(idToPartition.keySet());
+    }
+
     private synchronized boolean isExpire(long id, long currentTimeMs) {
         long latency = currentTimeMs - idToRecycleTime.get(id);
         return latency > minEraseLatency && latency > Config.catalog_trash_expire_second * 1000L;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
@@ -19,6 +19,7 @@ package org.apache.doris.catalog;
 
 import org.apache.doris.catalog.Replica.ReplicaState;
 import org.apache.doris.common.Config;
+import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.Pair;
 import org.apache.doris.cooldown.CooldownConf;
 import org.apache.doris.task.PublishVersionTask;
@@ -718,7 +719,10 @@ public class TabletInvertedIndex {
         Set<Long> dbIds = Sets.newHashSet();
         Set<Long> tableIds = Sets.newHashSet();
         Set<Long> partitionIds = Sets.newHashSet();
-        Env.getCurrentRecycleBin().getRecycleIds(dbIds, tableIds, partitionIds);
+        // Clone ut mocked env, but CatalogRecycleBin is not mockable (it extends from Thread)
+        if (!FeConstants.runningUnitTest) {
+            Env.getCurrentRecycleBin().getRecycleIds(dbIds, tableIds, partitionIds);
+        }
         long stamp = readLock();
 
         // 1. gen <partitionId-indexId, <beId, replicaCount>>

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/BeLoadRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/BeLoadRebalancer.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.clone;
 
+import org.apache.doris.catalog.CatalogRecycleBin;
 import org.apache.doris.catalog.ColocateTableIndex;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.Replica;
@@ -117,6 +118,7 @@ public class BeLoadRebalancer extends Rebalancer {
 
         int clusterAvailableBEnum = infoService.getAllBackendIds(true).size();
         ColocateTableIndex colocateTableIndex = Env.getCurrentColocateIndex();
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
         // choose tablets from high load backends.
         // BackendLoadStatistic is sorted by load score in ascend order,
         // so we need to traverse it from last to first
@@ -175,6 +177,11 @@ public class BeLoadRebalancer extends Rebalancer {
                     }
 
                     if (colocateTableIndex.isColocateTable(tabletMeta.getTableId())) {
+                        continue;
+                    }
+
+                    if (recycleBin.isRecyclePartition(tabletMeta.getDbId(), tabletMeta.getTableId(),
+                            tabletMeta.getPartitionId())) {
                         continue;
                     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DiskRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DiskRebalancer.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.clone;
 
+import org.apache.doris.catalog.CatalogRecycleBin;
 import org.apache.doris.catalog.DataProperty;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
@@ -160,6 +161,7 @@ public class DiskRebalancer extends Rebalancer {
             return alternativeTablets;
         }
 
+        CatalogRecycleBin recycleBin = Env.getCurrentRecycleBin();
         Set<Long> alternativeTabletIds = Sets.newHashSet();
         Set<Long> unbalancedBEs = Sets.newHashSet();
         // choose tablets from backends randomly.
@@ -220,6 +222,10 @@ public class DiskRebalancer extends Rebalancer {
                 if (remainingPaths.containsKey(replicaPathHash)) {
                     TabletMeta tabletMeta = invertedIndex.getTabletMeta(tabletId);
                     if (tabletMeta == null) {
+                        continue;
+                    }
+                    if (recycleBin.isRecyclePartition(tabletMeta.getDbId(), tabletMeta.getTableId(),
+                            tabletMeta.getPartitionId())) {
                         continue;
                     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/clone/DiskRebalanceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/clone/DiskRebalanceTest.java
@@ -80,6 +80,7 @@ public class DiskRebalanceTest {
 
     @Before
     public void setUp() throws Exception {
+        FeConstants.runningUnitTest = true;
         Config.used_capacity_percent_max_diff = 1.0;
         Config.balance_slot_num_per_path = 1;
         db = new Database(1, "test db");

--- a/fe/fe-core/src/test/java/org/apache/doris/clone/RebalanceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/clone/RebalanceTest.java
@@ -90,6 +90,7 @@ public class RebalanceTest {
 
     @Before
     public void setUp() throws Exception {
+        FeConstants.runningUnitTest = true;
         db = new Database(1, "test db");
         db.setClusterName(SystemInfoService.DEFAULT_CLUSTER);
         new Expectations() {


### PR DESCRIPTION
## Proposed changes

When delete a db/table/partition unforce,  tablet invent index will not delete the tablets. For partition rebalancer,  it may always pick the deleted partitions if their skews are the biggest,  but of course sched on the deleted partitions will always fail.  So it will pick them again next round.  Let rebalancer  always check if the partition has be deleted.


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

