### PR TITLE
[fix](load) restore load job progress before retry failed load task

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BulkLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BulkLoadJob.java
@@ -231,6 +231,8 @@ public abstract class BulkLoadJob extends LoadJob implements GsonPostProcessable
                 idToTasks.remove(loadTask.getSignature());
                 if (loadTask instanceof LoadLoadingTask) {
                     loadStatistic.removeLoad(((LoadLoadingTask) loadTask).getLoadId());
+                    // restore load progress
+                    Env.getCurrentProgressManager().registerProgressSimple(String.valueOf(id));
                 }
                 loadTask.updateRetryInfo();
                 idToTasks.put(loadTask.getSignature(), loadTask);


### PR DESCRIPTION
## Proposed changes

Currently if a loadloading task fails, in retry the failed task's progress would retain with double the total file num.
Because the load job progress was initiated in BrokerLoadJob::createLoadingTask() and the total file num is added every time in Coordinator::exec(), the progress is not properly reset in retry.
For example, previously the progress looks like this after retry:
```
progress: 68.72% (68717/100000)
----------task-failed----------
progress: 34.38% (68753/200000)
```

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

