### PR TITLE
[Fix](show-load)Show load npe(userinfo is null)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -826,8 +826,12 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
             jobInfo.add(transactionId);
             // error tablets
             jobInfo.add(errorTabletsToJson());
-            // user
-            jobInfo.add(userInfo.getQualifiedUser());
+            // user, some load job may not have user info
+            if (userInfo == null || userInfo.getQualifiedUser() == null) {
+                jobInfo.add(FeConstants.null_string);
+            } else {
+                jobInfo.add(userInfo.getQualifiedUser());
+            }
             // comment
             jobInfo.add(comment);
             return jobInfo;

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
@@ -572,8 +572,9 @@ public class LoadManager implements Writable {
                     }
                     // add load job info
                     loadJobInfos.add(loadJob.getShowInfo());
-                } catch (DdlException e) {
-                    continue;
+                } catch (RuntimeException | DdlException e) {
+                    // ignore this load job
+                    LOG.warn("get load job info failed. job id: {}", loadJob.getId(), e);
                 }
             }
             return loadJobInfos;


### PR DESCRIPTION
### What happend
In some cases, the user information of the job may be lost, so this will cause NPE to occur.
**version 2.0.2**
**execute sql : show load**

```
java.lang.NullPointerException: null
    at org.apache.doris.load.loadv2.LoadJob.getShowInfo(LoadJob.java:823) ~[doris-fe.jar:1.2-SNAPSHOT]
    at org.apache.doris.load.loadv2.LoadManager.getLoadJobInfosByDb(LoadManager.java:565) ~[doris-fe.jar:1.2-SNAPSHOT]
```
### changes
Check whether the user information is null, and add peripheral exception capture and logs to avoid exceptions in a single piece of data, causing the entire show load to fail.

