### PR TITLE
[deps](compression) Opt gzip decompress by libdeflate on X86 and X86_64 platforms: 1. Add libdeflate lib.

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1633,6 +1633,20 @@ build_dragonbox() {
     "${BUILD_SYSTEM}" install
 }
 
+# libdeflate
+build_libdeflate() {
+    check_if_source_exist "${LIBDEFLATE_SOURCE}"
+    cd "${TP_SOURCE_DIR}/${LIBDEFLATE_SOURCE}"
+
+    rm -rf "${BUILD_DIR}"
+    mkdir -p "${BUILD_DIR}"
+    cd "${BUILD_DIR}"
+
+    "${CMAKE_CMD}" -G "${GENERATOR}" -DCMAKE_INSTALL_PREFIX="${TP_INSTALL_DIR}" -DCMAKE_BUILD_TYPE=Release ..
+    "${BUILD_SYSTEM}" -j "${PARALLEL}"
+    "${BUILD_SYSTEM}" install
+}
+
 if [[ "${#packages[@]}" -eq 0 ]]; then
     packages=(
         libunixodbc
@@ -1694,6 +1708,7 @@ if [[ "${#packages[@]}" -eq 0 ]]; then
         fast_float
         libunwind
         dragonbox
+        libdeflate
     )
     if [[ "$(uname -s)" == 'Darwin' ]]; then
         read -r -a packages <<<"binutils gettext ${packages[*]}"

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -470,6 +470,12 @@ DRAGONBOX_NAME=dragonbox-1.1.3.tar.gz
 DRAGONBOX_SOURCE=dragonbox-1.1.3
 DRAGONBOX_MD5SUM="889dc00db9612c6949a4ccf8115e0e6a"
 
+# libdeflate
+LIBDEFLATE_DOWNLOAD="https://github.com/ebiggers/libdeflate/archive/refs/tags/v1.19.tar.gz"
+LIBDEFLATE_NAME=libdeflate-1.19.tar.gz
+LIBDEFLATE_SOURCE=libdeflate-1.19
+LIBDEFLATE_MD5SUM="c69e9193d2975a729068ffa862c81fb6"
+
 # all thirdparties which need to be downloaded is set in array TP_ARCHIVES
 export TP_ARCHIVES=(
     'LIBEVENT'
@@ -539,6 +545,7 @@ export TP_ARCHIVES=(
     'FAST_FLOAT'
     'HADOOP_LIBS'
     'DRAGONBOX'
+    'LIBDEFLATE'
 )
 
 if [[ "$(uname -s)" == 'Darwin' ]]; then


### PR DESCRIPTION
## Proposed changes

Backport from #27542.

Opt gzip decompression by libdeflate on X86 and X86_64 platforms: 1. Add libdeflate lib. 

Test result:

- env: 1 node(16 cores, 64G).
- parquet column: 100 million rows of char(255) column.
- result: 9.09 s -> 6.04 s.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

