### PR TITLE
[fix](stats) Fix creating too many tasks on new env

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
@@ -1087,4 +1087,8 @@ public class AnalysisManager implements Writable {
     public void removeJob(long id) {
         idToAnalysisJob.remove(id);
     }
+
+    public boolean hasUnFinished() {
+        return !analysisJobIdToTaskMap.isEmpty();
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticConstants.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticConstants.java
@@ -94,6 +94,8 @@ public class StatisticConstants {
 
     public static final int ANALYZE_TIMEOUT_IN_SEC = 43200;
 
+    public static final int SUBMIT_JOB_LIMIT = 5;
+
     static {
         SYSTEM_DBS.add(SystemInfoService.DEFAULT_CLUSTER
                 + ClusterNamespace.CLUSTER_DELIMITER + FeConstants.INTERNAL_DB_NAME);

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsAutoCollector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsAutoCollector.java
@@ -50,7 +50,7 @@ public class StatisticsAutoCollector extends StatisticsCollector {
 
     public StatisticsAutoCollector() {
         super("Automatic Analyzer",
-                TimeUnit.MINUTES.toMillis(Config.auto_check_statistics_in_minutes),
+                TimeUnit.MINUTES.toMillis(Config.full_auto_analyze_simultaneously_running_task_num),
                 new AnalysisTaskExecutor(Config.full_auto_analyze_simultaneously_running_task_num));
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisJobTest.java
@@ -44,7 +44,9 @@ public class AnalysisJobTest {
     }
 
     @Test
-    public void testAppendBufTest1(@Mocked AnalysisInfo analysisInfo, @Mocked OlapAnalysisTask olapAnalysisTask) {
+    public void testAppendBufTest1(@Mocked AnalysisInfo analysisInfo,
+            @Mocked OlapAnalysisTask olapAnalysisTask,
+            @Mocked OlapAnalysisTask olapAnalysisTask2) {
         AtomicInteger writeBufInvokeTimes = new AtomicInteger();
         new MockUp<AnalysisJob>() {
             @Mock
@@ -63,9 +65,9 @@ public class AnalysisJobTest {
         AnalysisJob job = new AnalysisJob(analysisInfo, Arrays.asList(olapAnalysisTask));
         job.queryingTask = new HashSet<>();
         job.queryingTask.add(olapAnalysisTask);
+        job.queryingTask.add(olapAnalysisTask2);
         job.queryFinished = new HashSet<>();
         job.buf = new ArrayList<>();
-        job.totalTaskCount = 20;
 
         // not all task finished nor cached limit exceed, shouldn't  write
         job.appendBuf(olapAnalysisTask, Arrays.asList(new ColStatsData()));
@@ -97,7 +99,6 @@ public class AnalysisJobTest {
         job.queryingTask.add(olapAnalysisTask);
         job.queryFinished = new HashSet<>();
         job.buf = new ArrayList<>();
-        job.totalTaskCount = 1;
 
         job.appendBuf(olapAnalysisTask, Arrays.asList(new ColStatsData()));
         // all task finished, should write and deregister this job
@@ -132,7 +133,6 @@ public class AnalysisJobTest {
         for (int i = 0; i < StatisticsUtil.getInsertMergeCount(); i++) {
             job.buf.add(colStatsData);
         }
-        job.totalTaskCount = 100;
 
         job.appendBuf(olapAnalysisTask, Arrays.asList(new ColStatsData()));
         // cache limit exceed, should write them


### PR DESCRIPTION
## Proposed changes

If there exists huge datasets with many database and may tables and many columns, Auto collector might be submit too many jobs which would occupy too much of FE memory.

In this PR, limit job each round could submit up to 5

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

