### PR TITLE
[refactor](move-memtable) rename proto OpenStreamSink to OpenLoadStream

### DIFF
--- a/be/src/runtime/load_stream.cpp
+++ b/be/src/runtime/load_stream.cpp
@@ -242,7 +242,7 @@ LoadStream::~LoadStream() {
     LOG(INFO) << "load stream is deconstructed " << *this;
 }
 
-Status LoadStream::init(const POpenStreamSinkRequest* request) {
+Status LoadStream::init(const POpenLoadStreamRequest* request) {
     _txn_id = request->txn_id();
 
     _schema = std::make_shared<OlapTableSchemaParam>();

--- a/be/src/runtime/load_stream.h
+++ b/be/src/runtime/load_stream.h
@@ -106,7 +106,7 @@ public:
     LoadStream(PUniqueId load_id, LoadStreamMgr* load_stream_mgr, bool enable_profile);
     ~LoadStream();
 
-    Status init(const POpenStreamSinkRequest* request);
+    Status init(const POpenLoadStreamRequest* request);
 
     void add_source(int64_t src_id) {
         std::lock_guard lock_guard(_lock);

--- a/be/src/runtime/load_stream_mgr.cpp
+++ b/be/src/runtime/load_stream_mgr.cpp
@@ -45,7 +45,7 @@ LoadStreamMgr::~LoadStreamMgr() {
     _file_writer_thread_pool->shutdown();
 }
 
-Status LoadStreamMgr::open_load_stream(const POpenStreamSinkRequest* request,
+Status LoadStreamMgr::open_load_stream(const POpenLoadStreamRequest* request,
                                        LoadStreamSharedPtr& load_stream) {
     UniqueId load_id(request->load_id());
 

--- a/be/src/runtime/load_stream_mgr.h
+++ b/be/src/runtime/load_stream_mgr.h
@@ -39,7 +39,7 @@ public:
                   FifoThreadPool* light_work_pool);
     ~LoadStreamMgr();
 
-    Status open_load_stream(const POpenStreamSinkRequest* request,
+    Status open_load_stream(const POpenLoadStreamRequest* request,
                             LoadStreamSharedPtr& load_stream);
     void clear_load(UniqueId loadid);
     std::unique_ptr<ThreadPoolToken> new_token() {

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -355,8 +355,8 @@ void PInternalServiceImpl::exec_plan_fragment_start(google::protobuf::RpcControl
 }
 
 void PInternalServiceImpl::open_load_stream(google::protobuf::RpcController* controller,
-                                            const POpenStreamSinkRequest* request,
-                                            POpenStreamSinkResponse* response,
+                                            const POpenLoadStreamRequest* request,
+                                            POpenLoadStreamResponse* response,
                                             google::protobuf::Closure* done) {
     bool ret = _light_work_pool.try_offer([this, controller, request, response, done]() {
         signal::set_signal_task_id(request->load_id());

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -94,7 +94,7 @@ public:
                             google::protobuf::Closure* done) override;
 
     void open_load_stream(google::protobuf::RpcController* controller,
-                          const POpenStreamSinkRequest* request, POpenStreamSinkResponse* response,
+                          const POpenLoadStreamRequest* request, POpenLoadStreamResponse* response,
                           google::protobuf::Closure* done) override;
 
     void tablet_writer_add_block(google::protobuf::RpcController* controller,

--- a/be/src/vec/sink/load_stream_stub.cpp
+++ b/be/src/vec/sink/load_stream_stub.cpp
@@ -125,7 +125,7 @@ Status LoadStreamStub::open(BrpcClientCache<PBackendService_Stub>* client_cache,
         return Status::Error<true>(ret, "Failed to create stream");
     }
     cntl.set_timeout_ms(config::open_load_stream_timeout_ms);
-    POpenStreamSinkRequest request;
+    POpenLoadStreamRequest request;
     *request.mutable_load_id() = _load_id;
     request.set_src_id(_src_id);
     request.set_txn_id(txn_id);
@@ -134,7 +134,7 @@ Status LoadStreamStub::open(BrpcClientCache<PBackendService_Stub>* client_cache,
     for (auto& tablet : tablets_for_schema) {
         *request.add_tablets() = tablet;
     }
-    POpenStreamSinkResponse response;
+    POpenLoadStreamResponse response;
     // use "pooled" connection to avoid conflicts between streaming rpc and regular rpc,
     // see: https://github.com/apache/brpc/issues/392
     const auto& stub = client_cache->get_new_client_no_cache(host_port, "baidu_std", "pooled");

--- a/be/test/runtime/load_stream_test.cpp
+++ b/be/test/runtime/load_stream_test.cpp
@@ -348,8 +348,8 @@ public:
                 : _sd(brpc::INVALID_STREAM_ID), _load_stream_mgr(load_stream_mgr) {}
         virtual ~StreamService() { brpc::StreamClose(_sd); };
         virtual void open_load_stream(google::protobuf::RpcController* controller,
-                                      const POpenStreamSinkRequest* request,
-                                      POpenStreamSinkResponse* response,
+                                      const POpenLoadStreamRequest* request,
+                                      POpenLoadStreamResponse* response,
                                       google::protobuf::Closure* done) {
             brpc::ClosureGuard done_guard(done);
             std::unique_ptr<PStatus> status = std::make_unique<PStatus>();
@@ -438,8 +438,8 @@ public:
                 return Status::InternalError("Fail to create stream");
             }
 
-            POpenStreamSinkRequest request;
-            POpenStreamSinkResponse response;
+            POpenLoadStreamRequest request;
+            POpenLoadStreamResponse response;
             PUniqueId id;
             id.set_hi(1);
             id.set_lo(1);

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -742,7 +742,7 @@ message PGroupCommitInsertResponse {
     optional int64 filtered_rows = 5;
 }
 
-message POpenStreamSinkRequest {
+message POpenLoadStreamRequest {
     optional PUniqueId load_id = 1;
     optional int64 txn_id = 2;
     optional int64 src_id = 3;
@@ -757,7 +757,7 @@ message PTabletSchemaWithIndex {
     optional bool enable_unique_key_merge_on_write = 3;
 }
 
-message POpenStreamSinkResponse {
+message POpenLoadStreamResponse {
     optional PStatus status = 1;
     repeated PTabletSchemaWithIndex tablet_schemas = 2;
 }
@@ -798,7 +798,7 @@ service PBackendService {
     rpc cancel_plan_fragment(PCancelPlanFragmentRequest) returns (PCancelPlanFragmentResult);
     rpc fetch_data(PFetchDataRequest) returns (PFetchDataResult);
     rpc tablet_writer_open(PTabletWriterOpenRequest) returns (PTabletWriterOpenResult);
-    rpc open_load_stream(POpenStreamSinkRequest) returns (POpenStreamSinkResponse);
+    rpc open_load_stream(POpenLoadStreamRequest) returns (POpenLoadStreamResponse);
     rpc tablet_writer_add_block(PTabletWriterAddBlockRequest) returns (PTabletWriterAddBlockResult);
     rpc tablet_writer_add_block_by_http(PEmptyRequest) returns (PTabletWriterAddBlockResult);
     rpc tablet_writer_cancel(PTabletWriterCancelRequest) returns (PTabletWriterCancelResult);


### PR DESCRIPTION
## Proposed changes

RPC name was changed in #25883, but we forgot to change message name.
Rename proto OpenStreamSink to OpenLoadStream.

This is an incompatible change, but this feature has not been released yet.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

