### PR TITLE
[enhane](S3) Use pool executor for s3 operation

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -888,7 +888,7 @@ DEFINE_Validator(file_cache_type, [](std::string_view config) -> bool {
     return config == "" || config == "file_block_cache";
 });
 
-DEFINE_Int32(s3_transfer_executor_pool_size, "2");
+DEFINE_Int32(aws_io_executor_pool_size, "200");
 
 DEFINE_Bool(enable_time_lut, "true");
 DEFINE_mBool(enable_simdjson_reader, "true");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -939,7 +939,7 @@ DECLARE_Int32(concurrency_per_dir);
 // "whole_file_cache": the whole file.
 DECLARE_mString(file_cache_type);
 
-DECLARE_Int32(s3_transfer_executor_pool_size);
+DECLARE_Int32(aws_io_executor_pool_size);
 
 DECLARE_Bool(enable_time_lut);
 DECLARE_mBool(enable_simdjson_reader);

--- a/be/src/io/fs/aws_io_executor.h
+++ b/be/src/io/fs/aws_io_executor.h
@@ -1,0 +1,51 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include "common/logging.h"
+#include "common/status.h"
+#include "util/threadpool.h"
+
+namespace Aws::Utils::Threading {
+class Executor;
+} // namespace Aws::Utils::Threading
+
+namespace doris::io {
+// Serve as the io executor for all the S3 operation including aws S3, google cloud storage
+// COS, OSS, OBS
+class AwsIOExecutor final : public Aws::Utils::Threading::Executor {
+public:
+    AwsIOExecutor(std::shared_ptr<ThreadPool> thread_pool, std::string name)
+            : _thread_pool(std::move(thread_pool)), _name(std::move(name)) {}
+    ~AwsIOExecutor() override = default;
+    bool SubmitToThread(std::function<void()>&& task) override {
+        if (Status s = _thread_pool->submit_func(std::move(task)); !s.ok()) {
+            LOG_WARNING("Failed to summit to remote io executor {} because {}", _name, s);
+            return false;
+        }
+        return true;
+    }
+
+private:
+    std::shared_ptr<ThreadPool> _thread_pool;
+    std::string _name;
+};
+} // namespace doris::io

--- a/be/src/io/fs/s3_file_reader.cpp
+++ b/be/src/io/fs/s3_file_reader.cpp
@@ -94,7 +94,7 @@ Status S3FileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_rea
     if (!client) {
         return Status::InternalError("init s3 client error");
     }
-    auto outcome = client->GetObject(request);
+    auto outcome = client->GetObjectCallable(request).get();
     s3_bvar::s3_get_total << 1;
     if (!outcome.IsSuccess()) {
         return Status::IOError("failed to read from {}: {}, exception {}, error code {}",

--- a/be/src/io/fs/s3_file_system.h
+++ b/be/src/io/fs/s3_file_system.h
@@ -129,4 +129,4 @@ private:
     std::shared_ptr<Aws::Utils::Threading::Executor> _executor;
 };
 
-} // namespace doris
+} // namespace doris::io

--- a/be/src/io/fs/s3_file_writer.cpp
+++ b/be/src/io/fs/s3_file_writer.cpp
@@ -125,7 +125,7 @@ Status S3FileWriter::_create_multi_upload_request() {
                 _bucket, _path.native(), _upload_id);
     });
 
-    auto outcome = _client->CreateMultipartUpload(create_request);
+    auto outcome = _client->CreateMultipartUploadCallable(create_request).get();
     s3_bvar::s3_multi_part_upload_total << 1;
 
     if (outcome.IsSuccess()) {
@@ -177,7 +177,7 @@ Status S3FileWriter::abort() {
     _wait_until_finish("Abort");
     AbortMultipartUploadRequest request;
     request.WithBucket(_bucket).WithKey(_key).WithUploadId(_upload_id);
-    auto outcome = _client->AbortMultipartUpload(request);
+    auto outcome = _client->AbortMultipartUploadCallable(request).get();
     s3_bvar::s3_multi_part_upload_total << 1;
     if (outcome.IsSuccess() ||
         outcome.GetError().GetErrorType() == Aws::S3::S3Errors::NO_SUCH_UPLOAD ||
@@ -418,7 +418,7 @@ Status S3FileWriter::_complete() {
         LOG_WARNING(s.to_string());
         return s;
     });
-    auto compute_outcome = _client->CompleteMultipartUpload(complete_request);
+    auto compute_outcome = _client->CompleteMultipartUploadCallable(complete_request).get();
     s3_bvar::s3_multi_part_upload_total << 1;
 
     if (!compute_outcome.IsSuccess()) {
@@ -472,7 +472,7 @@ void S3FileWriter::_put_object(UploadFileBuffer& buf) {
         LOG(WARNING) << _st;
         return;
     });
-    auto response = _client->PutObject(request);
+    auto response = _client->PutObjectCallable(request).get();
     s3_bvar::s3_put_total << 1;
     if (!response.IsSuccess()) {
         _st = Status::InternalError(

--- a/be/src/util/s3_util.cpp
+++ b/be/src/util/s3_util.cpp
@@ -181,6 +181,8 @@ std::shared_ptr<Aws::S3::S3Client> S3ClientFactory::create(const S3Conf& s3_conf
         aws_config.connectTimeoutMs = s3_conf.connect_timeout_ms;
     }
 
+    aws_config.executor = s3_conf.executor;
+
     std::shared_ptr<Aws::S3::S3Client> new_client = std::make_shared<Aws::S3::S3Client>(
             std::move(aws_cred), std::move(aws_config),
             Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,

--- a/be/src/util/s3_util.h
+++ b/be/src/util/s3_util.h
@@ -33,7 +33,7 @@
 
 namespace Aws::S3 {
 class S3Client;
-} // namespace Aws
+} // namespace Aws::S3
 namespace Aws::Utils::Threading {
 class Executor;
 } // namespace Aws::Utils::Threading

--- a/be/src/util/s3_util.h
+++ b/be/src/util/s3_util.h
@@ -31,11 +31,12 @@
 #include "common/status.h"
 #include "gutil/hash/hash.h"
 
-namespace Aws {
-namespace S3 {
+namespace Aws::S3 {
 class S3Client;
-} // namespace S3
 } // namespace Aws
+namespace Aws::Utils::Threading {
+class Executor;
+} // namespace Aws::Utils::Threading
 namespace bvar {
 template <typename T>
 class Adder;
@@ -78,6 +79,7 @@ struct S3Conf {
     int request_timeout_ms = -1;
     int connect_timeout_ms = -1;
     bool use_virtual_addressing = true;
+    std::shared_ptr<Aws::Utils::Threading::Executor> executor;
 
     std::string to_string() const {
         return fmt::format(


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
The default executor of Aws S3 SDK is so cpu-consuming because it uses one atomic bool to do cas operation to do thread allocation and detach logic.

![image](https://github.com/apache/doris/assets/43750022/5648a146-011f-4960-ad87-a00c1435951d)

There would be a lot of CPU consumption when concurrent request reaches.

So this pr makes all the S3 operation invoked in one thread pool.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

