### PR TITLE
[fix](load) fix DataSink prepared check in PlanFragmentExecutor

### DIFF
--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -661,7 +661,7 @@ void PlanFragmentExecutor::close() {
         }
 
         if (_sink != nullptr) {
-            if (_opened) {
+            if (_prepared && _opened) {
                 Status status;
                 {
                     std::lock_guard<std::mutex> l(_status_lock);
@@ -669,8 +669,9 @@ void PlanFragmentExecutor::close() {
                 }
                 static_cast<void>(_sink->close(runtime_state(), status));
             } else {
-                static_cast<void>(
-                        _sink->close(runtime_state(), Status::InternalError("open failed")));
+                static_cast<void>(_sink->close(
+                        runtime_state(),
+                        Status::InternalError(!_prepared ? "prepare failed" : "open failed")));
             }
         }
 

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -89,6 +89,7 @@ PlanFragmentExecutor::PlanFragmentExecutor(ExecEnv* exec_env,
           _report_thread_active(false),
           _done(false),
           _prepared(false),
+          _opened(false),
           _closed(false),
           _is_report_success(false),
           _is_report_on_cancel(true),
@@ -318,6 +319,7 @@ Status PlanFragmentExecutor::open_vectorized_internal() {
             return Status::OK();
         }
         RETURN_IF_ERROR(_sink->open(runtime_state()));
+        _opened = true;
         std::unique_ptr<doris::vectorized::Block> block =
                 _group_commit ? doris::vectorized::FutureBlock::create_unique()
                               : doris::vectorized::Block::create_unique();
@@ -659,7 +661,7 @@ void PlanFragmentExecutor::close() {
         }
 
         if (_sink != nullptr) {
-            if (_prepared) {
+            if (_opened) {
                 Status status;
                 {
                     std::lock_guard<std::mutex> l(_status_lock);
@@ -668,7 +670,7 @@ void PlanFragmentExecutor::close() {
                 static_cast<void>(_sink->close(runtime_state(), status));
             } else {
                 static_cast<void>(
-                        _sink->close(runtime_state(), Status::InternalError("prepare failed")));
+                        _sink->close(runtime_state(), Status::InternalError("open failed")));
             }
         }
 

--- a/be/src/runtime/plan_fragment_executor.h
+++ b/be/src/runtime/plan_fragment_executor.h
@@ -183,6 +183,9 @@ private:
     // true if prepare() returned OK
     bool _prepared;
 
+    // true if open() returned OK
+    bool _opened;
+
     // true if close() has been called
     bool _closed;
 


### PR DESCRIPTION
## Proposed changes

`PlanFragmentExecutor` called `DataSink::prepare()` and set `_prepared` to true.
But `AsyncWriterSink` had moved `prepare()` into `open()` (renamed to `_init()`), nothing is done (`VTabletWriter::_inited` = false).
Then `PlanFragmentExecutor` calls `DataSink::close()` and goes into the `_prepared` branch:

```cpp
void PlanFragmentExecutor::close() {
    if (_closed) {
        return;
    }

    // Prepare may not have been called, which sets _runtime_state
    if (_runtime_state != nullptr) {
        // _runtime_state init failed
        if (_plan != nullptr) {
            static_cast<void>(_plan->close(_runtime_state.get()));
        }

        if (_sink != nullptr) {
            if (_prepared) {
                Status status;
                {
                    std::lock_guard<std::mutex> l(_status_lock);
                    status = _status;
                }
                static_cast<void>(_sink->close(runtime_state(), status));
            } else {
                static_cast<void>(
                        _sink->close(runtime_state(), Status::InternalError("prepare failed")));
            }
        }
```

Causing this DCHECK to fail:

```cpp
Status VTabletWriter::close(Status exec_status) {
    if (!_inited) {
        DCHECK(!exec_status.ok());
        _cancel_all_channel(exec_status);
        _close_status = exec_status;
        return _close_status;
    }
```

So now we need to check `_opened` instead of `_prepared` in `PlanFragmentExecutor`.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

