### PR TITLE
[opt](nereids) penalty to shuffle join if data skew

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
@@ -322,21 +322,24 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
                                int totalInstanceNumber) {
         double penalty = 1.0;
         for (Expression conj : physicalHashJoin.getHashJoinConjuncts()) {
-            EqualTo eq = (EqualTo) JoinUtils.swapEqualToForChildrenOrder(
-                    (EqualTo) conj, physicalHashJoin.left().getOutputSet());
-            ColumnStatistic leftColStats = probeStats.findColumnStatistics(eq.left());
-            if (leftColStats != null && !leftColStats.isUnKnown()) {
-                if (leftColStats.ndv < beNumber) {
-                    penalty = Math.max(totalInstanceNumber / Math.max(1.0, leftColStats.ndv), penalty);
-                    break;
+            // TODO: NullSafeEqualTo need refactor
+            if (conj instanceof EqualTo) {
+                EqualTo eq = (EqualTo) JoinUtils.swapEqualToForChildrenOrder(
+                        (EqualTo) conj, physicalHashJoin.left().getOutputSet());
+                ColumnStatistic leftColStats = probeStats.findColumnStatistics(eq.left());
+                if (leftColStats != null && !leftColStats.isUnKnown()) {
+                    if (leftColStats.ndv < beNumber) {
+                        penalty = Math.max(totalInstanceNumber / Math.max(1.0, leftColStats.ndv), penalty);
+                        break;
+                    }
                 }
-            }
 
-            ColumnStatistic rightColStats = buildStats.findColumnStatistics(eq.right());
-            if (rightColStats != null && !rightColStats.isUnKnown()) {
-                if (rightColStats.ndv < beNumber) {
-                    penalty = Math.max(totalInstanceNumber / Math.max(1.0, rightColStats.ndv), penalty);
-                    break;
+                ColumnStatistic rightColStats = buildStats.findColumnStatistics(eq.right());
+                if (rightColStats != null && !rightColStats.isUnKnown()) {
+                    if (rightColStats.ndv < beNumber) {
+                        penalty = Math.max(totalInstanceNumber / Math.max(1.0, rightColStats.ndv), penalty);
+                        break;
+                    }
                 }
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -1025,7 +1025,8 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
                 .setMaxValue(newRange.getHigh())
                 .setNdv(newRange.getDistinctValues())
                 .setNumNulls(leftStats.numNulls + rightStats.numNulls)
-                .setAvgSizeByte(newAverageRowSize);
+                .setAvgSizeByte(newAverageRowSize)
+                .setIsUnknown(leftStats.isUnKnown || rightStats.isUnKnown);
         return columnStatisticBuilder.build();
     }
 

--- a/regression-test/data/nereids_tpcds_shape_sf1000_p0/shape/query44.out
+++ b/regression-test/data/nereids_tpcds_shape_sf1000_p0/shape/query44.out
@@ -6,11 +6,41 @@ PhysicalResultSink
 ------PhysicalTopN[LOCAL_SORT]
 --------PhysicalProject
 ----------hashJoin[INNER_JOIN] hashCondition=((asceding.rnk = descending.rnk)) otherCondition=()
+------------hashJoin[INNER_JOIN] hashCondition=((i2.i_item_sk = descending.item_sk)) otherCondition=() build RFs:RF1 item_sk->[i_item_sk]
+--------------PhysicalProject
+----------------PhysicalOlapScan[item] apply RFs: RF1
+--------------PhysicalDistribute
+----------------PhysicalProject
+------------------filter((rnk < 11))
+--------------------PhysicalWindow
+----------------------PhysicalQuickSort[MERGE_SORT]
+------------------------PhysicalDistribute
+--------------------------PhysicalQuickSort[LOCAL_SORT]
+----------------------------PhysicalPartitionTopN
+------------------------------PhysicalProject
+--------------------------------NestedLoopJoin[INNER_JOIN](cast(rank_col as DOUBLE) > cast((0.9 * rank_col) as DOUBLE))
+----------------------------------PhysicalProject
+------------------------------------hashAgg[GLOBAL]
+--------------------------------------PhysicalDistribute
+----------------------------------------hashAgg[LOCAL]
+------------------------------------------PhysicalProject
+--------------------------------------------filter((ss1.ss_store_sk = 4))
+----------------------------------------------PhysicalOlapScan[store_sales]
+----------------------------------PhysicalDistribute
+------------------------------------PhysicalAssertNumRows
+--------------------------------------PhysicalDistribute
+----------------------------------------PhysicalProject
+------------------------------------------hashAgg[GLOBAL]
+--------------------------------------------PhysicalDistribute
+----------------------------------------------hashAgg[LOCAL]
+------------------------------------------------PhysicalProject
+--------------------------------------------------filter((store_sales.ss_store_sk = 4) and ss_hdemo_sk IS NULL)
+----------------------------------------------------PhysicalOlapScan[store_sales]
 ------------PhysicalDistribute
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((i1.i_item_sk = asceding.item_sk)) otherCondition=() build RFs:RF1 item_sk->[i_item_sk]
+----------------hashJoin[INNER_JOIN] hashCondition=((i1.i_item_sk = asceding.item_sk)) otherCondition=() build RFs:RF0 item_sk->[i_item_sk]
 ------------------PhysicalProject
---------------------PhysicalOlapScan[item] apply RFs: RF1
+--------------------PhysicalOlapScan[item] apply RFs: RF0
 ------------------PhysicalDistribute
 --------------------PhysicalProject
 ----------------------filter((rnk < 11))
@@ -38,35 +68,4 @@ PhysicalResultSink
 ----------------------------------------------------PhysicalProject
 ------------------------------------------------------filter((store_sales.ss_store_sk = 4) and ss_hdemo_sk IS NULL)
 --------------------------------------------------------PhysicalOlapScan[store_sales]
-------------PhysicalDistribute
---------------hashJoin[INNER_JOIN] hashCondition=((i2.i_item_sk = descending.item_sk)) otherCondition=() build RFs:RF0 item_sk->[i_item_sk]
-----------------PhysicalProject
-------------------PhysicalOlapScan[item] apply RFs: RF0
-----------------PhysicalDistribute
-------------------PhysicalProject
---------------------filter((rnk < 11))
-----------------------PhysicalWindow
-------------------------PhysicalQuickSort[MERGE_SORT]
---------------------------PhysicalDistribute
-----------------------------PhysicalQuickSort[LOCAL_SORT]
-------------------------------PhysicalPartitionTopN
---------------------------------PhysicalProject
-----------------------------------NestedLoopJoin[INNER_JOIN](cast(rank_col as DOUBLE) > cast((0.9 * rank_col) as DOUBLE))
-------------------------------------PhysicalProject
---------------------------------------hashAgg[GLOBAL]
-----------------------------------------PhysicalDistribute
-------------------------------------------hashAgg[LOCAL]
---------------------------------------------PhysicalProject
-----------------------------------------------filter((ss1.ss_store_sk = 4))
-------------------------------------------------PhysicalOlapScan[store_sales]
-------------------------------------PhysicalDistribute
---------------------------------------PhysicalAssertNumRows
-----------------------------------------PhysicalDistribute
-------------------------------------------PhysicalProject
---------------------------------------------hashAgg[GLOBAL]
-----------------------------------------------PhysicalDistribute
-------------------------------------------------hashAgg[LOCAL]
---------------------------------------------------PhysicalProject
-----------------------------------------------------filter((store_sales.ss_store_sk = 4) and ss_hdemo_sk IS NULL)
-------------------------------------------------------PhysicalOlapScan[store_sales]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query44.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query44.out
@@ -12,33 +12,32 @@ PhysicalResultSink
 ------------------PhysicalDistribute
 --------------------PhysicalProject
 ----------------------hashJoin[INNER_JOIN] hashCondition=((asceding.rnk = descending.rnk)) otherCondition=()
-------------------------PhysicalDistribute
---------------------------PhysicalProject
-----------------------------filter((rnk < 11))
-------------------------------PhysicalWindow
---------------------------------PhysicalQuickSort[MERGE_SORT]
-----------------------------------PhysicalDistribute
-------------------------------------PhysicalQuickSort[LOCAL_SORT]
---------------------------------------PhysicalPartitionTopN
-----------------------------------------PhysicalProject
-------------------------------------------NestedLoopJoin[INNER_JOIN](cast(rank_col as DOUBLE) > cast((0.9 * rank_col) as DOUBLE))
---------------------------------------------PhysicalProject
-----------------------------------------------hashAgg[GLOBAL]
-------------------------------------------------PhysicalDistribute
---------------------------------------------------hashAgg[LOCAL]
-----------------------------------------------------PhysicalProject
-------------------------------------------------------filter((ss1.ss_store_sk = 146))
---------------------------------------------------------PhysicalOlapScan[store_sales]
---------------------------------------------PhysicalDistribute
-----------------------------------------------PhysicalAssertNumRows
-------------------------------------------------PhysicalDistribute
+------------------------PhysicalProject
+--------------------------filter((rnk < 11))
+----------------------------PhysicalWindow
+------------------------------PhysicalQuickSort[MERGE_SORT]
+--------------------------------PhysicalDistribute
+----------------------------------PhysicalQuickSort[LOCAL_SORT]
+------------------------------------PhysicalPartitionTopN
+--------------------------------------PhysicalProject
+----------------------------------------NestedLoopJoin[INNER_JOIN](cast(rank_col as DOUBLE) > cast((0.9 * rank_col) as DOUBLE))
+------------------------------------------PhysicalProject
+--------------------------------------------hashAgg[GLOBAL]
+----------------------------------------------PhysicalDistribute
+------------------------------------------------hashAgg[LOCAL]
 --------------------------------------------------PhysicalProject
-----------------------------------------------------hashAgg[GLOBAL]
-------------------------------------------------------PhysicalDistribute
---------------------------------------------------------hashAgg[LOCAL]
-----------------------------------------------------------PhysicalProject
-------------------------------------------------------------filter((store_sales.ss_store_sk = 146) and ss_addr_sk IS NULL)
---------------------------------------------------------------PhysicalOlapScan[store_sales]
+----------------------------------------------------filter((ss1.ss_store_sk = 146))
+------------------------------------------------------PhysicalOlapScan[store_sales]
+------------------------------------------PhysicalDistribute
+--------------------------------------------PhysicalAssertNumRows
+----------------------------------------------PhysicalDistribute
+------------------------------------------------PhysicalProject
+--------------------------------------------------hashAgg[GLOBAL]
+----------------------------------------------------PhysicalDistribute
+------------------------------------------------------hashAgg[LOCAL]
+--------------------------------------------------------PhysicalProject
+----------------------------------------------------------filter((store_sales.ss_store_sk = 146) and ss_addr_sk IS NULL)
+------------------------------------------------------------PhysicalOlapScan[store_sales]
 ------------------------PhysicalDistribute
 --------------------------PhysicalProject
 ----------------------------filter((rnk < 11))

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query5.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query5.out
@@ -15,33 +15,34 @@ PhysicalResultSink
 ------------------------PhysicalDistribute
 --------------------------hashAgg[LOCAL]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk,sr_returned_date_sk]
---------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.store_sk = store.s_store_sk)) otherCondition=()
-----------------------------------PhysicalUnion
+------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.store_sk = store.s_store_sk)) otherCondition=()
+--------------------------------PhysicalProject
+----------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk,sr_returned_date_sk]
+------------------------------------PhysicalUnion
+--------------------------------------PhysicalDistribute
+----------------------------------------PhysicalProject
+------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0
+--------------------------------------PhysicalDistribute
+----------------------------------------PhysicalProject
+------------------------------------------PhysicalOlapScan[store_returns]
 ------------------------------------PhysicalDistribute
 --------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1
