### PR TITLE
[Enhance](multi-catalog) parse hive view ddl first to avoid NPE.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -39,6 +39,7 @@ import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.IdGenerator;
 import org.apache.doris.common.Pair;
+import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.planner.AggregationNode;
 import org.apache.doris.planner.AnalyticEvalNode;
@@ -852,6 +853,13 @@ public class Analyzer {
                     View hmsView = new View(table.getId(), table.getName(), table.getFullSchema());
                     hmsView.setInlineViewDefWithSqlMode(((HMSExternalTable) table).getViewText(),
                             ConnectContext.get().getSessionVariable().getSqlMode());
+                    // for user experience consideration, parse hive view ddl first to avoid NPE
+                    // if legacy parser can not parse hive view ddl properly
+                    try {
+                        hmsView.init();
+                    } catch (UserException e) {
+                        throw new AnalysisException(e.getMessage(), e);
+                    }
                     InlineViewRef inlineViewRef = new InlineViewRef(hmsView, tableRef);
                     if (StringUtils.isNotEmpty(tableName.getCtl())) {
                         inlineViewRef.setExternalCtl(tableName.getCtl());


### PR DESCRIPTION
## Proposed changes

When enable query hive views, legacy parser always try to lazy parse the hive view ddl, method `org.apache.doris.catalog.View#getQueryStmt` will catch the exception and doesn't throw it if parser can not parse the stmt rightly, so an NPE will be thrown later, we can parse the hive view ddl eariler to avoid the NPE and make the error message more clear.

Audit log: 
![image](https://github.com/apache/doris/assets/5926365/f6aa0860-8f61-4280-920f-5043049caecd)


Error log at FE node: 

```java
2023-12-06 14:05:12,261 ERROR (mysql-nio-pool-28|3049) [View.getQueryStmt():129] unexpected exception
org.apache.doris.common.UserException: errCode = 2, detailMessage = Failed to parse view-definition statement of view: xxx, stmt is SELECT
`aa`.`xxx`, `aa`.`xxx`, `aa`.`msg`, `aa`.`xxx`,
default.arraytomapnew(get_json_object(`aa`.`xxx`, '$.xxx'), 'item,val') as `xxx`,
`aa`.`xxx`, substr(trim(`aa`.`xxx`), 1, 19) as `xxx`, `aa`.`xxx`
FROM (
SELECT
SPLIT(`xxx`.`message`, '\t')[0] as `xxx`,
coalesce(SPLIT(`xxx`.`message`, '\t')[1], '') as `xxx`,
coalesce(SPLIT(`xxx`.`message`, '\t')[2], '') as `msg`,
coalesce(SPLIT(`xxx`.`message`, '\t')[3], '') as `result`,
coalesce(SPLIT(`xxx`.`message`, '\t')[4], '') as `version`,
coalesce(SPLIT(`xxx`.`message`, '\t')[5], '') as `xxx`,
`xxx`.`pday`
FROM
`xxx`.`xxx`
WHERE
`xxx`.`pday`=CURRENT_DATE and `xxx`.`xxx`='xxx'
UNION ALL
SELECT
`xxx`.`xxx`, `xxx`.`xxx`, `xxx`.`msg`, `xxx`.`result`, `xxx`.`version`, `xxx`.`date_updated`, `dwd_credit_bjxe_xd_credit_online_inout_pdi`.`pday`
FROM `xxx`.`xxx`
WHERE
`xxx`.`pday` < CURRENT_DATE
) as `aa`
WHERE `aa`.`xxx` in ('xxx', 'xxx', 'xxx', 'xxx', 'xxx', 'xxx'), reason is errCode = 2, detailMessage = Syntax error
        at org.apache.doris.catalog.View.init(View.java:174) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.View.getQueryStmt(View.java:126) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.analysis.InlineViewRef.<init>(InlineViewRef.java:110) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.analysis.Analyzer.resolveTableRef(Analyzer.java:848) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.analysis.FromClause.analyze(FromClause.java:132) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.analysis.SelectStmt.analyze(SelectStmt.java:505) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.analyzeAndGenerateQueryPlan(StmtExecutor.java:1105) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.analyze(StmtExecutor.java:1014) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.executeByLegacy(StmtExecutor.java:699) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:468) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:441) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:358) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.dispatch(ConnectProcessor.java:511) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.processOnce(ConnectProcessor.java:762) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52) ~[doris-fe.jar:1.2-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_301]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_301]
        at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_301]
2023-12-06 14:05:12,261 WARN (mysql-nio-pool-28|3049) [StmtExecutor.analyze():1031] Analyze failed. stmt[7723, 25d427d4383841d4-a873e26b42f6d555]
java.lang.NullPointerException: null
        at org.apache.doris.analysis.InlineViewRef.<init>(InlineViewRef.java:110) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.analysis.Analyzer.resolveTableRef(Analyzer.java:848) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.analysis.FromClause.analyze(FromClause.java:132) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.analysis.SelectStmt.analyze(SelectStmt.java:505) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.analyzeAndGenerateQueryPlan(StmtExecutor.java:1105) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.analyze(StmtExecutor.java:1014) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.executeByLegacy(StmtExecutor.java:699) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:468) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:441) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:358) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.dispatch(ConnectProcessor.java:511) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.processOnce(ConnectProcessor.java:762) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52) ~[doris-fe.jar:1.2-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_301]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_301]
        at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_301]
2023-12-06 14:05:12,261 WARN (mysql-nio-pool-28|3049) [StmtExecutor.executeByLegacy():808] execute Exception. stmt[7723, 25d427d4383841d4-a873e26b42f6d555]
org.apache.doris.common.AnalysisException: errCode = 2, detailMessage = Unexpected exception: null
        at org.apache.doris.qe.StmtExecutor.analyze(StmtExecutor.java:1032) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.executeByLegacy(StmtExecutor.java:699) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:468) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:441) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:358) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.dispatch(ConnectProcessor.java:511) ~[doris-fe.jar:1.2-SNAPSHOT]
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

