### PR TITLE
[fix](feature request) add a configuration to enable filtering queries that should not be stored in the query profile

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1731,6 +1731,13 @@ public class Config extends ConfigBase {
     public static int max_query_profile_num = 100;
 
     /**
+     * Regular expressions are used to filter query statments.
+     * When a query match the pattern, it will not be recorded to query profile store.
+     */
+    @ConfField(mutable = true, masterOnly = false)
+    public static String query_profile_filter_pattern = null;
+
+    /**
      * Set to true to disable backend black list, so that even if we failed to send task to a backend,
      * that backend won't be added to black list.
      * This should only be set when running tests, such as regression test.

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
@@ -46,6 +46,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
+import java.util.regex.Pattern;
 
 /*
  * if you want to visit the attribute(such as queryID,defaultDb)
@@ -168,6 +169,12 @@ public class ProfileManager {
         }
 
         ProfileElement element = createElement(profile);
+        if (!Strings.isNullOrEmpty(Config.query_profile_filter_pattern)) {
+            Pattern pattern = Pattern.compile(Config.query_profile_filter_pattern, Pattern.CASE_INSENSITIVE);
+            if (pattern.matcher(element.infoStrings.get(SummaryProfile.SQL_STATEMENT)).matches()) {
+                return;
+            }
+        }
         // 'insert into' does have job_id, put all profiles key with query_id
         String key = element.infoStrings.get(SummaryProfile.PROFILE_ID);
         // check when push in, which can ensure every element in the list has QUERY_ID column,


### PR DESCRIPTION
## Proposed changes

close https://github.com/apache/doris/issues/25657

<!--Describe your changes.-->

add a configuration: query_profile_filter_pattern to enable filtering queries that should not be stored in the query profile

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

