### PR TITLE
[bug](function) fix regexp_extract_all can't handle empty str

### DIFF
--- a/be/src/vec/functions/function_regexp.cpp
+++ b/be/src/vec/functions/function_regexp.cpp
@@ -361,6 +361,7 @@ struct RegexpExtractAllImpl {
         }
 
         if (res_matches.empty()) {
+            StringOP::push_empty_string(index_now, result_data, result_offset);
             return;
         }
 

--- a/regression-test/data/query_p0/sql_functions/string_functions/test_string_function_regexp.out
+++ b/regression-test/data/query_p0/sql_functions/string_functions/test_string_function_regexp.out
@@ -67,6 +67,12 @@ d
 -- !sql --
 ['ab','c','c','c']
 
+-- !sql_regexp_extract_all --
+	0
+	0
+	0
+	0
+
 -- !sql --
 a-b-c
 

--- a/regression-test/suites/query_p0/sql_functions/string_functions/test_string_function_regexp.groovy
+++ b/regression-test/suites/query_p0/sql_functions/string_functions/test_string_function_regexp.groovy
@@ -58,6 +58,7 @@ suite("test_string_function_regexp") {
     qt_sql "select regexp_extract_all('xxfs','f');"
     qt_sql "select regexp_extract_all('asdfg', '(z|x|c|)');"
     qt_sql "select regexp_extract_all('abcdfesscca', '(ab|c|)');"
+    qt_sql_regexp_extract_all "select regexp_extract_all('', '\"([^\"]+)\":'), length(regexp_extract_all('', '\"([^\"]+)\":')) from test_string_function_regexp;"
 
     qt_sql "SELECT regexp_replace('a b c', \" \", \"-\");"
     qt_sql "SELECT regexp_replace('a b c','(b)','<\\\\1>');"


### PR DESCRIPTION
## Proposed changes
regexp_extract_all need return empty result when input is empty str.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

