### PR TITLE
[Fix](create-table-like)Fix create table like error, the converted table field COMMENT contains extra characters

### DIFF
--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisLexer.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisLexer.g4
@@ -564,12 +564,12 @@ HINT_END: '*/';
 ATSIGN: '@';
 DOUBLEATSIGN: '@@';
 
-STRING_LITERAL
-    : '\'' ( ~('\''|'\\') | ('\\' .) )* '\''
-    | '"' ( ~('"'|'\\') | ('\\' .) )* '"'
-    | 'R\'' (~'\'')* '\''
-    | 'R"'(~'"')* '"'
-    ;
+STRING_LITERAL: '"' (~["\\\r\n] | EscapeSequence)* '"'
+    {
+        String text = getText();
+        setText(text.substring(1, text.length() - 1));
+    };
+fragment EscapeSequence: '\\' .;    
 
 LEADING_STRING
     : LEFT_BRACE

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Column.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Column.java
@@ -477,7 +477,7 @@ public class Column implements Writable, GsonPostProcessable {
         if (!escapeQuota) {
             return comment;
         }
-        return SqlUtils.escapeQuota(comment);
+        return SqlUtils.addEscapeCharacters(comment);
     }
 
     public int getOlapColumnIndexSize() {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/SqlUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/SqlUtils.java
@@ -29,6 +29,7 @@ import org.antlr.v4.runtime.atn.PredictionMode;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.antlr.v4.runtime.tree.ParseTree;
 
+import java.io.StringWriter;
 import java.util.Collections;
 import java.util.List;
 
@@ -56,6 +57,51 @@ public class SqlUtils {
             return str;
         }
         return str.replaceAll("\"", "\\\\\"");
+    }
+
+    /**
+     * add escape characters for string
+     * @param str
+     * @return
+     */
+    public static String addEscapeCharacters(String str) {
+        StringWriter writer = new StringWriter();
+        int strLen = str.length();
+        for (int i = 0; i < strLen; ++i) {
+            char c = str.charAt(i);
+            switch (c) {
+                case '\n':
+                    writer.append("\\n");
+                    break;
+                case '\t':
+                    writer.append("\\t");
+                    break;
+                case '\r':
+                    writer.append("\\r");
+                    break;
+                case '\b':
+                    writer.append("\\b");
+                    break;
+                case '\0':
+                    writer.append("\\0");
+                    break;
+                case '\032':
+                    writer.append("\\Z");
+                    break;
+                case '\'':
+                    writer.append("\\'");
+                    break;
+                case '\"':
+                    writer.append("\\\"");
+                    break;
+
+                default:
+                    writer.append(c);
+                    break;
+            }
+        }
+
+        return writer.toString();
     }
 
     public static List<String> splitMultiStmts(String sql) {

--- a/regression-test/suites/table_p0/create_table_like_p0.groovy
+++ b/regression-test/suites/table_p0/create_table_like_p0.groovy
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("create_table_like_p0") {
+    sql """DROP TABLE IF EXISTS test_create_table_like"""
+    sql """ 
+            CREATE TABLE test_create_table_like (
+              a DATEV2 NOT NULL COMMENT "'a' is a date, but it's not a date/n,/r/n/t/n/'",
+              b VARCHAR(96) NOT NULL COMMENT '/'a/' is a date, but it's not a date/n,/r/n/t/n/'',
+              c VARCHAR(96) NOT NULL COMMENT 'c',
+              d VARCHAR(96) COMMENT '',
+              e bigint NOT NULL  )
+            DISTRIBUTED BY HASH(e) BUCKETS 1
+            PROPERTIES( 'replication_num' = '1');
+    """
+    sql """DROP TABLE IF EXISTS tctl_2"""
+    sql """DROP TABLE IF EXISTS tctl_3"""
+    sql """DROP TABLE IF EXISTS tctl_1"""
+    sql """create table tctl_1 like test_create_table_like"""
+    sql """create table tctl_2 like tctl_1"""
+    sql """create table tctl_3 like tctl_2"""
+}


### PR DESCRIPTION
### Error Context
```sql
CREATE TABLE test_create_table (
  a DATEV2 NOT NULL COMMENT "a",
  b VARCHAR(96) NOT NULL COMMENT 'b',
  c VARCHAR(96) NOT NULL COMMENT 'c',
  d VARCHAR(96) COMMENT '',
  e bigint NOT NULL  )
DISTRIBUTED BY HASH(e) BUCKETS 1
PROPERTIES( 'replication_num' = '1');

create table test_create_table_like like test_create_table

show create table test_create_table_like
```

``` error log
2023-10-16 11:46:39,422 WARN (mysql-nio-pool-1|298) [StmtExecutor.handleDdlStmt():2321] DDL statement(/* ApplicationName=DataGrip 2023.1.1 */ create table test_create_table_like like test_create_table) process failed.
org.apache.doris.common.DdlException: errCode = 2, detailMessage = Failed to execute CREATE TABLE LIKE test_create_table. Reason: errCode = 2, detailMessage = Syntax error in line 3:
  `b` varchar(96) NOT NULL COMMENT ''b'',
                                     ^
Encountered: IDENTIFIER
Expected: COMMA

        at org.apache.doris.datasource.InternalCatalog.createTableLike(InternalCatalog.java:1187) ~[classes/:?]
        at org.apache.doris.catalog.Env.createTableLike(Env.java:2878) ~[classes/:?]
        at org.apache.doris.qe.DdlExecutor.execute(DdlExecutor.java:163) ~[classes/:?]
        at org.apache.doris.qe.StmtExecutor.handleDdlStmt(StmtExecutor.java:2312) ~[classes/:?]
        at org.apache.doris.qe.StmtExecutor.executeByLegacy(StmtExecutor.java:772) ~[classes/:?]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:468) ~[classes/:?]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:438) ~[classes/:?]
        at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:353) ~[classes/:?]

```

### Affected version
master 
### Changes

In the lexical analysis stage, quotes are automatically filtered when characters are matched, and escaping is added when querying.