### PR TITLE
[fix](information_schema)fix bug that metadata_name_ids error tableid and append information_schema case. 

### DIFF
--- a/be/src/exec/schema_scanner.cpp
+++ b/be/src/exec/schema_scanner.cpp
@@ -60,8 +60,6 @@
 namespace doris {
 class ObjectPool;
 
-DorisServer* SchemaScanner::_s_doris_server;
-
 SchemaScanner::SchemaScanner(const std::vector<ColumnDesc>& columns)
         : _is_init(false),
           _param(nullptr),

--- a/be/src/exec/schema_scanner.h
+++ b/be/src/exec/schema_scanner.h
@@ -33,7 +33,7 @@
 namespace doris {
 
 // forehead declare class, because jni function init in DorisServer.
-class DorisServer;
+
 class RuntimeState;
 class ObjectPool;
 class TUserIdentity;
@@ -101,8 +101,6 @@ public:
     static std::unique_ptr<SchemaScanner> create(TSchemaTableType::type type);
     TSchemaTableType::type type() const { return _schema_table_type; }
 
-    static void set_doris_server(DorisServer* doris_server) { _s_doris_server = doris_server; }
-
 protected:
     Status fill_dest_column_for_range(vectorized::Block* block, size_t pos,
                                       const std::vector<void*>& datas);
@@ -112,8 +110,6 @@ protected:
     SchemaScannerParam* _param;
     // schema table's column desc
     std::vector<ColumnDesc> _columns;
-
-    static DorisServer* _s_doris_server;
 
     TSchemaTableType::type _schema_table_type;
 

--- a/be/src/exec/schema_scanner/schema_helper.cpp
+++ b/be/src/exec/schema_scanner/schema_helper.cpp
@@ -69,15 +69,6 @@ Status SchemaHelper::list_table_metadata_name_ids(const std::string& ip, const i
             });
 }
 
-Status SchemaHelper::describe_table(const std::string& ip, const int32_t port,
-                                    const TDescribeTableParams& request,
-                                    TDescribeTableResult* result) {
-    return ThriftRpcHelper::rpc<FrontendServiceClient>(
-            ip, port, [&request, &result](FrontendServiceConnection& client) {
-                client->describeTable(*result, request);
-            });
-}
-
 Status SchemaHelper::describe_tables(const std::string& ip, const int32_t port,
                                      const TDescribeTablesParams& request,
                                      TDescribeTablesResult* result) {

--- a/be/src/exec/schema_scanner/schema_helper.h
+++ b/be/src/exec/schema_scanner/schema_helper.h
@@ -55,10 +55,6 @@ public:
                                                const doris::TGetTablesParams& request,
                                                TListTableMetadataNameIdsResult* result);
 
-    static Status describe_table(const std::string& ip, const int32_t port,
-                                 const TDescribeTableParams& desc_params,
-                                 TDescribeTableResult* desc_result);
-
     static Status describe_tables(const std::string& ip, const int32_t port,
                                   const TDescribeTablesParams& desc_params,
                                   TDescribeTablesResult* desc_result);

--- a/be/src/exec/schema_scanner/schema_metadata_name_ids_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_metadata_name_ids_scanner.cpp
@@ -193,13 +193,13 @@ Status SchemaMetadataNameIdsScanner::_fill_block_impl(vectorized::Block* block) 
             RETURN_IF_ERROR(fill_dest_column_for_range(block, 3, null_datas));
         }
     }
