### PR TITLE
[fix](backup) return if status not ok and reduce summit job

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -87,8 +87,7 @@ public class BackupJob extends AbstractJob {
         SAVE_META, // Save copied meta info to local file. When finished, transfer to UPLOAD_INFO
         UPLOAD_INFO, // Upload meta and job info file to repository. When finished, transfer to FINISHED
         FINISHED, // Job is finished.
-        CANCELLED, // Job is cancelled.
-        PARTIAL_FINISHED
+        CANCELLED // Job is cancelled.
     }
 
     // all objects which need backup
@@ -1023,13 +1022,6 @@ public class BackupJob extends AbstractJob {
             String key = Text.readString(in);
             String value = Text.readString(in);
             properties.put(key, value);
-        }
-        if (Env.getCurrentEnvJournalVersion() >= org.apache.doris.common.FeMetaVersion.VERSION_127) {
-            size = in.readInt();
-            for (int i = 0; i < size; i++) {
-                Text.readString(in);
-                Text.readString(in);
-            }
         }
     }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

when backup is prepareAndSendSnapshotTask(), if some table has error, return status not ok, but not return, and other tables continue put snapshot job into batchTask and summit jobs to be while these jobs need cancel. so when status is not ok, return and do not summit jobs

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

