### PR TITLE
[fix](planner)isnull predicate can't be safely constant folded in inlineview

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/IsNullPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/IsNullPredicate.java
@@ -156,9 +156,9 @@ public class IsNullPredicate extends Predicate {
      */
     @Override
     public Expr getResultValue(boolean inView) throws AnalysisException {
-        recursiveResetChildrenResult(inView);
+        recursiveResetChildrenResult(!inView);
         final Expr childValue = getChild(0);
-        if (!(childValue instanceof LiteralExpr)) {
+        if (inView || !(childValue instanceof LiteralExpr)) {
             return this;
         }
         return childValue instanceof NullLiteral ? new BoolLiteral(!isNotNull) : new BoolLiteral(isNotNull);

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/FoldConstantsRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/FoldConstantsRule.java
@@ -29,6 +29,7 @@ import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.InformationFunction;
 import org.apache.doris.analysis.LiteralExpr;
 import org.apache.doris.analysis.NullLiteral;
+import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.analysis.VariableExpr;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.PrimitiveType;
@@ -124,7 +125,10 @@ public class FoldConstantsRule implements ExprRewriteRule {
                 return expr;
             }
         }
-        return expr.getResultValue(false);
+        // it may be wrong to fold constant value in inline view
+        // so pass the info to getResultValue method to let predicate itself
+        // to decide if it can fold constant value safely
+        return expr.getResultValue(expr instanceof SlotRef ? false : analyzer.isInlineViewAnalyzer());
     }
 
     /**

--- a/regression-test/suites/query_p0/literal_view/lietral_test.groovy
+++ b/regression-test/suites/query_p0/literal_view/lietral_test.groovy
@@ -131,4 +131,10 @@ suite("literal_view_test") {
         sql "select * from (select null as top) t where top = 5"
         result ([])
     }
+
+    sql """set enable_nereids_planner=false;"""
+    explain {
+        sql """ select c.* from ( select a.*, '' x from test_insert a left join test_insert b on true ) c where c.x is null; """
+        notContains("VEMPTYSET")
+    }
 }


### PR DESCRIPTION
pick from master https://github.com/apache/doris/pull/25377

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

