### PR TITLE
[improvement](tablet clone) furthur repair replicas should be check even if they are versions catchup

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/LoadStatisticForTag.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/LoadStatisticForTag.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.clone.BackendLoadStatistic.Classification;
 import org.apache.doris.clone.BackendLoadStatistic.LoadScore;
 import org.apache.doris.common.Config;
+import org.apache.doris.common.util.DebugPointUtil;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.resource.Tag;
 import org.apache.doris.system.Backend;
@@ -186,34 +187,57 @@ public class LoadStatisticForTag {
         int lowCounter = 0;
         int midCounter = 0;
         int highCounter = 0;
+
+        long debugHighBeId = DebugPointUtil.getDebugParamOrDefault("FE.HIGH_LOAD_BE_ID", -1L);
+        if (debugHighBeId > 0) {
+            final long targetBeId = debugHighBeId; // debugHighBeId can not put in lambda cause it's updated later
+            if (!beLoadStatistics.stream().anyMatch(it -> it.getBeId() == targetBeId)) {
+                debugHighBeId = -1L;
+            }
+        }
+
         for (BackendLoadStatistic beStat : beLoadStatistics) {
             if (!beStat.hasMedium(medium)) {
                 continue;
             }
 
-
-            if (Config.be_rebalancer_fuzzy_test) {
+            Classification clazz = Classification.MID;
+            if (debugHighBeId > 0) {
+                if (beStat.getBeId() == debugHighBeId) {
+                    clazz = Classification.HIGH;
+                } else {
+                    clazz = Classification.LOW;
+                }
+            } else if (Config.be_rebalancer_fuzzy_test) {
                 if (beStat.getLoadScore(medium) > avgLoadScore) {
-                    beStat.setClazz(medium, Classification.HIGH);
-                    highCounter++;
+                    clazz = Classification.HIGH;
                 } else if (beStat.getLoadScore(medium) < avgLoadScore) {
-                    beStat.setClazz(medium, Classification.LOW);
-                    lowCounter++;
+                    clazz = Classification.LOW;
                 }
             } else {
                 if (Math.abs(beStat.getLoadScore(medium) - avgLoadScore) / avgLoadScore
                         > Config.balance_load_score_threshold) {
                     if (beStat.getLoadScore(medium) > avgLoadScore) {
-                        beStat.setClazz(medium, Classification.HIGH);
-                        highCounter++;
+                        clazz = Classification.HIGH;
                     } else if (beStat.getLoadScore(medium) < avgLoadScore) {
-                        beStat.setClazz(medium, Classification.LOW);
-                        lowCounter++;
+                        clazz = Classification.LOW;
                     }
-                } else {
-                    beStat.setClazz(medium, Classification.MID);
-                    midCounter++;
                 }
+            }
+
+            beStat.setClazz(medium, clazz);
+            switch (clazz) {
+                case HIGH:
+                    highCounter++;
+                    break;
+                case LOW:
+                    lowCounter++;
+                    break;
+                case MID:
+                    midCounter++;
+                    break;
+                default:
+                    break;
             }
         }
 
@@ -263,6 +287,11 @@ public class LoadStatisticForTag {
 
         if (!srcBeStat.hasMedium(medium) || !destBeStat.hasMedium(medium)) {
             return false;
+        }
+
+        long debugHighBeId = DebugPointUtil.getDebugParamOrDefault("FE.HIGH_LOAD_BE_ID", -1L);
+        if (srcBeStat.getBeId() == debugHighBeId) {
+            return true;
         }
 
         currentSrcBeScore = srcBeStat.getLoadScore(medium);

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
@@ -666,6 +666,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         List<Replica> decommissionCand = Lists.newArrayList();
         List<Replica> colocateCand = Lists.newArrayList();
         List<Replica> notColocateCand = Lists.newArrayList();
+        List<Replica> furtherRepairs = Lists.newArrayList();
         for (Replica replica : tablet.getReplicas()) {
             if (replica.isBad()) {
                 LOG.debug("replica {} is bad, skip. tablet: {}",
@@ -688,6 +689,11 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
 
             if (replica.getLastFailedVersion() <= 0
                     && replica.getVersion() >= visibleVersion) {
+
+                if (tabletStatus == TabletStatus.NEED_FURTHER_REPAIR && replica.needFurtherRepair()) {
+                    furtherRepairs.add(replica);
+                }
+
                 // skip healthy replica
                 LOG.debug("replica {} version {} is healthy, visible version {}, replica state {}, skip. tablet: {}",
                         replica.getId(), replica.getVersion(), visibleVersion, replica.getState(), tabletId);
@@ -709,8 +715,24 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         } else {
             candidates = decommissionCand;
         }
+
         if (candidates.isEmpty()) {
-            throw new SchedException(Status.UNRECOVERABLE, "unable to choose dest replica");
+            if (furtherRepairs.isEmpty()) {
+                throw new SchedException(Status.UNRECOVERABLE, "unable to choose dest replica");
+            }
+
+            boolean allCatchup = true;
+            for (Replica replica : furtherRepairs) {
+                if (checkFurthurRepairFinish(replica, visibleVersion)) {
+                    replica.setNeedFurtherRepair(false);
+                    replica.setFurtherRepairWatermarkTxnTd(-1);
+                } else {
+                    allCatchup = false;
+                }
+            }
+
+            throw new SchedException(Status.FINISHED,
+                    allCatchup ? "further repair all catchup" : "further repair waiting catchup");
         }
 
         Replica chosenReplica = null;
@@ -780,6 +802,32 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                     chosenReplica.getId(), chosenReplica.getBackendId(), tabletId);
         }
         setDest(chosenReplica.getBackendId(), chosenReplica.getPathHash());
+    }
+
+    private boolean checkFurthurRepairFinish(Replica replica, long version) {
+        if (replica.getVersion() < version || replica.getLastFailedVersion() > 0) {
+            return false;
+        }
+
+        long furtherRepairWatermarkTxnTd = replica.getFurtherRepairWatermarkTxnTd();
+        if (furtherRepairWatermarkTxnTd < 0) {
+            return true;
+        }
+
+        try {
+            if (Env.getCurrentGlobalTransactionMgr().isPreviousTransactionsFinished(
+                        furtherRepairWatermarkTxnTd, dbId, tblId, partitionId)) {
+                LOG.info("replica {} of tablet {} has catchup with further repair watermark id {}",
+                        replica, tabletId, furtherRepairWatermarkTxnTd);
+                return true;
+            } else {
+                return false;
+            }
+        } catch (Exception e) {
+            LOG.warn("replica {} of tablet {} check catchup with further repair watermark id {} failed",
+                    replica, tabletId, furtherRepairWatermarkTxnTd, e);
+            return true;
+        }
     }
 
     public void releaseResource(TabletScheduler tabletScheduler) {
@@ -1097,25 +1145,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
             // change from prepare to committed or visible, this replica will be fall behind and be removed
             // in REDUNDANT detection.
             //
-            boolean isCatchup = false;
-            if (replica.getVersion() >= partition.getVisibleVersion() && replica.getLastFailedVersion() < 0) {
-                long furtherRepairWatermarkTxnTd = replica.getFurtherRepairWatermarkTxnTd();
-                if (furtherRepairWatermarkTxnTd < 0) {
-                    isCatchup = true;
-                } else {
-                    try {
-                        if (Env.getCurrentGlobalTransactionMgr().isPreviousTransactionsFinished(
-                                furtherRepairWatermarkTxnTd, dbId, tblId, partitionId)) {
-                            isCatchup = true;
-                            LOG.info("new replica {} of tablet {} has catchup with further repair watermark id {}",
-                                    replica, tabletId, furtherRepairWatermarkTxnTd);
-                        }
-                    } catch (Exception e) {
-                        isCatchup = true;
-                    }
-                }
-            }
-
+            boolean isCatchup = checkFurthurRepairFinish(replica, partition.getVisibleVersion());
             replica.incrFurtherRepairCount();
             if (isCatchup || replica.getLeftFurtherRepairCount() <= 0) {
                 replica.setNeedFurtherRepair(false);

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -45,6 +45,7 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.Pair;
+import org.apache.doris.common.util.DebugPointUtil;
 import org.apache.doris.common.util.MasterDaemon;
 import org.apache.doris.persist.ReplicaPersistInfo;
 import org.apache.doris.resource.Tag;
@@ -976,6 +977,7 @@ public class TabletScheduler extends MasterDaemon {
             boolean force, LoadStatisticForTag statistic) throws SchedException {
         Replica chosenReplica = null;
         double maxScore = 0;
+        long debugHighBeId = DebugPointUtil.getDebugParamOrDefault("FE.HIGH_LOAD_BE_ID", -1L);
         for (Replica replica : replicas) {
             BackendLoadStatistic beStatistic = statistic.getBackendLoadStatistic(replica.getBackendId());
             if (beStatistic == null) {
@@ -999,6 +1001,11 @@ public class TabletScheduler extends MasterDaemon {
             if (loadScore > maxScore) {
                 maxScore = loadScore;
                 chosenReplica = replica;
+            }
+
+            if (debugHighBeId > 0 && replica.getBackendId() == debugHighBeId) {
+                chosenReplica = replica;
+                break;
             }
         }
 
@@ -1521,6 +1528,16 @@ public class TabletScheduler extends MasterDaemon {
 
                 if (statusPair.second.ordinal() < tabletCtx.getPriority().ordinal()) {
                     statusPair.second = tabletCtx.getPriority();
+                }
+            }
+
+            if (statusPair.first == TabletStatus.NEED_FURTHER_REPAIR) {
+                // replica is just waiting for finishing txns before furtherRepairWatermarkTxnTd,
+                // no need to add it immediately
+                Replica replica = tablet.getReplicaByBackendId(tabletCtx.getDestBackendId());
+                if (replica != null && replica.getVersion() >= partition.getVisibleVersion()
+                        && replica.getLastFailedVersion() < 0) {
+                    return;
                 }
             }
         } finally {


### PR DESCRIPTION

## Proposed changes

pick: #25551

If there are loading txns, PR https://github.com/apache/doris/pull/24845 will try to furthur repair a balance tablet even if their versions are catchup.

Then in scheduler's NEED_FURTHER_REPAIR handler, if no replicas are version fallbehind, the sched ctx will convert to REPLICA_MISSING, then add missing replicas will fail because they don't really miss replicas.

Improvement: for NEED_FURTHER_REPAIR handler, if all the replicas are version catchup, then try to check the txns before further repair txn has finished, if it finished, then mark the replica as further repair finish.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