-------------------------------------PhysicalDistribute
---------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[store_returns]
-----------------------------------PhysicalDistribute
-------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[store]
+----------------------------------------filter((date_dim.d_date <= '2000-09-02') and (date_dim.d_date >= '2000-08-19'))
+------------------------------------------PhysicalOlapScan[date_dim]
 --------------------------------PhysicalDistribute
 ----------------------------------PhysicalProject
-------------------------------------filter((date_dim.d_date <= '2000-09-02') and (date_dim.d_date >= '2000-08-19'))
---------------------------------------PhysicalOlapScan[date_dim]
+------------------------------------PhysicalOlapScan[store]
 --------------------PhysicalProject
 ----------------------hashAgg[GLOBAL]
 ------------------------PhysicalDistribute
 --------------------------hashAgg[LOCAL]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[cs_sold_date_sk,cr_returned_date_sk]
---------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.page_sk = catalog_page.cp_catalog_page_sk)) otherCondition=() build RFs:RF2 cp_catalog_page_sk->[cs_catalog_page_sk,cr_catalog_page_sk]
+------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[cs_sold_date_sk,cr_returned_date_sk]
+--------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.page_sk = catalog_page.cp_catalog_page_sk)) otherCondition=() build RFs:RF1 cp_catalog_page_sk->[cs_catalog_page_sk,cr_catalog_page_sk]
 ----------------------------------PhysicalUnion
 ------------------------------------PhysicalDistribute
 --------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF2 RF3
+----------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF1 RF2
 ------------------------------------PhysicalDistribute
 --------------------------------------PhysicalProject
 ----------------------------------------PhysicalOlapScan[catalog_returns]
@@ -57,24 +58,25 @@ PhysicalResultSink
 ------------------------PhysicalDistribute
 --------------------------hashAgg[LOCAL]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[ws_sold_date_sk,wr_returned_date_sk]
---------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.wsr_web_site_sk = web_site.web_site_sk)) otherCondition=() build RFs:RF6 web_site_sk->[ws_web_site_sk,ws_web_site_sk]
-----------------------------------PhysicalUnion
+------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.wsr_web_site_sk = web_site.web_site_sk)) otherCondition=()
+--------------------------------PhysicalProject
+----------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[ws_sold_date_sk,wr_returned_date_sk]
+------------------------------------PhysicalUnion
+--------------------------------------PhysicalDistribute
+----------------------------------------PhysicalProject
+------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF5
+--------------------------------------PhysicalDistribute
+----------------------------------------PhysicalProject
+------------------------------------------hashJoin[INNER_JOIN] hashCondition=((web_returns.wr_item_sk = web_sales.ws_item_sk) and (web_returns.wr_order_number = web_sales.ws_order_number)) otherCondition=() build RFs:RF3 wr_item_sk->[ws_item_sk];RF4 wr_order_number->[ws_order_number]
+--------------------------------------------PhysicalProject
+----------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF3 RF4
+--------------------------------------------PhysicalProject
+----------------------------------------------PhysicalOlapScan[web_returns]
 ------------------------------------PhysicalDistribute
 --------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF6 RF7
-------------------------------------PhysicalDistribute
---------------------------------------PhysicalProject
-----------------------------------------hashJoin[INNER_JOIN] hashCondition=((web_returns.wr_item_sk = web_sales.ws_item_sk) and (web_returns.wr_order_number = web_sales.ws_order_number)) otherCondition=() build RFs:RF4 wr_item_sk->[ws_item_sk];RF5 wr_order_number->[ws_order_number]
-------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF4 RF5
-------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[web_returns]
-----------------------------------PhysicalDistribute
-------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[web_site]
+----------------------------------------filter((date_dim.d_date <= '2000-09-02') and (date_dim.d_date >= '2000-08-19'))
+------------------------------------------PhysicalOlapScan[date_dim]
 --------------------------------PhysicalDistribute
 ----------------------------------PhysicalProject
