### PR TITLE
[improvement](routine load) fe metadata add routine load error reason

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/FeMetaVersion.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/FeMetaVersion.java
@@ -72,9 +72,11 @@ public final class FeMetaVersion {
     public static final int VERSION_125 = 125;
     // For write/read function nullable mode info
     public static final int VERSION_126 = 126;
+    // For recover info for recover routine load job error reason
+    public static final int VERSION_127 = 127;
 
     // note: when increment meta version, should assign the latest version to VERSION_CURRENT
-    public static final int VERSION_CURRENT = VERSION_126;
+    public static final int VERSION_CURRENT = VERSION_127;
 
     // all logs meta version should >= the minimum version, so that we could remove many if clause, for example
     // if (FE_METAVERSION < VERSION_94) ...

--- a/fe/fe-core/src/main/java/org/apache/doris/common/InternalErrorCode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/InternalErrorCode.java
@@ -42,6 +42,19 @@ public enum InternalErrorCode {
         this.errCode = code;
     }
 
+    public long getValue() {
+        return errCode;
+    }
+
+    public static InternalErrorCode valueOf(long value) {
+        for (InternalErrorCode e : values()) {
+            if (e.getValue() == value) {
+                return e;
+            }
+        }
+        return InternalErrorCode.IMPOSSIBLE_ERROR_ERR;
+    }
+
     @Override
     public String toString() {
         return "errCode = " + errCode;

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/ErrorReason.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/ErrorReason.java
@@ -18,8 +18,14 @@
 package org.apache.doris.load.routineload;
 
 import org.apache.doris.common.InternalErrorCode;
+import org.apache.doris.common.io.Text;
+import org.apache.doris.common.io.Writable;
 
-public class ErrorReason {
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+public class ErrorReason implements Writable {
     private InternalErrorCode code;
     private String msg;
 
@@ -47,5 +53,27 @@ public class ErrorReason {
     @Override
     public String toString() {
         return "ErrorReason{" + "code=" + code + ", msg='" + msg + '\'' + '}';
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        if (code != null) {
+            out.writeLong(code.getValue());
+        } else {
+            out.writeLong(InternalErrorCode.OK.getValue());
+        }
+        Text.writeString(out, msg);
+    }
+
+    public static ErrorReason read(DataInput in) throws IOException {
+        ErrorReason reason = new ErrorReason(InternalErrorCode.OK, "");
+        reason.readFields(in);
+        return reason;
+    }
+
+    @Deprecated
+    private void readFields(DataInput in) throws IOException {
+        code = InternalErrorCode.valueOf(in.readLong());
+        msg = Text.readString(in);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadManager.java
@@ -697,7 +697,7 @@ public class RoutineLoadManager implements Writable {
                     iterator.remove();
 
                     RoutineLoadOperation operation = new RoutineLoadOperation(routineLoadJob.getId(),
-                            routineLoadJob.getState());
+                            routineLoadJob.getState(), routineLoadJob.getStateChangeReason());
                     Env.getCurrentEnv().getEditLog().logRemoveRoutineLoadJob(operation);
                     LOG.info(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, routineLoadJob.getId())
                             .add("end_timestamp", routineLoadJob.getEndTimestamp())
@@ -753,7 +753,7 @@ public class RoutineLoadManager implements Writable {
     public void replayChangeRoutineLoadJob(RoutineLoadOperation operation) {
         RoutineLoadJob job = getJob(operation.getId());
         try {
-            job.updateState(operation.getJobState(), null, true /* is replay */);
+            job.updateState(operation.getJobState(), operation.getStateChangeReason(), true /* is replay */);
         } catch (UserException e) {
             LOG.error("should not happened", e);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/ScheduleRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/ScheduleRule.java
@@ -58,8 +58,9 @@ public class ScheduleRule {
         LOG.debug("try to auto reschedule routine load {}, firstResumeTimestamp: {}, autoResumeCount: {}, "
                         + "pause reason: {}",
                 jobRoutine.id, jobRoutine.firstResumeTimestamp, jobRoutine.autoResumeCount,
-                jobRoutine.pauseReason == null ? "null" : jobRoutine.pauseReason.getCode().name());
-        if (jobRoutine.pauseReason != null && jobRoutine.pauseReason.getCode() == InternalErrorCode.REPLICA_FEW_ERR) {
+                jobRoutine.stateChangeReason == null ? "null" : jobRoutine.stateChangeReason.getCode().name());
+        if (jobRoutine.stateChangeReason != null
+                && jobRoutine.stateChangeReason.getCode() == InternalErrorCode.REPLICA_FEW_ERR) {
             int dead = deadBeCount();
             if (dead > Config.max_tolerable_backend_down_num) {
                 LOG.debug("dead backend num {} is larger than config {}, "

--- a/fe/fe-core/src/test/java/org/apache/doris/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/routineload/RoutineLoadJobTest.java
@@ -191,7 +191,7 @@ public class RoutineLoadJobTest {
         Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.PAUSED);
         ErrorReason errorReason = new ErrorReason(InternalErrorCode.INTERNAL_ERR,
                 TransactionState.TxnStatusChangeReason.OFFSET_OUT_OF_RANGE.toString());
-        Deencapsulation.setField(routineLoadJob, "pauseReason", errorReason);
+        Deencapsulation.setField(routineLoadJob, "stateChangeReason", errorReason);
         Deencapsulation.setField(routineLoadJob, "progress", kafkaProgress);
         Deencapsulation.setField(routineLoadJob, "userIdentity", userIdentity);
 

--- a/fe/fe-core/src/test/java/org/apache/doris/load/routineload/RoutineLoadManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/routineload/RoutineLoadManagerTest.java
@@ -640,7 +640,7 @@ public class RoutineLoadManagerTest {
 
         // 第一次自动恢复
         for (int i = 0; i < 3; i++) {
-            Deencapsulation.setField(routineLoadJob, "pauseReason",
+            Deencapsulation.setField(routineLoadJob, "stateChangeReason",
                     new ErrorReason(InternalErrorCode.REPLICA_FEW_ERR, ""));
             routineLoadManager.updateRoutineLoadJob();
             Assert.assertEquals(RoutineLoadJob.JobState.NEED_SCHEDULE, routineLoadJob.getState());
@@ -904,11 +904,16 @@ public class RoutineLoadManagerTest {
                 operation.getJobState();
                 minTimes = 0;
                 result = RoutineLoadJob.JobState.PAUSED;
+                operation.getStateChangeReason();
+                minTimes = 0;
+                result = new ErrorReason(InternalErrorCode.MANUAL_STOP_ERR, "User stop routine load job");
             }
         };
 
         routineLoadManager.replayChangeRoutineLoadJob(operation);
         Assert.assertEquals(RoutineLoadJob.JobState.PAUSED, routineLoadJob.getState());
+        Assert.assertEquals(InternalErrorCode.MANUAL_STOP_ERR, routineLoadJob.getStateChangeReason().getCode());
+        Assert.assertEquals("User stop routine load job", routineLoadJob.getStateChangeReason().getMsg());
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes
Add routine load pause reason and cancel reason to fe metadata to prevent the loss of these messages after restarting the FE node. which will make auto resume routine load job faild, and users may be confused about the error reason of the routine load job.

## Further comments
If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
