### PR TITLE
[chore](macOS) Reduce the size of executables on macOS arm64

### DIFF
--- a/be/src/service/CMakeLists.txt
+++ b/be/src/service/CMakeLists.txt
@@ -45,14 +45,31 @@ if (${MAKE_TEST} STREQUAL "OFF")
     install(DIRECTORY DESTINATION ${OUTPUT_DIR}/lib/)
     install(TARGETS doris_be DESTINATION ${OUTPUT_DIR}/lib/)
 
-    if ("${STRIP_DEBUG_INFO}" STREQUAL "ON")
-        add_custom_command(TARGET doris_be POST_BUILD
-            COMMAND ${CMAKE_OBJCOPY} --only-keep-debug $<TARGET_FILE:doris_be> $<TARGET_FILE:doris_be>.dbg
-            COMMAND ${CMAKE_STRIP} --strip-debug --strip-unneeded $<TARGET_FILE:doris_be>
-            COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=$<TARGET_FILE:doris_be>.dbg $<TARGET_FILE:doris_be>
-            )
+    if (OS_MACOSX AND ARCH_ARM AND "${CMAKE_BUILD_TYPE}" STREQUAL "ASAN")
+        set(SHOULD_STRIP_DEBUG_INFO "ON")
+    endif()
 
-        install(DIRECTORY DESTINATION ${OUTPUT_DIR}/lib/debug_info/)
-        install(FILES $<TARGET_FILE:doris_be>.dbg DESTINATION ${OUTPUT_DIR}/lib/debug_info/)
+    if ("${STRIP_DEBUG_INFO}" STREQUAL "ON" OR "${SHOULD_STRIP_DEBUG_INFO}" STREQUAL "ON")
+        if (OS_MACOSX)
+            find_program(DSYMUTIL NAMES dsymutil)
+            message(STATUS "dsymutil found: ${DSYMUTIL}")
+            find_program(LLVM_STRIP NAMES llvm-strip)
+            message(STATUS "llvm-strip found: ${LLVM_STRIP}")
+            add_custom_command(TARGET doris_be POST_BUILD
+                COMMAND ${DSYMUTIL} $<TARGET_FILE:doris_be>
+                COMMAND ${LLVM_STRIP} --strip-all $<TARGET_FILE:doris_be>
+                COMMAND mkdir -p ${OUTPUT_DIR}/lib
+                COMMAND cp -rf doris_be.dSYM ${OUTPUT_DIR}/lib/
+            )
+        else()
+            add_custom_command(TARGET doris_be POST_BUILD
+                COMMAND ${CMAKE_OBJCOPY} --only-keep-debug $<TARGET_FILE:doris_be> $<TARGET_FILE:doris_be>.dbg
+                COMMAND ${CMAKE_STRIP} --strip-debug --strip-unneeded $<TARGET_FILE:doris_be>
+                COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=$<TARGET_FILE:doris_be>.dbg $<TARGET_FILE:doris_be>
+                )
+
+            install(DIRECTORY DESTINATION ${OUTPUT_DIR}/lib/debug_info/)
+            install(FILES $<TARGET_FILE:doris_be>.dbg DESTINATION ${OUTPUT_DIR}/lib/debug_info/)
+        endif()
     endif()
 endif()

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -67,9 +67,11 @@ set_target_properties(doris_be_test PROPERTIES COMPILE_FLAGS "-fno-access-contro
 if (OS_MACOSX AND ARCH_ARM)
     find_program(DSYMUTIL NAMES dsymutil)
     message(STATUS "dsymutil found: ${DSYMUTIL}")
+    find_program(LLVM_STRIP NAMES llvm-strip)
+    message(STATUS "llvm-strip found: ${LLVM_STRIP}")
     add_custom_command(TARGET doris_be_test POST_BUILD
         COMMAND ${DSYMUTIL} $<TARGET_FILE:doris_be_test>
-        COMMAND ${CMAKE_STRIP} -S $<TARGET_FILE:doris_be_test>
+        COMMAND ${LLVM_STRIP} --strip-all $<TARGET_FILE:doris_be_test>
     )
 endif()
 

--- a/be/test/util/threadpool_test.cpp
+++ b/be/test/util/threadpool_test.cpp
@@ -331,10 +331,7 @@ TEST_F(ThreadPoolTest, TestDeadlocks) {
 #ifdef NDEBUG
     const char* death_msg = "doris::ThreadPool::check_not_pool_thread_unlocked()";
 #elif defined(__APPLE__)
-    const char* death_msg =
-            "_ZNSt3__1L8__invokeIRNS_6__bindIMN5doris10ThreadPoolEFvvEJPS3_EEEJEEEDTclscT_fp_"
-            "spscT0_fp0_EEOS9_DpOSA_|6__bindIMN5doris10ThreadPoolEFvvEJPS3_"
-            "EEEJEEEDTclclsr3stdE7declvalIT_EEspclsr3stdE7declvalIT0_EEEEOS9_DpOSA_";
+    const char* death_msg = "pthread_start";
 #else
     const char* death_msg =
             "_ZNSt5_BindIFMN5doris10ThreadPoolEFvvEPS1_EE6__callIvJEJLm0EEEET_OSt5tupleIJDpT0_"

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -75,16 +75,16 @@ if [[ "$(uname -s)" != 'Darwin' ]]; then
         echo "Please set vm.max_map_count to be 2000000 under root using 'sysctl -w vm.max_map_count=2000000'."
         exit 1
     fi
+
+    if [[ "$(swapon -s | wc -l)" -gt 1 ]]; then
+        echo "Please disable swap memory before installation."
+        exit 1
+    fi
 fi
 
 MAX_FILE_COUNT="$(ulimit -n)"
 if [[ "${MAX_FILE_COUNT}" -lt 60000 ]]; then
     echo "Please set the maximum number of open file descriptors larger than 60000, eg: 'ulimit -n 60000'."
-    exit 1
-fi
-
-if [[ "$(swapon -s | wc -l)" -gt 1 ]]; then
-    echo "Please disable swap memory before installation."
     exit 1
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -669,6 +669,10 @@ EOF
     # See: https://stackoverflow.com/questions/67378106/mac-m1-cping-binary-over-another-results-in-crash
     rm -f "${DORIS_OUTPUT}/be/lib/doris_be"
     cp -r -p "${DORIS_HOME}/be/output/lib/doris_be" "${DORIS_OUTPUT}/be/lib"/
+    if [[ -d "${DORIS_HOME}/be/output/lib/doris_be.dSYM" ]]; then
+        rm -rf "${DORIS_OUTPUT}/be/lib/doris_be.dSYM"
+        cp -r "${DORIS_HOME}/be/output/lib/doris_be.dSYM" "${DORIS_OUTPUT}/be/lib"/
+    fi
     if [[ -f "${DORIS_HOME}/be/output/lib/fs_benchmark_tool" ]]; then
         cp -r -p "${DORIS_HOME}/be/output/lib/fs_benchmark_tool" "${DORIS_OUTPUT}/be/lib"/
     fi

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -388,11 +388,11 @@ MACHINE_OS=$(uname -s)
 if [[ "${MACHINE_OS}" == "Darwin" ]]; then
     max_fd_limit='-XX:-MaxFDLimit'
 
-    if ! echo "${final_java_opt}" | grep "${max_fd_limit/-/\-}" >/dev/null; then
+    if ! echo "${final_java_opt}" | grep "${max_fd_limit/-/\\-}" >/dev/null; then
         final_java_opt="${final_java_opt} ${max_fd_limit}"
     fi
 
-    if [[ -n "${JAVA_OPTS}" ]] && ! echo "${JAVA_OPTS}" | grep "${max_fd_limit/-/\-}" >/dev/null; then
+    if [[ -n "${JAVA_OPTS}" ]] && ! echo "${JAVA_OPTS}" | grep "${max_fd_limit/-/\\-}" >/dev/null; then
         JAVA_OPTS="${JAVA_OPTS} ${max_fd_limit}"
     fi
 fi


### PR DESCRIPTION
## Proposed changes

~~Issue Number: close #xxx~~

Like #15641, we should reduce the size of executables on macOS arm64. Otherwise, we can not run `doris_be` and `doris_be_test` with ASAN build type on macOS arm64 now.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

