### PR TITLE
[fix](session) fix NereidsTracer shouldLog always true after set enable_nereids_trace from true to false

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -98,6 +98,8 @@ public class NereidsPlanner extends Planner {
     public void plan(StatementBase queryStmt, org.apache.doris.thrift.TQueryOptions queryOptions) {
         if (statementContext.getConnectContext().getSessionVariable().isEnableNereidsTrace()) {
             NereidsTracer.init();
+        } else {
+            NereidsTracer.disable();
         }
         if (!(queryStmt instanceof LogicalPlanAdapter)) {
             throw new RuntimeException("Wrong type of queryStmt, expected: <? extends LogicalPlanAdapter>");

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/minidump/NereidsTracer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/minidump/NereidsTracer.java
@@ -175,5 +175,9 @@ public class NereidsTracer {
         TRACE_PATH = Optional.ofNullable(TRACE_PATH).orElse(System.getenv("DORIS_HOME") + "/log/nereids_trace");
         new File(TRACE_PATH).mkdirs();
     }
+
+    public static void disable() {
+        NereidsTracer.shouldLog = false;
+    }
 }
 


### PR DESCRIPTION


## Proposed changes

Issue Number: close #xxx

when set enable_nereids_trace = true, NereidsTracer init and set shouldLog = true. ater set enable_nereids_trace = false, NereidsTracer.shouldLog always is true, it need set false when enable_nereids_trace = false

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

