### PR TITLE
[chore](docker cases): support for specifying output from the command line

### DIFF
--- a/docker/runtime/doris-compose/Dockerfile
+++ b/docker/runtime/doris-compose/Dockerfile
@@ -19,16 +19,15 @@
 # choose a base image
 FROM openjdk:8u342-jdk
 
+ARG OUT_DIRECTORY=output
+
 # set environment variables
 ENV JAVA_HOME="/usr/local/openjdk-8/"
 ENV jacoco_version 0.8.8
 
-ADD output /opt/apache-doris/
-
 RUN  sed -i s@/deb.debian.org/@/mirrors.aliyun.com/@g /etc/apt/sources.list
 RUN  apt-get clean
 
-RUN  mkdir /opt/apache-doris/coverage
 
 RUN apt-get update && \
     apt-get install -y default-mysql-client python lsof tzdata curl unzip && \
@@ -40,5 +39,7 @@ RUN curl -f https://repo1.maven.org/maven2/org/jacoco/jacoco/$jacoco_version/jac
     mkdir /jacoco && \
     unzip jacoco.zip -d /jacoco
 
+ADD $OUT_DIRECTORY /opt/apache-doris/
+RUN  mkdir -p /opt/apache-doris/coverage
 # in docker, run 'chmod 755 doris_be' first time cost 1min, remove it.
 RUN sed -i 's/\<chmod\>/echo/g' /opt/apache-doris/be/bin/start_be.sh


### PR DESCRIPTION
Build image in pipeline
`docker build --build-arg OUT_DIRECTORY=. -f Dockerfile -t xx-doris:asan /path/to/doris/output`

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

