### PR TITLE
[enhancement](log) add config for storage to reduce stacktrace log on fe

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2310,6 +2310,12 @@ public class Config extends ConfigBase {
     })
     public static int restore_download_task_num_per_be = 3;
 
+    @ConfField(mutable = true, masterOnly = true, description = {
+            "是否在log中打印异常的stacktrace信息",
+            "Whether to print the stacktrace information of the exception in the log"
+    })
+    public static boolean print_error_no_stacktrace = false;
+
     @ConfField(description = {"是否开启通过http接口获取log文件的功能",
             "Whether to enable the function of getting log files through http interface"})
     public static boolean enable_get_log_file_api = false;

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2310,7 +2310,7 @@ public class Config extends ConfigBase {
     })
     public static int restore_download_task_num_per_be = 3;
 
-    @ConfField(mutable = true, masterOnly = true, description = {
+    @ConfField(mutable = true, description = {
             "是否在log中打印异常的stacktrace信息",
             "Whether to print the stacktrace information of the exception in the log"
     })

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/obj/S3ObjStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/obj/S3ObjStorage.java
@@ -18,6 +18,7 @@
 package org.apache.doris.fs.obj;
 
 import org.apache.doris.backup.Status;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.S3URI;
@@ -157,11 +158,19 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
             if (e.statusCode() == HttpStatus.SC_NOT_FOUND) {
                 return new Status(Status.ErrCode.NOT_FOUND, "remote path does not exist: " + remotePath);
             } else {
-                LOG.warn("headObject failed:", e);
+                if (Config.print_error_no_stacktrace) {
+                    LOG.warn("headObject failed:" + e.getMessage());
+                } else {
+                    LOG.warn("headObject failed:", e);
+                }
                 return new Status(Status.ErrCode.COMMON_ERROR, "headObject failed: " + e.getMessage());
             }
         } catch (UserException ue) {
-            LOG.warn("connect to s3 failed: ", ue);
+            if (Config.print_error_no_stacktrace) {
+                LOG.warn("connect to s3 failed: " + ue.getMessage());
+            } else {
+                LOG.warn("connect to s3 failed: ", ue);
+            }
             return new Status(Status.ErrCode.COMMON_ERROR, "connect to s3 failed: " + ue.getMessage());
         }
     }
@@ -179,7 +188,11 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
                     Status.ErrCode.COMMON_ERROR,
                     "get file from s3 error: " + s3Exception.awsErrorDetails().errorMessage());
         } catch (UserException ue) {
-            LOG.warn("connect to s3 failed: ", ue);
+            if (Config.print_error_no_stacktrace) {
+                LOG.warn("connect to s3 failed: " + ue.getMessage());
+            } else {
+                LOG.warn("connect to s3 failed: " + ue);
+            }
             return new Status(Status.ErrCode.COMMON_ERROR, "connect to s3 failed: " + ue.getMessage());
         } catch (Exception e) {
             return new Status(Status.ErrCode.COMMON_ERROR, e.toString());
@@ -198,10 +211,18 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
             LOG.info("put object success: " + response.toString());
             return Status.OK;
         } catch (S3Exception e) {
-            LOG.error("put object failed:", e);
+            if (Config.print_error_no_stacktrace) {
+                LOG.error("put object failed:" + e.getMessage());
+            } else {
+                LOG.error("put object failed:", e);
+            }
             return new Status(Status.ErrCode.COMMON_ERROR, "put object failed: " + e.getMessage());
         } catch (Exception ue) {
-            LOG.error("connect to s3 failed: ", ue);
+            if (Config.print_error_no_stacktrace) {
+                LOG.warn("connect to s3 failed: " + ue.getMessage());
+            } else {
+                LOG.warn("connect to s3 failed: ", ue);
+            }
             return new Status(Status.ErrCode.COMMON_ERROR, "connect to s3 failed: " + ue.getMessage());
         }
     }
@@ -217,13 +238,21 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
             LOG.info("delete file " + remotePath + " success: " + response.toString());
             return Status.OK;
         } catch (S3Exception e) {
-            LOG.warn("delete file failed: ", e);
+            if (Config.print_error_no_stacktrace) {
+                LOG.warn("delete file failed: " + e.getMessage());
+            } else {
+                LOG.warn("delete file failed: ", e);
+            }
             if (e.statusCode() == HttpStatus.SC_NOT_FOUND) {
                 return Status.OK;
             }
             return new Status(Status.ErrCode.COMMON_ERROR, "delete file failed: " + e.getMessage());
         } catch (UserException ue) {
-            LOG.warn("connect to s3 failed: ", ue);
+            if (Config.print_error_no_stacktrace) {
+                LOG.warn("connect to s3 failed: " + ue.getMessage());
+            } else {
+                LOG.warn("connect to s3 failed: ", ue);
+            }
             return new Status(Status.ErrCode.COMMON_ERROR, "connect to s3 failed: " + ue.getMessage());
         }
     }
