### PR TITLE
FE ssl certificates are of various formats #26039

### DIFF
--- a/docs/en/docs/admin-manual/certificate.md
+++ b/docs/en/docs/admin-manual/certificate.md
@@ -65,7 +65,7 @@ openssl x509 -req -in client-req.pem -days 3600 \
 openssl verify -CAfile ca.pem server-cert.pem client-cert.pem
 ```
 
-3. Combine your key and certificate in a PKCS#12 (P12) bundle.
+3. Combine your key and certificate in a PKCS#12 (P12) bundle. You can also specify a certificate format (PKCS12 by default). You can modify the conf/fe.conf configuration file and add parameter ssl_trust_store_type to specify the certificate format.
 ```bash
 # Package the CA key and certificate
 openssl pkcs12 -inkey ca-key.pem -in ca.pem -export -out ca_certificate.p12

--- a/docs/zh-CN/docs/admin-manual/certificate.md
+++ b/docs/zh-CN/docs/admin-manual/certificate.md
@@ -65,7 +65,7 @@ openssl x509 -req -in client-req.pem -days 3600 \
 openssl verify -CAfile ca.pem server-cert.pem client-cert.pem
 ```
 
-3.将您的CA密钥和证书和Sever端密钥和证书分别合并到 PKCS#12 (P12) 包中。
+3.将您的CA密钥和证书和Sever端密钥和证书分别合并到 PKCS#12 (P12) 包中。您也可以指定某个证书格式，默认PKCS12，可以通过修改conf/fe.conf配置文件，添加参数ssl_trust_store_type指定证书格式
 
 ```bash
 # 打包CA密钥和证书

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1919,6 +1919,12 @@ public class Config extends ConfigBase {
     public static boolean ssl_force_client_auth = false;
 
     /**
+     * ssl connection needs to authenticate client's certificate store type.
+     */
+    @ConfField(mutable = false, masterOnly = false)
+    public static String ssl_trust_store_type = "PKCS12";
+
+    /**
      * Default CA certificate file location for mysql ssl connection.
      */
     @ConfField(mutable = false, masterOnly = false)

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlSslContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlSslContext.java
@@ -52,6 +52,7 @@ public class MysqlSslContext {
     private static final String trustStoreFile = Config.mysql_ssl_default_ca_certificate;
     private static final String caCertificatePassword = Config.mysql_ssl_default_ca_certificate_password;
     private static final String serverCertificatePassword = Config.mysql_ssl_default_server_certificate_password;
+    private static final String trustStoreType = Config.ssl_trust_store_type;
     private ByteBuffer serverNetData;
     private ByteBuffer clientAppData;
     private ByteBuffer clientNetData;
@@ -67,8 +68,8 @@ public class MysqlSslContext {
 
     private void initSslContext() {
         try {
-            KeyStore ks = KeyStore.getInstance("PKCS12");
-            KeyStore ts = KeyStore.getInstance("PKCS12");
+            KeyStore ks = KeyStore.getInstance(trustStoreType);
+            KeyStore ts = KeyStore.getInstance(trustStoreType);
 
             char[] serverPassword = serverCertificatePassword.toCharArray();
             char[] caPassword = caCertificatePassword.toCharArray();


### PR DESCRIPTION
## Proposed changes
FE ssl certificates support other type set param ssl_trust_store_type, default is PKCS12
Issue Number: close #26039

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

