### PR TITLE
[fix](publish version) publish version task no need return VERSION_NOT_EXIST

### DIFF
--- a/be/src/olap/task/engine_publish_version_task.cpp
+++ b/be/src/olap/task/engine_publish_version_task.cpp
@@ -242,12 +242,6 @@ Status EnginePublishVersionTask::finish() {
                         (*_succ_tablets)[tablet_id] = 0;
                     } else {
                         add_error_tablet_id(tablet_id);
-                        if (res.ok()) {
-                            res = Status::Error<VERSION_NOT_EXIST>(
-                                    "tablet {} with state {} not exists version {}", tablet_id,
-                                    tablet_state_name(tablet->tablet_state()),
-                                    par_ver_info.version);
-                        }
                         LOG(WARNING)
                                 << "publish version failed on transaction, tablet version not "
                                    "exists. "


### PR DESCRIPTION
if BE's tablet not contains a txn,  publish txn on them will no error,  when check version exists it will indicate the tablet as error_tablet_id in task's response,  so FE can know this tablet has fail.

Also for  task,  it's no need  to set its status as "VERSION_NOT_EXIST".   Because if set it as not ok,  the BE will try this task two times.  Since not contains this tablet's txn,  the retry is in vain.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

