### PR TITLE
[Improvement](inverted index) improve inverted index bkd performance in high concurrent scenario

### DIFF
--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -121,11 +121,13 @@ public:
         // mask out null_bitmap, since NULL cmp VALUE will produce NULL
         //  and be treated as false in WHERE
         // keep it after query, since query will try to read null_bitmap and put it to cache
-        InvertedIndexQueryCacheHandle null_bitmap_cache_handle;
-        RETURN_IF_ERROR(iterator->read_null_bitmap(&null_bitmap_cache_handle));
-        std::shared_ptr<roaring::Roaring> null_bitmap = null_bitmap_cache_handle.get_bitmap();
-        if (null_bitmap) {
-            *bitmap -= *null_bitmap;
+        if (iterator->has_null()) {
+            InvertedIndexQueryCacheHandle null_bitmap_cache_handle;
+            RETURN_IF_ERROR(iterator->read_null_bitmap(&null_bitmap_cache_handle));
+            std::shared_ptr<roaring::Roaring> null_bitmap = null_bitmap_cache_handle.get_bitmap();
+            if (null_bitmap) {
+                *bitmap -= *null_bitmap;
+            }
         }
 
         if constexpr (PT == PredicateType::NE) {

--- a/be/src/olap/in_list_predicate.h
+++ b/be/src/olap/in_list_predicate.h
@@ -211,11 +211,13 @@ public:
         // mask out null_bitmap, since NULL cmp VALUE will produce NULL
         //  and be treated as false in WHERE
         // keep it after query, since query will try to read null_bitmap and put it to cache
-        InvertedIndexQueryCacheHandle null_bitmap_cache_handle;
-        RETURN_IF_ERROR(iterator->read_null_bitmap(&null_bitmap_cache_handle));
-        std::shared_ptr<roaring::Roaring> null_bitmap = null_bitmap_cache_handle.get_bitmap();
-        if (null_bitmap) {
-            *result -= *null_bitmap;
+        if (iterator->has_null()) {
+            InvertedIndexQueryCacheHandle null_bitmap_cache_handle;
+            RETURN_IF_ERROR(iterator->read_null_bitmap(&null_bitmap_cache_handle));
+            std::shared_ptr<roaring::Roaring> null_bitmap = null_bitmap_cache_handle.get_bitmap();
+            if (null_bitmap) {
+                *result -= *null_bitmap;
+            }
         }
 
         if constexpr (PT == PredicateType::IN_LIST) {

--- a/be/src/olap/match_predicate.cpp
+++ b/be/src/olap/match_predicate.cpp
@@ -82,11 +82,13 @@ Status MatchPredicate::evaluate(const vectorized::NameAndTypePair& name_with_typ
     // mask out null_bitmap, since NULL cmp VALUE will produce NULL
     //  and be treated as false in WHERE
     // keep it after query, since query will try to read null_bitmap and put it to cache
-    InvertedIndexQueryCacheHandle null_bitmap_cache_handle;
-    RETURN_IF_ERROR(iterator->read_null_bitmap(&null_bitmap_cache_handle));
-    std::shared_ptr<roaring::Roaring> null_bitmap = null_bitmap_cache_handle.get_bitmap();
-    if (null_bitmap) {
-        *bitmap -= *null_bitmap;
+    if (iterator->has_null()) {
+        InvertedIndexQueryCacheHandle null_bitmap_cache_handle;
+        RETURN_IF_ERROR(iterator->read_null_bitmap(&null_bitmap_cache_handle));
+        std::shared_ptr<roaring::Roaring> null_bitmap = null_bitmap_cache_handle.get_bitmap();
+        if (null_bitmap) {
+            *bitmap -= *null_bitmap;
+        }
     }
 
     *bitmap &= roaring;

--- a/be/src/olap/null_predicate.cpp
+++ b/be/src/olap/null_predicate.cpp
@@ -56,22 +56,22 @@ Status NullPredicate::evaluate(BitmapIndexIterator* iterator, uint32_t num_rows,
 Status NullPredicate::evaluate(const vectorized::NameAndTypePair& name_with_type,
                                InvertedIndexIterator* iterator, uint32_t num_rows,
                                roaring::Roaring* bitmap) const {
-    // mask out null_bitmap, since NULL cmp VALUE will produce NULL
-    //  and be treated as false in WHERE
-    InvertedIndexQueryCacheHandle null_bitmap_cache_handle;
-    RETURN_IF_ERROR(iterator->read_null_bitmap(&null_bitmap_cache_handle));
-    std::shared_ptr<roaring::Roaring> null_bitmap = null_bitmap_cache_handle.get_bitmap();
-    if (null_bitmap) {
-        if (_is_null) {
-            *bitmap &= *null_bitmap;
-        } else {
-            *bitmap -= *null_bitmap;
+    if (iterator->has_null()) {
+        InvertedIndexQueryCacheHandle null_bitmap_cache_handle;
+        RETURN_IF_ERROR(iterator->read_null_bitmap(&null_bitmap_cache_handle));
+        std::shared_ptr<roaring::Roaring> null_bitmap = null_bitmap_cache_handle.get_bitmap();
+
+        if (null_bitmap) {
+            if (_is_null) {
+                *bitmap &= *null_bitmap; // Keep only nulls in bitmap if _is_null is true
+            } else {
+                *bitmap -= *null_bitmap; // Remove nulls from bitmap if _is_null is false
+            }
+        } else if (_is_null) {
+            *bitmap = roaring::Roaring(); // Reset bitmap to an empty bitmap
         }
-    } else {
-        // all rows not null
-        if (_is_null) {
-            *bitmap -= *bitmap;
-        }
+    } else if (_is_null) {
+        *bitmap = roaring::Roaring(); // Reset bitmap to an empty bitmap
     }
 
     return Status::OK();

--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -552,7 +552,6 @@ Status ColumnReader::_load_inverted_index_index(const TabletIndex* index_meta) {
             try {
                 _inverted_index = FullTextIndexReader::create_shared(
                         _file_reader->fs(), _file_reader->path().native(), index_meta);
-                return Status::OK();
             } catch (const CLuceneError& e) {
                 return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
                         "create FullTextIndexReader error: {}", e.what());
@@ -577,7 +576,6 @@ Status ColumnReader::_load_inverted_index_index(const TabletIndex* index_meta) {
     } else {
         _inverted_index.reset();
     }
-
     return Status::OK();
 }
 

--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
@@ -19,6 +19,7 @@
 
 #include <CLucene/debug/mem.h>
 #include <CLucene/search/IndexSearcher.h>
+#include <CLucene/util/bkd/bkd_reader.h>
 // IWYU pragma: no_include <bthread/errno.h>
 #include <errno.h> // IWYU pragma: keep
 #include <string.h>
@@ -31,6 +32,7 @@
 #include "olap/olap_common.h"
 #include "olap/rowset/segment_v2/inverted_index_compound_directory.h"
 #include "olap/rowset/segment_v2/inverted_index_compound_reader.h"
+#include "olap/rowset/segment_v2/inverted_index_desc.h"
 #include "runtime/exec_env.h"
 #include "runtime/thread_context.h"
 #include "util/defer_op.h"
@@ -39,20 +41,42 @@
 namespace doris {
 namespace segment_v2 {
 
-IndexSearcherPtr InvertedIndexSearcherCache::build_index_searcher(const io::FileSystemSPtr& fs,
-                                                                  const std::string& index_dir,
-                                                                  const std::string& file_name) {
-    DorisCompoundReader* directory =
-            new DorisCompoundReader(DorisCompoundDirectory::getDirectory(fs, index_dir.c_str()),
-                                    file_name.c_str(), config::inverted_index_read_buffer_size);
+Status FulltextIndexSearcherBuilder::build(DorisCompoundReader* directory,
+                                           OptionalIndexSearcherPtr& output_searcher) {
     auto closeDirectory = true;
     auto reader = lucene::index::IndexReader::open(
             directory, config::inverted_index_read_buffer_size, closeDirectory);
     auto index_searcher = std::make_shared<lucene::search::IndexSearcher>(reader);
+    if (!index_searcher) {
+        _CLDECDELETE(directory)
+        output_searcher = std::nullopt;
+        return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
+                "FulltextIndexSearcherBuilder build index_searcher error.");
+    }
     // NOTE: need to cl_refcount-- here, so that directory will be deleted when
     // index_searcher is destroyed
     _CLDECDELETE(directory)
-    return index_searcher;
+    output_searcher = index_searcher;
+    return Status::OK();
+}
+
+Status BKDIndexSearcherBuilder::build(DorisCompoundReader* directory,
+                                      OptionalIndexSearcherPtr& output_searcher) {
+    try {
+        auto closeDirectory = true;
+        auto bkd_reader =
+                std::make_shared<lucene::util::bkd::bkd_reader>(directory, closeDirectory);
+        if (!bkd_reader->open()) {
+            LOG(INFO) << "bkd index file " << directory->getPath() + "/" + directory->getFileName()
+                      << " is empty";
+        }
+        output_searcher = bkd_reader;
+        _CLDECDELETE(directory)
+        return Status::OK();
+    } catch (const CLuceneError& e) {
+        return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
+                "BKDIndexSearcherBuilder build error: {}", e.what());
+    }
 }
 
 InvertedIndexSearcherCache* InvertedIndexSearcherCache::create_global_instance(
@@ -99,13 +123,18 @@ InvertedIndexSearcherCache::InvertedIndexSearcherCache(size_t capacity, uint32_t
     }
 }
 
-Status InvertedIndexSearcherCache::get_index_searcher(const io::FileSystemSPtr& fs,
-                                                      const std::string& index_dir,
-                                                      const std::string& file_name,
-                                                      InvertedIndexCacheHandle* cache_handle,
-                                                      OlapReaderStatistics* stats, bool use_cache) {
+Status InvertedIndexSearcherCache::get_index_searcher(
+        const io::FileSystemSPtr& fs, const std::string& index_dir, const std::string& file_name,
+        InvertedIndexCacheHandle* cache_handle, OlapReaderStatistics* stats,
+        InvertedIndexReaderType reader_type, bool& has_null, bool use_cache) {
     auto file_path = index_dir + "/" + file_name;
-
+    bool exists = false;
+    RETURN_IF_ERROR(fs->exists(file_path, &exists));
+    if (!exists) {
+        LOG(WARNING) << "inverted index: " << file_path << " not exist.";
+        return Status::Error<ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND>(
+                "inverted index input file {} not found", file_path);
+    }
     using namespace std::chrono;
     auto start_time = steady_clock::now();
     Defer cost {[&]() {
@@ -120,14 +149,52 @@ Status InvertedIndexSearcherCache::get_index_searcher(const io::FileSystemSPtr& 
     }
 
     cache_handle->owned = !use_cache;
-    IndexSearcherPtr index_searcher = nullptr;
+    IndexSearcherPtr index_searcher;
+    std::unique_ptr<IndexSearcherBuilder> index_builder = nullptr;
     auto mem_tracker =
             std::unique_ptr<MemTracker>(new MemTracker("InvertedIndexSearcherCacheWithRead"));
 #ifndef BE_TEST
     {
         SCOPED_RAW_TIMER(&stats->inverted_index_searcher_open_timer);
         SCOPED_CONSUME_MEM_TRACKER(mem_tracker.get());
-        index_searcher = build_index_searcher(fs, index_dir, file_name);
+        switch (reader_type) {
+        case InvertedIndexReaderType::STRING_TYPE:
+        case InvertedIndexReaderType::FULLTEXT: {
+            index_builder = std::make_unique<FulltextIndexSearcherBuilder>();
+            break;
+        }
+        case InvertedIndexReaderType::BKD: {
+            index_builder = std::make_unique<BKDIndexSearcherBuilder>();
+            break;
+        }
+
+        default:
+            LOG(ERROR) << "InvertedIndexReaderType:" << reader_type_to_string(reader_type)
+                       << " is not support for InvertedIndexSearcherCache";
+            return Status::Error<ErrorCode::INVERTED_INDEX_NOT_SUPPORTED>(
+                    "InvertedIndexSearcherCache do not support reader type.");
+        }
+        auto* directory =
+                new DorisCompoundReader(DorisCompoundDirectory::getDirectory(fs, index_dir.c_str()),
+                                        file_name.c_str(), config::inverted_index_read_buffer_size);
+        auto null_bitmap_file_name = InvertedIndexDescriptor::get_temporary_null_bitmap_file_name();
+        if (!directory->fileExists(null_bitmap_file_name.c_str())) {
+            has_null = false;
+        } else {
+            // roaring bitmap cookie header size is 5
+            if (directory->fileLength(null_bitmap_file_name.c_str()) <= 5) {
+                has_null = false;
+            }
+        }
+        OptionalIndexSearcherPtr result;
+        RETURN_IF_ERROR(index_builder->build(directory, result));
+        if (!result.has_value()) {
+            LOG(ERROR) << "InvertedIndexReaderType:" << reader_type_to_string(reader_type)
+                       << " build for InvertedIndexSearcherCache error";
+            return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
+                    "InvertedIndexSearcherCache build error.");
+        }
+        index_searcher = *result;
     }
 #endif
 
@@ -145,9 +212,16 @@ Status InvertedIndexSearcherCache::get_index_searcher(const io::FileSystemSPtr& 
 
 Status InvertedIndexSearcherCache::insert(const io::FileSystemSPtr& fs,
                                           const std::string& index_dir,
-                                          const std::string& file_name) {
+                                          const std::string& file_name,
+                                          InvertedIndexReaderType reader_type) {
     auto file_path = index_dir + "/" + file_name;
-
+    bool exists = false;
+    RETURN_IF_ERROR(fs->exists(file_path, &exists));
+    if (!exists) {
+        LOG(WARNING) << "inverted index: " << file_path << " not exist.";
+        return Status::Error<ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND>(
+                "inverted index input file {} not found", file_path);
+    }
     using namespace std::chrono;
     auto start_time = steady_clock::now();
     Defer cost {[&]() {
@@ -157,13 +231,41 @@ Status InvertedIndexSearcherCache::insert(const io::FileSystemSPtr& fs,
 
     InvertedIndexSearcherCache::CacheKey cache_key(file_path);
     IndexCacheValuePtr cache_value = std::make_unique<InvertedIndexSearcherCache::CacheValue>();
-    IndexSearcherPtr index_searcher = nullptr;
-    auto mem_tracker =
-            std::unique_ptr<MemTracker>(new MemTracker("InvertedIndexSearcherCacheWithInsert"));
+    IndexSearcherPtr index_searcher;
+    std::unique_ptr<IndexSearcherBuilder> builder = nullptr;
+    auto mem_tracker = std::make_unique<MemTracker>("InvertedIndexSearcherCacheWithInsert");
 #ifndef BE_TEST
     {
         SCOPED_CONSUME_MEM_TRACKER(mem_tracker.get());
-        index_searcher = build_index_searcher(fs, index_dir, file_name);
+        switch (reader_type) {
+        case InvertedIndexReaderType::STRING_TYPE:
+        case InvertedIndexReaderType::FULLTEXT: {
+            builder = std::make_unique<FulltextIndexSearcherBuilder>();
+            break;
+        }
+        case InvertedIndexReaderType::BKD: {
+            builder = std::make_unique<BKDIndexSearcherBuilder>();
+            break;
+        }
+
+        default:
+            LOG(ERROR) << "InvertedIndexReaderType:" << reader_type_to_string(reader_type)
+                       << " is not support for InvertedIndexSearcherCache";
+            return Status::Error<ErrorCode::INVERTED_INDEX_NOT_SUPPORTED>(
+                    "InvertedIndexSearcherCache do not support reader type.");
+        }
+        auto* directory =
+                new DorisCompoundReader(DorisCompoundDirectory::getDirectory(fs, index_dir.c_str()),
+                                        file_name.c_str(), config::inverted_index_read_buffer_size);
+        OptionalIndexSearcherPtr result;
+        RETURN_IF_ERROR(builder->build(directory, result));
+        if (!result.has_value()) {
+            LOG(ERROR) << "InvertedIndexReaderType:" << reader_type_to_string(reader_type)
+                       << " build for InvertedIndexSearcherCache error";
+            return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
+                    "InvertedIndexSearcherCache build error.");
+        }
+        index_searcher = *result;
     }
 #endif
 

--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
@@ -128,13 +128,7 @@ Status InvertedIndexSearcherCache::get_index_searcher(
         InvertedIndexCacheHandle* cache_handle, OlapReaderStatistics* stats,
         InvertedIndexReaderType reader_type, bool& has_null, bool use_cache) {
     auto file_path = index_dir + "/" + file_name;
-    bool exists = false;
-    RETURN_IF_ERROR(fs->exists(file_path, &exists));
-    if (!exists) {
-        LOG(WARNING) << "inverted index: " << file_path << " not exist.";
-        return Status::Error<ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND>(
-                "inverted index input file {} not found", file_path);
-    }
+
     using namespace std::chrono;
     auto start_time = steady_clock::now();
     Defer cost {[&]() {
@@ -155,6 +149,13 @@ Status InvertedIndexSearcherCache::get_index_searcher(
             std::unique_ptr<MemTracker>(new MemTracker("InvertedIndexSearcherCacheWithRead"));
 #ifndef BE_TEST
     {
+        bool exists = false;
+        RETURN_IF_ERROR(fs->exists(file_path, &exists));
+        if (!exists) {
+            LOG(WARNING) << "inverted index: " << file_path << " not exist.";
+            return Status::Error<ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND>(
+                    "inverted index input file {} not found", file_path);
+        }
         SCOPED_RAW_TIMER(&stats->inverted_index_searcher_open_timer);
         SCOPED_CONSUME_MEM_TRACKER(mem_tracker.get());
         switch (reader_type) {
@@ -215,13 +216,7 @@ Status InvertedIndexSearcherCache::insert(const io::FileSystemSPtr& fs,
                                           const std::string& file_name,
                                           InvertedIndexReaderType reader_type) {
     auto file_path = index_dir + "/" + file_name;
-    bool exists = false;
-    RETURN_IF_ERROR(fs->exists(file_path, &exists));
-    if (!exists) {
-        LOG(WARNING) << "inverted index: " << file_path << " not exist.";
-        return Status::Error<ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND>(
-                "inverted index input file {} not found", file_path);
-    }
+
     using namespace std::chrono;
     auto start_time = steady_clock::now();
     Defer cost {[&]() {
@@ -236,6 +231,13 @@ Status InvertedIndexSearcherCache::insert(const io::FileSystemSPtr& fs,
     auto mem_tracker = std::make_unique<MemTracker>("InvertedIndexSearcherCacheWithInsert");
 #ifndef BE_TEST
     {
+        bool exists = false;
+        RETURN_IF_ERROR(fs->exists(file_path, &exists));
+        if (!exists) {
+            LOG(WARNING) << "inverted index: " << file_path << " not exist.";
+            return Status::Error<ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND>(
+                    "inverted index input file {} not found", file_path);
+        }
         SCOPED_CONSUME_MEM_TRACKER(mem_tracker.get());
         switch (reader_type) {
         case InvertedIndexReaderType::STRING_TYPE:

--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.h
@@ -211,6 +211,8 @@ public:
 public:
     // If set to true, the loaded index_searcher will be saved in index_searcher, not in lru cache;
     bool owned = false;
+    // If index searcher include non-null bitmap.
+    bool has_null = true;
     IndexSearcherPtr index_searcher;
 
 private:

--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.h
@@ -34,9 +34,11 @@
 
 #include <atomic>
 #include <memory>
+#include <optional>
 #include <roaring/roaring.hh>
 #include <string>
 #include <utility>
+#include <variant>
 
 #include "common/config.h"
 #include "common/status.h"
@@ -54,26 +56,54 @@ namespace lucene {
 namespace search {
 class IndexSearcher;
 } // namespace search
+namespace util {
+namespace bkd {
+class bkd_reader;
+}
+} // namespace util
 } // namespace lucene
 
 namespace doris {
 struct OlapReaderStatistics;
 
 namespace segment_v2 {
-using IndexSearcherPtr = std::shared_ptr<lucene::search::IndexSearcher>;
+using FulltextIndexSearcherPtr = std::shared_ptr<lucene::search::IndexSearcher>;
+using BKDIndexSearcherPtr = std::shared_ptr<lucene::util::bkd::bkd_reader>;
+using IndexSearcherPtr = std::variant<FulltextIndexSearcherPtr, BKDIndexSearcherPtr>;
+using OptionalIndexSearcherPtr = std::optional<IndexSearcherPtr>;
 
 class InvertedIndexCacheHandle;
+class DorisCompoundReader;
+
+class IndexSearcherBuilder {
+public:
+    virtual Status build(DorisCompoundReader* directory,
+                         OptionalIndexSearcherPtr& output_searcher) = 0;
+    virtual ~IndexSearcherBuilder() = default;
+};
+
+class FulltextIndexSearcherBuilder : public IndexSearcherBuilder {
+public:
+    Status build(DorisCompoundReader* directory,
+                 OptionalIndexSearcherPtr& output_searcher) override;
+};
+
+class BKDIndexSearcherBuilder : public IndexSearcherBuilder {
+public:
+    Status build(DorisCompoundReader* directory,
+                 OptionalIndexSearcherPtr& output_searcher) override;
+};
 
 class InvertedIndexSearcherCache : public LRUCachePolicy {
 public:
     // The cache key of index_searcher lru cache
     struct CacheKey {
-        CacheKey(std::string index_file_path) : index_file_path(index_file_path) {}
+        CacheKey(std::string index_file_path) : index_file_path(std::move(index_file_path)) {}
         std::string index_file_path;
     };
 
     // The cache value of index_searcher lru cache.
-    // Holding a opened index_searcher.
+    // Holding an opened index_searcher.
     struct CacheValue : public LRUCacheValueBase {
         IndexSearcherPtr index_searcher;
     };
@@ -95,19 +125,16 @@ public:
         return ExecEnv::GetInstance()->get_inverted_index_searcher_cache();
     }
 
-    static IndexSearcherPtr build_index_searcher(const io::FileSystemSPtr& fs,
-                                                 const std::string& index_dir,
-                                                 const std::string& file_name);
-
     InvertedIndexSearcherCache(size_t capacity, uint32_t num_shards);
 
     Status get_index_searcher(const io::FileSystemSPtr& fs, const std::string& index_dir,
                               const std::string& file_name, InvertedIndexCacheHandle* cache_handle,
-                              OlapReaderStatistics* stats, bool use_cache = true);
+                              OlapReaderStatistics* stats, InvertedIndexReaderType reader_type,
+                              bool& has_null, bool use_cache = true);
 
     // function `insert` called after inverted index writer close
     Status insert(const io::FileSystemSPtr& fs, const std::string& index_dir,
-                  const std::string& file_name);
+                  const std::string& file_name, InvertedIndexReaderType reader_type);
 
     // function `erase` called after compaction remove segment
     Status erase(const std::string& index_file_path);
@@ -211,7 +238,7 @@ public:
             key_buf.append("/");
             key_buf.append(column_name);
             key_buf.append("/");
-            auto query_type_str = InvertedIndexQueryType_toString(query_type);
+            auto query_type_str = query_type_to_string(query_type);
             if (query_type_str.empty()) {
                 return "";
             }

--- a/be/src/olap/rowset/segment_v2/inverted_index_compound_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_compound_reader.cpp
@@ -234,6 +234,10 @@ lucene::store::Directory* DorisCompoundReader::getDirectory() {
     return dir;
 }
 
+std::string DorisCompoundReader::getPath() const {
+    return ((DorisCompoundDirectory*)dir)->getCfsDirName();
+}
+
 int64_t DorisCompoundReader::fileModified(const char* name) const {
     return dir->fileModified(name);
 }

--- a/be/src/olap/rowset/segment_v2/inverted_index_compound_reader.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_compound_reader.h
@@ -91,6 +91,7 @@ public:
     void close() override;
     std::string toString() const override;
     std::string getFileName() { return file_name; }
+    std::string getPath() const;
     static const char* getClassName();
     const char* getObjectName() const override;
 };

--- a/be/src/olap/rowset/segment_v2/inverted_index_query_type.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_query_type.h
@@ -22,6 +22,50 @@
 namespace doris {
 namespace segment_v2 {
 
+enum class InvertedIndexReaderType {
+    UNKNOWN = -1,
+    FULLTEXT = 0,
+    STRING_TYPE = 1,
+    BKD = 2,
+};
+
+template <InvertedIndexReaderType T>
+constexpr const char* InvertedIndexReaderTypeToString();
+
+template <>
+constexpr const char* InvertedIndexReaderTypeToString<InvertedIndexReaderType::UNKNOWN>() {
+    return "UNKNOWN";
+}
+
+template <>
+constexpr const char* InvertedIndexReaderTypeToString<InvertedIndexReaderType::FULLTEXT>() {
+    return "FULLTEXT";
+}
+
+template <>
+constexpr const char* InvertedIndexReaderTypeToString<InvertedIndexReaderType::STRING_TYPE>() {
+    return "STRING_TYPE";
+}
+
+template <>
+constexpr const char* InvertedIndexReaderTypeToString<InvertedIndexReaderType::BKD>() {
+    return "BKD";
+}
+
+inline std::string reader_type_to_string(InvertedIndexReaderType query_type) {
+    switch (query_type) {
+    case InvertedIndexReaderType::UNKNOWN:
+        return InvertedIndexReaderTypeToString<InvertedIndexReaderType::UNKNOWN>();
+    case InvertedIndexReaderType::FULLTEXT:
+        return InvertedIndexReaderTypeToString<InvertedIndexReaderType::FULLTEXT>();
+    case InvertedIndexReaderType::STRING_TYPE:
+        return InvertedIndexReaderTypeToString<InvertedIndexReaderType::STRING_TYPE>();
+    case InvertedIndexReaderType::BKD:
+        return InvertedIndexReaderTypeToString<InvertedIndexReaderType::BKD>();
+    }
+    return ""; // Explicitly handle all cases
+}
+
 enum class InvertedIndexQueryType {
     UNKNOWN_QUERY = -1,
     EQUAL_QUERY = 0,
@@ -34,7 +78,7 @@ enum class InvertedIndexQueryType {
     MATCH_PHRASE_QUERY = 7,
 };
 
-inline std::string InvertedIndexQueryType_toString(InvertedIndexQueryType query_type) {
+inline std::string query_type_to_string(InvertedIndexQueryType query_type) {
     switch (query_type) {
     case InvertedIndexQueryType::UNKNOWN_QUERY: {
         return "UNKNOWN";

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
@@ -20,12 +20,8 @@
 #include <CLucene/analysis/AnalysisHeader.h>
 #include <CLucene/analysis/Analyzers.h>
 #include <CLucene/analysis/LanguageBasedAnalyzer.h>
-#include <CLucene/analysis/standard/StandardAnalyzer.h>
-#include <CLucene/clucene-config.h>
-#include <CLucene/config/repl_wchar.h>
 #include <CLucene/debug/error.h>
 #include <CLucene/debug/mem.h>
-#include <CLucene/index/IndexReader.h>
 #include <CLucene/index/Term.h>
 #include <CLucene/search/IndexSearcher.h>
 #include <CLucene/search/PhraseQuery.h>
@@ -38,11 +34,8 @@
 #include <CLucene/util/FutureArrays.h>
 #include <CLucene/util/bkd/bkd_docid_iterator.h>
 #include <CLucene/util/stringUtil.h>
-#include <math.h>
 #include <string.h>
 
-#include <algorithm>
-#include <filesystem>
 #include <ostream>
 #include <roaring/roaring.hh>
 #include <set>
@@ -66,24 +59,12 @@
 #include "olap/rowset/segment_v2/inverted_index/query/conjunction_query.h"
 #include "olap/rowset/segment_v2/inverted_index_cache.h"
 #include "olap/rowset/segment_v2/inverted_index_compound_directory.h"
-#include "olap/rowset/segment_v2/inverted_index_desc.h"
 #include "olap/types.h"
 #include "runtime/runtime_state.h"
 #include "util/faststring.h"
 #include "util/runtime_profile.h"
 #include "util/time.h"
 #include "vec/common/string_ref.h"
-
-#define FINALIZE_INPUT(x) \
-    if (x != nullptr) {   \
-        x->close();       \
-        _CLDELETE(x);     \
-    }
-#define FINALLY_FINALIZE_INPUT(x) \
-    try {                         \
-        FINALIZE_INPUT(x)         \
-    } catch (...) {               \
-    }
 
 namespace doris {
 namespace segment_v2 {
@@ -289,13 +270,6 @@ Status FullTextIndexReader::query(OlapReaderStatistics* stats, RuntimeState* run
                     "inverted index path: {} not exist.", index_file_path.string());
         }
 
-        auto get_index_search = [this, &index_dir, &index_file_name, &stats]() {
-            InvertedIndexCacheHandle inverted_index_cache_handle;
-            static_cast<void>(InvertedIndexSearcherCache::instance()->get_index_searcher(
-                    _fs, index_dir.c_str(), index_file_name, &inverted_index_cache_handle, stats));
-            return inverted_index_cache_handle.get_index_searcher();
-        };
-
         std::unique_ptr<lucene::search::Query> query;
         std::wstring field_ws = std::wstring(column_name.begin(), column_name.end());
 
@@ -324,34 +298,41 @@ Status FullTextIndexReader::query(OlapReaderStatistics* stats, RuntimeState* run
                 term_match_bitmap = cache_handle.get_bitmap();
             } else {
                 stats->inverted_index_query_cache_miss++;
+                InvertedIndexCacheHandle inverted_index_cache_handle;
+                RETURN_IF_ERROR(InvertedIndexSearcherCache::instance()->get_index_searcher(
+                        _fs, _index_dir.c_str(), _index_file_name, &inverted_index_cache_handle,
+                        stats, type(), _has_null));
+                auto searcher_variant = inverted_index_cache_handle.get_index_searcher();
+                if (FulltextIndexSearcherPtr* searcher_ptr =
+                            std::get_if<FulltextIndexSearcherPtr>(&searcher_variant)) {
+                    term_match_bitmap = std::make_shared<roaring::Roaring>();
 
-                auto index_searcher = get_index_search();
-
-                term_match_bitmap = std::make_shared<roaring::Roaring>();
-
-                Status res = Status::OK();
-                if (query_type == InvertedIndexQueryType::MATCH_PHRASE_QUERY) {
-                    auto* phrase_query = new lucene::search::PhraseQuery();
-                    for (auto& token : analyse_result) {
-                        std::wstring wtoken = StringUtil::string_to_wstring(token);
-                        auto* term = _CLNEW lucene::index::Term(field_ws.c_str(), wtoken.c_str());
-                        phrase_query->add(term);
-                        _CLDECDELETE(term);
+                    Status res = Status::OK();
+                    if (query_type == InvertedIndexQueryType::MATCH_PHRASE_QUERY) {
+                        auto* phrase_query = new lucene::search::PhraseQuery();
+                        for (auto& token : analyse_result) {
+                            std::wstring wtoken = StringUtil::string_to_wstring(token);
+                            auto* term =
+                                    _CLNEW lucene::index::Term(field_ws.c_str(), wtoken.c_str());
+                            phrase_query->add(term);
+                            _CLDECDELETE(term);
+                        }
+                        query.reset(phrase_query);
+                        res = normal_index_search(stats, query_type, *searcher_ptr,
+                                                  null_bitmap_already_read, query,
+                                                  term_match_bitmap);
+                    } else {
+                        res = match_all_index_search(stats, runtime_state, field_ws, analyse_result,
+                                                     *searcher_ptr, term_match_bitmap);
                     }
-                    query.reset(phrase_query);
-                    res = normal_index_search(stats, query_type, index_searcher,
-                                              null_bitmap_already_read, query, term_match_bitmap);
-                } else {
-                    res = match_all_index_search(stats, runtime_state, field_ws, analyse_result,
-                                                 index_searcher, term_match_bitmap);
-                }
-                if (!res.ok()) {
-                    return res;
-                }
+                    if (!res.ok()) {
+                        return res;
+                    }
 
-                // add to cache
-                term_match_bitmap->runOptimize();
-                cache->insert(cache_key, term_match_bitmap, &cache_handle);
+                    // add to cache
+                    term_match_bitmap->runOptimize();
+                    cache->insert(cache_key, term_match_bitmap, &cache_handle);
+                }
             }
             query_match_bitmap = *term_match_bitmap;
         } else {
@@ -374,26 +355,31 @@ Status FullTextIndexReader::query(OlapReaderStatistics* stats, RuntimeState* run
                     term_match_bitmap = cache_handle.get_bitmap();
                 } else {
                     stats->inverted_index_query_cache_miss++;
+                    InvertedIndexCacheHandle inverted_index_cache_handle;
+                    RETURN_IF_ERROR(InvertedIndexSearcherCache::instance()->get_index_searcher(
+                            _fs, _index_dir.c_str(), _index_file_name, &inverted_index_cache_handle,
+                            stats, type(), _has_null));
+                    auto searcher_variant = inverted_index_cache_handle.get_index_searcher();
+                    if (FulltextIndexSearcherPtr* searcher_ptr =
+                                std::get_if<FulltextIndexSearcherPtr>(&searcher_variant)) {
+                        term_match_bitmap = std::make_shared<roaring::Roaring>();
+                        // unique_ptr with custom deleter
+                        std::unique_ptr<lucene::index::Term, void (*)(lucene::index::Term*)> term {
+                                _CLNEW lucene::index::Term(field_ws.c_str(), token_ws.c_str()),
+                                [](lucene::index::Term* term) { _CLDECDELETE(term); }};
+                        query.reset(new lucene::search::TermQuery(term.get()));
 
-                    auto index_searcher = get_index_search();
+                        Status res = normal_index_search(stats, query_type, *searcher_ptr,
+                                                         null_bitmap_already_read, query,
+                                                         term_match_bitmap);
+                        if (!res.ok()) {
+                            return res;
+                        }
 
-                    term_match_bitmap = std::make_shared<roaring::Roaring>();
-                    // unique_ptr with custom deleter
-                    std::unique_ptr<lucene::index::Term, void (*)(lucene::index::Term*)> term {
-                            _CLNEW lucene::index::Term(field_ws.c_str(), token_ws.c_str()),
-                            [](lucene::index::Term* term) { _CLDECDELETE(term); }};
-                    query.reset(new lucene::search::TermQuery(term.get()));
-
-                    Status res =
-                            normal_index_search(stats, query_type, index_searcher,
-                                                null_bitmap_already_read, query, term_match_bitmap);
-                    if (!res.ok()) {
-                        return res;
+                        // add to cache
+                        term_match_bitmap->runOptimize();
+                        cache->insert(cache_key, term_match_bitmap, &cache_handle);
                     }
-
-                    // add to cache
-                    term_match_bitmap->runOptimize();
-                    cache->insert(cache_key, term_match_bitmap, &cache_handle);
                 }
 
                 // add to query_match_bitmap
@@ -428,7 +414,7 @@ Status FullTextIndexReader::query(OlapReaderStatistics* stats, RuntimeState* run
 
 Status FullTextIndexReader::normal_index_search(
         OlapReaderStatistics* stats, InvertedIndexQueryType query_type,
-        const IndexSearcherPtr& index_searcher, bool& null_bitmap_already_read,
+        const FulltextIndexSearcherPtr& index_searcher, bool& null_bitmap_already_read,
         const std::unique_ptr<lucene::search::Query>& query,
         const std::shared_ptr<roaring::Roaring>& term_match_bitmap) {
     check_null_bitmap(index_searcher, null_bitmap_already_read);
@@ -463,7 +449,8 @@ Status FullTextIndexReader::normal_index_search(
 
 Status FullTextIndexReader::match_all_index_search(
         OlapReaderStatistics* stats, RuntimeState* runtime_state, const std::wstring& field_ws,
-        const std::vector<std::string>& analyse_result, const IndexSearcherPtr& index_searcher,
+        const std::vector<std::string>& analyse_result,
+        const FulltextIndexSearcherPtr& index_searcher,
         const std::shared_ptr<roaring::Roaring>& term_match_bitmap) {
     TQueryOptions queryOptions = runtime_state->query_options();
     try {
@@ -479,7 +466,7 @@ Status FullTextIndexReader::match_all_index_search(
     return Status::OK();
 }
 
-void FullTextIndexReader::check_null_bitmap(const IndexSearcherPtr& index_searcher,
+void FullTextIndexReader::check_null_bitmap(const FulltextIndexSearcherPtr& index_searcher,
                                             bool& null_bitmap_already_read) {
     // try to reuse index_searcher's directory to read null_bitmap to cache
     // to avoid open directory additionally for null_bitmap
@@ -580,81 +567,66 @@ Status StringTypeInvertedIndexReader::query(OlapReaderStatistics* stats,
 
     roaring::Roaring result;
     InvertedIndexCacheHandle inverted_index_cache_handle;
-    static_cast<void>(InvertedIndexSearcherCache::instance()->get_index_searcher(
-            _fs, index_dir.c_str(), index_file_name, &inverted_index_cache_handle, stats));
-    auto index_searcher = inverted_index_cache_handle.get_index_searcher();
+    RETURN_IF_ERROR(InvertedIndexSearcherCache::instance()->get_index_searcher(
+            _fs, _index_dir.c_str(), _index_file_name, &inverted_index_cache_handle, stats, type(),
+            _has_null));
+    auto searcher_variant = inverted_index_cache_handle.get_index_searcher();
+    if (FulltextIndexSearcherPtr* index_searcher =
+                std::get_if<FulltextIndexSearcherPtr>(&searcher_variant)) {
+        // try to reuse index_searcher's directory to read null_bitmap to cache
+        // to avoid open directory additionally for null_bitmap
+        InvertedIndexQueryCacheHandle null_bitmap_cache_handle;
+        static_cast<void>(read_null_bitmap(&null_bitmap_cache_handle,
+                                           (*index_searcher)->getReader()->directory()));
 
-    // try to reuse index_searcher's directory to read null_bitmap to cache
-    // to avoid open directory additionally for null_bitmap
-    InvertedIndexQueryCacheHandle null_bitmap_cache_handle;
-    static_cast<void>(
-            read_null_bitmap(&null_bitmap_cache_handle, index_searcher->getReader()->directory()));
+        try {
+            if (query_type == InvertedIndexQueryType::MATCH_ANY_QUERY ||
+                query_type == InvertedIndexQueryType::MATCH_ALL_QUERY ||
+                query_type == InvertedIndexQueryType::EQUAL_QUERY) {
+                SCOPED_RAW_TIMER(&stats->inverted_index_searcher_search_timer);
+                (*index_searcher)->_search(query.get(), [&result](DocRange* doc_range) {
+                    if (doc_range->type_ == DocRangeType::kMany) {
+                        result.addMany(doc_range->doc_many_size_, doc_range->doc_many->data());
+                    } else {
+                        result.addRange(doc_range->doc_range.first, doc_range->doc_range.second);
+                    }
+                });
+            } else {
+                SCOPED_RAW_TIMER(&stats->inverted_index_searcher_search_timer);
+                (*index_searcher)
+                        ->_search(query.get(),
+                                  [&result](const int32_t docid, const float_t /*score*/) {
+                                      // docid equal to rowid in segment
+                                      result.add(docid);
+                                  });
+            }
+        } catch (const CLuceneError& e) {
+            if (_is_range_query(query_type) && e.number() == CL_ERR_TooManyClauses) {
+                return Status::Error<ErrorCode::INVERTED_INDEX_BYPASS>(
+                        "range query term exceeds limits, try to downgrade from inverted index, "
+                        "column "
+                        "name:{}, search_str:{}",
+                        column_name, search_str);
+            } else {
+                return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
+                        "CLuceneError occured, error msg: {}, column name: {}, search_str: {}",
+                        e.what(), column_name, search_str);
+            }
+        }
 
-    try {
-        if (query_type == InvertedIndexQueryType::MATCH_ANY_QUERY ||
-            query_type == InvertedIndexQueryType::MATCH_ALL_QUERY ||
-            query_type == InvertedIndexQueryType::EQUAL_QUERY) {
-            SCOPED_RAW_TIMER(&stats->inverted_index_searcher_search_timer);
-            index_searcher->_search(query.get(), [&result](DocRange* doc_range) {
-                if (doc_range->type_ == DocRangeType::kMany) {
-                    result.addMany(doc_range->doc_many_size_, doc_range->doc_many->data());
-                } else {
-                    result.addRange(doc_range->doc_range.first, doc_range->doc_range.second);
-                }
-            });
-        } else {
-            SCOPED_RAW_TIMER(&stats->inverted_index_searcher_search_timer);
-            index_searcher->_search(query.get(),
-                                    [&result](const int32_t docid, const float_t /*score*/) {
-                                        // docid equal to rowid in segment
-                                        result.add(docid);
-                                    });
-        }
-    } catch (const CLuceneError& e) {
-        if (_is_range_query(query_type) && e.number() == CL_ERR_TooManyClauses) {
-            return Status::Error<ErrorCode::INVERTED_INDEX_BYPASS>(
-                    "range query term exceeds limits, try to downgrade from inverted index, column "
-                    "name:{}, search_str:{}",
-                    column_name, search_str);
-        } else {
-            return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
-                    "CLuceneError occured, error msg: {}, column name: {}, search_str: {}",
-                    e.what(), column_name, search_str);
-        }
+        // add to cache
+        std::shared_ptr<roaring::Roaring> term_match_bitmap =
+                std::make_shared<roaring::Roaring>(result);
+        term_match_bitmap->runOptimize();
+        cache->insert(cache_key, term_match_bitmap, &cache_handle);
+
+        bit_map->swap(result);
     }
-
-    // add to cache
-    std::shared_ptr<roaring::Roaring> term_match_bitmap =
-            std::make_shared<roaring::Roaring>(result);
-    term_match_bitmap->runOptimize();
-    cache->insert(cache_key, term_match_bitmap, &cache_handle);
-
-    bit_map->swap(result);
     return Status::OK();
 }
 
 InvertedIndexReaderType StringTypeInvertedIndexReader::type() {
     return InvertedIndexReaderType::STRING_TYPE;
-}
-
-BkdIndexReader::BkdIndexReader(io::FileSystemSPtr fs, const std::string& path,
-                               const TabletIndex* index_meta)
-        : InvertedIndexReader(fs, path, index_meta), _compoundReader(nullptr) {
-    io::Path io_path(_path);
-    auto index_dir = io_path.parent_path();
-    auto index_file_name = InvertedIndexDescriptor::get_index_file_name(
-            io_path.filename(), index_meta->index_id(), index_meta->get_index_suffix());
-
-    // check index file existence
-    auto index_file = index_dir / index_file_name;
-    if (!indexExists(index_file)) {
-        LOG(WARNING) << "bkd index: " << index_file.string() << " not exist.";
-        return;
-    }
-    _file_full_path = index_file;
-    _compoundReader = std::make_unique<DorisCompoundReader>(
-            DorisCompoundDirectory::getDirectory(fs, index_dir.c_str()), index_file_name.c_str(),
-            config::inverted_index_read_buffer_size);
 }
 
 Status BkdIndexReader::new_iterator(OlapReaderStatistics* stats, RuntimeState* runtime_state,
@@ -663,32 +635,26 @@ Status BkdIndexReader::new_iterator(OlapReaderStatistics* stats, RuntimeState* r
     return Status::OK();
 }
 
+template <InvertedIndexQueryType QT>
 Status BkdIndexReader::bkd_query(OlapReaderStatistics* stats, const std::string& column_name,
-                                 const void* query_value, InvertedIndexQueryType query_type,
+                                 const void* query_value,
                                  std::shared_ptr<lucene::util::bkd::bkd_reader> r,
-                                 InvertedIndexVisitor* visitor) {
+                                 InvertedIndexVisitor<QT>* visitor) {
     char tmp[r->bytes_per_dim_];
-    switch (query_type) {
-    case InvertedIndexQueryType::EQUAL_QUERY: {
+    if constexpr (QT == InvertedIndexQueryType::EQUAL_QUERY) {
         _value_key_coder->full_encode_ascending(query_value, &visitor->query_max);
         _value_key_coder->full_encode_ascending(query_value, &visitor->query_min);
-        break;
-    }
-    case InvertedIndexQueryType::LESS_THAN_QUERY:
-    case InvertedIndexQueryType::LESS_EQUAL_QUERY: {
+    } else if constexpr (QT == InvertedIndexQueryType::LESS_THAN_QUERY ||
+                         QT == InvertedIndexQueryType::LESS_EQUAL_QUERY) {
         _value_key_coder->full_encode_ascending(query_value, &visitor->query_max);
         _type_info->set_to_min(tmp);
         _value_key_coder->full_encode_ascending(tmp, &visitor->query_min);
-        break;
-    }
-    case InvertedIndexQueryType::GREATER_THAN_QUERY:
-    case InvertedIndexQueryType::GREATER_EQUAL_QUERY: {
+    } else if constexpr (QT == InvertedIndexQueryType::GREATER_THAN_QUERY ||
+                         QT == InvertedIndexQueryType::GREATER_EQUAL_QUERY) {
         _value_key_coder->full_encode_ascending(query_value, &visitor->query_min);
         _type_info->set_to_max(tmp);
         _value_key_coder->full_encode_ascending(tmp, &visitor->query_max);
-        break;
-    }
-    default:
+    } else {
         return Status::Error<ErrorCode::INVERTED_INDEX_NOT_SUPPORTED>(
                 "invalid query type when query bkd index");
     }
@@ -696,35 +662,133 @@ Status BkdIndexReader::bkd_query(OlapReaderStatistics* stats, const std::string&
     return Status::OK();
 }
 
+Status BkdIndexReader::invoke_bkd_try_query(OlapReaderStatistics* stats,
+                                            const std::string& column_name, const void* query_value,
+                                            InvertedIndexQueryType query_type,
+                                            std::shared_ptr<lucene::util::bkd::bkd_reader> r,
+                                            uint32_t* count) {
+    switch (query_type) {
+    case InvertedIndexQueryType::LESS_THAN_QUERY: {
+        auto visitor =
+                std::make_unique<InvertedIndexVisitor<InvertedIndexQueryType::LESS_THAN_QUERY>>(
+                        nullptr, true);
+        RETURN_IF_ERROR(bkd_query(stats, column_name, query_value, r, visitor.get()));
+        *count = r->estimate_point_count(visitor.get());
+        break;
+    }
+    case InvertedIndexQueryType::LESS_EQUAL_QUERY: {
+        auto visitor =
+                std::make_unique<InvertedIndexVisitor<InvertedIndexQueryType::LESS_EQUAL_QUERY>>(
+                        nullptr, true);
+        RETURN_IF_ERROR(bkd_query(stats, column_name, query_value, r, visitor.get()));
+        *count = r->estimate_point_count(visitor.get());
+        break;
+    }
+    case InvertedIndexQueryType::GREATER_THAN_QUERY: {
+        auto visitor =
+                std::make_unique<InvertedIndexVisitor<InvertedIndexQueryType::GREATER_THAN_QUERY>>(
+                        nullptr, true);
+        RETURN_IF_ERROR(bkd_query(stats, column_name, query_value, r, visitor.get()));
+        *count = r->estimate_point_count(visitor.get());
+        break;
+    }
+    case InvertedIndexQueryType::GREATER_EQUAL_QUERY: {
+        auto visitor =
+                std::make_unique<InvertedIndexVisitor<InvertedIndexQueryType::GREATER_EQUAL_QUERY>>(
+                        nullptr, true);
+        RETURN_IF_ERROR(bkd_query(stats, column_name, query_value, r, visitor.get()));
+        *count = r->estimate_point_count(visitor.get());
+        break;
+    }
+    case InvertedIndexQueryType::EQUAL_QUERY: {
+        auto visitor = std::make_unique<InvertedIndexVisitor<InvertedIndexQueryType::EQUAL_QUERY>>(
+                nullptr, true);
+        RETURN_IF_ERROR(bkd_query(stats, column_name, query_value, r, visitor.get()));
+        *count = r->estimate_point_count(visitor.get());
+        break;
+    }
+    default:
+        return Status::Error<ErrorCode::INVERTED_INDEX_NOT_SUPPORTED>("Invalid query type");
+    }
+    return Status::OK();
+}
+
+Status BkdIndexReader::invoke_bkd_query(OlapReaderStatistics* stats, const std::string& column_name,
+                                        const void* query_value, InvertedIndexQueryType query_type,
+                                        std::shared_ptr<lucene::util::bkd::bkd_reader> r,
+                                        roaring::Roaring* bit_map) {
+    switch (query_type) {
+    case InvertedIndexQueryType::LESS_THAN_QUERY: {
+        auto visitor =
+                std::make_unique<InvertedIndexVisitor<InvertedIndexQueryType::LESS_THAN_QUERY>>(
+                        bit_map);
+        RETURN_IF_ERROR(bkd_query(stats, column_name, query_value, r, visitor.get()));
+        r->intersect(visitor.get());
+        break;
+    }
+    case InvertedIndexQueryType::LESS_EQUAL_QUERY: {
+        auto visitor =
+                std::make_unique<InvertedIndexVisitor<InvertedIndexQueryType::LESS_EQUAL_QUERY>>(
+                        bit_map);
+        RETURN_IF_ERROR(bkd_query(stats, column_name, query_value, r, visitor.get()));
+        r->intersect(visitor.get());
+        break;
+    }
+    case InvertedIndexQueryType::GREATER_THAN_QUERY: {
+        auto visitor =
+                std::make_unique<InvertedIndexVisitor<InvertedIndexQueryType::GREATER_THAN_QUERY>>(
+                        bit_map);
+        RETURN_IF_ERROR(bkd_query(stats, column_name, query_value, r, visitor.get()));
+        r->intersect(visitor.get());
+        break;
+    }
+    case InvertedIndexQueryType::GREATER_EQUAL_QUERY: {
+        auto visitor =
+                std::make_unique<InvertedIndexVisitor<InvertedIndexQueryType::GREATER_EQUAL_QUERY>>(
+                        bit_map);
+        RETURN_IF_ERROR(bkd_query(stats, column_name, query_value, r, visitor.get()));
+        r->intersect(visitor.get());
+        break;
+    }
+    case InvertedIndexQueryType::EQUAL_QUERY: {
+        auto visitor = std::make_unique<InvertedIndexVisitor<InvertedIndexQueryType::EQUAL_QUERY>>(
+                bit_map);
+        RETURN_IF_ERROR(bkd_query(stats, column_name, query_value, r, visitor.get()));
+        r->intersect(visitor.get());
+        break;
+    }
+    default:
+        return Status::Error<ErrorCode::INVERTED_INDEX_NOT_SUPPORTED>("Invalid query type");
+    }
+    return Status::OK();
+}
+
 Status BkdIndexReader::try_query(OlapReaderStatistics* stats, const std::string& column_name,
                                  const void* query_value, InvertedIndexQueryType query_type,
                                  uint32_t* count) {
-    auto visitor = std::make_unique<InvertedIndexVisitor>(nullptr, query_type, true);
-    std::shared_ptr<lucene::util::bkd::bkd_reader> r;
-    RETURN_IF_ERROR(get_bkd_reader(&r));
-    std::string query_str;
-    _value_key_coder->full_encode_ascending(query_value, &query_str);
-
-    InvertedIndexQueryCache::CacheKey cache_key {_file_full_path, column_name, query_type,
-                                                 query_str};
-    auto cache = InvertedIndexQueryCache::instance();
-    InvertedIndexQueryCacheHandle cache_handler;
-    roaring::Roaring bit_map;
-    auto cache_status = handle_cache(cache, cache_key, &cache_handler, stats, &bit_map);
-    if (cache_status.ok()) {
-        *count = bit_map.cardinality();
-        return Status::OK();
-    }
     try {
-        auto st = bkd_query(stats, column_name, query_value, query_type, r, visitor.get());
+        std::shared_ptr<lucene::util::bkd::bkd_reader> r;
+        auto st = get_bkd_reader(r, stats);
         if (!st.ok()) {
-            if (st.code() == ErrorCode::END_OF_FILE) {
-                return Status::OK();
-            }
-            LOG(WARNING) << "bkd_query for column " << column_name << " failed: " << st;
+            LOG(WARNING) << "get bkd reader for  " << _index_dir / _index_file_name
+                         << " failed: " << st;
             return st;
         }
-        *count = r->estimate_point_count(visitor.get());
+        std::string query_str;
+        _value_key_coder->full_encode_ascending(query_value, &query_str);
+
+        InvertedIndexQueryCache::CacheKey cache_key {_index_dir / _index_file_name, column_name,
+                                                     query_type, query_str};
+        auto* cache = InvertedIndexQueryCache::instance();
+        InvertedIndexQueryCacheHandle cache_handler;
+        roaring::Roaring bit_map;
+        auto cache_status = handle_cache(cache, cache_key, &cache_handler, stats, &bit_map);
+        if (cache_status.ok()) {
+            *count = bit_map.cardinality();
+            return Status::OK();
+        }
+
+        return invoke_bkd_try_query(stats, column_name, query_value, query_type, r, count);
     } catch (const CLuceneError& e) {
         return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
                 "BKD Query CLuceneError Occurred, error msg: {}", e.what());
@@ -754,150 +818,164 @@ Status BkdIndexReader::query(OlapReaderStatistics* stats, RuntimeState* runtime_
                              InvertedIndexQueryType query_type, roaring::Roaring* bit_map) {
     SCOPED_RAW_TIMER(&stats->inverted_index_query_timer);
 
-    auto visitor = std::make_unique<InvertedIndexVisitor>(bit_map, query_type);
-    std::shared_ptr<lucene::util::bkd::bkd_reader> r;
-    RETURN_IF_ERROR(get_bkd_reader(&r));
-
-    std::string query_str;
-    _value_key_coder->full_encode_ascending(query_value, &query_str);
-
-    InvertedIndexQueryCache::CacheKey cache_key {_file_full_path, column_name, query_type,
-                                                 query_str};
-    auto cache = InvertedIndexQueryCache::instance();
-    InvertedIndexQueryCacheHandle cache_handler;
-    auto cache_status = handle_cache(cache, cache_key, &cache_handler, stats, bit_map);
-    if (cache_status.ok()) {
-        return Status::OK();
-    }
-
     try {
-        auto st = bkd_query(stats, column_name, query_value, query_type, r, visitor.get());
+        std::shared_ptr<lucene::util::bkd::bkd_reader> r;
+        auto st = get_bkd_reader(r, stats);
         if (!st.ok()) {
-            if (st.code() == ErrorCode::END_OF_FILE) {
-                return Status::OK();
-            }
-            LOG(WARNING) << "bkd_query for column " << column_name << " failed: " << st;
+            LOG(WARNING) << "get bkd reader for  " << _index_dir / _index_file_name
+                         << " failed: " << st;
             return st;
         }
-        r->intersect(visitor.get());
+        std::string query_str;
+        _value_key_coder->full_encode_ascending(query_value, &query_str);
+
+        InvertedIndexQueryCache::CacheKey cache_key {_index_dir / _index_file_name, column_name,
+                                                     query_type, query_str};
+        auto cache = InvertedIndexQueryCache::instance();
+        InvertedIndexQueryCacheHandle cache_handler;
+        auto cache_status = handle_cache(cache, cache_key, &cache_handler, stats, bit_map);
+        if (cache_status.ok()) {
+            return Status::OK();
+        }
+
+        RETURN_IF_ERROR(invoke_bkd_query(stats, column_name, query_value, query_type, r, bit_map));
+        std::shared_ptr<roaring::Roaring> query_bitmap =
+                std::make_shared<roaring::Roaring>(*bit_map);
+        query_bitmap->runOptimize();
+        cache->insert(cache_key, query_bitmap, &cache_handler);
+
+        VLOG_DEBUG << "BKD index search column: " << column_name
+                   << " result: " << bit_map->cardinality();
+
+        return Status::OK();
     } catch (const CLuceneError& e) {
         return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
                 "BKD Query CLuceneError Occurred, error msg: {}", e.what());
     }
-
-    std::shared_ptr<roaring::Roaring> query_bitmap = std::make_shared<roaring::Roaring>(*bit_map);
-    query_bitmap->runOptimize();
-    cache->insert(cache_key, query_bitmap, &cache_handler);
-
-    VLOG_DEBUG << "BKD index search column: " << column_name
-               << " result: " << bit_map->cardinality();
-
-    return Status::OK();
 }
 
-Status BkdIndexReader::get_bkd_reader(std::shared_ptr<lucene::util::bkd::bkd_reader>* bkdReader) {
-    // bkd file reader
-    if (_compoundReader == nullptr) {
-        return Status::Error<ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND>(
-                "bkd index input file not found");
+Status BkdIndexReader::get_bkd_reader(BKDIndexSearcherPtr& bkd_reader,
+                                      OlapReaderStatistics* stats) {
+    InvertedIndexCacheHandle inverted_index_cache_handle;
+    RETURN_IF_ERROR(InvertedIndexSearcherCache::instance()->get_index_searcher(
+            _fs, _index_dir.c_str(), _index_file_name, &inverted_index_cache_handle, stats, type(),
+            _has_null));
+    auto searcher_variant = inverted_index_cache_handle.get_index_searcher();
+    auto* bkd_searcher = std::get_if<BKDIndexSearcherPtr>(&searcher_variant);
+    if (bkd_searcher) {
+        _type_info = get_scalar_type_info((FieldType)(*bkd_searcher)->type);
+        if (_type_info == nullptr) {
+            return Status::Error<ErrorCode::INVERTED_INDEX_NOT_SUPPORTED>(
+                    "unsupported typeinfo, type={}", (*bkd_searcher)->type);
+        }
+        _value_key_coder = get_key_coder(_type_info->type());
+        bkd_reader = *bkd_searcher;
+        if (bkd_reader->bytes_per_dim_ == 0) {
+            bkd_reader->bytes_per_dim_ = _type_info->size();
+        }
+        return Status::OK();
     }
-    CLuceneError err;
-    std::unique_ptr<lucene::store::IndexInput> data_in;
-    std::unique_ptr<lucene::store::IndexInput> meta_in;
-    std::unique_ptr<lucene::store::IndexInput> index_in;
-
-    if (!_compoundReader->openInput(
-                InvertedIndexDescriptor::get_temporary_bkd_index_data_file_name().c_str(), data_in,
-                err) ||
-        !_compoundReader->openInput(
-                InvertedIndexDescriptor::get_temporary_bkd_index_meta_file_name().c_str(), meta_in,
-                err) ||
-        !_compoundReader->openInput(
-                InvertedIndexDescriptor::get_temporary_bkd_index_file_name().c_str(), index_in,
-                err)) {
-        return Status::Error<ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND>("bkd index input error: {}",
-                                                                       err.what());
-    }
-
-    *bkdReader = std::make_shared<lucene::util::bkd::bkd_reader>(data_in.release());
-    if (0 == (*bkdReader)->read_meta(meta_in.get())) {
-        VLOG_NOTICE << "bkd index file is empty:" << _compoundReader->toString();
-        return Status::EndOfFile("bkd index file is empty");
-    }
-
-    (*bkdReader)->read_index(index_in.get());
-
-    _type_info = get_scalar_type_info((FieldType)(*bkdReader)->type);
-    if (_type_info == nullptr) {
-        return Status::Error<ErrorCode::INVERTED_INDEX_NOT_SUPPORTED>(
-                "unsupported typeinfo, type={}", (*bkdReader)->type);
-    }
-    _value_key_coder = get_key_coder(_type_info->type());
-    return Status::OK();
+    return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
+            "get bkd reader from searcher cache builder error");
 }
 
 InvertedIndexReaderType BkdIndexReader::type() {
     return InvertedIndexReaderType::BKD;
 }
 
-InvertedIndexVisitor::InvertedIndexVisitor(roaring::Roaring* h, InvertedIndexQueryType query_type,
-                                           bool only_count)
-        : _hits(h), _num_hits(0), _only_count(only_count), _query_type(query_type) {}
+template <InvertedIndexQueryType QT>
+InvertedIndexVisitor<QT>::InvertedIndexVisitor(roaring::Roaring* h, bool only_count)
+        : _hits(h), _num_hits(0), _only_count(only_count) {}
 
-bool InvertedIndexVisitor::matches(uint8_t* packed_value) {
+template <InvertedIndexQueryType QT>
+int InvertedIndexVisitor<QT>::matches(uint8_t* packed_value) {
     for (int dim = 0; dim < _reader->num_data_dims_; dim++) {
         int offset = dim * _reader->bytes_per_dim_;
-        if (_query_type == InvertedIndexQueryType::LESS_THAN_QUERY) {
-            if (lucene::util::FutureArrays::CompareUnsigned(
-                        packed_value, offset, offset + _reader->bytes_per_dim_,
-                        (const uint8_t*)query_max.c_str(), offset,
-                        offset + _reader->bytes_per_dim_) >= 0) {
-                // Doc's value is too high, in this dimension
-                return false;
-            }
-        } else if (_query_type == InvertedIndexQueryType::GREATER_THAN_QUERY) {
-            if (lucene::util::FutureArrays::CompareUnsigned(
-                        packed_value, offset, offset + _reader->bytes_per_dim_,
-                        (const uint8_t*)query_min.c_str(), offset,
-                        offset + _reader->bytes_per_dim_) <= 0) {
-                // Doc's value is too high, in this dimension
-                return false;
-            }
-        } else {
-            if (lucene::util::FutureArrays::CompareUnsigned(
-                        packed_value, offset, offset + _reader->bytes_per_dim_,
-                        (const uint8_t*)query_min.c_str(), offset,
-                        offset + _reader->bytes_per_dim_) < 0) {
-                // Doc's value is too low, in this dimension
-                return false;
-            }
-            if (lucene::util::FutureArrays::CompareUnsigned(
-                        packed_value, offset, offset + _reader->bytes_per_dim_,
-                        (const uint8_t*)query_max.c_str(), offset,
-                        offset + _reader->bytes_per_dim_) > 0) {
-                // Doc's value is too high, in this dimension
-                return false;
-            }
+        auto result = lucene::util::FutureArrays::CompareUnsigned(
+                packed_value, offset, offset + _reader->bytes_per_dim_,
+                (const uint8_t*)query_min.c_str(), offset, offset + _reader->bytes_per_dim_);
+        if (result < 0) {
+            return result;
+        }
+        result = lucene::util::FutureArrays::CompareUnsigned(
+                packed_value, offset, offset + _reader->bytes_per_dim_,
+                (const uint8_t*)query_max.c_str(), offset, offset + _reader->bytes_per_dim_);
+        if (result > 0) {
+            return result;
         }
     }
-    return true;
+    return 0;
 }
 
-void InvertedIndexVisitor::visit(std::vector<char>& doc_id, std::vector<uint8_t>& packed_value) {
-    if (!matches(packed_value.data())) {
+template <>
+int InvertedIndexVisitor<InvertedIndexQueryType::EQUAL_QUERY>::matches(uint8_t* packed_value) {
+    // if query type is equal, query_min == query_max
+    if (_reader->num_data_dims_ == 1) {
+        return std::memcmp(packed_value, (const uint8_t*)query_min.c_str(),
+                           _reader->bytes_per_dim_);
+    } else {
+        for (int dim = 0; dim < _reader->num_data_dims_; dim++) {
+            int offset = dim * _reader->bytes_per_dim_;
+            auto result = lucene::util::FutureArrays::CompareUnsigned(
+                    packed_value, offset, offset + _reader->bytes_per_dim_,
+                    (const uint8_t*)query_min.c_str(), offset, offset + _reader->bytes_per_dim_);
+            if (result != 0) {
+                return result;
+            }
+        }
+        return 0;
+    }
+}
+
+template <>
+int InvertedIndexVisitor<InvertedIndexQueryType::LESS_THAN_QUERY>::matches(uint8_t* packed_value) {
+    for (int dim = 0; dim < _reader->num_data_dims_; dim++) {
+        int offset = dim * _reader->bytes_per_dim_;
+        auto result = lucene::util::FutureArrays::CompareUnsigned(
+                packed_value, offset, offset + _reader->bytes_per_dim_,
+                (const uint8_t*)query_max.c_str(), offset, offset + _reader->bytes_per_dim_);
+        if (result >= 0) {
+            // we can't return result here, because if result == 0, we also need to return -1.
+            return 1;
+        }
+    }
+    return 0;
+}
+
+template <>
+int InvertedIndexVisitor<InvertedIndexQueryType::GREATER_THAN_QUERY>::matches(
+        uint8_t* packed_value) {
+    for (int dim = 0; dim < _reader->num_data_dims_; dim++) {
+        int offset = dim * _reader->bytes_per_dim_;
+        auto result = lucene::util::FutureArrays::CompareUnsigned(
+                packed_value, offset, offset + _reader->bytes_per_dim_,
+                (const uint8_t*)query_min.c_str(), offset, offset + _reader->bytes_per_dim_);
+        if (result <= 0) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+template <InvertedIndexQueryType QT>
+void InvertedIndexVisitor<QT>::visit(std::vector<char>& doc_id,
+                                     std::vector<uint8_t>& packed_value) {
+    if (matches(packed_value.data()) != 0) {
         return;
     }
     visit(roaring::Roaring::read(doc_id.data(), false));
 }
 
-void InvertedIndexVisitor::visit(roaring::Roaring* doc_id, std::vector<uint8_t>& packed_value) {
-    if (!matches(packed_value.data())) {
+template <InvertedIndexQueryType QT>
+void InvertedIndexVisitor<QT>::visit(roaring::Roaring* doc_id, std::vector<uint8_t>& packed_value) {
+    if (matches(packed_value.data()) != 0) {
         return;
     }
     visit(*doc_id);
 }
 
-void InvertedIndexVisitor::visit(roaring::Roaring&& r) {
+template <InvertedIndexQueryType QT>
+void InvertedIndexVisitor<QT>::visit(roaring::Roaring&& r) {
     if (_only_count) {
         _num_hits += r.cardinality();
     } else {
@@ -905,7 +983,8 @@ void InvertedIndexVisitor::visit(roaring::Roaring&& r) {
     }
 }
 
-void InvertedIndexVisitor::visit(roaring::Roaring& r) {
+template <InvertedIndexQueryType QT>
+void InvertedIndexVisitor<QT>::visit(roaring::Roaring& r) {
     if (_only_count) {
         _num_hits += r.cardinality();
     } else {
@@ -913,7 +992,8 @@ void InvertedIndexVisitor::visit(roaring::Roaring& r) {
     }
 }
 
-void InvertedIndexVisitor::visit(int row_id) {
+template <InvertedIndexQueryType QT>
+void InvertedIndexVisitor<QT>::visit(int row_id) {
     if (_only_count) {
         _num_hits++;
     } else {
@@ -921,9 +1001,10 @@ void InvertedIndexVisitor::visit(int row_id) {
     }
 }
 
-void InvertedIndexVisitor::visit(lucene::util::bkd::bkd_docid_set_iterator* iter,
-                                 std::vector<uint8_t>& packed_value) {
-    if (!matches(packed_value.data())) {
+template <InvertedIndexQueryType QT>
+void InvertedIndexVisitor<QT>::visit(lucene::util::bkd::bkd_docid_set_iterator* iter,
+                                     std::vector<uint8_t>& packed_value) {
+    if (matches(packed_value.data()) != 0) {
         return;
     }
     int32_t doc_id = iter->docid_set->nextDoc();
@@ -937,69 +1018,122 @@ void InvertedIndexVisitor::visit(lucene::util::bkd::bkd_docid_set_iterator* iter
     }
 }
 
-void InvertedIndexVisitor::visit(int row_id, std::vector<uint8_t>& packed_value) {
-    if (matches(packed_value.data())) {
-        if (_only_count) {
-            _num_hits++;
-        } else {
-            _hits->add(row_id);
+template <InvertedIndexQueryType QT>
+int InvertedIndexVisitor<QT>::visit(int row_id, std::vector<uint8_t>& packed_value) {
+    auto result = matches(packed_value.data());
+    if (result != 0) {
+        return result;
+    }
+    if (_only_count) {
+        _num_hits++;
+    } else {
+        _hits->add(row_id);
+    }
+    return 0;
+}
+
+template <>
+lucene::util::bkd::relation InvertedIndexVisitor<InvertedIndexQueryType::LESS_THAN_QUERY>::compare(
+        std::vector<uint8_t>& min_packed, std::vector<uint8_t>& max_packed) {
+    bool crosses = false;
+    for (int dim = 0; dim < _reader->num_data_dims_; dim++) {
+        int offset = dim * _reader->bytes_per_dim_;
+        if (lucene::util::FutureArrays::CompareUnsigned(min_packed.data(), offset,
+                                                        offset + _reader->bytes_per_dim_,
+                                                        (const uint8_t*)query_max.c_str(), offset,
+                                                        offset + _reader->bytes_per_dim_) >= 0) {
+            return lucene::util::bkd::relation::CELL_OUTSIDE_QUERY;
         }
+        crosses |= lucene::util::FutureArrays::CompareUnsigned(
+                           min_packed.data(), offset, offset + _reader->bytes_per_dim_,
+                           (const uint8_t*)query_min.c_str(), offset,
+                           offset + _reader->bytes_per_dim_) <= 0 ||
+                   lucene::util::FutureArrays::CompareUnsigned(
+                           max_packed.data(), offset, offset + _reader->bytes_per_dim_,
+                           (const uint8_t*)query_max.c_str(), offset,
+                           offset + _reader->bytes_per_dim_) >= 0;
+    }
+    if (crosses) {
+        return lucene::util::bkd::relation::CELL_CROSSES_QUERY;
+    } else {
+        return lucene::util::bkd::relation::CELL_INSIDE_QUERY;
     }
 }
 
-lucene::util::bkd::relation InvertedIndexVisitor::compare(std::vector<uint8_t>& min_packed,
-                                                          std::vector<uint8_t>& max_packed) {
+template <>
+lucene::util::bkd::relation
+InvertedIndexVisitor<InvertedIndexQueryType::GREATER_THAN_QUERY>::compare(
+        std::vector<uint8_t>& min_packed, std::vector<uint8_t>& max_packed) {
     bool crosses = false;
-
     for (int dim = 0; dim < _reader->num_data_dims_; dim++) {
         int offset = dim * _reader->bytes_per_dim_;
+        if (lucene::util::FutureArrays::CompareUnsigned(max_packed.data(), offset,
+                                                        offset + _reader->bytes_per_dim_,
+                                                        (const uint8_t*)query_min.c_str(), offset,
+                                                        offset + _reader->bytes_per_dim_) <= 0) {
+            return lucene::util::bkd::relation::CELL_OUTSIDE_QUERY;
+        }
+        crosses |= lucene::util::FutureArrays::CompareUnsigned(
+                           min_packed.data(), offset, offset + _reader->bytes_per_dim_,
+                           (const uint8_t*)query_min.c_str(), offset,
+                           offset + _reader->bytes_per_dim_) <= 0 ||
+                   lucene::util::FutureArrays::CompareUnsigned(
+                           max_packed.data(), offset, offset + _reader->bytes_per_dim_,
+                           (const uint8_t*)query_max.c_str(), offset,
+                           offset + _reader->bytes_per_dim_) >= 0;
+    }
+    if (crosses) {
+        return lucene::util::bkd::relation::CELL_CROSSES_QUERY;
+    } else {
+        return lucene::util::bkd::relation::CELL_INSIDE_QUERY;
+    }
+}
 
-        if (_query_type == InvertedIndexQueryType::LESS_THAN_QUERY) {
-            if (lucene::util::FutureArrays::CompareUnsigned(
-                        min_packed.data(), offset, offset + _reader->bytes_per_dim_,
-                        (const uint8_t*)query_max.c_str(), offset,
-                        offset + _reader->bytes_per_dim_) >= 0) {
-                return lucene::util::bkd::relation::CELL_OUTSIDE_QUERY;
-            }
-        } else if (_query_type == InvertedIndexQueryType::GREATER_THAN_QUERY) {
-            if (lucene::util::FutureArrays::CompareUnsigned(
-                        max_packed.data(), offset, offset + _reader->bytes_per_dim_,
-                        (const uint8_t*)query_min.c_str(), offset,
-                        offset + _reader->bytes_per_dim_) <= 0) {
-                return lucene::util::bkd::relation::CELL_OUTSIDE_QUERY;
-            }
-        } else {
-            if (lucene::util::FutureArrays::CompareUnsigned(
-                        min_packed.data(), offset, offset + _reader->bytes_per_dim_,
-                        (const uint8_t*)query_max.c_str(), offset,
-                        offset + _reader->bytes_per_dim_) > 0 ||
-                lucene::util::FutureArrays::CompareUnsigned(
-                        max_packed.data(), offset, offset + _reader->bytes_per_dim_,
-                        (const uint8_t*)query_min.c_str(), offset,
-                        offset + _reader->bytes_per_dim_) < 0) {
-                return lucene::util::bkd::relation::CELL_OUTSIDE_QUERY;
-            }
+template <InvertedIndexQueryType QT>
+lucene::util::bkd::relation InvertedIndexVisitor<QT>::compare_prefix(std::vector<uint8_t>& prefix) {
+    if (lucene::util::FutureArrays::CompareUnsigned(prefix.data(), 0, prefix.size(),
+                                                    (const uint8_t*)query_max.c_str(), 0,
+                                                    prefix.size()) > 0 ||
+        lucene::util::FutureArrays::CompareUnsigned(prefix.data(), 0, prefix.size(),
+                                                    (const uint8_t*)query_min.c_str(), 0,
+                                                    prefix.size()) < 0) {
+        return lucene::util::bkd::relation::CELL_OUTSIDE_QUERY;
+    }
+    if (lucene::util::FutureArrays::CompareUnsigned(prefix.data(), 0, prefix.size(),
+                                                    (const uint8_t*)query_min.c_str(), 0,
+                                                    prefix.size()) > 0 &&
+        lucene::util::FutureArrays::CompareUnsigned(prefix.data(), 0, prefix.size(),
+                                                    (const uint8_t*)query_max.c_str(), 0,
+                                                    prefix.size()) < 0) {
+        return lucene::util::bkd::relation::CELL_INSIDE_QUERY;
+    }
+    return lucene::util::bkd::relation::CELL_CROSSES_QUERY;
+}
+
+template <InvertedIndexQueryType QT>
+lucene::util::bkd::relation InvertedIndexVisitor<QT>::compare(std::vector<uint8_t>& min_packed,
+                                                              std::vector<uint8_t>& max_packed) {
+    bool crosses = false;
+    for (int dim = 0; dim < _reader->num_data_dims_; dim++) {
+        int offset = dim * _reader->bytes_per_dim_;
+        if (lucene::util::FutureArrays::CompareUnsigned(min_packed.data(), offset,
+                                                        offset + _reader->bytes_per_dim_,
+                                                        (const uint8_t*)query_max.c_str(), offset,
+                                                        offset + _reader->bytes_per_dim_) > 0 ||
+            lucene::util::FutureArrays::CompareUnsigned(max_packed.data(), offset,
+                                                        offset + _reader->bytes_per_dim_,
+                                                        (const uint8_t*)query_min.c_str(), offset,
+                                                        offset + _reader->bytes_per_dim_) < 0) {
+            return lucene::util::bkd::relation::CELL_OUTSIDE_QUERY;
         }
-        if (_query_type == InvertedIndexQueryType::LESS_THAN_QUERY ||
-            _query_type == InvertedIndexQueryType::GREATER_THAN_QUERY) {
-            crosses |= lucene::util::FutureArrays::CompareUnsigned(
-                               min_packed.data(), offset, offset + _reader->bytes_per_dim_,
-                               (const uint8_t*)query_min.c_str(), offset,
-                               offset + _reader->bytes_per_dim_) <= 0 ||
-                       lucene::util::FutureArrays::CompareUnsigned(
-                               max_packed.data(), offset, offset + _reader->bytes_per_dim_,
-                               (const uint8_t*)query_max.c_str(), offset,
-                               offset + _reader->bytes_per_dim_) >= 0;
-        } else {
-            crosses |= lucene::util::FutureArrays::CompareUnsigned(
-                               min_packed.data(), offset, offset + _reader->bytes_per_dim_,
-                               (const uint8_t*)query_min.c_str(), offset,
-                               offset + _reader->bytes_per_dim_) < 0 ||
-                       lucene::util::FutureArrays::CompareUnsigned(
-                               max_packed.data(), offset, offset + _reader->bytes_per_dim_,
-                               (const uint8_t*)query_max.c_str(), offset,
-                               offset + _reader->bytes_per_dim_) > 0;
-        }
+        crosses |= lucene::util::FutureArrays::CompareUnsigned(
+                           min_packed.data(), offset, offset + _reader->bytes_per_dim_,
+                           (const uint8_t*)query_min.c_str(), offset,
+                           offset + _reader->bytes_per_dim_) < 0 ||
+                   lucene::util::FutureArrays::CompareUnsigned(
+                           max_packed.data(), offset, offset + _reader->bytes_per_dim_,
+                           (const uint8_t*)query_max.c_str(), offset,
+                           offset + _reader->bytes_per_dim_) > 0;
     }
     if (crosses) {
         return lucene::util::bkd::relation::CELL_CROSSES_QUERY;

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.h
@@ -31,8 +31,21 @@
 #include "olap/inverted_index_parser.h"
 #include "olap/rowset/segment_v2/inverted_index_cache.h"
 #include "olap/rowset/segment_v2/inverted_index_compound_reader.h"
+#include "olap/rowset/segment_v2/inverted_index_desc.h"
 #include "olap/rowset/segment_v2/inverted_index_query_type.h"
 #include "olap/tablet_schema.h"
+#include "util/once.h"
+
+#define FINALIZE_INPUT(x) \
+    if (x != nullptr) {   \
+        x->close();       \
+        _CLDELETE(x);     \
+    }
+#define FINALLY_FINALIZE_INPUT(x) \
+    try {                         \
+        FINALIZE_INPUT(x)         \
+    } catch (...) {               \
+    }
 
 namespace lucene {
 namespace store {
@@ -59,20 +72,16 @@ namespace segment_v2 {
 class InvertedIndexIterator;
 class InvertedIndexQueryCacheHandle;
 
-enum class InvertedIndexReaderType {
-    UNKNOWN = -1,
-    FULLTEXT = 0,
-    STRING_TYPE = 1,
-    BKD = 2,
-};
-
-using IndexSearcherPtr = std::shared_ptr<lucene::search::IndexSearcher>;
-
 class InvertedIndexReader : public std::enable_shared_from_this<InvertedIndexReader> {
 public:
     explicit InvertedIndexReader(io::FileSystemSPtr fs, const std::string& path,
                                  const TabletIndex* index_meta)
-            : _fs(fs), _path(path), _index_meta(*index_meta) {}
+            : _fs(fs), _path(path), _index_meta(*index_meta) {
+        io::Path io_path(_path);
+        _index_dir = io_path.parent_path();
+        _index_file_name = InvertedIndexDescriptor::get_index_file_name(
+                io_path.filename(), index_meta->index_id(), index_meta->get_index_suffix());
+    }
     virtual ~InvertedIndexReader() = default;
 
     // create a new column iterator. Client should delete returned iterator
@@ -97,6 +106,8 @@ public:
         return _index_meta.properties();
     }
 
+    [[nodiscard]] bool has_null() const { return _has_null; }
+
     static std::vector<std::string> get_analyse_result(lucene::util::Reader* reader,
                                                        lucene::analysis::Analyzer* analyzer,
                                                        const std::string& field_name,
@@ -114,6 +125,9 @@ protected:
     io::FileSystemSPtr _fs;
     const std::string& _path;
     TabletIndex _index_meta;
+    std::string _index_file_name;
+    io::Path _index_dir;
+    bool _has_null {true};
 };
 
 class FullTextIndexReader : public InvertedIndexReader {
@@ -141,7 +155,7 @@ public:
 
 private:
     Status normal_index_search(OlapReaderStatistics* stats, InvertedIndexQueryType query_type,
-                               const IndexSearcherPtr& index_searcher,
+                               const FulltextIndexSearcherPtr& index_searcher,
                                bool& null_bitmap_already_read,
                                const std::unique_ptr<lucene::search::Query>& query,
                                const std::shared_ptr<roaring::Roaring>& term_match_bitmap);
@@ -149,10 +163,11 @@ private:
     Status match_all_index_search(OlapReaderStatistics* stats, RuntimeState* runtime_state,
                                   const std::wstring& field_ws,
                                   const std::vector<std::string>& analyse_result,
-                                  const IndexSearcherPtr& index_searcher,
+                                  const FulltextIndexSearcherPtr& index_searcher,
                                   const std::shared_ptr<roaring::Roaring>& term_match_bitmap);
 
-    void check_null_bitmap(const IndexSearcherPtr& index_searcher, bool& null_bitmap_already_read);
+    void check_null_bitmap(const FulltextIndexSearcherPtr& index_searcher,
+                           bool& null_bitmap_already_read);
 };
 
 class StringTypeInvertedIndexReader : public InvertedIndexReader {
@@ -178,21 +193,20 @@ public:
     InvertedIndexReaderType type() override;
 };
 
+template <InvertedIndexQueryType QT>
 class InvertedIndexVisitor : public lucene::util::bkd::bkd_reader::intersect_visitor {
 private:
     roaring::Roaring* _hits = nullptr;
     uint32_t _num_hits;
     bool _only_count;
     lucene::util::bkd::bkd_reader* _reader = nullptr;
-    InvertedIndexQueryType _query_type;
 
 public:
     std::string query_min;
     std::string query_max;
 
 public:
-    InvertedIndexVisitor(roaring::Roaring* hits, InvertedIndexQueryType query_type,
-                         bool only_count = false);
+    InvertedIndexVisitor(roaring::Roaring* hits, bool only_count = false);
     ~InvertedIndexVisitor() override = default;
 
     void set_reader(lucene::util::bkd::bkd_reader* r) { _reader = r; }
@@ -203,38 +217,24 @@ public:
     void visit(roaring::Roaring&& r) override;
     void visit(roaring::Roaring* doc_id, std::vector<uint8_t>& packed_value) override;
     void visit(std::vector<char>& doc_id, std::vector<uint8_t>& packed_value) override;
-    void visit(int row_id, std::vector<uint8_t>& packed_value) override;
+    int visit(int row_id, std::vector<uint8_t>& packed_value) override;
     void visit(lucene::util::bkd::bkd_docid_set_iterator* iter,
                std::vector<uint8_t>& packed_value) override;
-    bool matches(uint8_t* packed_value);
+    int matches(uint8_t* packed_value);
     lucene::util::bkd::relation compare(std::vector<uint8_t>& min_packed,
                                         std::vector<uint8_t>& max_packed) override;
+    lucene::util::bkd::relation compare_prefix(std::vector<uint8_t>& prefix) override;
     uint32_t get_num_hits() const { return _num_hits; }
 };
 
 class BkdIndexReader : public InvertedIndexReader {
     ENABLE_FACTORY_CREATOR(BkdIndexReader);
 
-private:
-    std::string _file_full_path;
-
 public:
     explicit BkdIndexReader(io::FileSystemSPtr fs, const std::string& path,
-                            const TabletIndex* index_meta);
-    ~BkdIndexReader() override {
-        if (_compoundReader != nullptr) {
-            try {
-                _compoundReader->close();
-            } catch (const CLuceneError& e) {
-                // Handle exception, e.g., log it, but don't rethrow.
-                LOG(ERROR) << "Exception caught in BkdIndexReader destructor: " << e.what()
-                           << std::endl;
-            } catch (...) {
-                // Handle all other exceptions, but don't rethrow.
-                LOG(ERROR) << "Unknown exception caught in BkdIndexReader destructor." << std::endl;
-            }
-        }
-    }
+                            const TabletIndex* index_meta)
+            : InvertedIndexReader(fs, path, index_meta) {}
+    ~BkdIndexReader() override = default;
 
     Status new_iterator(OlapReaderStatistics* stats, RuntimeState* runtime_state,
                         std::unique_ptr<InvertedIndexIterator>* iterator) override;
@@ -245,10 +245,17 @@ public:
     Status try_query(OlapReaderStatistics* stats, const std::string& column_name,
                      const void* query_value, InvertedIndexQueryType query_type,
                      uint32_t* count) override;
+    Status invoke_bkd_try_query(OlapReaderStatistics* stats, const std::string& column_name,
+                                const void* query_value, InvertedIndexQueryType query_type,
+                                std::shared_ptr<lucene::util::bkd::bkd_reader> r, uint32_t* count);
+    Status invoke_bkd_query(OlapReaderStatistics* stats, const std::string& column_name,
+                            const void* query_value, InvertedIndexQueryType query_type,
+                            std::shared_ptr<lucene::util::bkd::bkd_reader> r,
+                            roaring::Roaring* bit_map);
+    template <InvertedIndexQueryType QT>
     Status bkd_query(OlapReaderStatistics* stats, const std::string& column_name,
-                     const void* query_value, InvertedIndexQueryType query_type,
-                     std::shared_ptr<lucene::util::bkd::bkd_reader> r,
-                     InvertedIndexVisitor* visitor);
+                     const void* query_value, std::shared_ptr<lucene::util::bkd::bkd_reader> r,
+                     InvertedIndexVisitor<QT>* visitor);
 
     Status handle_cache(InvertedIndexQueryCache* cache,
                         const InvertedIndexQueryCache::CacheKey& cache_key,
@@ -256,12 +263,11 @@ public:
                         roaring::Roaring* bit_map);
 
     InvertedIndexReaderType type() override;
-    Status get_bkd_reader(std::shared_ptr<lucene::util::bkd::bkd_reader>* reader);
+    Status get_bkd_reader(BKDIndexSearcherPtr& reader, OlapReaderStatistics* stats);
 
 private:
     const TypeInfo* _type_info {};
     const KeyCoder* _value_key_coder {};
-    std::unique_ptr<DorisCompoundReader> _compoundReader;
 };
 
 class InvertedIndexIterator {
@@ -274,7 +280,7 @@ public:
 
     Status read_from_inverted_index(const std::string& column_name, const void* query_value,
                                     InvertedIndexQueryType query_type, uint32_t segment_num_rows,
-                                    roaring::Roaring* bit_map, bool skip_try = false);
+                                    roaring::Roaring* bit_map, bool skip_try = true);
     Status try_read_from_inverted_index(const std::string& column_name, const void* query_value,
                                         InvertedIndexQueryType query_type, uint32_t* count);
 
@@ -285,6 +291,7 @@ public:
 
     [[nodiscard]] InvertedIndexReaderType get_inverted_index_reader_type() const;
     [[nodiscard]] const std::map<string, string>& get_index_properties() const;
+    [[nodiscard]] bool has_null() { return _reader->has_null(); };
 
 private:
     OlapReaderStatistics* _stats = nullptr;

--- a/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
@@ -119,8 +119,11 @@ public:
                 auto index_file_name = InvertedIndexDescriptor::get_index_file_name(
                         _segment_file_name, _index_meta->index_id(),
                         _index_meta->get_index_suffix());
-                static_cast<void>(InvertedIndexSearcherCache::instance()->insert(_fs, _directory,
-                                                                                 index_file_name));
+                auto st = InvertedIndexSearcherCache::instance()->insert(
+                        _fs, _directory, index_file_name, InvertedIndexReaderType::FULLTEXT);
+                if (!st.ok()) {
+                    LOG(ERROR) << "insert inverted index searcher cache error:" << st;
+                }
             }
         }
     }
@@ -143,7 +146,6 @@ public:
                 _directory + "/" + _segment_file_name, _index_meta->index_id(),
                 _index_meta->get_index_suffix());
 
-        // LOG(INFO) << "inverted index path: " << index_path;
         bool exists = false;
         auto st = _fs->exists(index_path.c_str(), &exists);
         if (!st.ok()) {
@@ -153,12 +155,7 @@ public:
         }
         if (exists) {
             LOG(ERROR) << "try to init a directory:" << index_path << " already exists";
-            return Status::InternalError("init_fulltext_index a directory already exists");
-            //st = _fs->delete_directory(index_path.c_str());
-            //if (!st.ok()) {
-            //    LOG(ERROR) << "delete directory:" << index_path << " error:" << st;
-            //    return st;
-            //}
+            return Status::InternalError("init_fulltext_index directory already exists");
         }
 
         _char_string_reader = std::make_unique<lucene::util::SStringReader<char>>();

--- a/be/test/olap/rowset/segment_v2/inverted_index_searcher_cache_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index_searcher_cache_test.cpp
@@ -62,20 +62,24 @@ TEST_F(InvertedIndexSearcherCacheTest, insert_lookup) {
 
     //insert searcher
     Status status = Status::OK();
-    status = index_searcher_cache->insert(fs, kTestDir, file_name_1);
+    status = index_searcher_cache->insert(fs, kTestDir, file_name_1,
+                                          InvertedIndexReaderType::FULLTEXT);
     EXPECT_EQ(Status::OK(), status);
 
-    status = index_searcher_cache->insert(fs, kTestDir, file_name_2);
+    status = index_searcher_cache->insert(fs, kTestDir, file_name_2,
+                                          InvertedIndexReaderType::FULLTEXT);
     EXPECT_EQ(Status::OK(), status);
 
     OlapReaderStatistics stats;
+    bool has_null = true;
 
     // lookup after insert
     {
         // case 1: lookup exist entry
         InvertedIndexCacheHandle inverted_index_cache_handle;
-        status = index_searcher_cache->get_index_searcher(fs, kTestDir, file_name_1,
-                                                          &inverted_index_cache_handle, &stats);
+        status = index_searcher_cache->get_index_searcher(
+                fs, kTestDir, file_name_1, &inverted_index_cache_handle, &stats,
+                InvertedIndexReaderType::FULLTEXT, has_null);
         EXPECT_EQ(Status::OK(), status);
 
         auto cache_value_1 =
@@ -83,8 +87,9 @@ TEST_F(InvertedIndexSearcherCacheTest, insert_lookup) {
                         ->value(inverted_index_cache_handle._handle);
         EXPECT_GE(UnixMillis(), cache_value_1->last_visit_time);
 
-        status = index_searcher_cache->get_index_searcher(fs, kTestDir, file_name_2,
-                                                          &inverted_index_cache_handle, &stats);
+        status = index_searcher_cache->get_index_searcher(
+                fs, kTestDir, file_name_2, &inverted_index_cache_handle, &stats,
+                InvertedIndexReaderType::FULLTEXT, has_null);
         EXPECT_EQ(Status::OK(), status);
 
         auto cache_value_2 =
@@ -101,7 +106,8 @@ TEST_F(InvertedIndexSearcherCacheTest, insert_lookup) {
         {
             InvertedIndexCacheHandle inverted_index_cache_handle_1;
             status = index_searcher_cache->get_index_searcher(
-                    fs, kTestDir, file_name_not_exist_1, &inverted_index_cache_handle_1, &stats);
+                    fs, kTestDir, file_name_not_exist_1, &inverted_index_cache_handle_1, &stats,
+                    InvertedIndexReaderType::FULLTEXT, has_null);
             EXPECT_EQ(Status::OK(), status);
             EXPECT_FALSE(inverted_index_cache_handle_1.owned);
         }
@@ -110,7 +116,8 @@ TEST_F(InvertedIndexSearcherCacheTest, insert_lookup) {
         {
             InvertedIndexCacheHandle inverted_index_cache_handle_1;
             status = index_searcher_cache->get_index_searcher(
-                    fs, kTestDir, file_name_not_exist_1, &inverted_index_cache_handle_1, &stats);
+                    fs, kTestDir, file_name_not_exist_1, &inverted_index_cache_handle_1, &stats,
+                    InvertedIndexReaderType::FULLTEXT, has_null);
             EXPECT_EQ(Status::OK(), status);
             EXPECT_FALSE(inverted_index_cache_handle_1.owned);
 
@@ -123,14 +130,16 @@ TEST_F(InvertedIndexSearcherCacheTest, insert_lookup) {
         // not use cache
         InvertedIndexCacheHandle inverted_index_cache_handle_2;
         status = index_searcher_cache->get_index_searcher(
-                fs, kTestDir, file_name_not_exist_2, &inverted_index_cache_handle_2, &stats, false);
+                fs, kTestDir, file_name_not_exist_2, &inverted_index_cache_handle_2, &stats,
+                InvertedIndexReaderType::FULLTEXT, has_null);
         EXPECT_EQ(Status::OK(), status);
         EXPECT_TRUE(inverted_index_cache_handle_2.owned);
         EXPECT_EQ(nullptr, inverted_index_cache_handle_2._cache);
         EXPECT_EQ(nullptr, inverted_index_cache_handle_2._handle);
 
-        status = index_searcher_cache->get_index_searcher(fs, kTestDir, file_name_not_exist_2,
-                                                          &inverted_index_cache_handle_2, &stats);
+        status = index_searcher_cache->get_index_searcher(
+                fs, kTestDir, file_name_not_exist_2, &inverted_index_cache_handle_2, &stats,
+                InvertedIndexReaderType::FULLTEXT, has_null);
         EXPECT_EQ(Status::OK(), status);
         EXPECT_FALSE(inverted_index_cache_handle_2.owned);
         auto cache_value_use_cache_2 =
@@ -150,7 +159,7 @@ TEST_F(InvertedIndexSearcherCacheTest, evict_by_usage) {
     InvertedIndexSearcherCache::CacheKey key_1(file_name_1);
     IndexCacheValuePtr cache_value_1 = std::make_unique<InvertedIndexSearcherCache::CacheValue>();
     cache_value_1->size = 200;
-    cache_value_1->index_searcher = nullptr;
+    //cache_value_1->index_searcher;
     cache_value_1->last_visit_time = 10;
     index_searcher_cache->_cache->release(
             index_searcher_cache->_insert(key_1, cache_value_1.release()));
@@ -160,7 +169,7 @@ TEST_F(InvertedIndexSearcherCacheTest, evict_by_usage) {
     InvertedIndexSearcherCache::CacheKey key_2(file_name_2);
     IndexCacheValuePtr cache_value_2 = std::make_unique<InvertedIndexSearcherCache::CacheValue>();
     cache_value_2->size = 800;
-    cache_value_2->index_searcher = nullptr;
+    //cache_value_2->index_searcher;
     cache_value_2->last_visit_time = 20;
     index_searcher_cache->_cache->release(
             index_searcher_cache->_insert(key_2, cache_value_2.release()));
@@ -177,7 +186,7 @@ TEST_F(InvertedIndexSearcherCacheTest, evict_by_usage) {
     InvertedIndexSearcherCache::CacheKey key_3(file_name_3);
     IndexCacheValuePtr cache_value_3 = std::make_unique<InvertedIndexSearcherCache::CacheValue>();
     cache_value_3->size = 400;
-    cache_value_3->index_searcher = nullptr;
+    //cache_value_3->index_searcher;
     cache_value_3->last_visit_time = 30;
     index_searcher_cache->_cache->release(
             index_searcher_cache->_insert(key_3, cache_value_3.release()));
@@ -194,7 +203,7 @@ TEST_F(InvertedIndexSearcherCacheTest, evict_by_usage) {
     InvertedIndexSearcherCache::CacheKey key_4(file_name_4);
     IndexCacheValuePtr cache_value_4 = std::make_unique<InvertedIndexSearcherCache::CacheValue>();
     cache_value_4->size = 100;
-    cache_value_4->index_searcher = nullptr;
+    //cache_value_4->index_searcher;
     cache_value_4->last_visit_time = 40;
     index_searcher_cache->_cache->release(
             index_searcher_cache->_insert(key_4, cache_value_4.release()));
@@ -217,7 +226,7 @@ TEST_F(InvertedIndexSearcherCacheTest, evict_by_element_count_limit) {
     InvertedIndexSearcherCache::CacheKey key_1(file_name_1);
     IndexCacheValuePtr cache_value_1 = std::make_unique<InvertedIndexSearcherCache::CacheValue>();
     cache_value_1->size = 20;
-    cache_value_1->index_searcher = nullptr;
+    //cache_value_1->index_searcher;
     cache_value_1->last_visit_time = 10;
     index_searcher_cache->_cache->release(
             index_searcher_cache->_insert(key_1, cache_value_1.release()));
@@ -227,7 +236,7 @@ TEST_F(InvertedIndexSearcherCacheTest, evict_by_element_count_limit) {
     InvertedIndexSearcherCache::CacheKey key_2(file_name_2);
     IndexCacheValuePtr cache_value_2 = std::make_unique<InvertedIndexSearcherCache::CacheValue>();
     cache_value_2->size = 50;
-    cache_value_2->index_searcher = nullptr;
+    //cache_value_2->index_searcher;
     cache_value_2->last_visit_time = 20;
     index_searcher_cache->_cache->release(
             index_searcher_cache->_insert(key_2, cache_value_2.release()));
@@ -248,7 +257,7 @@ TEST_F(InvertedIndexSearcherCacheTest, evict_by_element_count_limit) {
     InvertedIndexSearcherCache::CacheKey key_3(file_name_3);
     IndexCacheValuePtr cache_value_3 = std::make_unique<InvertedIndexSearcherCache::CacheValue>();
     cache_value_3->size = 80;
-    cache_value_3->index_searcher = nullptr;
+    //cache_value_3->index_searcher;
     cache_value_3->last_visit_time = 30;
     index_searcher_cache->_cache->release(
             index_searcher_cache->_insert(key_3, cache_value_3.release()));
@@ -275,7 +284,7 @@ TEST_F(InvertedIndexSearcherCacheTest, evict_by_element_count_limit) {
     InvertedIndexSearcherCache::CacheKey key_4(file_name_4);
     IndexCacheValuePtr cache_value_4 = std::make_unique<InvertedIndexSearcherCache::CacheValue>();
     cache_value_4->size = 100;
-    cache_value_4->index_searcher = nullptr;
+    //cache_value_4->index_searcher;
     cache_value_4->last_visit_time = 40;
     index_searcher_cache->_cache->release(
             index_searcher_cache->_insert(key_4, cache_value_4.release()));
@@ -310,7 +319,7 @@ TEST_F(InvertedIndexSearcherCacheTest, remove_element_only_in_table) {
     InvertedIndexSearcherCache::CacheKey key_1(file_name_1);
     IndexCacheValuePtr cache_value_1 = std::make_unique<InvertedIndexSearcherCache::CacheValue>();
     cache_value_1->size = 200;
-    cache_value_1->index_searcher = nullptr;
+    //cache_value_1->index_searcher;
     cache_value_1->last_visit_time = 10;
     index_searcher_cache->_cache->release(
             index_searcher_cache->_insert(key_1, cache_value_1.release()));
@@ -327,7 +336,7 @@ TEST_F(InvertedIndexSearcherCacheTest, remove_element_only_in_table) {
 
         // insert key_2, and then evict {key_1, cache_value_1}
         cache_value_2->size = 800;
-        cache_value_2->index_searcher = nullptr;
+        //cache_value_2->index_searcher;
         cache_value_2->last_visit_time = 20;
         index_searcher_cache->_cache->release(
                 index_searcher_cache->_insert(key_2, cache_value_2.release()));
@@ -347,10 +356,12 @@ TEST_F(InvertedIndexSearcherCacheTest, remove_element_only_in_table) {
 
     // lookup key_2 not exist, then insert into cache, and evict key_1
     OlapReaderStatistics stats;
+    bool has_null = false;
     {
         InvertedIndexCacheHandle inverted_index_cache_handle;
         auto status = index_searcher_cache->get_index_searcher(
-                fs, kTestDir, file_name_2, &inverted_index_cache_handle, &stats);
+                fs, kTestDir, file_name_2, &inverted_index_cache_handle, &stats,
+                InvertedIndexReaderType::FULLTEXT, has_null);
         EXPECT_EQ(Status::OK(), status);
         EXPECT_FALSE(inverted_index_cache_handle.owned);
     }
@@ -358,7 +369,8 @@ TEST_F(InvertedIndexSearcherCacheTest, remove_element_only_in_table) {
     {
         InvertedIndexCacheHandle inverted_index_cache_handle;
         auto status = index_searcher_cache->get_index_searcher(
-                fs, kTestDir, file_name_2, &inverted_index_cache_handle, &stats);
+                fs, kTestDir, file_name_2, &inverted_index_cache_handle, &stats,
+                InvertedIndexReaderType::FULLTEXT, has_null);
         EXPECT_EQ(Status::OK(), status);
         EXPECT_FALSE(inverted_index_cache_handle.owned);
         auto cache_value_use_cache =

--- a/be/test/olap/rowset/segment_v2/inverted_index_searcher_cache_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index_searcher_cache_test.cpp
@@ -131,7 +131,7 @@ TEST_F(InvertedIndexSearcherCacheTest, insert_lookup) {
         InvertedIndexCacheHandle inverted_index_cache_handle_2;
         status = index_searcher_cache->get_index_searcher(
                 fs, kTestDir, file_name_not_exist_2, &inverted_index_cache_handle_2, &stats,
-                InvertedIndexReaderType::FULLTEXT, has_null);
+                InvertedIndexReaderType::FULLTEXT, has_null, false);
         EXPECT_EQ(Status::OK(), status);
         EXPECT_TRUE(inverted_index_cache_handle_2.owned);
         EXPECT_EQ(nullptr, inverted_index_cache_handle_2._cache);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

improve BKD performance by enable bkd reader cache and improvement of fast compare and visit in compressed values in BKD tree.
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

