### PR TITLE
[BUG][COLOCATE] fix colocate balance bug that bucket index cannot be set correctly

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/ColocateTableCheckerAndBalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/ColocateTableCheckerAndBalancer.java
@@ -513,8 +513,9 @@ public class ColocateTableCheckerAndBalancer extends MasterDaemon {
                         for (MaterializedIndex index : partition.getMaterializedIndices(IndexExtState.VISIBLE)) {
                             Preconditions.checkState(backendBucketsSeq.size() == index.getTablets().size(),
                                     backendBucketsSeq.size() + " vs. " + index.getTablets().size());
-                            int idx = 0;
-                            for (Long tabletId : index.getTabletIdsInOrder()) {
+                            List<Long> tabletIdsInOrder = index.getTabletIdsInOrder();
+                            for (int idx = 0; idx < tabletIdsInOrder.size(); idx++) {
+                                Long tabletId = tabletIdsInOrder.get(idx);
                                 counter.totalTabletNum++;
                                 Set<Long> bucketsSeq = backendBucketsSeq.get(idx);
                                 Preconditions.checkState(bucketsSeq.size() == replicationNum,
@@ -530,7 +531,6 @@ public class ColocateTableCheckerAndBalancer extends MasterDaemon {
 
                                     if (!tablet.readyToBeRepaired(infoService, Priority.NORMAL)) {
                                         counter.tabletNotReady++;
-                                        idx++;
                                         continue;
                                     }
 
@@ -555,7 +555,6 @@ public class ColocateTableCheckerAndBalancer extends MasterDaemon {
                                         counter.tabletInScheduler++;
                                     }
                                 }
-                                idx++;
                             }
                         }
                     }

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/ColocateTableCheckerAndBalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/ColocateTableCheckerAndBalancer.java
@@ -530,6 +530,7 @@ public class ColocateTableCheckerAndBalancer extends MasterDaemon {
 
                                     if (!tablet.readyToBeRepaired(infoService, Priority.NORMAL)) {
                                         counter.tabletNotReady++;
+                                        idx++;
                                         continue;
                                     }
 


### PR DESCRIPTION
```java
for (Partition partition : olapTable.getPartitions()) {
    short replicationNum = replicaAlloc.getTotalReplicaNum();
    long visibleVersion = partition.getVisibleVersion();
    // Here we only get VISIBLE indexes. All other indexes are not queryable.
    // So it does not matter if tablets of other indexes are not matched.
    for (MaterializedIndex index : partition.getMaterializedIndices(IndexExtState.VISIBLE)) {
        Preconditions.checkState(backendBucketsSeq.size() == index.getTablets().size(),
                backendBucketsSeq.size() + " vs. " + index.getTablets().size());
        int idx = 0;
        for (Long tabletId : index.getTabletIdsInOrder()) {
            counter.totalTabletNum++;
            Set<Long> bucketsSeq = backendBucketsSeq.get(idx);
            Preconditions.checkState(bucketsSeq.size() == replicationNum,
                    bucketsSeq.size() + " vs. " + replicationNum);
            Tablet tablet = index.getTablet(tabletId);
            TabletStatus st = tablet.getColocateHealthStatus(
                    visibleVersion, replicaAlloc, bucketsSeq);
            if (st != TabletStatus.HEALTHY) {
                counter.unhealthyTabletNum++;
                unstableReason = String.format("get unhealthy tablet %d in colocate table."
                        + " status: %s", tablet.getId(), st);
                LOG.debug(unstableReason);

                if (!tablet.readyToBeRepaired(infoService, Priority.NORMAL)) {
                    counter.tabletNotReady++;
                    // 这里需要将  idx++ ，否则 bucketsSeq和 tablet replicas backends 对应不上
                    idx++;
                    continue;
                }

                TabletSchedCtx tabletCtx = new TabletSchedCtx(
                        TabletSchedCtx.Type.REPAIR,
                        db.getId(), tableId, partition.getId(), index.getId(), tablet.getId(),
                        replicaAlloc, System.currentTimeMillis());
                // the tablet status will be set again when being scheduled
                tabletCtx.setTabletStatus(st);
                tabletCtx.setPriority(Priority.NORMAL);
                tabletCtx.setTabletOrderIdx(idx);

                AddResult res = tabletScheduler.addTablet(tabletCtx, false /* not force */);
                if (res == AddResult.LIMIT_EXCEED || res == AddResult.DISABLED) {
                    // tablet in scheduler exceed limit, or scheduler is disabled,
                    // skip this group and check next one.
                    LOG.info("tablet scheduler return: {}. stop colocate table check", res.name());
                    break OUT;
                } else if (res == AddResult.ADDED) {
                    counter.addToSchedulerTabletNum++;
                }  else {
                    counter.tabletInScheduler++;
                }
            }
            idx++;
        }
    }
}
```
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

