### PR TITLE
[fix](thrift)limit be and fe thrift server max pkg size,avoid accepti…

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -929,6 +929,9 @@ CONF_mBool(allow_invalid_decimalv2_literal, "false");
 // data page size for primary key index.
 CONF_Int32(primary_key_data_page_size, "32768");
 
+// the max package size be thrift server can receive,avoid accepting error or too large package causing OOM,default 20M
+CONF_Int32(be_thrift_max_pkg_bytes, "20000000");
+
 #ifdef BE_TEST
 // test s3
 CONF_String(test_s3_resource, "resource");

--- a/be/src/util/thrift_server.cpp
+++ b/be/src/util/thrift_server.cpp
@@ -285,6 +285,11 @@ Status ThriftServer::start() {
     DCHECK(!_started);
     std::shared_ptr<apache::thrift::protocol::TProtocolFactory> protocol_factory(
             new apache::thrift::protocol::TBinaryProtocolFactory());
+    // binary_protocal_factory for setStringSizeLimit function
+    std::shared_ptr<apache::thrift::protocol::TBinaryProtocolFactory> binary_protocal_factory =
+            std::dynamic_pointer_cast<apache::thrift::protocol::TBinaryProtocolFactory>(
+                    protocol_factory);
+    binary_protocal_factory->setStringSizeLimit(config::be_thrift_max_pkg_bytes);
     std::shared_ptr<apache::thrift::concurrency::ThreadManager> thread_mgr;
     std::shared_ptr<apache::thrift::concurrency::ThreadFactory> thread_factory =
             std::make_shared<apache::thrift::concurrency::ThreadFactory>();

--- a/docs/zh-CN/docs/admin-manual/config/be-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/be-config.md
@@ -1446,4 +1446,10 @@ load tablets from header failed, failed tablets size: xxx, path=xxx
 * 描述: 是否在导入json数据时用simdjson来解析。
 * 默认值: false
 
+
+#### `be_thrift_max_pkg_bytes`
+
+* 描述: be节点thrift端口最大接收包大小
+* 默认值: 20000000
+
 </version>

--- a/docs/zh-CN/docs/admin-manual/config/fe-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/fe-config.md
@@ -2734,3 +2734,15 @@ show data （其他用法：HELP SHOW DATA）
 
 这个参数主要用于避免因 external catalog 无法访问、信息过多等原因导致的查询 `information_schema` 超时的问题。
 
+
+#### `fe_thrift_max_pkg_bytes`
+
+默认值：20000000
+
+是否可以动态配置：false
+
+是否为 Master FE 节点独有的配置项：false
+
+用于限制fe节点thrift端口可以接收的最大包长度，避免接收到过大或者错误的包导致OOM
+
+

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2053,5 +2053,11 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true)
     public static boolean use_mysql_bigint_for_largeint = false;
+
+    /** 
+    * the max package size fe thrift server can receive,avoid accepting error or too large package causing OOM,default 20M
+    */
+    @ConfField
+    public static int fe_thrift_max_pkg_bytes = 20000000;
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/ThriftServer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/ThriftServer.java
@@ -91,14 +91,14 @@ public class ThriftServer {
 
     private void createSimpleServer() throws TTransportException {
         TServer.Args args = new TServer.Args(new TServerSocket(port)).protocolFactory(
-                new TBinaryProtocol.Factory()).processor(processor);
+                new TBinaryProtocol.Factory(Config.fe_thrift_max_pkg_bytes, -1)).processor(processor);
         server = new TSimpleServer(args);
     }
 
     private void createThreadedServer() throws TTransportException {
         TThreadedSelectorServer.Args args = new TThreadedSelectorServer.Args(
                 new TNonblockingServerSocket(port, Config.thrift_client_timeout_ms)).protocolFactory(
-                        new TBinaryProtocol.Factory()).processor(processor);
+                        new TBinaryProtocol.Factory(Config.fe_thrift_max_pkg_bytes, -1)).processor(processor);
         ThreadPoolExecutor threadPoolExecutor = ThreadPoolManager.newDaemonCacheThreadPool(
                 Config.thrift_server_max_worker_threads, "thrift-server-pool", true);
         args.executorService(threadPoolExecutor);
@@ -114,7 +114,7 @@ public class ThriftServer {
 
         TThreadPoolServer.Args serverArgs =
                 new TThreadPoolServer.Args(new TServerSocket(socketTransportArgs)).protocolFactory(
-                        new TBinaryProtocol.Factory()).processor(processor);
+                        new TBinaryProtocol.Factory(Config.fe_thrift_max_pkg_bytes, -1)).processor(processor);
         ThreadPoolExecutor threadPoolExecutor = ThreadPoolManager.newDaemonCacheThreadPool(
                 Config.thrift_server_max_worker_threads, "thrift-server-pool", true);
         serverArgs.executorService(threadPoolExecutor);


### PR DESCRIPTION
…ng error or too large package causing OOM

## Proposed changes
Thrift server reads the first four bytes of a packet as the packet size, and without setting the string_limit parameter, it will directly request the memory corresponding to the packet size represented by the first four bytes. When receiving an error or large packet, it is easy to encounter OOM.
![image](https://github.com/apache/doris/assets/143597717/8d06b555-ed4d-412c-90a6-a630f704ef35)
Doris currently does not set the string_limit parameter, so when receiving a corrupted packet, it is easy to encounter OOM.

We  can send multiple HTTP packets to the Thrift port simultaneously to reproduce：
#/bin/bash
for (( i=0; i< 20 ;i++))
do
curl -X POST -d'{test}' "http://127.0.0.1:9020" &
done


<!--Describe your changes.-->

This PR add string_limit parameter for be and fe thrift server