-------------------------------------filter((date_dim.d_date <= '2000-09-02') and (date_dim.d_date >= '2000-08-19'))
---------------------------------------PhysicalOlapScan[date_dim]
+------------------------------------PhysicalOlapScan[web_site]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query54.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query54.out
@@ -16,36 +16,36 @@ PhysicalResultSink
 --------------------------PhysicalProject
 ----------------------------hashJoin[INNER_JOIN] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=()
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN] hashCondition=((my_customers.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->[ss_customer_sk]
+--------------------------------hashJoin[INNER_JOIN] hashCondition=((my_customers.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF1 c_customer_sk->[ss_customer_sk]
 ----------------------------------PhysicalDistribute
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2
+--------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1
 ----------------------------------PhysicalProject
 ------------------------------------hashAgg[LOCAL]
 --------------------------------------PhysicalProject
-----------------------------------------hashJoin[INNER_JOIN] hashCondition=((customer.c_customer_sk = cs_or_ws_sales.customer_sk)) otherCondition=()
-------------------------------------------PhysicalDistribute
---------------------------------------------PhysicalProject
-----------------------------------------------hashJoin[INNER_JOIN] hashCondition=((cs_or_ws_sales.item_sk = item.i_item_sk)) otherCondition=() build RFs:RF1 i_item_sk->[cs_item_sk,ws_item_sk]
-------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((cs_or_ws_sales.sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[cs_sold_date_sk,ws_sold_date_sk]
+----------------------------------------hashJoin[INNER_JOIN] hashCondition=((cs_or_ws_sales.sold_date_sk = date_dim.d_date_sk)) otherCondition=()
+------------------------------------------hashJoin[INNER_JOIN] hashCondition=((customer.c_customer_sk = cs_or_ws_sales.customer_sk)) otherCondition=()
+--------------------------------------------PhysicalDistribute
+----------------------------------------------PhysicalProject
+------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((cs_or_ws_sales.item_sk = item.i_item_sk)) otherCondition=() build RFs:RF0 i_item_sk->[cs_item_sk,ws_item_sk]
 --------------------------------------------------PhysicalUnion
 ----------------------------------------------------PhysicalDistribute
 ------------------------------------------------------PhysicalProject
---------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1
+--------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
 ----------------------------------------------------PhysicalDistribute
 ------------------------------------------------------PhysicalProject
 --------------------------------------------------------PhysicalOlapScan[web_sales]
 --------------------------------------------------PhysicalDistribute
 ----------------------------------------------------PhysicalProject
-------------------------------------------------------filter((date_dim.d_moy = 5) and (date_dim.d_year = 1998))
---------------------------------------------------------PhysicalOlapScan[date_dim]
-------------------------------------------------PhysicalDistribute
---------------------------------------------------PhysicalProject
-----------------------------------------------------filter((item.i_category = 'Women') and (item.i_class = 'maternity'))
-------------------------------------------------------PhysicalOlapScan[item]
+------------------------------------------------------filter((item.i_category = 'Women') and (item.i_class = 'maternity'))
+--------------------------------------------------------PhysicalOlapScan[item]
+--------------------------------------------PhysicalDistribute
+----------------------------------------------PhysicalProject
+------------------------------------------------PhysicalOlapScan[customer]
 ------------------------------------------PhysicalDistribute
 --------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[customer]
+----------------------------------------------filter((date_dim.d_moy = 5) and (date_dim.d_year = 1998))
+------------------------------------------------PhysicalOlapScan[date_dim]
 ------------------------------PhysicalDistribute
 --------------------------------PhysicalProject
 ----------------------------------PhysicalOlapScan[customer_address]

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query71.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query71.out
@@ -9,42 +9,43 @@ PhysicalResultSink
 ------------PhysicalDistribute
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN] hashCondition=((tmp.sold_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF4 i_item_sk->[ws_item_sk,cs_item_sk,ss_item_sk]
---------------------hashJoin[INNER_JOIN] hashCondition=((tmp.time_sk = time_dim.t_time_sk)) otherCondition=() build RFs:RF3 t_time_sk->[ws_sold_time_sk,cs_sold_time_sk,ss_sold_time_sk]
-----------------------PhysicalUnion
+------------------hashJoin[INNER_JOIN] hashCondition=((tmp.time_sk = time_dim.t_time_sk)) otherCondition=()
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN] hashCondition=((tmp.sold_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ws_item_sk,cs_item_sk,ss_item_sk]
+------------------------PhysicalUnion
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------hashJoin[INNER_JOIN] hashCondition=((date_dim.d_date_sk = web_sales.ws_sold_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ws_sold_date_sk]
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0 RF3
+--------------------------------PhysicalDistribute
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 1998))
+--------------------------------------PhysicalOlapScan[date_dim]
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------hashJoin[INNER_JOIN] hashCondition=((date_dim.d_date_sk = catalog_sales.cs_sold_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk]
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF1
+--------------------------------PhysicalDistribute
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 1998))
+--------------------------------------PhysicalOlapScan[date_dim]
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------hashJoin[INNER_JOIN] hashCondition=((date_dim.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ss_sold_date_sk]
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2
+--------------------------------PhysicalDistribute
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 1998))
+--------------------------------------PhysicalOlapScan[date_dim]
 ------------------------PhysicalDistribute
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN] hashCondition=((date_dim.d_date_sk = web_sales.ws_sold_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ws_sold_date_sk]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0 RF3 RF4
-------------------------------PhysicalDistribute
---------------------------------PhysicalProject
-----------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 1998))
-------------------------------------PhysicalOlapScan[date_dim]
-------------------------PhysicalDistribute
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN] hashCondition=((date_dim.d_date_sk = catalog_sales.cs_sold_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF1
-------------------------------PhysicalDistribute
---------------------------------PhysicalProject
-----------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 1998))
-------------------------------------PhysicalOlapScan[date_dim]
-------------------------PhysicalDistribute
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN] hashCondition=((date_dim.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ss_sold_date_sk]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2
-------------------------------PhysicalDistribute
---------------------------------PhysicalProject
-----------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 1998))
-------------------------------------PhysicalOlapScan[date_dim]
-----------------------PhysicalDistribute
-------------------------PhysicalProject
---------------------------filter(t_meal_time IN ('breakfast', 'dinner'))
-----------------------------PhysicalOlapScan[time_dim]
+----------------------------filter((item.i_manager_id = 1))
+------------------------------PhysicalOlapScan[item]
 --------------------PhysicalDistribute
 ----------------------PhysicalProject
-------------------------filter((item.i_manager_id = 1))
---------------------------PhysicalOlapScan[item]
+------------------------filter(t_meal_time IN ('breakfast', 'dinner'))
+--------------------------PhysicalOlapScan[time_dim]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query74.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/noStatsRfPrune/query74.out
@@ -44,24 +44,23 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------PhysicalDistribute
 --------PhysicalTopN[LOCAL_SORT]
 ----------PhysicalProject
-------------hashJoin[INNER_JOIN] hashCondition=((t_s_firstyear.customer_id = t_w_secyear.customer_id)) otherCondition=((if((year_total > 0), (year_total / year_total), NULL) > if((year_total > 0), (year_total / year_total), NULL)))
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((t_s_firstyear.customer_id = t_w_firstyear.customer_id)) otherCondition=()
-------------------hashJoin[INNER_JOIN] hashCondition=((t_s_secyear.customer_id = t_s_firstyear.customer_id)) otherCondition=()
---------------------PhysicalDistribute
-----------------------PhysicalProject
-------------------------filter((t_s_firstyear.sale_type = 's') and (t_s_firstyear.year = 1999) and (t_s_firstyear.year_total > 0))
---------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
---------------------PhysicalDistribute
-----------------------PhysicalProject
-------------------------filter((t_s_secyear.sale_type = 's') and (t_s_secyear.year = 2000))
---------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+------------hashJoin[INNER_JOIN] hashCondition=((t_s_firstyear.customer_id = t_w_firstyear.customer_id)) otherCondition=((if((year_total > 0), (year_total / year_total), NULL) > if((year_total > 0), (year_total / year_total), NULL)))
+--------------hashJoin[INNER_JOIN] hashCondition=((t_s_firstyear.customer_id = t_w_secyear.customer_id)) otherCondition=()
+----------------hashJoin[INNER_JOIN] hashCondition=((t_s_secyear.customer_id = t_s_firstyear.customer_id)) otherCondition=()
 ------------------PhysicalDistribute
 --------------------PhysicalProject
-----------------------filter((t_w_firstyear.sale_type = 'w') and (t_w_firstyear.year = 1999) and (t_w_firstyear.year_total > 0))
+----------------------filter((t_s_secyear.sale_type = 's') and (t_s_secyear.year = 2000))
 ------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+------------------PhysicalDistribute
+--------------------PhysicalProject
+----------------------filter((t_s_firstyear.sale_type = 's') and (t_s_firstyear.year = 1999) and (t_s_firstyear.year_total > 0))
+------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+----------------PhysicalDistribute
+------------------PhysicalProject
+--------------------filter((t_w_secyear.sale_type = 'w') and (t_w_secyear.year = 2000))
+----------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 --------------PhysicalDistribute
 ----------------PhysicalProject
-------------------filter((t_w_secyear.sale_type = 'w') and (t_w_secyear.year = 2000))
+------------------filter((t_w_firstyear.sale_type = 'w') and (t_w_firstyear.year = 1999) and (t_w_firstyear.year_total > 0))
 --------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query44.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query44.out
