### PR TITLE
[minor](fe) convert `MysqlPassword.twoStageHash` Chinese annotations into English

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlPassword.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlPassword.java
@@ -179,8 +179,8 @@ public class MysqlPassword {
         return scramblePassword;
     }
 
-    // 将用户传入的字符串转化为对应的密码Hash值
-    // 用于用户设定密码
+    // Convert plaintext password into the corresponding 2-staged hashed password
+    // Used for users to set password
     private static byte[] twoStageHash(String password) {
         try {
             byte[] passBytes = password.getBytes("UTF-8");


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Convert `MysqlPassword.twoStageHash` annotations from Chinese into English

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

