### PR TITLE
[branch-1.2](TabletScheduler) Fix need further repair task stuck in running state

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
@@ -881,7 +881,8 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
 
             // addReplica() method will add this replica to tablet inverted index too.
             tablet.addReplica(cloneReplica);
-        } else if (tabletStatus == TabletStatus.VERSION_INCOMPLETE) {
+        } else {
+            // tabletStatus is VERSION_INCOMPLETE || NEED_FURTHER_REPAIR
             Preconditions.checkState(type == Type.REPAIR, type);
             // double check
             Replica replica = tablet.getReplicaByBackendId(destBackendId);


### PR DESCRIPTION
## Proposed changes

<img width="1469" alt="image" src="https://github.com/apache/doris/assets/22125576/b1a9cd5e-efca-4388-9baa-b32e794168bc">

This bug will cause some tablets with missing versions unable to be schedule repaired and compaction until the Need_Further_Repair task schedule timeout.

<img width="419" alt="image" src="https://github.com/apache/doris/assets/22125576/6871d6cb-5929-4352-8946-78775af511fe">


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

