### PR TITLE
[fix](fe-meta) make FE meta be compatible with branch 2.0 (2.0.2.1 or later)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/persist/meta/PersistMetaModules.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/meta/PersistMetaModules.java
@@ -39,11 +39,11 @@ public class PersistMetaModules {
             "globalVariable", "cluster", "broker", "resources", "exportJob", "syncJob", "backupHandler",
             "paloAuth", "transactionState", "colocateTableIndex", "routineLoadJobs", "loadJobV2", "smallFiles",
             "plugins", "deleteHandler", "sqlBlockRule", "policy", "mtmvJobManager", "globalFunction", "workloadGroups",
-            "binlogs", "resourceGroups", "AnalysisMgr", "AsyncJobManager", "JobTaskManager");
+            "binlogs", "resourceGroups", "AnalysisMgrV2", "AsyncJobManager", "JobTaskManager");
 
     // Modules in this list is deprecated and will not be saved in meta file. (also should not be in MODULE_NAMES)
     public static final ImmutableList<String> DEPRECATED_MODULE_NAMES = ImmutableList.of(
-            "loadJob", "cooldownJob");
+            "loadJob", "cooldownJob", "AnalysisMgr");
 
     static {
         MODULES_MAP = Maps.newHashMap();


### PR DESCRIPTION
## Proposed changes

In branch 2.0, we changed the read/write method of AnalysisManager,
and rename the image module name to AnalysisMgrV2.
So we need to make the same change in master branch, so that user
can upgrade Doris from branch-2.0 to master branch.

After this PR, user can:

- upgrade from 2.0.x(or branch-2.0) to master

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

