### PR TITLE
[improve](heartbeat) invalid heartbeat does not preempt lock

### DIFF
--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -90,138 +90,144 @@ void HeartbeatServer::heartbeat(THeartbeatResult& heartbeat_result,
 }
 
 Status HeartbeatServer::_heartbeat(const TMasterInfo& master_info) {
-    std::lock_guard<std::mutex> lk(_hb_mtx);
-
-    // Check cluster id
-    if (_master_info->cluster_id == -1) {
-        LOG(INFO) << "get first heartbeat. update cluster id";
-        // write and update cluster id
-        RETURN_IF_ERROR(_olap_engine->set_cluster_id(master_info.cluster_id));
-
-        _master_info->cluster_id = master_info.cluster_id;
-        LOG(INFO) << "record cluster id. host: " << master_info.network_address.hostname
-                  << ". port: " << master_info.network_address.port
-                  << ". cluster id: " << master_info.cluster_id
-                  << ". frontend_infos: " << PrintFrontendInfos(master_info.frontend_infos);
-    } else {
-        if (_master_info->cluster_id != master_info.cluster_id) {
-            return Status::InternalError("invalid cluster id. ignore. cluster_id={}",
-                                         master_info.cluster_id);
-        }
+    bool first_heartbeat = _master_info->cluster_id == -1;
+    if (!first_heartbeat && _master_info->cluster_id != master_info.cluster_id) {
+        return Status::InternalError("invalid cluster id. ignore. cluster_id={}",
+                                     master_info.cluster_id);
     }
 
-    if (master_info.__isset.backend_ip) {
-        // master_info.backend_ip may be an IP or domain name, and it should be renamed 'backend_host', as it requires compatibility with historical versions, the name is still 'backend_ ip'
-        if (master_info.backend_ip != BackendOptions::get_localhost()) {
-            LOG(INFO) << master_info.backend_ip << " not equal to to backend localhost "
-                      << BackendOptions::get_localhost();
-            // step1: check master_info.backend_ip is IP or FQDN
-            if (!is_valid_ip(master_info.backend_ip)) {
-                //step2: resolve FQDN to IP
-                std::string ip;
-                Status status =
-                        hostname_to_ip(master_info.backend_ip, ip, BackendOptions::is_bind_ipv6());
-                if (!status.ok()) {
-                    std::stringstream ss;
-                    ss << "can not get ip from fqdn: " << status.to_string();
-                    LOG(WARNING) << ss.str();
-                    return status;
-                }
-                LOG(INFO) << "master_info.backend_ip: " << master_info.backend_ip
-                          << ", hostname_to_ip: " << ip;
-                //step3: get all ips of the interfaces on this machine
-                std::vector<InetAddress> hosts;
-                status = get_hosts(&hosts);
-                if (!status.ok() || hosts.empty()) {
-                    return Status::InternalError(
-                            "the status was not ok when get_hosts, error is {}",
-                            status.to_string());
-                }
+    {
+        std::lock_guard<std::mutex> lk(_hb_mtx);
 
-                //step4: check if the IP of FQDN belongs to the current machine and update BackendOptions._s_localhost
-                bool set_new_localhost = false;
-                for (auto& addr : hosts) {
-                    if (addr.get_host_address() == ip) {
-                        BackendOptions::set_localhost(master_info.backend_ip);
-                        set_new_localhost = true;
-                        break;
+        // set cluster id
+        if (first_heartbeat) {
+            LOG(INFO) << "get first heartbeat. update cluster id";
+            // write and update cluster id
+            RETURN_IF_ERROR(_olap_engine->set_cluster_id(master_info.cluster_id));
+
+            _master_info->cluster_id = master_info.cluster_id;
+            LOG(INFO) << "record cluster id. host: " << master_info.network_address.hostname
+                      << ". port: " << master_info.network_address.port
+                      << ". cluster id: " << master_info.cluster_id
+                      << ". frontend_infos: " << PrintFrontendInfos(master_info.frontend_infos);
+        }
+
+        if (master_info.__isset.backend_ip) {
+            // master_info.backend_ip may be an IP or domain name, and it should be renamed 'backend_host', as it requires compatibility with historical versions, the name is still 'backend_ ip'
+            if (master_info.backend_ip != BackendOptions::get_localhost()) {
+                LOG(INFO) << master_info.backend_ip << " not equal to to backend localhost "
+                          << BackendOptions::get_localhost();
+                // step1: check master_info.backend_ip is IP or FQDN
+                if (!is_valid_ip(master_info.backend_ip)) {
+                    //step2: resolve FQDN to IP
+                    std::string ip;
+                    Status status = hostname_to_ip(master_info.backend_ip, ip,
+                                                   BackendOptions::is_bind_ipv6());
+                    if (!status.ok()) {
+                        std::stringstream ss;
+                        ss << "can not get ip from fqdn: " << status.to_string();
+                        LOG(WARNING) << ss.str();
+                        return status;
                     }
+                    LOG(INFO) << "master_info.backend_ip: " << master_info.backend_ip
+                              << ", hostname_to_ip: " << ip;
+                    //step3: get all ips of the interfaces on this machine
+                    std::vector<InetAddress> hosts;
+                    status = get_hosts(&hosts);
+                    if (!status.ok() || hosts.empty()) {
+                        return Status::InternalError(
+                                "the status was not ok when get_hosts, error is {}",
+                                status.to_string());
+                    }
+
+                    //step4: check if the IP of FQDN belongs to the current machine and update BackendOptions._s_localhost
+                    bool set_new_localhost = false;
+                    for (auto& addr : hosts) {
+                        if (addr.get_host_address() == ip) {
+                            BackendOptions::set_localhost(master_info.backend_ip);
+                            set_new_localhost = true;
+                            break;
+                        }
+                    }
+
+                    if (!set_new_localhost) {
+                        return Status::InternalError(
+                                "the host recorded in master is {}, but we cannot found the local "
+                                "ip "
+                                "that mapped to that host. backend={}",
+                                master_info.backend_ip, BackendOptions::get_localhost());
+                    }
+                } else {
+                    // if is ip,not check anything,use it
+                    BackendOptions::set_localhost(master_info.backend_ip);
                 }
 
-                if (!set_new_localhost) {
-                    return Status::InternalError(
-                            "the host recorded in master is {}, but we cannot found the local ip "
-                            "that mapped to that host. backend={}",
-                            master_info.backend_ip, BackendOptions::get_localhost());
-                }
-            } else {
-                // if is ip,not check anything,use it
-                BackendOptions::set_localhost(master_info.backend_ip);
+                LOG(WARNING) << "update localhost done, the new localhost is "
+                             << BackendOptions::get_localhost();
             }
-
-            LOG(WARNING) << "update localhost done, the new localhost is "
-                         << BackendOptions::get_localhost();
         }
-    }
 
-    bool need_report = false;
-    if (_master_info->network_address.hostname != master_info.network_address.hostname ||
-        _master_info->network_address.port != master_info.network_address.port) {
-        if (master_info.epoch > _fe_epoch) {
-            _master_info->network_address.hostname = master_info.network_address.hostname;
-            _master_info->network_address.port = master_info.network_address.port;
-            _fe_epoch = master_info.epoch;
-            need_report = true;
-            LOG(INFO) << "master change. new master host: "
-                      << _master_info->network_address.hostname
-                      << ". port: " << _master_info->network_address.port
-                      << ". epoch: " << _fe_epoch;
+        bool need_report = false;
+        if (_master_info->network_address.hostname != master_info.network_address.hostname ||
+            _master_info->network_address.port != master_info.network_address.port) {
+            if (master_info.epoch > _fe_epoch) {
+                _master_info->network_address.hostname = master_info.network_address.hostname;
+                _master_info->network_address.port = master_info.network_address.port;
+                _fe_epoch = master_info.epoch;
+                need_report = true;
+                LOG(INFO) << "master change. new master host: "
+                          << _master_info->network_address.hostname
+                          << ". port: " << _master_info->network_address.port
+                          << ". epoch: " << _fe_epoch;
+            } else {
+                return Status::InternalError(
+                        "epoch is not greater than local. ignore heartbeat. host: {}, port: {}, "
+                        "local "
+                        "epoch: {}, received epoch: {}",
+                        _master_info->network_address.hostname, _master_info->network_address.port,
+                        _fe_epoch, master_info.epoch);
+            }
         } else {
-            return Status::InternalError(
-                    "epoch is not greater than local. ignore heartbeat. host: {}, port: {}, local "
-                    "epoch: {}, received epoch: {}",
-                    _master_info->network_address.hostname, _master_info->network_address.port,
-                    _fe_epoch, master_info.epoch);
+            // when Master FE restarted, host and port remains the same, but epoch will be increased.
+            if (master_info.epoch > _fe_epoch) {
+                _fe_epoch = master_info.epoch;
+                need_report = true;
+                LOG(INFO) << "master restarted. epoch: " << _fe_epoch;
+            }
         }
-    } else {
-        // when Master FE restarted, host and port remains the same, but epoch will be increased.
-        if (master_info.epoch > _fe_epoch) {
-            _fe_epoch = master_info.epoch;
-            need_report = true;
-            LOG(INFO) << "master restarted. epoch: " << _fe_epoch;
+
+        if (master_info.__isset.token) {
+            if (!_master_info->__isset.token) {
+                _master_info->__set_token(master_info.token);
+                LOG(INFO) << "get token. token: " << _master_info->token;
+            } else if (_master_info->token != master_info.token) {
+                return Status::InternalError("invalid token. local_token: {}, token: {}",
+                                             _master_info->token, master_info.token);
+            }
         }
-    }
 
-    if (master_info.__isset.token) {
-        if (!_master_info->__isset.token) {
-            _master_info->__set_token(master_info.token);
-            LOG(INFO) << "get token. token: " << _master_info->token;
-        } else if (_master_info->token != master_info.token) {
-            return Status::InternalError("invalid token. local_token: {}, token: {}",
-                                         _master_info->token, master_info.token);
+        if (master_info.__isset.http_port) {
+            _master_info->__set_http_port(master_info.http_port);
         }
-    }
 
-    if (master_info.__isset.http_port) {
-        _master_info->__set_http_port(master_info.http_port);
-    }
+        if (master_info.__isset.heartbeat_flags) {
+            HeartbeatFlags* heartbeat_flags = ExecEnv::GetInstance()->heartbeat_flags();
+            heartbeat_flags->update(master_info.heartbeat_flags);
+        }
 
-    if (master_info.__isset.heartbeat_flags) {
-        HeartbeatFlags* heartbeat_flags = ExecEnv::GetInstance()->heartbeat_flags();
-        heartbeat_flags->update(master_info.heartbeat_flags);
-    }
+        if (master_info.__isset.backend_id) {
+            _master_info->__set_backend_id(master_info.backend_id);
+        }
 
-    if (master_info.__isset.backend_id) {
-        _master_info->__set_backend_id(master_info.backend_id);
-    }
+        if (master_info.__isset.frontend_infos) {
+            ExecEnv::GetInstance()->update_frontends(master_info.frontend_infos);
+        }
 
-    if (master_info.__isset.frontend_infos) {
-        ExecEnv::GetInstance()->update_frontends(master_info.frontend_infos);
-    }
-
-    if (need_report) {
-        LOG(INFO) << "Master FE is changed or restarted. report tablet and disk info immediately";
-        _olap_engine->notify_listeners();
+        if (need_report) {
+            LOG(INFO)
+                    << "Master FE is changed or restarted. report tablet and disk info immediately";
+            _olap_engine->notify_listeners();
+        }
     }
 
     return Status::OK();


### PR DESCRIPTION
## Proposed changes

Other FE mistakenly sent heartbeat to BE, invalid heartbeat and normal heartbeat forcibly occupied the lock, resulting in heartbeat processing timeout and load transactions being aborted.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

