### PR TITLE
[branch2021](meta) add OP_ALTER_CATALOG_COMMENT for compatibility

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
@@ -844,9 +844,11 @@ public class JournalEntity implements Writable {
                 isRead = true;
                 break;
             }
+            case OperationType.OP_ALTER_CATALOG_COMMENT:
             case OperationType.OP_UPDATE_TABLE_STATS:
             case OperationType.OP_PERSIST_AUTO_JOB:
             case OperationType.OP_DELETE_TABLE_STATS: {
+                // For backward compatible with 2.0.3
                 isRead = true;
                 break;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -1059,16 +1059,11 @@ public class EditLog {
                     env.getBinlogManager().addBarrierLog(log, logId);
                     break;
                 }
-                // For backward compatible with 2.0.3
-                case OperationType.OP_UPDATE_TABLE_STATS: {
-                    break;
-                }
-                // For backward compatible with 2.0.3
-                case OperationType.OP_PERSIST_AUTO_JOB: {
-                    break;
-                }
-                // For backward compatible with 2.0.3
-                case OperationType.OP_DELETE_TABLE_STATS: {
+                case OperationType.OP_ALTER_CATALOG_COMMENT:
+                case OperationType.OP_UPDATE_TABLE_STATS:
+                case OperationType.OP_PERSIST_AUTO_JOB:
+                case OperationType.OP_DELETE_TABLE_STATS:{
+                    // For backward compatible with 2.0.3
                     break;
                 }
                 default: {

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
@@ -323,6 +323,9 @@ public class OperationType {
     // For backward compatible with 2.0.3
     public static final short OP_DELETE_TABLE_STATS = 457;
 
+    // For backward compatible with 2.0.3
+    public static final short OP_ALTER_CATALOG_COMMENT = 458;
+
     /**
      * Get opcode name by op code.
      **/


### PR DESCRIPTION
## Proposed changes

In PR #24857, we add a new OpType for `alter catalog comment` in branch 2.0.
For downgrade compatibility, this should be added to 2.0.2.1,
so that user can downgrade from branch-2.0(after 2.0.3) to 2.0.2.1

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

