### PR TITLE
[chore] Print FE version even if it has been started

### DIFF
--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -218,7 +218,7 @@ export CLASSPATH="${DORIS_HOME}/conf:${CLASSPATH}:${DORIS_HOME}/lib"
 
 pidfile="${PID_DIR}/fe.pid"
 
-if [[ -f "${pidfile}" ]]; then
+if [[ -f "${pidfile}" ]] && [[ "${OPT_VERSION}" == "" ]]; then
     if kill -0 "$(cat "${pidfile}")" >/dev/null 2>&1; then
         echo "Frontend running as process $(cat "${pidfile}"). Stop it first."
         exit 1
@@ -258,4 +258,7 @@ else
     ${LIMIT:+${LIMIT}} "${JAVA}" ${final_java_opt:+${final_java_opt}} -XX:-OmitStackTraceInFastThrow -XX:OnOutOfMemoryError="kill -9 %p" ${coverage_opt:+${coverage_opt}} org.apache.doris.DorisFE ${HELPER:+${HELPER}} ${OPT_VERSION:+${OPT_VERSION}} "$@" >>"${LOG_DIR}/fe.out" 2>&1 </dev/null
 fi
 
+if [[ "${OPT_VERSION}" != "" ]]; then
+    exit 0
+fi
 echo $! >"${pidfile}"

--- a/fe/fe-core/src/main/java/org/apache/doris/DorisFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/DorisFE.java
@@ -101,6 +101,11 @@ public class DorisFE {
         CommandLineOptions cmdLineOpts = parseArgs(args);
 
         try {
+            if (cmdLineOpts.isVersion()) {
+                printVersion();
+                System.exit(0);
+            }
+
             // pid file
             if (!createAndLockPidFile(pidDir + "/fe.pid")) {
                 throw new IOException("pid file is already locked.");
@@ -371,13 +376,17 @@ public class DorisFE {
         return new CommandLineOptions(false, null, null, "");
     }
 
+    private static void printVersion() {
+        System.out.println("Build version: " + Version.DORIS_BUILD_VERSION);
+        System.out.println("Build time: " + Version.DORIS_BUILD_TIME);
+        System.out.println("Build info: " + Version.DORIS_BUILD_INFO);
+        System.out.println("Build hash: " + Version.DORIS_BUILD_HASH);
+        System.out.println("Java compile version: " + Version.DORIS_JAVA_COMPILE_VERSION);
+    }
+
     private static void checkCommandLineOptions(CommandLineOptions cmdLineOpts) {
         if (cmdLineOpts.isVersion()) {
-            System.out.println("Build version: " + Version.DORIS_BUILD_VERSION);
-            System.out.println("Build time: " + Version.DORIS_BUILD_TIME);
-            System.out.println("Build info: " + Version.DORIS_BUILD_INFO);
-            System.out.println("Build hash: " + Version.DORIS_BUILD_HASH);
-            System.out.println("Java compile version: " + Version.DORIS_JAVA_COMPILE_VERSION);
+            printVersion();
             System.exit(0);
         } else if (cmdLineOpts.runBdbTools()) {
             BDBTool bdbTool = new BDBTool(Env.getCurrentEnv().getBdbDir(), cmdLineOpts.getBdbToolOpts());


### PR DESCRIPTION
In the previous implementation,
`bin/start_fe.sh --version` will complain that "Frontend running as process xxx. Stop it first."

To show version
1. `bin/start_fe.sh --version` will print version info to fe.out
2. `bin/start_fe.sh --console --version` will print version info to stdout