### PR TITLE
[chore](config) temporary change fetch_rpc_timeout_seconds to 150s to…

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -236,7 +236,7 @@ DEFINE_Int32(doris_max_remote_scanner_thread_pool_thread_num, "-1");
 DEFINE_Int32(doris_scanner_thread_pool_queue_size, "102400");
 // default thrift client connect timeout(in seconds)
 DEFINE_mInt32(thrift_connect_timeout_seconds, "3");
-DEFINE_mInt32(fetch_rpc_timeout_seconds, "30");
+DEFINE_mInt32(fetch_rpc_timeout_seconds, "150");
 // default thrift client retry interval (in milliseconds)
 DEFINE_mInt64(thrift_client_retry_interval_ms, "1000");
 // max row count number for single scan range, used in segmentv1


### PR DESCRIPTION
… solve rpc timeout

Rpc timeout is due to fetch phase acquire tablet lock, but the related PR(#26151) is now pending to merge to branch-2.0. So change fetch_rpc_timeout_seconds from 30 to 150 to solve the problem temporarily

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

