### PR TITLE
[bugfix](core) child block is shared between operator and node, it should be shared ptr related with #28106

### DIFF
--- a/be/src/pipeline/exec/nested_loop_join_probe_operator.cpp
+++ b/be/src/pipeline/exec/nested_loop_join_probe_operator.cpp
@@ -33,12 +33,11 @@ OPERATOR_CODE_GENERATOR(NestLoopJoinProbeOperator, StatefulOperator)
 
 Status NestLoopJoinProbeOperator::prepare(doris::RuntimeState* state) {
     // just for speed up, the way is dangerous
-    _child_block.reset(_node->get_left_block());
+    _child_block = _node->get_left_block();
     return StatefulOperator::prepare(state);
 }
 
 Status NestLoopJoinProbeOperator::close(doris::RuntimeState* state) {
-    _child_block.release();
     return StatefulOperator::close(state);
 }
 

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -447,14 +447,14 @@ public:
 
         if (node->need_more_input_data()) {
             _child_block->clear_column_data();
-            RETURN_IF_ERROR(child->get_block(state, _child_block.get(), _child_source_state));
+            RETURN_IF_ERROR(child->get_block(state, _child_block, _child_source_state));
             source_state = _child_source_state;
             if (_child_block->rows() == 0 && _child_source_state != SourceState::FINISHED) {
                 return Status::OK();
             }
             node->prepare_for_next();
-            RETURN_IF_ERROR(node->push(state, _child_block.get(),
-                                       _child_source_state == SourceState::FINISHED));
+            RETURN_IF_ERROR(
+                    node->push(state, _child_block, _child_source_state == SourceState::FINISHED));
         }
 
         if (!node->need_more_input_data()) {
@@ -475,7 +475,10 @@ public:
     }
 
 protected:
-    std::unique_ptr<vectorized::Block> _child_block;
+    // _child_block is owned by execnode, not by this operator, so that it should
+    // be a shared ptr here. I have already modify it in master branch, it need modify
+    // many codes, so that it is simple to use raw ptr here.
+    vectorized::Block* _child_block;
     SourceState _child_source_state;
 };
 

--- a/be/src/pipeline/exec/repeat_operator.cpp
+++ b/be/src/pipeline/exec/repeat_operator.cpp
@@ -33,12 +33,11 @@ OPERATOR_CODE_GENERATOR(RepeatOperator, StatefulOperator)
 
 Status RepeatOperator::prepare(doris::RuntimeState* state) {
     // just for speed up, the way is dangerous
-    _child_block.reset(_node->get_child_block());
+    _child_block = _node->get_child_block();
     return StatefulOperator::prepare(state);
 }
 
 Status RepeatOperator::close(doris::RuntimeState* state) {
-    _child_block.release();
     return StatefulOperator::close(state);
 }
 

--- a/be/src/pipeline/exec/table_function_operator.cpp
+++ b/be/src/pipeline/exec/table_function_operator.cpp
@@ -32,12 +32,11 @@ OPERATOR_CODE_GENERATOR(TableFunctionOperator, StatefulOperator)
 
 Status TableFunctionOperator::prepare(doris::RuntimeState* state) {
     // just for speed up, the way is dangerous
-    _child_block.reset(_node->get_child_block());
+    _child_block = _node->get_child_block();
     return StatefulOperator::prepare(state);
 }
 
 Status TableFunctionOperator::close(doris::RuntimeState* state) {
-    _child_block.release();
     return StatefulOperator::close(state);
 }
 


### PR DESCRIPTION
## Proposed changes
A simple fix pick from master #28106 

