### PR TITLE
[FIX](decimal)fix column is decimalv3 cast to decimalv2 make be core

### DIFF
--- a/be/src/vec/sink/vmysql_result_writer.cpp
+++ b/be/src/vec/sink/vmysql_result_writer.cpp
@@ -147,7 +147,15 @@ Status VMysqlResultWriter<is_binary_format>::append_block(Block& input_block) {
             // from expr
             DataTypeSerDeSPtr serde;
             if (_output_vexpr_ctxs[i]->root()->type().is_decimal_v2_type()) {
-                serde = std::make_shared<DataTypeDecimalSerDe<vectorized::Decimal128>>(scale, 27);
+                if (_output_vexpr_ctxs[i]->root()->is_nullable()) {
+                    auto nested_serde =
+                            std::make_shared<DataTypeDecimalSerDe<vectorized::Decimal128>>(scale,
+                                                                                           27);
+                    serde = std::make_shared<DataTypeNullableSerDe>(nested_serde);
+                } else {
+                    serde = std::make_shared<DataTypeDecimalSerDe<vectorized::Decimal128>>(scale,
+                                                                                           27);
+                }
             } else {
                 serde = block.get_by_position(i).type->get_serde();
             }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
when after cast expr , block column is nullable, so decimalv2 serde should handle nullable 
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

