### PR TITLE
[fix](delta-writer) fix total received rows in delta writer incorrect

### DIFF
--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -105,7 +105,7 @@ public:
 
     int64_t txn_id() const { return _req.txn_id; }
 
-    int64_t total_received_rows() const { return _total_received_rows; }
+    int64_t total_received_rows() const { return _memtable_writer->total_received_rows(); }
 
     int64_t num_rows_filtered() const;
 

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -132,9 +132,6 @@ private:
     PSuccessSlaveTabletNodeIds _success_slave_node_ids;
     std::shared_mutex _slave_node_lock;
 
-    // total rows num written by DeltaWriter
-    std::atomic<int64_t> _total_received_rows = 0;
-
     RuntimeProfile* _profile = nullptr;
     RuntimeProfile::Counter* _close_wait_timer = nullptr;
     RuntimeProfile::Counter* _commit_txn_timer = nullptr;

--- a/be/src/olap/memtable_writer.h
+++ b/be/src/olap/memtable_writer.h
@@ -20,7 +20,7 @@
 #include <gen_cpp/Types_types.h>
 #include <gen_cpp/internal_service.pb.h>
 #include <gen_cpp/types.pb.h>
-#include <stdint.h>
+#include <cstdint>
 
 #include <atomic>
 #include <memory>
@@ -103,7 +103,7 @@ public:
     // Wait all memtable in flush queue to be flushed
     Status wait_flush();
 
-    int64_t tablet_id() { return _req.tablet_id; }
+    int64_t tablet_id() const { return _req.tablet_id; }
 
     int64_t total_received_rows() const { return _total_received_rows; }
 
@@ -137,7 +137,7 @@ private:
     std::mutex _lock;
 
     // total rows num written by MemTableWriter
-    int64_t _total_received_rows = 0;
+    std::atomic<int64_t> _total_received_rows = 0;
     int64_t _wait_flush_time_ns = 0;
     int64_t _close_wait_time_ns = 0;
     int64_t _segment_num = 0;

--- a/be/src/olap/memtable_writer.h
+++ b/be/src/olap/memtable_writer.h
@@ -20,9 +20,9 @@
 #include <gen_cpp/Types_types.h>
 #include <gen_cpp/internal_service.pb.h>
 #include <gen_cpp/types.pb.h>
-#include <cstdint>
 
 #include <atomic>
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>


### PR DESCRIPTION
## Proposed changes

As title. `total received rows` in memtable writer was not passed to delta writer.