### PR TITLE
[fix](fe ut) Fix OlapQueryCacheTest failed

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/DorisFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/DorisFE.java
@@ -33,6 +33,7 @@ import org.apache.doris.journal.bdbje.BDBTool;
 import org.apache.doris.journal.bdbje.BDBToolOptions;
 import org.apache.doris.persist.meta.MetaReader;
 import org.apache.doris.qe.QeService;
+import org.apache.doris.qe.SimpleScheduler;
 import org.apache.doris.service.ExecuteEnv;
 import org.apache.doris.service.FeServer;
 import org.apache.doris.service.FrontendOptions;
@@ -193,6 +194,8 @@ public class DorisFE {
                 httpServer.start();
                 Env.getCurrentEnv().setHttpReady(true);
             }
+
+            SimpleScheduler.init();
 
             if (options.enableQeService) {
                 QeService qeService = new QeService(Config.query_port, Config.arrow_flight_sql_port,

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SimpleScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SimpleScheduler.java
@@ -53,7 +53,7 @@ public class SimpleScheduler {
     private static Map<Long, Pair<Integer, String>> blacklistBackends = Maps.newConcurrentMap();
     private static UpdateBlacklistThread updateBlacklistThread;
 
-    static {
+    public static void init () {
         updateBlacklistThread = new UpdateBlacklistThread();
         updateBlacklistThread.start();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SimpleScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SimpleScheduler.java
@@ -53,7 +53,7 @@ public class SimpleScheduler {
     private static Map<Long, Pair<Integer, String>> blacklistBackends = Maps.newConcurrentMap();
     private static UpdateBlacklistThread updateBlacklistThread;
 
-    public static void init () {
+    public static void init() {
         updateBlacklistThread = new UpdateBlacklistThread();
         updateBlacklistThread.start();
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/OlapQueryCacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/OlapQueryCacheTest.java
@@ -27,6 +27,7 @@ import org.apache.doris.analysis.SqlScanner;
 import org.apache.doris.analysis.StatementBase;
 import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.analysis.TupleId;
+import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
@@ -51,13 +52,10 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.common.util.SqlParserUtils;
 import org.apache.doris.common.util.Util;
-import org.apache.doris.datasource.CatalogMgr;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.mysql.MysqlChannel;
 import org.apache.doris.mysql.MysqlSerializer;
-import org.apache.doris.mysql.privilege.AccessControllerManager;
-import org.apache.doris.mysql.privilege.MockedAuth;
 import org.apache.doris.nereids.NereidsPlanner;
 import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.glue.LogicalPlanAdapter;
@@ -78,7 +76,6 @@ import org.apache.doris.qe.cache.RowBatchBuilder;
 import org.apache.doris.qe.cache.SqlCache;
 import org.apache.doris.service.FrontendOptions;
 import org.apache.doris.system.Backend;
-import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TStorageType;
 import org.apache.doris.thrift.TUniqueId;
 
@@ -97,17 +94,15 @@ import org.junit.Test;
 
 import java.io.StringReader;
 import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.function.Function;
 
 public class OlapQueryCacheTest {
     private static final Logger LOG = LogManager.getLogger(OlapQueryCacheTest.class);
     public static String clusterName = "testCluster";
-    public static String dbName = "testDb";
     public static String fullDbName = "testCluster:testDb";
-    public static String tableName = "testTbl";
     public static String userName = "testUser";
 
     private static ConnectContext context;
@@ -116,21 +111,12 @@ public class OlapQueryCacheTest {
     private Cache.HitRange hitRange;
     private Analyzer analyzer;
     private Database db;
-
-    @Mocked
-    private AccessControllerManager accessManager;
-    @Mocked
-    private SystemInfoService service;
-    @Mocked
     private Env env;
-    @Mocked
-    private InternalCatalog catalog;
-    @Mocked
     private ConnectContext ctx;
+    private QueryState state;
+    private ConnectScheduler scheduler;
     @Mocked
-    MysqlChannel channel;
-    @Mocked
-    ConnectScheduler scheduler;
+    private MysqlChannel channel = null;
 
     @BeforeClass
     public static void start() {
@@ -151,9 +137,15 @@ public class OlapQueryCacheTest {
 
     @Before
     public void setUp() throws Exception {
-        service = AccessTestUtil.fetchSystemInfoService();
-        MockedAuth.mockedAccess(accessManager);
-        MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
+        state = new QueryState();
+        scheduler = new ConnectScheduler(10);
+        ctx = new ConnectContext();
+
+        SessionVariable sessionVariable = new SessionVariable();
+        Deencapsulation.setField(sessionVariable, "beNumberForTest", 1);
+        MysqlSerializer serializer = MysqlSerializer.newInstance();
+        env = AccessTestUtil.fetchAdminCatalog();
+
         new MockUp<Util>() {
             @Mock
             public boolean showHiddenColumns() {
@@ -165,89 +157,25 @@ public class OlapQueryCacheTest {
             Env getCurrentEnv() {
                 return env;
             }
-
-            @Mock
-            public SystemInfoService getCurrentSystemInfo() {
-                return service;
-            }
-        };
-        db = new Database(1L, fullDbName);
-
-        new Expectations(catalog) {
-            {
-                catalog.getDbNullable(fullDbName);
-                minTimes = 0;
-                result = db;
-
-                catalog.getDbNullable(dbName);
-                minTimes = 0;
-                result = db;
-
-                catalog.getDbNullable(db.getId());
-                minTimes = 0;
-                result = db;
-
-                catalog.getDbNames();
-                minTimes = 0;
-                result = Lists.newArrayList(fullDbName);
-            }
         };
 
-        CatalogMgr dsMgr = new CatalogMgr();
-        new Expectations(dsMgr) {
-            {
-                dsMgr.getCatalog((String) any);
-                minTimes = 0;
-                result = catalog;
-
-                dsMgr.getCatalogOrException((String) any, (Function) any);
-                minTimes = 0;
-                result = catalog;
-
-                dsMgr.getCatalogOrAnalysisException((String) any);
-                minTimes = 0;
-                result = catalog;
-            }
-        };
-
-        env = AccessTestUtil.fetchAdminCatalog();
-        new Expectations(env) {
-            {
-                env.getAccessManager();
-                minTimes = 0;
-                result = accessManager;
-
-                env.getCurrentCatalog();
-                minTimes = 0;
-                result = catalog;
-
-                env.getInternalCatalog();
-                minTimes = 0;
-                result = catalog;
-
-                env.getCatalogMgr();
-                minTimes = 0;
-                result = dsMgr;
-
-                Env.isCheckpointThread();
-                minTimes = 0;
-                result = false;
-            }
-        };
         FunctionSet fs = new FunctionSet();
         fs.init();
         Deencapsulation.setField(env, "functionSet", fs);
-        QueryState state = new QueryState();
-        channel.reset();
 
-        SessionVariable sessionVariable = new SessionVariable();
-        Deencapsulation.setField(sessionVariable, "beNumberForTest", 1);
+        channel.reset();
 
         new Expectations(channel) {
             {
+                channel.sendOnePacket((ByteBuffer) any);
+                minTimes = 0;
+
+                channel.reset();
+                minTimes = 0;
+
                 channel.getSerializer();
                 minTimes = 0;
-                result = MysqlSerializer.newInstance();
+                result = serializer;
             }
         };
 
@@ -302,7 +230,7 @@ public class OlapQueryCacheTest {
 
                 ctx.getDatabase();
                 minTimes = 0;
-                result = dbName;
+                result = fullDbName;
 
                 ctx.getSessionVariable();
                 minTimes = 0;
@@ -317,17 +245,32 @@ public class OlapQueryCacheTest {
 
                 ctx.getCurrentCatalog();
                 minTimes = 0;
-                result = catalog;
+                result = env.getCurrentCatalog();
 
                 ctx.getCatalog(anyString);
                 minTimes = 0;
-                result = catalog;
+                result = env.getCurrentCatalog();
+
+                ConnectContext.get();
+                minTimes = 0;
+                result = ctx;
+
+                ctx.getRemoteIP();
+                minTimes = 0;
+                result = "192.168.1.1";
+
+                ctx.getCurrentUserIdentity();
+                minTimes = 0;
+                UserIdentity userIdentity = new UserIdentity(userName, "192.168.1.1");
+                userIdentity.setIsAnalyzed();
+                result = userIdentity;
             }
         };
 
         analyzer = new Analyzer(env, ctx);
         newRangeList = Lists.newArrayList();
 
+        db = ((InternalCatalog) env.getCurrentCatalog()).getDbNullable(fullDbName);
         // table and view init use analyzer, should init after analyzer build
         OlapTable tbl1 = createOrderTable();
         db.createTable(tbl1);
@@ -612,7 +555,6 @@ public class OlapQueryCacheTest {
 
     @Test
     public void testCacheNode() throws Exception {
-        Env.getCurrentSystemInfo();
         CacheCoordinator cp = CacheCoordinator.getInstance();
         cp.debugModel = true;
         Backend bd1 = new Backend(1, "", 1000);
@@ -638,7 +580,6 @@ public class OlapQueryCacheTest {
 
     @Test
     public void testCacheModeNone() throws Exception {
-        Env.getCurrentSystemInfo();
         StatementBase parseStmt = parseSql("select @@version_comment limit 1");
         List<ScanNode> scanNodes = Lists.newArrayList();
         CacheAnalyzer ca = new CacheAnalyzer(context, parseStmt, scanNodes);
@@ -648,7 +589,6 @@ public class OlapQueryCacheTest {
 
     @Test
     public void testCacheModeTable() throws Exception {
-        Env.getCurrentSystemInfo();
         StatementBase parseStmt = parseSql(
                 "SELECT country, COUNT(userid) FROM userprofile GROUP BY country"
         );
@@ -662,7 +602,6 @@ public class OlapQueryCacheTest {
 
     @Test
     public void testWithinMinTime() throws Exception {
-        Env.getCurrentSystemInfo();
         StatementBase parseStmt = parseSql(
                 "SELECT country, COUNT(userid) FROM userprofile GROUP BY country"
         );
@@ -676,7 +615,6 @@ public class OlapQueryCacheTest {
 
     @Test
     public void testPartitionModel() throws Exception {
-        Env.getCurrentSystemInfo();
         StatementBase parseStmt = parseSql(
                 "SELECT eventdate, COUNT(DISTINCT userid) FROM appevent WHERE eventdate>=\"2020-01-12\" and "
                         + "eventdate<=\"2020-01-15\" GROUP BY eventdate"
@@ -692,7 +630,6 @@ public class OlapQueryCacheTest {
 
     @Test
     public void testParseByte() throws Exception {
-        Env.getCurrentSystemInfo();
         RowBatchBuilder sb = new RowBatchBuilder(CacheMode.Partition);
         byte[] buffer = new byte[]{10, 50, 48, 50, 48, 45, 48, 51, 45, 49, 48, 1, 51, 2, 67, 78};
         PartitionRange.PartitionKeyType key1 = sb.getKeyFromRow(buffer, 0, Type.DATE);
@@ -705,7 +642,6 @@ public class OlapQueryCacheTest {
 
     @Test
     public void testPartitionIntTypeSql() throws Exception {
-        Env.getCurrentSystemInfo();
         StatementBase parseStmt = parseSql(
                 "SELECT `date`, COUNT(id) FROM `order` WHERE `date`>=20200112 and `date`<=20200115 GROUP BY date"
         );
@@ -749,7 +685,6 @@ public class OlapQueryCacheTest {
 
     @Test
     public void testSimpleCacheSql() throws Exception {
-        Env.getCurrentSystemInfo();
         StatementBase parseStmt = parseSql(
                 "SELECT eventdate, COUNT(userid) FROM appevent WHERE eventdate>=\"2020-01-12\" and "
                         + "eventdate<=\"2020-01-15\" GROUP BY eventdate"
@@ -792,7 +727,6 @@ public class OlapQueryCacheTest {
 
     @Test
     public void testHitSqlCache() throws Exception {
-        Env.getCurrentSystemInfo();
         StatementBase parseStmt = parseSql(
                 "SELECT eventdate, COUNT(userid) FROM appevent WHERE eventdate>=\"2020-01-12\" and "
                         + "eventdate<=\"2020-01-14\" GROUP BY eventdate"
@@ -807,7 +741,6 @@ public class OlapQueryCacheTest {
 
     @Test
     public void testHitPartPartition() throws Exception {
-        Env.getCurrentSystemInfo();
         StatementBase parseStmt = parseSql(
                 "SELECT eventdate, COUNT(userid) FROM appevent WHERE eventdate>=\"2020-01-12\" and "
                         + "eventdate<=\"2020-01-14\" GROUP BY eventdate"
@@ -853,7 +786,6 @@ public class OlapQueryCacheTest {
 
     @Test
     public void testNoUpdatePartition() throws Exception {
-        Env.getCurrentSystemInfo();
         StatementBase parseStmt = parseSql(
                 "SELECT eventdate, COUNT(userid) FROM appevent WHERE eventdate>=\"2020-01-12\" and "
                         + "eventdate<=\"2020-01-14\" GROUP BY eventdate"
@@ -895,7 +827,6 @@ public class OlapQueryCacheTest {
 
     @Test
     public void testUpdatePartition() throws Exception {
-        Env.getCurrentSystemInfo();
         StatementBase parseStmt = parseSql(
                 "SELECT eventdate, COUNT(userid) FROM appevent WHERE eventdate>=\"2020-01-12\" and "
                         + "eventdate<=\"2020-01-15\" GROUP BY eventdate"
@@ -944,7 +875,6 @@ public class OlapQueryCacheTest {
 
     @Test
     public void testRewriteMultiPredicate1() throws Exception {
-        Env.getCurrentSystemInfo();
         StatementBase parseStmt = parseSql(
                 "SELECT eventdate, COUNT(userid) FROM appevent WHERE eventdate>\"2020-01-11\" and "
                         + "eventdate<\"2020-01-16\""
@@ -988,7 +918,6 @@ public class OlapQueryCacheTest {
 
     @Test
     public void testRewriteJoin() throws Exception {
-        Env.getCurrentSystemInfo();
         StatementBase parseStmt = parseSql(
                 "SELECT appevent.eventdate, country, COUNT(appevent.userid) FROM appevent"
                         + " INNER JOIN userprofile ON appevent.userid = userprofile.userid"
@@ -1033,7 +962,6 @@ public class OlapQueryCacheTest {
 
     @Test
     public void testSubSelect() throws Exception {
-        Env.getCurrentSystemInfo();
         StatementBase parseStmt = parseSql(
                 "SELECT eventdate, sum(pv) FROM (SELECT eventdate, COUNT(userid) AS pv FROM appevent WHERE "
                         + "eventdate>\"2020-01-11\" AND eventdate<\"2020-01-16\""
@@ -1086,7 +1014,6 @@ public class OlapQueryCacheTest {
 
     @Test
     public void testNotHitPartition() throws Exception {
-        Env.getCurrentSystemInfo();
         StatementBase parseStmt = parseSql(
                 "SELECT eventdate, COUNT(userid) FROM appevent WHERE eventdate>=\"2020-01-12\" and "
                         + "eventdate<=\"2020-01-14\" GROUP BY eventdate"
@@ -1115,7 +1042,6 @@ public class OlapQueryCacheTest {
 
     @Test
     public void testSqlCacheKey() {
-        Env.getCurrentSystemInfo();
         StatementBase parseStmt = parseSql(
                 "SELECT eventdate, COUNT(userid) FROM appevent WHERE eventdate>=\"2020-01-12\" and "
                         + "eventdate<=\"2020-01-14\" GROUP BY eventdate"
@@ -1137,7 +1063,6 @@ public class OlapQueryCacheTest {
 
     @Test
     public void testSqlCacheKeyWithChineseChar() {
-        Env.getCurrentSystemInfo();
         StatementBase parseStmt = parseSql(
                 "SELECT eventdate, COUNT(userid) FROM appevent WHERE eventdate>=\"2020-01-12\" and "
                         + "eventdate<=\"2020-01-14\" and city=\"北京\" GROUP BY eventdate"
@@ -1157,7 +1082,6 @@ public class OlapQueryCacheTest {
 
     @Test
     public void testSqlCacheKeyWithView() {
-        Env.getCurrentSystemInfo();
         StatementBase parseStmt = parseSql("SELECT * from testDb.view1");
         ArrayList<Long> selectedPartitionIds
                 = Lists.newArrayList(20200112L, 20200113L, 20200114L);
@@ -1178,7 +1102,6 @@ public class OlapQueryCacheTest {
 
     @Test
     public void testSqlCacheKeyWithViewForNereids() {
-        Env.getCurrentSystemInfo();
         StatementBase parseStmt = parseSqlByNereids("SELECT * from testDb.view1");
         ArrayList<Long> selectedPartitionIds
                 = Lists.newArrayList(20200112L, 20200113L, 20200114L);
@@ -1197,7 +1120,6 @@ public class OlapQueryCacheTest {
 
     @Test
     public void testSqlCacheKeyWithSubSelectView() {
-        Env.getCurrentSystemInfo();
         StatementBase parseStmt = parseSql(
                 "select origin.eventdate as eventdate, origin.userid as userid\n"
                         + "from (\n"
@@ -1226,7 +1148,6 @@ public class OlapQueryCacheTest {
 
     @Test
     public void testSqlCacheKeyWithSubSelectViewForNereids() {
-        Env.getCurrentSystemInfo();
         StatementBase parseStmt = parseSqlByNereids(
                 "select origin.eventdate as eventdate, origin.userid as userid\n"
                         + "from (\n"
@@ -1255,7 +1176,6 @@ public class OlapQueryCacheTest {
 
     @Test
     public void testPartitionCacheKeyWithView() {
-        Env.getCurrentSystemInfo();
         StatementBase parseStmt = parseSql("SELECT * from testDb.view3");
         ArrayList<Long> selectedPartitionIds
                 = Lists.newArrayList(20200112L, 20200113L, 20200114L, 20200115L);
@@ -1282,7 +1202,6 @@ public class OlapQueryCacheTest {
 
     @Test
     public void testPartitionCacheKeyWithSubSelectView() {
-        Env.getCurrentSystemInfo();
         StatementBase parseStmt = parseSql(
                 "select origin.eventdate as eventdate, origin.cnt as cnt\n"
                         + "from (\n"
@@ -1306,8 +1225,8 @@ public class OlapQueryCacheTest {
             Assert.assertEquals(cache.getSqlWithViewStmt(),
                     "SELECT `origin`.`eventdate` AS `eventdate`, `origin`.`cnt` AS `cnt` "
                             + "FROM (SELECT <slot 4> `eventdate` AS `eventdate`, <slot 5> count(`userid`) AS `cnt` "
-                            + "FROM `testDb`.`view2` GROUP BY `eventdate`) origin|SELECT `eventdate` AS `eventdate`, "
-                            + "`userid` AS `userid` FROM `testCluster:testDb`.`appevent`");
+                            + "FROM `testCluster:testDb`.`view2` GROUP BY `eventdate`) origin|SELECT `eventdate` "
+                            + "AS `eventdate`, `userid` AS `userid` FROM `testCluster:testDb`.`appevent`");
         } catch (Exception e) {
             LOG.warn("ex={}", e);
             Assert.fail(e.getMessage());
@@ -1316,7 +1235,6 @@ public class OlapQueryCacheTest {
 
     @Test
     public void testSqlCacheKeyWithNestedView() {
-        Env.getCurrentSystemInfo();
         StatementBase parseStmt = parseSql("SELECT * from testDb.view4");
         ArrayList<Long> selectedPartitionIds
                 = Lists.newArrayList(20200112L, 20200113L, 20200114L);
@@ -1329,7 +1247,7 @@ public class OlapQueryCacheTest {
         String cacheKey = sqlCache.getSqlWithViewStmt();
         Assert.assertEquals(cacheKey, "SELECT `testCluster:testDb`.`view4`.`eventdate` AS `eventdate`, "
                 + "`testCluster:testDb`.`view4`.`__count_1` AS `__count_1` FROM `testCluster:testDb`.`view4`|"
-                + "SELECT `eventdate` AS `eventdate`, count(`userid`) AS `__count_1` FROM `testDb`.`view2` "
+                + "SELECT `eventdate` AS `eventdate`, count(`userid`) AS `__count_1` FROM `testCluster:testDb`.`view2` "
                 + "WHERE `eventdate` >= '2020-01-12' AND `eventdate` <= '2020-01-14' GROUP BY `eventdate`|"
                 + "SELECT `eventdate` AS `eventdate`, `userid` AS `userid` FROM `testCluster:testDb`.`appevent`");
         Assert.assertEquals(selectedPartitionIds.size(), sqlCache.getSumOfPartitionNum());
@@ -1337,7 +1255,6 @@ public class OlapQueryCacheTest {
 
     @Test
     public void testSqlCacheKeyWithNestedViewForNereids() {
-        Env.getCurrentSystemInfo();
         StatementBase parseStmt = parseSqlByNereids("SELECT * from testDb.view4");
         ArrayList<Long> selectedPartitionIds
                 = Lists.newArrayList(20200112L, 20200113L, 20200114L);
@@ -1349,15 +1266,14 @@ public class OlapQueryCacheTest {
         SqlCache sqlCache = (SqlCache) ca.getCache();
         String cacheKey = sqlCache.getSqlWithViewStmt();
         Assert.assertEquals(cacheKey, "SELECT * from testDb.view4|SELECT `eventdate` AS `eventdate`, "
-                + "count(`userid`) AS `__count_1` FROM `testDb`.`view2` WHERE `eventdate` >= '2020-01-12' AND "
-                + "`eventdate` <= '2020-01-14' GROUP BY `eventdate`|SELECT `eventdate` AS `eventdate`, "
+                + "count(`userid`) AS `__count_1` FROM `testCluster:testDb`.`view2` WHERE `eventdate` >= '2020-01-12' "
+                + "AND `eventdate` <= '2020-01-14' GROUP BY `eventdate`|SELECT `eventdate` AS `eventdate`, "
                 + "`userid` AS `userid` FROM `testCluster:testDb`.`appevent`");
         Assert.assertEquals(selectedPartitionIds.size(), sqlCache.getSumOfPartitionNum());
     }
 
     @Test
     public void testCacheLocalViewMultiOperand() {
-        Env.getCurrentSystemInfo();
         StatementBase parseStmt = parseSql(
                 "SELECT COUNT(userid)\n"
                         + "FROM (\n"
@@ -1381,7 +1297,6 @@ public class OlapQueryCacheTest {
     @Test
     // test that some partitions do not exist in the table
     public void testNotExistPartitionSql() {
-        Env.getCurrentSystemInfo();
         StatementBase parseStmt = parseSql(
                 "SELECT `date`, COUNT(id) FROM `order` WHERE `date`>=20200110 and `date`<=20200115 GROUP BY date"
         );

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/OlapQueryCacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/OlapQueryCacheTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.qe;
 
+import org.apache.doris.analysis.AccessTestUtil;
 import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.analysis.CreateViewStmt;
 import org.apache.doris.analysis.PartitionValue;
@@ -150,6 +151,7 @@ public class OlapQueryCacheTest {
 
     @Before
     public void setUp() throws Exception {
+        service = AccessTestUtil.fetchSystemInfoService();
         MockedAuth.mockedAccess(accessManager);
         MockedAuth.mockedConnectContext(ctx, "root", "192.168.1.1");
         new MockUp<Util>() {
@@ -159,6 +161,11 @@ public class OlapQueryCacheTest {
             }
         };
         new MockUp<Env>() {
+            @Mock
+            Env getCurrentEnv() {
+                return env;
+            }
+
             @Mock
             public SystemInfoService getCurrentSystemInfo() {
                 return service;
@@ -203,6 +210,7 @@ public class OlapQueryCacheTest {
             }
         };
 
+        env = AccessTestUtil.fetchAdminCatalog();
         new Expectations(env) {
             {
                 env.getAccessManager();
@@ -220,6 +228,10 @@ public class OlapQueryCacheTest {
                 env.getCatalogMgr();
                 minTimes = 0;
                 result = dsMgr;
+
+                Env.isCheckpointThread();
+                minTimes = 0;
+                result = false;
             }
         };
         FunctionSet fs = new FunctionSet();

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/SimpleSchedulerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/SimpleSchedulerTest.java
@@ -46,6 +46,7 @@ public class SimpleSchedulerTest {
 
     @BeforeClass
     public static void setUp() {
+        SimpleScheduler.init();
         FeConstants.heartbeat_interval_second = 2;
         be1 = new Backend(1000L, "192.168.100.0", 9050);
         be2 = new Backend(1001L, "192.168.100.1", 9050);


### PR DESCRIPTION
## Proposed changes

1. 
```
java.lang.NullPointerException: null
        at org.apache.doris.catalog.Env.getCurrentSystemInfo(Env.java:793) ~[classes/:?]
        at org.apache.doris.qe.SimpleScheduler$UpdateBlacklistThread.run(SimpleScheduler.java:206) ~[classes/:?]
        at java.lang.Thread.run(Thread.java:750) ~[?:1.8.0_382]

java.lang.NullPointerException
        at org.apache.doris.qe.OlapQueryCacheTest.setUp(OlapQueryCacheTest.java:226)
```

2.
```
[ERROR] testSqlCacheKeyWithNestedViewForNereids  Time elapsed: 1.962 s  <<< FAILURE!
java.lang.AssertionError: SELECT command denied to user 'testCluster:testUser'@'192.168.1.1' for table 'internal: testCluster:testDb: appevent'
	at org.apache.doris.qe.OlapQueryCacheTest.parseSqlByNereids(OlapQueryCacheTest.java:579)
	at org.apache.doris.qe.OlapQueryCacheTest.testSqlCacheKeyWithNestedViewForNereids(OlapQueryCacheTest.java:1338)
```

3.
```
[ERROR] Tests run: 28, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 113.63 s <<< FAILURE! - in org.apache.doris.qe.OlapQueryCacheTest
[ERROR] testCacheModeTable  Time elapsed: 1.657 s  <<< ERROR!
java.lang.IllegalArgumentException: Value of type org.apache.doris.qe.QueryState incompatible with return type org.apache.doris.system.SystemInfoService of org.apache.doris.catalog.Env#getCurrentSystemInfo()
        at org.apache.doris.qe.OlapQueryCacheTest.setUp(OlapQueryCacheTest.java:156)
```
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

