### PR TITLE
[fix](pipelineX) add double check in Coordinator

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -1087,6 +1087,9 @@ public class Coordinator implements CoordInterface {
     void updateDeltas(List<String> urls) {
         lock.lock();
         try {
+            if (deltaUrls == null) {
+                deltaUrls = Lists.newArrayList();
+            }
             deltaUrls.addAll(urls);
         } finally {
             lock.unlock();
@@ -1125,7 +1128,9 @@ public class Coordinator implements CoordInterface {
             if (value != null) {
                 numRowsUnselected += Long.parseLong(value);
             }
-
+            if (this.loadCounters == null) {
+                this.loadCounters = Maps.newHashMap();
+            }
             this.loadCounters.put(LoadEtlTask.DPP_NORMAL_ALL, "" + numRowsNormal);
             this.loadCounters.put(LoadEtlTask.DPP_ABNORMAL_ALL, "" + numRowsAbnormal);
             this.loadCounters.put(LoadJob.UNSELECTED_ROWS, "" + numRowsUnselected);
@@ -2403,7 +2408,7 @@ public class Coordinator implements CoordInterface {
             if (params.isSetLoadCounters()) {
                 updateLoadCounters(params.getLoadCounters());
             }
-            if (params.isSetTrackingUrl()) {
+            if (params.isSetTrackingUrl() && trackingUrl != null) {
                 trackingUrl = params.getTrackingUrl();
             }
             if (params.isSetExportFiles()) {


### PR DESCRIPTION
## Proposed changes

Because some of the properties on pipelineX are not properly configured, a nullptr exception may occur. This, in turn, will affect the call to markOneInstanceDone.


wait for 2 seconds
```java
        if (isFinished && profileDoneSignal != null) {
            try {
                profileDoneSignal.await(2, TimeUnit.SECONDS);
            } catch (InterruptedException e1) {
                LOG.warn("signal await error", e1);
            }
        }
```

In the past, it could be observed that enabling pipelineX and profiling would consistently result in a 2-second increase in time.
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

