### PR TITLE
[fix](Nereids) query failed when fold constant on be failed (#25982)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnBE.java
@@ -127,7 +127,13 @@ public class FoldConstantRuleOnBE extends AbstractExpressionRewriteRule {
             }
             String id = idGenerator.getNextId().toString();
             constMap.put(id, expr);
-            Expr staleExpr = ExpressionTranslator.translate(expr, null);
+            Expr staleExpr;
+            try {
+                staleExpr = ExpressionTranslator.translate(expr, null);
+            } catch (Exception e) {
+                LOG.warn("expression {} translate to legacy expr failed. ", expr, e);
+                return;
+            }
             tExprMap.put(id, staleExpr.treeToThrift());
         } else {
             for (int i = 0; i < expr.children().size(); i++) {


### PR DESCRIPTION
pick from master
PR: #25982
commit id: e3dbbed47c31440519671be0bade3438c1c72664

we translate expression to legacy one when do fold constant on BE. some times, we generate invalid expression that cannot be tranlsated. So, we should catch translate exception to avoid query failed.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

