### PR TITLE
[hotfix](jdbc catalog) fix realColumnNames serialize npe

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcTable.java
@@ -244,8 +244,12 @@ public class JdbcTable extends Table {
         realDatabaseName = serializeMap.get(REAL_DATABASE);
         realTableName = serializeMap.get(REAL_TABLE);
         String realColumnNamesJson = serializeMap.get(REAL_COLUMNS);
-        realColumnNames = objectMapper.readValue(realColumnNamesJson, new TypeReference<Map<String, String>>() {
-        });
+        if (realColumnNamesJson != null) {
+            realColumnNames = objectMapper.readValue(realColumnNamesJson, new TypeReference<Map<String, String>>() {
+            });
+        } else {
+            realColumnNames = Maps.newHashMap();
+        }
     }
 
     public String getResourceName() {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

In the previous PR #27124, we used `objectMapper.readValue` for deserialization. However, this method does not handle null fields, which can lead to issues when upgrading from older versions. Specifically, if a required field is missing in the persistent data, `String realColumnNamesJson = serializeMap.get(REAL_COLUMNS);` will return null, resulting in deserialization errors and frontend startup failure. This issue is likely to occur when upgrading from an older version that uses Jdbc Catalog to a new version including PR #27124. As this represents a specific upgrade scenario involving compatibility with old version data structures, it was not covered in the regular PR test cases. Given the specificity and difficulty in replicating such a scenario, no special test cases were added for this PR.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

