### PR TITLE
[fix](Cooldown) Quit cooldown task when remote fs attached to policy id is not found

### DIFF
--- a/be/src/olap/storage_policy.cpp
+++ b/be/src/olap/storage_policy.cpp
@@ -40,13 +40,13 @@ Status get_remote_file_system(int64_t storage_policy_id,
     auto storage_policy = get_storage_policy(storage_policy_id);
     if (storage_policy == nullptr) {
         return Status::NotFound("could not find storage_policy, storage_policy_id={}",
-                                     storage_policy_id);
+                                storage_policy_id);
     }
     auto resource = get_storage_resource(storage_policy->resource_id);
     *fs = std::static_pointer_cast<io::RemoteFileSystem>(resource.fs);
     if (*fs == nullptr) {
         return Status::NotFound("could not find resource, resouce_id={}",
-                                     storage_policy->resource_id);
+                                storage_policy->resource_id);
     }
     DCHECK((*fs)->type() != io::FileSystemType::LOCAL);
     return Status::OK();

--- a/be/src/olap/storage_policy.cpp
+++ b/be/src/olap/storage_policy.cpp
@@ -39,13 +39,13 @@ Status get_remote_file_system(int64_t storage_policy_id,
                               std::shared_ptr<io::RemoteFileSystem>* fs) {
     auto storage_policy = get_storage_policy(storage_policy_id);
     if (storage_policy == nullptr) {
-        return Status::InternalError("could not find storage_policy, storage_policy_id={}",
+        return Status::NotFound("could not find storage_policy, storage_policy_id={}",
                                      storage_policy_id);
     }
     auto resource = get_storage_resource(storage_policy->resource_id);
     *fs = std::static_pointer_cast<io::RemoteFileSystem>(resource.fs);
     if (*fs == nullptr) {
-        return Status::InternalError("could not find resource, resouce_id={}",
+        return Status::NotFound("could not find resource, resouce_id={}",
                                      storage_policy->resource_id);
     }
     DCHECK((*fs)->type() != io::FileSystemType::LOCAL);

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2213,8 +2213,8 @@ Status Tablet::write_cooldown_meta() {
     }
 
     std::shared_ptr<io::RemoteFileSystem> fs;
-    if (auto s = get_remote_file_system(storage_policy_id(), &fs);
-        s.is<TStatusCode::NOT_FOUND>()) [[unlikely]] {
+    if (auto s = get_remote_file_system(storage_policy_id(), &fs); s.is<TStatusCode::NOT_FOUND>())
+            [[unlikely]] {
         return Status::Aborted<false>(
                 "Failed to get remote fs when cooldown for tablet {} due to {}, the storage policy "
                 "might be dropped",

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2214,7 +2214,7 @@ Status Tablet::write_cooldown_meta() {
 
     std::shared_ptr<io::RemoteFileSystem> fs;
     if (auto s = get_remote_file_system(storage_policy_id(), &fs);
-        s.is<TStatusCode::INTERNAL_ERROR>()) [[unlikely]] {
+        s.is<TStatusCode::NOT_FOUND>()) [[unlikely]] {
         return Status::Aborted<false>(
                 "Failed to get remote fs when cooldown for tablet {} due to {}, the storage policy "
                 "might be dropped",


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
If the user has dropped the storage policy, the corresponding cooldown task should correctly quit the following procedure instead of limitless retry.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

