### PR TITLE
[opt](scanner) increase the connection num of s3 client

### DIFF
--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -123,13 +123,13 @@ Status ScannerScheduler::init(ExecEnv* env) {
             config::doris_scanner_thread_pool_queue_size, "local_scan");
 
     // 3. remote scan thread pool
+    _remote_thread_pool_max_size = config::doris_max_remote_scanner_thread_pool_thread_num != -1
+                                           ? config::doris_max_remote_scanner_thread_pool_thread_num
+                                           : std::max(512, CpuInfo::num_cores() * 10);
     static_cast<void>(
             ThreadPoolBuilder("RemoteScanThreadPool")
                     .set_min_threads(config::doris_scanner_thread_pool_thread_num) // 48 default
-                    .set_max_threads(
-                            config::doris_max_remote_scanner_thread_pool_thread_num != -1
-                                    ? config::doris_max_remote_scanner_thread_pool_thread_num
-                                    : std::max(512, CpuInfo::num_cores() * 10))
+                    .set_max_threads(_remote_thread_pool_max_size)
                     .set_max_queue_size(config::doris_scanner_thread_pool_queue_size)
                     .build(&_remote_scan_thread_pool));
 

--- a/be/src/vec/exec/scan/scanner_scheduler.h
+++ b/be/src/vec/exec/scan/scanner_scheduler.h
@@ -76,6 +76,8 @@ public:
         return _task_group_local_scan_queue.get();
     }
 
+    int remote_thread_pool_max_size() const { return _remote_thread_pool_max_size; }
+
 private:
     // scheduling thread function
     void _schedule_thread(int queue_id);
@@ -118,6 +120,7 @@ private:
     // true is the scheduler is closed.
     std::atomic_bool _is_closed = {false};
     bool _is_init = false;
+    int _remote_thread_pool_max_size;
 };
 
 struct SimplifiedScanTask {


### PR DESCRIPTION
## Proposed changes

The s3 client on BE side may be shared by many threads, so the connection num of s3 client
need to be large enough for all threads, otherwise, the parallelism will be low when scanning file on oss.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

