### PR TITLE
[Enhancenment](wal) disable group commit when streamload size is too large

### DIFF
--- a/be/src/http/action/http_stream.cpp
+++ b/be/src/http/action/http_stream.cpp
@@ -167,10 +167,24 @@ int HttpStreamAction::on_header(HttpRequest* req) {
     ctx->load_type = TLoadType::MANUL_LOAD;
     ctx->load_src_type = TLoadSourceType::RAW;
 
-    ctx->group_commit = iequal(req->header(HTTP_GROUP_COMMIT), "true") ||
-                        config::wait_internal_group_commit_finish;
+    if (iequal(req->header(HTTP_GROUP_COMMIT), "true") ||
+        config::wait_internal_group_commit_finish) {
+        // 1. req->header(HttpHeaders::CONTENT_LENGTH) will return streamload content length. If it is empty, it means this streamload
+        // is a chunked streamload and we are not sure its size.
+        // 2. if streamload content length is too large, like larger than 80% of the WAL constrain.
+        //
+        // This two cases, we are not certain that the Write-Ahead Logging (WAL) constraints allow for writing down
+        // these blocks within the limited space. So we need to set group_commit = false to avoid dead lock.
+        if (!req->header(HttpHeaders::CONTENT_LENGTH).empty()) {
+            size_t body_bytes = std::stol(req->header(HttpHeaders::CONTENT_LENGTH));
+            // TODO(Yukang): change it to WalManager::wal_limit
+            ctx->group_commit = !(body_bytes > config::wal_max_disk_size * 0.8);
+        } else {
+            ctx->group_commit = false;
+        }
+    }
 
-    ctx->two_phase_commit = req->header(HTTP_TWO_PHASE_COMMIT) == "true" ? true : false;
+    ctx->two_phase_commit = req->header(HTTP_TWO_PHASE_COMMIT) == "true";
 
     LOG(INFO) << "new income streaming load request." << ctx->brief()
               << " sql : " << req->header(HTTP_SQL);

--- a/be/src/http/action/stream_load.h
+++ b/be/src/http/action/stream_load.h
@@ -50,6 +50,7 @@ private:
     Status _data_saved_path(HttpRequest* req, std::string* file_path);
     Status _process_put(HttpRequest* http_req, std::shared_ptr<StreamLoadContext> ctx);
     void _save_stream_load_record(std::shared_ptr<StreamLoadContext> ctx, const std::string& str);
+    bool _load_size_smaller_than_wal_limit(HttpRequest* req);
 
 private:
     ExecEnv* _exec_env;

--- a/be/src/http/utils.cpp
+++ b/be/src/http/utils.cpp
@@ -26,6 +26,7 @@
 #include <ostream>
 #include <vector>
 
+#include "common/config.h"
 #include "common/logging.h"
 #include "common/status.h"
 #include "common/utils.h"

--- a/be/src/http/utils.cpp
+++ b/be/src/http/utils.cpp
@@ -189,4 +189,20 @@ void do_dir_response(const std::string& dir_path, HttpRequest* req) {
     HttpChannel::send_reply(req, result_str);
 }
 
+bool load_size_smaller_than_wal_limit(HttpRequest* req) {
+    // 1. req->header(HttpHeaders::CONTENT_LENGTH) will return streamload content length. If it is empty, it means this streamload
+    // is a chunked streamload and we are not sure its size.
+    // 2. if streamload content length is too large, like larger than 80% of the WAL constrain.
+    //
+    // This two cases, we are not certain that the Write-Ahead Logging (WAL) constraints allow for writing down
+    // these blocks within the limited space. So we need to set group_commit = false to avoid dead lock.
+    if (!req->header(HttpHeaders::CONTENT_LENGTH).empty()) {
+        size_t body_bytes = std::stol(req->header(HttpHeaders::CONTENT_LENGTH));
+        // TODO(Yukang): change it to WalManager::wal_limit
+        return !(body_bytes > config::wal_max_disk_size * 0.8);
+    } else {
+        return false;
+    }
+}
+
 } // namespace doris

--- a/be/src/http/utils.h
+++ b/be/src/http/utils.h
@@ -42,4 +42,6 @@ void do_file_response(const std::string& dir_path, HttpRequest* req,
 void do_dir_response(const std::string& dir_path, HttpRequest* req);
 
 std::string get_content_type(const std::string& file_name);
+
+bool load_size_smaller_than_wal_limit(HttpRequest* req);
 } // namespace doris

--- a/be/test/http/stream_load_test.cpp
+++ b/be/test/http/stream_load_test.cpp
@@ -21,6 +21,9 @@
 
 #include "common/config.h"
 #include "event2/http.h"
