### PR TITLE
[fix](remote-scanner-pool) missing _remote_thread_pool_max_size value

### DIFF
--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -123,9 +123,12 @@ Status ScannerScheduler::init(ExecEnv* env) {
             config::doris_scanner_thread_pool_queue_size, "local_scan");
 
     // 3. remote scan thread pool
+    _remote_thread_pool_max_size = config::doris_max_remote_scanner_thread_pool_thread_num != -1
+                                           ? config::doris_max_remote_scanner_thread_pool_thread_num
+                                           : std::max(512, CpuInfo::num_cores() * 10);
     _remote_scan_thread_pool = std::make_unique<PriorityThreadPool>(
-            config::doris_remote_scanner_thread_pool_thread_num,
-            config::doris_remote_scanner_thread_pool_queue_size, "RemoteScanThreadPool");
+            _remote_thread_pool_max_size, config::doris_remote_scanner_thread_pool_queue_size,
+            "RemoteScanThreadPool");
 
     // 4. limited scan thread pool
     static_cast<void>(ThreadPoolBuilder("LimitedScanThreadPool")


### PR DESCRIPTION
## Proposed changes

The assignment of `_remote_thread_pool_max_size` is missing in #27053.
It will result the maxConnection in S3 client to be 0, and block some operation such as list file in s3.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

