### PR TITLE
[Fix](wal) Fix wal space back pressure core

### DIFF
--- a/be/src/olap/wal_manager.cpp
+++ b/be/src/olap/wal_manager.cpp
@@ -258,6 +258,11 @@ Status WalManager::delete_wal(int64_t wal_id) {
                                                    std::memory_order_relaxed),
                     std::memory_order_relaxed);
             _wal_id_to_writer_map[wal_id]->cv.notify_one();
+            std::string wal_path = _wal_path_map[wal_id];
+            LOG(INFO) << "wal delete file=" << wal_path << ", this file disk usage is"
+                      << _wal_id_to_writer_map[wal_id]->disk_bytes()
+                      << " ,after deleting it, all wals disk usage is "
+                      << _all_wal_disk_bytes->load(std::memory_order_relaxed);
             _wal_id_to_writer_map.erase(wal_id);
         }
         if (_wal_id_to_writer_map.empty()) {

--- a/be/src/olap/wal_writer.cpp
+++ b/be/src/olap/wal_writer.cpp
@@ -76,7 +76,8 @@ Status WalWriter::append_blocks(const PBlockArray& blocks) {
         offset += CHECKSUM_SIZE;
     }
     DCHECK(offset == total_size);
-    _disk_bytes += total_size;
+    _disk_bytes.store(_disk_bytes.fetch_add(total_size, std::memory_order_relaxed),
+                      std::memory_order_relaxed);
     _all_wal_disk_bytes->store(
             _all_wal_disk_bytes->fetch_add(total_size, std::memory_order_relaxed),
             std::memory_order_relaxed);

--- a/be/src/olap/wal_writer.h
+++ b/be/src/olap/wal_writer.h
@@ -39,7 +39,7 @@ public:
     Status finalize();
 
     Status append_blocks(const PBlockArray& blocks);
-    size_t disk_bytes() const { return _disk_bytes; };
+    size_t disk_bytes() const { return _disk_bytes.load(std::memory_order_relaxed); };
 
     std::string file_name() { return _file_name; };
     static const int64_t LENGTH_SIZE = 8;
@@ -52,7 +52,7 @@ private:
     io::FileWriterPtr _file_writer;
     int64_t _count;
     int64_t _batch;
-    size_t _disk_bytes;
+    std::atomic_size_t _disk_bytes;
     std::shared_ptr<std::atomic_size_t> _all_wal_disk_bytes;
     doris::Mutex _mutex;
 };


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

F20231113 19:23:15.223846 97124 wal_manager.cpp:264] Check failed: _all_wal_disk_bytes->load(std::memory_order_relaxed) == 0 (195248 vs. 0) 
*** Check failure stack trace: ***
    @     0x55fa173181e6  google::LogMessageFatal::~LogMessageFatal()
    @     0x55f9ed1dfef0  doris::WalManager::delete_wal()
    @     0x55f9ed3399ee  doris::GroupCommitTable::_finish_group_commit_load()
    @     0x55f9ed342e9b  std::_Function_handler<>::_M_invoke()
    @     0x55f9ed2232dd  doris::FragmentMgr::_exec_actual()
    @     0x55f9ed24b897  std::_Function_handler<>::_M_invoke()
    @     0x55f9ed9d31ed  doris::ThreadPool::dispatch_thread()
    @     0x55f9ed9afb54  doris::Thread::supervise_thread()
    @     0x7f1f5119d609  start_thread
    @     0x7f1f5144a133  clone
    @              (nil)  (unknown)
*** Query id: 134f683a46909868-4de91b9c81f032aa ***
*** tablet id: 0 ***
*** Aborted at 1699874595 (unix time) try "date -d @1699874595" if you are using GNU date ***
*** Current BE git commitID: 5dee24f ***
*** SIGABRT unknown detail explain (@0x179ea) received by PID 96746 (TID 97124 OR 0x7f1d212f1700) from PID 96746; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:417
 1# 0x00007F1F5136E090 in /lib/x86_64-linux-gnu/libc.so.6
 2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
 3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
 4# 0x000055FA1731F0ED in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
 5# google::LogMessage::SendToLog() in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
 6# google::LogMessage::Flush() in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
 7# google::LogMessageFatal::~LogMessageFatal() in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
 8# doris::WalManager::delete_wal(long) in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
 9# doris::GroupCommitTable::_finish_group_commit_load(long, long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, long, doris::TUniqueId const&, doris::Status&, bool, doris::RuntimeState*) at /root/doris/be/src/runtime/group_commit_mgr.cpp:351
10# std::_Function_handler<void (doris::RuntimeState*, doris::Status*), doris::GroupCommitTable::_exec_plan_fragment(long, long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, long, bool, doris::TExecPlanFragmentParams const&, doris::TPipelineFragmentParams const&)::$_0>::_M_invoke(std::_Any_data const&, doris::RuntimeState*&&, doris::Status*&&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
11# doris::FragmentMgr::_exec_actual(std::shared_ptr<doris::PlanFragmentExecutor>, std::function<void (doris::RuntimeState*, doris::Status*)> const&) at /root/doris/be/src/runtime/fragment_mgr.cpp:462
12# std::_Function_handler<void (), doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_0>::_M_invoke(std::_Any_data const&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
13# doris::ThreadPool::dispatch_thread() at /root/doris/be/src/util/threadpool.cpp:551
14# doris::Thread::supervise_thread(void*) at /root/doris/be/src/util/thread.cpp:495
15# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
16# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

