### PR TITLE
[chore](fs) Don't print the stack for file system and it's derived class

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -504,6 +504,12 @@ public:
 
     std::string msg() const { return _err_msg ? _err_msg->_msg : ""; }
 
+    void reset_stack() const {
+        if (nullptr != _err_msg) {
+            _err_msg->_msg.clear();
+        }
+    }
+
 private:
     int _code;
     struct ErrMsg {

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -504,12 +504,6 @@ public:
 
     std::string msg() const { return _err_msg ? _err_msg->_msg : ""; }
 
-    void reset_stack() const {
-        if (nullptr != _err_msg) {
-            _err_msg->_msg.clear();
-        }
-    }
-
 private:
     int _code;
     struct ErrMsg {

--- a/be/src/io/fs/file_system.h
+++ b/be/src/io/fs/file_system.h
@@ -33,20 +33,20 @@ namespace doris {
 namespace io {
 
 #ifndef FILESYSTEM_M
-#define FILESYSTEM_M(stmt)                    \
-    do {                                      \
-        Status _s;                            \
-        if (bthread_self() == 0) {            \
-            _s = (stmt);                      \
-        } else {                              \
-            auto task = [&] { _s = (stmt); }; \
-            AsyncIO::run_task(task, _type);   \
-        }                                     \
-        if (!_s) {                            \
-            LOG(WARNING) << _s;               \
-        }                                     \
-        _s.reset_stack();                     \
-        return _s;                            \
+#define FILESYSTEM_M(stmt)                                  \
+    do {                                                    \
+        Status _s;                                          \
+        if (bthread_self() == 0) {                          \
+            _s = (stmt);                                    \
+        } else {                                            \
+            auto task = [&] { _s = (stmt); };               \
+            AsyncIO::run_task(task, _type);                 \
+        }                                                   \
+        if (!_s) {                                          \
+            LOG(WARNING) << _s;                             \
+            _s = Status::Error<false>(_s.code(), _s.msg()); \
+        }                                                   \
+        return _s;                                          \
     } while (0);
 #endif
 

--- a/be/src/io/fs/file_system.h
+++ b/be/src/io/fs/file_system.h
@@ -45,6 +45,7 @@ namespace io {
         if (!_s) {                            \
             LOG(WARNING) << _s;               \
         }                                     \
+        _s.reset_stack();                     \
         return _s;                            \
     } while (0);
 #endif


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

It would print tons of logs when fs returns error and it's too disk-consuming. This pr tries to disable all the stackprint logic for fs class and it's derivation. 

This implementation is not the most optimal in terms of performance because the default-constructed Status carries a stack, which consumes a certain amount of memory. However, considering that error conditions are expected to be rare and this implementation requires minimal code modifications, I chose this approach. I would appreciate the reviewer's input: Should I specialize the template to false when constructing Status at each occurrence, or should I keep the current implementation?

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

