### PR TITLE
[feature](profile) add avg/min/max info in uint counter

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/AggCounter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/AggCounter.java
@@ -65,7 +65,17 @@ public class AggCounter extends Counter {
                     + RuntimeProfile.printCounter(min.getValue(), min.getType());
             return infoString;
         } else {
-            String infoString = RuntimeProfile.printCounter(sum.getValue(), sum.getType());
+            Counter avg = new Counter(sum.getType(), sum.getValue());
+            avg.divValue(number);
+            String infoString = ""
+                    + RuntimeProfile.SUM_TIME_PRE
+                    + RuntimeProfile.printCounter(sum.getValue(), sum.getType()) + ", "
+                    + RuntimeProfile.AVG_TIME_PRE
+                    + RuntimeProfile.printCounter(avg.getValue(), avg.getType()) + ", "
+                    + RuntimeProfile.MAX_TIME_PRE
+                    + RuntimeProfile.printCounter(max.getValue(), max.getType()) + ", "
+                    + RuntimeProfile.MIN_TIME_PRE
+                    + RuntimeProfile.printCounter(min.getValue(), min.getType());
             return infoString;
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
@@ -51,6 +51,7 @@ public class RuntimeProfile {
     public static String MAX_TIME_PRE = "max ";
     public static String MIN_TIME_PRE = "min ";
     public static String AVG_TIME_PRE = "avg ";
+    public static String SUM_TIME_PRE = "sum ";
     private Counter counterTotalTime;
     private double localTimePercent;
 


### PR DESCRIPTION
## Proposed changes

```
        HASH_JOIN_OPERATOR  (id=959):
                                -  BlocksProduced:  sum  96,  avg  3,  max  3,  min  3
                                -  CloseTime:  avg  11.639us,  max  25.267us,  min  3.434us
                                -  ExecTime:  avg  357.853us,  max  1.85ms,  min  184.547us
                                -  OpenTime:  avg  17.981us,  max  33.539us,  min  12.562us
                                -  ProbeRows:  sum  39.631K  (39631),  avg  1.238K  (1238),  max  1.309K  (1309),  min  1.148K  (1148)
                                -  ProjectionTime:  avg  87.406us,  max  335.509us,  min  27.120us
                                -  RowsProduced:  sum  39.631K  (39631),  avg  1.238K  (1238),  max  1.309K  (1309),  min  1.148K  (1148)
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