@@ -268,7 +297,12 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
         } catch (DdlException e) {
             return new Status(Status.ErrCode.COMMON_ERROR, "list objects for delete objects failed: " + e.getMessage());
         } catch (Exception e) {
-            LOG.warn("delete objects {} failed, force visual host style {}", absolutePath, e, forceHostedStyle);
+            if (Config.print_error_no_stacktrace) {
+                LOG.warn("delete objects {} failed, force visual host style {}" + e.getMessage(),
+                            absolutePath, forceHostedStyle);
+            } else {
+                LOG.warn("delete objects {} failed, force visual host style {}. {}", absolutePath, forceHostedStyle, e);
+            }
             return new Status(Status.ErrCode.COMMON_ERROR, "delete objects failed: " + e.getMessage());
         }
     }
@@ -288,10 +322,18 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
             LOG.info("copy file from " + origFilePath + " to " + destFilePath + " success: " + response.toString());
             return Status.OK;
         } catch (S3Exception e) {
-            LOG.error("copy file failed: ", e);
+            if (Config.print_error_no_stacktrace) {
+                LOG.error("copy to s3 failed: " + e.getMessage());
+            } else {
+                LOG.error("copy to s3 failed: ", e);
+            }
             return new Status(Status.ErrCode.COMMON_ERROR, "copy file failed: " + e.getMessage());
         } catch (UserException ue) {
-            LOG.error("copy to s3 failed: ", ue);
+            if (Config.print_error_no_stacktrace) {
+                LOG.error("copy to s3 failed: " + ue.getMessage());
+            } else {
+                LOG.error("copy to s3 failed: ", ue);
+            }
             return new Status(Status.ErrCode.COMMON_ERROR, "connect to s3 failed: " + ue.getMessage());
         }
     }
@@ -331,7 +373,11 @@ public class S3ObjStorage implements ObjStorage<S3Client> {
             }
             return new RemoteObjects(remoteObjects, response.isTruncated(), response.nextContinuationToken());
         } catch (Exception e) {
-            LOG.warn("Failed to list objects for S3: {}", absolutePath, e);
+            if (Config.print_error_no_stacktrace) {
+                LOG.warn("Failed to list objects for S3: {}. " + e.getMessage(), absolutePath);
+            } else {
+                LOG.warn("Failed to list objects for S3: {}", absolutePath, e);
+            }
             throw new DdlException("Failed to list objects for S3, Error message: " + e.getMessage(), e);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/operations/HDFSFileOperations.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/operations/HDFSFileOperations.java
@@ -18,6 +18,7 @@
 package org.apache.doris.fs.operations;
 
 import org.apache.doris.backup.Status;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.URI;
 
@@ -59,10 +60,18 @@ public class HDFSFileOperations implements FileOperations {
             hdfsOpParams.withFsDataInputStream(fsDataInputStream);
             return Status.OK;
         } catch (IOException e) {
-            LOG.error("errors while open path", e);
+            if (Config.print_error_no_stacktrace) {
+                LOG.error("errors while open path" + e.getMessage());
+            } else {
+                LOG.error("errors while open path", e);
+            }
             return new Status(Status.ErrCode.COMMON_ERROR, "failed to open reader, msg:" + e.getMessage());
         } catch (UserException ex) {
-            LOG.error("errors while get filesystem", ex);
+            if (Config.print_error_no_stacktrace) {
+                LOG.error("errors while get filesystem" + ex.getMessage());
+            } else {
+                LOG.error("errors while get filesystem", ex);
+            }
             return new Status(Status.ErrCode.COMMON_ERROR, "failed to get filesystem, msg:" + ex.getMessage());
         }
     }
