### PR TITLE
[fix](sink) clear filter bitmap per batch to get the correct filtered rows

### DIFF
--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -1331,7 +1331,8 @@ Status VOlapTableSink::send(RuntimeState* state, vectorized::Block* input_block,
     int filtered_rows = 0;
     {
         SCOPED_RAW_TIMER(&_validate_data_ns);
-        _filter_bitmap.resize(block.rows());
+        _filter_bitmap.clear();
+        _filter_bitmap.resize(block.rows(), 0);
         bool stop_processing = false;
         RETURN_IF_ERROR(
                 _validate_data(state, &block, _filter_bitmap, &filtered_rows, &stop_processing));


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

