### PR TITLE
[fix](faststring) fix memtracking in faststring free

### DIFF
--- a/be/src/util/faststring.h
+++ b/be/src/util/faststring.h
@@ -54,7 +54,7 @@ public:
     ~faststring() {
         ASAN_UNPOISON_MEMORY_REGION(initial_data_, arraysize(initial_data_));
         if (data_ != initial_data_) {
-            Allocator::free(data_);
+            Allocator::free(data_, capacity_);
         }
     }
 


### PR DESCRIPTION
## Proposed changes

There was no capacity when calling `Allocator::free`, causing memtracking to be incorrect.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

