### PR TITLE
[Fix](executor)Make blockscheduler first stop then delete

### DIFF
--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -143,10 +143,8 @@ public:
     ClientCache<FrontendServiceClient>* frontend_client_cache() { return _frontend_client_cache; }
     ClientCache<TPaloBrokerServiceClient>* broker_client_cache() { return _broker_client_cache; }
 
-    pipeline::TaskScheduler* pipeline_task_scheduler() { return _pipeline_task_scheduler; }
-    pipeline::TaskScheduler* pipeline_task_group_scheduler() {
-        return _pipeline_task_group_scheduler;
-    }
+    pipeline::TaskScheduler* pipeline_task_scheduler() { return _without_group_task_scheduler; }
+    pipeline::TaskScheduler* pipeline_task_group_scheduler() { return _with_group_task_scheduler; }
     taskgroup::TaskGroupManager* task_group_manager() { return _task_group_manager; }
 
     // using template to simplify client cache management
@@ -328,8 +326,8 @@ private:
     // ThreadPoolToken -> buffer
     std::unordered_map<ThreadPoolToken*, std::unique_ptr<char[]>> _download_cache_buf_map;
     FragmentMgr* _fragment_mgr = nullptr;
-    pipeline::TaskScheduler* _pipeline_task_scheduler = nullptr;
-    pipeline::TaskScheduler* _pipeline_task_group_scheduler = nullptr;
+    pipeline::TaskScheduler* _without_group_task_scheduler = nullptr;
+    pipeline::TaskScheduler* _with_group_task_scheduler = nullptr;
     taskgroup::TaskGroupManager* _task_group_manager = nullptr;
 
     ResultCache* _result_cache = nullptr;

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -283,16 +283,16 @@ Status ExecEnv::init_pipeline_task_scheduler() {
     // TODO pipeline task group combie two blocked schedulers.
     auto t_queue = std::make_shared<pipeline::MultiCoreTaskQueue>(executors_size);
     _without_group_block_scheduler = std::make_shared<pipeline::BlockedTaskScheduler>();
-    _pipeline_task_scheduler = new pipeline::TaskScheduler(
+    _without_group_task_scheduler = new pipeline::TaskScheduler(
             this, _without_group_block_scheduler, t_queue, "WithoutGroupTaskSchePool", nullptr);
-    RETURN_IF_ERROR(_pipeline_task_scheduler->start());
+    RETURN_IF_ERROR(_without_group_task_scheduler->start());
     RETURN_IF_ERROR(_without_group_block_scheduler->start("WithoutGroupBlockSche"));
 
     auto tg_queue = std::make_shared<pipeline::TaskGroupTaskQueue>(executors_size);
     _with_group_block_scheduler = std::make_shared<pipeline::BlockedTaskScheduler>();
-    _pipeline_task_group_scheduler = new pipeline::TaskScheduler(
+    _with_group_task_scheduler = new pipeline::TaskScheduler(
             this, _with_group_block_scheduler, tg_queue, "WithGroupTaskSchePool", nullptr);
-    RETURN_IF_ERROR(_pipeline_task_group_scheduler->start());
+    RETURN_IF_ERROR(_with_group_task_scheduler->start());
     RETURN_IF_ERROR(_with_group_block_scheduler->start("WithGroupBlockSche"));
 
     _global_block_scheduler = std::make_shared<pipeline::BlockedTaskScheduler>();
@@ -539,9 +539,15 @@ void ExecEnv::destroy() {
     SAFE_STOP(_group_commit_mgr);
     // _routine_load_task_executor should be stopped before _new_load_stream_mgr.
     SAFE_STOP(_routine_load_task_executor);
-    SAFE_STOP(_pipeline_task_scheduler);
-    SAFE_STOP(_pipeline_task_group_scheduler);
+    // stop pipline step 1, non-cgroup execution
+    SAFE_SHUTDOWN(_without_group_block_scheduler.get());
+    SAFE_STOP(_without_group_task_scheduler);
+    SAFE_SHUTDOWN(_with_group_block_scheduler.get());
+    SAFE_STOP(_with_group_task_scheduler);
+    // stop pipline step 2, cgroup execution
+    SAFE_SHUTDOWN(_global_block_scheduler.get());
     SAFE_STOP(_task_group_manager);
+
     SAFE_STOP(_external_scan_context_mgr);
     SAFE_STOP(_fragment_mgr);
     // NewLoadStreamMgr should be destoried before storage_engine & after fragment_mgr stopped.
@@ -608,8 +614,8 @@ void ExecEnv::destroy() {
     SAFE_DELETE(_result_cache);
     SAFE_DELETE(_fragment_mgr);
     SAFE_DELETE(_task_group_manager);
-    SAFE_DELETE(_pipeline_task_group_scheduler);
-    SAFE_DELETE(_pipeline_task_scheduler);
+    SAFE_DELETE(_with_group_task_scheduler);
+    SAFE_DELETE(_without_group_task_scheduler);
     SAFE_DELETE(_file_cache_factory);
     // TODO(zhiqiang): Maybe we should call shutdown before release thread pool?
     _join_node_thread_pool.reset(nullptr);
@@ -638,10 +644,6 @@ void ExecEnv::destroy() {
     // access master_info.backend id to access some info. If there is a running query and master
     // info is deconstructed then BE process will core at coordinator back method in fragment mgr.
     SAFE_DELETE(_master_info);
-
-    SAFE_SHUTDOWN(_global_block_scheduler.get());
-    SAFE_SHUTDOWN(_without_group_block_scheduler.get());
-    SAFE_SHUTDOWN(_with_group_block_scheduler.get());
 
     LOG(INFO) << "Doris exec envorinment is destoried.";
 }


### PR DESCRIPTION
## Proposed changes
Whether ```first stop BlockScheduler then stop TaskScheduler``` or ```first stop TaskScheduler then stop BlockScheduler``` does not matter, because this just stop active thread.
But the ```stop of a scheduler```  must precede the ```resources deletion```.
Currently BlockScheduler's stop is after resource delete, this may cause NPE.
Because the PipelineTask maybe is deleted when BlockScheduler try to visit PipelineTask.