### PR TITLE
[enhancement](backup) add property for backup to ignore table error

### DIFF
--- a/docs/en/docs/sql-manual/sql-reference/Data-Definition-Statements/Backup-and-Restore/BACKUP.md
+++ b/docs/en/docs/sql-manual/sql-reference/Data-Definition-Statements/Backup-and-Restore/BACKUP.md
@@ -56,6 +56,7 @@ illustrate:
 - PROPERTIES currently supports the following properties:
   - "type" = "full": indicates that this is a full update (default)
   - "timeout" = "3600": The task timeout period, the default is one day. in seconds.
+  - "backup_tables_error_ignore_ratio" = "0.1": When the backup table is wrong, the ratio ignored by default is 0.0, that is, the error is not ignored. Users can configure the ratio to be ignored as needed, for example, 0.1 means to ignore 10% of the error tables.
 
 ### Example
 
@@ -86,6 +87,23 @@ ON
 BACKUP SNAPSHOT example_db.snapshot_label3
 TO example_repo
 EXCLUDE (example_tbl);
+```
+
+4. Full backup of some tables under example_db, and ignore 10% of the error tables:
+
+```sql
+BACKUP SNAPSHOT example_db.snapshot_label1
+TO example_repo
+ON 
+(
+    example_tbl1, example_tbl2, example_tbl3, example_tbl4, example_tbl5, 
+    example_tbl6, example_tbl7, example_tbl8, example_tbl9, example_tbl10
+)
+PROPERTIES 
+(
+    "type" = "full", 
+    "backup_tables_error_ignore_ratio" = "0.1"
+);
 ```
 
 ### Keywords

--- a/docs/en/docs/sql-manual/sql-reference/Show-Statements/SHOW-BACKUP.md
+++ b/docs/en/docs/sql-manual/sql-reference/Show-Statements/SHOW-BACKUP.md
@@ -56,7 +56,10 @@ illustrate:
                 UPLOAD_INFO: Upload job meta information
                 FINISHED: The job was successful
                 CANCELLED: Job failed
+                PARTIAL_FINISHED: Partial tables of job succeeded
             BackupObjs: Backed up tables and partitions
+            BackupTablesErrorIgnoreRatio: The ratio of error tables ignored by the backup task
+            BackupTablesError: Error tables encountered by the backup task
             CreateTime: task submission time
             SnapshotFinishedTime: Snapshot completion time
             UploadFinishedTime: Snapshot upload completion time

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Data-Definition-Statements/Backup-and-Restore/BACKUP.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Data-Definition-Statements/Backup-and-Restore/BACKUP.md
@@ -58,6 +58,7 @@ PROPERTIES ("key"="value", ...);
 - PROPERTIES 目前支持以下属性：
   -  "type" = "full"：表示这是一次全量更新（默认）
   - "timeout" = "3600"：任务超时时间，默认为一天。单位秒。          
+  - "backup_tables_error_ignore_ratio" = "0.1"：备份表出错时，忽略的比例，默认为0.0，即不忽略错误。用户可以根据需要配置忽略的比例，例如0.1表示忽略10%的错误表。
 
 ### Example
 
@@ -88,6 +89,23 @@ ON
 BACKUP SNAPSHOT example_db.snapshot_label3
 TO example_repo
 EXCLUDE (example_tbl);
+```
+
+4. 全量备份 example_db 下的若干表，忽略10%的错误表：
+
+```sql
+BACKUP SNAPSHOT example_db.snapshot_label1
+TO example_repo
+ON 
+(
+    example_tbl1, example_tbl2, example_tbl3, example_tbl4, example_tbl5, 
+    example_tbl6, example_tbl7, example_tbl8, example_tbl9, example_tbl10
+)
+PROPERTIES 
+(
+    "type" = "full", 
+    "backup_tables_error_ignore_ratio" = "0.1"
+);
 ```
 
 ### Keywords

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Show-Statements/SHOW-BACKUP.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Show-Statements/SHOW-BACKUP.md
@@ -44,26 +44,29 @@ SHOW BACKUP
 
         1. Doris 中仅保存最近一次 BACKUP 任务。
         2. 各列含义如下：
