### PR TITLE
[fix](Nereids) only search internal funcftion when dbName is empty (#26296)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
@@ -33,6 +33,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 import java.util.Map;
@@ -86,24 +87,31 @@ public class FunctionRegistry {
 
     // currently we only find function by name and arity and args' types.
     public FunctionBuilder findFunctionBuilder(String dbName, String name, List<?> arguments) {
+        List<FunctionBuilder> functionBuilders = null;
         int arity = arguments.size();
-        List<FunctionBuilder> functionBuilders = name2InternalBuiltinBuilders.get(name.toLowerCase());
-        if (CollectionUtils.isEmpty(functionBuilders) && AggStateFunctionBuilder.isAggStateCombinator(name)) {
-            String nestedName = AggStateFunctionBuilder.getNestedName(name);
-            String combinatorSuffix = AggStateFunctionBuilder.getCombinatorSuffix(name);
+        String qualifiedName = StringUtils.isEmpty(dbName) ? name : dbName + "." + name;
 
-            functionBuilders = name2InternalBuiltinBuilders.get(nestedName.toLowerCase());
-
-            if (functionBuilders != null) {
-                functionBuilders = functionBuilders.stream().map(builder -> {
-                    return new AggStateFunctionBuilder(combinatorSuffix, builder);
-                }).filter(functionBuilder -> functionBuilder.canApply(arguments)).collect(Collectors.toList());
+        if (StringUtils.isEmpty(dbName)) {
+            // search internal function only if dbName is empty
+            functionBuilders = name2InternalBuiltinBuilders.get(name.toLowerCase());
+            if (CollectionUtils.isEmpty(functionBuilders) && AggStateFunctionBuilder.isAggStateCombinator(name)) {
+                String nestedName = AggStateFunctionBuilder.getNestedName(name);
+                String combinatorSuffix = AggStateFunctionBuilder.getCombinatorSuffix(name);
+                functionBuilders = name2InternalBuiltinBuilders.get(nestedName.toLowerCase());
+                if (functionBuilders != null) {
+                    functionBuilders = functionBuilders.stream()
+                            .map(builder -> new AggStateFunctionBuilder(combinatorSuffix, builder))
+                            .filter(functionBuilder -> functionBuilder.canApply(arguments))
+                            .collect(Collectors.toList());
+                }
             }
         }
-        if (functionBuilders == null || functionBuilders.isEmpty()) {
+
+        // search udf
+        if (CollectionUtils.isEmpty(functionBuilders)) {
             functionBuilders = findUdfBuilder(dbName, name);
             if (functionBuilders == null || functionBuilders.isEmpty()) {
-                throw new AnalysisException("Can not found function '" + name + "'");
+                throw new AnalysisException("Can not found function '" + qualifiedName + "'");
             }
         }
 
@@ -113,15 +121,15 @@ public class FunctionRegistry {
                 .collect(Collectors.toList());
         if (candidateBuilders.isEmpty()) {
             String candidateHints = getCandidateHint(name, functionBuilders);
-            throw new AnalysisException("Can not found function '" + name
+            throw new AnalysisException("Can not found function '" + qualifiedName
                     + "' which has " + arity + " arity. Candidate functions are: " + candidateHints);
         }
-
         if (candidateBuilders.size() > 1) {
             String candidateHints = getCandidateHint(name, candidateBuilders);
             // NereidsPlanner not supported override function by the same arity, should we support it?
-            throw new AnalysisException("Function '" + name + "' is ambiguous: " + candidateHints);
+            throw new AnalysisException("Function '" + qualifiedName + "' is ambiguous: " + candidateHints);
         }
+
         return candidateBuilders.get(0);
     }
 

--- a/regression-test/suites/nereids_syntax_p0/function.groovy
+++ b/regression-test/suites/nereids_syntax_p0/function.groovy
@@ -242,5 +242,10 @@ suite("nereids_function") {
     qt_regexp_extract_all """
         SELECT regexp_extract_all('AbCdE', '([[:lower:]]+)C([[:lower:]]+)')
     """
+
+    test {
+        sql "select `hello`.now(3)"
+        exception "Can not found function"
+    }
 }
 


### PR DESCRIPTION
pick from master
PR: #26296
commit id: 6892fc99f89e7deee0817d51183b2c918c3627b1

if call function with database name. we should only search UDF

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