+#include "event2/http_struct.h"
+#include "event2/buffer.h"
+#include "event2/event.h"
 #include "evhttp.h"
 #include "http/ev_http_server.h"
 #include "http/http_channel.h"
@@ -54,16 +57,14 @@ TEST_F(StreamLoadTest, TestHeader) {
         auto evhttp_req = evhttp_request_new(nullptr, nullptr);
         HttpRequest req(evhttp_req);
         EXPECT_EQ(load_size_smaller_than_wal_limit(&req), false);
+        evhttp_request_free(evhttp_req);
     }
 
     // 2. chunked stream load whih group commit
     {
-        struct event_base* base = nullptr;
-        struct evhttp_request* evhttp_req = nullptr;
+        //struct event_base* base = nullptr;
         char uri[] = "Http://127.0.0.1/test.txt";
-        event_init();
-        base = event_base_new();
-        evhttp_req = evhttp_request_new(http_request_done_cb, base);
+        auto evhttp_req = evhttp_request_new(nullptr, nullptr);
         evhttp_req->type = EVHTTP_REQ_GET;
         evhttp_req->uri = uri;
         evhttp_req->uri_elems = evhttp_uri_parse(uri);
@@ -71,16 +72,16 @@ TEST_F(StreamLoadTest, TestHeader) {
         HttpRequest req(evhttp_req);
         req.init_from_evhttp();
         EXPECT_EQ(load_size_smaller_than_wal_limit(&req), false);
+        evhttp_uri_free(evhttp_req->uri_elems);
+        evhttp_req->uri=nullptr;
+        evhttp_req->uri_elems=nullptr;
+        evhttp_request_free(evhttp_req);
     }
 
     // 3. small stream load whih group commit
     {
-        struct event_base* base = nullptr;
-        struct evhttp_request* evhttp_req = nullptr;
         char uri[] = "Http://127.0.0.1/test.txt";
-        event_init();
-        base = event_base_new();
-        evhttp_req = evhttp_request_new(http_request_done_cb, base);
+        auto evhttp_req = evhttp_request_new(nullptr, nullptr);
         evhttp_req->type = EVHTTP_REQ_GET;
         evhttp_req->uri = uri;
         evhttp_req->uri_elems = evhttp_uri_parse(uri);
@@ -89,16 +90,16 @@ TEST_F(StreamLoadTest, TestHeader) {
         HttpRequest req(evhttp_req);
         req.init_from_evhttp();
         EXPECT_EQ(load_size_smaller_than_wal_limit(&req), true);
+        evhttp_uri_free(evhttp_req->uri_elems);
+        evhttp_req->uri=nullptr;
+        evhttp_req->uri_elems=nullptr;
+        evhttp_request_free(evhttp_req);
     }
 
     // 4. large stream load whih group commit
     {
-        struct event_base* base = nullptr;
-        struct evhttp_request* evhttp_req = nullptr;
         char uri[] = "Http://127.0.0.1/test.txt";
-        event_init();
-        base = event_base_new();
-        evhttp_req = evhttp_request_new(http_request_done_cb, base);
+        auto evhttp_req = evhttp_request_new(nullptr, nullptr);
         evhttp_req->type = EVHTTP_REQ_GET;
         evhttp_req->uri = uri;
         evhttp_req->uri_elems = evhttp_uri_parse(uri);
@@ -107,6 +108,10 @@ TEST_F(StreamLoadTest, TestHeader) {
         HttpRequest req(evhttp_req);
         req.init_from_evhttp();
         EXPECT_EQ(load_size_smaller_than_wal_limit(&req), false);
+        evhttp_uri_free(evhttp_req->uri_elems);
+        evhttp_req->uri=nullptr;
+        evhttp_req->uri_elems=nullptr;
+        evhttp_request_free(evhttp_req);
     }
 }
 } // namespace doris

--- a/be/test/http/stream_load_test.cpp
+++ b/be/test/http/stream_load_test.cpp
@@ -1,0 +1,90 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "http/action/stream_load.h"
+
+#include <gtest/gtest.h>
+
+#include "common/config.h"
+#include "http/ev_http_server.h"
+#include "http/http_channel.h"
+#include "http/http_common.h"
+#include "http/http_handler.h"
+#include "http/http_handler_with_auth.h"
+#include "http/http_headers.h"
+#include "http/http_request.h"
+#include "http/utils.h"
+#include "olap/wal_manager.h"
+
+namespace doris {
+
+ExecEnv* _env = nullptr;
+
+class StreamLoadTest : public testing::Test {
+public:
+    StreamLoadTest() {}
+    virtual ~StreamLoadTest() {}
+    void SetUp() override {
+        // 1G
+        WalManager::wal_limit = 1073741824;
+    }
+    void TearDown() override {}
+};
+
+TEST_F(StreamLoadTest, TestHeader) {
+    // 1. empty info
+    {
+        StreamLoadAction stream_load_action(_env);
+        auto evhttp_req = evhttp_request_new(nullptr, nullptr);
+        HttpRequest req(evhttp_req);
+        EXPECT_EQ(load_size_smaller_than_wal_limit(&req), false);
+        EXPECT_EQ(stream_load_action.on_header(&req), -1);
+    }
+
+    // 2. chunked stream load whih group commit
+    {
+        StreamLoadAction stream_load_action(_env);
+        auto evhttp_req = evhttp_request_new(nullptr, nullptr);
+        HttpRequest req(evhttp_req);
+        req.add_output_header(HTTP_GROUP_COMMIT, "true");
+        EXPECT_EQ(load_size_smaller_than_wal_limit(&req), false);
+        EXPECT_EQ(stream_load_action.on_header(&req), -1);
+    }
+
+    // 3. small stream load whih group commit
+    {
+        StreamLoadAction stream_load_action(_env);
+        auto evhttp_req = evhttp_request_new(nullptr, nullptr);
+        HttpRequest req(evhttp_req);
+        req.add_output_header(HTTP_GROUP_COMMIT, "true");
+        req.add_output_header(HttpHeaders::CONTENT_LENGTH, "1000");
+        EXPECT_EQ(load_size_smaller_than_wal_limit(&req), true);
+        EXPECT_EQ(stream_load_action.on_header(&req), -1);
+    }
+
+    // 4. lager stream load whih group commit
+    {
+        StreamLoadAction stream_load_action(_env);
+        auto evhttp_req = evhttp_request_new(nullptr, nullptr);
+        HttpRequest req(evhttp_req);
+        req.add_output_header(HTTP_GROUP_COMMIT, "true");
+        req.add_output_header(HttpHeaders::CONTENT_LENGTH, "1073741824");
+        EXPECT_EQ(load_size_smaller_than_wal_limit(&req), true);
+        EXPECT_EQ(stream_load_action.on_header(&req), -1);
+    }
+}
+} // namespace doris

--- a/be/test/http/stream_load_test.cpp
+++ b/be/test/http/stream_load_test.cpp
@@ -20,10 +20,10 @@
 #include <gtest/gtest.h>
 
 #include "common/config.h"
-#include "event2/http.h"
-#include "event2/http_struct.h"
 #include "event2/buffer.h"
 #include "event2/event.h"
+#include "event2/http.h"
+#include "event2/http_struct.h"
 #include "evhttp.h"
 #include "http/ev_http_server.h"
 #include "http/http_channel.h"
@@ -73,8 +73,8 @@ TEST_F(StreamLoadTest, TestHeader) {
         req.init_from_evhttp();
         EXPECT_EQ(load_size_smaller_than_wal_limit(&req), false);
         evhttp_uri_free(evhttp_req->uri_elems);
-        evhttp_req->uri=nullptr;
-        evhttp_req->uri_elems=nullptr;
+        evhttp_req->uri = nullptr;
+        evhttp_req->uri_elems = nullptr;
         evhttp_request_free(evhttp_req);
     }
 
@@ -91,8 +91,8 @@ TEST_F(StreamLoadTest, TestHeader) {
         req.init_from_evhttp();
         EXPECT_EQ(load_size_smaller_than_wal_limit(&req), true);
         evhttp_uri_free(evhttp_req->uri_elems);
-        evhttp_req->uri=nullptr;
-        evhttp_req->uri_elems=nullptr;
+        evhttp_req->uri = nullptr;
+        evhttp_req->uri_elems = nullptr;
         evhttp_request_free(evhttp_req);
     }
 
@@ -109,8 +109,8 @@ TEST_F(StreamLoadTest, TestHeader) {
         req.init_from_evhttp();
         EXPECT_EQ(load_size_smaller_than_wal_limit(&req), false);
         evhttp_uri_free(evhttp_req->uri_elems);
-        evhttp_req->uri=nullptr;
-        evhttp_req->uri_elems=nullptr;
+        evhttp_req->uri = nullptr;
+        evhttp_req->uri_elems = nullptr;
         evhttp_request_free(evhttp_req);
     }
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

When streamload starts, it determines the size of the data to be imported through the header. If it exceeds 80% of the maximum WAL limit, it is considered a large import and does not execute with the group commit. Chunked streamload cannot determine the size of the imported data, so it also does not execute with group commit.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

