### PR TITLE
[improvement](tablet clone) furthur repair replicas should be check even if they are versions catchup

### DIFF
--- a/be/test/util/debug_points_test.cpp
+++ b/be/test/util/debug_points_test.cpp
@@ -60,7 +60,7 @@ TEST(DebugPointsTest, BaseTest) {
     DBUG_EXECUTE_IF("dbug5", EXPECT_EQ(1, dp->param<int>("v1", 100)));
     DBUG_EXECUTE_IF("dbug5", EXPECT_EQ("a", dp->param<std::string>("v2")));
     DBUG_EXECUTE_IF("dbug5", EXPECT_EQ("a", dp->param("v2", std::string())));
-    DBUG_EXECUTE_IF("dbug5", EXPECT_EQ("a", dp->param("v2", "b")));
+    DBUG_EXECUTE_IF("dbug5", EXPECT_STREQ("a", dp->param("v2", "b")));
     DBUG_EXECUTE_IF("dbug5", EXPECT_EQ(1.2, dp->param<double>("v3")));
     DBUG_EXECUTE_IF("dbug5", EXPECT_EQ(1.2, dp->param("v3", 0.0)));
     DBUG_EXECUTE_IF("dbug5", EXPECT_TRUE(dp->param("v4", false)));
@@ -68,7 +68,32 @@ TEST(DebugPointsTest, BaseTest) {
     DBUG_EXECUTE_IF("dbug5", EXPECT_EQ(0L, dp->param<int64_t>("v_not_exist")));
     DBUG_EXECUTE_IF("dbug5", EXPECT_EQ(0L, dp->param("v_not_exist", 0L)));
     DBUG_EXECUTE_IF("dbug5", EXPECT_EQ(123, dp->param("v_not_exist", 123)));
-    DBUG_EXECUTE_IF("dbug5", EXPECT_EQ("abcd", dp->param("v_not_exist", "abcd")));
+    DBUG_EXECUTE_IF("dbug5", EXPECT_STREQ("abcd", dp->param("v_not_exist", "abcd")));
+
+    EXPECT_EQ(1.2, DebugPoints::instance()->get_debug_param_or_default("dbug5", "v3", 0.0));
+    EXPECT_EQ(100,
+              DebugPoints::instance()->get_debug_param_or_default("point_not_exists", "k", 100));
+
+    POST_HTTP_TO_TEST_SERVER("/api/debug_point/add/dbug6?value=567");
+    EXPECT_EQ(567, DebugPoints::instance()->get_debug_param_or_default("dbug6", 0));
+}
+
+TEST(DebugPointsTest, AddTest) {
+    config::enable_debug_points = true;
+    DebugPoints::instance()->clear();
+
+    DebugPoints::instance()->add("dbug1");
+    EXPECT_TRUE(DebugPoints::instance()->is_enable("dbug1"));
+
+    DebugPoints::instance()->add_with_params("dbug2", {{"k1", "100"}});
+    EXPECT_EQ(100, DebugPoints::instance()->get_debug_param_or_default("dbug2", "k1", 0));
+
+    DebugPoints::instance()->add_with_value("dbug3", 567);
+    EXPECT_EQ(567, DebugPoints::instance()->get_debug_param_or_default("dbug3", 567));
+
+    DebugPoints::instance()->add_with_value("dbug4", "hello");
+    EXPECT_EQ("hello",
+              DebugPoints::instance()->get_debug_param_or_default<std::string>("dbug4", ""));
 }
 
 } // namespace doris

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/LoadStatisticForTag.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/LoadStatisticForTag.java
@@ -289,6 +289,11 @@ public class LoadStatisticForTag {
             return false;
         }
 
+        long debugHighBeId = DebugPointUtil.getDebugParamOrDefault("FE.HIGH_LOAD_BE_ID", -1L);
+        if (srcBeStat.getBeId() == debugHighBeId) {
+            return true;
+        }
+
         currentSrcBeScore = srcBeStat.getLoadScore(medium);
         currentDestBeScore = destBeStat.getLoadScore(medium);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
