### PR TITLE
[enhancement](Nereids): GroupPlan don't generate ObjectId

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
@@ -97,11 +97,13 @@ public class GroupExpression {
         this.plan = Objects.requireNonNull(plan, "plan can not be null")
                 .withGroupExpression(Optional.of(this));
         this.children = Objects.requireNonNull(children, "children can not be null");
-        this.children.forEach(childGroup -> childGroup.addParentExpression(this));
         this.ruleMasks = new BitSet(RuleType.SENTINEL.ordinal());
         this.statDerived = false;
         this.lowestCostTable = Maps.newHashMap();
         this.requestPropertiesMap = Maps.newHashMap();
+        for (Group child : children) {
+            child.addParentExpression(this);
+        }
     }
 
     public PhysicalProperties getOutputProperties(PhysicalProperties requestProperties) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/GroupPlan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/GroupPlan.java
@@ -26,6 +26,7 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalLeaf;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.statistics.Statistics;
 
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -41,7 +42,7 @@ public class GroupPlan extends LogicalLeaf {
     private final Group group;
 
     public GroupPlan(Group group) {
-        super(PlanType.GROUP_PLAN, Optional.empty(), Optional.of(group.getLogicalProperties()));
+        super(PlanType.GROUP_PLAN, Optional.empty(), Suppliers.ofInstance(group.getLogicalProperties()), true);
         this.group = group;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/Command.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/Command.java
@@ -39,7 +39,7 @@ import java.util.Optional;
 public abstract class Command extends AbstractPlan implements LogicalPlan {
 
     protected Command(PlanType type) {
-        super(type, ImmutableList.of());
+        super(type, Optional.empty(), Optional.empty(), null, ImmutableList.of());
     }
 
     public void run(ConnectContext ctx, StmtExecutor executor) throws Exception {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/AbstractLogicalPlan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/AbstractLogicalPlan.java
@@ -25,6 +25,7 @@ import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.qe.ConnectContext;
 
+import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -35,7 +36,7 @@ import java.util.Optional;
  */
 public abstract class AbstractLogicalPlan extends AbstractPlan implements LogicalPlan, Explainable {
     protected AbstractLogicalPlan(PlanType type, List<Plan> children) {
-        super(type, children);
+        this(type, Optional.empty(), Optional.empty(), children);
     }
 
     protected AbstractLogicalPlan(PlanType type, Optional<GroupExpression> groupExpression,
@@ -46,6 +47,12 @@ public abstract class AbstractLogicalPlan extends AbstractPlan implements Logica
     protected AbstractLogicalPlan(PlanType type, Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         super(type, groupExpression, logicalProperties, null, children);
+    }
+
+    // Don't generate ObjectId for LogicalPlan
+    protected AbstractLogicalPlan(PlanType type, Optional<GroupExpression> groupExpression,
+            Supplier<LogicalProperties> logicalPropertiesSupplier, List<Plan> children, boolean useZeroId) {
+        super(type, groupExpression, logicalPropertiesSupplier, null, children, useZeroId);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalLeaf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalLeaf.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.plans.LeafPlan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 
+import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -33,9 +34,14 @@ import java.util.Optional;
  */
 public abstract class LogicalLeaf extends AbstractLogicalPlan implements LeafPlan, OutputSavePoint {
 
-    public LogicalLeaf(PlanType nodeType, Optional<GroupExpression> groupExpression,
-                           Optional<LogicalProperties> logicalProperties) {
+    protected LogicalLeaf(PlanType nodeType, Optional<GroupExpression> groupExpression,
+            Optional<LogicalProperties> logicalProperties) {
         super(nodeType, groupExpression, logicalProperties, ImmutableList.of());
+    }
+
+    protected LogicalLeaf(PlanType nodeType, Optional<GroupExpression> groupExpression,
+            Supplier<LogicalProperties> logicalPropertiesSupplier, boolean useZeroId) {
+        super(nodeType, groupExpression, logicalPropertiesSupplier, ImmutableList.of(), useZeroId);
     }
 
     public abstract List<Slot> computeOutput();


### PR DESCRIPTION
## Proposed changes

1. GroupPlan don't generate ObjectId
2. GroupPlan use Supplier<LogicalProperty> as param

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

