### PR TITLE
[fix](java udf) make executor class thread local

### DIFF
--- a/be/src/vec/functions/function_java_udf.h
+++ b/be/src/vec/functions/function_java_udf.h
@@ -38,9 +38,8 @@
 #include "vec/core/types.h"
 #include "vec/data_types/data_type.h"
 #include "vec/functions/function.h"
-namespace doris {
 
-namespace vectorized {
+namespace doris::vectorized {
 
 class JavaUdfPreparedFunction : public PreparedFunctionImpl {
 public:
@@ -114,26 +113,18 @@ private:
     const DataTypes _argument_types;
     const DataTypePtr _return_type;
 
-    struct JniEnv {
-        /// Global class reference to the UdfExecutor Java class and related method IDs. Set in
-        /// Init(). These have the lifetime of the process (i.e. 'executor_cl_' is never freed).
-        jclass executor_cl;
-        jmethodID executor_ctor_id;
-        jmethodID executor_evaluate_id;
-        jmethodID executor_close_id;
-    };
-
     struct JniContext {
         // Do not save parent directly, because parent is in VExpr, but jni context is in FunctionContext
         // The deconstruct sequence is not determined, it will core.
         // JniContext's lifecycle should same with function context, not related with expr
-        jclass executor_cl_;
-        jmethodID executor_close_id_;
+        jclass executor_cl;
+        jmethodID executor_ctor_id;
+        jmethodID executor_evaluate_id;
+        jmethodID executor_close_id;
         jobject executor = nullptr;
         bool is_closed = false;
 
-        JniContext(int64_t num_args, jclass executor_cl, jmethodID executor_close_id)
-                : executor_cl_(executor_cl), executor_close_id_(executor_close_id) {}
+        JniContext() = default;
 
         void close() {
             if (is_closed) {
@@ -146,15 +137,16 @@ private:
                 LOG(WARNING) << "errors while get jni env " << status;
                 return;
             }
-            env->CallNonvirtualVoidMethodA(executor, executor_cl_, executor_close_id_, NULL);
+            env->CallNonvirtualVoidMethodA(executor, executor_cl, executor_close_id, nullptr);
             env->DeleteGlobalRef(executor);
-            env->DeleteGlobalRef(executor_cl_);
+            env->DeleteGlobalRef(executor_cl);
             Status s = JniUtil::GetJniExceptionMsg(env);
-            if (!s.ok()) LOG(WARNING) << s;
+            if (!s.ok()) {
+                LOG(WARNING) << s;
+            }
             is_closed = true;
         }
     };
 };
 
-} // namespace vectorized
-} // namespace doris
+} // namespace doris::vectorized


### PR DESCRIPTION
## Proposed changes

Java udf will be failed when enable `experimental_enable_pipeline_x_engine`, because `pipeline_x` makes `Expr` shared among fragments. However, PR(https://github.com/apache/doris/pull/25302) has deleted the global reference of executor class when calling `JniContext::close` in thread local, so another fragment can't call `JavaFunctionCall::open` in its local thread.
We have to deleted the global reference of executor class, before PR(https://github.com/apache/doris/pull/25302) exists memory leakage, and there's no need to make executor class fragment local, so we make all the context thread local.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

