### PR TITLE
[Fix](s3 fs) create_file_impl doesn't create a file as expected

### DIFF
--- a/be/src/io/fs/s3_file_system.cpp
+++ b/be/src/io/fs/s3_file_system.cpp
@@ -131,6 +131,7 @@ Status S3FileSystem::connect_impl() {
 
 Status S3FileSystem::create_file_impl(const Path& file, FileWriterPtr* writer,
                                       const FileWriterOptions* opts) {
+    RETURN_IF_ERROR(direct_upload_impl(file, ""));
     GET_KEY(key, file);
     *writer = std::make_unique<S3FileWriter>(
             key, std::static_pointer_cast<S3FileSystem>(shared_from_this()), opts);

--- a/be/test/io/fs/s3_file_writer_test.cpp
+++ b/be/test/io/fs/s3_file_writer_test.cpp
@@ -117,10 +117,9 @@ TEST_F(S3FileWriterTest, multi_part_io_error) {
         // The second part would fail uploading itself to s3
         // so the result of close should be not ok
         ASSERT_TRUE(!s3_file_writer->close().ok());
-        bool exits = false;
-        auto s = s3_fs->exists("multi_part_io_error", &exits);
-        LOG(INFO) << "status is " << s;
-        ASSERT_TRUE(!exits);
+        int64_t size = -1;
+        ASSERT_TRUE((s3_fs->file_size("multi_part_io_error", &size)).ok());
+        ASSERT_EQ(0, size);
     }
 }
 
@@ -187,9 +186,9 @@ TEST_F(S3FileWriterTest, appendv_random_quit) {
         size_t bytes_read = 0;
         ASSERT_TRUE(local_file_reader->read_at(offset, slice, &bytes_read).ok());
         ASSERT_TRUE(!s3_file_writer->append(Slice(buf, bytes_read)).ok());
-        bool exits = false;
-        static_cast<void>(s3_fs->exists("appendv_random_quit", &exits));
-        ASSERT_TRUE(!exits);
+        int64_t size = -1;
+        ASSERT_TRUE((s3_fs->file_size("appendv_random_quit", &size)).ok());
+        ASSERT_EQ(0, size);
     }
 }
 
@@ -224,9 +223,9 @@ TEST_F(S3FileWriterTest, multi_part_open_error) {
         // and it would be rejectd one error
         auto st = s3_file_writer->append(Slice(buf.get(), bytes_read));
         ASSERT_TRUE(!st.ok());
-        bool exits = false;
-        static_cast<void>(s3_fs->exists("multi_part_open_error", &exits));
-        ASSERT_TRUE(!exits);
+        int64_t size = -1;
+        ASSERT_TRUE((s3_fs->file_size("multi_part_open_error", &size)).ok());
+        ASSERT_EQ(0, size);
     }
 }
 
@@ -313,9 +312,9 @@ TEST_F(S3FileWriterTest, close_error) {
         io::FileWriterPtr s3_file_writer;
         ASSERT_TRUE(s3_fs->create_file("close_error", &s3_file_writer, &state).ok());
         ASSERT_TRUE(!s3_file_writer->close().ok());
-        bool exits = false;
-        static_cast<void>(s3_fs->exists("close_error", &exits));
-        ASSERT_TRUE(!exits);
+        int64_t size = -1;
+        ASSERT_TRUE((s3_fs->file_size("close_error", &size)).ok());
+        ASSERT_EQ(0, size);
     }
 }
 
@@ -350,9 +349,9 @@ TEST_F(S3FileWriterTest, finalize_error) {
         }
         ASSERT_EQ(s3_file_writer->bytes_appended(), file_size);
         ASSERT_TRUE(!s3_file_writer->finalize().ok());
-        bool exits = false;
-        static_cast<void>(s3_fs->exists("finalize_error", &exits));
-        ASSERT_TRUE(!exits);
+        int64_t size = -1;
+        ASSERT_TRUE((s3_fs->file_size("finalize_error", &size)).ok());
+        ASSERT_EQ(0, size);
     }
 }
 

