### PR TITLE
[improvement](group commit) Group commit insert into can be executed on observer fe

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1109,6 +1109,10 @@ public class StmtExecutor {
 
             analyzeVariablesInStmt();
         }
+        if (context.getSessionVariable().enableInsertGroupCommit && parsedStmt instanceof NativeInsertStmt) {
+            NativeInsertStmt nativeInsertStmt = (NativeInsertStmt) parsedStmt;
+            nativeInsertStmt.analyzeGroupCommit(new Analyzer(context.getEnv(), context));
+        }
         redirectStatus = parsedStmt.getRedirectStatus();
     }
 


### PR DESCRIPTION
## Proposed changes

The group commit insert can be executed on both follower and observer fe because:
1.  it does not write edit log such as begin transaction
2. the table schema version is compared on BE and if version does not match, there is retry on FE.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

