### PR TITLE
[Bug](decimalv2)  getCmpType return decimalv2 when lhs/rhs type both is decimalv2 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
@@ -453,7 +453,8 @@ public class BinaryPredicate extends Predicate implements Writable {
         }
 
         if (t1 == PrimitiveType.DECIMALV2 && t2 == PrimitiveType.DECIMALV2) {
-            return getChild(0).getType().getResultType();
+            return ScalarType.getAssignmentCompatibleDecimalV2Type((ScalarType) getChild(0).getType(),
+                    (ScalarType) getChild(1).getType());
         }
 
         if ((t1 == PrimitiveType.BIGINT && t2 == PrimitiveType.DECIMALV2)

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
@@ -451,6 +451,11 @@ public class BinaryPredicate extends Predicate implements Writable {
             return Type.getAssignmentCompatibleType(getChild(0).getType(), getChild(1).getType(), false,
                     SessionVariable.getEnableDecimal256());
         }
+
+        if (t1 == PrimitiveType.DECIMALV2 && t2 == PrimitiveType.DECIMALV2) {
+            return getChild(0).getType().getResultType();
+        }
+
         if ((t1 == PrimitiveType.BIGINT && t2 == PrimitiveType.DECIMALV2)
                 || (t2 == PrimitiveType.BIGINT && t1 == PrimitiveType.DECIMALV2)
                 || (t1 == PrimitiveType.LARGEINT && t2 == PrimitiveType.DECIMALV2)

--- a/regression-test/suites/delete_p0/test_delete.groovy
+++ b/regression-test/suites/delete_p0/test_delete.groovy
@@ -280,4 +280,23 @@ PROPERTIES
     """
 
     sql "delete from dwd_pay partitions(p202310) where pay_time = '20231002';"
+
+    sql """
+    ADMIN SET FRONTEND CONFIG ('disable_decimalv2' = 'false');
+    """
+
+    sql """
+    CREATE TABLE `test`  
+    (
+            col_1 int,
+            col_2 decimalv2(10,3)
+    )ENGINE=OLAP
+    duplicate KEY(`col_1`)
+    COMMENT 'OLAP'
+    DISTRIBUTED BY HASH(`col_1`) BUCKETS 1
+    PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+    sql "DELETE FROM test  WHERE col_2 = cast(123.45 as decimalv2(10,3));"
 }

--- a/regression-test/suites/delete_p0/test_delete.groovy
+++ b/regression-test/suites/delete_p0/test_delete.groovy
@@ -285,6 +285,7 @@ PROPERTIES
     ADMIN SET FRONTEND CONFIG ('disable_decimalv2' = 'false');
     """
 
+    sql "drop table if exists test"
     sql """
     CREATE TABLE `test`  
     (


### PR DESCRIPTION
## Proposed changes

getCmpType return decimalv2 when lhs/rhs type both is decimalv2 

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

