### PR TITLE
[refactor](profilev2) unify the counter name in shuffle operator and normal operator

### DIFF
--- a/be/src/exec/data_sink.h
+++ b/be/src/exec/data_sink.h
@@ -133,7 +133,7 @@ protected:
 
     void init_sink_common_profile() {
         _exec_timer = ADD_TIMER_WITH_LEVEL(_profile, "ExecTime", 1);
-        _output_rows_counter = ADD_COUNTER_WITH_LEVEL(_profile, "OutputRows", TUnit::UNIT, 1);
+        _output_rows_counter = ADD_COUNTER_WITH_LEVEL(_profile, "RowsProduced", TUnit::UNIT, 1);
         _blocks_sent_counter = ADD_COUNTER_WITH_LEVEL(_profile, "BlocksProduced", TUnit::UNIT, 1);
     }
 };

--- a/be/src/exec/data_sink.h
+++ b/be/src/exec/data_sink.h
@@ -134,7 +134,7 @@ protected:
     void init_sink_common_profile() {
         _exec_timer = ADD_TIMER_WITH_LEVEL(_profile, "ExecTime", 1);
         _output_rows_counter = ADD_COUNTER_WITH_LEVEL(_profile, "OutputRows", TUnit::UNIT, 1);
-        _blocks_sent_counter = ADD_COUNTER_WITH_LEVEL(_profile, "OutputBlockCount", TUnit::UNIT, 1);
+        _blocks_sent_counter = ADD_COUNTER_WITH_LEVEL(_profile, "BlocksProduced", TUnit::UNIT, 1);
     }
 };
 

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -129,7 +129,7 @@ Status ExecNode::prepare(RuntimeState* state) {
     _exec_timer = ADD_TIMER_WITH_LEVEL(runtime_profile(), "ExecTime", 1);
     _rows_returned_counter = ADD_COUNTER_WITH_LEVEL(_runtime_profile, "OutputRows", TUnit::UNIT, 1);
     _output_bytes_counter =
-            ADD_COUNTER_WITH_LEVEL(_runtime_profile, "OutputBytes", TUnit::BYTES, 1);
+            ADD_COUNTER_WITH_LEVEL(_runtime_profile, "BytesProduced", TUnit::BYTES, 1);
     _block_count_counter =
             ADD_COUNTER_WITH_LEVEL(_runtime_profile, "BlocksProduced", TUnit::UNIT, 1);
     _projection_timer = ADD_TIMER(_runtime_profile, "ProjectionTime");

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -76,7 +76,7 @@
 namespace doris {
 class QueryStatistics;
 
-const std::string ExecNode::ROW_THROUGHPUT_COUNTER = "RowsReturnedRate";
+const std::string ExecNode::ROW_THROUGHPUT_COUNTER = "RowsProducedRate";
 
 ExecNode::ExecNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs)
         : _id(tnode.node_id),
@@ -127,7 +127,8 @@ Status ExecNode::init(const TPlanNode& tnode, RuntimeState* state) {
 Status ExecNode::prepare(RuntimeState* state) {
     DCHECK(_runtime_profile.get() != nullptr);
     _exec_timer = ADD_TIMER_WITH_LEVEL(runtime_profile(), "ExecTime", 1);
-    _rows_returned_counter = ADD_COUNTER_WITH_LEVEL(_runtime_profile, "OutputRows", TUnit::UNIT, 1);
+    _rows_returned_counter =
+            ADD_COUNTER_WITH_LEVEL(_runtime_profile, "RowsProduced", TUnit::UNIT, 1);
     _output_bytes_counter =
             ADD_COUNTER_WITH_LEVEL(_runtime_profile, "BytesProduced", TUnit::BYTES, 1);
     _block_count_counter =

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -131,7 +131,7 @@ Status ExecNode::prepare(RuntimeState* state) {
     _output_bytes_counter =
             ADD_COUNTER_WITH_LEVEL(_runtime_profile, "OutputBytes", TUnit::BYTES, 1);
     _block_count_counter =
-            ADD_COUNTER_WITH_LEVEL(_runtime_profile, "OutputBlockCount", TUnit::UNIT, 1);
+            ADD_COUNTER_WITH_LEVEL(_runtime_profile, "BlocksProduced", TUnit::UNIT, 1);
     _projection_timer = ADD_TIMER(_runtime_profile, "ProjectionTime");
     _rows_returned_rate = runtime_profile()->add_derived_counter(
             ROW_THROUGHPUT_COUNTER, TUnit::UNIT_PER_SECOND,

--- a/be/src/pipeline/exec/exchange_sink_operator.cpp
+++ b/be/src/pipeline/exec/exchange_sink_operator.cpp
@@ -113,7 +113,7 @@ Status ExchangeSinkLocalState::init(RuntimeState* state, LocalSinkStateInfo& inf
     _split_block_hash_compute_timer = ADD_TIMER(_profile, "SplitBlockHashComputeTime");
     _split_block_distribute_by_channel_timer =
             ADD_TIMER(_profile, "SplitBlockDistributeByChannelTime");
-    _blocks_sent_counter = ADD_COUNTER_WITH_LEVEL(_profile, "BlocksSent", TUnit::UNIT, 1);
+    _blocks_sent_counter = ADD_COUNTER_WITH_LEVEL(_profile, "BlocksProduced", TUnit::UNIT, 1);
     _overall_throughput = _profile->add_derived_counter(
             "OverallThroughput", TUnit::BYTES_PER_SECOND,
             std::bind<int64_t>(&RuntimeProfile::units_per_second, _bytes_sent_counter,

--- a/be/src/pipeline/pipeline_x/operator.cpp
+++ b/be/src/pipeline/pipeline_x/operator.cpp
@@ -354,9 +354,9 @@ Status PipelineXLocalState<DependencyType>::init(RuntimeState* state, LocalState
         RETURN_IF_ERROR(_parent->_projections[i]->clone(state, _projections[i]));
     }
     _rows_returned_counter =
-            ADD_COUNTER_WITH_LEVEL(_runtime_profile, "RowsReturned", TUnit::UNIT, 1);
+            ADD_COUNTER_WITH_LEVEL(_runtime_profile, "RowsProduced", TUnit::UNIT, 1);
     _blocks_returned_counter =
-            ADD_COUNTER_WITH_LEVEL(_runtime_profile, "BlocksReturned", TUnit::UNIT, 1);
+            ADD_COUNTER_WITH_LEVEL(_runtime_profile, "BlocksProduced", TUnit::UNIT, 1);
     _projection_timer = ADD_TIMER_WITH_LEVEL(_runtime_profile, "ProjectionTime", 1);
     _open_timer = ADD_TIMER_WITH_LEVEL(_runtime_profile, "OpenTime", 1);
     _close_timer = ADD_TIMER_WITH_LEVEL(_runtime_profile, "CloseTime", 1);

--- a/be/src/vec/sink/writer/vtablet_writer.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer.cpp
@@ -1151,7 +1151,7 @@ Status VTabletWriter::_init(RuntimeState* state, RuntimeProfile* profile) {
 
     // add all counter
     _input_rows_counter = ADD_COUNTER(profile, "RowsRead", TUnit::UNIT);
-    _output_rows_counter = ADD_COUNTER(profile, "RowsReturned", TUnit::UNIT);
+    _output_rows_counter = ADD_COUNTER(profile, "RowsProduced", TUnit::UNIT);
     _filtered_rows_counter = ADD_COUNTER(profile, "RowsFiltered", TUnit::UNIT);
     _send_data_timer = ADD_TIMER(profile, "SendDataTime");
     _wait_mem_limit_timer = ADD_CHILD_TIMER(profile, "WaitMemLimitTime", "SendDataTime");

--- a/be/src/vec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.cpp
@@ -215,7 +215,7 @@ Status VTabletWriterV2::_init(RuntimeState* state, RuntimeProfile* profile) {
 
     // add all counter
     _input_rows_counter = ADD_COUNTER(_profile, "RowsRead", TUnit::UNIT);
-    _output_rows_counter = ADD_COUNTER(_profile, "RowsReturned", TUnit::UNIT);
+    _output_rows_counter = ADD_COUNTER(_profile, "RowsProduced", TUnit::UNIT);
     _filtered_rows_counter = ADD_COUNTER(_profile, "RowsFiltered", TUnit::UNIT);
     _send_data_timer = ADD_TIMER(_profile, "SendDataTime");
     _wait_mem_limit_timer = ADD_CHILD_TIMER(_profile, "WaitMemLimitTime", "SendDataTime");


### PR DESCRIPTION
## Proposed changes

1. using blocksproduced and rowsproduced to unify the counter name in DataStreamSender and other exec node, or exchange operator and other operators.
2. blocks produced and rows produced are more easy to understand.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

