### PR TITLE
[enhance](sql-cache) lazy create scan range locations if sql cache is missing

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/FederationBackendPolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/FederationBackendPolicy.java
@@ -30,6 +30,9 @@ import org.apache.doris.thrift.TFileRangeDesc;
 import org.apache.doris.thrift.TScanRangeLocations;
 
 import com.google.common.base.Preconditions;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -46,7 +49,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public class FederationBackendPolicy {
@@ -58,6 +64,54 @@ public class FederationBackendPolicy {
 
     private int nextBe = 0;
     private boolean initialized = false;
+
+    // Create a ConsistentHash ring may be a time-consuming operation, so we cache it.
+    private static LoadingCache<HashCacheKey, ConsistentHash<TScanRangeLocations, Backend>> consistentHashCache;
+
+    static {
+        consistentHashCache = CacheBuilder.newBuilder().maximumSize(5)
+                .expireAfterAccess(86400, TimeUnit.SECONDS)
+                .build(new CacheLoader<HashCacheKey, ConsistentHash<TScanRangeLocations, Backend>>() {
+                    @Override
+                    public ConsistentHash<TScanRangeLocations, Backend> load(HashCacheKey key) {
+                        return new ConsistentHash<>(Hashing.murmur3_128(), new ScanRangeHash(),
+                                new BackendHash(), key.bes, Config.virtual_node_number);
+                    }
+                });
+    }
+
+    private static class HashCacheKey {
+        // sorted backend ids as key
+        private List<Long> beIds;
+        // backends is not part of key, just an attachment
+        private List<Backend> bes;
+
+        HashCacheKey(List<Backend> backends) {
+            this.bes = backends;
+            this.beIds = backends.stream().map(b -> b.getId()).sorted().collect(Collectors.toList());
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof HashCacheKey)) {
+                return false;
+            }
+            return Objects.equals(beIds, ((HashCacheKey) obj).beIds);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(beIds);
+        }
+
+        @Override
+        public String toString() {
+            return "HashCache{" + "beIds=" + beIds + '}';
+        }
+    }
 
     public void init() throws UserException {
         if (!initialized) {
@@ -96,8 +150,11 @@ public class FederationBackendPolicy {
             throw new UserException("No available backends");
         }
         backendMap.putAll(backends.stream().collect(Collectors.groupingBy(Backend::getHost)));
-        consistentHash = new ConsistentHash<>(Hashing.murmur3_128(), new ScanRangeHash(),
-                new BackendHash(), backends, Config.virtual_node_number);
+        try {
+            consistentHash = consistentHashCache.get(new HashCacheKey(backends));
+        } catch (ExecutionException e) {
+            throw new UserException("failed to get consistent hash", e);
+        }
     }
 
     public Backend getNextBe() {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileScanNode.java
@@ -70,6 +70,8 @@ public abstract class FileScanNode extends ExternalScanNode {
     protected long totalPartitionNum = 0;
     protected long readPartitionNum = 0;
 
+    List<Split> inputSplits = Lists.newArrayList();
+
     public FileScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName, StatisticalType statisticalType,
             boolean needCheckColumnPriv) {
         super(id, desc, planNodeName, statisticalType, needCheckColumnPriv);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -206,6 +206,12 @@ public class ConnectContext {
     // In this case, `skipAuth` needs to be set to `true` to skip the permission check of `AlterTable`
     private boolean skipAuth = false;
 
+    // Set to true the sql cache is enabled.
+    // Not same as sessionVariable.isEnableSqlCache, this is set to true only if the sql cache can be used
+    // in the current query.
+    // And after the query is finished, this flag will be set to false again.
+    private boolean isEnableSqlCache = false;
+
     public void setUserQueryTimeout(int queryTimeout) {
         if (queryTimeout > 0) {
             sessionVariable.setQueryTimeoutS(queryTimeout);
@@ -874,6 +880,14 @@ public class ConnectContext {
 
     public Map<String, String> getResultAttachedInfo() {
         return resultAttachedInfo;
+    }
+
+    public void setIsEnableSqlCache(boolean isEnableSqlCache) {
+        this.isEnableSqlCache = isEnableSqlCache;
+    }
+
+    public boolean isEnableSqlCache() {
+        return isEnableSqlCache;
     }
 
     public class ThreadInfo {


### PR DESCRIPTION
## Proposed changes

Previously, if sql cache is enabled, Doris will first do the query plan, than check is cache is hit.
But query plan may be a time-consuming operation, and some of plan results are useless for sql cache.
This will result in very low QPS even if sql cache is enabled and hit.

This PR mainly changes:

1. Cache the ConsistentHash in FederationBackendPolicy
    Creation of ConsistentHash is also time-consuming because it will create 2048 virtual node by default.

2. Lazy creation scan range locations for FileScanNode
    When there are many splits in FileScanNode, the creation of scan range locations may be very slow.
    But these info is not used for sql cache.
    So we can do a lazy creation, to check the sql cache first, and if cache is missed, create the scan range locations.

In my case, a sql on hive table(which has 2000 files), the QPS with sql cache enable can increase from 100+ to 1000+

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

