### PR TITLE
[fix](compile) fix BE compile failure on Mac

### DIFF
--- a/be/src/vec/exprs/table_function/vexplode_numbers.cpp
+++ b/be/src/vec/exprs/table_function/vexplode_numbers.cpp
@@ -64,7 +64,7 @@ Status VExplodeNumbersTableFunction::process_init(Block* block, RuntimeState* st
         }
         ((ColumnInt32*)_elements_column.get())->clear();
         //_cur_size may be a negative number
-        _cur_size = std::max(0LL, _cur_size);
+        _cur_size = std::max<int64_t>(0, _cur_size);
         if (_cur_size &&
             _cur_size <= state->batch_size()) { // avoid elements_column too big or empty
             _is_const = true;                   // use const optimize

--- a/be/src/vec/exprs/table_function/vexplode_numbers.cpp
+++ b/be/src/vec/exprs/table_function/vexplode_numbers.cpp
@@ -64,7 +64,7 @@ Status VExplodeNumbersTableFunction::process_init(Block* block, RuntimeState* st
         }
         ((ColumnInt32*)_elements_column.get())->clear();
         //_cur_size may be a negative number
-        _cur_size = std::max(0L, _cur_size);
+        _cur_size = std::max(0LL, _cur_size);
         if (_cur_size &&
             _cur_size <= state->batch_size()) { // avoid elements_column too big or empty
             _is_const = true;                   // use const optimize


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

fix
```
/Users/zhongyongkang/LocalDoris/doris/be/src/vec/exprs/table_function/vexplode_numbers.cpp:67:21: error: no matching function for call to 'max'
        _cur_size = std::max(0L, _cur_size);
                    ^~~~~~~~
/opt/homebrew/opt/llvm@16/bin/../include/c++/v1/__algorithm/max.h:40:1: note: candidate template ignored: deduced conflicting types for parameter '_Tp' ('long' vs. 'int64_t' (aka 'long long'))
max(const _Tp& __a, const _Tp& __b)
^
/opt/homebrew/opt/llvm@16/bin/../include/c++/v1/__algorithm/max.h:51:1: note: candidate template ignored: could not match 'initializer_list<_Tp>' against 'long'
max(initializer_list<_Tp> __t, _Compare __comp)
^
/opt/homebrew/opt/llvm@16/bin/../include/c++/v1/__algorithm/max.h:60:1: note: candidate function template not viable: requires single argument '__t', but 2 arguments were provided
max(initializer_list<_Tp> __t)
^
/opt/homebrew/opt/llvm@16/bin/../include/c++/v1/__algorithm/max.h:31:1: note: candidate function template not viable: requires 3 arguments, but 2 were provided
max(const _Tp& __a, const _Tp& __b, _Compare __comp)
^
1 error generated.
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

