### PR TITLE
[fix](move-memtable) free resources before storage engine stop

### DIFF
--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -556,6 +556,9 @@ void ExecEnv::destroy() {
     // NewLoadStreamMgr should be destoried before storage_engine & after fragment_mgr stopped.
     _new_load_stream_mgr.reset();
     _stream_load_executor.reset();
+    _memtable_memory_limiter.reset();
+    _load_stream_stub_pool.reset();
+    _delta_writer_v2_pool.reset();
     SAFE_STOP(_storage_engine);
     SAFE_SHUTDOWN(_buffered_reader_prefetch_thread_pool);
     SAFE_SHUTDOWN(_s3_file_upload_thread_pool);
@@ -572,9 +575,6 @@ void ExecEnv::destroy() {
     SAFE_DELETE(_tablet_schema_cache);
     _deregister_metrics();
     SAFE_DELETE(_load_channel_mgr);
-    _memtable_memory_limiter.reset(nullptr);
-    _load_stream_stub_pool.reset();
-    _delta_writer_v2_pool.reset();
 
     // shared_ptr maybe no need to be reset
     // _brpc_iobuf_block_memory_tracker.reset();

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -557,8 +557,8 @@ void ExecEnv::destroy() {
     _new_load_stream_mgr.reset();
     _stream_load_executor.reset();
     _memtable_memory_limiter.reset();
-    _load_stream_stub_pool.reset();
     _delta_writer_v2_pool.reset();
+    _load_stream_stub_pool.reset();
     SAFE_STOP(_storage_engine);
     SAFE_SHUTDOWN(_buffered_reader_prefetch_thread_pool);
     SAFE_SHUTDOWN(_s3_file_upload_thread_pool);


### PR DESCRIPTION
## Proposed changes

`DeltaWriterV2->MemTableWriter->FlushToken` are shared in `_delta_writer_v2_pool`.
We may get this error if we don't free resources before `StorageEngine` stop:

```
dcheck failed: F20231203 04:14:54.634037 1465773 threadpool.cpp:253] Check failed: 1 == _tokens.size() (1 vs. 73) Threadpool MemTableFlushThreadPool destroyed with 73 allocated tokens
``` 

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

