### PR TITLE
[Fix](exec) Add `++_get_waiting` in `BlockingPriorityQueue` USE_BTHREAD_SCANNER is defined.

### DIFF
--- a/be/src/util/blocking_priority_queue.hpp
+++ b/be/src/util/blocking_priority_queue.hpp
@@ -87,6 +87,7 @@ public:
             }
         } else {
             while (!(_shutdown || !_queue.empty())) {
+                ++_get_waiting;
                 _get_cv.wait(unique_lock);
             }
             wait_successful = true;


### PR DESCRIPTION
## Proposed changes

[Fix](exec) Add `++_get_waiting` in `BlockingPriorityQueue` USE_BTHREAD_SCANNER is defined.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

