### PR TITLE
[opt](nereids) disable infer column name when query

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -554,11 +554,14 @@ public class SelectStmt extends QueryStmt {
                     }
                     resultExprs.add(rewriteQueryExprByMvColumnExpr(item.getExpr(), analyzer));
                     String columnLabel = null;
-                    // Infer column name when item is expr, both query and ddl
-                    columnLabel = item.toColumnLabel(i);
+                    Class<? extends StatementBase> statementClazz = analyzer.getRootStatementClazz();
+                    if (statementClazz != null
+                            && (!QueryStmt.class.isAssignableFrom(statementClazz) || hasOutFileClause())) {
+                        // Infer column name when item is expr
+                        columnLabel = item.toColumnLabel(i);
+                    }
                     if (columnLabel == null) {
-                        // column label without position is applicative for query and do not infer
-                        // column name when item is expr
+                        // use original column label
                         columnLabel = item.toColumnLabel();
                     }
                     SlotRef aliasRef = new SlotRef(null, columnLabel);

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/OlapQueryCacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/OlapQueryCacheTest.java
@@ -979,10 +979,10 @@ public class OlapQueryCacheTest {
             cache.rewriteSelectStmt(null);
             LOG.warn("Sub nokey={}", cache.getNokeyStmt().toSql());
             Assert.assertEquals(cache.getNokeyStmt().toSql(),
-                    "SELECT <slot 7> `eventdate` AS `eventdate`, <slot 8> sum(`pv`) AS `__sum_1` "
+                    "SELECT <slot 7> `eventdate` AS `eventdate`, <slot 8> sum(`pv`) AS `sum(``pv``)` "
                             + "FROM (SELECT <slot 3> `eventdate` AS `eventdate`, <slot 4> count(`userid`) AS `pv` "
-                            + "FROM `testCluster:testDb`.`appevent` WHERE `eventid` = 1 "
-                            + "GROUP BY `eventdate`) tbl GROUP BY `eventdate`");
+                            + "FROM `testCluster:testDb`.`appevent` WHERE `eventid` = 1 GROUP BY `eventdate`) tbl "
+                            + "GROUP BY `eventdate`");
 
             PartitionRange range = cache.getPartitionRange();
             boolean flag = range.analytics();
@@ -1001,11 +1001,11 @@ public class OlapQueryCacheTest {
             sql = ca.getRewriteStmt().toSql();
             LOG.warn("Sub rewrite={}", sql);
             Assert.assertEquals(sql,
-                    "SELECT <slot 7> `eventdate` AS `eventdate`, <slot 8> sum(`pv`) AS `__sum_1` "
+                    "SELECT <slot 7> `eventdate` AS `eventdate`, <slot 8> sum(`pv`) AS `sum(``pv``)` "
                             + "FROM (SELECT <slot 3> `eventdate` AS `eventdate`, <slot 4> count(`userid`) AS `pv` "
                             + "FROM `testCluster:testDb`.`appevent` WHERE `eventdate` > '2020-01-13' "
-                            + "AND `eventdate` < '2020-01-16' AND `eventid` = 1 "
-                            + "GROUP BY `eventdate`) tbl GROUP BY `eventdate`");
+                            + "AND `eventdate` < '2020-01-16' AND `eventid` = 1 GROUP BY `eventdate`) tbl "
+                            + "GROUP BY `eventdate`");
         } catch (Exception e) {
             LOG.warn("sub ex={}", e);
             Assert.fail(e.getMessage());
@@ -1056,8 +1056,8 @@ public class OlapQueryCacheTest {
         SqlCache sqlCache = (SqlCache) ca.getCache();
         String cacheKey = sqlCache.getSqlWithViewStmt();
         Assert.assertEquals(cacheKey, "SELECT <slot 2> `eventdate` AS `eventdate`, <slot 3> count(`userid`) "
-                + "AS `__count_1` FROM `testCluster:testDb`.`appevent` WHERE `eventdate` >= '2020-01-12' AND "
-                + "`eventdate` <= '2020-01-14' GROUP BY `eventdate`|");
+                + "AS `count(``userid``)` FROM `testCluster:testDb`.`appevent` WHERE `eventdate` >= '2020-01-12' "
+                + "AND `eventdate` <= '2020-01-14' GROUP BY `eventdate`|");
         Assert.assertEquals(selectedPartitionIds.size(), sqlCache.getSumOfPartitionNum());
     }
 


### PR DESCRIPTION
## Proposed changes

Disable infer column name when query, because it cause some errors when using BI tools 
This feature is firstly developed by https://github.com/apache/doris/pull/26055

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

