### PR TITLE
[fix](nereids)set operation's result type is wrong if decimal overflows

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSetOperation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSetOperation.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.trees.plans.logical;
 
+import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.memo.GroupExpression;
@@ -251,10 +252,21 @@ public abstract class LogicalSetOperation extends AbstractLogicalPlan implements
             }
             return new StructType(commonFields.build());
         }
-        return DataType.fromCatalogType(Type.getAssignmentCompatibleType(
-                left.toCatalogDataType(),
-                right.toCatalogDataType(),
-                false,
-                SessionVariable.getEnableDecimal256()));
+        boolean enableDecimal256 = SessionVariable.getEnableDecimal256();
+        Type resultType = Type.getAssignmentCompatibleType(left.toCatalogDataType(),
+                right.toCatalogDataType(), false, enableDecimal256);
+        if (resultType.isDecimalV3()) {
+            int oldPrecision = resultType.getPrecision();
+            int oldScale = resultType.getDecimalDigits();
+            int integerPart = oldPrecision - oldScale;
+            int maxPrecision = enableDecimal256 ? ScalarType.MAX_DECIMAL256_PRECISION
+                    : ScalarType.MAX_DECIMAL128_PRECISION;
+            if (oldPrecision > maxPrecision) {
+                int newScale = maxPrecision - integerPart;
+                resultType =
+                        ScalarType.createDecimalType(maxPrecision, newScale < 0 ? 0 : newScale);
+            }
+        }
+        return DataType.fromCatalogType(resultType);
     }
 }

--- a/regression-test/suites/nereids_p0/datatype/test_cast.groovy
+++ b/regression-test/suites/nereids_p0/datatype/test_cast.groovy
@@ -94,4 +94,23 @@ suite("test_cast") {
         sql "select cast(true as date);"
         result([[null]])
     }
+    sql """ DROP TABLE IF EXISTS table_decimal38_4;"""
+    sql """
+        CREATE TABLE IF NOT EXISTS table_decimal38_4 (
+            `k0` decimal(38, 4)
+        )
+        DISTRIBUTED BY HASH(`k0`) BUCKETS 5 properties("replication_num" = "1");
+        """
+
+    sql """ DROP TABLE IF EXISTS table_decimal27_9;"""
+    sql """
+        CREATE TABLE IF NOT EXISTS table_decimal27_9 (
+            `k0` decimal(27, 9)
+        )
+        DISTRIBUTED BY HASH(`k0`) BUCKETS 5 properties("replication_num" = "1");
+        """
+    explain {
+        sql """select k0 from table_decimal38_4 union all select k0 from table_decimal27_9;"""
+        contains """AS DECIMALV3(38, 4)"""
+    }
 }


### PR DESCRIPTION
## Proposed changes
select cast(1.0 as decimal(27,9))  union all select cast(2.0 as decimal(34,4));
the old result type is decimal(43, 9) which overflows. This pr limit the result type to decimal(38, 4).
Operation | Result precision | Result scale
-- | -- | --
e1 { UNION \| EXCEPT \| INTERSECT } e2 | max(s1, s2) + max(p1 - s1, p2 - s2) | max(s1, s2)

The result precision and scale have an absolute maximum of 38. When a result precision is greater than 38, it's reduced to 38, and the corresponding scale is reduced to try to prevent truncating the integral part of a result

fix https://github.com/apache/doris/issues/27841

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

