### PR TITLE
[Improvement](iceberg) add switch to controll whether load default hd…

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1882,6 +1882,12 @@ public class Config extends ConfigBase {
     public static long hive_metastore_client_timeout_second = 10;
 
     /**
+     * Whether to load default config files when creating hive metastore client.
+     */
+    @ConfField(mutable = true, masterOnly = false)
+    public static boolean load_default_conf_for_hms_client = true;
+
+    /**
      * Used to determined how many statistics collection SQL could run simultaneously.
      */
     @ConfField

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
@@ -834,7 +834,7 @@ public class HiveMetaStoreClientHelper {
     }
 
     public static Configuration getConfiguration(HMSExternalTable table) {
-        Configuration conf = new HdfsConfiguration();
+        Configuration conf = new HdfsConfiguration(Config.load_default_conf_for_hms_client);
         for (Map.Entry<String, String> entry : table.getHadoopProperties().entrySet()) {
             conf.set(entry.getKey(), entry.getValue());
         }


### PR DESCRIPTION
…fs conf when creating hms client

<img width="1500" alt="image" src="https://github.com/apache/doris/assets/28004179/1cf547d2-cf40-4c66-8045-9ba1bed44df0">

new HdfsConfiguration(); cost too much time, especially on iceberg-on-gfs case. it's ok to not load default config file, and it will speed up the process.
It's more safe when using a switch config, you can change it at runtime.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

