### PR TITLE
[Bug](udf) java-udf function open failed cause BE core dump

### DIFF
--- a/be/src/vec/functions/function_java_udf.cpp
+++ b/be/src/vec/functions/function_java_udf.cpp
@@ -83,6 +83,7 @@ Status JavaFunctionCall::open(FunctionContext* context, FunctionContext::Functio
         }
         RETURN_ERROR_IF_EXC(env);
         RETURN_IF_ERROR(JniUtil::LocalToGlobalRef(env, jni_ctx->executor, &jni_ctx->executor));
+        jni_ctx->open_successes = true;
     }
     return Status::OK();
 }

--- a/be/src/vec/functions/function_java_udf.h
+++ b/be/src/vec/functions/function_java_udf.h
@@ -123,10 +123,15 @@ private:
         jmethodID executor_close_id;
         jobject executor = nullptr;
         bool is_closed = false;
+        bool open_successes = false;
 
         JniContext() = default;
 
         void close() {
+            if (!open_successes) {
+                LOG_WARNING("maybe open failed, need check the reason");
+                return; //maybe open failed, so can't call some jni
+            }
             if (is_closed) {
                 return;
             }


### PR DESCRIPTION
## Proposed changes
when the java-udf open function failed, and some JNI have not set,
so in close function can't call jni.

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

