### PR TITLE
[cleanup](move-memtable) remove namespace `stream_load`

### DIFF
--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -236,9 +236,7 @@ public:
     }
 
 #endif
-    LoadStreamStubPool* load_stream_stub_pool() {
-        return _load_stream_stub_pool.get();
-    }
+    LoadStreamStubPool* load_stream_stub_pool() { return _load_stream_stub_pool.get(); }
 
     vectorized::DeltaWriterV2Pool* delta_writer_v2_pool() { return _delta_writer_v2_pool.get(); }
 

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -51,9 +51,6 @@ struct RuntimeFilterTimerQueue;
 namespace taskgroup {
 class TaskGroupManager;
 }
-namespace stream_load {
-class LoadStreamStubPool;
-} // namespace stream_load
 namespace io {
 class S3FileBufferPool;
 class FileCacheFactory;
@@ -81,6 +78,7 @@ class ResultQueueMgr;
 class TMasterInfo;
 class LoadChannelMgr;
 class LoadStreamMgr;
+class LoadStreamStubPool;
 class StreamLoadExecutor;
 class RoutineLoadTaskExecutor;
 class SmallFileMgr;
@@ -238,7 +236,7 @@ public:
     }
 
 #endif
-    stream_load::LoadStreamStubPool* load_stream_stub_pool() {
+    LoadStreamStubPool* load_stream_stub_pool() {
         return _load_stream_stub_pool.get();
     }
 
@@ -352,7 +350,7 @@ private:
     // To save meta info of external file, such as parquet footer.
     FileMetaCache* _file_meta_cache = nullptr;
     std::unique_ptr<MemTableMemoryLimiter> _memtable_memory_limiter;
-    std::unique_ptr<stream_load::LoadStreamStubPool> _load_stream_stub_pool;
+    std::unique_ptr<LoadStreamStubPool> _load_stream_stub_pool;
     std::unique_ptr<vectorized::DeltaWriterV2Pool> _delta_writer_v2_pool;
     std::shared_ptr<WalManager> _wal_manager;
 

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -217,7 +217,7 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths,
     _block_spill_mgr = new BlockSpillManager(store_paths);
     _group_commit_mgr = new GroupCommitMgr(this);
     _memtable_memory_limiter = std::make_unique<MemTableMemoryLimiter>();
-    _load_stream_stub_pool = std::make_unique<stream_load::LoadStreamStubPool>();
+    _load_stream_stub_pool = std::make_unique<LoadStreamStubPool>();
     _delta_writer_v2_pool = std::make_unique<vectorized::DeltaWriterV2Pool>();
     _wal_manager = WalManager::create_shared(this, config::group_commit_wal_path);
 

--- a/be/src/vec/sink/load_stream_stub_pool.cpp
+++ b/be/src/vec/sink/load_stream_stub_pool.cpp
@@ -23,8 +23,6 @@
 namespace doris {
 class TExpr;
 
-namespace stream_load {
-
 LoadStreams::LoadStreams(UniqueId load_id, int64_t dst_id, int num_use, LoadStreamStubPool* pool)
         : _load_id(load_id), _dst_id(dst_id), _use_cnt(num_use), _pool(pool) {}
 
@@ -87,5 +85,4 @@ void LoadStreamStubPool::erase(UniqueId load_id, int64_t dst_id) {
     _template_stubs.erase(load_id);
 }
 
-} // namespace stream_load
 } // namespace doris

--- a/be/src/vec/sink/load_stream_stub_pool.h
+++ b/be/src/vec/sink/load_stream_stub_pool.h
@@ -68,8 +68,6 @@ namespace doris {
 
 class LoadStreamStub;
 
-namespace stream_load {
-
 class LoadStreamStubPool;
 
 using Streams = std::vector<std::shared_ptr<LoadStreamStub>>;
@@ -118,5 +116,4 @@ private:
     std::unordered_map<std::pair<UniqueId, int64_t>, std::shared_ptr<LoadStreams>> _pool;
 };
 
-} // namespace stream_load
 } // namespace doris

--- a/be/src/vec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.cpp
@@ -268,8 +268,7 @@ Status VTabletWriterV2::_open_streams(int64_t src_id) {
     return Status::OK();
 }
 
-Status VTabletWriterV2::_open_streams_to_backend(int64_t dst_id,
-                                                 LoadStreams& streams) {
+Status VTabletWriterV2::_open_streams_to_backend(int64_t dst_id, LoadStreams& streams) {
     const auto* node_info = _nodes_info->find_node(dst_id);
     DBUG_EXECUTE_IF("VTabletWriterV2._open_streams_to_backend.node_info_null",
                     { node_info = nullptr; });

--- a/be/src/vec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.cpp
@@ -269,7 +269,7 @@ Status VTabletWriterV2::_open_streams(int64_t src_id) {
 }
 
 Status VTabletWriterV2::_open_streams_to_backend(int64_t dst_id,
-                                                 ::doris::stream_load::LoadStreams& streams) {
+                                                 LoadStreams& streams) {
     const auto* node_info = _nodes_info->find_node(dst_id);
     DBUG_EXECUTE_IF("VTabletWriterV2._open_streams_to_backend.node_info_null",
                     { node_info = nullptr; });

--- a/be/src/vec/sink/writer/vtablet_writer_v2.h
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.h
@@ -123,7 +123,7 @@ private:
 
     Status _open_streams(int64_t src_id);
 
-    Status _open_streams_to_backend(int64_t dst_id, ::doris::stream_load::LoadStreams& streams);
+    Status _open_streams_to_backend(int64_t dst_id, LoadStreams& streams);
 
     Status _incremental_open_streams(const std::vector<TOlapTablePartition>& partitions);
 

--- a/be/src/vec/sink/writer/vtablet_writer_v2.h
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.h
@@ -69,6 +69,7 @@
 namespace doris {
 class DeltaWriterV2;
 class LoadStreamStub;
+class LoadStreams;
 class ObjectPool;
 class RowDescriptor;
 class RuntimeState;
@@ -76,10 +77,6 @@ class TDataSink;
 class TExpr;
 class TabletSchema;
 class TupleDescriptor;
-
-namespace stream_load {
-class LoadStreams;
-}
 
 namespace vectorized {
 
@@ -219,8 +216,7 @@ private:
     std::unordered_map<int64_t, std::unordered_map<int64_t, PTabletID>> _tablets_for_node;
     std::unordered_map<int64_t, std::vector<PTabletID>> _indexes_from_node;
 
-    std::unordered_map<int64_t, std::shared_ptr<::doris::stream_load::LoadStreams>>
-            _streams_for_node;
+    std::unordered_map<int64_t, std::shared_ptr<LoadStreams>> _streams_for_node;
 
     size_t _stream_index = 0;
     std::shared_ptr<DeltaWriterV2Map> _delta_writer_for_tablet;

--- a/be/test/vec/exec/load_stream_stub_pool_test.cpp
+++ b/be/test/vec/exec/load_stream_stub_pool_test.cpp
@@ -22,8 +22,6 @@
 
 namespace doris {
 
-namespace stream_load {
-
 class LoadStreamStubPoolTest : public testing::Test {
 public:
     LoadStreamStubPoolTest() = default;
@@ -50,5 +48,4 @@ TEST_F(LoadStreamStubPoolTest, test) {
     EXPECT_EQ(0, pool.templates_size());
 }
 
-} // namespace stream_load
 } // namespace doris


### PR DESCRIPTION
## Proposed changes

The namespace `stream_load` was used in legacy code.
After we convert sink v2 to tablet writer v2, this namespace should be removed.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

