### PR TITLE
[feature](backup) add property to remove snapshot before creating repo

### DIFF
--- a/docs/en/docs/sql-manual/sql-reference/Data-Definition-Statements/Backup-and-Restore/CREATE-REPOSITORY.md
+++ b/docs/en/docs/sql-manual/sql-reference/Data-Definition-Statements/Backup-and-Restore/CREATE-REPOSITORY.md
@@ -174,6 +174,25 @@ PROPERTIES
 );
 ```
 
+9. Create repository and delete snapshots if exists.
+
+```sql
+CREATE REPOSITORY `s3_repo`
+WITH S3
+ON LOCATION "s3://s3-repo"
+PROPERTIES
+(
+    "s3.endpoint" = "http://s3-REGION.amazonaws.com",
+    "s3.region" = "s3-REGION",
+    "s3.access_key" = "AWS_ACCESS_KEY",
+    "s3.secret_key"="AWS_SECRET_KEY",
+    "s3.region" = "REGION",
+    "delete_if_exists" = "true"
+);
+```
+
+Note: only the s3 service supports the "delete_if_exists" property.
+
 ### Keywords
 
     CREATE, REPOSITORY

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Data-Definition-Statements/Backup-and-Restore/CREATE-REPOSITORY.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Data-Definition-Statements/Backup-and-Restore/CREATE-REPOSITORY.md
@@ -170,6 +170,25 @@ PROPERTIES
 );
 ```
 
+9. 创建仓库并删除已经存在的 snapshot
+
+```sql
+CREATE REPOSITORY `s3_repo`
+WITH S3
+ON LOCATION "s3://s3-repo"
+PROPERTIES
+(
+    "s3.endpoint" = "http://s3-REGION.amazonaws.com",
+    "s3.region" = "s3-REGION",
+    "s3.access_key" = "AWS_ACCESS_KEY",
+    "s3.secret_key"="AWS_SECRET_KEY",
+    "s3.region" = "REGION",
+    "delete_if_exists" = "true"
+);
+```
+
+注：目前只有 s3 支持 "delete_if_exists" 属性。
+
 ### Keywords
 
     CREATE, REPOSITORY

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateRepositoryStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateRepositoryStmt.java
@@ -28,6 +28,8 @@ import org.apache.doris.qe.ConnectContext;
 import java.util.Map;
 
 public class CreateRepositoryStmt extends DdlStmt {
+    public static String PROP_DELETE_IF_EXISTS = "delete_if_exists";
+
     private boolean isReadOnly;
     private String name;
     private StorageBackend storage;
@@ -71,6 +73,16 @@ public class CreateRepositoryStmt extends DdlStmt {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "ADMIN");
         }
         FeNameFormat.checkCommonName("repository", name);
+
+        // check delete_if_exists, this property will be used by Repository.initRepository.
+        Map<String, String> properties = getProperties();
+        String deleteIfExistsStr = properties.get(PROP_DELETE_IF_EXISTS);
+        if (deleteIfExistsStr != null) {
+            if (!deleteIfExistsStr.equalsIgnoreCase("true") && !deleteIfExistsStr.equalsIgnoreCase("false")) {
+                ErrorReport.reportAnalysisException(ErrorCode.ERR_COMMON_ERROR,
+                        "'" + PROP_DELETE_IF_EXISTS + "' in properties, you should set it false or true");
+            }
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/obj/ObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/obj/ObjStorage.java
@@ -44,6 +44,8 @@ public interface ObjStorage<C> {
 
     Status deleteObject(String remotePath);
 
+    Status deleteObjects(String remotePath);
+
     Status copyObject(String origFilePath, String destFilePath);
 
     RemoteObjects listObjects(String remotePath, String continuationToken) throws DdlException;

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/S3FileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/S3FileSystem.java
@@ -107,5 +107,9 @@ public class S3FileSystem extends ObjFileSystem {
         }
         return Status.OK;
     }
+
+    public Status deleteDirectory(String absolutePath) {
+        return ((S3ObjStorage) objStorage).deleteObjects(absolutePath);
+    }
 }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/fs/obj/S3ObjStorageTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/fs/obj/S3ObjStorageTest.java
