### PR TITLE
[branch-2.0](tablesample) Fix computeSampleTabletIds NullPointerException

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -947,9 +947,13 @@ public class OlapScanNode extends ScanNode {
         }
         for (Long partitionId : selectedPartitionIds) {
             final Partition partition = olapTable.getPartition(partitionId);
-            final MaterializedIndex selectedTable = partition.getIndex(selectedIndexId);
-            selectedRows += selectedTable.getRowCount();
-            selectedPartitionList.add(partitionId);
+            final MaterializedIndex selectedIndex = partition.getIndex(selectedIndexId);
+            // selectedIndex is not expected to be null, because MaterializedIndex ids in one rollup's partitions
+            // are all same. skip this partition here.
+            if (selectedIndex != null) {
+                selectedRows += selectedIndex.getRowCount();
+                selectedPartitionList.add(partitionId);
+            }
         }
         selectedPartitionList.sort(Comparator.naturalOrder());
 
@@ -969,7 +973,7 @@ public class OlapScanNode extends ScanNode {
         // 3. Sampling partition. If Seek is specified, the partition will be the same for each sampling.
         long hitRows = 0; // The number of rows hit by the tablet
         long partitionSeek = tableSample.getSeek() != -1
-                ? tableSample.getSeek() : (long) (new SecureRandom().nextDouble() * selectedPartitionIds.size());
+                ? tableSample.getSeek() : (long) (new SecureRandom().nextDouble() * selectedPartitionList.size());
         for (int i = 0; i < selectedPartitionList.size(); i++) {
             int seekPid = (int) ((i + partitionSeek) % selectedPartitionList.size());
             final Partition partition = olapTable.getPartition(selectedPartitionList.get(seekPid));


### PR DESCRIPTION
pick #27165

```
2023-11-05 22:52:01,914 WARN (mysql-nio-pool-167|1655) [StmtExecutor.analyze():992] Analyze failed. stmt[222101, ec1adf0f9f7b405d-8cb71a522bc50b82]
java.lang.NullPointerException: null
        at org.apache.doris.planner.OlapScanNode.computeSampleTabletIds(OlapScanNode.java:952) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.OlapScanNode.init(OlapScanNode.java:548) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.SingleNodePlanner.createScanNode(SingleNodePlanner.java:2064) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.SingleNodePlanner.createTableRefNode(SingleNodePlanner.java:2213) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.SingleNodePlanner.createSelectPlan(SingleNodePlanner.java:1244) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.SingleNodePlanner.createQueryPlan(SingleNodePlanner.java:266) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.SingleNodePlanner.createSingleNodePlan(SingleNodePlanner.java:189) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.OriginalPlanner.createPlanFragments(OriginalPlanner.java:160) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.planner.OriginalPlanner.plan(OriginalPlanner.java:101) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.analyzeAndGenerateQueryPlan(StmtExecutor.java:1141) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.analyze(StmtExecutor.java:975) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.executeByLegacy(StmtExecutor.java:673) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:451) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:422) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:435) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.dispatch(ConnectProcessor.java:583) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.processOnce(ConnectProcessor.java:834) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52) ~[doris-fe.jar:1.2-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_333]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_333]
        at java.lang.Thread.run(Thread.java:750) ~[?:1.8.0_333]
2023-11-05 22:52:01,914 WARN (mysql-nio-pool-167|1655) [StmtExecutor.executeByLegacy():776] execute Exception. stmt[222101, ec1adf0f9f7b405d-8cb71a522bc50b82]
org.apache.doris.common.AnalysisException: errCode = 2, detailMessage = Unexpected exception: null
        at org.apache.doris.qe.StmtExecutor.analyze(StmtExecutor.java:993) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.executeByLegacy(StmtExecutor.java:673) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:451) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:422) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:435) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.dispatch(ConnectProcessor.java:583) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.processOnce(ConnectProcessor.java:834) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52) ~[doris-fe.jar:1.2-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_333]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_333]
        at java.lang.Thread.run(Thread.java:750) ~[?:1.8.0_333]
```

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

