### PR TITLE
[fix](move-memtable) wait stream close before free stream handler

### DIFF
--- a/be/src/vec/sink/load_stream_stub.cpp
+++ b/be/src/vec/sink/load_stream_stub.cpp
@@ -108,6 +108,10 @@ LoadStreamStub::LoadStreamStub(LoadStreamStub& stub)
 LoadStreamStub::~LoadStreamStub() {
     if (_is_init.load() && !_handler.is_closed()) {
         brpc::StreamClose(_stream_id);
+        auto st = close_wait(60000); // timeout 60s
+        if (!st.ok()) {
+            LOG(WARNING) << st;
+        }
     }
 }
 


### PR DESCRIPTION
## Proposed changes

After brpc StreamClose is called, both side will receive `on_closed`.
We should wait for close to prevent memory use-after-free.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

