### PR TITLE
[feature](move-memtable) support auto partition in sink v2

### DIFF
--- a/be/src/runtime/load_stream.h
+++ b/be/src/runtime/load_stream.h
@@ -130,6 +130,7 @@ private:
     void _report_result(StreamId stream, const Status& st,
                         const std::vector<int64_t>& success_tablet_ids,
                         const std::vector<int64_t>& failed_tablet_ids);
+    void _report_schema(StreamId stream, const PStreamHeader& hdr);
 
     // report failure for one message
     void _report_failure(StreamId stream, const Status& status, const PStreamHeader& header) {

--- a/be/src/vec/sink/load_stream_stub.cpp
+++ b/be/src/vec/sink/load_stream_stub.cpp
@@ -17,6 +17,8 @@
 
 #include "vec/sink/load_stream_stub.h"
 
+#include <sstream>
+
 #include "olap/rowset/rowset_writer.h"
 #include "util/brpc_client_cache.h"
 #include "util/network_util.h"
@@ -72,6 +74,12 @@ int LoadStreamStub::LoadStreamReplyHandler::on_received_messages(brpc::StreamId 
                 LOG(WARNING) << "load stream TRuntimeProfileTree deserialize failed, errmsg="
                              << status;
             }
+        }
+
+        if (response.tablet_schemas_size() > 0) {
+            std::vector<PTabletSchemaWithIndex> schemas(response.tablet_schemas().begin(),
+                                                        response.tablet_schemas().end());
+            _stub->add_schema(schemas);
         }
     }
     return 0;
@@ -206,10 +214,63 @@ Status LoadStreamStub::close_load(const std::vector<PTabletID>& tablets_to_commi
     {
         std::lock_guard<std::mutex> lock(_tablets_to_commit_mutex);
         for (const auto& tablet : _tablets_to_commit) {
-            *header.add_tablets_to_commit() = tablet;
+            *header.add_tablets() = tablet;
         }
     }
     return _encode_and_send(header);
+}
+
+// GET_SCHEMA
+Status LoadStreamStub::get_schema(const std::vector<PTabletID>& tablets) {
+    PStreamHeader header;
+    *header.mutable_load_id() = _load_id;
+    header.set_src_id(_src_id);
+    header.set_opcode(doris::PStreamHeader::CLOSE_LOAD);
+    std::ostringstream oss;
+    oss << "fetching tablet schema from stream " << _stream_id << ", load id: " << _load_id
+        << ", tablet id:";
+    for (const auto& tablet : tablets) {
+        *header.add_tablets() = tablet;
+        oss << " " << tablet.tablet_id();
+    }
+    LOG(INFO) << oss.str();
+    return _encode_and_send(header);
+}
+
+void LoadStreamStub::add_schema(const std::vector<PTabletSchemaWithIndex>& schemas) {
+    std::lock_guard<bthread::Mutex> lock(_mutex);
+    for (const auto& schema : schemas) {
+        auto tablet_schema = std::make_unique<TabletSchema>();
+        tablet_schema->init_from_pb(schema.tablet_schema());
+        _tablet_schema_for_index->emplace(schema.index_id(), std::move(tablet_schema));
+        _enable_unique_mow_for_index->emplace(schema.index_id(),
+                                                schema.enable_unique_key_merge_on_write());
+    }
+    _schema_cv.notify_all();
+}
+
+Status LoadStreamStub::wait_for_schema(int64_t partition_id, int64_t index_id, int64_t tablet_id,
+                                       int64_t timeout_ms) {
+    if (_tablet_schema_for_index->contains(index_id)) {
+        return Status::OK();
+    }
+    PTabletID tablet;
+    tablet.set_partition_id(partition_id);
+    tablet.set_index_id(index_id);
+    tablet.set_tablet_id(tablet_id);
+    RETURN_IF_ERROR(get_schema({tablet}));
+
+    MonotonicStopWatch watch;
+    watch.start();
+    while (!_tablet_schema_for_index->contains(index_id) &&
+           watch.elapsed_time() / 1000 / 1000 < timeout_ms) {
+        static_cast<void>(wait_for_new_schema(100));
+    }
+
+    if (!_tablet_schema_for_index->contains(index_id)) {
+        return Status::TimedOut("timeout to get tablet schema for index {}", index_id);
+    }
+    return Status::OK();
 }
 
 Status LoadStreamStub::_encode_and_send(PStreamHeader& header, std::span<const Slice> data) {
@@ -224,21 +285,22 @@ Status LoadStreamStub::_encode_and_send(PStreamHeader& header, std::span<const S
         buf.append(slice.get_data(), slice.get_size());
     }
     bool eos = header.opcode() == doris::PStreamHeader::CLOSE_LOAD;
-    return _send_with_buffer(buf, eos);
+    bool get_schema = header.opcode() == doris::PStreamHeader::GET_SCHEMA;
+    return _send_with_buffer(buf, eos || get_schema);
 }
 
