### PR TITLE
[improvement](config)Disable drop be automatically after finishing decommission

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1150,7 +1150,7 @@ public class Config extends ConfigBase {
      * If set to false, the backend will not be dropped and remaining in DECOMMISSION state.
      */
     @ConfField(mutable = true, masterOnly = true)
-    public static boolean drop_backend_after_decommission = true;
+    public static boolean drop_backend_after_decommission = false;
 
     /**
      * When tablet size of decommissioned backend is lower than this threshold,


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

If use local/k8s DeployManager, if we decommission the backend and drop it, the backend will be added back to the cluster.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