@@ -824,6 +824,8 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                 return false;
             }
         } catch (Exception e) {
+            LOG.warn("replica {} of tablet {} check catchup with further repair watermark id {} failed",
+                    replica, tabletId, furtherRepairWatermarkTxnTd, e);
             return true;
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -46,6 +46,7 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.Pair;
+import org.apache.doris.common.util.DebugPointUtil;
 import org.apache.doris.common.util.MasterDaemon;
 import org.apache.doris.persist.ReplicaPersistInfo;
 import org.apache.doris.resource.Tag;
@@ -979,6 +980,7 @@ public class TabletScheduler extends MasterDaemon {
             boolean force, LoadStatisticForTag statistic) throws SchedException {
         Replica chosenReplica = null;
         double maxScore = 0;
+        long debugHighBeId = DebugPointUtil.getDebugParamOrDefault("FE.HIGH_LOAD_BE_ID", -1L);
         for (Replica replica : replicas) {
             BackendLoadStatistic beStatistic = statistic.getBackendLoadStatistic(replica.getBackendId());
             if (beStatistic == null) {
@@ -1002,6 +1004,11 @@ public class TabletScheduler extends MasterDaemon {
             if (loadScore > maxScore) {
                 maxScore = loadScore;
                 chosenReplica = replica;
+            }
+
+            if (debugHighBeId > 0 && replica.getBackendId() == debugHighBeId) {
+                chosenReplica = replica;
+                break;
             }
         }
 
@@ -1522,6 +1529,16 @@ public class TabletScheduler extends MasterDaemon {
 
                 if (statusPair.second.ordinal() < tabletCtx.getPriority().ordinal()) {
                     statusPair.second = tabletCtx.getPriority();
+                }
+            }
+
+            if (statusPair.first == TabletStatus.NEED_FURTHER_REPAIR) {
+                // replica is just waiting for finishing txns before furtherRepairWatermarkTxnTd,
+                // no need to add it immediately
+                Replica replica = tablet.getReplicaByBackendId(tabletCtx.getDestBackendId());
+                if (replica != null && replica.getVersion() >= partition.getVisibleVersion()
+                        && replica.getLastFailedVersion() < 0) {
+                    return;
                 }
             }
         } finally {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/DebugPointUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/DebugPointUtil.java
@@ -30,6 +30,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Use for manage debug points.
+ *
+ * usage example can see DebugPointUtilTest.java
+ *
  **/
 public class DebugPointUtil {
     private static final Logger LOG = LogManager.getLogger(DebugPointUtil.class);
@@ -109,9 +112,32 @@ public class DebugPointUtil {
         return debugPoint;
     }
 
+    // if not enable debug point or its params not contains `key`, then return `defaultValue`
+    // url: /api/debug_point/add/name?k1=v1&k2=v2&...
+    public static <E> E getDebugParamOrDefault(String debugPointName, String key, E defaultValue) {
+        DebugPoint debugPoint = getDebugPoint(debugPointName);
+
+        return debugPoint != null ? debugPoint.param(key, defaultValue) : defaultValue;
+    }
+
+    // url: /api/debug_point/add/name?value=v
+    public static <E> E getDebugParamOrDefault(String debugPointName, E defaultValue) {
+        return getDebugParamOrDefault(debugPointName, "value", defaultValue);
+    }
+
     public static void addDebugPoint(String name, DebugPoint debugPoint) {
         debugPoints.put(name, debugPoint);
         LOG.info("add debug point: name={}, params={}", name, debugPoint.params);
+    }
+
+    public static void addDebugPoint(String name) {
+        addDebugPoint(name, new DebugPoint());
+    }
+
+    public static <E> void addDebugPointWithValue(String name, E value) {
+        DebugPoint debugPoint = new DebugPoint();
+        debugPoint.params.put("value", String.format("%s", value));
+        addDebugPoint(name, debugPoint);
     }
 
     public static void removeDebugPoint(String name) {

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/DebugPointUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/DebugPointUtilTest.java
@@ -66,6 +66,12 @@ public class DebugPointUtilTest extends DorisHttpTestCase {
         Assert.assertTrue(debugPoint.param("v4", false));
         Assert.assertFalse(debugPoint.param("v5", false));
         Assert.assertEquals(123L, (long) debugPoint.param("v_no_exist", 123L));
+
+        Assert.assertEquals(1, (int) DebugPointUtil.getDebugParamOrDefault("dbug5", "v1", 0));
+        Assert.assertEquals(100, (int) DebugPointUtil.getDebugParamOrDefault("point_not_exists", "v1", 100));
+
+        sendRequest("/api/debug_point/add/dbug6?value=100");
+        Assert.assertEquals(100, (int) DebugPointUtil.getDebugParamOrDefault("dbug6", 0));
     }
 
     private void sendRequest(String uri) throws Exception {


### PR DESCRIPTION
## Proposed changes

If there are loading txns,  PR #24845  will try to furthur repair a balance tablet even if their versions are catchup.

Then in scheduler's NEED_FURTHER_REPAIR handler,  if no replicas are version fallbehind, the sched ctx will convert to REPLICA_MISSING,  then add missing replicas will fail because they don't really miss replicas.

Improvement:   for NEED_FURTHER_REPAIR handler,  if all the replicas are version catchup,  then try to check the txns before further repair txn has finished, if it finished, then mark the replica as further repair finish. 


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

