### PR TITLE
[fix](hudi) fix wrong schema when query hudi table on obs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/hudi/HudiScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/hudi/HudiScanNode.java
@@ -26,6 +26,7 @@ import org.apache.doris.catalog.Type;
 import org.apache.doris.catalog.external.ExternalTable;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.util.S3Util;
 import org.apache.doris.datasource.hive.HivePartition;
 import org.apache.doris.planner.ListPartitionPrunerV2;
 import org.apache.doris.planner.PlanNodeId;
@@ -42,6 +43,7 @@ import org.apache.doris.thrift.THudiFileDesc;
 import org.apache.doris.thrift.TTableFormatFileDesc;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import org.apache.avro.Schema;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
@@ -284,7 +286,8 @@ public class HudiScanNode extends HiveScanNode {
                     noLogsSplitNum.incrementAndGet();
                     String filePath = baseFile.getPath();
                     long fileSize = baseFile.getFileSize();
-                    splits.add(new FileSplit(new Path(filePath), 0, fileSize, fileSize, new String[0],
+                    splits.add(new FileSplit(S3Util.toScanRangeLocation(filePath, Maps.newHashMap()),
+                            0, fileSize, fileSize, new String[0],
                             partition.getPartitionValues()));
                 });
             } else {


### PR DESCRIPTION
## Proposed changes

When query hudi table which file stored on huawei obs, the path's scheme is wrong, expected  `s3://`, but real is `obs://`.
This PR fix this issue.

## Further comments

If this not a complete fix for this issue, same issue may happen on other kind of catalog such as iceberg, paimon, etc.
I will submit another PR to fix them all.

## TODO
test case is missing, we need to find a way to cover it