### PR TITLE
[improvement](merge-on-write) Optimize publish when there are missing versions

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1458,6 +1458,11 @@ void PublishVersionWorkerPool::publish_version_callback(const TAgentTaskRequest&
         }
 
         if (status.is<PUBLISH_VERSION_NOT_CONTINUOUS>()) {
+            // there are too many missing versions, it has been be added to async
+            // publish task, so no need to retry here.
+            if (discontinuous_version_tablets.empty()) {
+                break;
+            }
             LOG_EVERY_SECOND(INFO) << "wait for previous publish version task to be done, "
                                    << "transaction_id: " << publish_version_req.transaction_id;
 

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1084,6 +1084,9 @@ DEFINE_mInt64(LZ4_HC_compression_level, "9");
 DEFINE_mBool(enable_merge_on_write_correctness_check, "true");
 // rowid conversion correctness check when compaction for mow table
 DEFINE_mBool(enable_rowid_conversion_correctness_check, "false");
+// When the number of missing versions is more than this value, do not directly
+// retry the publish and handle it through async publish.
+DEFINE_mInt32(mow_publish_max_discontinuous_version_num, "20");
 
 // The secure path with user files, used in the `local` table function.
 DEFINE_mString(user_files_secure_path, "${DORIS_HOME}");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1149,6 +1149,9 @@ DECLARE_mInt64(variant_threshold_rows_to_estimate_sparse_column);
 DECLARE_mBool(enable_merge_on_write_correctness_check);
 // rowid conversion correctness check when compaction for mow table
 DECLARE_mBool(enable_rowid_conversion_correctness_check);
+// When the number of missing versions is more than this value, do not directly
+// retry the publish and handle it through async publish.
+DECLARE_mInt32(mow_publish_max_discontinuous_version_num);
 
 // The secure path with user files, used in the `local` table function.
 DECLARE_mString(user_files_secure_path);

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -30,6 +30,7 @@
 #include <memory>
 #include <mutex>
 #include <set>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -333,6 +334,8 @@ private:
 
     void _async_publish_callback();
 
+    void _process_async_publish();
+
     Status _persist_broken_paths();
 
 private:
@@ -484,7 +487,7 @@ private:
     std::map<int64_t, std::map<int64_t, std::pair<int64_t, int64_t>>> _async_publish_tasks;
     // aync publish for discontinuous versions of merge_on_write table
     scoped_refptr<Thread> _async_publish_thread;
-    std::mutex _async_publish_mutex;
+    std::shared_mutex _async_publish_lock;
 
     bool _clear_segment_cache = false;
 

--- a/be/src/olap/task/engine_publish_version_task.cpp
+++ b/be/src/olap/task/engine_publish_version_task.cpp
@@ -193,7 +193,8 @@ Status EnginePublishVersionTask::execute() {
                         add_error_tablet_id(tablet_info.tablet_id);
                         // When there are too many missing versions, do not directly retry the
                         // publish and handle it through async publish.
-                        if (max_version + 20 < version.first) {
+                        if (max_version + config::mow_publish_max_discontinuous_version_num <
+                            version.first) {
                             StorageEngine::instance()->add_async_publish_task(
                                     partition_id, tablet_info.tablet_id, version.first,
                                     _publish_version_req.transaction_id, false);

--- a/be/test/olap/storage_engine_test.cpp
+++ b/be/test/olap/storage_engine_test.cpp
@@ -21,17 +21,16 @@
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest-message.h>
 #include <gtest/gtest-test-part.h>
+#include <gtest/gtest.h>
 
 #include <filesystem>
 
 #include "common/status.h"
 #include "gtest/gtest_pred_impl.h"
-#include "testutil/test_util.h"
-
-using ::testing::_;
-using ::testing::Return;
-using ::testing::SetArgPointee;
-using std::string;
+#include "io/fs/local_file_system.h"
+#include "olap/data_dir.h"
+#include "olap/tablet_manager.h"
+#include "util/threadpool.h"
 
 namespace doris {
 using namespace config;
@@ -39,14 +38,29 @@ using namespace config;
 class StorageEngineTest : public testing::Test {
 public:
     virtual void SetUp() {
+        _engine_data_path = "./be/test/olap/test_data/converter_test_data/tmp";
+        EXPECT_TRUE(
+                io::global_local_filesystem()->delete_and_create_directory(_engine_data_path).ok());
+        EXPECT_TRUE(
+                io::global_local_filesystem()->create_directory(_engine_data_path + "/meta").ok());
+        _data_dir.reset(new DataDir(_engine_data_path, 100000000));
+        static_cast<void>(_data_dir->init());
+
         EngineOptions options;
+        options.backend_uid = UniqueId::gen_uid();
 
         _storage_engine.reset(new StorageEngine(options));
+        ExecEnv::GetInstance()->set_storage_engine(_storage_engine.get());
     }
 
-    virtual void TearDown() {}
+    virtual void TearDown() {
+        EXPECT_TRUE(io::global_local_filesystem()->delete_directory(_engine_data_path).ok());
+        ExecEnv::GetInstance()->set_storage_engine(nullptr);
+    }
 
     std::unique_ptr<StorageEngine> _storage_engine;
+    std::string _engine_data_path;
+    std::unique_ptr<DataDir> _data_dir;
 };
 
 TEST_F(StorageEngineTest, TestBrokenDisk) {
@@ -84,6 +98,82 @@ TEST_F(StorageEngineTest, TestBrokenDisk) {
         EXPECT_EQ(_storage_engine->get_broken_paths().count("broken_path2"), 0);
         EXPECT_EQ(broken_storage_path, "broken_path1;");
     }
+}
+
+TEST_F(StorageEngineTest, TestAsyncPublish) {
+    auto st = ThreadPoolBuilder("TabletPublishTxnThreadPool")
+                      .set_min_threads(config::tablet_publish_txn_max_thread)
+                      .set_max_threads(config::tablet_publish_txn_max_thread)
+                      .build(&_storage_engine->tablet_publish_txn_thread_pool());
+    EXPECT_EQ(st, Status::OK());
+
+    int64_t partition_id = 1;
+    int64_t tablet_id = 111;
+
+    TColumnType col_type;
+    col_type.__set_type(TPrimitiveType::SMALLINT);
+    TColumn col1;
+    col1.__set_column_name("col1");
+    col1.__set_column_type(col_type);
+    col1.__set_is_key(true);
+    std::vector<TColumn> cols;
+    cols.push_back(col1);
+    TTabletSchema tablet_schema;
+    tablet_schema.__set_short_key_column_count(1);
+    tablet_schema.__set_schema_hash(3333);
+    tablet_schema.__set_keys_type(TKeysType::AGG_KEYS);
+    tablet_schema.__set_storage_type(TStorageType::COLUMN);
+    tablet_schema.__set_columns(cols);
+    TCreateTabletReq create_tablet_req;
+    create_tablet_req.__set_tablet_schema(tablet_schema);
+    create_tablet_req.__set_tablet_id(tablet_id);
+    create_tablet_req.__set_version(10);
+
+    std::vector<DataDir*> data_dirs;
+    data_dirs.push_back(_data_dir.get());
+    RuntimeProfile profile("CreateTablet");
+    st = _storage_engine->tablet_manager()->create_tablet(create_tablet_req, data_dirs, &profile);
+    EXPECT_EQ(st, Status::OK());
+    TabletSharedPtr tablet = _storage_engine->tablet_manager()->get_tablet(tablet_id);
+    EXPECT_EQ(tablet->max_version().second, 10);
+
+    for (int64_t i = 5; i < 12; ++i) {
+        _storage_engine->add_async_publish_task(partition_id, tablet_id, i, i, false);
+    }
+    EXPECT_EQ(_storage_engine->_async_publish_tasks[tablet_id].size(), 7);
+    EXPECT_EQ(_storage_engine->get_pending_publish_min_version(tablet_id), 5);
+    for (int64_t i = 1; i < 8; ++i) {
+        _storage_engine->_process_async_publish();
+        EXPECT_EQ(_storage_engine->_async_publish_tasks[tablet_id].size(), 7 - i);
+    }
+    _storage_engine->_process_async_publish();
+    EXPECT_EQ(_storage_engine->_async_publish_tasks.size(), 0);
+
+    for (int64_t i = 100; i < config::max_tablet_version_num + 120; ++i) {
+        _storage_engine->add_async_publish_task(partition_id, tablet_id, i, i, false);
+    }
+    EXPECT_EQ(_storage_engine->_async_publish_tasks[tablet_id].size(),
+              config::max_tablet_version_num + 20);
+
+    for (int64_t i = 90; i < 120; ++i) {
+        _storage_engine->add_async_publish_task(partition_id, tablet_id, i, i, false);
+    }
+    EXPECT_EQ(_storage_engine->_async_publish_tasks[tablet_id].size(),
+              config::max_tablet_version_num + 30);
+    EXPECT_EQ(_storage_engine->get_pending_publish_min_version(tablet_id), 90);
+
+    _storage_engine->_process_async_publish();
+    EXPECT_EQ(_storage_engine->_async_publish_tasks[tablet_id].size(),
+              config::max_tablet_version_num);
+    EXPECT_EQ(_storage_engine->get_pending_publish_min_version(tablet_id), 120);
+
+    st = _storage_engine->tablet_manager()->drop_tablet(tablet_id, 0, false);
+    EXPECT_EQ(st, Status::OK());
+
+    EXPECT_EQ(_storage_engine->_async_publish_tasks[tablet_id].size(),
+              config::max_tablet_version_num);
+    _storage_engine->_process_async_publish();
+    EXPECT_EQ(_storage_engine->_async_publish_tasks.size(), 0);
 }
 
 } // namespace doris


### PR DESCRIPTION


## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
1. Do not retry publishing on be When there are too many missing versions, just add to async publish task.
2. To reduce memory consumption, clean up the tasks when there are too many async publish tasks.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

