### PR TITLE
[fix](jni) avoid BE crash and NPE when close paimon reader

### DIFF
--- a/be/src/vec/exec/jni_connector.cpp
+++ b/be/src/vec/exec/jni_connector.cpp
@@ -206,7 +206,7 @@ Status JniConnector::close() {
         jthrowable exc = (env)->ExceptionOccurred();
         if (exc != nullptr) {
             LOG(WARNING) << "Failed to release jni resource: "
-                       << JniUtil::GetJniExceptionMsg(env).to_string();
+                         << JniUtil::GetJniExceptionMsg(env).to_string();
         }
     }
     return Status::OK();

--- a/be/src/vec/exec/jni_connector.cpp
+++ b/be/src/vec/exec/jni_connector.cpp
@@ -95,6 +95,7 @@ Status JniConnector::open(RuntimeState* state, RuntimeProfile* profile) {
     RETURN_IF_ERROR(_init_jni_scanner(env, batch_size));
     // Call org.apache.doris.common.jni.JniScanner#open
     env->CallVoidMethod(_jni_scanner_obj, _jni_scanner_open);
+    _scanner_opened = true;
     RETURN_ERROR_IF_EXC(env);
     return Status::OK();
 }
@@ -167,7 +168,7 @@ Status JniConnector::close() {
     if (!_closed) {
         JNIEnv* env = nullptr;
         RETURN_IF_ERROR(JniUtil::GetJNIEnv(&env));
-        if (_scanner_initialized) {
+        if (_scanner_opened) {
             // update scanner metrics
             for (const auto& metric : get_statistics(env)) {
                 std::vector<std::string> type_and_name = split(metric.first, ":");
@@ -204,7 +205,7 @@ Status JniConnector::close() {
         _closed = true;
         jthrowable exc = (env)->ExceptionOccurred();
         if (exc != nullptr) {
-            LOG(FATAL) << "Failed to release jni resource: "
+            LOG(WARNING) << "Failed to release jni resource: "
                        << JniUtil::GetJniExceptionMsg(env).to_string();
         }
     }
@@ -241,7 +242,6 @@ Status JniConnector::_init_jni_scanner(JNIEnv* env, int batch_size) {
     _jni_scanner_get_statistics =
             env->GetMethodID(_jni_scanner_cls, "getStatistics", "()Ljava/util/Map;");
     RETURN_IF_ERROR(JniUtil::LocalToGlobalRef(env, jni_scanner_obj, &_jni_scanner_obj));
-    _scanner_initialized = true;
     env->DeleteLocalRef(jni_scanner_obj);
     RETURN_ERROR_IF_EXC(env);
     return Status::OK();

--- a/be/src/vec/exec/jni_connector.h
+++ b/be/src/vec/exec/jni_connector.h
@@ -292,7 +292,7 @@ private:
     size_t _has_read = 0;
 
     bool _closed = false;
-    bool _scanner_initialized = false;
+    bool _scanner_opened = false;
     jclass _jni_scanner_cls;
     jobject _jni_scanner_obj;
     jmethodID _jni_scanner_open;

--- a/fe/be-java-extensions/paimon-scanner/src/main/java/org/apache/doris/paimon/PaimonJniScanner.java
+++ b/fe/be-java-extensions/paimon-scanner/src/main/java/org/apache/doris/paimon/PaimonJniScanner.java
@@ -124,7 +124,9 @@ public class PaimonJniScanner extends JniScanner {
 
     @Override
     public void close() throws IOException {
-        reader.close();
+        if (reader != null) {
+            reader.close();
+        }
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes

1. Do not use FATAL log when jni encounter error, to avoid crash.
2. Fix NPE when closing PaimonReader, the reader may not be assigned if PaimonReader open failed.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

