### PR TITLE
[chore](StoragePolicy) Don't print stack when invoking the storage manager

### DIFF
--- a/be/src/olap/storage_policy.cpp
+++ b/be/src/olap/storage_policy.cpp
@@ -37,14 +37,14 @@ Status get_remote_file_system(int64_t storage_policy_id,
                               std::shared_ptr<io::RemoteFileSystem>* fs) {
     auto storage_policy = get_storage_policy(storage_policy_id);
     if (storage_policy == nullptr) {
-        return Status::InternalError("could not find storage_policy, storage_policy_id={}",
-                                     storage_policy_id);
+        return Status::NotFound<false>("could not find storage_policy, storage_policy_id={}",
+                                       storage_policy_id);
     }
     auto resource = get_storage_resource(storage_policy->resource_id);
     *fs = std::static_pointer_cast<io::RemoteFileSystem>(resource.fs);
     if (*fs == nullptr) {
-        return Status::InternalError("could not find resource, resouce_id={}",
-                                     storage_policy->resource_id);
+        return Status::NotFound<false>("could not find resource, resouce_id={}",
+                                       storage_policy->resource_id);
     }
     DCHECK((*fs)->type() != io::FileSystemType::LOCAL);
     return Status::OK();


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

