### PR TITLE
[fix](move-memtable) wait stream close before releasing streams

### DIFF
--- a/be/src/vec/sink/load_stream_stub.cpp
+++ b/be/src/vec/sink/load_stream_stub.cpp
@@ -113,10 +113,18 @@ LoadStreamStub::LoadStreamStub(LoadStreamStub& stub)
           _tablet_schema_for_index(stub._tablet_schema_for_index),
           _enable_unique_mow_for_index(stub._enable_unique_mow_for_index) {};
 
-LoadStreamStub::~LoadStreamStub() {
+LoadStreamStub::~LoadStreamStub() = default;
+
+Status LoadStreamStub::close_stream() {
     if (_is_init.load() && !_handler.is_closed()) {
-        brpc::StreamClose(_stream_id);
+        LOG(INFO) << "closing stream, load_id=" << print_id(_load_id) << ", src_id=" << _src_id
+                  << ", dst_id=" << _dst_id << ", stream_id=" << _stream_id;
+        auto ret = brpc::StreamClose(_stream_id);
+        if (ret != 0) {
+            return Status::InternalError("StreamClose failed, err={}", ret);
+        }
     }
+    return Status::OK();
 }
 
 // open_load_stream

--- a/be/src/vec/sink/load_stream_stub.h
+++ b/be/src/vec/sink/load_stream_stub.h
@@ -178,6 +178,10 @@ public:
     // GET_SCHEMA
     Status get_schema(const std::vector<PTabletID>& tablets);
 
+    // close stream, usually close is initiated by the remote.
+    // in case of remote failure, we should be able to close stream locally.
+    Status close_stream();
+
     // wait remote to close stream,
     // remote will close stream when it receives CLOSE_LOAD
     Status close_wait(int64_t timeout_ms = 0) {

--- a/be/src/vec/sink/load_stream_stub_pool.cpp
+++ b/be/src/vec/sink/load_stream_stub_pool.cpp
@@ -31,6 +31,18 @@ void LoadStreams::release() {
     int num_use = --_use_cnt;
     if (num_use == 0) {
         LOG(INFO) << "releasing streams, load_id=" << _load_id << ", dst_id=" << _dst_id;
+        for (auto& stream : _streams) {
+            auto st = stream->close_stream();
+            if (!st.ok()) {
+                LOG(WARNING) << "close stream failed " << st;
+            }
+        }
+        for (auto& stream : _streams) {
+            auto st = stream->close_wait();
+            if (!st.ok()) {
+                LOG(WARNING) << "close wait failed " << st;
+            }
+        }
         _pool->erase(_load_id, _dst_id);
     } else {
         LOG(INFO) << "keeping streams, load_id=" << _load_id << ", dst_id=" << _dst_id


### PR DESCRIPTION
## Proposed changes

We should wait stream close before releasing streams, otherwise `on_closed` may be called later and cause use-after-free.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

