### PR TITLE
[deps](odbc) undefined the BOOL in include/sqltypes.h

### DIFF
--- a/thirdparty/patches/sqltypes.h.patch
+++ b/thirdparty/patches/sqltypes.h.patch
@@ -26,3 +26,26 @@
  typedef char*               LPSTR;
  typedef DWORD*           	LPDWORD;
  
+--- a/include/sqlext.h	2023-12-05 15:56:09.623865253 +0800
++++ a/include/sqlext.h	2023-12-05 15:55:28.852847283 +0800
+@@ -2190,7 +2190,7 @@ void	FireVSDebugEvent(PODBC_VS_ARGS);
+  * connection pooling retry times
+  */
+
+-BOOL ODBCSetTryWaitValue ( DWORD dwValue );
++int ODBCSetTryWaitValue ( DWORD dwValue );
+ #ifdef __cplusplus
+ DWORD ODBCGetTryWaitValue ( );
+ #else
+
+--- a/include/sqltypes.h	2023-12-05 15:56:24.372871756 +0800
++++ a/include/sqltypes.h	2023-12-05 15:17:26.558878980 +0800
+@@ -68,7 +68,7 @@ extern "C" {
+ #else
+ #define SQL_API
+ #endif
+-#define	BOOL				int
++// #define	BOOL				int
+ #ifndef _WINDOWS_
+ typedef void*				HWND;
+ #endif


### PR DESCRIPTION
## Proposed changes

When `ENABLE_PCH = false`, this define will be conflict with BOOL in `include/arrow/type_fwd.h`.
The ODBC table will be deprecated in 2.1, so I just simply undefined the BOOL in include/sqltypes.h
to make compile OK

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

