### PR TITLE
[fix](memory)Fix MacOS perf_counters.cpp compile Error

### DIFF
--- a/be/src/util/perf_counters_mac.cpp
+++ b/be/src/util/perf_counters_mac.cpp
@@ -21,6 +21,9 @@ namespace doris {
 
 int64_t PerfCounters::_vm_rss = 0;
 std::string PerfCounters::_vm_rss_str = "";
+int64_t PerfCounters::_vm_hwm = 0;
+int64_t PerfCounters::_vm_peak = 0;
+int64_t PerfCounters::_vm_size = 0;
 
 void PerfCounters::refresh_proc_status() {}
 


### PR DESCRIPTION
## Proposed changes

```
Undefined symbols for architecture x86_64:
  "doris::PerfCounters::_vm_hwm", referenced from:
      doris::PerfCounters::get_vm_hwm() in libRuntime.a(mem_tracker_limiter.cpp.o)
  "doris::PerfCounters::_vm_peak", referenced from:
      doris::PerfCounters::get_vm_peak() in libRuntime.a(mem_tracker_limiter.cpp.o)
  "doris::PerfCounters::_vm_size", referenced from:
      doris::PerfCounters::get_vm_size() in libRuntime.a(mem_tracker_limiter.cpp.o)
ld: symbol(s) not found for architecture x86_64
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

