### PR TITLE
[FeMeta](function) write function nullable mode info

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/FeMetaVersion.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/FeMetaVersion.java
@@ -70,9 +70,11 @@ public final class FeMetaVersion {
     public static final int VERSION_124 = 124;
     // For write/read auto create partition expr
     public static final int VERSION_125 = 125;
+    // For write/read function nullable mode info
+    public static final int VERSION_126 = 126;
 
     // note: when increment meta version, should assign the latest version to VERSION_CURRENT
-    public static final int VERSION_CURRENT = VERSION_125;
+    public static final int VERSION_CURRENT = VERSION_126;
 
     // all logs meta version should >= the minimum version, so that we could remove many if clause, for example
     // if (FE_METAVERSION < VERSION_94) ...

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Function.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Function.java
@@ -21,6 +21,7 @@ import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.FunctionCallExpr;
 import org.apache.doris.analysis.FunctionName;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.io.IOUtils;
 import org.apache.doris.common.io.Text;
@@ -664,6 +665,7 @@ public class Function implements Writable {
         }
         IOUtils.writeOptionString(output, libUrl);
         IOUtils.writeOptionString(output, checksum);
+        output.writeUTF(nullableMode.toString());
     }
 
     @Override
@@ -697,6 +699,9 @@ public class Function implements Writable {
         boolean hasChecksum = input.readBoolean();
         if (hasChecksum) {
             checksum = Text.readString(input);
+        }
+        if (Env.getCurrentEnvJournalVersion() >= FeMetaVersion.VERSION_126) {
+            nullableMode = NullableMode.valueOf(input.readUTF());
         }
     }
 


### PR DESCRIPTION
## Proposed changes
**notice: this PR have change the fe meta version**.
the nullable mode of udf-function is important,
if not write to info, it's will be loss after restart.


Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

