### PR TITLE
[fix](memtracking) fix capacity when releasing owned slice

### DIFF
--- a/be/src/util/faststring.h
+++ b/be/src/util/faststring.h
@@ -88,7 +88,7 @@ public:
             ret = reinterpret_cast<uint8_t*>(Allocator::alloc(len_));
             memcpy(ret, data_, len_);
         }
-        OwnedSlice result(ret, len_);
+        OwnedSlice result(ret, len_, capacity_);
         len_ = 0;
         capacity_ = kInitialCapacity;
         data_ = initial_data_;

--- a/be/src/util/slice.h
+++ b/be/src/util/slice.h
@@ -344,19 +344,21 @@ class OwnedSlice : private Allocator<false, false, false> {
 public:
     OwnedSlice() : _slice((uint8_t*)nullptr, 0) {}
 
-    OwnedSlice(OwnedSlice&& src) : _slice(src._slice) {
+    OwnedSlice(OwnedSlice&& src) : _slice(src._slice), _capacity(src._capacity) {
         src._slice.data = nullptr;
         src._slice.size = 0;
+        src._capacity = 0;
     }
 
     OwnedSlice& operator=(OwnedSlice&& src) {
         if (this != &src) {
             std::swap(_slice, src._slice);
+            std::swap(_capacity, src._capacity);
         }
         return *this;
     }
 
-    ~OwnedSlice() { Allocator::free(_slice.data, _slice.size); }
+    ~OwnedSlice() { Allocator::free(_slice.data, _capacity); }
 
     const Slice& slice() const { return _slice; }
 
@@ -364,7 +366,8 @@ private:
     // faststring also inherits Allocator and disables mmap.
     friend class faststring;
 
-    OwnedSlice(uint8_t* _data, size_t size) : _slice(_data, size) {}
+    OwnedSlice(uint8_t* _data, size_t size, size_t capacity)
+            : _slice(_data, size), _capacity(capacity) {}
 
 private:
     // disable copy constructor and copy assignment
@@ -372,6 +375,7 @@ private:
     void operator=(const OwnedSlice&) = delete;
 
     Slice _slice;
+    size_t _capacity = 0;
 };
 
 } // namespace doris


### PR DESCRIPTION
## Proposed changes

`faststring::len_` is data size, `faststring::capacity_` is memory size.
Store capacity when building `OwnedSlice` and fix memtracking when releasing `OwnedSlice`.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

