### PR TITLE
[fix](nereids)count in correlated subquery shoud not output null value

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FunctionBinder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FunctionBinder.java
@@ -44,7 +44,10 @@ import org.apache.doris.nereids.trees.expressions.TimestampArithmetic;
 import org.apache.doris.nereids.trees.expressions.WhenClause;
 import org.apache.doris.nereids.trees.expressions.functions.BoundFunction;
 import org.apache.doris.nereids.trees.expressions.functions.FunctionBuilder;
+import org.apache.doris.nereids.trees.expressions.functions.agg.Count;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.Nvl;
 import org.apache.doris.nereids.trees.expressions.functions.udf.AliasUdfBuilder;
+import org.apache.doris.nereids.trees.expressions.literal.BigIntLiteral;
 import org.apache.doris.nereids.trees.expressions.typecoercion.ImplicitCastInputTypes;
 import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.types.BooleanType;
@@ -114,7 +117,21 @@ public class FunctionBinder extends AbstractExpressionRewriteRule {
             // we do type coercion in build function in alias function, so it's ok to return directly.
             return builder.build(functionName, arguments);
         } else {
-            return TypeCoercionUtils.processBoundFunction((BoundFunction) builder.build(functionName, arguments));
+            Expression boundFunction = TypeCoercionUtils
+                    .processBoundFunction((BoundFunction) builder.build(functionName, arguments));
+            if (boundFunction instanceof Count
+                    && context.cascadesContext.getOuterScope().isPresent()
+                    && !context.cascadesContext.getOuterScope().get().getCorrelatedSlots()
+                            .isEmpty()) {
+                // consider sql: SELECT * FROM t1 WHERE t1.a <= (SELECT COUNT(t2.a) FROM t2 WHERE (t1.b = t2.b)); 
+                // when unnest correlated subquery, we create a left join node.
+                // outer query is left table and subquery is right one
+                // if there is no match, the row from right table is filled with nulls
+                // but COUNT function is always not nullable.
+                // so wrap COUNT with Nvl to ensure it's result is 0 instead of null to get the correct result
+                boundFunction = new Nvl(boundFunction, new BigIntLiteral(0));
+            }
+            return boundFunction;
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FunctionBinder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FunctionBinder.java
@@ -123,7 +123,7 @@ public class FunctionBinder extends AbstractExpressionRewriteRule {
                     && context.cascadesContext.getOuterScope().isPresent()
                     && !context.cascadesContext.getOuterScope().get().getCorrelatedSlots()
                             .isEmpty()) {
-                // consider sql: SELECT * FROM t1 WHERE t1.a <= (SELECT COUNT(t2.a) FROM t2 WHERE (t1.b = t2.b)); 
+                // consider sql: SELECT * FROM t1 WHERE t1.a <= (SELECT COUNT(t2.a) FROM t2 WHERE (t1.b = t2.b));
                 // when unnest correlated subquery, we create a left join node.
                 // outer query is left table and subquery is right one
                 // if there is no match, the row from right table is filled with nulls


### PR DESCRIPTION
pick from master https://github.com/apache/doris/pull/27064

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

