### PR TITLE
[fix](fe ut) fix unstable test DecommissionBackendTest

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/cluster/DecommissionBackendTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cluster/DecommissionBackendTest.java
@@ -56,6 +56,7 @@ public class DecommissionBackendTest extends TestWithFeService {
         Config.tablet_checker_interval_ms = 1000;
         Config.tablet_repair_delay_factor_second = 1;
         Config.allow_replica_on_same_host = true;
+        Config.disable_balance = true;
     }
 
     @Test
@@ -104,11 +105,8 @@ public class DecommissionBackendTest extends TestWithFeService {
                 Env.getCurrentInvertedIndex().getTabletMetaMap().size());
 
         // 6. add backend
-        String addBackendStmtStr = "alter system add backend \"127.0.0.1:" + srcBackend.getHeartbeatPort() + "\"";
-        AlterSystemStmt addBackendStmt = (AlterSystemStmt) parseAndAnalyzeStmt(addBackendStmtStr);
-        Env.getCurrentEnv().getAlterInstance().processAlterCluster(addBackendStmt);
+        addNewBackend();
         Assertions.assertEquals(backendNum(), Env.getCurrentSystemInfo().getIdToBackend().size());
-
     }
 
     @Test
@@ -132,9 +130,7 @@ public class DecommissionBackendTest extends TestWithFeService {
         Assertions.assertEquals(backendNum() - 1, Env.getCurrentSystemInfo().getIdToBackend().size());
 
         // add backend
-        String addBackendStmtStr = "alter system add backend \"127.0.0.1:" + srcBackend.getHeartbeatPort() + "\"";
-        AlterSystemStmt addBackendStmt = (AlterSystemStmt) parseAndAnalyzeStmt(addBackendStmtStr);
-        Env.getCurrentEnv().getAlterInstance().processAlterCluster(addBackendStmt);
+        addNewBackend();
         Assertions.assertEquals(backendNum(), Env.getCurrentSystemInfo().getIdToBackend().size());
 
     }
@@ -205,9 +201,7 @@ public class DecommissionBackendTest extends TestWithFeService {
         Assertions.assertDoesNotThrow(() -> recoverTable("db2.tbl1"));
         Assertions.assertDoesNotThrow(() -> showCreateTable(sql));
 
-        String addBackendStmtStr = "alter system add backend \"127.0.0.1:" + srcBackend.getHeartbeatPort() + "\"";
-        AlterSystemStmt addBackendStmt = (AlterSystemStmt) parseAndAnalyzeStmt(addBackendStmtStr);
-        Env.getCurrentEnv().getAlterInstance().processAlterCluster(addBackendStmt);
+        addNewBackend();
         Assertions.assertEquals(backendNum(), Env.getCurrentSystemInfo().getIdToBackend().size());
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
@@ -125,6 +125,7 @@ public abstract class TestWithFeService {
     protected String runningDir = "fe/mocked/" + getClass().getSimpleName() + "/" + UUID.randomUUID() + "/";
     protected ConnectContext connectContext;
     protected boolean needCleanDir = true;
+    protected int lastFeRpcPort = 0;
 
     protected static final String DEFAULT_CLUSTER_PREFIX = "default_cluster:";
 
@@ -379,6 +380,7 @@ public abstract class TestWithFeService {
         MockedFrontend frontend = new MockedFrontend();
         frontend.init(dorisHome + "/" + runningDir, feConfMap);
         frontend.start(new String[0]);
+        lastFeRpcPort = feRpcPort;
         return feRpcPort;
     }
 
@@ -433,6 +435,10 @@ public abstract class TestWithFeService {
             bes.add(createBackend(host, feRpcPort));
         }
         checkBEHeartbeat(bes);
+    }
+
+    protected Backend addNewBackend() throws IOException, InterruptedException {
+        return createBackend("127.0.0.1", lastFeRpcPort);
     }
 
     protected Backend createBackend(String beHost, int feRpcPort) throws IOException, InterruptedException {


### PR DESCRIPTION
fix unstable test DecommissionBackendTest.testDecommissionBackendWithDropTable by PR #25444
because it increase backend num.  The new create table 'tb1''s tablets maynot create on the decommission backend.

Also fix "alter system add backend",  because it's new create backend's state is alive = false;

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

