### PR TITLE
[fix](s3) Prevent data race when finishing s3 file writer's _put_object operation

### DIFF
--- a/be/src/io/fs/s3_file_writer.cpp
+++ b/be/src/io/fs/s3_file_writer.cpp
@@ -467,8 +467,8 @@ void S3FileWriter::_put_object(UploadFileBuffer& buf) {
                                     response.GetError().GetExceptionName(),
                                     response.GetError().GetMessage(),
                                     static_cast<int>(response.GetError().GetResponseCode()));
-        buf.set_val(_st);
         LOG(WARNING) << _st;
+        buf.set_val(_st);
         return;
     }
     _bytes_written += buf.get_size();


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
`buf.set_val(_st);` would decrement the condition variable waiting for the task to be finished, which might result the `s3_file_writer` to be destructed before the line `LOG(WARNING) << _st;` to take effect and turn out to be one heap-use-after-free for accessing the member variable `_st`.
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

