### PR TITLE
[fix](be) the mapped was not initialized when the agg state was destroyed  

### DIFF
--- a/be/src/vec/exec/vaggregation_node.cpp
+++ b/be/src/vec/exec/vaggregation_node.cpp
@@ -1338,7 +1338,7 @@ void AggregationNode::_close_with_serialized_key() {
             [&](auto&& agg_method) -> void {
                 auto& data = agg_method.data;
                 data.for_each_mapped([&](auto& mapped) {
-                    if (mapped) {
+                    if (mapped && *mapped != '\0') {
                         _destroy_agg_status(mapped);
                         mapped = nullptr;
                     }


### PR DESCRIPTION
…oyed

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

(gdb) f 8
#8  operator()<char*> (mapped=@0x7f6780c797e8: 0x7f6780c797f8 "", __closure=<optimized out>)
    at /data/doris-1.x/be/src/vec/exec/vaggregation_node.cpp:1342
1342    in /data/doris-1.x/be/src/vec/exec/vaggregation_node.cpp
(gdb) p mapped
$38 = (char *&) @0x7f6780c797e8: 0x7f6780c797f8 ""



