### PR TITLE
[fix](load) set partition id in RowsetMeta

### DIFF
--- a/be/src/olap/rowset_builder.cpp
+++ b/be/src/olap/rowset_builder.cpp
@@ -196,6 +196,7 @@ Status RowsetBuilder::init() {
     context.tablet_schema = _tablet_schema;
     context.original_tablet_schema = _tablet_schema;
     context.newest_write_timestamp = UnixSeconds();
+    context.partition_id = _req.partition_id; 
     context.tablet_id = _tablet->tablet_id();
     context.tablet = _tablet;
     context.write_type = DataWriteType::TYPE_DIRECT;


### PR DESCRIPTION
## Proposed changes

Partition id is not set in rowset writer context, causing partition id missing in rowset meta.

```cpp
Status BetaRowsetWriter::init(const RowsetWriterContext& rowset_writer_context) {
    _context = rowset_writer_context;
    _rowset_meta.reset(new RowsetMeta);
    _rowset_meta->set_fs(_context.fs);
    _rowset_meta->set_rowset_id(_context.rowset_id);
    _rowset_meta->set_partition_id(_context.partition_id);
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