@@ -12,33 +12,32 @@ PhysicalResultSink
 ------------------PhysicalDistribute
 --------------------PhysicalProject
 ----------------------hashJoin[INNER_JOIN] hashCondition=((asceding.rnk = descending.rnk)) otherCondition=()
-------------------------PhysicalDistribute
---------------------------PhysicalProject
-----------------------------filter((rnk < 11))
-------------------------------PhysicalWindow
---------------------------------PhysicalQuickSort[MERGE_SORT]
-----------------------------------PhysicalDistribute
-------------------------------------PhysicalQuickSort[LOCAL_SORT]
---------------------------------------PhysicalPartitionTopN
-----------------------------------------PhysicalProject
-------------------------------------------NestedLoopJoin[INNER_JOIN](cast(rank_col as DOUBLE) > cast((0.9 * rank_col) as DOUBLE))
---------------------------------------------PhysicalProject
-----------------------------------------------hashAgg[GLOBAL]
-------------------------------------------------PhysicalDistribute
---------------------------------------------------hashAgg[LOCAL]
-----------------------------------------------------PhysicalProject
-------------------------------------------------------filter((ss1.ss_store_sk = 146))
---------------------------------------------------------PhysicalOlapScan[store_sales]
---------------------------------------------PhysicalDistribute
-----------------------------------------------PhysicalAssertNumRows
-------------------------------------------------PhysicalDistribute
+------------------------PhysicalProject
+--------------------------filter((rnk < 11))
+----------------------------PhysicalWindow
+------------------------------PhysicalQuickSort[MERGE_SORT]
+--------------------------------PhysicalDistribute
+----------------------------------PhysicalQuickSort[LOCAL_SORT]
+------------------------------------PhysicalPartitionTopN
+--------------------------------------PhysicalProject
+----------------------------------------NestedLoopJoin[INNER_JOIN](cast(rank_col as DOUBLE) > cast((0.9 * rank_col) as DOUBLE))
+------------------------------------------PhysicalProject
+--------------------------------------------hashAgg[GLOBAL]
+----------------------------------------------PhysicalDistribute
+------------------------------------------------hashAgg[LOCAL]
 --------------------------------------------------PhysicalProject
-----------------------------------------------------hashAgg[GLOBAL]
-------------------------------------------------------PhysicalDistribute
---------------------------------------------------------hashAgg[LOCAL]
-----------------------------------------------------------PhysicalProject
-------------------------------------------------------------filter((store_sales.ss_store_sk = 146) and ss_addr_sk IS NULL)
---------------------------------------------------------------PhysicalOlapScan[store_sales]
+----------------------------------------------------filter((ss1.ss_store_sk = 146))
+------------------------------------------------------PhysicalOlapScan[store_sales]
+------------------------------------------PhysicalDistribute
+--------------------------------------------PhysicalAssertNumRows
+----------------------------------------------PhysicalDistribute
+------------------------------------------------PhysicalProject
+--------------------------------------------------hashAgg[GLOBAL]
+----------------------------------------------------PhysicalDistribute
+------------------------------------------------------hashAgg[LOCAL]
+--------------------------------------------------------PhysicalProject
+----------------------------------------------------------filter((store_sales.ss_store_sk = 146) and ss_addr_sk IS NULL)
+------------------------------------------------------------PhysicalOlapScan[store_sales]
 ------------------------PhysicalDistribute
 --------------------------PhysicalProject
 ----------------------------filter((rnk < 11))

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query5.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query5.out
@@ -15,33 +15,34 @@ PhysicalResultSink
 ------------------------PhysicalDistribute
 --------------------------hashAgg[LOCAL]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ss_sold_date_sk,sr_returned_date_sk]
---------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.store_sk = store.s_store_sk)) otherCondition=() build RFs:RF0 s_store_sk->[ss_store_sk,sr_store_sk]
-----------------------------------PhysicalUnion
+------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.store_sk = store.s_store_sk)) otherCondition=()
+--------------------------------PhysicalProject
+----------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ss_sold_date_sk,sr_returned_date_sk]
+------------------------------------PhysicalUnion
+--------------------------------------PhysicalDistribute
+----------------------------------------PhysicalProject
+------------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0
+--------------------------------------PhysicalDistribute
+----------------------------------------PhysicalProject
+------------------------------------------PhysicalOlapScan[store_returns]
 ------------------------------------PhysicalDistribute
 --------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1
-------------------------------------PhysicalDistribute
---------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[store_returns]
-----------------------------------PhysicalDistribute
-------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[store]
+----------------------------------------filter((date_dim.d_date <= '2000-09-02') and (date_dim.d_date >= '2000-08-19'))
+------------------------------------------PhysicalOlapScan[date_dim]
 --------------------------------PhysicalDistribute
 ----------------------------------PhysicalProject
-------------------------------------filter((date_dim.d_date <= '2000-09-02') and (date_dim.d_date >= '2000-08-19'))
---------------------------------------PhysicalOlapScan[date_dim]
+------------------------------------PhysicalOlapScan[store]
 --------------------PhysicalProject
 ----------------------hashAgg[GLOBAL]
 ------------------------PhysicalDistribute
 --------------------------hashAgg[LOCAL]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[cs_sold_date_sk,cr_returned_date_sk]
---------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.page_sk = catalog_page.cp_catalog_page_sk)) otherCondition=() build RFs:RF2 cp_catalog_page_sk->[cs_catalog_page_sk,cr_catalog_page_sk]
+------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[cs_sold_date_sk,cr_returned_date_sk]
+--------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.page_sk = catalog_page.cp_catalog_page_sk)) otherCondition=() build RFs:RF1 cp_catalog_page_sk->[cs_catalog_page_sk,cr_catalog_page_sk]
 ----------------------------------PhysicalUnion
 ------------------------------------PhysicalDistribute
 --------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF2 RF3
+----------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF1 RF2
 ------------------------------------PhysicalDistribute
 --------------------------------------PhysicalProject
 ----------------------------------------PhysicalOlapScan[catalog_returns]
@@ -57,24 +58,25 @@ PhysicalResultSink
 ------------------------PhysicalDistribute
 --------------------------hashAgg[LOCAL]
 ----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF7 d_date_sk->[ws_sold_date_sk,wr_returned_date_sk]
