### PR TITLE
[fix](nereids) prune partition bug in pattern ColA <> ColB

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PruneOlapScanPartitionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PruneOlapScanPartitionTest.java
@@ -228,6 +228,8 @@ class PruneOlapScanPartitionTest extends TestWithFeService implements MemoPatter
     public void canNotPruneComplexPredicate() {
         test("test_range_parts", "(part = 10) or (part + id = 1)", 4);
         test("test_range_parts", "(part + id = 1) and (part = 4)", 1);
+        test("test_range_parts", "(part = 2) and (part <> id)", 1);
+        test("test_range_parts", "(part = 2) or (part <> id)", 4);
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

in predicate rewrite phase, we eliminate some conjuncts which contains un-interested columns.
for example: T (a, b) partition by (a)
interest cols: a
uninsterest cols: b
for parition prune, 
filter "a=1 and a>b" is equivalent to "a=1", 
filter "a=1 or a>b" is equivalent to "TRUE"



Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

