### PR TITLE
[Improvement](schema-change) Reserve some memory for use by other parts except hold block of schem…

### DIFF
--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -565,7 +565,11 @@ Status VSchemaChangeWithSorting::_inner_process(RowsetReaderSharedPtr rowset_rea
         }
 
         RETURN_IF_ERROR(_changer.change_block(ref_block.get(), new_block.get()));
-        if (_mem_tracker->consumption() + new_block->allocated_bytes() > _memory_limitation) {
+
+        constexpr double HOLD_BLOCK_MEMORY_RATE =
+                0.66; // Reserve some memory for use by other parts of this job
+        if (_mem_tracker->consumption() + new_block->allocated_bytes() > _memory_limitation ||
+            _mem_tracker->consumption() > _memory_limitation * HOLD_BLOCK_MEMORY_RATE) {
             RETURN_IF_ERROR(create_rowset());
 
             if (_mem_tracker->consumption() + new_block->allocated_bytes() > _memory_limitation) {


### PR DESCRIPTION
…a change job

## Proposed changes
Reserve some memory for use by other parts except hold block of schema change job

```cpp
W0922 15:57:10.657173 62550 beta_rowset_reader.cpp:289] failed to read next block: [MEM_LIMIT_EXCEEDED]PreCatch error code:11, [E11] Memory limit exceeded:[MEM_LIMIT_EXCEEDED]failed alloc size 1.00 MB, exceeded tracker:<EngineAlterTabletTask#baseTabletId=61523:newTabletId=61950>, limit 2.00 GB, peak used 2.00 GB, current used 2.00 GB, exec node:<>, execute msg:Allocator mem tracker check failed. backend 172.30.199.214 process memory used 12.95 GB, limit 402.55 GB. Can `set exec_mem_limit=8G` to change limit, details see be.INFO.
0. /root/src/doris-2.0/be/src/common/stack_trace.cpp:302: StackTrace::tryCapture() @ 0x000000000b8a51a7 in /opt/app/apache-doris-2.0.1/be/lib/doris_be
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