---------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.wsr_web_site_sk = web_site.web_site_sk)) otherCondition=() build RFs:RF6 web_site_sk->[ws_web_site_sk,ws_web_site_sk]
-----------------------------------PhysicalUnion
+------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.wsr_web_site_sk = web_site.web_site_sk)) otherCondition=()
+--------------------------------PhysicalProject
+----------------------------------hashJoin[INNER_JOIN] hashCondition=((salesreturns.date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->[ws_sold_date_sk,wr_returned_date_sk]
+------------------------------------PhysicalUnion
+--------------------------------------PhysicalDistribute
+----------------------------------------PhysicalProject
+------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF5
+--------------------------------------PhysicalDistribute
+----------------------------------------PhysicalProject
+------------------------------------------hashJoin[INNER_JOIN] hashCondition=((web_returns.wr_item_sk = web_sales.ws_item_sk) and (web_returns.wr_order_number = web_sales.ws_order_number)) otherCondition=() build RFs:RF3 wr_item_sk->[ws_item_sk];RF4 wr_order_number->[ws_order_number]
+--------------------------------------------PhysicalProject
+----------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF3 RF4
+--------------------------------------------PhysicalProject
+----------------------------------------------PhysicalOlapScan[web_returns]
 ------------------------------------PhysicalDistribute
 --------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF6 RF7
-------------------------------------PhysicalDistribute
---------------------------------------PhysicalProject
-----------------------------------------hashJoin[INNER_JOIN] hashCondition=((web_returns.wr_item_sk = web_sales.ws_item_sk) and (web_returns.wr_order_number = web_sales.ws_order_number)) otherCondition=() build RFs:RF4 wr_item_sk->[ws_item_sk];RF5 wr_order_number->[ws_order_number]
-------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF4 RF5
-------------------------------------------PhysicalProject
---------------------------------------------PhysicalOlapScan[web_returns]
-----------------------------------PhysicalDistribute
-------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[web_site]
+----------------------------------------filter((date_dim.d_date <= '2000-09-02') and (date_dim.d_date >= '2000-08-19'))
+------------------------------------------PhysicalOlapScan[date_dim]
 --------------------------------PhysicalDistribute
 ----------------------------------PhysicalProject
-------------------------------------filter((date_dim.d_date <= '2000-09-02') and (date_dim.d_date >= '2000-08-19'))
---------------------------------------PhysicalOlapScan[date_dim]
+------------------------------------PhysicalOlapScan[web_site]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query54.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query54.out
@@ -11,44 +11,44 @@ PhysicalResultSink
 ----------------PhysicalProject
 ------------------hashAgg[LOCAL]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN] hashCondition=((customer_address.ca_county = store.s_county) and (customer_address.ca_state = store.s_state)) otherCondition=() build RFs:RF5 s_county->[ca_county];RF6 s_state->[ca_state]
-------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->[ss_sold_date_sk]
+----------------------hashJoin[INNER_JOIN] hashCondition=((customer_address.ca_county = store.s_county) and (customer_address.ca_state = store.s_state)) otherCondition=() build RFs:RF4 s_county->[ca_county];RF5 s_state->[ca_state]
+------------------------hashJoin[INNER_JOIN] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->[ss_sold_date_sk]
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF3 ca_address_sk->[c_current_addr_sk]
+----------------------------hashJoin[INNER_JOIN] hashCondition=((my_customers.c_current_addr_sk = customer_address.ca_address_sk)) otherCondition=() build RFs:RF2 ca_address_sk->[c_current_addr_sk]
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN] hashCondition=((my_customers.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->[ss_customer_sk]
+--------------------------------hashJoin[INNER_JOIN] hashCondition=((my_customers.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF1 c_customer_sk->[ss_customer_sk]
 ----------------------------------PhysicalDistribute
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF4
+--------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF3
 ----------------------------------PhysicalProject
 ------------------------------------hashAgg[LOCAL]
 --------------------------------------PhysicalProject
-----------------------------------------hashJoin[INNER_JOIN] hashCondition=((customer.c_customer_sk = cs_or_ws_sales.customer_sk)) otherCondition=()
-------------------------------------------PhysicalDistribute
---------------------------------------------PhysicalProject
-----------------------------------------------hashJoin[INNER_JOIN] hashCondition=((cs_or_ws_sales.item_sk = item.i_item_sk)) otherCondition=() build RFs:RF1 i_item_sk->[cs_item_sk,ws_item_sk]
-------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((cs_or_ws_sales.sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[cs_sold_date_sk,ws_sold_date_sk]
+----------------------------------------hashJoin[INNER_JOIN] hashCondition=((cs_or_ws_sales.sold_date_sk = date_dim.d_date_sk)) otherCondition=()
+------------------------------------------hashJoin[INNER_JOIN] hashCondition=((customer.c_customer_sk = cs_or_ws_sales.customer_sk)) otherCondition=()
+--------------------------------------------PhysicalDistribute
+----------------------------------------------PhysicalProject
+------------------------------------------------hashJoin[INNER_JOIN] hashCondition=((cs_or_ws_sales.item_sk = item.i_item_sk)) otherCondition=() build RFs:RF0 i_item_sk->[cs_item_sk,ws_item_sk]
 --------------------------------------------------PhysicalUnion
 ----------------------------------------------------PhysicalDistribute
 ------------------------------------------------------PhysicalProject
---------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0 RF1
+--------------------------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
 ----------------------------------------------------PhysicalDistribute
 ------------------------------------------------------PhysicalProject
 --------------------------------------------------------PhysicalOlapScan[web_sales]
 --------------------------------------------------PhysicalDistribute
 ----------------------------------------------------PhysicalProject
-------------------------------------------------------filter((date_dim.d_moy = 5) and (date_dim.d_year = 1998))
---------------------------------------------------------PhysicalOlapScan[date_dim]
-------------------------------------------------PhysicalDistribute
---------------------------------------------------PhysicalProject
-----------------------------------------------------filter((item.i_category = 'Women') and (item.i_class = 'maternity'))
-------------------------------------------------------PhysicalOlapScan[item]
+------------------------------------------------------filter((item.i_category = 'Women') and (item.i_class = 'maternity'))
+--------------------------------------------------------PhysicalOlapScan[item]
+--------------------------------------------PhysicalDistribute
+----------------------------------------------PhysicalProject
+------------------------------------------------PhysicalOlapScan[customer] apply RFs: RF2
 ------------------------------------------PhysicalDistribute
 --------------------------------------------PhysicalProject
-----------------------------------------------PhysicalOlapScan[customer] apply RFs: RF3
+----------------------------------------------filter((date_dim.d_moy = 5) and (date_dim.d_year = 1998))
+------------------------------------------------PhysicalOlapScan[date_dim]
 ------------------------------PhysicalDistribute
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[customer_address] apply RFs: RF5 RF6
+----------------------------------PhysicalOlapScan[customer_address] apply RFs: RF4 RF5
 --------------------------PhysicalDistribute
 ----------------------------PhysicalProject
 ------------------------------NestedLoopJoin[INNER_JOIN](cast(d_month_seq as BIGINT) >= (d_month_seq + 1))

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query71.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query71.out
@@ -9,42 +9,43 @@ PhysicalResultSink
 ------------PhysicalDistribute
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------hashJoin[INNER_JOIN] hashCondition=((tmp.sold_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF4 i_item_sk->[ws_item_sk,cs_item_sk,ss_item_sk]
---------------------hashJoin[INNER_JOIN] hashCondition=((tmp.time_sk = time_dim.t_time_sk)) otherCondition=() build RFs:RF3 t_time_sk->[ws_sold_time_sk,cs_sold_time_sk,ss_sold_time_sk]
-----------------------PhysicalUnion
+------------------hashJoin[INNER_JOIN] hashCondition=((tmp.time_sk = time_dim.t_time_sk)) otherCondition=()
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN] hashCondition=((tmp.sold_item_sk = item.i_item_sk)) otherCondition=() build RFs:RF3 i_item_sk->[ws_item_sk,cs_item_sk,ss_item_sk]
+------------------------PhysicalUnion
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------hashJoin[INNER_JOIN] hashCondition=((date_dim.d_date_sk = web_sales.ws_sold_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ws_sold_date_sk]
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0 RF3
+--------------------------------PhysicalDistribute
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 1998))
+--------------------------------------PhysicalOlapScan[date_dim]
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------hashJoin[INNER_JOIN] hashCondition=((date_dim.d_date_sk = catalog_sales.cs_sold_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk]
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF1
+--------------------------------PhysicalDistribute
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 1998))
+--------------------------------------PhysicalOlapScan[date_dim]
+--------------------------PhysicalDistribute
+----------------------------PhysicalProject
+------------------------------hashJoin[INNER_JOIN] hashCondition=((date_dim.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ss_sold_date_sk]
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2
+--------------------------------PhysicalDistribute
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 1998))
+--------------------------------------PhysicalOlapScan[date_dim]
 ------------------------PhysicalDistribute
 --------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN] hashCondition=((date_dim.d_date_sk = web_sales.ws_sold_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[ws_sold_date_sk]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0 RF3 RF4
-------------------------------PhysicalDistribute
---------------------------------PhysicalProject
-----------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 1998))
-------------------------------------PhysicalOlapScan[date_dim]
-------------------------PhysicalDistribute
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN] hashCondition=((date_dim.d_date_sk = catalog_sales.cs_sold_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[cs_sold_date_sk]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF1
-------------------------------PhysicalDistribute
---------------------------------PhysicalProject
-----------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 1998))
-------------------------------------PhysicalOlapScan[date_dim]
-------------------------PhysicalDistribute
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN] hashCondition=((date_dim.d_date_sk = store_sales.ss_sold_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->[ss_sold_date_sk]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2
-------------------------------PhysicalDistribute
---------------------------------PhysicalProject
-----------------------------------filter((date_dim.d_moy = 12) and (date_dim.d_year = 1998))
-------------------------------------PhysicalOlapScan[date_dim]
-----------------------PhysicalDistribute
-------------------------PhysicalProject
---------------------------filter(t_meal_time IN ('breakfast', 'dinner'))
-----------------------------PhysicalOlapScan[time_dim]
+----------------------------filter((item.i_manager_id = 1))
+------------------------------PhysicalOlapScan[item]
 --------------------PhysicalDistribute
 ----------------------PhysicalProject
-------------------------filter((item.i_manager_id = 1))
---------------------------PhysicalOlapScan[item]
+------------------------filter(t_meal_time IN ('breakfast', 'dinner'))
+--------------------------PhysicalOlapScan[time_dim]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query74.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/no_stats_shape/query74.out
@@ -44,24 +44,23 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------PhysicalDistribute
 --------PhysicalTopN[LOCAL_SORT]
 ----------PhysicalProject
-------------hashJoin[INNER_JOIN] hashCondition=((t_s_firstyear.customer_id = t_w_secyear.customer_id)) otherCondition=((if((year_total > 0), (year_total / year_total), NULL) > if((year_total > 0), (year_total / year_total), NULL)))
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((t_s_firstyear.customer_id = t_w_firstyear.customer_id)) otherCondition=()
-------------------hashJoin[INNER_JOIN] hashCondition=((t_s_secyear.customer_id = t_s_firstyear.customer_id)) otherCondition=()
---------------------PhysicalDistribute
-----------------------PhysicalProject
-------------------------filter((t_s_firstyear.sale_type = 's') and (t_s_firstyear.year = 1999) and (t_s_firstyear.year_total > 0))
---------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
---------------------PhysicalDistribute
-----------------------PhysicalProject
-------------------------filter((t_s_secyear.sale_type = 's') and (t_s_secyear.year = 2000))
---------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+------------hashJoin[INNER_JOIN] hashCondition=((t_s_firstyear.customer_id = t_w_firstyear.customer_id)) otherCondition=((if((year_total > 0), (year_total / year_total), NULL) > if((year_total > 0), (year_total / year_total), NULL)))
+--------------hashJoin[INNER_JOIN] hashCondition=((t_s_firstyear.customer_id = t_w_secyear.customer_id)) otherCondition=()
+----------------hashJoin[INNER_JOIN] hashCondition=((t_s_secyear.customer_id = t_s_firstyear.customer_id)) otherCondition=()
 ------------------PhysicalDistribute
 --------------------PhysicalProject
-----------------------filter((t_w_firstyear.sale_type = 'w') and (t_w_firstyear.year = 1999) and (t_w_firstyear.year_total > 0))
+----------------------filter((t_s_secyear.sale_type = 's') and (t_s_secyear.year = 2000))
 ------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+------------------PhysicalDistribute
+--------------------PhysicalProject
+----------------------filter((t_s_firstyear.sale_type = 's') and (t_s_firstyear.year = 1999) and (t_s_firstyear.year_total > 0))
+------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+----------------PhysicalDistribute
+------------------PhysicalProject
+--------------------filter((t_w_secyear.sale_type = 'w') and (t_w_secyear.year = 2000))
+----------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 --------------PhysicalDistribute
 ----------------PhysicalProject
-------------------filter((t_w_secyear.sale_type = 'w') and (t_w_secyear.year = 2000))
+------------------filter((t_w_firstyear.sale_type = 'w') and (t_w_firstyear.year = 1999) and (t_w_firstyear.year_total > 0))
 --------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/rf_prune/query44.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/rf_prune/query44.out
@@ -6,11 +6,41 @@ PhysicalResultSink
 ------PhysicalTopN[LOCAL_SORT]
 --------PhysicalProject
 ----------hashJoin[INNER_JOIN] hashCondition=((asceding.rnk = descending.rnk)) otherCondition=()
+------------hashJoin[INNER_JOIN] hashCondition=((i2.i_item_sk = descending.item_sk)) otherCondition=() build RFs:RF1 item_sk->[i_item_sk]
+--------------PhysicalProject
+----------------PhysicalOlapScan[item] apply RFs: RF1
+--------------PhysicalDistribute
+----------------PhysicalProject
+------------------filter((rnk < 11))
+--------------------PhysicalWindow
+----------------------PhysicalQuickSort[MERGE_SORT]
+------------------------PhysicalDistribute
+--------------------------PhysicalQuickSort[LOCAL_SORT]
+----------------------------PhysicalPartitionTopN
+------------------------------PhysicalProject
+--------------------------------NestedLoopJoin[INNER_JOIN](cast(rank_col as DOUBLE) > cast((0.9 * rank_col) as DOUBLE))
+----------------------------------PhysicalProject
+------------------------------------hashAgg[GLOBAL]
+--------------------------------------PhysicalDistribute
+----------------------------------------hashAgg[LOCAL]
+------------------------------------------PhysicalProject
+--------------------------------------------filter((ss1.ss_store_sk = 146))
+----------------------------------------------PhysicalOlapScan[store_sales]
+----------------------------------PhysicalDistribute
+------------------------------------PhysicalAssertNumRows
+--------------------------------------PhysicalDistribute
+----------------------------------------PhysicalProject
+------------------------------------------hashAgg[GLOBAL]
+--------------------------------------------PhysicalDistribute
+----------------------------------------------hashAgg[LOCAL]
+------------------------------------------------PhysicalProject
+--------------------------------------------------filter((store_sales.ss_store_sk = 146) and ss_addr_sk IS NULL)
+----------------------------------------------------PhysicalOlapScan[store_sales]
 ------------PhysicalDistribute
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((i1.i_item_sk = asceding.item_sk)) otherCondition=() build RFs:RF1 item_sk->[i_item_sk]
+----------------hashJoin[INNER_JOIN] hashCondition=((i1.i_item_sk = asceding.item_sk)) otherCondition=() build RFs:RF0 item_sk->[i_item_sk]
 ------------------PhysicalProject
---------------------PhysicalOlapScan[item] apply RFs: RF1
+--------------------PhysicalOlapScan[item] apply RFs: RF0
 ------------------PhysicalDistribute
 --------------------PhysicalProject
 ----------------------filter((rnk < 11))
@@ -38,35 +68,4 @@ PhysicalResultSink
 ----------------------------------------------------PhysicalProject
 ------------------------------------------------------filter((store_sales.ss_store_sk = 146) and ss_addr_sk IS NULL)
 --------------------------------------------------------PhysicalOlapScan[store_sales]
-------------PhysicalDistribute
---------------hashJoin[INNER_JOIN] hashCondition=((i2.i_item_sk = descending.item_sk)) otherCondition=() build RFs:RF0 item_sk->[i_item_sk]
-----------------PhysicalProject
-------------------PhysicalOlapScan[item] apply RFs: RF0
-----------------PhysicalDistribute
-------------------PhysicalProject
---------------------filter((rnk < 11))
-----------------------PhysicalWindow
-------------------------PhysicalQuickSort[MERGE_SORT]
---------------------------PhysicalDistribute
-----------------------------PhysicalQuickSort[LOCAL_SORT]
-------------------------------PhysicalPartitionTopN
---------------------------------PhysicalProject
-----------------------------------NestedLoopJoin[INNER_JOIN](cast(rank_col as DOUBLE) > cast((0.9 * rank_col) as DOUBLE))
-------------------------------------PhysicalProject
---------------------------------------hashAgg[GLOBAL]
-----------------------------------------PhysicalDistribute
-------------------------------------------hashAgg[LOCAL]
---------------------------------------------PhysicalProject
-----------------------------------------------filter((ss1.ss_store_sk = 146))
-------------------------------------------------PhysicalOlapScan[store_sales]
-------------------------------------PhysicalDistribute
---------------------------------------PhysicalAssertNumRows
-----------------------------------------PhysicalDistribute
-------------------------------------------PhysicalProject
---------------------------------------------hashAgg[GLOBAL]
-----------------------------------------------PhysicalDistribute
-------------------------------------------------hashAgg[LOCAL]
---------------------------------------------------PhysicalProject
-----------------------------------------------------filter((store_sales.ss_store_sk = 146) and ss_addr_sk IS NULL)
-------------------------------------------------------PhysicalOlapScan[store_sales]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/rf_prune/query74.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/rf_prune/query74.out
@@ -42,23 +42,24 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------PhysicalDistribute
 --------PhysicalTopN[LOCAL_SORT]
 ----------PhysicalProject
-------------hashJoin[INNER_JOIN] hashCondition=((t_s_firstyear.customer_id = t_w_firstyear.customer_id)) otherCondition=((if((year_total > 0), (year_total / year_total), NULL) > if((year_total > 0), (year_total / year_total), NULL)))
---------------hashJoin[INNER_JOIN] hashCondition=((t_s_firstyear.customer_id = t_w_secyear.customer_id)) otherCondition=()
+------------hashJoin[INNER_JOIN] hashCondition=((t_s_firstyear.customer_id = t_w_secyear.customer_id)) otherCondition=((if((year_total > 0), (year_total / year_total), NULL) > if((year_total > 0), (year_total / year_total), NULL)))
+--------------PhysicalProject
 ----------------hashJoin[INNER_JOIN] hashCondition=((t_s_secyear.customer_id = t_s_firstyear.customer_id)) otherCondition=()
-------------------PhysicalDistribute
---------------------PhysicalProject
-----------------------filter((t_s_firstyear.sale_type = 's') and (t_s_firstyear.year = 1999) and (t_s_firstyear.year_total > 0))
-------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+------------------hashJoin[INNER_JOIN] hashCondition=((t_s_firstyear.customer_id = t_w_firstyear.customer_id)) otherCondition=()
+--------------------PhysicalDistribute
+----------------------PhysicalProject
+------------------------filter((t_s_firstyear.sale_type = 's') and (t_s_firstyear.year = 1999) and (t_s_firstyear.year_total > 0))
+--------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+--------------------PhysicalDistribute
+----------------------PhysicalProject
+------------------------filter((t_w_firstyear.sale_type = 'w') and (t_w_firstyear.year = 1999) and (t_w_firstyear.year_total > 0))
+--------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 ------------------PhysicalDistribute
 --------------------PhysicalProject
 ----------------------filter((t_s_secyear.sale_type = 's') and (t_s_secyear.year = 2000))
 ------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
-----------------PhysicalDistribute
-------------------PhysicalProject
---------------------filter((t_w_secyear.sale_type = 'w') and (t_w_secyear.year = 2000))
-----------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 --------------PhysicalDistribute
 ----------------PhysicalProject
-------------------filter((t_w_firstyear.sale_type = 'w') and (t_w_firstyear.year = 1999) and (t_w_firstyear.year_total > 0))
+------------------filter((t_w_secyear.sale_type = 'w') and (t_w_secyear.year = 2000))
 --------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/rf_prune/query78.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/rf_prune/query78.out
@@ -24,34 +24,36 @@ PhysicalResultSink
 --------------------------------------PhysicalOlapScan[date_dim]
 ------------------------------PhysicalProject
 --------------------------------PhysicalOlapScan[store_returns]
-------------------PhysicalProject
---------------------hashAgg[GLOBAL]
-----------------------PhysicalDistribute
-------------------------hashAgg[LOCAL]
---------------------------PhysicalProject
-----------------------------hashJoin[LEFT_ANTI_JOIN] hashCondition=((web_returns.wr_order_number = web_sales.ws_order_number) and (web_sales.ws_item_sk = web_returns.wr_item_sk)) otherCondition=()
-------------------------------hashJoin[INNER_JOIN] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ws_sold_date_sk]
---------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[web_sales] apply RFs: RF1
---------------------------------PhysicalDistribute
-----------------------------------PhysicalProject
-------------------------------------filter((date_dim.d_year = 2000))
---------------------------------------PhysicalOlapScan[date_dim]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[web_returns]
---------------PhysicalProject
-----------------hashAgg[GLOBAL]
 ------------------PhysicalDistribute
---------------------hashAgg[LOCAL]
-----------------------PhysicalProject
-------------------------hashJoin[LEFT_ANTI_JOIN] hashCondition=((catalog_returns.cr_order_number = catalog_sales.cs_order_number) and (catalog_sales.cs_item_sk = catalog_returns.cr_item_sk)) otherCondition=()
---------------------------hashJoin[INNER_JOIN] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[cs_sold_date_sk]
+--------------------PhysicalProject
+----------------------hashAgg[GLOBAL]
+------------------------PhysicalDistribute
+--------------------------hashAgg[LOCAL]
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
-----------------------------PhysicalDistribute
+------------------------------hashJoin[LEFT_ANTI_JOIN] hashCondition=((web_returns.wr_order_number = web_sales.ws_order_number) and (web_sales.ws_item_sk = web_returns.wr_item_sk)) otherCondition=()
+--------------------------------hashJoin[INNER_JOIN] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ws_sold_date_sk]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF1
+----------------------------------PhysicalDistribute
+------------------------------------PhysicalProject
+--------------------------------------filter((date_dim.d_year = 2000))
+----------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[web_returns]
+--------------PhysicalDistribute
+----------------PhysicalProject
+------------------hashAgg[GLOBAL]
+--------------------PhysicalDistribute
+----------------------hashAgg[LOCAL]
+------------------------PhysicalProject
+--------------------------hashJoin[LEFT_ANTI_JOIN] hashCondition=((catalog_returns.cr_order_number = catalog_sales.cs_order_number) and (catalog_sales.cs_item_sk = catalog_returns.cr_item_sk)) otherCondition=()
+----------------------------hashJoin[INNER_JOIN] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[cs_sold_date_sk]
 ------------------------------PhysicalProject
---------------------------------filter((date_dim.d_year = 2000))
-----------------------------------PhysicalOlapScan[date_dim]
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_returns]
+--------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
+------------------------------PhysicalDistribute
+--------------------------------PhysicalProject
+----------------------------------filter((date_dim.d_year = 2000))
+------------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[catalog_returns]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query44.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query44.out
@@ -6,11 +6,41 @@ PhysicalResultSink
 ------PhysicalTopN[LOCAL_SORT]
 --------PhysicalProject
 ----------hashJoin[INNER_JOIN] hashCondition=((asceding.rnk = descending.rnk)) otherCondition=()
