### PR TITLE
[fix](move-memtable) handle status when possible

### DIFF
--- a/be/src/olap/delta_writer_v2.cpp
+++ b/be/src/olap/delta_writer_v2.cpp
@@ -64,11 +64,11 @@
 namespace doris {
 using namespace ErrorCode;
 
-Status DeltaWriterV2::open(WriteRequest* req,
-                           const std::vector<std::shared_ptr<LoadStreamStub>>& streams,
-                           DeltaWriterV2** writer) {
-    *writer = new DeltaWriterV2(req, streams, StorageEngine::instance());
-    return Status::OK();
+std::unique_ptr<DeltaWriterV2> DeltaWriterV2::open(
+        WriteRequest* req, const std::vector<std::shared_ptr<LoadStreamStub>>& streams) {
+    std::unique_ptr<DeltaWriterV2> writer(
+            new DeltaWriterV2(req, streams, StorageEngine::instance()));
+    return writer;
 }
 
 DeltaWriterV2::DeltaWriterV2(WriteRequest* req,

--- a/be/src/olap/delta_writer_v2.h
+++ b/be/src/olap/delta_writer_v2.h
@@ -63,9 +63,8 @@ class Block;
 // This class is NOT thread-safe, external synchronization is required.
 class DeltaWriterV2 {
 public:
-    static Status open(WriteRequest* req,
-                       const std::vector<std::shared_ptr<LoadStreamStub>>& streams,
-                       DeltaWriterV2** writer);
+    static std::unique_ptr<DeltaWriterV2> open(
+            WriteRequest* req, const std::vector<std::shared_ptr<LoadStreamStub>>& streams);
 
     ~DeltaWriterV2();
 

--- a/be/src/olap/rowset/beta_rowset_writer_v2.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer_v2.cpp
@@ -72,7 +72,7 @@ Status BetaRowsetWriterV2::init(const RowsetWriterContext& rowset_writer_context
     _context = rowset_writer_context;
     _context.segment_collector = std::make_shared<SegmentCollectorT<BetaRowsetWriterV2>>(this);
     _context.file_writer_creator = std::make_shared<FileWriterCreatorT<BetaRowsetWriterV2>>(this);
-    static_cast<void>(_segment_creator.init(_context));
+    RETURN_IF_ERROR(_segment_creator.init(_context));
     return Status::OK();
 }
 

--- a/be/src/vec/sink/delta_writer_v2_pool.cpp
+++ b/be/src/vec/sink/delta_writer_v2_pool.cpp
@@ -29,8 +29,8 @@ DeltaWriterV2Map::DeltaWriterV2Map(UniqueId load_id) : _load_id(load_id), _use_c
 
 DeltaWriterV2Map::~DeltaWriterV2Map() = default;
 
-DeltaWriterV2* DeltaWriterV2Map::get_or_create(int64_t tablet_id,
-                                               std::function<DeltaWriterV2*()> creator) {
+DeltaWriterV2* DeltaWriterV2Map::get_or_create(
+        int64_t tablet_id, std::function<std::unique_ptr<DeltaWriterV2>()> creator) {
     _map.lazy_emplace(tablet_id, [&](const TabletToDeltaWriterV2Map::constructor& ctor) {
         ctor(tablet_id, creator());
     });

--- a/be/src/vec/sink/delta_writer_v2_pool.h
+++ b/be/src/vec/sink/delta_writer_v2_pool.h
@@ -67,7 +67,8 @@ public:
     void grab() { ++_use_cnt; }
 
     // get or create delta writer for the given tablet, memory is managed by DeltaWriterV2Map
-    DeltaWriterV2* get_or_create(int64_t tablet_id, std::function<DeltaWriterV2*()> creator);
+    DeltaWriterV2* get_or_create(int64_t tablet_id,
+                                 std::function<std::unique_ptr<DeltaWriterV2>()> creator);
 
     // close all delta writers in this DeltaWriterV2Map if there is no other users
     Status close(RuntimeProfile* profile);

--- a/be/test/vec/exec/delta_writer_v2_pool_test.cpp
+++ b/be/test/vec/exec/delta_writer_v2_pool_test.cpp
@@ -56,18 +56,9 @@ TEST_F(DeltaWriterV2PoolTest, test_map) {
     auto map = pool.get_or_create(load_id);
     EXPECT_EQ(1, pool.size());
     WriteRequest req;
-    auto writer = map->get_or_create(100, [&req]() {
-        DeltaWriterV2* writer;
-        return DeltaWriterV2::open(&req, {});
-    });
-    auto writer2 = map->get_or_create(101, [&req]() {
-        DeltaWriterV2* writer;
-        return DeltaWriterV2::open(&req, {});
-    });
-    auto writer3 = map->get_or_create(100, [&req]() {
-        DeltaWriterV2* writer;
-        return DeltaWriterV2::open(&req, {});
-    });
+    auto writer = map->get_or_create(100, [&req]() { return DeltaWriterV2::open(&req, {}); });
+    auto writer2 = map->get_or_create(101, [&req]() { return DeltaWriterV2::open(&req, {}); });
+    auto writer3 = map->get_or_create(100, [&req]() { return DeltaWriterV2::open(&req, {}); });
     EXPECT_EQ(2, map->size());
     EXPECT_EQ(writer, writer3);
     EXPECT_NE(writer, writer2);

--- a/be/test/vec/exec/delta_writer_v2_pool_test.cpp
+++ b/be/test/vec/exec/delta_writer_v2_pool_test.cpp
@@ -58,18 +58,15 @@ TEST_F(DeltaWriterV2PoolTest, test_map) {
     WriteRequest req;
     auto writer = map->get_or_create(100, [&req]() {
         DeltaWriterV2* writer;
-        static_cast<void>(DeltaWriterV2::open(&req, {}, &writer));
-        return writer;
+        return DeltaWriterV2::open(&req, {});
     });
     auto writer2 = map->get_or_create(101, [&req]() {
         DeltaWriterV2* writer;
-        static_cast<void>(DeltaWriterV2::open(&req, {}, &writer));
-        return writer;
+        return DeltaWriterV2::open(&req, {});
     });
     auto writer3 = map->get_or_create(100, [&req]() {
         DeltaWriterV2* writer;
-        static_cast<void>(DeltaWriterV2::open(&req, {}, &writer));
-        return writer;
+        return DeltaWriterV2::open(&req, {});
     });
     EXPECT_EQ(2, map->size());
     EXPECT_EQ(writer, writer3);


### PR DESCRIPTION
## Proposed changes

Some `Status` are ignored, we should handle them when possible.

`DeltaWriterV2::open()` always returns `Status::OK()`, it's meaningless to return `Status`.
Change it to return the result pointer directly.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

