### PR TITLE
[runtimefilter](refactor) not need return merge entity because it is never used

### DIFF
--- a/be/src/pipeline/pipeline_fragment_context.h
+++ b/be/src/pipeline/pipeline_fragment_context.h
@@ -111,11 +111,6 @@ public:
 
     void close_a_pipeline();
 
-    void set_merge_controller_handler(
-            std::shared_ptr<RuntimeFilterMergeControllerEntity>& handler) {
-        _merge_controller_handler = handler;
-    }
-
     virtual void add_merge_controller_handler(
             std::shared_ptr<RuntimeFilterMergeControllerEntity>& handler) {}
 
@@ -203,8 +198,6 @@ protected:
     std::shared_ptr<QueryContext> _query_ctx;
 
     taskgroup::TaskGroupPipelineTaskEntity* _task_group_entity = nullptr;
-
-    std::shared_ptr<RuntimeFilterMergeControllerEntity> _merge_controller_handler;
 
     MonotonicStopWatch _fragment_watcher;
     RuntimeProfile::Counter* _start_timer = nullptr;

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -768,11 +768,9 @@ Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params,
         RETURN_IF_ERROR(fragment_executor->prepare(params));
     }
     g_fragmentmgr_prepare_latency << (duration_ns / 1000);
-    std::shared_ptr<RuntimeFilterMergeControllerEntity> handler;
     // TODO need check the status, but when I add return_if_error the P0 will not pass
-    static_cast<void>(_runtimefilter_controller.add_entity(params, &handler,
-                                                           fragment_executor->runtime_state()));
-    fragment_executor->set_merge_controller_handler(handler);
+    static_cast<void>(
+            _runtimefilter_controller.add_entity(params, fragment_executor->runtime_state()));
     {
         std::lock_guard<std::mutex> lock(_lock);
         _fragment_instance_map.insert(
@@ -852,11 +850,8 @@ Status FragmentMgr::exec_plan_fragment(const TPipelineFragmentParams& params,
         g_fragmentmgr_prepare_latency << (duration_ns / 1000);
 
         for (size_t i = 0; i < params.local_params.size(); i++) {
-            std::shared_ptr<RuntimeFilterMergeControllerEntity> handler;
-            static_cast<void>(
-                    _runtimefilter_controller.add_entity(params, params.local_params[i], &handler,
-                                                         context->get_runtime_state(UniqueId())));
-            context->set_merge_controller_handler(handler);
+            static_cast<void>(_runtimefilter_controller.add_entity(
+                    params, params.local_params[i], context->get_runtime_state(UniqueId())));
             const TUniqueId& fragment_instance_id = params.local_params[i].fragment_instance_id;
             {
                 std::lock_guard<std::mutex> lock(_lock);
@@ -932,10 +927,8 @@ Status FragmentMgr::exec_plan_fragment(const TPipelineFragmentParams& params,
             }
             g_fragmentmgr_prepare_latency << (duration_ns / 1000);
 
-            std::shared_ptr<RuntimeFilterMergeControllerEntity> handler;
             static_cast<void>(_runtimefilter_controller.add_entity(
-                    params, local_params, &handler, context->get_runtime_state(UniqueId())));
-            context->set_merge_controller_handler(handler);
+                    params, local_params, context->get_runtime_state(UniqueId())));
 
             {
                 std::lock_guard<std::mutex> lock(_lock);

--- a/be/src/runtime/plan_fragment_executor.h
+++ b/be/src/runtime/plan_fragment_executor.h
@@ -135,11 +135,6 @@ public:
 
     void set_need_wait_execution_trigger() { _need_wait_execution_trigger = true; }
 
-    void set_merge_controller_handler(
-            std::shared_ptr<RuntimeFilterMergeControllerEntity>& handler) {
-        _merge_controller_handler = handler;
-    }
-
     std::shared_ptr<QueryContext> get_query_ctx() { return _query_ctx; }
 
     TUniqueId fragment_instance_id() const { return _fragment_instance_id; }
@@ -220,8 +215,6 @@ private:
     RuntimeProfile::Counter* _blocks_produced_counter = nullptr;
 
     RuntimeProfile::Counter* _fragment_cpu_timer = nullptr;
-
-    std::shared_ptr<RuntimeFilterMergeControllerEntity> _merge_controller_handler;
 
     // If set the true, this plan fragment will be executed only after FE send execution start rpc.
     bool _need_wait_execution_trigger = false;

--- a/be/src/runtime/runtime_filter_mgr.cpp
+++ b/be/src/runtime/runtime_filter_mgr.cpp
@@ -495,8 +495,8 @@ Status RuntimeFilterMergeController::add_entity(const TExecPlanFragmentParams& p
                 new RuntimeFilterMergeControllerEntity(state), entity_closer);
         _filter_controller_map[shard][query_id_str] = handle;
         const TRuntimeFilterParams& filter_params = params.params.runtime_filter_params;
-        RETURN_IF_ERROR(handle->get()->init(query_id, fragment_instance_id, filter_params,
-                                            params.query_options));
+        RETURN_IF_ERROR(
+                handle->init(query_id, fragment_instance_id, filter_params, params.query_options));
     }
     return Status::OK();
 }
@@ -524,8 +524,8 @@ Status RuntimeFilterMergeController::add_entity(const TPipelineFragmentParams& p
                 new RuntimeFilterMergeControllerEntity(state), entity_closer);
         _filter_controller_map[shard][query_id_str] = handle;
         const TRuntimeFilterParams& filter_params = local_params.runtime_filter_params;
-        RETURN_IF_ERROR(handle->get()->init(query_id, fragment_instance_id, filter_params,
-                                            params.query_options));
+        RETURN_IF_ERROR(
+                handle->init(query_id, fragment_instance_id, filter_params, params.query_options));
     }
     return Status::OK();
 }

