### PR TITLE
[bugfix](topn) fix coredump in copy_column_data_to_block when nullable mismatch

### DIFF
--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -154,6 +154,12 @@ public:
                     reinterpret_cast<vectorized::ColumnNullable*>(raw_res_ptr.get());
             col_ptr_nullable->get_null_map_column().insert_many_defaults(select_size);
             raw_res_ptr = col_ptr_nullable->get_nested_column_ptr();
+        } else if (!raw_res_ptr->is_nullable() && input_col_ptr->is_nullable()) {
+            LOG(WARNING) << "nullable mismatch for raw_res_column: "
+                         << this->get_by_position(block_cid).dump_structure()
+                         << " input_column: " << input_col_ptr->dump_structure()
+                         << " block_cid: " << block_cid << " select_size: " << select_size;
+            return Status::RuntimeError("copy_column_data_to_block nullable mismatch");
         }
 
         return input_col_ptr->filter_by_selector(sel_rowid_idx, select_size, raw_res_ptr);


### PR DESCRIPTION

## Proposed changes

Issue Number: close #xxx

return RuntimeError if `copy_column_data_to_block` nullable mismatch to avoid coredump in `input_col_ptr->filter_by_selector(sel_rowid_idx, select_size, raw_res_ptr)` .

The problem is reported by a doris user but I can not reproduce it, so there is no testcase added currently.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

