### PR TITLE
[Fix](row store) cache invalidate key should not include sequence column

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -317,7 +317,7 @@ DEFINE_Int32(index_page_cache_percentage, "10");
 // whether to disable page cache feature in storage
 DEFINE_Bool(disable_storage_page_cache, "false");
 // whether to disable row cache feature in storage
-DEFINE_Bool(disable_storage_row_cache, "true");
+DEFINE_mBool(disable_storage_row_cache, "true");
 // whether to disable pk page cache feature in storage
 DEFINE_Bool(disable_pk_storage_page_cache, "false");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -363,7 +363,7 @@ DECLARE_Int32(index_page_cache_percentage);
 // whether to disable page cache feature in storage
 DECLARE_Bool(disable_storage_page_cache);
 // whether to disable row cache feature in storage
-DECLARE_Bool(disable_storage_row_cache);
+DECLARE_mBool(disable_storage_row_cache);
 // whether to disable pk page cache feature in storage
 DECLARE_Bool(disable_pk_storage_page_cache);
 

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -751,6 +751,7 @@ Status SegmentWriter::append_block(const vectorized::Block* block, size_t row_po
             std::string last_key;
             for (size_t pos = 0; pos < num_rows; pos++) {
                 std::string key = _full_encode_keys(key_columns, pos);
+                _maybe_invalid_row_cache(key);
                 if (_tablet_schema->has_sequence_col()) {
                     _encode_seq_column(seq_column, pos, &key);
                 }
@@ -758,7 +759,6 @@ Status SegmentWriter::append_block(const vectorized::Block* block, size_t row_po
                         << "found duplicate key or key is not sorted! current key: " << key
                         << ", last key" << last_key;
                 RETURN_IF_ERROR(_primary_key_index_builder->add_item(key));
-                _maybe_invalid_row_cache(key);
                 last_key = std::move(key);
             }
         } else {

--- a/regression-test/plugins/plugin_curl_requester.groovy
+++ b/regression-test/plugins/plugin_curl_requester.groovy
@@ -71,3 +71,8 @@ Suite.metaClass.be_run_full_compaction_by_table_id = { String ip, String port, S
 }
 
 logger.info("Added 'be_run_full_compaction' function to Suite")
+Suite.metaClass.update_be_config = { String ip, String port, String key, String value /*param */ ->
+    return curl("POST", String.format("http://%s:%s/api/update_config?%s=%s", ip, port, key, value))
+}
+
+logger.info("Added 'update_be_config' function to Suite")

--- a/regression-test/suites/point_query_p0/test_point_query.groovy
+++ b/regression-test/suites/point_query_p0/test_point_query.groovy
@@ -18,228 +18,246 @@
 import java.math.BigDecimal;
 
 suite("test_point_query") {
-    def user = context.config.jdbcUser
-    def password = context.config.jdbcPassword
-    def realDb = "regression_test_serving_p0"
-    def tableName = realDb + ".tbl_point_query"
-    sql "CREATE DATABASE IF NOT EXISTS ${realDb}"
+    def set_be_config = { key, value ->
+        String backend_id;
+        def backendId_to_backendIP = [:]
+        def backendId_to_backendHttpPort = [:]
+        getBackendIpHttpPort(backendId_to_backendIP, backendId_to_backendHttpPort);
 
-    // Parse url
-    String jdbcUrl = context.config.jdbcUrl
-    String urlWithoutSchema = jdbcUrl.substring(jdbcUrl.indexOf("://") + 3)
-    def sql_ip = urlWithoutSchema.substring(0, urlWithoutSchema.indexOf(":"))
-    def sql_port
-    if (urlWithoutSchema.indexOf("/") >= 0) {
-        // e.g: jdbc:mysql://locahost:8080/?a=b
-        sql_port = urlWithoutSchema.substring(urlWithoutSchema.indexOf(":") + 1, urlWithoutSchema.indexOf("/"))
-    } else {
-        // e.g: jdbc:mysql://locahost:8080
-        sql_port = urlWithoutSchema.substring(urlWithoutSchema.indexOf(":") + 1)
+        backend_id = backendId_to_backendIP.keySet()[0]
+        def (code, out, err) = update_be_config(backendId_to_backendIP.get(backend_id), backendId_to_backendHttpPort.get(backend_id), key, value)
+        logger.info("update config: code=" + code + ", out=" + out + ", err=" + err)
     }
-    // set server side prepared statement url
-    def prepare_url = "jdbc:mysql://" + sql_ip + ":" + sql_port + "/" + realDb + "?&useServerPrepStmts=true"
+    try {
+        set_be_config.call("disable_storage_row_cache", "false")
+        // nereids do not support point query now
+        sql """set enable_nereids_planner=false"""
 
-    def generateString = {len ->
-        def str = ""
-        for (int i = 0; i < len; i++) {
-            str += "a"
-        }
-        return str
-    }
+        def user = context.config.jdbcUser
+        def password = context.config.jdbcPassword
+        def realDb = "regression_test_serving_p0"
+        def tableName = realDb + ".tbl_point_query"
+        sql "CREATE DATABASE IF NOT EXISTS ${realDb}"
 
-    def nprep_sql = { sql_str ->
-        def url_without_prep = "jdbc:mysql://" + sql_ip + ":" + sql_port + "/" + realDb
-        connect(user = user, password = password, url = url_without_prep) {
-            sql sql_str
-        }
-    }
-
-    sql """DROP TABLE IF EXISTS ${tableName}"""
-    test {
-        // abnormal case
-        sql """
-              CREATE TABLE IF NOT EXISTS ${tableName} (
-                `k1` int NULL COMMENT ""
-              ) ENGINE=OLAP
-              UNIQUE KEY(`k1`)
-              DISTRIBUTED BY HASH(`k1`) BUCKETS 1
-              PROPERTIES (
-              "replication_allocation" = "tag.location.default: 1",
-              "store_row_column" = "true",
-              "light_schema_change" = "false"
-              )
-          """
-        exception "errCode = 2, detailMessage = Row store column rely on light schema change, enable light schema change first"
-    }
-
-    def create_table_sql = { property ->
-        return String.format("""
-              CREATE TABLE IF NOT EXISTS ${tableName} (
-                `k1` int(11) NULL COMMENT "",
-                `k2` decimalv3(27, 9) NULL COMMENT "",
-                `k3` varchar(300) NULL COMMENT "",
-                `k4` varchar(30) NULL COMMENT "",
-                `k5` date NULL COMMENT "",
-                `k6` datetime NULL COMMENT "",
-                `k7` float NULL COMMENT "",
-                `k8` datev2 NULL COMMENT "",
-                `k9` boolean NULL COMMENT "",
-                `k10` decimalv3(20, 3) NULL COMMENT "",
-                `k11` array<decimalv3(27, 9)> NULL COMMENT "",
-                `k12` array<text> NULL COMMENT ""
-              ) ENGINE=OLAP
-              UNIQUE KEY(`k1`, `k2`, `k3`)
-              DISTRIBUTED BY HASH(`k1`, k2, k3) BUCKETS 1
-              PROPERTIES (
-              "replication_allocation" = "tag.location.default: 1",
-              "store_row_column" = "true",
-              "enable_unique_key_merge_on_write" = "true",
-              "light_schema_change" = "true",
-              %s
-              "storage_format" = "V2")
-              """, property)
-    }
-
-    for (int i = 0; i < 3; i++) {
-        tableName = realDb + ".tbl_point_query" + i
-        sql """DROP TABLE IF EXISTS ${tableName}"""
-        if (i == 0) {
-            def sql0 = create_table_sql("")
-            sql """ ${sql0} """
-        } else if (i == 1) {
-            def sql1 = create_table_sql("\"function_column.sequence_type\" = 'int',")
-            sql """ ${sql1} """
+        // Parse url
+        String jdbcUrl = context.config.jdbcUrl
+        String urlWithoutSchema = jdbcUrl.substring(jdbcUrl.indexOf("://") + 3)
+        def sql_ip = urlWithoutSchema.substring(0, urlWithoutSchema.indexOf(":"))
+        def sql_port
+        if (urlWithoutSchema.indexOf("/") >= 0) {
+            // e.g: jdbc:mysql://locahost:8080/?a=b
+            sql_port = urlWithoutSchema.substring(urlWithoutSchema.indexOf(":") + 1, urlWithoutSchema.indexOf("/"))
         } else {
-            def sql2 = create_table_sql("\"function_column.sequence_col\" = 'k6',")
-            sql """ ${sql2} """
+            // e.g: jdbc:mysql://locahost:8080
+            sql_port = urlWithoutSchema.substring(urlWithoutSchema.indexOf(":") + 1)
         }
-        sql """ INSERT INTO ${tableName} VALUES(1231, 119291.11, "ddd", "laooq", null, "2020-01-01 12:36:38", null, "1022-01-01 11:30:38", null, 1.111112, [119181.1111, 819019.1191, null], null) """
-        sql """ INSERT INTO ${tableName} VALUES(1232, 12222.99121135, "xxx", "laooq", "2023-01-02", "2020-01-01 12:36:38", 522.762, "2022-01-01 11:30:38", 1, 212.111, null, null) """
-        sql """ INSERT INTO ${tableName} VALUES(1233, 1.392932911, "yyy", "laooq", "2024-01-02", "2020-01-01 12:36:38", 52.862, "3022-01-01 11:30:38", 0, 5973903488739435.668, [119181.1111, null, 819019.1191], ["dijiiixxx"]) """
-        sql """ INSERT INTO ${tableName} VALUES(1234, 12919291.129191137, "xxddd", "laooq", "2025-01-02", "2020-01-01 12:36:38", 552.872, "4022-01-01 11:30:38", 1, 5973903488739435.668, [1888109181.192111, 192129019.1191], ["1", "2", "3"]) """
-        sql """ INSERT INTO ${tableName} VALUES(1235, 991129292901.11138, "dd", null, "2120-01-02", "2020-01-01 12:36:38", 652.692, "5022-01-01 11:30:38", 0, 90696620686827832.374, [119181.1111], ["${generateString(251)}"]) """
-        sql """ INSERT INTO ${tableName} VALUES(1236, 100320.11139, "laa    ddd", "laooq", "2220-01-02", "2020-01-01 12:36:38", 2.7692, "6022-01-01 11:30:38", 1, 23698.299, [], ["${generateString(251)}"]) """
-        sql """ INSERT INTO ${tableName} VALUES(1237, 120939.11130, "a    ddd", "laooq", "2030-01-02", "2020-01-01 12:36:38", 22.822, "7022-01-01 11:30:38", 0, 90696620686827832.374, [1.1, 2.2, 3.3, 4.4, 5.5], []) """
-        sql """ INSERT INTO ${tableName} VALUES(251, 120939.11130, "${generateString(251)}", "laooq", "2030-01-02", "2020-01-01 12:36:38", 251, "7022-01-01 11:30:38", 1, 90696620686827832.374, [11111], []) """
-        sql """ INSERT INTO ${tableName} VALUES(252, 120939.11130, "${generateString(252)}", "laooq", "2030-01-02", "2020-01-01 12:36:38", 252, "7022-01-01 11:30:38", 0, 90696620686827832.374, [0], null) """
-        sql """ INSERT INTO ${tableName} VALUES(298, 120939.11130, "${generateString(298)}", "laooq", "2030-01-02", "2020-01-01 12:36:38", 298, "7022-01-01 11:30:38", 1, 90696620686827832.374, [], []) """
+        // set server side prepared statement url
+        def prepare_url = "jdbc:mysql://" + sql_ip + ":" + sql_port + "/" + realDb + "?&useServerPrepStmts=true"
 
-        def result1 = connect(user=user, password=password, url=prepare_url) {
-            def stmt = prepareStatement "select /*+ SET_VAR(enable_nereids_planner=false) */ * from ${tableName} where k1 = ? and k2 = ? and k3 = ?"
-            assertEquals(stmt.class, com.mysql.cj.jdbc.ServerPreparedStatement);
-            stmt.setInt(1, 1231)
-            stmt.setBigDecimal(2, new BigDecimal("119291.11"))
-            stmt.setString(3, "ddd")
-            qe_point_select stmt
-            stmt.setInt(1, 1231)
-            stmt.setBigDecimal(2, new BigDecimal("119291.11"))
-            stmt.setString(3, "ddd")
-            qe_point_select stmt
-            stmt.setInt(1, 1237)
-            stmt.setBigDecimal(2, new BigDecimal("120939.11130"))
-            stmt.setString(3, "a    ddd")
-            qe_point_select stmt
+        def generateString = {len ->
+            def str = ""
+            for (int i = 0; i < len; i++) {
+                str += "a"
+            }
+            return str
+        }
 
-            stmt.setInt(1, 1232)
-            stmt.setBigDecimal(2, new BigDecimal("12222.99121135"))
-            stmt.setString(3, 'xxx')
-            qe_point_select stmt
+        def nprep_sql = { sql_str ->
+            def url_without_prep = "jdbc:mysql://" + sql_ip + ":" + sql_port + "/" + realDb
+            connect(user = user, password = password, url = url_without_prep) {
+                sql sql_str
+            }
+        }
 
-            stmt.setInt(1, 251)
-            stmt.setBigDecimal(2, new BigDecimal("120939.11130"))
-            stmt.setString(3, generateString(251))
-            qe_point_select stmt
-
-            stmt.setInt(1, 252)
-            stmt.setBigDecimal(2, new BigDecimal("120939.11130"))
-            stmt.setString(3, generateString(252))
-            qe_point_select stmt
-
-            stmt.setInt(1, 298)
-            stmt.setBigDecimal(2, new BigDecimal("120939.11130"))
-            stmt.setString(3, generateString(298))
-            qe_point_select stmt
-            stmt.close()
-
-            stmt = prepareStatement "select /*+ SET_VAR(enable_nereids_planner=false) */ * from ${tableName} where k1 = 1235 and k2 = ? and k3 = ?"
-            assertEquals(stmt.class, com.mysql.cj.jdbc.ServerPreparedStatement);
-            stmt.setBigDecimal(1, new BigDecimal("991129292901.11138"))
-            stmt.setString(2, "dd")
-            qe_point_select stmt
-
-            def stmt_fn = prepareStatement "select /*+ SET_VAR(enable_nereids_planner=false) */ hex(k3), hex(k4) from ${tableName} where k1 = ? and k2 =? and k3 = ?"
-            assertEquals(stmt_fn.class, com.mysql.cj.jdbc.ServerPreparedStatement);
-            stmt_fn.setInt(1, 1231)
-            stmt_fn.setBigDecimal(2, new BigDecimal("119291.11"))
-            stmt_fn.setString(3, "ddd")
-            qe_point_select stmt_fn
-            qe_point_select stmt_fn
-            qe_point_select stmt_fn
-
-            nprep_sql """
-            ALTER table ${tableName} ADD COLUMN new_column0 INT default "0";
-            """
-            sleep(1);
-            nprep_sql """ INSERT INTO ${tableName} VALUES(1235, 120939.11130, "a    ddd", "laooq", "2030-01-02", "2020-01-01 12:36:38", 22.822, "7022-01-01 11:30:38", 1, 1.1111299, [119291.19291], ["111", "222", "333"], 1) """
-            stmt.setBigDecimal(1, new BigDecimal("120939.11130"))
-            stmt.setString(2, "a    ddd")
-            qe_point_select stmt
-            qe_point_select stmt
-            // invalidate cache
-            nprep_sql """ INSERT INTO ${tableName} VALUES(1235, 120939.11130, "a    ddd", "xxxxxx", "2030-01-02", "2020-01-01 12:36:38", 22.822, "7022-01-01 11:30:38", 0, 1929111.1111,[119291.19291], ["111", "222", "333"], 2) """
-            qe_point_select stmt
-            qe_point_select stmt
-            qe_point_select stmt
-            nprep_sql """
-            ALTER table ${tableName} ADD COLUMN new_column1 INT default "0";
-            """
-            qe_point_select stmt
-            qe_point_select stmt
-            nprep_sql """
-            ALTER table ${tableName} DROP COLUMN new_column1;
-            """
-            qe_point_select stmt
-            qe_point_select stmt
-
+        sql """DROP TABLE IF EXISTS ${tableName}"""
+        test {
+            // abnormal case
             sql """
-              ALTER table ${tableName} ADD COLUMN new_column1 INT default "0";
-            """
-            qe_point_select stmt
+                  CREATE TABLE IF NOT EXISTS ${tableName} (
+                    `k1` int NULL COMMENT ""
+                  ) ENGINE=OLAP
+                  UNIQUE KEY(`k1`)
+                  DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+                  PROPERTIES (
+                  "replication_allocation" = "tag.location.default: 1",
+                  "store_row_column" = "true",
+                  "light_schema_change" = "false"
+                  )
+              """
+            exception "errCode = 2, detailMessage = Row store column rely on light schema change, enable light schema change first"
         }
-        // disable useServerPrepStmts
-        def result2 = connect(user=user, password=password, url=context.config.jdbcUrl) {
-            qt_sql """select /*+ SET_VAR(enable_nereids_planner=false) */ * from ${tableName} where k1 = 1231 and k2 = 119291.11 and k3 = 'ddd'"""
-            qt_sql """select /*+ SET_VAR(enable_nereids_planner=false) */ * from ${tableName} where k1 = 1237 and k2 = 120939.11130 and k3 = 'a    ddd'"""
-            qt_sql """select /*+ SET_VAR(enable_nereids_planner=false) */ hex(k3), hex(k4), k7 + 10.1 from ${tableName} where k1 = 1237 and k2 = 120939.11130 and k3 = 'a    ddd'"""
-            // prepared text
-            sql """ prepare stmt1 from  select * from ${tableName} where k1 = % and k2 = % and k3 = % """
-            qt_sql """execute stmt1 using (1231, 119291.11, 'ddd')"""
-            qt_sql """execute stmt1 using (1237, 120939.11130, 'a    ddd')"""
 
-            sql """prepare stmt2 from  select * from ${tableName} where k1 = % and k2 = % and k3 = %"""
-            qt_sql """execute stmt2 using (1231, 119291.11, 'ddd')"""
-            qt_sql """execute stmt2 using (1237, 120939.11130, 'a    ddd')"""
-            tableName = "test_query"
-            sql """DROP TABLE IF EXISTS ${tableName}"""
-            sql """CREATE TABLE ${tableName} (
-                    `customer_key` bigint(20) NULL,
-                    `customer_btm_value_0` text NULL,
-                    `customer_btm_value_1` text NULL,
-                    `customer_btm_value_2` text NULL
-                ) ENGINE=OLAP
-                UNIQUE KEY(`customer_key`)
-                COMMENT 'OLAP'
-                DISTRIBUTED BY HASH(`customer_key`) BUCKETS 16
-                PROPERTIES (
-                "replication_allocation" = "tag.location.default: 1",
-                "storage_format" = "V2",
-                "light_schema_change" = "true",
-                "store_row_column" = "true",
-                "enable_unique_key_merge_on_write" = "true",
-                "disable_auto_compaction" = "false"
-                );"""
-            sql """insert into ${tableName} values (0, "1", "2", "3")"""
-            qt_sql "select /*+ SET_VAR(enable_nereids_planner=false) */ * from test_query where customer_key = 0"
+        def create_table_sql = { property ->
+            return String.format("""
+                  CREATE TABLE IF NOT EXISTS ${tableName} (
+                    `k1` int(11) NULL COMMENT "",
+                    `k2` decimalv3(27, 9) NULL COMMENT "",
+                    `k3` varchar(300) NULL COMMENT "",
+                    `k4` varchar(30) NULL COMMENT "",
+                    `k5` date NULL COMMENT "",
+                    `k6` datetime NULL COMMENT "",
+                    `k7` float NULL COMMENT "",
+                    `k8` datev2 NULL COMMENT "",
+                    `k9` boolean NULL COMMENT "",
+                    `k10` decimalv3(20, 3) NULL COMMENT "",
+                    `k11` array<decimalv3(27, 9)> NULL COMMENT "",
+                    `k12` array<text> NULL COMMENT ""
+                  ) ENGINE=OLAP
+                  UNIQUE KEY(`k1`, `k2`, `k3`)
+                  DISTRIBUTED BY HASH(`k1`, k2, k3) BUCKETS 1
+                  PROPERTIES (
+                  "replication_allocation" = "tag.location.default: 1",
+                  "store_row_column" = "true",
+                  "enable_unique_key_merge_on_write" = "true",
+                  "light_schema_change" = "true",
+                  %s
+                  "storage_format" = "V2")
+                  """, property)
         }
+
+        for (int i = 0; i < 3; i++) {
+            tableName = realDb + ".tbl_point_query" + i
+            sql """DROP TABLE IF EXISTS ${tableName}"""
+            if (i == 0) {
+                def sql0 = create_table_sql("")
+                sql """ ${sql0} """
+            } else if (i == 1) {
+                def sql1 = create_table_sql("\"function_column.sequence_type\" = 'int',")
+                sql """ ${sql1} """
+            } else {
+                def sql2 = create_table_sql("\"function_column.sequence_col\" = 'k6',")
+                sql """ ${sql2} """
+            }
+            sql """ INSERT INTO ${tableName} VALUES(1231, 119291.11, "ddd", "laooq", null, "2020-01-01 12:36:38", null, "1022-01-01 11:30:38", null, 1.111112, [119181.1111, 819019.1191, null], null) """
+            sql """ INSERT INTO ${tableName} VALUES(1232, 12222.99121135, "xxx", "laooq", "2023-01-02", "2020-01-01 12:36:38", 522.762, "2022-01-01 11:30:38", 1, 212.111, null, null) """
+            sql """ INSERT INTO ${tableName} VALUES(1233, 1.392932911, "yyy", "laooq", "2024-01-02", "2020-01-01 12:36:38", 52.862, "3022-01-01 11:30:38", 0, 5973903488739435.668, [119181.1111, null, 819019.1191], ["dijiiixxx"]) """
+            sql """ INSERT INTO ${tableName} VALUES(1234, 12919291.129191137, "xxddd", "laooq", "2025-01-02", "2020-01-01 12:36:38", 552.872, "4022-01-01 11:30:38", 1, 5973903488739435.668, [1888109181.192111, 192129019.1191], ["1", "2", "3"]) """
+            sql """ INSERT INTO ${tableName} VALUES(1235, 991129292901.11138, "dd", null, "2120-01-02", "2020-01-01 12:36:38", 652.692, "5022-01-01 11:30:38", 0, 90696620686827832.374, [119181.1111], ["${generateString(251)}"]) """
+            sql """ INSERT INTO ${tableName} VALUES(1236, 100320.11139, "laa    ddd", "laooq", "2220-01-02", "2020-01-01 12:36:38", 2.7692, "6022-01-01 11:30:38", 1, 23698.299, [], ["${generateString(251)}"]) """
+            sql """ INSERT INTO ${tableName} VALUES(1237, 120939.11130, "a    ddd", "laooq", "2030-01-02", "2020-01-01 12:36:38", 22.822, "7022-01-01 11:30:38", 0, 90696620686827832.374, [1.1, 2.2, 3.3, 4.4, 5.5], []) """
+            sql """ INSERT INTO ${tableName} VALUES(251, 120939.11130, "${generateString(251)}", "laooq", "2030-01-02", "2020-01-01 12:36:38", 251, "7022-01-01 11:30:38", 1, 90696620686827832.374, [11111], []) """
+            sql """ INSERT INTO ${tableName} VALUES(252, 120939.11130, "${generateString(252)}", "laooq", "2030-01-02", "2020-01-01 12:36:38", 252, "7022-01-01 11:30:38", 0, 90696620686827832.374, [0], null) """
+            sql """ INSERT INTO ${tableName} VALUES(298, 120939.11130, "${generateString(298)}", "laooq", "2030-01-02", "2020-01-01 12:36:38", 298, "7022-01-01 11:30:38", 1, 90696620686827832.374, [], []) """
+
+            def result1 = connect(user=user, password=password, url=prepare_url) {
+                def stmt = prepareStatement "select /*+ SET_VAR(enable_nereids_planner=false) */ * from ${tableName} where k1 = ? and k2 = ? and k3 = ?"
+                assertEquals(stmt.class, com.mysql.cj.jdbc.ServerPreparedStatement);
+                stmt.setInt(1, 1231)
+                stmt.setBigDecimal(2, new BigDecimal("119291.11"))
+                stmt.setString(3, "ddd")
+                qe_point_select stmt
+                stmt.setInt(1, 1231)
+                stmt.setBigDecimal(2, new BigDecimal("119291.11"))
+                stmt.setString(3, "ddd")
+                qe_point_select stmt
+                stmt.setInt(1, 1237)
+                stmt.setBigDecimal(2, new BigDecimal("120939.11130"))
+                stmt.setString(3, "a    ddd")
+                qe_point_select stmt
+
+                stmt.setInt(1, 1232)
+                stmt.setBigDecimal(2, new BigDecimal("12222.99121135"))
+                stmt.setString(3, 'xxx')
+                qe_point_select stmt
+
+                stmt.setInt(1, 251)
+                stmt.setBigDecimal(2, new BigDecimal("120939.11130"))
+                stmt.setString(3, generateString(251))
+                qe_point_select stmt
+
+                stmt.setInt(1, 252)
+                stmt.setBigDecimal(2, new BigDecimal("120939.11130"))
+                stmt.setString(3, generateString(252))
+                qe_point_select stmt
+
+                stmt.setInt(1, 298)
+                stmt.setBigDecimal(2, new BigDecimal("120939.11130"))
+                stmt.setString(3, generateString(298))
+                qe_point_select stmt
+                stmt.close()
+
+                stmt = prepareStatement "select /*+ SET_VAR(enable_nereids_planner=false) */ * from ${tableName} where k1 = 1235 and k2 = ? and k3 = ?"
+                assertEquals(stmt.class, com.mysql.cj.jdbc.ServerPreparedStatement);
+                stmt.setBigDecimal(1, new BigDecimal("991129292901.11138"))
+                stmt.setString(2, "dd")
+                qe_point_select stmt
+
+                def stmt_fn = prepareStatement "select /*+ SET_VAR(enable_nereids_planner=false) */ hex(k3), hex(k4) from ${tableName} where k1 = ? and k2 =? and k3 = ?"
+                assertEquals(stmt_fn.class, com.mysql.cj.jdbc.ServerPreparedStatement);
+                stmt_fn.setInt(1, 1231)
+                stmt_fn.setBigDecimal(2, new BigDecimal("119291.11"))
+                stmt_fn.setString(3, "ddd")
+                qe_point_select stmt_fn
+                qe_point_select stmt_fn
+                qe_point_select stmt_fn
+
+                nprep_sql """
+                ALTER table ${tableName} ADD COLUMN new_column0 INT default "0";
+                """
+                sleep(1);
+                nprep_sql """ INSERT INTO ${tableName} VALUES(1235, 120939.11130, "a    ddd", "laooq", "2030-01-02", "2020-01-01 12:36:38", 22.822, "7022-01-01 11:30:38", 1, 1.1111299, [119291.19291], ["111", "222", "333"], 1) """
+                stmt.setBigDecimal(1, new BigDecimal("120939.11130"))
+                stmt.setString(2, "a    ddd")
+                qe_point_select stmt
+                qe_point_select stmt
+                // invalidate cache
+                nprep_sql """ INSERT INTO ${tableName} VALUES(1235, 120939.11130, "a    ddd", "xxxxxx", "2030-01-02", "2020-01-01 12:36:38", 22.822, "7022-01-01 11:30:38", 0, 1929111.1111,[119291.19291], ["111", "222", "333"], 2) """
+                qe_point_select stmt
+                qe_point_select stmt
+                qe_point_select stmt
+                nprep_sql """
+                ALTER table ${tableName} ADD COLUMN new_column1 INT default "0";
+                """
+                qe_point_select stmt
+                qe_point_select stmt
+                nprep_sql """
+                ALTER table ${tableName} DROP COLUMN new_column1;
+                """
+                qe_point_select stmt
+                qe_point_select stmt
+
+                sql """
+                  ALTER table ${tableName} ADD COLUMN new_column1 INT default "0";
+                """
+                qe_point_select stmt
+            }
+            // disable useServerPrepStmts
+            def result2 = connect(user=user, password=password, url=context.config.jdbcUrl) {
+                qt_sql """select /*+ SET_VAR(enable_nereids_planner=false) */ * from ${tableName} where k1 = 1231 and k2 = 119291.11 and k3 = 'ddd'"""
+                qt_sql """select /*+ SET_VAR(enable_nereids_planner=false) */ * from ${tableName} where k1 = 1237 and k2 = 120939.11130 and k3 = 'a    ddd'"""
+                qt_sql """select /*+ SET_VAR(enable_nereids_planner=false) */ hex(k3), hex(k4), k7 + 10.1 from ${tableName} where k1 = 1237 and k2 = 120939.11130 and k3 = 'a    ddd'"""
+                // prepared text
+                sql """ prepare stmt1 from  select * from ${tableName} where k1 = % and k2 = % and k3 = % """
+                qt_sql """execute stmt1 using (1231, 119291.11, 'ddd')"""
+                qt_sql """execute stmt1 using (1237, 120939.11130, 'a    ddd')"""
+
+                sql """prepare stmt2 from  select * from ${tableName} where k1 = % and k2 = % and k3 = %"""
+                qt_sql """execute stmt2 using (1231, 119291.11, 'ddd')"""
+                qt_sql """execute stmt2 using (1237, 120939.11130, 'a    ddd')"""
+                tableName = "test_query"
+                sql """DROP TABLE IF EXISTS ${tableName}"""
+                sql """CREATE TABLE ${tableName} (
+                        `customer_key` bigint(20) NULL,
+                        `customer_btm_value_0` text NULL,
+                        `customer_btm_value_1` text NULL,
+                        `customer_btm_value_2` text NULL
+                    ) ENGINE=OLAP
+                    UNIQUE KEY(`customer_key`)
+                    COMMENT 'OLAP'
+                    DISTRIBUTED BY HASH(`customer_key`) BUCKETS 16
+                    PROPERTIES (
+                    "replication_allocation" = "tag.location.default: 1",
+                    "storage_format" = "V2",
+                    "light_schema_change" = "true",
+                    "store_row_column" = "true",
+                    "enable_unique_key_merge_on_write" = "true",
+                    "disable_auto_compaction" = "false"
+                    );"""
+                sql """insert into ${tableName} values (0, "1", "2", "3")"""
+                qt_sql "select /*+ SET_VAR(enable_nereids_planner=false) */ * from test_query where customer_key = 0"
+            }
+        }
+    } finally {
+        set_be_config.call("disable_storage_row_cache", "true")
     }
-}
+} 


### PR DESCRIPTION
Other wise the key loaded cache with is without sequence column, and lead to stale data read

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

