### PR TITLE
[fix](load) fix merged row number miscounting because of race condition

### DIFF
--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -133,7 +133,7 @@ private:
     std::shared_mutex _slave_node_lock;
 
     // total rows num written by DeltaWriter
-    int64_t _total_received_rows = 0;
+    std::atomic<int64_t> _total_received_rows = 0;
 
     RuntimeProfile* _profile = nullptr;
     RuntimeProfile::Counter* _close_wait_timer = nullptr;

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -155,14 +155,14 @@ public:
         return *this;
     }
 
-    int64_t raw_rows = 0;
-    int64_t merged_rows = 0;
+    std::atomic<int64_t> raw_rows = 0;
+    std::atomic<int64_t> merged_rows = 0;
     int64_t sort_ns = 0;
     int64_t agg_ns = 0;
     int64_t put_into_output_ns = 0;
     int64_t duration_ns = 0;
-    int64_t sort_times = 0;
-    int64_t agg_times = 0;
+    std::atomic<int64_t> sort_times = 0;
+    std::atomic<int64_t> agg_times = 0;
 };
 
 class MemTable {


### PR DESCRIPTION
row numbers miscounting because of race condition, will cause load to fail sometimes with warning 'the rows number written doesn't match'.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