@@ -21,8 +21,8 @@ import org.apache.doris.backup.Status;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.S3URI;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -36,26 +36,85 @@ import java.util.Map;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class S3ObjStorageTest {
-    private S3ObjStorage storage;
+    @Test
+    public void testS3BaseOp() throws UserException {
+        String ak = System.getenv("S3_ACCESS_KEY");
+        String sk = System.getenv("S3_SECRET_KEY");
+        String endpoint = System.getenv("S3_ENDPOINT");
+        String region = System.getenv("S3_REGION");
+        String bucket = System.getenv("S3_BUCKET");
+        String prefix = System.getenv("S3_PREFIX");
 
-    private MockedS3Client mockedClient;
+        // Skip this test if ENV variables are not set.
+        if (StringUtils.isEmpty(endpoint) || StringUtils.isEmpty(ak)
+                || StringUtils.isEmpty(sk) || StringUtils.isEmpty(region)
+                || StringUtils.isEmpty(bucket) || StringUtils.isEmpty(prefix)) {
+            return;
+        }
 
-    @BeforeAll
-    public void beforeAll() throws Exception {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("s3.endpoint", endpoint);
+        properties.put("s3.access_key", ak);
+        properties.put("s3.secret_key", sk);
+        properties.put("s3.region", region);
+        S3ObjStorage storage = new S3ObjStorage(properties);
+
+        String baseUrl = "s3://" + bucket + "/" + prefix + "/";
+        for (int i = 0; i < 5; ++i) {
+            Status st = storage.putObject(baseUrl + "key" + i, RequestBody.fromString("mocked"));
+            Assertions.assertEquals(Status.OK, st);
+        }
+
+        RemoteObjects remoteObjects = storage.listObjects(baseUrl, null);
+        Assertions.assertEquals(5, remoteObjects.getObjectList().size());
+        Assertions.assertFalse(remoteObjects.isTruncated());
+        Assertions.assertEquals(null, remoteObjects.getContinuationToken());
+
+        List<RemoteObject> objectList = remoteObjects.getObjectList();
+        for (int i = 0; i < objectList.size(); i++) {
+            RemoteObject remoteObject = objectList.get(i);
+            Assertions.assertEquals("key" + i, remoteObject.getRelativePath());
+        }
+
+        Status st = storage.headObject(baseUrl + "key" + 0);
+        Assertions.assertEquals(Status.OK, st);
+
+        File file = new File("test-file.txt");
+        file.delete();
+        st = storage.getObject(baseUrl + "key" + 0, file);
+        Assertions.assertEquals(Status.OK, st);
+
+        st = storage.deleteObject(baseUrl + "key" + 0);
+        Assertions.assertEquals(Status.OK, st);
+
+        file.delete();
+        st = storage.getObject(baseUrl + "key" + 0, file);
+        Assertions.assertEquals(Status.ErrCode.COMMON_ERROR, st.getErrCode());
+        Assertions.assertTrue(st.getErrMsg().contains("The specified key does not exist"));
+        file.delete();
+
+        st = storage.deleteObjects(baseUrl);
+        Assertions.assertEquals(Status.OK, st);
+
+        remoteObjects = storage.listObjects(baseUrl, null);
+        Assertions.assertEquals(0, remoteObjects.getObjectList().size());
+        Assertions.assertFalse(remoteObjects.isTruncated());
+        Assertions.assertEquals(null, remoteObjects.getContinuationToken());
+    }
+
+    @Test
+    public void testBaseOp() throws Exception {
         Map<String, String> properties = new HashMap<>();
         properties.put("s3.endpoint", "s3.e.c");
         properties.put("s3.access_key", "abc");
         properties.put("s3.secret_key", "123");
-        storage = new S3ObjStorage(properties);
+        S3ObjStorage storage = new S3ObjStorage(properties);
         Field client = storage.getClass().getDeclaredField("client");
         client.setAccessible(true);
-        mockedClient = new MockedS3Client();
+        MockedS3Client mockedClient = new MockedS3Client();
         client.set(storage, mockedClient);
         Assertions.assertTrue(storage.getClient("mocked") instanceof MockedS3Client);
-    }
 
-    @Test
-    public void testBaseOp() throws UserException {
         S3URI vUri = S3URI.create("s3://bucket/key", true);
         S3URI uri = S3URI.create("s3://bucket/key", false);
         Assertions.assertEquals(vUri.getVirtualBucket(), "bucket");
@@ -98,7 +157,16 @@ class S3ObjStorageTest {
         List<RemoteObject> list = remoteObjectsVBucket.getObjectList();
         for (int i = 0; i < list.size(); i++) {
             RemoteObject remoteObject = list.get(i);
-            Assertions.assertTrue(remoteObject.getRelativePath().startsWith("keys/key" + i));
+            Assertions.assertTrue(remoteObject.getRelativePath().startsWith("key" + i));
+        }
+
+        storage.properties.put("use_path_style", "true");
+        storage.setProperties(storage.properties);
+        remoteObjectsVBucket = storage.listObjects("oss://bucket/keys", null);
+        list = remoteObjectsVBucket.getObjectList();
+        for (int i = 0; i < list.size(); i++) {
+            RemoteObject remoteObject = list.get(i);
+            Assertions.assertTrue(remoteObject.getRelativePath().startsWith("key" + i));
         }
     }
 }

--- a/regression-test/suites/backup_restore/test_backup_restore.groovy
+++ b/regression-test/suites/backup_restore/test_backup_restore.groovy
@@ -16,6 +16,68 @@
 // under the License.
 
 suite("test_backup_restore", "backup_restore") {
-    // todo: test repository/backup/restore/cancel backup ...
-    sql "SHOW REPOSITORIES"
+    String repoName = "test_backup_restore_repo"
+
+    def syncer = getSyncer()
+    syncer.createS3Repository(repoName)
+
+    String tableName = "test_backup_restore_table"
+    sql "DROP TABLE IF EXISTS ${tableName}"
+    sql """
+        CREATE TABLE ${tableName} (
+            `id` LARGEINT NOT NULL,
+            `count` LARGEINT SUM DEFAULT "0")
+        AGGREGATE KEY(`id`)
+        DISTRIBUTED BY HASH(`id`) BUCKETS 2
+        PROPERTIES
+        (
+            "replication_num" = "1"
+        )
+        """
+
+    List<String> values = []
+    for (i = 1; i <= 10; ++i) {
+        values.add("(${i}, ${i})")
+    }
+    sql "INSERT INTO ${tableName} VALUES ${values.join(",")}"
+    def result = sql "SELECT * FROM ${tableName}"
+    assertEquals(result.size(), values.size());
+
+    String snapshotName = "test_backup_restore_snapshot"
+    sql """
+        BACKUP SNAPSHOT ${snapshotName}
+        TO `${repoName}`
+        ON (${tableName})
+    """
+
+    while (!syncer.checkSnapshotFinish()) {
+        Thread.sleep(3000)
+    }
+
+    snapshot = syncer.getSnapshotTimestamp(repoName, snapshotName)
+    assertTrue(snapshot != null)
+
+    sql "TRUNCATE TABLE ${tableName}"
+
+    sql """
+        RESTORE SNAPSHOT ${snapshotName}
+        FROM `${repoName}`
+        ON ( `${tableName}`)
+        PROPERTIES
+        (
+            "backup_timestamp" = "${snapshot}",
+            "replication_num" = "1"
+        )
+    """
+
+    while (!syncer.checkAllRestoreFinish()) {
+        Thread.sleep(3000)
+    }
+
+    result = sql "SELECT * FROM ${tableName}"
+    assertEquals(result.size(), values.size());
+
+    sql "DROP TABLE ${tableName} FORCE"
+    sql "DROP REPOSITORY `${repoName}`"
 }
+


### PR DESCRIPTION
Doris is not responsible for managing snapshots, but it needs to clear all snapshots before doing backup/restore regression testing, so a property is added to indicate that existing snapshots need to be cleared when creating a repo. This property is only used during testing and should not be exposed to users.

In addition, a regression test case for backup/restore has been added.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

