### PR TITLE
[DoNotMerge](test) Test bug for glog 6.0

### DIFF
--- a/be/src/util/thrift_rpc_helper.cpp
+++ b/be/src/util/thrift_rpc_helper.cpp
@@ -32,8 +32,13 @@
 #include "runtime/exec_env.h" // IWYU pragma: keep
 #include "util/network_util.h"
 
-namespace apache {
-namespace thrift {
+#if defined(__clang__) || defined(__GNUC__)
+#define ATTRIBUTE_NO_SANITIZE_ADDRESS __attribute__((no_sanitize_address))
+#else
+#define ATTRIBUTE_NO_SANITIZE_ADDRESS
+#endif
+
+namespace apache::thrift {
 namespace protocol {
 class TProtocol;
 } // namespace protocol
@@ -42,8 +47,7 @@ class TBufferedTransport;
 class TSocket;
 class TTransport;
 } // namespace transport
-} // namespace thrift
-} // namespace apache
+} // namespace apache::thrift
 
 namespace doris {
 
@@ -60,8 +64,9 @@ void ThriftRpcHelper::setup(ExecEnv* exec_env) {
 }
 
 template <typename T>
-Status ThriftRpcHelper::rpc(const std::string& ip, const int32_t port,
-                            std::function<void(ClientConnection<T>&)> callback, int timeout_ms) {
+ATTRIBUTE_NO_SANITIZE_ADDRESS Status
+ThriftRpcHelper::rpc(const std::string& ip, const int32_t port,
+                     std::function<void(ClientConnection<T>&)> callback, int timeout_ms) {
     TNetworkAddress address = make_network_address(ip, port);
     Status status;
     ClientConnection<T> client(_s_exec_env->get_client_cache<T>(), address, timeout_ms, &status);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Database.java
@@ -322,6 +322,29 @@ public class Database extends MetaObject implements Writable, DatabaseIf<Table> 
         return Math.max(leftReplicaQuota, 0L);
     }
 
+    public long getReplicaCountWithoutLock() {
+        readLock();
+        try {
+            long usedReplicaCount = 0;
+            for (Table table : this.idToTable.values()) {
+                if (table.getType() != TableType.OLAP) {
+                    continue;
+                }
+
+                OlapTable olapTable = (OlapTable) table;
+                usedReplicaCount = usedReplicaCount + olapTable.getReplicaCount();
+            }
+            return usedReplicaCount;
+        } finally {
+            readUnlock();
+        }
+    }
+
+    public long getReplicaQuotaLeftWithoutLock() {
+        long leftReplicaQuota = replicaQuotaSize - getReplicaCountWithoutLock();
+        return Math.max(leftReplicaQuota, 0L);
+    }
+
     public void checkDataSizeQuota() throws DdlException {
         Pair<Double, String> quotaUnitPair = DebugUtil.getByteUint(dataQuotaBytes);
         String readableQuota = DebugUtil.DECIMAL_FORMAT_SCALE_3.format(quotaUnitPair.first) + " "

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -2892,7 +2892,12 @@ public class Env {
     }
 
     public void addPartition(Database db, String tableName, AddPartitionClause addPartitionClause) throws DdlException {
-        getInternalCatalog().addPartition(db, tableName, addPartitionClause);
+        getInternalCatalog().addPartition(db, tableName, addPartitionClause, false);
+    }
+
+    public void addPartitionSkipLock(Database db, OlapTable table, AddPartitionClause addPartitionClause)
+            throws DdlException {
+        getInternalCatalog().addPartition(db, table.getName(), addPartitionClause, true);
     }
 
     public void addPartitionLike(Database db, String tableName, AddPartitionLikeClause addPartitionLikeClause)


### PR DESCRIPTION
## Proposed changes

**now this PR is for testing the bug below only.**

------

last time we meet:
```
AddressSanitizer: CHECK failed: asan_thread.cpp:368 "((ptr[0] == kCurrentStackFrameMagic)) != (0)" (0x0, 0x0) (tid=9826)
    #0 0x558688a23941 in __asan::CheckUnwind() crtstuff.c
    #1 0x558688a3b412 in __sanitizer::CheckFailed(char const*, int, char const*, unsigned long long, unsigned long long) crtstuff.c
    #2 0x558688a27663 in __asan::AsanThread::GetStackFrameAccessByAddr(unsigned long, __asan::AsanThread::StackFrameAccess*) crtstuff.c
    #3 0x55868898bd87 in __asan::AddressDescription::AddressDescription(unsigned long, unsigned long, bool) crtstuff.c
    #4 0x55868898da73 in __asan::ErrorGeneric::ErrorGeneric(unsigned int, unsigned long, unsigned long, unsigned long, unsigned long, bool, unsigned long) crtstuff.c
    #5 0x558688a2150e in __asan::ReportGenericError(unsigned long, unsigned long, unsigned long, unsigned long, bool, unsigned long, unsigned int, bool) crtstuff.c
    #6 0x5586889a1405 in localtime_r (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be+0x12672405) (BuildId: 389de21a976dd7ca)
    #7 0x5586b4ce3eea in google::LogMessageTime::LogMessageTime(long, double) gflags_completions.cc
    #8 0x5586b4cdf05c in google::LogMessage::Init(char const*, int, int, void (google::LogMessage::*)()) gflags_completions.cc
    #9 0x55868b5fbf46 in doris::Status doris::ThriftRpcHelper::rpc<doris::FrontendServiceClient>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, std::function<void (doris::ClientConnection<doris::FrontendServiceClient>&)>, int) /root/doris/be/src/util/thrift_rpc_helper.cpp:76:13
    #10 0x5586b301cc28 in doris::vectorized::VTabletWriter::_automatic_create_partition() /root/doris/be/src/vec/sink/writer/vtablet_writer.cpp:1262:5
```

but in the logfile, it could be confirmed that there has not been any request about creating partitions sent to FE. The `TTransportException` could be confirmed as caused by a network error or something. it was expected to do again. but because we run it in ASAN. when we try to record it in logfile, the glog violates the expectation of asan. so BE crashed. we have to find another way to avoid it.

FYI: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101476

now republish this pr again. will run it many times before it is merged.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