@@ -80,7 +89,11 @@ public class HDFSFileOperations implements FileOperations {
             try {
                 fsDataInputStream.close();
             } catch (IOException e) {
-                LOG.error("errors while close file input stream", e);
+                if (Config.print_error_no_stacktrace) {
+                    LOG.error("errors while close file input stream" + e.getMessage());
+                } else {
+                    LOG.error("errors while close file input stream", e);
+                }
                 return new Status(Status.ErrCode.COMMON_ERROR,
                         "errors while close file input stream, msg: " + e.getMessage());
             }
@@ -103,10 +116,18 @@ public class HDFSFileOperations implements FileOperations {
             hdfsOpParams.withFsDataOutputStream(hdfsClient.create(inputFilePath, true, WRITE_BUFFER_SIZE));
             return Status.OK;
         } catch (IOException e) {
-            LOG.error("errors while open path", e);
+            if (Config.print_error_no_stacktrace) {
+                LOG.error("errors while open path" + e.getMessage());
+            } else {
+                LOG.error("errors while open path", e);
+            }
             return new Status(Status.ErrCode.COMMON_ERROR, "failed to open writer, msg:" + e.getMessage());
         } catch (UserException ex) {
-            LOG.error("errors while get filesystem", ex);
+            if (Config.print_error_no_stacktrace) {
+                LOG.error("errors while get filesystem" + ex.getMessage());
+            } else {
+                LOG.error("errors while get filesystem", ex);
+            }
             return new Status(Status.ErrCode.COMMON_ERROR, "failed to get filesystem, msg:" + ex.getMessage());
         }
     }
@@ -126,7 +147,11 @@ public class HDFSFileOperations implements FileOperations {
                 fsDataOutputStream.close();
                 LOG.info("finished to close writer");
             } catch (IOException e) {
-                LOG.error("errors while close file output stream", e);
+                if (Config.print_error_no_stacktrace) {
+                    LOG.error("errors while close file output stream" + e.getMessage());
+                } else {
+                    LOG.error("errors while close file output stream", e);
+                }
                 return new Status(Status.ErrCode.COMMON_ERROR, "failed to close writer, msg:" + e.getMessage());
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/BrokerFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/BrokerFileSystem.java
@@ -23,6 +23,7 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.FsBroker;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ClientPool;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.BrokerUtil;
@@ -430,7 +431,11 @@ public class BrokerFileSystem extends RemoteFileSystem {
                                 BrokerUtil.printBroker(name, address),
                                 writeOffset, bytesRead, fileLength,
                                 remotePath, e.getMessage());
-                        LOG.warn(lastErrMsg, e);
+                        if (Config.print_error_no_stacktrace) {
+                            LOG.warn(lastErrMsg);
+                        } else {
+                            LOG.warn(lastErrMsg, e);
+                        }
                         status = new Status(Status.ErrCode.COMMON_ERROR, lastErrMsg);
                         break;
                     } catch (TException e) {
@@ -440,7 +445,11 @@ public class BrokerFileSystem extends RemoteFileSystem {
                                 BrokerUtil.printBroker(name, address),
                                 writeOffset, bytesRead, fileLength,
                                 remotePath, e.getMessage());
-                        LOG.warn(lastErrMsg, e);
+                        if (Config.print_error_no_stacktrace) {
+                            LOG.warn(lastErrMsg);
+                        } else {
+                            LOG.warn(lastErrMsg, e);
+                        }
                         status = new Status(Status.ErrCode.COMMON_ERROR, lastErrMsg);
                         break;
                     }

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/S3FileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/S3FileSystem.java
@@ -19,6 +19,7 @@ package org.apache.doris.fs.remote;
 
 import org.apache.doris.analysis.StorageBackend;
 import org.apache.doris.backup.Status;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.property.PropertyConverter;
 import org.apache.doris.fs.obj.S3ObjStorage;
@@ -102,7 +103,12 @@ public class S3FileSystem extends ObjFileSystem {
                     }
                 }
             }
-            LOG.error("errors while get file status ", e);
+
+            if (Config.print_error_no_stacktrace) {
+                LOG.error("errors while get file status " + e.getMessage());
+            } else {
+                LOG.error("errors while get file status ", e);
+            }
             return new Status(Status.ErrCode.COMMON_ERROR, "errors while get file status " + e.getMessage());
         }
         return Status.OK;

--- a/fe/fe-core/src/main/java/org/apache/doris/fs/remote/dfs/DFSFileSystem.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/fs/remote/dfs/DFSFileSystem.java
@@ -21,6 +21,7 @@ import org.apache.doris.analysis.StorageBackend;
 import org.apache.doris.backup.Status;
 import org.apache.doris.catalog.AuthType;
 import org.apache.doris.catalog.HdfsResource;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.URI;
 import org.apache.doris.fs.operations.HDFSFileOperations;
