### PR TITLE
[regression](conf) Make checkpoint/clean thread trigger more frequently

### DIFF
--- a/regression-test/pipeline/p0/conf/fe.conf
+++ b/regression-test/pipeline/p0/conf/fe.conf
@@ -85,3 +85,11 @@ dynamic_partition_check_interval_seconds=3
 
 enable_full_auto_analyze=true
 desired_max_waiting_jobs=200
+
+# make checkpoint more frequent
+edit_log_roll_num = 1000
+
+# make job/label clean more frequent
+history_job_keep_max_second = 300
+streaming_label_keep_max_second = 300
+label_keep_max_second = 300


### PR DESCRIPTION
* When run p0, we want some checkpoint/clean thread in FE work more frequently

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

