### PR TITLE
[fix](tools)  Fixing Date Type Issue in TPCDS Test Tool for Doris Table Creation

### DIFF
--- a/tools/tpcds-tools/ddl/create-tpcds-tables-sf1.sql
+++ b/tools/tpcds-tools/ddl/create-tpcds-tables-sf1.sql
@@ -5,9 +5,9 @@
 -- to you under the Apache License, Version 2.0 (the
 -- "License"); you may not use this file except in compliance
 -- with the License.  You may obtain a copy of the License at
--- 
+--
 --   http://www.apache.org/licenses/LICENSE-2.0
--- 
+--
 -- Unless required by applicable law or agreed to in writing,
 -- software distributed under the License is distributed on an
 -- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -44,7 +44,7 @@ PROPERTIES (
 CREATE TABLE IF NOT EXISTS date_dim (
     d_date_sk bigint not null,
     d_date_id char(16) not null,
-    d_date date,
+    d_date datev2,
     d_month_seq integer,
     d_week_seq integer,
     d_quarter_seq integer,
@@ -142,8 +142,8 @@ PROPERTIES (
 CREATE TABLE IF NOT EXISTS call_center (
   cc_call_center_sk bigint not null,
   cc_call_center_id char(16) not null,
-  cc_rec_start_date date,
-  cc_rec_end_date date,
+  cc_rec_start_date datev2,
+  cc_rec_end_date datev2,
   cc_closed_date_sk integer,
   cc_open_date_sk integer,
   cc_name varchar(50),
@@ -286,8 +286,8 @@ PROPERTIES (
 CREATE TABLE IF NOT EXISTS item (
     i_item_sk bigint not null,
     i_item_id char(16) not null,
-    i_rec_start_date date,
-    i_rec_end_date date,
+    i_rec_start_date datev2,
+    i_rec_end_date datev2,
     i_item_desc varchar(200),
     i_current_price decimal(7,2),
     i_wholesale_cost decimal(7,2),
@@ -347,8 +347,8 @@ PROPERTIES (
 CREATE TABLE IF NOT EXISTS web_site (
     web_site_sk bigint not null,
     web_site_id char(16) not null,
-    web_rec_start_date date,
-    web_rec_end_date date,
+    web_rec_start_date datev2,
+    web_rec_end_date datev2,
     web_name varchar(50),
     web_open_date_sk bigint,
     web_close_date_sk bigint,
@@ -448,8 +448,8 @@ PROPERTIES (
 CREATE TABLE IF NOT EXISTS store (
     s_store_sk bigint not null,
     s_store_id char(16) not null,
-    s_rec_start_date date,
-    s_rec_end_date date,
+    s_rec_start_date datev2,
+    s_rec_end_date datev2,
     s_closed_date_sk bigint,
     s_store_name varchar(50),
     s_number_employees integer,
@@ -501,8 +501,8 @@ PROPERTIES (
 CREATE TABLE IF NOT EXISTS web_page (
         wp_web_page_sk bigint not null,
         wp_web_page_id char(16) not null,
-        wp_rec_start_date date,
-        wp_rec_end_date date,
+        wp_rec_start_date datev2,
+        wp_rec_end_date datev2,
         wp_creation_date_sk bigint,
         wp_access_date_sk bigint,
         wp_autogen_flag char(1),
@@ -619,9 +619,9 @@ PROPERTIES (
 CREATE TABLE IF NOT EXISTS dbgen_version
 (
     dv_version                varchar(16)                   ,
-    dv_create_date            date                          ,
+    dv_create_date            datev2                        ,
     dv_create_time            datetime                      ,
-    dv_cmdline_args           varchar(200)                  
+    dv_cmdline_args           varchar(200)
 )
 DUPLICATE KEY(dv_version)
 DISTRIBUTED BY HASH(dv_version) BUCKETS 1


### PR DESCRIPTION
date to datev2

## Proposed changes

Issue Number: close #25886

After conducting local testing, simply modifying "date" to "datev2" in the SQL statement will successfully create the table.

## Further comments

I am conducting a tpcds test on Doris, but I have found a slight issue with the tpcds test tool provided by Doris. Currently, I have noticed a problem with the table creation statement when the size factor is set to 1. In simple terms, the date type has not been modified to datev2 type. The table creation statements for other specifications were modified in a commit three months ago, but this specific issue was overlooked. I believe it was missed at that time.

After conducting local testing, simply modifying "date" to "datev2" in the SQL statement will successfully create the table. After conducting local testing, it was found that it can run on version 2.0.2.
