### PR TITLE
[performance](Planner): avoid toStringValue() in DateLiteral compare

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/PlaceHolderExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/PlaceHolderExpr.java
@@ -93,16 +93,15 @@ public class PlaceHolderExpr extends LiteralExpr {
         return lExpr.compareLiteral(expr);
     }
 
-    @Override
-    public int compareTo(LiteralExpr literalExpr) {
-        return compareLiteral(literalExpr);
-    }
-
     public String getStringValue() {
         if (lExpr == null) {
             return "";
         }
         return lExpr.getStringValue();
+    }
+
+    public LiteralExpr getlExpr() {
+        return lExpr;
     }
 
     public long getLongValue() {

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/FEFunctions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/FEFunctions.java
@@ -81,9 +81,10 @@ public class FEFunctions {
     @FEFunction(name = "dayofweek", argTypes = {"DATETIME"}, returnType = "TINYINT")
     public static IntLiteral dayOfWeek(LiteralExpr date) throws AnalysisException {
         // use zellar algorithm.
-        long year = ((DateLiteral) date).getYear();
-        long month = ((DateLiteral) date).getMonth();
-        long day = ((DateLiteral) date).getDay();
+        DateLiteral dateLiteral = (DateLiteral) date;
+        long year = dateLiteral.getYear();
+        long month = dateLiteral.getMonth();
+        long day = dateLiteral.getDay();
         if (month < 3) {
             month += 12;
             year -= 1;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

