### PR TITLE
[fix](partial update) fix a ASAN core, caused by release SegmentCacheHandle too early

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2695,14 +2695,15 @@ void Tablet::update_max_version_schema(const TabletSchemaSPtr& tablet_schema) {
 
 Status Tablet::_get_segment_column_iterator(
         const BetaRowsetSharedPtr& rowset, uint32_t segid, const TabletColumn& target_column,
+        SegmentCacheHandle* segment_cache_handle,
         std::unique_ptr<segment_v2::ColumnIterator>* column_iterator, OlapReaderStatistics* stats) {
-    SegmentCacheHandle segment_cache;
-    RETURN_IF_ERROR(SegmentLoader::instance()->load_segments(rowset, &segment_cache, true));
+    RETURN_IF_ERROR(SegmentLoader::instance()->load_segments(rowset, segment_cache_handle, true));
     // find segment
     auto it = std::find_if(
-            segment_cache.get_segments().begin(), segment_cache.get_segments().end(),
+            segment_cache_handle->get_segments().begin(),
+            segment_cache_handle->get_segments().end(),
             [&segid](const segment_v2::SegmentSharedPtr& seg) { return seg->id() == segid; });
-    if (it == segment_cache.get_segments().end()) {
+    if (it == segment_cache_handle->get_segments().end()) {
         return Status::NotFound(fmt::format("rowset {} 's segemnt not found, seg_id {}",
                                             rowset->rowset_id().to_string(), segid));
     }
@@ -2734,11 +2735,12 @@ Status Tablet::fetch_value_through_row_column(RowsetSharedPtr input_rowset, uint
     CHECK(rowset);
     const TabletSchemaSPtr tablet_schema = rowset->tablet_schema();
     CHECK(tablet_schema->store_row_column());
+    SegmentCacheHandle segment_cache_handle;
     std::unique_ptr<segment_v2::ColumnIterator> column_iterator;
     OlapReaderStatistics stats;
     RETURN_IF_ERROR(_get_segment_column_iterator(rowset, segid,
                                                  tablet_schema->column(BeConsts::ROW_STORE_COL),
-                                                 &column_iterator, &stats));
+                                                 &segment_cache_handle, &column_iterator, &stats));
     // get and parse tuple row
     vectorized::MutableColumnPtr column_ptr = vectorized::ColumnString::create();
     RETURN_IF_ERROR(column_iterator->read_by_rowids(rowids.data(), rowids.size(), column_ptr));
@@ -2776,10 +2778,11 @@ Status Tablet::fetch_value_by_rowids(RowsetSharedPtr input_rowset, uint32_t segi
     // read row data
     BetaRowsetSharedPtr rowset = std::static_pointer_cast<BetaRowset>(input_rowset);
     CHECK(rowset);
+    SegmentCacheHandle segment_cache_handle;
     std::unique_ptr<segment_v2::ColumnIterator> column_iterator;
     OlapReaderStatistics stats;
-    RETURN_IF_ERROR(
-            _get_segment_column_iterator(rowset, segid, tablet_column, &column_iterator, &stats));
+    RETURN_IF_ERROR(_get_segment_column_iterator(rowset, segid, tablet_column,
+                                                 &segment_cache_handle, &column_iterator, &stats));
     RETURN_IF_ERROR(column_iterator->read_by_rowids(rowids.data(), rowids.size(), dst));
     return Status::OK();
 }
@@ -2800,10 +2803,11 @@ Status Tablet::lookup_row_data(const Slice& encoded_key, const RowLocation& row_
     CHECK(rowset);
     const TabletSchemaSPtr tablet_schema = rowset->tablet_schema();
     CHECK(tablet_schema->store_row_column());
+    SegmentCacheHandle segment_cache_handle;
     std::unique_ptr<segment_v2::ColumnIterator> column_iterator;
     RETURN_IF_ERROR(_get_segment_column_iterator(rowset, row_location.segment_id,
                                                  tablet_schema->column(BeConsts::ROW_STORE_COL),
-                                                 &column_iterator, &stats));
+                                                 &segment_cache_handle, &column_iterator, &stats));
     // get and parse tuple row
     vectorized::MutableColumnPtr column_ptr = vectorized::ColumnString::create();
     std::vector<segment_v2::rowid_t> rowids {static_cast<segment_v2::rowid_t>(row_location.row_id)};

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -566,6 +566,7 @@ public:
                                            std::vector<RowsetSharedPtr>* rowsets = nullptr);
     Status _get_segment_column_iterator(
             const BetaRowsetSharedPtr& rowset, uint32_t segid, const TabletColumn& target_column,
+            SegmentCacheHandle* segment_cache_handle,
             std::unique_ptr<segment_v2::ColumnIterator>* column_iterator,
             OlapReaderStatistics* stats);
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

