### PR TITLE
[chore](regression) Do stale resource reclaim before executing cold heat separation p2 case

### DIFF
--- a/regression-test/suites/cold_heat_separation_p2/load.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/load.groovy
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import groovy.json.JsonSlurper
+import org.codehaus.groovy.runtime.IOGroovyMethods
+
+suite("cold_heat_separation", "p2") {
+    try_sql """
+        drop database regression_test_cold_heat_separation_p2 force;
+    """
+
+    try_sql """
+        create database regression_test_cold_heat_separation_p2;
+    """
+
+    def polices = sql """
+        show storage policy;
+    """
+
+    for (policy in polices) {
+        if (policy[3].equals("STORAGE")) {
+            try_sql """
+                drop storage policy if exists ${policy[0]}
+            """
+        }
+    }
+
+    def resources = sql """
+        show resources;
+    """
+
+    for (resource in resources) {
+        if (resource[1].equals("s3")) {
+            try_sql """
+                drop resource if exists ${resource[0]}
+            """
+        }
+    }
+}

--- a/regression-test/suites/cold_heat_separation_p2/table_modify_resouce_and_policy.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/table_modify_resouce_and_policy.groovy
@@ -234,7 +234,7 @@ suite("table_modify_resouce") {
     log.info( "test all remote size not zero")
     for (int i = 0; i < tablets2.size(); i++) {
         fetchDataSize(sizes, tablets2[i])
-        assertEquals(sizes[1], tablets[i][9])
+        assertTrue(sizes[1] > 0)
     }
 
 
@@ -317,7 +317,7 @@ suite("table_modify_resouce") {
     log.info( "test all remote size not zero")
     for (int i = 0; i < tablets2.size(); i++) {
         fetchDataSize(sizes, tablets2[i])
-        assertEquals(sizes[1], tablets[i][9])
+        assertTrue(sizes[1] > 0)
     }
 
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

The former code tried to drop the used resource and policy and tables in the test code, however it's not robust and other case's failure might effect the drop logic. So this pr turn out to add one `load.groovy` file which would be executed before the actual test logic to do all the sweep up logic.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

