### PR TITLE
[opt](filecache) do not sync segment data into storage system

### DIFF
--- a/be/src/io/cache/block/block_file_segment.cpp
+++ b/be/src/io/cache/block/block_file_segment.cpp
@@ -159,7 +159,8 @@ Status FileBlock::append(Slice data) {
     Status st = Status::OK();
     if (!_cache_writer) {
         auto download_path = get_path_in_local_cache();
-        st = global_local_filesystem()->create_file(download_path, &_cache_writer);
+        FileWriterOptions not_sync {.sync_file_data = false};
+        st = global_local_filesystem()->create_file(download_path, &_cache_writer, &not_sync);
         if (!st) {
             _cache_writer.reset();
             return st;

--- a/be/src/io/fs/file_writer.h
+++ b/be/src/io/fs/file_writer.h
@@ -32,6 +32,7 @@ class FileSystem;
 struct FileWriterOptions {
     bool write_file_cache = false;
     bool is_cold_data = false;
+    bool sync_file_data = true;        // Whether flush data into storage system
     int64_t file_cache_expiration = 0; // Absolute time
 };
 

--- a/be/src/io/fs/local_file_system.cpp
+++ b/be/src/io/fs/local_file_system.cpp
@@ -60,8 +60,9 @@ Status LocalFileSystem::create_file_impl(const Path& file, FileWriterPtr* writer
     if (-1 == fd) {
         return Status::IOError("failed to open {}: {}", file.native(), errno_to_str());
     }
+    bool sync_data = opts != nullptr ? opts->sync_file_data : true;
     *writer = std::make_unique<LocalFileWriter>(
-            file, fd, std::static_pointer_cast<LocalFileSystem>(shared_from_this()));
+            file, fd, std::static_pointer_cast<LocalFileSystem>(shared_from_this()), sync_data);
     return Status::OK();
 }
 

--- a/be/src/io/fs/local_file_writer.cpp
+++ b/be/src/io/fs/local_file_writer.cpp
@@ -67,8 +67,8 @@ Status sync_dir(const io::Path& dirname) {
 
 namespace io {
 
-LocalFileWriter::LocalFileWriter(Path path, int fd, FileSystemSPtr fs)
-        : FileWriter(std::move(path), fs), _fd(fd) {
+LocalFileWriter::LocalFileWriter(Path path, int fd, FileSystemSPtr fs, bool sync_data)
+        : FileWriter(std::move(path), fs), _fd(fd), _sync_data(sync_data) {
     _opened = true;
     DorisMetrics::instance()->local_file_open_writing->increment(1);
     DorisMetrics::instance()->local_file_writer_total->increment(1);
@@ -85,7 +85,7 @@ LocalFileWriter::~LocalFileWriter() {
 }
 
 Status LocalFileWriter::close() {
-    return _close(true);
+    return _close(_sync_data);
 }
 
 Status LocalFileWriter::abort() {

--- a/be/src/io/fs/local_file_writer.h
+++ b/be/src/io/fs/local_file_writer.h
@@ -30,7 +30,7 @@ namespace io {
 
 class LocalFileWriter final : public FileWriter {
 public:
-    LocalFileWriter(Path path, int fd, FileSystemSPtr fs);
+    LocalFileWriter(Path path, int fd, FileSystemSPtr fs, bool sync_data = true);
     LocalFileWriter(Path path, int fd);
     ~LocalFileWriter() override;
 
@@ -46,6 +46,7 @@ private:
 private:
     int _fd; // owned
     bool _dirty = false;
+    const bool _sync_data;
 };
 
 } // namespace io


### PR DESCRIPTION
## Proposed changes

File cache will return the reading data only when its writer has finished the write operation and close the segment file. However there's no need to call `fdatasync` when closing segment file. `fdatasync` takes a lot of time, and severely impact on cache performance.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

