### PR TITLE
[opt](expr) common expr pushdown supports unique key MoR and agg key table if all slot is key column.

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -587,7 +587,9 @@ Status SegmentIterator::_extract_common_expr_columns(const vectorized::VExprSPtr
     auto node_type = expr->node_type();
     if (node_type == TExprNodeType::SLOT_REF) {
         auto slot_expr = std::dynamic_pointer_cast<doris::vectorized::VSlotRef>(expr);
-        auto cid = slot_expr->tablet_schema_column_id();
+        auto unique_id = slot_expr->col_unique_id();
+        DCHECK(unique_id >= 0);
+        auto cid = _opts.tablet_schema->field_index(unique_id);
         DCHECK(cid >= 0);
         _is_common_expr_column[cid] = true;
         _common_expr_columns.insert(cid);

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -587,11 +587,13 @@ Status SegmentIterator::_extract_common_expr_columns(const vectorized::VExprSPtr
     auto node_type = expr->node_type();
     if (node_type == TExprNodeType::SLOT_REF) {
         auto slot_expr = std::dynamic_pointer_cast<doris::vectorized::VSlotRef>(expr);
-        DCHECK(_schema->unique_id_to_index(slot_expr->col_unique_id()) != -1);
-        auto cid = _schema->column_id(_schema->unique_id_to_index(slot_expr->col_unique_id()));
-        slot_expr->set_push_down_column_id(cid);
+        auto cid = slot_expr->tablet_schema_column_id();
+        DCHECK(cid != -1);
         _is_common_expr_column[cid] = true;
         _common_expr_columns.insert(cid);
+        auto col_ids_index = _schema->col_id_to_col_ids_index(cid);
+        DCHECK(col_ids_index != -1);
+        slot_expr->set_push_down_column_index(col_ids_index);
     }
 
     return Status::OK();

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -588,11 +588,11 @@ Status SegmentIterator::_extract_common_expr_columns(const vectorized::VExprSPtr
     if (node_type == TExprNodeType::SLOT_REF) {
         auto slot_expr = std::dynamic_pointer_cast<doris::vectorized::VSlotRef>(expr);
         auto cid = slot_expr->tablet_schema_column_id();
-        DCHECK(cid != -1);
+        DCHECK(cid >= 0);
         _is_common_expr_column[cid] = true;
         _common_expr_columns.insert(cid);
         auto col_ids_index = _schema->col_id_to_col_ids_index(cid);
-        DCHECK(col_ids_index != -1);
+        DCHECK(col_ids_index >= 0);
         slot_expr->set_push_down_column_index(col_ids_index);
     }
 

--- a/be/src/olap/schema.h
+++ b/be/src/olap/schema.h
@@ -176,9 +176,10 @@ public:
     const std::vector<int32_t>& unique_ids() const { return _unique_ids; }
     ColumnId column_id(size_t index) const { return _col_ids[index]; }
     int32_t unique_id(size_t index) const { return _unique_ids[index]; }
-    size_t unique_id_to_index(int32_t unique_id) const {
-        for (int index = 0; index < _unique_ids.size(); index++) {
-            if (unique_id == _unique_ids[index]) {
+    size_t col_id_to_col_ids_index(int cid) const {
+        DCHECK(cid >= 0);
+        for (int index = 0; index < _col_ids.size(); index++) {
+            if (cid == _col_ids[index]) {
                 return index;
             }
         }
@@ -198,6 +199,8 @@ private:
 
     void _copy_from(const Schema& other);
 
+    // All the columns of one table may exist in the _cols, but col_ids is only a subset.
+    // In segment interator, only include the columns that need to be read.
     // NOTE: The ColumnId here represents the sequential index number (starting from 0) of
     // a column in current row, not the unique id-identifier of each column
     std::vector<ColumnId> _col_ids;

--- a/be/src/olap/schema.h
+++ b/be/src/olap/schema.h
@@ -176,6 +176,14 @@ public:
     const std::vector<int32_t>& unique_ids() const { return _unique_ids; }
     ColumnId column_id(size_t index) const { return _col_ids[index]; }
     int32_t unique_id(size_t index) const { return _unique_ids[index]; }
+    size_t unique_id_to_index(int32_t unique_id) const {
+        for (int index = 0; index < _unique_ids.size(); index++) {
+            if (unique_id == _unique_ids[index]) {
+                return index;
+            }
+        }
+        return -1;
+    }
     int32_t delete_sign_idx() const { return _delete_sign_idx; }
     bool has_sequence_col() const { return _has_sequence_col; }
     int32_t rowid_col_idx() const { return _rowid_col_idx; }

--- a/be/src/olap/schema.h
+++ b/be/src/olap/schema.h
@@ -176,7 +176,7 @@ public:
     const std::vector<int32_t>& unique_ids() const { return _unique_ids; }
     ColumnId column_id(size_t index) const { return _col_ids[index]; }
     int32_t unique_id(size_t index) const { return _unique_ids[index]; }
-    size_t col_id_to_col_ids_index(int cid) const {
+    int32_t col_id_to_col_ids_index(int cid) const {
         DCHECK(cid >= 0);
         for (int index = 0; index < _col_ids.size(); index++) {
             if (cid == _col_ids[index]) {

--- a/be/src/pipeline/exec/olap_scan_operator.h
+++ b/be/src/pipeline/exec/olap_scan_operator.h
@@ -29,6 +29,7 @@
 
 namespace doris {
 class ExecNode;
+class VExpr;
 
 namespace vectorized {
 class NewOlapScanner;
@@ -74,7 +75,9 @@ private:
         return vectorized::VScanNode::PushDownType::ACCEPTABLE;
     }
 
-    bool _should_push_down_common_expr() override;
+    bool _all_slots_is_key_column(const vectorized::VExpr& expr) override;
+
+    bool _should_push_down_common_expr(const vectorized::VExpr& expr) override;
 
     bool _storage_no_merge() override;
 

--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -248,7 +248,7 @@ Status ScanLocalState<Derived>::_normalize_conjuncts() {
             RETURN_IF_ERROR(_normalize_predicate(conjunct->root(), conjunct.get(), new_root));
             if (new_root) {
                 conjunct->set_root(new_root);
-                if (_should_push_down_common_expr() &&
+                if (_should_push_down_common_expr(*(conjunct->root())) &&
                     vectorized::VExpr::is_acting_on_a_slot(*(conjunct->root()))) {
                     _common_expr_ctxs_push_down.emplace_back(conjunct);
                     it = _conjuncts.erase(it);

--- a/be/src/pipeline/exec/scan_operator.h
+++ b/be/src/pipeline/exec/scan_operator.h
@@ -29,6 +29,7 @@
 
 namespace doris {
 class ExecNode;
+class VExpr;
 } // namespace doris
 
 namespace doris::pipeline {
@@ -240,7 +241,8 @@ protected:
         RETURN_IF_ERROR(_normalize_conjuncts());
         return Status::OK();
     }
-    virtual bool _should_push_down_common_expr() { return false; }
+    virtual bool _all_slots_is_key_column(const vectorized::VExpr& expr) { return false; }
+    virtual bool _should_push_down_common_expr(const vectorized::VExpr& expr) { return false; }
 
     virtual bool _storage_no_merge() { return false; }
     virtual bool _is_key_column(const std::string& col_name) { return false; }

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -118,9 +118,6 @@ void NewOlapScanner::_perfect_slot_column_id(const VExprSPtr& expr) {
             DCHECK(slot_unique_id >= 0);
             slot_expr->set_col_unique_id(slot_unique_id);
         }
-        auto index = tablet_schema->field_index(slot_expr->expr_name());
-        DCHECK(index >= 0);
-        slot_expr->set_tablet_schema_column_id(index);
     }
 }
 

--- a/be/src/vec/exec/scan/new_olap_scanner.h
+++ b/be/src/vec/exec/scan/new_olap_scanner.h
@@ -87,6 +87,8 @@ protected:
 private:
     void _update_realtime_counters();
 
+    void _perfect_slot_column_id(const VExprSPtr& expr);
+
     Status _init_tablet_reader_params(const std::vector<OlapScanRange*>& key_ranges,
                                       const std::vector<TCondition>& filters,
                                       const FilterPredicates& filter_predicates,

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -418,7 +418,7 @@ Status VScanNode::_normalize_conjuncts() {
             RETURN_IF_ERROR(_normalize_predicate(conjunct->root(), conjunct.get(), new_root));
             if (new_root) {
                 conjunct->set_root(new_root);
-                if (_should_push_down_common_expr() &&
+                if (_should_push_down_common_expr(*(conjunct->root())) &&
                     VExpr::is_acting_on_a_slot(*(conjunct->root()))) {
                     // We need to make sure conjunct is acting on a slot before push it down.
                     // Or it will not be executed by SegmentIterator::_vec_init_lazy_materialization

--- a/be/src/vec/exec/scan/vscan_node.h
+++ b/be/src/vec/exec/scan/vscan_node.h
@@ -227,7 +227,8 @@ protected:
         return Status::OK();
     }
 
-    virtual bool _should_push_down_common_expr() { return false; }
+    virtual bool _all_slots_is_key_column(const VExpr& expr) { return false; }
+    virtual bool _should_push_down_common_expr(const VExpr& expr) { return false; }
 
     virtual bool _storage_no_merge() { return false; }
 

--- a/be/src/vec/exprs/vslot_ref.cpp
+++ b/be/src/vec/exprs/vslot_ref.cpp
@@ -41,7 +41,6 @@ VSlotRef::VSlotRef(const doris::TExprNode& node)
         : VExpr(node),
           _slot_id(node.slot_ref.slot_id),
           _column_id(-1),
-          _tablet_schema_column_id(-1),
           _col_unique_id(-1),
           _push_down_column_index(-1),
           _column_name(nullptr) {}
@@ -50,7 +49,6 @@ VSlotRef::VSlotRef(const SlotDescriptor* desc)
         : VExpr(desc->type(), true, desc->is_nullable()),
           _slot_id(desc->id()),
           _column_id(-1),
-          _tablet_schema_column_id(-1),
           _col_unique_id(-1),
           _push_down_column_index(-1),
           _column_name(nullptr) {}

--- a/be/src/vec/exprs/vslot_ref.h
+++ b/be/src/vec/exprs/vslot_ref.h
@@ -48,9 +48,16 @@ public:
 
     int slot_id() const { return _slot_id; }
 
+    int col_unique_id() const { return _col_unique_id; }
+    void set_push_down_column_id(int push_down_column_id) {
+        _push_down_column_id = push_down_column_id;
+    }
+
 private:
     int _slot_id;
     int _column_id;
+    int32_t _col_unique_id;
+    int _push_down_column_id;
     const std::string* _column_name;
 };
 } // namespace vectorized

--- a/be/src/vec/exprs/vslot_ref.h
+++ b/be/src/vec/exprs/vslot_ref.h
@@ -48,12 +48,6 @@ public:
 
     int slot_id() const { return _slot_id; }
 
-    int32_t tablet_schema_column_id() const { return _tablet_schema_column_id; }
-
-    void set_tablet_schema_column_id(int32_t tablet_schema_column_id) {
-        _tablet_schema_column_id = tablet_schema_column_id;
-    }
-
     int32_t col_unique_id() const { return _col_unique_id; }
 
     void set_col_unique_id(int32_t col_unique_id) { _col_unique_id = col_unique_id; }
@@ -64,9 +58,8 @@ public:
 
 private:
     int _slot_id;
-    int _column_id;                   // scan tuple/block column index
-    int32_t _tablet_schema_column_id; // tablet schema column index
-    int32_t _col_unique_id;           // column unique id, global unique
+    int _column_id;         // scan tuple/block column index
+    int32_t _col_unique_id; // column unique id, global unique
     // segment iterator output batch/block column index.
     // when reade unique mor/agg key table, all key columns will be read,
     // which may lead to different column index from scan tuple/block.

--- a/be/src/vec/exprs/vslot_ref.h
+++ b/be/src/vec/exprs/vslot_ref.h
@@ -48,16 +48,29 @@ public:
 
     int slot_id() const { return _slot_id; }
 
+    int tablet_schema_column_id() const { return _tablet_schema_column_id; }
+
+    void set_tablet_schema_column_id(int32_t tablet_schema_column_id) {
+        _tablet_schema_column_id = tablet_schema_column_id;
+    }
+
     int col_unique_id() const { return _col_unique_id; }
-    void set_push_down_column_id(int push_down_column_id) {
-        _push_down_column_id = push_down_column_id;
+
+    void set_col_unique_id(int32_t col_unique_id) { _col_unique_id = col_unique_id; }
+
+    void set_push_down_column_index(int push_down_column_index) {
+        _push_down_column_index = push_down_column_index;
     }
 
 private:
     int _slot_id;
-    int _column_id;
-    int32_t _col_unique_id;
-    int _push_down_column_id;
+    int _column_id;               // scan tuple/block column index
+    int _tablet_schema_column_id; // tablet schema column index
+    int32_t _col_unique_id;       // column unique id, global unique
+    // segment iterator output batch/block column index.
+    // when reade unique mor/agg key table, all key columns will be read,
+    // which may lead to different column index from scan tuple/block.
+    int _push_down_column_index;
     const std::string* _column_name;
 };
 } // namespace vectorized

--- a/be/src/vec/exprs/vslot_ref.h
+++ b/be/src/vec/exprs/vslot_ref.h
@@ -48,29 +48,29 @@ public:
 
     int slot_id() const { return _slot_id; }
 
-    int tablet_schema_column_id() const { return _tablet_schema_column_id; }
+    int32_t tablet_schema_column_id() const { return _tablet_schema_column_id; }
 
     void set_tablet_schema_column_id(int32_t tablet_schema_column_id) {
         _tablet_schema_column_id = tablet_schema_column_id;
     }
 
-    int col_unique_id() const { return _col_unique_id; }
+    int32_t col_unique_id() const { return _col_unique_id; }
 
     void set_col_unique_id(int32_t col_unique_id) { _col_unique_id = col_unique_id; }
 
-    void set_push_down_column_index(int push_down_column_index) {
+    void set_push_down_column_index(int32_t push_down_column_index) {
         _push_down_column_index = push_down_column_index;
     }
 
 private:
     int _slot_id;
-    int _column_id;               // scan tuple/block column index
-    int _tablet_schema_column_id; // tablet schema column index
-    int32_t _col_unique_id;       // column unique id, global unique
+    int _column_id;                   // scan tuple/block column index
+    int32_t _tablet_schema_column_id; // tablet schema column index
+    int32_t _col_unique_id;           // column unique id, global unique
     // segment iterator output batch/block column index.
     // when reade unique mor/agg key table, all key columns will be read,
     // which may lead to different column index from scan tuple/block.
-    int _push_down_column_index;
+    int32_t _push_down_column_index;
     const std::string* _column_name;
 };
 } // namespace vectorized

--- a/be/test/vec/exprs/vexpr_test.cpp
+++ b/be/test/vec/exprs/vexpr_test.cpp
@@ -162,6 +162,7 @@ TEST(TEST_VEXPR, ABSTEST2) {
     runtime_stat.set_desc_tbl(&desc_tbl);
     auto state = Status::OK();
     state = context->prepare(&runtime_stat, row_desc);
+    std::cout << state.to_string() << std::endl;
     ASSERT_TRUE(state.ok());
     state = context->open(&runtime_stat);
     ASSERT_TRUE(state.ok());

--- a/be/test/vec/exprs/vexpr_test.cpp
+++ b/be/test/vec/exprs/vexpr_test.cpp
@@ -162,7 +162,6 @@ TEST(TEST_VEXPR, ABSTEST2) {
     runtime_stat.set_desc_tbl(&desc_tbl);
     auto state = Status::OK();
     state = context->prepare(&runtime_stat, row_desc);
-    std::cout << state.to_string() << std::endl;
     ASSERT_TRUE(state.ok());
     state = context->open(&runtime_stat);
     ASSERT_TRUE(state.ok());


### PR DESCRIPTION
## Proposed changes

common expr pushdown in
dup key table, 
unique key MoW table, 
unique key MoR table and agg key table must satisfy all expr slot is key column.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

