### PR TITLE
[fix](Nereids): Preserve `""` in single quote strings and `''` in double quote strings.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -1929,7 +1929,13 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
     public Literal visitStringLiteral(StringLiteralContext ctx) {
         String txt = ctx.STRING_LITERAL().getText();
         String s = txt.substring(1, txt.length() - 1);
-        s = s.replace("''", "'").replace("\"\"", "\"");
+        if (txt.charAt(0) == '\'') {
+            // for single quote string, '' should be converted to '
+            s = s.replace("''", "'");
+        } else if (txt.charAt(0) == '"') {
+            // for double quote string, "" should be converted to "
+            s = s.replace("\"\"", "\"");
+        }
         if (!SqlModeHelper.hasNoBackSlashEscapes()) {
             s = LogicalPlanBuilderAssistant.escapeBackSlash(s);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -789,8 +789,7 @@ public class StatisticsUtil {
             return null;
         }
         return str.replace("'", "''")
-                .replace("\\", "\\\\")
-                .replace("\"", "\"\"");
+                .replace("\\", "\\\\");
     }
 
     public static boolean isExternalTable(String catalogName, String dbName, String tblName) {

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/util/StatisticsUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/util/StatisticsUtilTest.java
@@ -34,9 +34,9 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Base64;
 
-public class StatisticsUtilTest {
+class StatisticsUtilTest {
     @Test
-    public void testConvertToDouble() {
+    void testConvertToDouble() {
         try {
             //test DATE
             double date1 = StatisticsUtil.convertToDouble(Type.DATE, "1990-01-01");
@@ -80,7 +80,7 @@ public class StatisticsUtilTest {
     }
 
     @Test
-    public void testInAnalyzeTime1() {
+    void testInAnalyzeTime1() {
         new MockUp<StatisticsUtil>() {
 
             @Mock
@@ -99,7 +99,7 @@ public class StatisticsUtilTest {
     }
 
     @Test
-    public void testInAnalyzeTime2() {
+    void testInAnalyzeTime2() {
         new MockUp<StatisticsUtil>() {
 
             @Mock
@@ -119,7 +119,7 @@ public class StatisticsUtilTest {
 
 
     @Test
-    public void testEncodeValue() throws Exception {
+    void testEncodeValue() throws Exception {
         Assertions.assertEquals("NULL", StatisticsUtil.encodeValue(null, 0));
 
         ResultRow row = new ResultRow(null);
@@ -144,10 +144,10 @@ public class StatisticsUtilTest {
     }
 
     @Test
-    public void testEscape() {
+    void testEscape() {
         // \'"
         String origin = "\\'\"";
         // \\''""
-        Assertions.assertEquals("\\\\''\"\"", StatisticsUtil.escapeSQL(origin));
+        Assertions.assertEquals("\\\\''\"", StatisticsUtil.escapeSQL(origin));
     }
 }

--- a/regression-test/data/nereids_syntax_p0/one_row_relation.out
+++ b/regression-test/data/nereids_syntax_p0/one_row_relation.out
@@ -5,3 +5,9 @@ A'B	A''B	A''B
 -- !string2 --
 A"B	A""B	
 
+-- !string3 --
+A""B	A""B
+
+-- !string4 --
+A''B	A''B
+

--- a/regression-test/suites/nereids_syntax_p0/one_row_relation.groovy
+++ b/regression-test/suites/nereids_syntax_p0/one_row_relation.groovy
@@ -34,4 +34,6 @@ suite("one_row_relation") {
 
     qt_string1 """ select 'A''B', 'A''''B', 'A\\'\\'B', ''; """
     qt_string2 """ select "A""B", "A\\"\\"B", "";  """
+    qt_string3 """ select 'A""B', 'A\\"\\"B';  """
+    qt_string4 """ select "A''B", "A\\'\\'B";  """
 }


### PR DESCRIPTION
## Proposed changes

Preserve "" in single quote strings and '' in double quote strings.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

