### PR TITLE
[improve](nereids) support agg function of count(const value) pushdown

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/CountLiteralToCountStar.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/CountLiteralToCountStar.java
@@ -57,7 +57,7 @@ public class CountLiteralToCountStar extends OneRewriteRuleFactory {
                     .filter(this::isCountLiteral)
                     .forEach(c -> replaced.put(c, new Count()));
             expr = expr.rewriteUp(s -> replaced.getOrDefault(s, s));
-            changed = !replaced.isEmpty();
+            changed |= !replaced.isEmpty();
             newExprs.add((NamedExpression) expr);
         }
         return changed;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
support sql: select count(1)-count(not null) from table, the agg of count could push down.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

