### PR TITLE
[fix][chore](clang-tidy) Fix order of tidy Checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,8 +1,8 @@
 ---
 Checks: |
+  -*,
   clang-diagnostic-*,
   clang-analyzer-*,
-  -*,
   bugprone-redundant-branch-condition,
   modernize-*,
   -modernize-use-trailing-return-type,
@@ -30,3 +30,4 @@ CheckOptions:
     value:           '80'
   - key:             readability-function-cognitive-complexity.Threshold
     value:           '50'
+


### PR DESCRIPTION
Clang-tidy add checks based on the order of `Checks` field. Here the `-*` removes the `clang-diagnostic-*,clang-analyzer-*` before.

This PR may break CI.

## Proposed changes

Moved `-*` to the beginning of `Checks`.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

