### PR TITLE
[enhancement](backup) Add build version in backup snapshot info

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJobInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJobInfo.java
@@ -33,6 +33,7 @@ import org.apache.doris.catalog.TableIf.TableType;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.catalog.View;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.Version;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.persist.gson.GsonUtils;
@@ -92,6 +93,12 @@ public class BackupJobInfo implements Writable {
 
     @SerializedName("meta_version")
     public int metaVersion;
+    @SerializedName("major_version")
+    public int majorVersion;
+    @SerializedName("minor_version")
+    public int minorVersion;
+    @SerializedName("patch_version")
+    public int patchVersion;
 
     @SerializedName("tablet_be_map")
     public Map<Long, Long> tabletBeMap = Maps.newHashMap();
@@ -588,6 +595,9 @@ public class BackupJobInfo implements Writable {
         jobInfo.metaVersion = FeConstants.meta_version;
         jobInfo.content = content;
         jobInfo.tableCommitSeqMap = tableCommitSeqMap;
+        jobInfo.majorVersion = Version.DORIS_BUILD_VERSION_MAJOR;
+        jobInfo.minorVersion = Version.DORIS_BUILD_VERSION_MINOR;
+        jobInfo.patchVersion = Version.DORIS_BUILD_VERSION_PATCH;
 
         Collection<Table> tbls = backupMeta.getTables().values();
         // tbls


### PR DESCRIPTION
## Proposed changes

The snapshot info uploaded to S3 obj system by backup job is a json file, which is useful for us to get information about this snapshot.

If we add version info to the JSON file, we can know what version of the cluster used to manufacture this snapshot was, in order to prevent restoring the newer version of the snapshot to the older version of the cluster.


```
{
  "name": "snapshot_label2",
  "database": "test",
  "id": 10004,
  "backup_time": 1697525648496,
  "content": "ALL",
  "backup_objects": {
    "table1": {
      "id": 10013,
      "partitions": {
        "table1": {
          "id": 10012,
          "version": 3,
          "indexes": {
            "table1": {
              "id": 10014,
              "schema_hash": 791565523,
              "tablets": {
                "10015": [
                  "0200000000000003b0400c3870adc1c7d4e9f04c07630c99_0.dat.a102397f803a5f18c8582ba673b0239a",
                  "0200000000000002b0400c3870adc1c7d4e9f04c07630c99_0.dat.c12784643e6a351235859c11b88e0269",
                  "10015.hdr.1833ecb7c31c0cd099cc28da30d389f0"
                ]
              },
              "tablets_order": [
                10015
              ]
            }
          }
        }
      }
    }
  },
  "new_backup_objects": {
    "views": [],
    "odbc_tables": [],
    "odbc_resources": []
  },
  "backup_result": "succeed",
  "meta_version": 114,
  "major_version": 1,
  "minor_version": 2,
  "patch_version": 6
}
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

