### PR TITLE
[fix](statistics)Fix alter column stats bug (#27093)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsRepository.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsRepository.java
@@ -35,6 +35,8 @@ import org.apache.commons.text.StringSubstitutor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -269,8 +271,10 @@ public class StatisticsRepository {
         params.put("count", String.valueOf(columnStatistic.count));
         params.put("ndv", String.valueOf(columnStatistic.ndv));
         params.put("nullCount", String.valueOf(columnStatistic.numNulls));
-        params.put("min", min == null ? "NULL" : min);
-        params.put("max", max == null ? "NULL" : max);
+        params.put("min", min == null ? "NULL" :
+                Base64.getEncoder().encodeToString(min.getBytes(StandardCharsets.UTF_8)));
+        params.put("max", max == null ? "NULL" :
+                Base64.getEncoder().encodeToString(max.getBytes(StandardCharsets.UTF_8)));
         params.put("dataSize", String.valueOf(columnStatistic.dataSize));
 
         if (partitionIds.isEmpty()) {
@@ -278,7 +282,7 @@ public class StatisticsRepository {
             params.put("partId", "NULL");
             StatisticsUtil.execUpdate(INSERT_INTO_COLUMN_STATISTICS, params);
             Env.getCurrentEnv().getStatisticsCache()
-                    .updateColStatsCache(objects.table.getId(), -1, colName, builder.build());
+                    .updateColStatsCache(objects.table.getId(), -1, colName, columnStatistic);
         } else {
             // update partition granularity statistics
             for (Long partitionId : partitionIds) {

--- a/regression-test/suites/external_table_p2/hive/test_hive_statistic.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_hive_statistic.groovy
@@ -293,6 +293,45 @@ suite("test_hive_statistic", "p2") {
         assertEquals(result.size(), 1)
         assertEquals(result[0][6], "N/A")
         assertEquals(result[0][7], "N/A")
+
+	sql """use tpch1_parquet;"""
+	sql """drop stats region"""
+	sql """alter table region modify column r_comment set stats ('row_count'='5.0', 'ndv'='5.0', 'num_nulls'='0.0', 'data_size'='330.0', 'min_value'='ges. thinly even pinto beans ca', 'max_value'='uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl');"""
+	sql """alter table region modify column r_name set stats ('row_count'='5.0', 'ndv'='5.0', 'num_nulls'='0.0', 'data_size'='34.0', 'min_value'='AFRICA', 'max_value'='MIDDLE EAST');"""
+	sql """alter table region modify column r_regionkey set stats ('row_count'='5.0', 'ndv'='5.0', 'num_nulls'='0.0', 'data_size'='20.0', 'min_value'='0', 'max_value'='4');"""
+        result = sql """show column stats region(r_regionkey)"""
+        assertEquals(result.size(), 1)
+        assertEquals(result[0][0], "r_regionkey")
+        assertEquals(result[0][1], "5.0")
+        assertEquals(result[0][2], "5.0")
+        assertEquals(result[0][3], "0.0")
+        assertEquals(result[0][4], "20.0")
+        assertEquals(result[0][5], "4.0")
+        assertEquals(result[0][6], "0")
+        assertEquals(result[0][7], "4")
+
+        result = sql """show column stats region(r_comment)"""
+        assertEquals(result.size(), 1)
+        assertEquals(result[0][0], "r_comment")
+        assertEquals(result[0][1], "5.0")
+        assertEquals(result[0][2], "5.0")
+        assertEquals(result[0][3], "0.0")
+        assertEquals(result[0][4], "330.0")
+        assertEquals(result[0][5], "66.0")
+        assertEquals(result[0][6], "\'ges. thinly even pinto beans ca\'")
+        assertEquals(result[0][7], "\'uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl\'")
+
+        result = sql """show column stats region(r_name)"""
+        assertEquals(result.size(), 1)
+        assertEquals(result[0][0], "r_name")
+        assertEquals(result[0][1], "5.0")
+        assertEquals(result[0][2], "5.0")
+        assertEquals(result[0][3], "0.0")
+        assertEquals(result[0][4], "34.0")
+        assertEquals(result[0][5], "6.8")
+        assertEquals(result[0][6], "\'AFRICA\'")
+        assertEquals(result[0][7], "\'MIDDLE EAST\'")
+
         sql """drop catalog ${catalog_name}"""
     }
 }


### PR DESCRIPTION
Encode the min and max value with base64 encoder while inject the column stats.
backport https://github.com/apache/doris/pull/27093

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

