### PR TITLE
[fix](move-memtable) fix use-after-free in load stream stub

### DIFF
--- a/be/src/vec/sink/load_stream_stub.h
+++ b/be/src/vec/sink/load_stream_stub.h
@@ -183,13 +183,9 @@ public:
         return _enable_unique_mow_for_index->at(index_id);
     }
 
-    std::vector<int64_t> success_tablets() {
-        return _handler.success_tablets();
-    }
+    std::vector<int64_t> success_tablets() { return _handler.success_tablets(); }
 
-    std::vector<int64_t> failed_tablets() {
-        return _handler.failed_tablets();
-    }
+    std::vector<int64_t> failed_tablets() { return _handler.failed_tablets(); }
 
     brpc::StreamId stream_id() const { return _stream_id; }
 

--- a/be/src/vec/sink/load_stream_stub.h
+++ b/be/src/vec/sink/load_stream_stub.h
@@ -105,6 +105,7 @@ private:
                                 : Status::Error<true>(ret, "stream close_wait timeout");
             }
             _close_cv.wait(lock);
+            return Status::OK();
         };
 
     private:

--- a/be/src/vec/sink/load_stream_stub.h
+++ b/be/src/vec/sink/load_stream_stub.h
@@ -85,8 +85,6 @@ class LoadStreamStub {
 private:
     class LoadStreamReplyHandler : public brpc::StreamInputHandler {
     public:
-        LoadStreamReplyHandler(LoadStreamStub* stub) : _stub(stub) {}
-
         int on_received_messages(brpc::StreamId id, butil::IOBuf* const messages[],
                                  size_t size) override;
 
@@ -201,7 +199,7 @@ protected:
     brpc::StreamId _stream_id;
     int64_t _src_id = -1; // source backend_id
     int64_t _dst_id = -1; // destination backend_id
-    LoadStreamReplyHandler _handler {this};
+    LoadStreamReplyHandler _handler;
 
     bthread::Mutex _success_tablets_mutex;
     bthread::Mutex _failed_tablets_mutex;

--- a/be/src/vec/sink/vtablet_sink_v2.cpp
+++ b/be/src/vec/sink/vtablet_sink_v2.cpp
@@ -394,7 +394,7 @@ Status VOlapTableSinkV2::close(RuntimeState* state, Status exec_status) {
             SCOPED_TIMER(_close_load_timer);
             for (const auto& [_, streams] : _streams_for_node) {
                 for (const auto& stream : *streams) {
-                    static_cast<void>(stream->close_wait());
+                    RETURN_IF_ERROR(stream->close_wait());
                 }
             }
         }


### PR DESCRIPTION
## Proposed changes

Fix use-after-free in load stream stub handler `on_closed()`.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

