### PR TITLE
[optimize](invert index) inverted indexes optimize the file cache

### DIFF
--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
@@ -44,7 +44,7 @@ namespace segment_v2 {
 Status FulltextIndexSearcherBuilder::build(DorisCompoundReader* directory,
                                            OptionalIndexSearcherPtr& output_searcher) {
     auto closeDirectory = true;
-    auto reader = lucene::index::IndexReader::open(
+    auto* reader = lucene::index::IndexReader::open(
             directory, config::inverted_index_read_buffer_size, closeDirectory);
     bool close_reader = true;
     auto index_searcher = std::make_shared<lucene::search::IndexSearcher>(reader, close_reader);
@@ -176,9 +176,11 @@ Status InvertedIndexSearcherCache::get_index_searcher(
             return Status::Error<ErrorCode::INVERTED_INDEX_NOT_SUPPORTED>(
                     "InvertedIndexSearcherCache do not support reader type.");
         }
-        auto* directory =
-                new DorisCompoundReader(DorisCompoundDirectory::getDirectory(fs, index_dir.c_str()),
-                                        file_name.c_str(), config::inverted_index_read_buffer_size);
+        // During the process of opening the index, write the file information read to the idx file cache.
+        bool open_idx_file_cache = true;
+        auto* directory = new DorisCompoundReader(
+                DorisCompoundDirectory::getDirectory(fs, index_dir.c_str()), file_name.c_str(),
+                config::inverted_index_read_buffer_size, open_idx_file_cache);
         auto null_bitmap_file_name = InvertedIndexDescriptor::get_temporary_null_bitmap_file_name();
         if (!directory->fileExists(null_bitmap_file_name.c_str())) {
             has_null = false;
@@ -192,6 +194,7 @@ Status InvertedIndexSearcherCache::get_index_searcher(
         }
         OptionalIndexSearcherPtr result;
         RETURN_IF_ERROR(index_builder->build(directory, result));
+        directory->getDorisIndexInput()->setIdxFileCache(false);
         if (!result.has_value()) {
             LOG(ERROR) << "InvertedIndexReaderType:" << reader_type_to_string(reader_type)
                        << " build for InvertedIndexSearcherCache error";

--- a/be/src/olap/rowset/segment_v2/inverted_index_compound_directory.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_compound_directory.cpp
@@ -97,6 +97,22 @@ CL_NS(store)::Directory* DorisCompoundFileWriter::getDirectory() {
     return directory;
 }
 
+void DorisCompoundFileWriter::sort_files(std::vector<FileInfo>& file_infos) {
+    auto file_priority = [](const std::string& filename) {
+        if (filename.find("segments") != std::string::npos) return 1;
+        if (filename.find("fnm") != std::string::npos) return 2;
+        if (filename.find("tii") != std::string::npos) return 3;
+        return 4; // Other files
+    };
+
+    std::sort(file_infos.begin(), file_infos.end(), [&](const FileInfo& a, const FileInfo& b) {
+        int32_t priority_a = file_priority(a.filename);
+        int32_t priority_b = file_priority(b.filename);
+        if (priority_a != priority_b) return priority_a < priority_b;
+        return a.filesize < b.filesize;
+    });
+}
+
 void DorisCompoundFileWriter::writeCompoundFile() {
     // list files in current dir
     std::vector<std::string> files;
@@ -106,15 +122,15 @@ void DorisCompoundFileWriter::writeCompoundFile() {
     if (it != files.end()) {
         files.erase(it);
     }
-    // sort file list by file length
-    std::vector<std::pair<std::string, int64_t>> sorted_files;
+
+    std::vector<FileInfo> sorted_files;
     for (auto file : files) {
-        sorted_files.push_back(std::make_pair(
-                file, ((DorisCompoundDirectory*)directory)->fileLength(file.c_str())));
+        FileInfo file_info;
+        file_info.filename = file;
+        file_info.filesize = ((DorisCompoundDirectory*)directory)->fileLength(file.c_str());
+        sorted_files.emplace_back(std::move(file_info));
     }
-    std::sort(sorted_files.begin(), sorted_files.end(),
-              [](const std::pair<std::string, int64_t>& a,
-                 const std::pair<std::string, int64_t>& b) { return (a.second < b.second); });
+    sort_files(sorted_files);
 
     int32_t file_count = sorted_files.size();
 
@@ -138,12 +154,12 @@ void DorisCompoundFileWriter::writeCompoundFile() {
     const int64_t buffer_length = 16384;
     uint8_t ram_buffer[buffer_length];
     for (auto file : sorted_files) {
-        ram_output->writeString(file.first); // file name
-        ram_output->writeLong(0);            // data offset
-        ram_output->writeLong(file.second);  // file length
-        header_file_length += file.second;
+        ram_output->writeString(file.filename); // file name
+        ram_output->writeLong(0);               // data offset
+        ram_output->writeLong(file.filesize);   // file length
+        header_file_length += file.filesize;
         if (header_file_length <= MAX_HEADER_DATA_SIZE) {
-            copyFile(file.first.c_str(), ram_output.get(), ram_buffer, buffer_length);
+            copyFile(file.filename.c_str(), ram_output.get(), ram_buffer, buffer_length);
             header_file_count++;
         }
     }
@@ -167,7 +183,7 @@ void DorisCompoundFileWriter::writeCompoundFile() {
     uint8_t header_buffer[buffer_length];
     for (int i = 0; i < sorted_files.size(); ++i) {
         auto file = sorted_files[i];
-        output->writeString(file.first); // FileName
+        output->writeString(file.filename); // FileName
         // DataOffset
         if (i < header_file_count) {
             // file data write in header, so we set its offset to -1.
@@ -175,19 +191,19 @@ void DorisCompoundFileWriter::writeCompoundFile() {
         } else {
             output->writeLong(data_offset);
         }
-        output->writeLong(file.second); // FileLength
+        output->writeLong(file.filesize); // FileLength
         if (i < header_file_count) {
             // append data
-            copyFile(file.first.c_str(), output.get(), header_buffer, buffer_length);
+            copyFile(file.filename.c_str(), output.get(), header_buffer, buffer_length);
         } else {
-            data_offset += file.second;
+            data_offset += file.filesize;
         }
     }
     // write rest files' data
     uint8_t data_buffer[buffer_length];
     for (int i = header_file_count; i < sorted_files.size(); ++i) {
         auto file = sorted_files[i];
-        copyFile(file.first.c_str(), output.get(), data_buffer, buffer_length);
+        copyFile(file.filename.c_str(), output.get(), data_buffer, buffer_length);
     }
     out_dir->close();
     // NOTE: need to decrease ref count, but not to delete here,
@@ -263,7 +279,11 @@ bool DorisCompoundDirectory::FSIndexInput::open(const io::FileSystemSPtr& fs, co
     }
     SharedHandle* h = _CLNEW SharedHandle(path);
 
-    if (!fs->open_file(path, &h->_reader).ok()) {
+    io::FileReaderOptions reader_options;
+    reader_options.cache_type = config::enable_file_cache ? io::FileCachePolicy::FILE_BLOCK_CACHE
+                                                          : io::FileCachePolicy::NO_CACHE;
+    reader_options.is_doris_table = true;
+    if (!fs->open_file(path, &h->_reader, &reader_options).ok()) {
         error.set(CL_ERR_IO, "open file error");
     }
 
@@ -301,6 +321,7 @@ DorisCompoundDirectory::FSIndexInput::FSIndexInput(const FSIndexInput& other)
     std::lock_guard<std::mutex> wlock(*other._handle->_shared_lock);
     _handle = _CL_POINTER(other._handle);
     _pos = other._handle->_fpos; //note where we are currently...
+    _io_ctx = other._io_ctx;
 }
 
 DorisCompoundDirectory::FSIndexInput::SharedHandle::SharedHandle(const char* path) {
@@ -367,7 +388,7 @@ void DorisCompoundDirectory::FSIndexInput::readInternal(uint8_t* b, const int32_
 
     Slice result {b, (size_t)len};
     size_t bytes_read = 0;
-    if (!_handle->_reader->read_at(_pos, result, &bytes_read).ok()) {
+    if (!_handle->_reader->read_at(_pos, result, &bytes_read, &_io_ctx).ok()) {
         _CLTHROWA(CL_ERR_IO, "read past EOF");
     }
     bufferLength = len;

--- a/be/src/olap/rowset/segment_v2/inverted_index_compound_directory.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_compound_directory.h
@@ -29,6 +29,7 @@
 #include "CLucene/SharedHeader.h"
 #include "io/fs/file_reader_writer_fwd.h"
 #include "io/fs/file_system.h"
+#include "io/io_common.h"
 
 class CLuceneError;
 
@@ -53,6 +54,14 @@ public:
                   int64_t bufferLength);
 
 private:
+    class FileInfo {
+    public:
+        std::string filename;
+        int32_t filesize;
+    };
+
+    void sort_files(std::vector<FileInfo>& file_infos);
+
     CL_NS(store)::Directory* directory = nullptr;
 };
 
@@ -135,10 +144,13 @@ class DorisCompoundDirectory::FSIndexInput : public lucene::store::BufferedIndex
 
     SharedHandle* _handle = nullptr;
     int64_t _pos;
+    io::IOContext _io_ctx;
 
     FSIndexInput(SharedHandle* handle, int32_t buffer_size) : BufferedIndexInput(buffer_size) {
         this->_pos = 0;
         this->_handle = handle;
+        this->_io_ctx.reader_type = ReaderType::READER_QUERY;
+        this->_io_ctx.is_index_data = false;
     }
 
 protected:
@@ -156,6 +168,8 @@ public:
     const char* getDirectoryType() const override { return DorisCompoundDirectory::getClassName(); }
     const char* getObjectName() const override { return getClassName(); }
     static const char* getClassName() { return "FSIndexInput"; }
+
+    void setIdxFileCache(bool index) override { _io_ctx.is_index_data = index; }
 
     std::mutex _this_lock;
 

--- a/be/src/olap/rowset/segment_v2/inverted_index_compound_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_compound_reader.cpp
@@ -124,7 +124,7 @@ CSIndexInput::CSIndexInput(const CSIndexInput& clone) : BufferedIndexInput(clone
 void CSIndexInput::close() {}
 
 DorisCompoundReader::DorisCompoundReader(lucene::store::Directory* d, const char* name,
-                                         int32_t read_buffer_size)
+                                         int32_t read_buffer_size, bool open_idx_file_cache)
         : readBufferSize(read_buffer_size),
           dir(d),
           ram_dir(new lucene::store::RAMDirectory()),
@@ -140,6 +140,7 @@ DorisCompoundReader::DorisCompoundReader(lucene::store::Directory* d, const char
                               .c_str());
         }
         stream = dir->openInput(name, readBufferSize);
+        stream->setIdxFileCache(open_idx_file_cache);
 
         int32_t count = stream->readVInt();
         ReaderFileEntry* entry = nullptr;
@@ -329,6 +330,10 @@ lucene::store::IndexOutput* DorisCompoundReader::createOutput(const char* /*name
 std::string DorisCompoundReader::toString() const {
     return std::string("DorisCompoundReader@") + this->directory + std::string("; file_name: ") +
            std::string(file_name);
+}
+
+CL_NS(store)::IndexInput* DorisCompoundReader::getDorisIndexInput() {
+    return stream;
 }
 
 } // namespace segment_v2

--- a/be/src/olap/rowset/segment_v2/inverted_index_compound_reader.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_compound_reader.h
@@ -73,7 +73,8 @@ protected:
 
 public:
     DorisCompoundReader(lucene::store::Directory* dir, const char* name,
-                        int32_t _readBufferSize = CL_NS(store)::BufferedIndexInput::BUFFER_SIZE);
+                        int32_t _readBufferSize = CL_NS(store)::BufferedIndexInput::BUFFER_SIZE,
+                        bool open_idx_file_cache = false);
     ~DorisCompoundReader() override;
     void copyFile(const char* file, int64_t file_length, uint8_t* buffer, int64_t buffer_length);
     bool list(std::vector<std::string>* names) const override;
@@ -94,6 +95,7 @@ public:
     std::string getPath() const;
     static const char* getClassName();
     const char* getObjectName() const override;
+    CL_NS(store)::IndexInput* getDorisIndexInput();
 };
 
 } // namespace segment_v2


### PR DESCRIPTION
## Proposed changes

1. Arrange idx files in the order of segment, fnm, tii, tis to ensure that data opened during the open index phase is added to the idx file cache.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

