### PR TITLE
Revert "[feature](pipelineX) Use dependency instead of block queue in…

### DIFF
--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -42,7 +42,6 @@
 #include "exprs/hybrid_set.h"
 #include "exprs/minmax_predicate.h"
 #include "gutil/strings/substitute.h"
-#include "pipeline/pipeline_x/dependency.h"
 #include "runtime/define_primitive_type.h"
 #include "runtime/large_int_value.h"
 #include "runtime/primitive_type.h"
@@ -63,6 +62,7 @@
 #include "vec/exprs/vliteral.h"
 #include "vec/exprs/vruntimefilter_wrapper.h"
 #include "vec/runtime/shared_hash_table_controller.h"
+
 namespace doris {
 
 // PrimitiveType-> PColumnType
@@ -1235,11 +1235,6 @@ void IRuntimeFilter::signal() {
     DCHECK(is_consumer());
     if (_enable_pipeline_exec) {
         _rf_state_atomic.store(RuntimeFilterState::READY);
-        if (!_filter_timer.empty()) {
-            for (auto& timer : _filter_timer) {
-                timer->call_ready();
-            }
-        }
     } else {
         std::unique_lock lock(_inner_mutex);
         _rf_state = RuntimeFilterState::READY;
@@ -1258,10 +1253,6 @@ void IRuntimeFilter::signal() {
         _profile->add_info_string("BloomFilterSize",
                                   std::to_string(_wrapper->get_bloom_filter_size()));
     }
-}
-
-void IRuntimeFilter::set_filter_timer(std::shared_ptr<pipeline::RuntimeFilterTimer> timer) {
-    _filter_timer.push_back(timer);
 }
 
 BloomFilterFuncBase* IRuntimeFilter::get_bloomfilter() const {

--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -69,10 +69,6 @@ class VExprContext;
 struct SharedRuntimeFilterContext;
 } // namespace vectorized
 
-namespace pipeline {
-class RuntimeFilterTimer;
-} // namespace pipeline
-
 enum class RuntimeFilterType {
     UNKNOWN_FILTER = -1,
     IN_FILTER = 0,
@@ -409,8 +405,6 @@ public:
 
     int64_t registration_time() const { return registration_time_; }
 
-    void set_filter_timer(std::shared_ptr<pipeline::RuntimeFilterTimer>);
-
 protected:
     // serialize _wrapper to protobuf
     void to_protobuf(PInFilter* filter);
@@ -505,8 +499,6 @@ protected:
     // only effect on consumer
     std::unique_ptr<RuntimeProfile> _profile;
     bool _opt_remote_rf;
-
-    std::vector<std::shared_ptr<pipeline::RuntimeFilterTimer>> _filter_timer;
 };
 
 // avoid expose RuntimePredicateWrapper

--- a/be/src/pipeline/exec/multi_cast_data_stream_source.cpp
+++ b/be/src/pipeline/exec/multi_cast_data_stream_source.cpp
@@ -145,7 +145,8 @@ Status MultiCastDataStreamSourceLocalState::init(RuntimeState* state, LocalState
     }
     // init profile for runtime filter
     RuntimeFilterConsumer::_init_profile(profile());
-    init_runtime_filter_dependency(_filter_dependency.get());
+    _filter_dependency->set_filter_blocked_by_fn(
+            [this]() { return this->runtime_filters_are_ready_or_timeout(); });
     return Status::OK();
 }
 

--- a/be/src/pipeline/exec/multi_cast_data_stream_source.cpp
+++ b/be/src/pipeline/exec/multi_cast_data_stream_source.cpp
@@ -145,8 +145,7 @@ Status MultiCastDataStreamSourceLocalState::init(RuntimeState* state, LocalState
     }
     // init profile for runtime filter
     RuntimeFilterConsumer::_init_profile(profile());
-    _filter_dependency->set_filter_blocked_by_fn(
-            [this]() { return this->runtime_filters_are_ready_or_timeout(); });
+    _filter_dependency->set_filter_blocked_by_fn(this);
     return Status::OK();
 }
 

--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -128,6 +128,8 @@ Status ScanLocalState<Derived>::init(RuntimeState* state, LocalStateInfo& info) 
     _source_dependency->add_child(_open_dependency);
     _eos_dependency = EosDependency::create_shared(PipelineXLocalState<>::_parent->operator_id());
     _source_dependency->add_child(_eos_dependency);
+    _filter_dependency->set_filter_blocked_by_fn(
+            [this]() { return this->runtime_filters_are_ready_or_timeout(); });
     auto& p = _parent->cast<typename Derived::Parent>();
     set_scan_ranges(state, info.scan_ranges);
     _common_expr_ctxs_push_down.resize(p._common_expr_ctxs_push_down.size());
