### PR TITLE
[cherry-pick](nereids) support agg function of count(const value) pushdown #26677

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/CountLiteralToCountStar.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/CountLiteralToCountStar.java
@@ -57,7 +57,7 @@ public class CountLiteralToCountStar extends OneRewriteRuleFactory {
                     .filter(this::isCountLiteral)
                     .forEach(c -> replaced.put(c, new Count()));
             expr = expr.rewriteUp(s -> replaced.getOrDefault(s, s));
-            changed = !replaced.isEmpty();
+            changed |= !replaced.isEmpty();
             newExprs.add((NamedExpression) expr);
         }
         return changed;

--- a/regression-test/suites/nereids_p0/explain/test_pushdown_explain.groovy
+++ b/regression-test/suites/nereids_p0/explain/test_pushdown_explain.groovy
@@ -25,4 +25,37 @@ suite("test_pushdown_explain") {
         contains "PREDICATES:"
     }
     qt_select "select k1 from baseall where k1 = 1"
+
+    sql "DROP TABLE IF EXISTS test_lineorder"
+    sql """ CREATE TABLE `test_lineorder` (
+        `lo_orderkey` INT NOT NULL COMMENT '\"\"',
+        `lo_linenumber` INT NOT NULL COMMENT '\"\"',
+        `lo_shipmode` VARCHAR(11) NOT NULL COMMENT '\"\"'
+    ) ENGINE=OLAP
+    DUPLICATE KEY(`lo_orderkey`)
+    DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48
+    PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1"
+    ); """
+    sql """ insert into test_lineorder values(1,2,"asd"); """
+    explain {
+        sql("select count(1) from test_lineorder;")
+        contains "pushAggOp=COUNT"
+    }
+    explain {
+        sql("select count(*) from test_lineorder;")
+        contains "pushAggOp=COUNT"
+    }
+    explain {
+        sql("select count(1) - count(lo_shipmode) from test_lineorder;")
+        contains "pushAggOp=COUNT"
+    }
+    explain {
+        sql("select count(lo_orderkey) from test_lineorder;")
+        contains "pushAggOp=COUNT"
+    }
+    explain {
+        sql("select count(cast(lo_orderkey as bigint)) from test_lineorder;")
+        contains "pushAggOp=COUNT"
+    }
 }


### PR DESCRIPTION
cherry-pick from master https://github.com/apache/doris/pull/26677

support sql: select count(1)-count(not null) from table, the agg of count could push down.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

