### PR TITLE
[Fix](executor)Fix exchange operator can not aware end of file

### DIFF
--- a/be/src/pipeline/exec/exchange_sink_buffer.cpp
+++ b/be/src/pipeline/exec/exchange_sink_buffer.cpp
@@ -148,6 +148,9 @@ Status ExchangeSinkBuffer<Parent>::add_block(TransmitInfo<Parent>&& request) {
         return Status::OK();
     }
     TUniqueId ins_id = request.channel->_fragment_instance_id;
+    if (_is_receiver_eof(ins_id.lo)) {
+        return Status::EndOfFile("receiver eof");
+    }
     bool send_now = false;
     {
         std::unique_lock<std::mutex> lock(*_instance_to_package_queue_mutex[ins_id.lo]);

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -295,12 +295,7 @@ public:
     Status sink(RuntimeState* state, vectorized::Block* in_block,
                 SourceState source_state) override {
         if (in_block->rows() > 0 || source_state == SourceState::FINISHED) {
-            auto st = _sink->sink(state, in_block, source_state == SourceState::FINISHED);
-            // TODO: improvement: if sink returned END_OF_FILE, pipeline task can be finished
-            if (st.template is<ErrorCode::END_OF_FILE>()) {
-                return Status::OK();
-            }
-            return st;
+            return _sink->sink(state, in_block, source_state == SourceState::FINISHED);
         }
         return Status::OK();
     }


### PR DESCRIPTION
## Proposed changes
![image](https://github.com/apache/doris/assets/12951030/64699709-4cb9-4593-8e4b-0c1377d7bcbb)


In some cases, the same shuffle client may duplicate send shuffle rpc even server has EOF.
This may result in delayed release of resources.