@@ -141,7 +143,6 @@ Status ScanLocalState<Derived>::init(RuntimeState* state, LocalStateInfo& info) 
     }
     // init profile for runtime filter
     RuntimeFilterConsumer::_init_profile(profile());
-    init_runtime_filter_dependency(_filter_dependency.get());
 
     // 1: running at not pipeline mode will init profile.
     // 2: the scan node should create scanner at pipeline mode will init profile.

--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -128,8 +128,7 @@ Status ScanLocalState<Derived>::init(RuntimeState* state, LocalStateInfo& info) 
     _source_dependency->add_child(_open_dependency);
     _eos_dependency = EosDependency::create_shared(PipelineXLocalState<>::_parent->operator_id());
     _source_dependency->add_child(_eos_dependency);
-    _filter_dependency->set_filter_blocked_by_fn(
-            [this]() { return this->runtime_filters_are_ready_or_timeout(); });
+    _filter_dependency->set_filter_blocked_by_fn(this);
     auto& p = _parent->cast<typename Derived::Parent>();
     set_scan_ranges(state, info.scan_ranges);
     _common_expr_ctxs_push_down.resize(p._common_expr_ctxs_push_down.size());

--- a/be/src/pipeline/pipeline_x/dependency.cpp
+++ b/be/src/pipeline/pipeline_x/dependency.cpp
@@ -18,6 +18,7 @@
 #include "dependency.h"
 
 #include "runtime/memory/mem_tracker.h"
+#include "vec/exec/runtime_filter_consumer.h"
 
 namespace doris::pipeline {
 
@@ -324,6 +325,16 @@ Status HashJoinDependency::extract_join_column(vectorized::Block& block,
         }
     }
     return Status::OK();
+}
+
+FilterDependency* FilterDependency::filter_blocked_by() {
+    if (!_runtimeFilterConsumer) {
+        return nullptr;
+    }
+    if (!_runtimeFilterConsumer->runtime_filters_are_ready_or_timeout()) {
+        return this;
+    }
+    return nullptr;
 }
 
 } // namespace doris::pipeline

--- a/be/src/pipeline/pipeline_x/dependency.cpp
+++ b/be/src/pipeline/pipeline_x/dependency.cpp
@@ -17,10 +17,6 @@
 
 #include "dependency.h"
 
-#include <memory>
-#include <mutex>
-
-#include "common/logging.h"
 #include "runtime/memory/mem_tracker.h"
 
 namespace doris::pipeline {
@@ -328,115 +324,6 @@ Status HashJoinDependency::extract_join_column(vectorized::Block& block,
         }
     }
     return Status::OK();
