### PR TITLE
[Chore](function) set normal function use_default_implementation_for_constants to default

### DIFF
--- a/be/src/vec/functions/function.h
+++ b/be/src/vec/functions/function.h
@@ -238,13 +238,6 @@ public:
 
     virtual bool is_deterministic_in_scope_of_query() const = 0;
 
-    /** Lets you know if the function is monotonic in a range of values.
-      * This is used to work with the index in a sorted chunk of data.
-      * And allows to use the index not only when it is written, for example `date >= const`, but also, for example, `toMonth(date) >= 11`.
-      * All this is considered only for functions of one argument.
-      */
-    virtual bool has_information_about_monotonicity() const { return false; }
-
     virtual bool is_use_default_implementation_for_constants() const = 0;
 
     /// The property of monotonicity for a certain range.
@@ -581,10 +574,6 @@ public:
 
     bool is_deterministic_in_scope_of_query() const override {
         return function->is_deterministic_in_scope_of_query();
-    }
-
-    bool has_information_about_monotonicity() const override {
-        return function->has_information_about_monotonicity();
     }
 
     IFunctionBase::Monotonicity get_monotonicity_for_range(const IDataType& type, const Field& left,

--- a/be/src/vec/functions/function_agg_state.h
+++ b/be/src/vec/functions/function_agg_state.h
@@ -52,7 +52,6 @@ public:
 
     size_t get_number_of_arguments() const override { return _argument_types.size(); }
 
-    bool use_default_implementation_for_constants() const override { return true; }
     bool use_default_implementation_for_nulls() const override { return false; }
 
     String get_name() const override { return fmt::format("{}_state", _agg_function->get_name()); }

--- a/be/src/vec/functions/function_cast.h
+++ b/be/src/vec/functions/function_cast.h
@@ -1291,8 +1291,6 @@ public:
         }
     }
 
-    bool has_information_about_monotonicity() const override { return Monotonic::has(); }
-
     Monotonicity get_monotonicity_for_range(const IDataType& type, const Field& left,
                                             const Field& right) const override {
         return Monotonic::get(type, left, right);
@@ -1698,10 +1696,6 @@ public:
 
     bool is_deterministic() const override { return true; }
     bool is_deterministic_in_scope_of_query() const override { return true; }
-
-    bool has_information_about_monotonicity() const override {
-        return static_cast<bool>(monotonicity_for_range);
-    }
 
     Monotonicity get_monotonicity_for_range(const IDataType& type, const Field& left,
                                             const Field& right) const override {

--- a/be/src/vec/functions/function_date_or_datetime_to_something.h
+++ b/be/src/vec/functions/function_date_or_datetime_to_something.h
@@ -97,8 +97,6 @@ public:
                                      Transform>::execute(block, arguments, result,
                                                          input_rows_count);
     }
-
-    bool has_information_about_monotonicity() const override { return true; }
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/functions/function_fake.h
+++ b/be/src/vec/functions/function_fake.h
@@ -54,7 +54,6 @@ public:
     }
 
     bool use_default_implementation_for_nulls() const override { return true; }
-    bool use_default_implementation_for_constants() const override { return false; }
 
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         size_t result, size_t input_rows_count) const override {

--- a/be/src/vec/functions/function_fake.h
+++ b/be/src/vec/functions/function_fake.h
@@ -55,6 +55,8 @@ public:
 
     bool use_default_implementation_for_nulls() const override { return true; }
 
+    bool use_default_implementation_for_constants() const override { return false; }
+
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         size_t result, size_t input_rows_count) const override {
         return Status::NotSupported(Impl::get_error_msg());

--- a/be/src/vec/functions/function_json.cpp
+++ b/be/src/vec/functions/function_json.cpp
@@ -892,7 +892,6 @@ public:
     String get_name() const override { return name; }
     size_t get_number_of_arguments() const override { return 0; }
     bool is_variadic() const override { return true; }
-    bool use_default_implementation_for_constants() const override { return true; }
     DataTypePtr get_return_type_impl(const DataTypes& arguments) const override {
         return make_nullable(std::make_shared<DataTypeString>());
     }

--- a/be/src/vec/functions/function_multi_same_args.h
+++ b/be/src/vec/functions/function_multi_same_args.h
@@ -36,8 +36,6 @@ public:
 
     bool use_default_implementation_for_nulls() const override { return true; }
 
-    bool use_default_implementation_for_constants() const override { return false; }
-
     bool is_variadic() const override { return true; }
 
     size_t get_number_of_arguments() const override { return 0; }

--- a/be/src/vec/functions/function_struct_element.cpp
+++ b/be/src/vec/functions/function_struct_element.cpp
@@ -49,8 +49,6 @@ public:
 
     bool use_default_implementation_for_nulls() const override { return true; }
 
-    bool use_default_implementation_for_constants() const override { return true; }
-
     size_t get_number_of_arguments() const override { return 2; }
 
     ColumnNumbers get_arguments_that_are_always_constant() const override { return {1}; }

--- a/be/src/vec/functions/function_unary_arithmetic.h
+++ b/be/src/vec/functions/function_unary_arithmetic.h
@@ -146,8 +146,6 @@ public:
         }
         return Status::OK();
     }
-
-    bool has_information_about_monotonicity() const override { return false; }
 };
 
 struct PositiveMonotonicity {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/SubstringIndex.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/SubstringIndex.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.trees.expressions.functions.scalar;
 
 import org.apache.doris.catalog.FunctionSignature;
+import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.functions.AlwaysNullable;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
@@ -50,6 +51,16 @@ public class SubstringIndex extends ScalarFunction
      */
     public SubstringIndex(Expression arg0, Expression arg1, Expression arg2) {
         super("substring_index", arg0, arg1, arg2);
+    }
+
+    @Override
+    public void checkLegalityBeforeTypeCoercion() {
+        for (int i = 1; i < children.size(); ++i) {
+            if (!getArgument(i).isConstant()) {
+                throw new AnalysisException(getName()
+                        + " function except for the first argument, other parameter must be a constant.");
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
## Proposed changes

set normal function use_default_implementation_for_constants to default

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

