### PR TITLE
[minor](s3client) use LOG(INFO) to print s3 client debug log if enabled

### DIFF
--- a/be/src/util/s3_util.cpp
+++ b/be/src/util/s3_util.cpp
@@ -87,10 +87,10 @@ private:
             LOG(INFO) << "[" << tag << "] " << message;
             break;
         case Aws::Utils::Logging::LogLevel::Debug:
-            VLOG_ROW << "[" << tag << "] " << message;
+            LOG(INFO) << "[" << tag << "] " << message;
             break;
         case Aws::Utils::Logging::LogLevel::Trace:
-            VLOG_ROW << "[" << tag << "] " << message;
+            LOG(INFO) << "[" << tag << "] " << message;
             break;
         default:
             break;


### PR DESCRIPTION
## Proposed changes

So that user only need to set the BE config `aws_log_level` to enable/disable s3 client's debug log,
no need to set `sys_log_verbose_modules` at same time.
It is useful when we only want to debug s3 client.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

