### PR TITLE
[fix](bdbje) Fix bdbje logging level not work (#27597)

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1963,7 +1963,7 @@ public class Config extends ConfigBase {
      * OFF, SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST, ALL
      */
     @ConfField
-    public static String bdbje_file_logging_level = "ALL";
+    public static String bdbje_file_logging_level = "INFO";
 
     /**
      * When holding lock time exceeds the threshold, need to report it.

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
@@ -59,6 +59,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 /* this class contains the reference to bdb environment.
@@ -139,6 +140,8 @@ public class BDBEnvironment {
                 String.valueOf(Config.bdbje_reserved_disk_bytes));
 
         if (BDBJE_LOG_LEVEL.contains(Config.bdbje_file_logging_level)) {
+            java.util.logging.Logger parent = java.util.logging.Logger.getLogger("com.sleepycat.je");
+            parent.setLevel(Level.parse(Config.bdbje_file_logging_level));
             environmentConfig.setConfigParam(EnvironmentConfig.FILE_LOGGING_LEVEL, Config.bdbje_file_logging_level);
         } else {
             LOG.warn("bdbje_file_logging_level invalid value: {}, will not take effort, use default",


### PR DESCRIPTION
* `EnvironmentConfig.FILE_LOGGING_LEVEL` only set FileHandlerLevel, we should set logger level firstly, otherwise it will not take effect.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

