### PR TITLE
[Fix](show-frontends-disk)Fix NPE and macOS compatibility

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/io/DiskUtils.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/io/DiskUtils.java
@@ -23,18 +23,16 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 
 @Slf4j
 public class DiskUtils {
 
     public static class Df {
         public String fileSystem = "";
-        public long blocks;
-        public long used;
-        public long available;
-        public int useRate;
+        public long blocks = 0L;
+        public long used = 0L;
+        public long available = 0L;
+        public int useRate = 0;
         public String mountedOn = "";
     }
 
@@ -46,52 +44,83 @@ public class DiskUtils {
             return df;
         }
 
+
         Process process;
         try {
-            process = Runtime.getRuntime().exec("df " + dir);
+            process = Runtime.getRuntime().exec("df -k " + dir);
             InputStream inputStream = process.getInputStream();
             BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
-
+            Df df = new Df();
             // Filesystem      1K-blocks       Used Available Use% Mounted on
             // /dev/sdc       5814186096 5814169712         0 100% /home/spy-sd/sdc
             String titleLine = reader.readLine();
             String dataLine = reader.readLine();
             if (titleLine == null || dataLine == null) {
-                return null;
+                return df;
             }
-            String[] values = dataLine.split("\\s+");
-            if (values.length != 6) {
-                return null;
+            String[] dfValues = dataLine.split("\\s+");
+            if (os.startsWith("Mac")) {
+                parseMacOSDiskInfo(dfValues, df);
+            } else {
+                parseLinuxDiskInfo(dfValues, df);
             }
-
-            Df df = new Df();
-            df.fileSystem = values[0];
-            df.blocks = Long.parseLong(values[1]);
-            df.used = Long.parseLong(values[2]);
-            df.available = Long.parseLong(values[3]);
-            df.useRate = Integer.parseInt(values[4].replace("%", ""));
-            df.mountedOn = values[5];
             return df;
         } catch (IOException e) {
             log.info("failed to obtain disk information", e);
-            return null;
+            return new Df();
         }
     }
 
-    private static List<String> getTitles(String titlesLine) {
-        List<String> titles = new ArrayList<>();
-        String[] titleArray = titlesLine.split("\\s+");
-        for (String title : titleArray) {
-            if (title.equalsIgnoreCase("on")) {
-                if (!titles.isEmpty()) {
-                    int lastIdx = titles.size() - 1;
-                    titles.set(lastIdx, titles.get(lastIdx) + "On");
-                }
-            } else {
-                titles.add(title);
-            }
+    /**
+     * Linux df -k output
+     * Filesystem     1K-blocks     Used Available Use% Mounted on
+     * /dev/sda1       8256952  2094712   5742232  27% /
+     */
+    private static void parseLinuxDiskInfo(String[] dfValues, Df df) {
+        if (dfValues.length != 6) {
+            return;
         }
-        return titles;
+        df.fileSystem = dfValues[0];
+        df.blocks = parseLongValue(dfValues[1]);
+        df.used = parseLongValue(dfValues[2]);
+        df.available = parseLongValue(dfValues[3]);
+        df.useRate = parseIntegerValue(dfValues[4].replace("%", ""));
+        df.mountedOn = dfValues[5];
+    }
+
+    /**
+     * MacOS df -k output
+     * Filesystem    1024-blocks      Used Available Capacity iused      ifree %iused  Mounted on
+     * /dev/disk1s1   488555536  97511104  390044432    20%  121655 4884849711    0%   /
+     */
+    private static void parseMacOSDiskInfo(String[] dfValues, Df df) {
+        if (dfValues.length != 9) {
+            return;
+        }
+        df.fileSystem = dfValues[0];
+        df.blocks = Long.parseLong(dfValues[1]);
+        df.used = parseLongValue(dfValues[2]);
+        df.available = parseLongValue(dfValues[3]);
+        df.useRate = parseIntegerValue(dfValues[4].replace("%", ""));
+        df.mountedOn = dfValues[8];
+    }
+
+    private static long parseLongValue(String value) {
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            log.info("failed to parse long value", e);
+            return 0L;
+        }
+    }
+
+    private static int parseIntegerValue(String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            log.info("failed to parse integer value", e);
+            return 0;
+        }
     }
 
     private static String[] units = new String[]{"", "K", "M", "G", "T", "P"};


### PR DESCRIPTION
## What happened

**env macOS**

**SQL:**
``` show frontends disks```
**exception**
```log
2023-10-18 10:18:03,360 WARN (mysql-nio-pool-12|2513) [StmtExecutor.executeByLegacy():807] execute Exception. stmt[3670, 8b87bca4bb7c465b-9a90ab8003c5760e]
java.lang.NullPointerException: null
        at org.apache.doris.common.proc.FrontendsProcNode.getFrontendsDiskInfo(FrontendsProcNode.java:184) ~[classes/:?]
        at org.apache.doris.common.proc.FrontendsProcNode.getFrontendsInfo(FrontendsProcNode.java:87) ~[classes/:?]
        at org.apache.doris.qe.ShowExecutor.handleShowFrontends(ShowExecutor.java:1983) ~[classes/:?]
        at org.apache.doris.qe.ShowExecutor.execute(ShowExecutor.java:356) ~[classes/:?]
        at org.apache.doris.qe.StmtExecutor.handleShow(StmtExecutor.java:2210) ~[classes/:?]
        at org.apache.doris.qe.StmtExecutor.executeByLegacy(StmtExecutor.java:775) ~[classes/:?]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:468) ~[classes/:?]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:438) ~[classes/:?]
        at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:353) ~[classes/:?]
        at org.apache.doris.qe.ConnectProcessor.dispatch(ConnectProcessor.java:501) ~[classes/:?]
        at org.apache.doris.qe.ConnectProcessor.processOnce(ConnectProcessor.java:752) ~[classes/:?]
        at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52) ~[classes/:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_362]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_362]
        at java.lang.Thread.run(Thread.java:750) ~[?:1.8.0_362]

```
```
     Linux df -k output
     Filesystem     1K-blocks     Used Available Use% Mounted on
     /dev/sda1       8256952  2094712   5742232  27% /
     Max OS df -k output
      Filesystem    1024-blocks      Used Available Capacity iused      ifree %iused  Mounted on
      /dev/disk1s1   488555536  97511104  390044432    20%  121655 4884849711    0%   /
```
## Further comments
The default size of mac `df` is 512blocks, and the default size of linux is 1024 bloks. Therefore, when executing the command, use `df -k` to limit the output unit to 1024blocks.

The output results of mac os and Linux os are also different, so the corresponding information is obtained according to different systems.
The default size of mac `df` is 512blocks, and the default size of linux is 1024 bloks. Therefore, when executing the command, use `df -k` to limit the output unit to 1024blocks.

The output results of mac os and Linux os are also different, so the corresponding information is obtained according to different systems.

## Affected version

**master**

## Test
<img width="1155" alt="image" src="https://github.com/apache/doris/assets/16631152/d25024c1-336a-43cb-9f77-5813429033b8">
