### PR TITLE
[improvement](grace stop)BE grace stop improvement

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -932,6 +932,10 @@ CONF_Int32(primary_key_data_page_size, "32768");
 // the max package size be thrift server can receive,avoid accepting error or too large package causing OOM,default 20M
 CONF_Int32(be_thrift_max_pkg_bytes, "20000000");
 
+// grace stop time limit, exit() will be called if be dose not stop within this time limit
+// default value is 0, which means there is no time limit and be will wait until it is successfully stopped
+CONF_Int32(grace_shutdown_wait_seconds, "0");
+
 #ifdef BE_TEST
 // test s3
 CONF_String(test_s3_resource, "resource");

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -365,6 +365,7 @@ void ExecEnv::_destroy() {
     _deregister_metrics();
     SAFE_DELETE(_internal_client_cache);
     SAFE_DELETE(_function_client_cache);
+    SAFE_DELETE(_routine_load_task_executor);
     SAFE_DELETE(_load_stream_mgr);
     SAFE_DELETE(_load_channel_mgr);
     SAFE_DELETE(_broker_mgr);
@@ -385,7 +386,6 @@ void ExecEnv::_destroy() {
     SAFE_DELETE(_result_queue_mgr);
     SAFE_DELETE(_stream_mgr);
     SAFE_DELETE(_stream_load_executor);
-    SAFE_DELETE(_routine_load_task_executor);
     SAFE_DELETE(_external_scan_context_mgr);
     SAFE_DELETE(_heartbeat_flags);
     SAFE_DELETE(_scanner_scheduler);

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -218,7 +218,9 @@ public:
                 // The brpc server should respond as quickly as possible.
                 bthread_context->thread_mem_tracker_mgr->disable_wait_gc();
                 // set the data so that next time bthread_getspecific in the thread returns the data.
-                CHECK((0 == bthread_setspecific(btls_key, bthread_context)) || doris::k_doris_exit);
+                if (!doris::k_doris_exit) {
+                    CHECK(0 == bthread_setspecific(btls_key, bthread_context));
+                }
                 thread_context_ptr.init = true;
             }
             bthread_id = bthread_self();


### PR DESCRIPTION
## Proposed changes

1. Add new be config parameter grace_stop_limit_sec, which enables the control of the grace stop time. The reason is that we found it difficult to estimate and control the time required for graceful stop of the BE when there are many queries and import tasks running in the backend, resulting in a long time for graceful stop.
2. Fix the core issue in grace stop.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

