### PR TITLE
 [fix](be-ut) Fix compilation errors caused by missing opentelemetry headers

### DIFF
--- a/be/test/vec/function/function_test_util.cpp
+++ b/be/test/vec/function/function_test_util.cpp
@@ -18,7 +18,6 @@
 #include "vec/function/function_test_util.h"
 
 #include <glog/logging.h>
-#include <opentelemetry/common/threadlocal.h>
 
 #include <iostream>
 


### PR DESCRIPTION
Opentelemetry has been removed by https://github.com/apache/doris/pull/26605

A weird thing: 26605 succeed in BE UT(mac OS) test

