### PR TITLE
[Bug](column) support insert default for ColumnFixedLengthObject

### DIFF
--- a/be/src/vec/columns/column_fixed_length_object.h
+++ b/be/src/vec/columns/column_fixed_length_object.h
@@ -38,9 +38,9 @@ private:
 
 public:
     using Container = PaddedPODArray<uint8_t>;
+    ColumnFixedLengthObject() = delete;
 
 private:
-    ColumnFixedLengthObject() = delete;
     ColumnFixedLengthObject(const size_t _item_size_) : _item_size(_item_size_), _item_count(0) {}
     ColumnFixedLengthObject(const ColumnFixedLengthObject& src)
             : _item_size(src._item_size),
@@ -63,7 +63,7 @@ public:
     }
 
     MutableColumnPtr clone_resized(size_t size) const override {
-        auto res = this->create(_item_size);
+        auto res = create(_item_size);
 
         if (size > 0) {
             auto& new_col = assert_cast<Self&>(*res);
@@ -137,13 +137,13 @@ public:
     void get(size_t n, Field& res) const override { LOG(FATAL) << "get not supported"; }
 
     StringRef get_data_at(size_t n) const override {
-        return StringRef(reinterpret_cast<const char*>(&_data[n * _item_size]), _item_size);
+        return {reinterpret_cast<const char*>(&_data[n * _item_size]), _item_size};
     }
 
     void insert(const Field& x) override { LOG(FATAL) << "insert not supported"; }
 
     void insert_range_from(const IColumn& src, size_t start, size_t length) override {
-        const ColumnFixedLengthObject& src_col = assert_cast<const ColumnFixedLengthObject&>(src);
+        const auto& src_col = assert_cast<const ColumnFixedLengthObject&>(src);
         CHECK_EQ(src_col._item_size, _item_size);
 
         if (length == 0) {
@@ -164,7 +164,7 @@ public:
     }
 
     void insert_from(const IColumn& src, size_t n) override {
-        const ColumnFixedLengthObject& src_col = assert_cast<const ColumnFixedLengthObject&>(src);
+        const auto& src_col = assert_cast<const ColumnFixedLengthObject&>(src);
         DCHECK(_item_size == src_col._item_size) << "dst and src should have the same _item_size  "
                                                  << _item_size << " " << src_col._item_size;
         size_t old_size = size();
@@ -173,10 +173,16 @@ public:
     }
 
     void insert_data(const char* pos, size_t length) override {
-        LOG(FATAL) << "insert_data not supported";
+        size_t old_size = size();
+        resize(old_size + 1);
+        memcpy(&_data[old_size * _item_size], pos, _item_size);
     }
 
-    void insert_default() override { LOG(FATAL) << "insert_default not supported"; }
+    void insert_default() override {
+        size_t old_size = size();
+        resize(old_size + 1);
+        memset(&_data[old_size * _item_size], 0, _item_size);
+    }
 
     void pop_back(size_t n) override { LOG(FATAL) << "pop_back not supported"; }
 
@@ -308,9 +314,9 @@ public:
 
         size_t old_count = _item_count;
         resize(old_count + num);
-        auto dst = _data.data() + old_count * _item_size;
+        auto* dst = _data.data() + old_count * _item_size;
         for (size_t i = 0; i < num; i++) {
-            auto src = data_array + start_offset_array[i];
+            auto* src = data_array + start_offset_array[i];
             uint32_t len = len_array[i];
             dst += i * _item_size;
             memcpy(dst, src, len);


### PR DESCRIPTION
## Proposed changes
support insert default for ColumnFixedLengthObject

0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:417
 1# 0x00007F81C1853090 in /lib/x86_64-linux-gnu/libc.so.6
 2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
 3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
 4# 0x000055976D9B2ADD in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 5# 0x000055976D9A4DEA in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 6# google::LogMessage::SendToLog() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 7# google::LogMessage::Flush() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 8# google::LogMessageFatal::~LogMessageFatal() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
 9# doris::vectorized::ColumnFixedLengthObject::insert_default() in /mnt/hdd01/ci/master-deploy/be/lib/doris_be
10# doris::vectorized::IColumn::insert_many_defaults(unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/vec/columns/column.h:313
11# doris::vectorized::Block::create_same_struct_block(unsigned long, bool) const at /home/zcp/repo_center/doris_master/doris/be/src/vec/core/block.cpp:1092
12# doris::vectorized::BlockReader::_init_agg_state(doris::TabletReader::ReaderParams const&) at /home/zcp/repo_center/doris_master/doris/be/src/vec/olap/block_reader.cpp:170
13# doris::vectorized::BlockReader::init(doris::TabletReader::ReaderParams const&) at /home/zcp/repo_center/doris_master/doris/be/src/vec/olap/block_reader.cpp:263
14# doris::EngineChecksumTask::_compute_checksum() at /home/zcp/repo_center/doris_master/doris/be/src/olap/task/engine_checksum_task.cpp:93
15# doris::EngineChecksumTask::execute() at /home/zcp/repo_center/doris_master/doris/be/src/olap/task/engine_checksum_task.cpp:54
16# doris::StorageEngine::execute_task(doris::EngineTask*) at /home/zcp/repo_center/doris_master/doris/be/src/olap/storage_engine.cpp:1232
17# doris::TaskWorkerPool::_check_consistency_worker_thread_callback() at /home/zcp/repo_center/doris_master/doris/be/src/agent/task_worker_pool.cpp:572


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

