### PR TITLE
[feature](move-memtable) add switch for stream load in fe config

### DIFF
--- a/docs/en/docs/admin-manual/config/fe-config.md
+++ b/docs/en/docs/admin-manual/config/fe-config.md
@@ -1341,6 +1341,17 @@ MasterOnly：true
 
 Default stream load pre-submission timeout
 
+#### `stream_load_default_memtable_on_sink_node`
+
+Default：false
+
+IsMutable：true
+
+MasterOnly：false
+
+Enable memtable on sink node for stream load by default.
+When HTTP header `memtable_on_sink_node` is not set.
+
 #### `insert_load_default_timeout_second`
 
 Default：3600（1 hour）

--- a/docs/zh-CN/docs/admin-manual/config/fe-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/fe-config.md
@@ -1342,6 +1342,16 @@ load 最大超时时间，适用于除 stream load 之外的所有类型的加�
 
 默认 stream load 预提交超时时间
 
+#### `stream_load_default_memtable_on_sink_node`
+
+默认值：false
+
+是否可以动态配置：true
+
+是否为 Master FE 节点独有的配置项：false
+
+当 HTTP header 没有设置 `memtable_on_sink_node` 的时候，stream load 是否默认打开前移
+
 #### `insert_load_default_timeout_second`
 
 默认值：3600（1小时）

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -505,6 +505,10 @@ public class Config extends ConfigBase {
             "Default pre-commit timeout for stream load job, in seconds."})
     public static int stream_load_default_precommit_timeout_second = 3600; // 3600s
 
+    @ConfField(description = {"Stream Load 是否默认打开 memtable 前移",
+            "Whether to enable memtable on sink node by default in stream load"})
+    public static boolean stream_load_default_memtable_on_sink_node = false;
+
     @ConfField(mutable = true, masterOnly = true, description = {"Load 的最大超时时间，单位是秒。",
             "Maximal timeout for load job, in seconds."})
     public static int max_load_timeout_second = 259200; // 3days
@@ -1559,6 +1563,7 @@ public class Config extends ConfigBase {
 
     @ConfField
     public static boolean enable_pipeline_load = false;
+
     /*---------------------- JOB CONFIG START------------------------*/
     /**
      * The number of threads used to dispatch timer job.

--- a/fe/fe-core/src/main/java/org/apache/doris/task/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/StreamLoadTask.java
@@ -456,6 +456,8 @@ public class StreamLoadTask implements LoadTaskInfo {
         }
         if (request.isSetMemtableOnSinkNode()) {
             this.memtableOnSinkNode = request.isMemtableOnSinkNode();
+        } else {
+            this.memtableOnSinkNode = Config.stream_load_default_memtable_on_sink_node;
         }
         if (request.isSetStreamPerNode()) {
             this.streamPerNode = request.getStreamPerNode();


### PR DESCRIPTION
## Proposed changes

Add `stream_load_default_memtable_on_sink_node` (default: false) in `fe.conf`.
This option controls whether to enable sink v2 if HTTP header `memtable_on_sink_node` is not set.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

