### PR TITLE
[fix](hdfs) Fix hdfsExists that return staled root cause

### DIFF
--- a/be/src/io/fs/hdfs_file_system.cpp
+++ b/be/src/io/fs/hdfs_file_system.cpp
@@ -227,15 +227,28 @@ Status HdfsFileSystem::delete_internal(const Path& path, int is_recursive) {
 Status HdfsFileSystem::exists_impl(const Path& path, bool* res) const {
     CHECK_HDFS_HANDLE(_fs_handle);
     Path real_path = convert_path(path, _fs_name);
+#ifdef USE_HADOOP_HDFS
+    // HACK: the HDFS native client won't clear the last exception as expected so
+    // `hdfsGetLastExceptionRootCause` might return a staled root cause. Save the
+    // last root cause here and verify after hdfsExists returns a non-zero code.
+    //
+    // See details:
+    //  https://github.com/apache/hadoop/blob/5cda162a804fb0cfc2a5ac0058ab407662c5fb00/
+    //  hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/jni_helper.c#L795
+    char* former_root_cause = hdfsGetLastExceptionRootCause();
+#endif
     int is_exists = hdfsExists(_fs_handle->hdfs_fs, real_path.string().c_str());
 #ifdef USE_HADOOP_HDFS
     // when calling hdfsExists() and return non-zero code,
     // if root_cause is nullptr, which means the file does not exist.
     // if root_cause is not nullptr, which means it encounter other error, should return.
     // NOTE: not for libhdfs3 since it only runs on MaxOS, don't have to support it.
-    char* root_cause = hdfsGetLastExceptionRootCause();
-    if (root_cause != nullptr) {
-        return Status::IOError("failed to check path existence {}: {}", path.native(), root_cause);
+    if (is_exists != 0) {
+        char* root_cause = hdfsGetLastExceptionRootCause();
+        if (root_cause != nullptr && root_cause != former_root_cause) {
+            return Status::IOError("failed to check path existence {}: {}", path.native(),
+                                   root_cause);
+        }
     }
 #endif
     *res = (is_exists == 0);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

The HDFS native client won't clear the last exception as expected so `hdfsGetLastExceptionRootCause` might return a staled root cause. This PR saves the last root cause here and verifies after hdfsExists returns a non-zero code.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