+------------hashJoin[INNER_JOIN] hashCondition=((i2.i_item_sk = descending.item_sk)) otherCondition=() build RFs:RF1 item_sk->[i_item_sk]
+--------------PhysicalProject
+----------------PhysicalOlapScan[item] apply RFs: RF1
+--------------PhysicalDistribute
+----------------PhysicalProject
+------------------filter((rnk < 11))
+--------------------PhysicalWindow
+----------------------PhysicalQuickSort[MERGE_SORT]
+------------------------PhysicalDistribute
+--------------------------PhysicalQuickSort[LOCAL_SORT]
+----------------------------PhysicalPartitionTopN
+------------------------------PhysicalProject
+--------------------------------NestedLoopJoin[INNER_JOIN](cast(rank_col as DOUBLE) > cast((0.9 * rank_col) as DOUBLE))
+----------------------------------PhysicalProject
+------------------------------------hashAgg[GLOBAL]
+--------------------------------------PhysicalDistribute
+----------------------------------------hashAgg[LOCAL]
+------------------------------------------PhysicalProject
+--------------------------------------------filter((ss1.ss_store_sk = 146))
+----------------------------------------------PhysicalOlapScan[store_sales]
+----------------------------------PhysicalDistribute
+------------------------------------PhysicalAssertNumRows
+--------------------------------------PhysicalDistribute
+----------------------------------------PhysicalProject
+------------------------------------------hashAgg[GLOBAL]
+--------------------------------------------PhysicalDistribute
+----------------------------------------------hashAgg[LOCAL]
+------------------------------------------------PhysicalProject
+--------------------------------------------------filter((store_sales.ss_store_sk = 146) and ss_addr_sk IS NULL)
+----------------------------------------------------PhysicalOlapScan[store_sales]
 ------------PhysicalDistribute
 --------------PhysicalProject
