### PR TITLE
[Bug](function) fix to_quantile_state input type judge

### DIFF
--- a/be/src/vec/functions/function_quantile_state.cpp
+++ b/be/src/vec/functions/function_quantile_state.cpp
@@ -198,9 +198,9 @@ public:
                 status = execute_internal<ColumnString, true>(column, data_type, column_result);
             } else if (nested_which.is_int64()) {
                 status = execute_internal<ColumnInt64, true>(column, data_type, column_result);
-            } else if (which.is_float32()) {
+            } else if (nested_which.is_float32()) {
                 status = execute_internal<ColumnFloat32, true>(column, data_type, column_result);
-            } else if (which.is_float64()) {
+            } else if (nested_which.is_float64()) {
                 status = execute_internal<ColumnFloat64, true>(column, data_type, column_result);
             } else {
                 return type_error();


### PR DESCRIPTION
## Proposed changes
[RUNTIME_ERROR]Illegal column Nullable(Float64) of argument of function to_quantile_state\n\n\

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

