### PR TITLE
[fix](block) fix be core while mutable block merge may cause different row size between columns in origin block

### DIFF
--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -561,7 +561,7 @@ Status ExecNode::do_projections(vectorized::Block* origin_block, vectorized::Blo
             }
         }
         DCHECK(mutable_block.rows() == rows);
-        output_block->swap(mutable_block.to_block());
+        output_block->set_columns(std::move(mutable_block.mutable_columns()));
     }
 
     return Status::OK();

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -561,6 +561,7 @@ Status ExecNode::do_projections(vectorized::Block* origin_block, vectorized::Blo
             }
         }
         DCHECK(mutable_block.rows() == rows);
+        output_block->swap(mutable_block.to_block());
     }
 
     return Status::OK();

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -561,7 +561,7 @@ Status ExecNode::do_projections(vectorized::Block* origin_block, vectorized::Blo
             }
         }
         DCHECK(mutable_block.rows() == rows);
-        output_block->set_columns(std::move(mutable_block.mutable_columns()));
+        output_block->set_columns(std::move(mutable_columns));
     }
 
     return Status::OK();

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -646,7 +646,6 @@ Status SegmentWriter::fill_missing_columns(vectorized::MutableColumns& mutable_f
             }
         }
     }
-    default_value_block.set_columns(std::move(mutable_default_value_columns));
 
     // fill all missing value from mutable_old_columns, need to consider default value and null value
     for (auto idx = 0; idx < use_default_or_null_flag.size(); idx++) {
@@ -686,6 +685,7 @@ Status SegmentWriter::fill_missing_columns(vectorized::MutableColumns& mutable_f
                     pos_in_old_block);
         }
     }
+    default_value_block.set_columns(std::move(mutable_default_value_columns));
     return Status::OK();
 }
 

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -516,6 +516,7 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
     auto mutable_full_columns = full_block.mutate_columns();
     RETURN_IF_ERROR(fill_missing_columns(mutable_full_columns, use_default_or_null_flag,
                                          has_default_or_nullable, segment_start_pos));
+    full_block.set_columns(std::move(mutable_full_columns));
     // row column should be filled here
     if (_tablet_schema->store_row_column()) {
         // convert block to row store format
@@ -618,6 +619,8 @@ Status SegmentWriter::fill_missing_columns(vectorized::MutableColumns& mutable_f
             }
         }
     }
+    old_value_block.set_columns(std::move(mutable_old_columns));
+
     // build default value columns
     auto default_value_block = old_value_block.clone_empty();
     auto mutable_default_value_columns = default_value_block.mutate_columns();
@@ -643,6 +646,7 @@ Status SegmentWriter::fill_missing_columns(vectorized::MutableColumns& mutable_f
             }
         }
     }
+    default_value_block.set_columns(std::move(mutable_default_value_columns));
 
     // fill all missing value from mutable_old_columns, need to consider default value and null value
     for (auto idx = 0; idx < use_default_or_null_flag.size(); idx++) {

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -3196,6 +3196,7 @@ Status Tablet::generate_new_block_for_partial_update(
                     read_index_update[idx]);
         }
     }
+    output_block->set_columns(std::move(full_mutable_columns));
     VLOG_DEBUG << "full block when publish: " << output_block->dump_data();
     return Status::OK();
 }
@@ -3241,6 +3242,7 @@ Status Tablet::read_columns_by_plan(TabletSchemaSPtr tablet_schema,
             }
         }
     }
+    block.set_columns(std::move(mutable_columns));
     return Status::OK();
 }
 

--- a/be/src/pipeline/exec/join_probe_operator.cpp
+++ b/be/src/pipeline/exec/join_probe_operator.cpp
@@ -104,6 +104,7 @@ Status JoinProbeLocalState<DependencyType, Derived>::_build_output_block(
         }
     };
     if (rows != 0) {
+        auto old_output_rows = output_block->rows();
         auto& mutable_columns = mutable_block.mutable_columns();
         if (_output_expr_ctxs.empty()) {
             DCHECK(mutable_columns.size() == p.row_desc().num_materialized_slots());
@@ -134,9 +135,9 @@ Status JoinProbeLocalState<DependencyType, Derived>::_build_output_block(
             }
         }
 
-        output_block->set_columns(std::move(mutable_block.mutable_columns()));
+        output_block->swap(mutable_block.to_block());
 
-        DCHECK(output_block->rows() == rows);
+        DCHECK(output_block->rows() == old_output_rows + rows);
     }
 
     return Status::OK();

--- a/be/src/pipeline/exec/join_probe_operator.cpp
+++ b/be/src/pipeline/exec/join_probe_operator.cpp
@@ -104,7 +104,6 @@ Status JoinProbeLocalState<DependencyType, Derived>::_build_output_block(
         }
     };
     if (rows != 0) {
-        auto old_output_rows = output_block->rows();
         auto& mutable_columns = mutable_block.mutable_columns();
         if (_output_expr_ctxs.empty()) {
             DCHECK(mutable_columns.size() == p.row_desc().num_materialized_slots());
@@ -137,7 +136,7 @@ Status JoinProbeLocalState<DependencyType, Derived>::_build_output_block(
 
         output_block->swap(mutable_block.to_block());
 
-        DCHECK(output_block->rows() == old_output_rows + rows);
+        DCHECK(output_block->rows() == rows);
     }
 
     return Status::OK();

--- a/be/src/pipeline/exec/join_probe_operator.cpp
+++ b/be/src/pipeline/exec/join_probe_operator.cpp
@@ -134,9 +134,8 @@ Status JoinProbeLocalState<DependencyType, Derived>::_build_output_block(
             }
         }
 
-        if (!is_mem_reuse || !keep_origin) {
-            output_block->swap(mutable_block.to_block());
-        }
+        output_block->set_columns(std::move(mutable_block.mutable_columns()));
+
         DCHECK(output_block->rows() == rows);
     }
 

