### PR TITLE
[chore](regression-test) Fix error add partition operation due to duplicate partition range

### DIFF
--- a/regression-test/suites/cold_heat_separation_p2/add_drop_partition.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/add_drop_partition.groovy
@@ -251,11 +251,11 @@ suite("add_drop_partition") {
     
     sql """
         alter table ${tableName} ADD PARTITION np
-        VALUES LESS THAN ("2016-01-01");
+        VALUES LESS THAN ("2017-01-01");
     """
 
     sql """
-        insert into ${tableName} values(1, "2016-01-01");
+        insert into ${tableName} values(1, "2017-01-01");
     """
 
     partitions = sql "show partitions from ${tableName}"

--- a/regression-test/suites/cold_heat_separation_p2/create_table_use_dynamic_partition.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/create_table_use_dynamic_partition.groovy
@@ -259,7 +259,7 @@ suite("cold_heat_dynamic_partition") {
     }
 
     sql """
-    sql * from ${tableName}
+    select * from ${tableName}
     """
 
     sql """


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
The former create table stmt has 3 partitions
```
partition p1 VALUES LESS THAN ("2014-01-01"),
partition p2 VALUES LESS THAN ("2015-01-01"),
partition p3 VALUES LESS THAN ("2016-01-01")
```

But the following add partition operation tried to add with one duplicate range `2016-01-01`. So this pr changes the range one correct partition.
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

