### PR TITLE
[fix](doc) spell error and aligned with code

### DIFF
--- a/docs/en/docs/admin-manual/maint-monitor/metadata-operation.md
+++ b/docs/en/docs/admin-manual/maint-monitor/metadata-operation.md
@@ -124,7 +124,7 @@ Single node FE is the most basic deployment mode. A complete Doris cluster requi
 		* begin to generate new image: image.xxxx
 		*  start save image to /path/to/doris-meta/image/image.ckpt. is ckpt: true
 		*  finished save image /path/to/doris-meta/image/image.ckpt in xxx ms. checksum is xxxx
-		*  push image.xxx to other nodes. totally xx nodes, push successed xx nodes
+		*  push image.xxx to other nodes. totally xx nodes, push succeeded xx nodes
 		* QE service start
 		* thrift server started
 
@@ -380,7 +380,7 @@ The deployment recommendation of FE is described in the Installation and [Deploy
 
 4. The size of the `bdb/` directory is very large, reaching several Gs or more.
 
-	The BDB directory will remain large for some time after eliminating the error that the new image cannot be generated. Maybe it's because Master FE failed to push image. You can search `push image.XXXX to other nodes. totally XX nodes, push successed YY nodes` in the fe. log of Master FE. If YY is smaller than xx, then some FEs are not pushed successfully. You can see the specific error `Exception when pushing image file.url = xxx` in the fe. log.
+	The BDB directory will remain large for some time after eliminating the error that the new image cannot be generated. Maybe it's because Master FE failed to push image. You can search `push image.XXXX to other nodes. totally XX nodes, push succeeded YY nodes` in the fe. log of Master FE. If YY is smaller than xx, then some FEs are not pushed successfully. You can see the specific error `Exception when pushing image file.url = xxx` in the fe. log.
 
 	At the same time, you can add the configuration in the FE configuration file: `edit_log_roll_num = xxxx`. This parameter sets the number of metadata journals and makes an image once. The default is 50000. This number can be reduced appropriately to make images more frequent, thus speeding up the deletion of old journals.
 

--- a/docs/zh-CN/docs/admin-manual/maint-monitor/metadata-operation.md
+++ b/docs/zh-CN/docs/admin-manual/maint-monitor/metadata-operation.md
@@ -124,7 +124,7 @@ under the License.
         * begin to generate new image: image.xxxx
         *  start save image to /path/to/doris-meta/image/image.ckpt. is ckpt: true
         *  finished save image /path/to/doris-meta/image/image.ckpt in xxx ms. checksum is xxxx
-        *  push image.xxx to other nodes. totally xx nodes, push successed xx nodes
+        *  push image.xxx to other nodes. totally xx nodes, push succeeded xx nodes
         * QE service start
         * thrift server started
 
@@ -384,7 +384,7 @@ FE 的部署推荐，在 [安装与部署文档](../../install/standard-deployme
 
 4. `bdb/` 目录的大小非常大，达到几个G或更多
 
-    如果在排除无法生成新的 image 的错误后，bdb 目录在一段时间内依然很大。则可能是因为 Master FE 推送 image 不成功。可以在 Master FE 的 fe.log 中搜索 `push image.xxxx to other nodes. totally xx nodes, push successed yy nodes`。如果 yy 比 xx 小，则说明有的 FE 没有被推送成功。可以在 fe.log 中查看到具体的错误 `Exception when pushing image file. url = xxx`。
+    如果在排除无法生成新的 image 的错误后，bdb 目录在一段时间内依然很大。则可能是因为 Master FE 推送 image 不成功。可以在 Master FE 的 fe.log 中搜索 `push image.xxxx to other nodes. totally xx nodes, push succeeded yy nodes`。如果 yy 比 xx 小，则说明有的 FE 没有被推送成功。可以在 fe.log 中查看到具体的错误 `Exception when pushing image file. url = xxx`。
 
     同时，你也可以在 FE 的配置文件中添加配置：`edit_log_roll_num=xxxx`。该参数设定了每多少条元数据 journal，做一次 image。默认是 50000。可以适当改小这个数字，使得 image 更加频繁，从而加速删除旧的 journal。
 

--- a/fe/fe-core/src/main/java/org/apache/doris/master/Checkpoint.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/Checkpoint.java
@@ -214,7 +214,7 @@ public class Checkpoint extends MasterDaemon {
                 }
             }
 
-            LOG.info("push image.{} to other nodes. totally {} nodes, push succeed {} nodes",
+            LOG.info("push image.{} to other nodes. totally {} nodes, push succeeded {} nodes",
                     replayedJournalId, otherNodesCount, successPushed);
         }
         if (successPushed == otherNodesCount) {


### PR DESCRIPTION
## Proposed changes
Aligned the spelling for log in code to log sample,
Additionally corrected spell for succeed to succeeded

