### PR TITLE
[Fix](Outfile) The `Struct` type data exported from `select outfile` to the `csv` file format should contain a column name

### DIFF
--- a/be/src/vec/data_types/serde/data_type_struct_serde.cpp
+++ b/be/src/vec/data_types/serde/data_type_struct_serde.cpp
@@ -60,6 +60,8 @@ Status DataTypeStructSerDe::serialize_one_cell_to_json(const IColumn& column, in
             bw.write(',');
             bw.write(' ');
         }
+        std::string col_name = "\"" + elemNames[i] + "\": ";
+        bw.write(col_name.c_str(), col_name.length());
         RETURN_IF_ERROR(elemSerDeSPtrs[i]->serialize_one_cell_to_json(struct_column.get_column(i),
                                                                       row_num, bw, options));
     }

--- a/regression-test/data/export_p0/outfile/csv/test_outfile_csv_complex_type.out
+++ b/regression-test/data/export_p0/outfile/csv/test_outfile_csv_complex_type.out
@@ -10,13 +10,13 @@
 8	\N	\N
 
 -- !select_load1 --
-1	doris1	{1, "sn1", "sa1"}
-2	doris2	{2, "sn2", "sa2"}
-3	doris3	{3, "sn3", "sa3"}
+1	doris1	{"s_id": 1, "s_name": "sn1", "s_address": "sa1"}
+2	doris2	{"s_id": 2, "s_name": "sn2", "s_address": "sa2"}
+3	doris3	{"s_id": 3, "s_name": "sn3", "s_address": "sa3"}
 4	doris4	\N
-5	doris5	{5, null, "sa5"}
-6	doris6	{null, null, null}
-7	\N	{null, null, null}
+5	doris5	{"s_id": 5, "s_name": null, "s_address": "sa5"}
+6	doris6	{"s_id": null, "s_name": null, "s_address": null}
+7	\N	{"s_id": null, "s_name": null, "s_address": null}
 8	\N	\N
 
 -- !select_base2 --
@@ -28,12 +28,12 @@
 7	\N	{"s_id": null, "s_name": null, "s_address": null}
 
 -- !select_load2 --
-1	doris1	{1, "sn1", "sa1"}
-2	doris2	{2, "sn2", "sa2"}
-3	doris3	{3, "sn3", "sa3"}
-5	doris5	{5, null, "sa5"}
-6	doris6	{null, null, null}
-7	\N	{null, null, null}
+1	doris1	{"s_id": 1, "s_name": "sn1", "s_address": "sa1"}
+2	doris2	{"s_id": 2, "s_name": "sn2", "s_address": "sa2"}
+3	doris3	{"s_id": 3, "s_name": "sn3", "s_address": "sa3"}
+5	doris5	{"s_id": 5, "s_name": null, "s_address": "sa5"}
+6	doris6	{"s_id": null, "s_name": null, "s_address": null}
+7	\N	{"s_id": null, "s_name": null, "s_address": null}
 
 -- !select_base3 --
 1	doris1	{"a":100, "b":111}
@@ -116,14 +116,14 @@
 10	doris_10	{"user_id": 10, "date": "2017-10-01", "datetime": "2017-10-01 00:00:00", "city": null, "age": null, "sex": null, "bool_col": null, "int_col": null, "bigint_col": null, "largeint_col": null, "float_col": null, "double_col": null, "char_col": null, "decimal_col": null}
 
 -- !select_load1 --
