### PR TITLE
[fix](hive-catalog) fix issue when read hive table stored on tencent OFS

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveScanProvider.java
@@ -126,7 +126,7 @@ public class HiveScanProvider extends HMSTableScanProvider {
             } else if (location.startsWith(FeConstants.FS_PREFIX_FILE)) {
                 return TFileType.FILE_LOCAL;
             } else if (location.startsWith(FeConstants.FS_PREFIX_OFS)) {
-                return TFileType.FILE_BROKER;
+                return TFileType.FILE_HDFS;
             } else if (location.startsWith(FeConstants.FS_PREFIX_GFS)) {
                 return TFileType.FILE_HDFS;
             } else if (location.startsWith(FeConstants.FS_PREFIX_JFS)) {


### PR DESCRIPTION
Fix two issues:
1. error when read hive parquet table with snappy compression on ofs:  Invalid magic number in parquet file
2. error when read hive orc table with none  compression on ofs:  Init OrcReader failed. reason = Read past EOF in DecompressionStream::readBuffer

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

