### PR TITLE
[fix](move-memtable) use pthread mutex in LoadStreamMgr

### DIFF
--- a/be/src/runtime/load_stream_mgr.cpp
+++ b/be/src/runtime/load_stream_mgr.cpp
@@ -50,7 +50,7 @@ Status LoadStreamMgr::open_load_stream(const POpenStreamSinkRequest* request,
     UniqueId load_id(request->load_id());
 
     {
-        std::lock_guard l(_lock);
+        std::lock_guard<decltype(_lock)> l(_lock);
         auto it = _load_streams_map.find(load_id);
         if (it != _load_streams_map.end()) {
             load_stream = it->second;
@@ -66,7 +66,7 @@ Status LoadStreamMgr::open_load_stream(const POpenStreamSinkRequest* request,
 }
 
 void LoadStreamMgr::clear_load(UniqueId load_id) {
-    std::lock_guard l(_lock);
+    std::lock_guard<decltype(_lock)> l(_lock);
     _load_streams_map.erase(load_id);
 }
 

--- a/be/src/runtime/load_stream_mgr.h
+++ b/be/src/runtime/load_stream_mgr.h
@@ -53,7 +53,7 @@ public:
     FifoThreadPool* light_work_pool() { return _light_work_pool; }
 
 private:
-    bthread::Mutex _lock;
+    std::mutex _lock;
     std::unordered_map<UniqueId, LoadStreamSharedPtr> _load_streams_map;
     std::unique_ptr<ThreadPool> _file_writer_thread_pool;
 


### PR DESCRIPTION
## Proposed changes

LoadStreamMgr is called in pthread pool, use `std::mutex` instead of `bthread::Mutex` here .

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

