### PR TITLE
[enhancement](stats) Param tune which would get a better balance between execution time and cost

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1766,7 +1766,7 @@ public class Config extends ConfigBase {
      * Used to determined how many statistics collection SQL could run simultaneously.
      */
     @ConfField
-    public static int statistics_simultaneously_running_task_num = 5;
+    public static int statistics_simultaneously_running_task_num = 3;
 
     /**
      * if table has too many replicas, Fe occur oom when schema change.

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
@@ -67,7 +67,7 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
                     + "${partId} AS part_id, "
                     + "COUNT(1) AS row_count, "
                     + "NDV(`${colName}`) AS ndv, "
-                    + "SUM(CASE WHEN `${colName}` IS NULL THEN 1 ELSE 0 END) AS null_count, "
+                    + "COUNT(1) - COUNT(`${colName}`) AS null_count, "
                     + "MIN(`${colName}`) AS min, "
                     + "MAX(`${colName}`) AS max, "
                     + "${dataSizeFunction} AS data_size, "
@@ -83,7 +83,7 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
             + "NULL AS part_id, "
             + "ROUND(COUNT(1) * ${scaleFactor}) AS row_count, "
             + NDV_SAMPLE_TEMPLATE
-            + "SUM(CASE WHEN `${colName}` IS NULL THEN 1 ELSE 0 END) * ${scaleFactor} AS null_count, "
+            + "(COUNT(1) - COUNT(`${colName}`)) * ${scaleFactor} AS null_count, "
             + "NULL AS min, "
             + "NULL AS max, "
             + "${dataSizeFunction} * ${scaleFactor} AS data_size, "

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticConstants.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticConstants.java
@@ -79,7 +79,7 @@ public class StatisticConstants {
     public static final int LOAD_RETRY_TIMES = 3;
 
     // union more relation than 512 may cause StackOverFlowException in the future.
-    public static final int UNION_ALL_LIMIT = 512;
+    public static final int UNION_ALL_LIMIT = 2048;
 
     public static final String FULL_AUTO_ANALYZE_START_TIME = "00:00:00";
     public static final String FULL_AUTO_ANALYZE_END_TIME = "23:59:59";


### PR DESCRIPTION
## Proposed changes

1. Change the default parallel execution analyze task to 3, which would reduce 15% - 20% cpu cost and increase the execution time a litle
2. Use `count(1) - count(col1)` rather than sum(case when) which could leverage some optimize like read count from tablet metadata directly

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

