### PR TITLE
[fix](tvf) fix 'frontends()' inconsistent with return 'show proc /fro…

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/FrontendsTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/FrontendsTableValuedFunction.java
@@ -51,6 +51,7 @@ public class FrontendsTableValuedFunction extends MetadataTableValuedFunction {
             new Column("Join", ScalarType.createStringType()),
             new Column("Alive", ScalarType.createStringType()),
             new Column("ReplayedJournalId", ScalarType.createStringType()),
+            new Column("LastStartTime", ScalarType.createStringType()),
             new Column("LastHeartbeat", ScalarType.createStringType()),
             new Column("IsHelper", ScalarType.createStringType()),
             new Column("ErrMsg", ScalarType.createStringType()),

--- a/regression-test/suites/external_table_p0/tvf/test_frontends_tvf.groovy
+++ b/regression-test/suites/external_table_p0/tvf/test_frontends_tvf.groovy
@@ -19,7 +19,7 @@
 suite("test_frontends_tvf","p0,external,tvf,external_docker") {
     List<List<Object>> table =  sql """ select * from `frontends`(); """
     assertTrue(table.size() > 0)
-    assertTrue(table[0].size == 18)
+    assertTrue(table[0].size == 19)
 
     // filter columns
     table = sql """ select Name from `frontends`();"""


### PR DESCRIPTION
…ntends'

## Proposed changes

fix `select * from frontends()` inconsistent with return `show proc '/frontends'\G`
<img width="1334" alt="image" src="https://github.com/apache/doris/assets/3887565/9e185b2c-a38c-4fa5-a410-4ac95650b69e">


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

