### PR TITLE
[enhancement](compaction) Add support for limiting low priority compaction scheduling

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1512,8 +1512,8 @@ void PublishVersionWorkerPool::publish_version_callback(const TAgentTaskRequest&
                 TabletSharedPtr tablet = _engine.tablet_manager()->get_tablet(tablet_id);
                 if (tablet != nullptr) {
                     if (!tablet->tablet_meta()->tablet_schema()->disable_auto_compaction()) {
-                        int64_t published_count =
-                                tablet->published_count.fetch_add(1, std::memory_order_relaxed);
+                        tablet->published_count.fetch_add(1);
+                        int64_t published_count = tablet->published_count.load();
                         if (published_count % 10 == 0) {
                             auto st = _engine.submit_compaction_task(
                                     tablet, CompactionType::CUMULATIVE_COMPACTION, true);

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -430,6 +430,11 @@ DEFINE_mBool(disable_compaction_trace_log, "true");
 // Interval to picking rowset to compact, in seconds
 DEFINE_mInt64(pick_rowset_to_compact_interval_sec, "86400");
 
+// Compaction priority schedule
+DEFINE_mBool(enable_compaction_priority_scheduling, "false");
+DEFINE_mInt32(low_priority_compaction_task_num_per_disk, "1");
+DEFINE_mDouble(low_priority_tablet_version_num_ratio, "0.7");
+
 // Thread count to do tablet meta checkpoint, -1 means use the data directories count.
 DEFINE_Int32(max_meta_checkpoint_threads, "-1");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -481,6 +481,11 @@ DECLARE_mBool(disable_compaction_trace_log);
 // Interval to picking rowset to compact, in seconds
 DECLARE_mInt64(pick_rowset_to_compact_interval_sec);
 
+// Compaction priority schedule
+DECLARE_mBool(enable_compaction_priority_scheduling);
+DECLARE_mInt32(low_priority_compaction_task_num_per_disk);
+DECLARE_mDouble(low_priority_tablet_version_num_ratio);
+
 // Thread count to do tablet meta checkpoint, -1 means use the data directories count.
 DECLARE_Int32(max_meta_checkpoint_threads);
 

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -941,7 +941,7 @@ Status StorageEngine::_submit_compaction_task(TabletSharedPtr tablet,
                                             this]() {
             if (is_low_priority_task && !_increase_low_priority_task_nums(tablet->data_dir())) {
                 VLOG_DEBUG << "skip low priority compaction task for tablet: "
-                          << tablet->tablet_id();
+                           << tablet->tablet_id();
                 // Todo: push task back
             } else {
                 tablet->execute_compaction(compaction_type);

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -1428,7 +1428,7 @@ Status StorageEngine::_persist_broken_paths() {
 
 bool StorageEngine::_increase_low_priority_task_nums(DataDir* dir) {
     if (!config::enable_compaction_priority_scheduling) {
-        return false;
+        return true;
     }
     std::lock_guard l(_low_priority_task_nums_mutex);
     if (_low_priority_task_nums[dir] < config::low_priority_compaction_task_num_per_disk) {

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -335,6 +335,10 @@ private:
 
     Status _persist_broken_paths();
 
+    bool _increase_low_priority_task_nums(DataDir* dir);
+
+    void _decrease_low_priority_task_nums(DataDir* dir);
+
 private:
     struct CompactionCandidate {
         CompactionCandidate(uint32_t nicumulative_compaction_, int64_t tablet_id_, uint32_t index_)
@@ -452,6 +456,9 @@ private:
     // a tablet can do base and cumulative compaction at same time
     std::map<DataDir*, std::unordered_set<TTabletId>> _tablet_submitted_cumu_compaction;
     std::map<DataDir*, std::unordered_set<TTabletId>> _tablet_submitted_base_compaction;
+
+    std::mutex _low_priority_task_nums_mutex;
+    std::unordered_map<DataDir*, int32_t> _low_priority_task_nums;
 
     std::mutex _peer_replica_infos_mutex;
     // key: tabletId


### PR DESCRIPTION
Consider treating non-forced compaction tasks as low priority tasks and limit the concurrency of low priority tasks to reduce the utilization of hardware resources by compaction tasks.