### PR TITLE
[fix](mark_join) core caused by null pointer

### DIFF
--- a/be/src/vec/exec/join/process_hash_table_probe_impl.h
+++ b/be/src/vec/exec/join/process_hash_table_probe_impl.h
@@ -292,7 +292,7 @@ Status ProcessHashTableProbe<JoinOpType>::do_process(HashTableType& hash_table_c
                     if (is_mark_join) {
                         ++current_offset;
                         bool null_result =
-                                (*null_map)[probe_index] ||
+                                (need_null_map_for_probe && (*null_map)[probe_index]) ||
                                 (!find_result.is_found() && _join_node->_has_null_in_build_side);
                         if (null_result) {
                             mark_column->insert_null();
@@ -309,7 +309,7 @@ Status ProcessHashTableProbe<JoinOpType>::do_process(HashTableType& hash_table_c
                     if (is_mark_join) {
                         ++current_offset;
                         bool null_result =
-                                (*null_map)[probe_index] ||
+                                (need_null_map_for_probe && (*null_map)[probe_index]) ||
                                 (!find_result.is_found() && _join_node->_has_null_in_build_side);
                         if (null_result) {
                             mark_column->insert_null();


### PR DESCRIPTION
## Proposed changes

```bash
*** Query id: 86fa46824a8248ac-a547e44b950b11ab ***
*** tablet id: 0 ***
*** Aborted at 1698898805 (unix time) try "date -d @1698898805" if you are using GNU date ***
*** Current BE git commitID: 475c03709d ***
*** SIGSEGV address not mapped to object (@0x8) received by PID 2394332 (TID 2394744 OR 0x7fc1501ad700) from PID 8; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:417
 1# 0x00007FC30F8770A7 in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 3# 0x00007FC30F87002C in /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/libjvm.so
 4# 0x00007FC317E32090 in /lib/x86_64-linux-gnu/libc.so.6
 5# doris::vectorized::PODArrayBase<1ul, 4096ul, Allocator, 15ul, 16ul>::size() const at /root/doris/be/src/vec/common/pod_array.h:209
 6# doris::vectorized::PODArray, 15ul, 16ul>::operator[](long) const at /root/doris/be/src/vec/common/pod_array.h:326
 7# doris::Status doris::vectorized::ProcessHashTableProbe<2>::do_process >(doris::vectorized::SerializedHashTableContext&, doris::vectorized::PODArray, 15ul, 16ul> const*, doris::vectorized::MutableBlock&, doris::vectorized::Block*, unsigned long, bool) at /root/doris/be/src/vec/exec/join/process_hash_table_probe_impl.h:312
 8# auto doris::vectorized::HashJoinNode::pull(doris::RuntimeState*, doris::vectorized::Block*, bool*)::$_0::operator()&, doris::vectorized::ProcessHashTableProbe<2>&, std::integral_constant, std::integral_constant >(doris::vectorized::SerializedHashTableContext&, doris::vectorized::ProcessHashTableProbe<2>&, std::integral_constant, std::integral_constant) const at /root/doris/be/src/vec/exec/join/vhash_join_node.cpp:630
 9# void std::__invoke_impl&, doris::vectorized::ProcessHashTableProbe<2>&, std::integral_constant, std::integral_constant >(std::__invoke_other, doris::vectorized::HashJoinNode::pull(doris::RuntimeState*, doris::vectorized::Block*, bool*)::$_0&&, doris::vectorized::SerializedHashTableContext&, doris::vectorized::ProcessHashTableProbe<2>&, std::integral_constant&&, std::integral_constant&&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
10# std::__invoke_result&, doris::vectorized::ProcessHashTableProbe<2>&, std::integral_constant, std::integral_constant >::type std::__invoke&, doris::vectorized::ProcessHashTableProbe<2>&, std::integral_constant, std::integral_constant >(doris::vectorized::HashJoinNode::pull(doris::RuntimeState*, doris::vectorized::Block*, bool*)::$_0&&, doris::vectorized::SerializedHashTableContext&, doris::vectorized::ProcessHashTableProbe<2>&, std::integral_constant&&, std::integral_constant&&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
11# _ZNSt8__detail9__variant17__gen_vtable_implINS0_12_Multi_arrayIPFNS0_21__deduce_visit_resultIvEEOZN5doris10vectorized12HashJoinNode4pullEPNS5_12RuntimeStateEPNS6_5BlockEPbE3$_0RSt7variantIJSt9monostateNS6_26SerializedHashTableContextINS6_10RowRefListEEENS6_27PrimaryTypeHashTableContextIhSI_EENSK_ItSI_EENSK_IjSI_EENSK_ImSI_EENSK_INS6_7UInt128ESI_EENSK_INS6_7UInt256ESI_EENS6_24FixedKeyHashTableContextImLb1ESI_EENST_ImLb0ESI_EENST_ISP_Lb1ESI_EENST_ISP_Lb0ESI_EENST_ISR_Lb1ESI_EENST_ISR_Lb0ESI_EENSH_INS6_18RowRefListWithFlagEEENSK_IhS10_EENSK_ItS10_EENSK_IjS10_EENSK_ImS10_EENSK_ISP_S10_EENSK_ISR_S10_EENST_ImLb1ES10_EENST_ImLb0ES10_EENST_ISP_Lb1ES10_EENST_ISP_Lb0ES10_EENST_ISR_Lb1ES10_EENST_ISR_Lb0ES10_EENSH_INS6_19RowRefListWithFlagsEEENSK_IhS1E_EENSK_ItS1E_EENSK_IjS1E_EENSK_ImS1E_EENSK_ISP_S1E_EENSK_ISR_S1E_EENST_ImLb1ES1E_EENST_ImLb0ES1E_EENST_ISP_Lb1ES1E_EENST_ISP_Lb0ES1E_EENST_ISR_Lb1ES1E_EENST_ISR_Lb0ES1E_EEEERSF_IJSG_NS6_21ProcessHashTableProbeILi0EEENS1U_ILi2EEENS1U_ILi8EEENS1U_ILi1EEENS1U_ILi4EEENS1U_ILi3EEENS1U_ILi5EEENS1U_ILi7EEENS1U_ILi9EEENS1U_ILi10EEEEEOSF_IJSt17integral_constantIbLb0EES27_IbLb1EEEES2B_EJEEESt16integer_sequenceImJLm1ELm2ELm0ELm1EEEE14__visit_invokeESE_S1T_S26_S2B_S2B_ at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1013
12# _ZSt10__do_visitINSt8__detail9__variant21__deduce_visit_resultIvEEZN5doris10vectorized12HashJoinNode4pullEPNS4_12RuntimeStateEPNS5_5BlockEPbE3$_0JRSt7variantIJSt9monostateNS5_26SerializedHashTableContextINS5_10RowRefListEEENS5_27PrimaryTypeHashTableContextIhSG_EENSI_ItSG_EENSI_IjSG_EENSI_ImSG_EENSI_INS5_7UInt128ESG_EENSI_INS5_7UInt256ESG_EENS5_24FixedKeyHashTableContextImLb1ESG_EENSR_ImLb0ESG_EENSR_ISN_Lb1ESG_EENSR_ISN_Lb0ESG_EENSR_ISP_Lb1ESG_EENSR_ISP_Lb0ESG_EENSF_INS5_18RowRefListWithFlagEEENSI_IhSY_EENSI_ItSY_EENSI_IjSY_EENSI_ImSY_EENSI_ISN_SY_EENSI_ISP_SY_EENSR_ImLb1ESY_EENSR_ImLb0ESY_EENSR_ISN_Lb1ESY_EENSR_ISN_Lb0ESY_EENSR_ISP_Lb1ESY_EENSR_ISP_Lb0ESY_EENSF_INS5_19RowRefListWithFlagsEEENSI_IhS1C_EENSI_ItS1C_EENSI_IjS1C_EENSI_ImS1C_EENSI_ISN_S1C_EENSI_ISP_S1C_EENSR_ImLb1ES1C_EENSR_ImLb0ES1C_EENSR_ISN_Lb1ES1C_EENSR_ISN_Lb0ES1C_EENSR_ISP_Lb1ES1C_EENSR_ISP_Lb0ES1C_EEEERSD_IJSE_NS5_21ProcessHashTableProbeILi0EEENS1S_ILi2EEENS1S_ILi8EEENS1S_ILi1EEENS1S_ILi4EEENS1S_ILi3EEENS1S_ILi5EEENS1S_ILi7EEENS1S_ILi9EEENS1S_ILi10EEEEESD_IJSt17integral_constantIbLb0EES25_IbLb1EEEES28_EEDcOT0_DpOT1_ at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1716
13# _ZSt5visitIZN5doris10vectorized12HashJoinNode4pullEPNS0_12RuntimeStateEPNS1_5BlockEPbE3$_0JRSt7variantIJSt9monostateNS1_26SerializedHashTableContextINS1_10RowRefListEEENS1_27PrimaryTypeHashTableContextIhSC_EENSE_ItSC_EENSE_IjSC_EENSE_ImSC_EENSE_INS1_7UInt128ESC_EENSE_INS1_7UInt256ESC_EENS1_24FixedKeyHashTableContextImLb1ESC_EENSN_ImLb0ESC_EENSN_ISJ_Lb1ESC_EENSN_ISJ_Lb0ESC_EENSN_ISL_Lb1ESC_EENSN_ISL_Lb0ESC_EENSB_INS1_18RowRefListWithFlagEEENSE_IhSU_EENSE_ItSU_EENSE_IjSU_EENSE_ImSU_EENSE_ISJ_SU_EENSE_ISL_SU_EENSN_ImLb1ESU_EENSN_ImLb0ESU_EENSN_ISJ_Lb1ESU_EENSN_ISJ_Lb0ESU_EENSN_ISL_Lb1ESU_EENSN_ISL_Lb0ESU_EENSB_INS1_19RowRefListWithFlagsEEENSE_IhS18_EENSE_ItS18_EENSE_IjS18_EENSE_ImS18_EENSE_ISJ_S18_EENSE_ISL_S18_EENSN_ImLb1ES18_EENSN_ImLb0ES18_EENSN_ISJ_Lb1ES18_EENSN_ISJ_Lb0ES18_EENSN_ISL_Lb1ES18_EENSN_ISL_Lb0ES18_EEEERS9_IJSA_NS1_21ProcessHashTableProbeILi0EEENS1O_ILi2EEENS1O_ILi8EEENS1O_ILi1EEENS1O_ILi4EEENS1O_ILi3EEENS1O_ILi5EEENS1O_ILi7EEENS1O_ILi9EEENS1O_ILi10EEEEES9_IJSt17integral_constantIbLb0EES21_IbLb1EEEES24_EEDcOT_DpOT0_ at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1769
14# doris::vectorized::HashJoinNode::pull(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /root/doris/be/src/vec/exec/join/vhash_join_node.cpp:630
15# doris::Status std::__invoke_impl(std::__invoke_memfun_deref, doris::Status (doris::ExecNode::*&)(doris::RuntimeState*, doris::vectorized::Block*, bool*), doris::vectorized::HashJoinNode*&, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
16# std::__invoke_result::type std::__invoke(doris::Status (doris::ExecNode::*&)(doris::RuntimeState*, doris::vectorized::Block*, bool*), doris::vectorized::HashJoinNode*&, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
17# doris::Status std::_Bind, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>::__call(std::tuple&&, std::_Index_tuple<0ul, 1ul, 2ul, 3ul>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420
18# doris::Status std::_Bind, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>::operator()(doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503
19# doris::Status std::__invoke_impl, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>&, doris::RuntimeState*, doris::vectorized::Block*, bool*>(std::__invoke_other, std::_Bind, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>&, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
20# std::enable_if, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>&, doris::RuntimeState*, doris::vectorized::Block*, bool*>, doris::Status>::type std::__invoke_r, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>&, doris::RuntimeState*, doris::vectorized::Block*, bool*>(std::_Bind, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>&, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:114
21# std::_Function_handler, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)> >::_M_invoke(std::_Any_data const&, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
22# std::function::operator()(doris::RuntimeState*, doris::vectorized::Block*, bool*) const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
23# doris::ExecNode::get_next_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*, std::function const&, bool) in /mnt/hdd01/ci/branch20-deploy/be/lib/doris_be
24# doris::pipeline::StatefulOperator::get_block(doris::RuntimeState*, doris::vectorized::Block*, doris::pipeline::SourceState&) at /root/doris/be/src/pipeline/exec/operator.h:441
25# doris::pipeline::PipelineTask::execute(bool*) at /root/doris/be/src/pipeline/pipeline_task.cpp:254
26# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /root/doris/be/src/pipeline/task_scheduler.cpp:266
27# void std::__invoke_impl(std::__invoke_memfun_deref, void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
28# std::__invoke_result::type std::__invoke(void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
29# void std::_Bind::__call(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420
30# void std::_Bind::operator()<, void>() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503
31# void std::__invoke_impl&>(std::__invoke_other, std::_Bind&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
32# std::enable_if&>, void>::type std::__invoke_r&>(std::_Bind&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
33# std::_Function_handler >::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
34# std::function::operator()() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
35# doris::FunctionRunnable::run() at /root/doris/be/src/util/threadpool.cpp:48
36# doris::ThreadPool::dispatch_thread() at /root/doris/be/src/util/threadpool.cpp:533
37# void std::__invoke_impl(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
38# std::__invoke_result::type std::__invoke(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
39# void std::_Bind::__call(std::tuple<>&&, std::_Index_tuple<0ul>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420
40# void std::_Bind::operator()<, void>() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503
41# void std::__invoke_impl&>(std::__invoke_other, std::_Bind&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
42# std::enable_if&>, void>::type std::__invoke_r&>(std::_Bind&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
43# std::_Function_handler >::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
44# std::function::operator()() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
45# doris::Thread::supervise_thread(void*) at /root/doris/be/src/util/thread.cpp:498
46# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
47# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