--- a/be/src/runtime/runtime_filter_mgr.cpp
+++ b/be/src/runtime/runtime_filter_mgr.cpp
@@ -473,9 +473,8 @@ Status RuntimeFilterMergeControllerEntity::merge(const PMergeFilterRequest* requ
     return Status::OK();
 }
 
-Status RuntimeFilterMergeController::add_entity(
-        const TExecPlanFragmentParams& params,
-        std::shared_ptr<RuntimeFilterMergeControllerEntity>* handle, RuntimeState* state) {
+Status RuntimeFilterMergeController::add_entity(const TExecPlanFragmentParams& params,
+                                                RuntimeState* state) {
     if (!params.params.__isset.runtime_filter_params ||
         params.params.runtime_filter_params.rid_to_runtime_filter.size() == 0) {
         return Status::OK();
@@ -492,21 +491,19 @@ Status RuntimeFilterMergeController::add_entity(
     auto iter = _filter_controller_map[shard].find(query_id_str);
 
     if (iter == _filter_controller_map[shard].end()) {
-        *handle = std::shared_ptr<RuntimeFilterMergeControllerEntity>(
+        auto handle = std::shared_ptr<RuntimeFilterMergeControllerEntity>(
                 new RuntimeFilterMergeControllerEntity(state), entity_closer);
-        _filter_controller_map[shard][query_id_str] = *handle;
+        _filter_controller_map[shard][query_id_str] = handle;
         const TRuntimeFilterParams& filter_params = params.params.runtime_filter_params;
         RETURN_IF_ERROR(handle->get()->init(query_id, fragment_instance_id, filter_params,
                                             params.query_options));
-    } else {
-        *handle = _filter_controller_map[shard][query_id_str].lock();
     }
     return Status::OK();
 }
 
-Status RuntimeFilterMergeController::add_entity(
-        const TPipelineFragmentParams& params, const TPipelineInstanceParams& local_params,
-        std::shared_ptr<RuntimeFilterMergeControllerEntity>* handle, RuntimeState* state) {
+Status RuntimeFilterMergeController::add_entity(const TPipelineFragmentParams& params,
+                                                const TPipelineInstanceParams& local_params,
+                                                RuntimeState* state) {
     if (!local_params.__isset.runtime_filter_params ||
         local_params.runtime_filter_params.rid_to_runtime_filter.size() == 0) {
         return Status::OK();
@@ -523,14 +520,12 @@ Status RuntimeFilterMergeController::add_entity(
     auto iter = _filter_controller_map[shard].find(query_id_str);
 
     if (iter == _filter_controller_map[shard].end()) {
-        *handle = std::shared_ptr<RuntimeFilterMergeControllerEntity>(
+        auto handle = std::shared_ptr<RuntimeFilterMergeControllerEntity>(
                 new RuntimeFilterMergeControllerEntity(state), entity_closer);
-        _filter_controller_map[shard][query_id_str] = *handle;
+        _filter_controller_map[shard][query_id_str] = handle;
         const TRuntimeFilterParams& filter_params = local_params.runtime_filter_params;
         RETURN_IF_ERROR(handle->get()->init(query_id, fragment_instance_id, filter_params,
                                             params.query_options));
-    } else {
-        *handle = _filter_controller_map[shard][query_id_str].lock();
     }
     return Status::OK();
 }

--- a/be/src/runtime/runtime_filter_mgr.h
+++ b/be/src/runtime/runtime_filter_mgr.h
@@ -186,13 +186,9 @@ public:
     // add a query-id -> entity
     // If a query-id -> entity already exists
     // add_entity will return a exists entity
-    Status add_entity(const TExecPlanFragmentParams& params,
-                      std::shared_ptr<RuntimeFilterMergeControllerEntity>* handle,
-                      RuntimeState* state);
+    Status add_entity(const TExecPlanFragmentParams& params, RuntimeState* state);
     Status add_entity(const TPipelineFragmentParams& params,
-                      const TPipelineInstanceParams& local_params,
-                      std::shared_ptr<RuntimeFilterMergeControllerEntity>* handle,
-                      RuntimeState* state);
+                      const TPipelineInstanceParams& local_params, RuntimeState* state);
     // thread safe
     // increase a reference count
     // if a query-id is not exist


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

