### PR TITLE
[fix](mvn source) fix audit compile java-cup and cup-maven-plugin not found

### DIFF
--- a/fe_plugins/pom.xml
+++ b/fe_plugins/pom.xml
@@ -108,7 +108,7 @@ under the License.
                 </repository>
                 <repository>
                     <id>cloudera-public</id>
-                    <url>https://repository.cloudera.com/artifactory/public/</url>
+                    <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
                 </repository>
             </repositories>
         </profile>


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Reference #25348

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

