### PR TITLE
[opt](memory) jemalloc conf `lg_tcache_max` restore default

### DIFF
--- a/conf/be.conf
+++ b/conf/be.conf
@@ -29,7 +29,7 @@ JAVA_OPTS_FOR_JDK_9="-Xmx1024m -DlogPath=$DORIS_HOME/log/jni.log -Xlog:gc:$DORIS
 
 # https://github.com/apache/doris/blob/master/docs/zh-CN/community/developer-guide/debug-tool.md#jemalloc-heap-profile
 # https://jemalloc.net/jemalloc.3.html
-JEMALLOC_CONF="percpu_arena:percpu,background_thread:true,metadata_thp:auto,muzzy_decay_ms:15000,dirty_decay_ms:15000,oversize_threshold:0,lg_tcache_max:20,prof:false,lg_prof_interval:32,lg_prof_sample:19,prof_gdump:false,prof_accum:false,prof_leak:false,prof_final:false"
+JEMALLOC_CONF="percpu_arena:percpu,background_thread:true,metadata_thp:auto,muzzy_decay_ms:15000,dirty_decay_ms:15000,oversize_threshold:0,prof:false,lg_prof_interval:32,lg_prof_sample:19,prof_gdump:false,prof_accum:false,prof_leak:false,prof_final:false"
 JEMALLOC_PROF_PRFIX=""
 
 # INFO, WARNING, ERROR, FATAL


### PR DESCRIPTION
## Proposed changes

`tc/jemalloc_free_memory` in web `beip:8040/mem_tracker` is the cache size of Jemalloc.

Previously `lg_tcache_max:20`, this will cache up to 1M Bin in the thread cache, which will cause the Jemalloc cache to be too large in some scenarios.

Restore the default `lg_tcache_max:16`, which can cache a maximum of 64K Bins.

If you are doing a performance POC, you can consider increasing it.
![image](https://github.com/apache/doris/assets/13197424/6a2e5ed0-8c4d-4ee3-bf7d-abd0ba3d4f29)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

