### PR TITLE
[chore](key_util) remove useless null_first parameter

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -1185,7 +1185,7 @@ Status SegmentIterator::_lookup_ordinal_from_pk_index(const RowCursor& key, bool
     std::string index_key;
     // when is_include is false, we shoudle append KEY_NORMAL_MARKER to the
     // encode key. Otherwise, we will get an incorrect upper bound.
-    encode_key_with_padding<RowCursor, true, true>(
+    encode_key_with_padding<RowCursor, true>(
             &index_key, key, _segment->_tablet_schema->num_key_columns(), is_include, true);
     if (index_key < _segment->min_key()) {
         *rowid = 0;

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -768,8 +768,7 @@ int64_t SegmentWriter::max_row_to_add(size_t row_avg_size_in_bytes) {
 }
 
 std::string SegmentWriter::_full_encode_keys(
-        const std::vector<vectorized::IOlapColumnDataAccessor*>& key_columns, size_t pos,
-        bool null_first) {
+        const std::vector<vectorized::IOlapColumnDataAccessor*>& key_columns, size_t pos) {
     assert(_key_index_size.size() == _num_key_columns);
     assert(key_columns.size() == _num_key_columns && _key_coders.size() == _num_key_columns);
 
@@ -778,11 +777,7 @@ std::string SegmentWriter::_full_encode_keys(
     for (const auto& column : key_columns) {
         auto field = column->get_data_at(pos);
         if (UNLIKELY(!field)) {
-            if (null_first) {
-                encoded_keys.push_back(KEY_NULL_FIRST_MARKER);
-            } else {
-                encoded_keys.push_back(KEY_NULL_LAST_MARKER);
-            }
+            encoded_keys.push_back(KEY_NULL_FIRST_MARKER);
             ++cid;
             continue;
         }
@@ -810,8 +805,7 @@ void SegmentWriter::_encode_seq_column(const vectorized::IOlapColumnDataAccessor
 }
 
 std::string SegmentWriter::_encode_keys(
-        const std::vector<vectorized::IOlapColumnDataAccessor*>& key_columns, size_t pos,
-        bool null_first) {
+        const std::vector<vectorized::IOlapColumnDataAccessor*>& key_columns, size_t pos) {
     assert(key_columns.size() == _num_short_key_columns);
 
     std::string encoded_keys;
@@ -819,11 +813,7 @@ std::string SegmentWriter::_encode_keys(
     for (const auto& column : key_columns) {
         auto field = column->get_data_at(pos);
         if (UNLIKELY(!field)) {
-            if (null_first) {
-                encoded_keys.push_back(KEY_NULL_FIRST_MARKER);
-            } else {
-                encoded_keys.push_back(KEY_NULL_LAST_MARKER);
-            }
+            encoded_keys.push_back(KEY_NULL_FIRST_MARKER);
             ++cid;
             continue;
         }
@@ -841,7 +831,7 @@ Status SegmentWriter::append_row(const RowType& row) {
         RETURN_IF_ERROR(_column_writers[cid]->append(cell));
     }
     std::string full_encoded_key;
-    encode_key<RowType, true, true>(&full_encoded_key, row, _num_key_columns);
+    encode_key<RowType, true>(&full_encoded_key, row, _num_key_columns);
     if (_tablet_schema->has_sequence_col()) {
         full_encoded_key.push_back(KEY_NORMAL_MARKER);
         auto cid = _tablet_schema->sequence_col_idx();

--- a/be/src/olap/rowset/segment_v2/segment_writer.h
+++ b/be/src/olap/rowset/segment_v2/segment_writer.h
@@ -146,11 +146,10 @@ private:
     Status _write_raw_data(const std::vector<Slice>& slices);
     void _maybe_invalid_row_cache(const std::string& key);
     std::string _encode_keys(const std::vector<vectorized::IOlapColumnDataAccessor*>& key_columns,
-                             size_t pos, bool null_first = true);
+                             size_t pos);
     // used for unique-key with merge on write and segment min_max key
     std::string _full_encode_keys(
-            const std::vector<vectorized::IOlapColumnDataAccessor*>& key_columns, size_t pos,
-            bool null_first = true);
+            const std::vector<vectorized::IOlapColumnDataAccessor*>& key_columns, size_t pos);
     // used for unique-key with merge on write
     void _encode_seq_column(const vectorized::IOlapColumnDataAccessor* seq_column, size_t pos,
                             string* encoded_keys);

--- a/be/src/service/point_query_executor.cpp
+++ b/be/src/service/point_query_executor.cpp
@@ -254,9 +254,8 @@ Status PointQueryExecutor::_init_keys(const PTabletKeyLookupRequest* request) {
         RowCursor cursor;
         RETURN_IF_ERROR(cursor.init_scan_key(_tablet->tablet_schema(), olap_tuples[i].values()));
         RETURN_IF_ERROR(cursor.from_tuple(olap_tuples[i]));
-        encode_key_with_padding<RowCursor, true, true>(&_row_read_ctxs[i]._primary_key, cursor,
-                                                       _tablet->tablet_schema()->num_key_columns(),
-                                                       true);
+        encode_key_with_padding<RowCursor, true>(&_row_read_ctxs[i]._primary_key, cursor,
+                                                 _tablet->tablet_schema()->num_key_columns(), true);
     }
     return Status::OK();
 }

--- a/be/src/util/key_util.h
+++ b/be/src/util/key_util.h
@@ -48,8 +48,6 @@ constexpr uint8_t KEY_MINIMAL_MARKER = 0x00;
 constexpr uint8_t KEY_NULL_FIRST_MARKER = 0x01;
 // Used to represent a normal field, which content is encoded after this marker
 constexpr uint8_t KEY_NORMAL_MARKER = 0x02;
-// Used to represent
-constexpr uint8_t KEY_NULL_LAST_MARKER = 0xFE;
 // Used to represent maximal value for that field
 constexpr uint8_t KEY_MAXIMAL_MARKER = 0xFF;
 
@@ -61,7 +59,7 @@ constexpr uint8_t KEY_MAXIMAL_MARKER = 0xFF;
 // If all num_keys are found in row, no marker will be added.
 // if padding_minimal is false and padding_normal_marker is true,
 // KEY_NORMAL_MARKER will be added.
-template <typename RowType, bool null_first = true, bool full_encode = false>
+template <typename RowType, bool full_encode = false>
 void encode_key_with_padding(std::string* buf, const RowType& row, size_t num_keys,
                              bool padding_minimal, bool padding_normal_marker = false) {
     for (auto cid = 0; cid < num_keys; cid++) {
@@ -80,11 +78,7 @@ void encode_key_with_padding(std::string* buf, const RowType& row, size_t num_ke
 
         auto cell = row.cell(cid);
         if (cell.is_null()) {
-            if (null_first) {
-                buf->push_back(KEY_NULL_FIRST_MARKER);
-            } else {
-                buf->push_back(KEY_NULL_LAST_MARKER);
-            }
+            buf->push_back(KEY_NULL_FIRST_MARKER);
             continue;
         }
         buf->push_back(KEY_NORMAL_MARKER);
@@ -99,16 +93,12 @@ void encode_key_with_padding(std::string* buf, const RowType& row, size_t num_ke
 // Encode one row into binary according given num_keys.
 // Client call this function must assure that row contains the first
 // num_keys columns.
-template <typename RowType, bool null_first = true, bool full_encode = false>
+template <typename RowType, bool full_encode = false>
 void encode_key(std::string* buf, const RowType& row, size_t num_keys) {
     for (auto cid = 0; cid < num_keys; cid++) {
         auto cell = row.cell(cid);
         if (cell.is_null()) {
-            if (null_first) {
-                buf->push_back(KEY_NULL_FIRST_MARKER);
-            } else {
-                buf->push_back(KEY_NULL_LAST_MARKER);
-            }
+            buf->push_back(KEY_NULL_FIRST_MARKER);
             continue;
         }
         buf->push_back(KEY_NORMAL_MARKER);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Doris always put null in the first when sorting key, the parameter `null_first` of `encode_keys` is useless.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