--- a/be/src/pipeline/exec/nested_loop_join_probe_operator.cpp
+++ b/be/src/pipeline/exec/nested_loop_join_probe_operator.cpp
@@ -130,7 +130,6 @@ Status NestedLoopJoinProbeLocalState::generate_join_block_data(RuntimeState* sta
     _left_side_process_count = 0;
     DCHECK(!_need_more_input_data || !_matched_rows_done);
 
-    vectorized::MutableBlock mutable_join_block(&_join_block);
     if (!_matched_rows_done && !_need_more_input_data) {
         // We should try to join rows if there still are some rows from probe side.
         while (_join_block.rows() < state->batch_size()) {
@@ -144,7 +143,7 @@ Status NestedLoopJoinProbeLocalState::generate_join_block_data(RuntimeState* sta
                 _reset_with_next_probe_row();
                 if (_left_block_pos < _child_block->rows()) {
                     if constexpr (set_probe_side_flag) {
-                        _probe_offset_stack.push(mutable_join_block.rows());
+                        _probe_offset_stack.push(_join_block.rows());
                     }
                 } else {
                     if (_shared_state->left_side_eos) {
@@ -163,9 +162,9 @@ Status NestedLoopJoinProbeLocalState::generate_join_block_data(RuntimeState* sta
 
             const auto& now_process_build_block = _shared_state->build_blocks[_current_build_pos++];
             if constexpr (set_build_side_flag) {
-                _build_offset_stack.push(mutable_join_block.rows());
+                _build_offset_stack.push(_join_block.rows());
             }
-            _process_left_child_block(mutable_join_block, now_process_build_block);
+            _process_left_child_block(_join_block, now_process_build_block);
         }
 
         if constexpr (set_probe_side_flag) {
@@ -178,21 +177,20 @@ Status NestedLoopJoinProbeLocalState::generate_join_block_data(RuntimeState* sta
             if (!status.ok()) {
                 return status;
             }
-            mutable_join_block = vectorized::MutableBlock(&_join_block);
             // If this join operation is left outer join or full outer join, when
             // `_left_side_process_count`, means all rows from build
             // side have been joined with _left_side_process_count, we should output current
             // probe row with null from build side.
             if (_left_side_process_count) {
                 _finalize_current_phase<false, JoinOpType::value == TJoinOp::LEFT_SEMI_JOIN>(
-                        mutable_join_block, state->batch_size());
+                        _join_block, state->batch_size());
             }
         }
 
         if (_left_side_process_count) {
             if (p._is_mark_join && _shared_state->build_blocks.empty()) {
                 DCHECK_EQ(JoinOpType::value, TJoinOp::CROSS_JOIN);
-                _append_left_data_with_null(mutable_join_block);
+                _append_left_data_with_null(_join_block);
             }
         }
     }
@@ -204,7 +202,6 @@ Status NestedLoopJoinProbeLocalState::generate_join_block_data(RuntimeState* sta
                                                                  set_probe_side_flag, ignore_null>(
                          &_join_block, !p._is_right_semi_anti)));
         _update_additional_flags(&_join_block);
-        mutable_join_block = vectorized::MutableBlock(&_join_block);
         if (!status.ok()) {
             return status;
         }
@@ -214,7 +211,7 @@ Status NestedLoopJoinProbeLocalState::generate_join_block_data(RuntimeState* sta
         if (_matched_rows_done &&
             _output_null_idx_build_side < _shared_state->build_blocks.size()) {
             _finalize_current_phase<true, JoinOpType::value == TJoinOp::RIGHT_SEMI_JOIN>(
-                    mutable_join_block, state->batch_size());
+                    _join_block, state->batch_size());
         }
     }
     return Status::OK();
@@ -235,10 +232,10 @@ void NestedLoopJoinProbeLocalState::_resize_fill_tuple_is_null_column(size_t new
 }
 
 template <bool BuildSide, bool IsSemi>
-void NestedLoopJoinProbeLocalState::_finalize_current_phase(vectorized::MutableBlock& mutable_block,
+void NestedLoopJoinProbeLocalState::_finalize_current_phase(vectorized::Block& block,
                                                             size_t batch_size) {
     auto& p = _parent->cast<NestedLoopJoinProbeOperatorX>();
-    auto& dst_columns = mutable_block.mutable_columns();
+    auto dst_columns = block.mutate_columns();
     DCHECK_GT(dst_columns.size(), 0);
     auto column_size = dst_columns[0]->size();
     if constexpr (BuildSide) {
@@ -355,12 +352,12 @@ void NestedLoopJoinProbeLocalState::_finalize_current_phase(vectorized::MutableB
             _resize_fill_tuple_is_null_column(_left_side_process_count, 0, 1);
         }
     }
+    block.set_columns(std::move(dst_columns));
 }
 
-void NestedLoopJoinProbeLocalState::_append_left_data_with_null(
-        vectorized::MutableBlock& mutable_block) const {
+void NestedLoopJoinProbeLocalState::_append_left_data_with_null(vectorized::Block& block) const {
     auto& p = _parent->cast<NestedLoopJoinProbeOperatorX>();
-    auto& dst_columns = mutable_block.mutable_columns();
+    auto dst_columns = block.mutate_columns();
     DCHECK(p._is_mark_join);
     for (size_t i = 0; i < p._num_probe_side_columns; ++i) {
         const vectorized::ColumnWithTypeAndName& src_column = _child_block->get_by_position(i);
@@ -387,13 +384,13 @@ void NestedLoopJoinProbeLocalState::_append_left_data_with_null(
     auto& mark_column = *dst_columns[dst_columns.size() - 1];
     vectorized::ColumnFilterHelper(mark_column)
             .resize_fill(mark_column.size() + _left_side_process_count, 0);
+    block.set_columns(std::move(dst_columns));
 }
 
 void NestedLoopJoinProbeLocalState::_process_left_child_block(
-        vectorized::MutableBlock& mutable_block,
-        const vectorized::Block& now_process_build_block) const {
+        vectorized::Block& block, const vectorized::Block& now_process_build_block) const {
     auto& p = _parent->cast<NestedLoopJoinProbeOperatorX>();
-    auto& dst_columns = mutable_block.mutable_columns();
+    auto dst_columns = block.mutate_columns();
     const int max_added_rows = now_process_build_block.rows();
     for (size_t i = 0; i < p._num_probe_side_columns; ++i) {
         const vectorized::ColumnWithTypeAndName& src_column = _child_block->get_by_position(i);
@@ -434,6 +431,7 @@ void NestedLoopJoinProbeLocalState::_process_left_child_block(
                                                                           0, max_added_rows);
         }
     }
+    block.set_columns(std::move(dst_columns));
 }
 
 NestedLoopJoinProbeOperatorX::NestedLoopJoinProbeOperatorX(ObjectPool* pool, const TPlanNode& tnode,

--- a/be/src/pipeline/exec/nested_loop_join_probe_operator.h
+++ b/be/src/pipeline/exec/nested_loop_join_probe_operator.h
@@ -82,11 +82,11 @@ private:
     friend class NestedLoopJoinProbeOperatorX;
     void _update_additional_flags(vectorized::Block* block);
     template <bool BuildSide, bool IsSemi>
-    void _finalize_current_phase(vectorized::MutableBlock& mutable_block, size_t batch_size);
+    void _finalize_current_phase(vectorized::Block& block, size_t batch_size);
     void _resize_fill_tuple_is_null_column(size_t new_size, int left_flag, int right_flag);
     void _reset_with_next_probe_row();
-    void _append_left_data_with_null(vectorized::MutableBlock& mutable_block) const;
-    void _process_left_child_block(vectorized::MutableBlock& mutable_block,
+    void _append_left_data_with_null(vectorized::Block& block) const;
+    void _process_left_child_block(vectorized::Block& block,
                                    const vectorized::Block& now_process_build_block) const;
     template <typename Filter, bool SetBuildSideFlag, bool SetProbeSideFlag>
     void _do_filtering_and_update_visited_flags_impl(vectorized::Block* block, int column_to_keep,

--- a/be/src/pipeline/pipeline_x/operator.cpp
+++ b/be/src/pipeline/pipeline_x/operator.cpp
@@ -187,6 +187,7 @@ Status OperatorXBase::do_projections(RuntimeState* state, vectorized::Block* ori
             }
         }
         DCHECK(mutable_block.rows() == rows);
+        output_block->set_columns(std::move(mutable_columns));
     }
 
     return Status::OK();

--- a/be/src/vec/common/sort/sorter.cpp
+++ b/be/src/vec/common/sort/sorter.cpp
@@ -186,6 +186,7 @@ Status MergeSorterState::_merge_sort_read_not_spilled(int batch_size,
 
         if (merged_rows == batch_size) break;
     }
+    block->set_columns(std::move(merged_columns));
 
     if (merged_rows == 0) {
         *eos = true;

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -577,7 +577,7 @@ MutableColumns Block::mutate_columns() {
     size_t num_columns = data.size();
     MutableColumns columns(num_columns);
     for (size_t i = 0; i < num_columns; ++i) {
-        columns[i] = data[i].column ? (*std::move(data[i].column)).mutate()
+        columns[i] = data[i].column ? IColumn::mutate(std::move(data[i].column))
                                     : data[i].type->create_column();
     }
     return columns;

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -364,6 +364,15 @@ size_t Block::rows() const {
     return 0;
 }
 
+bool Block::is_valid(size_t rows) const {
+    for (const auto& elem : data) {
+        if (elem.column && elem.column->size() != rows) {
+            return false;
+        }
+    }
+    return true;
+}
+
 std::string Block::each_col_size() const {
     std::string ss;
     for (const auto& elem : data) {

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -577,7 +577,7 @@ MutableColumns Block::mutate_columns() {
     size_t num_columns = data.size();
     MutableColumns columns(num_columns);
     for (size_t i = 0; i < num_columns; ++i) {
-        columns[i] = data[i].column ? (*std::move(data[i].column)).assume_mutable()
+        columns[i] = data[i].column ? (*std::move(data[i].column)).mutate()
                                     : data[i].type->create_column();
     }
     return columns;

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -364,15 +364,6 @@ size_t Block::rows() const {
     return 0;
 }
 
-bool Block::is_valid(size_t rows) const {
-    for (const auto& elem : data) {
-        if (elem.column && elem.column->size() != rows) {
-            return false;
-        }
-    }
-    return true;
-}
-
 std::string Block::each_col_size() const {
     std::string ss;
     for (const auto& elem : data) {
@@ -721,7 +712,7 @@ void Block::swap(Block& other) noexcept {
 void Block::swap(Block&& other) noexcept {
     clear();
     data = std::move(other.data);
-    initialize_index_by_name();
+    index_by_name = std::move(other.index_by_name);
     row_same_bit = std::move(other.row_same_bit);
 }
 
@@ -941,7 +932,7 @@ void MutableBlock::swap(MutableBlock& another) noexcept {
     _columns.swap(another._columns);
     _data_types.swap(another._data_types);
     _names.swap(another._names);
-    initialize_index_by_name();
+    index_by_name.swap(another.index_by_name);
 }
 
 void MutableBlock::swap(MutableBlock&& another) noexcept {
@@ -949,7 +940,7 @@ void MutableBlock::swap(MutableBlock&& another) noexcept {
     _columns = std::move(another._columns);
     _data_types = std::move(another._data_types);
     _names = std::move(another._names);
-    initialize_index_by_name();
+    index_by_name = std::move(another.index_by_name);
 }
 
 void MutableBlock::add_row(const Block* block, int row) {
@@ -1032,6 +1023,7 @@ Block MutableBlock::to_block(int start_column) {
 
 Block MutableBlock::to_block(int start_column, int end_column) {
     ColumnsWithTypeAndName columns_with_schema;
+    columns_with_schema.reserve(end_column - start_column);
     for (size_t i = start_column; i < end_column; ++i) {
         columns_with_schema.emplace_back(std::move(_columns[i]), _data_types[i], _names[i]);
     }

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -577,7 +577,7 @@ MutableColumns Block::mutate_columns() {
     size_t num_columns = data.size();
     MutableColumns columns(num_columns);
     for (size_t i = 0; i < num_columns; ++i) {
-        columns[i] = data[i].column ? IColumn::mutate(std::move(data[i].column))
+        columns[i] = data[i].column ? (*std::move(data[i].column)).mutate()
                                     : data[i].type->create_column();
     }
     return columns;

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -577,7 +577,7 @@ MutableColumns Block::mutate_columns() {
     size_t num_columns = data.size();
     MutableColumns columns(num_columns);
     for (size_t i = 0; i < num_columns; ++i) {
-        columns[i] = data[i].column ? (*std::move(data[i].column)).mutate()
+        columns[i] = data[i].column ? (*std::move(data[i].column)).assume_mutable()
                                     : data[i].type->create_column();
     }
     return columns;

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -586,7 +586,7 @@ MutableColumns Block::mutate_columns() {
     size_t num_columns = data.size();
     MutableColumns columns(num_columns);
     for (size_t i = 0; i < num_columns; ++i) {
-        columns[i] = data[i].column ? (*std::move(data[i].column)).assume_mutable()
+        columns[i] = data[i].column ? (*std::move(data[i].column)).mutate()
                                     : data[i].type->create_column();
     }
     return columns;

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -183,9 +183,6 @@ public:
     /// Returns number of rows from first column in block, not equal to nullptr. If no columns, returns 0.
     size_t rows() const;
 
-    // check block is still valid with given rows after mutable block merging other block
-    bool is_valid(size_t rows) const;
-
     std::string each_col_size() const;
 
     // Cut the rows in block, use in LIMIT operation

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -183,6 +183,9 @@ public:
     /// Returns number of rows from first column in block, not equal to nullptr. If no columns, returns 0.
     size_t rows() const;
 
+    // check block is still valid with given rows after mutable block merging other block
+    bool is_valid(size_t rows) const;
+
     std::string each_col_size() const;
 
     // Cut the rows in block, use in LIMIT operation

--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -1407,11 +1407,11 @@ Status OrcReader::get_next_block(Block* block, size_t* read_rows, bool* eof) {
         auto rows = std::min(get_remaining_rows(), (int64_t)_batch_size);
 
         set_remaining_rows(get_remaining_rows() - rows);
-
-        for (auto& col : block->mutate_columns()) {
+        auto mutate_columns = block->mutate_columns();
+        for (auto& col : mutate_columns) {
             col->resize(rows);
         }
-
+        block->set_columns(std::move(mutate_columns));
         *read_rows = rows;
         if (get_remaining_rows() == 0) {
             *eof = true;

--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -528,10 +528,11 @@ Status ParquetReader::get_next_block(Block* block, size_t* read_rows, bool* eof)
 
         _current_group_reader->set_remaining_rows(_current_group_reader->get_remaining_rows() -
                                                   rows);
-
-        for (auto& col : block->mutate_columns()) {
+        auto mutate_columns = block->mutate_columns();
+        for (auto& col : mutate_columns) {
             col->resize(rows);
         }
+        block->set_columns(std::move(mutate_columns));
 
         *read_rows = rows;
         if (_current_group_reader->get_remaining_rows() == 0) {

--- a/be/src/vec/exec/format/table/iceberg_reader.cpp
+++ b/be/src/vec/exec/format/table/iceberg_reader.cpp
@@ -143,9 +143,11 @@ Status IcebergTableReader::get_next_block(Block* block, size_t* read_rows, bool*
         auto rows =
                 std::min(_remaining_push_down_count, (int64_t)_state->query_options().batch_size);
         _remaining_push_down_count -= rows;
-        for (auto& col : block->mutate_columns()) {
+        auto mutate_columns = block->mutate_columns();
+        for (auto& col : mutate_columns) {
             col->resize(rows);
         }
+        block->set_columns(std::move(mutate_columns));
         *read_rows = rows;
         if (_remaining_push_down_count == 0) {
             *eof = true;

--- a/be/src/vec/exec/join/vjoin_node_base.cpp
+++ b/be/src/vec/exec/join/vjoin_node_base.cpp
@@ -177,7 +177,9 @@ Status VJoinNodeBase::_build_output_block(Block* origin_block, Block* output_blo
             }
         }
     };
+
     if (rows != 0) {
+        auto old_output_rows = output_block->rows();
         auto& mutable_columns = mutable_block.mutable_columns();
         if (_output_expr_ctxs.empty()) {
             DCHECK(mutable_columns.size() == row_desc().num_materialized_slots());
@@ -207,9 +209,8 @@ Status VJoinNodeBase::_build_output_block(Block* origin_block, Block* output_blo
             }
         }
 
-        output_block->set_columns(std::move(mutable_block.mutable_columns()));
-
-        DCHECK(output_block->rows() == rows);
+        output_block->swap(mutable_block.to_block());
+        DCHECK(output_block->rows() == old_output_rows + rows);
     }
 
     return Status::OK();

--- a/be/src/vec/exec/join/vjoin_node_base.cpp
+++ b/be/src/vec/exec/join/vjoin_node_base.cpp
@@ -179,7 +179,6 @@ Status VJoinNodeBase::_build_output_block(Block* origin_block, Block* output_blo
     };
 
     if (rows != 0) {
-        auto old_output_rows = output_block->rows();
         auto& mutable_columns = mutable_block.mutable_columns();
         if (_output_expr_ctxs.empty()) {
             DCHECK(mutable_columns.size() == row_desc().num_materialized_slots());
@@ -210,7 +209,7 @@ Status VJoinNodeBase::_build_output_block(Block* origin_block, Block* output_blo
         }
 
         output_block->swap(mutable_block.to_block());
-        DCHECK(output_block->rows() == old_output_rows + rows);
+        DCHECK(output_block->rows() == rows);
     }
 
     return Status::OK();

--- a/be/src/vec/exec/join/vjoin_node_base.cpp
+++ b/be/src/vec/exec/join/vjoin_node_base.cpp
@@ -207,9 +207,8 @@ Status VJoinNodeBase::_build_output_block(Block* origin_block, Block* output_blo
             }
         }
 
-        if (!is_mem_reuse || !keep_origin) {
-            output_block->swap(mutable_block.to_block());
-        }
+        output_block->set_columns(std::move(mutable_block.mutable_columns()));
+
         DCHECK(output_block->rows() == rows);
     }
 

--- a/be/src/vec/exec/join/vnested_loop_join_node.h
+++ b/be/src/vec/exec/join/vnested_loop_join_node.h
@@ -205,8 +205,7 @@ private:
     // Processes a block from the left child.
     //  dst_columns: left_child_row and now_process_build_block to construct a bundle column of new block
     //  now_process_build_block: right child block now to process
-    void _process_left_child_block(Block& block,
-                                   const Block& now_process_build_block) const;
+    void _process_left_child_block(Block& block, const Block& now_process_build_block) const;
 
     template <bool SetBuildSideFlag, bool SetProbeSideFlag, bool IgnoreNull>
     Status _do_filtering_and_update_visited_flags(Block* block, bool materialize);

--- a/be/src/vec/exec/join/vnested_loop_join_node.h
+++ b/be/src/vec/exec/join/vnested_loop_join_node.h
@@ -115,7 +115,6 @@ private:
         _left_side_process_count = 0;
         DCHECK(!_need_more_input_data || !_matched_rows_done);
 
-        MutableBlock mutable_join_block(&_join_block);
         if (!_matched_rows_done && !_need_more_input_data) {
             // We should try to join rows if there still are some rows from probe side.
             while (_join_block.rows() < state->batch_size()) {
@@ -129,7 +128,7 @@ private:
                     _reset_with_next_probe_row();
                     if (_left_block_pos < _left_block->rows()) {
                         if constexpr (set_probe_side_flag) {
-                            _probe_offset_stack.push(mutable_join_block.rows());
+                            _probe_offset_stack.push(_join_block.rows());
                         }
                     } else {
                         if (_left_side_eos) {
@@ -148,9 +147,9 @@ private:
 
                 const auto& now_process_build_block = _build_blocks[_current_build_pos++];
                 if constexpr (set_build_side_flag) {
-                    _build_offset_stack.push(mutable_join_block.rows());
+                    _build_offset_stack.push(_join_block.rows());
                 }
-                _process_left_child_block(mutable_join_block, now_process_build_block);
+                _process_left_child_block(_join_block, now_process_build_block);
             }
 
             if constexpr (set_probe_side_flag) {
@@ -163,21 +162,20 @@ private:
                 if (!status.ok()) {
                     return status;
                 }
-                mutable_join_block = MutableBlock(&_join_block);
                 // If this join operation is left outer join or full outer join, when
                 // `_left_side_process_count`, means all rows from build
                 // side have been joined with _left_side_process_count, we should output current
                 // probe row with null from build side.
                 if (_left_side_process_count) {
                     _finalize_current_phase<false, JoinOpType::value == TJoinOp::LEFT_SEMI_JOIN>(
-                            mutable_join_block, state->batch_size());
+                            _join_block, state->batch_size());
                 }
             }
 
             if (_left_side_process_count) {
                 if (_is_mark_join && _build_blocks.empty()) {
                     DCHECK_EQ(JoinOpType::value, TJoinOp::CROSS_JOIN);
-                    _append_left_data_with_null(mutable_join_block);
+                    _append_left_data_with_null(_join_block);
                 }
             }
         }
@@ -189,7 +187,6 @@ private:
                              set_build_side_flag, set_probe_side_flag, ignore_null>(
                              &_join_block, !_is_right_semi_anti)));
             _update_additional_flags(&_join_block);
-            mutable_join_block = MutableBlock(&_join_block);
             if (!status.ok()) {
                 return status;
             }
@@ -198,7 +195,7 @@ private:
         if constexpr (set_build_side_flag) {
             if (_matched_rows_done && _output_null_idx_build_side < _build_blocks.size()) {
                 _finalize_current_phase<true, JoinOpType::value == TJoinOp::RIGHT_SEMI_JOIN>(
-                        mutable_join_block, state->batch_size());
+                        _join_block, state->batch_size());
             }
         }
         return Status::OK();
@@ -208,7 +205,7 @@ private:
     // Processes a block from the left child.
     //  dst_columns: left_child_row and now_process_build_block to construct a bundle column of new block
     //  now_process_build_block: right child block now to process
-    void _process_left_child_block(MutableBlock& mutable_block,
+    void _process_left_child_block(Block& block,
                                    const Block& now_process_build_block) const;
 
     template <bool SetBuildSideFlag, bool SetProbeSideFlag, bool IgnoreNull>
@@ -221,7 +218,7 @@ private:
                                                      bool materialize, Filter& filter);
 
     template <bool BuildSide, bool IsSemi>
-    void _finalize_current_phase(MutableBlock& mutable_block, size_t batch_size);
+    void _finalize_current_phase(Block& block, size_t batch_size);
 
     void _reset_with_next_probe_row();
 
@@ -238,7 +235,7 @@ private:
 
     // For mark join, if the relation from right side is empty, we should construct intermediate
     // block with data from left side and filled with null for right side
-    void _append_left_data_with_null(MutableBlock& mutable_block) const;
+    void _append_left_data_with_null(Block& block) const;
 
     // List of build blocks, constructed in prepare()
     Blocks _build_blocks;

--- a/be/src/vec/exec/scan/pip_scanner_context.h
+++ b/be/src/vec/exec/scan/pip_scanner_context.h
@@ -106,6 +106,9 @@ public:
                 static_cast<void>(m.merge(*merge_block));
                 return_free_block(std::move(merge_block));
             }
+            if (!(*block)->is_valid(m.rows())) {
+                (*block)->swap(m.to_block());
+            }
         }
 
         return Status::OK();

--- a/be/src/vec/exec/scan/pip_scanner_context.h
+++ b/be/src/vec/exec/scan/pip_scanner_context.h
@@ -106,9 +106,7 @@ public:
                 static_cast<void>(m.merge(*merge_block));
                 return_free_block(std::move(merge_block));
             }
-            if (!(*block)->is_valid(m.rows())) {
-                (*block)->swap(m.to_block());
-            }
+            (*block)->set_columns(std::move(m.mutable_columns()));
         }
 
         return Status::OK();

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -340,9 +340,7 @@ Status ScannerContext::get_block_from_queue(RuntimeState* state, vectorized::Blo
             static_cast<void>(m.merge(*merge_block));
             return_free_block(std::move(merge_block));
         }
-        if (!(*block)->is_valid(m.rows())) {
-            (*block)->swap(m.to_block());
-        }
+        (*block)->set_columns(std::move(m.mutable_columns()));
     }
 
     return Status::OK();

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -340,6 +340,9 @@ Status ScannerContext::get_block_from_queue(RuntimeState* state, vectorized::Blo
             static_cast<void>(m.merge(*merge_block));
             return_free_block(std::move(merge_block));
         }
+        if (!(*block)->is_valid(m.rows())) {
+            (*block)->swap(m.to_block());
+        }
     }
 
     return Status::OK();

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -400,9 +400,7 @@ void ScannerScheduler::_scanner_scan(ScannerScheduler* scheduler,
             if (!blocks.empty() && blocks.back()->rows() + block->rows() <= state->batch_size()) {
                 vectorized::MutableBlock mutable_block(blocks.back().get());
                 static_cast<void>(mutable_block.merge(*block));
-                if (!blocks.back().get()->is_valid(mutable_block.rows())) {
-                    blocks.back().get()->swap(mutable_block.to_block());
-                }
+                blocks.back().get()->set_columns(std::move(mutable_block.mutable_columns()));
                 ctx->return_free_block(std::move(block));
             } else {
                 blocks.push_back(std::move(block));

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -398,13 +398,9 @@ void ScannerScheduler::_scanner_scan(ScannerScheduler* scheduler,
             ctx->return_free_block(std::move(block));
         } else {
             if (!blocks.empty() && blocks.back()->rows() + block->rows() <= state->batch_size()) {
-                auto rows = blocks.back()->rows() + block->rows();
                 vectorized::MutableBlock mutable_block(blocks.back().get());
-                status = mutable_block.merge(*block);
-                if (!status.ok()) {
-                    break;
-                }
-                if (!blocks.back().get()->is_valid(rows)) {
+                static_cast<void>(mutable_block.merge(*block));
+                if (!blocks.back().get()->is_valid(mutable_block.rows())) {
                     blocks.back().get()->swap(mutable_block.to_block());
                 }
                 ctx->return_free_block(std::move(block));

--- a/be/src/vec/exec/vpartition_sort_node.h
+++ b/be/src/vec/exec/vpartition_sort_node.h
@@ -58,6 +58,7 @@ public:
         for (int i = 0; i < mutable_columns.size(); ++i) {
             columns[i]->append_data_by_selector(mutable_columns[i], selector);
         }
+        blocks.back()->set_columns(std::move(mutable_columns));
         init_rows = init_rows - selector.size();
         total_rows = total_rows + selector.size();
         selector.clear();

--- a/be/src/vec/exec/vrepeat_node.cpp
+++ b/be/src/vec/exec/vrepeat_node.cpp
@@ -167,7 +167,7 @@ Status VRepeatNode::get_repeated_block(Block* child_block, int repeat_id_idx, Bl
         }
         cur_col++;
     }
-
+    output_block->set_columns(std::move(columns));
     DCHECK_EQ(cur_col, column_size);
 
     return Status::OK();

--- a/be/src/vec/exec/vtable_function_node.cpp
+++ b/be/src/vec/exec/vtable_function_node.cpp
@@ -218,7 +218,7 @@ Status VTableFunctionNode::_get_expanded_block(RuntimeState* state, Block* outpu
     for (auto index : _useless_slot_indexs) {
         columns[index]->insert_many_defaults(row_size - columns[index]->size());
     }
-
+    output_block->set_columns(std::move(columns));
     // 3. eval conjuncts
     RETURN_IF_ERROR(VExprContext::filter_block(_conjuncts, output_block, output_block->columns()));
 

--- a/be/src/vec/exec/vunion_node.cpp
+++ b/be/src/vec/exec/vunion_node.cpp
@@ -205,7 +205,9 @@ Status VUnionNode::get_next_materialized(RuntimeState* state, Block* block) {
             ++_child_idx;
         }
     }
-
+    if (!block->is_valid(mblock.rows())) {
+        block->swap(mblock.to_block());
+    }
     DCHECK_LE(_child_idx, _children.size());
     return Status::OK();
 }
@@ -233,7 +235,9 @@ Status VUnionNode::get_next_const(RuntimeState* state, Block* block) {
             tmp_block.clear();
         }
     }
-
+    if (!block->is_valid(mblock.rows())) {
+        block->swap(mblock.to_block());
+    }
     // some insert query like "insert into string_test select 1, repeat('a', 1024 * 1024);"
     // the const expr will be in output expr cause the union node return a empty block. so here we
     // need add one row to make sure the union node exec const expr return at least one row
@@ -256,6 +260,9 @@ Status VUnionNode::materialize_child_block(RuntimeState* state, int child_id,
         Block res;
         RETURN_IF_ERROR(materialize_block(input_block, child_id, &res));
         RETURN_IF_ERROR(mblock.merge(res));
+        if (!output_block->is_valid(mblock.rows())) {
+            output_block->swap(mblock.to_block());
+        }
     }
     return Status::OK();
 }

--- a/be/src/vec/olap/block_reader.cpp
+++ b/be/src/vec/olap/block_reader.cpp
@@ -337,6 +337,7 @@ Status BlockReader::_agg_key_next_block(Block* block, bool* eof) {
     _agg_data_counters.push_back(_last_agg_data_counter);
     _last_agg_data_counter = 0;
     _update_agg_data(target_columns);
+    block->set_columns(std::move(target_columns));
 
     _merged_rows += merged_row;
     return Status::OK();
@@ -379,6 +380,7 @@ Status BlockReader::_unique_key_next_block(Block* block, bool* eof) {
             return res;
         }
     } while (target_block_row < _reader_context.batch_size);
+    block->set_columns(std::move(target_columns));
 
     // do filter delete row in base compaction, only base compaction need to do the job
     if (_filter_delete) {

--- a/be/src/vec/olap/vcollect_iterator.cpp
+++ b/be/src/vec/olap/vcollect_iterator.cpp
@@ -842,6 +842,7 @@ Status VCollectIterator::Level1Iterator::_merge_next(Block* block) {
             pre_row_ref = cur_row;
         }
     } while (true);
+    block->set_columns(std::move(target_columns));
 
     return Status::OK();
 }

--- a/be/src/vec/olap/vcollect_iterator.cpp
+++ b/be/src/vec/olap/vcollect_iterator.cpp
@@ -770,7 +770,7 @@ Status VCollectIterator::Level1Iterator::_normal_next(IteratorRowRef* ref) {
 Status VCollectIterator::Level1Iterator::_merge_next(Block* block) {
     int target_block_row = 0;
     auto target_columns = block->mutate_columns();
-    size_t column_count = block->columns();
+    size_t column_count = target_columns.size();
     IteratorRowRef cur_row = _ref;
     IteratorRowRef pre_row_ref = _ref;
 
@@ -809,6 +809,7 @@ Status VCollectIterator::Level1Iterator::_merge_next(Block* block) {
             if (UNLIKELY(_reader->_reader_context.record_rowids)) {
                 _block_row_locations.resize(target_block_row);
             }
+            block->set_columns(std::move(target_columns));
             return res;
         }
 
@@ -825,6 +826,7 @@ Status VCollectIterator::Level1Iterator::_merge_next(Block* block) {
                                                          continuous_row_in_block);
                 }
             }
+            block->set_columns(std::move(target_columns));
             return Status::OK();
         }
         if (continuous_row_in_block == 0) {
@@ -842,7 +844,6 @@ Status VCollectIterator::Level1Iterator::_merge_next(Block* block) {
             pre_row_ref = cur_row;
         }
     } while (true);
-    block->set_columns(std::move(target_columns));
 
     return Status::OK();
 }

--- a/be/src/vec/olap/vertical_block_reader.cpp
+++ b/be/src/vec/olap/vertical_block_reader.cpp
@@ -405,6 +405,7 @@ Status VerticalBlockReader::_agg_key_next_block(Block* block, bool* eof) {
     _agg_data_counters.push_back(_last_agg_data_counter);
     _last_agg_data_counter = 0;
     _update_agg_data(target_columns);
+    block->set_columns(std::move(target_columns));
 
     return Status::OK();
 }
@@ -543,6 +544,7 @@ Status VerticalBlockReader::_unique_key_next_block(Block* block, bool* eof) {
         }
         ++target_block_row;
     } while (target_block_row < _reader_context.batch_size);
+    block->set_columns(std::move(target_columns));
     return Status::OK();
 }
 

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -75,14 +75,15 @@ Status VStatisticsIterator::next_batch(Block* block) {
                               : std::min(_target_rows - _output_rows, MAX_ROW_SIZE_IN_COUNT);
         if (_push_down_agg_type_opt == TPushAggOp::COUNT) {
             size = std::min(_target_rows - _output_rows, MAX_ROW_SIZE_IN_COUNT);
-            for (int i = 0; i < block->columns(); ++i) {
+            for (int i = 0; i < columns.size(); ++i) {
                 columns[i]->resize(size);
             }
         } else {
-            for (int i = 0; i < block->columns(); ++i) {
+            for (int i = 0; i < columns.size(); ++i) {
                 RETURN_IF_ERROR(_column_iterators[i]->next_batch_of_zone_map(&size, columns[i]));
             }
         }
+        block->set_columns(std::move(columns));
         _output_rows += size;
         return Status::OK();
     }

--- a/be/src/vec/runtime/vsorted_run_merger.cpp
+++ b/be/src/vec/runtime/vsorted_run_merger.cpp
@@ -194,6 +194,7 @@ Status VSortedRunMerger::get_next(Block* output_block, bool* eos) {
                 break;
             }
         }
+        output_block->set_columns(std::move(merged_columns));
 
         if (merged_rows == 0) {
             *eos = true;

--- a/be/test/vec/core/block_test.cpp
+++ b/be/test/vec/core/block_test.cpp
@@ -420,7 +420,7 @@ TEST(BlockTest, merge_with_shared_columns) {
         int32_data_temp.push_back(i);
     }
 
-    vectorized::ColumnWithTypeAndName test_k1_temp(vec->get_ptr(), int32_type, "k1");
+    vectorized::ColumnWithTypeAndName test_k1_temp(vec_temp->get_ptr(), int32_type, "k1");
 
     auto strcol_temp = vectorized::ColumnString::create();
     for (int i = 0; i < 10; ++i) {
@@ -431,11 +431,11 @@ TEST(BlockTest, merge_with_shared_columns) {
     vectorized::ColumnWithTypeAndName test_v1_temp(strcol_temp->get_ptr(), string_type, "v1");
     vectorized::ColumnWithTypeAndName test_v2_temp(strcol_temp->get_ptr(), string_type, "v2");
 
-    vectorized::Block temp_block({test_k1, test_v1, test_v2});
+    vectorized::Block temp_block({test_k1_temp, test_v1_temp, test_v2_temp});
 
     vectorized::MutableBlock mutable_block(&src_block);
-    mutable_block.merge(temp_block);
-
+    auto status = mutable_block.merge(temp_block);
+    ASSERT_TRUE(status.ok());
     ASSERT_FALSE(src_block.is_valid(1034));
 
     src_block.swap(mutable_block.to_block());

--- a/be/test/vec/core/block_test.cpp
+++ b/be/test/vec/core/block_test.cpp
@@ -436,10 +436,12 @@ TEST(BlockTest, merge_with_shared_columns) {
     vectorized::MutableBlock mutable_block(&src_block);
     auto status = mutable_block.merge(temp_block);
     ASSERT_TRUE(status.ok());
-    ASSERT_FALSE(src_block.is_valid(1034));
 
-    src_block.swap(mutable_block.to_block());
-    ASSERT_TRUE(src_block.is_valid(1034));
+    src_block.set_columns(std::move(mutable_block.mutable_columns()));
+
+    for (auto& column : src_block.get_columns()) {
+        EXPECT_EQ(1034, column->size());
+    }
     EXPECT_EQ(1034, src_block.rows());
 }
 

--- a/be/test/vec/core/block_test.cpp
+++ b/be/test/vec/core/block_test.cpp
@@ -392,4 +392,55 @@ TEST(BlockTest, dump_data) {
     vectorized::Block::filter_block_internal(&block1, filter, block1.columns());
     EXPECT_EQ(size, block1.rows());
 }
+
+TEST(BlockTest, merge_with_shared_columns) {
+    auto vec = vectorized::ColumnVector<Int32>::create();
+    auto& int32_data = vec->get_data();
+    for (int i = 0; i < 1024; ++i) {
+        int32_data.push_back(i);
+    }
+    vectorized::DataTypePtr int32_type(std::make_shared<vectorized::DataTypeInt32>());
+    vectorized::ColumnWithTypeAndName test_k1(vec->get_ptr(), int32_type, "k1");
+
+    auto strcol = vectorized::ColumnString::create();
+    for (int i = 0; i < 1024; ++i) {
+        std::string is = std::to_string(i);
+        strcol->insert_data(is.c_str(), is.size());
+    }
+    vectorized::DataTypePtr string_type(std::make_shared<vectorized::DataTypeString>());
+    vectorized::ColumnWithTypeAndName test_v1(strcol->get_ptr(), string_type, "v1");
+
+    vectorized::ColumnWithTypeAndName test_v2(strcol->get_ptr(), string_type, "v2");
+
+    vectorized::Block src_block({test_k1, test_v1, test_v2});
+
+    auto vec_temp = vectorized::ColumnVector<Int32>::create();
+    auto& int32_data_temp = vec_temp->get_data();
+    for (int i = 0; i < 10; ++i) {
+        int32_data_temp.push_back(i);
+    }
+
+    vectorized::ColumnWithTypeAndName test_k1_temp(vec->get_ptr(), int32_type, "k1");
+
+    auto strcol_temp = vectorized::ColumnString::create();
+    for (int i = 0; i < 10; ++i) {
+        std::string is = std::to_string(i);
+        strcol_temp->insert_data(is.c_str(), is.size());
+    }
+
+    vectorized::ColumnWithTypeAndName test_v1_temp(strcol_temp->get_ptr(), string_type, "v1");
+    vectorized::ColumnWithTypeAndName test_v2_temp(strcol_temp->get_ptr(), string_type, "v2");
+
+    vectorized::Block temp_block({test_k1, test_v1, test_v2});
+
+    vectorized::MutableBlock mutable_block(&src_block);
+    mutable_block.merge(temp_block);
+
+    ASSERT_FALSE(src_block.is_valid(1034));
+
+    src_block.swap(mutable_block.to_block());
+    ASSERT_TRUE(src_block.is_valid(1034));
+    EXPECT_EQ(1034, src_block.rows());
+}
+
 } // namespace doris


### PR DESCRIPTION
## Proposed changes

if columns in block share column ptr, the mutable block on it will create new column ptr after merging other non-empty block, which would make origin block invalid, here is to fix it.
has different row size  

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

