### PR TITLE
[fix](arrow-flight) Modify FE Arrow version to 14.0.1

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -305,11 +305,7 @@ under the License.
         <iceberg.version>1.1.0</iceberg.version>
         <maxcompute.version>0.45.2-public</maxcompute.version>
         <avro.version>1.11.2</avro.version>
-        <!-- Temporarily upgrade Arrow to dev version 15.0.0-SNAPSHOT,
-        because the latest release version Arrow 14.0.1 jdbc:arrow-flight-sql has BUG,
-        see: https://github.com/apache/arrow/issues/38785
-        TODO upgrade to 15.0.0 release version -->
-        <arrow.version>15.0.0-SNAPSHOT</arrow.version>
+        <arrow.version>14.0.1</arrow.version>
         <!-- hudi -->
         <hudi.version>0.13.1</hudi.version>
         <presto.hadoop.version>2.7.4-11</presto.hadoop.version>
@@ -378,10 +374,6 @@ under the License.
                 <repository>
                     <id>cloudera</id>
                     <url>https://repository.cloudera.com/repository/libs-release-local/</url>
-                </repository>
-                <repository>
-                    <id>arrow-apache-nightlies</id>
-                    <url>https://nightlies.apache.org/arrow/java</url>
                 </repository>
             </repositories>
             <pluginRepositories>


### PR DESCRIPTION
## Proposed changes

Previously temporarily upgrade Arrow to dev version 15.0.0-SNAPSHOT, because the latest release version Arrow 14.0.1 jdbc:arrow-flight-sql has BUG, `jdbc:arrow-flight-sql` cannot be used normally, see: https://github.com/apache/arrow/issues/38785

But Arrow 15.0.0-SNAPSHOT was not published to the Maven central repository, and the network could not be connected sometimes, so back to Arrow 14.0.1.  `jdbc:arrow-flight-sql` will be supported after upgrading to Arrow 15.0.0 release version.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

