### PR TITLE
[test](Nereids) add subquery pull up rule group ut

### DIFF
--- a/regression-test/conf/regression-conf.groovy
+++ b/regression-test/conf/regression-conf.groovy
@@ -86,7 +86,7 @@ excludeGroups = ""
 // this suites will not be executed
 excludeSuites = "test_broker_load"
 // this directories will not be executed
-excludeDirectories = "segcompaction_p2,workload_manager_p1,subquery"
+excludeDirectories = "segcompaction_p2,workload_manager_p1"
 
 customConf1 = "test_custom_conf_value"
 

--- a/regression-test/conf/regression-conf.groovy
+++ b/regression-test/conf/regression-conf.groovy
@@ -86,7 +86,7 @@ excludeGroups = ""
 // this suites will not be executed
 excludeSuites = "test_broker_load"
 // this directories will not be executed
-excludeDirectories = "segcompaction_p2,workload_manager_p1"
+excludeDirectories = "segcompaction_p2,workload_manager_p1,subquery"
 
 customConf1 = "test_custom_conf_value"
 

--- a/regression-test/pipeline/p0/conf/regression-conf.groovy
+++ b/regression-test/pipeline/p0/conf/regression-conf.groovy
@@ -58,7 +58,7 @@ excludeGroups = ""
 excludeSuites = "test_profile,test_spark_load,test_refresh_mtmv,test_bitmap_filter,test_information_schema_external"
 
 // this directories will not be executed
-excludeDirectories = "workload_manager_p1,fault_injection_p0"
+excludeDirectories = "workload_manager_p1,fault_injection_p0,nereids_rule_p0/subquery"
 
 customConf1 = "test_custom_conf_value"
 

--- a/regression-test/pipeline/p0/conf/regression-conf.groovy
+++ b/regression-test/pipeline/p0/conf/regression-conf.groovy
@@ -58,7 +58,7 @@ excludeGroups = ""
 excludeSuites = "test_profile,test_spark_load,test_refresh_mtmv,test_bitmap_filter,test_information_schema_external"
 
 // this directories will not be executed
-excludeDirectories = "workload_manager_p1,fault_injection_p0,nereids_rule_p0/subquery"
+excludeDirectories = "workload_manager_p1,fault_injection_p0,nereids_rule_p0/subquery/basic,nereids_rule_p0/subquery/multitable,nereids_rule_p0/subquery/topop,nereids_rule_p0/subquery/misc"
 
 customConf1 = "test_custom_conf_value"
 

--- a/regression-test/pipeline/p0/conf/regression-conf.groovy
+++ b/regression-test/pipeline/p0/conf/regression-conf.groovy
@@ -58,7 +58,7 @@ excludeGroups = ""
 excludeSuites = "test_profile,test_spark_load,test_refresh_mtmv,test_bitmap_filter,test_information_schema_external"
 
 // this directories will not be executed
-excludeDirectories = "workload_manager_p1,fault_injection_p0,nereids_rule_p0/subquery/basic,nereids_rule_p0/subquery/multitable,nereids_rule_p0/subquery/topop,nereids_rule_p0/subquery/misc"
+excludeDirectories = "workload_manager_p1,fault_injection_p0,nereids_rules_p0/subquery"
 
 customConf1 = "test_custom_conf_value"
 

--- a/regression-test/suites/nereids_rules_p0/subquery/basic/subquery_basic_pullup_and_subquery.groovy
+++ b/regression-test/suites/nereids_rules_p0/subquery/basic/subquery_basic_pullup_and_subquery.groovy
@@ -1,0 +1,157 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("subquery_basic_pullup_and_subquery") {
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+
+    sql """DROP TABLE IF EXISTS t1;"""
+    sql """DROP TABLE IF EXISTS t2;"""
+    sql """DROP TABLE IF EXISTS t3;"""
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t1(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t2(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t3(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """INSERT INTO t1 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t1 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t1 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t1 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t2 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t2 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t2 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t2 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t3 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t3 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t3 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t3 VALUES (3,3,3,3);"""
+
+    /**
+     * | DML      | insert/update/delete |
+     * | select   | SELECT LIST: SubQuery |
+     * | From     | (OlapScan/ExternalScan)/view/partition(hash/range)/MV |
+     * | Join     | JOIN TYPE: inner/outer(left/right/full)/semi(left/right)/anti(left/right) ON condition: SubQuery |
+     * | Filter   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Group by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Having   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Order by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Winfunc  | Partition by / Order by EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Limit    | Limit / offset |
+     * | Set op   | union(all)/intersect(all)/except(all) |
+     * | SubQuery | Correlated subquery / non-correlated subquery / Scalar |
+     * EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery/bitmap type()
+     * 1. (not) in/exists SubQuery
+     * 2. (not) in/exists SubQuery OR/AND (not) in/exists SubQuery
+     * 3. (not) in/exists SubQuery OR/AND (equal/non-equal)
+     * 4. Corelated / non-correlated / Scalar
+     * 5. composed expr：SubQuery
+     * 6. null/not null/uk/no-uk
+     */
+    // 1. single table + olap table + filter + and + correlated + equal
+    qt_1_1 """select * from t1 where t1.c1 in (select c1 from t2) and t1.c2 in (select c1 from t3);"""
+    qt_1_2 """select * from t1 where t1.c1 not in (select c1 from t2) and t1.c2 in (select c1 from t3);"""
+    qt_1_3 """select * from t1 where t1.c1 not in (select c1 from t2) and t1.c2 not in (select c1 from t3);"""
+
+    qt_1_4 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_1_5 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_1_6 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) and t1.c2 not in (select c1 from t3 where t1.c3 = t3.c2);"""
+
+    qt_1_7 """select * from t1 where exists (select c1 from t2 where t1.c1 = t2.c1) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_1_8 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_1_9 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1) and not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+
+    // 2. single table + olap table + filter + in + and + exists + correlated + equal
+    qt_2_1 """select * from t1 where t1.c1 in (select c1 from t2) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_2_2 """select * from t1 where t1.c1 not in (select c1 from t2) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_2_3 """select * from t1 where t1.c1 in (select c1 from t2) and t1.c2 not in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_2_4 """select * from t1 where t1.c1 not in (select c1 from t2) and t1.c2 not in (select c1 from t3 where t1.c3 = t3.c2);"""
+
+    qt_2_5 """select * from t1 where t1.c1 in (select c1 from t2) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_6 """select * from t1 where t1.c1 not in (select c1 from t2) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_7 """select * from t1 where t1.c1 in (select c1 from t2) and not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_8 """select * from t1 where t1.c1 not in (select c1 from t2) and not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+
+    qt_2_9 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_10 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_11 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) and not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_12 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) and not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+
+    // 3. single table + olap table + filter + and + correlated + non-equal
+    qt_3_1 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 < t2.c2) and t1.c3 in (select c1 from t3 where t1.c4 < t3.c2);"""
+    qt_3_2 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2) and t1.c3 in (select c1 from t3 where t1.c4 < t3.c2);"""
+    qt_3_3 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2) and t1.c3 not in (select c1 from t3 where t1.c4 < t3.c2);"""
+
+    qt_3_4 """select * from t1 where exists (select c1 from t2 where t1.c1 < t2.c1) and exists (select c1 from t3 where t1.c2 < t3.c1);"""
+    qt_3_5 """select * from t1 where not exists (select c1 from t2 where t1.c1 < t2.c1) and exists (select c1 from t3 where t1.c2 < t3.c1);"""
+    qt_3_6 """select * from t1 where not exists (select c1 from t2 where t1.c1 < t2.c1) and not exists (select c1 from t3 where t1.c2 < t3.c1);"""
+
+    // 4. single table + olap table + filter + and + non-correlated
+    qt_4_1 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = 1) and t1.c2 in (select c1 from t3 where t3.c2 = 1);"""
+    qt_4_2 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = 1) and t1.c2 in (select c1 from t3 where t3.c2 = 1);"""
+    qt_4_3 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = 1) and t1.c2 not in (select c1 from t3 where t3.c2 = 1);"""
+
+    qt_4_4 """select * from t1 where exists (select c1 from t2 where t2.c1 = 1) and exists (select c1 from t3 where t3.c1 = 1);"""
+    qt_4_5 """select * from t1 where not exists (select c1 from t2 where t1.c1 = 1) and exists (select c1 from t3 where t3.c1 = 1);"""
+    qt_4_6 """select * from t1 where not exists (select c1 from t2 where t1.c1 = 1) and not exists (select c1 from t3 where t3.c1 = 1);"""
+
+    // 5. single table + olap table + filter + correlated + and + non-correlated
+    qt_5_1 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = 1) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_5_2 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = 1) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_5_3 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = 1) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+
+    qt_5_4 """select * from t1 where exists (select c1 from t2 where t2.c1 = 1) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_5_5 """select * from t1 where not exists (select c1 from t2 where t2.c1 = 1) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_5_6 """select * from t1 where not exists (select c1 from t2 where t2.c1 = 1) and not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+}
+

--- a/regression-test/suites/nereids_rules_p0/subquery/basic/subquery_basic_pullup_basic.groovy
+++ b/regression-test/suites/nereids_rules_p0/subquery/basic/subquery_basic_pullup_basic.groovy
@@ -1,0 +1,234 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("subquery_basic_pullup_basic") {
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+
+    sql """DROP TABLE IF EXISTS t1;"""
+    sql """DROP TABLE IF EXISTS t2;"""
+    sql """DROP TABLE IF EXISTS t3;"""
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t1(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t2(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t3(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """INSERT INTO t1 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t1 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t1 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t1 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t2 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t2 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t2 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t2 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t3 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t3 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t3 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t3 VALUES (3,3,3,3);"""
+
+    /**
+     * | DML      | insert/update/delete |
+     * | select   | SELECT LIST: SubQuery |
+     * | From     | (OlapScan/ExternalScan)/view/partition(hash/range)/MV |
+     * | Join     | JOIN TYPE: inner/outer(left/right/full)/semi(left/right)/anti(left/right) ON condition: SubQuery |
+     * | Filter   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Group by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Having   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Order by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Winfunc  | Partition by / Order by EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Limit    | Limit / offset |
+     * | Set op   | union(all)/intersect(all)/except(all) |
+     * | SubQuery | Correlated subquery / non-correlated subquery / Scalar |
+     * EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery/bitmap type()
+     * 1. (not) in/exists SubQuery
+     * 2. (not) in/exists SubQuery OR/AND (not) in/exists SubQuery
+     * 3. (not) in/exists SubQuery OR/AND (equal/non-equal)
+     * 4. Corelated / non-correlated / Scalar
+     * 5. composed expr：SubQuery
+     * 6. null/not null/uk/no-uk
+     */
+    // 1. single table + olap table + filter + basic + correlated + equal
+    qt_1_1 """select * from t1 where t1.c1 in (select c1 from t2);"""
+    qt_1_2 """select * from t1 where t1.c1 not in (select c1 from t2);"""
+
+    qt_1_3 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2);"""
+    qt_1_4 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2);"""
+
+    qt_1_5 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 + 1);"""
+    qt_1_6 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 + 1);"""
+
+    qt_1_7 """select * from t1 where exists (select c1 from t2 where t1.c1 = t2.c1);"""
+    qt_1_8 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1);"""
+
+    qt_1_9 """select * from t1 where exists (select c1 from t2 where t1.c1 = t2.c1 + 1);"""
+    qt_1_10 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1 + 1);"""
+
+    // 2. single table + olap table + filter + basic + correlated + non-equal
+    qt_2_1 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 < t2.c2);"""
+    qt_2_2 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2);"""
+
+    qt_2_3 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 < t2.c2 + 1);"""
+    qt_2_4 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2 + 1);"""
+
+    qt_2_5 """select * from t1 where exists (select c1 from t2 where t1.c1 < t2.c1);"""
+    qt_2_6 """select * from t1 where not exists (select c1 from t2 where t1.c1 < t2.c1);"""
+
+    qt_2_7 """select * from t1 where exists (select c1 from t2 where t1.c1 < t2.c1 + 1);"""
+    qt_2_8 """select * from t1 where not exists (select c1 from t2 where t1.c1 < t2.c1 + 1);"""
+
+    // 3. single table + olap table + filter + basic + correlated + non-equal
+    qt_3_1 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 <= t2.c2);"""
+    qt_3_2 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 <= t2.c2);"""
+
+    qt_3_3 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 <= t2.c2 + 1);"""
+    qt_3_4 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 <= t2.c2 + 1);"""
+
+    qt_3_5 """select * from t1 where exists (select c1 from t2 where t1.c1 <= t2.c1);"""
+    qt_3_6 """select * from t1 where not exists (select c1 from t2 where t1.c1 <= t2.c1);"""
+
+    qt_3_7 """select * from t1 where exists (select c1 from t2 where t1.c1 <= t2.c1 + 1);"""
+    qt_3_8 """select * from t1 where not exists (select c1 from t2 where t1.c1 <= t2.c1 + 1);"""
+
+    // 4. single table + olap table + filter + basic + correlated + non-equal
+    qt_4_1 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 != t2.c2);"""
+    qt_4_2 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 != t2.c2);"""
+
+    qt_4_3 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 != t2.c2 + 1);"""
+    qt_4_4 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 != t2.c2 + 1);"""
+
+    qt_4_5 """select * from t1 where exists (select c1 from t2 where t1.c1 != t2.c1);"""
+    qt_4_6 """select * from t1 where not exists (select c1 from t2 where t1.c1 != t2.c1);"""
+
+    qt_4_7 """select * from t1 where exists (select c1 from t2 where t1.c1 != t2.c1 + 1);"""
+    qt_4_8 """select * from t1 where not exists (select c1 from t2 where t1.c1 != t2.c1 + 1);"""
+
+    // 5. single table + olap table + filter + basic + correlated + non-equal
+    qt_5_1 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 <=> t2.c2);"""
+    qt_5_2 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 <=> t2.c2);"""
+
+    qt_5_3 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 <=> t2.c2 + 1);"""
+    qt_5_4 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 <=> t2.c2 + 1);"""
+
+    qt_5_5 """select * from t1 where exists (select c1 from t2 where t1.c1 <=> t2.c1);"""
+    qt_5_6 """select * from t1 where not exists (select c1 from t2 where t1.c1 <=> t2.c1);"""
+
+    qt_5_7 """select * from t1 where exists (select c1 from t2 where t1.c1 <=> t2.c1 + 1);"""
+    qt_5_8 """select * from t1 where not exists (select c1 from t2 where t1.c1 <=> t2.c1 + 1);"""
+
+    // 6. single table + olap table + filter + basic + correlated + (mixed equal & non-equal)
+    qt_6_1 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3);"""
+    qt_6_2 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3);"""
+
+    qt_6_3 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 + 1 and t1.c3 < t2.c3);"""
+    qt_6_4 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 + 1 and t1.c3 < t2.c3);"""
+
+    qt_6_5 """select * from t1 where exists (select c1 from t2 where t1.c1 = t2.c1 and t1.c3 < t2.c3);"""
+    qt_6_6 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1 and t1.c3 < t2.c3);"""
+
+    qt_6_7 """select * from t1 where exists (select c1 from t2 where t1.c1 = t2.c1 + 1 and t1.c3 < t2.c3);"""
+    qt_6_8 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1 + 1 and t1.c3 < t2.c3);"""
+
+    // 7. single table + olap table + filter + basic + non-correlated
+    qt_7_1 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = 1);"""
+    qt_7_2 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = 1);"""
+
+    qt_7_3 """select * from t1 where exists (select c1 from t2 where t1.c1 = 1);"""
+    qt_7_4 """select * from t1 where not exists (select c1 from t2 where t1.c1 = 1);"""
+
+    // 8. single table + olap table + filter + basic + scalar
+    qt_8_1 """select * from t1 where t1.c1 in (select max(c1) from t2);"""
+    qt_8_2 """select * from t1 where t1.c1 not in (select max(c1) from t2);"""
+
+    qt_8_3 """select * from t1 where t1.c1 in (select max(c1) from t2 where t1.c2 = t2.c2);"""
+    qt_8_4 """select * from t1 where t1.c1 not in (select max(c1) from t2 where t1.c2 = t2.c2);"""
+
+    qt_8_5 """select * from t1 where exists (select max(c1) from t2 where t1.c1 = t2.c1);"""
+    qt_8_6 """select * from t1 where not exists (select max(c1) from t2 where t1.c1 = t2.c1);"""
+
+    qt_8_7 """select * from t1 where exists (select max(c1), count(c2) from t2 where t1.c1 = t2.c1);"""
+    qt_8_8 """select * from t1 where not exists (select max(c1), count(c2) from t2 where t1.c1 = t2.c1);"""
+
+    // 9. single table + olap table + filter + basic + correlated + limit
+    qt_9_1 """select * from t1 where t1.c1 in (select c1 from t2 limit 1);"""
+    qt_9_2 """select * from t1 where t1.c1 not in (select c1 from t2 limit 1);"""
+
+    qt_9_3 """select * from t1 where t1.c1 in (select c1 from t2 limit 0);"""
+    qt_9_4 """select * from t1 where t1.c1 not in (select c1 from t2 limit 0);"""
+
+    qt_9_5 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 limit 1);"""
+    qt_9_6 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 limit 1);"""
+
+    qt_9_7 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 limit 0);"""
+    qt_9_8 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 limit 0);"""
+
+    qt_9_9 """select * from t1 where exists (select c1 from t2 where t1.c1 = t2.c1 limit 1);"""
+    qt_9_10 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1 limit 1);"""
+
+    qt_9_11 """select * from t1 where exists (select c1 from t2 where t1.c1 = t2.c1 limit 0);"""
+    qt_9_12 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1 limit 0);"""
+
+    // 10. single table + olap table + filter + basic + group by / having
+    qt_10_1 """select * from t1 where t1.c1 in (select c1 from t2 group by c1 having c1 > 1);"""
+    qt_10_2 """select * from t1 where t1.c1 not in (select c1 from t2 group by c1 having c1 > 1);"""
+
+    qt_10_3 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 group by c1 having c1 > 1);"""
+    qt_10_4 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 group by c1 having c1 > 1);"""
+
+    qt_10_5 """select * from t1 where exists (select c1 from t2 where t1.c1 = t2.c1 group by c1 having c1 > 1);"""
+    qt_10_6 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1 group by c1 having c1 > 1);"""
+
+    qt_10_7 """select * from t1 where exists (select c1, max(c2) from t2 where t1.c1 = t2.c1 group by c1 having max(c2) > 1);"""
+    qt_10_8 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1 group by c1 having max(c2) > 1);"""
+}
+

