### PR TITLE
[fix](move-memtable) always include timeout in load stream close wait

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -745,6 +745,8 @@ DEFINE_mDouble(tablet_version_graph_orphan_vertex_ratio, "0.1");
 DEFINE_Bool(share_delta_writers, "true");
 // timeout for open load stream rpc in ms
 DEFINE_Int64(open_load_stream_timeout_ms, "500");
+// timeout for load stream close wait in ms
+DEFINE_Int64(close_load_stream_timeout_ms, "600000"); // 10 min
 
 // max send batch parallelism for OlapTableSink
 // The value set by the user for send_batch_parallelism is not allowed to exceed max_send_batch_parallelism_per_job,

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -802,6 +802,8 @@ DECLARE_mDouble(tablet_version_graph_orphan_vertex_ratio);
 DECLARE_Bool(share_delta_writers);
 // timeout for open load stream rpc in ms
 DECLARE_Int64(open_load_stream_timeout_ms);
+// timeout for load stream close wait in ms
+DECLARE_Int64(close_load_stream_timeout_ms);
 
 // max send batch parallelism for OlapTableSink
 // The value set by the user for send_batch_parallelism is not allowed to exceed max_send_batch_parallelism_per_job,

--- a/be/src/vec/sink/load_stream_stub.h
+++ b/be/src/vec/sink/load_stream_stub.h
@@ -97,17 +97,13 @@ private:
         bool is_closed() { return _is_closed.load(); }
 
         Status close_wait(int64_t timeout_ms) {
+            DCHECK(timeout_ms > 0) << "timeout_ms should be greator than 0";
             std::unique_lock<bthread::Mutex> lock(_mutex);
             if (_is_closed) {
                 return Status::OK();
             }
-            if (timeout_ms > 0) {
-                int ret = _close_cv.wait_for(lock, timeout_ms * 1000);
-                return ret == 0 ? Status::OK()
-                                : Status::Error<true>(ret, "stream close_wait timeout");
-            }
-            _close_cv.wait(lock);
-            return Status::OK();
+            int ret = _close_cv.wait_for(lock, timeout_ms * 1000);
+            return ret == 0 ? Status::OK() : Status::Error<true>(ret, "stream close_wait timeout");
         };
 
         std::vector<int64_t> success_tablets() {
@@ -179,6 +175,9 @@ public:
     Status close_wait(int64_t timeout_ms = 0) {
         if (!_is_init.load() || _handler.is_closed()) {
             return Status::OK();
+        }
+        if (timeout_ms <= 0) {
+            timeout_ms = config::close_load_stream_timeout_ms;
         }
         return _handler.close_wait(timeout_ms);
     }


### PR DESCRIPTION
## Proposed changes

Currently there is no timeout for load stream close wait, causing sink v2 to wait forever in some rare cases.
Add `close_load_stream_timeout_ms` (default: 10min) in be.conf to avoid this problem.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

