### PR TITLE
[fix](move-memtable) fix sink v2 profile

### DIFF
--- a/be/src/vec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.cpp
@@ -189,8 +189,6 @@ Status VTabletWriterV2::_init(RuntimeState* state, RuntimeProfile* profile) {
     _is_high_priority =
             (state->execution_timeout() <= config::load_task_high_priority_threshold_second);
 
-    // profile must add to state's object pool
-    _profile = state->obj_pool()->add(new RuntimeProfile("VTabletWriterV2"));
     _mem_tracker =
             std::make_shared<MemTracker>("VTabletWriterV2:" + std::to_string(state->load_job_id()));
     SCOPED_TIMER(_profile->total_time_counter());


### PR DESCRIPTION
## Proposed changes

Profile is created by `AsyncWriterSink`, and profile name is expected to be hard-coded.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

