### PR TITLE
[Fix](thrift api) column should be converted if const before serializ…

### DIFF
--- a/be/src/util/arrow/block_convertor.cpp
+++ b/be/src/util/arrow/block_convertor.cpp
@@ -391,8 +391,14 @@ Status FromBlockConverter::convert(std::shared_ptr<arrow::RecordBatch>* out) {
             return to_status(arrow_st);
         }
         _cur_builder = builder.get();
-        _cur_type->get_serde()->write_column_to_arrow(*_cur_col, nullptr, _cur_builder, _cur_start,
-                                                      _cur_start + _cur_rows);
+        auto column = _cur_col->convert_to_full_column_if_const();
+        try {
+            _cur_type->get_serde()->write_column_to_arrow(*column, nullptr, _cur_builder,
+                                                          _cur_start, _cur_start + _cur_rows);
+        } catch (std::exception& e) {
+            return Status::InternalError("Fail to convert block data to arrow data, error: {}",
+                                         e.what());
+        }
         arrow_st = _cur_builder->Finish(&_arrays[_cur_field_idx]);
         if (!arrow_st.ok()) {
             return to_status(arrow_st);


### PR DESCRIPTION
…e to arrow format (#26111)

```
select null;
```

The above sql from thrift api will cause crash in `write_column_to_arrow` since it's column const, we should convert to full column

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

