### PR TITLE
[fix](topn) add defensive code in topn opt to avoid crash due to column not in tablet schema #26990

### DIFF
--- a/be/src/runtime/runtime_predicate.cpp
+++ b/be/src/runtime/runtime_predicate.cpp
@@ -132,11 +132,6 @@ Status RuntimePredicate::update(const Field& value, const String& col_name, bool
 
     std::unique_lock<std::shared_mutex> wlock(_rwlock);
 
-    // TODO why null
-    if (!_tablet_schema) {
-        return Status::OK();
-    }
-
     bool updated = false;
 
     if (UNLIKELY(_orderby_extrem.is_null())) {
@@ -158,6 +153,10 @@ Status RuntimePredicate::update(const Field& value, const String& col_name, bool
         return Status::OK();
     }
 
+    // TODO defensive code
+    if (!_tablet_schema || !_tablet_schema->have_column(col_name)) {
+        return Status::OK();
+    }
     // update _predictate
     int32_t col_unique_id = _tablet_schema->column(col_name).unique_id();
     const TabletColumn& column = _tablet_schema->column_by_uid(col_unique_id);

--- a/be/src/runtime/runtime_predicate.h
+++ b/be/src/runtime/runtime_predicate.h
@@ -66,8 +66,8 @@ private:
     mutable std::shared_mutex _rwlock;
     Field _orderby_extrem {Field::Types::Null};
     std::shared_ptr<ColumnPredicate> _predictate {nullptr};
-    TabletSchemaSPtr _tablet_schema;
-    std::unique_ptr<Arena> _predicate_arena;
+    TabletSchemaSPtr _tablet_schema {nullptr};
+    std::unique_ptr<Arena> _predicate_arena {nullptr};
     std::function<std::string(const Field&)> _get_value_fn;
     bool _nulls_first = true;
     bool _inited = false;


### PR DESCRIPTION
pick from #26990

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

