### PR TITLE
[Bug](SchemeChange) Loading tasks during alter job cause modify column failed

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.planner;
 
+import org.apache.doris.alter.SchemaChangeHandler;
 import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.SlotDescriptor;
@@ -254,6 +255,12 @@ public class OlapTableSink extends DataSink {
             columns.addAll(indexMeta.getSchema().stream().map(Column::getNonShadowName).collect(Collectors.toList()));
             for (Column column : indexMeta.getSchema()) {
                 TColumn tColumn = column.toThrift();
+                // When schema change is doing, some modified column has prefix in name. Columns here
+                // is for the schema in rowset meta, which should be no column with shadow prefix.
+                // So we should remove the shadow prefix here.
+                if (column.getName().startsWith(SchemaChangeHandler.SHADOW_NAME_PREFIX)) {
+                    tColumn.setColumnName(column.getNonShadowName());
+                }
                 column.setIndexFlag(tColumn, table);
                 columnsDesc.add(tColumn);
             }


### PR DESCRIPTION
## Proposed changes

Issue Number: fix #26964 

When a table is doing schema-change, it adds `_doris_shadow` prefix in name of modified columns in shadow index.

The writes during schema-change will generate rowset schema with `_doris_shadow` prefix in BE.

If the alter task arrives at be after the write request, it will use the rowset schema with max version which has the `_doris_shadow` prefix.

And an error will be thrown as below:

<img width="1386" alt="image" src="https://github.com/apache/doris/assets/22125576/104f5174-8c14-4b57-99b4-cf8a0db5f223">

```
a shadow column is encountered __doris_shadow_p_retailprice
[INTERNAL_ERROR]failed due to operate on shadow column
```

This commit will disable shadow prefix in rowset meta schema.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

