### PR TITLE
[improvement](log) log desensitization without displaying user info

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
@@ -356,7 +356,8 @@ public class LoadAction extends RestBaseController {
             if (!Strings.isNullOrEmpty(request.getQueryString())) {
                 redirectUrl += request.getQueryString();
             }
-            LOG.info("Redirect url: {}", redirectUrl);
+            LOG.info("Redirect url: {}", "http://" + redirectAddr.getHostname() + ":"
+                    + redirectAddr.getPort() + urlObj.getPath());
             RedirectView redirectView = new RedirectView(redirectUrl);
             redirectView.setContentType("text/html;charset=utf-8");
             redirectView.setStatusCode(org.springframework.http.HttpStatus.TEMPORARY_REDIRECT);

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/RestBaseController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/RestBaseController.java
@@ -105,7 +105,8 @@ public class RestBaseController extends BaseController {
         if (!Strings.isNullOrEmpty(request.getQueryString())) {
             redirectUrl += request.getQueryString();
         }
-        LOG.info("redirect url: {}", redirectUrl);
+        LOG.info("Redirect url: {}", "http://" + addr.getHostname() + ":"
+                    + addr.getPort() + urlObj.getPath());
         RedirectView redirectView = new RedirectView(redirectUrl);
         redirectView.setContentType("text/html;charset=utf-8");
         redirectView.setStatusCode(org.springframework.http.HttpStatus.TEMPORARY_REDIRECT);


### PR DESCRIPTION
## Proposed changes

redirect will record user name and password in log.For example:
```
redirect url: http://test%40default_cluster:123456@127.0.0.1:8030/api/db/lineitem/_stream_load?
```
This pr is is to desensitize logs without displaying username and password.For example:
```
Redirect url: http://127.0.0.1:8030/api/db/lineitem/_stream_load
```


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

