### PR TITLE
[Fix](Variant) ColumnObject need to be finalized when doing ColumnObject::update_hash_with_value

### DIFF
--- a/be/src/vec/columns/column_object.cpp
+++ b/be/src/vec/columns/column_object.cpp
@@ -1430,8 +1430,18 @@ void ColumnObject::insert_indices_from(const IColumn& src, const uint32_t* indic
 }
 
 void ColumnObject::update_hash_with_value(size_t n, SipHash& hash) const {
-    for_each_imutable_subcolumn(
-            [&](const auto& subcolumn) { return subcolumn.update_hash_with_value(n, hash); });
+    if (!is_finalized()) {
+        // finalize has no side effect and can be safely used in const functions
+        const_cast<ColumnObject*>(this)->finalize();
+    }
+    for_each_imutable_subcolumn([&](const auto& subcolumn) {
+        if (n >= subcolumn.size()) {
+            LOG(FATAL) << n << " greater than column size " << subcolumn.size()
+                       << " sub_column_info:" << subcolumn.dump_structure()
+                       << " total lines of this column " << num_rows;
+        }
+        return subcolumn.update_hash_with_value(n, hash);
+    });
 }
 
 void ColumnObject::for_each_imutable_subcolumn(ImutableColumnCallback callback) const {


### PR DESCRIPTION
…ect::update_hash_with_value

Otherwise accessing rows at `n` will lead to heap buffer overflow

```
 5# SipHash::update(char const*, unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/vec/common/sip_hash.h:132
 6# doris::vectorized::ColumnString::update_hash_with_value(unsigned long, SipHash&) const at /home/zcp/repo_center/doris_master/doris/be/src/vec/columns/column_string.h:452
 7# doris::vectorized::ColumnObject::update_hash_with_value(unsigned long, SipHash&) const at /home/zcp/repo_center/doris_master/doris/be/src/vec/columns/column_object.cpp:1433
 8# doris::vectorized::Block::update_hash(SipHash&) const at /home/zcp/repo_center/doris_master/doris/be/src/vec/core/block.cpp:721
 9# doris::EngineChecksumTask::_compute_checksum() at
```

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

