### PR TITLE
[imporove] there is no space before the semicolon, keep consistent with other sql.

### DIFF
--- a/docs/en/docs/data-table/data-model.md
+++ b/docs/en/docs/data-table/data-model.md
@@ -376,7 +376,7 @@ mysql> select group_concat_merge(k3) from aggstate;
 If you do not want the final aggregation result, you can use 'union' to combine multiple intermediate aggregation results and generate a new intermediate result.
 
 ```sql
-insert into aggstate select 3,sum_union(k2),group_concat_union(k3) from aggstate ;
+insert into aggstate select 3,sum_union(k2),group_concat_union(k3) from aggstate;
 ```
 
 The table's structure at this moment is...

--- a/docs/zh-CN/docs/data-table/data-model.md
+++ b/docs/zh-CN/docs/data-table/data-model.md
@@ -380,7 +380,7 @@ mysql> select group_concat_merge(k3) from aggstate;
 如果不想要聚合的最终结果，可以使用union来合并多个聚合的中间结果，生成一个新的中间结果。
 
 ```sql
-insert into aggstate select 3,sum_union(k2),group_concat_union(k3) from aggstate ;
+insert into aggstate select 3,sum_union(k2),group_concat_union(k3) from aggstate;
 ```
 此时的表结构为
 


### PR DESCRIPTION
There is no space before the semicolon, keep consistent with other sql.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