-Status LoadStreamStub::_send_with_buffer(butil::IOBuf& buf, bool eos) {
+Status LoadStreamStub::_send_with_buffer(butil::IOBuf& buf, bool sync) {
     butil::IOBuf output;
     std::unique_lock<decltype(_buffer_mutex)> buffer_lock(_buffer_mutex);
     _buffer.append(buf);
-    if (!eos && _buffer.size() < config::brpc_streaming_client_batch_bytes) {
+    if (!sync && _buffer.size() < config::brpc_streaming_client_batch_bytes) {
         return Status::OK();
     }
     output.swap(_buffer);
     // acquire send lock while holding buffer lock, to ensure the message order
     std::lock_guard<decltype(_send_mutex)> send_lock(_send_mutex);
     buffer_lock.unlock();
-    VLOG_DEBUG << "send buf size : " << output.size() << ", eos: " << eos;
+    VLOG_DEBUG << "send buf size : " << output.size() << ", sync: " << sync;
     return _send_with_retry(output);
 }
 

--- a/be/src/vec/sink/load_stream_stub.cpp
+++ b/be/src/vec/sink/load_stream_stub.cpp
@@ -244,7 +244,7 @@ void LoadStreamStub::add_schema(const std::vector<PTabletSchemaWithIndex>& schem
         tablet_schema->init_from_pb(schema.tablet_schema());
         _tablet_schema_for_index->emplace(schema.index_id(), std::move(tablet_schema));
         _enable_unique_mow_for_index->emplace(schema.index_id(),
-                                                schema.enable_unique_key_merge_on_write());
+                                              schema.enable_unique_key_merge_on_write());
     }
     _schema_cv.notify_all();
 }

--- a/be/src/vec/sink/load_stream_stub.h
+++ b/be/src/vec/sink/load_stream_stub.h
@@ -85,6 +85,8 @@ class LoadStreamStub {
 private:
     class LoadStreamReplyHandler : public brpc::StreamInputHandler {
     public:
+        LoadStreamReplyHandler(LoadStreamStub* stub) : _stub(stub) {}
+
         int on_received_messages(brpc::StreamId id, butil::IOBuf* const messages[],
                                  size_t size) override;
 
@@ -130,6 +132,8 @@ private:
         bthread::Mutex _failed_tablets_mutex;
         std::vector<int64_t> _success_tablets;
         std::vector<int64_t> _failed_tablets;
+
+        LoadStreamStub* _stub;
     };
 
 public:
@@ -167,6 +171,9 @@ public:
     // CLOSE_LOAD
     Status close_load(const std::vector<PTabletID>& tablets_to_commit);
 
+    // GET_SCHEMA
+    Status get_schema(const std::vector<PTabletID>& tablets);
+
     // wait remote to close stream,
     // remote will close stream when it receives CLOSE_LOAD
     Status close_wait(int64_t timeout_ms = 0) {
@@ -175,6 +182,22 @@ public:
         }
         return _handler.close_wait(timeout_ms);
     }