--- a/regression-test/suites/nereids_rules_p0/subquery/basic/subquery_basic_pullup_or.groovy
+++ b/regression-test/suites/nereids_rules_p0/subquery/basic/subquery_basic_pullup_or.groovy
@@ -1,0 +1,180 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("subquery_basic_pullup_or") {
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+
+    sql """DROP TABLE IF EXISTS t1;"""
+    sql """DROP TABLE IF EXISTS t2;"""
+    sql """DROP TABLE IF EXISTS t3;"""
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t1(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t2(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t3(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """INSERT INTO t1 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t1 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t1 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t1 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t2 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t2 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t2 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t2 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t3 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t3 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t3 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t3 VALUES (3,3,3,3);"""
+
+    /**
+     * | DML      | insert/update/delete |
+     * | select   | SELECT LIST: SubQuery |
+     * | From     | (OlapScan/ExternalScan)/view/partition(hash/range)/MV |
+     * | Join     | JOIN TYPE: inner/outer(left/right/full)/semi(left/right)/anti(left/right) ON condition: SubQuery |
+     * | Filter   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Group by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Having   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Order by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Winfunc  | Partition by / Order by EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Limit    | Limit / offset |
+     * | Set op   | union(all)/intersect(all)/except(all) |
+     * | SubQuery | Correlated subquery / non-correlated subquery / Scalar |
+     * EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery/bitmap type()
+     * 1. (not) in/exists SubQuery
+     * 2. (not) in/exists SubQuery OR/AND (not) in/exists SubQuery
+     * 3. (not) in/exists SubQuery OR/AND (equal/non-equal)
+     * 4. Corelated / non-correlated / Scalar
+     * 5. composed expr：SubQuery
+     * 6. null/not null/uk/no-uk
+     */
+    // 1. single table + olap table + filter + or + correlated + equal
+    qt_1_1 """select * from t1 where t1.c1 in (select c1 from t2) or t1.c2 > 1;"""
+    qt_1_2 """select * from t1 where t1.c1 not in (select c1 from t2) or t1.c2 > 1;"""
+
+    qt_1_3 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) or t1.c2 > 1;"""
+    qt_1_4 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) or t1.c2 > 1;"""
+
+    qt_1_3 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) or t1.c2 > 1;"""
+    qt_1_4 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) or t1.c2 > 1;"""
+
+    qt_1_7 """select * from t1 where exists (select c1 from t2 where t1.c1 = t2.c1) or t1.c2 > 1;"""
+    qt_1_8 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1) or t1.c2 > 1;"""
+
+    // 2. single table + olap table + filter + or + correlated + non-equal
+    qt_2_1 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 < t2.c2) or t1.c2 > 1;"""
+    qt_2_2 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2) or t1.c2 > 1;"""
+
+    qt_2_3 """select * from t1 where exists (select c1 from t2 where t1.c1 < t2.c1) or t1.c2 > 1;"""
+    qt_2_4 """select * from t1 where not exists (select c1 from t2 where t1.c1 < t2.c1) or t1.c2 > 1;"""
+
+    // 3. single table + olap table + filter + or + correlated + (mixed equal & non-equal)
+    qt_3_1 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3) or t1.c2 > 1;"""
+    qt_3_2 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3) or t1.c2 > 1;"""
+
+    qt_3_3 """select * from t1 where exists (select c1 from t2 where t1.c1 = t2.c1 and t1.c3 < t2.c3) or t1.c2 > 1;"""
+    qt_3_4 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1 and t1.c3 < t2.c3) or t1.c2 > 1;"""
+
+    // 4. single table + olap table + filter + or + non-correlated
+    qt_4_1 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = 1) or t1.c2 > 1;"""
+    qt_4_2 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = 1) or t1.c2 > 1;"""
+
+    qt_4_3 """select * from t1 where exists (select c1 from t2 where t1.c1 = 1) or t1.c2 > 1;"""
+    qt_4_4 """select * from t1 where not exists (select c1 from t2 where t1.c1 = 1) or t1.c2 > 1;"""
+
+    // 5. single table + olap table + filter + or + scalar
+    qt_5_1 """select * from t1 where t1.c1 in (select max(c1) from t2) or t1.c2 > 1;"""
+    qt_5_2 """select * from t1 where t1.c1 not in (select max(c1) from t2) or t1.c2 > 1;"""
+
+    qt_5_3 """select * from t1 where t1.c1 in (select max(c1) from t2 where t1.c2 = t2.c2) or t1.c2 > 1;"""
+    qt_5_4 """select * from t1 where t1.c1 not in (select max(c1) from t2 where t1.c2 = t2.c2) or t1.c2 > 1;"""
+
+    qt_5_5 """select * from t1 where exists (select max(c1) from t2 where t1.c1 = t2.c1) or t1.c2 > 1;"""
+    qt_5_6 """select * from t1 where not exists (select max(c1) from t2 where t1.c1 = t2.c1) or t1.c2 > 1;"""
+
+    qt_5_7 """select * from t1 where exists (select max(c1), count(c2) from t2 where t1.c1 = t2.c1) or t1.c2 > 1;"""
+    qt_5_8 """select * from t1 where not exists (select max(c1), count(c2) from t2 where t1.c1 = t2.c1) or t1.c2 > 1;"""
+
+    // 6. single table + olap table + filter + or + correlated + limit
+    qt_6_1 """select * from t1 where t1.c1 in (select c1 from t2 limit 1) or t1.c2 > 1;"""
+    qt_6_2 """select * from t1 where t1.c1 not in (select c1 from t2 limit 1) or t1.c2 > 1;"""
+
+    qt_6_3 """select * from t1 where t1.c1 in (select c1 from t2 limit 0) or t1.c2 > 1;"""
+    qt_6_4 """select * from t1 where t1.c1 not in (select c1 from t2 limit 0) or t1.c2 > 1;"""
+
+    qt_6_5 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 limit 1) or t1.c2 > 1;"""
+    qt_6_6 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 limit 1) or t1.c2 > 1;"""
+
+    qt_6_7 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 limit 0) or t1.c2 > 1;"""
+    qt_6_8 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 limit 0) or t1.c2 > 1;"""
+
+    qt_6_9 """select * from t1 where exists (select c1 from t2 where t1.c1 = t2.c1 limit 1) or t1.c2 > 1;"""
+    qt_6_10 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1 limit 1) or t1.c2 > 1;"""
+
+    qt_6_11 """select * from t1 where exists (select c1 from t2 where t1.c1 = t2.c1 limit 0) or t1.c2 > 1;"""
+    qt_6_12 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1 limit 0) or t1.c2 > 1;"""
+
+    // 7. single table + olap table + filter + or + group by / having
+    qt_7_1 """select * from t1 where t1.c1 in (select c1 from t2 group by c1 having c1 > 1) or t1.c2 > 1;"""
+    qt_7_2 """select * from t1 where t1.c1 not in (select c1 from t2 group by c1 having c1 > 1) or t1.c2 > 1;"""
+
+    qt_7_3 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 group by c1 having c1 > 1) or t1.c2 > 1;"""
+    qt_7_4 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 group by c1 having c1 > 1) or t1.c2 > 1;"""
+
+    qt_7_5 """select * from t1 where exists (select c1 from t2 where t1.c1 = t2.c1 group by c1 having c1 > 1) or t1.c2 > 1;"""
+    qt_10_6 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1 group by c1 having c1 > 1) or t1.c2 > 1;"""
+
+    qt_7_7 """select * from t1 where exists (select c1, max(c2) from t2 where t1.c1 = t2.c1 group by c1 having max(c2) > 1) or t1.c2 > 1;"""
+    qt_7_8 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1 group by c1 having max(c2) > 1) or t1.c2 > 1;"""
+}
+

--- a/regression-test/suites/nereids_rules_p0/subquery/basic/subquery_basic_pullup_or_subquery.groovy
+++ b/regression-test/suites/nereids_rules_p0/subquery/basic/subquery_basic_pullup_or_subquery.groovy
@@ -1,0 +1,157 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("subquery_basic_pullup_or_subquery") {
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+
+    sql """DROP TABLE IF EXISTS t1;"""
+    sql """DROP TABLE IF EXISTS t2;"""
+    sql """DROP TABLE IF EXISTS t3;"""
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t1(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t2(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t3(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """INSERT INTO t1 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t1 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t1 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t1 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t2 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t2 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t2 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t2 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t3 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t3 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t3 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t3 VALUES (3,3,3,3);"""
+
+    /**
+     * | DML      | insert/update/delete |
+     * | select   | SELECT LIST: SubQuery |
+     * | From     | (OlapScan/ExternalScan)/view/partition(hash/range)/MV |
+     * | Join     | JOIN TYPE: inner/outer(left/right/full)/semi(left/right)/anti(left/right) ON condition: SubQuery |
+     * | Filter   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Group by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Having   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Order by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Winfunc  | Partition by / Order by EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Limit    | Limit / offset |
+     * | Set op   | union(all)/intersect(all)/except(all) |
+     * | SubQuery | Correlated subquery / non-correlated subquery / Scalar |
+     * EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery/bitmap type()
+     * 1. (not) in/exists SubQuery
+     * 2. (not) in/exists SubQuery OR/AND (not) in/exists SubQuery
+     * 3. (not) in/exists SubQuery OR/AND (equal/non-equal)
+     * 4. Corelated / non-correlated / Scalar
+     * 5. composed expr：SubQuery
+     * 6. null/not null/uk/no-uk
+     */
+    // 1. single table + olap table + filter + or + correlated(=)
+    qt_1_1 """select * from t1 where t1.c1 in (select c1 from t2) or t1.c2 in (select c1 from t3);"""
+    qt_1_2 """select * from t1 where t1.c1 not in (select c1 from t2) or t1.c2 in (select c1 from t3);"""
+    qt_1_3 """select * from t1 where t1.c1 not in (select c1 from t2) or t1.c2 not in (select c1 from t3);"""
+
+    qt_1_4 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) or t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_1_5 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) or t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_1_6 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) or t1.c2 not in (select c1 from t3 where t1.c3 = t3.c2);"""
+
+    qt_1_7 """select * from t1 where exists (select c1 from t2 where t1.c1 = t2.c1) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_1_8 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_1_9 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1) or not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+
+    // 2. single table + olap table + filter + in + or + exists + correlated(=)
+    qt_2_1 """select * from t1 where t1.c1 in (select c1 from t2) or t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_2_2 """select * from t1 where t1.c1 not in (select c1 from t2) or t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_2_3 """select * from t1 where t1.c1 in (select c1 from t2) or t1.c2 not in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_2_4 """select * from t1 where t1.c1 not in (select c1 from t2) or t1.c2 not in (select c1 from t3 where t1.c3 = t3.c2);"""
+
+    qt_2_5 """select * from t1 where t1.c1 in (select c1 from t2) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_6 """select * from t1 where t1.c1 not in (select c1 from t2) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_7 """select * from t1 where t1.c1 in (select c1 from t2) or not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_8 """select * from t1 where t1.c1 not in (select c1 from t2) or not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+
+    qt_2_9 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_10 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_11 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) or not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_12 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) or not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+
+    // 3. single table + olap table + filter + or + correlated(<)
+    qt_3_1 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 < t2.c2) or t1.c3 in (select c1 from t3 where t1.c4 < t3.c2);"""
+    qt_3_2 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2) or t1.c3 in (select c1 from t3 where t1.c4 < t3.c2);"""
+    qt_3_3 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2) or t1.c3 not in (select c1 from t3 where t1.c4 < t3.c2);"""
+
+    qt_3_4 """select * from t1 where exists (select c1 from t2 where t1.c1 < t2.c1) or exists (select c1 from t3 where t1.c2 < t3.c1);"""
+    qt_3_5 """select * from t1 where not exists (select c1 from t2 where t1.c1 < t2.c1) or exists (select c1 from t3 where t1.c2 < t3.c1);"""
+    qt_3_6 """select * from t1 where not exists (select c1 from t2 where t1.c1 < t2.c1) or not exists (select c1 from t3 where t1.c2 < t3.c1);"""
+
+    // 4. single table + olap table + filter + or + non-correlated
+    qt_4_1 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = 1) or t1.c2 in (select c1 from t3 where t3.c2 = 1);"""
+    qt_4_2 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = 1) or t1.c2 in (select c1 from t3 where t3.c2 = 1);"""
+    qt_4_3 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = 1) or t1.c2 not in (select c1 from t3 where t3.c2 = 1);"""
+
+    qt_4_4 """select * from t1 where exists (select c1 from t2 where t2.c1 = 1) or exists (select c1 from t3 where t3.c1 = 1);"""
+    qt_4_5 """select * from t1 where not exists (select c1 from t2 where t1.c1 = 1) or exists (select c1 from t3 where t3.c1 = 1);"""
+    qt_4_6 """select * from t1 where not exists (select c1 from t2 where t1.c1 = 1) or not exists (select c1 from t3 where t3.c1 = 1);"""
+
+    // 5. single table + olap table + filter + correlated + or + non-correlated
+    qt_5_1 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = 1) or t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_5_2 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = 1) or t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_5_3 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = 1) or t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+
+    qt_5_4 """select * from t1 where exists (select c1 from t2 where t2.c1 = 1) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_5_5 """select * from t1 where not exists (select c1 from t2 where t2.c1 = 1) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_5_6 """select * from t1 where not exists (select c1 from t2 where t2.c1 = 1) or not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+}
+

--- a/regression-test/suites/nereids_rules_p0/subquery/basic/subquery_basic_pullup_uk.groovy
+++ b/regression-test/suites/nereids_rules_p0/subquery/basic/subquery_basic_pullup_uk.groovy
@@ -1,0 +1,237 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("subquery_basic_pullup_uk") {
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+
+    sql """DROP TABLE IF EXISTS t1;"""
+    sql """DROP TABLE IF EXISTS t2;"""
+    sql """DROP TABLE IF EXISTS t3;"""
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t1(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    UNIQUE KEY (c1)
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t2(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    UNIQUE KEY (c1)
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t3(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    UNIQUE KEY (c1)
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """INSERT INTO t1 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t1 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t1 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t1 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t2 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t2 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t2 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t2 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t3 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t3 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t3 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t3 VALUES (3,3,3,3);"""
+
+    /**
+     * | DML      | insert/update/delete |
+     * | select   | SELECT LIST: SubQuery |
+     * | From     | (OlapScan/ExternalScan)/view/partition(hash/range)/MV |
+     * | Join     | JOIN TYPE: inner/outer(left/right/full)/semi(left/right)/anti(left/right) ON condition: SubQuery |
+     * | Filter   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Group by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Having   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Order by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Winfunc  | Partition by / Order by EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Limit    | Limit / offset |
+     * | Set op   | union(all)/intersect(all)/except(all) |
+     * | SubQuery | Correlated subquery / non-correlated subquery / Scalar |
+     * EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery/bitmap type()
+     * 1. (not) in/exists SubQuery
+     * 2. (not) in/exists SubQuery OR/AND (not) in/exists SubQuery
+     * 3. (not) in/exists SubQuery OR/AND (equal/non-equal)
+     * 4. Corelated / non-correlated / Scalar
+     * 5. composed expr：SubQuery
+     * 6. null/not null/uk/non-uk
+     */
+    // 1. single table + olap table + filter + uk + correlated + equal
+    qt_1_1 """select * from t1 where t1.c1 in (select c1 from t2);"""
+    qt_1_2 """select * from t1 where t1.c1 not in (select c1 from t2);"""
+
+    qt_1_3 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2);"""
+    qt_1_4 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2);"""
+
+    qt_1_5 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 + 1);"""
+    qt_1_6 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 + 1);"""
+
+    qt_1_7 """select * from t1 where exists (select c1 from t2 where t1.c1 = t2.c1);"""
+    qt_1_8 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1);"""
+
+    qt_1_9 """select * from t1 where exists (select c1 from t2 where t1.c1 = t2.c1 + 1);"""
+    qt_1_10 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1 + 1);"""
+
+    // 2. single table + olap table + filter + uk + correlated + non-eqau
+    qt_2_1 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 < t2.c2);"""
+    qt_2_2 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2);"""
+
+    qt_2_3 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 < t2.c2 + 1);"""
+    qt_2_4 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2 + 1);"""
+
+    qt_2_5 """select * from t1 where exists (select c1 from t2 where t1.c1 < t2.c1);"""
+    qt_2_6 """select * from t1 where not exists (select c1 from t2 where t1.c1 < t2.c1);"""
+
+    qt_2_7 """select * from t1 where exists (select c1 from t2 where t1.c1 < t2.c1 + 1);"""
+    qt_2_8 """select * from t1 where not exists (select c1 from t2 where t1.c1 < t2.c1 + 1);"""
+
+    // 3. single table + olap table + filter + uk + correlated + non-equal
+    qt_3_1 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 <= t2.c2);"""
+    qt_3_2 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 <= t2.c2);"""
+
+    qt_3_3 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 <= t2.c2 + 1);"""
+    qt_3_4 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 <= t2.c2 + 1);"""
+
+    qt_3_5 """select * from t1 where exists (select c1 from t2 where t1.c1 <= t2.c1);"""
+    qt_3_6 """select * from t1 where not exists (select c1 from t2 where t1.c1 <= t2.c1);"""
+
+    qt_3_7 """select * from t1 where exists (select c1 from t2 where t1.c1 <= t2.c1 + 1);"""
+    qt_3_8 """select * from t1 where not exists (select c1 from t2 where t1.c1 <= t2.c1 + 1);"""
+
+    // 4. single table + olap table + filter + uk + correlated + non-equal
+    qt_4_1 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 != t2.c2);"""
+    qt_4_2 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 != t2.c2);"""
+
+    qt_4_3 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 != t2.c2 + 1);"""
+    qt_4_4 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 != t2.c2 + 1);"""
+
+    qt_4_5 """select * from t1 where exists (select c1 from t2 where t1.c1 != t2.c1);"""
+    qt_4_6 """select * from t1 where not exists (select c1 from t2 where t1.c1 != t2.c1);"""
+
+    qt_4_7 """select * from t1 where exists (select c1 from t2 where t1.c1 != t2.c1 + 1);"""
+    qt_4_8 """select * from t1 where not exists (select c1 from t2 where t1.c1 != t2.c1 + 1);"""
+
+    // 5. single table + olap table + filter + uk + correlated + non-equal
+    qt_5_1 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 <=> t2.c2);"""
+    qt_5_2 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 <=> t2.c2);"""
+
+    qt_5_3 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 <=> t2.c2 + 1);"""
+    qt_5_4 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 <=> t2.c2 + 1);"""
+
+    qt_5_5 """select * from t1 where exists (select c1 from t2 where t1.c1 <=> t2.c1);"""
+    qt_5_6 """select * from t1 where not exists (select c1 from t2 where t1.c1 <=> t2.c1);"""
+
+    qt_5_7 """select * from t1 where exists (select c1 from t2 where t1.c1 <=> t2.c1 + 1);"""
+    qt_5_8 """select * from t1 where not exists (select c1 from t2 where t1.c1 <=> t2.c1 + 1);"""
+
+    // 6. single table + olap table + filter + uk + correlated + (mixed equal & non-equal)
+    qt_6_1 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3);"""
+    qt_6_2 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3);"""
+
+    qt_6_3 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 + 1 and t1.c3 < t2.c3);"""
+    qt_6_4 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 + 1 and t1.c3 < t2.c3);"""
+
+    qt_6_5 """select * from t1 where exists (select c1 from t2 where t1.c1 = t2.c1 and t1.c3 < t2.c3);"""
+    qt_6_6 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1 and t1.c3 < t2.c3);"""
+
+    qt_6_7 """select * from t1 where exists (select c1 from t2 where t1.c1 = t2.c1 + 1 and t1.c3 < t2.c3);"""
+    qt_6_8 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1 + 1 and t1.c3 < t2.c3);"""
+
+    // 7. single table + olap table + filter + uk + non-correlated
+    qt_7_1 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = 1);"""
+    qt_7_2 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = 1);"""
+
+    qt_7_3 """select * from t1 where exists (select c1 from t2 where t1.c1 = 1);"""
+    qt_7_4 """select * from t1 where not exists (select c1 from t2 where t1.c1 = 1);"""
+
+    // 8. single table + olap table + filter + uk + scalar
+    qt_8_1 """select * from t1 where t1.c1 in (select max(c1) from t2);"""
+    qt_8_2 """select * from t1 where t1.c1 not in (select max(c1) from t2);"""
+
+    qt_8_3 """select * from t1 where t1.c1 in (select max(c1) from t2 where t1.c2 = t2.c2);"""
+    qt_8_4 """select * from t1 where t1.c1 not in (select max(c1) from t2 where t1.c2 = t2.c2);"""
+
+    qt_8_5 """select * from t1 where exists (select max(c1) from t2 where t1.c1 = t2.c1);"""
+    qt_8_6 """select * from t1 where not exists (select max(c1) from t2 where t1.c1 = t2.c1);"""
+
+    qt_8_7 """select * from t1 where exists (select max(c1), count(c2) from t2 where t1.c1 = t2.c1);"""
+    qt_8_8 """select * from t1 where not exists (select max(c1), count(c2) from t2 where t1.c1 = t2.c1);"""
+
+    // 9. single table + olap table + filter + uk + correlated + limit
+    qt_9_1 """select * from t1 where t1.c1 in (select c1 from t2 limit 1);"""
+    qt_9_2 """select * from t1 where t1.c1 not in (select c1 from t2 limit 1);"""
+
+    qt_9_3 """select * from t1 where t1.c1 in (select c1 from t2 limit 0);"""
+    qt_9_4 """select * from t1 where t1.c1 not in (select c1 from t2 limit 0);"""
+
+    qt_9_5 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 limit 1);"""
+    qt_9_6 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 limit 1);"""
+
+    qt_9_7 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 limit 0);"""
+    qt_9_8 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 limit 0);"""
+
+    qt_9_9 """select * from t1 where exists (select c1 from t2 where t1.c1 = t2.c1 limit 1);"""
+    qt_9_10 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1 limit 1);"""
+
+    qt_9_11 """select * from t1 where exists (select c1 from t2 where t1.c1 = t2.c1 limit 0);"""
+    qt_9_12 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1 limit 0);"""
+
+    // 10. single table + olap table + filter + uk + group by / having
+    qt_10_1 """select * from t1 where t1.c1 in (select c1 from t2 group by c1 having c1 > 1);"""
+    qt_10_2 """select * from t1 where t1.c1 not in (select c1 from t2 group by c1 having c1 > 1);"""
+
+    qt_10_3 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 group by c1 having c1 > 1);"""
+    qt_10_4 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 group by c1 having c1 > 1);"""
+
+    qt_10_5 """select * from t1 where exists (select c1 from t2 where t1.c1 = t2.c1 group by c1 having c1 > 1);"""
+    qt_10_6 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1 group by c1 having c1 > 1);"""
+
+    qt_10_7 """select * from t1 where exists (select c1, max(c2) from t2 where t1.c1 = t2.c1 group by c1 having max(c2) > 1);"""
+    qt_10_8 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1 group by c1 having max(c2) > 1);"""
+}
+

