### PR TITLE
[improvement](disk balance) Prevent duplicate disk balance tasks afte…

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1943,9 +1943,10 @@ void StorageMediumMigrateTaskPool::_storage_medium_migrate_worker_thread_callbac
         // check request and get info
         TabletSharedPtr tablet;
         DataDir* dest_store = nullptr;
-
-        auto status = _check_migrate_request(storage_medium_migrate_req, tablet, &dest_store);
-        if (status.ok()) {
+        
+        bool need_deal = true;
+        auto status = _check_migrate_request(storage_medium_migrate_req, tablet, &dest_store, &need_deal);
+        if (status.ok() && need_deal) {
             EngineStorageMigrationTask engine_task(tablet, dest_store);
             status = StorageEngine::instance()->execute_task(&engine_task);
         }
@@ -1973,7 +1974,8 @@ void StorageMediumMigrateTaskPool::_storage_medium_migrate_worker_thread_callbac
 
 Status StorageMediumMigrateTaskPool::_check_migrate_request(const TStorageMediumMigrateReq& req,
                                                             TabletSharedPtr& tablet,
-                                                            DataDir** dest_store) {
+                                                            DataDir** dest_store,
+                                                            bool* need_deal) {
     int64_t tablet_id = req.tablet_id;
     tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
     if (tablet == nullptr) {
@@ -2011,8 +2013,10 @@ Status StorageMediumMigrateTaskPool::_check_migrate_request(const TStorageMedium
         *dest_store = stores[0];
     }
     if (tablet->data_dir()->path() == (*dest_store)->path()) {
-        return Status::InternalError("tablet is already on specified path {}",
-                                     tablet->data_dir()->path());
+        LOG_WARNING("tablet is already on specified path")
+                .tag("path", tablet->data_dir()->path());
+        *need_deal = false;
+        return Status::OK();
     }
 
     // check local disk capacity
@@ -2021,7 +2025,7 @@ Status StorageMediumMigrateTaskPool::_check_migrate_request(const TStorageMedium
         return Status::InternalError("reach the capacity limit of path {}, tablet_size={}",
                                      (*dest_store)->path(), tablet_size);
     }
-
+    *need_deal = true;
     return Status::OK();
 }
 

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1943,9 +1943,10 @@ void StorageMediumMigrateTaskPool::_storage_medium_migrate_worker_thread_callbac
         // check request and get info
         TabletSharedPtr tablet;
         DataDir* dest_store = nullptr;
-        
+
         bool need_deal = true;
-        auto status = _check_migrate_request(storage_medium_migrate_req, tablet, &dest_store, &need_deal);
+        auto status =
+                _check_migrate_request(storage_medium_migrate_req, tablet, &dest_store, &need_deal);
         if (status.ok() && need_deal) {
             EngineStorageMigrationTask engine_task(tablet, dest_store);
             status = StorageEngine::instance()->execute_task(&engine_task);
@@ -1974,8 +1975,7 @@ void StorageMediumMigrateTaskPool::_storage_medium_migrate_worker_thread_callbac
 
 Status StorageMediumMigrateTaskPool::_check_migrate_request(const TStorageMediumMigrateReq& req,
                                                             TabletSharedPtr& tablet,
-                                                            DataDir** dest_store,
-                                                            bool* need_deal) {
+                                                            DataDir** dest_store, bool* need_deal) {
     int64_t tablet_id = req.tablet_id;
     tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
     if (tablet == nullptr) {
@@ -2013,8 +2013,7 @@ Status StorageMediumMigrateTaskPool::_check_migrate_request(const TStorageMedium
         *dest_store = stores[0];
     }
     if (tablet->data_dir()->path() == (*dest_store)->path()) {
-        LOG_WARNING("tablet is already on specified path")
-                .tag("path", tablet->data_dir()->path());
+        LOG_WARNING("tablet is already on specified path").tag("path", tablet->data_dir()->path());
         *need_deal = false;
         return Status::OK();
     }

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -323,7 +323,7 @@ class StorageMediumMigrateTaskPool : public TaskWorkerPool {
 public:
     StorageMediumMigrateTaskPool(ExecEnv* env, ThreadModel thread_model);
     Status _check_migrate_request(const TStorageMediumMigrateReq& req, TabletSharedPtr& tablet,
-                                  DataDir** dest_store);
+                                  DataDir** dest_store, bool* need_deal);
     void _storage_medium_migrate_worker_thread_callback();
 
     DISALLOW_COPY_AND_ASSIGN(StorageMediumMigrateTaskPool);

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -323,7 +323,7 @@ class StorageMediumMigrateTaskPool : public TaskWorkerPool {
 public:
     StorageMediumMigrateTaskPool(ExecEnv* env, ThreadModel thread_model);
     Status _check_migrate_request(const TStorageMediumMigrateReq& req, TabletSharedPtr& tablet,
-                                  DataDir** dest_store, bool* need_deal);
+                                  DataDir** dest_store);
     void _storage_medium_migrate_worker_thread_callback();
 
     DISALLOW_COPY_AND_ASSIGN(StorageMediumMigrateTaskPool);

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DiskRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DiskRebalancer.java
@@ -189,7 +189,11 @@ public class DiskRebalancer extends Rebalancer {
             LOG.info("dx test select before low={} mid={} high={} medium={}", pathLow, pathMid, pathHigh, medium);
             // check if BE has low and high paths for balance after reclassification
             pathHigh.add(-2606726262674133323L);
+            pathHigh.add(384536254535458899L);
+            pathHigh.add(528047762753362128L);
             pathLow.add(1252949013258184268L);
+            pathMid.remove(384536254535458899L);
+            pathMid.remove(528047762753362128L);
             pathMid.remove(-2606726262674133323L);
             pathMid.remove(1252949013258184268L);
             LOG.info("dx test select after low={} mid={} high={} medium={}", pathLow, pathMid, pathHigh, medium);
@@ -352,10 +356,14 @@ public class DiskRebalancer extends Rebalancer {
         LOG.info("dx test complete before low={} mid={} high={} medium={}",
                 pathLow, pathMid, pathHigh, tabletCtx.getStorageMedium());
         pathHigh.add(-2606726262674133323L);
+        pathHigh.add(384536254535458899L);
+        pathHigh.add(528047762753362128L);
         pathLow.add(1252949013258184268L);
+        pathMid.remove(384536254535458899L);
+        pathMid.remove(528047762753362128L);
         pathMid.remove(-2606726262674133323L);
         pathMid.remove(1252949013258184268L);
-        LOG.info("dx test complete before low={} mid={} high={} medium={}",
+        LOG.info("dx test complete after low={} mid={} high={} medium={}",
                 pathLow, pathMid, pathHigh, tabletCtx.getStorageMedium());
         if (pathHigh.contains(replica.getPathHash())) {
             pathLow.addAll(pathMid);

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DiskRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DiskRebalancer.java
@@ -186,8 +186,13 @@ public class DiskRebalancer extends Rebalancer {
             Set<Long> pathHigh = Sets.newHashSet();
             // we only select tablets from available high load path
             beStat.getPathStatisticByClass(pathLow, pathMid, pathHigh, medium);
-            LOG.info("dx test low={} mid={} high={} medium={}", pathLow, pathMid, pathHigh, medium);
+            LOG.info("dx test select before low={} mid={} high={} medium={}", pathLow, pathMid, pathHigh, medium);
             // check if BE has low and high paths for balance after reclassification
+            pathHigh.add(384536254535458899L);
+            pathLow.add(528047762753362128L);
+            pathMid.remove(384536254535458899L);
+            pathMid.remove(528047762753362128L);
+            LOG.info("dx test select after low={} mid={} high={} medium={}", pathLow, pathMid, pathHigh, medium);
             if (!checkAndReclassifyPaths(pathLow, pathMid, pathHigh)) {
                 continue;
             }
@@ -344,6 +349,14 @@ public class DiskRebalancer extends Rebalancer {
         Set<Long> pathMid = Sets.newHashSet();
         Set<Long> pathHigh = Sets.newHashSet();
         beStat.getPathStatisticByClass(pathLow, pathMid, pathHigh, tabletCtx.getStorageMedium());
+        LOG.info("dx test complete before low={} mid={} high={} medium={}",
+                pathLow, pathMid, pathHigh, tabletCtx.getStorageMedium());
+        pathHigh.add(384536254535458899L);
+        pathLow.add(528047762753362128L);
+        pathMid.remove(384536254535458899L);
+        pathMid.remove(528047762753362128L);
+        LOG.info("dx test complete before low={} mid={} high={} medium={}",
+                pathLow, pathMid, pathHigh, tabletCtx.getStorageMedium());
         if (pathHigh.contains(replica.getPathHash())) {
             pathLow.addAll(pathMid);
         } else if (!pathMid.contains(replica.getPathHash())) {

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DiskRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DiskRebalancer.java
@@ -188,10 +188,10 @@ public class DiskRebalancer extends Rebalancer {
             beStat.getPathStatisticByClass(pathLow, pathMid, pathHigh, medium);
             LOG.info("dx test select before low={} mid={} high={} medium={}", pathLow, pathMid, pathHigh, medium);
             // check if BE has low and high paths for balance after reclassification
-            pathHigh.add(384536254535458899L);
-            pathLow.add(528047762753362128L);
-            pathMid.remove(384536254535458899L);
-            pathMid.remove(528047762753362128L);
+            pathHigh.add(-2606726262674133323L);
+            pathLow.add(1252949013258184268L);
+            pathMid.remove(-2606726262674133323L);
+            pathMid.remove(1252949013258184268L);
             LOG.info("dx test select after low={} mid={} high={} medium={}", pathLow, pathMid, pathHigh, medium);
             if (!checkAndReclassifyPaths(pathLow, pathMid, pathHigh)) {
                 continue;
@@ -351,10 +351,10 @@ public class DiskRebalancer extends Rebalancer {
         beStat.getPathStatisticByClass(pathLow, pathMid, pathHigh, tabletCtx.getStorageMedium());
         LOG.info("dx test complete before low={} mid={} high={} medium={}",
                 pathLow, pathMid, pathHigh, tabletCtx.getStorageMedium());
-        pathHigh.add(384536254535458899L);
-        pathLow.add(528047762753362128L);
-        pathMid.remove(384536254535458899L);
-        pathMid.remove(528047762753362128L);
+        pathHigh.add(-2606726262674133323L);
+        pathLow.add(1252949013258184268L);
+        pathMid.remove(-2606726262674133323L);
+        pathMid.remove(1252949013258184268L);
         LOG.info("dx test complete before low={} mid={} high={} medium={}",
                 pathLow, pathMid, pathHigh, tabletCtx.getStorageMedium());
         if (pathHigh.contains(replica.getPathHash())) {

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DiskRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DiskRebalancer.java
@@ -120,6 +120,7 @@ public class DiskRebalancer extends Rebalancer {
     @Override
     protected List<TabletSchedCtx> selectAlternativeTabletsForCluster(
             LoadStatisticForTag clusterStat, TStorageMedium medium) {
+        LOG.info("dx test enter selectAlternativeTabletsForCluster");
         List<TabletSchedCtx> alternativeTablets = Lists.newArrayList();
 
         // get classification of backends
@@ -185,6 +186,7 @@ public class DiskRebalancer extends Rebalancer {
             Set<Long> pathHigh = Sets.newHashSet();
             // we only select tablets from available high load path
             beStat.getPathStatisticByClass(pathLow, pathMid, pathHigh, medium);
+            LOG.info("dx test low={} mid={} high={} medium={}", pathLow, pathMid, pathHigh, medium);
             // check if BE has low and high paths for balance after reclassification
             if (!checkAndReclassifyPaths(pathLow, pathMid, pathHigh)) {
                 continue;
@@ -273,6 +275,7 @@ public class DiskRebalancer extends Rebalancer {
                     medium, alternativeTablets.size(),
                     alternativeTablets.stream().mapToLong(TabletSchedCtx::getTabletId).toArray());
         }
+        LOG.info("dx test out selectAlternativeTabletsForCluster, alternativeTablets={}", alternativeTablets);
         return alternativeTablets;
     }
 
@@ -284,6 +287,7 @@ public class DiskRebalancer extends Rebalancer {
      */
     @Override
     public void completeSchedCtx(TabletSchedCtx tabletCtx) throws SchedException {
+        LOG.info("dx test enter completeSchedCtx");
         LoadStatisticForTag clusterStat = statisticMap.get(tabletCtx.getTag());
         if (clusterStat == null) {
             throw new SchedException(Status.UNRECOVERABLE,
@@ -382,5 +386,6 @@ public class DiskRebalancer extends Rebalancer {
         if (!setDest) {
             throw new SchedException(Status.UNRECOVERABLE, "unable to find low load path");
         }
+        LOG.info("dx test out completeSchedCtx");
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -621,6 +621,8 @@ public class TabletScheduler extends MasterDaemon {
         Optional<Replica> destReplica = tabletCtx.getReplicas()
                 .stream().filter(replica -> replica.getBackendId() == tabletCtx.getDestBackendId()).findAny();
         if (destReplica.isPresent() && tabletCtx.getDestPathHash() != -1) {
+            LOG.info("dx test success report old {} : new {}",
+                    destReplica.get().getPathHash(), tabletCtx.getDestPathHash());
             destReplica.get().setPathHash(tabletCtx.getDestPathHash());
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -79,6 +79,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.Set;
@@ -612,6 +613,15 @@ public class TabletScheduler extends MasterDaemon {
         long succTime = pathSlot.getDiskBalanceLastSuccTime(pathHash);
         if (succTime > lastStatUpdateTime) {
             throw new SchedException(Status.UNRECOVERABLE, "stat info is outdated");
+        }
+    }
+
+    public void updateDestPathHash(TabletSchedCtx tabletCtx) {
+        // find dest replica
+        Optional<Replica> destReplica = tabletCtx.getReplicas()
+                .stream().filter(replica -> replica.getBackendId() == tabletCtx.getDestBackendId()).findAny();
+        if (destReplica.isPresent() && tabletCtx.getDestPathHash() != -1) {
+            destReplica.get().setPathHash(tabletCtx.getDestPathHash());
         }
     }
 
@@ -1642,6 +1652,7 @@ public class TabletScheduler extends MasterDaemon {
             // if we have a success task, then stat must be refreshed before schedule a new task
             updateDiskBalanceLastSuccTime(tabletCtx.getSrcBackendId(), tabletCtx.getSrcPathHash());
             updateDiskBalanceLastSuccTime(tabletCtx.getDestBackendId(), tabletCtx.getDestPathHash());
+            updateDestPathHash(tabletCtx);
             finalizeTabletCtx(tabletCtx, TabletSchedCtx.State.FINISHED, Status.FINISHED, "finished");
         } else {
             finalizeTabletCtx(tabletCtx, TabletSchedCtx.State.CANCELLED, Status.UNRECOVERABLE,


### PR DESCRIPTION
…r a disk balance task has succ

## Proposed changes

1. When the BE side discovers that the migration path is already in the dest path, an error will be returned, and an OK should be returned at this time
2. After the task is completed, FE does not update the path hash of the replica current. This may still result in the tablet being disk rebalanced in the future. Until one minute later when the tablet is updated and reported

![img_v2_136c7582-f2cc-414d-8457-2db5278270eg](https://github.com/apache/doris/assets/3887565/3bc486e9-3df1-47de-8fd2-9b073d9169c3)


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

