### PR TITLE
[feature-wip](arrow-flight)(step6) Support regression test

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -447,6 +447,7 @@ public:
     void to_protobuf(PStatus* status) const;
 
     std::string to_string() const;
+    std::string to_string_no_stack() const;
 
     /// @return A json representation of this status.
     std::string to_json() const;
@@ -516,6 +517,13 @@ inline std::ostream& operator<<(std::ostream& ostr, const Status& status) {
 inline std::string Status::to_string() const {
     std::stringstream ss;
     ss << *this;
+    return ss.str();
+}
+
+inline std::string Status::to_string_no_stack() const {
+    std::stringstream ss;
+    ss << '[' << code_as_string() << ']';
+    ss << msg();
     return ss.str();
 }
 

--- a/be/src/util/arrow/row_batch.cpp
+++ b/be/src/util/arrow/row_batch.cpp
@@ -138,7 +138,8 @@ Status convert_to_arrow_type(const TypeDescriptor& type, std::shared_ptr<arrow::
         break;
     }
     default:
-        return Status::InvalidArgument("Unknown primitive type({}) convert to Arrow type", type.type);
+        return Status::InvalidArgument("Unknown primitive type({}) convert to Arrow type",
+                                       type.type);
     }
     return Status::OK();
 }

--- a/be/src/util/arrow/row_batch.cpp
+++ b/be/src/util/arrow/row_batch.cpp
@@ -95,6 +95,9 @@ Status convert_to_arrow_type(const TypeDescriptor& type, std::shared_ptr<arrow::
     case TYPE_IPV6:
         *result = arrow::utf8();
         break;
+    case TYPE_DECIMAL256:
+        *result = std::make_shared<arrow::Decimal256Type>(type.precision, type.scale);
+        break;
     case TYPE_BOOLEAN:
         *result = arrow::boolean();
         break;
@@ -131,7 +134,7 @@ Status convert_to_arrow_type(const TypeDescriptor& type, std::shared_ptr<arrow::
         break;
     }
     default:
-        return Status::InvalidArgument("Unknown primitive type({})", type.type);
+        return Status::InvalidArgument("Unknown primitive type({}) convert to Arrow type", type.type);
     }
     return Status::OK();
 }

