### PR TITLE
[improvement](disk migration) disk migration skip cooldown tablets

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DiskRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DiskRebalancer.java
@@ -33,6 +33,7 @@ import org.apache.doris.clone.TabletScheduler.PathSlot;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TStorageMedium;
+import org.apache.doris.thrift.TUniqueId;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -222,6 +223,12 @@ public class DiskRebalancer extends Rebalancer {
                     continue;
                 }
 
+                // backend not support migrate cooldown tablets
+                TUniqueId cooldownMetaId = replica.getCooldownMetaId();
+                if (cooldownMetaId != null && (cooldownMetaId.getLo() != 0 || cooldownMetaId.getHi() != 0)) {
+                    continue;
+                }
+
                 // check if replica's is on 'high' path.
                 // and only select it if the selected tablets num of this path
                 // does not exceed the limit (BALANCE_SLOT_NUM_FOR_PATH).
@@ -302,21 +309,6 @@ public class DiskRebalancer extends Rebalancer {
         // ignore empty replicas as they do not make disk more balance
         if (replica.getDataSize() == 0) {
             throw new SchedException(Status.UNRECOVERABLE, SubCode.DIAGNOSE_IGNORE, "size of src replica is zero");
-        }
-        Database db = Env.getCurrentInternalCatalog().getDbOrException(tabletCtx.getDbId(),
-                s -> new SchedException(Status.UNRECOVERABLE, SubCode.DIAGNOSE_IGNORE,
-                        "db " + tabletCtx.getDbId() + " does not exist"));
-        OlapTable tbl = (OlapTable) db.getTableOrException(tabletCtx.getTblId(),
-                s -> new SchedException(Status.UNRECOVERABLE, SubCode.DIAGNOSE_IGNORE,
-                        "tbl " + tabletCtx.getTblId() + " does not exist"));
-        DataProperty dataProperty = tbl.getPartitionInfo().getDataProperty(tabletCtx.getPartitionId());
-        if (dataProperty == null) {
-            throw new SchedException(Status.UNRECOVERABLE, "data property is null");
-        }
-        String storagePolicy = dataProperty.getStoragePolicy();
-        if (!Strings.isNullOrEmpty(storagePolicy)) {
-            throw new SchedException(Status.UNRECOVERABLE, SubCode.DIAGNOSE_IGNORE,
-                    "disk balance not support for cooldown storage");
         }
 
         // check src slot

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DiskRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DiskRebalancer.java
@@ -18,10 +18,7 @@
 package org.apache.doris.clone;
 
 import org.apache.doris.catalog.CatalogRecycleBin;
-import org.apache.doris.catalog.DataProperty;
-import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
-import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.catalog.TabletMeta;
@@ -35,7 +32,6 @@ import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TStorageMedium;
 import org.apache.doris.thrift.TUniqueId;
 
-import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;


### PR DESCRIPTION
even a partition had set cooldown policy,  the backend's replica may not cooldown to remote (cooldown meta id = null),  at that time, this replica still can migrate between disks;

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

