### PR TITLE
[fix](move-memtable) init profile on memtable writer init

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -95,10 +95,10 @@ Status DeltaWriter::init() {
         return Status::OK();
     }
     RETURN_IF_ERROR(_rowset_builder.init());
-    RETURN_IF_ERROR(
-            _memtable_writer->init(_rowset_builder.rowset_writer(), _rowset_builder.tablet_schema(),
-                                   _rowset_builder.get_partial_update_info(),
-                                   _rowset_builder.tablet()->enable_unique_key_merge_on_write()));
+    RETURN_IF_ERROR(_memtable_writer->init(
+            _rowset_builder.rowset_writer(), _rowset_builder.tablet_schema(),
+            _rowset_builder.get_partial_update_info(),
+            _rowset_builder.tablet()->enable_unique_key_merge_on_write(), _profile));
     ExecEnv::GetInstance()->memtable_memory_limiter()->register_writer(_memtable_writer);
     _is_init = true;
     return Status::OK();
@@ -146,7 +146,7 @@ Status DeltaWriter::build_rowset() {
             << "delta writer is supposed be to initialized before build_rowset() being called";
 
     SCOPED_TIMER(_close_wait_timer);
-    RETURN_IF_ERROR(_memtable_writer->close_wait(_profile));
+    RETURN_IF_ERROR(_memtable_writer->close_wait());
     return _rowset_builder.build_rowset();
 }
 

--- a/be/src/olap/delta_writer_v2.cpp
+++ b/be/src/olap/delta_writer_v2.cpp
@@ -127,7 +127,8 @@ Status DeltaWriterV2::init() {
     _rowset_writer = std::make_shared<BetaRowsetWriterV2>(_streams);
     RETURN_IF_ERROR(_rowset_writer->init(context));
     RETURN_IF_ERROR(_memtable_writer->init(_rowset_writer, _tablet_schema, _partial_update_info,
-                                           _streams[0]->enable_unique_mow(_req.index_id)));
+                                           _streams[0]->enable_unique_mow(_req.index_id),
+                                           _profile));
     ExecEnv::GetInstance()->memtable_memory_limiter()->register_writer(_memtable_writer);
     _is_init = true;
     _streams.clear();
@@ -174,7 +175,7 @@ Status DeltaWriterV2::close_wait() {
     DCHECK(_is_init)
             << "delta writer is supposed be to initialized before close_wait() being called";
 
-    RETURN_IF_ERROR(_memtable_writer->close_wait(_profile));
+    RETURN_IF_ERROR(_memtable_writer->close_wait());
 
     _delta_written_success = true;
     return Status::OK();


### PR DESCRIPTION
## Proposed changes

Currently `MemtableWriter::close()` may be called for multiple times. Resulting DCHECK failure due to duplicate profile name.
Move profile init to `MemtableWriter::init()` to prevent this failure.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

