### PR TITLE
[fix](move-memtable) only report load stream profile in the end

### DIFF
--- a/be/src/runtime/load_stream.cpp
+++ b/be/src/runtime/load_stream.cpp
@@ -338,7 +338,7 @@ void LoadStream::_report_result(StreamId stream, const Status& st,
         response.add_failed_tablet_ids(id);
     }
 
-    if (_enable_profile) {
+    if (_enable_profile && _close_load_cnt == _total_streams) {
         TRuntimeProfileTree tprofile;
         ThriftSerializer ser(false, 4096);
         uint8_t* buf = nullptr;


### PR DESCRIPTION
## Proposed changes

Only report `LoadStream` profile in the last `CLOSE_LOAD` response.
Also fix error in `RuntimeProfile::to_thrift` because it's not thread-safe.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

