### PR TITLE
[feature](profile) add RuntimeFilterInfo in merge profile

### DIFF
--- a/be/src/pipeline/exec/olap_scan_operator.h
+++ b/be/src/pipeline/exec/olap_scan_operator.h
@@ -175,6 +175,8 @@ private:
     // total number of segment related to this scan node
     RuntimeProfile::Counter* _total_segment_counter = nullptr;
 
+    RuntimeProfile::Counter* _runtime_filter_info = nullptr;
+
     std::mutex _profile_mtx;
 };
 

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -51,6 +51,8 @@ class TRuntimeProfileTree;
 #define MACRO_CONCAT(x, y) CONCAT_IMPL(x, y)
 
 #define ADD_LABEL_COUNTER(profile, name) (profile)->add_counter(name, TUnit::NONE)
+#define ADD_LABEL_COUNTER_WITH_LEVEL(profile, name, type) \
+    (profile)->add_counter_with_level(name, TUnit::NONE, type)
 #define ADD_COUNTER(profile, name, type) (profile)->add_counter(name, type)
 #define ADD_COUNTER_WITH_LEVEL(profile, name, type, level) \
     (profile)->add_counter_with_level(name, type, level)

--- a/be/src/vec/exec/scan/new_olap_scan_node.cpp
+++ b/be/src/vec/exec/scan/new_olap_scan_node.cpp
@@ -193,6 +193,7 @@ Status NewOlapScanNode::_init_profile() {
     _filtered_segment_counter = ADD_COUNTER(_segment_profile, "NumSegmentFiltered", TUnit::UNIT);
     _total_segment_counter = ADD_COUNTER(_segment_profile, "NumSegmentTotal", TUnit::UNIT);
 
+    _runtime_filter_info = ADD_LABEL_COUNTER_WITH_LEVEL(_runtime_profile, "RuntimeFilterInfo", 1);
     return Status::OK();
 }
 
@@ -718,6 +719,16 @@ void NewOlapScanNode::add_filter_info(int id, const PredicateFilterInfo& update_
 
     // add info
     _segment_profile->add_info_string(filter_name, info_str);
+
+    const std::string rf_name = "filter id = " + std::to_string(id) + " ";
+
+    // add counter
+    auto* input_count = ADD_CHILD_COUNTER_WITH_LEVEL(_runtime_profile, rf_name + "input",
+                                                     TUnit::UNIT, "RuntimeFilterInfo", 1);
+    auto* filtered_count = ADD_CHILD_COUNTER_WITH_LEVEL(_runtime_profile, rf_name + "filtered",
+                                                        TUnit::UNIT, "RuntimeFilterInfo", 1);
+    COUNTER_UPDATE(input_count, info.input_row);
+    COUNTER_UPDATE(filtered_count, info.filtered_row);
 }
 
 }; // namespace doris::vectorized

--- a/be/src/vec/exec/scan/new_olap_scan_node.h
+++ b/be/src/vec/exec/scan/new_olap_scan_node.h
@@ -202,6 +202,8 @@ private:
 
     RuntimeProfile::Counter* _output_index_result_column_timer = nullptr;
 
