### PR TITLE
[Fix](match) fix match null for no index

### DIFF
--- a/be/src/vec/exprs/vmatch_predicate.cpp
+++ b/be/src/vec/exprs/vmatch_predicate.cpp
@@ -69,9 +69,14 @@ Status VMatchPredicate::prepare(RuntimeState* state, const RowDescriptor& desc,
         argument_template.emplace_back(nullptr, child->data_type(), child->expr_name());
         child_expr_name.emplace_back(child->expr_name());
     }
-
-    _function = SimpleFunctionFactory::instance().get_function(_fn.name.function_name,
-                                                               argument_template, _data_type);
+    // result column always not null
+    if (_data_type->is_nullable()) {
+        _function = SimpleFunctionFactory::instance().get_function(
+                _fn.name.function_name, argument_template, remove_nullable(_data_type));
+    } else {
+        _function = SimpleFunctionFactory::instance().get_function(_fn.name.function_name,
+                                                                   argument_template, _data_type);
+    }
     if (_function == nullptr) {
         std::string type_str;
         for (auto arg : argument_template) {
@@ -125,6 +130,11 @@ Status VMatchPredicate::execute(VExprContext* context, Block* block, int* result
     RETURN_IF_ERROR(_function->execute(context->fn_context(_fn_context_index), *block, arguments,
                                        num_columns_without_result, block->rows(), false));
     *result_column_id = num_columns_without_result;
+    if (_data_type->is_nullable()) {
+        auto nested = block->get_by_position(num_columns_without_result).column;
+        auto nullable = ColumnNullable::create(nested, ColumnUInt8::create(block->rows(), 0));
+        block->replace_by_position(num_columns_without_result, nullable);
+    }
     return Status::OK();
 }
 

--- a/be/src/vec/functions/match.cpp
+++ b/be/src/vec/functions/match.cpp
@@ -46,7 +46,12 @@ Status FunctionMatchBase::execute_impl(FunctionContext* context, Block& block,
         const auto* values = check_and_get_column<ColumnString>(source_col.get());
         const ColumnArray* array_col = nullptr;
         if (source_col->is_column_array()) {
-            array_col = check_and_get_column<ColumnArray>(source_col.get());
+            if (source_col->is_nullable()) {
+                auto* nullable = check_and_get_column<ColumnNullable>(source_col.get());
+                array_col = check_and_get_column<ColumnArray>(*nullable->get_nested_column_ptr());
+            } else {
+                array_col = check_and_get_column<ColumnArray>(source_col.get());
+            }
             if (array_col && !array_col->get_data().is_column_string()) {
                 return Status::NotSupported(
                         fmt::format("unsupported nested array of type {} for function {}",
@@ -62,10 +67,19 @@ Status FunctionMatchBase::execute_impl(FunctionContext* context, Block& block,
                 values = check_and_get_column<ColumnString>(
                         *(array_nested_null_column.get_nested_column_ptr()));
             } else {
+                // array column element is always set Nullable for now.
                 values = check_and_get_column<ColumnString>(*(array_col->get_data_ptr()));
             }
         } else if (auto* nullable = check_and_get_column<ColumnNullable>(source_col.get())) {
-            values = check_and_get_column<ColumnString>(*nullable->get_nested_column_ptr());
+            // match null
+            if (type_ptr->is_nullable()) {
+                if (column_ptr->only_null()) {
+                    block.get_by_position(result).column = nullable->get_null_map_column_ptr();
+                    return Status::OK();
+                }
+            } else {
+                values = check_and_get_column<ColumnString>(*nullable->get_nested_column_ptr());
+            }
         }
 
         if (!values) {

--- a/be/src/vec/functions/match.h
+++ b/be/src/vec/functions/match.h
@@ -56,6 +56,8 @@ const std::string MATCH_PHRASE_FUNCTION = "match_phrase";
 
 class FunctionMatchBase : public IFunction {
 public:
+    bool use_default_implementation_for_nulls() const override { return false; }
+
     size_t get_number_of_arguments() const override { return 2; }
 
     String get_name() const override { return "match"; }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

This pull request addresses an issue observed with inverted index tables or tables without indices when querying null values using the MATCH function. 
Previously, executing a query like `SELECT * FROM table WHERE column MATCH null;` would yield incorrect results. 

The update introduces enhanced handling of nullable columns within the MATCH function, ensuring accurate query results when null values are involved. 

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