--- a/regression-test/suites/nereids_rules_p0/subquery/basic/subquery_basic_ullup_and.groovy
+++ b/regression-test/suites/nereids_rules_p0/subquery/basic/subquery_basic_ullup_and.groovy
@@ -1,0 +1,180 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("subquery_basic_pullup_and") {
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+
+    sql """DROP TABLE IF EXISTS t1;"""
+    sql """DROP TABLE IF EXISTS t2;"""
+    sql """DROP TABLE IF EXISTS t3;"""
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t1(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t2(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t3(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """INSERT INTO t1 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t1 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t1 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t1 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t2 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t2 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t2 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t2 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t3 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t3 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t3 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t3 VALUES (3,3,3,3);"""
+
+    /**
+     * | DML      | insert/update/delete |
+     * | select   | SELECT LIST: SubQuery |
+     * | From     | (OlapScan/ExternalScan)/view/partition(hash/range)/MV |
+     * | Join     | JOIN TYPE: inner/outer(left/right/full)/semi(left/right)/anti(left/right) ON condition: SubQuery |
+     * | Filter   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Group by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Having   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Order by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Winfunc  | Partition by / Order by EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Limit    | Limit / offset |
+     * | Set op   | union(all)/intersect(all)/except(all) |
+     * | SubQuery | Correlated subquery / non-correlated subquery / Scalar |
+     * EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery/bitmap type()
+     * 1. (not) in/exists SubQuery
+     * 2. (not) in/exists SubQuery OR/AND (not) in/exists SubQuery
+     * 3. (not) in/exists SubQuery OR/AND (equal/non-equal)
+     * 4. Corelated / non-correlated / Scalar
+     * 5. composed expr：SubQuery
+     * 6. null/not null/uk/no-uk
+     */
+    // 1. single table + olap table + filter + andor + correlated + equal
+    qt_1_1 """select * from t1 where t1.c1 in (select c1 from t2) and t1.c2 > 1;"""
+    qt_1_2 """select * from t1 where t1.c1 not in (select c1 from t2) and t1.c2 > 1;"""
+
+    qt_1_3 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) and t1.c2 > 1;"""
+    qt_1_4 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) and t1.c2 > 1;"""
+
+    qt_1_5 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) and t1.c2 > 1;"""
+    qt_1_6 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) and t1.c2 > 1;"""
+
+    qt_1_7 """select * from t1 where exists (select c1 from t2 where t1.c1 = t2.c1) and t1.c2 > 1;"""
+    qt_1_8 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1) and t1.c2 > 1;"""
+
+    // 2. single table + olap table + filter + andor + correlated + non-equal
+    qt_2_1 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 < t2.c2) and t1.c2 > 1;"""
+    qt_2_2 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2) and t1.c2 > 1;"""
+
+    qt_2_3 """select * from t1 where exists (select c1 from t2 where t1.c1 < t2.c1) and t1.c2 > 1;"""
+    qt_2_4 """select * from t1 where not exists (select c1 from t2 where t1.c1 < t2.c1) and t1.c2 > 1;"""
+
+    // 6. single table + olap table + filter + andor + correlated + (mixed equal & non-equal)
+    qt_6_1 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3) and t1.c2 > 1;"""
+    qt_6_2 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3) and t1.c2 > 1;"""
+
+    qt_6_5 """select * from t1 where exists (select c1 from t2 where t1.c1 = t2.c1 and t1.c3 < t2.c3) and t1.c2 > 1;"""
+    qt_6_6 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1 and t1.c3 < t2.c3) and t1.c2 > 1;"""
+
+    // 7. single table + olap table + filter + andor + non-correlated
+    qt_7_1 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = 1) and t1.c2 > 1;"""
+    qt_7_2 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = 1) and t1.c2 > 1;"""
+
+    qt_7_3 """select * from t1 where exists (select c1 from t2 where t1.c1 = 1) and t1.c2 > 1;"""
+    qt_7_4 """select * from t1 where not exists (select c1 from t2 where t1.c1 = 1) and t1.c2 > 1;"""
+
+    // 8. single table + olap table + filter + andor + scalar
+    qt_8_1 """select * from t1 where t1.c1 in (select max(c1) from t2) and t1.c2 > 1;"""
+    qt_8_2 """select * from t1 where t1.c1 not in (select max(c1) from t2) and t1.c2 > 1;"""
+
+    qt_8_3 """select * from t1 where t1.c1 in (select max(c1) from t2 where t1.c2 = t2.c2) and t1.c2 > 1;"""
+    qt_8_4 """select * from t1 where t1.c1 not in (select max(c1) from t2 where t1.c2 = t2.c2) and t1.c2 > 1;"""
+
+    qt_8_5 """select * from t1 where exists (select max(c1) from t2 where t1.c1 = t2.c1) and t1.c2 > 1;"""
+    qt_8_6 """select * from t1 where not exists (select max(c1) from t2 where t1.c1 = t2.c1) and t1.c2 > 1;"""
+
+    qt_8_7 """select * from t1 where exists (select max(c1), count(c2) from t2 where t1.c1 = t2.c1) and t1.c2 > 1;"""
+    qt_8_8 """select * from t1 where not exists (select max(c1), count(c2) from t2 where t1.c1 = t2.c1) and t1.c2 > 1;"""
+
+    // 9. single table + olap table + filter + andor + correlated + limit
+    qt_9_1 """select * from t1 where t1.c1 in (select c1 from t2 limit 1) and t1.c2 > 1;"""
+    qt_9_2 """select * from t1 where t1.c1 not in (select c1 from t2 limit 1) and t1.c2 > 1;"""
+
+    qt_9_3 """select * from t1 where t1.c1 in (select c1 from t2 limit 0) and t1.c2 > 1;"""
+    qt_9_4 """select * from t1 where t1.c1 not in (select c1 from t2 limit 0) and t1.c2 > 1;"""
+
+    qt_9_5 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 limit 1) and t1.c2 > 1;"""
+    qt_9_6 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 limit 1) and t1.c2 > 1;"""
+
+    qt_9_7 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 limit 0) and t1.c2 > 1;"""
+    qt_9_8 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 limit 0) and t1.c2 > 1;"""
+
+    qt_9_9 """select * from t1 where exists (select c1 from t2 where t1.c1 = t2.c1 limit 1) and t1.c2 > 1;"""
+    qt_9_10 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1 limit 1) and t1.c2 > 1;"""
+
+    qt_9_11 """select * from t1 where exists (select c1 from t2 where t1.c1 = t2.c1 limit 0) and t1.c2 > 1;"""
+    qt_9_12 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1 limit 0) and t1.c2 > 1;"""
+
+    // 10. single table + olap table + filter + andor + group by / having
+    qt_10_1 """select * from t1 where t1.c1 in (select c1 from t2 group by c1 having c1 > 1) and t1.c2 > 1;"""
+    qt_10_2 """select * from t1 where t1.c1 not in (select c1 from t2 group by c1 having c1 > 1) and t1.c2 > 1;"""
+
+    qt_10_3 """select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 group by c1 having c1 > 1) and t1.c2 > 1;"""
+    qt_10_4 """select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 group by c1 having c1 > 1) and t1.c2 > 1;"""
+
+    qt_10_5 """select * from t1 where exists (select c1 from t2 where t1.c1 = t2.c1 group by c1 having c1 > 1) and t1.c2 > 1;"""
+    qt_10_6 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1 group by c1 having c1 > 1) and t1.c2 > 1;"""
+
+    qt_10_7 """select * from t1 where exists (select c1, max(c2) from t2 where t1.c1 = t2.c1 group by c1 having max(c2) > 1) and t1.c2 > 1;"""
+    qt_10_8 """select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1 group by c1 having max(c2) > 1) and t1.c2 > 1;"""
+}
+

--- a/regression-test/suites/nereids_rules_p0/subquery/misc/subquery_misc_pullup_dml.groovy
+++ b/regression-test/suites/nereids_rules_p0/subquery/misc/subquery_misc_pullup_dml.groovy
@@ -1,0 +1,126 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("subquery_basic_pullup_dml") {
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+
+    sql """DROP TABLE IF EXISTS t1;"""
+    sql """DROP TABLE IF EXISTS t2;"""
+    sql """DROP TABLE IF EXISTS target;"""
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t1(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t2(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS target(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """INSERT INTO t1 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t1 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t1 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t1 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t2 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t2 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t2 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t2 VALUES (3,3,3,3);"""
+
+    /**
+     * | DML      | insert/update/delete |
+     * | select   | SELECT LIST: SubQuery |
+     * | From     | (OlapScan/ExternalScan)/view/partition(hash/range)/MV |
+     * | Join     | JOIN TYPE: inner/outer(left/right/full)/semi(left/right)/anti(left/right) ON condition: SubQuery |
+     * | Filter   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Group by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Having   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Order by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Winfunc  | Partition by / Order by EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Limit    | Limit / offset |
+     * | Set op   | union(all)/intersect(all)/except(all) |
+     * | SubQuery | Correlated subquery / non-correlated subquery / Scalar |
+     * EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery/bitmap type()
+     * 1. (not) in/exists SubQuery
+     * 2. (not) in/exists SubQuery OR/AND (not) in/exists SubQuery
+     * 3. (not) in/exists SubQuery OR/AND (equal/non-equal)
+     * 4. Corelated / non-correlated / Scalar
+     * 5. composed expr：SubQuery
+     * 6. null/not null/uk/no-uk
+     */
+    // 1. single table + olap table + insert into + basic + correlated + equal
+    qt_1_1 """insert into target select * from t1 where t1.c1 in (select c1 from t2);"""
+    qt_1_2 """insert into target select * from t1 where t1.c1 not in (select c1 from t2);"""
+
+    qt_1_3 """insert into target select * from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2);"""
+    qt_1_4 """insert into target select * from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2);"""
+
+    qt_1_5 """insert into target select * from t1 where exists (select c1 from t2 where t1.c1 = t2.c1);"""
+    qt_1_6 """insert into target select * from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1);"""
+
+    // 2. single table + olap table + update + basic + correlated + non-equal
+    qt_2_1 """update t1 set t1.c1 = 1 where t1.c1 in (select c1 from t2);"""
+    qt_2_2 """update t1 set t1.c1 = 1 where t1.c1 not in (select c1 from t2);"""
+
+    qt_2_3 """update t1 set t1.c1 = 1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2);"""
+    qt_2_4 """update t1 set t1.c1 = 1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2);"""
+
+    qt_2_5 """update t1 set t1.c1 = 1 where exists (select c1 from t2 where t1.c1 = t2.c1);"""
+    qt_2_6 """update t1 set t1.c1 = 1 where not exists (select c1 from t2 where t1.c1 = t2.c1);"""
+
+    // 3. single table + olap table + delete + basic + correlated + non-equal
+    qt_3_1 """delete from t1 where t1.c1 in (select c1 from t2);"""
+    qt_3_2 """delete from t1 where t1.c1 not in (select c1 from t2);"""
+
+    qt_3_3 """delete from t1 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2);"""
+    qt_3_4 """delete from t1 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2);"""
+
+    qt_3_5 """delete from t1 where exists (select c1 from t2 where t1.c1 = t2.c1);"""
+    qt_3_6 """delete from t1 where not exists (select c1 from t2 where t1.c1 = t2.c1);"""
+}
+

--- a/regression-test/suites/nereids_rules_p0/subquery/misc/subquery_misc_pullup_misc.groovy
+++ b/regression-test/suites/nereids_rules_p0/subquery/misc/subquery_misc_pullup_misc.groovy
@@ -1,0 +1,144 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("subquery_misc_pullup_misc") {
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+
+    sql """DROP TABLE IF EXISTS t1;"""
+    sql """DROP TABLE IF EXISTS t2;"""
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t1(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t2(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """INSERT INTO t1 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t1 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t1 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t1 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t2 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t2 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t2 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t2 VALUES (3,3,3,3);"""
+
+    /**
+     * | DML      | insert/update/delete |
+     * | select   | SELECT LIST: SubQuery |
+     * | From     | (OlapScan/ExternalScan)/view/partition(hash/range)/MV |
+     * | Join     | JOIN TYPE: inner/outer(left/right/full)/semi(left/right)/anti(left/right) ON condition: SubQuery |
+     * | Filter   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Group by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Having   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Order by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Winfunc  | Partition by / Order by EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Limit    | Limit / offset |
+     * | Set op   | union(all)/intersect(all)/except(all) |
+     * | SubQuery | Correlated subquery / non-correlated subquery / Scalar |
+     * EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery/bitmap type()
+     * 1. (not) in/exists SubQuery
+     * 2. (not) in/exists SubQuery OR/AND (not) in/exists SubQuery
+     * 3. (not) in/exists SubQuery OR/AND (equal/non-equal)
+     * 4. Corelated / non-correlated / Scalar
+     * 5. composed expr：SubQuery
+     * 6. null/not null/uk/no-uk
+     */
+    // 1. single table + olap table + filter + count + correlated + equal
+    qt_1_1 """select * from t1 where t1.c1 in (select count(c1) from t2);"""
+    qt_1_2 """select * from t1 where t1.c1 not in (select count(c1) from t2);"""
+
+    qt_1_3 """select * from t1 where t1.c1 in (select count(c1) from t2 where t1.c2 = t2.c2);"""
+    qt_1_4 """select * from t1 where t1.c1 not in (select count(c1) from t2 where t1.c2 = t2.c2);"""
+
+    qt_1_5 """select * from t1 where exists (select count(c1) from t2 where t1.c1 = t2.c1);"""
+    qt_1_6 """select * from t1 where not exists (select count(c1) from t2 where t1.c1 = t2.c1);"""
+
+    qt_1_7 """select * from t1 where t1.c1 <= (select count(c1) from t2);"""
+    qt_1_8 """select * from t1 where t1.c1 > (select count(c1) from t2);"""
+
+    qt_1_9 """select * from t1 where t1.c1 <= (select count(c1) from t2 where t1.c2 = t2.c2);"""
+    qt_1_10 """select * from t1 where t1.c1 > (select count(c1) from t2 where t1.c2 = t2.c2);"""
+
+    // 2. single table + olap table + filter + correlated + having
+    qt_2_1 """select * from t1 where t1.c1 in (select c1 from t2 group by c1 having t2.c1 = t1.c2);"""
+    qt_2_2 """select * from t1 where t1.c1 not in (select c1 from t2 group by c1 having t2.c1 = t1.c2);"""
+
+    qt_2_3 """select * from t1 where t1.c1 in (select c1 from t2 group by c1 having t2.c1 > t1.c2);"""
+    qt_2_4 """select * from t1 where t1.c1 not in (select c1 from t2 group by c1 having t2.c1 < t1.c2);"""
+
+    qt_2_5 """select * from t1 where exists (select c1 from t2 group by c1 having t2.c1 = t1.c2);"""
+    qt_2_6 """select * from t1 where not exists (select c1 from t2 group by c1 having t2.c1 = t1.c2);"""
+
+    qt_2_7 """select * from t1 where exists (select c1 from t2 group by c1 having t2.c1 > t1.c2);"""
+    qt_2_8 """select * from t1 where not exists (select c1 from t2 group by c1 having t2.c1 < t1.c2);"""
+
+    qt_2_9 """select * from t1 where t1.c1 > (select c1 from t2 group by c1 having t2.c1 = t1.c2);"""
+    qt_2_10 """select * from t1 where t1.c1 <= (select c1 from t2 group by c1 having t2.c1 = t1.c2);"""
+
+    // 3. single table + olap table + filter + const
+    qt_3_1 """select * from t1 where 1 in (select count(c1) from t2);"""
+    qt_3_2 """select * from t1 where 1 not in (select max(c1) from t2);"""
+    qt_3_3 """select * from t1 where 1 not in (select c1 from t2);"""
+
+    qt_3_4 """select * from t1 where 1 in (select count(c1) from t2 where t1.c2 = t2.c2);"""
+    qt_3_5 """select * from t1 where 1 not in (select max(c1) from t2 where t1.c2 = t2.c2);"""
+    qt_3_6 """select * from t1 where 1 not in (select c1 from t2 where t1.c2 = t2.c2);"""
+
+    qt_3_7 """select * from t1 where 1 <= (select count(c1) from t2);"""
+    qt_3_8 """select * from t1 where 1 > (select max(c1) from t2);"""
+    qt_3_9 """select * from t1 where 1 > (select c1 from t2);"""
+
+    qt_3_10 """select * from t1 where 1 <= (select count(c1) from t2 where t1.c2 = t2.c2);"""
+    qt_3_11 """select * from t1 where 1 > (select max(c1) from t2 where t1.c2 = t2.c2);"""
+    qt_3_12 """select * from t1 where 1 > (select c1 from t2 where t1.c2 = t2.c2);"""
+
+    // 4. single table + view + correlated
+    qt_4_1 """select * from (select c1 from t1 where t1.c2 = 1) t1 where t1.c1 in (select count(c1) from t2);"""
+    qt_4_2 """select * from (select t1.c1 from t1, t2 where t1.c1 = t2.c1) t1 where t1.c1 in (select count(c1) from t2);"""
+    qt_4_3 """select * from (select t1.c1 from t1 where t1.c2 = 1 union all select t2.c1 from t2 where t2.c2 = 2) t1 where t1.c1 in (select count(c1) from t2);"""
+
+    qt_4_4 """select * from (select c1 from t1 where t1.c2 = 1) t1 where t1.c1 not in (select count(c1) from t2);"""
+    qt_4_5 """select * from (select t1.c1 from t1, t2 where t1.c1 = t2.c1) t1 where t1.c1 not in (select count(c1) from t2);"""
+    qt_4_6 """select * from (select t1.c1 from t1 where t1.c2 = 1 union all select t2.c1 from t2 where t2.c2 = 2) t1 where t1.c1 not in (select count(c1) from t2);"""
+
+    qt_4_7 """select * from (select c1 from t1 where t1.c2 = 1) t1 where exists (select count(c1) from t2);"""
+    qt_4_8 """select * from (select t1.c1 from t1, t2 where t1.c1 = t2.c1) t1 where exists (select count(c1) from t2);"""
+    qt_4_9 """select * from (select t1.c1 from t1 where t1.c2 = 1 union all select t2.c1 from t2 where t2.c2 = 2) t1 where not exists (select count(c1) from t2);"""
+}
+

--- a/regression-test/suites/nereids_rules_p0/subquery/multitable/subquery_multitable_pullup_and.groovy
+++ b/regression-test/suites/nereids_rules_p0/subquery/multitable/subquery_multitable_pullup_and.groovy
@@ -1,0 +1,191 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("subquery_multitable_pullup_and") {
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+
+    sql """DROP TABLE IF EXISTS t1;"""
+    sql """DROP TABLE IF EXISTS t2;"""
+    sql """DROP TABLE IF EXISTS t3;"""
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t1(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t2(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t3(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """INSERT INTO t1 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t1 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t1 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t1 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t2 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t2 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t2 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t2 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t3 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t3 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t3 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t3 VALUES (3,3,3,3);"""
+
+    /**
+     * | DML      | insert/update/delete |
+     * | select   | SELECT LIST: SubQuery |
+     * | From     | (OlapScan/ExternalScan)/view/partition(hash/range)/MV |
+     * | Join     | JOIN TYPE: inner/outer(left/right/full)/semi(left/right)/anti(left/right) ON condition: SubQuery |
+     * | Filter   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Group by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Having   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Order by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Winfunc  | Partition by / Order by EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Limit    | Limit / offset |
+     * | Set op   | union(all)/intersect(all)/except(all) |
+     * | SubQuery | Correlated subquery / non-correlated subquery / Scalar |
+     * EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery/bitmap type()
+     * 1. (not) in/exists SubQuery
+     * 2. (not) in/exists SubQuery OR/AND (not) in/exists SubQuery
+     * 3. (not) in/exists SubQuery OR/AND (equal/non-equal)
+     * 4. Corelated / non-correlated / Scalar
+     * 5. composed expr：SubQuery
+     * 6. null/not null/uk/no-uk
+     */
+    // 1. multi table + olap table + filter/on condition + and + correlated + equal
+    qt_1_1 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 in (select c1 from t2) and t1.c1 > 1;"""
+    qt_1_2 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2) and t1.c1 > 1;"""
+
+    qt_1_3 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 in (select c1 from t2) and t1.c1 > 1;"""
+    qt_1_4 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2) and t1.c1 > 1;"""
+
+    qt_1_5 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) and t1.c1 > 1;"""
+    qt_1_6 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) and t1.c1 > 1;"""
+
+    qt_1_7 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) and t1.c1 > 1;"""
+    qt_1_8 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) and t1.c1 > 1;"""
+
+    qt_1_9 """select * from t1, t3 where t1.c3 = t3.c3 and exists (select c1 from t2 where t1.c1 = t2.c1) and t1.c1 > 1;"""
+    qt_1_10 """select * from t1, t3 where t1.c3 = t3.c3 and not exists (select c1 from t2 where t1.c1 = t2.c1) and t1.c1 > 1;"""
+
+    qt_1_11 """select * from t1 left join t3 on t1.c3 = t3.c3 and exists (select c1 from t2 where t1.c1 = t2.c1) and t1.c1 > 1;"""
+    qt_1_12 """select * from t1 left join t3 on t1.c3 = t3.c3 and not exists (select c1 from t2 where t1.c1 = t2.c1) and t1.c1 > 1;"""
+
+    // 2. multi table + olap table + filter/on condition + and + correlated + non-equal
+    qt_2_1 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 < t2.c2) and t1.c1 > 1;"""
+    qt_2_2 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2) and t1.c1 > 1;"""
+
+    qt_2_3 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 < t2.c2) and t1.c1 > 1;"""
+    qt_2_4 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2) and t1.c1 > 1;"""
+
+    qt_2_5 """select * from t1, t3 where t1.c3 = t3.c3 and exists (select c1 from t2 where t1.c1 < t2.c1) and t1.c1 > 1;"""
+    qt_2_6 """select * from t1, t3 where t1.c3 = t3.c3 and not exists (select c1 from t2 where t1.c1 < t2.c1) and t1.c1 > 1;"""
+
+    qt_2_7 """select * from t1 left join t3 on t1.c3 = t3.c3 and exists (select c1 from t2 where t1.c1 < t2.c1) and t1.c1 > 1;"""
+    qt_2_8 """select * from t1 left join t3 on t1.c3 = t3.c3 and not exists (select c1 from t2 where t1.c1 < t2.c1) and t1.c1 > 1;"""
+
+    // 3. multi table + olap table + filter/on condition + and + correlated + (mixed equal & non-equal)
+    qt_3_1 """select * from t1, t3 where t1.c4 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3) and t1.c1 > 1;"""
+    qt_3_2 """select * from t1, t3 where t1.c4 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3) and t1.c1 > 1;"""
+
+    qt_3_3 """select * from t1 left join t3 on t1.c4 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3) and t1.c1 > 1;"""
+    qt_3_4 """select * from t1 left join t3 on t1.c4 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3) and t1.c1 > 1;"""
+
+    qt_3_5 """select * from t1, t3 where t1.c4 = t3.c3 and exists (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3) and t1.c1 > 1;"""
+    qt_3_6 """select * from t1, t3 where t1.c4 = t3.c3 and not exists (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3) and t1.c1 > 1;"""
+
+    qt_3_7 """select * from t1 left join t3 on t1.c4 = t3.c3 and exists (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3) and t1.c1 > 1;"""
+    qt_3_8 """select * from t1 left join t3 on t1.c4 = t3.c3 and not exists (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3) and t1.c1 > 1;"""
+
+    // 4. multi table + olap table + filter/on condition + and + non-correlated
+    qt_4_1 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 = 1) and t1.c1 > 1;"""
+    qt_4_2 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 = 1) and t1.c1 > 1;"""
+
+    qt_4_3 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 = 1) and t1.c1 > 1;"""
+    qt_4_4 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 = 1) and t1.c1 > 1;"""
+
+    qt_4_5 """select * from t1, t3 where t1.c3 = t3.c3 and exists (select c1 from t2 where t1.c2 = 1) and t1.c1 > 1;"""
+    qt_4_6 """select * from t1, t3 where t1.c3 = t3.c3 and not exists (select c1 from t2 where t1.c2 = 1) and t1.c1 > 1;"""
+
+    qt_4_7 """select * from t1 left join t3 on t1.c3 = t3.c3 and exists (select c1 from t2 where t1.c2 = 1) and t1.c1 > 1;"""
+    qt_4_8 """select * from t1 left join t3 on t1.c3 = t3.c3 and not exists (select c1 from t2 where t1.c2 = 1) and t1.c1 > 1;"""
+
+    // 5. multi table + olap table + filter/on condition + and + scalar
+    qt_5_1 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 in (select max(c1) from t2) and t1.c1 > 1;"""
+    qt_5_2 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 not in (select max(c1) from t2) and t1.c1 > 1;"""
+
+    qt_5_3 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 in (select max(c1) from t2) and t1.c1 > 1;"""
+    qt_5_4 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 not in (select max(c1) from t2) and t1.c1 > 1;"""
+
+    qt_5_5 """select * from t1, t3 where t1.c3 = t3.c3 and exists (select max(c1) from t2 where t1.c1 = t2.c1) and t1.c1 > 1;"""
+    qt_5_6 """select * from t1, t3 where t1.c3 = t3.c3 and not exists (select max(c1) from t2 where t1.c1 = t2.c1) and t1.c1 > 1;"""
+
+    qt_5_7 """select * from t1 left join t3 on t1.c3 = t3.c3 and exists (select max(c1) from t2 where t1.c1 = t2.c1) and t1.c1 > 1;"""
+    qt_5_8 """select * from t1 left join t3 on t1.c3 = t3.c3 and not exists (select max(c1) from t2 where t1.c1 = t2.c1) and t1.c1 > 1;"""
+
+    // 6. multi table + olap table + filter/on condition + and + correlated + limit
+    qt_6_1 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 limit 1) and t1.c1 > 1;"""
+    qt_6_2 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 limit 0) and t1.c1 > 1;"""
+
+    qt_6_3 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 limit 1) and t1.c1 > 1;"""
+    qt_6_4 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 limit 0) and t1.c1 > 1;"""
+
+    qt_6_5 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 limit 1) and t1.c1 > 1;"""
+    qt_6_6 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 limit 0) and t1.c1 > 1;"""
+
+    qt_6_7 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 limit 1) and t1.c1 > 1;"""
+    qt_6_8 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 limit 0) and t1.c1 > 1;"""
+
+    qt_6_9 """select * from t1, t3 where t1.c3 = t3.c3 and exists (select c1 from t2 where t1.c1 = t2.c1 limit 0) and t1.c1 > 1;"""
+    qt_6_10 """select * from t1, t3 where t1.c3 = t3.c3 and not exists (select c1 from t2 where t1.c1 = t2.c1 limit 1) and t1.c1 > 1;"""
+
+    qt_6_11 """select * from t1 left join t3 on t1.c3 = t3.c3 and exists (select c1 from t2 where t1.c1 = t2.c1 limit 0) and t1.c1 > 1;"""
+    qt_6_12 """select * from t1 left join t3 on t1.c3 = t3.c3 and not exists (select c1 from t2 where t1.c1 = t2.c1 limit 1) and t1.c1 > 1;"""
+}
+

--- a/regression-test/suites/nereids_rules_p0/subquery/multitable/subquery_multitable_pullup_and_subquery.groovy
+++ b/regression-test/suites/nereids_rules_p0/subquery/multitable/subquery_multitable_pullup_and_subquery.groovy
@@ -1,0 +1,270 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("subquery_multitable_pullup_and_subquery") {
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+
+    sql """DROP TABLE IF EXISTS t1;"""
+    sql """DROP TABLE IF EXISTS t2;"""
+    sql """DROP TABLE IF EXISTS t3;"""
+    sql """DROP TABLE IF EXISTS t4;"""
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t1(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t2(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t3(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t4(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """INSERT INTO t1 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t1 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t1 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t1 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t2 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t2 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t2 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t2 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t3 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t3 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t3 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t3 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t4 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t4 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t4 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t4 VALUES (3,3,3,3);"""
+
+    /**
+     * | DML      | insert/update/delete |
+     * | select   | SELECT LIST: SubQuery |
+     * | From     | (OlapScan/ExternalScan)/view/partition(hash/range)/MV |
+     * | Join     | JOIN TYPE: inner/outer(left/right/full)/semi(left/right)/anti(left/right) ON condition: SubQuery |
+     * | Filter   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Group by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Having   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Order by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Winfunc  | Partition by / Order by EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Limit    | Limit / offset |
+     * | Set op   | union(all)/intersect(all)/except(all) |
+     * | SubQuery | Correlated subquery / non-correlated subquery / Scalar |
+     * EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery/bitmap type()
+     * 1. (not) in/exists SubQuery
+     * 2. (not) in/exists SubQuery OR/AND (not) in/exists SubQuery
+     * 3. (not) in/exists SubQuery OR/AND (equal/non-equal)
+     * 4. Corelated / non-correlated / Scalar
+     * 5. composed expr：SubQuery
+     * 6. null/not null/uk/no-uk
+     */
+    // 1. multi table + olap table + filter/on condition + and + correlated + equal
+    qt_1_1 """select * from t1, t4 where t1.c4 = t3.c4 and t1.c1 in (select c1 from t2) and t1.c2 in (select c1 from t3);"""
+    qt_1_2 """select * from t1, t4 where t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2) and t1.c2 in (select c1 from t3);"""
+    qt_1_3 """select * from t1, t4 where t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2) and t1.c2 not in (select c1 from t3);"""
+
+    qt_1_4 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 in (select c1 from t2) and t1.c2 in (select c1 from t3);"""
+    qt_1_5 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2) and t1.c2 in (select c1 from t3);"""
+    qt_1_6 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2) and t1.c2 not in (select c1 from t3);"""
+
+    qt_1_7 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2) and t1.c2 in (select c1 from t3);"""
+    qt_1_8 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2) and t1.c2 in (select c1 from t3);"""
+    qt_1_9 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2) and t1.c2 not in (select c1 from t3);"""
+
+    qt_1_10 """select * from t1, t4 where t1.c4 = t3.c4 and t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_1_11 """select * from t1, t4 where t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_1_12 """select * from t1, t4 where t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) and t1.c2 not in (select c1 from t3 where t1.c3 = t3.c2);"""
+
+    qt_1_13 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_1_14 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_1_15 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) and t1.c2 not in (select c1 from t3 where t1.c3 = t3.c2);"""
+
+    qt_1_16 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_1_17 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_1_18 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) and t1.c2 not in (select c1 from t3 where t1.c3 = t3.c2);"""
+
+    qt_1_19 """select * from t1, t4 where t1.c4 = t3.c4 and exists (select c1 from t2 where t1.c1 = t2.c1) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_1_20 """select * from t1, t4 where t1.c4 = t3.c4 and not exists (select c1 from t2 where t1.c1 = t2.c1) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_1_21 """select * from t1, t4 where t1.c4 = t3.c4 and not exists (select c1 from t2 where t1.c1 = t2.c1) and not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+
+    qt_1_22 """select * from t1 left join t4 on t1.c4 = t3.c4 and exists (select c1 from t2 where t1.c1 = t2.c1) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_1_23 """select * from t1 left join t4 on t1.c4 = t3.c4 and not exists (select c1 from t2 where t1.c1 = t2.c1) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_1_24 """select * from t1 left join t4 on t1.c4 = t3.c4 and not exists (select c1 from t2 where t1.c1 = t2.c1) and not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+
+    qt_1_25 """select * from t1 left join t4 on t1.c4 = t3.c4 where exists (select c1 from t2 where t1.c1 = t2.c1) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_1_26 """select * from t1 left join t4 on t1.c4 = t3.c4 where not exists (select c1 from t2 where t1.c1 = t2.c1) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_1_27 """select * from t1 left join t4 on t1.c4 = t3.c4 where not exists (select c1 from t2 where t1.c1 = t2.c1) and not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+
+    // 2. multi table + olap table + filter/on condition + in + and + exists + correlated + equal
+    qt_2_1 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_2_2 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_2_3 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2) and t1.c2 not in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_2_4 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2) and t1.c2 not in (select c1 from t3 where t1.c3 = t3.c2);"""
+
+    qt_2_5 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_2_6 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_2_7 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2) and t1.c2 not in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_2_8 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2) and t1.c2 not in (select c1 from t3 where t1.c3 = t3.c2);"""
+
+    qt_2_9 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 in (select c1 from t2) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_2_10 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_2_11 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 in (select c1 from t2) and t1.c2 not in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_2_12 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2) and t1.c2 not in (select c1 from t3 where t1.c3 = t3.c2);"""
+
+    qt_2_13 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_14 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_15 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2) and not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_16 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2) and not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+
+    qt_2_17 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_18 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_19 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2) and not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_20 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2) and not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+
+    qt_2_21 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 in (select c1 from t2) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_22 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_23 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 in (select c1 from t2) and not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_24 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2) and not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+
+    qt_2_25 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_26 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_27 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) and not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_28 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) and not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+
+    qt_2_29 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_30 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_31 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) and not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_32 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) and not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+
+    qt_2_33 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_34 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_35 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) and not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_36 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) and not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+
+    // 3. multi table + olap table + filter/on condition + and + correlated + non-equal
+    qt_3_1 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2 where t1.c2 < t2.c2) and t1.c3 in (select c1 from t3 where t1.c4 < t3.c2);"""
+    qt_3_2 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2) and t1.c3 in (select c1 from t3 where t1.c4 < t3.c2);"""
+    qt_3_3 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2) and t1.c3 not in (select c1 from t3 where t1.c4 < t3.c2);"""
+
+    qt_3_4 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2 where t1.c2 < t2.c2) and t1.c3 in (select c1 from t3 where t1.c4 < t3.c2);"""
+    qt_3_5 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2) and t1.c3 in (select c1 from t3 where t1.c4 < t3.c2);"""
+    qt_3_6 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2) and t1.c3 not in (select c1 from t3 where t1.c4 < t3.c2);"""
+
+    qt_3_7 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 in (select c1 from t2 where t1.c2 < t2.c2) and t1.c3 in (select c1 from t3 where t1.c4 < t3.c2);"""
+    qt_3_8 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2) and t1.c3 in (select c1 from t3 where t1.c4 < t3.c2);"""
+    qt_3_9 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2) and t1.c3 not in (select c1 from t3 where t1.c4 < t3.c2);"""
+
+    qt_3_10 """select * from t1 left join t4 on t1.c4 = t3.c4 and exists (select c1 from t2 where t1.c1 < t2.c1) and exists (select c1 from t3 where t1.c2 < t3.c1);"""
+    qt_3_11 """select * from t1 left join t4 on t1.c4 = t3.c4 and not exists (select c1 from t2 where t1.c1 < t2.c1) and exists (select c1 from t3 where t1.c2 < t3.c1);"""
+    qt_3_12 """select * from t1 left join t4 on t1.c4 = t3.c4 and not exists (select c1 from t2 where t1.c1 < t2.c1) and not exists (select c1 from t3 where t1.c2 < t3.c1);"""
+
+    // 4. multi table + olap table + filter/on condition + and + non-correlated
+    qt_4_1 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2 where t1.c2 = 1) and t1.c2 in (select c1 from t3 where t3.c2 = 1);"""
+    qt_4_2 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 = 1) and t1.c2 in (select c1 from t3 where t3.c2 = 1);"""
+    qt_4_3 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 = 1) and t1.c2 not in (select c1 from t3 where t3.c2 = 1);"""
+
+    qt_4_4 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2 where t1.c2 = 1) and t1.c2 in (select c1 from t3 where t3.c2 = 1);"""
+    qt_4_5 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 = 1) and t1.c2 in (select c1 from t3 where t3.c2 = 1);"""
+    qt_4_6 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 = 1) and t1.c2 not in (select c1 from t3 where t3.c2 = 1);"""
+
+    qt_4_7 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 in (select c1 from t2 where t1.c2 = 1) and t1.c2 in (select c1 from t3 where t3.c2 = 1);"""
+    qt_4_8 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2 where t1.c2 = 1) and t1.c2 in (select c1 from t3 where t3.c2 = 1);"""
+    qt_4_9 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2 where t1.c2 = 1) and t1.c2 not in (select c1 from t3 where t3.c2 = 1);"""
+
+    qt_4_10 """select * from t1 inner join t4 on t1.c4 = t3.c4 where exists (select c1 from t2 where t2.c1 = 1) and exists (select c1 from t3 where t3.c1 = 1);"""
+    qt_4_11 """select * from t1 inner join t4 on t1.c4 = t3.c4 where not exists (select c1 from t2 where t1.c1 = 1) and exists (select c1 from t3 where t3.c1 = 1);"""
+    qt_4_12 """select * from t1 inner join t4 on t1.c4 = t3.c4 where not exists (select c1 from t2 where t1.c1 = 1) and not exists (select c1 from t3 where t3.c1 = 1);"""
+
+    qt_4_13 """select * from t1 left join t4 on t1.c4 = t3.c4 where exists (select c1 from t2 where t2.c1 = 1) and exists (select c1 from t3 where t3.c1 = 1);"""
+    qt_4_14 """select * from t1 left join t4 on t1.c4 = t3.c4 where not exists (select c1 from t2 where t1.c1 = 1) and exists (select c1 from t3 where t3.c1 = 1);"""
+    qt_4_15 """select * from t1 left join t4 on t1.c4 = t3.c4 where not exists (select c1 from t2 where t1.c1 = 1) and not exists (select c1 from t3 where t3.c1 = 1);"""
+
+    qt_4_16 """select * from t1 left join t4 on t1.c4 = t3.c4 and exists (select c1 from t2 where t2.c1 = 1) and exists (select c1 from t3 where t3.c1 = 1);"""
+    qt_4_17 """select * from t1 left join t4 on t1.c4 = t3.c4 and not exists (select c1 from t2 where t1.c1 = 1) and exists (select c1 from t3 where t3.c1 = 1);"""
+    qt_4_18 """select * from t1 left join t4 on t1.c4 = t3.c4 and not exists (select c1 from t2 where t1.c1 = 1) and not exists (select c1 from t3 where t3.c1 = 1);"""
+
+    // 5. multi table + olap table + filter/on condition + correlated + and + non-correlated
+    qt_5_1 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2 where t1.c2 = 1) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_5_2 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 = 1) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_5_3 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 = 1) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+
+    qt_5_4 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2 where t1.c2 = 1) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_5_5 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 = 1) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_5_6 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 = 1) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+
+    qt_5_7 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 in (select c1 from t2 where t1.c2 = 1) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_5_8 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2 where t1.c2 = 1) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_5_9 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2 where t1.c2 = 1) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+
+    qt_5_10 """select * from t1 inner join t4 on t1.c4 = t3.c4 where exists (select c1 from t2 where t2.c1 = 1) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_5_11 """select * from t1 inner join t4 on t1.c4 = t3.c4 where not exists (select c1 from t2 where t2.c1 = 1) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_5_12 """select * from t1 inner join t4 on t1.c4 = t3.c4 where not exists (select c1 from t2 where t2.c1 = 1) and not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+
+    qt_5_13 """select * from t1 left join t4 on t1.c4 = t3.c4 where exists (select c1 from t2 where t2.c1 = 1) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_5_14 """select * from t1 left join t4 on t1.c4 = t3.c4 where not exists (select c1 from t2 where t2.c1 = 1) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_5_15 """select * from t1 left join t4 on t1.c4 = t3.c4 where not exists (select c1 from t2 where t2.c1 = 1) and not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+
+    qt_5_16 """select * from t1 left join t4 on t1.c4 = t3.c4 and exists (select c1 from t2 where t2.c1 = 1) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_5_17 """select * from t1 left join t4 on t1.c4 = t3.c4 and not exists (select c1 from t2 where t2.c1 = 1) and exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_5_18 """select * from t1 left join t4 on t1.c4 = t3.c4 and not exists (select c1 from t2 where t2.c1 = 1) and not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+}
+

