### PR TITLE
[fix](move-memtable) exclude memtable insert memory in query tracker

### DIFF
--- a/be/src/olap/delta_writer_v2.cpp
+++ b/be/src/olap/delta_writer_v2.cpp
@@ -142,6 +142,7 @@ Status DeltaWriterV2::append(const vectorized::Block* block) {
 
 Status DeltaWriterV2::write(const vectorized::Block* block, const std::vector<int>& row_idxs,
                             bool is_append) {
+    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->orphan_mem_tracker());
     if (UNLIKELY(row_idxs.empty() && !is_append)) {
         return Status::OK();
     }


### PR DESCRIPTION
## Proposed changes

Memtable insert is processed in the same thread with sink v2,
causing mem usage being tracked in query tracker.

This PR excludes memtable insert memory in query tracker.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

