### PR TITLE
[Opt](multi-catalog) Opt parquet orc reader null map decoding by `memset()`.

### DIFF
--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -1261,9 +1261,7 @@ Status OrcReader::_orc_column_to_doris_column(const std::string& col_name,
                 map_data_column[origin_size + i] = !cvb_nulls[i];
             }
         } else {
-            for (int i = 0; i < num_values; ++i) {
-                map_data_column[origin_size + i] = false;
-            }
+            memset(map_data_column.data() + origin_size, 0, num_values);
         }
     } else {
         if (cvb->hasNulls) {

--- a/be/src/vec/exec/format/parquet/parquet_common.cpp
+++ b/be/src/vec/exec/format/parquet/parquet_common.cpp
@@ -112,16 +112,15 @@ void ColumnSelectVector::set_run_length_null_map(const std::vector<uint16_t>& ru
             NullMap& map_data_column = *null_map;
             auto null_map_index = map_data_column.size();
             map_data_column.resize(null_map_index + num_values);
+
             for (auto& run_length : run_length_null_map) {
                 if (is_null) {
+                    memset(map_data_column.data() + null_map_index, 1, run_length);
+                    null_map_index += run_length;
                     _num_nulls += run_length;
-                    for (int i = 0; i < run_length; ++i) {
-                        map_data_column[null_map_index++] = 1;
-                    }
                 } else {
-                    for (int i = 0; i < run_length; ++i) {
-                        map_data_column[null_map_index++] = 0;
-                    }
+                    memset(map_data_column.data() + null_map_index, 0, run_length);
+                    null_map_index += run_length;
                 }
                 is_null = !is_null;
             }


### PR DESCRIPTION
## Proposed changes

Opt parquet orc reader null map decoding by `memset()`.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

