### PR TITLE
[Improvement](materialized-view) forbidden mv rewriter when select stmt's from clause not have mv

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -485,19 +485,21 @@ public class SelectStmt extends QueryStmt {
         }
         super.analyze(analyzer);
 
-        Boolean haveMv = false;
-        for (TableRef tbl : fromClause) {
-            if (!(tbl.getTable() instanceof OlapTable)) {
-                continue;
+        if (!isForbiddenMVRewrite()) {
+            Boolean haveMv = false;
+            for (TableRef tbl : fromClause) {
+                if (!tbl.haveDesc() || !(tbl.getTable() instanceof OlapTable)) {
+                    continue;
+                }
+                OlapTable olapTable = (OlapTable) tbl.getTable();
+                if (olapTable.getIndexIds().size() != 1) {
+                    haveMv = true;
+                }
             }
-            OlapTable olapTable = (OlapTable) tbl.getTable();
-            if (olapTable.getIndexIds().size() != 1) {
-                haveMv = true;
-            }
-        }
 
-        if (!haveMv) {
-            forbiddenMVRewrite();
+            if (!haveMv) {
+                forbiddenMVRewrite();
+            }
         }
 
         if (mvSMap.size() != 0) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -485,23 +485,6 @@ public class SelectStmt extends QueryStmt {
         }
         super.analyze(analyzer);
 
-        if (!isForbiddenMVRewrite()) {
-            Boolean haveMv = false;
-            for (TableRef tbl : fromClause) {
-                if (!tbl.haveDesc() || !(tbl.getTable() instanceof OlapTable)) {
-                    continue;
-                }
-                OlapTable olapTable = (OlapTable) tbl.getTable();
-                if (olapTable.getIndexIds().size() != 1) {
-                    haveMv = true;
-                }
-            }
-
-            if (!haveMv) {
-                forbiddenMVRewrite();
-            }
-        }
-
         if (mvSMap.size() != 0) {
             mvSMap.useNotCheckDescIdEquals();
             for (TableRef tableRef : getTableRefs()) {
@@ -520,6 +503,24 @@ public class SelectStmt extends QueryStmt {
         }
         fromClause.setNeedToSql(needToSql);
         fromClause.analyze(analyzer);
+
+        if (!isForbiddenMVRewrite()) {
+            Boolean haveMv = false;
+            for (TableRef tbl : fromClause) {
+                if (!tbl.haveDesc() || !(tbl.getTable() instanceof OlapTable)) {
+                    continue;
+                }
+                OlapTable olapTable = (OlapTable) tbl.getTable();
+                if (olapTable.getIndexIds().size() != 1) {
+                    haveMv = true;
+                }
+            }
+
+            if (!haveMv) {
+                forbiddenMVRewrite();
+            }
+        }
+
         // Generate !empty() predicates to filter out empty collections.
         // Skip this step when analyzing a WITH-clause because CollectionTableRefs
         // do not register collection slots in their parent in that context

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -485,6 +485,21 @@ public class SelectStmt extends QueryStmt {
         }
         super.analyze(analyzer);
 
+        Boolean haveMv = false;
+        for (TableRef tbl : fromClause) {
+            if (!(tbl.getTable() instanceof OlapTable)) {
+                continue;
+            }
+            OlapTable olapTable = (OlapTable) tbl.getTable();
+            if (olapTable.getIndexIds().size() != 1) {
+                haveMv = true;
+            }
+        }
+
+        if (!haveMv) {
+            forbiddenMVRewrite();
+        }
+
         if (mvSMap.size() != 0) {
             mvSMap.useNotCheckDescIdEquals();
             for (TableRef tableRef : getTableRefs()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TableRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TableRef.java
@@ -329,6 +329,10 @@ public class TableRef implements ParseNode, Writable {
         return tableSnapshot;
     }
 
+    public Boolean haveDesc() {
+        return desc != null;
+    }
+
     /**
      * This method should only be called after the TableRef has been analyzed.
      */


### PR DESCRIPTION
## Proposed changes
forbidden mv rewriter when select stmt's from clause not have mv
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

