### PR TITLE
[fix](mem-tracking) always require size in Allocator::free

### DIFF
--- a/be/src/util/slice.h
+++ b/be/src/util/slice.h
@@ -336,7 +336,7 @@ public:
         return *this;
     }
 
-    ~OwnedSlice() { Allocator::free(_slice.data); }
+    ~OwnedSlice() { Allocator::free(_slice.data, _slice.size); }
 
     const Slice& slice() const { return _slice; }
 

--- a/be/src/vec/common/allocator.h
+++ b/be/src/vec/common/allocator.h
@@ -142,9 +142,8 @@ public:
     }
 
     /// Free memory range.
-    void free(void* buf, size_t size = -1) {
+    void free(void* buf, size_t size) {
         if (use_mmap && size >= doris::config::mmap_threshold) {
-            DCHECK(size != -1);
             if (0 != munmap(buf, size)) {
                 throw_bad_alloc(fmt::format("Allocator: Cannot munmap {}.", size));
             }


### PR DESCRIPTION
## Proposed changes

Remove default value `-1` for parameter `size` in `Allocator::free()`, which is error-prone.

Also fix mem-tracking for `OwnedSlice`.

Mem-tracking `faststring` was fixed in #27731 

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

