### PR TITLE
[fix](Outfile) Fix exporting cast expression issue

### DIFF
--- a/be/src/vec/runtime/vfile_result_writer.cpp
+++ b/be/src/vec/runtime/vfile_result_writer.cpp
@@ -207,7 +207,7 @@ Status VFileResultWriter::append_block(Block& block) {
         return status;
     }
     if (_vfile_writer) {
-        _write_file(output_block);
+        RETURN_IF_ERROR(_write_file(output_block));
     } else {
         RETURN_IF_ERROR(_write_csv_file(output_block));
     }

--- a/be/src/vec/runtime/vorc_writer.cpp
+++ b/be/src/vec/runtime/vorc_writer.cpp
@@ -267,11 +267,15 @@ Status VOrcWriterWrapper::write(const Block& block) {
         for (size_t i = 0; i < block.columns(); i++) {
             auto& raw_column = block.get_by_position(i).column;
             auto nullable = raw_column->is_nullable();
-            const auto col = nullable ? reinterpret_cast<const ColumnNullable*>(
-                                                block.get_by_position(i).column.get())
-                                                ->get_nested_column_ptr()
-                                                .get()
-                                      : block.get_by_position(i).column.get();
+            auto column_ptr = block.get_by_position(i).column->convert_to_full_column_if_const();
+            doris::vectorized::ColumnPtr column;
+            if (nullable) {
+                column = assert_cast<const ColumnNullable&>(*column_ptr).get_nested_column_ptr();
+            } else {
+                column = column_ptr;
+            }
+            auto col = column.get();
+
             auto null_map = nullable && reinterpret_cast<const ColumnNullable*>(
                                                 block.get_by_position(i).column.get())
                                                     ->has_null()
@@ -500,7 +504,7 @@ Status VOrcWriterWrapper::write(const Block& block) {
             }
         }
     } catch (const std::exception& e) {
-        LOG(WARNING) << "Parquet write error: " << e.what();
+        LOG(WARNING) << "Orc write error: " << e.what();
         return Status::InternalError(e.what());
     }
     root->numElements = sz;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

When there is a constant conversion in the select statement in the `outfile` statement, `outfile` will show success, but the actual exported file content is incorrect.

bug reproduction:
```sql
select cast('2565' as string) as bb from student3
into outfile "s3://xxx/test/outfile_"
format as parquet
properties(
  "AWS_ENDPOINT" = "endpoint",
  "AWS_REGION" = "aaa",
  "AWS_ACCESS_KEY"= "xx",
  "AWS_SECRET_KEY" = "yy"
);
```

After fixed:
Can export data correctly.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

