### PR TITLE
[improvement](backend balance) adjust the capacity cofficient of be load score

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/BackendLoadStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/BackendLoadStatistic.java
@@ -380,12 +380,12 @@ public class BackendLoadStatistic {
 
     // the return cofficient:
     // 1. percent <= percentLowWatermark: cofficient = 0.5;
-    // 2. percentLowWatermark < percent < percentHighWatermark: cofficient linear increase from 0.5 to 1.0;
-    // 3. percent >= percentHighWatermark: cofficient = 1.0;
+    // 2. percentLowWatermark < percent < percentHighWatermark: cofficient linear increase from 0.5 to 0.99;
+    // 3. percent >= percentHighWatermark: cofficient = 0.99;
     public static double getSmoothCofficient(double percent, double percentLowWatermark,
             double percentHighWatermark) {
         final double lowCofficient = 0.5;
-        final double highCofficient = 1.0;
+        final double highCofficient = 0.99;
 
         // low watermark and high watermark equal, then return 0.75
         if (Math.abs(percentHighWatermark - percentLowWatermark) < 1e-6) {


### PR DESCRIPTION
Be load score =  replica num / avg replica num * replica num coef + used percent / avg used percent * capacity coef

And replica num coef = 1.0 - capacity coef

If capacity coef = 1.0, then replica num coef = 0, then the balance will ignore tablet num,  only considering tablet size.
So the be balance will not move a empty tablet from high load backend to low load backend.  Because moving this tablet,  these two backends' load score will not change.  And if there are lots of empty tablets,  the balance may always pick them,  but move failed.

So we let capacity coef <= 0.99， then the balance will always considering the tablet num. Then will make balance moving a tablet become possible.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