-    //     table_id
+    //  table_id
     {
         int64_t srcs[table_num];
         for (int i = 0; i < table_num; ++i) {
             if (_table_result.tables[i].__isset.id) {
                 srcs[i] = _table_result.tables[i].id;
-                datas[i] = &srcs;
+                datas[i] = srcs + i;
             } else {
                 datas[i] = nullptr;
             }

--- a/regression-test/data/query_p0/system/test_query_sys_tables.out
+++ b/regression-test/data/query_p0/system/test_query_sys_tables.out
@@ -61,6 +61,36 @@ EXTRA	VARCHAR(256)	Yes	false	\N
 
 -- !query_files --
 
+-- !desc_statistics --
+TABLE_CATALOG	VARCHAR(512)	Yes	false	\N	
+TABLE_SCHEMA	VARCHAR(64)	Yes	false	\N	
+TABLE_NAME	VARCHAR(64)	Yes	false	\N	
+NON_UNIQUE	BIGINT	Yes	false	\N	
+INDEX_SCHEMA	VARCHAR(64)	Yes	false	\N	
+INDEX_NAME	VARCHAR(64)	Yes	false	\N	
+SEQ_IN_INDEX	BIGINT	Yes	false	\N	
+COLUMN_NAME	VARCHAR(64)	Yes	false	\N	
+COLLATION	VARCHAR(1)	Yes	false	\N	
+CARDINALITY	BIGINT	Yes	false	\N	
+SUB_PART	BIGINT	Yes	false	\N	
+PACKED	VARCHAR(10)	Yes	false	\N	
+NULLABLE	VARCHAR(3)	Yes	false	\N	
+INDEX_TYPE	VARCHAR(16)	Yes	false	\N	
+COMMENT	VARCHAR(16)	Yes	false	\N	
+INDEX_COMMENT	VARCHAR(1024)	Yes	false	\N	
+
+-- !query_statistics --
+
+-- !desc_statistics --
+CONSTRAINT_CATALOG	VARCHAR(512)	Yes	false	\N	
+CONSTRAINT_SCHEMA	VARCHAR(64)	Yes	false	\N	
+CONSTRAINT_NAME	VARCHAR(64)	Yes	false	\N	
+TABLE_SCHEMA	VARCHAR(64)	Yes	false	\N	
+TABLE_NAME	VARCHAR(64)	Yes	false	\N	
+CONSTRAINT_TYPE	VARCHAR(64)	Yes	false	\N	
+
+-- !query_table_constraints --
+
 -- !desc_schema_privileges --
 GRANTEE	VARCHAR(81)	Yes	false	\N	
 TABLE_CATALOG	VARCHAR(512)	Yes	false	\N	
@@ -68,7 +98,13 @@ TABLE_SCHEMA	VARCHAR(64)	Yes	false	\N
 PRIVILEGE_TYPE	VARCHAR(64)	Yes	false	\N	
 IS_GRANTABLE	VARCHAR(3)	Yes	false	\N	
 
--- !select_schema_privileges --
+-- !schema_privileges1 --
+'root'@'%'	def	mysql	SELECT	NO
+
+-- !schema_privileges2 --
+'cyw'@'%'	def	mysql	SELECT	NO
+
+-- !schema_privileges3 --
 
 -- !desc_table_privileges --
 GRANTEE	VARCHAR(81)	Yes	false	\N	
@@ -78,7 +114,16 @@ TABLE_NAME	VARCHAR(64)	Yes	false	\N
 PRIVILEGE_TYPE	VARCHAR(64)	Yes	false	\N	
 IS_GRANTABLE	VARCHAR(3)	Yes	false	\N	
 
--- !select_schema_privileges --
+-- !table_privileges --
+
+-- !table_privileges2 --
+'cywtable'@'%'	def	table_privileges_demo	test_table_privileges	ALTER	NO
+'cywtable'@'%'	def	table_privileges_demo	test_table_privileges	INSERT	NO
+'cywtable'@'%'	def	table_privileges_demo	test_table_privileges	SELECT	NO
+
+-- !table_privileges3 --
+'cywtable'@'%'	def	table_privileges_demo	test_table_privileges	ALTER	NO
+'cywtable'@'%'	def	table_privileges_demo	test_table_privileges	INSERT	NO
 
 -- !desc_partitions --
 TABLE_CATALOG	VARCHAR(64)	Yes	false	\N	

--- a/regression-test/data/query_p0/system/test_query_sys_tables.out
+++ b/regression-test/data/query_p0/system/test_query_sys_tables.out
@@ -19,12 +19,130 @@ internal	bbb	2	varchar	varchar(20)	20
 internal	ccc	3	int	int(11)	10
 internal	ddd	4	smallint	smallint(6)	5
 
+-- !desc_files --
+FILE_ID	BIGINT	Yes	false	\N	
+FILE_NAME	TEXT	Yes	false	\N	
+FILE_TYPE	VARCHAR(256)	Yes	false	\N	
+TABLESPACE_NAME	VARCHAR(256)	Yes	false	\N	
+TABLE_CATALOG	CHAR(16)	Yes	false	\N	
+TABLE_SCHEMA	TEXT	Yes	false	\N	
+TABLE_NAME	TEXT	Yes	false	\N	
+LOGFILE_GROUP_NAME	VARCHAR(256)	Yes	false	\N	
+LOGFILE_GROUP_NUMBER	BIGINT	Yes	false	\N	
+ENGINE	VARCHAR(64)	Yes	false	\N	
+FULLTEXT_KEYS	TEXT	Yes	false	\N	
+DELETED_ROWS	TEXT	Yes	false	\N	
+UPDATE_COUNT	TEXT	Yes	false	\N	
+FREE_EXTENTS	BIGINT	Yes	false	\N	
+TOTAL_EXTENTS	BIGINT	Yes	false	\N	
+EXTENT_SIZE	BIGINT	Yes	false	\N	
+INITIAL_SIZE	BIGINT	Yes	false	\N	
+MAXIMUM_SIZE	BIGINT	Yes	false	\N	
+AUTOEXTEND_SIZE	BIGINT	Yes	false	\N	
+CREATION_TIME	TEXT	Yes	false	\N	
+LAST_UPDATE_TIME	TEXT	Yes	false	\N	
+LAST_ACCESS_TIME	TEXT	Yes	false	\N	
+RECOVER_TIME	TEXT	Yes	false	\N	
+TRANSACTION_COUNTER	TEXT	Yes	false	\N	
+VERSION	BIGINT	Yes	false	\N	
+ROW_FORMAT	VARCHAR(256)	Yes	false	\N	
+TABLE_ROWS	TEXT	Yes	false	\N	
+AVG_ROW_LENGTH	TEXT	Yes	false	\N	
+DATA_LENGTH	TEXT	Yes	false	\N	
+MAX_DATA_LENGTH	TEXT	Yes	false	\N	
+INDEX_LENGTH	TEXT	Yes	false	\N	
+DATA_FREE	BIGINT	Yes	false	\N	
+CREATE_TIME	TEXT	Yes	false	\N	
+UPDATE_TIME	TEXT	Yes	false	\N	
+CHECK_TIME	TEXT	Yes	false	\N	
+CHECKSUM	TEXT	Yes	false	\N	
+STATUS	VARCHAR(256)	Yes	false	\N	
+EXTRA	VARCHAR(256)	Yes	false	\N	
+
+-- !query_files --
+
+-- !desc_schema_privileges --
+GRANTEE	VARCHAR(81)	Yes	false	\N	
+TABLE_CATALOG	VARCHAR(512)	Yes	false	\N	
+TABLE_SCHEMA	VARCHAR(64)	Yes	false	\N	
+PRIVILEGE_TYPE	VARCHAR(64)	Yes	false	\N	
+IS_GRANTABLE	VARCHAR(3)	Yes	false	\N	
+
+-- !select_schema_privileges --
+
+-- !desc_table_privileges --
+GRANTEE	VARCHAR(81)	Yes	false	\N	
+TABLE_CATALOG	VARCHAR(512)	Yes	false	\N	
+TABLE_SCHEMA	VARCHAR(64)	Yes	false	\N	
+TABLE_NAME	VARCHAR(64)	Yes	false	\N	
+PRIVILEGE_TYPE	VARCHAR(64)	Yes	false	\N	
+IS_GRANTABLE	VARCHAR(3)	Yes	false	\N	
+
+-- !select_schema_privileges --
+
+-- !desc_partitions --
+TABLE_CATALOG	VARCHAR(64)	Yes	false	\N	
+TABLE_SCHEMA	VARCHAR(64)	Yes	false	\N	
+TABLE_NAME	VARCHAR(64)	Yes	false	\N	
+PARTITION_NAME	VARCHAR(64)	Yes	false	\N	
+SUBPARTITION_NAME	VARCHAR(64)	Yes	false	\N	
+PARTITION_ORDINAL_POSITION	INT	Yes	false	\N	
+SUBPARTITION_ORDINAL_POSITION	INT	Yes	false	\N	
+PARTITION_METHOD	VARCHAR(13)	Yes	false	\N	
+SUBPARTITION_METHOD	VARCHAR(13)	Yes	false	\N	
+PARTITION_EXPRESSION	VARCHAR(2048)	Yes	false	\N	
+SUBPARTITION_EXPRESSION	VARCHAR(2048)	Yes	false	\N	
+PARTITION_DESCRIPTION	TEXT	Yes	false	\N	
+TABLE_ROWS	BIGINT	Yes	false	\N	
+AVG_ROW_LENGTH	BIGINT	Yes	false	\N	
+DATA_LENGTH	BIGINT	Yes	false	\N	
+MAX_DATA_LENGTH	BIGINT	Yes	false	\N	
+INDEX_LENGTH	BIGINT	Yes	false	\N	
+DATA_FREE	BIGINT	Yes	false	\N	
+CREATE_TIME	BIGINT	Yes	false	\N	
+UPDATE_TIME	DATETIME	Yes	false	\N	
+CHECK_TIME	DATETIME	Yes	false	\N	
+CHECKSUM	BIGINT	Yes	false	\N	
+PARTITION_COMMENT	TEXT	Yes	false	\N	
+NODEGROUP	VARCHAR(256)	Yes	false	\N	
+TABLESPACE_NAME	VARCHAR(268)	Yes	false	\N	
+
+-- !select_partitions --
+
+-- !desc_rowsets --
+BACKEND_ID	BIGINT	Yes	false	\N	
+ROWSET_ID	VARCHAR(64)	Yes	false	\N	
+TABLET_ID	BIGINT	Yes	false	\N	
+ROWSET_NUM_ROWS	BIGINT	Yes	false	\N	
+TXN_ID	BIGINT	Yes	false	\N	
+NUM_SEGMENTS	BIGINT	Yes	false	\N	
+START_VERSION	BIGINT	Yes	false	\N	
+END_VERSION	BIGINT	Yes	false	\N	
+INDEX_DISK_SIZE	BIGINT	Yes	false	\N	
+DATA_DISK_SIZE	BIGINT	Yes	false	\N	
+CREATION_TIME	BIGINT	Yes	false	\N	
+NEWEST_WRITE_TIMESTAMP	BIGINT	Yes	false	\N	
+
+-- !rowsets1 --
+0	1
+
+-- !rowsets2 --
+0	1
+2	2
+
+-- !rowsets3 --
+0	1
+2	2
+3	3
+4	4
+
 -- !schemata --
 internal	test_query_sys_db_1	\N
 internal	test_query_sys_db_2	\N
 internal	test_query_sys_db_3	\N
 
 -- !tables --
+internal	test_query_rowset	BASE TABLE	0	\N	\N
 internal	test_query_sys_tb_1	BASE TABLE	0	\N	\N
 internal	test_query_sys_tb_2	BASE TABLE	0	\N	\N
 internal	test_query_sys_tb_3	BASE TABLE	0	\N	\N
@@ -58,3 +176,4 @@ test_view
 -- !sql --
 
 -- !sql --
+

--- a/regression-test/suites/query_p0/system/test_query_sys_tables.groovy
+++ b/regression-test/suites/query_p0/system/test_query_sys_tables.groovy
@@ -87,12 +87,53 @@ suite("test_query_sys_tables", "query,p0") {
 
     // test files
     // have no impl
+    qt_desc_files """desc `information_schema`.`files` """
+    qt_query_files """ select * from `information_schema`.`files` """
+
+    // test schema_privileges
+    // have no impl
+    qt_desc_schema_privileges """desc `information_schema`.`schema_privileges` """
+    qt_select_schema_privileges """  select * from information_schema.schema_privileges where GRANTEE = "root%"   """  
+    
+    // test table_privileges
+    // have no impl(fe:listTablePrivilegeStatus)
+    qt_desc_table_privileges """desc `information_schema`.`table_privileges` """
+    qt_select_schema_privileges """  select * from information_schema.table_privileges   """  
+
 
     // test partitions
     // have no impl
+    qt_desc_partitions """ desc `information_schema`.`partitions` """ 
+    qt_select_partitions """ select * from  `information_schema`.`partitions`; """ 
+
+
 
     // test rowsets
-    // have no tablet system table, add this later 
+    qt_desc_rowsets """ desc information_schema.rowsets """ 
+    def rowsets_table_name = """ test_query_sys_db_1.test_query_rowset """  
+    sql """ drop table if exists ${rowsets_table_name}  """ 
+
+    sql """ 
+        create table ${rowsets_table_name}( 
+            a int , 
+            b boolean , 
+            c string ) 
+        DISTRIBUTED BY HASH(`a`) BUCKETS 1 
+        PROPERTIES (
+            "replication_num" = "1",
+            "disable_auto_compaction" = "true",
+            "enable_single_replica_compaction"="true"
+        );
+    """
+    
+    List<List<Object>> rowsets_table_name_tablts   = sql """ show tablets from ${rowsets_table_name} """
+    qt_rowsets1 """  select START_VERSION,END_VERSION from information_schema.rowsets where TABLET_ID=${rowsets_table_name_tablts[0][0]}  order by START_VERSION,END_VERSION; """ 
+    sql """ insert into  ${rowsets_table_name} values (1,0,"abc");  """ 
+    qt_rowsets2 """  select START_VERSION,END_VERSION from information_schema.rowsets where TABLET_ID=${rowsets_table_name_tablts[0][0]}  order by START_VERSION,END_VERSION; """ 
+    sql """ insert into  ${rowsets_table_name} values (2,1,"hello world");  """ 
+    sql """ insert into  ${rowsets_table_name} values (3,0,"dssadasdsafafdf");  """ 
+    qt_rowsets3 """  select START_VERSION,END_VERSION from information_schema.rowsets where TABLET_ID=${rowsets_table_name_tablts[0][0]}  order by START_VERSION,END_VERSION; """ 
+
 
     // test schemata
     // create test dbs

--- a/regression-test/suites/query_p0/system/test_query_sys_tables.groovy
+++ b/regression-test/suites/query_p0/system/test_query_sys_tables.groovy
@@ -126,13 +126,13 @@ suite("test_query_sys_tables", "query,p0") {
         );
     """
     
-    List<List<Object>> rowsets_table_name_tablts   = sql """ show tablets from ${rowsets_table_name} """
-    qt_rowsets1 """  select START_VERSION,END_VERSION from information_schema.rowsets where TABLET_ID=${rowsets_table_name_tablts[0][0]}  order by START_VERSION,END_VERSION; """ 
+    List<List<Object>> rowsets_table_name_tablets   = sql """ show tablets from ${rowsets_table_name} """
+    qt_rowsets1 """  select START_VERSION,END_VERSION from information_schema.rowsets where TABLET_ID=${rowsets_table_name_tablets[0][0]}  order by START_VERSION,END_VERSION; """ 
     sql """ insert into  ${rowsets_table_name} values (1,0,"abc");  """ 
-    qt_rowsets2 """  select START_VERSION,END_VERSION from information_schema.rowsets where TABLET_ID=${rowsets_table_name_tablts[0][0]}  order by START_VERSION,END_VERSION; """ 
+    qt_rowsets2 """  select START_VERSION,END_VERSION from information_schema.rowsets where TABLET_ID=${rowsets_table_name_tablets[0][0]}  order by START_VERSION,END_VERSION; """ 
     sql """ insert into  ${rowsets_table_name} values (2,1,"hello world");  """ 
     sql """ insert into  ${rowsets_table_name} values (3,0,"dssadasdsafafdf");  """ 
-    qt_rowsets3 """  select START_VERSION,END_VERSION from information_schema.rowsets where TABLET_ID=${rowsets_table_name_tablts[0][0]}  order by START_VERSION,END_VERSION; """ 
+    qt_rowsets3 """  select START_VERSION,END_VERSION from information_schema.rowsets where TABLET_ID=${rowsets_table_name_tablets[0][0]}  order by START_VERSION,END_VERSION; """ 
 
 
     // test schemata


### PR DESCRIPTION
fix bug that  #24059 .
Added some information_schema scanner tests.
files
schema_privileges
table_privileges
partitions
rowsets
statistics
table_constraints

Based on infodb_support_ext_catalog=false, it currently includes tests for all tables under the information_schema database.


## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