-            JobId：                  唯一作业id
-            SnapshotName：           备份的名称
-            DbName：                 所属数据库
-            State：                  当前阶段
-                PENDING：        提交作业后的初始状态
-                SNAPSHOTING：    执行快照中
-                UPLOAD_SNAPSHOT：快照完成，准备上传
-                UPLOADING：      快照上传中
-                SAVE_META：      将作业元信息保存为本地文件
-                UPLOAD_INFO：    上传作业元信息
-                FINISHED：       作业成功
-                CANCELLED：      作业失败
-            BackupObjs：             备份的表和分区
-            CreateTime：             任务提交时间
-            SnapshotFinishedTime：   快照完成时间
-            UploadFinishedTime：     快照上传完成时间
-            FinishedTime：           作业结束时间
-            UnfinishedTasks：        在 SNAPSHOTING 和 UPLOADING 阶段会显示还未完成的子任务id
-            Status：                 如果作业失败，显示失败信息
-            Timeout：                作业超时时间，单位秒
+            JobId：                     唯一作业id
+            SnapshotName：              备份的名称
+            DbName：                    所属数据库
+            State：                     当前阶段
+                PENDING：               提交作业后的初始状态
+                SNAPSHOTING：           执行快照中
+                UPLOAD_SNAPSHOT：       快照完成，准备上传
+                UPLOADING：             快照上传中
+                SAVE_META：             将作业元信息保存为本地文件
+                UPLOAD_INFO：           上传作业元信息
+                FINISHED：              作业成功
+                CANCELLED：             作业失败
+                PARTIAL_FINISHED：      部分表作业成功
+            BackupObjs：                备份的表和分区
+            BackupTablesErrorIgnoreRatio：  备份任务配置的忽略的错误表比例
+            BackupTablesError：         备份任务遇到的错误表
+            CreateTime：                任务提交时间
+            SnapshotFinishedTime：      快照完成时间
+            UploadFinishedTime：        快照上传完成时间
+            FinishedTime：              作业结束时间
+            UnfinishedTasks：           在 SNAPSHOTING 和 UPLOADING 阶段会显示还未完成的子任务id
+            Status：                    如果作业失败，显示失败信息
+            Timeout：                   作业超时时间，单位秒
 
 ### Example
 

