### PR TITLE
[typo](doc) update default value of compaction_promotion_min_size_mbytes

### DIFF
--- a/docs/en/docs/admin-manual/config/be-config.md
+++ b/docs/en/docs/admin-manual/config/be-config.md
@@ -528,7 +528,7 @@ There are two ways to configure BE configuration items:
 * Type: int64
 * Description: If the total disk size of the output rowset of the cumulative compaction is lower than this configuration size, the rowset will not undergo base compaction and is still in the cumulative compaction process. The unit is m bytes.
   - Generally, the configuration is within 512m. If the configuration is too large, the size of the early base version is too small, and base compaction has not been performed.
-* Default value: 64
+* Default value: 128
 
 #### `compaction_min_size_mbytes`
 

--- a/docs/zh-CN/docs/admin-manual/config/be-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/be-config.md
@@ -542,7 +542,7 @@ BE 重启后该配置将失效。如果想持久化修改结果，使用如下�
 * 类型：int64
 * 描述：Cumulative compaction的输出rowset总磁盘大小低于此配置大小，该rowset将不进行base compaction，仍然处于cumulative compaction流程中。单位是m字节。
   - 一般情况下，配置在512m以内，配置过大会导致base版本早期的大小过小，一直不进行base compaction。
-* 默认值：64
+* 默认值：128
 
 #### `compaction_min_size_mbytes`
 


### PR DESCRIPTION
## Proposed changes

since 2.0 version, default value of compaction_promotion_min_size_mbytes is changed to 128, update doc

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

