### PR TITLE
[refactor](cluster)(step-3) remove cluster related to Auth

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterUserStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterUserStmt.java
@@ -18,7 +18,6 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Env;
-import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
@@ -103,7 +102,6 @@ public class AlterUserStmt extends DdlStmt {
         }
 
         if (!Strings.isNullOrEmpty(role)) {
-            role = ClusterNamespace.getFullName(analyzer.getClusterName(), role);
             ops.add(OpType.SET_ROLE);
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterUserStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterUserStmt.java
@@ -95,7 +95,7 @@ public class AlterUserStmt extends DdlStmt {
     @Override
     public void analyze(Analyzer analyzer) throws UserException {
         super.analyze(analyzer);
-        userDesc.getUserIdent().analyze(analyzer.getClusterName());
+        userDesc.getUserIdent().analyze();
         userDesc.getPassVar().analyze();
 
         if (userDesc.hasPassword()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreatePolicyStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreatePolicyStmt.java
@@ -106,7 +106,7 @@ public class CreatePolicyStmt extends DdlStmt {
             default:
                 tableName.analyze(analyzer);
                 if (user != null) {
-                    user.analyze(analyzer.getClusterName());
+                    user.analyze();
                     if (user.isRootUser() || user.isAdminUser()) {
                         ErrorReport.reportAnalysisException(ErrorCode.ERR_TABLEACCESS_DENIED_ERROR, "CreatePolicyStmt",
                                 user.getQualifiedUser(), user.getHost(), tableName.getTbl());

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateRoleStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateRoleStmt.java
@@ -18,7 +18,6 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Env;
-import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeNameFormat;
@@ -44,7 +43,7 @@ public class CreateRoleStmt extends DdlStmt {
         return ifNotExists;
     }
 
-    public String getQualifiedRole() {
+    public String getRole() {
         return role;
     }
 
@@ -52,7 +51,6 @@ public class CreateRoleStmt extends DdlStmt {
     public void analyze(Analyzer analyzer) throws UserException {
         super.analyze(analyzer);
         FeNameFormat.checkRoleName(role, false /* can not be admin */, "Can not create role");
-        role = ClusterNamespace.getFullName(analyzer.getClusterName(), role);
 
         // check if current user has GRANT priv on GLOBAL level.
         if (!Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ConnectContext.get(), PrivPredicate.GRANT)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateUserStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateUserStmt.java
@@ -109,7 +109,7 @@ public class CreateUserStmt extends DdlStmt {
     @Override
     public void analyze(Analyzer analyzer) throws UserException {
         super.analyze(analyzer);
-        userIdent.analyze(analyzer.getClusterName());
+        userIdent.analyze();
 
         if (userIdent.isRootUser()) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_COMMON_ERROR, "Can not create root user");

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateUserStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateUserStmt.java
@@ -18,7 +18,6 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Env;
-import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeNameFormat;
@@ -124,7 +123,6 @@ public class CreateUserStmt extends DdlStmt {
                 role = Role.ADMIN_ROLE;
             }
             FeNameFormat.checkRoleName(role, true /* can be admin */, "Can not granted user to role");
-            role = ClusterNamespace.getFullName(analyzer.getClusterName(), role);
         }
 
         passwordOptions.analyze();

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DropRoleStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DropRoleStmt.java
@@ -18,7 +18,6 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Env;
-import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeNameFormat;
@@ -44,7 +43,7 @@ public class DropRoleStmt extends DdlStmt {
         return ifExists;
     }
 
-    public String getQualifiedRole() {
+    public String getRole() {
         return role;
     }
 
@@ -52,7 +51,6 @@ public class DropRoleStmt extends DdlStmt {
     public void analyze(Analyzer analyzer) throws UserException {
         super.analyze(analyzer);
         FeNameFormat.checkRoleName(role, false /* can not be superuser */, "Can not drop role");
-        role = ClusterNamespace.getFullName(analyzer.getClusterName(), role);
 
         // check if current user has GRANT priv on GLOBAL level.
         if (!Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ConnectContext.get(), PrivPredicate.GRANT)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DropUserStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DropUserStmt.java
@@ -53,7 +53,7 @@ public class DropUserStmt extends DdlStmt {
     @Override
     public void analyze(Analyzer analyzer) throws AnalysisException, UserException {
         super.analyze(analyzer);
-        userIdent.analyze(analyzer.getClusterName());
+        userIdent.analyze();
 
         if (userIdent.isRootUser()) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_COMMON_ERROR, "Can not drop root user");

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/GrantStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/GrantStmt.java
@@ -135,7 +135,7 @@ public class GrantStmt extends DdlStmt {
     public void analyze(Analyzer analyzer) throws UserException {
         super.analyze(analyzer);
         if (userIdent != null) {
-            userIdent.analyze(analyzer.getClusterName());
+            userIdent.analyze();
         } else {
             FeNameFormat.checkRoleName(role, false /* can not be admin */, "Can not grant to role");
             role = ClusterNamespace.getFullName(analyzer.getClusterName(), role);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/GrantStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/GrantStmt.java
@@ -19,7 +19,6 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.AccessPrivilegeWithCols;
 import org.apache.doris.catalog.Env;
-import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
@@ -138,7 +137,6 @@ public class GrantStmt extends DdlStmt {
             userIdent.analyze();
         } else {
             FeNameFormat.checkRoleName(role, false /* can not be admin */, "Can not grant to role");
-            role = ClusterNamespace.getFullName(analyzer.getClusterName(), role);
         }
 
         if (tblPattern != null) {
@@ -151,10 +149,8 @@ public class GrantStmt extends DdlStmt {
             for (int i = 0; i < roles.size(); i++) {
                 String originalRoleName = roles.get(i);
                 FeNameFormat.checkRoleName(originalRoleName, true /* can be admin */, "Can not grant role");
-                roles.set(i, ClusterNamespace.getFullName(analyzer.getClusterName(), originalRoleName));
             }
         }
-
 
         if (!CollectionUtils.isEmpty(accessPrivileges)) {
             checkAccessPrivileges(accessPrivileges);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/RevokeStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/RevokeStmt.java
@@ -18,7 +18,6 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.AccessPrivilegeWithCols;
-import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.FeNameFormat;
 import org.apache.doris.mysql.privilege.ColPrivilegeKey;
@@ -121,7 +120,6 @@ public class RevokeStmt extends DdlStmt {
             userIdent.analyze();
         } else {
             FeNameFormat.checkRoleName(role, false /* can not be superuser */, "Can not revoke from role");
-            role = ClusterNamespace.getFullName(analyzer.getClusterName(), role);
         }
 
         if (tblPattern != null) {
@@ -134,7 +132,6 @@ public class RevokeStmt extends DdlStmt {
             for (int i = 0; i < roles.size(); i++) {
                 String originalRoleName = roles.get(i);
                 FeNameFormat.checkRoleName(originalRoleName, true /* can be admin */, "Can not revoke role");
-                roles.set(i, ClusterNamespace.getFullName(analyzer.getClusterName(), originalRoleName));
             }
         }
         if (!CollectionUtils.isEmpty(accessPrivileges)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/RevokeStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/RevokeStmt.java
@@ -118,7 +118,7 @@ public class RevokeStmt extends DdlStmt {
     @Override
     public void analyze(Analyzer analyzer) throws AnalysisException {
         if (userIdent != null) {
-            userIdent.analyze(analyzer.getClusterName());
+            userIdent.analyze();
         } else {
             FeNameFormat.checkRoleName(role, false /* can not be superuser */, "Can not revoke from role");
             role = ClusterNamespace.getFullName(analyzer.getClusterName(), role);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SetPassVar.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SetPassVar.java
@@ -60,7 +60,7 @@ public class SetPassVar extends SetVar {
             userIdent = ctx.getCurrentUserIdentity();
             isSelf = true;
         } else {
-            userIdent.analyze(analyzer.getClusterName());
+            userIdent.analyze();
             if (userIdent.equals(ctx.getCurrentUserIdentity())) {
                 isSelf = true;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowGrantsStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowGrantsStmt.java
@@ -73,7 +73,7 @@ public class ShowGrantsStmt extends ShowStmt {
             if (isAll) {
                 throw new AnalysisException("Can not specified keyword ALL when specified user");
             }
-            userIdent.analyze(analyzer.getClusterName());
+            userIdent.analyze();
         } else {
             if (!isAll) {
                 // self

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowPolicyStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowPolicyStmt.java
@@ -57,7 +57,7 @@ public class ShowPolicyStmt extends ShowStmt {
     public void analyze(Analyzer analyzer) throws UserException {
         super.analyze(analyzer);
         if (user != null) {
-            user.analyze(analyzer.getClusterName());
+            user.analyze();
         }
         // check auth
         if (!Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ConnectContext.get(), PrivPredicate.ADMIN)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/UserIdentity.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/UserIdentity.java
@@ -124,7 +124,7 @@ public class UserIdentity implements Writable, GsonPostProcessable {
         this.isAnalyzed = true;
     }
 
-    public void analyze(String clusterName) throws AnalysisException {
+    public void analyze() throws AnalysisException {
         if (isAnalyzed) {
             return;
         }
@@ -133,10 +133,6 @@ public class UserIdentity implements Writable, GsonPostProcessable {
         }
 
         FeNameFormat.checkUserName(user);
-        if (!user.equals(Auth.ROOT_USER) && !user.equals(Auth.ADMIN_USER)) {
-            user = ClusterNamespace.getFullName(clusterName, user);
-        }
-
         if (Strings.isNullOrEmpty(host)) {
             if (!isDomain) {
                 host = "%";
@@ -212,11 +208,17 @@ public class UserIdentity implements Writable, GsonPostProcessable {
         return sb.toString();
     }
 
+    // should be remove after version 3.0
+    public void removeClusterPrefix() {
+        user = ClusterNamespace.getNameFromFullName(user);
+    }
+
     public static UserIdentity read(DataInput in) throws IOException {
         // Use Gson in the VERSION_109
         if (Env.getCurrentEnvJournalVersion() < FeMetaVersion.VERSION_109) {
             UserIdentity userIdentity = new UserIdentity();
             userIdentity.readFields(in);
+            userIdentity.removeClusterPrefix();
             return userIdentity;
         } else {
             String json = Text.readString(in);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/UserIdentity.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/UserIdentity.java
@@ -218,7 +218,6 @@ public class UserIdentity implements Writable, GsonPostProcessable {
         if (Env.getCurrentEnvJournalVersion() < FeMetaVersion.VERSION_109) {
             UserIdentity userIdentity = new UserIdentity();
             userIdentity.readFields(in);
-            userIdentity.removeClusterPrefix();
             return userIdentity;
         } else {
             String json = Text.readString(in);
@@ -283,5 +282,6 @@ public class UserIdentity implements Writable, GsonPostProcessable {
     @Override
     public void gsonPostProcess() throws IOException {
         isAnalyzed = true;
+        removeClusterPrefix();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/BaseController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/controller/BaseController.java
@@ -266,11 +266,10 @@ public class BaseController {
             authInfo.fullUserName = authString.substring(0, index);
             final String[] elements = authInfo.fullUserName.split("@");
             if (elements != null && elements.length < 2) {
-                authInfo.fullUserName = ClusterNamespace.getFullName(SystemInfoService.DEFAULT_CLUSTER,
-                        authInfo.fullUserName);
+                authInfo.fullUserName = ClusterNamespace.getNameFromFullName(authInfo.fullUserName);
                 authInfo.cluster = SystemInfoService.DEFAULT_CLUSTER;
             } else if (elements != null && elements.length == 2) {
-                authInfo.fullUserName = ClusterNamespace.getFullName(elements[1], elements[0]);
+                authInfo.fullUserName = ClusterNamespace.getNameFromFullName(elements[0]);
                 authInfo.cluster = elements[1];
             }
             authInfo.password = authString.substring(index + 1);

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlProto.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlProto.java
@@ -87,9 +87,8 @@ public class MysqlProto {
             tmpUser = strList[0];
         }
 
-        String qualifiedUser = ClusterNamespace.getFullName(SystemInfoService.DEFAULT_CLUSTER, tmpUser);
-        context.setQualifiedUser(qualifiedUser);
-        return qualifiedUser;
+        context.setQualifiedUser(tmpUser);
+        return tmpUser;
     }
 
     // send response packet(OK/EOF/ERR).

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
@@ -866,7 +866,7 @@ public class Auth implements Writable {
 
     // create role
     public void createRole(CreateRoleStmt stmt) throws DdlException {
-        createRoleInternal(stmt.getQualifiedRole(), stmt.isSetIfNotExists(), false);
+        createRoleInternal(stmt.getRole(), stmt.isSetIfNotExists(), false);
     }
 
     public void replayCreateRole(PrivInfo info) {
@@ -900,7 +900,7 @@ public class Auth implements Writable {
 
     // drop role
     public void dropRole(DropRoleStmt stmt) throws DdlException {
-        dropRoleInternal(stmt.getQualifiedRole(), stmt.isSetIfExists(), false);
+        dropRoleInternal(stmt.getRole(), stmt.isSetIfExists(), false);
     }
 
     public void replayDropRole(PrivInfo info) {

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
@@ -54,7 +54,6 @@ import org.apache.doris.common.io.Writable;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.ldap.LdapManager;
 import org.apache.doris.ldap.LdapUserInfo;
-import org.apache.doris.load.DppConfig;
 import org.apache.doris.mysql.MysqlPassword;
 import org.apache.doris.persist.AlterUserOperationLog;
 import org.apache.doris.persist.LdapInfo;
@@ -1290,47 +1289,6 @@ public class Auth implements Writable {
             return propertyMgr.fetchUserProperty(qualifiedUser);
         } catch (AnalysisException e) {
             return Lists.newArrayList();
-        } finally {
-            readUnlock();
-        }
-    }
-
-    public void dropUserOfCluster(String clusterName, boolean isReplay) throws DdlException {
-        writeLock();
-        try {
-            Map<String, List<User>> nameToUsers = userManager.getNameToUsers();
-            for (List<User> users : nameToUsers.values()) {
-                for (User user : users) {
-                    if (user.getUserIdentity().getQualifiedUser().startsWith(clusterName)) {
-                        dropUserInternal(user.getUserIdentity(), false, isReplay);
-                    }
-                }
-            }
-        } finally {
-            writeUnlock();
-        }
-    }
-
-    public Pair<String, DppConfig> getLoadClusterInfo(String qualifiedUser, String cluster) throws DdlException {
-        readLock();
-        try {
-            return propertyMgr.getLoadClusterInfo(qualifiedUser, cluster);
-        } finally {
-            readUnlock();
-        }
-    }
-
-    // user can enter a cluster, if it has any privs of database or table in this cluster.
-    public boolean checkCanEnterCluster(ConnectContext ctx, String clusterName) {
-        readLock();
-        try {
-            Set<String> roles = userRoleManager.getRolesByUser(ctx.getCurrentUserIdentity());
-            for (String roleName : roles) {
-                if (roleManager.getRole(roleName).checkCanEnterCluster(clusterName)) {
-                    return true;
-                }
-            }
-            return false;
         } finally {
             readUnlock();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
@@ -835,8 +835,15 @@ public class Role implements Writable, GsonPostProcessable {
             return role;
         } else {
             String json = Text.readString(in);
-            return GsonUtils.GSON.fromJson(json, Role.class);
+            Role r = GsonUtils.GSON.fromJson(json, Role.class);
+            r.removeClusterPrefix();
+            return r;
         }
+    }
+
+    // should be removed after version 3.0
+    private void removeClusterPrefix() {
+        roleName = ClusterNamespace.getNameFromFullName(roleName);
     }
 
     @Deprecated

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Role.java
@@ -836,7 +836,6 @@ public class Role implements Writable, GsonPostProcessable {
         } else {
             String json = Text.readString(in);
             Role r = GsonUtils.GSON.fromJson(json, Role.class);
-            r.removeClusterPrefix();
             return r;
         }
     }
@@ -873,6 +872,7 @@ public class Role implements Writable, GsonPostProcessable {
 
     @Override
     public void gsonPostProcess() {
+        removeClusterPrefix();
         rebuildPrivTables();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/RoleManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/RoleManager.java
@@ -32,6 +32,7 @@ import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.mysql.privilege.Auth.PrivLevel;
+import org.apache.doris.persist.gson.GsonPostProcessable;
 import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.resource.workloadgroup.WorkloadGroupMgr;
@@ -55,7 +56,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class RoleManager implements Writable {
+public class RoleManager implements Writable, GsonPostProcessable {
     private static final Logger LOG = LogManager.getLogger(RoleManager.class);
     //prefix of each user default role
     public static String DEFAULT_ROLE_PREFIX = "default_role_rbac_";
@@ -263,7 +264,6 @@ public class RoleManager implements Writable {
         } else {
             String json = Text.readString(in);
             RoleManager rm = GsonUtils.GSON.fromJson(json, RoleManager.class);
-            rm.removeClusterPrefix();
             return rm;
         }
     }
@@ -285,5 +285,10 @@ public class RoleManager implements Writable {
             Role role = Role.read(in);
             roles.put(role.getRoleName(), role);
         }
+    }
+
+    @Override
+    public void gsonPostProcess() throws IOException {
+        removeClusterPrefix();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/RoleManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/RoleManager.java
@@ -262,8 +262,20 @@ public class RoleManager implements Writable {
             return roleManager;
         } else {
             String json = Text.readString(in);
-            return GsonUtils.GSON.fromJson(json, RoleManager.class);
+            RoleManager rm = GsonUtils.GSON.fromJson(json, RoleManager.class);
+            rm.removeClusterPrefix();
+            return rm;
         }
+    }
+
+    // should be removed after version 3.0
+    private void removeClusterPrefix() {
+        Map<String, Role> newRoles = Maps.newHashMap();
+        for (Map.Entry<String, Role> entry : roles.entrySet()) {
+            String roleName = ClusterNamespace.getNameFromFullName(entry.getKey());
+            newRoles.put(roleName, entry.getValue());
+        }
+        roles = newRoles;
     }
 
     @Deprecated

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserManager.java
@@ -19,6 +19,7 @@ package org.apache.doris.mysql.privilege;
 
 import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.AuthenticationException;
 import org.apache.doris.common.CaseSensibility;
 import org.apache.doris.common.DdlException;
@@ -314,6 +315,17 @@ public class UserManager implements Writable {
 
     public static UserManager read(DataInput in) throws IOException {
         String json = Text.readString(in);
-        return GsonUtils.GSON.fromJson(json, UserManager.class);
+        UserManager um = GsonUtils.GSON.fromJson(json, UserManager.class);
+        um.removeClusterPrefix();
+        return um;
+    }
+
+    // should be removed after version 3.0
+    private void removeClusterPrefix() {
+        Map<String, List<User>> newNameToUsers = Maps.newHashMap();
+        for (Entry<String, List<User>> entry : nameToUsers.entrySet()) {
+            String user = entry.getKey();
+            newNameToUsers.put(ClusterNamespace.getNameFromFullName(user), entry.getValue());
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserManager.java
@@ -29,6 +29,7 @@ import org.apache.doris.common.PatternMatcherException;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.mysql.MysqlPassword;
+import org.apache.doris.persist.gson.GsonPostProcessable;
 import org.apache.doris.persist.gson.GsonUtils;
 
 import com.google.common.base.Preconditions;
@@ -49,7 +50,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-public class UserManager implements Writable {
+public class UserManager implements Writable, GsonPostProcessable {
     public static final String ANY_HOST = "%";
     private static final Logger LOG = LogManager.getLogger(UserManager.class);
     // Concurrency control is delegated by Auth, so not concurrentMap
@@ -316,7 +317,6 @@ public class UserManager implements Writable {
     public static UserManager read(DataInput in) throws IOException {
         String json = Text.readString(in);
         UserManager um = GsonUtils.GSON.fromJson(json, UserManager.class);
-        um.removeClusterPrefix();
         return um;
     }
 
@@ -327,5 +327,10 @@ public class UserManager implements Writable {
             String user = entry.getKey();
             newNameToUsers.put(ClusterNamespace.getNameFromFullName(user), entry.getValue());
         }
+    }
+
+    @Override
+    public void gsonPostProcess() throws IOException {
+        removeClusterPrefix();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserProperty.java
@@ -19,6 +19,7 @@ package org.apache.doris.mysql.privilege;
 
 import org.apache.doris.analysis.SetUserPropertyVar;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeMetaVersion;
@@ -537,6 +538,8 @@ public class UserProperty implements Writable {
 
     public void readFields(DataInput in) throws IOException {
         qualifiedUser = Text.readString(in);
+        // should be removed after version 3.0
+        qualifiedUser = ClusterNamespace.getNameFromFullName(qualifiedUser);
 
         if (Env.getCurrentEnvJournalVersion() < FeMetaVersion.VERSION_100) {
             long maxConn = in.readLong();

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserRoleManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserRoleManager.java
@@ -160,8 +160,21 @@ public class UserRoleManager implements Writable, GsonPostProcessable {
         return GsonUtils.GSON.fromJson(json, UserRoleManager.class);
     }
 
+    private void removeClusterPrefix() {
+        Map<UserIdentity, Set<String>> newUserToRoles = Maps.newHashMap();
+        for (Entry<UserIdentity, Set<String>> entry : userToRoles.entrySet()) {
+            Set<String> newRoles = Sets.newHashSet();
+            for (String role : entry.getValue()) {
+                newRoles.add(ClusterNamespace.getNameFromFullName(role));
+            }
+            newUserToRoles.put(entry.getKey(), newRoles);
+        }
+        userToRoles = newUserToRoles;
+    }
+
     @Override
     public void gsonPostProcess() throws IOException {
+        removeClusterPrefix();
         roleToUsers = Maps.newHashMap();
         for (Entry<UserIdentity, Set<String>> entry : userToRoles.entrySet()) {
             for (String roleName : entry.getValue()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/policy/Policy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/policy/Policy.java
@@ -28,7 +28,6 @@ import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.persist.gson.GsonPostProcessable;
 import org.apache.doris.persist.gson.GsonUtils;
-import org.apache.doris.qe.ConnectContext;
 
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;
@@ -119,7 +118,7 @@ public abstract class Policy implements Writable, GsonPostProcessable {
                         .getDbOrAnalysisException(stmt.getTableName().getDb());
                 UserIdentity userIdent = stmt.getUser();
                 if (userIdent != null) {
-                    userIdent.analyze(ConnectContext.get().getClusterName());
+                    userIdent.analyze();
                 }
                 TableIf table = db.getTableOrAnalysisException(stmt.getTableName().getTbl());
                 return new RowPolicy(policyId, stmt.getPolicyName(), db.getId(), userIdent, stmt.getRoleName(),

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -1010,7 +1010,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     private void checkPasswordAndPrivs(String cluster, String user, String passwd, String db, List<String> tables,
             String clientIp, PrivPredicate predicate) throws AuthenticationException {
 
-        final String fullUserName = ClusterNamespace.getFullName(cluster, user);
+        final String fullUserName = ClusterNamespace.getNameFromFullName(user);
         final String fullDbName = ClusterNamespace.getFullName(cluster, db);
         List<UserIdentity> currentUser = Lists.newArrayList();
         Env.getCurrentEnv().getAuth().checkPlainPassword(fullUserName, clientIp, passwd, currentUser);
@@ -1045,7 +1045,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         if (Strings.isNullOrEmpty(cluster)) {
             cluster = SystemInfoService.DEFAULT_CLUSTER;
         }
-        final String fullUserName = ClusterNamespace.getFullName(cluster, user);
+        final String fullUserName = ClusterNamespace.getNameFromFullName(user);
         List<UserIdentity> currentUser = Lists.newArrayList();
         Env.getCurrentEnv().getAuth().checkPlainPassword(fullUserName, clientIp, passwd, currentUser);
         Preconditions.checkState(currentUser.size() == 1);
@@ -2347,7 +2347,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         }
 
         // check account and password
-        final String fullUserName = ClusterNamespace.getFullName(cluster, request.getUser());
+        final String fullUserName = ClusterNamespace.getNameFromFullName(request.getUser());
         List<UserIdentity> currentUser = Lists.newArrayList();
         try {
             Env.getCurrentEnv().getAuth().checkPlainPassword(fullUserName, request.getUserIp(), request.getPasswd(),
@@ -2938,7 +2938,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             }
             ctx.setCluster(cluster);
             ctx.setQualifiedUser(request.getUser());
-            String fullUserName = ClusterNamespace.getFullName(cluster, request.getUser());
+            String fullUserName = ClusterNamespace.getNameFromFullName(request.getUser());
             UserIdentity currentUserIdentity = new UserIdentity(fullUserName, "%");
             ctx.setCurrentUserIdentity(currentUserIdentity);
 

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateUserStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateUserStmtTest.java
@@ -61,22 +61,22 @@ public class CreateUserStmtTest {
         CreateUserStmt stmt = new CreateUserStmt(new UserDesc(new UserIdentity("user", "%"), "passwd", true));
         stmt.analyze(analyzer);
 
-        Assert.assertEquals("CREATE USER 'testCluster:user'@'%' IDENTIFIED BY '*XXX'", stmt.toString());
+        Assert.assertEquals("CREATE USER 'user'@'%' IDENTIFIED BY '*XXX'", stmt.toString());
         Assert.assertEquals(new String(stmt.getPassword()), "*59C70DA2F3E3A5BDF46B68F5C8B8F25762BCCEF0");
 
         stmt = new CreateUserStmt(
                 new UserDesc(new UserIdentity("user", "%"), "*59c70da2f3e3a5bdf46b68f5c8b8f25762bccef0", false));
         stmt.analyze(analyzer);
-        Assert.assertEquals("testCluster:user", stmt.getUserIdent().getQualifiedUser());
+        Assert.assertEquals("user", stmt.getUserIdent().getQualifiedUser());
 
-        Assert.assertEquals("CREATE USER 'testCluster:user'@'%' IDENTIFIED BY PASSWORD '*59c70da2f3e3a5bdf46b68f5c8b8f25762bccef0'",
+        Assert.assertEquals("CREATE USER 'user'@'%' IDENTIFIED BY PASSWORD '*59c70da2f3e3a5bdf46b68f5c8b8f25762bccef0'",
                 stmt.toString());
         Assert.assertEquals(new String(stmt.getPassword()), "*59C70DA2F3E3A5BDF46B68F5C8B8F25762BCCEF0");
 
         stmt = new CreateUserStmt(new UserDesc(new UserIdentity("user", "%"), "", false));
         stmt.analyze(analyzer);
 
-        Assert.assertEquals("CREATE USER 'testCluster:user'@'%'", stmt.toString());
+        Assert.assertEquals("CREATE USER 'user'@'%'", stmt.toString());
         Assert.assertEquals(new String(stmt.getPassword()), "");
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/DropUserStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/DropUserStmtTest.java
@@ -47,8 +47,8 @@ public class DropUserStmtTest {
     public void testNormal() throws UserException, AnalysisException {
         DropUserStmt stmt = new DropUserStmt(new UserIdentity("user", "%"));
         stmt.analyze(analyzer);
-        Assert.assertEquals("DROP USER 'testCluster:user'@'%'", stmt.toString());
-        Assert.assertEquals("testCluster:user", stmt.getUserIdentity().getQualifiedUser());
+        Assert.assertEquals("DROP USER 'user'@'%'", stmt.toString());
+        Assert.assertEquals("user", stmt.getUserIdentity().getQualifiedUser());
     }
 
     @Test(expected = AnalysisException.class)

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/GrantStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/GrantStmtTest.java
@@ -87,7 +87,7 @@ public class GrantStmtTest {
         List<AccessPrivilegeWithCols> privileges = Lists.newArrayList(new AccessPrivilegeWithCols(AccessPrivilege.ALL));
         stmt = new GrantStmt(new UserIdentity("testUser", "%"), null, new TablePattern("testDb", "*"), privileges);
         stmt.analyze(analyzer);
-        Assert.assertEquals("testCluster:testUser", stmt.getUserIdent().getQualifiedUser());
+        Assert.assertEquals("testUser", stmt.getUserIdent().getQualifiedUser());
         Assert.assertEquals("testCluster:testDb", stmt.getTblPattern().getQualifiedDb());
 
         privileges = Lists.newArrayList(new AccessPrivilegeWithCols(AccessPrivilege.READ_ONLY), new AccessPrivilegeWithCols(AccessPrivilege.ALL));
@@ -107,7 +107,7 @@ public class GrantStmtTest {
         stmt = new GrantStmt(new UserIdentity("testUser", "%"), null, new ResourcePattern("*"), privileges);
         stmt.analyze(analyzer);
         Assert.assertEquals(Auth.PrivLevel.GLOBAL, stmt.getResourcePattern().getPrivLevel());
-        Assert.assertEquals("GRANT Usage_priv ON RESOURCE '*' TO 'testCluster:testUser'@'%'", stmt.toSql());
+        Assert.assertEquals("GRANT Usage_priv ON RESOURCE '*' TO 'testUser'@'%'", stmt.toSql());
     }
 
     @Test(expected = AnalysisException.class)

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SetPassVarTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SetPassVarTest.java
@@ -54,15 +54,15 @@ public class SetPassVarTest {
         stmt = new SetPassVar(new UserIdentity("testUser", "%"),
                 new PassVar("*88EEBA7D913688E7278E2AD071FDB5E76D76D34B", false));
         stmt.analyze(analyzer);
-        Assert.assertEquals("testCluster:testUser", stmt.getUserIdent().getQualifiedUser());
+        Assert.assertEquals("testUser", stmt.getUserIdent().getQualifiedUser());
         Assert.assertEquals("*88EEBA7D913688E7278E2AD071FDB5E76D76D34B", new String(stmt.getPassword()));
-        Assert.assertEquals("SET PASSWORD FOR 'testCluster:testUser'@'%' = '*XXX'",
+        Assert.assertEquals("SET PASSWORD FOR 'testUser'@'%' = '*XXX'",
                 stmt.toString());
 
         // empty password
         stmt = new SetPassVar(new UserIdentity("testUser", "%"), new PassVar("", true));
         stmt.analyze(analyzer);
-        Assert.assertEquals("SET PASSWORD FOR 'testCluster:testUser'@'%' = '*XXX'", stmt.toString());
+        Assert.assertEquals("SET PASSWORD FOR 'testUser'@'%' = '*XXX'", stmt.toString());
 
         // empty user
         // empty password

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/RefreshDbTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/RefreshDbTest.java
@@ -34,7 +34,6 @@ import org.apache.doris.datasource.test.TestExternalCatalog;
 import org.apache.doris.mysql.privilege.Auth;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.DdlExecutor;
-import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.Lists;
@@ -125,7 +124,7 @@ public class RefreshDbTest extends TestWithFeService {
 
         // mock login user1
         UserIdentity user1 = new UserIdentity("user1", "%");
-        user1.analyze(SystemInfoService.DEFAULT_CLUSTER);
+        user1.analyze();
         ConnectContext user1Ctx = createCtx(user1, "127.0.0.1");
         ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
                 "Access denied for user 'default_cluster:user1' to database 'default_cluster:db1'",

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/RefreshDbTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/RefreshDbTest.java
@@ -127,7 +127,7 @@ public class RefreshDbTest extends TestWithFeService {
         user1.analyze();
         ConnectContext user1Ctx = createCtx(user1, "127.0.0.1");
         ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
-                "Access denied for user 'default_cluster:user1' to database 'default_cluster:db1'",
+                "Access denied for user 'user1' to database 'default_cluster:db1'",
                 () -> parseAndAnalyzeStmt("refresh database test1.db1", user1Ctx));
         ConnectContext.remove();
 

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/RefreshTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/RefreshTableTest.java
@@ -33,7 +33,6 @@ import org.apache.doris.datasource.test.TestExternalCatalog;
 import org.apache.doris.mysql.privilege.Auth;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.DdlExecutor;
-import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.Lists;
@@ -113,7 +112,7 @@ public class RefreshTableTest extends TestWithFeService {
 
         // mock login user1
         UserIdentity user1 = new UserIdentity("user1", "%");
-        user1.analyze(SystemInfoService.DEFAULT_CLUSTER);
+        user1.analyze();
         ConnectContext user1Ctx = createCtx(user1, "127.0.0.1");
         ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
                 "Access denied; you need (at least one of) the DROP privilege(s) for this operation",

--- a/fe/fe-core/src/test/java/org/apache/doris/cooldown/CooldownConfHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cooldown/CooldownConfHandlerTest.java
@@ -67,7 +67,7 @@ public class CooldownConfHandlerTest extends TestWithFeService {
                 + "properties(\"replication_num\" = \"1\");");
         // create user
         UserIdentity user = new UserIdentity("test_cooldown", "%");
-        user.analyze(SystemInfoService.DEFAULT_CLUSTER);
+        user.analyze();
         CreateUserStmt createUserStmt = new CreateUserStmt(new UserDesc(user));
         Env.getCurrentEnv().getAuth().createUser(createUserStmt);
         List<AccessPrivilegeWithCols> privileges = Lists.newArrayList(new AccessPrivilegeWithCols(AccessPrivilege.ADMIN_PRIV));

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/CatalogMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/CatalogMgrTest.java
@@ -344,7 +344,7 @@ public class CatalogMgrTest extends TestWithFeService {
             Assert.fail("user1 switch to hive with no privilege.");
         } catch (AnalysisException e) {
             Assert.assertEquals(e.getMessage(),
-                    "errCode = 2, detailMessage = Access denied for user 'default_cluster:user1' to catalog 'hive'");
+                    "errCode = 2, detailMessage = Access denied for user 'user1' to catalog 'hive'");
         }
         Assert.assertEquals(InternalCatalog.INTERNAL_CATALOG_NAME, user1Ctx.getDefaultCatalog());
 
@@ -414,7 +414,7 @@ public class CatalogMgrTest extends TestWithFeService {
             Assert.fail("");
         } catch (AnalysisException e) {
             Assert.assertEquals(e.getMessage(),
-                    "errCode = 2, detailMessage = Access denied for user 'default_cluster:user2' to catalog 'iceberg'");
+                    "errCode = 2, detailMessage = Access denied for user 'user2' to catalog 'iceberg'");
         }
 
         //test show create catalog: have permission to hive, have no permission to iceberg;
@@ -431,7 +431,7 @@ public class CatalogMgrTest extends TestWithFeService {
             Assert.fail("");
         } catch (AnalysisException e) {
             Assert.assertEquals(e.getMessage(),
-                    "errCode = 2, detailMessage = Access denied for user 'default_cluster:user2' to catalog 'iceberg'");
+                    "errCode = 2, detailMessage = Access denied for user 'user2' to catalog 'iceberg'");
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/CatalogMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/CatalogMgrTest.java
@@ -56,7 +56,6 @@ import org.apache.doris.planner.ListPartitionPrunerV2;
 import org.apache.doris.planner.PartitionPrunerV2Base.UniqueId;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ShowResultSet;
-import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.base.Preconditions;
@@ -111,7 +110,7 @@ public class CatalogMgrTest extends TestWithFeService {
         auth.createUser((CreateUserStmt) parseAndAnalyzeStmt(
                 "create user 'user1'@'%' identified by 'pwd1' default role 'role1';", rootCtx));
         user1 = new UserIdentity("user1", "%");
-        user1.analyze(SystemInfoService.DEFAULT_CLUSTER);
+        user1.analyze();
         // user1 has the privileges of testc which is granted by ctl.db.tbl format.
         // TODO: 2023/1/20 zdtodo
         //        Assert.assertTrue(auth.getDbPrivTable().hasPrivsOfCatalog(user1, "testc"));
@@ -158,7 +157,7 @@ public class CatalogMgrTest extends TestWithFeService {
         auth.createUser((CreateUserStmt) parseAndAnalyzeStmt(
                 "create user 'user2'@'%' identified by 'pwd2' default role 'role2';", rootCtx));
         user2 = new UserIdentity("user2", "%");
-        user2.analyze(SystemInfoService.DEFAULT_CLUSTER);
+        user2.analyze();
     }
 
     private void createDbAndTableForCatalog(CatalogIf catalog) {

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/AuthTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/AuthTest.java
@@ -220,7 +220,7 @@ public class AuthTest {
         // 2. check if cmy from specified ip can access to palo
         List<UserIdentity> currentUser = Lists.newArrayList();
         Assert.assertTrue(
-                auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":cmy", "192.168.0.1", "12345",
+                auth.checkPlainPasswordForTest("cmy", "192.168.0.1", "12345",
                         currentUser));
         Assert.assertFalse(auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":cmy", "192.168.0.1",
                 "123456", null));
@@ -244,13 +244,9 @@ public class AuthTest {
             Assert.fail();
         }
 
-        // 4. check if zhangsan from specified ip can access to palo
-        Assert.assertTrue(auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "192.168.0.1",
-                "12345", null));
-        Assert.assertFalse(
-                auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "172.168.0.1",
-                        "12345", null));
-        Assert.assertFalse(auth.checkPlainPasswordForTest("zhangsan", "192.168.0.1", "12345", null));
+        // 4. check if zhangsan from specified ip can access to doris
+        Assert.assertTrue(auth.checkPlainPasswordForTest("zhangsan", "192.168.0.1", "12345", null));
+        Assert.assertFalse(auth.checkPlainPasswordForTest("zhangsan", "172.168.0.1", "12345", null));
 
         // 4.1 check if we can create same user
         userIdentity = new UserIdentity("zhangsan", "192.%");
@@ -288,7 +284,7 @@ public class AuthTest {
         } catch (DdlException e) {
             Assert.fail();
         }
-        Assert.assertTrue(auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "172.18.1.1",
+        Assert.assertTrue(auth.checkPlainPasswordForTest("zhangsan", "172.18.1.1",
                 "12345", null));
 
         // 5. create a user with domain [palo.domain]
@@ -313,11 +309,11 @@ public class AuthTest {
         resolver.runAfterCatalogReady();
 
         // 6. check if user from resolved ip can access to palo
-        Assert.assertTrue(auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.1",
+        Assert.assertTrue(auth.checkPlainPasswordForTest("zhangsan", "10.1.1.1",
                 "12345", null));
-        Assert.assertFalse(auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.1",
+        Assert.assertFalse(auth.checkPlainPasswordForTest("zhangsan", "10.1.1.1",
                 "123456", null));
-        Assert.assertFalse(auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "11.1.1.1",
+        Assert.assertFalse(auth.checkPlainPasswordForTest("zhangsan", "11.1.1.1",
                 "12345", null));
 
         // 7. add duplicated user@['palo.domain1']
@@ -361,11 +357,11 @@ public class AuthTest {
         // 8.1 resolve domain [palo.domain2]
         resolver.runAfterCatalogReady();
 
-        Assert.assertTrue(auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "20.1.1.1",
+        Assert.assertTrue(auth.checkPlainPasswordForTest("lisi", "20.1.1.1",
                 "123456", null));
-        Assert.assertFalse(auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "10.1.1.1",
+        Assert.assertFalse(auth.checkPlainPasswordForTest("lisi", "10.1.1.1",
                 "123456", null));
-        Assert.assertFalse(auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "20.1.1.2",
+        Assert.assertFalse(auth.checkPlainPasswordForTest("lisi", "20.1.1.2",
                 "123455", null));
 
         /*
@@ -391,7 +387,7 @@ public class AuthTest {
         }
 
         List<UserIdentity> currentUser2 = Lists.newArrayList();
-        auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":cmy", "172.1.1.1", "12345", currentUser2);
+        auth.checkPlainPasswordForTest("cmy", "172.1.1.1", "12345", currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         // check auth before grant
         Assert.assertFalse(
@@ -409,7 +405,7 @@ public class AuthTest {
         Assert.assertTrue(accessManager.checkDbPriv(currentUser2.get(0), SystemInfoService.DEFAULT_CLUSTER + ":db1",
                 PrivPredicate.CREATE));
         UserIdentity zhangsan1 = UserIdentity
-                .createAnalyzedUserIdentWithIp(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan",
+                .createAnalyzedUserIdentWithIp("zhangsan",
                         "172.1.1.1");
         Assert.assertFalse(accessManager.checkDbPriv(zhangsan1, SystemInfoService.DEFAULT_CLUSTER + ":db1",
                 PrivPredicate.CREATE));
@@ -479,7 +475,7 @@ public class AuthTest {
         }
 
         currentUser2.clear();
-        auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "192.168.1.1", "12345",
+        auth.checkPlainPasswordForTest("zhangsan", "192.168.1.1", "12345",
                 currentUser2);
         Assert.assertEquals(1, currentUser2.size());
 
@@ -511,7 +507,7 @@ public class AuthTest {
         }
 
         currentUser2.clear();
-        auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "192.168.1.1", "12345",
+        auth.checkPlainPasswordForTest("zhangsan", "192.168.1.1", "12345",
                 currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertFalse(
@@ -542,7 +538,7 @@ public class AuthTest {
         }
 
         currentUser2.clear();
-        auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "192.168.1.1", "12345",
+        auth.checkPlainPasswordForTest("zhangsan", "192.168.1.1", "12345",
                 currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertTrue(
@@ -575,7 +571,7 @@ public class AuthTest {
         }
 
         currentUser2.clear();
-        auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.1", "12345",
+        auth.checkPlainPasswordForTest("zhangsan", "10.1.1.1", "12345",
                 currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertTrue(accessManager.checkDbPriv(currentUser2.get(0), SystemInfoService.DEFAULT_CLUSTER + ":db3",
@@ -600,20 +596,20 @@ public class AuthTest {
         }
 
         currentUser2.clear();
-        auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.1", "12345",
+        auth.checkPlainPasswordForTest("zhangsan", "10.1.1.1", "12345",
                 currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertTrue(accessManager.checkDbPriv(currentUser2.get(0), SystemInfoService.DEFAULT_CLUSTER + ":db3",
                 PrivPredicate.SELECT));
 
         currentUser2.clear();
-        auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.2", "12345",
+        auth.checkPlainPasswordForTest("zhangsan", "10.1.1.2", "12345",
                 currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertTrue(accessManager.checkDbPriv(currentUser2.get(0), SystemInfoService.DEFAULT_CLUSTER + ":db3",
                 PrivPredicate.ALTER));
         currentUser2.clear();
-        auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.3", "12345",
+        auth.checkPlainPasswordForTest("zhangsan", "10.1.1.3", "12345",
                 currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertTrue(accessManager.checkDbPriv(currentUser2.get(0), SystemInfoService.DEFAULT_CLUSTER + ":db3",
@@ -708,7 +704,7 @@ public class AuthTest {
         }
 
         currentUser2.clear();
-        auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":cmy", "172.1.1.1", "12345", currentUser2);
+        auth.checkPlainPasswordForTest("cmy", "172.1.1.1", "12345", currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertTrue(accessManager.checkDbPriv(currentUser2.get(0), SystemInfoService.DEFAULT_CLUSTER + ":db",
                 PrivPredicate.CREATE));
@@ -736,7 +732,7 @@ public class AuthTest {
         }
 
         currentUser2.clear();
-        auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "192.1.1.1", "12345",
+        auth.checkPlainPasswordForTest("zhangsan", "192.1.1.1", "12345",
                 currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertTrue(
@@ -750,7 +746,7 @@ public class AuthTest {
         }
 
         currentUser2.clear();
-        auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "192.1.1.1", "12345",
+        auth.checkPlainPasswordForTest("zhangsan", "192.1.1.1", "12345",
                 currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertFalse(
@@ -814,7 +810,7 @@ public class AuthTest {
         }
 
         currentUser2.clear();
-        auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.1", "12345",
+        auth.checkPlainPasswordForTest("zhangsan", "10.1.1.1", "12345",
                 currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertTrue(accessManager.checkDbPriv(currentUser2.get(0), SystemInfoService.DEFAULT_CLUSTER + ":db3",
@@ -828,7 +824,7 @@ public class AuthTest {
         }
 
         currentUser2.clear();
-        auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.1", "12345",
+        auth.checkPlainPasswordForTest("zhangsan", "10.1.1.1", "12345",
                 currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertFalse(
@@ -985,7 +981,7 @@ public class AuthTest {
         }
 
         currentUser2.clear();
-        auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":wangwu", "10.17.2.1", "12345",
+        auth.checkPlainPasswordForTest("wangwu", "10.17.2.1", "12345",
                 currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertTrue(accessManager.checkDbPriv(currentUser2.get(0), SystemInfoService.DEFAULT_CLUSTER + ":db4",
@@ -1010,12 +1006,12 @@ public class AuthTest {
         }
 
         currentUser2.clear();
-        auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":chenliu", "20.1.1.1", "12345",
+        auth.checkPlainPasswordForTest("chenliu", "20.1.1.1", "12345",
                 currentUser2);
         Assert.assertEquals(0, currentUser2.size());
         resolver.runAfterCatalogReady();
         currentUser2.clear();
-        auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":chenliu", "20.1.1.1", "12345",
+        auth.checkPlainPasswordForTest("chenliu", "20.1.1.1", "12345",
                 currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertTrue(accessManager.checkDbPriv(currentUser2.get(0), SystemInfoService.DEFAULT_CLUSTER + ":db4",
@@ -1058,7 +1054,7 @@ public class AuthTest {
         }
 
         currentUser2.clear();
-        auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":chenliu", "20.1.1.1", "12345",
+        auth.checkPlainPasswordForTest("chenliu", "20.1.1.1", "12345",
                 currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertFalse(
@@ -1081,7 +1077,7 @@ public class AuthTest {
             Assert.fail();
         }
         currentUser2.clear();
-        auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":chenliu", "20.1.1.1", "12345",
+        auth.checkPlainPasswordForTest("chenliu", "20.1.1.1", "12345",
                 currentUser2);
         Assert.assertEquals(1, currentUser2.size());
         Assert.assertFalse(
@@ -1138,9 +1134,9 @@ public class AuthTest {
         }
 
         Assert.assertFalse(
-                auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":cmy", "192.168.0.1", "12345",
+                auth.checkPlainPasswordForTest("cmy", "192.168.0.1", "12345",
                         null));
-        Assert.assertTrue(auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "192.168.0.1",
+        Assert.assertTrue(auth.checkPlainPasswordForTest("zhangsan", "192.168.0.1",
                 "12345", null));
 
         // 32.1 drop user cmy@"%" again with IF EXISTS
@@ -1185,7 +1181,7 @@ public class AuthTest {
             Assert.fail();
         }
         Assert.assertTrue(
-                auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "192.168.0.1", "12345",
+                auth.checkPlainPasswordForTest("zhangsan", "192.168.0.1", "12345",
                         null));
 
         try {
@@ -1194,10 +1190,10 @@ public class AuthTest {
             Assert.fail();
         }
         Assert.assertFalse(
-                auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "192.168.0.1", "12345",
+                auth.checkPlainPasswordForTest("zhangsan", "192.168.0.1", "12345",
                         null));
         Assert.assertTrue(
-                auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.1", "12345",
+                auth.checkPlainPasswordForTest("zhangsan", "10.1.1.1", "12345",
                         null));
 
         // 34. create user zhangsan@'10.1.1.1' to overwrite one of zhangsan@['palo.domain1']
@@ -1212,7 +1208,7 @@ public class AuthTest {
         }
 
         Assert.assertTrue(
-                auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.1", "12345",
+                auth.checkPlainPasswordForTest("zhangsan", "10.1.1.1", "12345",
                         null));
 
         try {
@@ -1222,10 +1218,10 @@ public class AuthTest {
             Assert.fail();
         }
         Assert.assertFalse(
-                auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.1", "12345",
+                auth.checkPlainPasswordForTest("zhangsan", "10.1.1.1", "12345",
                         null));
         Assert.assertTrue(
-                auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.1", "abcde",
+                auth.checkPlainPasswordForTest("zhangsan", "10.1.1.1", "abcde",
                         null));
 
         // 35. drop user zhangsan@['palo.domain1']
@@ -1237,7 +1233,7 @@ public class AuthTest {
             Assert.fail();
         }
         Assert.assertTrue(
-                auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.2", "12345",
+                auth.checkPlainPasswordForTest("zhangsan", "10.1.1.2", "12345",
                         null));
 
         try {
@@ -1246,15 +1242,15 @@ public class AuthTest {
             Assert.fail();
         }
         Assert.assertTrue(
-                auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.2", "12345",
+                auth.checkPlainPasswordForTest("zhangsan", "10.1.1.2", "12345",
                         null));
 
         resolver.runAfterCatalogReady();
         Assert.assertFalse(
-                auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.2", "12345",
+                auth.checkPlainPasswordForTest("zhangsan", "10.1.1.2", "12345",
                         null));
         Assert.assertTrue(
-                auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.1", "abcde",
+                auth.checkPlainPasswordForTest("zhangsan", "10.1.1.1", "abcde",
                         null));
 
         // 36. drop user lisi@['palo.domain1']
@@ -1266,10 +1262,10 @@ public class AuthTest {
             Assert.fail();
         }
         Assert.assertTrue(
-                auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "20.1.1.1", "123456",
+                auth.checkPlainPasswordForTest("lisi", "20.1.1.1", "123456",
                         null));
         Assert.assertFalse(
-                auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "10.1.1.1", "123456",
+                auth.checkPlainPasswordForTest("lisi", "10.1.1.1", "123456",
                         null));
 
         try {
@@ -1278,18 +1274,18 @@ public class AuthTest {
             Assert.fail();
         }
         Assert.assertTrue(
-                auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "20.1.1.1", "123456",
+                auth.checkPlainPasswordForTest("lisi", "20.1.1.1", "123456",
                         null));
         Assert.assertFalse(
-                auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "10.1.1.1", "123456",
+                auth.checkPlainPasswordForTest("lisi", "10.1.1.1", "123456",
                         null));
 
         resolver.runAfterCatalogReady();
         Assert.assertFalse(
-                auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "20.1.1.1", "123456",
+                auth.checkPlainPasswordForTest("lisi", "20.1.1.1", "123456",
                         null));
         Assert.assertFalse(
-                auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":lisi", "10.1.1.1", "123456",
+                auth.checkPlainPasswordForTest("lisi", "10.1.1.1", "123456",
                         null));
 
         // 37. drop zhangsan@'172.18.1.1' and zhangsan@'10.1.1.1'
@@ -1321,7 +1317,7 @@ public class AuthTest {
             Assert.fail();
         }
         Assert.assertFalse(
-                auth.checkPlainPasswordForTest(SystemInfoService.DEFAULT_CLUSTER + ":zhangsan", "10.1.1.1", "abcde",
+                auth.checkPlainPasswordForTest("zhangsan", "10.1.1.1", "abcde",
                         null));
 
         // 38. drop root user(not allowed)

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/CheckRowPolicyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/CheckRowPolicyTest.java
@@ -88,7 +88,7 @@ public class CheckRowPolicyTest extends TestWithFeService {
                 KeysType.PRIMARY_KEYS);
         // create user
         UserIdentity user = new UserIdentity(userName, "%");
-        user.analyze(SystemInfoService.DEFAULT_CLUSTER);
+        user.analyze();
         CreateUserStmt createUserStmt = new CreateUserStmt(new UserDesc(user));
         Env.getCurrentEnv().getAuth().createUser(createUserStmt);
         List<AccessPrivilegeWithCols> privileges = Lists.newArrayList(new AccessPrivilegeWithCols(AccessPrivilege.ADMIN_PRIV));

--- a/fe/fe-core/src/test/java/org/apache/doris/policy/PolicyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/policy/PolicyTest.java
@@ -70,7 +70,7 @@ public class PolicyTest extends TestWithFeService {
                 + "properties(\"replication_num\" = \"1\");");
         // create user
         UserIdentity user = new UserIdentity("test_policy", "%");
-        user.analyze(SystemInfoService.DEFAULT_CLUSTER);
+        user.analyze();
         CreateUserStmt createUserStmt = new CreateUserStmt(new UserDesc(user));
         Env.getCurrentEnv().getAuth().createUser(createUserStmt);
         List<AccessPrivilegeWithCols> privileges = Lists
@@ -332,7 +332,7 @@ public class PolicyTest extends TestWithFeService {
         String policyName = "policy_name";
         long dbId = 10;
         UserIdentity user = new UserIdentity("test_policy", "%");
-        user.analyze(SystemInfoService.DEFAULT_CLUSTER);
+        user.analyze();
         String originStmt = "CREATE ROW POLICY test_row_policy ON test.table1"
                 + " AS PERMISSIVE TO test_policy USING (k1 = 1)";
         long tableId = 100;
@@ -355,8 +355,8 @@ public class PolicyTest extends TestWithFeService {
         Assertions.assertEquals(type, newRowPolicy.getType());
         Assertions.assertEquals(policyName, newRowPolicy.getPolicyName());
         Assertions.assertEquals(dbId, newRowPolicy.getDbId());
-        user.analyze(SystemInfoService.DEFAULT_CLUSTER);
-        newRowPolicy.getUser().analyze(SystemInfoService.DEFAULT_CLUSTER);
+        user.analyze();
+        newRowPolicy.getUser().analyze();
         Assertions.assertEquals(user.getQualifiedUser(), newRowPolicy.getUser().getQualifiedUser());
         Assertions.assertEquals(originStmt, newRowPolicy.getOriginStmt());
         Assertions.assertEquals(tableId, newRowPolicy.getTableId());

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
@@ -724,7 +724,7 @@ public abstract class TestWithFeService {
 
     protected void useUser(String userName) throws AnalysisException {
         UserIdentity user = new UserIdentity(userName, "%");
-        user.analyze(SystemInfoService.DEFAULT_CLUSTER);
+        user.analyze();
         connectContext.setCurrentUserIdentity(user);
         connectContext.setQualifiedUser(SystemInfoService.DEFAULT_CLUSTER + ":" + userName);
     }

--- a/regression-test/suites/account_p0/test_alter_user.groovy
+++ b/regression-test/suites/account_p0/test_alter_user.groovy
@@ -31,7 +31,7 @@ suite("test_alter_user", "account") {
     sql """set global password_history=1""" // set to 1
     test {
         sql """alter user test_auth_user2 identified by '12345'"""
-        exception "Cannot use these credentials for 'default_cluster:test_auth_user2'@'%' because they contradict the password history policy"
+        exception "Cannot use these credentials for 'test_auth_user2'@'%' because they contradict the password history policy"
     }
 
     sql """alter user test_auth_user2 password_history 0"""
@@ -46,7 +46,7 @@ suite("test_alter_user", "account") {
     sql """alter user test_auth_user2 identified by 'abc123456'"""
     test {
         sql """alter user test_auth_user2 identified by 'abc12345'"""
-        exception "Cannot use these credentials for 'default_cluster:test_auth_user2'@'%' because they contradict the password history policy"
+        exception "Cannot use these credentials for 'test_auth_user2'@'%' because they contradict the password history policy"
     }
     result1 = connect(user = 'test_auth_user2', password = 'abc123456', url = context.config.jdbcUrl) {
         sql 'select 1'
@@ -72,20 +72,20 @@ suite("test_alter_user", "account") {
         connect(user = 'test_auth_user3', password = 'wrong', url = context.config.jdbcUrl) {}
         assertTrue(false. "should not be able to login")
     } catch (Exception e) {
-        assertTrue(e.getMessage().contains("Access denied for user 'default_cluster:test_auth_user3"), e.getMessage())
+        assertTrue(e.getMessage().contains("Access denied for user 'test_auth_user3"), e.getMessage())
     } 
     try {
         connect(user = 'test_auth_user3', password = 'wrong', url = context.config.jdbcUrl) {}
         assertTrue(false. "should not be able to login")
     } catch (Exception e) {
-        assertTrue(e.getMessage().contains("Access denied for user 'default_cluster:test_auth_user3"), e.getMessage())
+        assertTrue(e.getMessage().contains("Access denied for user 'test_auth_user3"), e.getMessage())
     } 
     // login with correct password but also failed
     try {
         connect(user = 'test_auth_user3', password = '12345', url = context.config.jdbcUrl) {}
         assertTrue(false. "should not be able to login")
     } catch (Exception e) {
-        assertTrue(e.getMessage().contains("Access denied for user 'default_cluster:test_auth_user3'@'%'. Account is blocked for 86400 second(s) (86400 second(s) remaining) due to 2 consecutive failed logins."), e.getMessage())
+        assertTrue(e.getMessage().contains("Access denied for user 'test_auth_user3'@'%'. Account is blocked for 86400 second(s) (86400 second(s) remaining) due to 2 consecutive failed logins."), e.getMessage())
     } 
 
     // unlock user and login again
@@ -101,20 +101,20 @@ suite("test_alter_user", "account") {
         connect(user = 'test_auth_user3', password = 'wrong', url = context.config.jdbcUrl) {}
         assertTrue(false. "should not be able to login")
     } catch (Exception e) {
-        assertTrue(e.getMessage().contains("Access denied for user 'default_cluster:test_auth_user3"), e.getMessage())
+        assertTrue(e.getMessage().contains("Access denied for user 'test_auth_user3"), e.getMessage())
     } 
     try {
         connect(user = 'test_auth_user3', password = 'wrong', url = context.config.jdbcUrl) {}
         assertTrue(false. "should not be able to login")
     } catch (Exception e) {
-        assertTrue(e.getMessage().contains("Access denied for user 'default_cluster:test_auth_user3"), e.getMessage())
+        assertTrue(e.getMessage().contains("Access denied for user 'test_auth_user3"), e.getMessage())
     } 
     // login with correct password but also failed
     try {
         connect(user = 'test_auth_user3', password = '12345', url = context.config.jdbcUrl) {}
         assertTrue(false. "should not be able to login")
     } catch (Exception e) {
-        assertTrue(e.getMessage().contains("Access denied for user 'default_cluster:test_auth_user3'@'%'. Account is blocked for 5 second(s) (5 second(s) remaining) due to 2 consecutive failed logins."), e.getMessage())
+        assertTrue(e.getMessage().contains("Access denied for user 'test_auth_user3'@'%'. Account is blocked for 5 second(s) (5 second(s) remaining) due to 2 consecutive failed logins."), e.getMessage())
     } 
     // sleep 5 second to unlock account
     sleep(5000)


### PR DESCRIPTION
## Proposed changes

Issue Number: #19897

Remove `default_cluster` prefix related to:
1. User
2. Role
3. UserManager
4. RoleManager
5. UserRoleManager
6. UserProperty
7. Create/Drop user Stmt
8. Create/Drop role Stmt
9. Grant/Revoke

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

