### PR TITLE
[fix](judge-partition) Fix incorrect logic in determining partitioned table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -1302,14 +1302,7 @@ public class OlapTable extends Table {
 
     @Override
     public boolean isPartitioned() {
-        int numSegs = 0;
-        for (Partition part : getPartitions()) {
-            numSegs += part.getDistributionInfo().getBucketNum();
-            if (numSegs > 1) {
-                return true;
-            }
-        }
-        return false;
+        return !PartitionType.UNPARTITIONED.equals(partitionInfo.getType());
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

The old logic used to determine whether it was a partition table based on the number of buckets, but if I had a partition table with only one partition and the number of buckets in that partition was 1, it would be mistakenly recognized as a non partition table.

```
Table[test_load_doris_to_hive_2] is not partitioned
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

