### PR TITLE
[Bug](decimalv2)  getCmpType return decimalv2 when lhs/rhs type both …

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
@@ -422,6 +422,12 @@ public class BinaryPredicate extends Predicate implements Writable {
         if (t1 == PrimitiveType.BIGINT && t2 == PrimitiveType.BIGINT) {
             return Type.getAssignmentCompatibleType(getChild(0).getType(), getChild(1).getType(), false);
         }
+
+        if (t1 == PrimitiveType.DECIMALV2 && t2 == PrimitiveType.DECIMALV2) {
+            return ScalarType.getAssignmentCompatibleDecimalV2Type((ScalarType) getChild(0).getType(),
+                    (ScalarType) getChild(1).getType());
+        }
+
         if ((t1 == PrimitiveType.BIGINT && t2 == PrimitiveType.DECIMALV2)
                 || (t2 == PrimitiveType.BIGINT && t1 == PrimitiveType.DECIMALV2)
                 || (t1 == PrimitiveType.LARGEINT && t2 == PrimitiveType.DECIMALV2)

--- a/regression-test/suites/delete_p0/test_delete.groovy
+++ b/regression-test/suites/delete_p0/test_delete.groovy
@@ -280,4 +280,24 @@ PROPERTIES
     """
 
     sql "delete from dwd_pay partitions(p202310) where pay_time = '20231002';"
+
+    sql """
+    ADMIN SET FRONTEND CONFIG ('disable_decimalv2' = 'false');
+    """
+
+    sql "drop table if exists test"
+    sql """
+    CREATE TABLE `test`  
+    (
+            col_1 int,
+            col_2 decimalv2(10,3)
+    )ENGINE=OLAP
+    duplicate KEY(`col_1`)
+    COMMENT 'OLAP'
+    DISTRIBUTED BY HASH(`col_1`) BUCKETS 1
+    PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+    sql "DELETE FROM test  WHERE col_2 = cast(123.45 as decimalv2(10,3));"
 }


### PR DESCRIPTION
…is decimalv2  (#26705)

getCmpType return decimalv2 when lhs/rhs type both is decimalv2

## Proposed changes
pick from #26705
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