-}
-
-bool RuntimeFilterTimer::has_ready() {
-    std::unique_lock<std::mutex> lc(_lock);
-    return _runtime_filter->is_ready();
-}
-
-void RuntimeFilterTimer::call_timeout() {
-    std::unique_lock<std::mutex> lc(_lock);
-    if (_call_ready) {
-        return;
-    }
-    _call_timeout = true;
-    if (_parent) {
-        _parent->sub_filters();
-    }
-}
-
-void RuntimeFilterTimer::call_ready() {
-    std::unique_lock<std::mutex> lc(_lock);
-    if (_call_timeout) {
-        return;
-    }
-    _call_ready = true;
-    if (_parent) {
-        _parent->sub_filters();
-    }
-}
-
-void RuntimeFilterTimer::call_has_ready() {
-    std::unique_lock<std::mutex> lc(_lock);
-    DCHECK(!_call_timeout);
-    if (!_call_ready) {
-        _parent->sub_filters();
-    }
-}
-
-void RuntimeFilterTimer::call_has_release() {
-    // When the use count is equal to 1, only the timer queue still holds ownership,
-    // so there is no need to take any action.
-}
-
-struct RuntimeFilterTimerQueue {
-    constexpr static int64_t interval = 50;
-    void start() {
-        while (true) {
-            std::unique_lock<std::mutex> lk(cv_m);
-
-            cv.wait(lk, [this] { return !_que.empty(); });
-            {
-                std::unique_lock<std::mutex> lc(_que_lock);
-                std::list<std::shared_ptr<RuntimeFilterTimer>> new_que;
-                for (auto& it : _que) {
-                    if (it.use_count() == 1) {
-                        it->call_has_release();
-                    } else if (it->has_ready()) {
-                        it->call_has_ready();
-                    } else {
-                        int64_t ms_since_registration = MonotonicMillis() - it->registration_time();
-                        if (ms_since_registration > it->wait_time_ms()) {
-                            it->call_timeout();
-                        } else {
-                            new_que.push_back(std::move(it));
-                        }
-                    }
-                }
-                new_que.swap(_que);
-            }
-            std::this_thread::sleep_for(std::chrono::milliseconds(interval));
-        }
-    }
-    ~RuntimeFilterTimerQueue() { _thread.detach(); }
-    RuntimeFilterTimerQueue() { _thread = std::thread(&RuntimeFilterTimerQueue::start, this); }
-    static void push_filter_timer(std::shared_ptr<RuntimeFilterTimer> filter) {
-        static RuntimeFilterTimerQueue timer_que;
-
-        timer_que.push(filter);
-    }
-
-    void push(std::shared_ptr<RuntimeFilterTimer> filter) {
-        std::unique_lock<std::mutex> lc(_que_lock);
-        _que.push_back(filter);
-        cv.notify_all();
-    }
-
-    std::thread _thread;
-    std::condition_variable cv;
-    std::mutex cv_m;
-    std::mutex _que_lock;
-
-    std::list<std::shared_ptr<RuntimeFilterTimer>> _que;
-};
-
-void RuntimeFilterDependency::add_filters(IRuntimeFilter* runtime_filter) {
-    _filters++;
-    int64_t registration_time = runtime_filter->registration_time();
-    int32 wait_time_ms = runtime_filter->wait_time_ms();
-    auto filter_timer = std::make_shared<RuntimeFilterTimer>(
-            registration_time, wait_time_ms,
-            std::dynamic_pointer_cast<RuntimeFilterDependency>(shared_from_this()), runtime_filter);
-    runtime_filter->set_filter_timer(filter_timer);
-    RuntimeFilterTimerQueue::push_filter_timer(filter_timer);
-}
-
-void RuntimeFilterDependency::sub_filters() {
-    _filters--;
-    if (_filters == 0) {
-        *_blocked_by_rf = false;
-    }
 }
 
 } // namespace doris::pipeline

--- a/be/src/pipeline/pipeline_x/dependency.h
+++ b/be/src/pipeline/pipeline_x/dependency.h
@@ -19,16 +19,11 @@
 
 #include <sqltypes.h>
 
-#include <atomic>
 #include <functional>
 #include <memory>
 #include <mutex>
-#include <thread>
-#include <utility>
 
-#include "common/logging.h"
 #include "concurrentqueue.h"
-#include "gutil/integral_types.h"
 #include "pipeline/exec/data_queue.h"
 #include "pipeline/exec/multi_cast_data_streamer.h"
 #include "vec/common/hash_table/hash_map_context_creator.h"
@@ -213,64 +208,30 @@ protected:
     const int _node_id;
 };
 
