### PR TITLE
[Fix](profile) Reload profile content if profile is unfinished

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
@@ -74,8 +74,8 @@ public class RuntimeProfile {
 
     private Long timestamp = -1L;
 
-    private Boolean isDone = false;
-    private Boolean isCancel = false;
+    private volatile Boolean isDone = false;
+    private volatile Boolean isCancel = false;
     // In pipelineX, we have explicitly split the Operator into sink and operator,
     // and we can distinguish them using tags.
     // In the old pipeline, we can only differentiate them based on their position


### PR DESCRIPTION
## Proposed changes

Users can get the profile content of a query when the profile is not finished, so we should cache profile content only when the profile is finished.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

