### PR TITLE
[fix](profilev2) fix merge profile min is zero 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
@@ -493,7 +493,8 @@ public class RuntimeProfile {
             Counter counter = templateProfile.counterMap.get(childCounterName);
             mergeCounters(childCounterName, profiles, simpleProfile);
             if (counter.getLevel() == 1) {
-                AggCounter aggCounter = new AggCounter(profiles.get(0).counterMap.get(childCounterName).getType(), 0);
+                Counter oldCounter = profiles.get(0).counterMap.get(childCounterName);
+                AggCounter aggCounter = new AggCounter(oldCounter.getType(), oldCounter.getValue());
                 for (RuntimeProfile profile : profiles) {
                     Counter orgCounter = profile.counterMap.get(childCounterName);
                     aggCounter.addCounter(orgCounter);


### PR DESCRIPTION
## Proposed changes

before
```
                            -  ExecTime:  avg  50.514us,  max  101.28us,  min  0ns
                            -  OpenTime:  avg  39.126us,  max  78.252us,  min  0ns
```
now
```
                                -  ExecTime:  avg  15.413us,  max  17.80us,  min  14.677us
                                -  OpenTime:  avg  15.281us,  max  16.953us,  min  14.553us
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

