### PR TITLE
[cleanup](load) remove unused LoadChannel::get_tablets_channels()

### DIFF
--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -81,11 +81,6 @@ public:
     RuntimeProfile::Counter* get_mgr_add_batch_timer() { return _mgr_add_batch_timer; }
     RuntimeProfile::Counter* get_handle_mem_limit_timer() { return _handle_mem_limit_timer; }
 
-    std::unordered_map<int64_t, std::shared_ptr<TabletsChannel>> get_tablets_channels() {
-        std::lock_guard<SpinLock> l(_tablets_channels_lock);
-        return _tablets_channels;
-    }
-
 protected:
     Status _get_tablets_channel(std::shared_ptr<TabletsChannel>& channel, bool& is_finished,
                                 const int64_t index_id);


### PR DESCRIPTION
## Proposed changes

Remove unused interface `LoadChannel::get_tablets_channels()`.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