--- a/regression-test/suites/nereids_rules_p0/subquery/multitable/subquery_multitable_pullup_basic.groovy
+++ b/regression-test/suites/nereids_rules_p0/subquery/multitable/subquery_multitable_pullup_basic.groovy
@@ -1,0 +1,191 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("subquery_multitable_pullup_basic") {
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+
+    sql """DROP TABLE IF EXISTS t1;"""
+    sql """DROP TABLE IF EXISTS t2;"""
+    sql """DROP TABLE IF EXISTS t3;"""
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t1(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t2(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t3(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """INSERT INTO t1 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t1 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t1 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t1 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t2 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t2 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t2 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t2 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t3 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t3 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t3 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t3 VALUES (3,3,3,3);"""
+
+    /**
+     * | DML      | insert/update/delete |
+     * | select   | SELECT LIST: SubQuery |
+     * | From     | (OlapScan/ExternalScan)/view/partition(hash/range)/MV |
+     * | Join     | JOIN TYPE: inner/outer(left/right/full)/semi(left/right)/anti(left/right) ON condition: SubQuery |
+     * | Filter   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Group by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Having   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Order by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Winfunc  | Partition by / Order by EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Limit    | Limit / offset |
+     * | Set op   | union(all)/intersect(all)/except(all) |
+     * | SubQuery | Correlated subquery / non-correlated subquery / Scalar |
+     * EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery/bitmap type()
+     * 1. (not) in/exists SubQuery
+     * 2. (not) in/exists SubQuery OR/AND (not) in/exists SubQuery
+     * 3. (not) in/exists SubQuery OR/AND (equal/non-equal)
+     * 4. Corelated / non-correlated / Scalar
+     * 5. composed expr：SubQuery
+     * 6. null/not null/uk/no-uk
+     */
+    // 1. multi table + olap table + filter/on condition + basic + correlated + equal
+    qt_1_1 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 in (select c1 from t2);"""
+    qt_1_2 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2);"""
+
+    qt_1_3 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 in (select c1 from t2);"""
+    qt_1_4 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2);"""
+
+    qt_1_5 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 = t2.c2);"""
+    qt_1_6 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2);"""
+
+    qt_1_7 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 = t2.c2);"""
+    qt_1_8 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2);"""
+
+    qt_1_9 """select * from t1, t3 where t1.c3 = t3.c3 and exists (select c1 from t2 where t1.c1 = t2.c1);"""
+    qt_1_10 """select * from t1, t3 where t1.c3 = t3.c3 and not exists (select c1 from t2 where t1.c1 = t2.c1);"""
+
+    qt_1_11 """select * from t1 left join t3 on t1.c3 = t3.c3 and exists (select c1 from t2 where t1.c1 = t2.c1);"""
+    qt_1_12 """select * from t1 left join t3 on t1.c3 = t3.c3 and not exists (select c1 from t2 where t1.c1 = t2.c1);"""
+
+    // 2. multi table + olap table + filter/on condition + basic + correlated + non-equal
+    qt_2_1 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 < t2.c2);"""
+    qt_2_2 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2);"""
+
+    qt_2_3 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 < t2.c2);"""
+    qt_2_4 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2);"""
+
+    qt_2_5 """select * from t1, t3 where t1.c3 = t3.c3 and exists (select c1 from t2 where t1.c1 < t2.c1);"""
+    qt_2_6 """select * from t1, t3 where t1.c3 = t3.c3 and not exists (select c1 from t2 where t1.c1 < t2.c1);"""
+
+    qt_2_7 """select * from t1 left join t3 on t1.c3 = t3.c3 and exists (select c1 from t2 where t1.c1 < t2.c1);"""
+    qt_2_8 """select * from t1 left join t3 on t1.c3 = t3.c3 and not exists (select c1 from t2 where t1.c1 < t2.c1);"""
+
+    // 3. multi table + olap table + filter/on condition + basic + correlated + (mixed equal & non-equal)
+    qt_3_1 """select * from t1, t3 where t1.c4 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3);"""
+    qt_3_2 """select * from t1, t3 where t1.c4 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3);"""
+
+    qt_3_3 """select * from t1 left join t3 on t1.c4 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3);"""
+    qt_3_4 """select * from t1 left join t3 on t1.c4 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3);"""
+
+    qt_3_5 """select * from t1, t3 where t1.c4 = t3.c3 and exists (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3);"""
+    qt_3_6 """select * from t1, t3 where t1.c4 = t3.c3 and not exists (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3);"""
+
+    qt_3_7 """select * from t1 left join t3 on t1.c4 = t3.c3 and exists (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3);"""
+    qt_3_8 """select * from t1 left join t3 on t1.c4 = t3.c3 and not exists (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3);"""
+
+    // 4. multi table + olap table + filter/on condition + basic + non-correlated
+    qt_4_1 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 = 1);"""
+    qt_4_2 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 = 1);"""
+
+    qt_4_3 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 = 1);"""
+    qt_4_4 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 = 1);"""
+
+    qt_4_5 """select * from t1, t3 where t1.c3 = t3.c3 and exists (select c1 from t2 where t1.c2 = 1);"""
+    qt_4_6 """select * from t1, t3 where t1.c3 = t3.c3 and not exists (select c1 from t2 where t1.c2 = 1);"""
+
+    qt_4_7 """select * from t1 left join t3 on t1.c3 = t3.c3 and exists (select c1 from t2 where t1.c2 = 1);"""
+    qt_4_8 """select * from t1 left join t3 on t1.c3 = t3.c3 and not exists (select c1 from t2 where t1.c2 = 1);"""
+
+    // 5. multi table + olap table + filter/on condition + basic + scalar
+    qt_5_1 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 in (select max(c1) from t2);"""
+    qt_5_2 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 not in (select max(c1) from t2);"""
+
+    qt_5_3 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 in (select max(c1) from t2);"""
+    qt_5_4 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 not in (select max(c1) from t2);"""
+
+    qt_5_5 """select * from t1, t3 where t1.c3 = t3.c3 and exists (select max(c1) from t2 where t1.c1 = t2.c1);"""
+    qt_5_6 """select * from t1, t3 where t1.c3 = t3.c3 and not exists (select max(c1) from t2 where t1.c1 = t2.c1);"""
+
+    qt_5_7 """select * from t1 left join t3 on t1.c3 = t3.c3 and exists (select max(c1) from t2 where t1.c1 = t2.c1);"""
+    qt_5_8 """select * from t1 left join t3 on t1.c3 = t3.c3 and not exists (select max(c1) from t2 where t1.c1 = t2.c1);"""
+
+    // 6. multi table + olap table + filter/on condition + basic + correlated + limit
+    qt_6_1 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 limit 1);"""
+    qt_6_2 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 limit 0);"""
+
+    qt_6_3 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 limit 1);"""
+    qt_6_4 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 limit 0);"""
+
+    qt_6_5 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 limit 1);"""
+    qt_6_6 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 limit 0);"""
+
+    qt_6_7 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 limit 1);"""
+    qt_6_8 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 limit 0);"""
+
+    qt_6_9 """select * from t1, t3 where t1.c3 = t3.c3 and exists (select c1 from t2 where t1.c1 = t2.c1 limit 0);"""
+    qt_6_10 """select * from t1, t3 where t1.c3 = t3.c3 and not exists (select c1 from t2 where t1.c1 = t2.c1 limit 1);"""
+
+    qt_6_11 """select * from t1 left join t3 on t1.c3 = t3.c3 and exists (select c1 from t2 where t1.c1 = t2.c1 limit 0);"""
+    qt_6_12 """select * from t1 left join t3 on t1.c3 = t3.c3 and not exists (select c1 from t2 where t1.c1 = t2.c1 limit 1);"""
+}
+

