### PR TITLE
[fix](statistics)Escape load stats sql.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
@@ -112,7 +112,7 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
             params.put("dbId", String.valueOf(db.getId()));
             params.put("tblId", String.valueOf(tbl.getId()));
             params.put("idxId", String.valueOf(info.indexId));
-            params.put("colId", String.valueOf(info.colName));
+            params.put("colId", StatisticsUtil.escapeSQL(String.valueOf(info.colName)));
             params.put("dataSizeFunction", getDataSizeFunction(col, false));
             params.put("dbName", db.getFullName());
             params.put("colName", info.colName);
@@ -184,7 +184,7 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
         params.put("dbId", String.valueOf(db.getId()));
         params.put("tblId", String.valueOf(tbl.getId()));
         params.put("idxId", String.valueOf(info.indexId));
-        params.put("colId", String.valueOf(info.colName));
+        params.put("colId", StatisticsUtil.escapeSQL(String.valueOf(info.colName)));
         params.put("dataSizeFunction", getDataSizeFunction(col, false));
         params.put("catalogName", catalog.getName());
         params.put("dbName", db.getFullName());

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsRepository.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsRepository.java
@@ -142,7 +142,7 @@ public class StatisticsRepository {
     private static ResultRow queryColumnStatisticById(long tblId, String colName, boolean isHistogram) {
         Map<String, String> map = new HashMap<>();
         String id = constructId(tblId, -1, colName);
-        map.put("id", id);
+        map.put("id", StatisticsUtil.escapeSQL(id));
         List<ResultRow> rows = isHistogram ? StatisticsUtil.executeQuery(FETCH_COLUMN_HISTOGRAM_TEMPLATE, map) :
                 StatisticsUtil.executeQuery(FETCH_COLUMN_STATISTIC_TEMPLATE, map);
         int size = rows.size();
@@ -336,7 +336,7 @@ public class StatisticsRepository {
         Map<String, String> params = new HashMap<>();
         params.put("tblId", String.valueOf(tableId));
         params.put("idxId", String.valueOf(idxId));
-        params.put("colId", colName);
+        params.put("colId", StatisticsUtil.escapeSQL(colName));
 
         return StatisticsUtil.execStatisticQuery(new StringSubstitutor(params)
                 .replace(QUERY_COLUMN_STATISTICS));

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatsId.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatsId.java
@@ -69,12 +69,12 @@ public class StatsId {
 
     public String toSQL() {
         StringJoiner sj = new StringJoiner(",");
-        sj.add(StatisticsUtil.quote(id));
+        sj.add(StatisticsUtil.quote(StatisticsUtil.escapeSQL(id)));
         sj.add(String.valueOf(catalogId));
         sj.add(String.valueOf(dbId));
         sj.add(String.valueOf(tblId));
         sj.add(String.valueOf(idxId));
-        sj.add(StatisticsUtil.quote(colId));
+        sj.add(StatisticsUtil.quote(StatisticsUtil.escapeSQL(colId)));
         sj.add(partId);
         return sj.toString();
     }

--- a/regression-test/suites/statistics/analyze_stats.groovy
+++ b/regression-test/suites/statistics/analyze_stats.groovy
@@ -1434,4 +1434,32 @@ PARTITION `p599` VALUES IN (599)
     assertEquals("0.0", result[0][5])
     assertEquals("N/A", result[0][6])
     assertEquals("N/A", result[0][7])
+
+    // Test analyze column with special character in name.
+    sql """
+      CREATE TABLE region  (
+       `r_regionkey`      int NOT NULL,
+       `r'name`     VARCHAR(25) NOT NULL,
+       `r_comment`    VARCHAR(152)
+      )ENGINE=OLAP
+      DUPLICATE KEY(`r_regionkey`)
+      COMMENT "OLAP"
+      DISTRIBUTED BY HASH(`r_regionkey`) BUCKETS 1
+      PROPERTIES (
+       "replication_num" = "1"
+      );
+   """
+   sql """insert into region values(1,'name1', 'comment1') """
+   sql """insert into region values(2,'name2', 'comment2') """
+   sql """insert into region values(3,'name3', 'comment3') """
+   sql """ANALYZE TABLE region WITH SYNC"""
+   result = sql """show column stats region (`r'name`);"""
+   assertEquals(1, result.size())
+   assertEquals("r'name", result[0][0])
+   assertEquals("3.0", result[0][1])
+   assertEquals("3.0", result[0][2])
+   assertEquals("0.0", result[0][3])
+   assertEquals("\'name1\'", result[0][6])
+   assertEquals("\'name3\'", result[0][7])
+
 }


### PR DESCRIPTION
Escape load stats sql, because column name may contain special characters.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

