### PR TITLE
[fix](nereids)fix bug of select mv in nereids

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/mv/AbstractSelectMaterializedIndexRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/mv/AbstractSelectMaterializedIndexRule.java
@@ -139,9 +139,9 @@ public abstract class AbstractSelectMaterializedIndexRule {
         mvColNames.addAll(indexConjuncts);
 
         return mvColNames.containsAll(requiredMvColumnNames)
-                && ((indexConjuncts.isEmpty() || commonConjuncts.size() == predicateExprSql.size())
+                && (indexConjuncts.isEmpty() || commonConjuncts.size() == predicateExprSql.size())
                 || requiredExpr.stream().filter(e -> !containsAllColumn(e, mvColNames)).collect(Collectors.toSet())
-                        .isEmpty());
+                        .isEmpty();
     }
 
     public static String parseMvColumnToSql(String mvName) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/mv/AbstractSelectMaterializedIndexRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/mv/AbstractSelectMaterializedIndexRule.java
@@ -139,9 +139,9 @@ public abstract class AbstractSelectMaterializedIndexRule {
         mvColNames.addAll(indexConjuncts);
 
         return mvColNames.containsAll(requiredMvColumnNames)
-                && (indexConjuncts.isEmpty() || commonConjuncts.size() == predicateExprSql.size())
+                && ((indexConjuncts.isEmpty() || commonConjuncts.size() == predicateExprSql.size())
                 || requiredExpr.stream().filter(e -> !containsAllColumn(e, mvColNames)).collect(Collectors.toSet())
-                        .isEmpty();
+                        .isEmpty());
     }
 
     public static String parseMvColumnToSql(String mvName) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/mv/SelectMaterializedIndexWithAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/mv/SelectMaterializedIndexWithAggregate.java
