### PR TITLE
[Fix](multi-catalog) Fix NPE when replaying hms events.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MasterCatalogExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MasterCatalogExecutor.java
@@ -66,7 +66,7 @@ public class MasterCatalogExecutor {
         boolean isReturnToPool = false;
         try {
             TInitExternalCtlMetaResult result = client.initExternalCtlMeta(request);
-            ConnectContext.get().getEnv().getJournalObservable().waitOn(result.maxJournalId, waitTimeoutMs);
+            Env.getCurrentEnv().getJournalObservable().waitOn(result.maxJournalId, waitTimeoutMs);
             if (!result.getStatus().equalsIgnoreCase(STATUS_OK)) {
                 throw new UserException(result.getStatus());
             }


### PR DESCRIPTION
## Proposed changes

```java
2023-11-09 05:41:50,635 WARN (replayer|105) [MasterCatalogExecutor.forward():75] Failed to finish forward init operation, please try again.
java.lang.NullPointerException: null
        at org.apache.doris.qe.MasterCatalogExecutor.forward(MasterCatalogExecutor.java:69) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.datasource.ExternalCatalog.makeSureInitialized(ExternalCatalog.java:170) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.datasource.ExternalCatalog.getDbNullable(ExternalCatalog.java:374) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.datasource.ExternalCatalog.getDbNullable(ExternalCatalog.java:74) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.datasource.CatalogIf.getDbOrException(CatalogIf.java:105) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.datasource.CatalogIf.getDbOrAnalysisException(CatalogIf.java:141) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.external.ExternalTable.makeSureInitialized(ExternalTable.java:122) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.external.HMSExternalTable.makeSureInitialized(HMSExternalTable.java:148) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.external.HMSExternalTable.getPartitionColumnTypes(HMSExternalTable.java:225) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.datasource.ExternalMetaCacheMgr.addPartitionsCache(ExternalMetaCacheMgr.java:165) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.datasource.CatalogMgr.replayAddExternalPartitions(CatalogMgr.java:1035) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.persist.EditLog.loadJournal(EditLog.java:1022) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.Env.replayJournal(Env.java:2624) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.Env$4.runOneCycle(Env.java:2401) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.common.util.Daemon.run(Daemon.java:116) ~[doris-fe.jar:1.2-SNAPSHOT]
```

Invoke `ConnectContext.get()` at `replayer` thread of slave FE nodes maybe return null, so a NPE will be thrown and slave nodes will be crashed.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

