### PR TITLE
[Opt](scanner-scheduler) Optimize `BlockingQueue`, `BlockingPriorityQueue` and change remote scan thread pool.

### DIFF
--- a/be/src/util/blocking_priority_queue.hpp
+++ b/be/src/util/blocking_priority_queue.hpp
@@ -42,7 +42,9 @@ public:
               _max_element(max_elements),
               _upgrade_counter(0),
               _total_get_wait_time(0),
-              _total_put_wait_time(0) {}
+              _total_put_wait_time(0),
+              _get_waiting(0),
+              _put_waiting(0) {}
 
     // Get an element from the queue, waiting indefinitely (or until timeout) for one to become available.
     // Returns false if we were shut down prior to getting the element, and there
@@ -55,17 +57,29 @@ public:
         bool wait_successful = false;
 #if !defined(USE_BTHREAD_SCANNER)
         if (timeout_ms > 0) {
-            wait_successful = _get_cv.wait_for(unique_lock, std::chrono::milliseconds(timeout_ms),
-                                               [this] { return _shutdown || !_queue.empty(); });
+            while (!(_shutdown || !_queue.empty())) {
+                ++_get_waiting;
+                if (_get_cv.wait_for(unique_lock, std::chrono::milliseconds(timeout_ms)) ==
+                    std::cv_status::timeout) {
+                    // timeout
+                    wait_successful = _shutdown || !_queue.empty();
+                    break;
+                }
+            }
         } else {
-            _get_cv.wait(unique_lock, [this] { return _shutdown || !_queue.empty(); });
+            while (!(_shutdown || !_queue.empty())) {
+                ++_get_waiting;
+                _get_cv.wait(unique_lock);
+            }
             wait_successful = true;
         }
 #else
         if (timeout_ms > 0) {
             wait_successful = true;
             while (!(_shutdown || !_queue.empty())) {
-                if (_get_cv.wait_for(unique_lock, timeout_ms * 1000) != 0) {
+                ++_get_waiting;
+                if (_get_cv.wait_for(unique_lock, std::chrono::milliseconds(timeout_ms)) ==
+                    std::cv_status::timeout) {
                     // timeout
                     wait_successful = _shutdown || !_queue.empty();
                     break;
@@ -95,7 +109,11 @@ public:
                 *out = _queue.top();
                 _queue.pop();
                 ++_upgrade_counter;
-                _put_cv.notify_one();
+                if (_put_waiting > 0) {
+                    --_put_waiting;
+                    unique_lock.unlock();
+                    _put_cv.notify_one();
+                }
                 return true;
             } else {
                 assert(_shutdown);
@@ -131,7 +149,11 @@ public:
             _queue.pop();
             ++_upgrade_counter;
             _total_get_wait_time += timer.elapsed_time();
-            _put_cv.notify_one();
+            if (_put_waiting > 0) {
+                --_put_waiting;
+                unique_lock.unlock();
+                _put_cv.notify_one();
+            }
             return true;
         }
 
@@ -145,6 +167,7 @@ public:
         timer.start();
         std::unique_lock unique_lock(_lock);
         while (!(_shutdown || _queue.size() < _max_element)) {
+            ++_put_waiting;
             _put_cv.wait(unique_lock);
         }
         _total_put_wait_time += timer.elapsed_time();
@@ -154,7 +177,11 @@ public:
         }
 
         _queue.push(val);
-        _get_cv.notify_one();
+        if (_get_waiting > 0) {
+            --_get_waiting;
+            unique_lock.unlock();
+            _get_cv.notify_one();
+        }
         return true;
     }
 
@@ -163,8 +190,11 @@ public:
         std::unique_lock unique_lock(_lock);
         if (_queue.size() < _max_element && !_shutdown) {
             _queue.push(val);
-            unique_lock.unlock();
-            _get_cv.notify_one();
+            if (_get_waiting > 0) {
+                --_get_waiting;
+                unique_lock.unlock();
+                _get_cv.notify_one();
+            }
             return true;
         }
         return false;
@@ -204,6 +234,8 @@ private:
     int _upgrade_counter;
     std::atomic<uint64_t> _total_get_wait_time;
     std::atomic<uint64_t> _total_put_wait_time;
+    size_t _get_waiting;
+    size_t _put_waiting;
 };
 
 } // namespace doris

--- a/be/src/util/blocking_queue.hpp
+++ b/be/src/util/blocking_queue.hpp
@@ -41,7 +41,9 @@ public:
             : _shutdown(false),
               _max_elements(max_elements),
               _total_get_wait_time(0),
