### PR TITLE
[bug](user login)fix PASSWORD_LOCK_TIME setting UNBOUNDED does not take effect

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/PasswordPolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/PasswordPolicy.java
@@ -410,7 +410,7 @@ public class PasswordPolicy implements Writable {
             }
             if (lockTime.get() > 0 && passwordLockSeconds == UNBOUNDED) {
                 // unbounded lock
-                return 0;
+                return 9999;
             }
             return Math.max(0, passwordLockSeconds - ((System.currentTimeMillis() - lockTime.get()) / 1000));
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/PasswordPolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/PasswordPolicy.java
@@ -410,6 +410,7 @@ public class PasswordPolicy implements Writable {
             }
             if (lockTime.get() > 0 && passwordLockSeconds == UNBOUNDED) {
                 // unbounded lock
+                // Returns 9999 seconds every time instead of 9999 seconds countdown
                 return 9999;
             }
             return Math.max(0, passwordLockSeconds - ((System.currentTimeMillis() - lockTime.get()) / 1000));


### PR DESCRIPTION
fix https://github.com/apache/doris/issues/26559
```shell
[lemon@centos ~]$ mysql -h127.0.0.1 -P9938 -ujack -p12345
mysql: [Warning] Using a password on the command line interface can be insecure.
ERROR 1045 (28000): Access denied for user 'default_cluster:jack@127.0.0.1' (using password: YES)
[lemon@centos ~]$ mysql -h127.0.0.1 -P9938 -ujack -p12345
mysql: [Warning] Using a password on the command line interface can be insecure.
ERROR 1045 (28000): Access denied for user 'default_cluster:jack@127.0.0.1' (using password: YES)
[lemon@centos ~]$ mysql -h127.0.0.1 -P9938 -ujack -p12345
mysql: [Warning] Using a password on the command line interface can be insecure.
ERROR 1045 (28000): Access denied for user 'default_cluster:jack@127.0.0.1' (using password: YES)
[lemon@centos ~]$ mysql -h127.0.0.1 -P9938 -ujack -p123456
mysql: [Warning] Using a password on the command line interface can be insecure.
ERROR 3955 (HY000): Access denied for user 'default_cluster:jack'@'%'. Account is blocked for -1 second(s) (9999 second(s) remaining) due to 3 consecutive failed logins.

```

