### PR TITLE
[fix](nereids)when range bounder is inifinte, range length should be POSITIVE_INFINITE

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DataType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DataType.java
@@ -678,6 +678,9 @@ public abstract class DataType {
     }
 
     public double rangeLength(double high, double low) {
+        if (Double.isInfinite(high) || Double.isInfinite(low)) {
+            return Double.POSITIVE_INFINITY;
+        }
         return high - low;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticRange.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticRange.java
@@ -239,4 +239,8 @@ public class StatisticRange {
         return distinctValues;
     }
 
+    @Override
+    public String toString() {
+        return "range(" + lowExpr + ", " + highExpr + "), ndv:" + distinctValues;
+    }
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

