### PR TITLE
[information_schema](tables)modify information_schema.tables rows column use cache rows.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -1209,6 +1209,11 @@ public class OlapTable extends Table {
     }
 
     @Override
+    public long getCacheRowCount() {
+        return getRowCount();
+    }
+
+    @Override
     public long getAvgRowLength() {
         long rowCount = 0;
         long dataSize = 0;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Table.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Table.java
@@ -344,6 +344,10 @@ public abstract class Table extends MetaObject implements Writable, TableIf {
         return 0;
     }
 
+    public long getCacheRowCount() {
+        return getRowCount();
+    }
+
     public long getAvgRowLength() {
         return 0;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
@@ -121,6 +121,8 @@ public interface TableIf {
 
     long getRowCount();
 
+    // Get the exact number of rows in the internal table;
+    // Get the number of cached rows or estimated rows in the external table, if not, return -1.
     long getCacheRowCount();
 
     long getDataLength();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
@@ -121,6 +121,8 @@ public interface TableIf {
 
     long getRowCount();
 
+    long getCacheRowCount();
+
     long getDataLength();
 
     long getAvgRowLength();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
@@ -282,6 +282,10 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
         return 0;
     }
 
+    public long getCacheRowCount() {
+        return 0;
+    }
+
     @Override
     public long getAvgRowLength() {
         return 0;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
@@ -453,6 +453,23 @@ public class HMSExternalTable extends ExternalTable {
     }
 
     @Override
+    public long getCacheRowCount() {
+        //Cached accurate information
+        TableStatsMeta tableStats = Env.getCurrentEnv().getAnalysisManager().findTableStatsStatus(id);
+        if (tableStats != null) {
+            long rowCount = tableStats.rowCount;
+            LOG.debug("Estimated row count for db {} table {} is {}.", dbName, name, rowCount);
+            return rowCount;
+        }
+
+        //estimated information
+        if (estimatedRowCount != -1) {
+            return estimatedRowCount;
+        }
+        return -1;
+    }
+
+    @Override
     public long estimatedRowCount() {
         try {
             TableStatsMeta tableStats = Env.getCurrentEnv().getAnalysisManager().findTableStatsStatus(id);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/JdbcExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/JdbcExternalTable.java
@@ -123,6 +123,11 @@ public class JdbcExternalTable extends ExternalTable {
     }
 
     @Override
+    public long getCacheRowCount() {
+        return getRowCount();
+    }
+
+    @Override
     public long estimatedRowCount() {
         return getRowCount();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -747,7 +747,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                             status.setUpdateTime(table.getUpdateTime() / 1000);
                             status.setCheckTime(lastCheckTime / 1000);
                             status.setCollation("utf-8");
-                            status.setRows(table.getRowCount());
+                            status.setRows(table.getCacheRowCount());
                             status.setDataLength(table.getDataLength());
                             status.setAvgRowLength(table.getAvgRowLength());
                             tablesResult.add(status);


### PR DESCRIPTION
Use the cached information and estimated information of the table in the rows column under information_schema.tables. Avoid querying information_schema.tables that will cause rpc timeout when there are a large number of tables in the catalog.


## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

