### PR TITLE
[opt](MergedIO) no need to merge large columns

### DIFF
--- a/be/test/io/fs/buffered_reader_test.cpp
+++ b/be/test/io/fs/buffered_reader_test.cpp
@@ -295,13 +295,13 @@ TEST_F(BufferedReaderTest, test_read_amplify) {
     static_cast<void>(merge_reader.read_at(1024 * kb, result, &bytes_read, nullptr));
     EXPECT_EQ(bytes_read, 1024 * kb);
     EXPECT_EQ(merge_reader.statistics().request_bytes, 1024 * kb);
-    EXPECT_EQ(merge_reader.statistics().read_bytes, 1024 * kb);
+    EXPECT_EQ(merge_reader.statistics().merged_bytes, 1024 * kb);
     // read column0
     result.size = 1 * kb;
     // will merge column 0 ~ 3
     static_cast<void>(merge_reader.read_at(0, result, &bytes_read, nullptr));
     EXPECT_EQ(bytes_read, 1 * kb);
-    EXPECT_EQ(merge_reader.statistics().read_bytes, 1024 * kb + 12 * kb);
+    EXPECT_EQ(merge_reader.statistics().merged_bytes, 1024 * kb + 12 * kb);
     // read column1
     result.size = 1 * kb;
     static_cast<void>(merge_reader.read_at(3 * kb, result, &bytes_read, nullptr));
@@ -312,7 +312,7 @@ TEST_F(BufferedReaderTest, test_read_amplify) {
     result.size = 5 * kb;
     static_cast<void>(merge_reader.read_at(7 * kb, result, &bytes_read, nullptr));
     EXPECT_EQ(merge_reader.statistics().request_bytes, 1024 * kb + 8 * kb);
-    EXPECT_EQ(merge_reader.statistics().read_bytes, 1024 * kb + 12 * kb);
+    EXPECT_EQ(merge_reader.statistics().merged_bytes, 1024 * kb + 12 * kb);
 }
 
 TEST_F(BufferedReaderTest, test_merged_io) {


### PR DESCRIPTION
## Proposed changes
1. Fix a profile bug of `MergeRangeFileReader`, and add a profile `ApplyBytes` to show the total bytes  of ranges.
2. There's no need to merge large columns, because `MergeRangeFileReader` will increase the copy time.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