--- a/regression-test/suites/nereids_rules_p0/subquery/multitable/subquery_multitable_pullup_or.groovy
+++ b/regression-test/suites/nereids_rules_p0/subquery/multitable/subquery_multitable_pullup_or.groovy
@@ -1,0 +1,191 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("subquery_multitable_pullup_or") {
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+
+    sql """DROP TABLE IF EXISTS t1;"""
+    sql """DROP TABLE IF EXISTS t2;"""
+    sql """DROP TABLE IF EXISTS t3;"""
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t1(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t2(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t3(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """INSERT INTO t1 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t1 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t1 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t1 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t2 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t2 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t2 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t2 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t3 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t3 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t3 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t3 VALUES (3,3,3,3);"""
+
+    /**
+     * | DML      | insert/update/delete |
+     * | select   | SELECT LIST: SubQuery |
+     * | From     | (OlapScan/ExternalScan)/view/partition(hash/range)/MV |
+     * | Join     | JOIN TYPE: inner/outer(left/right/full)/semi(left/right)/anti(left/right) ON condition: SubQuery |
+     * | Filter   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Group by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Having   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Order by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Winfunc  | Partition by / Order by EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Limit    | Limit / offset |
+     * | Set op   | union(all)/intersect(all)/except(all) |
+     * | SubQuery | Correlated subquery / non-correlated subquery / Scalar |
+     * EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery/bitmap type()
+     * 1. (not) in/exists SubQuery
+     * 2. (not) in/exists SubQuery OR/AND (not) in/exists SubQuery
+     * 3. (not) in/exists SubQuery OR/AND (equal/non-equal)
+     * 4. Corelated / non-correlated / Scalar
+     * 5. composed expr：SubQuery
+     * 6. null/not null/uk/no-uk
+     */
+    // 1. multi table + olap table + filter/on condition + or + correlated + equal
+    qt_1_1 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 in (select c1 from t2) or t1.c1 > 1;"""
+    qt_1_2 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2) or t1.c1 > 1;"""
+
+    qt_1_3 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 in (select c1 from t2) or t1.c1 > 1;"""
+    qt_1_4 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2) or t1.c1 > 1;"""
+
+    qt_1_5 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) or t1.c1 > 1;"""
+    qt_1_6 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) or t1.c1 > 1;"""
+
+    qt_1_7 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) or t1.c1 > 1;"""
+    qt_1_8 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) or t1.c1 > 1;"""
+
+    qt_1_9 """select * from t1, t3 where t1.c3 = t3.c3 and exists (select c1 from t2 where t1.c1 = t2.c1) or t1.c1 > 1;"""
+    qt_1_10 """select * from t1, t3 where t1.c3 = t3.c3 and not exists (select c1 from t2 where t1.c1 = t2.c1) or t1.c1 > 1;"""
+
+    qt_1_11 """select * from t1 left join t3 on t1.c3 = t3.c3 and exists (select c1 from t2 where t1.c1 = t2.c1) or t1.c1 > 1;"""
+    qt_1_12 """select * from t1 left join t3 on t1.c3 = t3.c3 and not exists (select c1 from t2 where t1.c1 = t2.c1) or t1.c1 > 1;"""
+
+    // 2. multi table + olap table + filter/on condition + or + correlated + non-equal
+    qt_2_1 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 < t2.c2) or t1.c1 > 1;"""
+    qt_2_2 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2) or t1.c1 > 1;"""
+
+    qt_2_3 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 < t2.c2) or t1.c1 > 1;"""
+    qt_2_4 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2) or t1.c1 > 1;"""
+
+    qt_2_5 """select * from t1, t3 where t1.c3 = t3.c3 and exists (select c1 from t2 where t1.c1 < t2.c1) or t1.c1 > 1;"""
+    qt_2_6 """select * from t1, t3 where t1.c3 = t3.c3 and not exists (select c1 from t2 where t1.c1 < t2.c1) or t1.c1 > 1;"""
+
+    qt_2_7 """select * from t1 left join t3 on t1.c3 = t3.c3 and exists (select c1 from t2 where t1.c1 < t2.c1) or t1.c1 > 1;"""
+    qt_2_8 """select * from t1 left join t3 on t1.c3 = t3.c3 and not exists (select c1 from t2 where t1.c1 < t2.c1) or t1.c1 > 1;"""
+
+    // 3. multi table + olap table + filter/on condition + or + correlated + (mixed equal & non-equal)
+    qt_3_1 """select * from t1, t3 where t1.c4 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3) or t1.c1 > 1;"""
+    qt_3_2 """select * from t1, t3 where t1.c4 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3) or t1.c1 > 1;"""
+
+    qt_3_3 """select * from t1 left join t3 on t1.c4 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3) or t1.c1 > 1;"""
+    qt_3_4 """select * from t1 left join t3 on t1.c4 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3) or t1.c1 > 1;"""
+
+    qt_3_5 """select * from t1, t3 where t1.c4 = t3.c3 and exists (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3) or t1.c1 > 1;"""
+    qt_3_6 """select * from t1, t3 where t1.c4 = t3.c3 and not exists (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3) or t1.c1 > 1;"""
+
+    qt_3_7 """select * from t1 left join t3 on t1.c4 = t3.c3 and exists (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3) or t1.c1 > 1;"""
+    qt_3_8 """select * from t1 left join t3 on t1.c4 = t3.c3 and not exists (select c1 from t2 where t1.c2 = t2.c2 and t1.c3 < t2.c3) or t1.c1 > 1;"""
+
+    // 4. multi table + olap table + filter/on condition + or + non-correlated
+    qt_4_1 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 = 1) or t1.c1 > 1;"""
+    qt_4_2 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 = 1) or t1.c1 > 1;"""
+
+    qt_4_3 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 = 1) or t1.c1 > 1;"""
+    qt_4_4 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 = 1) or t1.c1 > 1;"""
+
+    qt_4_5 """select * from t1, t3 where t1.c3 = t3.c3 and exists (select c1 from t2 where t1.c2 = 1) or t1.c1 > 1;"""
+    qt_4_6 """select * from t1, t3 where t1.c3 = t3.c3 and not exists (select c1 from t2 where t1.c2 = 1) or t1.c1 > 1;"""
+
+    qt_4_7 """select * from t1 left join t3 on t1.c3 = t3.c3 and exists (select c1 from t2 where t1.c2 = 1) or t1.c1 > 1;"""
+    qt_4_8 """select * from t1 left join t3 on t1.c3 = t3.c3 and not exists (select c1 from t2 where t1.c2 = 1) or t1.c1 > 1;"""
+
+    // 5. multi table + olap table + filter/on condition + or + scalar
+    qt_5_1 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 in (select max(c1) from t2) or t1.c1 > 1;"""
+    qt_5_2 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 not in (select max(c1) from t2) or t1.c1 > 1;"""
+
+    qt_5_3 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 in (select max(c1) from t2) or t1.c1 > 1;"""
+    qt_5_4 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 not in (select max(c1) from t2) or t1.c1 > 1;"""
+
+    qt_5_5 """select * from t1, t3 where t1.c3 = t3.c3 and exists (select max(c1) from t2 where t1.c1 = t2.c1) or t1.c1 > 1;"""
+    qt_5_6 """select * from t1, t3 where t1.c3 = t3.c3 and not exists (select max(c1) from t2 where t1.c1 = t2.c1) or t1.c1 > 1;"""
+
+    qt_5_7 """select * from t1 left join t3 on t1.c3 = t3.c3 and exists (select max(c1) from t2 where t1.c1 = t2.c1) or t1.c1 > 1;"""
+    qt_5_8 """select * from t1 left join t3 on t1.c3 = t3.c3 and not exists (select max(c1) from t2 where t1.c1 = t2.c1) or t1.c1 > 1;"""
+
+    // 6. multi table + olap table + filter/on condition + or + correlated + limit
+    qt_6_1 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 limit 1) or t1.c1 > 1;"""
+    qt_6_2 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 limit 0) or t1.c1 > 1;"""
+
+    qt_6_3 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 limit 1) or t1.c1 > 1;"""
+    qt_6_4 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 limit 0) or t1.c1 > 1;"""
+
+    qt_6_5 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 limit 1) or t1.c1 > 1;"""
+    qt_6_6 """select * from t1, t3 where t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 limit 0) or t1.c1 > 1;"""
+
+    qt_6_7 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 in (select c1 from t2 where t1.c2 = t2.c2 limit 1) or t1.c1 > 1;"""
+    qt_6_8 """select * from t1 left join t3 on t1.c3 = t3.c3 and t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2 limit 0) or t1.c1 > 1;"""
+
+    qt_6_9 """select * from t1, t3 where t1.c3 = t3.c3 and exists (select c1 from t2 where t1.c1 = t2.c1 limit 0) or t1.c1 > 1;"""
+    qt_6_10 """select * from t1, t3 where t1.c3 = t3.c3 and not exists (select c1 from t2 where t1.c1 = t2.c1 limit 1) or t1.c1 > 1;"""
+
+    qt_6_11 """select * from t1 left join t3 on t1.c3 = t3.c3 and exists (select c1 from t2 where t1.c1 = t2.c1 limit 0) or t1.c1 > 1;"""
+    qt_6_12 """select * from t1 left join t3 on t1.c3 = t3.c3 and not exists (select c1 from t2 where t1.c1 = t2.c1 limit 1) or t1.c1 > 1;"""
+}
+

