### PR TITLE
[improvement](tablet clone) partition rebalancer invalidate tablet move when sched failed

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/MovesCacheMap.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/MovesCacheMap.java
@@ -92,6 +92,18 @@ public class MovesCacheMap {
         return null;
     }
 
+    public void invalidateTablet(TabletSchedCtx tabletCtx) {
+        Map<TStorageMedium, MovesCache> mediumMoves = cacheMap.get(tabletCtx.getTag());
+        if (mediumMoves != null) {
+            MovesCache cache = mediumMoves.get(tabletCtx.getStorageMedium());
+            if (cache != null) {
+                cache.get().invalidate(tabletCtx.getTabletId());
+            } else {
+                mediumMoves.values().forEach(it -> it.get().invalidate(tabletCtx.getTabletId()));
+            }
+        }
+    }
+
     // For given tablet ctx, find it in cacheMap
     public Pair<PartitionRebalancer.TabletMove, Long> getTabletMove(TabletSchedCtx tabletCtx) {
         for (Map<TStorageMedium, MovesCache> mediumMap : cacheMap.values()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/PartitionRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/PartitionRebalancer.java
@@ -300,12 +300,17 @@ public class PartitionRebalancer extends Rebalancer {
     }
 
     @Override
+    public void onTabletFailed(TabletSchedCtx tabletCtx) {
+        movesCacheMap.invalidateTablet(tabletCtx);
+    }
+
+    @Override
     public Long getToDeleteReplicaId(TabletSchedCtx tabletCtx) {
         // We don't invalidate the cached move here, cuz the redundant repair progress is just started.
         // The move should be invalidated by TTL or Algo.CheckMoveCompleted()
         Pair<TabletMove, Long> pair = movesCacheMap.getTabletMove(tabletCtx);
         if (pair != null) {
-            Preconditions.checkState(pair.second != -1L);
+            //Preconditions.checkState(pair.second != -1L);
             return pair.second;
         } else {
             return (long) -1;

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/Rebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/Rebalancer.java
@@ -100,6 +100,9 @@ public abstract class Rebalancer {
         return -1L;
     }
 
+    public void onTabletFailed(TabletSchedCtx tabletCtx) {
+    }
+
     public void updateLoadStatistic(Map<Tag, LoadStatisticForTag> statisticMap) {
         this.statisticMap = statisticMap;
     }


### PR DESCRIPTION

## Proposed changes

For partition rebalancer,  when sched a tablet failed or add it into pending queue failed, should invalidate it in move cache.
Otherwise the cache will keep this tablet until time expire.

Also fix partition reblancer's getToDeleteReplicaId check condition failed.  Because the move cache is not always sync with TabletScheduler's tablet's lastest status,  the move cache may be stale. So this function no need to check failed.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

