### PR TITLE
[fix](Nereids) fix plan shape of query64 unstable  (#26012)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Optimizer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Optimizer.java
@@ -80,8 +80,6 @@ public class Optimizer {
         // Due to EnsureProjectOnTopJoin, root group can't be Join Group, so DPHyp doesn't change the root group
         cascadesContext.pushJob(new JoinOrderJob(root, cascadesContext.getCurrentJobContext()));
         cascadesContext.getJobScheduler().executeJobPool(cascadesContext);
-        // after DPHyp just keep logical expression
-        cascadesContext.getMemo().removePhysicalExpression();
         cascadesContext.getStatementContext().setOtherJoinReorder(true);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -47,7 +47,6 @@ import org.apache.logging.log4j.Logger;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -109,31 +108,6 @@ public class Memo {
 
     public int getGroupExpressionsSize() {
         return groupExpressions.size();
-    }
-
-    /** just keep LogicalExpression in Memo. */
-    public void removePhysicalExpression() {
-        groupExpressions.entrySet().removeIf(entry -> entry.getValue().getPlan() instanceof PhysicalPlan);
-
-        Iterator<Map.Entry<GroupId, Group>> iterator = groups.entrySet().iterator();
-        while (iterator.hasNext()) {
-            Map.Entry<GroupId, Group> entry = iterator.next();
-            Group group = entry.getValue();
-
-            group.clearPhysicalExpressions();
-            group.clearLowestCostPlans();
-            group.removeParentPhysicalExpressions();
-            group.setExplored(false);
-
-            if (group.getLogicalExpressions().isEmpty() && group.getPhysicalExpressions().isEmpty()) {
-                iterator.remove();
-            }
-        }
-
-        // logical groupExpression reset ruleMask
-        groupExpressions.values().stream()
-                .filter(groupExpression -> groupExpression.getPlan() instanceof LogicalPlan)
-                .forEach(GroupExpression::clearApplied);
     }
 
     private Plan skipProject(Plan plan, Group targetGroup) {


### PR DESCRIPTION
don't remove the physical plan after optimizing the plan in dphyper.
[26012](https://github.com/apache/doris/pull/26012)

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

