### PR TITLE
[fix](fe ut) fix unstable ut TabletRepairAndBalanceTest

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/clone/TabletRepairAndBalanceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/clone/TabletRepairAndBalanceTest.java
@@ -109,6 +109,7 @@ public class TabletRepairAndBalanceTest {
         Config.tablet_checker_interval_ms = 1000;
         Config.tablet_repair_delay_factor_second = 1;
         Config.colocate_group_relocate_delay_second = 1;
+        Config.disable_balance = true;
         // 5 backends:
         // 127.0.0.1
         // 127.0.0.2


### PR DESCRIPTION
```
java.lang.AssertionError: expected:<90> but was:<91>  at org.apache.doris.clone.TabletRepairAndBalanceTest.test(TabletRepairAndBalanceTest.java:303)------- Stdout: -------fe/mocked/TabletRepairAndBalanceTest/a7919f90-ace1-4f01-b9bd-c92328dde8e2/mocked frontend running in dir: /root/doris/fe/mocked/TabletRepairAndBalanceTest/a7919f90-ace1-4f01-b9bd-c92328dde8e2/ 
```

when doing normal tablet balance, the total replicas size will increase.

Also this ut only test tablet repair and colocate relocate,  so we stop sched balance.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

