### PR TITLE
[fix](meta) fix bug for using full name in show_full_columns stmt

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -1000,7 +1000,7 @@ public class ShowExecutor {
     private void handleShowColumn() throws AnalysisException {
         ShowColumnStmt showStmt = (ShowColumnStmt) stmt;
         List<List<String>> rows = Lists.newArrayList();
-        DatabaseIf db = ctx.getCurrentCatalog().getDbOrAnalysisException(showStmt.getDb());
+        DatabaseIf db = Env.getCurrentEnv().getInternalCatalog().getDbOrAnalysisException(showStmt.getDb());
         TableIf table = db.getTableOrAnalysisException(showStmt.getTable());
         PatternMatcher matcher = null;
         if (showStmt.getPattern() != null) {

--- a/regression-test/suites/external_table_p0/hive/test_show_columns.groovy
+++ b/regression-test/suites/external_table_p0/hive/test_show_columns.groovy
@@ -1,0 +1,62 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_show_colums", "p0,external,hive,external_docker,external_docker_hive") {
+
+    sql """create database if not exists db1"""
+    sql """drop table if exists db1.test_full_column"""
+    sql '''create table db1.test_full_column (
+                id int not null,
+                name varchar(20) not null
+        )
+        distributed by hash(id) buckets 4
+        properties (
+                "replication_num"="1"
+        );
+        '''
+    result = sql """show full columns from db1.test_full_column"""
+    assertEquals(result.size(), 2)
+    assertEquals(result[0][0], "id")
+
+    String enabled = context.config.otherConfigs.get("enableHiveTest")
+    if (enabled != null && enabled.equalsIgnoreCase("true")) {
+        String hms_port = context.config.otherConfigs.get("hms_port")
+        String externalEnvIp = context.config.otherConfigs.get("externalEnvIp")
+
+        String catalog_name = "hive_test_other"
+
+        sql """drop catalog if exists ${catalog_name}"""
+        sql """create catalog if not exists ${catalog_name} properties (
+            "type"="hms",
+            'hive.metastore.uris' = 'thrift://${externalEnvIp}:${hms_port}'
+        );"""
+
+        sql """switch ${catalog_name}"""
+
+        result = sql """show full columns from internal.db1.test_full_column"""
+        assertEquals(result.size(), 2)
+        assertEquals(result[0][0], "id")
+
+        sql """switch internal"""
+
+        result = sql """show full columns from internal.db1.test_full_column"""
+        assertEquals(result.size(), 2)
+        assertEquals(result[1][0], "name")
+
+        sql """drop catalog if exists ${catalog_name}"""
+    }
+}


### PR DESCRIPTION
Issue:
![image](https://github.com/apache/doris/assets/28004179/6eacbc27-32f0-434f-8037-9b1ee4bfa48e)

show_full_columns stmt only support internal catalog.
<img width="1221" alt="企业微信截图_8c918d1c-962b-49b8-acad-ae00ac8e1cf3" src="https://github.com/apache/doris/assets/28004179/37ebcf98-617e-4464-8ac4-3f503894a140">


## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

