### PR TITLE
[fix](BE)Branch-2.0 unknown runtime filter when get filter from _consumer_map

### DIFF
--- a/be/src/runtime/runtime_filter_mgr.cpp
+++ b/be/src/runtime/runtime_filter_mgr.cpp
@@ -124,9 +124,7 @@ Status RuntimeFilterMgr::register_consumer_filter(const TRuntimeFilterDesc& desc
         desc.type == TRuntimeFilterType::BLOOM) {
         // if this runtime filter has remote target (e.g. need merge), we reuse the runtime filter between all instances
         DCHECK(_query_ctx != nullptr);
-
         {
-
             iter = _consumer_map.find(key);
             if (iter != _consumer_map.end()) {
                 for (auto holder : iter->second) {

--- a/be/src/runtime/runtime_filter_mgr.cpp
+++ b/be/src/runtime/runtime_filter_mgr.cpp
@@ -64,6 +64,7 @@ Status RuntimeFilterMgr::init() {
 
 Status RuntimeFilterMgr::get_producer_filter(const int filter_id, IRuntimeFilter** target) {
     int32_t key = filter_id;
+    std::lock_guard<std::mutex> l(_lock);
 
     auto iter = _producer_map.find(key);
     if (iter == _producer_map.end()) {
@@ -77,6 +78,7 @@ Status RuntimeFilterMgr::get_producer_filter(const int filter_id, IRuntimeFilter
 
 Status RuntimeFilterMgr::get_consume_filter(const int filter_id, const int node_id,
                                             IRuntimeFilter** consumer_filter) {
+    std::lock_guard<std::mutex> l(_lock);
     auto iter = _consumer_map.find(filter_id);
     if (iter == _consumer_map.cend()) {
         LOG(WARNING) << "unknown runtime filter: " << filter_id << ", role: consumer";
@@ -97,6 +99,8 @@ Status RuntimeFilterMgr::get_consume_filter(const int filter_id, const int node_
 Status RuntimeFilterMgr::get_consume_filters(const int filter_id,
                                              std::vector<IRuntimeFilter*>& consumer_filters) {
     int32_t key = filter_id;
+    std::lock_guard<std::mutex> l(_lock);
+
     auto iter = _consumer_map.find(key);
     if (iter == _consumer_map.end()) {
         LOG(WARNING) << "unknown runtime filter: " << key << ", role: consumer";
@@ -113,6 +117,7 @@ Status RuntimeFilterMgr::register_consumer_filter(const TRuntimeFilterDesc& desc
                                                   bool build_bf_exactly) {
     SCOPED_CONSUME_MEM_TRACKER(_tracker.get());
     int32_t key = desc.filter_id;
+    std::lock_guard<std::mutex> l(_lock);
 
     auto iter = _consumer_map.find(key);
     if (desc.__isset.opt_remote_rf && desc.opt_remote_rf && desc.has_remote_targets &&
@@ -121,7 +126,6 @@ Status RuntimeFilterMgr::register_consumer_filter(const TRuntimeFilterDesc& desc
         DCHECK(_query_ctx != nullptr);
 
         {
-            std::lock_guard<std::mutex> l(_lock);
 
             iter = _consumer_map.find(key);
             if (iter != _consumer_map.end()) {
@@ -162,6 +166,8 @@ Status RuntimeFilterMgr::register_producer_filter(const TRuntimeFilterDesc& desc
                                                   bool build_bf_exactly) {
     SCOPED_CONSUME_MEM_TRACKER(_tracker.get());
     int32_t key = desc.filter_id;
+    std::lock_guard<std::mutex> l(_lock);
+
     auto iter = _producer_map.find(key);
 
     DCHECK(_state != nullptr);


### PR DESCRIPTION
## Proposed changes

W1107 19:39:14.676594 1687242 runtime_filter_mgr.cpp:82] unknown runtime filter: 1, role: consumer
W1107 19:39:14.726465 1687242 status.h:390] meet error status: [INVALID_ARGUMENT]unknown filter

        0#  doris::RuntimeFilterMgr::get_consume_filter(int, int, doris::IRuntimeFilter**) at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/runtime/runtime_filter_mgr.cpp:95
        1#  doris::vectorized::RuntimeFilterConsumer::_register_runtime_filter() at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/vec/exec/runtime_filter_consumer.cpp:0
        2#  doris::vectorized::RuntimeFilterConsumer::init(doris::RuntimeState*) at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/common/status.h:439
        3#  doris::vectorized::VScanNode::init(doris::TPlanNode const&, doris::RuntimeState*) at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/common/status.h:439
        4#  doris::ExecNode::create_tree_helper(doris::RuntimeState*, doris::ObjectPool*, std::vector<doris::TPlanNode, std::allocator<doris::TPlanNode> > const&, doris::DescriptorTbl const&, doris::ExecNode*, int*, doris::ExecNode**) at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/common/status.h:439
        5#  doris::ExecNode::create_tree_helper(doris::RuntimeState*, doris::ObjectPool*, std::vector<doris::TPlanNode, std::allocator<doris::TPlanNode> > const&, doris::DescriptorTbl const&, doris::ExecNode*, int*, doris::ExecNode**) at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/exec/exec_node.cpp:281
        6#  doris::ExecNode::create_tree(doris::RuntimeState*, doris::ObjectPool*, doris::TPlan const&, doris::DescriptorTbl const&, doris::ExecNode**) at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/exec/exec_node.cpp:246
        7#  doris::pipeline::PipelineFragmentContext::prepare(doris::TPipelineFragmentParams const&, unsigned long) at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/common/status.h:439
        8#  doris::FragmentMgr::exec_plan_fragment(doris::TPipelineFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_0::operator()(int) const at /home/zcp/repo_
:
Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

