### PR TITLE
[fix](nereids) patition prune is affected by non-paritition-key condition

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/TryEliminateUninterestedPredicates.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/TryEliminateUninterestedPredicates.java
@@ -109,7 +109,9 @@ public class TryEliminateUninterestedPredicates extends DefaultExpressionRewrite
     public Expression visitAnd(And and, Context parentContext) {
         Expression left = and.left();
         Context leftContext = new Context();
-        Expression newLeft = this.visit(left, leftContext);
+        // Expression newLeft = this.visit(left, leftContext);
+        Expression newLeft = left.accept(this, leftContext);
+
         if (leftContext.childrenContainsNonInterestedSlots) {
             newLeft = BooleanLiteral.TRUE;
         }

--- a/regression-test/suites/nereids_rules_p0/partition_prune/test_partition_unique_model.groovy
+++ b/regression-test/suites/nereids_rules_p0/partition_prune/test_partition_unique_model.groovy
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_partition_unique_model") {
+    // filter about invisible column "DORIS_DELETE_SIGN = 0" has no impaction on partition pruning
+    String db = context.config.getDbNameByFile(context.file)
+    sql "use ${db}"
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+    sql "set partition_pruning_expand_threshold=10;"
+    sql "drop table if exists xinan;"
+    sql """
+        create table xinan
+        (
+            init_date int null
+        )
+        engine=olap
+        unique key(init_date)
+        partition by range(init_date)
+        (partition p202209 values[("20220901"), ("20221001")),
+        partition p202210 values[("20221001"), ("20221101")))
+        distributed by hash (init_date) buckets auto
+        properties(
+            "replication_allocation" = "tag.location.default: 1"
+        );
+        """
+    sql "insert into xinan values(20220901), (20221003);"
+
+    explain {
+        sql "select * from xinan where init_date >=20221001;"
+        contains "partitions=1/2 (p202210)"
+    }
+
+    explain {
+        sql "select * from xinan where init_date<20221101;"
+        contains "partitions=2/2 (p202209,p202210)"
+    } 
+
+    explain {
+        sql "select * from xinan where init_date >=20221001 and init_date<20221101;"
+        contains "partitions=1/2 (p202210)"
+    }
+
+}


### PR DESCRIPTION
TryEliminateUninterestedPredicates
transform "init_date >=20221001 and init_date<20221101“
to  "init_date<20221101"

after eliminate "(_DORIS_DELETE_SIGN_#1 = 0)",  its context.childrenContainsNonInterestedSlots is true.
we replace "(_DORIS_DELETE_SIGN_#1 = 0)" by TRUE, and propage childrenContainsNonInterestedSlots to upper level,
and hence the childrenContainsNonInterestedSlots  for ((init_date#0 >= 20221001) AND (_DORIS_DELETE_SIGN_#1 = 0)) becomes TRUE

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