-              _total_put_wait_time(0) {}
+              _total_put_wait_time(0),
+              _get_waiting(0),
+              _put_waiting(0) {}
 
     // Get an element from the queue, waiting indefinitely for one to become available.
     // Returns false if we were shut down prior to getting the element, and there
@@ -50,13 +52,20 @@ public:
         MonotonicStopWatch timer;
         timer.start();
         std::unique_lock<std::mutex> unique_lock(_lock);
-        _get_cv.wait(unique_lock, [this] { return _shutdown || !_list.empty(); });
+        while (!(_shutdown || !_list.empty())) {
+            ++_get_waiting;
+            _get_cv.wait(unique_lock);
+        }
         _total_get_wait_time += timer.elapsed_time();
 
         if (!_list.empty()) {
             *out = _list.front();
             _list.pop_front();
-            _put_cv.notify_one();
+            if (_put_waiting > 0) {
+                --_put_waiting;
+                unique_lock.unlock();
+                _put_cv.notify_one();
+            }
             return true;
         } else {
             assert(_shutdown);
@@ -70,7 +79,10 @@ public:
         MonotonicStopWatch timer;
         timer.start();
         std::unique_lock<std::mutex> unique_lock(_lock);
-        _put_cv.wait(unique_lock, [this] { return _shutdown || _list.size() < _max_elements; });
+        while (!(_shutdown || _list.size() < _max_elements)) {
+            ++_put_waiting;
+            _get_cv.wait(unique_lock);
+        }
         _total_put_wait_time += timer.elapsed_time();
 
         if (_shutdown) {
@@ -78,7 +90,11 @@ public:
         }
 
         _list.push_back(val);
-        _get_cv.notify_one();
+        if (_get_waiting > 0) {
+            --_get_waiting;
+            unique_lock.unlock();
+            _get_cv.notify_one();
+        }
         return true;
     }
 
@@ -98,7 +114,11 @@ public:
         }
 
         _list.push_back(val);
-        _get_cv.notify_one();
+        if (_get_waiting > 0) {
+            --_get_waiting;
+            unique_lock.unlock();
+            _get_cv.notify_one();
+        }
         return true;
     }
 
@@ -136,6 +156,8 @@ private:
     std::list<T> _list;
     std::atomic<uint64_t> _total_get_wait_time;
     std::atomic<uint64_t> _total_put_wait_time;
+    size_t _get_waiting;
+    size_t _put_waiting;
 };
 
 } // namespace doris

--- a/be/src/util/blocking_queue.hpp
+++ b/be/src/util/blocking_queue.hpp
@@ -81,7 +81,7 @@ public:
         std::unique_lock<std::mutex> unique_lock(_lock);
         while (!(_shutdown || _list.size() < _max_elements)) {
             ++_put_waiting;
-            _get_cv.wait(unique_lock);
+            _put_cv.wait(unique_lock);
         }
         _total_put_wait_time += timer.elapsed_time();
 

--- a/be/src/vec/exec/scan/scanner_scheduler.h
+++ b/be/src/vec/exec/scan/scanner_scheduler.h
@@ -111,7 +111,7 @@ private:
     // _remote_scan_thread_pool is for remote scan task(cold data on s3, hdfs, etc.)
     // _limited_scan_thread_pool is a special pool for queries with resource limit
     std::unique_ptr<PriorityThreadPool> _local_scan_thread_pool;
-    std::unique_ptr<ThreadPool> _remote_scan_thread_pool;
+    std::unique_ptr<PriorityThreadPool> _remote_scan_thread_pool;
     std::unique_ptr<ThreadPool> _limited_scan_thread_pool;
 
     std::unique_ptr<taskgroup::ScanTaskTaskGroupQueue> _task_group_local_scan_queue;


### PR DESCRIPTION
## Proposed changes
- Optimize `BlockingQueue`, `BlockingPriorityQueue` by swapping `notify` and `unlock` to reduce lock competition. Ref: https://www.boost.org/doc/libs/1_54_0/boost/thread/sync_bounded_queue.hpp
- Change remote scan thread pool to `PriorityQueue`.

### Test result
Before:
```
mysql> select  sum(lo_partkey)  from  lineorder;
+-----------------+
| sum(lo_partkey) |
+-----------------+
| 300021444265405 |
+-----------------+
1 row in set (1.11 sec)
```

After:
```
mysql> select  sum(lo_partkey)  from  lineorder;
+-----------------+
| sum(lo_partkey) |
+-----------------+
| 300021444265405 |
+-----------------+
1 row in set (0.80 sec)
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

