### PR TITLE
[fix](field) fix coredump of field function when the first argument is const

### DIFF
--- a/be/src/vec/functions/function_multi_same_args.h
+++ b/be/src/vec/functions/function_multi_same_args.h
@@ -37,6 +37,8 @@ public:
 
     bool use_default_implementation_for_nulls() const override { return true; }
 
+    bool use_default_implementation_for_constants() const override { return false; }
+
     bool is_variadic() const override { return true; }
 
     size_t get_number_of_arguments() const override { return 0; }

--- a/regression-test/data/query_p0/sql_functions/string_functions/test_string_function_regexp.out
+++ b/regression-test/data/query_p0/sql_functions/string_functions/test_string_function_regexp.out
@@ -230,3 +230,9 @@ Suzi
 Suzi
 Ben
 
+-- !sql_field4 --
+3
+
+-- !sql_field5 --
+2
+

--- a/regression-test/suites/query_p0/sql_functions/string_functions/test_string_function_regexp.groovy
+++ b/regression-test/suites/query_p0/sql_functions/string_functions/test_string_function_regexp.groovy
@@ -151,5 +151,8 @@ suite("test_string_function_regexp") {
     qt_sql_field1 "select name from ${tbName2} order by field(name,'Suzi','Ben','Henry');"
     qt_sql_field2 "select name from ${tbName2} order by field(name,'Ben','Henry');"
     qt_sql_field3 "select name from ${tbName2} order by field(name,'Henry') desc,id;"
+
+    qt_sql_field4 "SELECT FIELD('21','2130', '2131', '21');"
+    qt_sql_field5 "SELECT FIELD(21, 2130, 21, 2131);"
 }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
sql: `SELECT FIELD('21','2130');`
coredump callstack:
```
gdb) f 0
#0  0x000055558459e07a in doris::vectorized::ColumnConst::get_data_at (this=0x6070012a03d0)
    at /mnt/disk2/doris/be/src/vec/columns/column_const.h:96
96          StringRef get_data_at(size_t) const override { return data->get_data_at(0); }
(gdb) p this
$8 = (const doris::vectorized::ColumnString *) 0x6070012a03d0


Thread 325 "WithoutGroupTas" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7ec2b238c700 (LWP 271178)]
0x000055558459e07a in doris::vectorized::ColumnConst::get_data_at (this=0x6070012a03d0) at /mnt/disk2/doris/be/src/vec/columns/column_const.h:96
96          StringRef get_data_at(size_t) const override { return data->get_data_at(0); }
(gdb) bt
#0  0x000055558459e07a in doris::vectorized::ColumnConst::get_data_at (this=0x6070012a03d0)
    at /mnt/disk2/doris/be/src/vec/columns/column_const.h:96
#1  0x000055559656e45a in doris::vectorized::FunctionFieldImpl::execute (block=..., arguments=..., input_rows_count=1)
    at /mnt/disk2/doris/be/src/vec/functions/least_greast.cpp:194
#2  0x000055559656cfcb in doris::vectorized::FunctionMultiSameArgs<doris::vectorized::FunctionFieldImpl>::execute_impl (this=0x606003c85ef0, 
    context=0x613005b600c0, block=..., arguments=..., result=2, input_rows_count=1)
    at /mnt/disk2/doris/be/src/vec/functions/function_multi_same_args.h:51
#3  0x000055558ec0af36 in doris::vectorized::DefaultExecutable::execute_impl (this=0x604000616160, context=0x613005b600c0, block=..., arguments=..., 
    result=2, input_rows_count=1) at /mnt/disk2/doris/be/src/vec/functions/function.h:506
#4  0x0000555591a647c3 in doris::vectorized::PreparedFunctionImpl::_execute_skipped_constant_deal (this=0x604000616160, context=0x613005b600c0, 
    block=..., args=..., result=2, input_rows_count=1, dry_run=false) at /mnt/disk2/doris/be/src/vec/functions/function.cpp:151
#5  0x0000555591a57804 in doris::vectorized::PreparedFunctionImpl::default_implementation_for_constant_arguments (this=0x604000616160, 
    context=0x613005b600c0, block=..., args=..., result=3, input_rows_count=1, dry_run=false, executed=0x7ec0bce23c20)
    at /mnt/disk2/doris/be/src/vec/functions/function.cpp:201
#6  0x0000555591a58cdc in doris::vectorized::PreparedFunctionImpl::execute_without_low_cardinality_columns (this=0x604000616160, 
    context=0x613005b600c0, block=..., args=..., result=3, input_rows_count=1, dry_run=false)
    at /mnt/disk2/doris/be/src/vec/functions/function.cpp:256
#7  0x0000555591a58f30 in doris::vectorized::PreparedFunctionImpl::execute (this=0x604000616160, context=0x613005b600c0, block=..., args=..., result=3, 
    input_rows_count=1, dry_run=false) at /mnt/disk2/doris/be/src/vec/functions/function.cpp:268
#8  0x000055558ec07b3b in doris::vectorized::IFunctionBase::execute (this=0x6070012a3780, context=0x613005b600c0, block=..., arguments=..., result=3, 
    input_rows_count=1, dry_run=false) at /mnt/disk2/doris/be/src/vec/functions/function.h:177
#9  0x000055558ebf7dbb in doris::vectorized::VectorizedFnCall::execute (this=0x61a0014aa890, context=0x6070012a0140, block=0x7ec0bd16e0c0, 
    result_column_id=0x7ec0bd16e0b0) at /mnt/disk2/doris/be/src/vec/exprs/vectorized_fn_call.cpp:164
#10 0x000055558ec16623 in doris::vectorized::VExpr::get_const_col (this=0x61a0014aa890, context=0x6070012a0140, column_wrapper=0x0)
    at /mnt/disk2/doris/be/src/vec/exprs/vexpr.cpp:483
#11 0x000055558ebf708e in doris::vectorized::VectorizedFnCall::open (this=0x61a0014aa890, state=0x61e000222080, context=0x6070012a0140, 
    scope=doris::FunctionContext::FRAGMENT_LOCAL) at /mnt/disk2/doris/be/src/vec/exprs/vectorized_fn_call.cpp:129
#12 0x000055558ec8fb2f in doris::vectorized::VExprContext::open (this=0x6070012a0140, state=0x61e000222080)
    at /mnt/disk2/doris/be/src/vec/exprs/vexpr_context.cpp:86
#13 0x000055558ec1a5f1 in doris::vectorized::VExpr::open (ctxs=..., state=0x61e000222080)
--Type <RET> for more, q to quit, c to continue without paging--c
    at /mnt/disk2/doris/be/src/vec/exprs/vexpr.cpp:402
#14 0x000055558eb1b135 in doris::vectorized::VUnionNode::alloc_resource (this=0x6170004d0780, state=0x61e000222080) at /mnt/disk2/doris/be/src/vec/exec/vunion_node.cpp:119
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

