### PR TITLE
[fix](Nereids) should not push down project to the nullable side of outer join

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/PushDownProjectThroughInnerOuterJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/PushDownProjectThroughInnerOuterJoin.java
@@ -136,8 +136,8 @@ public class PushDownProjectThroughInnerOuterJoin implements ExplorationRuleFact
             return null;
         }
         // we could not push nullable side project
-        if ((join.getJoinType().isLeftOuterJoin() && rightContains)
-                || (join.getJoinType().isRightOuterJoin() && leftContains)) {
+        if (((join.getJoinType().isLeftOuterJoin() || join.getJoinType().isFullOuterJoin()) && rightContains)
+                || ((join.getJoinType().isRightOuterJoin() || join.getJoinType().isFullOuterJoin()) && leftContains)) {
             return null;
         }
 


### PR DESCRIPTION

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