==30143==ERROR: AddressSanitizer: heap-use-after-free on address 0x61b0029a31d8 at pc 0x557c0b9cbf45 bp 0x7f3032029ed0 sp 0x7f3032029ec8
00:03:16   READ of size 8 at 0x61b0029a31d8 thread T284 (WithoutGroupTas)
00:03:16       #0 0x557c0b9cbf44 in std::_Bvector_base<std::allocator<bool> >::_M_deallocate() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_bvector.h:555:23
00:03:16       #1 0x557c0b9cbf44 in std::_Bvector_base<std::allocator<bool> >::~_Bvector_base() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_bvector.h:543:15
00:03:16       #2 0x557c0b9cbf44 in doris::vectorized::Block::~Block() /root/doris/be/src/vec/core/block.h:71:7
00:03:16       #3 0x557c0b9cbf44 in std::default_delete<doris::vectorized::Block>::operator()(doris::vectorized::Block*) const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:85:2
00:03:16       #4 0x557c0b9cbf44 in std::unique_ptr<doris::vectorized::Block, std::default_delete<doris::vectorized::Block> >::~unique_ptr() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:361:4
00:03:16       #5 0x557c2b94d409 in doris::pipeline::StatefulOperator<doris::pipeline::NestLoopJoinProbeOperatorBuilder>::~StatefulOperator() /root/doris/be/src/pipeline/exec/operator.h:441:41
00:03:16       #6 0x557c2b94d409 in void std::destroy_at<doris::pipeline::NestLoopJoinProbeOperator>(doris::pipeline::NestLoopJoinProbeOperator*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:88:15
00:03:16       #7 0x557c2b94d409 in void std::allocator_traits<std::allocator<doris::pipeline::NestLoopJoinProbeOperator> >::destroy<doris::pipeline::NestLoopJoinProbeOperator>(std::allocator<doris::pipeline::NestLoopJoinProbeOperator>&, doris::pipeline::NestLoopJoinProbeOperator*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:533:4
00:03:16       #8 0x557c2b94d409 in std::_Sp_counted_ptr_inplace<doris::pipeline::NestLoopJoinProbeOperator, std::allocator<doris::pipeline::NestLoopJoinProbeOperator>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:528:2
00:03:16       #9 0x557c2b8bae0d in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:168:6
00:03:16       #10 0x557c2b8bae0d in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:702:11
00:03:16       #11 0x557c2b8bae0d in std::__shared_ptr<doris::pipeline::OperatorBase, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1149:31
00:03:16       #12 0x557c2b8bae0d in void std::destroy_at<std::shared_ptr<doris::pipeline::OperatorBase> >(std::shared_ptr<doris::pipeline::OperatorBase>*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:88:15
00:03:16       #13 0x557c2b8bae0d in void std::_Destroy<std::shared_ptr<doris::pipeline::OperatorBase> >(std::shared_ptr<doris::pipeline::OperatorBase>*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:138:7
00:03:16       #14 0x557c2b8bae0d in void std::_Destroy_aux<false>::__destroy<std::shared_ptr<doris::pipeline::OperatorBase>*>(std::shared_ptr<doris::pipeline::OperatorBase>*, std::shared_ptr<doris::pipeline::OperatorBase>*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:152:6
00:03:16       #15 0x557c2b8bae0d in void std::_Destroy<std::shared_ptr<doris::pipeline::OperatorBase>*>(std::shared_ptr<doris::pipeline::OperatorBase>*, std::shared_ptr<doris::pipeline::OperatorBase>*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:184:7
00:03:16       #16 0x557c2b8bae0d in void std::_Destroy<std::shared_ptr<doris::pipeline::OperatorBase>*, std::shared_ptr<doris::pipeline::OperatorBase> >(std::shared_ptr<doris::pipeline::OperatorBase>*, std::shared_ptr<doris::pipeline::OperatorBase>*, std::allocator<std::shared_ptr<doris::pipeline::OperatorBase> >&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:746:7
00:03:16       #17 0x557c2b8bae0d in std::vector<std::shared_ptr<doris::pipeline::OperatorBase>, std::allocator<std::shared_ptr<doris::pipeline::OperatorBase> > >::~vector() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:680:2
00:03:16       #18 0x557c2b8bae0d in doris::pipeline::Pipeline::~Pipeline() /root/doris/be/src/pipeline/pipeline.h:46:7
00:03:16       #19 0x557c2b87bf30 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:168:6
00:03:16       #20 0x557c2b87bf30 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:702:11
00:03:16       #21 0x557c2b87bf30 in std::__shared_ptr<doris::pipeline::Pipeline, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1149:31
00:03:16       #22 0x557c2b87bf30 in void std::destroy_at<std::shared_ptr<doris::pipeline::Pipeline> >(std::shared_ptr<doris::pipeline::Pipeline>*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:88:15
00:03:16       #23 0x557c2b87bf30 in void std::_Destroy<std::shared_ptr<doris::pipeline::Pipeline> >(std::shared_ptr<doris::pipeline::Pipeline>*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:138:7
00:03:16       #24 0x557c2b87bf30 in void std::_Destroy_aux<false>::__destroy<std::shared_ptr<doris::pipeline::Pipeline>*>(std::shared_ptr<doris::pipeline::Pipeline>*, std::shared_ptr<doris::pipeline::Pipeline>*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:152:6
00:03:16       #25 0x557c2b87bf30 in void std::_Destroy<std::shared_ptr<doris::pipeline::Pipeline>*>(std::shared_ptr<doris::pipeline::Pipeline>*, std::shared_ptr<doris::pipeline::Pipeline>*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:184:7
00:03:16       #26 0x557c2b87bf30 in void std::_Destroy<std::shared_ptr<doris::pipeline::Pipeline>*, std::shared_ptr<doris::pipeline::Pipeline> >(std::shared_ptr<doris::pipeline::Pipeline>*, std::shared_ptr<doris::pipeline::Pipeline>*, std::allocator<std::shared_ptr<doris::pipeline::Pipeline> >&) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:746:7
00:03:16       #27 0x557c2b87bf30 in std::vector<std::shared_ptr<doris::pipeline::Pipeline>, std::allocator<std::shared_ptr<doris::pipeline::Pipeline> > >::~vector() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:680:2
00:03:16       #28 0x557c2b87bf30 in doris::pipeline::PipelineFragmentContext::~PipelineFragmentContext() /root/doris/be/src/pipeline/pipeline_fragment_context.cpp:148:1
00:03:16       #29 0x557c2b9aecd7 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:168:6
00:03:16       #30 0x557c2b9aecd7 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:702:11
00:03:16       #31 0x557c2b9aecd7 in std::__shared_ptr<doris::pipeline::PipelineFragmentContext, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1149:31
00:03:16       #32 0x557c2b9aecd7 in doris::pipeline::TaskScheduler::_try_close_task(doris::pipeline::PipelineTask*, doris::pipeline::PipelineTaskState) /root/doris/be/src/pipeline/task_scheduler.cpp:359:1
00:03:16       #33 0x557c2b9ac721 in doris::pipeline::TaskScheduler::_do_work(unsigned long) /root/doris/be/src/pipeline/task_scheduler.cpp:242:13
00:03:16       #34 0x557c0c61772a in doris::ThreadPool::dispatch_thread() /root/doris/be/src/util/threadpool.cpp:533:24
00:03:16       #35 0x557c0c5f825d in std::function<void ()>::operator()() const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
00:03:16       #36 0x557c0c5f825d in doris::Thread::supervise_thread(void*) /root/doris/be/src/util/thread.cpp:498:5
00:03:16       #37 0x7f32137f2608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477:8
00:03:16       #38 0x7f3213a9f132 in __clone /build/glibc-SzIz7B/glibc-2.31/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95
00:03:16   
00:03:16   0x61b0029a31d8 is located 1112 bytes inside of 1472-byte region [0x61b0029a2d80,0x61b0029a3340)
00:03:16   freed by thread T284 (WithoutGroupTas) here:
00:03:16       #0 0x557c09fdb80d in operator delete(void*) (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be+0xe8c780d) (BuildId: 3c7aebf9dab039d1)
00:03:16       #1 0x557c0c153a61 in doris::ObjectPool::clear() /root/doris/be/src/common/object_pool.h:57:13
00:03:16       #2 0x557c0c153a61 in doris::RuntimeState::~RuntimeState() /root/doris/be/src/runtime/runtime_state.cpp:191:16
00:03:16       #3 0x557c2b87b41d in std::default_delete<doris::RuntimeState>::operator()(doris::RuntimeState*) const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:85:2
00:03:16       #4 0x557c2b87b41d in std::__uniq_ptr_impl<doris::RuntimeState, std::default_delete<doris::RuntimeState> >::reset(doris::RuntimeState*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:182:4
00:03:16       #5 0x557c2b87b41d in std::unique_ptr<doris::RuntimeState, std::default_delete<doris::RuntimeState> >::reset(doris::RuntimeState*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:456:7
00:03:16       #6 0x557c2b87b41d in doris::pipeline::PipelineFragmentContext::~PipelineFragmentContext() /root/doris/be/src/pipeline/pipeline_fragment_context.cpp:143:24
00:03:16       #7 0x557c2b9aecd7 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:168:6
00:03:16       #8 0x557c2b9aecd7 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:702:11
00:03:16       #9 0x557c2b9aecd7 in std::__shared_ptr<doris::pipeline::PipelineFragmentContext, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1149:31
00:03:16       #10 0x557c2b9aecd7 in doris::pipeline::TaskScheduler::_try_close_task(doris::pipeline::PipelineTask*, doris::pipeline::PipelineTaskState) /root/doris/be/src/pipeline/task_scheduler.cpp:359:1
00:03:16       #11 0x557c2b9ac721 in doris::pipeline::TaskScheduler::_do_work(unsigned long) /root/doris/be/src/pipeline/task_scheduler.cpp:242:13
00:03:16       #12 0x557c0c61772a in doris::ThreadPool::dispatch_thread() /root/doris/be/src/util/threadpool.cpp:533:24
00:03:16       #13 0x557c0c5f825d in std::function<void ()>::operator()() const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
00:03:16       #14 0x557c0c5f825d in doris::Thread::supervise_thread(void*) /root/doris/be/src/util/thread.cpp:498:5
00:03:16       #15 0x7f32137f2608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477:8

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

