### PR TITLE
[Improve](topn opt) change `multiget_data` RPC worker pool from `_hea…

### DIFF
--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -1731,7 +1731,7 @@ void PInternalServiceImpl::multiget_data(google::protobuf::RpcController* contro
                                          const PMultiGetRequest* request,
                                          PMultiGetResponse* response,
                                          google::protobuf::Closure* done) {
-    bool ret = _heavy_work_pool.try_offer([request, response, done, this]() {
+    bool ret = _light_work_pool.try_offer([request, response, done, this]() {
         // multi get data by rowid
         MonotonicStopWatch watch;
         watch.start();


### PR DESCRIPTION
…vy_work_pool` to `_light_work_pool`

Under some workload the `multiget_data` maybe stuck and raise rpc timeout. Inorder to to minimize the RPC latency of point queries, so it should be placed in `_light_work_pool`, since it's typically finished in hundreds of millisecond

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

