### PR TITLE
[opt](MergeIO) use equivalent merge size to measure merge effectiveness

### DIFF
--- a/be/src/io/fs/buffered_reader.cpp
+++ b/be/src/io/fs/buffered_reader.cpp
@@ -152,7 +152,6 @@ Status MergeRangeFileReader::read_at_impl(size_t offset, Slice result, size_t* b
     }
     content_size = 0;
     hollow_size = 0;
-    double amplified_ratio = config::max_amplified_read_ratio;
     std::vector<std::pair<double, size_t>> ratio_and_size;
     // Calculate the read amplified ratio for each merge operation and the size of the merged data.
     // Find the largest size of the merged data whose amplified ratio is less than config::max_amplified_read_ratio
@@ -168,9 +167,12 @@ Status MergeRangeFileReader::read_at_impl(size_t offset, Slice result, size_t* b
         }
     }
     size_t best_merged_size = 0;
-    for (const std::pair<double, size_t>& rs : ratio_and_size) {
+    for (int i = 0; i < ratio_and_size.size(); ++i) {
+        const std::pair<double, size_t>& rs = ratio_and_size[i];
+        size_t equivalent_size = rs.second / (i + 1);
         if (rs.second > best_merged_size) {
-            if (rs.first < amplified_ratio || rs.second <= MIN_READ_SIZE) {
+            if (rs.first <= _max_amplified_ratio ||
+                (_max_amplified_ratio < 1 && equivalent_size <= _equivalent_io_size)) {
                 best_merged_size = rs.second;
             }
         }

--- a/be/src/io/fs/buffered_reader.h
+++ b/be/src/io/fs/buffered_reader.h
@@ -131,8 +131,9 @@ public:
     static constexpr size_t READ_SLICE_SIZE = 8 * 1024 * 1024;      // 8MB
     static constexpr size_t BOX_SIZE = 1 * 1024 * 1024;             // 1MB
     static constexpr size_t SMALL_IO = 2 * 1024 * 1024;             // 2MB
+    static constexpr size_t HDFS_MIN_IO_SIZE = 4 * 1024;            // 4KB
+    static constexpr size_t OSS_MIN_IO_SIZE = 512 * 1024;           // 512KB
     static constexpr size_t NUM_BOX = TOTAL_BUFFER_SIZE / BOX_SIZE; // 128
-    static constexpr size_t MIN_READ_SIZE = 4096;                   // 4KB
 
     MergeRangeFileReader(RuntimeProfile* profile, io::FileReaderSPtr reader,
                          const std::vector<PrefetchRange>& random_access_ranges)
@@ -142,6 +143,11 @@ public:
         _range_cached_data.resize(random_access_ranges.size());
         _size = _reader->size();
         _remaining = TOTAL_BUFFER_SIZE;
+        _is_oss = typeid_cast<io::S3FileReader*>(_reader.get()) != nullptr;
+        _max_amplified_ratio = config::max_amplified_read_ratio;
+        // Equivalent min size of each IO that can reach the maximum storage speed limit:
+        // 512KB for oss, 4KB for hdfs
+        _equivalent_io_size = _is_oss ? OSS_MIN_IO_SIZE : HDFS_MIN_IO_SIZE;
         if (_profile != nullptr) {
             const char* random_profile = "MergedSmallIO";
             ADD_TIMER(_profile, random_profile);
@@ -235,6 +241,9 @@ private:
     int16 _last_box_ref = -1;
     uint32 _last_box_usage = 0;
     std::vector<int16> _box_ref;
+    bool _is_oss;
+    double _max_amplified_ratio;
+    size_t _equivalent_io_size;
 
     Statistics _statistics;
 };


### PR DESCRIPTION
backport #26741

`MergeRangeFileReader` is used to merge small IOs, and `max_amplified_read_ratio` controls the proportion of read amplification. However, in some extreme cases(eg. `orc strip size`/`parquet row group size` is less than 3MB), the control effect of `max_amplified_read_ratio` is not good, resulting in a large amount of small IOs.

After testing, the return time of a single IO for IO size smaller than 4kb in hdfs(512kb in oss) remains basically unchanged. Therefore, equivalent IO size is used to measure merge effectiveness:
```
EquivalentIOSize = MergeSize / Request IOs
```
When `EquivalentIOSize` is greater than 4kb in hdfs, or 512kb in oss, we believe that this kind of merge is effective.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

