### PR TITLE
[minor](lower-table-names) use GlobalVariable.lowerCaseTableNames instead of Config.lower_case_table_names

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LateralViewRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LateralViewRef.java
@@ -21,7 +21,6 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Function.NullableMode;
 import org.apache.doris.catalog.InlineView;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
 import org.apache.doris.qe.GlobalVariable;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LateralViewRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LateralViewRef.java
@@ -23,6 +23,7 @@ import org.apache.doris.catalog.InlineView;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
+import org.apache.doris.qe.GlobalVariable;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
@@ -146,7 +147,7 @@ public class LateralViewRef extends TableRef {
             }
 
             if (tableName.getTbl() != null) {
-                switch (Config.lower_case_table_names) {
+                switch (GlobalVariable.lowerCaseTableNames) {
                     case 0:
                         if (tableName.getTbl().equals(relatedTableName.getTbl())) {
                             // t1 lateral view explode_split(t1.k1, ",")

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/authorizer/RangerHiveAccessController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/authorizer/RangerHiveAccessController.java
@@ -57,7 +57,6 @@ public class RangerHiveAccessController implements CatalogAccessController {
         auditHandler = new RangerHiveAuditHandler(hivePlugin.getConfig());
         //start a timed log flusher
         logFlushTimer.scheduleAtFixedRate(new RangerHiveAuditLogFlusher(auditHandler), 10, 20L, TimeUnit.SECONDS);
-        hivePlugin.
     }
 
     private RangerAccessRequestImpl createRequest(UserIdentity currentUser, HiveAccessType accessType) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/authorizer/RangerHiveAccessController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/authorizer/RangerHiveAccessController.java
@@ -57,6 +57,7 @@ public class RangerHiveAccessController implements CatalogAccessController {
         auditHandler = new RangerHiveAuditHandler(hivePlugin.getConfig());
         //start a timed log flusher
         logFlushTimer.scheduleAtFixedRate(new RangerHiveAuditLogFlusher(auditHandler), 10, 20L, TimeUnit.SECONDS);
+        hivePlugin.
     }
 
     private RangerAccessRequestImpl createRequest(UserIdentity currentUser, HiveAccessType accessType) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
@@ -19,7 +19,6 @@ package org.apache.doris.datasource.jdbc;
 
 import org.apache.doris.catalog.JdbcResource;
 import org.apache.doris.catalog.external.JdbcExternalDatabase;
-import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.datasource.CatalogProperty;
 import org.apache.doris.datasource.ExternalCatalog;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/jdbc/JdbcExternalCatalog.java
@@ -27,6 +27,7 @@ import org.apache.doris.datasource.InitCatalogLog;
 import org.apache.doris.datasource.SessionContext;
 import org.apache.doris.datasource.jdbc.client.JdbcClient;
 import org.apache.doris.datasource.jdbc.client.JdbcClientConfig;
+import org.apache.doris.qe.GlobalVariable;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -127,7 +128,7 @@ public class JdbcExternalCatalog extends ExternalCatalog {
 
     public String getLowerCaseTableNames() {
         // Forced to true if Config.lower_case_table_names has a value of 1 or 2
-        if (Config.lower_case_table_names == 1 || Config.lower_case_table_names == 2) {
+        if (GlobalVariable.lowerCaseTableNames == 1 || GlobalVariable.lowerCaseTableNames == 2) {
             return "true";
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/CTEContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/CTEContext.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.nereids;
 
-import org.apache.doris.common.Config;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.CTEId;
 import org.apache.doris.nereids.trees.plans.Plan;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/CTEContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/CTEContext.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.trees.expressions.CTEId;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalSubQueryAlias;
+import org.apache.doris.qe.GlobalVariable;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -56,7 +57,7 @@ public class CTEContext {
         if ((parsedPlan == null && previousCteContext != null) || (parsedPlan != null && previousCteContext == null)) {
             throw new AnalysisException("Only first CteContext can contains null cte plan or previousCteContext");
         }
-        this.name = parsedPlan == null ? null : Config.lower_case_table_names != 0
+        this.name = parsedPlan == null ? null : GlobalVariable.lowerCaseTableNames != 0
                 ? parsedPlan.getAlias().toLowerCase(Locale.ROOT) : parsedPlan.getAlias();
         this.cteContextMap = previousCteContext == null
                 ? ImmutableMap.of()
@@ -86,7 +87,7 @@ public class CTEContext {
      * findCTEContext
      */
     public Optional<CTEContext> findCTEContext(String cteName) {
-        if (Config.lower_case_table_names != 0) {
+        if (GlobalVariable.lowerCaseTableNames != 0) {
             cteName = cteName.toLowerCase(Locale.ROOT);
         }
         if (cteName.equals(name)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/SlotBinder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/SlotBinder.java
@@ -19,7 +19,6 @@ package org.apache.doris.nereids.rules.analysis;
 
 import org.apache.doris.analysis.SetType;
 import org.apache.doris.cluster.ClusterNamespace;
-import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.nereids.CascadesContext;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/SlotBinder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/SlotBinder.java
@@ -41,6 +41,7 @@ import org.apache.doris.nereids.trees.expressions.literal.IntegerLikeLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.GlobalVariable;
 import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.qe.VariableMgr;
 import org.apache.doris.qe.VariableVarConverters;
@@ -315,7 +316,7 @@ public class SlotBinder extends SubExprAnalyzer {
     }
 
     private boolean sameTableName(String boundSlot, String unboundSlot) {
-        if (Config.lower_case_table_names != 1) {
+        if (GlobalVariable.lowerCaseTableNames != 1) {
             return boundSlot.equals(unboundSlot);
         } else {
             return boundSlot.equalsIgnoreCase(unboundSlot);


### PR DESCRIPTION
…tead of Config.lower_case_table_names

## Proposed changes

The FE `Config.lower_case_table_names` can only be set when Doris cluster init,
and can not be changed after that.

When Doris cluster first init, it will save this config value to `GlobalVariable.lowerCaseTableNames`
and persist it.
So callers should use `GlobalVariable.lowerCaseTableNames` instead of `Config.lower_case_table_names`.

The PR does not change any logic, just make the code more reasonable.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

