### PR TITLE
[fix](thrift)limit be and fe thrift server max pkg size,avoid accepting error or too large package causing OOM

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1091,6 +1091,13 @@ DEFINE_Bool(ignore_always_true_predicate_for_segment, "true");
 // Dir of default timezone files
 DEFINE_String(default_tzfiles_path, "${DORIS_HOME}/zoneinfo");
 
+// Max size(bytes) of group commit queues, used for mem back pressure.
+DEFINE_Int32(group_commit_max_queue_size, "65536");
+
+// the max package bytes be thrift server can receive
+// avoid accepting error or too large package causing OOM,default 20000000(20M)
+DEFINE_Int32(be_thrift_max_pkg_bytes, "20000000");
+
 // clang-format off
 #ifdef BE_TEST
 // test s3

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1091,9 +1091,6 @@ DEFINE_Bool(ignore_always_true_predicate_for_segment, "true");
 // Dir of default timezone files
 DEFINE_String(default_tzfiles_path, "${DORIS_HOME}/zoneinfo");
 
-// Max size(bytes) of group commit queues, used for mem back pressure.
-DEFINE_Int32(group_commit_max_queue_size, "65536");
-
 // the max package bytes be thrift server can receive
 // avoid accepting error or too large package causing OOM,default 20000000(20M)
 DEFINE_Int32(be_thrift_max_pkg_bytes, "20000000");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1148,9 +1148,6 @@ DECLARE_Bool(ignore_always_true_predicate_for_segment);
 // Dir of default timezone files
 DECLARE_String(default_tzfiles_path);
 
-// Max size(bytes) of group commit queues, used for mem back pressure.
-DECLARE_Int32(group_commit_max_queue_size);
-
 // the max package bytes be thrift server can receive
 // avoid accepting error or too large package causing OOM,default 20000000(20M)
 DECLARE_Int32(be_thrift_max_pkg_bytes);

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1148,6 +1148,13 @@ DECLARE_Bool(ignore_always_true_predicate_for_segment);
 // Dir of default timezone files
 DECLARE_String(default_tzfiles_path);
 
+// Max size(bytes) of group commit queues, used for mem back pressure.
+DECLARE_Int32(group_commit_max_queue_size);
+
+// the max package bytes be thrift server can receive
+// avoid accepting error or too large package causing OOM,default 20000000(20M)
+DECLARE_Int32(be_thrift_max_pkg_bytes);
+
 #ifdef BE_TEST
 // test s3
 DECLARE_String(test_s3_resource);

--- a/be/src/util/thrift_server.cpp
+++ b/be/src/util/thrift_server.cpp
@@ -303,6 +303,11 @@ Status ThriftServer::start() {
     DCHECK(!_started);
     std::shared_ptr<apache::thrift::protocol::TProtocolFactory> protocol_factory(
             new apache::thrift::protocol::TBinaryProtocolFactory());
+    // add binary_protocal_factory to call TBinaryProtocolFactory's member function:setStringSizeLimit
+    std::shared_ptr<apache::thrift::protocol::TBinaryProtocolFactory> binary_protocal_factory =
+            std::dynamic_pointer_cast<apache::thrift::protocol::TBinaryProtocolFactory>(
+                    protocol_factory);
+    binary_protocal_factory->setStringSizeLimit(config::be_thrift_max_pkg_bytes);
     std::shared_ptr<apache::thrift::concurrency::ThreadManager> thread_mgr;
     std::shared_ptr<apache::thrift::concurrency::ThreadFactory> thread_factory =
             std::make_shared<apache::thrift::concurrency::ThreadFactory>();

--- a/docs/zh-CN/docs/admin-manual/config/be-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/be-config.md
@@ -1529,3 +1529,9 @@ load tablets from header failed, failed tablets size: xxx, path=xxx
 
 * Description: BE 是否开启使用java-jni，开启后允许 c++  与 java 之间的相互调用。目前已经支持hudi、java-udf、jdbc、max-compute、paimon、preload、avro
 * Default value: true
+
+
+#### `be_thrift_max_pkg_bytes`
+
+* 描述: be节点thrift端口最大接收包大小(字节)
+* 默认值: 20000000

--- a/docs/zh-CN/docs/admin-manual/config/fe-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/fe-config.md
@@ -2731,3 +2731,13 @@ Doris 为了兼用 mysql 周边工具生态，会内置一个名为 mysql 的数
 默认值：2000
 
 对于自动分区表，防止用户意外创建大量分区，每个OLAP表允许的分区数量为`max_auto_partition_num`。默认2000。
+
+#### `fe_thrift_max_pkg_bytes`
+
+默认值：20000000
+
+是否可以动态配置：false
+
+是否为 Master FE 节点独有的配置项：false
+
+用于限制fe节点thrift端口可以接收的最大包长度，避免接收到过大或者错误的包导致OOM

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2237,4 +2237,12 @@ public class Config extends ConfigBase {
     })
     public static int sync_image_timeout_second = 300;
 
