### PR TITLE
[compability](segment) fix compability issue introduced by #27676

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -360,7 +360,8 @@ Status Segment::_create_column_readers(const SegmentFooterPB& footer) {
             vectorized::PathInData path;
             path.from_protobuf(column_pb.column_path_info());
             column_path_to_footer_ordinal.emplace(path, ordinal);
-        } else {
+        }
+        if (column_pb.has_unique_id()) {
             // unique id
             column_id_to_footer_ordinal.emplace(column_pb.unique_id(), ordinal);
         }


### PR DESCRIPTION
## Proposed changes

Prior to PR #27676, data was written with empty path information. Consequently, after implementing #27676, data that already exists in a segment is not included in `column_id_to_footer_ordinal`. This issue will lead to `invalid nonexistent column without default value` error.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

