### PR TITLE
[improve](env) Add disk usage in not ready msg

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -5862,6 +5862,11 @@ public class Env {
             sb.append(frontend.toString()).append("\n");
         }
 
+        long diskUsagePercent = editLog.getEnvDiskUsagePercent();
+        sb.append("Disk usage: ")
+                .append(diskUsagePercent != -1 ? String.valueOf(diskUsagePercent) : "<unknown>")
+                .append("%\n");
+
         if (haProtocol instanceof BDBHA) {
             try {
                 BDBHA ha = (BDBHA) haProtocol;

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBJEJournal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBJEJournal.java
@@ -514,6 +514,13 @@ public class BDBJEJournal implements Journal { // CHECKSTYLE IGNORE THIS LINE: B
         return this.bdbEnvironment;
     }
 
+    public long getEnvDiskUsagePercent() {
+        if (bdbEnvironment == null) {
+            return -1;
+        }
+        return bdbEnvironment.getEnvDiskUsagePercent();
+    }
+
     public String getBDBStats() {
         if (bdbEnvironment == null) {
             return "";

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -151,6 +151,13 @@ public class EditLog {
         return journal == null ? 0 : 1;
     }
 
+    public long getEnvDiskUsagePercent() {
+        if (journal instanceof BDBJEJournal) {
+            return ((BDBJEJournal) journal).getEnvDiskUsagePercent();
+        }
+        return -1;
+    }
+
     /**
      * Load journal.
      **/


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

When the disk space is insufficient, BDBJE will stop writing. This PR adds the disk usage log to locate the problem faster when not ready.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

