### PR TITLE
[fix](fe) Fix show frontends npt in some situations (#27295)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/FrontendsProcNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/FrontendsProcNode.java
@@ -93,7 +93,6 @@ public class FrontendsProcNode implements ProcNodeInterface {
         }
 
         for (Frontend fe : env.getFrontends(null /* all */)) {
-
             List<String> info = new ArrayList<String>();
             info.add(fe.getNodeName());
             info.add(fe.getHost());

--- a/fe/fe-core/src/main/java/org/apache/doris/ha/BDBHA.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/ha/BDBHA.java
@@ -104,11 +104,12 @@ public class BDBHA implements HAProtocol {
 
     @Override
     public List<InetSocketAddress> getObserverNodes() {
+        List<InetSocketAddress> ret = new ArrayList<InetSocketAddress>();
         ReplicationGroupAdmin replicationGroupAdmin = environment.getReplicationGroupAdmin();
         if (replicationGroupAdmin == null) {
-            return null;
+            return ret;
         }
-        List<InetSocketAddress> ret = new ArrayList<InetSocketAddress>();
+
         try {
             ReplicationGroup replicationGroup = replicationGroupAdmin.getGroup();
             for (ReplicationNode replicationNode : replicationGroup.getSecondaryNodes()) {
@@ -123,11 +124,12 @@ public class BDBHA implements HAProtocol {
 
     @Override
     public List<InetSocketAddress> getElectableNodes(boolean leaderIncluded) {
+        List<InetSocketAddress> ret = new ArrayList<InetSocketAddress>();
         ReplicationGroupAdmin replicationGroupAdmin = environment.getReplicationGroupAdmin();
         if (replicationGroupAdmin == null) {
-            return null;
+            return ret;
         }
-        List<InetSocketAddress> ret = new ArrayList<InetSocketAddress>();
+
         try {
             ReplicationGroup replicationGroup = replicationGroupAdmin.getGroup();
             for (ReplicationNode replicationNode : replicationGroup.getElectableNodes()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
@@ -209,6 +209,11 @@ public class BDBEnvironment {
                 .filter(Frontend::isAlive)
                 .map(fe -> new InetSocketAddress(fe.getHost(), fe.getEditLogPort()))
                 .collect(Collectors.toSet());
+
+        if (addresses.isEmpty()) {
+            LOG.info("addresses is empty");
+            return null;
+        }
         return new ReplicationGroupAdmin(PALO_JOURNAL_GROUP, addresses);
     }
 


### PR DESCRIPTION
```
java.lang.NullPointerException: null
    at com.sleepycat.je.rep.util.ReplicationGroupAdmin.getMasterSocket(ReplicationGroupAdmin.java:191)
    at com.sleepycat.je.rep.util.ReplicationGroupAdmin.doMessageExchange(ReplicationGroupAdmin.java:607)
    at com.sleepycat.je.rep.util.ReplicationGroupAdmin.getGroup(ReplicationGroupAdmin.java:406)
    at org.apache.doris.ha.BDBHA.getElectableNodes(BDBHA.java:132)
    at org.apache.doris.common.proc.FrontendsProcNode.getFrontendsInfo(FrontendsProcNode.java:84)
    at org.apache.doris.qe.ShowExecutor.handleShowFrontends(ShowExecutor.java:1923)
    at org.apache.doris.qe.ShowExecutor.execute(ShowExecutor.java:355)
    at org.apache.doris.qe.StmtExecutor.handleShow(StmtExecutor.java:2113)
    ...
```

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