@@ -115,7 +116,12 @@ public class DFSFileSystem extends RemoteFileSystem {
                     return ugi;
                 }
             } catch (IOException e) {
-                LOG.warn("A SecurityException occurs with kerberos, do login immediately.", e);
+
+                if (Config.print_error_no_stacktrace) {
+                    LOG.warn("A SecurityException occurs with kerberos, do login immediately." + e.getMessage());
+                } else {
+                    LOG.warn("A SecurityException occurs with kerberos, do login immediately.", e);
+                }
                 return doLogin(conf);
             }
         }
@@ -249,7 +255,11 @@ public class DFSFileSystem extends RemoteFileSystem {
             try {
                 currentStreamOffset = fsDataInputStream.getPos();
             } catch (IOException e) {
-                LOG.error("errors while get file pos from output stream", e);
+                if (Config.print_error_no_stacktrace) {
+                    LOG.error("errors while get file pos from output stream" + e.getMessage());
+                } else {
+                    LOG.error("errors while get file pos from output stream", e);
+                }
                 throw new IOException("errors while get file pos from output stream", e);
             }
             if (currentStreamOffset != readOffset) {
@@ -285,7 +295,11 @@ public class DFSFileSystem extends RemoteFileSystem {
                 }
                 return ByteBuffer.wrap(buf, 0, readLength);
             } catch (IOException e) {
-                LOG.error("errors while read data from stream", e);
+                if (Config.print_error_no_stacktrace) {
+                    LOG.error("errors while read data from stream" + e.getMessage());
+                } else {
+                    LOG.error("errors while read data from stream", e);
+                }
                 throw new IOException("errors while read data from stream " + e.getMessage());
             }
         }
@@ -316,7 +330,11 @@ public class DFSFileSystem extends RemoteFileSystem {
             }
             return Status.OK;
         } catch (Exception e) {
-            LOG.error("errors while check path exist " + remotePath, e);
+            if (Config.print_error_no_stacktrace) {
+                LOG.error("errors while check path exist " + remotePath + ", " + e.getMessage());
+            } else {
+                LOG.error("errors while check path exist " + remotePath, e);
+            }
             return new Status(Status.ErrCode.COMMON_ERROR,
                     "failed to check remote path exist: " + remotePath + ". msg: " + e.getMessage());
         }
@@ -336,7 +354,11 @@ public class DFSFileSystem extends RemoteFileSystem {
         try {
             fsDataOutputStream.writeBytes(content);
         } catch (IOException e) {
-            LOG.error("errors while write data to output stream", e);
+            if (Config.print_error_no_stacktrace) {
+                LOG.error("errors while write data to output stream " + e.getMessage());
+            } else {
+                LOG.error("errors while write data to output stream", e);
+            }
             status = new Status(Status.ErrCode.COMMON_ERROR, "write exception: " + e.getMessage());
         } finally {
             Status closeStatus = operations.closeWriter(OpParams.of(fsDataOutputStream));
@@ -377,7 +399,11 @@ public class DFSFileSystem extends RemoteFileSystem {
                 try {
                     fsDataOutputStream.write(readBuf, 0, bytesRead);
                 } catch (IOException e) {
-                    LOG.error("errors while write data to output stream", e);
+                    if (Config.print_error_no_stacktrace) {
+                        LOG.error("errors while write data to output stream " + e.getMessage());
+                    } else {
+                        LOG.error("errors while write data to output stream", e);
+                    }
                     lastErrMsg = String.format(
                             "failed to write hdfs. current write offset: %d, write length: %d, "
                                     + "file length: %d, file: %s, msg: errors while write data to output stream",
@@ -486,7 +512,11 @@ public class DFSFileSystem extends RemoteFileSystem {
             LOG.info("file not found: " + e.getMessage());
             return new Status(Status.ErrCode.NOT_FOUND, "file not found: " + e.getMessage());
         } catch (Exception e) {
-            LOG.error("errors while get file status ", e);
+            if (Config.print_error_no_stacktrace) {
+                LOG.error("errors while get file status " + e.getMessage());
+            } else {
+                LOG.error("errors while get file status ", e);
+            }
             return new Status(Status.ErrCode.COMMON_ERROR, "errors while get file status " + e.getMessage());
         }
         LOG.info("finish list path {}", remotePath);


### PR DESCRIPTION


## Proposed changes

Issue Number: close #xxx

in some cases, for example, repo use aws_token and token is expired. if RepositoryMgr exec repo ping, will get a lot of stacktrace info in fe.log. 

add a fe config print_error_no_stacktrace, user can print error no stacktrace, only exception message.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