-class RuntimeFilterDependency;
-class RuntimeFilterTimer {
+class FilterDependency final : public Dependency {
 public:
-    RuntimeFilterTimer(int64_t registration_time, int32_t wait_time_ms,
-                       std::shared_ptr<RuntimeFilterDependency> parent,
-                       IRuntimeFilter* runtime_filter)
-            : _parent(std::move(parent)),
-              _registration_time(registration_time),
-              _wait_time_ms(wait_time_ms),
-              _runtime_filter(runtime_filter) {}
+    FilterDependency(int id, int node_id, std::string name)
+            : Dependency(id, name),
+              _runtime_filters_are_ready_or_timeout(nullptr),
+              _node_id(node_id) {}
 
-    void call_ready();
-
-    void call_timeout();
-
-    void call_has_ready();
-
-    void call_has_release();
-
-    bool has_ready();
-
-    int64_t registration_time() const { return _registration_time; }
-    int32_t wait_time_ms() const { return _wait_time_ms; }
-
-private:
-    bool _call_ready {};
-    bool _call_timeout {};
-    std::shared_ptr<RuntimeFilterDependency> _parent;
-    std::mutex _lock;
-    const int64_t _registration_time;
-    const int32_t _wait_time_ms;
-    IRuntimeFilter* _runtime_filter;
-};
-class RuntimeFilterDependency final : public Dependency {
-public:
-    RuntimeFilterDependency(int id, int node_id, std::string name)
-            : Dependency(id, name), _node_id(node_id) {}
-
-    RuntimeFilterDependency* filter_blocked_by() {
-        if (!_blocked_by_rf) {
+    FilterDependency* filter_blocked_by() {
+        if (!_runtime_filters_are_ready_or_timeout) {
             return nullptr;
         }
-        if (*_blocked_by_rf) {
+        if (!_runtime_filters_are_ready_or_timeout()) {
             return this;
         }
         return nullptr;
     }
     void* shared_state() override { return nullptr; }
-    void add_filters(IRuntimeFilter* runtime_filter);
-    void sub_filters();
-    void set_blocked_by_rf(std::shared_ptr<std::atomic_bool> blocked_by_rf) {
-        _blocked_by_rf = blocked_by_rf;
+    void set_filter_blocked_by_fn(std::function<bool()> call_fn) {
+        _runtime_filters_are_ready_or_timeout = call_fn;
     }
 
 protected:
+    std::function<bool()> _runtime_filters_are_ready_or_timeout;
     const int _node_id;
-    std::atomic_int _filters;
-    std::shared_ptr<std::atomic_bool> _blocked_by_rf;
 };
 
 class AndDependency final : public WriteDependency {

--- a/be/src/pipeline/pipeline_x/dependency.h
+++ b/be/src/pipeline/pipeline_x/dependency.h
@@ -36,6 +36,9 @@
 #include "vec/exec/vpartition_sort_node.h"
 
 namespace doris {
+namespace vectorized {
+class RuntimeFilterConsumer;
+} // namespace doris::vectorized
 namespace pipeline {
 class Dependency;
 using DependencySPtr = std::shared_ptr<Dependency>;
@@ -211,26 +214,17 @@ protected:
 class FilterDependency final : public Dependency {
 public:
     FilterDependency(int id, int node_id, std::string name)
-            : Dependency(id, name),
-              _runtime_filters_are_ready_or_timeout(nullptr),
-              _node_id(node_id) {}
+            : Dependency(id, name), _node_id(node_id) {}
 
-    FilterDependency* filter_blocked_by() {
-        if (!_runtime_filters_are_ready_or_timeout) {
-            return nullptr;
-        }
-        if (!_runtime_filters_are_ready_or_timeout()) {
-            return this;
-        }
-        return nullptr;
-    }
+    FilterDependency* filter_blocked_by();
     void* shared_state() override { return nullptr; }
-    void set_filter_blocked_by_fn(std::function<bool()> call_fn) {
-        _runtime_filters_are_ready_or_timeout = call_fn;
+    void set_filter_blocked_by_fn(
+            ::doris::vectorized::RuntimeFilterConsumer* runtimeFilterConsumer) {
+        _runtimeFilterConsumer = runtimeFilterConsumer;
     }
 
 protected:
-    std::function<bool()> _runtime_filters_are_ready_or_timeout;
+    ::doris::vectorized::RuntimeFilterConsumer* _runtimeFilterConsumer {};
     const int _node_id;
 };
 

--- a/be/src/pipeline/pipeline_x/operator.cpp
+++ b/be/src/pipeline/pipeline_x/operator.cpp
@@ -318,7 +318,7 @@ PipelineXLocalStateBase::PipelineXLocalStateBase(RuntimeState* state, OperatorXB
           _state(state),
           _finish_dependency(new FinishDependency(parent->operator_id(), parent->node_id(),
                                                   parent->get_name() + "_FINISH_DEPENDENCY")) {
-    _filter_dependency = std::make_shared<RuntimeFilterDependency>(
+    _filter_dependency = std::make_unique<FilterDependency>(
             parent->operator_id(), parent->node_id(), parent->get_name() + "_FILTER_DEPENDENCY");
 }
 

--- a/be/src/pipeline/pipeline_x/operator.h
+++ b/be/src/pipeline/pipeline_x/operator.h
@@ -100,7 +100,7 @@ public:
     virtual Dependency* dependency() { return nullptr; }
 
     FinishDependency* finishdependency() { return _finish_dependency.get(); }
-    RuntimeFilterDependency* filterdependency() { return _filter_dependency.get(); }
+    FilterDependency* filterdependency() { return _filter_dependency.get(); }
 
 protected:
     friend class OperatorXBase;
@@ -133,7 +133,7 @@ protected:
     bool _closed = false;
     vectorized::Block _origin_block;
     std::shared_ptr<FinishDependency> _finish_dependency;
-    std::shared_ptr<RuntimeFilterDependency> _filter_dependency;
+    std::unique_ptr<FilterDependency> _filter_dependency;
 };
 
 class OperatorXBase : public OperatorBase {

--- a/be/src/pipeline/pipeline_x/pipeline_x_task.h
+++ b/be/src/pipeline/pipeline_x/pipeline_x_task.h
@@ -172,7 +172,7 @@ private:
     std::vector<Dependency*> _read_dependencies;
     WriteDependency* _write_dependencies;
     std::vector<FinishDependency*> _finish_dependencies;
-    RuntimeFilterDependency* _filter_dependency;
+    FilterDependency* _filter_dependency;
 
     DependencyMap _upstream_dependency;
 

--- a/be/src/vec/exec/runtime_filter_consumer.cpp
+++ b/be/src/vec/exec/runtime_filter_consumer.cpp
@@ -26,9 +26,7 @@ RuntimeFilterConsumer::RuntimeFilterConsumer(const int32_t filter_id,
         : _filter_id(filter_id),
           _runtime_filter_descs(runtime_filters),
           _row_descriptor_ref(row_descriptor),
-          _conjuncts_ref(conjuncts) {
-    _blocked_by_rf = std::make_shared<std::atomic_bool>(false);
-}
+          _conjuncts_ref(conjuncts) {}
 
 Status RuntimeFilterConsumer::init(RuntimeState* state) {
     _state = state;
@@ -74,7 +72,7 @@ Status RuntimeFilterConsumer::_register_runtime_filter() {
 }
 
 bool RuntimeFilterConsumer::runtime_filters_are_ready_or_timeout() {
-    if (!*_blocked_by_rf) {
+    if (!_blocked_by_rf) {
         return true;
     }
     for (size_t i = 0; i < _runtime_filter_descs.size(); ++i) {
@@ -83,17 +81,8 @@ bool RuntimeFilterConsumer::runtime_filters_are_ready_or_timeout() {
             return false;
         }
     }
-    *_blocked_by_rf = false;
+    _blocked_by_rf = false;
     return true;
-}
-
-void RuntimeFilterConsumer::init_runtime_filter_dependency(
-        doris::pipeline::RuntimeFilterDependency* _runtime_filter_dependency) {
-    _runtime_filter_dependency->set_blocked_by_rf(_blocked_by_rf);
-    for (size_t i = 0; i < _runtime_filter_descs.size(); ++i) {
-        IRuntimeFilter* runtime_filter = _runtime_filter_ctxs[i].runtime_filter;
-        _runtime_filter_dependency->add_filters(runtime_filter);
-    }
 }
 
 Status RuntimeFilterConsumer::_acquire_runtime_filter() {
@@ -110,14 +99,14 @@ Status RuntimeFilterConsumer::_acquire_runtime_filter() {
             _runtime_filter_ctxs[i].apply_mark = true;
         } else if (runtime_filter->current_state() == RuntimeFilterState::NOT_READY &&
                    !_runtime_filter_ctxs[i].apply_mark) {
-            *_blocked_by_rf = true;
+            _blocked_by_rf = true;
         } else if (!_runtime_filter_ctxs[i].apply_mark) {
             DCHECK(runtime_filter->current_state() != RuntimeFilterState::NOT_READY);
             _is_all_rf_applied = false;
         }
     }
     RETURN_IF_ERROR(_append_rf_into_conjuncts(vexprs));
-    if (*_blocked_by_rf) {
+    if (_blocked_by_rf) {
         return Status::WaitForRf("Runtime filters are neither not ready nor timeout");
     }
 

--- a/be/src/vec/exec/runtime_filter_consumer.h
+++ b/be/src/vec/exec/runtime_filter_consumer.h
@@ -19,7 +19,6 @@
 
 #include "exec/exec_node.h"
 #include "exprs/runtime_filter.h"
-#include "pipeline/pipeline_x/dependency.h"
 
 namespace doris::vectorized {
 
@@ -37,8 +36,6 @@ public:
     Status try_append_late_arrival_runtime_filter(int* arrived_rf_num);
 
     bool runtime_filters_are_ready_or_timeout();
-
-    void init_runtime_filter_dependency(doris::pipeline::RuntimeFilterDependency*);
 
 protected:
     // Register and get all runtime filters at Init phase.
@@ -79,7 +76,7 @@ private:
 
     // True means all runtime filters are applied to scanners
     bool _is_all_rf_applied = true;
-    std::shared_ptr<std::atomic_bool> _blocked_by_rf;
+    bool _blocked_by_rf = false;
 
     RuntimeProfile::Counter* _acquire_runtime_filter_timer = nullptr;
 };


### PR DESCRIPTION
… the runtime filter (#26078)"

This reverts commit 9d8394898722953284ffe69e6b575bea09940815.

In PipelineX, we use Dependency to schedule tasks instead of using a block queue. 
However, for runtime filters, it is necessary to notify if there is a timeout. 
Previously, this pull request was only for test. 
Now,  both the block queue and the filter timeout queue coexist, which is not conducive to performance testing. 
This will be addressed later in conjunction with Dependency scheduling.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

