### PR TITLE
[Chore](clang-tidy)enable readability-function-size.LineThreshold and readability-functi…

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,7 +14,6 @@ Checks: |
   readability-*,
   -readability-identifier-length,
   -readability-implicit-bool-conversion,
-  -readability-function-cognitive-complexity,
   -readability-magic-numbers,
   -readability-else-after-return,
   -readability-inconsistent-declaration-parameter-name,
@@ -26,3 +25,8 @@ Checks: |
   performance-inefficient-algorithm,
   performance-move-const-arg
 WarningsAsErrors: '*'
+CheckOptions:
+  - key:             readability-function-size.LineThreshold
+    value:           '80'
+  - key:             readability-function-cognitive-complexity.Threshold
+    value:           '50'


### PR DESCRIPTION
…on-cognitive-complexity.Threshold limit

## Proposed changes

set readability-function-size.LineThreshold to 80 and enable readability-function-cognitive-complexity

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

