### PR TITLE
[opt](load) catch Throwable to make load error msg more clear

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadTask.java
@@ -91,10 +91,10 @@ public abstract class LoadTask extends MasterTask {
             failMsg.setMsg(e.getMessage() == null ? "" : e.getMessage());
             LOG.warn(new LogBuilder(LogKey.LOAD_JOB, callback.getCallbackId())
                     .add("error_msg", "Failed to execute load task").build(), e);
-        } catch (Exception e) {
-            failMsg.setMsg(e.getMessage() == null ? "" : e.getMessage());
+        } catch (Throwable t) {
+            failMsg.setMsg(t.getMessage() == null ? "" : t.getMessage());
             LOG.warn(new LogBuilder(LogKey.LOAD_JOB, callback.getCallbackId())
-                    .add("error_msg", "Unexpected failed to execute load task").build(), e);
+                    .add("error_msg", "Unexpected failed to execute load task").build(), t);
         } finally {
             if (!isFinished) {
                 // callback on pending task failed


### PR DESCRIPTION
## Proposed changes

When doing LoadPendingTask or LoadLoadingTask, there may be some Error thrown,
such as `NoClassDefFoundError`, but previously, we only catch java's `Exception`, so
other kind of error can not be shown clearly.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

