### PR TITLE
[fix](auth) fix overwrite logic of user with domain

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
@@ -453,7 +453,7 @@ public class Auth implements Writable {
 
             // create user
             try {
-                //we should not throw AnalysisException at here,so transfer it
+                // we should not throw AnalysisException at here,so transfer it
                 userManager.createUser(userIdent, password, null, false);
             } catch (PatternMatcherException e) {
                 throw new DdlException("create user failed,", e);

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserManager.java
@@ -183,6 +183,12 @@ public class UserManager implements Writable {
             throws PatternMatcherException {
         if (userIdentityExist(userIdent, true)) {
             User userByUserIdentity = getUserByUserIdentity(userIdent);
+            if (!userByUserIdentity.isSetByDomainResolver() && setByResolver) {
+                // If the user is NOT created by domain resolver,
+                // and the current operation is done by DomainResolver,
+                // we should not override it, just return
+                return userByUserIdentity;
+            }
             userByUserIdentity.setPassword(pwd);
             userByUserIdentity.setSetByDomainResolver(setByResolver);
             return userByUserIdentity;


### PR DESCRIPTION
## Proposed changes

Reproduce:
DBA do following operations:
1. create user user1@['domain'];   // the domain will be resolved as 2 ip: ip1 and ip2;
2. create user user1@'ip1';
3. wait at least 10 second
4. grant all on *.*.* to user1@'ip1';  // will return error: user1@'ip1' does not exist

This is because the daemon thread DomainResolver resolve the "domain" and overwrite the `user1@'ip1'`
which is created by DBA.

This PR fix it.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