+
+    Status wait_for_schema(int64_t partition_id, int64_t index_id, int64_t tablet_id,
+                           int64_t timeout_ms = 60000);
+    
+    Status wait_for_new_schema(int64_t timeout_ms) {
+        std::unique_lock<bthread::Mutex> lock(_mutex);
+        if (timeout_ms > 0) {
+            int ret = _schema_cv.wait_for(lock, timeout_ms * 1000);
+            return ret == 0 ? Status::OK()
+                            : Status::Error<true>(ret, "wait schema update timeout");
+        }
+        _schema_cv.wait(lock);
+        return Status::OK();
+    };
+
+    void add_schema(const std::vector<PTabletSchemaWithIndex>& schemas);
 
     std::shared_ptr<TabletSchema> tablet_schema(int64_t index_id) const {
         return (*_tablet_schema_for_index)[index_id];
@@ -196,7 +219,7 @@ public:
 
 private:
     Status _encode_and_send(PStreamHeader& header, std::span<const Slice> data = {});
-    Status _send_with_buffer(butil::IOBuf& buf, bool eos = false);
+    Status _send_with_buffer(butil::IOBuf& buf, bool sync = false);
     Status _send_with_retry(butil::IOBuf& buf);
 
 protected:
@@ -216,8 +239,9 @@ protected:
     brpc::StreamId _stream_id;
     int64_t _src_id = -1; // source backend_id
     int64_t _dst_id = -1; // destination backend_id
-    LoadStreamReplyHandler _handler;
+    LoadStreamReplyHandler _handler {this};
 
+    bthread::ConditionVariable _schema_cv;
     std::shared_ptr<IndexToTabletSchema> _tablet_schema_for_index;
     std::shared_ptr<IndexToEnableMoW> _enable_unique_mow_for_index;
 };

--- a/be/src/vec/sink/load_stream_stub.h
+++ b/be/src/vec/sink/load_stream_stub.h
@@ -185,13 +185,12 @@ public:
 
     Status wait_for_schema(int64_t partition_id, int64_t index_id, int64_t tablet_id,
                            int64_t timeout_ms = 60000);
