### PR TITLE
[Fix](ExportTask)NPE when the tablet version is inconsistent

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/task/ExportExportingTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/ExportExportingTask.java
@@ -206,7 +206,11 @@ public class ExportExportingTask extends MasterTask {
             // cancel all executor
             if (isFailed) {
                 for (int idx = 0; idx < parallelNum; ++idx) {
-                    job.getStmtExecutor(idx).cancel();
+                    //if tablet version changed, we don't need to execute task, so stmtExecutor is null,
+                    //and there is no need to cancel it.
+                    if (null != job.getStmtExecutor(idx)) {
+                        job.getStmtExecutor(idx).cancel();
+                    }
                 }
             }
             exportExecPool.shutdownNow();


### PR DESCRIPTION
### What happened

When executing an export job, when the tablet version is inconsistent, the task execution fails, but an NPE exception occurs.

```

23-10-24 13:35:03,983 WARN (exporting-pool--5|1008623) [ExportExportingTask.lambda$exec$0():143] Tablet 241755 has changed version, old version = 468061, now version = 468063
2023-10-24 13:35:03,984 ERROR (export-exporting-job-pool-0|523471) [MasterTask.run():33] task exec error 
java.lang.NullPointerException: null
	at org.apache.doris.task.ExportExportingTask.exec(ExportExportingTask.java:209) ~[doris-fe.jar:1.2-SNAPSHOT]
	at org.apache.doris.task.MasterTask.run(MasterTask.java:31) ~[doris-fe.jar:1.2-SNAPSHOT]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_131]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_131]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[?:1.8.0_131]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[?:1.8.0_131]
	at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_131]
```

When the tablet version is inconsistent, an exception is thrown directly, so the second step will not be executed. At this time, the task error is expected, so this error will only be reported when the execution fails. We need to deal with NPE.


![image](https://github.com/apache/doris/assets/16631152/92738978-1abf-4521-8923-553931d227ee)
