### PR TITLE
[BugFix](JDBC Catalog) fix jdbc catalog  query bitmap may cause be core sometimes

### DIFF
--- a/be/src/util/bitmap_value.h
+++ b/be/src/util/bitmap_value.h
@@ -1259,10 +1259,9 @@ public:
     }
 
     static std::string empty_bitmap() {
-        static BitmapValue bitmap;
-        std::string buf;
-        buf.resize(bitmap.getSizeInBytes());
-        bitmap.write_to(buf.data());
+        std::string buf(sizeof(BitmapValue), 0);
+        BitmapValue* bitmap_value = reinterpret_cast<BitmapValue*>(buf.data());
+        bitmap_value->_type = EMPTY;
         return buf;
     }
 


### PR DESCRIPTION
## Proposed changes

fix issue that sometimes be will core like below:

Aborted at 1699756702 (unix time) try "date -d @1699756702" if you are using GNU date ***
Current BE git commitID: ca47d75e83 ***
SIGABRT unknown detail explain (@0x25ce1c) received by PID 2477596 (TID 2478098 OR 0x7f3ec817c700) from PID 2477596; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk1/yyq/doris/be/src/common/signal_handler.h:417
 1# 0x00007F3FF2C5F090 in /lib/x86_64-linux-gnu/libc.so.6
 2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
 3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
 4# _gnu_cxx::_verbose_terminate_handler() [clone .cold] at ../../../../libstdc+-v3/libsupc+/vterminate.cc:75
 5# _cxxabiv1::_terminate(void ()) at ../../../../libstdc+-v3/libsupc+/eh_terminate.cc:48
 6# 0x00005612E3DEC791 in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 7# 0x00005612E3DEC8E4 in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 8# 0x00005612E3DECCD6 in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 9# phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<unsigned long>, phmap::Hash<unsigned long>, phmap::EqualTo<unsigned long>, std::allocator<unsigned long> >::resize(unsigned long) at /mnt/disk1/yyq/doris/thirdparty/installed/include/parallel_hashmap/phmap.h:2014
10# phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<unsigned long>, phmap::Hash<unsigned long>, phmap::EqualTo<unsigned long>, std::allocator<unsigned long> >::raw_hash_set(phmap::priv::raw_hash_set<phmap::priv::FlatHashSetPolicy<unsigned long>, phmap::Hash<unsigned long>, phmap::EqualTo<unsigned long>, std::allocator<unsigned long> > const&, std::allocator<unsigned long> const&) at /mnt/disk1/yyq/doris/thirdparty/installed/include/parallel_hashmap/phmap.h:1167
11# doris::BitmapValue::BitmapValue(doris::BitmapValue const&) at /mnt/disk1/yyq/doris/be/src/util/bitmap_value.h:1199
12# doris::vectorized::ColumnComplexType<doris::BitmapValue>::insert(doris::vectorized::Field const&) at /mnt/disk1/yyq/doris/be/src/vec/columns/column_complex.h:146
13# doris::vectorized::IDataType::create_column_const(unsigned long, doris::vectorized::Field const&) const at /mnt/disk1/yyq/doris/be/src/vec/data_types/data_type.cpp:75
14# doris::vectorized::IDataType::create_column_const_with_default_value(unsigned long) const in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
15# doris::vectorized::JdbcConnector::_cast_string_to_bitmap(doris::SlotDescriptor const*, doris::vectorized::Block*, int, int) at /mnt/disk1/yyq/doris/be/src/vec/exec/vjdbc_connector.cpp:893
16# doris::vectorized::JdbcConnector::get_next(bool*, std::vector<COW<doris::vectorized::IColumn>::mutable_ptr<doris::vectorized::IColumn>, std::allocator<COW<doris::vectorized::IColumn>::mutable_ptr<doris::vectorized::IColumn> > >&, doris::vectorized::Block*, int) at /mnt/disk1/yyq/doris/be/src/vec/exec/vjdbc_connector.cpp:502
17# doris::vectorized::NewJdbcScanner::_get_block_impl(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /mnt/disk1/yyq/doris/be/src/vec/exec/scan/new_jdbc_scanner.cpp:192
18# doris::vectorized::VScanner::get_block(doris::RuntimeState*, doris::vectorized::Block*, bool*) in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
19# doris::vectorized::ScannerScheduler::_scanner_scan(doris::vectorized::ScannerScheduler*, doris::vectorized::ScannerContext*, std::shared_ptr<doris::vectorized::VScanner>) at /mnt/disk1/yyq/doris/be/src/vec/exec/scan/scanner_scheduler.cpp:397
20# std::_Function_handler<void (), doris::vectorized::ScannerScheduler::_schedule_scanners(doris::vectorized::ScannerContext*)::$_1::operator()() const::{lambda()#5}>::_M_invoke(std::_Any_data const&) at /mnt/disk1/yyq/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
21# doris::ThreadPool::dispatch_thread() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
22# doris::Thread::supervise_thread(void*) at /mnt/disk1/yyq/doris/be/src/util/thread.cpp:495
23# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
24# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97



<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

