### PR TITLE
[workflow](branch-2.0) disable branch-2.0 protection temporarily

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -80,31 +80,6 @@ github:
         dismiss_stale_reviews: true
         required_approving_review_count: 1
 
-    branch-2.0:
-      required_status_checks:
-      # if strict is true, means "Require branches to be up to date before merging".
-        strict: false
-        contexts:
-          - License Check
-          - Clang Formatter
-          - CheckStyle
-          - P0 Regression (Doris Regression)
-          - P1 Regression (Doris Regression)
-          - External Regression (Doris External Regression)
-          - FE UT (Doris FE UT)
-          - BE UT (Doris BE UT)
-          - Build Broker
-          - Build Documents
-          - ShellCheck
-          - clickbench-new (clickbench)
-          - Build Third Party Libraries (Linux)
-          - Build Third Party Libraries (macOS)
-          - COMPILE (DORIS_COMPILE)
-
-        required_pull_request_reviews:
-          dismiss_stale_reviews: true
-          required_approving_review_count: 1
-
   collaborators:
     - LemonLiTree
     - Yukang-Lian


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

disable branch-2.0 protection temporarily for merge pr faster.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

