### PR TITLE
[BugFix](MutilCatalog) fix local file system unavailable in iceberg hadoop catalog

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergHadoopExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/IcebergHadoopExternalCatalog.java
@@ -38,13 +38,16 @@ public class IcebergHadoopExternalCatalog extends IcebergExternalCatalog {
         String warehouse = props.get(CatalogProperties.WAREHOUSE_LOCATION);
         Preconditions.checkArgument(StringUtils.isNotEmpty(warehouse),
                 "Cannot initialize Iceberg HadoopCatalog because 'warehouse' must not be null or empty");
-        String nameService = StringUtils.substringBetween(warehouse, HdfsResource.HDFS_FILE_PREFIX, "/");
-        if (StringUtils.isEmpty(nameService)) {
-            throw new IllegalArgumentException("Unrecognized 'warehouse' location format"
-                    + " because name service is required.");
-        }
+
         catalogProperty = new CatalogProperty(resource, props);
-        catalogProperty.addProperty(HdfsResource.HADOOP_FS_NAME, HdfsResource.HDFS_FILE_PREFIX + nameService);
+        if (StringUtils.startsWith(warehouse, HdfsResource.HDFS_PREFIX)) {
+            String nameService = StringUtils.substringBetween(warehouse, HdfsResource.HDFS_FILE_PREFIX, "/");
+            if (StringUtils.isEmpty(nameService)) {
+                throw new IllegalArgumentException("Unrecognized 'warehouse' location format"
+                        + " because name service is required.");
+            }
+            catalogProperty.addProperty(HdfsResource.HADOOP_FS_NAME, HdfsResource.HDFS_FILE_PREFIX + nameService);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes

create catalog in local test/dev env like below:
create catalog iceberg PROPERTIES ('type'='iceberg','iceberg.catalog.type' = 'hadoop', 'warehouse' = '/export/workspace/warehouse');

we will get error: "Unrecognized 'warehouse' location format because name service is required." 

expect:
should be OK


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

