### PR TITLE
[fix](block-convertor) clear filter bitmap per batch to get the correct filtered rows

### DIFF
--- a/be/src/vec/sink/vtablet_block_convertor.cpp
+++ b/be/src/vec/sink/vtablet_block_convertor.cpp
@@ -75,6 +75,7 @@ Status OlapTableBlockConvertor::validate_and_convert_block(
     int filtered_rows = 0;
     {
         SCOPED_RAW_TIMER(&_validate_data_ns);
+        _filter_map.clear();
         _filter_map.resize(rows, 0);
         bool stop_processing = false;
         RETURN_IF_ERROR(_validate_data(state, block.get(), rows, filtered_rows, &stop_processing));


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

