### PR TITLE
[fix](move-memtable) don't call StreamClose in LoadStreamStub destructor

### DIFF
--- a/be/src/vec/sink/load_stream_stub.cpp
+++ b/be/src/vec/sink/load_stream_stub.cpp
@@ -105,11 +105,7 @@ LoadStreamStub::LoadStreamStub(LoadStreamStub& stub)
           _tablet_schema_for_index(stub._tablet_schema_for_index),
           _enable_unique_mow_for_index(stub._enable_unique_mow_for_index) {};
 
-LoadStreamStub::~LoadStreamStub() {
-    if (_is_init.load() && !_handler.is_closed()) {
-        brpc::StreamClose(_stream_id);
-    }
-}
+LoadStreamStub::~LoadStreamStub() = default;
 
 // open_load_stream
 Status LoadStreamStub::open(BrpcClientCache<PBackendService_Stub>* client_cache,


### PR DESCRIPTION
## Proposed changes

Don't call StreamClose in LoadStreamStub destructor, `on_idle_timeout` on server side will close orphan streams.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

