### PR TITLE
[branch-2.0-pick] PIck "[Fix](partial update) Fix partial update info loss when the delete bitmaps of the committed transactions are calculated by the compaction #26556"

### DIFF
--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -719,25 +719,24 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
                     // Therefore, we need to check if every committed rowset has calculated delete bitmap for
                     // all compaction input rowsets.
                     continue;
-                } else {
-                    DeleteBitmap txn_output_delete_bitmap(_tablet->tablet_id());
-                    _tablet->calc_compaction_output_rowset_delete_bitmap(
-                            _input_rowsets, _rowid_conversion, 0, UINT64_MAX, &missed_rows,
-                            &location_map, *it.delete_bitmap.get(), &txn_output_delete_bitmap);
-                    if (config::enable_merge_on_write_correctness_check) {
-                        RowsetIdUnorderedSet rowsetids;
-                        rowsetids.insert(_output_rowset->rowset_id());
-                        _tablet->add_sentinel_mark_to_delete_bitmap(&txn_output_delete_bitmap,
-                                                                    rowsetids);
-                    }
-                    it.delete_bitmap->merge(txn_output_delete_bitmap);
-                    // Step3: write back updated delete bitmap and tablet info.
-                    it.rowset_ids.insert(_output_rowset->rowset_id());
-                    StorageEngine::instance()->txn_manager()->set_txn_related_delete_bitmap(
-                            it.partition_id, it.transaction_id, _tablet->tablet_id(),
-                            _tablet->schema_hash(), _tablet->tablet_uid(), true, it.delete_bitmap,
-                            it.rowset_ids, nullptr);
                 }
+                DeleteBitmap txn_output_delete_bitmap(_tablet->tablet_id());
+                _tablet->calc_compaction_output_rowset_delete_bitmap(
+                        _input_rowsets, _rowid_conversion, 0, UINT64_MAX, &missed_rows,
+                        &location_map, *it.delete_bitmap.get(), &txn_output_delete_bitmap);
+                if (config::enable_merge_on_write_correctness_check) {
+                    RowsetIdUnorderedSet rowsetids;
+                    rowsetids.insert(_output_rowset->rowset_id());
+                    _tablet->add_sentinel_mark_to_delete_bitmap(&txn_output_delete_bitmap,
+                                                                rowsetids);
+                }
+                it.delete_bitmap->merge(txn_output_delete_bitmap);
+                // Step3: write back updated delete bitmap and tablet info.
+                it.rowset_ids.insert(_output_rowset->rowset_id());
+                StorageEngine::instance()->txn_manager()->set_txn_related_delete_bitmap(
+                        it.partition_id, it.transaction_id, _tablet->tablet_id(),
+                        _tablet->schema_hash(), _tablet->tablet_uid(), true, it.delete_bitmap,
+                        it.rowset_ids, it.partial_update_info);
             }
 
             // Convert the delete bitmap of the input rowsets to output rowset for

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -638,11 +638,14 @@ void TxnManager::get_all_commit_tablet_txn_info_by_tablet(
                 const RowsetSharedPtr& rowset = tablet_load_it->second.rowset;
                 const DeleteBitmapPtr& delete_bitmap = tablet_load_it->second.delete_bitmap;
                 const RowsetIdUnorderedSet& rowset_ids = tablet_load_it->second.rowset_ids;
+                const std::shared_ptr<PartialUpdateInfo> partial_update_info =
+                        tablet_load_it->second.partial_update_info;
                 if (!rowset || !delete_bitmap) {
                     continue;
                 }
-                commit_tablet_txn_info_vec->push_back(CommitTabletTxnInfo(
-                        partition_id, transaction_id, delete_bitmap, rowset_ids));
+                commit_tablet_txn_info_vec->push_back(
+                        CommitTabletTxnInfo(partition_id, transaction_id, delete_bitmap, rowset_ids,
+                                            partial_update_info));
             }
         }
     }

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -82,15 +82,18 @@ struct TabletTxnInfo {
 
 struct CommitTabletTxnInfo {
     CommitTabletTxnInfo(TPartitionId partition_id, TTransactionId transaction_id,
-                        DeleteBitmapPtr delete_bitmap, RowsetIdUnorderedSet rowset_ids)
+                        DeleteBitmapPtr delete_bitmap, RowsetIdUnorderedSet rowset_ids,
+                        std::shared_ptr<PartialUpdateInfo> partial_update_info)
             : transaction_id(transaction_id),
               partition_id(partition_id),
               delete_bitmap(delete_bitmap),
-              rowset_ids(rowset_ids) {}
+              rowset_ids(rowset_ids),
+              partial_update_info(partial_update_info) {}
     TTransactionId transaction_id;
     TPartitionId partition_id;
     DeleteBitmapPtr delete_bitmap;
     RowsetIdUnorderedSet rowset_ids;
+    std::shared_ptr<PartialUpdateInfo> partial_update_info;
 };
 
 using CommitTabletTxnInfoVec = std::vector<CommitTabletTxnInfo>;


### PR DESCRIPTION
## Proposed changes

picks https://github.com/apache/doris/pull/26556

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

