### PR TITLE
[enhancement](Nereids): optimize GroupExpressionMatching

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/pattern/GroupMatching.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/pattern/GroupMatching.java
@@ -45,12 +45,6 @@ public class GroupMatching {
                     matchingPlans.add(plan);
                 }
             }
-            // Jackwener: We don't need to match physical expressions.
-            // for (GroupExpression groupExpression : group.getPhysicalExpressions()) {
-            //     for (Plan plan : new GroupExpressionMatching(pattern, groupExpression)) {
-            //         matchingPlans.add(plan);
-            //     }
-            // }
         }
         return matchingPlans;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
@@ -37,6 +37,7 @@ import org.apache.doris.nereids.types.coercion.AnyDataType;
 import org.apache.doris.nereids.util.Utils;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
 
@@ -44,7 +45,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Abstract class for all Expression in Nereids.
@@ -247,8 +247,19 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
         return collect(Slot.class::isInstance);
     }
 
+    /**
+     * Get all the input slot ids of the expression.
+     * <p>
+     * Note that the input slots of subquery's inner plan is not included.
+     */
     public final Set<ExprId> getInputSlotExprIds() {
-        return getInputSlots().stream().map(NamedExpression::getExprId).collect(Collectors.toSet());
+        ImmutableSet.Builder<ExprId> result = ImmutableSet.builder();
+        foreach(node -> {
+            if (node instanceof Slot) {
+                result.add(((Slot) node).getExprId());
+            }
+        });
+        return result.build();
     }
 
     public boolean isLiteral() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
@@ -43,9 +43,9 @@ import org.apache.doris.statistics.Statistics;
 import org.apache.doris.thrift.TRuntimeFilterType;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -113,22 +113,25 @@ public class PhysicalHashJoin<
      * Return pair of left used slots and right used slots.
      */
     public Pair<List<ExprId>, List<ExprId>> getHashConjunctsExprIds() {
-        List<ExprId> exprIds1 = Lists.newArrayListWithCapacity(hashJoinConjuncts.size());
-        List<ExprId> exprIds2 = Lists.newArrayListWithCapacity(hashJoinConjuncts.size());
+        int size = hashJoinConjuncts.size();
+
+        List<ExprId> exprIds1 = new ArrayList<>(size);
+        List<ExprId> exprIds2 = new ArrayList<>(size);
 
         Set<ExprId> leftExprIds = left().getOutputExprIdSet();
         Set<ExprId> rightExprIds = right().getOutputExprIdSet();
 
         for (Expression expr : hashJoinConjuncts) {
-            expr.getInputSlotExprIds().forEach(exprId -> {
+            for (ExprId exprId : expr.getInputSlotExprIds()) {
                 if (leftExprIds.contains(exprId)) {
                     exprIds1.add(exprId);
                 } else if (rightExprIds.contains(exprId)) {
                     exprIds2.add(exprId);
                 } else {
-                    throw new RuntimeException("Could not generate valid equal on clause slot pairs for join");
+                    throw new RuntimeException("Invalid ExprId found: " + exprId
+                            + ". Cannot generate valid equal on clause slot pairs for join.");
                 }
-            });
+            }
         }
         return Pair.of(exprIds1, exprIds2);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/PlanUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/PlanUtils.java
@@ -55,7 +55,7 @@ public class PlanUtils {
      * normalize comparison predicate on a binary plan to its two sides are corresponding to the child's output.
      */
     public static ComparisonPredicate maybeCommuteComparisonPredicate(ComparisonPredicate expression, Plan left) {
-        Set<Slot> slots = expression.left().collect(Slot.class::isInstance);
+        Set<Slot> slots = expression.left().getInputSlots();
         Set<Slot> leftSlots = left.getOutputSet();
         Set<Slot> buffer = Sets.newHashSet(slots);
         buffer.removeAll(leftSlots);


### PR DESCRIPTION
## Proposed changes

pattern can't be SubTreePattern in CBO phase.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

