### PR TITLE
[fix](broker) not print broker request detail default

### DIFF
--- a/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/HDFSBrokerServiceImpl.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/HDFSBrokerServiceImpl.java
@@ -69,13 +69,13 @@ public class HDFSBrokerServiceImpl implements TPaloBrokerService.Iface {
     @Override
     public TBrokerListResponse listPath(TBrokerListPathRequest request)
             throws TException {
-        logger.debug("received a list path request, request detail: " + request);
         TBrokerListResponse response = new TBrokerListResponse();
         try {
             boolean fileNameOnly = false;
             if (request.isSetFileNameOnly()) {
                 fileNameOnly = request.isFileNameOnly();
             }
+            logger.info("received a list path request, request path: " + request.path + ", fileNameOnly: " + fileNameOnly);
             List<TBrokerFileStatus> fileStatuses = fileSystemManager.listPath(request.path, fileNameOnly,
                     request.properties);
             response.setOpStatus(generateOKStatus());
@@ -92,7 +92,6 @@ public class HDFSBrokerServiceImpl implements TPaloBrokerService.Iface {
     @Override
     public TBrokerListResponse listLocatedFiles(TBrokerListPathRequest request)
             throws TException {
-        logger.debug("received a listLocatedFiles request, request detail: " + request);
         TBrokerListResponse response = new TBrokerListResponse();
         try {
             boolean recursive = request.isIsRecursive();
@@ -100,6 +99,8 @@ public class HDFSBrokerServiceImpl implements TPaloBrokerService.Iface {
             if (request.isSetOnlyFiles()) {
                 onlyFiles = request.isOnlyFiles();
             }
+            logger.info("received a listLocatedFiles request, request path: "
+                                + request.path + ", onlyFiles: " + onlyFiles + ", recursive: " + recursive);
             List<TBrokerFileStatus> fileStatuses = fileSystemManager.listLocatedFiles(request.path,
                 onlyFiles, recursive, request.properties);
             response.setOpStatus(generateOKStatus());
@@ -115,7 +116,8 @@ public class HDFSBrokerServiceImpl implements TPaloBrokerService.Iface {
 
     @Override
     public TBrokerIsSplittableResponse isSplittable(TBrokerIsSplittableRequest request) throws TException {
-        logger.debug("received a isSplittable request, request detail: " + request);
+        logger.info("received a isSplittable request, request path: "
+                            + request.path + ", inputFormat: " +request.inputFormat);
         TBrokerIsSplittableResponse response = new TBrokerIsSplittableResponse();
         try {
             boolean isSplittable = HiveUtils.isSplittable(request.path, request.inputFormat, request.properties);
@@ -133,7 +135,7 @@ public class HDFSBrokerServiceImpl implements TPaloBrokerService.Iface {
     @Override
     public TBrokerOperationStatus deletePath(TBrokerDeletePathRequest request)
             throws TException {
-        logger.debug("receive a delete path request, request detail: " + request);
+        logger.info("receive a delete path request, request path: " + request.path);
         try {
             fileSystemManager.deletePath(request.path, request.properties);
         } catch (BrokerException e) {
@@ -147,7 +149,8 @@ public class HDFSBrokerServiceImpl implements TPaloBrokerService.Iface {
     @Override
     public TBrokerOperationStatus renamePath(TBrokerRenamePathRequest request)
             throws TException {
-        logger.debug("receive a rename path request, request detail: " + request);
+        logger.info("receive a rename path request, request srcPath: "
+                            + request.srcPath + ", destPath: " + request.destPath);
         try {
             fileSystemManager.renamePath(request.srcPath, request.destPath, request.properties);
         } catch (BrokerException e) {
@@ -161,7 +164,7 @@ public class HDFSBrokerServiceImpl implements TPaloBrokerService.Iface {
     @Override
     public TBrokerCheckPathExistResponse checkPathExist(
             TBrokerCheckPathExistRequest request) throws TException {
-        logger.debug("receive a check path request, request detail: " + request);
+        logger.info("receive a check path request, request path: " + request.path);
         TBrokerCheckPathExistResponse response = new TBrokerCheckPathExistResponse();
         try {
             boolean isPathExist = fileSystemManager.checkPathExist(request.path, request.properties);
@@ -178,7 +181,8 @@ public class HDFSBrokerServiceImpl implements TPaloBrokerService.Iface {
     @Override
     public TBrokerOpenReaderResponse openReader(TBrokerOpenReaderRequest request)
             throws TException {
-        logger.debug("receive a open reader request, request detail: " + request);
+        logger.info("receive a open reader request, request client id: "
+                            + request.clientId + ", path: " + request.path + ", startOffset: " +request.startOffset);
         TBrokerOpenReaderResponse response = new TBrokerOpenReaderResponse();
         try {
             TBrokerFD fd = fileSystemManager.openReader(request.clientId, request.path,
@@ -196,7 +200,7 @@ public class HDFSBrokerServiceImpl implements TPaloBrokerService.Iface {
     @Override
     public TBrokerReadResponse pread(TBrokerPReadRequest request)
             throws TException {
-        logger.debug("receive a read request, request detail: " + request);
+        logger.info("receive a read request, request detail: " + request);
         Stopwatch stopwatch = BrokerPerfMonitor.startWatch();
         TBrokerReadResponse response = new TBrokerReadResponse();
         try {
@@ -220,7 +224,7 @@ public class HDFSBrokerServiceImpl implements TPaloBrokerService.Iface {
     @Override
     public TBrokerOperationStatus seek(TBrokerSeekRequest request)
             throws TException {
-        logger.debug("receive a seek request, request detail: " + request);
+        logger.info("receive a seek request, request detail: " + request);
         try {
             fileSystemManager.seek(request.fd, request.offset);
         } catch (BrokerException e) {
@@ -234,7 +238,7 @@ public class HDFSBrokerServiceImpl implements TPaloBrokerService.Iface {
     @Override
     public TBrokerOperationStatus closeReader(TBrokerCloseReaderRequest request)
             throws TException {
-        logger.debug("receive a close reader request, request detail: " + request);
+        logger.info("receive a close reader request, request detail: " + request);
         try {
             fileSystemManager.closeReader(request.fd);
         } catch (BrokerException e) {
@@ -248,7 +252,8 @@ public class HDFSBrokerServiceImpl implements TPaloBrokerService.Iface {
     @Override
     public TBrokerOpenWriterResponse openWriter(TBrokerOpenWriterRequest request)
             throws TException {
-        logger.debug("receive a open writer request, request detail: " + request);
+        logger.info("receive a open writer request, request client id: "
+                            + request.clientId + ", path: " +request.path);
         TBrokerOpenWriterResponse response = new TBrokerOpenWriterResponse();
         try {
             TBrokerFD fd = fileSystemManager.openWriter(request.clientId, request.path, request.properties);
@@ -265,7 +270,7 @@ public class HDFSBrokerServiceImpl implements TPaloBrokerService.Iface {
     @Override
     public TBrokerOperationStatus pwrite(TBrokerPWriteRequest request)
             throws TException {
-        logger.debug("receive a pwrite request, request detail: " + request);
+        logger.info("receive a pwrite request, request detail: " + request);
         Stopwatch stopwatch = BrokerPerfMonitor.startWatch();
         try {
             fileSystemManager.pwrite(request.fd, request.offset, request.getData());
@@ -285,7 +290,7 @@ public class HDFSBrokerServiceImpl implements TPaloBrokerService.Iface {
     @Override
     public TBrokerOperationStatus closeWriter(TBrokerCloseWriterRequest request)
             throws TException {
-        logger.debug("receive a close writer request, request detail: " + request);
+        logger.info("receive a close writer request, request detail: " + request);
         try {
             fileSystemManager.closeWriter(request.fd);
         } catch (BrokerException e) {
@@ -299,7 +304,7 @@ public class HDFSBrokerServiceImpl implements TPaloBrokerService.Iface {
     @Override
     public TBrokerOperationStatus ping(TBrokerPingBrokerRequest request)
             throws TException {
-        logger.debug("receive a ping request, request detail: " + request);
+        logger.info("receive a ping request, request detail: " + request);
         try {
             fileSystemManager.ping(request.clientId);
         } catch (BrokerException e) {
@@ -313,7 +318,7 @@ public class HDFSBrokerServiceImpl implements TPaloBrokerService.Iface {
     @Override
     public TBrokerFileSizeResponse fileSize(
             TBrokerFileSizeRequest request) throws TException {
-        logger.debug("receive a file size request, request detail: " + request);
+        logger.info("receive a file size request, request path: " + request.path);
         TBrokerFileSizeResponse response = new TBrokerFileSizeResponse();
         try {
             long fileSize = fileSystemManager.fileSize(request.path, request.properties);

--- a/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/HDFSBrokerServiceImpl.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/HDFSBrokerServiceImpl.java
@@ -69,7 +69,7 @@ public class HDFSBrokerServiceImpl implements TPaloBrokerService.Iface {
     @Override
     public TBrokerListResponse listPath(TBrokerListPathRequest request)
             throws TException {
-        logger.info("received a list path request, request detail: " + request);
+        logger.debug("received a list path request, request detail: " + request);
         TBrokerListResponse response = new TBrokerListResponse();
         try {
             boolean fileNameOnly = false;
@@ -92,7 +92,7 @@ public class HDFSBrokerServiceImpl implements TPaloBrokerService.Iface {
     @Override
     public TBrokerListResponse listLocatedFiles(TBrokerListPathRequest request)
             throws TException {
-        logger.info("received a listLocatedFiles request, request detail: " + request);
+        logger.debug("received a listLocatedFiles request, request detail: " + request);
         TBrokerListResponse response = new TBrokerListResponse();
         try {
             boolean recursive = request.isIsRecursive();
@@ -115,7 +115,7 @@ public class HDFSBrokerServiceImpl implements TPaloBrokerService.Iface {
 
     @Override
     public TBrokerIsSplittableResponse isSplittable(TBrokerIsSplittableRequest request) throws TException {
-        logger.info("received a isSplittable request, request detail: " + request);
+        logger.debug("received a isSplittable request, request detail: " + request);
         TBrokerIsSplittableResponse response = new TBrokerIsSplittableResponse();
         try {
             boolean isSplittable = HiveUtils.isSplittable(request.path, request.inputFormat, request.properties);
@@ -133,7 +133,7 @@ public class HDFSBrokerServiceImpl implements TPaloBrokerService.Iface {
     @Override
     public TBrokerOperationStatus deletePath(TBrokerDeletePathRequest request)
             throws TException {
-        logger.info("receive a delete path request, request detail: " + request);
+        logger.debug("receive a delete path request, request detail: " + request);
         try {
             fileSystemManager.deletePath(request.path, request.properties);
         } catch (BrokerException e) {
@@ -147,7 +147,7 @@ public class HDFSBrokerServiceImpl implements TPaloBrokerService.Iface {
     @Override
     public TBrokerOperationStatus renamePath(TBrokerRenamePathRequest request)
             throws TException {
-        logger.info("receive a rename path request, request detail: " + request);
+        logger.debug("receive a rename path request, request detail: " + request);
         try {
             fileSystemManager.renamePath(request.srcPath, request.destPath, request.properties);
         } catch (BrokerException e) {
@@ -161,7 +161,7 @@ public class HDFSBrokerServiceImpl implements TPaloBrokerService.Iface {
     @Override
     public TBrokerCheckPathExistResponse checkPathExist(
             TBrokerCheckPathExistRequest request) throws TException {
-        logger.info("receive a check path request, request detail: " + request);
+        logger.debug("receive a check path request, request detail: " + request);
         TBrokerCheckPathExistResponse response = new TBrokerCheckPathExistResponse();
         try {
             boolean isPathExist = fileSystemManager.checkPathExist(request.path, request.properties);
@@ -178,7 +178,7 @@ public class HDFSBrokerServiceImpl implements TPaloBrokerService.Iface {
     @Override
     public TBrokerOpenReaderResponse openReader(TBrokerOpenReaderRequest request)
             throws TException {
-        logger.info("receive a open reader request, request detail: " + request);
+        logger.debug("receive a open reader request, request detail: " + request);
         TBrokerOpenReaderResponse response = new TBrokerOpenReaderResponse();
         try {
             TBrokerFD fd = fileSystemManager.openReader(request.clientId, request.path,
@@ -234,7 +234,7 @@ public class HDFSBrokerServiceImpl implements TPaloBrokerService.Iface {
     @Override
     public TBrokerOperationStatus closeReader(TBrokerCloseReaderRequest request)
             throws TException {
-        logger.info("receive a close reader request, request detail: " + request);
+        logger.debug("receive a close reader request, request detail: " + request);
         try {
             fileSystemManager.closeReader(request.fd);
         } catch (BrokerException e) {
@@ -248,7 +248,7 @@ public class HDFSBrokerServiceImpl implements TPaloBrokerService.Iface {
     @Override
     public TBrokerOpenWriterResponse openWriter(TBrokerOpenWriterRequest request)
             throws TException {
-        logger.info("receive a open writer request, request detail: " + request);
+        logger.debug("receive a open writer request, request detail: " + request);
         TBrokerOpenWriterResponse response = new TBrokerOpenWriterResponse();
         try {
             TBrokerFD fd = fileSystemManager.openWriter(request.clientId, request.path, request.properties);
@@ -285,7 +285,7 @@ public class HDFSBrokerServiceImpl implements TPaloBrokerService.Iface {
     @Override
     public TBrokerOperationStatus closeWriter(TBrokerCloseWriterRequest request)
             throws TException {
-        logger.info("receive a close writer request, request detail: " + request);
+        logger.debug("receive a close writer request, request detail: " + request);
         try {
             fileSystemManager.closeWriter(request.fd);
         } catch (BrokerException e) {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

if broker detail contails ak/sk or some sensitive information, not print these info default in log 

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