--- a/regression-test/suites/nereids_rules_p0/subquery/multitable/subquery_multitable_pullup_or_subquery.groovy
+++ b/regression-test/suites/nereids_rules_p0/subquery/multitable/subquery_multitable_pullup_or_subquery.groovy
@@ -1,0 +1,270 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("subquery_multitable_pullup_or_subquery") {
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+
+    sql """DROP TABLE IF EXISTS t1;"""
+    sql """DROP TABLE IF EXISTS t2;"""
+    sql """DROP TABLE IF EXISTS t3;"""
+    sql """DROP TABLE IF EXISTS t4;"""
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t1(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t2(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t3(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t4(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """INSERT INTO t1 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t1 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t1 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t1 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t2 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t2 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t2 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t2 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t3 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t3 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t3 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t3 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t4 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t4 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t4 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t4 VALUES (3,3,3,3);"""
+
+    /**
+     * | DML      | insert/update/delete |
+     * | select   | SELECT LIST: SubQuery |
+     * | From     | (OlapScan/ExternalScan)/view/partition(hash/range)/MV |
+     * | Join     | JOIN TYPE: inner/outer(left/right/full)/semi(left/right)/anti(left/right) ON condition: SubQuery |
+     * | Filter   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Group by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Having   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Order by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Winfunc  | Partition by / Order by EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Limit    | Limit / offset |
+     * | Set op   | union(all)/intersect(all)/except(all) |
+     * | SubQuery | Correlated subquery / non-correlated subquery / Scalar |
+     * EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery/bitmap type()
+     * 1. (not) in/exists SubQuery
+     * 2. (not) in/exists SubQuery OR/AND (not) in/exists SubQuery
+     * 3. (not) in/exists SubQuery OR/AND (equal/non-equal)
+     * 4. Corelated / non-correlated / Scalar
+     * 5. composed expr：SubQuery
+     * 6. null/not null/uk/no-uk
+     */
+    // 1. multi table + olap table + filter/on condition + or + correlated + equal
+    qt_1_1 """select * from t1, t4 where t1.c4 = t3.c4 or t1.c1 in (select c1 from t2) and t1.c2 in (select c1 from t3);"""
+    qt_1_2 """select * from t1, t4 where t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2) or t1.c2 in (select c1 from t3);"""
+    qt_1_3 """select * from t1, t4 where t1.c4 = t3.c4 or t1.c1 not in (select c1 from t2) or t1.c2 not in (select c1 from t3);"""
+
+    qt_1_4 """select * from t1 left join t4 on t1.c4 = t3.c4 or t1.c1 in (select c1 from t2) and t1.c2 in (select c1 from t3);"""
+    qt_1_5 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2) or t1.c2 in (select c1 from t3);"""
+    qt_1_6 """select * from t1 left join t4 on t1.c4 = t3.c4 or t1.c1 not in (select c1 from t2) or t1.c2 not in (select c1 from t3);"""
+
+    qt_1_7 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2) or t1.c2 in (select c1 from t3);"""
+    qt_1_8 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2) or t1.c2 in (select c1 from t3);"""
+    qt_1_9 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2) or t1.c2 not in (select c1 from t3);"""
+
+    qt_1_10 """select * from t1, t4 where t1.c4 = t3.c4 and t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) or t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_1_11 """select * from t1, t4 where t1.c4 = t3.c4 or t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_1_12 """select * from t1, t4 where t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) or t1.c2 not in (select c1 from t3 where t1.c3 = t3.c2);"""
+
+    qt_1_13 """select * from t1 left join t4 on t1.c4 = t3.c4 or t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) and t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_1_14 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) or t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_1_15 """select * from t1 left join t4 on t1.c4 = t3.c4 or t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) or t1.c2 not in (select c1 from t3 where t1.c3 = t3.c2);"""
+
+    qt_1_16 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) or t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_1_17 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) or t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_1_18 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) or t1.c2 not in (select c1 from t3 where t1.c3 = t3.c2);"""
+
+    qt_1_19 """select * from t1, t4 where t1.c4 = t3.c4 and exists (select c1 from t2 where t1.c1 = t2.c1) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_1_20 """select * from t1, t4 where t1.c4 = t3.c4 and not exists (select c1 from t2 where t1.c1 = t2.c1) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_1_21 """select * from t1, t4 where t1.c4 = t3.c4 and not exists (select c1 from t2 where t1.c1 = t2.c1) or not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+
+    qt_1_22 """select * from t1 left join t4 on t1.c4 = t3.c4 and exists (select c1 from t2 where t1.c1 = t2.c1) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_1_23 """select * from t1 left join t4 on t1.c4 = t3.c4 and not exists (select c1 from t2 where t1.c1 = t2.c1) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_1_24 """select * from t1 left join t4 on t1.c4 = t3.c4 and not exists (select c1 from t2 where t1.c1 = t2.c1) or not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+
+    qt_1_25 """select * from t1 left join t4 on t1.c4 = t3.c4 where exists (select c1 from t2 where t1.c1 = t2.c1) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_1_26 """select * from t1 left join t4 on t1.c4 = t3.c4 where not exists (select c1 from t2 where t1.c1 = t2.c1) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_1_27 """select * from t1 left join t4 on t1.c4 = t3.c4 where not exists (select c1 from t2 where t1.c1 = t2.c1) or not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+
+    // 2. multi table + olap table + filter/on condition + in + or + exists + correlated + equal
+    qt_2_1 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2) or t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_2_2 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2) or t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_2_3 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2) and t1.c2 or in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_2_4 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2) or t1.c2 not in (select c1 from t3 where t1.c3 = t3.c2);"""
+
+    qt_2_5 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2) or t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_2_6 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2) or t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_2_7 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2) or t1.c2 not in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_2_8 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2) or t1.c2 not in (select c1 from t3 where t1.c3 = t3.c2);"""
+
+    qt_2_9 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 in (select c1 from t2) or t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_2_10 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2) or t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_2_11 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 in (select c1 from t2) or t1.c2 not in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_2_12 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2) or t1.c2 not in (select c1 from t3 where t1.c3 = t3.c2);"""
+
+    qt_2_13 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_14 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_15 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2) or not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_16 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2) or not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+
+    qt_2_17 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_18 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_19 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2) or not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_20 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2) or not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+
+    qt_2_21 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 in (select c1 from t2) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_22 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_23 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 in (select c1 from t2) or not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_24 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2) or not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+
+    qt_2_25 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_26 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_27 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) or not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_28 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) or not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+
+    qt_2_29 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_30 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_31 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) or not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_32 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) or not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+
+    qt_2_33 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_34 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_35 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) or not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_2_36 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) or not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+
+    // 3. multi table + olap table + filter/on condition + or + correlated + non-equal
+    qt_3_1 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2 where t1.c2 < t2.c2) or t1.c3 in (select c1 from t3 where t1.c4 < t3.c2);"""
+    qt_3_2 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2) or t1.c3 in (select c1 from t3 where t1.c4 < t3.c2);"""
+    qt_3_3 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2) or t1.c3 not in (select c1 from t3 where t1.c4 < t3.c2);"""
+
+    qt_3_4 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2 where t1.c2 < t2.c2) or t1.c3 in (select c1 from t3 where t1.c4 < t3.c2);"""
+    qt_3_5 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2) or t1.c3 in (select c1 from t3 where t1.c4 < t3.c2);"""
+    qt_3_6 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2) or t1.c3 not in (select c1 from t3 where t1.c4 < t3.c2);"""
+
+    qt_3_7 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 in (select c1 from t2 where t1.c2 < t2.c2) or t1.c3 in (select c1 from t3 where t1.c4 < t3.c2);"""
+    qt_3_8 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2) or t1.c3 in (select c1 from t3 where t1.c4 < t3.c2);"""
+    qt_3_9 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2) or t1.c3 not in (select c1 from t3 where t1.c4 < t3.c2);"""
+
+    qt_3_10 """select * from t1 left join t4 on t1.c4 = t3.c4 and exists (select c1 from t2 where t1.c1 < t2.c1) or exists (select c1 from t3 where t1.c2 < t3.c1);"""
+    qt_3_11 """select * from t1 left join t4 on t1.c4 = t3.c4 and not exists (select c1 from t2 where t1.c1 < t2.c1) or exists (select c1 from t3 where t1.c2 < t3.c1);"""
+    qt_3_12 """select * from t1 left join t4 on t1.c4 = t3.c4 and not exists (select c1 from t2 where t1.c1 < t2.c1) or not exists (select c1 from t3 where t1.c2 < t3.c1);"""
+
+    // 4. multi table + olap table + filter/on condition + or + non-correlated
+    qt_4_1 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2 where t1.c2 = 1) or t1.c2 in (select c1 from t3 where t3.c2 = 1);"""
+    qt_4_2 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 = 1) or t1.c2 in (select c1 from t3 where t3.c2 = 1);"""
+    qt_4_3 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 = 1) or t1.c2 not in (select c1 from t3 where t3.c2 = 1);"""
+
+    qt_4_4 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2 where t1.c2 = 1) or t1.c2 in (select c1 from t3 where t3.c2 = 1);"""
+    qt_4_5 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 = 1) or t1.c2 in (select c1 from t3 where t3.c2 = 1);"""
+    qt_4_6 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 = 1) or t1.c2 not in (select c1 from t3 where t3.c2 = 1);"""
+
+    qt_4_7 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 in (select c1 from t2 where t1.c2 = 1) or t1.c2 in (select c1 from t3 where t3.c2 = 1);"""
+    qt_4_8 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2 where t1.c2 = 1) or t1.c2 in (select c1 from t3 where t3.c2 = 1);"""
+    qt_4_9 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2 where t1.c2 = 1) or t1.c2 not in (select c1 from t3 where t3.c2 = 1);"""
+
+    qt_4_10 """select * from t1 inner join t4 on t1.c4 = t3.c4 where exists (select c1 from t2 where t2.c1 = 1) or exists (select c1 from t3 where t3.c1 = 1);"""
+    qt_4_11 """select * from t1 inner join t4 on t1.c4 = t3.c4 where not exists (select c1 from t2 where t1.c1 = 1) or exists (select c1 from t3 where t3.c1 = 1);"""
+    qt_4_12 """select * from t1 inner join t4 on t1.c4 = t3.c4 where not exists (select c1 from t2 where t1.c1 = 1) or not exists (select c1 from t3 where t3.c1 = 1);"""
+
+    qt_4_13 """select * from t1 left join t4 on t1.c4 = t3.c4 where exists (select c1 from t2 where t2.c1 = 1) or exists (select c1 from t3 where t3.c1 = 1);"""
+    qt_4_14 """select * from t1 left join t4 on t1.c4 = t3.c4 where not exists (select c1 from t2 where t1.c1 = 1) or exists (select c1 from t3 where t3.c1 = 1);"""
+    qt_4_15 """select * from t1 left join t4 on t1.c4 = t3.c4 where not exists (select c1 from t2 where t1.c1 = 1) or not exists (select c1 from t3 where t3.c1 = 1);"""
+
+    qt_4_16 """select * from t1 left join t4 on t1.c4 = t3.c4 and exists (select c1 from t2 where t2.c1 = 1) or exists (select c1 from t3 where t3.c1 = 1);"""
+    qt_4_17 """select * from t1 left join t4 on t1.c4 = t3.c4 and not exists (select c1 from t2 where t1.c1 = 1) or exists (select c1 from t3 where t3.c1 = 1);"""
+    qt_4_18 """select * from t1 left join t4 on t1.c4 = t3.c4 and not exists (select c1 from t2 where t1.c1 = 1) or not exists (select c1 from t3 where t3.c1 = 1);"""
+
+    // 5. multi table + olap table + filter/on condition + correlated + or + non-correlated
+    qt_5_1 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2 where t1.c2 = 1) or t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_5_2 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 = 1) or t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_5_3 """select * from t1 inner join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 = 1) or t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+
+    qt_5_4 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 in (select c1 from t2 where t1.c2 = 1) or t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_5_5 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 = 1) or t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_5_6 """select * from t1 left join t4 on t1.c4 = t3.c4 where t1.c1 not in (select c1 from t2 where t1.c2 = 1) or t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+
+    qt_5_7 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 in (select c1 from t2 where t1.c2 = 1) or t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_5_8 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2 where t1.c2 = 1) or t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+    qt_5_9 """select * from t1 left join t4 on t1.c4 = t3.c4 and t1.c1 not in (select c1 from t2 where t1.c2 = 1) or t1.c2 in (select c1 from t3 where t1.c3 = t3.c2);"""
+
+    qt_5_10 """select * from t1 inner join t4 on t1.c4 = t3.c4 where exists (select c1 from t2 where t2.c1 = 1) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_5_11 """select * from t1 inner join t4 on t1.c4 = t3.c4 where not exists (select c1 from t2 where t2.c1 = 1) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_5_12 """select * from t1 inner join t4 on t1.c4 = t3.c4 where not exists (select c1 from t2 where t2.c1 = 1) or not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+
+    qt_5_13 """select * from t1 left join t4 on t1.c4 = t3.c4 where exists (select c1 from t2 where t2.c1 = 1) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_5_14 """select * from t1 left join t4 on t1.c4 = t3.c4 where not exists (select c1 from t2 where t2.c1 = 1) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_5_15 """select * from t1 left join t4 on t1.c4 = t3.c4 where not exists (select c1 from t2 where t2.c1 = 1) or not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+
+    qt_5_16 """select * from t1 left join t4 on t1.c4 = t3.c4 and exists (select c1 from t2 where t2.c1 = 1) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_5_17 """select * from t1 left join t4 on t1.c4 = t3.c4 and not exists (select c1 from t2 where t2.c1 = 1) or exists (select c1 from t3 where t1.c2 = t3.c2);"""
+    qt_5_18 """select * from t1 left join t4 on t1.c4 = t3.c4 and not exists (select c1 from t2 where t2.c1 = 1) or not exists (select c1 from t3 where t1.c2 = t3.c2);"""
+}
+

--- a/regression-test/suites/nereids_rules_p0/subquery/topop/subquery_topop_pullup_groupby.groovy
+++ b/regression-test/suites/nereids_rules_p0/subquery/topop/subquery_topop_pullup_groupby.groovy
@@ -1,0 +1,273 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("subquery_basic_pullup_orderby") {
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+
+    sql """DROP TABLE IF EXISTS t1;"""
+    sql """DROP TABLE IF EXISTS t2;"""
+    sql """DROP TABLE IF EXISTS t3;"""
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t1(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t2(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t3(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """INSERT INTO t1 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t1 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t1 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t1 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t2 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t2 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t2 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t2 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t3 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t3 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t3 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t3 VALUES (3,3,3,3);"""
+
+    /**
+     * | DML      | insert/update/delete |
+     * | select   | SELECT LIST: SubQuery |
+     * | From     | (OlapScan/ExternalScan)/view/partition(hash/range)/MV |
+     * | Join     | JOIN TYPE: inner/outer(left/right/full)/semi(left/right)/anti(left/right) ON condition: SubQuery |
+     * | Filter   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Group by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Having   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Order by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Winfunc  | Partition by / Order by EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Limit    | Limit / offset |
+     * | Set op   | union(all)/intersect(all)/except(all) |
+     * | SubQuery | Correlated subquery / non-correlated subquery / Scalar |
+     * EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery/bitmap type()
+     * 1. (not) in/exists SubQuery
+     * 2. (not) in/exists SubQuery OR/AND (not) in/exists SubQuery
+     * 3. (not) in/exists SubQuery OR/AND (equal/non-equal)
+     * 4. Corelated / non-correlated / Scalar
+     * 5. composed expr：SubQuery
+     * 6. null/not null/uk/no-uk
+     */
+    // 1. single table + olap table + group by + correlated + equal
+    qt_1_1 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 in (select c1 from t2);"""
+    qt_1_2 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 in (select c2 from t2);"""
+
+    qt_1_3 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 not in (select c1 from t2);"""
+    qt_1_4 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 not in (select c2 from t2);"""
+
+    qt_1_5 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 in (select c1 from t2);"""
+    qt_1_6 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 in (select c2 from t2);"""
+
+    qt_1_7 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 not in (select c1 from t2);"""
+    qt_1_8 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 not in (select c2 from t2);"""
+
+    qt_1_9 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 in (select c1 from t3);"""
+    qt_1_10 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 in (select c2 from t3);"""
+
+    qt_1_11 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 not in (select c1 from t3);"""
+    qt_1_12 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 not in (select c2 from t3);"""
+
+    qt_1_13 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 in (select c1 from t3);"""
+    qt_1_14 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 in (select c2 from t3);"""
+
+    qt_1_15 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 not in (select c1 from t3);"""
+    qt_1_16 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 not in (select c2 from t3);"""
+
+    qt_1_17 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by exists (select c1 from t2);"""
+    qt_1_18 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by exists (select c2 from t2);"""
+
+    qt_1_19 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by not exists (select c1 from t2);"""
+    qt_1_20 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by not exists (select c2 from t2);"""
+
+    qt_1_21 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by exists (select c1 from t3);"""
+    qt_1_22 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by exists (select c2 from t3);"""
+
+    qt_1_23 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by not exists (select c1 from t3);"""
+    qt_1_24 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by not exists (select c2 from t3);"""
+
+    qt_1_25 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by exists (select c1 from t3);"""
+    qt_1_26 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by exists (select c2 from t3);"""
+
+    qt_1_27 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by not exists (select c1 from t3);"""
+    qt_1_28 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by not exists (select c2 from t3);"""
+
+    // 2. single table + olap table + group by + correlated + explicit equal
+    qt_2_1 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 in (select c1 from t2 where t1.c4 = t2.c4);"""
+    qt_2_2 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 in (select c2 from t2 where t1.c4 = t2.c4);"""
+
+    qt_2_3 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 not in (select c1 from t2 where t1.c4 = t2.c4);"""
+    qt_2_4 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 not in (select c2 from t2 where t1.c4 = t2.c4);"""
+
+    qt_2_5 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 in (select c1 from t2 where t1.c4 = t2.c4);"""
+    qt_2_6 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 in (select c2 from t2 where t1.c4 = t2.c4);"""
+
+    qt_2_7 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 not in (select c1 from t2 where t1.c4 = t2.c4);"""
+    qt_2_8 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 not in (select c2 from t2 where t1.c4 = t2.c4);"""
+
+    qt_2_9 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 in (select c1 from t3 where t1.c4 = t3.c4);"""
+    qt_2_10 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 in (select c2 from t3 where t1.c4 = t3.c4);"""
+
+    qt_2_11 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 not in (select c1 from t3 where t1.c4 = t3.c4);"""
+    qt_2_12 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 not in (select c2 from t3 where t1.c4 = t3.c4);"""
+
+    qt_2_13 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 in (select c1 from t3 where t1.c4 = t3.c4);"""
+    qt_2_14 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 in (select c2 from t3 where t1.c4 = t3.c4);"""
+
+    qt_2_15 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 not in (select c1 from t3 where t1.c4 = t3.c4);"""
+    qt_2_16 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 not in (select c2 from t3 where t1.c4 = t3.c4);"""
+
+    qt_2_17 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by exists (select c1 from t2 where t1.c4 = t2.c4);"""
+    qt_2_18 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by exists (select c2 from t2 where t1.c4 = t2.c4);"""
+
+    qt_2_19 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by not exists (select c1 from t2 where t1.c4 = t2.c4);"""
+    qt_2_20 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by not exists (select c2 from t2 where t1.c4 = t2.c4);"""
+
+    qt_2_21 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by exists (select c1 from t3 where t1.c4 = t3.c4);"""
+    qt_2_22 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by exists (select c2 from t3 where t1.c4 = t3.c4);"""
+
+    qt_2_23 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by not exists (select c1 from t3 where t1.c4 = t3.c4);"""
+    qt_2_24 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by not exists (select c2 from t3 where t1.c4 = t3.c4);"""
+
+    qt_2_25 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by exists (select c1 from t3 where t1.c4 = t3.c4);"""
+    qt_2_26 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by exists (select c2 from t3 where t1.c4 = t3.c4);"""
+
+    qt_2_27 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by not exists (select c1 from t3 where t1.c4 = t3.c4);"""
+    qt_2_28 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by not exists (select c2 from t3 where t1.c4 = t3.c4);"""
+
+    // 3. single table + olap table + group by + correlated + explicit non-equal
+    qt_3_1 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 in (select c1 from t2 where t1.c4 < t2.c4);"""
+    qt_3_2 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 in (select c2 from t2 where t1.c4 < t2.c4);"""
+
+    qt_3_3 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 not in (select c1 from t2 where t1.c4 < t2.c4);"""
+    qt_3_4 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 not in (select c2 from t2 where t1.c4 < t2.c4);"""
+
+    qt_3_5 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 in (select c1 from t2 where t1.c4 < t2.c4);"""
+    qt_3_6 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 in (select c2 from t2 where t1.c4 < t2.c4);"""
+
+    qt_3_7 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 not in (select c1 from t2 where t1.c4 < t2.c4);"""
+    qt_3_8 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 not in (select c2 from t2 where t1.c4 < t2.c4);"""
+
+    qt_3_9 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 in (select c1 from t3 where t1.c4 < t3.c4);"""
+    qt_3_10 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 in (select c2 from t3 where t1.c4 < t3.c4);"""
+
+    qt_3_11 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 not in (select c1 from t3 where t1.c4 < t3.c4);"""
+    qt_3_12 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 not in (select c2 from t3 where t1.c4 < t3.c4);"""
+
+    qt_3_13 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 in (select c1 from t3 where t1.c4 < t3.c4);"""
+    qt_3_14 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 in (select c2 from t3 where t1.c4 < t3.c4);"""
+
+    qt_3_15 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 not in (select c1 from t3 where t1.c4 < t3.c4);"""
+    qt_3_16 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 not in (select c2 from t3 where t1.c4 < t3.c4);"""
+
+    qt_3_17 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by exists (select c1 from t2 where t1.c4 < t2.c4);"""
+    qt_3_18 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by exists (select c2 from t2 where t1.c4 < t2.c4);"""
+
+    qt_3_19 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by not exists (select c1 from t2 where t1.c4 < t2.c4);"""
+    qt_3_20 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by not exists (select c2 from t2 where t1.c4 < t2.c4);"""
+
+    qt_3_21 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by exists (select c1 from t3 where t1.c4 < t3.c4);"""
+    qt_3_22 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by exists (select c2 from t3 where t1.c4 < t3.c4);"""
+
+    qt_3_23 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by not exists (select c1 from t3 where t1.c4 < t3.c4);"""
+    qt_3_24 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by not exists (select c2 from t3 where t1.c4 < t3.c4);"""
+
+    qt_3_25 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by exists (select c1 from t3 where t1.c4 < t3.c4);"""
+    qt_3_26 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by exists (select c2 from t3 where t1.c4 < t3.c4);"""
+
+    qt_3_27 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by not exists (select c1 from t3 where t1.c4 < t3.c4);"""
+    qt_3_28 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by not exists (select c2 from t3 where t1.c4 < t3.c4);"""
+
+    // 4. single table + olap table + group by + correlated + scalar group by
+    qt_4_1 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 in (select max(c1) from t2 where t1.c4 = t2.c4);"""
+    qt_4_2 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 in (select count(c2) from t2 where t1.c4 = t2.c4);"""
+
+    qt_4_3 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 not in (select max(c1) from t2 where t1.c4 = t2.c4);"""
+    qt_4_4 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 not in (select count(c2) from t2 where t1.c4 = t2.c4);"""
+
+    qt_4_5 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 in (select max(c1) from t2 where t1.c4 = t2.c4);"""
+    qt_4_6 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 in (select count(c2) from t2 where t1.c4 = t2.c4);"""
+
+    qt_4_7 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 not in (select max(c1) from t2 where t1.c4 = t2.c4);"""
+    qt_4_8 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 not in (select count(c2) from t2 where t1.c4 = t2.c4);"""
+
+    qt_4_9 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 in (select max(c1) from t3 where t1.c4 = t3.c4);"""
+    qt_4_10 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 in (select count(c2) from t3 where t1.c4 = t3.c4);"""
+
+    qt_4_11 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 not in (select max(c1) from t3 where t1.c4 = t3.c4);"""
+    qt_4_12 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c1 not in (select count(c2) from t3 where t1.c4 = t3.c4);"""
+
+    qt_4_13 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 in (select max(c1) from t3 where t1.c4 = t3.c4);"""
+    qt_4_14 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 in (select count(c2) from t3 where t1.c4 = t3.c4);"""
+
+    qt_4_15 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 not in (select max(c1) from t3 where t1.c4 = t3.c4);"""
+    qt_4_16 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 not in (select count(c2) from t3 where t1.c4 = t3.c4);"""
+
+    qt_4_17 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by exists (select max(c1) from t2 where t1.c4 = t2.c4);"""
+    qt_4_18 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by exists (select count(c2) from t2 where t1.c4 = t2.c4);"""
+
+    qt_4_19 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by not exists (select max(c1) from t2 where t1.c4 = t2.c4);"""
+    qt_4_20 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by not exists (select count(c2) from t2 where t1.c4 = t2.c4);"""
+
+    qt_4_21 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by exists (select max(c1) from t3 where t1.c4 = t3.c4);"""
+    qt_4_22 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by exists (select count(c2) from t3 where t1.c4 = t3.c4);"""
+
+    qt_4_23 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by not exists (select max(c1) from t3 where t1.c4 = t3.c4);"""
+    qt_4_24 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by not exists (select count(c2) from t3 where t1.c4 = t3.c4);"""
+
+    qt_4_25 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by exists (select max(c1) from t3 where t1.c4 = t3.c4);"""
+    qt_4_26 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by exists (select count(c2) from t3 where t1.c4 = t3.c4);"""
+
+    qt_4_27 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by not exists (select max(c1) from t3 where t1.c4 = t3.c4);"""
+    qt_4_28 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by not exists (select count(c2) from t3 where t1.c4 = t3.c4);"""
+}
+

--- a/regression-test/suites/nereids_rules_p0/subquery/topop/subquery_topop_pullup_having.groovy
+++ b/regression-test/suites/nereids_rules_p0/subquery/topop/subquery_topop_pullup_having.groovy
@@ -1,0 +1,273 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("subquery_basic_pullup_having") {
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+
+    sql """DROP TABLE IF EXISTS t1;"""
+    sql """DROP TABLE IF EXISTS t2;"""
+    sql """DROP TABLE IF EXISTS t3;"""
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t1(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t2(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t3(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """INSERT INTO t1 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t1 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t1 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t1 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t2 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t2 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t2 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t2 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t3 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t3 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t3 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t3 VALUES (3,3,3,3);"""
+
+    /**
+     * | DML      | insert/update/delete |
+     * | select   | SELECT LIST: SubQuery |
+     * | From     | (OlapScan/ExternalScan)/view/partition(hash/range)/MV |
+     * | Join     | JOIN TYPE: inner/outer(left/right/full)/semi(left/right)/anti(left/right) ON condition: SubQuery |
+     * | Filter   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Group by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Having   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Order by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Winfunc  | Partition by / Order by EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Limit    | Limit / offset |
+     * | Set op   | union(all)/intersect(all)/except(all) |
+     * | SubQuery | Correlated subquery / non-correlated subquery / Scalar |
+     * EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery/bitmap type()
+     * 1. (not) in/exists SubQuery
+     * 2. (not) in/exists SubQuery OR/AND (not) in/exists SubQuery
+     * 3. (not) in/exists SubQuery OR/AND (equal/non-equal)
+     * 4. Corelated / non-correlated / Scalar
+     * 5. composed expr：SubQuery
+     * 6. null/not null/uk/no-uk
+     */
+    // 1. single table + olap table + group by + having + correlated + equal
+    qt_1_1 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 in (select c1 from t2);"""
+    qt_1_2 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 in (select c2 from t2);"""
+
+    qt_1_3 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 not in (select c1 from t2);"""
+    qt_1_4 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 not in (select c2 from t2);"""
+
+    qt_1_5 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 in (select c1 from t2);"""
+    qt_1_6 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 in (select c2 from t2);"""
+
+    qt_1_7 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 not in (select c1 from t2);"""
+    qt_1_8 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 not in (select c2 from t2);"""
+
+    qt_1_9 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 in (select c1 from t3);"""
+    qt_1_10 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 in (select c2 from t3);"""
+
+    qt_1_11 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 not in (select c1 from t3);"""
+    qt_1_12 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 not in (select c2 from t3);"""
+
+    qt_1_13 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 in (select c1 from t3);"""
+    qt_1_14 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 in (select c2 from t3);"""
+
+    qt_1_15 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 not in (select c1 from t3);"""
+    qt_1_16 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 not in (select c2 from t3);"""
+
+    qt_1_17 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having exists (select c1 from t2);"""
+    qt_1_18 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having exists (select c2 from t2);"""
+
+    qt_1_19 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having not exists (select c1 from t2);"""
+    qt_1_20 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having not exists (select c2 from t2);"""
+
+    qt_1_21 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having exists (select c1 from t3);"""
+    qt_1_22 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having exists (select c2 from t3);"""
+
+    qt_1_23 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having not exists (select c1 from t3);"""
+    qt_1_24 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having not exists (select c2 from t3);"""
+
+    qt_1_25 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having exists (select c1 from t3);"""
+    qt_1_26 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having exists (select c2 from t3);"""
+
+    qt_1_27 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having not exists (select c1 from t3);"""
+    qt_1_28 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having not exists (select c2 from t3);"""
+
+    // 2. single table + olap table + group by + having + correlated + explicit equal
+    qt_2_1 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 in (select c1 from t2 where t1.c4 = t2.c4);"""
+    qt_2_2 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 in (select c2 from t2 where t1.c4 = t2.c4);"""
+
+    qt_2_3 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 not in (select c1 from t2 where t1.c4 = t2.c4);"""
+    qt_2_4 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 not in (select c2 from t2 where t1.c4 = t2.c4);"""
+
+    qt_2_5 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 in (select c1 from t2 where t1.c4 = t2.c4);"""
+    qt_2_6 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 in (select c2 from t2 where t1.c4 = t2.c4);"""
+
+    qt_2_7 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 not in (select c1 from t2 where t1.c4 = t2.c4);"""
+    qt_2_8 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 not in (select c2 from t2 where t1.c4 = t2.c4);"""
+
+    qt_2_9 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 in (select c1 from t3 where t1.c4 = t3.c4);"""
+    qt_2_10 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 in (select c2 from t3 where t1.c4 = t3.c4);"""
+
+    qt_2_11 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 not in (select c1 from t3 where t1.c4 = t3.c4);"""
+    qt_2_12 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 not in (select c2 from t3 where t1.c4 = t3.c4);"""
+
+    qt_2_13 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 in (select c1 from t3 where t1.c4 = t3.c4);"""
+    qt_2_14 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 in (select c2 from t3 where t1.c4 = t3.c4);"""
+
+    qt_2_15 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 not in (select c1 from t3 where t1.c4 = t3.c4);"""
+    qt_2_16 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 not in (select c2 from t3 where t1.c4 = t3.c4);"""
+
+    qt_2_17 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having exists (select c1 from t2 where t1.c4 = t2.c4);"""
+    qt_2_18 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having exists (select c2 from t2 where t1.c4 = t2.c4);"""
+
+    qt_2_19 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having not exists (select c1 from t2 where t1.c4 = t2.c4);"""
+    qt_2_20 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having not exists (select c2 from t2 where t1.c4 = t2.c4);"""
+
+    qt_2_21 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having exists (select c1 from t3 where t1.c4 = t3.c4);"""
+    qt_2_22 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having exists (select c2 from t3 where t1.c4 = t3.c4);"""
+
+    qt_2_23 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having not exists (select c1 from t3 where t1.c4 = t3.c4);"""
+    qt_2_24 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having not exists (select c2 from t3 where t1.c4 = t3.c4);"""
+
+    qt_2_25 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having exists (select c1 from t3 where t1.c4 = t3.c4);"""
+    qt_2_26 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having exists (select c2 from t3 where t1.c4 = t3.c4);"""
+
+    qt_2_27 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having not exists (select c1 from t3 where t1.c4 = t3.c4);"""
+    qt_2_28 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having not exists (select c2 from t3 where t1.c4 = t3.c4);"""
+
+    // 3. single table + olap table + group by + having + correlated + explicit non-equal
+    qt_3_1 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 in (select c1 from t2 where t1.c4 < t2.c4);"""
+    qt_3_2 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 in (select c2 from t2 where t1.c4 < t2.c4);"""
+
+    qt_3_3 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 not in (select c1 from t2 where t1.c4 < t2.c4);"""
+    qt_3_4 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 not in (select c2 from t2 where t1.c4 < t2.c4);"""
+
+    qt_3_5 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 in (select c1 from t2 where t1.c4 < t2.c4);"""
+    qt_3_6 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 in (select c2 from t2 where t1.c4 < t2.c4);"""
+
+    qt_3_7 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 not in (select c1 from t2 where t1.c4 < t2.c4);"""
+    qt_3_8 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 not in (select c2 from t2 where t1.c4 < t2.c4);"""
+
+    qt_3_9 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 in (select c1 from t3 where t1.c4 < t3.c4);"""
+    qt_3_10 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 in (select c2 from t3 where t1.c4 < t3.c4);"""
+
+    qt_3_11 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 not in (select c1 from t3 where t1.c4 < t3.c4);"""
+    qt_3_12 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 not in (select c2 from t3 where t1.c4 < t3.c4);"""
+
+    qt_3_13 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 in (select c1 from t3 where t1.c4 < t3.c4);"""
+    qt_3_14 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 in (select c2 from t3 where t1.c4 < t3.c4);"""
+
+    qt_3_15 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 not in (select c1 from t3 where t1.c4 < t3.c4);"""
+    qt_3_16 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 not in (select c2 from t3 where t1.c4 < t3.c4);"""
+
+    qt_3_17 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having exists (select c1 from t2 where t1.c4 < t2.c4);"""
+    qt_3_18 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having exists (select c2 from t2 where t1.c4 < t2.c4);"""
+
+    qt_3_19 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having not exists (select c1 from t2 where t1.c4 < t2.c4);"""
+    qt_3_20 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having not exists (select c2 from t2 where t1.c4 < t2.c4);"""
+
+    qt_3_21 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having exists (select c1 from t3 where t1.c4 < t3.c4);"""
+    qt_3_22 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having exists (select c2 from t3 where t1.c4 < t3.c4);"""
+
+    qt_3_23 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having not exists (select c1 from t3 where t1.c4 < t3.c4);"""
+    qt_3_24 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having not exists (select c2 from t3 where t1.c4 < t3.c4);"""
+
+    qt_3_25 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having exists (select c1 from t3 where t1.c4 < t3.c4);"""
+    qt_3_26 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having exists (select c2 from t3 where t1.c4 < t3.c4);"""
+
+    qt_3_27 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having not exists (select c1 from t3 where t1.c4 < t3.c4);"""
+    qt_3_28 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having not exists (select c2 from t3 where t1.c4 < t3.c4);"""
+
+    // 4. single table + olap table + group by + having + correlated + scalar group by
+    qt_4_1 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 in (select max(c1) from t2 where t1.c4 = t2.c4);"""
+    qt_4_2 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 in (select count(c2) from t2 where t1.c4 = t2.c4);"""
+
+    qt_4_3 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 not in (select max(c1) from t2 where t1.c4 = t2.c4);"""
+    qt_4_4 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 not in (select count(c2) from t2 where t1.c4 = t2.c4);"""
+
+    qt_4_5 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 in (select max(c1) from t2 where t1.c4 = t2.c4);"""
+    qt_4_6 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 in (select count(c2) from t2 where t1.c4 = t2.c4);"""
+
+    qt_4_7 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 not in (select max(c1) from t2 where t1.c4 = t2.c4);"""
+    qt_4_8 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 not in (select count(c2) from t2 where t1.c4 = t2.c4);"""
+
+    qt_4_9 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 in (select max(c1) from t3 where t1.c4 = t3.c4);"""
+    qt_4_10 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 in (select count(c2) from t3 where t1.c4 = t3.c4);"""
+
+    qt_4_11 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 not in (select max(c1) from t3 where t1.c4 = t3.c4);"""
+    qt_4_12 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c1 not in (select count(c2) from t3 where t1.c4 = t3.c4);"""
+
+    qt_4_13 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 in (select max(c1) from t3 where t1.c4 = t3.c4);"""
+    qt_4_14 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 in (select count(c2) from t3 where t1.c4 = t3.c4);"""
+
+    qt_4_15 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 not in (select max(c1) from t3 where t1.c4 = t3.c4);"""
+    qt_4_16 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having t1.c2 not in (select count(c2) from t3 where t1.c4 = t3.c4);"""
+
+    qt_4_17 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having exists (select max(c1) from t2 where t1.c4 = t2.c4);"""
+    qt_4_18 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having exists (select count(c2) from t2 where t1.c4 = t2.c4);"""
+
+    qt_4_19 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having not exists (select max(c1) from t2 where t1.c4 = t2.c4);"""
+    qt_4_20 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having not exists (select count(c2) from t2 where t1.c4 = t2.c4);"""
+
+    qt_4_21 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having exists (select max(c1) from t3 where t1.c4 = t3.c4);"""
+    qt_4_22 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having exists (select count(c2) from t3 where t1.c4 = t3.c4);"""
+
+    qt_4_23 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having not exists (select max(c1) from t3 where t1.c4 = t3.c4);"""
+    qt_4_24 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having not exists (select count(c2) from t3 where t1.c4 = t3.c4);"""
+
+    qt_4_25 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having exists (select max(c1) from t3 where t1.c4 = t3.c4);"""
+    qt_4_26 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having exists (select count(c2) from t3 where t1.c4 = t3.c4);"""
+
+    qt_4_27 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having not exists (select max(c1) from t3 where t1.c4 = t3.c4);"""
+    qt_4_28 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) group by t1.c2 having not exists (select count(c2) from t3 where t1.c4 = t3.c4);"""
+}
+

--- a/regression-test/suites/nereids_rules_p0/subquery/topop/subquery_topop_pullup_orderby.groovy
+++ b/regression-test/suites/nereids_rules_p0/subquery/topop/subquery_topop_pullup_orderby.groovy
@@ -1,0 +1,273 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("subquery_basic_pullup_orderby") {
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+
+    sql """DROP TABLE IF EXISTS t1;"""
+    sql """DROP TABLE IF EXISTS t2;"""
+    sql """DROP TABLE IF EXISTS t3;"""
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t1(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t2(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t3(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """INSERT INTO t1 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t1 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t1 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t1 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t2 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t2 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t2 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t2 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t3 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t3 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t3 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t3 VALUES (3,3,3,3);"""
+
+    /**
+     * | DML      | insert/update/delete |
+     * | select   | SELECT LIST: SubQuery |
+     * | From     | (OlapScan/ExternalScan)/view/partition(hash/range)/MV |
+     * | Join     | JOIN TYPE: inner/outer(left/right/full)/semi(left/right)/anti(left/right) ON condition: SubQuery |
+     * | Filter   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Group by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Having   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Order by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Winfunc  | Partition by / Order by EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Limit    | Limit / offset |
+     * | Set op   | union(all)/intersect(all)/except(all) |
+     * | SubQuery | Correlated subquery / non-correlated subquery / Scalar |
+     * EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery/bitmap type()
+     * 1. (not) in/exists SubQuery
+     * 2. (not) in/exists SubQuery OR/AND (not) in/exists SubQuery
+     * 3. (not) in/exists SubQuery OR/AND (equal/non-equal)
+     * 4. Corelated / non-correlated / Scalar
+     * 5. composed expr：SubQuery
+     * 6. null/not null/uk/no-uk
+     */
+    // 1. single table + olap table + order by + correlated + equal
+    qt_1_1 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 in (select c1 from t2);"""
+    qt_1_2 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 in (select c2 from t2);"""
+
+    qt_1_3 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 not in (select c1 from t2);"""
+    qt_1_4 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 not in (select c2 from t2);"""
+
+    qt_1_5 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 in (select c1 from t2);"""
+    qt_1_6 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 in (select c2 from t2);"""
+
+    qt_1_7 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 not in (select c1 from t2);"""
+    qt_1_8 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 not in (select c2 from t2);"""
+
+    qt_1_9 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 in (select c1 from t3);"""
+    qt_1_10 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 in (select c2 from t3);"""
+
+    qt_1_11 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 not in (select c1 from t3);"""
+    qt_1_12 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 not in (select c2 from t3);"""
+
+    qt_1_13 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 in (select c1 from t3);"""
+    qt_1_14 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 in (select c2 from t3);"""
+
+    qt_1_15 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 not in (select c1 from t3);"""
+    qt_1_16 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 not in (select c2 from t3);"""
+
+    qt_1_17 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by exists (select c1 from t2);"""
+    qt_1_18 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by exists (select c2 from t2);"""
+
+    qt_1_19 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by not exists (select c1 from t2);"""
+    qt_1_20 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by not exists (select c2 from t2);"""
+
+    qt_1_21 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by exists (select c1 from t3);"""
+    qt_1_22 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by exists (select c2 from t3);"""
+
+    qt_1_23 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by not exists (select c1 from t3);"""
+    qt_1_24 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by not exists (select c2 from t3);"""
+
+    qt_1_25 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by exists (select c1 from t3);"""
+    qt_1_26 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by exists (select c2 from t3);"""
+
+    qt_1_27 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by not exists (select c1 from t3);"""
+    qt_1_28 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by not exists (select c2 from t3);"""
+
+    // 2. single table + olap table + order by + correlated + explicit equal
+    qt_2_1 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 in (select c1 from t2 where t1.c4 = t2.c4);"""
+    qt_2_2 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 in (select c2 from t2 where t1.c4 = t2.c4);"""
+
+    qt_2_3 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 not in (select c1 from t2 where t1.c4 = t2.c4);"""
+    qt_2_4 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 not in (select c2 from t2 where t1.c4 = t2.c4);"""
+
+    qt_2_5 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 in (select c1 from t2 where t1.c4 = t2.c4);"""
+    qt_2_6 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 in (select c2 from t2 where t1.c4 = t2.c4);"""
+
+    qt_2_7 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 not in (select c1 from t2 where t1.c4 = t2.c4);"""
+    qt_2_8 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 not in (select c2 from t2 where t1.c4 = t2.c4);"""
+
+    qt_2_9 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 in (select c1 from t3 where t1.c4 = t3.c4);"""
+    qt_2_10 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 in (select c2 from t3 where t1.c4 = t3.c4);"""
+
+    qt_2_11 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 not in (select c1 from t3 where t1.c4 = t3.c4);"""
+    qt_2_12 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 not in (select c2 from t3 where t1.c4 = t3.c4);"""
+
+    qt_2_13 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 in (select c1 from t3 where t1.c4 = t3.c4);"""
+    qt_2_14 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 in (select c2 from t3 where t1.c4 = t3.c4);"""
+
+    qt_2_15 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 not in (select c1 from t3 where t1.c4 = t3.c4);"""
+    qt_2_16 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 not in (select c2 from t3 where t1.c4 = t3.c4);"""
+
+    qt_2_17 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by exists (select c1 from t2 where t1.c4 = t2.c4);"""
+    qt_2_18 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by exists (select c2 from t2 where t1.c4 = t2.c4);"""
+
+    qt_2_19 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by not exists (select c1 from t2 where t1.c4 = t2.c4);"""
+    qt_2_20 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by not exists (select c2 from t2 where t1.c4 = t2.c4);"""
+
+    qt_2_21 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by exists (select c1 from t3 where t1.c4 = t3.c4);"""
+    qt_2_22 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by exists (select c2 from t3 where t1.c4 = t3.c4);"""
+
+    qt_2_23 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by not exists (select c1 from t3 where t1.c4 = t3.c4);"""
+    qt_2_24 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by not exists (select c2 from t3 where t1.c4 = t3.c4);"""
+
+    qt_2_25 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by exists (select c1 from t3 where t1.c4 = t3.c4);"""
+    qt_2_26 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by exists (select c2 from t3 where t1.c4 = t3.c4);"""
+
+    qt_2_27 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by not exists (select c1 from t3 where t1.c4 = t3.c4);"""
+    qt_2_28 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by not exists (select c2 from t3 where t1.c4 = t3.c4);"""
+
+    // 3. single table + olap table + order by + correlated + explicit non-equal
+    qt_3_1 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 in (select c1 from t2 where t1.c4 < t2.c4);"""
+    qt_3_2 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 in (select c2 from t2 where t1.c4 < t2.c4);"""
+
+    qt_3_3 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 not in (select c1 from t2 where t1.c4 < t2.c4);"""
+    qt_3_4 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 not in (select c2 from t2 where t1.c4 < t2.c4);"""
+
+    qt_3_5 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 in (select c1 from t2 where t1.c4 < t2.c4);"""
+    qt_3_6 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 in (select c2 from t2 where t1.c4 < t2.c4);"""
+
+    qt_3_7 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 not in (select c1 from t2 where t1.c4 < t2.c4);"""
+    qt_3_8 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 not in (select c2 from t2 where t1.c4 < t2.c4);"""
+
+    qt_3_9 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 in (select c1 from t3 where t1.c4 < t3.c4);"""
+    qt_3_10 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 in (select c2 from t3 where t1.c4 < t3.c4);"""
+
+    qt_3_11 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 not in (select c1 from t3 where t1.c4 < t3.c4);"""
+    qt_3_12 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 not in (select c2 from t3 where t1.c4 < t3.c4);"""
+
+    qt_3_13 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 in (select c1 from t3 where t1.c4 < t3.c4);"""
+    qt_3_14 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 in (select c2 from t3 where t1.c4 < t3.c4);"""
+
+    qt_3_15 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 not in (select c1 from t3 where t1.c4 < t3.c4);"""
+    qt_3_16 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 not in (select c2 from t3 where t1.c4 < t3.c4);"""
+
+    qt_3_17 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by exists (select c1 from t2 where t1.c4 < t2.c4);"""
+    qt_3_18 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by exists (select c2 from t2 where t1.c4 < t2.c4);"""
+
+    qt_3_19 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by not exists (select c1 from t2 where t1.c4 < t2.c4);"""
+    qt_3_20 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by not exists (select c2 from t2 where t1.c4 < t2.c4);"""
+
+    qt_3_21 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by exists (select c1 from t3 where t1.c4 < t3.c4);"""
+    qt_3_22 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by exists (select c2 from t3 where t1.c4 < t3.c4);"""
+
+    qt_3_23 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by not exists (select c1 from t3 where t1.c4 < t3.c4);"""
+    qt_3_24 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by not exists (select c2 from t3 where t1.c4 < t3.c4);"""
+
+    qt_3_25 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by exists (select c1 from t3 where t1.c4 < t3.c4);"""
+    qt_3_26 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by exists (select c2 from t3 where t1.c4 < t3.c4);"""
+
+    qt_3_27 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by not exists (select c1 from t3 where t1.c4 < t3.c4);"""
+    qt_3_28 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by not exists (select c2 from t3 where t1.c4 < t3.c4);"""
+
+    // 4. single table + olap table + order by + correlated + scalar order by
+    qt_4_1 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 in (select max(c1) from t2 where t1.c4 = t2.c4);"""
+    qt_4_2 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 in (select count(c2) from t2 where t1.c4 = t2.c4);"""
+
+    qt_4_3 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 not in (select max(c1) from t2 where t1.c4 = t2.c4);"""
+    qt_4_4 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 not in (select count(c2) from t2 where t1.c4 = t2.c4);"""
+
+    qt_4_5 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 in (select max(c1) from t2 where t1.c4 = t2.c4);"""
+    qt_4_6 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 in (select count(c2) from t2 where t1.c4 = t2.c4);"""
+
+    qt_4_7 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 not in (select max(c1) from t2 where t1.c4 = t2.c4);"""
+    qt_4_8 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 not in (select count(c2) from t2 where t1.c4 = t2.c4);"""
+
+    qt_4_9 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 in (select max(c1) from t3 where t1.c4 = t3.c4);"""
+    qt_4_10 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 in (select count(c2) from t3 where t1.c4 = t3.c4);"""
+
+    qt_4_11 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 not in (select max(c1) from t3 where t1.c4 = t3.c4);"""
+    qt_4_12 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by t1.c1 not in (select count(c2) from t3 where t1.c4 = t3.c4);"""
+
+    qt_4_13 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 in (select max(c1) from t3 where t1.c4 = t3.c4);"""
+    qt_4_14 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 in (select count(c2) from t3 where t1.c4 = t3.c4);"""
+
+    qt_4_15 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 not in (select max(c1) from t3 where t1.c4 = t3.c4);"""
+    qt_4_16 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by t1.c2 not in (select count(c2) from t3 where t1.c4 = t3.c4);"""
+
+    qt_4_17 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by exists (select max(c1) from t2 where t1.c4 = t2.c4);"""
+    qt_4_18 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by exists (select count(c2) from t2 where t1.c4 = t2.c4);"""
+
+    qt_4_19 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by not exists (select max(c1) from t2 where t1.c4 = t2.c4);"""
+    qt_4_20 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by not exists (select count(c2) from t2 where t1.c4 = t2.c4);"""
+
+    qt_4_21 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by exists (select max(c1) from t3 where t1.c4 = t3.c4);"""
+    qt_4_22 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by exists (select count(c2) from t3 where t1.c4 = t3.c4);"""
+
+    qt_4_23 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by not exists (select max(c1) from t3 where t1.c4 = t3.c4);"""
+    qt_4_24 """select t1.c1 from t1 where t1.c1 in (select c1 from t2) order by not exists (select count(c2) from t3 where t1.c4 = t3.c4);"""
+
+    qt_4_25 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by exists (select max(c1) from t3 where t1.c4 = t3.c4);"""
+    qt_4_26 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by exists (select count(c2) from t3 where t1.c4 = t3.c4);"""
+
+    qt_4_27 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by not exists (select max(c1) from t3 where t1.c4 = t3.c4);"""
+    qt_4_28 """select t1.c2 from t1 where t1.c1 in (select c1 from t2) order by not exists (select count(c2) from t3 where t1.c4 = t3.c4);"""
+}
+

--- a/regression-test/suites/nereids_rules_p0/subquery/topop/subquery_topop_pullup_selectlist.groovy
+++ b/regression-test/suites/nereids_rules_p0/subquery/topop/subquery_topop_pullup_selectlist.groovy
@@ -1,0 +1,138 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("subquery_basic_pullup_selectlist") {
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+
+    sql """DROP TABLE IF EXISTS t1;"""
+    sql """DROP TABLE IF EXISTS t2;"""
+    sql """DROP TABLE IF EXISTS t3;"""
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t1(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t2(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t3(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """INSERT INTO t1 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t1 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t1 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t1 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t2 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t2 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t2 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t2 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t3 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t3 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t3 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t3 VALUES (3,3,3,3);"""
+
+    /**
+     * | DML      | insert/update/delete |
+     * | select   | SELECT LIST: SubQuery |
+     * | From     | (OlapScan/ExternalScan)/view/partition(hash/range)/MV |
+     * | Join     | JOIN TYPE: inner/outer(left/right/full)/semi(left/right)/anti(left/right) ON condition: SubQuery |
+     * | Filter   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Group by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Having   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Order by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Winfunc  | Partition by / Order by EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Limit    | Limit / offset |
+     * | Set op   | union(all)/intersect(all)/except(all) |
+     * | SubQuery | Correlated subquery / non-correlated subquery / Scalar |
+     * EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery/bitmap type()
+     * 1. (not) in/exists SubQuery
+     * 2. (not) in/exists SubQuery OR/AND (not) in/exists SubQuery
+     * 3. (not) in/exists SubQuery OR/AND (equal/non-equal)
+     * 4. Corelated / non-correlated / Scalar
+     * 5. composed expr：SubQuery
+     * 6. null/not null/uk/no-uk
+     */
+    // 1. single table + olap table + select list + basic + correlated + equal
+    qt_1_1 """select t1.c1 in (select c1 from t2) from t1;"""
+    qt_1_2 """select t1.c1 not in (select c1 from t2) from t1"""
+
+    qt_1_3 """select t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) from t1;"""
+    qt_1_4 """select t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) from t1;"""
+
+    qt_1_5 """select exists (select c1 from t2 where t1.c1 = t2.c1) from t1;"""
+    qt_1_6 """select not exists (select c1 from t2 where t1.c1 = t2.c1) from t1;"""
+
+    // 2. single table + olap table + select list + basic + correlated + non-equal
+    qt_2_1 """select t1.c1 in (select c1 from t2 where t1.c2 < t2.c2) from t1;"""
+    qt_2_2 """select t1.c1 not in (select c1 from t2 where t1.c2 < t2.c2) from t1;"""
+
+    qt_2_3 """select exists (select c1 from t2 where t1.c1 < t2.c1) from t1;"""
+    qt_2_4 """select not exists (select c1 from t2 where t1.c1 < t2.c1) from t1;"""
+
+    // 3. single table + olap table + select list + basic + correlated + filter
+    qt_3_1 """select t1.c1 in (select c1 from t2) from t1 where t1.c2 in (select c1 from t3);"""
+    qt_3_2 """select t1.c1 not in (select c1 from t2) from t1 where t1.c2 not in (select c1 from t3)"""
+
+    qt_3_3 """select t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) from t1 where t1.c2 in (select c1 from t3);"""
+    qt_3_4 """select t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) from t1 where t1.c2 not in (select c1 from t3);"""
+
+    qt_3_5 """select exists (select c1 from t2 where t1.c1 = t2.c1) from t1 where t1.c2 in (select c1 from t3);"""
+    qt_3_6 """select not exists (select c1 from t2 where t1.c1 = t2.c1) from t1 where t1.c2 not in (select c1 from t3);"""
+
+    // 4. single table + olap table + select list + case when
+    qt_4_1 """select case when t1.c1 in (select c1 from t2) then c1 else c2 end from t1;"""
+    qt_4_2 """select case when t1.c1 not in (select c1 from t2) then c1 else c2 end  from t1"""
+
+    qt_4_3 """select case when t1.c1 in (select c1 from t2 where t1.c2 = t2.c2) then c1 else c2 end from t1;"""
+    qt_4_4 """select case when t1.c1 not in (select c1 from t2 where t1.c2 = t2.c2) then c1 else c2 end from t1;"""
+
+    qt_4_5 """select case when exists (select c1 from t2 where t1.c1 = t2.c1) then c1 else c2 end from t1;"""
+    qt_4_6 """select case when  not exists (select c1 from t2 where t1.c1 = t2.c1) then c1 else c2 end from t1;"""
+}
+

--- a/regression-test/suites/nereids_rules_p0/subquery/topop/subquery_topop_pullup_winfunc.groovy
+++ b/regression-test/suites/nereids_rules_p0/subquery/topop/subquery_topop_pullup_winfunc.groovy
@@ -1,0 +1,185 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("subquery_basic_pullup_winfunc") {
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+
+    sql """DROP TABLE IF EXISTS t1;"""
+    sql """DROP TABLE IF EXISTS t2;"""
+    sql """DROP TABLE IF EXISTS t3;"""
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t1(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t2(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS t3(
+      `c1` int(11) NULL,
+      `c2` int(11) NULL,
+      `c3` int(11) NULL,
+      `c4` int(11) NULL
+    ) ENGINE = OLAP
+    DISTRIBUTED BY HASH(c1) BUCKETS 4
+    PROPERTIES (
+      "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+
+    sql """INSERT INTO t1 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t1 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t1 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t1 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t2 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t2 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t2 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t2 VALUES (3,3,3,3);"""
+
+    sql """INSERT INTO t3 VALUES (null,null,null,null);"""
+    sql """INSERT INTO t3 VALUES (1,1,1,1);"""
+    sql """INSERT INTO t3 VALUES (2,2,2,2);"""
+    sql """INSERT INTO t3 VALUES (3,3,3,3);"""
+
+    /**
+     * | DML      | insert/update/delete |
+     * | select   | SELECT LIST: SubQuery |
+     * | From     | (OlapScan/ExternalScan)/view/partition(hash/range)/MV |
+     * | Join     | JOIN TYPE: inner/outer(left/right/full)/semi(left/right)/anti(left/right) ON condition: SubQuery |
+     * | Filter   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Group by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Having   | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Order by | EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Winfunc  | Partition by / Order by EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery |
+     * | Limit    | Limit / offset |
+     * | Set op   | union(all)/intersect(all)/except(all) |
+     * | SubQuery | Correlated subquery / non-correlated subquery / Scalar |
+     * EXPRS: OR/AND/not/in/exists/equal/non-equal/composed expr/SubQuery/bitmap type()
+     * 1. (not) in/exists SubQuery
+     * 2. (not) in/exists SubQuery OR/AND (not) in/exists SubQuery
+     * 3. (not) in/exists SubQuery OR/AND (equal/non-equal)
+     * 4. Corelated / non-correlated / Scalar
+     * 5. composed expr：SubQuery
+     * 6. null/not null/uk/no-uk
+     */
+    // 1. single table + olap table + partition by + correlated + equal
+    qt_1_1 """select c1, row_number() over(partition by c1 in (select c1 from t2)) as rn from t1;"""
+    qt_1_2 """select c1, row_number() over(partition by c1 not in (select c1 from t2)) as rn from t1;"""
+
+    qt_1_3 """select c1, row_number() over(partition by exists (select c1 from t2)) as rn from t1;"""
+    qt_1_4 """select c1, row_number() over(partition by not exists (select c1 from t2)) as rn from t1;"""
+
+    // 2. single table + olap table + order by + correlated + equal
+    qt_2_1 """select c1, row_number() over(order by c1 in (select c1 from t2)) as rn from t1;"""
+    qt_2_2 """select c1, row_number() over(order by c1 not in (select c1 from t2)) as rn from t1;"""
+
+    qt_2_3 """select c1, row_number() over(order by exists (select c1 from t2)) as rn from t1;"""
+    qt_2_4 """select c1, row_number() over(order by not exists (select c1 from t2)) as rn from t1;"""
+
+    // 3. single table + olap table + partition by + order by + correlated + equal
+    qt_3_1 """select c1, row_number() over(partition by c1 in (select c1 from t2) order by c1 in (select c1 from t2)) as rn from t1;"""
+    qt_3_2 """select c1, row_number() over(partition by c1 not in (select c1 from t2) order by c1 not in (select c1 from t2)) as rn from t1;"""
+
+    qt_3_3 """select c1, row_number() over(partition by exists (select c1 from t2) order by exists (select c1 from t2)) as rn from t1;"""
+    qt_3_4 """select c1, row_number() over(partition by not exists (select c1 from t2) order by not exists (select c1 from t2)) as rn from t1;"""
+
+    qt_3_5 """select c1, row_number() over(partition by c1 in (select c1 from t2) order by c1 not in (select c1 from t2)) as rn from t1;"""
+    qt_3_6 """select c1, row_number() over(partition by c1 not in (select c1 from t2) order by c1 in (select c1 from t2)) as rn from t1;"""
+
+    qt_3_7 """select c1, row_number() over(partition by c1 in (select c1 from t2) order by exists (select c1 from t2)) as rn from t1;"""
+    qt_3_8 """select c1, row_number() over(partition by not exists (select c1 from t2) order by c1 not in (select c1 from t2)) as rn from t1;"""
+
+    qt_3_9 """select c1, row_number() over(partition by c1 in (select c1 from t2) order by c1 in (select c1 from t3)) as rn from t1;"""
+    qt_3_10 """select c1, row_number() over(partition by c1 not in (select c1 from t2) order by c1 not in (select c1 from t3)) as rn from t1;"""
+
+    qt_3_11 """select c1, row_number() over(partition by exists (select c1 from t2) order by exists (select c1 from t3)) as rn from t1;"""
+    qt_3_12 """select c1, row_number() over(partition by not exists (select c1 from t2) order by not exists (select c1 from t3)) as rn from t1;"""
+
+    qt_3_13 """select c1, row_number() over(partition by c1 in (select c1 from t2) order by c1 not in (select c1 from t3)) as rn from t1;"""
+    qt_3_14 """select c1, row_number() over(partition by c1 not in (select c1 from t2) order by c1 in (select c1 from t3)) as rn from t1;"""
+
+    qt_3_15 """select c1, row_number() over(partition by c1 in (select c1 from t2) order by exists (select c1 from t3)) as rn from t1;"""
+    qt_3_16 """select c1, row_number() over(partition by not exists (select c1 from t2) order by c1 not in (select c1 from t3)) as rn from t1;"""
+
+    // 4. single table + olap table + partition by + order by + case when + equal
+    qt_4_1 """select c1, row_number() over(partition by case when c1 in (select c1 from t2) then c1 else c2 end order by c1 in (select c1 from t3)) as rn from t1;"""
+    qt_4_2 """select c1, row_number() over(partition by case when not c1 in (select c1 from t2) then c1 else c2 end order by c1 not in (select c1 from t3)) as rn from t1;"""
+
+    qt_4_3 """select c1, row_number() over(partition by case when exists (select c1 from t2) then c1 else c2 end order by c1 in (select c1 from t3)) as rn from t1;"""
+    qt_4_4 """select c1, row_number() over(partition by case when not exists (select c1 from t2) then c1 else c2 end order by c1 not in (select c1 from t3)) as rn from t1;"""
+
+    // 5. single table + olap table + partition by + order by + nested case when + equal
+    qt_5_1 """select c1, row_number() over(partition by case when c1 in (select c1 from t2) then c1 in (select c1 from t3) else c2 end) as rn from t1;"""
+    qt_5_2 """select c1, row_number() over(partition by case when not c1 in (select c1 from t2) then c1 not in (select c1 from t3) else c2 end) as rn from t1;"""
+
+    qt_5_3 """select c1, row_number() over(partition by case when exists (select c1 from t2) then c1 in (select c1 from t3) else c2 end) as rn from t1;"""
+    qt_5_4 """select c1, row_number() over(partition by case when not exists (select c1 from t2) then c1 not in (select c1 from t3) else c2 end) as rn from t1;"""
+
+    qt_5_5 """select c1, row_number() over(partition by case when c1 in (select c1 from t2) then c1 else c1 in (select c1 from t3) end) as rn from t1;"""
+    qt_5_6 """select c1, row_number() over(partition by case when not c1 in (select c1 from t2) then c1 else c1 not in (select c1 from t3) end) as rn from t1;"""
+
+    qt_5_7 """select c1, row_number() over(partition by case when exists (select c1 from t2) then c1 else c1 in (select c1 from t3) end) as rn from t1;"""
+    qt_5_8 """select c1, row_number() over(partition by case when not exists (select c1 from t2) then c1 else c1 not in (select c1 from t3) end) as rn from t1;"""
+
+    // 6. single table + olap table + partition by + order by + correlated + equal + filter
+    qt_6_1 """select c1, row_number() over(partition by c1 in (select c1 from t2) order by c1 in (select c1 from t2)) as rn from t1 where c3 in (select c3 from t3);"""
+    qt_6_2 """select c1, row_number() over(partition by c1 not in (select c1 from t2) order by c1 not in (select c1 from t2)) as rn from t1 where c3 in (select c3 from t3);"""
+
+    qt_6_3 """select c1, row_number() over(partition by exists (select c1 from t2) order by exists (select c1 from t2)) as rn from t1 where c3 in (select c3 from t3);"""
+    qt_6_4 """select c1, row_number() over(partition by not exists (select c1 from t2) order by not exists (select c1 from t2)) as rn from t1 where c3 in (select c3 from t3);"""
+
+    qt_6_5 """select c1, row_number() over(partition by c1 in (select c1 from t2) order by c1 not in (select c1 from t2)) as rn from t1 where c3 in (select c3 from t3);"""
+    qt_6_6 """select c1, row_number() over(partition by c1 not in (select c1 from t2) order by c1 in (select c1 from t2)) as rn from t1 where c3 in (select c3 from t3);"""
+
+    qt_6_7 """select c1, row_number() over(partition by c1 in (select c1 from t2) order by exists (select c1 from t2)) as rn from t1 where c3 in (select c3 from t3);"""
+    qt_6_8 """select c1, row_number() over(partition by not exists (select c1 from t2) order by c1 not in (select c1 from t2)) as rn from t1 where c3 in (select c3 from t3);"""
+
+    qt_6_9 """select c1, row_number() over(partition by case when c1 in (select c1 from t2) then c1 in (select c1 from t3) else c2 end) as rn from t1 where c3 in (select c3 from t3);"""
+    qt_6_10 """select c1, row_number() over(partition by case when not c1 in (select c1 from t2) then c1 not in (select c1 from t3) else c2 end) as rn from t1 where c3 in (select c3 from t3);"""
+
+    qt_6_11 """select c1, row_number() over(partition by case when exists (select c1 from t2) then c1 in (select c1 from t3) else c2 end) as rn from t1 where c3 in (select c3 from t3);"""
+    qt_6_12 """select c1, row_number() over(partition by case when not exists (select c1 from t2) then c1 not in (select c1 from t3) else c2 end) as rn from t1 where c3 in (select c3 from t3);"""
+
+    qt_6_13 """select c1, row_number() over(partition by case when c1 in (select c1 from t2) then c1 else c1 in (select c1 from t3) end) as rn from t1 where c3 in (select c3 from t3);"""
+    qt_6_14 """select c1, row_number() over(partition by case when not c1 in (select c1 from t2) then c1 else c1 not in (select c1 from t3) end) as rn from t1 where c3 in (select c3 from t3);"""
+
+    qt_6_15 """select c1, row_number() over(partition by case when exists (select c1 from t2) then c1 else c1 in (select c1 from t3) end) as rn from t1 where c3 in (select c3 from t3);"""
+    qt_6_16 """select c1, row_number() over(partition by case when not exists (select c1 from t2) then c1 else c1 not in (select c1 from t3) end) as rn from t1 where c3 in (select c3 from t3);"""
+}
+


### PR DESCRIPTION
## Proposed changes

add subquery pull up rule group ut:
single table part
(1) subquery_basic_pullup_basic: basic part
(2) subquery_basic_pullup_uk: using unique key
(3) subquery_basic_pullup_and: with and
(4) subquery_basic_pullup_or: with or
(5) subquery_basic_pullup_and_subquery: with and subquery
(6) subquery_basic_pullup_or_subquery: with or subquery

multi table part
(1) subquery_multitable_pullup_basic: basic part
(2) subquery_multitable_pullup_and: with and
(3) subquery_multitable_pullup_or: with or
(4) subquery_multitable_pullup_and_subquery: with and subquery
(5) subquery_multitable_pullup_or_subquery: with or subquery

top op related, such as group by/having, order by, win func, select list:
(1) subquery_topop_pullup_groupby: group by
(2) subquery_topop_pullup_having: having
(3) subquery_topop_pullup_orderby: order by
(4) subquery_topop_pullup_winfunc: window function
(5) subquery_topop_pullup_selectlist: select list

misc, such as group by correlated, view, dml, etc:
(1) subquery_misc_pullup_misc: group by correlated, view, etc
(2) subquery_misc_pullup_dml: insert/update/delete

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