-1	doris_1	{1, 2017-10-01, 2017-10-01 00:00:00, "Beijing", 1, 1, 1, 1, 1, 1, 1.1, 1.1, "char1_1234", 1}
-2	doris_2	{2, 2017-10-01, 2017-10-01 00:00:00, "Beijing", 2, 2, 1, 2, 2, 2, 2.2, 2.2, "char2_1234", 2}
-3	doris_3	{3, 2017-10-01, 2017-10-01 00:00:00, "Beijing", 3, 3, 1, 3, 3, 3, 3.3, 3.3, "char3_1234", 3}
-4	doris_4	{4, 2017-10-01, 2017-10-01 00:00:00, "Beijing", 4, 4, 1, 4, 4, 4, 4.4, 4.4, "char4_1234", 4}
-5	doris_5	{5, 2017-10-01, 2017-10-01 00:00:00, "Beijing", 5, 5, 1, 5, 5, 5, 5.5, 5.5, "char5_1234", 5}
-6	doris_6	{6, 2017-10-01, 2017-10-01 00:00:00, "Beijing", 6, 6, 1, 6, 6, 6, 6.6, 6.6, "char6_1234", 6}
-7	doris_7	{7, 2017-10-01, 2017-10-01 00:00:00, "Beijing", 7, 7, 1, 7, 7, 7, 7.7, 7.7, "char7_1234", 7}
-8	doris_8	{8, 2017-10-01, 2017-10-01 00:00:00, "Beijing", 8, 8, 1, 8, 8, 8, 8.8, 8.8, "char8_1234", 8}
-9	doris_9	{9, 2017-10-01, 2017-10-01 00:00:00, "Beijing", 9, 9, 1, 9, 9, 9, 9.9, 9.9, "char9_1234", 9}
-10	doris_10	{10, 2017-10-01, 2017-10-01 00:00:00, null, null, null, null, null, null, null, null, null, null, null}
+1	doris_1	{"user_id": 1, "date": 2017-10-01, "datetime": 2017-10-01 00:00:00, "city": "Beijing", "age": 1, "sex": 1, "bool_col": 1, "int_col": 1, "bigint_col": 1, "largeint_col": 1, "float_col": 1.1, "double_col": 1.1, "char_col": "char1_1234", "decimal_col": 1}
+2	doris_2	{"user_id": 2, "date": 2017-10-01, "datetime": 2017-10-01 00:00:00, "city": "Beijing", "age": 2, "sex": 2, "bool_col": 1, "int_col": 2, "bigint_col": 2, "largeint_col": 2, "float_col": 2.2, "double_col": 2.2, "char_col": "char2_1234", "decimal_col": 2}
+3	doris_3	{"user_id": 3, "date": 2017-10-01, "datetime": 2017-10-01 00:00:00, "city": "Beijing", "age": 3, "sex": 3, "bool_col": 1, "int_col": 3, "bigint_col": 3, "largeint_col": 3, "float_col": 3.3, "double_col": 3.3, "char_col": "char3_1234", "decimal_col": 3}
+4	doris_4	{"user_id": 4, "date": 2017-10-01, "datetime": 2017-10-01 00:00:00, "city": "Beijing", "age": 4, "sex": 4, "bool_col": 1, "int_col": 4, "bigint_col": 4, "largeint_col": 4, "float_col": 4.4, "double_col": 4.4, "char_col": "char4_1234", "decimal_col": 4}
+5	doris_5	{"user_id": 5, "date": 2017-10-01, "datetime": 2017-10-01 00:00:00, "city": "Beijing", "age": 5, "sex": 5, "bool_col": 1, "int_col": 5, "bigint_col": 5, "largeint_col": 5, "float_col": 5.5, "double_col": 5.5, "char_col": "char5_1234", "decimal_col": 5}
+6	doris_6	{"user_id": 6, "date": 2017-10-01, "datetime": 2017-10-01 00:00:00, "city": "Beijing", "age": 6, "sex": 6, "bool_col": 1, "int_col": 6, "bigint_col": 6, "largeint_col": 6, "float_col": 6.6, "double_col": 6.6, "char_col": "char6_1234", "decimal_col": 6}
+7	doris_7	{"user_id": 7, "date": 2017-10-01, "datetime": 2017-10-01 00:00:00, "city": "Beijing", "age": 7, "sex": 7, "bool_col": 1, "int_col": 7, "bigint_col": 7, "largeint_col": 7, "float_col": 7.7, "double_col": 7.7, "char_col": "char7_1234", "decimal_col": 7}
+8	doris_8	{"user_id": 8, "date": 2017-10-01, "datetime": 2017-10-01 00:00:00, "city": "Beijing", "age": 8, "sex": 8, "bool_col": 1, "int_col": 8, "bigint_col": 8, "largeint_col": 8, "float_col": 8.8, "double_col": 8.8, "char_col": "char8_1234", "decimal_col": 8}
+9	doris_9	{"user_id": 9, "date": 2017-10-01, "datetime": 2017-10-01 00:00:00, "city": "Beijing", "age": 9, "sex": 9, "bool_col": 1, "int_col": 9, "bigint_col": 9, "largeint_col": 9, "float_col": 9.9, "double_col": 9.9, "char_col": "char9_1234", "decimal_col": 9}
+10	doris_10	{"user_id": 10, "date": 2017-10-01, "datetime": 2017-10-01 00:00:00, "city": null, "age": null, "sex": null, "bool_col": null, "int_col": null, "bigint_col": null, "largeint_col": null, "float_col": null, "double_col": null, "char_col": null, "decimal_col": null}
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

If the original data is：
```sql
+-----------------------------------------------------+
| s_info                                              |
+-----------------------------------------------------+
| {"s_id": 2, "s_name": "nereids", "s_address": "20"} |
| {"s_id": 1, "s_name": "doris", "s_address": "18"}   |
+-----------------------------------------------------+
```

In the original logic, the struct type data exported to a csv file format did not contain column names,like
```
{2, "nereids", "20"} 
{1, "doris", "18"}
```

This pr do not need to be merged into branch-2.0


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

