### PR TITLE
[bugfix](core) child block is shared between operator and node, it should be shared ptr

### DIFF
--- a/be/src/pipeline/exec/nested_loop_join_probe_operator.cpp
+++ b/be/src/pipeline/exec/nested_loop_join_probe_operator.cpp
@@ -34,12 +34,11 @@ OPERATOR_CODE_GENERATOR(NestLoopJoinProbeOperator, StatefulOperator)
 
 Status NestLoopJoinProbeOperator::prepare(doris::RuntimeState* state) {
     // just for speed up, the way is dangerous
-    _child_block.reset(_node->get_left_block());
+    _child_block = _node->get_left_block();
     return StatefulOperator::prepare(state);
 }
 
 Status NestLoopJoinProbeOperator::close(doris::RuntimeState* state) {
-    _child_block.release();
     return StatefulOperator::close(state);
 }
 

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -444,7 +444,7 @@ public:
 
     StatefulOperator(OperatorBuilderBase* builder, ExecNode* node)
             : StreamingOperator<OperatorBuilderType>(builder, node),
-              _child_block(vectorized::Block::create_unique()),
+              _child_block(vectorized::Block::create_shared()),
               _child_source_state(SourceState::DEPEND_ON_SOURCE) {}
 
     virtual ~StatefulOperator() = default;

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -484,7 +484,7 @@ public:
     }
 
 protected:
-    std::unique_ptr<vectorized::Block> _child_block;
+    std::shared_ptr<vectorized::Block> _child_block;
     SourceState _child_source_state;
 };
 

--- a/be/src/pipeline/exec/repeat_operator.cpp
+++ b/be/src/pipeline/exec/repeat_operator.cpp
@@ -34,12 +34,11 @@ OPERATOR_CODE_GENERATOR(RepeatOperator, StatefulOperator)
 
 Status RepeatOperator::prepare(doris::RuntimeState* state) {
     // just for speed up, the way is dangerous
-    _child_block.reset(_node->get_child_block());
+    _child_block = _node->get_child_block();
     return StatefulOperator::prepare(state);
 }
 
 Status RepeatOperator::close(doris::RuntimeState* state) {
-    _child_block.release();
     return StatefulOperator::close(state);
 }
 
@@ -231,13 +230,13 @@ Status RepeatOperatorX::pull(doris::RuntimeState* state, vectorized::Block* outp
         int size = _repeat_id_list.size();
         if (_repeat_id_idx >= size) {
             _intermediate_block->clear();
-            _child_block.clear_column_data(_child_x->row_desc().num_materialized_slots());
+            _child_block->clear_column_data(_child_x->row_desc().num_materialized_slots());
             _repeat_id_idx = 0;
         }
     }
     RETURN_IF_ERROR(vectorized::VExprContext::filter_block(_conjuncts, output_block,
                                                            output_block->columns()));