-----------------hashJoin[INNER_JOIN] hashCondition=((i1.i_item_sk = asceding.item_sk)) otherCondition=() build RFs:RF1 item_sk->[i_item_sk]
+----------------hashJoin[INNER_JOIN] hashCondition=((i1.i_item_sk = asceding.item_sk)) otherCondition=() build RFs:RF0 item_sk->[i_item_sk]
 ------------------PhysicalProject
---------------------PhysicalOlapScan[item] apply RFs: RF1
+--------------------PhysicalOlapScan[item] apply RFs: RF0
 ------------------PhysicalDistribute
 --------------------PhysicalProject
 ----------------------filter((rnk < 11))
@@ -38,35 +68,4 @@ PhysicalResultSink
 ----------------------------------------------------PhysicalProject
 ------------------------------------------------------filter((store_sales.ss_store_sk = 146) and ss_addr_sk IS NULL)
 --------------------------------------------------------PhysicalOlapScan[store_sales]
-------------PhysicalDistribute
---------------hashJoin[INNER_JOIN] hashCondition=((i2.i_item_sk = descending.item_sk)) otherCondition=() build RFs:RF0 item_sk->[i_item_sk]
-----------------PhysicalProject
-------------------PhysicalOlapScan[item] apply RFs: RF0
-----------------PhysicalDistribute
-------------------PhysicalProject
---------------------filter((rnk < 11))
-----------------------PhysicalWindow
-------------------------PhysicalQuickSort[MERGE_SORT]
---------------------------PhysicalDistribute
-----------------------------PhysicalQuickSort[LOCAL_SORT]
-------------------------------PhysicalPartitionTopN
---------------------------------PhysicalProject
-----------------------------------NestedLoopJoin[INNER_JOIN](cast(rank_col as DOUBLE) > cast((0.9 * rank_col) as DOUBLE))
-------------------------------------PhysicalProject
---------------------------------------hashAgg[GLOBAL]
-----------------------------------------PhysicalDistribute
-------------------------------------------hashAgg[LOCAL]
---------------------------------------------PhysicalProject
-----------------------------------------------filter((ss1.ss_store_sk = 146))
-------------------------------------------------PhysicalOlapScan[store_sales]
-------------------------------------PhysicalDistribute
---------------------------------------PhysicalAssertNumRows
-----------------------------------------PhysicalDistribute
-------------------------------------------PhysicalProject
---------------------------------------------hashAgg[GLOBAL]
-----------------------------------------------PhysicalDistribute
-------------------------------------------------hashAgg[LOCAL]
---------------------------------------------------PhysicalProject
-----------------------------------------------------filter((store_sales.ss_store_sk = 146) and ss_addr_sk IS NULL)
-------------------------------------------------------PhysicalOlapScan[store_sales]
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query74.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query74.out
@@ -42,23 +42,24 @@ PhysicalCteAnchor ( cteId=CTEId#0 )
 ------PhysicalDistribute
 --------PhysicalTopN[LOCAL_SORT]
 ----------PhysicalProject
-------------hashJoin[INNER_JOIN] hashCondition=((t_s_firstyear.customer_id = t_w_firstyear.customer_id)) otherCondition=((if((year_total > 0), (year_total / year_total), NULL) > if((year_total > 0), (year_total / year_total), NULL)))
---------------hashJoin[INNER_JOIN] hashCondition=((t_s_firstyear.customer_id = t_w_secyear.customer_id)) otherCondition=()
+------------hashJoin[INNER_JOIN] hashCondition=((t_s_firstyear.customer_id = t_w_secyear.customer_id)) otherCondition=((if((year_total > 0), (year_total / year_total), NULL) > if((year_total > 0), (year_total / year_total), NULL)))
+--------------PhysicalProject
 ----------------hashJoin[INNER_JOIN] hashCondition=((t_s_secyear.customer_id = t_s_firstyear.customer_id)) otherCondition=()
-------------------PhysicalDistribute
---------------------PhysicalProject
-----------------------filter((t_s_firstyear.sale_type = 's') and (t_s_firstyear.year = 1999) and (t_s_firstyear.year_total > 0))
-------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+------------------hashJoin[INNER_JOIN] hashCondition=((t_s_firstyear.customer_id = t_w_firstyear.customer_id)) otherCondition=()
+--------------------PhysicalDistribute
+----------------------PhysicalProject
+------------------------filter((t_s_firstyear.sale_type = 's') and (t_s_firstyear.year = 1999) and (t_s_firstyear.year_total > 0))
+--------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
+--------------------PhysicalDistribute
+----------------------PhysicalProject
+------------------------filter((t_w_firstyear.sale_type = 'w') and (t_w_firstyear.year = 1999) and (t_w_firstyear.year_total > 0))
+--------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 ------------------PhysicalDistribute
 --------------------PhysicalProject
 ----------------------filter((t_s_secyear.sale_type = 's') and (t_s_secyear.year = 2000))
 ------------------------PhysicalCteConsumer ( cteId=CTEId#0 )
-----------------PhysicalDistribute
-------------------PhysicalProject
---------------------filter((t_w_secyear.sale_type = 'w') and (t_w_secyear.year = 2000))
-----------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 --------------PhysicalDistribute
 ----------------PhysicalProject
-------------------filter((t_w_firstyear.sale_type = 'w') and (t_w_firstyear.year = 1999) and (t_w_firstyear.year_total > 0))
+------------------filter((t_w_secyear.sale_type = 'w') and (t_w_secyear.year = 2000))
 --------------------PhysicalCteConsumer ( cteId=CTEId#0 )
 

--- a/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query78.out
+++ b/regression-test/data/nereids_tpcds_shape_sf100_p0/shape/query78.out
@@ -24,34 +24,36 @@ PhysicalResultSink
 --------------------------------------PhysicalOlapScan[date_dim]
 ------------------------------PhysicalProject
 --------------------------------PhysicalOlapScan[store_returns]
-------------------PhysicalProject
---------------------hashAgg[GLOBAL]
-----------------------PhysicalDistribute
-------------------------hashAgg[LOCAL]
---------------------------PhysicalProject
-----------------------------hashJoin[LEFT_ANTI_JOIN] hashCondition=((web_returns.wr_order_number = web_sales.ws_order_number) and (web_sales.ws_item_sk = web_returns.wr_item_sk)) otherCondition=()
-------------------------------hashJoin[INNER_JOIN] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ws_sold_date_sk]
---------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[web_sales] apply RFs: RF1
---------------------------------PhysicalDistribute
-----------------------------------PhysicalProject
-------------------------------------filter((date_dim.d_year = 2000))
---------------------------------------PhysicalOlapScan[date_dim]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[web_returns]
---------------PhysicalProject
-----------------hashAgg[GLOBAL]
 ------------------PhysicalDistribute
---------------------hashAgg[LOCAL]
-----------------------PhysicalProject
-------------------------hashJoin[LEFT_ANTI_JOIN] hashCondition=((catalog_returns.cr_order_number = catalog_sales.cs_order_number) and (catalog_sales.cs_item_sk = catalog_returns.cr_item_sk)) otherCondition=()
---------------------------hashJoin[INNER_JOIN] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[cs_sold_date_sk]
+--------------------PhysicalProject
+----------------------hashAgg[GLOBAL]
+------------------------PhysicalDistribute
+--------------------------hashAgg[LOCAL]
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
-----------------------------PhysicalDistribute
+------------------------------hashJoin[LEFT_ANTI_JOIN] hashCondition=((web_returns.wr_order_number = web_sales.ws_order_number) and (web_sales.ws_item_sk = web_returns.wr_item_sk)) otherCondition=()
+--------------------------------hashJoin[INNER_JOIN] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->[ws_sold_date_sk]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF1
+----------------------------------PhysicalDistribute
+------------------------------------PhysicalProject
+--------------------------------------filter((date_dim.d_year = 2000))
+----------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[web_returns]
+--------------PhysicalDistribute
+----------------PhysicalProject
+------------------hashAgg[GLOBAL]
+--------------------PhysicalDistribute
+----------------------hashAgg[LOCAL]
+------------------------PhysicalProject
+--------------------------hashJoin[LEFT_ANTI_JOIN] hashCondition=((catalog_returns.cr_order_number = catalog_sales.cs_order_number) and (catalog_sales.cs_item_sk = catalog_returns.cr_item_sk)) otherCondition=()
+----------------------------hashJoin[INNER_JOIN] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->[cs_sold_date_sk]
 ------------------------------PhysicalProject
---------------------------------filter((date_dim.d_year = 2000))
-----------------------------------PhysicalOlapScan[date_dim]
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_returns]
+--------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
+------------------------------PhysicalDistribute
+--------------------------------PhysicalProject
+----------------------------------filter((date_dim.d_year = 2000))
+------------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[catalog_returns]
 


### PR DESCRIPTION
## Proposed changes
1. data skew reduces shuffle join parallelism, where broadcast join is a better choice.
2. fix a bug in union column stats. when any child of union is unknown, union stats should be unknown. tpcds 74 is affected by this fix. but there is no impact on performance 
ds78 变差还需调查
before: 
query44 4358    1073    876     876
query74 6151    4995    4888    4888
query78 7655    5637    5704    5637
Total cold run time: 18164 ms
Total hot run time: 11401 ms

after: 
query44 4479    1066    781     781
query74 5851    4929    4830    4830
query78 12365   10523   10689   10523
Total cold run time: 22695 ms
Total hot run time: 16134 ms
Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

