### PR TITLE
[Fix](partial update) Fix partial update info loss when the delete bitmaps of the committed transactions are calculated by the compaction

### DIFF
--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -675,11 +675,14 @@ void TxnManager::get_all_commit_tablet_txn_info_by_tablet(
                 const RowsetSharedPtr& rowset = tablet_load_it->second.rowset;
                 const DeleteBitmapPtr& delete_bitmap = tablet_load_it->second.delete_bitmap;
                 const RowsetIdUnorderedSet& rowset_ids = tablet_load_it->second.rowset_ids;
+                const std::shared_ptr<PartialUpdateInfo> partial_update_info =
+                        tablet_load_it->second.partial_update_info;
                 if (!rowset || !delete_bitmap) {
                     continue;
                 }
-                commit_tablet_txn_info_vec->push_back(CommitTabletTxnInfo(
-                        partition_id, transaction_id, delete_bitmap, rowset_ids));
+                commit_tablet_txn_info_vec->push_back(
+                        CommitTabletTxnInfo(partition_id, transaction_id, delete_bitmap, rowset_ids,
+                                            partial_update_info));
             }
         }
     }

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -101,15 +101,18 @@ struct TabletTxnInfo {
 
 struct CommitTabletTxnInfo {
     CommitTabletTxnInfo(TPartitionId partition_id, TTransactionId transaction_id,
-                        DeleteBitmapPtr delete_bitmap, RowsetIdUnorderedSet rowset_ids)
+                        DeleteBitmapPtr delete_bitmap, RowsetIdUnorderedSet rowset_ids,
+                        std::shared_ptr<PartialUpdateInfo> partial_update_info)
             : transaction_id(transaction_id),
               partition_id(partition_id),
               delete_bitmap(delete_bitmap),
-              rowset_ids(rowset_ids) {}
+              rowset_ids(rowset_ids),
+              partial_update_info(partial_update_info) {}
     TTransactionId transaction_id;
     TPartitionId partition_id;
     DeleteBitmapPtr delete_bitmap;
     RowsetIdUnorderedSet rowset_ids;
+    std::shared_ptr<PartialUpdateInfo> partial_update_info;
 };
 
 using CommitTabletTxnInfoVec = std::vector<CommitTabletTxnInfo>;


### PR DESCRIPTION
## Proposed changes
a fix for https://github.com/apache/doris/pull/25147

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

