### PR TITLE
[fix](profile) fix error set with peak_memory_usage in pipeline

### DIFF
--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -200,6 +200,9 @@ void ExecNode::release_resource(doris::RuntimeState* state) {
 
         _is_resource_released = true;
     }
+    if (_peak_memory_usage_counter) {
+        _peak_memory_usage_counter->set(_mem_tracker->peak_consumption());
+    }
 }
 
 Status ExecNode::close(RuntimeState* state) {
@@ -217,9 +220,6 @@ Status ExecNode::close(RuntimeState* state) {
         if (result.ok() && !st.ok()) {
             result = st;
         }
-    }
-    if (_peak_memory_usage_counter) {
-        _peak_memory_usage_counter->set(_mem_tracker->peak_consumption());
     }
     release_resource(state);
     LOG(INFO) << "query= " << print_id(state->query_id())

--- a/be/src/pipeline/exec/exchange_sink_operator.cpp
+++ b/be/src/pipeline/exec/exchange_sink_operator.cpp
@@ -123,9 +123,6 @@ Status ExchangeSinkLocalState::init(RuntimeState* state, LocalSinkStateInfo& inf
     _merge_block_timer = ADD_TIMER(profile(), "MergeBlockTime");
     _local_bytes_send_counter = ADD_COUNTER(_profile, "LocalBytesSent", TUnit::BYTES);
     _memory_usage_counter = ADD_LABEL_COUNTER(_profile, "MemoryUsage");
-    _peak_memory_usage_counter =
-            _profile->AddHighWaterMarkCounter("PeakMemoryUsage", TUnit::BYTES, "MemoryUsage");
-
     static const std::string timer_name = "WaitForDependencyTime";
     _wait_for_dependency_timer = ADD_TIMER(_profile, timer_name);
     _wait_queue_timer = ADD_CHILD_TIMER(_profile, "WaitForRpcBufferQueue", timer_name);
@@ -312,7 +309,7 @@ Status ExchangeSinkOperatorX::sink(RuntimeState* state, vectorized::Block* block
     COUNTER_UPDATE(local_state.rows_input_counter(), (int64_t)block->rows());
     COUNTER_UPDATE(local_state.rows_sent_counter(), (int64_t)block->rows());
     SCOPED_TIMER(local_state.exec_time_counter());
-    local_state._peak_memory_usage_counter->set(_mem_tracker->peak_consumption());
+    local_state._peak_memory_usage_counter->set(local_state._mem_tracker->peak_consumption());
     bool all_receiver_eof = true;
     for (auto channel : local_state.channels) {
         if (!channel->is_receiver_eof()) {

--- a/be/src/pipeline/exec/exchange_sink_operator.h
+++ b/be/src/pipeline/exec/exchange_sink_operator.h
@@ -219,7 +219,6 @@ private:
     RuntimeProfile::Counter* _local_bytes_send_counter = nullptr;
     RuntimeProfile::Counter* _merge_block_timer = nullptr;
     RuntimeProfile::Counter* _memory_usage_counter = nullptr;
-    RuntimeProfile::Counter* _peak_memory_usage_counter = nullptr;
 
     RuntimeProfile::Counter* _wait_queue_timer = nullptr;
     RuntimeProfile::Counter* _wait_broadcast_buffer_timer = nullptr;

--- a/be/src/pipeline/pipeline_x/dependency.h
+++ b/be/src/pipeline/pipeline_x/dependency.h
@@ -353,13 +353,9 @@ public:
         int64_t used_in_state;
     };
     MemoryRecord mem_usage_record;
-    std::unique_ptr<MemTracker> mem_tracker = std::make_unique<MemTracker>("AggregateOperator");
     bool agg_data_created_without_key = false;
 
 private:
-    void _release_tracker() {
-        mem_tracker->release(mem_usage_record.used_in_state + mem_usage_record.used_in_arena);
-    }
     void _close_with_serialized_key() {
         std::visit(
                 [&](auto&& agg_method) -> void {
@@ -379,7 +375,6 @@ private:
                     }
                 },
                 agg_data->method_variant);
-        _release_tracker();
     }
     void _close_without_key() {
         //because prepare maybe failed, and couldn't create agg data.
@@ -389,7 +384,6 @@ private:
             static_cast<void>(_destroy_agg_status(agg_data->without_key));
             agg_data_created_without_key = false;
         }
-        _release_tracker();
     }
     Status _destroy_agg_status(vectorized::AggregateDataPtr data) {
         for (int i = 0; i < aggregate_evaluators.size(); ++i) {

--- a/be/src/pipeline/pipeline_x/operator.h
+++ b/be/src/pipeline/pipeline_x/operator.h
@@ -396,6 +396,8 @@ protected:
     RuntimeProfile::Counter* _wait_for_dependency_timer = nullptr;
     RuntimeProfile::Counter* _wait_for_finish_dependency_timer = nullptr;
     RuntimeProfile::Counter* _exec_timer = nullptr;
+    RuntimeProfile::Counter* _memory_used_counter = nullptr;
+    RuntimeProfile::Counter* _peak_memory_usage_counter = nullptr;
     std::shared_ptr<Dependency> _finish_dependency;
 };
 


### PR DESCRIPTION
## Proposed changes

1. The pipeline does not execute the close function on the exec node; it has been moved to release_resource.
2. On pipelineX, the sink does not have peak memory records.

```
                    AGGREGATION_SINK_OPERATOR  (id=2131):
                          -  BuildConvertToPartitionedTime:  0ns
                          -  BuildTime:  0ns
                          -  CloseTime:  25.516us
                          -  DeserializeAndMergeTime:  377.549ms
                          -  ExecTime:  1s857ms
                          -  ExprTime:  0ns
                          -  HashTableComputeTime:  1s474ms
                          -  HashTableEmplaceTime:  1s362ms
                          -  HashTableInputCount:  1.673608M  (1673608)
                          -  InputRows:  1.673608M  (1673608)
                          -  MaxRowSizeInBytes:  0
                          -  MemoryUsage:  
                              -  HashTable:  64.00  MB
                              -  PeakMemoryUsage:  203.87  MB
                              -  SerializeKeyArena:  139.87  MB
                          -  MergeTime:  1s855ms
                          -  OpenTime:  87.226us
                          -  PendingFinishDependency:  0ns
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

