### PR TITLE
[feature](nereids)print query id with memo and physical tree

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -55,6 +55,7 @@ import org.apache.doris.planner.Planner;
 import org.apache.doris.planner.RuntimeFilter;
 import org.apache.doris.planner.ScanNode;
 import org.apache.doris.qe.CommonResultSet;
+import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ResultSet;
 import org.apache.doris.qe.ResultSetMetaData;
 
@@ -227,7 +228,7 @@ public class NereidsPlanner extends Planner {
             // if chooseNthPlan failed, we could get memo to debug
             if (cascadesContext.getConnectContext().getSessionVariable().dumpNereidsMemo) {
                 String memo = cascadesContext.getMemo().toString();
-                LOG.info(memo);
+                LOG.info(ConnectContext.get().getQueryIdentifier() + "\n" + memo);
             }
 
             int nth = cascadesContext.getConnectContext().getSessionVariable().getNthOptimizedPlan();
@@ -236,7 +237,7 @@ public class NereidsPlanner extends Planner {
             physicalPlan = postProcess(physicalPlan);
             if (cascadesContext.getConnectContext().getSessionVariable().dumpNereidsMemo) {
                 String tree = physicalPlan.treeString();
-                LOG.info(tree);
+                LOG.info(ConnectContext.get().getQueryIdentifier() + "\n" + tree);
             }
             if (explainLevel == ExplainLevel.OPTIMIZED_PLAN
                     || explainLevel == ExplainLevel.ALL_PLAN


### PR DESCRIPTION
## Proposed changes
print query id with memo and physical tree when dump_nereids_memo switched on. This is used for regression test.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

