### PR TITLE
[enhancement](nereids)make error message more readable when bind logicalRepeat node

### DIFF
--- a/regression-test/suites/query_p0/grouping_sets/test_grouping_sets.groovy
+++ b/regression-test/suites/query_p0/grouping_sets/test_grouping_sets.groovy
@@ -46,7 +46,7 @@ suite("test_grouping_sets", "p0") {
 
     test {
         sql """
-              SELECT k1, k2, SUM(k3) FROM test_query_db.test
+              SELECT /*+ SET_VAR(enable_nereids_planner=false) */ k1, k2, SUM(k3) FROM test_query_db.test
               GROUP BY GROUPING SETS ((k1, k2), (k1), (k2), ( ), (k3) ) order by k1, k2
             """
         exception "errCode = 2, detailMessage = column: `k3` cannot both in select list and aggregate functions"
@@ -54,10 +54,26 @@ suite("test_grouping_sets", "p0") {
 
     test {
         sql """
-              SELECT k1, k2, SUM(k3)/(SUM(k3)+1) FROM test_query_db.test
+              SELECT /*+ SET_VAR(enable_nereids_planner=true) */ k1, k2, SUM(k3) FROM test_query_db.test
+              GROUP BY GROUPING SETS ((k1, k2), (k1), (k2), ( ), (k3) ) order by k1, k2
+            """
+        exception "errCode = 2, detailMessage = column: k3 cannot both in select list and aggregate functions"
+    }
+
+    test {
+        sql """
+              SELECT /*+ SET_VAR(enable_nereids_planner=false) */ k1, k2, SUM(k3)/(SUM(k3)+1) FROM test_query_db.test
               GROUP BY GROUPING SETS ((k1, k2), (k1), (k2), ( ), (k3) ) order by k1, k2
             """
         exception "errCode = 2, detailMessage = column: `k3` cannot both in select list and aggregate functions"
+    }
+
+    test {
+        sql """
+              SELECT /*+ SET_VAR(enable_nereids_planner=true) */ k1, k2, SUM(k3)/(SUM(k3)+1) FROM test_query_db.test
+              GROUP BY GROUPING SETS ((k1, k2), (k1), (k2), ( ), (k3) ) order by k1, k2
+            """
+        exception "errCode = 2, detailMessage = column: k3 cannot both in select list and aggregate functions"
     }
 
     qt_select7 """ select k1,k2,sum(k3) from test_query_db.test where 1 = 2 group by grouping sets((k1), (k1,k2)) """
@@ -164,9 +180,15 @@ suite("test_grouping_sets", "p0") {
     qt_select19 """SELECT k1 ,GROUPING(k1) FROM test_query_db.test GROUP BY ROLLUP (k1) ORDER BY k1"""
     qt_select20 """SELECT k1 ,GROUPING(k1) FROM test_query_db.test GROUP BY CUBE (k1) ORDER BY k1"""
     test {
-        sql "SELECT k1 ,GROUPING(k2) FROM test_query_db.test GROUP BY CUBE (k1) ORDER BY k1"
+        sql "SELECT /*+ SET_VAR(enable_nereids_planner=false) */ k1 ,GROUPING(k2) FROM test_query_db.test GROUP BY CUBE (k1) ORDER BY k1"
         exception "Column `k2` in GROUP_ID() does not exist in GROUP BY clause"
     }
+
+    test {
+        sql "SELECT /*+ SET_VAR(enable_nereids_planner=true) */ k1 ,GROUPING(k2) FROM test_query_db.test GROUP BY CUBE (k1) ORDER BY k1"
+        exception "Column in Grouping does not exist in GROUP BY clause"
+    }
+
     // test grouping sets id contain null data
     sql """drop table if exists test_query_db.test_grouping_sets_id_null"""
     sql """create table if not exists test_query_db.test_grouping_sets_id_null like test_query_db.test"""
@@ -192,8 +214,6 @@ suite("test_grouping_sets", "p0") {
         """
     sql """drop table if exists test_query_db.test_grouping_sets_id_null"""
     // test grouping sets shoot rollup
-    // because nereids cannot support rollup correctly forbid it temporary
-    sql """set enable_nereids_planner=false"""
     sql "drop table if exists test_query_db.test_grouping_sets_rollup"
     sql """
         create table if not exists test_query_db.test_grouping_sets_rollup(
@@ -232,8 +252,14 @@ suite("test_grouping_sets", "p0") {
     sql "drop table if exists test_query_db.test_grouping_sets_rollup"
     // test_grouping_select
     test {
-        sql "select k1, if(grouping(k1)=1, count(k1), 0) from test_query_db.test group by grouping sets((k1))"
+        sql "select /*+ SET_VAR(enable_nereids_planner=false) */ k1, if(grouping(k1)=1, count(k1), 0) from test_query_db.test group by grouping sets((k1))"
         exception "`k1` cannot both in select list and aggregate functions " +
+                "when using GROUPING SETS/CUBE/ROLLUP, please use union instead."
+    }
+
+    test {
+        sql "select /*+ SET_VAR(enable_nereids_planner=true) */ k1, if(grouping(k1)=1, count(k1), 0) from test_query_db.test group by grouping sets((k1))"
+        exception "k1 cannot both in select list and aggregate functions " +
                 "when using GROUPING SETS/CUBE/ROLLUP, please use union instead."
     }
 }

--- a/regression-test/suites/query_p0/grouping_sets/test_grouping_sets.groovy
+++ b/regression-test/suites/query_p0/grouping_sets/test_grouping_sets.groovy
@@ -53,6 +53,7 @@ suite("test_grouping_sets", "p0") {
     }
 
     sql """set enable_nereids_planner=true;"""
+    sql """set enable_fallback_to_original_planner=false;"""
     test {
         sql """
               SELECT k1, k2, SUM(k3) FROM test_query_db.test
@@ -61,6 +62,7 @@ suite("test_grouping_sets", "p0") {
         exception "errCode = 2, detailMessage = column: k3 cannot both in select list and aggregate functions"
     }
     sql """set enable_nereids_planner=false;"""
+    sql """set enable_fallback_to_original_planner=true;"""
     test {
         sql """
               SELECT /*+ SET_VAR(enable_nereids_planner=false) */ k1, k2, SUM(k3)/(SUM(k3)+1) FROM test_query_db.test
@@ -70,6 +72,7 @@ suite("test_grouping_sets", "p0") {
     }
 
     sql """set enable_nereids_planner=true;"""
+    sql """set enable_fallback_to_original_planner=false;"""
     test {
         sql """
               SELECT k1, k2, SUM(k3)/(SUM(k3)+1) FROM test_query_db.test
@@ -78,6 +81,7 @@ suite("test_grouping_sets", "p0") {
         exception "errCode = 2, detailMessage = column: k3 cannot both in select list and aggregate functions"
     }
     sql """set enable_nereids_planner=false;"""
+    sql """set enable_fallback_to_original_planner=true;"""
 
     qt_select7 """ select k1,k2,sum(k3) from test_query_db.test where 1 = 2 group by grouping sets((k1), (k1,k2)) """
 
@@ -187,11 +191,13 @@ suite("test_grouping_sets", "p0") {
         exception "Column `k2` in GROUP_ID() does not exist in GROUP BY clause"
     }
     sql """set enable_nereids_planner=true;"""
+    sql """set enable_fallback_to_original_planner=false;"""
     test {
         sql "SELECT k1 ,GROUPING(k2) FROM test_query_db.test GROUP BY CUBE (k1) ORDER BY k1"
         exception "Column in Grouping does not exist in GROUP BY clause"
     }
     sql """set enable_nereids_planner=false;"""
+    sql """set enable_fallback_to_original_planner=true;"""
 
     // test grouping sets id contain null data
     sql """drop table if exists test_query_db.test_grouping_sets_id_null"""
@@ -261,6 +267,7 @@ suite("test_grouping_sets", "p0") {
                 "when using GROUPING SETS/CUBE/ROLLUP, please use union instead."
     }
     sql """set enable_nereids_planner=true;"""
+    sql """set enable_fallback_to_original_planner=false;"""
 
     test {
         sql "select k1, if(grouping(k1)=1, count(k1), 0) from test_query_db.test group by grouping sets((k1))"

--- a/regression-test/suites/query_p0/grouping_sets/test_grouping_sets.groovy
+++ b/regression-test/suites/query_p0/grouping_sets/test_grouping_sets.groovy
@@ -52,14 +52,15 @@ suite("test_grouping_sets", "p0") {
         exception "errCode = 2, detailMessage = column: `k3` cannot both in select list and aggregate functions"
     }
 
+    sql """set enable_nereids_planner=true;"""
     test {
         sql """
-              SELECT /*+ SET_VAR(enable_nereids_planner=true) */ k1, k2, SUM(k3) FROM test_query_db.test
+              SELECT k1, k2, SUM(k3) FROM test_query_db.test
               GROUP BY GROUPING SETS ((k1, k2), (k1), (k2), ( ), (k3) ) order by k1, k2
             """
         exception "errCode = 2, detailMessage = column: k3 cannot both in select list and aggregate functions"
     }
-
+    sql """set enable_nereids_planner=false;"""
     test {
         sql """
               SELECT /*+ SET_VAR(enable_nereids_planner=false) */ k1, k2, SUM(k3)/(SUM(k3)+1) FROM test_query_db.test
@@ -68,13 +69,15 @@ suite("test_grouping_sets", "p0") {
         exception "errCode = 2, detailMessage = column: `k3` cannot both in select list and aggregate functions"
     }
 
+    sql """set enable_nereids_planner=true;"""
     test {
         sql """
-              SELECT /*+ SET_VAR(enable_nereids_planner=true) */ k1, k2, SUM(k3)/(SUM(k3)+1) FROM test_query_db.test
+              SELECT k1, k2, SUM(k3)/(SUM(k3)+1) FROM test_query_db.test
               GROUP BY GROUPING SETS ((k1, k2), (k1), (k2), ( ), (k3) ) order by k1, k2
             """
         exception "errCode = 2, detailMessage = column: k3 cannot both in select list and aggregate functions"
     }
+    sql """set enable_nereids_planner=false;"""
 
     qt_select7 """ select k1,k2,sum(k3) from test_query_db.test where 1 = 2 group by grouping sets((k1), (k1,k2)) """
 
@@ -183,11 +186,12 @@ suite("test_grouping_sets", "p0") {
         sql "SELECT /*+ SET_VAR(enable_nereids_planner=false) */ k1 ,GROUPING(k2) FROM test_query_db.test GROUP BY CUBE (k1) ORDER BY k1"
         exception "Column `k2` in GROUP_ID() does not exist in GROUP BY clause"
     }
-
+    sql """set enable_nereids_planner=true;"""
     test {
-        sql "SELECT /*+ SET_VAR(enable_nereids_planner=true) */ k1 ,GROUPING(k2) FROM test_query_db.test GROUP BY CUBE (k1) ORDER BY k1"
+        sql "SELECT k1 ,GROUPING(k2) FROM test_query_db.test GROUP BY CUBE (k1) ORDER BY k1"
         exception "Column in Grouping does not exist in GROUP BY clause"
     }
+    sql """set enable_nereids_planner=false;"""
 
     // test grouping sets id contain null data
     sql """drop table if exists test_query_db.test_grouping_sets_id_null"""
@@ -256,9 +260,10 @@ suite("test_grouping_sets", "p0") {
         exception "`k1` cannot both in select list and aggregate functions " +
                 "when using GROUPING SETS/CUBE/ROLLUP, please use union instead."
     }
+    sql """set enable_nereids_planner=true;"""
 
     test {
-        sql "select /*+ SET_VAR(enable_nereids_planner=true) */ k1, if(grouping(k1)=1, count(k1), 0) from test_query_db.test group by grouping sets((k1))"
+        sql "select k1, if(grouping(k1)=1, count(k1), 0) from test_query_db.test group by grouping sets((k1))"
         exception "k1 cannot both in select list and aggregate functions " +
                 "when using GROUPING SETS/CUBE/ROLLUP, please use union instead."
     }


### PR DESCRIPTION
SELECT k1 ,GROUPING(k2) FROM test_query_db.test GROUP BY CUBE (k1) ORDER BY k1;
**before:**
`ERROR 1105 (HY000): errCode = 2, detailMessage = Input slot(s) not in child's output: GROUPING_PREFIX_k2#15 originExpression=Grouping(k2#2) in plan: LogicalRepeat ( groupingSets=[[k1#1], []], outputExpressions=[k1#1, GROUPING_ID#16, GROUPING_PREFIX_k2#15 originExpression=Grouping(k2#2)] ), child output is: [k1#1]`
**after:**
`Column in Grouping does not exist in GROUP BY clause`



<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

