### PR TITLE
[Chore](log) do not print stack when stream load catch failed status on thrift

### DIFF
--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -190,7 +190,7 @@ Status StreamLoadExecutor::begin_txn(StreamLoadContext* ctx) {
 #else
         result = k_stream_load_begin_result;
 #endif
-        status = Status::create(result.status);
+        status = Status::create<false>(result.status);
     }
     g_stream_load_begin_txn_latency << duration_ns / 1000;
     if (!status.ok()) {


### PR DESCRIPTION
## Proposed changes
stack is useless here.
```
Enter host password for user 'root':
{ "TxnId": -1, "Label": "123", "Comment": "", "TwoPhaseCommit": "false", "Status": "Label Already Exists", "ExistingJobStatus": "FINISHED", "Message": "[LABEL_ALREADY_EXISTS]TStatus: errCode = 2, detailMessage = Label [123] has already been used, relate to txn [156130]\n\n\t0# doris::Status doris::Status::create<true>(doris::TStatus const&) at /mnt/disk1/xiaolei/incubator-doris/be/src/common/status.h:358\n\t0.1. inlined from std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_data() const: /mnt/disk1/xiaolei/ldb_16/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:187\n\t0.2. inlined from std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_is_local() const: /mnt/disk1/xiaolei/ldb_16/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:222\n\t0.3. inlined from std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_dispose(): /mnt/disk1/xiaolei/ldb_16/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:231\n\t0.4. inlined from ~basic_string: /mnt/disk1/xiaolei/ldb_16/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/basic_string.h:658\n\t1# doris::StreamLoadExecutor::begin_txn(doris::StreamLoadContext*) at /mnt/disk1/xiaolei/incubator-doris/be/src/runtime/stream_load/stream_load_executor.cpp:193\n\t1.1. inlined from doris::Status::operator=(doris::Status&&): /mnt/disk1/xiaolei/incubator-doris/be/src/common/status.h:349\n\t2# doris::StreamLoadAction::_on_header(doris::HttpRequest*, std::shared_ptr<doris::StreamLoadContext>) at /mnt/disk1/xiaolei/incubator-doris/be/src/http/action/stream_load.cpp:308\n\t2.1. inlined from ~__shared_count: /mnt/disk1/xiaolei/ldb_16/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:701\n\t2.2. inlined from ~__shared_ptr: /mnt/disk1/xiaolei/ldb_16/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1149\n\t3# doris::StreamLoadAction::on_header(doris::HttpRequest*) at /mnt/disk1/xiaolei/incubator-doris/be/src/http/action/stream_load.cpp:205\n\t3.1. inlined from doris::Status::operator=(doris::Status&&): /mnt/disk1/xiaolei/incubator-doris/be/src/common/status.h:349\n\t4# doris::EvHttpServer::on_header(evhttp_request*) at /mnt/disk1/xiaolei/incubator-doris/be/src/http/ev_http_server.cpp:251\n\t5# ?\n\t6# bufferevent_run_readcb_\n\t7# ?\n\t8# ?\n\t9# ?\n\t10# ?\n\t11# std::_Function_handler<void (), doris::EvHttpServer::start()::$_0>::_M_invoke(std::_Any_data const&) at /mnt/disk1/xiaolei/ldb_16/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291\n\t11.1. inlined from __gnu_cxx::__exchange_and_add_dispatch(int*, int): /mnt/disk1/xiaolei/ldb_16/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/ext/atomicity.h:98\n\t11.2. inlined from std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release(): /mnt/disk1/xiaolei/ldb_16/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:165\n\t11.3. inlined from ~__shared_count: /mnt/disk1/xiaolei/ldb_16/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:702\n\t11.4. inlined from ~__shared_ptr: /mnt/disk1/xiaolei/ldb_16/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1149\n\t11.5. inlined from operator(): /mnt/disk1/xiaolei/incubator-doris/be/src/http/ev_http_server.cpp:114\n\t11.6. inlined from void std::__invoke_impl<void, doris::EvHttpServer::start()::$_0&>(std::__invoke_other, doris::EvHttpServer::start()::$_0&): /mnt/disk1/xiaolei/ldb_16/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61\n\t11.7. inlined from std::enable_if<is_invocable_r_v<void, doris::EvHttpServer::start()::$_0&>, void>::type std::__invoke_r<void, doris::EvHttpServer::start()::$_0&>(doris::EvHttpServer::start()::$_0&): /mnt/disk1/xiaolei/ldb_16/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111\n\t12# doris::ThreadPool::dispatch_thread() at /mnt/disk1/xiaolei/incubator-doris/be/src/util/threadpool.cpp:0\n\t13# doris::Thread::supervise_thread(void*) at /mnt/disk1/xiaolei/incubator-doris/be/src/util/thread.cpp:495\n\t13.1. inlined from ~__pthread_cleanup_class: /mnt/disk1/xiaolei/ldb_16/ldb_toolchain/bin/../usr/include/pthread.h:562\n\t14# start_thread\n\t15# clone\n", "NumberTotalRows": 0, "NumberLoadedRows": 0, "NumberFilteredRows": 0, "NumberUnselectedRows": 0, "LoadBytes": 0, "LoadTimeMs": 0, "BeginTxnTimeMs": 0, "StreamLoadPutTimeMs": 0, "ReadDataTimeMs": 0, "WriteDataTimeMs": 0, "CommitAndPublishTimeMs": 0 } 
```
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

