### PR TITLE
[branch-2.0](fix) fix SHA2's error message

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -1755,7 +1755,7 @@ public class FunctionCallExpr extends Expr {
             }
             final Integer constParam = (int) ((IntLiteral) getChild(1)).getValue();
             if (!Lists.newArrayList(224, 256, 384, 512).contains(constParam)) {
-                throw new AnalysisException("sha2 functions only support digest length of 224/256/384/512");
+                throw new AnalysisException("sha2's digest length only support 224/256/384/512 but meet " + constParam);
             }
         }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Exception in query_p0/sql_functions/encryption_digest/test_digest.groovy(line 33):
assertTrue(e.getMessage().contains("only support 224/256/384/512"))
org.opentest4j.AssertionFailedError: expected: <true> but was: <false>

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

