### PR TITLE
[fix](tablet clone) fix replica last failed version after clone done

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Replica.java
@@ -435,9 +435,9 @@ public class Replica implements Writable {
 
         if (lastFailedVersion != this.lastFailedVersion) {
             // Case 2:
-            if (lastFailedVersion > this.lastFailedVersion) {
+            if (lastFailedVersion > this.lastFailedVersion || lastFailedVersion < 0) {
                 this.lastFailedVersion = lastFailedVersion;
-                this.lastFailedTimestamp = System.currentTimeMillis();
+                this.lastFailedTimestamp = lastFailedVersion > 0 ? System.currentTimeMillis() : -1L;
             }
 
             this.lastSuccessVersion = this.version;
@@ -504,10 +504,6 @@ public class Replica implements Writable {
             return false;
         }
         return true;
-    }
-
-    public void setLastFailedVersion(long lastFailedVersion) {
-        this.lastFailedVersion = lastFailedVersion;
     }
 
     public void setState(ReplicaState replicaState) {

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
@@ -1074,6 +1074,13 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
 
             replica.updateVersionInfo(reportedTablet.getVersion(), reportedTablet.getDataSize(),
                     reportedTablet.getDataSize(), reportedTablet.getRowCount());
+            if (replica.getLastFailedVersion() > partition.getCommittedVersion()
+                    && reportedTablet.getVersion() >= partition.getCommittedVersion()
+                    //&& !(reportedTablet.isSetVersionMiss() && reportedTablet.isVersionMiss()
+                    && !(reportedTablet.isSetUsed() && !reportedTablet.isUsed())) {
+                LOG.info("change replica {} of tablet {} 's last failed version to -1", replica, tabletId);
+                replica.updateLastFailedVersion(-1L);
+            }
             if (reportedTablet.isSetPathHash()) {
                 replica.setPathHash(reportedTablet.getPathHash());
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/clone/RepairVersionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/clone/RepairVersionTest.java
@@ -1,0 +1,105 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.clone;
+
+import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.MaterializedIndex;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.Partition;
+import org.apache.doris.catalog.Replica;
+import org.apache.doris.catalog.Tablet;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.utframe.TestWithFeService;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class RepairVersionTest extends TestWithFeService {
+    private class TableInfo {
+        Partition partition;
+        Tablet tablet;
+        Replica replica;
+    }
+
+    @Override
+    protected void beforeCreatingConnectContext() throws Exception {
+        Config.enable_debug_points = true;
+        Config.disable_balance = true;
+        Config.disable_tablet_scheduler = true;
+        Config.allow_replica_on_same_host = true;
+        FeConstants.tablet_checker_interval_ms = 100;
+        FeConstants.tablet_schedule_interval_ms = 100;
+    }
+
+    @Override
+    protected void runBeforeAll() throws Exception {
+        createDatabase("test");
+    }
+
+    @Override
+    protected int backendNum() {
+        return 2;
+    }
+
+    @Test
+    public void testRepairLastFailedVersionByClone() throws Exception {
+        TableInfo info = prepareTableForTest("tbl_repair_last_fail_version_by_clone");
+        Partition partition = info.partition;
+        Replica replica = info.replica;
+
+        replica.updateLastFailedVersion(replica.getVersion() + 1);
+        Assertions.assertEquals(partition.getCommittedVersion() + 1, replica.getLastFailedVersion());
+
+        Config.disable_tablet_scheduler = false;
+        Thread.sleep(1000);
+        Config.disable_tablet_scheduler = true;
+
+        Assertions.assertEquals(partition.getVisibleVersion(), replica.getVersion());
+        Assertions.assertEquals(-1L, replica.getLastFailedVersion());
+    }
+
+    private TableInfo prepareTableForTest(String tableName) throws Exception {
+        createTable("CREATE TABLE test." + tableName + " (k INT) DISTRIBUTED BY HASH(k) "
+                + " BUCKETS 1 PROPERTIES ( \"replication_num\" = \"2\" )");
+
+        Database db = Env.getCurrentInternalCatalog().getDbOrMetaException("default_cluster:test");
+        OlapTable tbl = (OlapTable) db.getTableOrMetaException(tableName);
+        Assertions.assertNotNull(tbl);
+        Partition partition = tbl.getPartitions().iterator().next();
+        Tablet tablet = partition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL).iterator().next()
+                .getTablets().iterator().next();
+
+        long visibleVersion = 2L;
+        partition.updateVisibleVersion(visibleVersion);
+        partition.setNextVersion(visibleVersion + 1);
+        tablet.getReplicas().forEach(replica -> replica.updateVersionInfo(visibleVersion, 1L, 1L, 1L));
+
+        Replica replica = tablet.getReplicas().iterator().next();
+        Assertions.assertEquals(visibleVersion, replica.getVersion());
+        Assertions.assertEquals(-1L, replica.getLastFailedVersion());
+
+        TableInfo info = new TableInfo();
+        info.partition = partition;
+        info.tablet = tablet;
+        info.replica = replica;
+
+        return info;
+    }
+}


### PR DESCRIPTION
## Proposed changes

partially pick: #25236

it may cause case replica's version = partition's visible version = partition's committed version, and replica's last failed version = partition's + 1. case as follow:
a. suppose partition visible version = 10, committed version = 11, the committed txn version T is not published yet;
b. clone a replica A to B, after cloning, B's version = 10.
c. publish txn T, A version = 11. Also due to txn publish bug, B's version = 11 (PR https://github.com/apache/doris/pull/23706 has fix this). (Another case is: even if this PR is fix and be publish txns ok, but if it powerf off and restart, the be may miss the version 11 because it's not ready to sync disk, and the writes will lost)
d. publish another txn, A and B's version become 12;
e. now B's backend version is: [1, 10], [12, 12], it will report it missing version = 11; then fe will mark this replica's last failed version = version + 1 = 12 + 1 = 13;
f. fe will let B clone version 11 from A, after cloning, B will contains all the version. But Replica.updateVersion has bug,
if it found its version not change (12 -> 12)，it will not set replica's last failed version to -1.
Then later, B will always be: version = 12, last failed version = 13.

To Fix this problem, after cloning, if replica's version >= partition's commit version(more precise, replica's version = partition's commit version), and replica's last failed version > partition's commit (more precise, replica's last failed version = partition's commit version + 1), then we should set replica's last failed version to -1.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

