### PR TITLE
[enhencement](RowsetWriter) Don't delete files when beta rowset writer destructed

### DIFF
--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -20,6 +20,7 @@
 #include <assert.h>
 // IWYU pragma: no_include <bthread/errno.h>
 #include <errno.h> // IWYU pragma: keep
+#include <fmt/format.h>
 #include <stdio.h>
 
 #include <ctime> // time

--- a/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
@@ -17,6 +17,7 @@
 
 #include "olap/rowset/vertical_beta_rowset_writer.h"
 
+#include <fmt/format.h>
 #include <gen_cpp/olap_file.pb.h>
 
 #include <algorithm>

--- a/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
@@ -29,7 +29,6 @@
 // IWYU pragma: no_include <opentelemetry/common/threadlocal.h>
 #include "common/compiler_util.h" // IWYU pragma: keep
 #include "common/logging.h"
-#include "gutil/strings/substitute.h"
 #include "io/fs/file_system.h"
 #include "io/fs/file_writer.h"
 #include "olap/rowset/beta_rowset.h"
@@ -44,8 +43,8 @@ using namespace ErrorCode;
 
 VerticalBetaRowsetWriter::~VerticalBetaRowsetWriter() {
     if (!_already_built) {
-        auto fs = _rowset_meta->fs();
-        if (!fs) {
+        const auto& fs = _rowset_meta->fs();
+        if (!fs || !_rowset_meta->is_local()) { // Remote fs will delete them asynchronously
             return;
         }
         for (auto& segment_writer : _segment_writers) {
@@ -56,8 +55,7 @@ VerticalBetaRowsetWriter::~VerticalBetaRowsetWriter() {
             // Even if an error is encountered, these files that have not been cleaned up
             // will be cleaned up by the GC background. So here we only print the error
             // message when we encounter an error.
-            WARN_IF_ERROR(fs->delete_file(path),
-                          strings::Substitute("Failed to delete file=$0", path));
+            WARN_IF_ERROR(fs->delete_file(path), fmt::format("Failed to delete file={}", path));
         }
     }
 }
@@ -105,7 +103,8 @@ Status VerticalBetaRowsetWriter::add_columns(const vectorized::Block* block,
             RETURN_IF_ERROR(_segment_writers[_cur_writer_idx]->init(col_ids, is_key));
         }
         // when splitting segment, need to make rows align between key columns and value columns
-        size_t start_offset = 0, limit = num_rows;
+        size_t start_offset = 0;
+        size_t limit = num_rows;
         if (num_rows_written + num_rows >= num_rows_key_group &&
             _cur_writer_idx < _segment_writers.size() - 1) {
             RETURN_IF_ERROR(_segment_writers[_cur_writer_idx]->append_block(


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

The files of corresponding remote file system shouldn't be deleted when the rowset writers's dtor is called, instead they should be deleted asynchronously by the remote file system. Otherwise the dtor would do S3 io which might cost a lot of time.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

