### PR TITLE
[fix](meta) fix ConcurrentModificationException when dump image

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -1033,8 +1033,10 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         return Stream.of(dbInfos, tableInfos, partitionInfos).flatMap(Collection::stream).collect(Collectors.toList());
     }
 
+    // Need to add "synchronized", because when calling /dump api to dump image,
+    // this class is not protected by any lock, will throw ConcurrentModificationException.
     @Override
-    public void write(DataOutput out) throws IOException {
+    public synchronized void write(DataOutput out) throws IOException {
         int count = idToDatabase.size();
         out.writeInt(count);
         for (Map.Entry<Long, RecycleDatabaseInfo> entry : idToDatabase.entrySet()) {


### PR DESCRIPTION
## Proposed changes

```
Caused by: java.util.ConcurrentModificationException
        at java.util.HashMap$HashIterator.nextNode(HashMap.java:1437) ~[?:1.8.0_131]
        at java.util.HashMap$EntryIterator.next(HashMap.java:1471) ~[?:1.8.0_131]
        at java.util.HashMap$EntryIterator.next(HashMap.java:1469) ~[?:1.8.0_131]
        at org.apache.doris.catalog.CatalogRecycleBin.write(CatalogRecycleBin.java:1047) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.Env.saveRecycleBin(Env.java:2298) ~[doris-fe.jar:1.2-SNAPSHOT]
```

When calling `/dump` api to dump image, ConcurrentModificationException may be thrown.
Because no lock to protect `CatalogRecycleBin`

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

