### PR TITLE
[chore](memory) Warning in log when turning on THP

### DIFF
--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -460,6 +460,19 @@ void MemInfo::init() {
         _s_sys_mem_available_warning_water_mark = _s_sys_mem_available_low_water_mark * 2;
     }
 
+    std::ifstream sys_transparent_hugepage("/sys/kernel/mm/transparent_hugepage/enabled",
+                                           std::ios::in);
+    std::string hugepage_enable;
+    getline(sys_transparent_hugepage, hugepage_enable);
+    if (sys_transparent_hugepage.is_open()) sys_transparent_hugepage.close();
+    if (hugepage_enable == "[always] madvise never") {
+        std::cout << "[WARNING!] /sys/kernel/mm/transparent_hugepage/enabled: " << hugepage_enable
+                  << ", Doris not recommend turning on THP, which may cause the BE process to use "
+                     "more memory and cannot be freed in time. Turn off THP: `echo madvise | sudo "
+                     "tee /sys/kernel/mm/transparent_hugepage/enabled`"
+                  << std::endl;
+    }
+
     // Expect vm overcommit memory value to be 1, system will no longer throw bad_alloc, memory alloc are always accepted,
     // memory limit check is handed over to Doris Allocator, make sure throw exception position is controllable,
     // otherwise bad_alloc can be thrown anywhere and it will be difficult to achieve exception safety.
@@ -468,7 +481,7 @@ void MemInfo::init() {
     getline(sys_vm, vm_overcommit);
     if (sys_vm.is_open()) sys_vm.close();
     if (std::stoi(vm_overcommit) == 2) {
-        std::cout << "/proc/sys/vm/overcommit_memory: " << vm_overcommit
+        std::cout << "[WARNING!] /proc/sys/vm/overcommit_memory: " << vm_overcommit
                   << ", expect is 1, memory limit check is handed over to Doris Allocator, "
                      "otherwise BE may crash even with remaining memory"
                   << std::endl;

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -481,7 +481,7 @@ void MemInfo::init() {
     std::string vm_overcommit;
     getline(sys_vm, vm_overcommit);
     if (sys_vm.is_open()) sys_vm.close();
-    if (vm_overcommit != "" && std::stoi(vm_overcommit) == 2) {
+    if (!vm_overcommit.empty() && std::stoi(vm_overcommit) == 2) {
         std::cout << "[WARNING!] /proc/sys/vm/overcommit_memory: " << vm_overcommit
                   << ", expect is 1, memory limit check is handed over to Doris Allocator, "
                      "otherwise BE may crash even with remaining memory"

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -463,6 +463,7 @@ void MemInfo::init() {
     std::ifstream sys_transparent_hugepage("/sys/kernel/mm/transparent_hugepage/enabled",
                                            std::ios::in);
     std::string hugepage_enable;
+    // If file not exist, getline returns an empty string.
     getline(sys_transparent_hugepage, hugepage_enable);
     if (sys_transparent_hugepage.is_open()) sys_transparent_hugepage.close();
     if (hugepage_enable == "[always] madvise never") {
@@ -480,7 +481,7 @@ void MemInfo::init() {
     std::string vm_overcommit;
     getline(sys_vm, vm_overcommit);
     if (sys_vm.is_open()) sys_vm.close();
-    if (std::stoi(vm_overcommit) == 2) {
+    if (vm_overcommit != "" && std::stoi(vm_overcommit) == 2) {
         std::cout << "[WARNING!] /proc/sys/vm/overcommit_memory: " << vm_overcommit
                   << ", expect is 1, memory limit check is handed over to Doris Allocator, "
                      "otherwise BE may crash even with remaining memory"


### PR DESCRIPTION
## Proposed changes

Doris not recommend turning on THP, which may cause the BE process to use more memory and cannot be freed in time.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

