### PR TITLE
[fix](trash core) fix get trash directory size core  (#25428)

### DIFF
--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -842,7 +842,12 @@ Status DataDir::update_capacity() {
 
 void DataDir::update_trash_capacity() {
     auto trash_path = fmt::format("{}/{}", _path, TRASH_PREFIX);
-    _trash_used_bytes = StorageEngine::instance()->get_file_or_directory_size(trash_path);
+    try {
+        _trash_used_bytes = StorageEngine::instance()->get_file_or_directory_size(trash_path);
+    } catch (const std::filesystem::filesystem_error& e) {
+        LOG(WARNING) << "update trash capacity failed, path: " << _path << ", err: " << e.what();
+        return;
+    }
     disks_trash_used_capacity->set_value(_trash_used_bytes);
     LOG(INFO) << "path: " << _path << " trash capacity: " << _trash_used_bytes;
 }


### PR DESCRIPTION
## Proposed changes

pick: #25428

When multithreads access one directory,  one thread create or delete a subdirectory,  the other thread use directory_iterator may raise bad file discriptor error. See [example](https://stackoverflow.com/questions/60202261/boostfilesystemrecursive-directory-iterator-multithreaded-safety). But I can not reproduce this.

The sweep thread use directory_iterator to calculate the trash directory size.  While the gc thread will move new trash tablet into this trash directory.  Sometimes stopping be will raise bad file discriptor when calcuating the trash directory size. We take a lot effect to find out the reason,  but still unknown. So we make a code defence and ignore the get trash directory size filesystem error.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

