### PR TITLE
[BugFix](JDBC Catalog) cherry-pick 26933 to  fix jdbc catalog query bitmap may cause be cor…

### DIFF
--- a/be/src/util/bitmap_value.h
+++ b/be/src/util/bitmap_value.h
@@ -1264,10 +1264,9 @@ public:
     }
 
     static std::string empty_bitmap() {
-        static BitmapValue bitmap;
-        std::string buf;
-        buf.resize(bitmap.getSizeInBytes());
-        bitmap.write_to(buf.data());
+        std::string buf(sizeof(BitmapValue), 0);
+        BitmapValue* bitmap_value = reinterpret_cast<BitmapValue*>(buf.data());
+        bitmap_value->_type = EMPTY;
         return buf;
     }
 


### PR DESCRIPTION
…e sometimes (#26933)

BitmapValue::write_to will get a string with size 1 for empty BitmapValue, however the size 1 string will reinterpret to BitmapValue* back in ColumnComplexType::insert: void insert(const Field& x) override {
const String& s = doris::vectorized::get<const String&>(x); data.push_back(reinterpret_cast<const T>(s.c_str())); }

in data.push_back will goto BitmapValue copy constructor, as the _type is not first member in BitmapValue, cause access to an unknown memory location.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