--- a/be/src/util/arrow/row_batch.cpp
+++ b/be/src/util/arrow/row_batch.cpp
@@ -48,6 +48,9 @@ using strings::Substitute;
 
 Status convert_to_arrow_type(const TypeDescriptor& type, std::shared_ptr<arrow::DataType>* result) {
     switch (type.type) {
+    case TYPE_NULL:
+        *result = arrow::null();
+        break;
     case TYPE_TINYINT:
         *result = arrow::int8();
         break;
@@ -79,6 +82,7 @@ Status convert_to_arrow_type(const TypeDescriptor& type, std::shared_ptr<arrow::
     case TYPE_DATETIMEV2:
     case TYPE_STRING:
     case TYPE_JSONB:
+    case TYPE_OBJECT:
         *result = arrow::utf8();
         break;
     case TYPE_DECIMALV2:

--- a/be/src/util/arrow/utils.cpp
+++ b/be/src/util/arrow/utils.cpp
@@ -36,7 +36,10 @@ arrow::Status to_arrow_status(const Status& status) {
     if (status.ok()) {
         return arrow::Status::OK();
     } else {
-        return arrow::Status::Invalid(status.to_string());
+        // The length of exception msg returned to the ADBC Client cannot larger than 8192,
+        // otherwise ADBC Client will receive:
+        // `INTERNAL: http2 exception Header size exceeded max allowed size (8192)`.
+        return arrow::Status::Invalid(status.to_string_no_stack());
     }
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1417,11 +1417,14 @@ public class StmtExecutor {
         }
 
         // handle selects that fe can do without be, so we can make sql tools happy, especially the setup step.
-        Optional<ResultSet> resultSet = planner.handleQueryInFe(parsedStmt);
-        if (resultSet.isPresent()) {
-            sendResultSet(resultSet.get());
-            LOG.info("Query {} finished", DebugUtil.printId(context.queryId));
-            return;
+        // TODO FE not support doris field type conversion to arrow field type.
+        if (!context.getConnectType().equals(ConnectType.ARROW_FLIGHT_SQL)) {
+            Optional<ResultSet> resultSet = planner.handleQueryInFe(parsedStmt);
+            if (resultSet.isPresent()) {
+                sendResultSet(resultSet.get());
+                LOG.info("Query {} finished", DebugUtil.printId(context.queryId));
+                return;
+            }
         }
 
         MysqlChannel channel = null;

--- a/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/DorisFlightSqlService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/DorisFlightSqlService.java
@@ -18,6 +18,7 @@
 package org.apache.doris.service.arrowflight;
 
 import org.apache.doris.common.Config;
+import org.apache.doris.service.FrontendOptions;
 import org.apache.doris.service.arrowflight.auth2.FlightBearerTokenAuthenticator;
 import org.apache.doris.service.arrowflight.sessions.FlightSessionsManager;
 import org.apache.doris.service.arrowflight.sessions.FlightSessionsWithTokenManager;
@@ -39,13 +40,13 @@ import java.io.IOException;
 public class DorisFlightSqlService {
     private static final Logger LOG = LogManager.getLogger(DorisFlightSqlService.class);
     private final FlightServer flightServer;
-    private volatile boolean running;
     private final FlightTokenManager flightTokenManager;
     private final FlightSessionsManager flightSessionsManager;
+    private volatile boolean running;
 
     public DorisFlightSqlService(int port) {
         BufferAllocator allocator = new RootAllocator();
-        Location location = Location.forGrpcInsecure("0.0.0.0", port);
+        Location location = Location.forGrpcInsecure(FrontendOptions.getLocalHostAddress(), port);
         this.flightTokenManager = new FlightTokenManagerImpl(Config.arrow_flight_token_cache_size,
                 Config.arrow_flight_token_alive_time);
         this.flightSessionsManager = new FlightSessionsWithTokenManager(flightTokenManager);

--- a/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/results/FlightSqlChannel.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/results/FlightSqlChannel.java
@@ -140,7 +140,7 @@ public class FlightSqlChannel {
 
     public void addOKResult(String queryId, String query) {
         final FlightSqlResultCacheEntry flightSqlResultCacheEntry = new FlightSqlResultCacheEntry(
-                createOneOneSchemaRoot("StatusResult", "OK"), query);
+                createOneOneSchemaRoot("StatusResult", "0"), query);
         resultCache.put(queryId, flightSqlResultCacheEntry);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/sessions/FlightSessionsManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/sessions/FlightSessionsManager.java
@@ -20,12 +20,9 @@ package org.apache.doris.service.arrowflight.sessions;
 
 import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Env;
-import org.apache.doris.common.ErrorCode;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.service.ExecuteEnv;
 import org.apache.doris.system.SystemInfoService;
-
-import org.apache.arrow.flight.CallStatus;
 
 /**
  * Manages Flight User Session ConnectContext.
@@ -65,10 +62,6 @@ public interface FlightSessionsManager {
                 connectContext.getEnv().getAuth().getInsertTimeout(connectContext.getQualifiedUser()));
 
         connectContext.setConnectScheduler(ExecuteEnv.getInstance().getScheduler());
-        if (!ExecuteEnv.getInstance().getScheduler().registerConnection(connectContext)) {
-            connectContext.getState().setError(ErrorCode.ERR_TOO_MANY_USER_CONNECTIONS, "Reach limit of connections");
-            throw CallStatus.UNAUTHENTICATED.withDescription("Reach limit of connections").toRuntimeException();
-        }
         return connectContext;
     }
 }

--- a/regression-test/conf/regression-conf.groovy
+++ b/regression-test/conf/regression-conf.groovy
@@ -182,6 +182,12 @@ s3Endpoint = "cos.ap-hongkong.myqcloud.com"
 s3BucketName = "doris-build-hk-1308700295"
 s3Region = "ap-hongkong"
 
+//arrow flight sql test config
+extArrowFlightSqlHost = "127.0.0.1"
+extArrowFlightSqlPort = 9090
+extArrowFlightSqlUser = "root"
+extArrowFlightSqlPassword= ""
+
 // iceberg rest catalog config
 iceberg_rest_uri_port=18181
 

--- a/regression-test/framework/pom.xml
+++ b/regression-test/framework/pom.xml
@@ -76,7 +76,24 @@ under the License.
         <groovy-eclipse-compiler.version>3.7.0</groovy-eclipse-compiler.version>
         <antlr.version>4.9.3</antlr.version>
         <hadoop.version>2.8.0</hadoop.version>
+        <arrow.version>15.0.0-SNAPSHOT</arrow.version>
     </properties>
+    <profiles>
+        <profile>
+            <id>general-env</id>
+            <activation>
+                <property>
+                    <name>!env.CUSTOM_MAVEN_REPO</name>
+                </property>
+            </activation>
+            <repositories>
+                <repository>
+                    <id>arrow-apache-nightlies</id>
+                    <url>https://nightlies.apache.org/arrow/java</url>
+                </repository>
+            </repositories>
+        </profile>
+    </profiles>
     <build>
         <plugins>
             <plugin>
@@ -295,6 +312,11 @@ under the License.
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-jdbc</artifactId>
             <version>2.3.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>flight-sql-jdbc-driver</artifactId>
+            <version>${arrow.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -44,6 +44,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import groovy.util.logging.Slf4j
 
+import java.sql.Connection
 import java.util.concurrent.Callable
 import java.util.concurrent.Future
 import java.util.concurrent.atomic.AtomicBoolean
@@ -257,24 +258,65 @@ class Suite implements GroovyInterceptable {
         return context.getSyncer(this)
     }
 
-    List<List<Object>> sql(String sqlStr, boolean isOrder = false) {
+    List<List<Object>> sql_impl(Connection conn, String sqlStr, boolean isOrder = false) {
         logger.info("Execute ${isOrder ? "order_" : ""}sql: ${sqlStr}".toString())
-        def (result, meta) = JdbcUtils.executeToList(context.getConnection(), sqlStr)
+        def (result, meta) = JdbcUtils.executeToList(conn, sqlStr)
         if (isOrder) {
             result = DataUtils.sortByToString(result)
         }
         return result
     }
 
-    List<List<Object>> insert_into_sql(String sqlStr, int num) {
-        logger.info("insert into " + num + " records")
-        def (result, meta) = JdbcUtils.executeToList(context.getConnection(), sqlStr)
+    List<List<Object>> jdbc_sql(String sqlStr, boolean isOrder = false) {
+        return sql_impl(context.getConnection(), sqlStr, isOrder)
+    }
+
+    List<List<Object>> arrow_flight_sql(String sqlStr, boolean isOrder = false) {
+        return sql_impl(context.getArrowFlightSqlConnection(), (String) ("USE ${context.dbName};" + sqlStr), isOrder)
+    }
+
+    List<List<Object>> sql(String sqlStr, boolean isOrder = false) {
+        if (group.contains("arrow_flight_sql")) {
+            return arrow_flight_sql(sqlStr, isOrder)
+        } else {
+            return jdbc_sql(sqlStr, isOrder)
+        }
+    }
+
+    List<List<Object>> arrow_flight_sql_no_prepared (String sqlStr, boolean isOrder = false){
+        logger.info("Execute ${isOrder ? "order_" : ""}sql: ${sqlStr}".toString())
+        def (result, meta) = JdbcUtils.executeQueryToList(context.getArrowFlightSqlConnection(), (String) ("USE ${context.dbName};" + sqlStr))
+        if (isOrder) {
+            result = DataUtils.sortByToString(result)
+        }
         return result
     }
 
-    def sql_return_maparray(String sqlStr) {
+    List<List<Object>> insert_into_sql_impl(Connection conn, String sqlStr, int num) {
+        logger.info("insert into " + num + " records")
+        def (result, meta) = JdbcUtils.executeToList(conn, sqlStr)
+        return result
+    }
+
+    List<List<Object>> jdbc_insert_into_sql(String sqlStr, int num) {
+        return insert_into_sql_impl(context.getConnection(), sqlStr, num)
+    }
+
+    List<List<Object>> arrow_flight_insert_into_sql(String sqlStr, int num) {
+        return insert_into_sql_impl(context.getArrowFlightSqlConnection(), (String) ("USE ${context.dbName};" + sqlStr), num)
+    }
+
+    List<List<Object>> insert_into_sql(String sqlStr, int num) {
+        if (group.contains("arrow_flight_sql")) {
+            return arrow_flight_insert_into_sql(sqlStr, num)
+        } else {
+            return jdbc_insert_into_sql(sqlStr, num)
+        }
+    }
+
+    def sql_return_maparray_impl(Connection conn, String sqlStr) {
         logger.info("Execute sql: ${sqlStr}".toString())
-        def (result, meta) = JdbcUtils.executeToList(context.getConnection(), sqlStr)
+        def (result, meta) = JdbcUtils.executeToList(conn, sqlStr)
 
         // get all column names as list
         List<String> columnNames = new ArrayList<>()
@@ -292,6 +334,22 @@ class Suite implements GroovyInterceptable {
             res.add(row)
         }
         return res;
+    }
+
+    def jdbc_sql_return_maparray(String sqlStr) {
+        return sql_return_maparray_impl(context.getConnection(), sqlStr)
+    }
+
+    def arrow_flight_sql_return_maparray(String sqlStr) {
+        return sql_return_maparray_impl(context.getArrowFlightSqlConnection(), (String) ("USE ${context.dbName};" + sqlStr))
+    }
+
+    def sql_return_maparray(String sqlStr) {
+        if (group.contains("arrow_flight_sql")) {
+            return arrow_flight_sql_return_maparray(sqlStr)
+        } else {
+            return jdbc_sql_return_maparray(sqlStr)
+        }
     }
 
     List<List<Object>> target_sql(String sqlStr, boolean isOrder = false) {
@@ -388,7 +446,11 @@ class Suite implements GroovyInterceptable {
     }
 
     void explain(Closure actionSupplier) {
-        runAction(new ExplainAction(context), actionSupplier)
+        if (group.contains("arrow_flight_sql")) {
+            runAction(new ExplainAction(context, "ARROW_FLIGHT_SQL"), actionSupplier)
+        } else {
+            runAction(new ExplainAction(context), actionSupplier)
+        }
     }
 
     void createMV(String sql) {
@@ -608,6 +670,8 @@ class Suite implements GroovyInterceptable {
                     tupleResult = JdbcUtils.executeToStringList(context.getHiveDockerConnection(),  (PreparedStatement) arg)
                 }else if (tag.contains("hive_remote")) {
                     tupleResult = JdbcUtils.executeToStringList(context.getHiveRemoteConnection(),  (PreparedStatement) arg)
+                } else if (tag.contains("arrow_flight_sql") || group.contains("arrow_flight_sql")) {
+                    tupleResult = JdbcUtils.executeToStringList(context.getArrowFlightSqlConnection(), (PreparedStatement) arg)
                 }
                 else{
                     tupleResult = JdbcUtils.executeToStringList(context.getConnection(),  (PreparedStatement) arg)
@@ -617,6 +681,9 @@ class Suite implements GroovyInterceptable {
                     tupleResult = JdbcUtils.executeToStringList(context.getHiveDockerConnection(), (String) arg)
                 }else if (tag.contains("hive_remote")) {
                     tupleResult = JdbcUtils.executeToStringList(context.getHiveRemoteConnection(), (String) arg)
+                } else if (tag.contains("arrow_flight_sql") || group.contains("arrow_flight_sql")) {
+                    tupleResult = JdbcUtils.executeToStringList(context.getArrowFlightSqlConnection(),
+                            (String) ("USE ${context.dbName};" + (String) arg))
                 }
                 else{
                     tupleResult = JdbcUtils.executeToStringList(context.getConnection(),  (String) arg)
@@ -646,6 +713,8 @@ class Suite implements GroovyInterceptable {
                     tupleResult = JdbcUtils.executeToStringList(context.getHiveDockerConnection(),  (PreparedStatement) arg)
                 }else if (tag.contains("hive_remote")) {
                     tupleResult = JdbcUtils.executeToStringList(context.getHiveRemoteConnection(),  (PreparedStatement) arg)
+                } else if (tag.contains("arrow_flight_sql") || group.contains("arrow_flight_sql")) {
+                    tupleResult = JdbcUtils.executeToStringList(context.getArrowFlightSqlConnection(), (PreparedStatement) arg)
                 }
                 else{
                     tupleResult = JdbcUtils.executeToStringList(context.getConnection(),  (PreparedStatement) arg)
@@ -655,6 +724,9 @@ class Suite implements GroovyInterceptable {
                     tupleResult = JdbcUtils.executeToStringList(context.getHiveDockerConnection(), (String) arg)
                 }else if (tag.contains("hive_remote")) {
                     tupleResult = JdbcUtils.executeToStringList(context.getHiveRemoteConnection(), (String) arg)
+                } else if (tag.contains("arrow_flight_sql") || group.contains("arrow_flight_sql")) {
+                    tupleResult = JdbcUtils.executeToStringList(context.getArrowFlightSqlConnection(),
+                            (String) ("USE ${context.dbName};" + (String) arg))
                 }
                 else{
                     tupleResult = JdbcUtils.executeToStringList(context.getConnection(),  (String) arg)

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -276,7 +276,7 @@ class Suite implements GroovyInterceptable {
     }
 
     List<List<Object>> sql(String sqlStr, boolean isOrder = false) {
-        if (group.contains("arrow_flight_sql")) {
+        if (context.useArrowFlightSql()) {
             return arrow_flight_sql(sqlStr, isOrder)
         } else {
             return jdbc_sql(sqlStr, isOrder)
@@ -307,7 +307,7 @@ class Suite implements GroovyInterceptable {
     }
 
     List<List<Object>> insert_into_sql(String sqlStr, int num) {
-        if (group.contains("arrow_flight_sql")) {
+        if (context.useArrowFlightSql()) {
             return arrow_flight_insert_into_sql(sqlStr, num)
         } else {
             return jdbc_insert_into_sql(sqlStr, num)
@@ -345,7 +345,7 @@ class Suite implements GroovyInterceptable {
     }
 
     def sql_return_maparray(String sqlStr) {
-        if (group.contains("arrow_flight_sql")) {
+        if (context.useArrowFlightSql()) {
             return arrow_flight_sql_return_maparray(sqlStr)
         } else {
             return jdbc_sql_return_maparray(sqlStr)
@@ -446,7 +446,7 @@ class Suite implements GroovyInterceptable {
     }
 
     void explain(Closure actionSupplier) {
-        if (group.contains("arrow_flight_sql")) {
+        if (context.useArrowFlightSql()) {
             runAction(new ExplainAction(context, "ARROW_FLIGHT_SQL"), actionSupplier)
         } else {
             runAction(new ExplainAction(context), actionSupplier)
@@ -670,7 +670,7 @@ class Suite implements GroovyInterceptable {
                     tupleResult = JdbcUtils.executeToStringList(context.getHiveDockerConnection(),  (PreparedStatement) arg)
                 }else if (tag.contains("hive_remote")) {
                     tupleResult = JdbcUtils.executeToStringList(context.getHiveRemoteConnection(),  (PreparedStatement) arg)
-                } else if (tag.contains("arrow_flight_sql") || group.contains("arrow_flight_sql")) {
+                } else if (tag.contains("arrow_flight_sql") || context.useArrowFlightSql()) {
                     tupleResult = JdbcUtils.executeToStringList(context.getArrowFlightSqlConnection(), (PreparedStatement) arg)
                 }
                 else{
@@ -681,7 +681,7 @@ class Suite implements GroovyInterceptable {
                     tupleResult = JdbcUtils.executeToStringList(context.getHiveDockerConnection(), (String) arg)
                 }else if (tag.contains("hive_remote")) {
                     tupleResult = JdbcUtils.executeToStringList(context.getHiveRemoteConnection(), (String) arg)
-                } else if (tag.contains("arrow_flight_sql") || group.contains("arrow_flight_sql")) {
+                } else if (tag.contains("arrow_flight_sql") || context.useArrowFlightSql()) {
                     tupleResult = JdbcUtils.executeToStringList(context.getArrowFlightSqlConnection(),
                             (String) ("USE ${context.dbName};" + (String) arg))
                 }
@@ -713,7 +713,7 @@ class Suite implements GroovyInterceptable {
                     tupleResult = JdbcUtils.executeToStringList(context.getHiveDockerConnection(),  (PreparedStatement) arg)
                 }else if (tag.contains("hive_remote")) {
                     tupleResult = JdbcUtils.executeToStringList(context.getHiveRemoteConnection(),  (PreparedStatement) arg)
-                } else if (tag.contains("arrow_flight_sql") || group.contains("arrow_flight_sql")) {
+                } else if (tag.contains("arrow_flight_sql") || context.useArrowFlightSql()) {
                     tupleResult = JdbcUtils.executeToStringList(context.getArrowFlightSqlConnection(), (PreparedStatement) arg)
                 }
                 else{
@@ -724,7 +724,7 @@ class Suite implements GroovyInterceptable {
                     tupleResult = JdbcUtils.executeToStringList(context.getHiveDockerConnection(), (String) arg)
                 }else if (tag.contains("hive_remote")) {
                     tupleResult = JdbcUtils.executeToStringList(context.getHiveRemoteConnection(), (String) arg)
-                } else if (tag.contains("arrow_flight_sql") || group.contains("arrow_flight_sql")) {
+                } else if (tag.contains("arrow_flight_sql") || context.useArrowFlightSql()) {
                     tupleResult = JdbcUtils.executeToStringList(context.getArrowFlightSqlConnection(),
                             (String) ("USE ${context.dbName};" + (String) arg))
                 }

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/SuiteContext.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/SuiteContext.groovy
@@ -129,6 +129,14 @@ class SuiteContext implements Closeable {
         return getConnection()
     }
 
+    boolean useArrowFlightSql() {
+        if (group.contains("arrow_flight_sql") && config.groups.contains("arrow_flight_sql")) {
+            return true
+        }
+        return false
+    }
+
+    // jdbc:mysql
     Connection getConnection() {
         def threadConnInfo = threadLocalConn.get()
         if (threadConnInfo == null) {
@@ -150,6 +158,7 @@ class SuiteContext implements Closeable {
             threadConnInfo.password = config.jdbcPassword
             threadArrowFlightSqlConn.set(threadConnInfo)
         }
+        println("Use arrow flight sql connection")
         return threadConnInfo.conn
     }
 

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/util/JdbcUtils.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/util/JdbcUtils.groovy
@@ -37,6 +37,12 @@ class JdbcUtils {
         }
     }
 
+    static Tuple2<List<List<Object>>, ResultSetMetaData> executeQueryToList(Connection conn, String sql) {
+        conn.createStatement().withCloseable { stmt ->
+            return toList(stmt.executeQuery(sql))
+        }
+    }
+
     static PreparedStatement prepareStatement(Connection conn, String sql) {
         return conn.prepareStatement(sql);
     }

--- a/regression-test/suites/demo_p0/qt_action.groovy
+++ b/regression-test/suites/demo_p0/qt_action.groovy
@@ -29,8 +29,6 @@ suite("qt_action") {
 
     qt_select2 "select 2"
 
-    qt_arrow_flight_sql "select 1, 'beijing' union all select 2, 'shanghai'"
-
     // order result by string dict then compare to .out file.
     // order_qt_xxx sql equals to quickTest(xxx, sql, true).
     order_qt_union_all  """

--- a/regression-test/suites/demo_p0/qt_action.groovy
+++ b/regression-test/suites/demo_p0/qt_action.groovy
@@ -29,6 +29,8 @@ suite("qt_action") {
 
     qt_select2 "select 2"
 
+    qt_arrow_flight_sql "select 1, 'beijing' union all select 2, 'shanghai'"
+
     // order result by string dict then compare to .out file.
     // order_qt_xxx sql equals to quickTest(xxx, sql, true).
     order_qt_union_all  """

--- a/regression-test/suites/query_p0/aggregate/aggregate_count1.groovy
+++ b/regression-test/suites/query_p0/aggregate/aggregate_count1.groovy
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-suite("aggregate_count1", "query") {
+suite("aggregate_count1", "query,arrow_flight_sql") {
     sql """ DROP TABLE IF EXISTS aggregate_count1 """
     sql """create table if not exists aggregate_count1 (
                 name varchar(128),

--- a/regression-test/suites/query_p0/aggregate/select_distinct.groovy
+++ b/regression-test/suites/query_p0/aggregate/select_distinct.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("select_distinct") {
+suite("select_distinct", "arrow_flight_sql") {
     sql """DROP TABLE IF EXISTS decimal_a;"""
     sql """DROP TABLE IF EXISTS decimal_b;"""
     sql """DROP TABLE IF EXISTS decimal_c;"""

--- a/regression-test/suites/query_p0/casesensetive_column/join_with_column_casesensetive.groovy
+++ b/regression-test/suites/query_p0/casesensetive_column/join_with_column_casesensetive.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("join_with_column_casesensetive") {
+suite("join_with_column_casesensetive", "arrow_flight_sql") {
     def tables=["ad_order_data_v1","ad_order_data"]
 
     for (String table in tables) {

--- a/regression-test/suites/query_p0/cast/test_cast.groovy
+++ b/regression-test/suites/query_p0/cast/test_cast.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite('test_cast') {
+suite('test_cast', "arrow_flight_sql") {
     def date = "date '2020-01-01'"
     def datev2 = "datev2 '2020-01-01'"
     def datetime = "timestamp '2020-01-01 12:34:45'"

--- a/regression-test/suites/query_p0/except/test_query_except.groovy
+++ b/regression-test/suites/query_p0/except/test_query_except.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_query_except") {
+suite("test_query_except", "arrow_flight_sql") {
     // test query except, depend on query_test_data_load.groovy
     sql "use test_query_db"
     qt_select_except1 """

--- a/regression-test/suites/query_p0/group_concat/test_group_concat.groovy
+++ b/regression-test/suites/query_p0/group_concat/test_group_concat.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_group_concat") {
+suite("test_group_concat", "query,p0,arrow_flight_sql") {
     qt_select """
                 SELECT group_concat(k6) FROM test_query_db.test where k6='false'
               """

--- a/regression-test/suites/query_p0/grouping_sets/test_grouping_sets1.groovy
+++ b/regression-test/suites/query_p0/grouping_sets/test_grouping_sets1.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_grouping_sets1") {
+suite("test_grouping_sets1", "arrow_flight_sql") {
     qt_select """
         select 
             col1

--- a/regression-test/suites/query_p0/having/having.groovy
+++ b/regression-test/suites/query_p0/having/having.groovy
@@ -19,7 +19,7 @@
 // /testing/trino-product-tests/src/main/resources/sql-tests/testcases/aggregate
 // and modified by Doris.
 
-suite("having") {
+suite("having", "query,p0,arrow_flight_sql") {
     sql "set enable_nereids_planner=false;"
     sql """DROP TABLE IF EXISTS supplier"""
     sql """CREATE TABLE `supplier` (

--- a/regression-test/suites/query_p0/intersect/test_intersect.groovy
+++ b/regression-test/suites/query_p0/intersect/test_intersect.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_intersect") {
+suite("test_intersect", "arrow_flight_sql") {
     qt_select """
                 SELECT * FROM (SELECT k1 FROM test_query_db.baseall
                     INTERSECT SELECT k1 FROM test_query_db.test) a ORDER BY k1

--- a/regression-test/suites/query_p0/join/test_join2.groovy
+++ b/regression-test/suites/query_p0/join/test_join2.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_join2", "query,p0") {
+suite("test_join2", "query,p0,arrow_flight_sql") {
     def DBname = "regression_test_join2"
     def TBname1 = "J1_TBL"
     def TBname2 = "J2_TBL"

--- a/regression-test/suites/query_p0/join/test_left_join1.groovy
+++ b/regression-test/suites/query_p0/join/test_left_join1.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_left_join1", "query,p0") {
+suite("test_left_join1", "query,p0,arrow_flight_sql") {
 
     def tableName = "test_left_join1"
     sql """drop table if exists ${tableName}"""

--- a/regression-test/suites/query_p0/join/test_nestedloop_outer_join.groovy
+++ b/regression-test/suites/query_p0/join/test_nestedloop_outer_join.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_nestedloop_outer_join", "query_p0") {
+suite("test_nestedloop_outer_join", "query_p0,arrow_flight_sql") {
     def tbl1 = "test_nestedloop_outer_join1"
     def tbl2 = "test_nestedloop_outer_join2"
 

--- a/regression-test/suites/query_p0/join/test_partitioned_hash_join.groovy
+++ b/regression-test/suites/query_p0/join/test_partitioned_hash_join.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_partitioned_hash_join", "query,p0") {
+suite("test_partitioned_hash_join", "query,p0,arrow_flight_sql") {
     sql "drop table if exists test_partitioned_hash_join_l"
     sql "drop table if exists test_partitioned_hash_join_r"
     sql """ create table test_partitioned_hash_join_l (

--- a/regression-test/suites/query_p0/lateral_view/lateral_view.groovy
+++ b/regression-test/suites/query_p0/lateral_view/lateral_view.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("lateral_view") {
+suite("lateral_view", "arrow_flight_sql") {
     sql """ DROP TABLE IF EXISTS `test_explode_bitmap` """
 	sql """
 		CREATE TABLE `test_explode_bitmap` (

--- a/regression-test/suites/query_p0/limit/OffsetInSubqueryWithJoin.groovy
+++ b/regression-test/suites/query_p0/limit/OffsetInSubqueryWithJoin.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_offset_in_subquery_with_join", "query") {
+suite("test_offset_in_subquery_with_join", "query,arrow_flight_sql") {
     // define a sql table
     def testTable = "test_offset_in_subquery_with_join"
 

--- a/regression-test/suites/query_p0/literal_view/lietral_test.groovy
+++ b/regression-test/suites/query_p0/literal_view/lietral_test.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("literal_view_test") {
+suite("literal_view_test", "arrow_flight_sql") {
 
     sql """DROP TABLE IF EXISTS table1"""
 

--- a/regression-test/suites/query_p0/operator/test_set_operator.groovy
+++ b/regression-test/suites/query_p0/operator/test_set_operator.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_set_operators", "query,p0") {
+suite("test_set_operators", "query,p0,arrow_flight_sql") {
 
     sql """
         DROP TABLE IF EXISTS t1;

--- a/regression-test/suites/query_p0/session_variable/test_default_limit.groovy
+++ b/regression-test/suites/query_p0/session_variable/test_default_limit.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite('test_default_limit') {
+suite('test_default_limit', "arrow_flight_sql") {
     sql 'drop table if exists baseall'
     sql 'drop table if exists bigtable'
 

--- a/regression-test/suites/query_p0/show/test_show_create_table.groovy
+++ b/regression-test/suites/query_p0/show/test_show_create_table.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_show_create_table", "query") {
+suite("test_show_create_table", "query,arrow_flight_sql") {
     String tb_name = "tb_show_create_table";
     try {  
         sql """drop table if exists ${tb_name} """

--- a/regression-test/suites/query_p0/sql_functions/aggregate_functions/test_aggregate_all_functions.groovy
+++ b/regression-test/suites/query_p0/sql_functions/aggregate_functions/test_aggregate_all_functions.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_aggregate_all_functions") {
+suite("test_aggregate_all_functions", "arrow_flight_sql") {
 
     sql "set batch_size = 4096"
     

--- a/regression-test/suites/query_p0/sql_functions/case_function/test_case_function_null.groovy
+++ b/regression-test/suites/query_p0/sql_functions/case_function/test_case_function_null.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_case_function_null", "query,p0") {
+suite("test_case_function_null", "query,p0,arrow_flight_sql") {
     sql """ drop table if exists case_null0 """
     sql """ create table case_null0 (
                 `c0` decimalv3(17, 1) NULL,

--- a/regression-test/suites/query_p0/sql_functions/hash_functions/test_hash_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/hash_functions/test_hash_function.groovy
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-suite("test_hash_function") {
+suite("test_hash_function", "arrow_flight_sql") {
     sql "set batch_size = 4096;"
     sql "set enable_profile = true;"
 

--- a/regression-test/suites/query_p0/sql_functions/ip_functions/test_ip_functions.groovy
+++ b/regression-test/suites/query_p0/sql_functions/ip_functions/test_ip_functions.groovy
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-suite("test_ip_functions") {
+suite("test_ip_functions", "arrow_flight_sql") {
     sql "set batch_size = 4096;"
 
     qt_sql "SELECT ipv4numtostring(-1);"

--- a/regression-test/suites/query_p0/sql_functions/json_function/test_query_json_insert.groovy
+++ b/regression-test/suites/query_p0/sql_functions/json_function/test_query_json_insert.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_query_json_insert", "query") {
+suite("test_query_json_insert", "query,arrow_flight_sql") {
     qt_sql "select json_insert('{\"a\": 1, \"b\": [2, 3]}', '\$', null);"
     qt_sql "select json_insert('{\"k\": [1, 2]}', '\$.k[0]', null, '\$.[1]', null);"
     def tableName = "test_query_json_insert"

--- a/regression-test/suites/query_p0/sql_functions/json_functions/test_json_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/json_functions/test_json_function.groovy
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-suite("test_json_function") {
+suite("test_json_function", "arrow_flight_sql") {
     sql "set batch_size = 4096;"
 
     qt_sql "SELECT get_json_double('{\"k1\":1.3, \"k2\":\"2\"}', \"\$.k1\");"

--- a/regression-test/suites/query_p0/sql_functions/math_functions/test_conv.groovy
+++ b/regression-test/suites/query_p0/sql_functions/math_functions/test_conv.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_conv") {
+suite("test_conv", "arrow_flight_sql") {
     qt_select "SELECT CONV(15,10,2)"
 
     sql """ drop table if exists test_conv; """

--- a/regression-test/suites/query_p0/sql_functions/search_functions/test_multi_string_search.groovy
+++ b/regression-test/suites/query_p0/sql_functions/search_functions/test_multi_string_search.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_multi_string_search") {
+suite("test_multi_string_search", "arrow_flight_sql") {
     def table_name = "test_multi_string_search_strings"
 
     sql """ DROP TABLE IF EXISTS ${table_name} """

--- a/regression-test/suites/query_p0/sql_functions/spatial_functions/test_gis_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/spatial_functions/test_gis_function.groovy
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-suite("test_gis_function") {
+suite("test_gis_function", "arrow_flight_sql") {
     sql "set batch_size = 4096;"
 
     qt_sql "SELECT ST_AsText(ST_Point(24.7, 56.7));"

--- a/regression-test/suites/query_p0/sql_functions/string_functions/test_string_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/string_functions/test_string_function.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_string_function") {
+suite("test_string_function", "arrow_flight_sql") {
     sql "set batch_size = 4096;"
 
     qt_sql "select elt(0, \"hello\", \"doris\");"

--- a/regression-test/suites/query_p0/sql_functions/table_function/explode_split.groovy
+++ b/regression-test/suites/query_p0/sql_functions/table_function/explode_split.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("explode_split") {
+suite("explode_split", "arrow_flight_sql") {
     def tableName = "test_lv_str"
 
     sql """ DROP TABLE IF EXISTS ${tableName} """

--- a/regression-test/suites/query_p0/sql_functions/test_alias_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/test_alias_function.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite('test_alias_function') {
+suite('test_alias_function', "arrow_flight_sql") {
     sql '''
         CREATE ALIAS FUNCTION IF NOT EXISTS f1(DATETIMEV2(3), INT)
             with PARAMETER (datetime1, int1) as date_trunc(days_sub(datetime1, int1), 'day')'''

--- a/regression-test/suites/query_p0/sql_functions/test_in_expr.groovy
+++ b/regression-test/suites/query_p0/sql_functions/test_in_expr.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_in_expr", "query") {
+suite("test_in_expr", "query,arrow_flight_sql") {
     def nullTableName = "in_expr_test_null"
     def notNullTableName = "in_expr_test_not_null"
 

--- a/regression-test/suites/query_p0/sql_functions/test_predicate.groovy
+++ b/regression-test/suites/query_p0/sql_functions/test_predicate.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_predicate") {
+suite("test_predicate", "arrow_flight_sql") {
     sql """drop table if exists t1;"""
     sql """
             create table t1 (

--- a/regression-test/suites/query_p0/sql_functions/width_bucket_fuctions/test_width_bucket_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/width_bucket_fuctions/test_width_bucket_function.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_width_bucket_function") {
+suite("test_width_bucket_function", "arrow_flight_sql") {
     qt_sql "select width_bucket(1, 2, 3, 2)"
     qt_sql "select width_bucket(null, 2, 3, 2)"
     qt_sql "select width_bucket(6, 2, 6, 4)"

--- a/regression-test/suites/query_p0/sql_functions/window_functions/test_window_fn.groovy
+++ b/regression-test/suites/query_p0/sql_functions/window_functions/test_window_fn.groovy
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-suite("test_window_fn") {
+suite("test_window_fn", "arrow_flight_sql") {
     def tbName1 = "empsalary"
     def tbName2 = "tenk1"
     sql """ DROP TABLE IF EXISTS ${tbName1} """

--- a/regression-test/suites/query_p0/subquery/test_subquery2.groovy
+++ b/regression-test/suites/query_p0/subquery/test_subquery2.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_subquery2") {
+suite("test_subquery2", "arrow_flight_sql") {
     
     sql """DROP TABLE IF EXISTS subquerytest2"""
     

--- a/regression-test/suites/query_p0/test_data_type_marks.groovy
+++ b/regression-test/suites/query_p0/test_data_type_marks.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_data_type_marks") {
+suite("test_data_type_marks", "arrow_flight_sql") {
     def tbName = "org"
     sql "DROP TABLE IF EXISTS ${tbName}"
     sql """

--- a/regression-test/suites/query_p0/test_dict_with_null.groovy
+++ b/regression-test/suites/query_p0/test_dict_with_null.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("dict_with_null", "query") {
+suite("dict_with_null", "query,arrow_flight_sql") {
     def tableName = "test_dict_with_null"
     sql "DROP TABLE IF EXISTS ${tableName}"
     sql """

--- a/regression-test/suites/query_p0/test_orderby_nullliteral.groovy
+++ b/regression-test/suites/query_p0/test_orderby_nullliteral.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("orderby_nullliteral", "query") {
+suite("orderby_nullliteral", "query,arrow_flight_sql") {
 
     def tableName = "test_orderby_nullliteral"
     sql "DROP TABLE IF EXISTS ${tableName}"

--- a/regression-test/suites/query_p0/test_select_constant.groovy
+++ b/regression-test/suites/query_p0/test_select_constant.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_select_constant") {
+suite("test_select_constant", "arrow_flight_sql") {
     qt_select1 'select 100, "test", date("2021-01-02");'
     qt_select_geo1 'SELECT ST_AsText(ST_Point(123.12345678901234567890,89.1234567890));'
 }

--- a/regression-test/suites/query_p0/test_select_with_predicate_like.groovy
+++ b/regression-test/suites/query_p0/test_select_with_predicate_like.groovy
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-suite("test_select_with_predicate_like") {
+suite("test_select_with_predicate_like", "arrow_flight_sql") {
     def tables=["test_basic_agg"]
 
     for (String table in tables) {

--- a/regression-test/suites/query_p0/test_select_with_predicate_prune.groovy
+++ b/regression-test/suites/query_p0/test_select_with_predicate_prune.groovy
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-suite("test_select_with_predicate_prune") {
+suite("test_select_with_predicate_prune", "arrow_flight_sql") {
     sql """
         drop table if exists `test_select_with_predicate_prune`;
     """

--- a/regression-test/suites/query_p0/test_two_phase_read_with_having.groovy
+++ b/regression-test/suites/query_p0/test_two_phase_read_with_having.groovy
@@ -14,7 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-suite("test_two_phase_read_with_having") {
+suite("test_two_phase_read_with_having", "arrow_flight_sql") {
 
     sql """ set enable_partition_topn = 1; """
     sql """ set topn_opt_limit_threshold = 1024; """

--- a/regression-test/suites/query_p0/type_inference/test_largeint.groovy
+++ b/regression-test/suites/query_p0/type_inference/test_largeint.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_largeint") {
+suite("test_largeint", "arrow_flight_sql") {
     def tbName = "test_largeint"
     sql "DROP TABLE IF EXISTS ${tbName}"
     sql """

--- a/regression-test/suites/query_p0/with/test_with_and_two_phase_agg.groovy
+++ b/regression-test/suites/query_p0/with/test_with_and_two_phase_agg.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_with_and_two_phase_agg") {
+suite("test_with_and_two_phase_agg", "arrow_flight_sql") {
     def tableName = "test_with_and_two_phase_agg_table"
     sql """ DROP TABLE IF EXISTS ${tableName} """
     sql """


### PR DESCRIPTION
## Proposed changes

Design Documentation Linked to https://github.com/apache/doris/issues/25514

Regression test add a new group: arrow_flight_sql,
- `./run-regression-test.sh -g arrow_flight_sql` to run regression-test, can use `jdbc:arrow-flight-sql` to run all Suites whose group contains arrow_flight_sql.
- `./run-regression-test.sh -g p0,arrow_flight_sql` to run regression-test, can use `jdbc:arrow-flight-sql` to run all Suites whose group contains arrow_flight_sql, and use `jdbc:mysql` to run other Suites whose group contains p0 but does not contain arrow_flight_sql.

Requires attention, the formats of `jdbc:arrow-flight-sql` and `jdbc:mysql` and `mysql client` query results are different, for example:
- Datatime field type: `jdbc:mysql` returns `2010-01-02T05:09:06`, mysql client returns `2010-01-02 05:09:06`, `jdbc:arrow-flight-sql` also returns `2010-01-02 05:09 :06`.
- Array and Map field types: `jdbc:mysql` returns `["ab", "efg", null]`, `{"f1": 1, "f2": "a"}`, `jdbc:arrow-flight-sql` returns `["ab ","efg",null]`, `{"f1":1,"f2":"a"}`, which is missing spaces.
- Float field type: `jdbc:mysql` and mysql client returns `6.333`, `jdbc:arrow-flight-sql` returns `6.333000183105469`, in query_p0/subquery/test_subquery.groovy.
- If the query result is empty, `jdbc:arrow-flight-sql` returns empty and `jdbc:mysql` returns `\N`. 
- use database; and query should be divided into two SQL executions as much as possible. otherwise the results may not be as expected. For example: USE information_schema; select cast ("0.0101031417" as datetime)  The result is 2000-01-01 03:14:1 (constant fold), select cast ("0.0101031417" as datetime) The result is null (no constant fold), 

In addition, doris `jdbc:arrow-flight-sql` still has unfinished parts, such as:
- Unsupported data type: Decimal256. `INVALID_ARGUMENT: [INTERNAL_ERROR]Fail to convert block data to arrow data, error: [E3] write_column_to_arrow with type Decimal256`
- Unsupported null value of map key. `INVALID_ARGUMENT: [INTERNAL_ERROR]Fail to convert block data to arrow data, error: [E33] Can not write null value of map key to arrow.`
- Unsupported data type: ARRAY<MAP<TEXT,TEXT>>
- `jdbc:arrow-flight-sql` not support connecting to specify DB name, such as`jdbc:arrow-flight-sql://127.0.0.1:9090/{db_name}", In order to be compatible with `regression-test`, `use db_name` is added before all SQLs when `jdbc:arrow-flight-sql` runs regression test.
- `select timediff("2010-01-01 01:00:00", "2010-01-02 01:00:00");`, error `java.lang.NumberFormatException: For input string: "-24:00:00"`

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