+    @ConfField(mutable = true, masterOnly = true)
+    public static int publish_topic_info_interval_ms = 30000; // 30s
+
+    @ConfField(description = {
+            "限制fe节点thrift server可以接收的最大包大小,默认20M,设置为-1表示不限制",
+            "the max package size fe thrift server can receive,avoid accepting error"
+            + "or too large package causing OOM,default 20000000(20M),set -1 for unlimited. "})
+    public static int fe_thrift_max_pkg_bytes = 20000000;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/ThriftServer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/ThriftServer.java
@@ -92,14 +92,14 @@ public class ThriftServer {
 
     private void createSimpleServer() throws TTransportException {
         TServer.Args args = new TServer.Args(new TServerSocket(port)).protocolFactory(
-                new TBinaryProtocol.Factory()).processor(processor);
+                new TBinaryProtocol.Factory(Config.fe_thrift_max_pkg_bytes, -1)).processor(processor);
         server = new TSimpleServer(args);
     }
 
     private void createThreadedServer() throws TTransportException {
         TThreadedSelectorServer.Args args = new TThreadedSelectorServer.Args(
                 new TNonblockingServerSocket(port, Config.thrift_client_timeout_ms)).protocolFactory(
-                        new TBinaryProtocol.Factory()).processor(processor);
+                        new TBinaryProtocol.Factory(Config.fe_thrift_max_pkg_bytes, -1)).processor(processor);
         ThreadPoolExecutor threadPoolExecutor = ThreadPoolManager.newDaemonCacheThreadPool(
                 Config.thrift_server_max_worker_threads, "thrift-server-pool", true);
         args.executorService(threadPoolExecutor);
@@ -123,7 +123,7 @@ public class ThriftServer {
 
         TThreadPoolServer.Args serverArgs =
                 new TThreadPoolServer.Args(new TServerSocket(socketTransportArgs)).protocolFactory(
-                        new TBinaryProtocol.Factory()).processor(processor);
+                        new TBinaryProtocol.Factory(Config.fe_thrift_max_pkg_bytes, -1)).processor(processor);
         ThreadPoolExecutor threadPoolExecutor = ThreadPoolManager.newDaemonCacheThreadPool(
                 Config.thrift_server_max_worker_threads, "thrift-server-pool", true);
         serverArgs.executorService(threadPoolExecutor);


### PR DESCRIPTION

Thrift server reads the first four bytes of a packet as the packet size, and without setting the string_limit parameter, it will directly request the memory corresponding to the packet size represented by the first four bytes. When receiving an error or large packet, it is easy to encounter OOM.
![image](https://github.com/apache/doris/assets/143597717/f17ae7bb-2ffa-404f-80be-a4319f04c934)


Doris currently does not set the string_limit parameter, so when receiving a corrupted packet, it is easy to encounter OOM.

We can send multiple HTTP packets to the Thrift port simultaneously to reproduce：
#/bin/bash
for (( i=0; i< 20 ;i++))
do
curl -X POST -d'{test}' "http://127.0.0.1:9020/" &
done

This PR add string_limit parameter for be and fe thrift server

I have submitted another identical PR to the 1.2 branch.