```
==2282647==ERROR: AddressSanitizer: heap-use-after-free on address 0x612002463051 at pc 0x55ccceee321e bp 0x7ef2aef31230 sp 0x7ef2aef31228
READ of size 1 at 0x612002463051 thread T2800 (TabletCalcDelet)
    #0 0x55ccceee321d in doris::segment_v2::ColumnReader::seek_at_or_before(unsigned long, doris::segment_v2::OrdinalPageIndexIterator*) /home/zcp/repo_center/doris_master/doris/be/src/olap/rowset/segment_v2/column_reader.cpp:598:5
    #1 0x55ccceef04c4 in doris::segment_v2::FileColumnIterator::seek_to_ordinal(unsigned long) /home/zcp/repo_center/doris_master/doris/be/src/olap/rowset/segment_v2/column_reader.cpp:1030:9
    #2 0x55ccceef2142 in doris::segment_v2::FileColumnIterator::read_by_rowids(unsigned int const*, unsigned long, COW<doris::vectorized::IColumn>::mutable_ptr<doris::vectorized::IColumn>&) /home/zcp/repo_center/doris_master/doris/be/src/olap/rowset/segment_v2/column_reader.cpp:1138:9
    #3 0x55ccd0ff0b38 in doris::Tablet::fetch_value_through_row_column(std::shared_ptr<doris::Rowset>, unsigned int, std::vector<unsigned int, std::allocator<unsigned int> > const&, std::vector<unsigned int, std::allocator<unsigned int> > const&, doris::vectorized::Block&) /home/zcp/repo_center/doris_master/doris/be/src/olap/tablet.cpp:2744:5
    #4 0x55ccd1000994 in doris::Tablet::read_columns_by_plan(std::shared_ptr<doris::TabletSchema>, std::vector<unsigned int, std::allocator<unsigned int> >, std::map<doris::RowsetId, std::map<unsigned int, std::vector<doris::RidAndPos, std::allocator<doris::RidAndPos> >, std::less<unsigned int>, std::allocator<std::pair<unsigned int const, std::vector<doris::RidAndPos, std::allocator<doris::RidAndPos> > > > >, std::less<doris::RowsetId>, std::allocator<std::pair<doris::RowsetId const, std::map<unsigned int, std::vector<doris::RidAndPos, std::allocator<doris::RidAndPos> >, std::less<unsigned int>, std::allocator<std::pair<unsigned int const, std::vector<doris::RidAndPos, std::allocator<doris::RidAndPos> > > > > > > > const&, std::map<doris::RowsetId, std::shared_ptr<doris::Rowset>, std::less<doris::RowsetId>, std::allocator<std::pair<doris::RowsetId const, std::shared_ptr<doris::Rowset> > > > const&, doris::vectorized::Block&, std::map<unsigned int, unsigned int, std::less<unsigned int>, std::allocator<std::pair<unsigned int const, unsigned int> > >*) /home/zcp/repo_center/doris_master/doris/be/src/olap/tablet.cpp:3232:27
    #5 0x55ccd0ffd2c7 in doris::Tablet::generate_new_block_for_partial_update(std::shared_ptr<doris::TabletSchema>, std::vector<unsigned int, std::allocator<unsigned int> > const&, std::vector<unsigned int, std::allocator<unsigned int> > const&, std::map<doris::RowsetId, std::map<unsigned int, std::vector<doris::RidAndPos, std::allocator<doris::RidAndPos> >, std::less<unsigned int>, std::allocator<std::pair<unsigned int const, std::vector<doris::RidAndPos, std::allocator<doris::RidAndPos> > > > >, std::less<doris::RowsetId>, std::allocator<std::pair<doris::RowsetId const, std::map<unsigned int, std::vector<doris::RidAndPos, std::allocator<doris::RidAndPos> >, std::less<unsigned int>, std::allocator<std::pair<unsigned int const, std::vector<doris::RidAndPos, std::allocator<doris::RidAndPos> > > > > > > > const&, std::map<doris::RowsetId, std::map<unsigned int, std::vector<doris::RidAndPos, std::allocator<doris::RidAndPos> >, std::less<unsigned int>, std::allocator<std::pair<unsigned int const, std::vector<doris::RidAndPos, std::allocator<doris::RidAndPos> > > > >, std::less<doris::RowsetId>, std::allocator<std::pair<doris::RowsetId const, std::map<unsigned int, std::vector<doris::RidAndPos, std::allocator<doris::RidAndPos> >, std::less<unsigned int>, std::allocator<std::pair<unsigned int const, std::vector<doris::RidAndPos, std::allocator<doris::RidAndPos> > > > > > > > const&, std::map<doris::RowsetId, std::shared_ptr<doris::Rowset>, std::less<doris::RowsetId>, std::allocator<std::pair<doris::RowsetId const, std::shared_ptr<doris::Rowset> > > > const&, doris::vectorized::Block*) /home/zcp/repo_center/doris_master/doris/be/src/olap/tablet.cpp:3184:5
    #6 0x55ccd0ffb144 in doris::Tablet::calc_segment_delete_bitmap(std::shared_ptr<doris::Rowset>, std::shared_ptr<doris::segment_v2::Segment> const&, std::vector<std::shared_ptr<doris::Rowset>, std::allocator<std::shared_ptr<doris::Rowset> > > const&, std::shared_ptr<doris::DeleteBitmap>, long, doris::RowsetWriter*) /home/zcp/repo_center/doris_master/doris/be/src/olap/tablet.cpp:3101:9
    #7 0x55ccce7ee2d4 in doris::CalcDeleteBitmapToken::submit(std::shared_ptr<doris::Tablet>, std::shared_ptr<doris::Rowset>, std::shared_ptr<doris::segment_v2::Segment> const&, std::vector<std::shared_ptr<doris::Rowset>, std::allocator<std::shared_ptr<doris::Rowset> > > const&, long, std::shared_ptr<doris::DeleteBitmap>, doris::RowsetWriter*)::$_0::operator()() const /home/zcp/repo_center/doris_master/doris/be/src/olap/calc_delete_bitmap_executor.cpp:44:27
    #8 0x55ccce7edfd6 in void std::__invoke_impl<void, doris::CalcDeleteBitmapToken::submit(std::shared_ptr<doris::Tablet>, std::shared_ptr<doris::Rowset>, std::shared_ptr<doris::segment_v2::Segment> const&, std::vector<std::shared_ptr<doris::Rowset>, std::allocator<std::shared_ptr<doris::Rowset> > > const&, long, std::shared_ptr<doris::DeleteBitmap>, doris::RowsetWriter*)::$_0&>(std::__invoke_other, doris::CalcDeleteBitmapToken::submit(std::shared_ptr<doris::Tablet>, std::shared_ptr<doris::Rowset>, std::shared_ptr<doris::segment_v2::Segment> const&, std::vector<std::shared_ptr<doris::Rowset>, std::allocator<std::shared_ptr<doris::Rowset> > > const&, long, std::shared_ptr<doris::DeleteBitmap>, doris::RowsetWriter*)::$_0&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #9 0x55ccce7edf48 in std::enable_if<is_invocable_r_v<void, doris::CalcDeleteBitmapToken::submit(std::shared_ptr<doris::Tablet>, std::shared_ptr<doris::Rowset>, std::shared_ptr<doris::segment_v2::Segment> const&, std::vector<std::shared_ptr<doris::Rowset>, std::allocator<std::shared_ptr<doris::Rowset> > > const&, long, std::shared_ptr<doris::DeleteBitmap>, doris::RowsetWriter*)::$_0&>, void>::type std::__invoke_r<void, doris::CalcDeleteBitmapToken::submit(std::shared_ptr<doris::Tablet>, std::shared_ptr<doris::Rowset>, std::shared_ptr<doris::segment_v2::Segment> const&, std::vector<std::shared_ptr<doris::Rowset>, std::allocator<std::shared_ptr<doris::Rowset> > > const&, long, std::shared_ptr<doris::DeleteBitmap>, doris::RowsetWriter*)::$_0&>(doris::CalcDeleteBitmapToken::submit(std::shared_ptr<doris::Tablet>, std::shared_ptr<doris::Rowset>, std::shared_ptr<doris::segment_v2::Segment> const&, std::vector<std::shared_ptr<doris::Rowset>, std::allocator<std::shared_ptr<doris::Rowset> > > const&, long, std::shared_ptr<doris::DeleteBitmap>, doris::RowsetWriter*)::$_0&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #10 0x55ccce7edbbe in std::_Function_handler<void (), doris::CalcDeleteBitmapToken::submit(std::shared_ptr<doris::Tablet>, std::shared_ptr<doris::Rowset>, std::shared_ptr<doris::segment_v2::Segment> const&, std::vector<std::shared_ptr<doris::Rowset>, std::allocator<std::shared_ptr<doris::Rowset> > > const&, long, std::shared_ptr<doris::DeleteBitmap>, doris::RowsetWriter*)::$_0>::_M_invoke(std::_Any_data const&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #11 0x55ccce54be16 in std::function<void ()>::operator()() const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #12 0x55ccd232c7ea in doris::FunctionRunnable::run() /home/zcp/repo_center/doris_master/doris/be/src/util/threadpool.cpp:48:27
    #13 0x55ccd231622e in doris::ThreadPool::dispatch_thread() /home/zcp/repo_center/doris_master/doris/be/src/util/threadpool.cpp:543:24
    #14 0x55ccd2341165 in void std::__invoke_impl<void, void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74:14
    #15 0x55ccd234100e in std::__invoke_result<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>::type std::__invoke<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96:14
    #16 0x55ccd2340f86 in void std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>::__call<void, 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420:11
    #17 0x55ccd2340e1f in void std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>::operator()<void>() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503:17
    #18 0x55ccd2340d26 in void std::__invoke_impl<void, std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #19 0x55ccd2340c98 in std::enable_if<is_invocable_r_v<void, std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>&>(std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #20 0x55ccd234085e in std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #21 0x55ccce54be16 in std::function<void ()>::operator()() const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #22 0x55ccd22de7f9 in doris::Thread::supervise_thread(void*) /home/zcp/repo_center/doris_master/doris/be/src/util/thread.cpp:494:5
    #23 0x7f018cd82608 in start_thread /build/glibc-sMfBJT/glibc-2.31/nptl/pthread_create.c:477:8
    #24 0x7f018d02f162 in __clone /build/glibc-sMfBJT/glibc-2.31/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95

0x612002463051 is located 17 bytes inside of 296-byte region [0x612002463040,0x612002463168)
freed by thread T2800 (TabletCalcDelet) here:
    #0 0x55ccce383d9d in operator delete(void*) (/mnt/hdd01/STRESS_ENV/be/lib/doris_be+0x2306ed9d) (BuildId: 95b6c7734cf5d10a)
    #1 0x55ccce93fd35 in std::default_delete<doris::segment_v2::ColumnReader>::operator()(doris::segment_v2::ColumnReader*) const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:85:2
    #2 0x55ccce90ba2b in std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> >::~unique_ptr() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:361:4
    #3 0x55ccce90f988 in std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >::~pair() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_iterator.h:2379:12
    #4 0x55ccce90f966 in void std::destroy_at<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >(std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:88:15
    #5 0x55ccce90f8b9 in void std::allocator_traits<std::allocator<std::_Rb_tree_node<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > > >::destroy<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >(std::allocator<std::_Rb_tree_node<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >&, std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:533:4
    #6 0x55ccce90f80c in std::_Rb_tree<int, std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >, std::_Select1st<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::_M_destroy_node(std::_Rb_tree_node<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:623:2
    #7 0x55ccce90f7a2 in std::_Rb_tree<int, std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >, std::_Select1st<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::_M_drop_node(std::_Rb_tree_node<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:631:2
    #8 0x55ccce90f645 in std::_Rb_tree<int, std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >, std::_Select1st<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::_M_erase(std::_Rb_tree_node<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:1889:4
    #9 0x55ccce90f62b in std::_Rb_tree<int, std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >, std::_Select1st<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::_M_erase(std::_Rb_tree_node<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:1887:4
    #10 0x55ccce90f62b in std::_Rb_tree<int, std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >, std::_Select1st<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::_M_erase(std::_Rb_tree_node<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:1887:4
    #11 0x55ccce90f62b in std::_Rb_tree<int, std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >, std::_Select1st<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::_M_erase(std::_Rb_tree_node<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:1887:4
    #12 0x55ccce90f62b in std::_Rb_tree<int, std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >, std::_Select1st<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::_M_erase(std::_Rb_tree_node<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:1887:4
    #13 0x55ccce90f62b in std::_Rb_tree<int, std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >, std::_Select1st<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::_M_erase(std::_Rb_tree_node<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:1887:4
    #14 0x55ccce90f62b in std::_Rb_tree<int, std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >, std::_Select1st<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::_M_erase(std::_Rb_tree_node<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:1887:4
    #15 0x55ccce90f62b in std::_Rb_tree<int, std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >, std::_Select1st<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::_M_erase(std::_Rb_tree_node<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:1887:4
    #16 0x55ccce90f62b in std::_Rb_tree<int, std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >, std::_Select1st<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::_M_erase(std::_Rb_tree_node<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:1887:4
    #17 0x55ccce90f62b in std::_Rb_tree<int, std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >, std::_Select1st<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::_M_erase(std::_Rb_tree_node<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:1887:4
    #18 0x55ccce90f62b in std::_Rb_tree<int, std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >, std::_Select1st<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::_M_erase(std::_Rb_tree_node<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:1887:4
    #19 0x55ccce90f62b in std::_Rb_tree<int, std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >, std::_Select1st<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::_M_erase(std::_Rb_tree_node<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:1887:4
    #20 0x55ccce90f5a5 in std::_Rb_tree<int, std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > >, std::_Select1st<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::~_Rb_tree() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:984:9
    #21 0x55ccce906576 in std::map<int, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> >, std::less<int>, std::allocator<std::pair<int const, std::unique_ptr<doris::segment_v2::ColumnReader, std::default_delete<doris::segment_v2::ColumnReader> > > > >::~map() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_map.h:302:22
    #22 0x55ccce8f1223 in doris::segment_v2::Segment::~Segment() /home/zcp/repo_center/doris_master/doris/be/src/olap/rowset/segment_v2/segment.cpp:94:1
    #23 0x55ccce928e31 in std::_Sp_counted_ptr<doris::segment_v2::Segment*, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:348:9
    #24 0x55ccce39df61 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:168:6
    #25 0x55ccce39dc99 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:702:11
    #26 0x55ccce7f643a in std::__shared_ptr<doris::segment_v2::Segment, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1149:31
    #27 0x55ccce7f6014 in std::shared_ptr<doris::segment_v2::Segment>::~shared_ptr() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr.h:122:11
    #28 0x55ccce8e3b36 in void std::destroy_at<std::shared_ptr<doris::segment_v2::Segment> >(std::shared_ptr<doris::segment_v2::Segment>*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:88:15
    #29 0x55ccce9939f6 in void std::_Destroy<std::shared_ptr<doris::segment_v2::Segment> >(std::shared_ptr<doris::segment_v2::Segment>*) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:138:7
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

