### PR TITLE
[Fix](statistics)Fix auto job start time incorrect bug.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -2613,7 +2613,7 @@ public class ShowExecutor {
             row.add(Env.getCurrentEnv().getAnalysisManager().getJobProgress(analysisInfo.jobId));
             row.add(analysisInfo.scheduleType.toString());
             LocalDateTime startTime =
-                    LocalDateTime.ofInstant(Instant.ofEpochMilli(analysisInfo.createTime),
+                    LocalDateTime.ofInstant(Instant.ofEpochMilli(analysisInfo.startTime),
                             java.time.ZoneId.systemDefault());
             LocalDateTime endTime =
                     LocalDateTime.ofInstant(Instant.ofEpochMilli(analysisInfo.endTime),

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisInfo.java
@@ -190,6 +190,9 @@ public class AnalysisInfo implements Writable {
     @SerializedName("createTime")
     public final long createTime = System.currentTimeMillis();
 
+    @SerializedName("startTime")
+    public long startTime;
+
     @SerializedName("endTime")
     public long endTime;
 
@@ -327,6 +330,10 @@ public class AnalysisInfo implements Writable {
             }
         }
         return analysisInfo;
+    }
+
+    public void markStartTime(long startTime) {
+        this.startTime = startTime;
     }
 
     public void markFinished() {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
@@ -158,6 +158,7 @@ public class AnalysisManager implements Writable {
             // Set the job state to RUNNING when its first task becomes RUNNING.
             if (info.state.equals(AnalysisState.RUNNING) && job.state.equals(AnalysisState.PENDING)) {
                 job.state = AnalysisState.RUNNING;
+                job.markStartTime(System.currentTimeMillis());
                 replayCreateAnalysisJob(job);
             }
             boolean allFinished = true;
@@ -199,6 +200,13 @@ public class AnalysisManager implements Writable {
         AnalysisInfo job = systemJobInfoMap.get(info.jobId);
         if (job == null) {
             return null;
+        }
+        synchronized (job) {
+            // Set the job state to RUNNING when its first task becomes RUNNING.
+            if (info.state.equals(AnalysisState.RUNNING) && job.state.equals(AnalysisState.PENDING)) {
+                job.state = AnalysisState.RUNNING;
+                job.markStartTime(System.currentTimeMillis());
+            }
         }
         int failedCount = 0;
         StringJoiner reason = new StringJoiner(", ");
@@ -1000,7 +1008,6 @@ public class AnalysisManager implements Writable {
     }
 
     public void registerSysJob(AnalysisInfo jobInfo, Map<Long, BaseAnalysisTask> taskInfos) {
-        jobInfo.state = AnalysisState.RUNNING;
         systemJobInfoMap.put(jobInfo.jobId, jobInfo);
         analysisJobIdToTaskMap.put(jobInfo.jobId, taskInfos);
     }


### PR DESCRIPTION
Before, the auto analyze job start time was the job creation time, not the start to execute time, which is inaccurate. This pr is to change the start time to the first task start to execute time.

backport https://github.com/apache/doris/pull/27402

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

