### PR TITLE
[refine](profileV2) use task dependency in profile and print pipelinetask index

### DIFF
--- a/be/src/pipeline/pipeline_task.h
+++ b/be/src/pipeline/pipeline_task.h
@@ -249,6 +249,9 @@ public:
 
     TUniqueId instance_id() const { return _state->fragment_instance_id(); }
 
+
+    void set_parent_profile(RuntimeProfile* profile) { _parent_profile = profile; }
+
 protected:
     void _finish_p_dependency() {
         for (const auto& p : _pipeline->_parents) {

--- a/be/src/pipeline/pipeline_task.h
+++ b/be/src/pipeline/pipeline_task.h
@@ -249,7 +249,6 @@ public:
 
     TUniqueId instance_id() const { return _state->fragment_instance_id(); }
 
-
     void set_parent_profile(RuntimeProfile* profile) { _parent_profile = profile; }
 
 protected:

--- a/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
@@ -450,6 +450,29 @@ Status PipelineXFragmentContext::_build_pipeline_tasks(
          * and JoinProbeOperator2.
          */
 
+        // First, set up the parent profile, 
+        // then prepare the task profile and add it to operator_id_to_task_profile.
+        std::vector<RuntimeProfile*> operator_id_to_task_profile(
+                max_operator_id(), _runtime_states[i]->runtime_profile());
+        auto prepare_and_set_parent_profile = [&](PipelineXTask* task) {
+            auto sink = task->sink();
+            const auto& dests_id = sink->dests_id();
+            int dest_id = dests_id.front();
+            DCHECK(dest_id < operator_id_to_task_profile.size());
+            task->set_parent_profile(operator_id_to_task_profile[dest_id]);
+
+            RETURN_IF_ERROR(task->prepare(_runtime_states[i].get(), local_params,
+                                          request.fragment.output_sink));
+
+            for (auto o : task->operatorXs()) {
+                int id = o->operator_id();
+                DCHECK(id < operator_id_to_task_profile.size());
+                auto* op_local_state = _runtime_states[i].get()->get_local_state(o->operator_id());
+                operator_id_to_task_profile[id] = op_local_state->profile();
+            }
+            return Status::OK();
+        };
+
         for (size_t pip_idx = 0; pip_idx < _pipelines.size(); pip_idx++) {
             auto task = pipeline_id_to_task[_pipelines[pip_idx]->id()];
             DCHECK(task != nullptr);
@@ -462,8 +485,7 @@ Status PipelineXFragmentContext::_build_pipeline_tasks(
                             pipeline_id_to_task[dep]->get_downstream_dependency());
                 }
             }
-            RETURN_IF_ERROR(task->prepare(_runtime_states[i].get(), local_params,
-                                          request.fragment.output_sink));
+            RETURN_IF_ERROR(prepare_and_set_parent_profile(task));
         }
 
         {

--- a/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_x/pipeline_x_fragment_context.cpp
@@ -450,7 +450,7 @@ Status PipelineXFragmentContext::_build_pipeline_tasks(
          * and JoinProbeOperator2.
          */
 
-        // First, set up the parent profile, 
+        // First, set up the parent profile,
         // then prepare the task profile and add it to operator_id_to_task_profile.
         std::vector<RuntimeProfile*> operator_id_to_task_profile(
                 max_operator_id(), _runtime_states[i]->runtime_profile());

--- a/be/src/pipeline/pipeline_x/pipeline_x_task.cpp
+++ b/be/src/pipeline/pipeline_x/pipeline_x_task.cpp
@@ -135,7 +135,7 @@ Status PipelineXTask::extract_dependencies() {
 
 void PipelineXTask::_init_profile() {
     std::stringstream ss;
-    ss << "PipelineTask"
+    ss << "PipelineXTask"
        << " (index=" << _index << ")";
     auto* task_profile = new RuntimeProfile(ss.str());
     _parent_profile->add_child(task_profile, true, nullptr);

--- a/be/src/pipeline/pipeline_x/pipeline_x_task.h
+++ b/be/src/pipeline/pipeline_x/pipeline_x_task.h
@@ -151,6 +151,12 @@ public:
 
     void push_blocked_task_to_dependency(Dependency* dep) {}
 
+    DataSinkOperatorXPtr sink() const { return _sink; }
+
+    OperatorXPtr source() const { return _source; }
+
+    OperatorXs operatorXs() { return _operators; }
+
 private:
     void set_close_pipeline_time() override {}
     void _init_profile() override;


### PR DESCRIPTION
## Proposed changes

```
SimpleProfile:
    Instance(1):
        PipelineXTask  (index=0):
        RESULT_SINK_OPERATOR  (id=0):
              -  CloseTime:  avg  7.595us,  max  7.595us,  min  7.595us
              -  InputRows:  0
              -  OpenTime:  avg  89.933us,  max  89.933us,  min  89.933us
        AGGREGATION_OPERATOR  (id=789):
              -  PlanInfo
                    -  output:  sum(partial_sum((lo_extendedprice  *  lo_discount)))[#45]
                    -  group  by:  
                    -  cardinality=1
              -  BlocksReturned:  1
              -  CloseTime:  avg  3.773us,  max  3.773us,  min  3.773us
              -  OpenTime:  avg  24.928us,  max  24.928us,  min  24.928us
              -  ProjectionTime:  avg  0ns,  max  0ns,  min  0ns
              -  RowsReturned:  1
            PipelineXTask  (index=1):
            AGGREGATION_SINK_OPERATOR  (id=789):
                  -  CloseTime:  avg  3.172us,  max  3.172us,  min  3.172us
                  -  InputRows:  1
                  -  OpenTime:  avg  85.961us,  max  85.961us,  min  85.961us
            EXCHANGE_OPERATOR  (id=786):
                  -  PlanInfo
                        -  offset:  0
                  -  BlocksReturned:  1
                  -  CloseTime:  avg  12.518us,  max  12.518us,  min  12.518us
                  -  OpenTime:  avg  78.899us,  max  78.899us,  min  78.899us
                  -  ProjectionTime:  avg  0ns,  max  0ns,  min  0ns
                  -  RowsReturned:  1
    Instance(1):
        PipelineXTask  (index=0):
        DATA_STREAM_SINK_OPERATOR  (id=786,dest_id=786):
              -  BlocksSent:  1
              -  CloseTime:  avg  31.507us,  max  31.507us,  min  31.507us
              -  InputRows:  1
              -  OpenTime:  avg  222.693us,  max  222.693us,  min  222.693us
        AGGREGATION_OPERATOR  (id=783):
              -  PlanInfo
                    -  output:  partial_sum((lo_extendedprice  *  lo_discount))[#44]
                    -  group  by:  
                    -  cardinality=1
              -  BlocksReturned:  1
              -  CloseTime:  avg  11.100us,  max  11.100us,  min  11.100us
              -  OpenTime:  avg  18.542us,  max  18.542us,  min  18.542us
              -  ProjectionTime:  avg  0ns,  max  0ns,  min  0ns
              -  RowsReturned:  1
            PipelineXTask  (index=1):
            AGGREGATION_SINK_OPERATOR  (id=783):
                  -  CloseTime:  avg  3.967us,  max  3.967us,  min  3.967us
                  -  InputRows:  11.913972M  (11913972)
                  -  OpenTime:  avg  74.274us,  max  74.274us,  min  74.274us
            HASH_JOIN_OPERATOR  (id=777):
                  -  PlanInfo
                        -  join  op:  INNER  JOIN(BROADCAST)[]
                        -  equal  join  conjunct:  lo_orderdate  =  d_datekey
                        -  runtime  filters:  RF000[in_or_bloom]  <-  d_datekey(-1/0/2097152)
                        -  cardinality=75,006,015
                        -  vec  output  tuple  id:  5
                        -  vIntermediate  tuple  ids:  4  
                        -  hash  output  slot  ids:  36  37  
                  -  BlocksReturned:  5.524K  (5524)
                  -  CloseTime:  avg  12.480us,  max  12.480us,  min  12.480us
                  -  OpenTime:  avg  73.759us,  max  73.759us,  min  73.759us
                  -  ProbeRows:  11.913972M  (11913972)
                  -  ProjectionTime:  avg  23.843ms,  max  23.843ms,  min  23.843ms
                  -  RowsReturned:  11.913972M  (11913972)
                OLAP_SCAN_OPERATOR  (id=756):
                      -  PlanInfo
                            -  TABLE:  default_cluster:ssb.lineorder(lineorder),  PREAGGREGATION:  ON
                            -  PREDICATES:  lo_discount  <=  3  AND  lo_discount  >=  1  AND  lo_quantity  <  25
                            -  runtime  filters:  RF000[in_or_bloom]  ->  lo_orderdate
                            -  partitions=7/7,  tablets=336/336,  tabletList=11074,11076,11078  ...
                            -  cardinality=600037902,  avgRowSize=130.72264,  numNodes=1
                            -  pushAggOp=NONE
                            -  projections:  lo_orderdate,  lo_extendedprice,  lo_discount
                            -  project  output  tuple  id:  3
                      -  BlocksReturned:  5.524K  (5524)
                      -  CloseTime:  avg  1.300ms,  max  1.300ms,  min  1.300ms
                      -  OpenTime:  avg  3.709ms,  max  3.709ms,  min  3.709ms
                      -  ProjectionTime:  avg  89.964ms,  max  89.964ms,  min  89.964ms
                      -  RowsReturned:  11.913972M  (11913972)
                    :
                    VScanner:
                        SegmentIterator:
                PipelineXTask  (index=2):
                HASH_JOIN_SINK_OPERATOR  (id=777):
                      -  CloseTime:  avg  0ns,  max  0ns,  min  0ns
                      -  InputRows:  365
                      -  OpenTime:  avg  166.66us,  max  166.66us,  min  166.66us
                EXCHANGE_OPERATOR  (id=774):
                      -  PlanInfo
                            -  offset:  0
                      -  BlocksReturned:  1
                      -  CloseTime:  avg  11.304us,  max  11.304us,  min  11.304us
                      -  OpenTime:  avg  67.194us,  max  67.194us,  min  67.194us
                      -  ProjectionTime:  avg  0ns,  max  0ns,  min  0ns
                      -  RowsReturned:  365
    Instance(1):
        PipelineXTask  (index=0):
        DATA_STREAM_SINK_OPERATOR  (id=774,dest_id=774):
              -  BlocksSent:  1
              -  CloseTime:  avg  24.673us,  max  24.673us,  min  24.673us
              -  InputRows:  365
              -  OpenTime:  avg  118.156us,  max  118.156us,  min  118.156us
        OLAP_SCAN_OPERATOR  (id=765):
              -  PlanInfo
                    -  TABLE:  default_cluster:ssb.dates(dates),  PREAGGREGATION:  ON
                    -  PREDICATES:  d_year  =  1993
                    -  partitions=1/1,  tablets=1/1,  tabletList=11778
                    -  cardinality=2556,  avgRowSize=68.56221,  numNodes=1
                    -  pushAggOp=NONE
                    -  projections:  d_datekey
                    -  project  output  tuple  id:  1
              -  BlocksReturned:  1
              -  CloseTime:  avg  71.528us,  max  71.528us,  min  71.528us
              -  OpenTime:  avg  537.55us,  max  537.55us,  min  537.55us
              -  ProjectionTime:  avg  27.600us,  max  27.600us,  min  27.600us
              -  RowsReturned:  365
            VScanner:
                SegmentIterator:
  
```

```
    Instance(1):
        PipelineXTask  (index=0):
        DATA_STREAM_SINK_OPERATOR  (id=786,dest_id=786):
        AGGREGATION_OPERATOR  (id=783):
            PipelineXTask  (index=1):
            AGGREGATION_SINK_OPERATOR  (id=783):
            HASH_JOIN_OPERATOR  (id=777):
                OLAP_SCAN_OPERATOR  (id=756):
                PipelineXTask  (index=2):
                HASH_JOIN_SINK_OPERATOR  (id=777):
                EXCHANGE_OPERATOR  (id=774):

```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

