### PR TITLE
[fix](show_proc) fix show statistic proc dir to ensure that result only contains dbs in internal catalog

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/StatisticProcNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/StatisticProcNode.java
@@ -52,7 +52,7 @@ public class StatisticProcNode implements ProcNodeInterface {
 
     @Override
     public ProcResult fetchResult() throws AnalysisException {
-        List<DBStatistic> statistics = env.getCatalogMgr().getDbIds().parallelStream()
+        List<DBStatistic> statistics = env.getInternalCatalog().getDbIds().parallelStream()
                 // skip information_schema database
                 .flatMap(id -> Stream.of(id == 0 ? null : env.getCatalogMgr().getDbNullable(id)))
                 .filter(Objects::nonNull).map(DBStatistic::new)

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
@@ -228,22 +228,6 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
         return null;
     }
 
-    public List<Long> getDbIds() {
-        List<Long> dbIds = Lists.newArrayList();
-        for (CatalogIf catalog : nameToCatalog.values()) {
-            dbIds.addAll(catalog.getDbIds());
-        }
-        return dbIds;
-    }
-
-    public List<String> getDbNames() {
-        List<String> dbNames = Lists.newArrayList();
-        for (CatalogIf catalog : nameToCatalog.values()) {
-            dbNames.addAll(catalog.getDbNames());
-        }
-        return dbNames;
-    }
-
     private void writeLock() {
         lock.writeLock().lock();
     }

--- a/regression-test/suites/show_p0/test_show_statistic_proc.groovy
+++ b/regression-test/suites/show_p0/test_show_statistic_proc.groovy
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_show_statistic_proc", "show") {
+
+    sql """drop user if exists test_show_statistic_proc_user1"""
+
+    sql """create user test_show_statistic_proc_user1 identified by '12345'"""
+
+    sql """grant ADMIN_PRIV on *.*.* to test_show_statistic_proc_user1"""
+
+    sql """create database test_statistic_proc_db"""
+
+    def result1 = connect(user = 'test_show_statistic_proc_user1', password = '12345', url = context.config.jdbcUrl) {
+        sql """ show proc '/statistic' """
+    }
+    def result2 = connect(user = 'test_show_statistic_proc_user1', password = '12345', url = context.config.jdbcUrl) {
+            sql """ show databases """
+        }
+    assertEquals(result1.size(), result2.size())
+    assertEquals(result1[result1.size() - 1][1].toInteger(), result2.size() - 1)
+    def containsTargetDb = false
+    result1.each {  row ->
+        if (row[1] == 'default_cluster:test_statistic_proc_db') {
+             containsTargetDb = true
+             return
+        }
+    }
+    assertTrue(containsTargetDb)
+}
+


### PR DESCRIPTION
## Proposed changes
```
before:
+-------+----------------------------------------+----------+--------------+----------+-----------+------------+
| DbId  | DbName                                 | TableNum | PartitionNum | IndexNum | TabletNum | ReplicaNum |
+-------+----------------------------------------+----------+--------------+----------+-----------+------------+
| 12003 | default_cluster:test_statistic_proc_db | 0        | 0            | 0        | 0         | 0          |
| 12005 | information_schema                     | 24       | 0            | 0        | 0         | 0          |
| 12006 | test_statistic_proc_db                 | 0        | 0            | 0        | 0         | 0          |
| Total | 3                                      | 24       | 0            | 0        | 0         | 0          |
+-------+----------------------------------------+----------+--------------+----------+-----------+------------+

now:
+-------+----------------------------------------+----------+--------------+----------+-----------+------------+
| DbId  | DbName                                 | TableNum | PartitionNum | IndexNum | TabletNum | ReplicaNum |
+-------+----------------------------------------+----------+--------------+----------+-----------+------------+
| 12003 | default_cluster:test_statistic_proc_db | 0        | 0            | 0        | 0         | 0          |
| Total | 1                                      | 0        | 0            | 0        | 0         | 0          |
+-------+----------------------------------------+----------+--------------+----------+-----------+------------+
```
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