--- a/regression-test/suites/export_p0/test_outfile_exception.groovy
+++ b/regression-test/suites/export_p0/test_outfile_exception.groovy
@@ -84,7 +84,7 @@ suite("test_outfile_exception") {
         """
 
         // check exception
-        exception "NoSuchBucket:The specified bucket does not exist"
+        exception "The specified bucket does not exist"
     }
 
 
@@ -103,7 +103,7 @@ suite("test_outfile_exception") {
         """
 
         // check exception
-        exception "NoSuchBucket:The specified bucket does not exist"
+        exception "The specified bucket does not exist"
     }
 
 
@@ -122,7 +122,7 @@ suite("test_outfile_exception") {
         """
 
         // check exception
-        exception "NoSuchBucket:The specified bucket does not exist"
+        exception "The specified bucket does not exist"
     }
 
 
@@ -141,7 +141,7 @@ suite("test_outfile_exception") {
         """
 
         // check exception
-        exception "NoSuchBucket:The specified bucket does not exist"
+        exception "The specified bucket does not exist"
     }
 
 
@@ -160,6 +160,6 @@ suite("test_outfile_exception") {
         """
 
         // check exception
-        exception "NoSuchBucket:The specified bucket does not exist"
+        exception "The specified bucket does not exist"
     }
 }

--- a/regression-test/suites/nereids_p0/outfile/test_outfile_exception.groovy
+++ b/regression-test/suites/nereids_p0/outfile/test_outfile_exception.groovy
@@ -85,7 +85,7 @@ suite("test_outfile_exception") {
         """
 
         // check exception
-        exception "NoSuchBucket:The specified bucket does not exist"
+        exception "The specified bucket does not exist"
     }
 
 
@@ -104,7 +104,7 @@ suite("test_outfile_exception") {
         """
 
         // check exception
-        exception "NoSuchBucket:The specified bucket does not exist"
+        exception "The specified bucket does not exist"
     }
 
 
@@ -123,7 +123,7 @@ suite("test_outfile_exception") {
         """
 
         // check exception
-        exception "NoSuchBucket:The specified bucket does not exist"
+        exception "The specified bucket does not exist"
     }
 
 
@@ -142,7 +142,7 @@ suite("test_outfile_exception") {
         """
 
         // check exception
-        exception "NoSuchBucket:The specified bucket does not exist"
+        exception "The specified bucket does not exist"
     }
 
 
@@ -161,6 +161,6 @@ suite("test_outfile_exception") {
         """
 
         // check exception
-        exception "NoSuchBucket:The specified bucket does not exist"
+        exception "The specified bucket does not exist"
     }
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #25735

The implementation of `S3FileSystem::create_file_impl` doesn't create a file on S3 file system.
```cpp
Status S3FileSystem::create_file_impl(const Path& file, FileWriterPtr* writer,
                                      const FileWriterOptions* opts) {
    GET_KEY(key, file);
    *writer = std::make_unique<S3FileWriter>(
            key, std::static_pointer_cast<S3FileSystem>(shared_from_this()), opts);
    return Status::OK();
}
```
However, the implementation of `LocalFileSystem::create_file_impl` does so. After calling the function `open`, an empty file was created on the local file system.
```cpp
Status LocalFileSystem::create_file_impl(const Path& file, FileWriterPtr* writer,
                                         const FileWriterOptions* opts) {
    int fd = ::open(file.c_str(), O_TRUNC | O_WRONLY | O_CREAT | O_CLOEXEC, 0666);
    if (-1 == fd) {
        return Status::IOError("failed to open {}: {}", file.native(), errno_to_str());
    }
    *writer = std::make_unique<LocalFileWriter>(
            file, fd, std::static_pointer_cast<LocalFileSystem>(shared_from_this()));
    return Status::OK();
}
```
They are inconsistent semantics.

Besides, in `DocumentsWriter::writeSegment`, the function calls `directory->createOutput((segmentName + ".frq").c_str())` and `S3FileSystem::create_file_impl` will be called finally. The interface `createOutput` is expected to create a new and empty file in the current directory. Therefore, the implementation is wrong and it makes errors occur when `InvertedIndexColumnWriter` finishes. 
```cpp
// Creates a new, empty file in the directory with the given name.
//	Returns a stream writing this file.
virtual IndexOutput* createOutput(const char* name) = 0;
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