--- a/fe/fe-common/src/main/java/org/apache/doris/common/FeMetaVersion.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/FeMetaVersion.java
@@ -72,9 +72,11 @@ public final class FeMetaVersion {
     public static final int VERSION_125 = 125;
     // For write/read function nullable mode info
     public static final int VERSION_126 = 126;
+    // For backup ignore error tables
+    public static final int VERSION_127 = 127;
 
     // note: when increment meta version, should assign the latest version to VERSION_CURRENT
-    public static final int VERSION_CURRENT = VERSION_126;
+    public static final int VERSION_CURRENT = VERSION_127;
 
     // all logs meta version should >= the minimum version, so that we could remove many if clause, for example
     // if (FE_METAVERSION < VERSION_94) ...

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BackupStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BackupStmt.java
@@ -30,6 +30,7 @@ import java.util.Map;
 public class BackupStmt extends AbstractBackupStmt {
     private static final String PROP_TYPE = "type";
     public static final String PROP_CONTENT = "content";
+    public static final String PROP_BACKUP_TABLES_ERROR_IGNORE_RATIO = "backup_tables_error_ignore_ratio";
 
     public enum BackupType {
         INCREMENTAL, FULL
@@ -42,6 +43,7 @@ public class BackupStmt extends AbstractBackupStmt {
     private BackupType type = BackupType.FULL;
     private BackupContent content = BackupContent.ALL;
 
+    private double backupTablesErrorIgnoreRatio = 0.0;
 
     public BackupStmt(LabelName labelName, String repoName, AbstractBackupTableRefClause abstractBackupTableRefClause,
                       Map<String, String> properties) {
@@ -58,6 +60,10 @@ public class BackupStmt extends AbstractBackupStmt {
 
     public BackupContent getContent() {
         return content;
+    }
+
+    public double getBackupTablesErrorIgnoreRatio() {
+        return backupTablesErrorIgnoreRatio;
     }
 
     @Override
@@ -101,6 +107,22 @@ public class BackupStmt extends AbstractBackupStmt {
                         "Invalid backup job content:" + contentProp);
             }
             copiedProperties.remove(PROP_CONTENT);
+        }
+        // backup_tables_error_ignore_ratio
+        if (copiedProperties.containsKey(PROP_BACKUP_TABLES_ERROR_IGNORE_RATIO)) {
+            try {
+                backupTablesErrorIgnoreRatio =
+                                Double.parseDouble(copiedProperties.get(PROP_BACKUP_TABLES_ERROR_IGNORE_RATIO));
+                if (backupTablesErrorIgnoreRatio < 0.0 || backupTablesErrorIgnoreRatio >= 1.0) {
+                    ErrorReport.reportAnalysisException(ErrorCode.ERR_COMMON_ERROR,
+                            "Invalid backup_tables_error_ignore_ratio: " + backupTablesErrorIgnoreRatio);
+                }
+            } catch (IllegalArgumentException e) {
+                ErrorReport.reportAnalysisException(ErrorCode.ERR_COMMON_ERROR,
+                        "Invalid backup_tables_error_ignore_ratio: "
+                        + copiedProperties.get(PROP_BACKUP_TABLES_ERROR_IGNORE_RATIO));
+            }
+            copiedProperties.remove(PROP_BACKUP_TABLES_ERROR_IGNORE_RATIO);
         }
 
         if (!copiedProperties.isEmpty()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowBackupStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowBackupStmt.java
@@ -39,7 +39,8 @@ import java.util.function.Predicate;
 
 public class ShowBackupStmt extends ShowStmt {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
-            .add("JobId").add("SnapshotName").add("DbName").add("State").add("BackupObjs").add("CreateTime")
+            .add("JobId").add("SnapshotName").add("DbName").add("State").add("BackupObjs")
+            .add("BackupTablesErrorIgnoreRatio").add("BackupObjectsErrorIgnore").add("CreateTime")
             .add("SnapshotFinishedTime").add("UploadFinishedTime").add("FinishedTime").add("UnfinishedTasks")
             .add("Progress").add("TaskErrMsg").add("Status").add("Timeout")
             .build();

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowBackupStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowBackupStmt.java
@@ -40,7 +40,7 @@ import java.util.function.Predicate;
 public class ShowBackupStmt extends ShowStmt {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("JobId").add("SnapshotName").add("DbName").add("State").add("BackupObjs")
-            .add("BackupTablesErrorIgnoreRatio").add("BackupObjectsErrorIgnore").add("CreateTime")
+            .add("BackupTablesErrorIgnoreRatio").add("BackupTablesError").add("CreateTime")
             .add("SnapshotFinishedTime").add("UploadFinishedTime").add("FinishedTime").add("UnfinishedTasks")
             .add("Progress").add("TaskErrMsg").add("Status").add("Timeout")
             .build();

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/AbstractJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/AbstractJob.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.backup;
 
+import org.apache.doris.backup.Status.ErrCode;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.io.Text;
@@ -203,6 +204,8 @@ public abstract class AbstractJob implements Writable {
         } else {
             out.writeBoolean(false);
         }
+        Text.writeString(out, status.getErrCode().name());
+        Text.writeString(out, status.getErrMsg());
     }
 
     public void readFields(DataInput in) throws IOException {
@@ -228,6 +231,11 @@ public abstract class AbstractJob implements Writable {
                 String msg = Text.readString(in);
                 taskErrMsg.put(taskId, msg);
             }
+        }
+        if (Env.getCurrentEnvJournalVersion() >= org.apache.doris.common.FeMetaVersion.VERSION_127) {
+            ErrCode errCode = ErrCode.valueOf(Text.readString(in));
+            String errMsg = Text.readString(in);
+            status = new Status(errCode, errMsg);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -395,7 +395,8 @@ public class BackupHandler extends MasterDaemon implements Writable {
         // Create a backup job
         BackupJob backupJob = new BackupJob(stmt.getLabel(), db.getId(),
                 ClusterNamespace.getNameFromFullName(db.getFullName()),
-                tblRefs, stmt.getTimeoutMs(), stmt.getContent(), env, repoId);
+                tblRefs, stmt.getTimeoutMs(), stmt.getContent(), env, repoId,
+                stmt.getBackupTablesErrorIgnoreRatio());
         // write log
         env.getEditLog().logBackupJob(backupJob);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -371,7 +371,7 @@ public class BackupJob extends AbstractJob {
     private boolean isTooManyBackupTablesErrorIgnoreToCancel() {
         return BigDecimal.valueOf(backupTablesErrorIgnoreRatio).compareTo(BigDecimal.valueOf(0.0)) != 0
                 && backupTablesErrorIgnore.size()
-                            >= tableRefs.size() * backupTablesErrorIgnoreRatio;
+                            > tableRefs.size() * backupTablesErrorIgnoreRatio;
     }
 
     private boolean isStrictBackup() {

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -164,6 +164,10 @@ public class BackupJob extends AbstractJob {
         return BackupContent.ALL;
     }
 
+    public Map<String, String> getBackupTablesErrorIgnore() {
+        return backupTablesErrorIgnore;
+    }
+
     public synchronized boolean finishTabletSnapshotTask(SnapshotTask task, TFinishTaskRequest request) {
         Preconditions.checkState(task.getJobId() == jobId);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJobInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJobInfo.java
@@ -84,6 +84,9 @@ public class BackupJobInfo implements Writable {
     // only include olap table
     @SerializedName("backup_objects")
     public Map<String, BackupOlapTableInfo> backupOlapTableObjects = Maps.newHashMap();
+    // only include olap table
+    @SerializedName("backup_tables_error_ignore")
+    public List<String> backupTablesErrorIgnore = new java.util.ArrayList<>();
     // include other objects: view, external table
     @SerializedName("new_backup_objects")
     public NewBackupObjects newBackupObjects = new NewBackupObjects();
@@ -585,7 +588,8 @@ public class BackupJobInfo implements Writable {
 
     public static BackupJobInfo fromCatalog(long backupTime, String label, String dbName, long dbId,
                                             BackupContent content, BackupMeta backupMeta,
-                                            Map<Long, SnapshotInfo> snapshotInfos, Map<Long, Long> tableCommitSeqMap) {
+                                            Map<Long, SnapshotInfo> snapshotInfos, Map<Long, Long> tableCommitSeqMap,
+                                            Set<String> backupTablesErrorIgnore) {
 
         BackupJobInfo jobInfo = new BackupJobInfo();
         jobInfo.backupTime = backupTime;
@@ -598,6 +602,7 @@ public class BackupJobInfo implements Writable {
         jobInfo.majorVersion = Version.DORIS_BUILD_VERSION_MAJOR;
         jobInfo.minorVersion = Version.DORIS_BUILD_VERSION_MINOR;
         jobInfo.patchVersion = Version.DORIS_BUILD_VERSION_PATCH;
+        jobInfo.backupTablesErrorIgnore.addAll(backupTablesErrorIgnore);
 
         Collection<Table> tbls = backupMeta.getTables().values();
         // tbls

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupHandlerTest.java
@@ -228,7 +228,7 @@ public class BackupHandlerTest {
                 BackupJobInfo info = BackupJobInfo.fromCatalog(System.currentTimeMillis(),
                         "ss2", CatalogMocker.TEST_DB_NAME,
                         CatalogMocker.TEST_DB_ID, BackupStmt.BackupContent.ALL,
-                        backupMeta, snapshotInfos, null);
+                        backupMeta, snapshotInfos, null, new java.util.HashSet<>());
                 infos.add(info);
                 return Status.OK;
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
@@ -212,7 +212,7 @@ public class BackupJobTest {
                 new TableName(InternalCatalog.INTERNAL_CATALOG_NAME, UnitTestUtil.DB_NAME, UnitTestUtil.TABLE_NAME),
                 null));
         job = new BackupJob("label", dbId, UnitTestUtil.DB_NAME, tableRefs, 13600 * 1000, BackupStmt.BackupContent.ALL,
-                env, repo.getId());
+                env, repo.getId(), 0.0);
     }
 
     @Test
@@ -348,7 +348,7 @@ public class BackupJobTest {
                 new TableRef(new TableName(InternalCatalog.INTERNAL_CATALOG_NAME, UnitTestUtil.DB_NAME, "unknown_tbl"),
                         null));
         job = new BackupJob("label", dbId, UnitTestUtil.DB_NAME, tableRefs, 13600 * 1000, BackupStmt.BackupContent.ALL,
-                env, repo.getId());
+                env, repo.getId(), 0.0);
         job.run();
         Assert.assertEquals(Status.ErrCode.NOT_FOUND, job.getStatus().getErrCode());
         Assert.assertEquals(BackupJobState.CANCELLED, job.getState());


### PR DESCRIPTION


## Proposed changes

Issue Number: close #xxx

in some case, user want backup data periodically, but sometimes only a little few table has error and make whole backup job error and cancel. when user know job cancel, and need retry backup all tables. 
add a property for backup to ignore some tables error, and make job can continue backup other tables.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

