### PR TITLE
[Fix](Nereids) fix case expectation error with nereids

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/InPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/InPredicate.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.trees.expressions;
 
+import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.exceptions.UnboundException;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
@@ -117,5 +118,17 @@ public class InPredicate extends Expression {
             }
         }
         return true;
+    }
+
+    @Override
+    public void checkLegalityBeforeTypeCoercion() {
+        children().forEach(c -> {
+            if (c.getDataType().isObjectType()) {
+                throw new AnalysisException("in predicate could not contains object type: " + this.toSql());
+            }
+            if (c.getDataType().isComplexType()) {
+                throw new AnalysisException("in predicate could not contains complex type: " + this.toSql());
+            }
+        });
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/TimestampArithmetic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/TimestampArithmetic.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.trees.expressions;
 
 import org.apache.doris.analysis.ArithmeticExpr.Operator;
+import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.exceptions.UnboundException;
 import org.apache.doris.nereids.trees.expressions.functions.PropagateNullableOnDateLikeV2Args;
 import org.apache.doris.nereids.trees.expressions.literal.Interval.TimeUnit;
@@ -165,5 +166,17 @@ public class TimestampArithmetic extends Expression implements BinaryExpression,
         TimestampArithmetic other = (TimestampArithmetic) o;
         return Objects.equals(funcName, other.funcName) && Objects.equals(timeUnit, other.timeUnit)
                 && Objects.equals(left(), other.left()) && Objects.equals(right(), other.right());
+    }
+
+    @Override
+    public void checkLegalityBeforeTypeCoercion() {
+        children().forEach(c -> {
+            if (c.getDataType().isObjectType()) {
+                throw new AnalysisException("in predicate could not contains object type: " + this.toSql());
+            }
+            if (c.getDataType().isComplexType()) {
+                throw new AnalysisException("in predicate could not contains complex type: " + this.toSql());
+            }
+        });
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
@@ -455,6 +455,9 @@ public class TypeCoercionUtils {
      * process divide
      */
     public static Expression processDivide(Divide divide, Expression left, Expression right) {
+        // check
+        divide.checkLegalityBeforeTypeCoercion();
+
         DataType t1 = TypeCoercionUtils.getNumResultType(left.getDataType());
         DataType t2 = TypeCoercionUtils.getNumResultType(right.getDataType());
 
@@ -496,6 +499,9 @@ public class TypeCoercionUtils {
      * process divide
      */
     public static Expression processIntegralDivide(IntegralDivide divide, Expression left, Expression right) {
+        // check
+        divide.checkLegalityBeforeTypeCoercion();
+
         DataType t1 = TypeCoercionUtils.getNumResultType(left.getDataType());
         DataType t2 = TypeCoercionUtils.getNumResultType(right.getDataType());
         left = castIfNotSameType(left, t1);
@@ -525,6 +531,9 @@ public class TypeCoercionUtils {
      */
     public static Expression processBinaryArithmetic(BinaryArithmetic binaryArithmetic,
             Expression left, Expression right) {
+        // check
+        binaryArithmetic.checkLegalityBeforeTypeCoercion();
+
         // characterLiteralTypeCoercion
         // we do this because string is cast to double by default
         // but if string literal could be cast to small type, we could use smaller type than double.
@@ -629,6 +638,9 @@ public class TypeCoercionUtils {
      */
     public static Expression processTimestampArithmetic(TimestampArithmetic timestampArithmetic,
             Expression left, Expression right) {
+        // check
+        timestampArithmetic.checkLegalityBeforeTypeCoercion();
+
         // left
         DataType leftType = left.getDataType();
 
@@ -675,6 +687,9 @@ public class TypeCoercionUtils {
      */
     public static Expression processComparisonPredicate(ComparisonPredicate comparisonPredicate,
             Expression left, Expression right) {
+        // check
+        comparisonPredicate.checkLegalityBeforeTypeCoercion();
+
         // same type
         if (left.getDataType().equals(right.getDataType())) {
             return comparisonPredicate.withChildren(left, right);
@@ -699,6 +714,9 @@ public class TypeCoercionUtils {
      * process in predicate type coercion.
      */
     public static Expression processInPredicate(InPredicate inPredicate) {
+        // check
+        inPredicate.checkLegalityBeforeTypeCoercion();
+
         if (inPredicate.getOptions().stream().map(Expression::getDataType)
                 .allMatch(dt -> dt.equals(inPredicate.getCompareExpr().getDataType()))) {
             return inPredicate;
@@ -723,6 +741,9 @@ public class TypeCoercionUtils {
      * process case when type coercion.
      */
     public static Expression processCaseWhen(CaseWhen caseWhen) {
+        // check
+        caseWhen.checkLegalityBeforeTypeCoercion();
+
         // type coercion
         List<DataType> dataTypesForCoercion = caseWhen.dataTypesForCoercion();
         if (dataTypesForCoercion.size() <= 1) {
@@ -767,6 +788,9 @@ public class TypeCoercionUtils {
      * process compound predicate type coercion.
      */
     public static Expression processCompoundPredicate(CompoundPredicate compoundPredicate) {
+        // check
+        compoundPredicate.checkLegalityBeforeTypeCoercion();
+
         compoundPredicate.children().forEach(e -> {
                     if (!e.getDataType().isBooleanType() && !e.getDataType().isNullType()
                             && !(e instanceof SubqueryExpr)) {


### PR DESCRIPTION
## Proposed changes

Problem:
expectation error when checking bitmap int
Example:
expecting an exception of (bitmap in null or 1 = 1)
Reason:
nereids lose check of datatype
Solved:
cherry-pick parts of checks from master pr #22851 

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

