### PR TITLE
[Fix](Nereids) bound error when in diff value of table name case config

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/CTEContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/CTEContext.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids;
 
+import org.apache.doris.common.Config;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.CTEId;
 import org.apache.doris.nereids.trees.plans.Plan;
@@ -25,6 +26,7 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalSubQueryAlias;
 
 import com.google.common.collect.ImmutableMap;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -54,7 +56,8 @@ public class CTEContext {
         if ((parsedPlan == null && previousCteContext != null) || (parsedPlan != null && previousCteContext == null)) {
             throw new AnalysisException("Only first CteContext can contains null cte plan or previousCteContext");
         }
-        this.name = parsedPlan == null ? null : parsedPlan.getAlias();
+        this.name = parsedPlan == null ? null : Config.lower_case_table_names != 0
+                ? parsedPlan.getAlias().toLowerCase(Locale.ROOT) : parsedPlan.getAlias();
         this.cteContextMap = previousCteContext == null
                 ? ImmutableMap.of()
                 : ImmutableMap.<String, CTEContext>builder()
@@ -89,6 +92,9 @@ public class CTEContext {
      * findCTEContext
      */
     public Optional<CTEContext> findCTEContext(String cteName) {
+        if (Config.lower_case_table_names != 0) {
+            cteName = cteName.toLowerCase(Locale.ROOT);
+        }
         if (cteName.equals(name)) {
             return Optional.of(this);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/SlotBinder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/SlotBinder.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids.rules.analysis;
 
 import org.apache.doris.analysis.SetType;
 import org.apache.doris.cluster.ClusterNamespace;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.nereids.CascadesContext;
@@ -284,14 +285,14 @@ class SlotBinder extends SubExprAnalyzer {
             }
             if (namePartsSize == 2) {
                 String qualifierTableName = boundSlot.getQualifier().get(qualifierSize - 1);
-                return qualifierTableName.equalsIgnoreCase(nameParts.get(0))
+                return sameTableName(qualifierTableName, nameParts.get(0))
                         && boundSlot.getName().equalsIgnoreCase(nameParts.get(1));
             }
             if (nameParts.size() == 3) {
                 String qualifierTableName = boundSlot.getQualifier().get(qualifierSize - 1);
                 String qualifierDbName = boundSlot.getQualifier().get(qualifierSize - 2);
                 return compareDbNameIgnoreClusterName(nameParts.get(0), qualifierDbName)
-                        && qualifierTableName.equalsIgnoreCase(nameParts.get(1))
+                        && sameTableName(qualifierTableName, nameParts.get(1))
                         && boundSlot.getName().equalsIgnoreCase(nameParts.get(2));
             }
             // catalog.db.table.column
@@ -301,12 +302,20 @@ class SlotBinder extends SubExprAnalyzer {
                 String qualifierCatalogName = boundSlot.getQualifier().get(qualifierSize - 3);
                 return qualifierCatalogName.equalsIgnoreCase(nameParts.get(0))
                     && compareDbNameIgnoreClusterName(nameParts.get(1), qualifierDbName)
-                    && qualifierTableName.equalsIgnoreCase(nameParts.get(2))
+                    && sameTableName(qualifierTableName, nameParts.get(2))
                     && boundSlot.getName().equalsIgnoreCase(nameParts.get(3));
             }
             //TODO: handle name parts more than three.
             throw new AnalysisException("Not supported name: "
                     + StringUtils.join(nameParts, "."));
         }).collect(Collectors.toList());
+    }
+
+    private boolean sameTableName(String boundSlot, String unboundSlot) {
+        if (Config.lower_case_table_names != 1) {
+            return boundSlot.equals(unboundSlot);
+        } else {
+            return boundSlot.equalsIgnoreCase(unboundSlot);
+        }
     }
 }


### PR DESCRIPTION
cherry-pick from pr #25957

- when lower_case_table_names = 0, reference of table name should case sensitive
- when lower_case_table_names = 1 and 2 cte name should case insensitive more details, please read doris doc: https://doris.apache.org/docs/advanced/variables#supported-variables

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

