### PR TITLE
[improvement](function) improve date_trunc function performance when timeunit is const

### DIFF
--- a/be/src/vec/functions/function_timestamp.cpp
+++ b/be/src/vec/functions/function_timestamp.cpp
@@ -441,42 +441,22 @@ private:
             }
         };
 
-        auto execute_impl = [&](const TimeUnit& UNIT) {
-            if (TimeUnit::YEAR == UNIT) {
-                _execute_inner_loop.template operator()<TimeUnit::YEAR>();
-            } else if (TimeUnit::QUARTER == UNIT) {
-                _execute_inner_loop.template operator()<TimeUnit::QUARTER>();
-            } else if (TimeUnit::MONTH == UNIT) {
-                _execute_inner_loop.template operator()<TimeUnit::MONTH>();
-            } else if (TimeUnit::WEEK == UNIT) {
-                _execute_inner_loop.template operator()<TimeUnit::WEEK>();
-            } else if (TimeUnit::DAY == UNIT) {
-                _execute_inner_loop.template operator()<TimeUnit::DAY>();
-            } else if (TimeUnit::HOUR == UNIT) {
-                _execute_inner_loop.template operator()<TimeUnit::HOUR>();
-            } else if (TimeUnit::MINUTE == UNIT) {
-                _execute_inner_loop.template operator()<TimeUnit::MINUTE>();
-            } else if (TimeUnit::SECOND == UNIT) {
-                _execute_inner_loop.template operator()<TimeUnit::SECOND>();
-            }
-        };
-
         if (std::strncmp("year", lower_str.data(), 4) == 0) {
-            execute_impl(TimeUnit::YEAR);
+            _execute_inner_loop.template operator()<TimeUnit::YEAR>();
         } else if (std::strncmp("quarter", lower_str.data(), 7) == 0) {
-            execute_impl(TimeUnit::QUARTER);
+            _execute_inner_loop.template operator()<TimeUnit::QUARTER>();
         } else if (std::strncmp("month", lower_str.data(), 5) == 0) {
-            execute_impl(TimeUnit::MONTH);
+            _execute_inner_loop.template operator()<TimeUnit::MONTH>();
         } else if (std::strncmp("week", lower_str.data(), 4) == 0) {
-            execute_impl(TimeUnit::WEEK);
+            _execute_inner_loop.template operator()<TimeUnit::WEEK>();
         } else if (std::strncmp("day", lower_str.data(), 3) == 0) {
-            execute_impl(TimeUnit::DAY);
+            _execute_inner_loop.template operator()<TimeUnit::DAY>();
         } else if (std::strncmp("hour", lower_str.data(), 4) == 0) {
-            execute_impl(TimeUnit::HOUR);
+            _execute_inner_loop.template operator()<TimeUnit::HOUR>();
         } else if (std::strncmp("minute", lower_str.data(), 6) == 0) {
-            execute_impl(TimeUnit::MINUTE);
+            _execute_inner_loop.template operator()<TimeUnit::MINUTE>();
         } else if (std::strncmp("second", lower_str.data(), 6) == 0) {
-            execute_impl(TimeUnit::SECOND);
+            _execute_inner_loop.template operator()<TimeUnit::SECOND>();
         } else { //here maybe unreachable
             for (size_t i = 0; i < input_rows_count; ++i) {
                 null_map[i] = 1;

--- a/be/src/vec/sink/writer/vtablet_writer.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer.cpp
@@ -1233,7 +1233,8 @@ Status VTabletWriter::_init(RuntimeState* state, RuntimeProfile* profile) {
     // prepare for auto partition functions
     if (_vpartition->is_auto_partition()) {
         auto [part_ctx, part_func] = _get_partition_function();
-        RETURN_IF_ERROR(part_func->prepare(_state, *_output_row_desc, part_ctx.get()));
+        RETURN_IF_ERROR(part_ctx->prepare(_state, *_output_row_desc));
+        RETURN_IF_ERROR(part_ctx->open(_state));
     }
     if (_group_commit) {
         RETURN_IF_ERROR(_state->exec_env()->wal_mgr()->add_wal_path(_db_id, _tb_id, _wal_id,

--- a/be/test/vec/function/function_time_test.cpp
+++ b/be/test/vec/function/function_time_test.cpp
@@ -1475,40 +1475,82 @@ TEST(VTimestampFunctionsTest, dayname_test) {
 TEST(VTimestampFunctionsTest, datetrunc_test) {
     std::string func_name = "date_trunc";
     {
-        InputTypeSet input_types = {TypeIndex::DateTime, TypeIndex::String};
-
+        InputTypeSet input_types = {TypeIndex::DateTime, Consted {TypeIndex::String}};
         DataSet data_set = {{{std::string("2022-10-08 11:44:23"), std::string("second")},
-                             str_to_date_time("2022-10-08 11:44:23")},
-                            {{std::string("2022-10-08 11:44:23"), std::string("minute")},
-                             str_to_date_time("2022-10-08 11:44:00")},
-                            {{std::string("2022-10-08 11:44:23"), std::string("hour")},
-                             str_to_date_time("2022-10-08 11:00:00")},
-                            {{std::string("2022-10-08 11:44:23"), std::string("day")},
-                             str_to_date_time("2022-10-08 00:00:00")},
-                            {{std::string("2022-10-08 11:44:23"), std::string("month")},
-                             str_to_date_time("2022-10-01 00:00:00")},
-                            {{std::string("2022-10-08 11:44:23"), std::string("year")},
+                             str_to_date_time("2022-10-08 11:44:23")}};
+        static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
+    }
+    {
+        InputTypeSet input_types = {TypeIndex::DateTime, Consted {TypeIndex::String}};
+        DataSet data_set = {{{std::string("2022-10-08 11:44:23"), std::string("minute")},
+                             str_to_date_time("2022-10-08 11:44:00")}};
+        static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
+    }
+    {
+        InputTypeSet input_types = {TypeIndex::DateTime, Consted {TypeIndex::String}};
+        DataSet data_set = {{{std::string("2022-10-08 11:44:23"), std::string("hour")},
+                             str_to_date_time("2022-10-08 11:00:00")}};
+        static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
+    }
+    {
+        InputTypeSet input_types = {TypeIndex::DateTime, Consted {TypeIndex::String}};
+        DataSet data_set = {{{std::string("2022-10-08 11:44:23"), std::string("day")},
+                             str_to_date_time("2022-10-08 00:00:00")}};
+        static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
+    }
+    {
+        InputTypeSet input_types = {TypeIndex::DateTime, Consted {TypeIndex::String}};
+        DataSet data_set = {{{std::string("2022-10-08 11:44:23"), std::string("month")},
+                             str_to_date_time("2022-10-01 00:00:00")}};
+        static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
+    }
+    {
+        InputTypeSet input_types = {TypeIndex::DateTime, Consted {TypeIndex::String}};
+        DataSet data_set = {{{std::string("2022-10-08 11:44:23"), std::string("year")},
                              str_to_date_time("2022-01-01 00:00:00")}};
-
         static_cast<void>(check_function<DataTypeDateTime, true>(func_name, input_types, data_set));
     }
 
     {
-        InputTypeSet input_types = {TypeIndex::DateTimeV2, TypeIndex::String};
-
-        DataSet data_set = {{{std::string("2022-10-08 11:44:23.123"), std::string("second")},
-                             str_to_datetime_v2("2022-10-08 11:44:23.000", "%Y-%m-%d %H:%i:%s.%f")},
-                            {{std::string("2022-10-08 11:44:23"), std::string("minute")},
-                             str_to_datetime_v2("2022-10-08 11:44:00", "%Y-%m-%d %H:%i:%s")},
-                            {{std::string("2022-10-08 11:44:23"), std::string("hour")},
-                             str_to_datetime_v2("2022-10-08 11:00:00", "%Y-%m-%d %H:%i:%s")},
-                            {{std::string("2022-10-08 11:44:23"), std::string("day")},
-                             str_to_datetime_v2("2022-10-08 00:00:00", "%Y-%m-%d %H:%i:%s")},
-                            {{std::string("2022-10-08 11:44:23"), std::string("month")},
-                             str_to_datetime_v2("2022-10-01 00:00:00", "%Y-%m-%d %H:%i:%s")},
-                            {{std::string("2022-10-08 11:44:23"), std::string("year")},
+        InputTypeSet input_types = {TypeIndex::DateTimeV2, Consted {TypeIndex::String}};
+        DataSet data_set = {
+                {{std::string("2022-10-08 11:44:23.123"), std::string("second")},
+                 str_to_datetime_v2("2022-10-08 11:44:23.000", "%Y-%m-%d %H:%i:%s.%f")}};
+        static_cast<void>(
+                check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set));
+    }
+    {
+        InputTypeSet input_types = {TypeIndex::DateTimeV2, Consted {TypeIndex::String}};
+        DataSet data_set = {{{std::string("2022-10-08 11:44:23"), std::string("minute")},
+                             str_to_datetime_v2("2022-10-08 11:44:00", "%Y-%m-%d %H:%i:%s")}};
+        static_cast<void>(
+                check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set));
+    }
+    {
+        InputTypeSet input_types = {TypeIndex::DateTimeV2, Consted {TypeIndex::String}};
+        DataSet data_set = {{{std::string("2022-10-08 11:44:23"), std::string("hour")},
+                             str_to_datetime_v2("2022-10-08 11:00:00", "%Y-%m-%d %H:%i:%s")}};
+        static_cast<void>(
+                check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set));
+    }
+    {
+        InputTypeSet input_types = {TypeIndex::DateTimeV2, Consted {TypeIndex::String}};
+        DataSet data_set = {{{std::string("2022-10-08 11:44:23"), std::string("day")},
+                             str_to_datetime_v2("2022-10-08 00:00:00", "%Y-%m-%d %H:%i:%s")}};
+        static_cast<void>(
+                check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set));
+    }
+    {
+        InputTypeSet input_types = {TypeIndex::DateTimeV2, Consted {TypeIndex::String}};
+        DataSet data_set = {{{std::string("2022-10-08 11:44:23"), std::string("month")},
+                             str_to_datetime_v2("2022-10-01 00:00:00", "%Y-%m-%d %H:%i:%s")}};
+        static_cast<void>(
+                check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set));
+    }
+    {
+        InputTypeSet input_types = {TypeIndex::DateTimeV2, Consted {TypeIndex::String}};
+        DataSet data_set = {{{std::string("2022-10-08 11:44:23"), std::string("year")},
                              str_to_datetime_v2("2022-01-01 00:00:00", "%Y-%m-%d %H:%i:%s")}};
-
         static_cast<void>(
                 check_function<DataTypeDateTimeV2, true>(func_name, input_types, data_set));
     }


### PR DESCRIPTION
this PR https://github.com/apache/doris/pull/22602 have check function.
only support date_trunc(column, const), so the second must be const literal
and no need to check time unit every row.


## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

