### PR TITLE
[fix](tablet sched) fix delete stale remain replica

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -1092,7 +1092,7 @@ public class TabletScheduler extends MasterDaemon {
 
         List<Replica> replicas = tabletCtx.getTablet().getReplicas();
         boolean otherCatchup = replicas.stream().anyMatch(
-                r -> r.getId() != replica.getId()
+                r -> r != replica
                 && (r.getVersion() > replica.getVersion()
                         || (r.getVersion() == replica.getVersion() && r.getLastFailedVersion() < 0)));
         if (!otherCatchup) {


### PR DESCRIPTION
we have met a case  a tablet's  multiple replicas  have the same replica id,   but only one of them's  backend id is in current backend ids,  the other's backends are unavailable.  maybe they are stale backend which has be decommissioned.

An example: a tablet contains two replicas:
replica 1: (replica id = 100,  backend id = 1000) ,  
replica 2: (replica id = 100,  backend id = 2000).

But the system not contains backend 1000 now.  Then if this tablet is REDUNDANT,  it will pick replica 1 to delete because its backend is not available. Then deleteReplicaInternal will count other replica which replica id is not equals with replica 1, it got 0, then deleteReplicaInternal will fail.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

