### PR TITLE
[fix](compile) fix BE compile failure on Mac

### DIFF
--- a/be/src/vec/sink/writer/vtablet_writer.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer.cpp
@@ -17,7 +17,6 @@
 
 #include "vtablet_writer.h"
 
-#include <bits/ranges_algo.h>
 #include <brpc/http_method.h>
 #include <bthread/bthread.h>
 #include <fmt/format.h>
@@ -35,10 +34,12 @@
 #include <google/protobuf/stubs/common.h>
 #include <sys/param.h>
 
+#include <algorithm>
 #include <exception>
 #include <initializer_list>
 #include <memory>
 #include <mutex>
+#include <ranges>
 #include <sstream>
 #include <string>
 #include <unordered_map>


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

fix:
```
/Users/runner/work/doris/doris/be/src/vec/sink/writer/vtablet_writer.cpp:20:10: fatal error: 'bits/ranges_algo.h' file not found
#include <bits/ranges_algo.h>
         ^~~~~~~~~~~~~~~~~~~~
1 error generated.
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

