### PR TITLE
[Bug](materialized-view) add limitation for duplicate expr on materialized view

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
@@ -39,6 +39,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -46,6 +47,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Materialized view is performed to materialize the results of query.
@@ -342,19 +344,19 @@ public class CreateMaterializedViewStmt extends DdlStmt {
             }
         }
 
-        for (Expr groupExpr : groupingExprs) {
-            boolean match = false;
-            String rhs = selectStmt.getExprFromAliasSMap(groupExpr).toSqlWithoutTbl();
-            for (Expr expr : selectExprs) {
-                String lhs = selectStmt.getExprFromAliasSMap(expr).toSqlWithoutTbl();
-                if (lhs.equalsIgnoreCase(rhs)) {
-                    match = true;
-                    break;
-                }
+        Set<String> selectExprNames = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
+        for (Expr expr : selectExprs) {
+            String selectExprName = selectStmt.getExprFromAliasSMap(expr).toSqlWithoutTbl();
+            if (selectExprNames.contains(selectExprName)) {
+                throw new AnalysisException("The select expr " + selectExprName + " is duplicated.");
             }
+            selectExprNames.add(selectExprName);
+        }
 
-            if (!match) {
-                throw new AnalysisException("The grouping expr " + rhs + " not in select list.");
+        for (Expr expr : groupingExprs) {
+            String groupExprName = selectStmt.getExprFromAliasSMap(expr).toSqlWithoutTbl();
+            if (!selectExprNames.contains(groupExprName)) {
+                throw new AnalysisException("The grouping expr " + groupExprName + " not in select list.");
             }
         }
     }

--- a/regression-test/suites/mv_p0/test_mv_useless/agg_invalid/agg_invalid.groovy
+++ b/regression-test/suites/mv_p0/test_mv_useless/agg_invalid/agg_invalid.groovy
@@ -41,4 +41,14 @@ suite ("agg_invalid") {
         sql "CREATE MATERIALIZED VIEW mv_4 AS SELECT p1, SUM(abs(v1)) FROM t1 GROUP BY p1;"
         exception "errCode = 2,"
     }
+
+    test {
+        sql "CREATE MATERIALIZED VIEW mv_5 AS SELECT p1, p2, p1, SUM(v1) FROM t1 GROUP BY p1,p2,p1;"
+        exception "errCode = 2,"
+    }
+
+    test {
+        sql "CREATE MATERIALIZED VIEW mv_5 AS SELECT p1, p2, SUM(v1), SUM(v1) FROM t1 GROUP BY p1,p2;"
+        exception "errCode = 2,"
+    }
 }


### PR DESCRIPTION
## Proposed changes
add limitation for duplicate expr on materialized view, duplicate expr will cause planning errors and lead to core dump.

```c++
*** Aborted at 1700795758 (unix time) try "date -d @1700795758" if you are using GNU date ***
*** Current BE git commitID: ea1c6b53e6 ***
*** SIGABRT unknown detail explain (@0x446000f3df1) received by PID 998897 (TID 1007038 OR 0x7ff4871ad700) from PID 998897; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk1/xiaolei/incubator-doris/be/src/common/signal_handler.h:417
 1# 0x00007FF914D57400 in /lib64/libc.so.6
 2# __GI_raise in /lib64/libc.so.6
 3# __GI_abort in /lib64/libc.so.6
 4# 0x000055D053A4375D in /mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be
 5# 0x000055D053A35A6A in /mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be
 6# google::LogMessage::SendToLog() in /mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be
 7# google::LogMessage::Flush() in /mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be
 8# google::LogMessageFatal::~LogMessageFatal() in /mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be
 9# doris::vectorized::ColumnString const& assert_cast<doris::vectorized::ColumnString const&, doris::vectorized::IColumn const&>(doris::vectorized::IColumn const&) in /mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be
10# doris::vectorized::ColumnString::insert_from(doris::vectorized::IColumn const&, unsigned long) at /mnt/disk1/xiaolei/incubator-doris/be/src/vec/columns/column_string.h:166
11# doris::MultiBlockMerger::merge(std::vector<std::unique_ptr<doris::vectorized::Block, std::default_delete<doris::vectorized::Block> >, std::allocator<std::unique_ptr<doris::vectorized::Block, std::default_delete<doris::vectorized::Block> > > > const&, doris::RowsetWriter*, unsigned long*) at /mnt/disk1/xiaolei/incubator-doris/be/src/olap/schema_change.cpp:162
12# doris::VSchemaChangeWithSorting::_internal_sorting(std::vector<std::unique_ptr<doris::vectorized::Block, std::default_delete<doris::vectorized::Block> >, std::allocator<std::unique_ptr<doris::vectorized::Block, std::default_delete<doris::vectorized::Block> > > > const&, doris::Version const&, long, std::shared_ptr<doris::Tablet>, doris::RowsetTypePB, doris::SegmentsOverlapPB) at /mnt/disk1/xiaolei/incubator-doris/be/src/olap/schema_change.cpp:624
13# doris::VSchemaChangeWithSorting::_inner_process(std::shared_ptr<doris::RowsetReader>, doris::RowsetWriter*, std::shared_ptr<doris::Tablet>, std::shared_ptr<doris::TabletSchema>)::$_1::operator()() const at /mnt/disk1/xiaolei/incubator-doris/be/src/olap/schema_change.cpp:544
14# doris::VSchemaChangeWithSorting::_inner_process(std::shared_ptr<doris::RowsetReader>, doris::RowsetWriter*, std::shared_ptr<doris::Tablet>, std::shared_ptr<doris::TabletSchema>) at /mnt/disk1/xiaolei/incubator-doris/be/src/olap/schema_change.cpp:591
15# doris::SchemaChange::process(std::shared_ptr<doris::RowsetReader>, doris::RowsetWriter*, std::shared_ptr<doris::Tablet>, std::shared_ptr<doris::Tablet>, std::shared_ptr<doris::TabletSchema>) at /mnt/disk1/xiaolei/incubator-doris/be/src/olap/schema_change.h:118
16# doris::SchemaChangeHandler::_convert_historical_rowsets(doris::SchemaChangeHandler::SchemaChangeParams const&) at /mnt/disk1/xiaolei/incubator-doris/be/src/olap/schema_change.cpp:1129
17# doris::SchemaChangeHandler::_do_process_alter_tablet_v2(doris::TAlterTabletReqV2 const&) at /mnt/disk1/xiaolei/incubator-doris/be/src/olap/schema_change.cpp:925
18# doris::SchemaChangeHandler::process_alter_tablet_v2(doris::TAlterTabletReqV2 const&) at /mnt/disk1/xiaolei/incubator-doris/be/src/olap/schema_change.cpp:675
19# doris::EngineAlterTabletTask::execute() at /mnt/disk1/xiaolei/incubator-doris/be/src/olap/task/engine_alter_tablet_task.cpp:51
20# doris::StorageEngine::execute_task(doris::EngineTask*) at /mnt/disk1/xiaolei/incubator-doris/be/src/olap/storage_engine.cpp:1232
21# doris::AlterTableTaskPool::_alter_tablet(doris::TAgentTaskRequest const&, long, doris::TTaskType::type, doris::TFinishTaskRequest*) at /mnt/disk1/xiaolei/incubator-doris/be/src/agent/task_worker_pool.cpp:1792
```
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

