### PR TITLE
[cleanup](move-memtable) cleanup unused fields in rowset writer v2

### DIFF
--- a/be/src/olap/rowset/beta_rowset_writer_v2.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer_v2.cpp
@@ -58,12 +58,7 @@ namespace doris {
 using namespace ErrorCode;
 
 BetaRowsetWriterV2::BetaRowsetWriterV2(const std::vector<std::shared_ptr<LoadStreamStub>>& streams)
-        : _next_segment_id(0),
-          _num_segment(0),
-          _num_rows_written(0),
-          _total_data_size(0),
-          _total_index_size(0),
-          _streams(streams) {}
+        : _streams(streams) {}
 
 BetaRowsetWriterV2::~BetaRowsetWriterV2() = default;
 

--- a/be/src/olap/rowset/beta_rowset_writer_v2.h
+++ b/be/src/olap/rowset/beta_rowset_writer_v2.h
@@ -124,7 +124,7 @@ public:
 
     Status add_segment(uint32_t segment_id, const SegmentStatistics& segstat) override;
 
-    int32_t allocate_segment_id() override { return _next_segment_id.fetch_add(1); };
+    int32_t allocate_segment_id() override { return _segment_creator.allocate_segment_id(); };
 
     bool is_doing_segcompaction() const override { return false; }
 
@@ -145,12 +145,6 @@ public:
 private:
     RowsetWriterContext _context;
 
-    std::atomic<int32_t> _next_segment_id; // the next available segment_id (offset),
-                                           // also the numer of allocated segments
-    std::atomic<int32_t> _num_segment;     // number of consecutive flushed segments
-    roaring::Roaring _segment_set;         // bitmap set to record flushed segment id
-    std::mutex _segment_set_mutex;         // mutex for _segment_set
-
     mutable SpinLock _lock; // protect following vectors.
     // record rows number of every segment already written, using for rowid
     // conversion when compaction in unique key with MoW model
@@ -159,10 +153,6 @@ private:
     // for unique key table with merge-on-write
     std::vector<KeyBoundsPB> _segments_encoded_key_bounds;
 
-    // counters and statistics maintained during add_rowset
-    std::atomic<int64_t> _num_rows_written;
-    std::atomic<int64_t> _total_data_size;
-    std::atomic<int64_t> _total_index_size;
     // TODO rowset Zonemap
 
     SegmentCreator _segment_creator;


### PR DESCRIPTION
## Proposed changes

cleanup unused fields in rowset writer v2

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