@@ -105,7 +105,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
         return ImmutableList.of(
                 // only agg above scan
                 // Aggregate(Scan)
-                logicalAggregate(logicalOlapScan().when(this::shouldSelectIndex)).thenApply(ctx -> {
+                logicalAggregate(logicalOlapScan().when(this::shouldSelectIndexWithAgg)).thenApply(ctx -> {
                     LogicalAggregate<LogicalOlapScan> agg = ctx.root;
                     LogicalOlapScan scan = agg.child();
                     SelectResult result = select(
@@ -116,11 +116,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                             agg.getGroupByExpressions(),
                             new HashSet<>(agg.getExpressions()));
 
-                    if (result.indexId == scan.getTable().getBaseIndexId()) {
-                        return ctx.root;
-                    }
-
-                    LogicalOlapScan mvPlan = scan.withMaterializedIndexSelected(result.preAggStatus, result.indexId);
+                    LogicalOlapScan mvPlan = createLogicalOlapScan(scan, result);
                     SlotContext slotContext = generateBaseScanExprToMvExpr(mvPlan);
 
                     if (result.exprRewriteMap.isEmpty()) {
@@ -143,7 +139,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
 
                 // filter could push down scan.
                 // Aggregate(Filter(Scan))
-                logicalAggregate(logicalFilter(logicalOlapScan().when(this::shouldSelectIndex)))
+                logicalAggregate(logicalFilter(logicalOlapScan().when(this::shouldSelectIndexWithAgg)))
                         .thenApply(ctx -> {
                             LogicalAggregate<LogicalFilter<LogicalOlapScan>> agg = ctx.root;
                             LogicalFilter<LogicalOlapScan> filter = agg.child();
@@ -166,12 +162,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                                     requiredExpr
                             );
 
-                            if (result.indexId == scan.getTable().getBaseIndexId()) {
-                                return ctx.root;
-                            }
-
-                            LogicalOlapScan mvPlan =
-                                    scan.withMaterializedIndexSelected(result.preAggStatus, result.indexId);
+                            LogicalOlapScan mvPlan = createLogicalOlapScan(scan, result);
                             SlotContext slotContext = generateBaseScanExprToMvExpr(mvPlan);
 
                             if (result.exprRewriteMap.isEmpty()) {
@@ -199,7 +190,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
 
                 // column pruning or other projections such as alias, etc.
                 // Aggregate(Project(Scan))
-                logicalAggregate(logicalProject(logicalOlapScan().when(this::shouldSelectIndex)))
+                logicalAggregate(logicalProject(logicalOlapScan().when(this::shouldSelectIndexWithAgg)))
                         .thenApply(ctx -> {
                             LogicalAggregate<LogicalProject<LogicalOlapScan>> agg = ctx.root;
                             LogicalProject<LogicalOlapScan> project = agg.child();
@@ -215,12 +206,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                                     collectRequireExprWithAggAndProject(agg.getExpressions(), project.getProjects())
                             );
 
-                            if (result.indexId == scan.getTable().getBaseIndexId()) {
-                                return ctx.root;
-                            }
-
-                            LogicalOlapScan mvPlan =
-                                    scan.withMaterializedIndexSelected(result.preAggStatus, result.indexId);
+                            LogicalOlapScan mvPlan = createLogicalOlapScan(scan, result);
                             SlotContext slotContext = generateBaseScanExprToMvExpr(mvPlan);
 
                             if (result.exprRewriteMap.isEmpty()) {
@@ -254,7 +240,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                 // filter could push down and project.
                 // Aggregate(Project(Filter(Scan)))
                 logicalAggregate(logicalProject(logicalFilter(logicalOlapScan()
-                        .when(this::shouldSelectIndex)))).thenApply(ctx -> {
+                        .when(this::shouldSelectIndexWithAgg)))).thenApply(ctx -> {
                             LogicalAggregate<LogicalProject<LogicalFilter<LogicalOlapScan>>> agg = ctx.root;
                             LogicalProject<LogicalFilter<LogicalOlapScan>> project = agg.child();
                             LogicalFilter<LogicalOlapScan> filter = project.child();
@@ -277,12 +263,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                                     requiredExpr
                             );
 
-                            if (result.indexId == scan.getTable().getBaseIndexId()) {
-                                return ctx.root;
-                            }
-
-                            LogicalOlapScan mvPlan =
-                                    scan.withMaterializedIndexSelected(result.preAggStatus, result.indexId);
+                            LogicalOlapScan mvPlan = createLogicalOlapScan(scan, result);
                             SlotContext slotContext = generateBaseScanExprToMvExpr(mvPlan);
 
                             if (result.exprRewriteMap.isEmpty()) {
@@ -317,7 +298,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                 // filter can't push down
                 // Aggregate(Filter(Project(Scan)))
                 logicalAggregate(logicalFilter(logicalProject(logicalOlapScan()
-                        .when(this::shouldSelectIndex)))).thenApply(ctx -> {
+                        .when(this::shouldSelectIndexWithAgg)))).thenApply(ctx -> {
                             LogicalAggregate<LogicalFilter<LogicalProject<LogicalOlapScan>>> agg = ctx.root;
                             LogicalFilter<LogicalProject<LogicalOlapScan>> filter = agg.child();
                             LogicalProject<LogicalOlapScan> project = filter.child();
@@ -338,12 +319,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                                     requiredExpr
                             );
 
-                            if (result.indexId == scan.getTable().getBaseIndexId()) {
-                                return ctx.root;
-                            }
-
-                            LogicalOlapScan mvPlan =
-                                    scan.withMaterializedIndexSelected(result.preAggStatus, result.indexId);
+                            LogicalOlapScan mvPlan = createLogicalOlapScan(scan, result);
                             SlotContext slotContext = generateBaseScanExprToMvExpr(mvPlan);
 
                             if (result.exprRewriteMap.isEmpty()) {
@@ -377,52 +353,49 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
 
                 // only agg above scan
                 // Aggregate(Repeat(Scan))
-                logicalAggregate(logicalRepeat(logicalOlapScan().when(this::shouldSelectIndex))).thenApply(ctx -> {
-                    LogicalAggregate<LogicalRepeat<LogicalOlapScan>> agg = ctx.root;
-                    LogicalRepeat<LogicalOlapScan> repeat = agg.child();
-                    LogicalOlapScan scan = repeat.child();
-                    SelectResult result = select(
-                            scan,
-                            agg.getInputSlots(),
-                            ImmutableSet.of(),
-                            extractAggFunctionAndReplaceSlot(agg, Optional.empty()),
-                            nonVirtualGroupByExprs(agg),
-                            new HashSet<>(agg.getExpressions()));
+                logicalAggregate(
+                    logicalRepeat(logicalOlapScan().when(this::shouldSelectIndexWithAgg))).thenApply(ctx -> {
+                        LogicalAggregate<LogicalRepeat<LogicalOlapScan>> agg = ctx.root;
+                        LogicalRepeat<LogicalOlapScan> repeat = agg.child();
+                        LogicalOlapScan scan = repeat.child();
+                        SelectResult result = select(
+                                scan,
+                                agg.getInputSlots(),
+                                ImmutableSet.of(),
+                                extractAggFunctionAndReplaceSlot(agg, Optional.empty()),
+                                nonVirtualGroupByExprs(agg),
+                                new HashSet<>(agg.getExpressions()));
 
-                    if (result.indexId == scan.getTable().getBaseIndexId()) {
-                        return ctx.root;
-                    }
+                        LogicalOlapScan mvPlan = createLogicalOlapScan(scan, result);
+                        SlotContext slotContext = generateBaseScanExprToMvExpr(mvPlan);
 
-                    LogicalOlapScan mvPlan = scan.withMaterializedIndexSelected(result.preAggStatus, result.indexId);
-                    SlotContext slotContext = generateBaseScanExprToMvExpr(mvPlan);
-
-                    if (result.exprRewriteMap.isEmpty()) {
-                        return new LogicalProject<>(
-                            generateProjectsAlias(agg.getOutputs(), slotContext),
-                                new ReplaceExpressions(slotContext).replace(
-                                agg.withChildren(
-                                    repeat.withAggOutputAndChild(
-                                        generateNewOutputsWithMvOutputs(mvPlan, repeat.getOutputs()), mvPlan)
-                                ), mvPlan));
-                    } else {
-                        return new LogicalProject<>(
-                            generateProjectsAlias(agg.getOutputs(), slotContext),
-                                new ReplaceExpressions(slotContext).replace(
-                                    new LogicalAggregate<>(
-                                        agg.getGroupByExpressions(),
-                                        replaceAggOutput(
-                                            agg, Optional.empty(), Optional.empty(), result.exprRewriteMap),
-                                        agg.isNormalized(),
-                                        agg.getSourceRepeat(),
+                        if (result.exprRewriteMap.isEmpty()) {
+                            return new LogicalProject<>(
+                                generateProjectsAlias(agg.getOutputs(), slotContext),
+                                    new ReplaceExpressions(slotContext).replace(
+                                    agg.withChildren(
                                         repeat.withAggOutputAndChild(
                                             generateNewOutputsWithMvOutputs(mvPlan, repeat.getOutputs()), mvPlan)
                                     ), mvPlan));
-                    }
-                }).toRule(RuleType.MATERIALIZED_INDEX_AGG_REPEAT_SCAN),
+                        } else {
+                            return new LogicalProject<>(
+                                generateProjectsAlias(agg.getOutputs(), slotContext),
+                                    new ReplaceExpressions(slotContext).replace(
+                                        new LogicalAggregate<>(
+                                            agg.getGroupByExpressions(),
+                                            replaceAggOutput(
+                                                agg, Optional.empty(), Optional.empty(), result.exprRewriteMap),
+                                            agg.isNormalized(),
+                                            agg.getSourceRepeat(),
+                                            repeat.withAggOutputAndChild(
+                                                generateNewOutputsWithMvOutputs(mvPlan, repeat.getOutputs()), mvPlan)
+                                        ), mvPlan));
+                        }
+                    }).toRule(RuleType.MATERIALIZED_INDEX_AGG_REPEAT_SCAN),
 
                 // filter could push down scan.
                 // Aggregate(Repeat(Filter(Scan)))
-                logicalAggregate(logicalRepeat(logicalFilter(logicalOlapScan().when(this::shouldSelectIndex))))
+                logicalAggregate(logicalRepeat(logicalFilter(logicalOlapScan().when(this::shouldSelectIndexWithAgg))))
                         .thenApply(ctx -> {
                             LogicalAggregate<LogicalRepeat<LogicalFilter<LogicalOlapScan>>> agg = ctx.root;
                             LogicalRepeat<LogicalFilter<LogicalOlapScan>> repeat = agg.child();
@@ -446,12 +419,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                                     requiredExpr
                             );
 
-                            if (result.indexId == scan.getTable().getBaseIndexId()) {
-                                return ctx.root;
-                            }
-
-                            LogicalOlapScan mvPlan =
-                                    scan.withMaterializedIndexSelected(result.preAggStatus, result.indexId);
+                            LogicalOlapScan mvPlan = createLogicalOlapScan(scan, result);
                             SlotContext slotContext = generateBaseScanExprToMvExpr(mvPlan);
 
                             if (result.exprRewriteMap.isEmpty()) {
@@ -485,7 +453,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
 
                 // column pruning or other projections such as alias, etc.
                 // Aggregate(Repeat(Project(Scan)))
-                logicalAggregate(logicalRepeat(logicalProject(logicalOlapScan().when(this::shouldSelectIndex))))
+                logicalAggregate(logicalRepeat(logicalProject(logicalOlapScan().when(this::shouldSelectIndexWithAgg))))
                         .thenApply(ctx -> {
                             LogicalAggregate<LogicalRepeat<LogicalProject<LogicalOlapScan>>> agg = ctx.root;
                             LogicalRepeat<LogicalProject<LogicalOlapScan>> repeat = agg.child();
@@ -502,12 +470,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                                     collectRequireExprWithAggAndProject(agg.getExpressions(), project.getProjects())
                             );
 
-                            if (result.indexId == scan.getTable().getBaseIndexId()) {
-                                return ctx.root;
-                            }
-
-                            LogicalOlapScan mvPlan =
-                                    scan.withMaterializedIndexSelected(result.preAggStatus, result.indexId);
+                            LogicalOlapScan mvPlan = createLogicalOlapScan(scan, result);
                             SlotContext slotContext = generateBaseScanExprToMvExpr(mvPlan);
 
                             if (result.exprRewriteMap.isEmpty()) {
@@ -546,7 +509,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                 // filter could push down and project.
                 // Aggregate(Repeat(Project(Filter(Scan))))
                 logicalAggregate(logicalRepeat(logicalProject(logicalFilter(logicalOlapScan()
-                        .when(this::shouldSelectIndex))))).thenApply(ctx -> {
+                        .when(this::shouldSelectIndexWithAgg))))).thenApply(ctx -> {
                             LogicalAggregate<LogicalRepeat<LogicalProject
                                     <LogicalFilter<LogicalOlapScan>>>> agg = ctx.root;
                             LogicalRepeat<LogicalProject<LogicalFilter<LogicalOlapScan>>> repeat = agg.child();
@@ -571,12 +534,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                                     requiredExpr
                             );
 
-                            if (result.indexId == scan.getTable().getBaseIndexId()) {
-                                return ctx.root;
-                            }
-
-                            LogicalOlapScan mvPlan =
-                                    scan.withMaterializedIndexSelected(result.preAggStatus, result.indexId);
+                            LogicalOlapScan mvPlan = createLogicalOlapScan(scan, result);
                             SlotContext slotContext = generateBaseScanExprToMvExpr(mvPlan);
 
                             if (result.exprRewriteMap.isEmpty()) {
@@ -618,7 +576,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                 // filter can't push down
                 // Aggregate(Repeat(Filter(Project(Scan))))
                 logicalAggregate(logicalRepeat(logicalFilter(logicalProject(logicalOlapScan()
-                        .when(this::shouldSelectIndex))))).thenApply(ctx -> {
+                        .when(this::shouldSelectIndexWithAgg))))).thenApply(ctx -> {
                             LogicalAggregate<LogicalRepeat<LogicalFilter
                                     <LogicalProject<LogicalOlapScan>>>> agg = ctx.root;
                             LogicalRepeat<LogicalFilter<LogicalProject<LogicalOlapScan>>> repeat = agg.child();
@@ -641,12 +599,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                                     requiredExpr
                             );
 
-                            if (result.indexId == scan.getTable().getBaseIndexId()) {
-                                return ctx.root;
-                            }
-
-                            LogicalOlapScan mvPlan =
-                                    scan.withMaterializedIndexSelected(result.preAggStatus, result.indexId);
+                            LogicalOlapScan mvPlan = createLogicalOlapScan(scan, result);
                             SlotContext slotContext = generateBaseScanExprToMvExpr(mvPlan);
 
                             if (result.exprRewriteMap.isEmpty()) {
@@ -685,6 +638,19 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
                             }
                         }).toRule(RuleType.MATERIALIZED_INDEX_AGG_REPEAT_FILTER_PROJECT_SCAN)
         );
+    }
+
+    private static LogicalOlapScan createLogicalOlapScan(LogicalOlapScan scan, SelectResult result) {
+        LogicalOlapScan mvPlan;
+        if (result.preAggStatus.isOff()) {
+            // we only set preAggStatus and make index unselected to let SelectMaterializedIndexWithoutAggregate
+            // have a chance to run and select proper index
+            mvPlan = scan.withPreAggStatus(result.preAggStatus);
+        } else {
+            mvPlan =
+                    scan.withMaterializedIndexSelected(result.preAggStatus, result.indexId);
+        }
+        return mvPlan;
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/mv/SelectMaterializedIndexWithoutAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/mv/SelectMaterializedIndexWithoutAggregate.java
@@ -106,7 +106,8 @@ public class SelectMaterializedIndexWithoutAggregate extends AbstractSelectMater
                             LogicalOlapScan scan = filter.child();
                             LogicalOlapScan mvPlan = select(
                                     scan, filter::getOutputSet, filter::getConjuncts,
-                                    new HashSet<>(filter.getExpressions()));
+                                    Stream.concat(filter.getExpressions().stream(),
+                                            filter.getOutputSet().stream()).collect(ImmutableSet.toImmutableSet()));
                             SlotContext slotContext = generateBaseScanExprToMvExpr(mvPlan);
 
                             return new LogicalProject(

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
@@ -178,8 +178,12 @@ public class LogicalOlapScan extends LogicalCatalogRelation implements OlapScan 
 
     @Override
     public String toString() {
-        return Utils.toSqlString("LogicalOlapScan", "qualified", qualifiedName(), "indexName",
-                getSelectedMaterializedIndexName(), "selectedIndexId", selectedIndexId, "preAgg", preAggStatus);
+        return Utils.toSqlString("LogicalOlapScan",
+                "qualified", qualifiedName(),
+                "indexName", getSelectedMaterializedIndexName().orElse("<index_not_selected>"),
+                "selectedIndexId", selectedIndexId,
+                "preAgg", preAggStatus
+        );
     }
 
     @Override
@@ -287,8 +291,9 @@ public class LogicalOlapScan extends LogicalCatalogRelation implements OlapScan 
     }
 
     @VisibleForTesting
-    public String getSelectedMaterializedIndexName() {
-        return ((OlapTable) table).getIndexNameById(selectedIndexId);
+    public Optional<String> getSelectedMaterializedIndexName() {
+        return indexSelected ? Optional.ofNullable(((OlapTable) table).getIndexNameById(selectedIndexId))
+                : Optional.empty();
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/mv/SelectMvIndexTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/mv/SelectMvIndexTest.java
@@ -875,11 +875,18 @@ class SelectMvIndexTest extends BaseMaterializedIndexSelectTest implements MemoP
         String query = "select * from (select user_id, bitmap_union_count(to_bitmap(tag_id)) x from "
                 + USER_TAG_TABLE_NAME + " group by user_id) a, (select user_name, bitmap_union_count(to_bitmap(tag_id))"
                 + "" + " y from " + USER_TAG_TABLE_NAME + " group by user_name) b where a.x=b.y;";
-        PlanChecker.from(connectContext).analyze(query).rewrite().matches(logicalJoin(
-                        logicalProject(logicalAggregate(logicalOlapScan()
-                                        .when(scan -> "user_tags_mv".equals(scan.getSelectedMaterializedIndexName())))),
-                        logicalAggregate(logicalProject(logicalOlapScan()
-                                        .when(scan -> "user_tags".equals(scan.getSelectedMaterializedIndexName()))))));
+        PlanChecker.from(connectContext)
+                .analyze(query)
+                .rewrite()
+                .matches(logicalJoin(
+                        logicalProject(
+                                logicalAggregate(
+                                        logicalOlapScan().when(scan -> "user_tags_mv".equals(
+                                                scan.getSelectedMaterializedIndexName().get())))),
+                        logicalAggregate(
+                                logicalProject(
+                                        logicalOlapScan().when(scan -> "user_tags".equals(
+                                                scan.getSelectedMaterializedIndexName().get()))))));
 
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanToStringTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanToStringTest.java
@@ -80,8 +80,10 @@ public class PlanToStringTest {
     @Test
     public void testLogicalOlapScan() {
         LogicalOlapScan plan = PlanConstructor.newLogicalOlapScan(0, "table", 0);
-        Assertions.assertTrue(plan.toString().matches("LogicalOlapScan \\( qualified=db\\.table, " + "indexName=table, "
-                + "selectedIndexId=-1, preAgg=ON \\)"), plan.toString());
+        Assertions.assertTrue(
+                plan.toString().matches("LogicalOlapScan \\( qualified=db\\.table, "
+                        + "indexName=<index_not_selected>, "
+                        + "selectedIndexId=-1, preAgg=ON \\)"));
     }
 
     @Test

--- a/regression-test/suites/mv_p0/ut/testProjectionMV1/testProjectionMV1.groovy
+++ b/regression-test/suites/mv_p0/ut/testProjectionMV1/testProjectionMV1.groovy
@@ -34,6 +34,7 @@ suite ("testProjectionMV1") {
     sql """insert into emps values("2020-01-01",1,"a",1,1,1);"""
     sql """insert into emps values("2020-01-02",2,"b",2,2,2);"""
 
+    sql """set enable_nereids_planner=false"""
     test {
         sql "create materialized view emps_mv as select deptno, empid from emps t order by deptno;"
         exception "errCode = 2,"

--- a/regression-test/suites/nereids_p0/test_mv_select.groovy
+++ b/regression-test/suites/nereids_p0/test_mv_select.groovy
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_mv_select") {
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+
+    sql "DROP TABLE IF EXISTS mv_test_table_t"
+    sql """
+	    CREATE TABLE `mv_test_table_t` (
+        `Uid` bigint(20) NOT NULL,
+        `DateCode` int(11) NOT NULL,
+        `ProductId` bigint(20) NOT NULL,
+        `LiveSales` int(11) REPLACE NULL
+        ) ENGINE=OLAP
+        AGGREGATE KEY(`Uid`, `DateCode`, `ProductId`)
+        DISTRIBUTED BY HASH(`Uid`, `ProductId`) BUCKETS 8
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1"
+        );
+    """
+    sql "ALTER TABLE mv_test_table_t ADD ROLLUP rollup_mv_test_table_t(ProductId,DateCode,Uid);"
+
+    explain {
+        sql ("""select Uid
+                        from mv_test_table_t  
+                where ProductId = 3570093298674738221  and DateCode >=20230919 and DateCode <=20231018
+                        group by Uid;""")
+        contains "mv_test_table_t"
+    }
+}


### PR DESCRIPTION
SelectMaterializedIndexWithAggregate(R1) run before SelectMaterializedIndexWithoutAggregate(R2).
If after R1, the base index is selected and preAggStatus is OFF,we should give a chance to let R2 check if some prefix-index can be selected.
So if R1 selects baseIndex, we keep scan's index unselected in order to let R2 to get a chance to do its work.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

