### PR TITLE
[fix](move-memtable) fallback if partial update

### DIFF
--- a/be/src/exec/data_sink.cpp
+++ b/be/src/exec/data_sink.cpp
@@ -149,7 +149,7 @@ Status DataSink::create_data_sink(ObjectPool* pool, const TDataSink& thrift_sink
         Status status = Status::OK();
         DCHECK(thrift_sink.__isset.olap_table_sink);
         if (state->query_options().enable_memtable_on_sink_node &&
-            _has_inverted_index(thrift_sink.olap_table_sink)) {
+            !_has_inverted_index(thrift_sink.olap_table_sink)) {
             sink->reset(new vectorized::VOlapTableSinkV2(pool, row_desc, output_exprs, &status));
         } else {
             sink->reset(new vectorized::VOlapTableSink(pool, row_desc, output_exprs, false));

--- a/be/src/exec/data_sink.cpp
+++ b/be/src/exec/data_sink.cpp
@@ -149,7 +149,7 @@ Status DataSink::create_data_sink(ObjectPool* pool, const TDataSink& thrift_sink
         Status status = Status::OK();
         DCHECK(thrift_sink.__isset.olap_table_sink);
         if (state->query_options().enable_memtable_on_sink_node &&
-            !_has_inverted_index(thrift_sink.olap_table_sink)) {
+            !_has_inverted_index_or_partial_update(thrift_sink.olap_table_sink)) {
             sink->reset(new vectorized::VOlapTableSinkV2(pool, row_desc, output_exprs, &status));
         } else {
             sink->reset(new vectorized::VOlapTableSink(pool, row_desc, output_exprs, false));
@@ -304,7 +304,7 @@ Status DataSink::create_data_sink(ObjectPool* pool, const TDataSink& thrift_sink
         Status status = Status::OK();
         DCHECK(thrift_sink.__isset.olap_table_sink);
         if (state->query_options().enable_memtable_on_sink_node &&
-            !_has_inverted_index(thrift_sink.olap_table_sink)) {
+            !_has_inverted_index_or_partial_update(thrift_sink.olap_table_sink)) {
             sink->reset(new vectorized::VOlapTableSinkV2(pool, row_desc, output_exprs, &status));
         } else {
             sink->reset(new vectorized::VOlapTableSink(pool, row_desc, output_exprs, false));
@@ -365,10 +365,13 @@ Status DataSink::prepare(RuntimeState* state) {
     return Status::OK();
 }
 
-bool DataSink::_has_inverted_index(TOlapTableSink sink) {
+bool DataSink::_has_inverted_index_or_partial_update(TOlapTableSink sink) {
     OlapTableSchemaParam schema;
     if (!schema.init(sink.schema).ok()) {
         return false;
+    }
+    if (schema.is_partial_update()) {
+        return true;
     }
     for (const auto& index_schema : schema.indexes()) {
         for (const auto& index : index_schema->indexes) {

--- a/be/src/exec/data_sink.h
+++ b/be/src/exec/data_sink.h
@@ -116,7 +116,7 @@ public:
     virtual bool can_write() { return true; }
 
 private:
-    static bool _has_inverted_index(TOlapTableSink sink);
+    static bool _has_inverted_index_or_partial_update(TOlapTableSink sink);
 
 protected:
     // Set to true after close() has been called. subclasses should check and set this in

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -762,7 +762,7 @@ Status PipelineFragmentContext::_create_sink(int sender_id, const TDataSink& thr
     case TDataSinkType::OLAP_TABLE_SINK: {
         DCHECK(thrift_sink.__isset.olap_table_sink);
         if (state->query_options().enable_memtable_on_sink_node &&
-            !_has_inverted_index(thrift_sink.olap_table_sink)) {
+            !_has_inverted_index_or_partial_update(thrift_sink.olap_table_sink)) {
             sink_ = std::make_shared<OlapTableSinkV2OperatorBuilder>(next_operator_builder_id(),
                                                                      _sink.get());
         } else {
@@ -897,10 +897,13 @@ Status PipelineFragmentContext::send_report(bool done) {
             shared_from_this());
 }
 
-bool PipelineFragmentContext::_has_inverted_index(TOlapTableSink sink) {
+bool PipelineFragmentContext::_has_inverted_index_or_partial_update(TOlapTableSink sink) {
     OlapTableSchemaParam schema;
     if (!schema.init(sink.schema).ok()) {
         return false;
+    }
+    if (schema.is_partial_update()) {
+        return true;
     }
     for (const auto& index_schema : schema.indexes()) {
         for (const auto& index : index_schema->indexes) {

--- a/be/src/pipeline/pipeline_fragment_context.h
+++ b/be/src/pipeline/pipeline_fragment_context.h
@@ -217,7 +217,7 @@ protected:
     report_status_callback _report_status_cb;
 
 private:
-    static bool _has_inverted_index(TOlapTableSink sink);
+    static bool _has_inverted_index_or_partial_update(TOlapTableSink sink);
     std::vector<std::unique_ptr<PipelineTask>> _tasks;
     bool _group_commit;
 };


### PR DESCRIPTION
## Proposed changes

Partial update is not supported by move-memtable, fallback when partial update.
Also, there is 1 reversed filter missing in #25684.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

