### PR TITLE
[fix](be) Make DorisCallOnce's function exception-safe

### DIFF
--- a/be/src/olap/rowset/segment_v2/ordinal_page_index.cpp
+++ b/be/src/olap/rowset/segment_v2/ordinal_page_index.cpp
@@ -24,6 +24,7 @@
 #include <ostream>
 #include <string>
 
+#include "common/exception.h"
 #include "io/fs/file_writer.h"
 #include "olap/key_coder.h"
 #include "olap/olap_common.h"

--- a/be/src/olap/rowset/segment_v2/ordinal_page_index.cpp
+++ b/be/src/olap/rowset/segment_v2/ordinal_page_index.cpp
@@ -24,7 +24,6 @@
 #include <ostream>
 #include <string>
 
-#include "common/exception.h"
 #include "io/fs/file_writer.h"
 #include "olap/key_coder.h"
 #include "olap/olap_common.h"

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -233,12 +233,25 @@ Status Segment::_load_pk_bloom_filter() {
     DCHECK(_tablet_schema->keys_type() == UNIQUE_KEYS);
     DCHECK(_pk_index_meta != nullptr);
     DCHECK(_pk_index_reader != nullptr);
-    return _load_pk_bf_once.call([this] {
-        RETURN_IF_ERROR(_pk_index_reader->parse_bf(_file_reader, *_pk_index_meta));
-        _meta_mem_usage += _pk_index_reader->get_bf_memory_size();
-        _segment_meta_mem_tracker->consume(_pk_index_reader->get_bf_memory_size());
-        return Status::OK();
-    });
+    auto status = [this]() {
+        return _load_pk_bf_once.call([this] {
+            RETURN_IF_ERROR(_pk_index_reader->parse_bf(_file_reader, *_pk_index_meta));
+            _meta_mem_usage += _pk_index_reader->get_bf_memory_size();
+            _segment_meta_mem_tracker->consume(_pk_index_reader->get_bf_memory_size());
+            return Status::OK();
+        });
+    }();
+    if (!status.ok() && !config::disable_segment_cache) {
+        remove_segment_cache();
+    }
+    return status;
+}
+
+void Segment::remove_segment_cache() const {
+    if (!config::disable_segment_cache) {
+        SegmentCache::CacheKey cache_key(_rowset_id, _segment_id);
+        SegmentLoader::instance()->erase_segment(cache_key);
+    }
 }
 
 Status Segment::load_pk_index_and_bf() {
@@ -247,39 +260,45 @@ Status Segment::load_pk_index_and_bf() {
     return Status::OK();
 }
 Status Segment::load_index() {
-    return _load_index_once.call([this] {
-        if (_tablet_schema->keys_type() == UNIQUE_KEYS && _pk_index_meta != nullptr) {
-            _pk_index_reader.reset(new PrimaryKeyIndexReader());
-            RETURN_IF_ERROR(_pk_index_reader->parse_index(_file_reader, *_pk_index_meta));
-            _meta_mem_usage += _pk_index_reader->get_memory_size();
-            _segment_meta_mem_tracker->consume(_pk_index_reader->get_memory_size());
-            return Status::OK();
-        } else {
-            // read and parse short key index page
-            OlapReaderStatistics tmp_stats;
-            PageReadOptions opts {
-                    .use_page_cache = true,
-                    .type = INDEX_PAGE,
-                    .file_reader = _file_reader.get(),
-                    .page_pointer = PagePointer(_sk_index_page),
-                    // short key index page uses NO_COMPRESSION for now
-                    .codec = nullptr,
-                    .stats = &tmp_stats,
-                    .io_ctx = io::IOContext {.is_index_data = true},
-            };
-            Slice body;
-            PageFooterPB footer;
-            RETURN_IF_ERROR(
-                    PageIO::read_and_decompress_page(opts, &_sk_index_handle, &body, &footer));
-            DCHECK_EQ(footer.type(), SHORT_KEY_PAGE);
-            DCHECK(footer.has_short_key_page_footer());
+    auto status = [this]() {
+        return _load_index_once.call([this] {
+            if (_tablet_schema->keys_type() == UNIQUE_KEYS && _pk_index_meta != nullptr) {
+                _pk_index_reader.reset(new PrimaryKeyIndexReader());
+                RETURN_IF_ERROR(_pk_index_reader->parse_index(_file_reader, *_pk_index_meta));
+                _meta_mem_usage += _pk_index_reader->get_memory_size();
+                _segment_meta_mem_tracker->consume(_pk_index_reader->get_memory_size());
+                return Status::OK();
+            } else {
+                // read and parse short key index page
+                OlapReaderStatistics tmp_stats;
+                PageReadOptions opts {
+                        .use_page_cache = true,
+                        .type = INDEX_PAGE,
+                        .file_reader = _file_reader.get(),
+                        .page_pointer = PagePointer(_sk_index_page),
+                        // short key index page uses NO_COMPRESSION for now
+                        .codec = nullptr,
+                        .stats = &tmp_stats,
+                        .io_ctx = io::IOContext {.is_index_data = true},
+                };
+                Slice body;
+                PageFooterPB footer;
+                RETURN_IF_ERROR(
+                        PageIO::read_and_decompress_page(opts, &_sk_index_handle, &body, &footer));
+                DCHECK_EQ(footer.type(), SHORT_KEY_PAGE);
+                DCHECK(footer.has_short_key_page_footer());
 
-            _meta_mem_usage += body.get_size();
-            _segment_meta_mem_tracker->consume(body.get_size());
-            _sk_index_decoder.reset(new ShortKeyIndexDecoder);
-            return _sk_index_decoder->parse(body, footer.short_key_page_footer());
-        }
-    });
+                _meta_mem_usage += body.get_size();
+                _segment_meta_mem_tracker->consume(body.get_size());
+                _sk_index_decoder.reset(new ShortKeyIndexDecoder);
+                return _sk_index_decoder->parse(body, footer.short_key_page_footer());
+            }
+        });
+    }();
+    if (!status.ok() && !config::disable_segment_cache) {
+        remove_segment_cache();
+    }
+    return status;
 }
 
 Status Segment::_create_column_readers(const SegmentFooterPB& footer) {

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -248,7 +248,9 @@ Status Segment::_load_pk_bloom_filter() {
 }
 
 void Segment::remove_from_segment_cache() const {
-    if (config::disable_segment_cache) { return; }
+    if (config::disable_segment_cache) {
+        return;
+    }
     SegmentCache::CacheKey cache_key(_rowset_id, _segment_id);
     SegmentLoader::instance()->erase_segment(cache_key);
 }

--- a/be/src/olap/rowset/segment_v2/segment.h
+++ b/be/src/olap/rowset/segment_v2/segment.h
@@ -125,7 +125,7 @@ public:
 
     int64_t meta_mem_usage() const { return _meta_mem_usage; }
 
-    void remove_segment_cache() const;
+    void remove_from_segment_cache() const;
 
 private:
     DISALLOW_COPY_AND_ASSIGN(Segment);
@@ -135,6 +135,8 @@ private:
     Status _parse_footer(SegmentFooterPB* footer);
     Status _create_column_readers(const SegmentFooterPB& footer);
     Status _load_pk_bloom_filter();
+
+    Status _load_index_impl();
 
 private:
     friend class SegmentIterator;

--- a/be/src/olap/rowset/segment_v2/segment.h
+++ b/be/src/olap/rowset/segment_v2/segment.h
@@ -125,6 +125,8 @@ public:
 
     int64_t meta_mem_usage() const { return _meta_mem_usage; }
 
+    void remove_segment_cache() const;
+
 private:
     DISALLOW_COPY_AND_ASSIGN(Segment);
     Segment(uint32_t segment_id, RowsetId rowset_id, TabletSchemaSPtr tablet_schema);

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -213,7 +213,7 @@ SegmentIterator::SegmentIterator(std::shared_ptr<Segment> segment, SchemaSPtr sc
 Status SegmentIterator::init(const StorageReadOptions& opts) {
     auto status = _init_impl(opts);
     if (!status.ok() && !config::disable_segment_cache) {
-        _segment->remove_segment_cache();
+        _segment->remove_from_segment_cache();
     }
     return status;
 }
@@ -1785,8 +1785,8 @@ Status SegmentIterator::_read_columns_by_rowids(std::vector<ColumnId>& read_colu
 
 Status SegmentIterator::next_batch(vectorized::Block* block) {
     auto status = [&]() { RETURN_IF_CATCH_EXCEPTION({ return _next_batch_internal(block); }); }();
-    if (!status.ok() && !config::disable_segment_cache) {
-        _segment->remove_segment_cache();
+    if (!status.ok()) {
+        _segment->remove_from_segment_cache();
     }
     return status;
 }

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -1784,9 +1784,7 @@ Status SegmentIterator::_read_columns_by_rowids(std::vector<ColumnId>& read_colu
 }
 
 Status SegmentIterator::next_batch(vectorized::Block* block) {
-    auto status = [&]() {
-        RETURN_IF_CATCH_EXCEPTION({ return _next_batch_internal(block); });
-    }();
+    auto status = [&]() { RETURN_IF_CATCH_EXCEPTION({ return _next_batch_internal(block); }); }();
     if (!status.ok() && !config::disable_segment_cache) {
         _segment->remove_segment_cache();
     }

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -211,6 +211,14 @@ SegmentIterator::SegmentIterator(std::shared_ptr<Segment> segment, SchemaSPtr sc
           _pool(new ObjectPool) {}
 
 Status SegmentIterator::init(const StorageReadOptions& opts) {
+    auto status = _init_impl(opts);
+    if (!status.ok() && !config::disable_segment_cache) {
+        _segment->remove_segment_cache();
+    }
+    return status;
+}
+
+Status SegmentIterator::_init_impl(const StorageReadOptions& opts) {
     // get file handle from file descriptor of segment
     if (_inited) {
         return Status::OK();
@@ -1776,8 +1784,13 @@ Status SegmentIterator::_read_columns_by_rowids(std::vector<ColumnId>& read_colu
 }
 
 Status SegmentIterator::next_batch(vectorized::Block* block) {
-    RETURN_IF_CATCH_EXCEPTION({ return _next_batch_internal(block); });
-    return Status::OK();
+    auto status = [&]() {
+        RETURN_IF_CATCH_EXCEPTION({ return _next_batch_internal(block); });
+    }();
+    if (!status.ok() && !config::disable_segment_cache) {
+        _segment->remove_segment_cache();
+    }
+    return status;
 }
 
 Status SegmentIterator::_next_batch_internal(vectorized::Block* block) {

--- a/be/src/olap/rowset/segment_v2/segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.h
@@ -152,7 +152,7 @@ private:
     }
 
     [[nodiscard]] Status _lazy_init();
-
+    [[nodiscard]] Status _init_impl(const StorageReadOptions& opts);
     [[nodiscard]] Status _init_return_column_iterators();
     [[nodiscard]] Status _init_bitmap_index_iterators();
     [[nodiscard]] Status _init_inverted_index_iterators();

--- a/be/src/util/once.h
+++ b/be/src/util/once.h
@@ -22,9 +22,9 @@
 
 #include <atomic>
 
+#include "common/exception.h"
 #include "olap/olap_common.h"
 #include "util/lock.h"
-#include "common/exception.h"
 
 namespace doris {
 
@@ -61,9 +61,7 @@ public:
                 std::lock_guard l(_mutex);
                 if (_has_called.load(std::memory_order_acquire)) break;
 
-                _status = [&]() {
-                    RETURN_IF_CATCH_EXCEPTION({ return fn(); });
-                }();
+                _status = [&]() { RETURN_IF_CATCH_EXCEPTION({ return fn(); }); }();
                 _has_called.store(true, std::memory_order_release);
 
             } while (false);

--- a/be/src/util/once.h
+++ b/be/src/util/once.h
@@ -24,6 +24,7 @@
 
 #include "olap/olap_common.h"
 #include "util/lock.h"
+#include "common/exception.h"
 
 namespace doris {
 
@@ -60,7 +61,9 @@ public:
                 std::lock_guard l(_mutex);
                 if (_has_called.load(std::memory_order_acquire)) break;
 
-                _status = fn();
+                _status = [&]() {
+                    RETURN_IF_CATCH_EXCEPTION({ return fn(); });
+                }();
                 _has_called.store(true, std::memory_order_release);
 
             } while (false);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Make the DorisCallOnce's function exception-safe. If the segment calls DorisCallOnce returns an error, remove the cache to prevent subsequent calls from always failing.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

