### PR TITLE
[regression-test][framework] support cases that can only run in non-concurrent-mode.

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
@@ -50,9 +50,11 @@ class RegressionTest {
     static GroovyShell shell
     static ExecutorService scriptExecutors
     static ExecutorService suiteExecutors
+    static ExecutorService singleSuiteExecutors
     static ExecutorService actionExecutors
     static ThreadLocal<Integer> threadLoadedClassNum = new ThreadLocal<>()
     static final int cleanLoadedClassesThreshold = 20
+    static String nonConcurrentTestGroup = "nonConcurrent"
 
     static void main(String[] args) {
         CommandLine cmd = ConfigOptions.initCommands(args)
@@ -70,6 +72,7 @@ class RegressionTest {
         }
         actionExecutors.shutdown()
         suiteExecutors.shutdown()
+        singleSuiteExecutors.shutdown()
         scriptExecutors.shutdown()
         log.info("Test finished")
         if (!success) {
@@ -95,6 +98,12 @@ class RegressionTest {
             .priority(Thread.MAX_PRIORITY)
             .build();
         suiteExecutors = Executors.newFixedThreadPool(config.suiteParallel, suiteFactory)
+
+        BasicThreadFactory singleSuiteFactory = new BasicThreadFactory.Builder()
+            .namingPattern("non-concurrent-thread-%d")
+            .priority(Thread.MAX_PRIORITY)
+            .build();
+        singleSuiteExecutors = Executors.newFixedThreadPool(1, singleSuiteFactory)
 
         BasicThreadFactory actionFactory = new BasicThreadFactory.Builder()
             .namingPattern("action-thread-%d")
@@ -131,9 +140,9 @@ class RegressionTest {
         return sources
     }
 
-    static void runScript(Config config, ScriptSource source, Recorder recorder) {
+    static void runScript(Config config, ScriptSource source, Recorder recorder, boolean isSingleThreadScript) {
         def suiteFilter = { String suiteName, String groupName ->
-            canRun(config, suiteName, groupName)
+            canRun(config, suiteName, groupName, isSingleThreadScript)
         }
         def file = source.getFile()
         int failureLimit = Integer.valueOf(config.otherConfigs.getOrDefault("max_failure_num", "-1").toString());
@@ -144,7 +153,14 @@ class RegressionTest {
             return;
         }
         def eventListeners = getEventListeners(config, recorder)
-        new ScriptContext(file, suiteExecutors, actionExecutors,
+        ExecutorService executors = null
+        if (isSingleThreadScript) {
+            executors = singleSuiteExecutors
+        } else {
+            executors = suiteExecutors
+        }
+
+        new ScriptContext(file, executors, actionExecutors,
                 config, eventListeners, suiteFilter).start { scriptContext ->
             try {
                 SuiteScript suiteScript = source.toScript(scriptContext, shell)
@@ -156,7 +172,7 @@ class RegressionTest {
         }
     }
 
-    static void runScripts(Config config, Recorder recorder,
+    static void runScripts(Config config, Recorder recorder, boolean isSingleThread,
                            Predicate<String> directoryFilter, Predicate<String> fileNameFilter) {
         def scriptSources = findScriptSources(config.suitePath, directoryFilter, fileNameFilter)
         if (config.randomOrder) {
@@ -168,7 +184,7 @@ class RegressionTest {
         scriptSources.eachWithIndex { source, i ->
 //            log.info("Prepare scripts [${i + 1}/${totalFile}]".toString())
             def future = scriptExecutors.submit {
-                runScript(config, source, recorder)
+                runScript(config, source, recorder, isSingleThread)
             }
             futures.add(future)
         }
@@ -192,8 +208,13 @@ class RegressionTest {
                     { fileName -> fileName.substring(0, fileName.lastIndexOf(".")) == "load" })
         }
         log.info('Start to run scripts')
-        runScripts(config, recorder, directoryFilter,
+        runScripts(config, recorder, false, directoryFilter, 
                 { fileName -> fileName.substring(0, fileName.lastIndexOf(".")) != "load" })
+
+        log.info('Start to run single thread scritps')
+        runScripts(config, recorder, true, directoryFilter, 
+                { fileName -> fileName.substring(0, fileName.lastIndexOf(".")) != "load" })
+
         return recorder
     }
 
@@ -228,7 +249,18 @@ class RegressionTest {
         return true
     }
 
-    static boolean canRun(Config config, String suiteName, String group) {
+    static boolean canRun(Config config, String suiteName, String group, bool isSingleThreadScript) {
+        Set<String> suiteGroups = group.split(',').collect { g -> g.trim() }.toSet();
+        if (isSingleThreadScript) {
+            if (!suiteGroups.contains(nonConcurrentTestGroup)) {
+                return false
+            }
+        } else {
+            if (suiteGroups.contains(nonConcurrentTestGroup)) {
+                return false
+            }
+        }
+
         return filterGroups(config, group) && filterSuites(config, suiteName)
     }
 

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
@@ -204,7 +204,7 @@ class RegressionTest {
         def directoryFilter = config.getDirectoryFilter()
         if (!config.withOutLoadData) {
             log.info('Start to run load scripts')
-            runScripts(config, recorder, directoryFilter,
+            runScripts(config, recorder, false, directoryFilter,
                     { fileName -> fileName.substring(0, fileName.lastIndexOf(".")) == "load" })
         }
         log.info('Start to run scripts')
@@ -249,7 +249,7 @@ class RegressionTest {
         return true
     }
 
-    static boolean canRun(Config config, String suiteName, String group, bool isSingleThreadScript) {
+    static boolean canRun(Config config, String suiteName, String group, boolean isSingleThreadScript) {
         Set<String> suiteGroups = group.split(',').collect { g -> g.trim() }.toSet();
         if (isSingleThreadScript) {
             if (!suiteGroups.contains(nonConcurrentTestGroup)) {

--- a/regression-test/pipeline/p0/conf/regression-conf.groovy
+++ b/regression-test/pipeline/p0/conf/regression-conf.groovy
@@ -55,10 +55,10 @@ testDirectories = ""
 excludeGroups = ""
 // this suites will not be executed
 
-excludeSuites = "test_sql_block_rule,test_profile,test_spark_load,test_refresh_mtmv,test_bitmap_filter,test_jdbc_query_mysql"
+excludeSuites = "test_profile,test_spark_load,test_refresh_mtmv,test_bitmap_filter,test_jdbc_query_mysql"
 
 // this directories will not be executed
-excludeDirectories = "workload_manager_p1,fault_injection_p0"
+excludeDirectories = "workload_manager_p1"
 
 customConf1 = "test_custom_conf_value"
 

--- a/regression-test/pipeline/p0/conf/regression-conf.groovy
+++ b/regression-test/pipeline/p0/conf/regression-conf.groovy
@@ -58,7 +58,7 @@ excludeGroups = ""
 excludeSuites = "test_profile,test_spark_load,test_refresh_mtmv,test_bitmap_filter,test_jdbc_query_mysql"
 
 // this directories will not be executed
-excludeDirectories = "workload_manager_p1"
+excludeDirectories = "workload_manager_p1,fault_injection_p0"
 
 customConf1 = "test_custom_conf_value"
 

--- a/regression-test/pipeline/p1/conf/regression-conf.groovy
+++ b/regression-test/pipeline/p1/conf/regression-conf.groovy
@@ -49,7 +49,7 @@ testSuites = ""
 // this suites will not be executed
 excludeSuites = "test_big_pad,test_profile,test_broker_load,test_spark_load,test_analyze_stats_p1,test_refresh_mtmv,test_bitmap_filter"
 // this dir will not be executed
-excludeDirectories = "workload_manager_p1"
+excludeDirectories = "workload_manager_p1,fault_injection_p0"
 cacheDataPath="/data/regression/"
 
 s3Endpoint = "cos.ap-hongkong.myqcloud.com"

--- a/regression-test/suites/fault_injection_p0/test_index_fault_injection.groovy
+++ b/regression-test/suites/fault_injection_p0/test_index_fault_injection.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_index_failure_injection", "p0") {
+suite("test_index_failure_injection", "p0", "nonConcurrent") {
     // define a sql table
     def testTable_dup = "httplogs_dup"
     def testTable_unique = "httplogs_unique"

--- a/regression-test/suites/fault_injection_p0/test_segcompaction_fault_injection.groovy
+++ b/regression-test/suites/fault_injection_p0/test_segcompaction_fault_injection.groovy
@@ -37,7 +37,7 @@ def create_table_sql = """
         """
 def columns = "col_0, col_1, col_2, col_3, col_4, col_5, col_6, col_7, col_8, col_9, col_10, col_11, col_12, col_13, col_14, col_15, col_16, col_17, col_18, col_19, col_20, col_21, col_22, col_23, col_24, col_25, col_26, col_27, col_28, col_29, col_30, col_31, col_32, col_33, col_34, col_35, col_36, col_37, col_38, col_39, col_40, col_41, col_42, col_43, col_44, col_45, col_46, col_47, col_48, col_49"
 
-suite("test_segcompaction_correctness") {
+suite("test_segcompaction_correctness", "nonConcurrent") {
     def runLoadWithSegcompaction = {
         String ak = getS3AK()
         String sk = getS3SK()

--- a/regression-test/suites/fault_injection_p0/test_too_many_segments_fault_injection.groovy
+++ b/regression-test/suites/fault_injection_p0/test_too_many_segments_fault_injection.groovy
@@ -37,7 +37,7 @@ def create_table_sql = """
         """
 def columns = "col_0, col_1, col_2, col_3, col_4, col_5, col_6, col_7, col_8, col_9, col_10, col_11, col_12, col_13, col_14, col_15, col_16, col_17, col_18, col_19, col_20, col_21, col_22, col_23, col_24, col_25, col_26, col_27, col_28, col_29, col_30, col_31, col_32, col_33, col_34, col_35, col_36, col_37, col_38, col_39, col_40, col_41, col_42, col_43, col_44, col_45, col_46, col_47, col_48, col_49"
 
-suite("test_too_many_segments") { // the epic -238 case
+suite("test_too_many_segments", "nonConcurrent") { // the epic -238 case
     def runLoadWithTooManySegments = {
         String ak = getS3AK()
         String sk = getS3SK()

--- a/regression-test/suites/sql_block_rule_p0/test_sql_block_rule.groovy
+++ b/regression-test/suites/sql_block_rule_p0/test_sql_block_rule.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_sql_block_rule") {
+suite("test_sql_block_rule", "nonConcurrent") {
 
     sql """
         DROP SQL_BLOCK_RULE if exists test_rule_partition


### PR DESCRIPTION
## Proposed changes
There are test cases that can be only run in non-concurrent-mode, e.g.
1. cases that will modify global variables
2. cases that will add global block rule
run these cases when other cases are finished in regression-test.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