-    
+
     Status wait_for_new_schema(int64_t timeout_ms) {
         std::unique_lock<bthread::Mutex> lock(_mutex);
         if (timeout_ms > 0) {
             int ret = _schema_cv.wait_for(lock, timeout_ms * 1000);
-            return ret == 0 ? Status::OK()
-                            : Status::Error<true>(ret, "wait schema update timeout");
+            return ret == 0 ? Status::OK() : Status::Error<true>(ret, "wait schema update timeout");
         }
         _schema_cv.wait(lock);
         return Status::OK();

--- a/be/src/vec/sink/vtablet_sink_v2.cpp
+++ b/be/src/vec/sink/vtablet_sink_v2.cpp
@@ -272,7 +272,8 @@ Status VOlapTableSinkV2::_open_streams(int64_t src_id) {
     return Status::OK();
 }
 
-Status VOlapTableSinkV2::_open_streams_to_backend(int64_t dst_id, ::doris::stream_load::LoadStreams& streams) {
+Status VOlapTableSinkV2::_open_streams_to_backend(int64_t dst_id,
+                                                  ::doris::stream_load::LoadStreams& streams) {
     auto node_info = _nodes_info->find_node(dst_id);
     if (node_info == nullptr) {
         return Status::InternalError("Unknown node {} in tablet location", dst_id);
@@ -280,15 +281,15 @@ Status VOlapTableSinkV2::_open_streams_to_backend(int64_t dst_id, ::doris::strea
     // get tablet schema from each backend only in the 1st stream
     for (auto& stream : streams.streams() | std::ranges::views::take(1)) {
         const std::vector<PTabletID>& tablets_for_schema = _indexes_from_node[node_info->id];
-        RETURN_IF_ERROR(stream->open(_state->exec_env()->brpc_internal_client_cache(),
-                                        *node_info, _txn_id, *_schema, tablets_for_schema,
-                                        _total_streams, _state->enable_profile()));
+        RETURN_IF_ERROR(stream->open(_state->exec_env()->brpc_internal_client_cache(), *node_info,
+                                     _txn_id, *_schema, tablets_for_schema, _total_streams,
+                                     _state->enable_profile()));
     }
     // for the rest streams, open without getting tablet schema
     for (auto& stream : streams.streams() | std::ranges::views::drop(1)) {
-        RETURN_IF_ERROR(stream->open(_state->exec_env()->brpc_internal_client_cache(),
-                                        *node_info, _txn_id, *_schema, {}, _total_streams,
-                                        _state->enable_profile()));
+        RETURN_IF_ERROR(stream->open(_state->exec_env()->brpc_internal_client_cache(), *node_info,
+                                     _txn_id, *_schema, {}, _total_streams,
+                                     _state->enable_profile()));
     }
     return Status::OK();
 }

--- a/be/src/vec/sink/vtablet_sink_v2.h
+++ b/be/src/vec/sink/vtablet_sink_v2.h
@@ -210,7 +210,7 @@ private:
 
     std::unordered_set<int64_t> _opened_partitions;
 
-    std::unordered_map<int64_t, std::vector<PTabletID>> _tablets_for_node;
+    std::unordered_map<int64_t, std::unordered_map<int64_t, PTabletID>> _tablets_for_node;
     std::unordered_map<int64_t, std::vector<PTabletID>> _indexes_from_node;
 
     std::unordered_map<int64_t, std::shared_ptr<::doris::stream_load::LoadStreams>>

--- a/be/src/vec/sink/vtablet_sink_v2.h
+++ b/be/src/vec/sink/vtablet_sink_v2.h
@@ -127,6 +127,8 @@ private:
 
     Status _open_streams(int64_t src_id);
 
+    Status _open_streams_to_backend(int64_t dst_id, ::doris::stream_load::LoadStreams& streams);
+
     void _build_tablet_node_mapping();
 
     void _generate_rows_for_tablet(std::vector<RowPartTabletIds>& row_part_tablet_ids,
@@ -160,6 +162,7 @@ private:
     // To support multiple senders, we maintain a channel for each sender.
     int _sender_id = -1;
     int _num_senders = -1;
+    int64_t _backend_id = -1;
     int _stream_per_node = -1;
     int _total_streams = -1;
     int _num_local_sink = -1;

--- a/be/src/vec/sink/vtablet_sink_v2.h
+++ b/be/src/vec/sink/vtablet_sink_v2.h
@@ -129,6 +129,8 @@ private:
 
     Status _open_streams_to_backend(int64_t dst_id, ::doris::stream_load::LoadStreams& streams);
 
+    Status _incremental_open_streams(const std::vector<TOlapTablePartition>& partitions);
+
     void _build_tablet_node_mapping();
 
     void _generate_rows_for_tablet(std::vector<RowPartTabletIds>& row_part_tablet_ids,

--- a/be/src/vec/sink/vtablet_sink_v2.h
+++ b/be/src/vec/sink/vtablet_sink_v2.h
@@ -137,7 +137,8 @@ private:
     Status _write_memtable(std::shared_ptr<vectorized::Block> block, int64_t tablet_id,
                            const Rows& rows, const Streams& streams);
 
-    Status _select_streams(int64_t tablet_id, Streams& streams);
+    Status _select_streams(int64_t tablet_id, int64_t partition_id, int64_t index_id,
+                           Streams& streams);
 
     Status _close_load(const Streams& streams);
 

--- a/be/test/runtime/load_stream_test.cpp
+++ b/be/test/runtime/load_stream_test.cpp
@@ -501,7 +501,7 @@ public:
         header.set_opcode(PStreamHeader::CLOSE_LOAD);
         header.set_src_id(sender_id);
         /* TODO: fix test with tablets_to_commit 
-        PTabletID* tablets_to_commit = header.add_tablets_to_commit();
+        PTabletID* tablets_to_commit = header.add_tablets();
         tablets_to_commit->set_partition_id(NORMAL_PARTITION_ID);
         tablets_to_commit->set_index_id(NORMAL_INDEX_ID);
         tablets_to_commit->set_tablet_id(NORMAL_TABLET_ID);

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -768,6 +768,7 @@ message PWriteStreamSinkResponse {
     repeated int64 success_tablet_ids = 2;
     repeated int64 failed_tablet_ids = 3;
     optional bytes load_stream_profile = 4;
+    repeated PTabletSchemaWithIndex tablet_schemas = 5;
 }
 
 message PStreamHeader {
@@ -775,6 +776,7 @@ message PStreamHeader {
         APPEND_DATA = 1;
         CLOSE_LOAD = 2;
         ADD_SEGMENT = 3;
+        GET_SCHEMA = 4;
     }
     optional PUniqueId load_id = 1;
     optional int64 partition_id = 2;
@@ -785,7 +787,7 @@ message PStreamHeader {
     optional bool segment_eos = 7;
     optional int64 src_id = 8;
     optional SegmentStatisticsPB segment_statistics = 9;
-    repeated PTabletID tablets_to_commit = 10;
+    repeated PTabletID tablets = 10;
 }
 
 service PBackendService {


### PR DESCRIPTION
## Proposed changes

Open streams dynamically when new partitions gets created.
Fetch tablet schema from downstream when it's not exist.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

