### PR TITLE
[refactor](http) disable snapshot and get_log_file api

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1122,6 +1122,8 @@ DEFINE_Int32(download_binlog_rate_limit_kbs, "0");
 
 DEFINE_mInt32(buffered_reader_read_timeout_ms, "20000");
 
+DEFINE_Bool(enable_snapshot_action, "false");
+
 // clang-format off
 #ifdef BE_TEST
 // test s3

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1202,6 +1202,9 @@ DECLARE_Int32(download_binlog_rate_limit_kbs);
 
 DECLARE_mInt32(buffered_reader_read_timeout_ms);
 
+// whether to enable /api/snapshot api
+DECLARE_Bool(enable_snapshot_action)
+
 #ifdef BE_TEST
 // test s3
 DECLARE_String(test_s3_resource);

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1203,7 +1203,7 @@ DECLARE_Int32(download_binlog_rate_limit_kbs);
 DECLARE_mInt32(buffered_reader_read_timeout_ms);
 
 // whether to enable /api/snapshot api
-DECLARE_Bool(enable_snapshot_action)
+DECLARE_Bool(enable_snapshot_action);
 
 #ifdef BE_TEST
 // test s3

--- a/be/src/http/action/snapshot_action.cpp
+++ b/be/src/http/action/snapshot_action.cpp
@@ -41,6 +41,10 @@ SnapshotAction::SnapshotAction(ExecEnv* exec_env, TPrivilegeHier::type hier,
         : HttpHandlerWithAuth(exec_env, hier, type) {}
 
 void SnapshotAction::handle(HttpRequest* req) {
+    if (!config::enable_snapshot_action) {
+        HttpChannel::send_reply(req, HttpStatus::BAD_REQUEST, "feature disabled");
+        return;
+    }
     LOG(INFO) << "accept one request " << req->debug_string();
     // Get tablet id
     const std::string& tablet_id_str = req->param(TABLET_ID);

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2290,4 +2290,8 @@ public class Config extends ConfigBase {
     @ConfField(description = {"nereids trace文件的存放路径。",
             "The path of the nereids trace file."})
     public static String nereids_trace_log_dir = System.getenv("DORIS_HOME") + "/log/nereids_trace";
+
+    @ConfField(description = {"是否开启通过http接口获取log文件的功能",
+            "Whether to enable the function of getting log files through http interface"})
+    public static boolean enable_get_log_file_api = false;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/GetLogFileAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/GetLogFileAction.java
@@ -55,6 +55,9 @@ public class GetLogFileAction extends RestBaseController {
 
     @RequestMapping(path = "/api/get_log_file", method = {RequestMethod.GET, RequestMethod.HEAD})
     public Object execute(HttpServletRequest request, HttpServletResponse response) {
+        if (!Config.enable_get_log_file_api) {
+            return ResponseEntityBuilder.badRequest("feature disabled");
+        }
         executeCheckPassword(request, response);
         checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.ADMIN);
 


### PR DESCRIPTION
## Proposed changes

Disable 2 http api by default:

1. BE's `/api/snapshot`
2. FE's `/get_log_file`

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

