### PR TITLE
[Chore](case) remove dynamic partition on test_delete case

### DIFF
--- a/regression-test/suites/delete_p0/test_delete.groovy
+++ b/regression-test/suites/delete_p0/test_delete.groovy
@@ -254,32 +254,22 @@ suite("test_delete") {
     sql "drop table if exists dwd_pay"
     sql """
     CREATE TABLE `dwd_pay` (
-  `tenant_id` int(11) DEFAULT NULL COMMENT '租户ID',
-  `pay_time` datetime DEFAULT NULL COMMENT '付款时间',
-)  ENGINE=OLAP
-DUPLICATE KEY(`tenant_id`)
-COMMENT "付款明细"
-PARTITION BY RANGE(`pay_time` ) (
-PARTITION p202012 VALUES LESS THAN ('2021-01-01 00:00:00')
-)
-DISTRIBUTED BY HASH(`tenant_id`) BUCKETS auto
-PROPERTIES
-(
-    "dynamic_partition.enable" = "true",
-    "dynamic_partition.time_unit" = "MONTH",
-    "dynamic_partition.end" = "2",
-    "dynamic_partition.prefix" = "p",
-    "dynamic_partition.start_day_of_month" = "1",
-    "dynamic_partition.create_history_partition" = "true",
-    "dynamic_partition.history_partition_num" = "120",
-    "dynamic_partition.buckets"="1",
-    "estimate_partition_size" = "1G",
-    "storage_type" = "COLUMN",
-    "replication_num" = "1"
-);
+    `tenant_id` int(11) DEFAULT NULL COMMENT '租户ID',
+    `pay_time` datetime DEFAULT NULL COMMENT '付款时间',
+    )  ENGINE=OLAP
+    DUPLICATE KEY(`tenant_id`)
+    COMMENT "付款明细"
+    PARTITION BY RANGE(`pay_time` ) (
+    PARTITION p202012 VALUES LESS THAN ('2021-01-01 00:00:00')
+    )
+    DISTRIBUTED BY HASH(`tenant_id`) BUCKETS auto
+    PROPERTIES
+    (
+        "replication_num" = "1"
+    );
     """
 
-    sql "delete from dwd_pay partitions(p202310) where pay_time = '20231002';"
+    sql "delete from dwd_pay partitions(p202012) where pay_time = '20231002';"
 
     sql """
     ADMIN SET FRONTEND CONFIG ('disable_decimalv2' = 'false');


### PR DESCRIPTION
## Proposed changes
remove dynamic partition on test_delete case to reduce logout
2023-12-06 16:23:12,733 WARN (DynamicPartitionScheduler|58) [DynamicPartitionScheduler.recordCreatePartitionFailedMsg():581] dynamic add partition failed: errCode = 2, detailMessage = Range [types: [DATETIMEV2]; keys: [0000-01-01 00:00:00]; ..types: [DATETIMEV2]; keys: [2021-01-01 00:00:00]; ) is intersected with range: [types: [DATETIMEV2]; keys: [2020-03-01 00:00:00]; ..types: [DATETIMEV2]; keys: [2020-04-01 00:00:00]; ), db: default_cluster:regression_test_delete_p0, table: dwd_pay

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

