### PR TITLE
[Fix](stress) fix JoinNode destruction crash

### DIFF
--- a/be/src/vec/exec/join/vnested_loop_join_node.cpp
+++ b/be/src/vec/exec/join/vnested_loop_join_node.cpp
@@ -347,8 +347,8 @@ void VNestedLoopJoinNode::_process_left_child_block(MutableBlock& mutable_block,
 
 void VNestedLoopJoinNode::_update_additional_flags(Block* block) {
     if (_is_outer_join) {
-        auto p0 = _tuple_is_null_left_flag_column->assume_mutable();
-        auto p1 = _tuple_is_null_right_flag_column->assume_mutable();
+        auto p0 = std::move(*_tuple_is_null_left_flag_column).mutate();
+        auto p1 = std::move(*_tuple_is_null_right_flag_column).mutate();
         auto& left_null_map = reinterpret_cast<ColumnUInt8&>(*p0);
         auto& right_null_map = reinterpret_cast<ColumnUInt8&>(*p1);
         auto left_size = left_null_map.size();
@@ -383,8 +383,8 @@ void VNestedLoopJoinNode::_resize_fill_tuple_is_null_column(size_t new_size, int
 
 void VNestedLoopJoinNode::_add_tuple_is_null_column(Block* block) {
     if (_is_outer_join) {
-        auto p0 = _tuple_is_null_left_flag_column->assume_mutable();
-        auto p1 = _tuple_is_null_right_flag_column->assume_mutable();
+        auto p0 = std::move(*_tuple_is_null_left_flag_column).mutate();
+        auto p1 = std::move(*_tuple_is_null_right_flag_column).mutate();
         block->insert({std::move(p0), std::make_shared<vectorized::DataTypeUInt8>(),
                        "left_tuples_is_null"});
         block->insert({std::move(p1), std::make_shared<vectorized::DataTypeUInt8>(),


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

backstrace:
```gdb
(gdb) p &this->_tuple_is_null_right_flag_column
$8 = (doris::vectorized::MutableColumnPtr *) 0x7fd81a74fd30
(gdb) bt
#0  std::__atomic_base<unsigned int>::operator-- (this=0x20)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/atomic_base.h:386
#1  COW<doris::vectorized::IColumn>::release_ref (this=0x20) at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/vec/common/cow.h:98
#2  COW<doris::vectorized::IColumn>::intrusive_ptr<doris::vectorized::IColumn>::~intrusive_ptr (this=0x7fd81a74fd30)
    at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/vec/common/cow.h:133
#3  doris::vectorized::VJoinNodeBase::~VJoinNodeBase (this=0x7fd81a74fa00)
    at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/vec/exec/join/vjoin_node_base.h:56
#4  0x000055af00704763 in doris::ObjectPool::add<doris::vectorized::VNestedLoopJoinNode>(doris::vectorized::VNestedLoopJoinNode*)::{lambda(void*)#1}::operator()(void*) const (obj=0x18, this=<optimized out>)
    at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/common/object_pool.h:40
#5  doris::ObjectPool::add<doris::vectorized::VNestedLoopJoinNode>(doris::vectorized::VNestedLoopJoinNode*)::{lambda(void*)#1}::__invoke(void*) (obj=0x18) at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/common/object_pool.h:40
#6  0x000055af007407b0 in doris::ObjectPool::clear (this=0x7fd99ce4e5e0)
    at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/common/object_pool.h:57
#7  doris::RuntimeState::~RuntimeState (this=0x7fd894fa8400)
    at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/runtime/runtime_state.cpp:191
#8  0x000055af07aaf551 in std::default_delete<doris::RuntimeState>::operator() (this=<optimized out>, __ptr=0x7fd894fa8400)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:85
#9  std::__uniq_ptr_impl<doris::RuntimeState, std::default_delete<doris::RuntimeState> >::reset (this=0x7fd8e0972f58, __p=0x0)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:182
#10 std::unique_ptr<doris::RuntimeState, std::default_delete<doris::RuntimeState> >::reset (this=0x7fd8e0972f58, __p=0x0)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:456
#11 doris::pipeline::PipelineFragmentContext::~PipelineFragmentContext (this=0x7fd8e0972e10)
    at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/pipeline/pipeline_fragment_context.cpp:143
#12 0x000055af07ab773d in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release (this=0x7fd8e0972e00)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:168
#13 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count (this=0x7fdcc3bc64d8)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:702
#14 std::__shared_ptr<doris::pipeline::PipelineFragmentContext, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr (this=0x7fdcc3bc64d0)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1149
#15 doris::pipeline::PipelineFragmentContext::_close_action (this=<optimized out>)
    at /home/zcp/repo_center/doris_branch-2.0/doris/be/src/pipeline/pipeline_fragment_context.cpp:837

```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