+    RuntimeProfile::Counter* _runtime_filter_info = nullptr;
+
     // number of segment filtered by column stat when creating seg iterator
     RuntimeProfile::Counter* _filtered_segment_counter = nullptr;
     // total number of segment related to this scan node

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/AggCounter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/AggCounter.java
@@ -35,6 +35,9 @@ public class AggCounter extends Counter {
     }
 
     public void addCounter(Counter counter) {
+        if (counter == null) {
+            return;
+        }
         if (number == 0) {
             max.setValue(counter.getValue());
             sum.setValue(counter.getValue());

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
@@ -479,19 +479,18 @@ public class RuntimeProfile {
         }
     }
 
-    private static void mergeCounters(String counterName, List<RuntimeProfile> profiles,
+    private static void mergeCounters(String parentCounterName, List<RuntimeProfile> profiles,
             RuntimeProfile simpleProfile) {
         if (profiles.size() == 0) {
             return;
         }
         RuntimeProfile templateProfile = profiles.get(0);
-        Set<String> childCounterSet = templateProfile.childCounterMap.get(counterName);
+        Set<String> childCounterSet = templateProfile.childCounterMap.get(parentCounterName);
         if (childCounterSet == null) {
             return;
         }
         for (String childCounterName : childCounterSet) {
             Counter counter = templateProfile.counterMap.get(childCounterName);
-            mergeCounters(childCounterName, profiles, simpleProfile);
             if (counter.getLevel() == 1) {
                 Counter oldCounter = profiles.get(0).counterMap.get(childCounterName);
                 AggCounter aggCounter = new AggCounter(oldCounter.getType());
@@ -499,8 +498,13 @@ public class RuntimeProfile {
                     Counter orgCounter = profile.counterMap.get(childCounterName);
                     aggCounter.addCounter(orgCounter);
                 }
-                simpleProfile.addCounter(childCounterName, aggCounter, ROOT_COUNTER);
+                if (simpleProfile.counterMap.containsKey(parentCounterName)) {
+                    simpleProfile.addCounter(childCounterName, aggCounter, parentCounterName);
+                } else {
+                    simpleProfile.addCounter(childCounterName, aggCounter, ROOT_COUNTER);
+                }
             }
+            mergeCounters(childCounterName, profiles, simpleProfile);
         }
     }
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

```
                              OLAP_SCAN_OPERATOR  (id=4804):
                                    -  PlanInfo
                                          -  TABLE:  default_cluster:tpcds.item(item),  PREAGGREGATION:  ON
                                          -  runtime  filters:  RF003[in_or_bloom]  ->  i_item_sk
                                          -  partitions=1/1  (item),  tablets=12/12,  tabletList=11509,11511,11513  ...
                                          -  cardinality=102000,  avgRowSize=659.5244,  numNodes=1
                                          -  pushAggOp=NONE
                                    -  BlocksProduced:  12
                                    -  CloseTime:  avg  56.509us,  max  100.554us,  min  37.528us
                                    -  ExecTime:  avg  229.644us,  max  361.417us,  min  161.896us
                                    -  OpenTime:  avg  166.987us,  max  285.12us,  min  107.403us
                                    -  ProjectionTime:  avg  0ns,  max  0ns,  min  0ns
                                    -  RowsProduced:  27.667K  (27667)
                                    -  RuntimeFilterInfo:  
                                        -  filter  id  =  3  filtered:  74.333K  (74333)
                                        -  filter  id  =  3  input:  102.0K  (102000)



                                  OLAP_SCAN_OPERATOR  (id=4808):
                                        -  PlanInfo
                                              -  TABLE:  default_cluster:tpcds.catalog_sales(catalog_sales),  PREAGGREGATION:  ON
                                              -  runtime  filters:  RF000[in_or_bloom]  ->  cs_bill_cdemo_sk,  RF001[in_or_bloom]  ->  cs_sold_date_sk,  RF002[in_or_bloom]  ->  cs_promo_sk
                                              -  partitions=1/1  (catalog_sales),  tablets=32/32,  tabletList=11252,11254,11256  ...
                                              -  cardinality=14401261,  avgRowSize=345.8473,  numNodes=1
                                              -  pushAggOp=NONE
                                        -  BlocksProduced:  96
                                        -  CloseTime:  avg  75.43us,  max  203.133us,  min  15.793us
                                        -  ExecTime:  avg  1.115ms,  max  1.866ms,  min  906.200us
                                        -  OpenTime:  avg  1.15ms,  max  1.774ms,  min  831.607us
                                        -  ProjectionTime:  avg  0ns,  max  0ns,  min  0ns
                                        -  RowsProduced:  69.08K  (69080)
                                        -  RuntimeFilterInfo:  
                                            -  filter  id  =  -1  filtered:  11.4374M  (11437400)
                                            -  filter  id  =  -1  input:  14.271377M  (14271377)
                                            -  filter  id  =  0  filtered:  2.764897M  (2764897)
                                            -  filter  id  =  0  input:  2.833977M  (2833977)

```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

