### PR TITLE
[Fix](variant) handle `StorageReadOptions` to avoid crash in `new_col…

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -423,7 +423,7 @@ static Status new_default_iterator(const TabletColumn& tablet_column,
 
 Status Segment::new_column_iterator_with_path(const TabletColumn& tablet_column,
                                               std::unique_ptr<ColumnIterator>* iter,
-                                              StorageReadOptions* opt) {
+                                              const StorageReadOptions* opt) {
     vectorized::PathInData root_path;
     if (tablet_column.path_info().empty()) {
         // Missing path info, but need read the whole variant column
@@ -433,7 +433,7 @@ Status Segment::new_column_iterator_with_path(const TabletColumn& tablet_column,
     }
     auto root = _sub_column_tree.find_leaf(root_path);
     auto node = _sub_column_tree.find_exact(tablet_column.path_info());
-    if (opt->io_ctx.reader_type == ReaderType::READER_ALTER_TABLE) {
+    if (opt != nullptr && opt->io_ctx.reader_type == ReaderType::READER_ALTER_TABLE) {
         CHECK(tablet_column.is_variant_type());
         if (node == nullptr) {
             // No such variant column in this segment, get a default one
@@ -448,7 +448,7 @@ Status Segment::new_column_iterator_with_path(const TabletColumn& tablet_column,
         return Status::OK();
     }
 
-    if (opt->io_ctx.reader_type != ReaderType::READER_QUERY) {
+    if (opt == nullptr || opt->io_ctx.reader_type != ReaderType::READER_QUERY) {
         // Could be compaction ..etc and read flat leaves nodes data
         auto node = _sub_column_tree.find_leaf(tablet_column.path_info());
         if (!node) {
@@ -503,7 +503,7 @@ Status Segment::new_column_iterator_with_path(const TabletColumn& tablet_column,
 // but they are not the same column
 Status Segment::new_column_iterator(const TabletColumn& tablet_column,
                                     std::unique_ptr<ColumnIterator>* iter,
-                                    StorageReadOptions* opt) {
+                                    const StorageReadOptions* opt) {
     // init column iterator by path info
     if (!tablet_column.path_info().empty() || tablet_column.is_variant_type()) {
         return new_column_iterator_with_path(tablet_column, iter, opt);

--- a/be/src/olap/rowset/segment_v2/segment.h
+++ b/be/src/olap/rowset/segment_v2/segment.h
@@ -92,11 +92,11 @@ public:
 
     Status new_column_iterator(const TabletColumn& tablet_column,
                                std::unique_ptr<ColumnIterator>* iter,
-                               StorageReadOptions* opt = nullptr);
+                               const StorageReadOptions* opt);
 
     Status new_column_iterator_with_path(const TabletColumn& tablet_column,
                                          std::unique_ptr<ColumnIterator>* iter,
-                                         StorageReadOptions* opt = nullptr);
+                                         const StorageReadOptions* opt);
 
     Status new_column_iterator(int32_t unique_id, std::unique_ptr<ColumnIterator>* iter);
 

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -466,7 +466,7 @@ Status SegmentIterator::_prepare_seek(const StorageReadOptions::KeyRange& key_ra
     for (auto cid : _seek_schema->column_ids()) {
         if (_column_iterators[cid] == nullptr) {
             RETURN_IF_ERROR(_segment->new_column_iterator(_opts.tablet_schema->column(cid),
-                                                          &_column_iterators[cid]));
+                                                          &_column_iterators[cid], &_opts));
             ColumnIteratorOptions iter_opts {
                     .use_page_cache = _opts.use_page_cache,
                     .file_reader = _file_reader.get(),

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2679,7 +2679,7 @@ Status Tablet::_get_segment_column_iterator(
                                             rowset->rowset_id().to_string(), segid));
     }
     segment_v2::SegmentSharedPtr segment = *it;
-    RETURN_IF_ERROR(segment->new_column_iterator(target_column, column_iterator));
+    RETURN_IF_ERROR(segment->new_column_iterator(target_column, column_iterator, nullptr));
     segment_v2::ColumnIteratorOptions opt {
             .use_page_cache = !config::disable_storage_page_cache,
             .file_reader = segment->file_reader().get(),

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -51,7 +51,8 @@ Status VStatisticsIterator::init(const StorageReadOptions& opts) {
             auto unique_id = _schema.column(cid)->unique_id();
             if (_column_iterators_map.count(unique_id) < 1) {
                 RETURN_IF_ERROR(_segment->new_column_iterator(opts.tablet_schema->column(cid),
-                                                              &_column_iterators_map[unique_id]));
+                                                              &_column_iterators_map[unique_id],
+                                                              nullptr));
             }
             _column_iterators.push_back(_column_iterators_map[unique_id].get());
         }


### PR DESCRIPTION
…umn_iterator_with_path`

In partial update, read variant without `opt` will lead to crash

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

