### PR TITLE
Fixed a bug that needed to be released if data had null keys

### DIFF
--- a/be/src/vec/exec/vaggregation_node.cpp
+++ b/be/src/vec/exec/vaggregation_node.cpp
@@ -1343,6 +1343,10 @@ void AggregationNode::_close_with_serialized_key() {
                         mapped = nullptr;
                     }
                 });
+
+                if (data.has_null_key_data()) {
+                    _destroy_agg_status(data.get_null_key_data());
+                }
             },
             _agg_data->_aggregated_method_variant);
     release_tracker();

--- a/be/src/vec/runtime/vdatetime_value.h
+++ b/be/src/vec/runtime/vdatetime_value.h
@@ -1317,8 +1317,9 @@ int64_t datetime_diff(const DateV2Value<T0>& ts_value1, const DateV2Value<T1>& t
         int month = (ts_value2.year() - ts_value1.year()) * 12 +
                     (ts_value2.month() - ts_value1.month());
         if constexpr (std::is_same_v<T0, T1>) {
-            int shift_bits = DateV2Value<T0>::is_datetime ? DATETIMEV2_YEAR_WIDTH + DATETIMEV2_MONTH_WIDTH
-                                                          : DATEV2_YEAR_WIDTH + DATETIMEV2_MONTH_WIDTH;
+            int shift_bits = DateV2Value<T0>::is_datetime
+                                     ? DATETIMEV2_YEAR_WIDTH + DATETIMEV2_MONTH_WIDTH
+                                     : DATEV2_YEAR_WIDTH + DATETIMEV2_MONTH_WIDTH;
             decltype(ts_value2.to_date_int_val()) minus_one = -1;
             if (month > 0) {
                 month -= ((ts_value2.to_date_int_val() & (minus_one >> shift_bits)) <
@@ -1332,20 +1333,24 @@ int64_t datetime_diff(const DateV2Value<T0>& ts_value1, const DateV2Value<T1>& t
             if (month > 0) {
                 month -= ((ts_value2.to_date_int_val() &
                            (uint64_minus_one >> (DATETIMEV2_YEAR_WIDTH + DATETIMEV2_MONTH_WIDTH))) <
-                          (ts1_int_value & (uint64_minus_one >> (DATETIMEV2_YEAR_WIDTH + DATETIMEV2_MONTH_WIDTH))));
+                          (ts1_int_value &
+                           (uint64_minus_one >> (DATETIMEV2_YEAR_WIDTH + DATETIMEV2_MONTH_WIDTH))));
             } else if (month < 0) {
                 month += ((ts_value2.to_date_int_val() &
                            (uint64_minus_one >> (DATETIMEV2_YEAR_WIDTH + DATETIMEV2_MONTH_WIDTH))) >
-                          (ts1_int_value & (uint64_minus_one >> (DATETIMEV2_YEAR_WIDTH + DATETIMEV2_MONTH_WIDTH))));
+                          (ts1_int_value &
+                           (uint64_minus_one >> (DATETIMEV2_YEAR_WIDTH + DATETIMEV2_MONTH_WIDTH))));
             }
         } else {
             auto ts2_int_value = ((uint64_t)ts_value2.to_date_int_val()) << TIME_PART_LENGTH;
             if (month > 0) {
-                month -= ((ts2_int_value & (uint64_minus_one >> (DATETIMEV2_YEAR_WIDTH + DATETIMEV2_MONTH_WIDTH))) <
+                month -= ((ts2_int_value &
+                           (uint64_minus_one >> (DATETIMEV2_YEAR_WIDTH + DATETIMEV2_MONTH_WIDTH))) <
                           (ts_value1.to_date_int_val() &
                            (uint64_minus_one >> (DATETIMEV2_YEAR_WIDTH + DATETIMEV2_MONTH_WIDTH))));
             } else if (month < 0) {
-                month += ((ts2_int_value & (uint64_minus_one >> (DATETIMEV2_YEAR_WIDTH + DATETIMEV2_MONTH_WIDTH))) >
+                month += ((ts2_int_value &
+                           (uint64_minus_one >> (DATETIMEV2_YEAR_WIDTH + DATETIMEV2_MONTH_WIDTH))) >
                           (ts_value1.to_date_int_val() &
                            (uint64_minus_one >> (DATETIMEV2_YEAR_WIDTH + DATETIMEV2_MONTH_WIDTH))));
             }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments
core

#0  0x000055a72acebb50 in doris::vectorized::IAggregateFunctionDataHelper<doris::vectorized::AggregateFunctionUniqExactData<long>, doris::vectorized::AggregateFunctionUniq<long, doris::vectorized::AggregateFunctionUniqExactData<long> > >::destroy(char*) const ()
#1  0x000055a72b3f26db in _ZNSt8__detail9__variant17__gen_vtable_implINS0_12_Multi_arrayIPFNS0_21__deduce_visit_resultIvEEOZN5doris10vectorized15AggregationNode26_close_with_serialized_keyEvEUlOT_E_RSt7variantIJNS6_27AggregationMethodSerializedI9PHHashMapI9StringRefPc11DefaultHashISF_vELb0EEEENS6_26AggregationMethodOneNumberIh12FixedHashMapIhSG_28FixedHashMapImplicitZeroCellIhSG_16HashTableNoStateE28FixedHashTableCalculatedSizeISP_E9AllocatorILb1ELb1EEELb0EEENSL_ItSM_ItSG_SN_ItSG_SO_E24FixedHashTableStoredSizeISW_EST_ELb0EEENSL_IjSE_IjSG_9HashCRC32IjELb0EELb0EEENSL_ImSE_ImSG_S11_ImELb0EELb0EEENS6_30AggregationMethodStringNoCacheI13StringHashMapISG_ST_EEENSL_INS6_7UInt128ESE_IS1C_SG_S11_IS1C_ELb0EELb0EEENSL_IjSE_IjSG_14HashMixWrapperIjS12_ELb0EELb0EEENSL_ImSE_ImSG_S1G_ImS15_ELb0EELb0EEENSL_IS1C_SE_IS1C_SG_S1G_IS1C_S1D_ELb0EELb0EEENS6_37AggregationMethodSingleNullableColumnINSL_IhNS6_26AggregationDataWithNullKeyISU_EELb0EEEEENS1Q_INSL_ItNS1R_ISZ_EELb0EEEEENS1Q_INSL_IjNS1R_IS13_EELb0EEEEENS1Q_INSL_ImNS1R_IS16_EELb0EEEEENS1Q_INSL_IjNS1R_IS1I_EELb0EEEEENS1Q_INSL_ImNS1R_IS1L_EELb0EEEEENS1Q_INSL_IS1C_NS1R_IS1E_EELb0EEEEENS1Q_INSL_IS1C_NS1R_IS1O_EELb0EEEEENS1Q_INS18_INS1R_IS1A_EEEEEENS6_26AggregationMethodKeysFixedIS16_Lb0EEENS2J_IS16_Lb1EEENS2J_IS1E_Lb0EEENS2J_IS1E_Lb1EEENS2J_ISE_INS6_7UInt256ESG_S11_IS2O_ELb0EELb0EEENS2J_IS2Q_Lb1EEENS2J_IS1L_Lb0EEENS2J_IS1L_Lb1EEENS2J_IS1O_Lb0EEENS2J_IS1O_Lb1EEENS2J_ISE_IS2O_SG_S1G_IS2O_S2P_ELb0EELb0EEENS2J_IS2Y_Lb1EEEEEEJEEESt16integer_sequenceImJLm13EEEE14__visit_invokeESB_S32_ ()
#2  0x000055a72b3f41b6 in doris::vectorized::AggregationNode::_close_with_serialized_key() ()
#3  0x000055a72b44957b in doris::vectorized::AggregationNode::close(doris::RuntimeState*) ()
#4  0x000055a72a1ea8f9 in doris::PlanFragmentExecutor::close() ()
#5  0x000055a72a1c92f5 in doris::FragmentExecState::execute() ()
#6  0x000055a72a1cc82e in doris::FragmentMgr::_exec_actual(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>) ()
#7  0x000055a72a1ccd62 in std::_Function_handler<void (), doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::PlanFragmentExecutor*)>)::{lambda()#1}>::_M_invoke(std::_Any_data const&) ()
#8  0x000055a72a486185 in doris::ThreadPool::dispatch_thread() ()
#9  0x000055a72a47b5df in doris::Thread::supervise_thread(void*) ()
#10 0x00007f1e77063ea5 in start_thread () from /lib64/libpthread.so.0
#11 0x00007f1e773769fd in clone () from /lib64/libc.so.6
