### PR TITLE
[Fix](variant) fix groupby multi variant columns leading to error

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
@@ -341,7 +341,14 @@ public class SlotRef extends Expr {
         if (desc != null) {
             return desc.getId().hashCode();
         }
-        return Objects.hashCode((tblName == null ? "" : tblName.toSql() + "." + label).toLowerCase());
+        if (subColLables == null || subColLables.isEmpty()) {
+            return Objects.hashCode((tblName == null ? "" : tblName.toSql() + "." + label).toLowerCase());
+        }
+        int result = Objects.hashCode((tblName == null ? "" : tblName.toSql() + "." + label).toLowerCase());
+        for (String sublabel : subColLables) {
+            result = 31 * result + Objects.hashCode(sublabel);
+        }
+        return result;
     }
 
     @Override

--- a/regression-test/suites/variant_p0/load.groovy
+++ b/regression-test/suites/variant_p0/load.groovy
@@ -449,6 +449,9 @@ suite("regression_test_variant", "variant_type"){
         sql """insert into var_index values(7, '{"a1" : 0, "b1": 3}', 'hello world'), (8, '{"a2" : 123}', 'world'),(9, '{"a3" : 123}', 'hello world')"""
         qt_sql_inv6 """select * from ${table_name} order by k desc limit 4"""
 
+        // test groupby with multiple variants
+        sql """select cast(v:xxx as int),  cast(v:yyy as text) from ${table_name} group by cast(v:xxx as int),  cast(v:yyy as text)"""
+
     } finally {
         // reset flags
         set_be_config.call("max_filter_ratio_for_variant_parsing", "0.05")


### PR DESCRIPTION
```
ERROR 1105 (HY000): errCode = 2, detailMessage = select list expression not produced by aggregation output (missing from GROUP BY clause?): CAST(`var` AS TEXT)
```

The hash code of slot ref should consider sub column names

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

