### PR TITLE
[tpcds-tools](nereids) remove sf100 cascades specific control for global config

### DIFF
--- a/tools/tpcds-tools/conf/opt/opt_sf100.sql
+++ b/tools/tpcds-tools/conf/opt/opt_sf100.sql
@@ -4,5 +4,3 @@ set global enable_runtime_filter_prune=false;
 set global runtime_filter_wait_time_ms=10000;
 set global enable_fallback_to_original_planner=false;
 set global forbid_unknown_col_stats=true;
-set global max_join_number_bushy_tree=10;
-set global memo_max_group_expression_size=15000;

--- a/tools/tpcds-tools/queries/sf100/query72.sql
+++ b/tools/tpcds-tools/queries/sf100/query72.sql
@@ -1,3 +1,5 @@
+set max_join_number_bushy_tree=10;
+set memo_max_group_expression_size=15000;
 select  i_item_desc
       ,w_warehouse_name
       ,d1.d_week_seq


### PR DESCRIPTION
## Proposed changes

remove sf100 cascades specific control for global config, which is only for q72

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

