### PR TITLE
[fix](be)fix merged_columns and num_columns lnconsistency problem

### DIFF
--- a/be/src/vec/runtime/vsorted_run_merger.cpp
+++ b/be/src/vec/runtime/vsorted_run_merger.cpp
@@ -106,6 +106,10 @@ Status VSortedRunMerger::get_next(Block* output_block, bool* eos) {
         MutableColumns merged_columns =
                 mem_reuse ? output_block->mutate_columns() : _empty_block.clone_empty_columns();
 
+        if (merged_columns.size() != num_columns) {
+            return Status::Error(ErrorCode::INTERNAL_ERROR);
+        }
+
         /// Take rows from queue in right order and push to 'merged'.
         size_t merged_rows = 0;
         while (!_priority_queue.empty()) {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

<img width="384" alt="image" src="https://github.com/apache/doris/assets/131352377/eebf3b82-8978-442e-9622-9a0d68b316a4">

Because the size of merged_columns and num_columns is not determined, the next execution will cause the be core to drop

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

