### PR TITLE
[Refactor](serde) 'null' in the serde should be represented by constants, instead of a string variable

### DIFF
--- a/be/src/vec/data_types/serde/data_type_array_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_array_serde.cpp
@@ -287,7 +287,8 @@ Status DataTypeArraySerDe::_write_column_to_mysql(const IColumn& column,
             }
         }
         if (data.is_null_at(j)) {
-            if (0 != result.push_string("null", strlen("null"))) {
+            if (0 != result.push_string(NULL_IN_COMPLEX_TYPE.c_str(),
+                                        strlen(NULL_IN_COMPLEX_TYPE.c_str()))) {
                 return Status::InternalError("pack mysql buffer failed.");
             }
         } else {

--- a/be/src/vec/data_types/serde/data_type_hll_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_hll_serde.cpp
@@ -53,9 +53,11 @@ Status DataTypeHLLSerDe::serialize_one_cell_to_json(const IColumn& column, int r
          * for null values in nested types, we use null to represent them, just like the json format.
          */
         if (_nesting_level >= 2) {
-            bw.write(DataTypeNullableSerDe::NULL_IN_CSV_FOR_NESTED_TYPE.c_str(), 4);
+            bw.write(DataTypeNullableSerDe::NULL_IN_COMPLEX_TYPE.c_str(),
+                     strlen(NULL_IN_COMPLEX_TYPE.c_str()));
         } else {
-            bw.write(DataTypeNullableSerDe::NULL_IN_CSV_FOR_ORDINARY_TYPE.c_str(), 2);
+            bw.write(DataTypeNullableSerDe::NULL_IN_CSV_FOR_ORDINARY_TYPE.c_str(),
+                     strlen(NULL_IN_CSV_FOR_ORDINARY_TYPE.c_str()));
         }
         return Status::OK();
     }

--- a/be/src/vec/data_types/serde/data_type_map_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_map_serde.cpp
@@ -417,7 +417,8 @@ Status DataTypeMapSerDe::_write_column_to_mysql(const IColumn& column,
             }
         }
         if (nested_keys_column.is_null_at(j)) {
-            if (0 != result.push_string("null", strlen("null"))) {
+            if (0 != result.push_string(NULL_IN_COMPLEX_TYPE.c_str(),
+                                        strlen(NULL_IN_COMPLEX_TYPE.c_str()))) {
                 return Status::InternalError("pack mysql buffer failed.");
             }
         } else {
@@ -439,7 +440,8 @@ Status DataTypeMapSerDe::_write_column_to_mysql(const IColumn& column,
             return Status::InternalError("pack mysql buffer failed.");
         }
         if (nested_values_column.is_null_at(j)) {
-            if (0 != result.push_string("null", strlen("null"))) {
+            if (0 != result.push_string(NULL_IN_COMPLEX_TYPE.c_str(),
+                                        strlen(NULL_IN_COMPLEX_TYPE.c_str()))) {
                 return Status::InternalError("pack mysql buffer failed.");
             }
         } else {

--- a/be/src/vec/data_types/serde/data_type_nullable_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_nullable_serde.cpp
@@ -60,9 +60,10 @@ Status DataTypeNullableSerDe::serialize_one_cell_to_json(const IColumn& column, 
          * for null values in nested types, we use null to represent them, just like the json format.
          */
         if (_nesting_level >= 2) {
-            bw.write(NULL_IN_CSV_FOR_NESTED_TYPE.c_str(), 4);
+            bw.write(NULL_IN_COMPLEX_TYPE.c_str(), strlen(NULL_IN_COMPLEX_TYPE.c_str()));
         } else {
-            bw.write(NULL_IN_CSV_FOR_ORDINARY_TYPE.c_str(), 2);
+            bw.write(NULL_IN_CSV_FOR_ORDINARY_TYPE.c_str(),
+                     strlen(NULL_IN_CSV_FOR_ORDINARY_TYPE.c_str()));
         }
     } else {
         RETURN_IF_ERROR(nested_serde->serialize_one_cell_to_json(col_null.get_nested_column(),
@@ -333,9 +334,6 @@ Status DataTypeNullableSerDe::write_column_to_orc(const std::string& timezone,
             orc_col_batch, start, end, buffer_list));
     return Status::OK();
 }
-
-const std::string DataTypeNullableSerDe::NULL_IN_CSV_FOR_ORDINARY_TYPE = "\\N";
-const std::string DataTypeNullableSerDe::NULL_IN_CSV_FOR_NESTED_TYPE = "null";
 
 } // namespace vectorized
 } // namespace doris

--- a/be/src/vec/data_types/serde/data_type_nullable_serde.h
+++ b/be/src/vec/data_types/serde/data_type_nullable_serde.h
@@ -89,10 +89,6 @@ public:
         nested_serde->set_return_object_as_string(value);
     }
 
-    static const std::string NULL_IN_CSV_FOR_ORDINARY_TYPE;
-
-    static const std::string NULL_IN_CSV_FOR_NESTED_TYPE;
-
 private:
     template <bool is_binary_format>
     Status _write_column_to_mysql(const IColumn& column, MysqlRowBuffer<is_binary_format>& result,

--- a/be/src/vec/data_types/serde/data_type_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_serde.cpp
@@ -40,5 +40,8 @@ DataTypeSerDeSPtrs create_data_type_serdes(const std::vector<SlotDescriptor*>& s
     }
     return serdes;
 }
+
+const std::string DataTypeSerDe::NULL_IN_COMPLEX_TYPE = "null";
+const std::string DataTypeSerDe::NULL_IN_CSV_FOR_ORDINARY_TYPE = "\\N";
 } // namespace vectorized
 } // namespace doris

--- a/be/src/vec/data_types/serde/data_type_serde.h
+++ b/be/src/vec/data_types/serde/data_type_serde.h
@@ -191,6 +191,12 @@ public:
     // buffer reserves 40 bytes. The reserved space is just to prevent Headp-Buffer-Overflow
     static constexpr size_t BUFFER_RESERVED_SIZE = 40;
 
+    // For the NULL value in the complex type, we use the `null` of the lowercase
+    static const std::string NULL_IN_COMPLEX_TYPE;
+
+    // For the NULL value in the ordinary type in csv file format, we use `\N`
+    static const std::string NULL_IN_CSV_FOR_ORDINARY_TYPE;
+
 public:
     DataTypeSerDe(int nesting_level = 1) : _nesting_level(nesting_level) {};
     virtual ~DataTypeSerDe();

--- a/be/src/vec/data_types/serde/data_type_struct_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_struct_serde.cpp
@@ -175,7 +175,8 @@ Status DataTypeStructSerDe::deserialize_one_cell_from_json(IColumn& column, Slic
             continue;
         }
         // handle null element
-        if (field_rb.count() == 4 && strncmp(field_rb.position(), "null", 4) == 0) {
+        if (field_rb.count() == 4 && strncmp(field_rb.position(), NULL_IN_COMPLEX_TYPE.c_str(),
+                                             strlen(NULL_IN_COMPLEX_TYPE.c_str())) == 0) {
             auto& nested_null_col =
                     reinterpret_cast<ColumnNullable&>(struct_column.get_column(idx));
             nested_null_col.insert_null_elements(1);
@@ -333,7 +334,8 @@ Status DataTypeStructSerDe::_write_column_to_mysql(const IColumn& column,
         }
 
         if (col.get_column_ptr(j)->is_null_at(col_index)) {
-            if (0 != result.push_string("null", strlen("null"))) {
+            if (0 != result.push_string(NULL_IN_COMPLEX_TYPE.c_str(),
+                                        strlen(NULL_IN_COMPLEX_TYPE.c_str()))) {
                 return Status::InternalError("pack mysql buffer failed.");
             }
         } else {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

No need to merge into branch-2.0


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