-    if (_child_eos && _child_block.rows() == 0) {
+    if (_child_eos && _child_block->rows() == 0) {
         source_state = SourceState::FINISHED;
     }
     local_state.reached_limit(output_block, source_state);

--- a/be/src/pipeline/exec/repeat_operator.cpp
+++ b/be/src/pipeline/exec/repeat_operator.cpp
@@ -230,13 +230,13 @@ Status RepeatOperatorX::pull(doris::RuntimeState* state, vectorized::Block* outp
         int size = _repeat_id_list.size();
         if (_repeat_id_idx >= size) {
             _intermediate_block->clear();
-            _child_block->clear_column_data(_child_x->row_desc().num_materialized_slots());
+            _child_block.clear_column_data(_child_x->row_desc().num_materialized_slots());
             _repeat_id_idx = 0;
         }
     }
     RETURN_IF_ERROR(vectorized::VExprContext::filter_block(_conjuncts, output_block,
                                                            output_block->columns()));
-    if (_child_eos && _child_block->rows() == 0) {
+    if (_child_eos && _child_block.rows() == 0) {
         source_state = SourceState::FINISHED;
     }
     local_state.reached_limit(output_block, source_state);

--- a/be/src/pipeline/exec/table_function_operator.cpp
+++ b/be/src/pipeline/exec/table_function_operator.cpp
@@ -33,12 +33,11 @@ OPERATOR_CODE_GENERATOR(TableFunctionOperator, StatefulOperator)
 
 Status TableFunctionOperator::prepare(doris::RuntimeState* state) {
     // just for speed up, the way is dangerous
-    _child_block.reset(_node->get_child_block());
+    _child_block = _node->get_child_block();
     return StatefulOperator::prepare(state);
 }
 
 Status TableFunctionOperator::close(doris::RuntimeState* state) {
-    _child_block.release();
     return StatefulOperator::close(state);
 }
 

--- a/be/src/vec/exec/join/vnested_loop_join_node.cpp
+++ b/be/src/vec/exec/join/vnested_loop_join_node.cpp
@@ -97,7 +97,9 @@ VNestedLoopJoinNode::VNestedLoopJoinNode(ObjectPool* pool, const TPlanNode& tnod
           _left_block_pos(0),
           _left_side_eos(false),
           _old_version_flag(!tnode.__isset.nested_loop_join_node),
-          _runtime_filter_descs(tnode.runtime_filters) {}
+          _runtime_filter_descs(tnode.runtime_filters) {
+    _left_block = Block::create_shared();
+}
 
 Status VNestedLoopJoinNode::init(const TPlanNode& tnode, RuntimeState* state) {
     RETURN_IF_ERROR(VJoinNodeBase::init(tnode, state));
@@ -252,15 +254,15 @@ Status VNestedLoopJoinNode::push(doris::RuntimeState* state, vectorized::Block* 
 
 Status VNestedLoopJoinNode::_fresh_left_block(doris::RuntimeState* state) {
     do {
-        release_block_memory(_left_block);
+        release_block_memory(_left_block.get());
         RETURN_IF_ERROR(child(0)->get_next_after_projects(
-                state, &_left_block, &_left_side_eos,
+                state, _left_block.get(), &_left_side_eos,
                 std::bind((Status(ExecNode::*)(RuntimeState*, vectorized::Block*, bool*)) &
                                   ExecNode::get_next,
                           _children[0], std::placeholders::_1, std::placeholders::_2,
                           std::placeholders::_3)));
 
-    } while (_left_block.rows() == 0 && !_left_side_eos);
+    } while (_left_block->rows() == 0 && !_left_side_eos);
 
     return Status::OK();
 }
@@ -270,7 +272,7 @@ Status VNestedLoopJoinNode::get_next(RuntimeState* state, Block* block, bool* eo
     RETURN_IF_CANCELLED(state);
     while (need_more_input_data()) {
         RETURN_IF_ERROR(_fresh_left_block(state));
-        RETURN_IF_ERROR(push(state, &_left_block, _left_side_eos));
+        RETURN_IF_ERROR(push(state, _left_block.get(), _left_side_eos));
     }
 
     return pull(state, block, eos);
@@ -280,7 +282,7 @@ void VNestedLoopJoinNode::_append_left_data_with_null(MutableBlock& mutable_bloc
     auto& dst_columns = mutable_block.mutable_columns();
     DCHECK(_is_mark_join);
     for (size_t i = 0; i < _num_probe_side_columns; ++i) {
-        const ColumnWithTypeAndName& src_column = _left_block.get_by_position(i);
+        const ColumnWithTypeAndName& src_column = _left_block->get_by_position(i);
         if (!src_column.column->is_nullable() && dst_columns[i]->is_nullable()) {
             auto origin_sz = dst_columns[i]->size();
             DCHECK(_join_op == TJoinOp::RIGHT_OUTER_JOIN || _join_op == TJoinOp::FULL_OUTER_JOIN);
@@ -310,7 +312,7 @@ void VNestedLoopJoinNode::_process_left_child_block(MutableBlock& mutable_block,
     auto& dst_columns = mutable_block.mutable_columns();
     const int max_added_rows = now_process_build_block.rows();
     for (size_t i = 0; i < _num_probe_side_columns; ++i) {
-        const ColumnWithTypeAndName& src_column = _left_block.get_by_position(i);
+        const ColumnWithTypeAndName& src_column = _left_block->get_by_position(i);
         if (!src_column.column->is_nullable() && dst_columns[i]->is_nullable()) {
             auto origin_sz = dst_columns[i]->size();
             DCHECK(_join_op == TJoinOp::RIGHT_OUTER_JOIN || _join_op == TJoinOp::FULL_OUTER_JOIN);
@@ -456,13 +458,13 @@ void VNestedLoopJoinNode::_finalize_current_phase(MutableBlock& mutable_block, s
     } else {
         if (!_is_mark_join) {
             auto new_size = column_size;
-            DCHECK_LE(_left_block_start_pos + _left_side_process_count, _left_block.rows());
+            DCHECK_LE(_left_block_start_pos + _left_side_process_count, _left_block->rows());
             for (int j = _left_block_start_pos;
                  j < _left_block_start_pos + _left_side_process_count; ++j) {
                 if (_cur_probe_row_visited_flags[j] == IsSemi) {
                     new_size++;
                     for (size_t i = 0; i < _num_probe_side_columns; ++i) {
-                        const ColumnWithTypeAndName src_column = _left_block.get_by_position(i);
+                        const ColumnWithTypeAndName src_column = _left_block->get_by_position(i);
                         if (!src_column.column->is_nullable() && dst_columns[i]->is_nullable()) {
                             DCHECK(_join_op == TJoinOp::FULL_OUTER_JOIN);
                             assert_cast<ColumnNullable*>(dst_columns[i].get())
@@ -488,13 +490,13 @@ void VNestedLoopJoinNode::_finalize_current_phase(MutableBlock& mutable_block, s
         } else {
             ColumnFilterHelper mark_column(*dst_columns[dst_columns.size() - 1]);
             mark_column.reserve(mark_column.size() + _left_side_process_count);
-            DCHECK_LE(_left_block_start_pos + _left_side_process_count, _left_block.rows());
+            DCHECK_LE(_left_block_start_pos + _left_side_process_count, _left_block->rows());
             for (int j = _left_block_start_pos;
                  j < _left_block_start_pos + _left_side_process_count; ++j) {
                 mark_column.insert_value(IsSemi == _cur_probe_row_visited_flags[j]);
             }
             for (size_t i = 0; i < _num_probe_side_columns; ++i) {
-                const ColumnWithTypeAndName src_column = _left_block.get_by_position(i);
+                const ColumnWithTypeAndName src_column = _left_block->get_by_position(i);
                 DCHECK(_join_op != TJoinOp::FULL_OUTER_JOIN);
                 dst_columns[i]->insert_range_from(*src_column.column, _left_block_start_pos,
                                                   _left_side_process_count);
@@ -541,7 +543,7 @@ void VNestedLoopJoinNode::_do_filtering_and_update_visited_flags_impl(
     }
     if constexpr (SetProbeSideFlag) {
         int end = filter.size();
-        for (int i = _left_block_pos == _left_block.rows() ? _left_block_pos - 1 : _left_block_pos;
+        for (int i = _left_block_pos == _left_block->rows() ? _left_block_pos - 1 : _left_block_pos;
              i >= _left_block_start_pos; i--) {
             int offset = 0;
             if (!_probe_offset_stack.empty()) {
@@ -648,7 +650,7 @@ void VNestedLoopJoinNode::debug_string(int indentation_level, std::stringstream*
 }
 
 void VNestedLoopJoinNode::_release_mem() {
-    _left_block.clear();
+    _left_block->clear();
 
     Blocks tmp_build_blocks;
     _build_blocks.swap(tmp_build_blocks);
@@ -664,7 +666,7 @@ Status VNestedLoopJoinNode::pull(RuntimeState* state, vectorized::Block* block, 
     SCOPED_TIMER(_exec_timer);
     SCOPED_TIMER(_probe_timer);
     if (_is_output_left_side_only) {
-        RETURN_IF_ERROR(_build_output_block(&_left_block, block));
+        RETURN_IF_ERROR(_build_output_block(_left_block.get(), block));
         *eos = _left_side_eos;
         _need_more_input_data = !_left_side_eos;
     } else {

--- a/be/src/vec/exec/join/vnested_loop_join_node.cpp
+++ b/be/src/vec/exec/join/vnested_loop_join_node.cpp
@@ -254,7 +254,7 @@ Status VNestedLoopJoinNode::push(doris::RuntimeState* state, vectorized::Block* 
 
 Status VNestedLoopJoinNode::_fresh_left_block(doris::RuntimeState* state) {
     do {
-        release_block_memory(_left_block.get());
+        release_block_memory(*_left_block);
         RETURN_IF_ERROR(child(0)->get_next_after_projects(
                 state, _left_block.get(), &_left_side_eos,
                 std::bind((Status(ExecNode::*)(RuntimeState*, vectorized::Block*, bool*)) &

--- a/be/src/vec/exec/join/vnested_loop_join_node.h
+++ b/be/src/vec/exec/join/vnested_loop_join_node.h
@@ -95,7 +95,7 @@ public:
                        : *_output_row_desc;
     }
 
-    std::shared<Block> get_left_block() { return _left_block; }
+    std::shared_ptr<Block> get_left_block() { return _left_block; }
 
     std::vector<TRuntimeFilterDesc>& runtime_filter_descs() { return _runtime_filter_descs; }
     VExprContextSPtrs& filter_src_expr_ctxs() { return _filter_src_expr_ctxs; }
@@ -260,7 +260,7 @@ private:
     // _left_block must be cleared before calling get_next().  The child node
     // does not initialize all tuple ptrs in the row, only the ones that it
     // is responsible for.
-    std::shared<Block> _left_block;
+    std::shared_ptr<Block> _left_block;
 
     int _left_block_start_pos = 0;
     int _left_block_pos; // current scan pos in _left_block

--- a/be/src/vec/exec/join/vnested_loop_join_node.h
+++ b/be/src/vec/exec/join/vnested_loop_join_node.h
@@ -120,14 +120,14 @@ private:
             // We should try to join rows if there still are some rows from probe side.
             while (_join_block.rows() < state->batch_size()) {
                 while (_current_build_pos == _build_blocks.size() ||
-                       _left_block_pos == _left_block.rows()) {
+                       _left_block_pos == _left_block->rows()) {
                     // if left block is empty(), do not need disprocess the left block rows
-                    if (_left_block.rows() > _left_block_pos) {
+                    if (_left_block->rows() > _left_block_pos) {
                         _left_side_process_count++;
                     }
 
                     _reset_with_next_probe_row();
-                    if (_left_block_pos < _left_block.rows()) {
+                    if (_left_block_pos < _left_block->rows()) {
                         if constexpr (set_probe_side_flag) {
                             _probe_offset_stack.push(mutable_join_block.rows());
                         }

--- a/be/src/vec/exec/join/vnested_loop_join_node.h
+++ b/be/src/vec/exec/join/vnested_loop_join_node.h
@@ -95,7 +95,7 @@ public:
                        : *_output_row_desc;
     }
 
-    BlockSPtr get_left_block() { return _left_block; }
+    std::shared<Block> get_left_block() { return _left_block; }
 
     std::vector<TRuntimeFilterDesc>& runtime_filter_descs() { return _runtime_filter_descs; }
     VExprContextSPtrs& filter_src_expr_ctxs() { return _filter_src_expr_ctxs; }
@@ -260,7 +260,7 @@ private:
     // _left_block must be cleared before calling get_next().  The child node
     // does not initialize all tuple ptrs in the row, only the ones that it
     // is responsible for.
-    BlockSPtr _left_block;
+    std::shared<Block> _left_block;
 
     int _left_block_start_pos = 0;
     int _left_block_pos; // current scan pos in _left_block

--- a/be/src/vec/exec/join/vnested_loop_join_node.h
+++ b/be/src/vec/exec/join/vnested_loop_join_node.h
@@ -95,7 +95,7 @@ public:
                        : *_output_row_desc;
     }
 
-    Block* get_left_block() { return &_left_block; }
+    BlockSPtr get_left_block() { return _left_block; }
 
     std::vector<TRuntimeFilterDesc>& runtime_filter_descs() { return _runtime_filter_descs; }
     VExprContextSPtrs& filter_src_expr_ctxs() { return _filter_src_expr_ctxs; }
@@ -260,7 +260,7 @@ private:
     // _left_block must be cleared before calling get_next().  The child node
     // does not initialize all tuple ptrs in the row, only the ones that it
     // is responsible for.
-    Block _left_block;
+    BlockSPtr _left_block;
 
     int _left_block_start_pos = 0;
     int _left_block_pos; // current scan pos in _left_block

--- a/be/src/vec/exec/vrepeat_node.cpp
+++ b/be/src/vec/exec/vrepeat_node.cpp
@@ -245,13 +245,13 @@ Status VRepeatNode::get_next(RuntimeState* state, Block* block, bool* eos) {
     DCHECK(block->rows() == 0);
     while (need_more_input_data()) {
         RETURN_IF_ERROR(child(0)->get_next_after_projects(
-                state, &_child_block, &_child_eos,
+                state, _child_block.get(), &_child_eos,
                 std::bind((Status(ExecNode::*)(RuntimeState*, vectorized::Block*, bool*)) &
                                   ExecNode::get_next,
                           _children[0], std::placeholders::_1, std::placeholders::_2,
                           std::placeholders::_3)));
 
-        static_cast<void>(push(state, &_child_block, _child_eos));
+        static_cast<void>(push(state, _child_block.get(), _child_eos));
     }
 
     return pull(state, block, eos);

--- a/be/src/vec/exec/vrepeat_node.cpp
+++ b/be/src/vec/exec/vrepeat_node.cpp
@@ -191,7 +191,7 @@ Status VRepeatNode::pull(doris::RuntimeState* state, vectorized::Block* output_b
         int size = _repeat_id_list.size();
         if (_repeat_id_idx >= size) {
             _intermediate_block->clear();
-            release_block_memory(_child_block);
+            release_block_memory(*_child_block);
             _repeat_id_idx = 0;
         }
     }

--- a/be/src/vec/exec/vrepeat_node.h
+++ b/be/src/vec/exec/vrepeat_node.h
@@ -57,7 +57,7 @@ public:
     Status pull(RuntimeState* state, vectorized::Block* output_block, bool* eos) override;
     Status push(RuntimeState* state, vectorized::Block* input_block, bool eos) override;
     bool need_more_input_data() const;
-    std::shared<Block> get_child_block() { return _child_block; }
+    std::shared_ptr<Block> get_child_block() { return _child_block; }
 
     void debug_string(int indentation_level, std::stringstream* out) const override;
 
@@ -74,7 +74,7 @@ private:
     TupleId _output_tuple_id;
     const TupleDescriptor* _output_tuple_desc;
 
-    std::shared<Block> _child_block;
+    std::shared_ptr<Block> _child_block;
     std::unique_ptr<Block> _intermediate_block {};
 
     std::vector<SlotDescriptor*> _output_slots;

--- a/be/src/vec/exec/vrepeat_node.h
+++ b/be/src/vec/exec/vrepeat_node.h
@@ -57,7 +57,7 @@ public:
     Status pull(RuntimeState* state, vectorized::Block* output_block, bool* eos) override;
     Status push(RuntimeState* state, vectorized::Block* input_block, bool eos) override;
     bool need_more_input_data() const;
-    BlockSPtr get_child_block() { return _child_block; }
+    std::shared<Block> get_child_block() { return _child_block; }
 
     void debug_string(int indentation_level, std::stringstream* out) const override;
 
@@ -74,7 +74,7 @@ private:
     TupleId _output_tuple_id;
     const TupleDescriptor* _output_tuple_desc;
 
-    BlockSPtr _child_block;
+    std::shared<Block> _child_block;
     std::unique_ptr<Block> _intermediate_block {};
 
     std::vector<SlotDescriptor*> _output_slots;

--- a/be/src/vec/exec/vrepeat_node.h
+++ b/be/src/vec/exec/vrepeat_node.h
@@ -57,7 +57,7 @@ public:
     Status pull(RuntimeState* state, vectorized::Block* output_block, bool* eos) override;
     Status push(RuntimeState* state, vectorized::Block* input_block, bool eos) override;
     bool need_more_input_data() const;
-    Block* get_child_block() { return &_child_block; }
+    BlockSPtr get_child_block() { return _child_block; }
 
     void debug_string(int indentation_level, std::stringstream* out) const override;
 
@@ -74,7 +74,7 @@ private:
     TupleId _output_tuple_id;
     const TupleDescriptor* _output_tuple_desc;
 
-    Block _child_block;
+    BlockSPtr _child_block;
     std::unique_ptr<Block> _intermediate_block {};
 
     std::vector<SlotDescriptor*> _output_slots;

--- a/be/src/vec/exec/vtable_function_node.cpp
+++ b/be/src/vec/exec/vtable_function_node.cpp
@@ -146,12 +146,12 @@ Status VTableFunctionNode::get_next(RuntimeState* state, Block* block, bool* eos
     // if child_block is empty, get data from child.
     while (need_more_input_data()) {
         RETURN_IF_ERROR(child(0)->get_next_after_projects(
-                state, &_child_block, &_child_eos,
+                state, _child_block.get(), &_child_eos,
                 std::bind((Status(ExecNode::*)(RuntimeState*, Block*, bool*)) & ExecNode::get_next,
                           _children[0], std::placeholders::_1, std::placeholders::_2,
                           std::placeholders::_3)));
 
-        RETURN_IF_ERROR(push(state, &_child_block, _child_eos));
+        RETURN_IF_ERROR(push(state, _child_block.get(), _child_eos));
     }
 
     return pull(state, block, eos);

--- a/be/src/vec/exec/vtable_function_node.cpp
+++ b/be/src/vec/exec/vtable_function_node.cpp
@@ -235,7 +235,7 @@ Status VTableFunctionNode::_process_next_child_row() {
             RETURN_IF_ERROR(fn->process_close());
         }
 
-        release_block_memory(_child_block);
+        release_block_memory(*_child_block);
         _cur_child_offset = -1;
         return Status::OK();
     }

--- a/be/src/vec/exec/vtable_function_node.cpp
+++ b/be/src/vec/exec/vtable_function_node.cpp
@@ -45,7 +45,9 @@ namespace doris::vectorized {
 
 VTableFunctionNode::VTableFunctionNode(doris::ObjectPool* pool, const TPlanNode& tnode,
                                        const DescriptorTbl& descs)
-        : ExecNode(pool, tnode, descs) {}
+        : ExecNode(pool, tnode, descs) {
+    _child_block = Block::create_shared();
+}
 
 Status VTableFunctionNode::init(const TPlanNode& tnode, RuntimeState* state) {
     RETURN_IF_ERROR(ExecNode::init(tnode, state));
@@ -170,7 +172,7 @@ Status VTableFunctionNode::_get_expanded_block(RuntimeState* state, Block* outpu
         RETURN_IF_CANCELLED(state);
         RETURN_IF_ERROR(state->check_query_state("VTableFunctionNode, while getting next batch."));
 
-        if (_child_block.rows() == 0) {
+        if (_child_block->rows() == 0) {
             break;
         }
 
@@ -227,7 +229,7 @@ Status VTableFunctionNode::_get_expanded_block(RuntimeState* state, Block* outpu
 Status VTableFunctionNode::_process_next_child_row() {
     _cur_child_offset++;
 
-    if (_cur_child_offset >= _child_block.rows()) {
+    if (_cur_child_offset >= _child_block->rows()) {
         // release block use count.
         for (TableFunction* fn : _fns) {
             RETURN_IF_ERROR(fn->process_close());

--- a/be/src/vec/exec/vtable_function_node.h
+++ b/be/src/vec/exec/vtable_function_node.h
@@ -62,7 +62,7 @@ public:
         return VExpr::open(_vfn_ctxs, state);
     }
     Status get_next(RuntimeState* state, Block* block, bool* eos) override;
-    bool need_more_input_data() const { return !_child_block.rows() && !_child_eos; }
+    bool need_more_input_data() const { return !_child_block->rows() && !_child_eos; }
 
     void release_resource(doris::RuntimeState* state) override {
         if (_num_rows_filtered_counter != nullptr) {
@@ -92,7 +92,7 @@ public:
         return Status::OK();
     }
 
-    Block* get_child_block() { return &_child_block; }
+    BlockSPtr get_child_block() { return _child_block; }
 
 private:
     Status _prepare_output_slot_ids(const TPlanNode& tnode);
@@ -135,7 +135,7 @@ private:
             return;
         }
         for (auto index : _output_slot_indexs) {
-            auto src_column = _child_block.get_by_position(index).column;
+            auto src_column = _child_block->get_by_position(index).column;
             columns[index]->insert_many_from(*src_column, _cur_child_offset,
                                              _current_row_insert_times);
         }
@@ -143,7 +143,7 @@ private:
     }
     int _current_row_insert_times = 0;
 
-    Block _child_block;
+    std::shared_ptr<Block> _child_block;
     std::vector<SlotDescriptor*> _child_slots;
     std::vector<SlotDescriptor*> _output_slots;
     int64_t _cur_child_offset = 0;

--- a/be/src/vec/exec/vtable_function_node.h
+++ b/be/src/vec/exec/vtable_function_node.h
@@ -92,7 +92,7 @@ public:
         return Status::OK();
     }
 
-    std::shared<Block> get_child_block() { return _child_block; }
+    std::shared_ptr<Block> get_child_block() { return _child_block; }
 
 private:
     Status _prepare_output_slot_ids(const TPlanNode& tnode);

--- a/be/src/vec/exec/vtable_function_node.h
+++ b/be/src/vec/exec/vtable_function_node.h
@@ -92,7 +92,7 @@ public:
         return Status::OK();
     }
 
-    BlockSPtr get_child_block() { return _child_block; }
+    std::shared<Block> get_child_block() { return _child_block; }
 
 private:
     Status _prepare_output_slot_ids(const TPlanNode& tnode);


### PR DESCRIPTION
## Proposed changes

_child_block in nest loop join , table value function, repeat node will be shared between ExecNode and related operator, but it should not be a unique ptr in operator, it belongs to exec node.

It will double free the block, if operator's close method is not called correctly.

It should be a shared ptr, then it will not core even if the opeartor's close method is not called.

==30143==ERROR: AddressSanitizer: heap-use-after-free on address 0x61b0029a31d8 at pc 0x557c0b9cbf45 bp 0x7f3032029ed0 sp 0x7f3032029ec8
00:03:16   READ of size 8 at 0x61b0029a31d8 thread T284 (WithoutGroupTas)
00:03:16       #0 0x557c0b9cbf44 in std::_Bvector_base<std::allocator<bool> >::_M_deallocate() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_bvector.h:555:23
00:03:16       #1 0x557c0b9cbf44 in std::_Bvector_base<std::allocator<bool> >::~_Bvector_base() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_bvector.h:543:15
00:03:16       #2 0x557c0b9cbf44 in doris::vectorized::Block::~Block() /root/doris/be/src/vec/core/block.h:71:7
00:03:16       #3 0x557c0b9cbf44 in std::default_delete<doris::vectorized::Block>::operator()(doris::vectorized::Block*) const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:85:2
00:03:16       #4 0x557c0b9cbf44 in std::unique_ptr<doris::vectorized::Block, std::default_delete<doris::vectorized::Block> >::~unique_ptr() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:361:4
00:03:16       #5 0x557c2b94d409 in doris::pipeline::StatefulOperator<doris::pipeline::NestLoopJoinProbeOperatorBuilder>::~StatefulOperator() /root/doris/be/src/pipeline/exec/operator.h:441:41
00:03:16       #6 0x557c2b94d409 in void std::destroy_at<doris::pipeline::NestLoopJoinProbeOperator>(doris::pipeline::NestLoopJoinProbeOperator*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:88:15
00:03:16       #7 0x557c2b94d409 in void std::allocator_traits<std::allocator<doris::pipeline::NestLoopJoinProbeOperator> >::destroy<doris::pipeline::NestLoopJoinProbeOperator>(std::allocator<doris::pipeline::NestLoopJoinProbeOperator>&, doris::pipeline::NestLoopJoinProbeOperator*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:533:4
00:03:16       #8 0x557c2b94d409 in std::_Sp_counted_ptr_inplace<doris::pipeline::NestLoopJoinProbeOperator, std::allocator<doris::pipeline::NestLoopJoinProbeOperator>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:528:2
00:03:16       #9 0x557c2b8bae0d in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:168:6
00:03:16       #10 0x557c2b8bae0d in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:702:11
00:03:16       #11 0x557c2b8bae0d in std::__shared_ptr<doris::pipeline::OperatorBase, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1149:31
00:03:16       #12 0x557c2b8bae0d in void std::destroy_at<std::shared_ptr<doris::pipeline::OperatorBase> >(std::shared_ptr<doris::pipeline::OperatorBase>*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:88:15
00:03:16       #13 0x557c2b8bae0d in void std::_Destroy<std::shared_ptr<doris::pipeline::OperatorBase> >(std::shared_ptr<doris::pipeline::OperatorBase>*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:138:7
00:03:16       #14 0x557c2b8bae0d in void std::_Destroy_aux<false>::__destroy<std::shared_ptr<doris::pipeline::OperatorBase>*>(std::shared_ptr<doris::pipeline::OperatorBase>*, std::shared_ptr<doris::pipeline::OperatorBase>*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:152:6
00:03:16       #15 0x557c2b8bae0d in void std::_Destroy<std::shared_ptr<doris::pipeline::OperatorBase>*>(std::shared_ptr<doris::pipeline::OperatorBase>*, std::shared_ptr<doris::pipeline::OperatorBase>*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:184:7
00:03:16       #16 0x557c2b8bae0d in void std::_Destroy<std::shared_ptr<doris::pipeline::OperatorBase>*, std::shared_ptr<doris::pipeline::OperatorBase> >(std::shared_ptr<doris::pipeline::OperatorBase>*, std::shared_ptr<doris::pipeline::OperatorBase>*, std::allocator<std::shared_ptr<doris::pipeline::OperatorBase> >&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:746:7
00:03:16       #17 0x557c2b8bae0d in std::vector<std::shared_ptr<doris::pipeline::OperatorBase>, std::allocator<std::shared_ptr<doris::pipeline::OperatorBase> > >::~vector() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:680:2
00:03:16       #18 0x557c2b8bae0d in doris::pipeline::Pipeline::~Pipeline() /root/doris/be/src/pipeline/pipeline.h:46:7
00:03:16       #19 0x557c2b87bf30 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:168:6
00:03:16       #20 0x557c2b87bf30 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:702:11
00:03:16       #21 0x557c2b87bf30 in std::__shared_ptr<doris::pipeline::Pipeline, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1149:31
00:03:16       #22 0x557c2b87bf30 in void std::destroy_at<std::shared_ptr<doris::pipeline::Pipeline> >(std::shared_ptr<doris::pipeline::Pipeline>*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:88:15
00:03:16       #23 0x557c2b87bf30 in void std::_Destroy<std::shared_ptr<doris::pipeline::Pipeline> >(std::shared_ptr<doris::pipeline::Pipeline>*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:138:7
00:03:16       #24 0x557c2b87bf30 in void std::_Destroy_aux<false>::__destroy<std::shared_ptr<doris::pipeline::Pipeline>*>(std::shared_ptr<doris::pipeline::Pipeline>*, std::shared_ptr<doris::pipeline::Pipeline>*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:152:6
00:03:16       #25 0x557c2b87bf30 in void std::_Destroy<std::shared_ptr<doris::pipeline::Pipeline>*>(std::shared_ptr<doris::pipeline::Pipeline>*, std::shared_ptr<doris::pipeline::Pipeline>*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:184:7
00:03:16       #26 0x557c2b87bf30 in void std::_Destroy<std::shared_ptr<doris::pipeline::Pipeline>*, std::shared_ptr<doris::pipeline::Pipeline> >(std::shared_ptr<doris::pipeline::Pipeline>*, std::shared_ptr<doris::pipeline::Pipeline>*, std::allocator<std::shared_ptr<doris::pipeline::Pipeline> >&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:746:7
00:03:16       #27 0x557c2b87bf30 in std::vector<std::shared_ptr<doris::pipeline::Pipeline>, std::allocator<std::shared_ptr<doris::pipeline::Pipeline> > >::~vector() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:680:2
00:03:16       #28 0x557c2b87bf30 in doris::pipeline::PipelineFragmentContext::~PipelineFragmentContext() /root/doris/be/src/pipeline/pipeline_fragment_context.cpp:148:1
00:03:16       #29 0x557c2b9aecd7 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:168:6
00:03:16       #30 0x557c2b9aecd7 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:702:11
00:03:16       #31 0x557c2b9aecd7 in std::__shared_ptr<doris::pipeline::PipelineFragmentContext, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1149:31
00:03:16       #32 0x557c2b9aecd7 in doris::pipeline::TaskScheduler::_try_close_task(doris::pipeline::PipelineTask*, doris::pipeline::PipelineTaskState) /root/doris/be/src/pipeline/task_scheduler.cpp:359:1
00:03:16       #33 0x557c2b9ac721 in doris::pipeline::TaskScheduler::_do_work(unsigned long) /root/doris/be/src/pipeline/task_scheduler.cpp:242:13
00:03:16       #34 0x557c0c61772a in doris::ThreadPool::dispatch_thread() /root/doris/be/src/util/threadpool.cpp:533:24
00:03:16       #35 0x557c0c5f825d in std::function<void ()>::operator()() const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
00:03:16       #36 0x557c0c5f825d in doris::Thread::supervise_thread(void*) /root/doris/be/src/util/thread.cpp:498:5
00:03:16       #37 0x7f32137f2608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477:8
00:03:16       #38 0x7f3213a9f132 in __clone /build/glibc-SzIz7B/glibc-2.31/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95
00:03:16   
00:03:16   0x61b0029a31d8 is located 1112 bytes inside of 1472-byte region [0x61b0029a2d80,0x61b0029a3340)
00:03:16   freed by thread T284 (WithoutGroupTas) here:
00:03:16       #0 0x557c09fdb80d in operator delete(void*) (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be+0xe8c780d) (BuildId: 3c7aebf9dab039d1)
00:03:16       #1 0x557c0c153a61 in doris::ObjectPool::clear() /root/doris/be/src/common/object_pool.h:57:13
00:03:16       #2 0x557c0c153a61 in doris::RuntimeState::~RuntimeState() /root/doris/be/src/runtime/runtime_state.cpp:191:16
00:03:16       #3 0x557c2b87b41d in std::default_delete<doris::RuntimeState>::operator()(doris::RuntimeState*) const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:85:2
00:03:16       #4 0x557c2b87b41d in std::__uniq_ptr_impl<doris::RuntimeState, std::default_delete<doris::RuntimeState> >::reset(doris::RuntimeState*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:182:4
00:03:16       #5 0x557c2b87b41d in std::unique_ptr<doris::RuntimeState, std::default_delete<doris::RuntimeState> >::reset(doris::RuntimeState*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:456:7
00:03:16       #6 0x557c2b87b41d in doris::pipeline::PipelineFragmentContext::~PipelineFragmentContext() /root/doris/be/src/pipeline/pipeline_fragment_context.cpp:143:24
00:03:16       #7 0x557c2b9aecd7 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:168:6
00:03:16       #8 0x557c2b9aecd7 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:702:11
00:03:16       #9 0x557c2b9aecd7 in std::__shared_ptr<doris::pipeline::PipelineFragmentContext, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1149:31
00:03:16       #10 0x557c2b9aecd7 in doris::pipeline::TaskScheduler::_try_close_task(doris::pipeline::PipelineTask*, doris::pipeline::PipelineTaskState) /root/doris/be/src/pipeline/task_scheduler.cpp:359:1
00:03:16       #11 0x557c2b9ac721 in doris::pipeline::TaskScheduler::_do_work(unsigned long) /root/doris/be/src/pipeline/task_scheduler.cpp:242:13
00:03:16       #12 0x557c0c61772a in doris::ThreadPool::dispatch_thread() /root/doris/be/src/util/threadpool.cpp:533:24
00:03:16       #13 0x557c0c5f825d in std::function<void ()>::operator()() const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
00:03:16       #14 0x557c0c5f825d in doris::Thread::supervise_thread(void*) /root/doris/be/src/util/thread.cpp:498:5
00:03:16       #15 0x7f32137f2608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477:8

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

