### PR TITLE
[enhance](session)check invalid value when set parallel instance variables

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -679,10 +679,12 @@ public class SessionVariable implements Serializable, Writable {
      * the parallel exec instance num for one Fragment in one BE
      * 1 means disable this feature
      */
-    @VariableMgr.VarAttr(name = PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM, needForward = true, fuzzy = true)
+    @VariableMgr.VarAttr(name = PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM, needForward = true, fuzzy = true,
+                        setter = "checkFragmentInstanceNum")
     public int parallelExecInstanceNum = 1;
 
-    @VariableMgr.VarAttr(name = PARALLEL_PIPELINE_TASK_NUM, fuzzy = true, needForward = true)
+    @VariableMgr.VarAttr(name = PARALLEL_PIPELINE_TASK_NUM, fuzzy = true, needForward = true,
+                        setter = "checkPipelineTaskNum")
     public int parallelPipelineTaskNum = 0;
 
     @VariableMgr.VarAttr(name = PROFILE_LEVEL, fuzzy = true)
@@ -1840,6 +1842,23 @@ public class SessionVariable implements Serializable, Writable {
     public void setMaxExecutionTimeMS(String maxExecutionTimeMS) {
         this.maxExecutionTimeMS = Integer.valueOf(maxExecutionTimeMS);
         this.queryTimeoutS = this.maxExecutionTimeMS / 1000;
+    }
+
+    public void checkPipelineTaskNum(String value) throws Exception {
+        checkFieldValue("parallel_pipeline_task_num", 0, value);
+    }
+
+    public void checkFragmentInstanceNum(String value) throws Exception {
+        checkFieldValue("parallel_fragment_exec_instance_num", 1, value);
+    }
+
+    private void checkFieldValue(String variableName, int minValue, String value) throws Exception {
+        int val = Integer.valueOf(value);
+        if (val < minValue) {
+            throw new DdlException(
+                    variableName + " value should greater than or equal " + String.valueOf(minValue)
+                            + ", you set value is: " + value);
+        }
     }
 
     public String getWorkloadGroup() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -680,11 +680,11 @@ public class SessionVariable implements Serializable, Writable {
      * 1 means disable this feature
      */
     @VariableMgr.VarAttr(name = PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM, needForward = true, fuzzy = true,
-                        setter = "checkFragmentInstanceNum")
+                        setter = "setFragmentInstanceNum")
     public int parallelExecInstanceNum = 1;
 
     @VariableMgr.VarAttr(name = PARALLEL_PIPELINE_TASK_NUM, fuzzy = true, needForward = true,
-                        setter = "checkPipelineTaskNum")
+                        setter = "setPipelineTaskNum")
     public int parallelPipelineTaskNum = 0;
 
     @VariableMgr.VarAttr(name = PROFILE_LEVEL, fuzzy = true)
@@ -1844,21 +1844,24 @@ public class SessionVariable implements Serializable, Writable {
         this.queryTimeoutS = this.maxExecutionTimeMS / 1000;
     }
 
-    public void checkPipelineTaskNum(String value) throws Exception {
-        checkFieldValue("parallel_pipeline_task_num", 0, value);
+    public void setPipelineTaskNum(String value) throws Exception {
+        int val = checkFieldValue(PARALLEL_PIPELINE_TASK_NUM, 0, value);
+        this.parallelPipelineTaskNum = val;
     }
 
-    public void checkFragmentInstanceNum(String value) throws Exception {
-        checkFieldValue("parallel_fragment_exec_instance_num", 1, value);
+    public void setFragmentInstanceNum(String value) throws Exception {
+        int val = checkFieldValue(PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM, 1, value);
+        this.parallelExecInstanceNum = val;
     }
 
-    private void checkFieldValue(String variableName, int minValue, String value) throws Exception {
+    private int checkFieldValue(String variableName, int minValue, String value) throws Exception {
         int val = Integer.valueOf(value);
         if (val < minValue) {
-            throw new DdlException(
+            throw new Exception(
                     variableName + " value should greater than or equal " + String.valueOf(minValue)
                             + ", you set value is: " + value);
         }
+        return val;
     }
 
     public String getWorkloadGroup() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -150,9 +150,24 @@ public class VariableMgr {
         return defaultSessionVariable;
     }
 
+    private static void checkFieldValue(String variableName, int minValue, String value) throws DdlException {
+        int val = Integer.valueOf(value);
+        if (val < minValue) {
+            throw new DdlException(
+                    variableName + " value should greater than or equal " + String.valueOf(minValue)
+                            + ", you set value is: " + value);
+        }
+    }
+
     // Set value to a variable
     private static boolean setValue(Object obj, Field field, String value) throws DdlException {
         VarAttr attr = field.getAnnotation(VarAttr.class);
+        if ("parallel_pipeline_task_num".equalsIgnoreCase(attr.name())) {
+            checkFieldValue("parallel_pipeline_task_num", 0, value);
+        }
+        if ("parallel_fragment_exec_instance_num".equalsIgnoreCase(attr.name())) {
+            checkFieldValue("parallel_fragment_exec_instance_num", 1, value);
+        }
         if (VariableVarConverters.hasConverter(attr.name())) {
             value = VariableVarConverters.encode(attr.name(), value).toString();
         }

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/action/TestAction.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/action/TestAction.groovy
@@ -54,11 +54,9 @@ class TestAction implements SuiteAction {
     private String exception
     private Closure check
     SuiteContext context
-    private Random rd
 
     TestAction(SuiteContext context) {
         this.context = context
-        this.rd = new Random()
     }
 
     @Override
@@ -193,16 +191,6 @@ class TestAction implements SuiteAction {
     }
 
     void sql(String sql, boolean setRandomParallel = true) {
-        if (setRandomParallel && (! sql.contains('SET_VAR')) && sql.containsIgnoreCase('select')) {
-            def num = rd.nextInt(16)
-            def replace_str = 'select /*+SET_VAR(parallel_fragment_exec_instance_num=' + num.toString() + ')*/'
-            if(sql.contains('SELECT')) {
-                sql = sql.replaceFirst('SELECT', replace_str)
-            }
-            else if (sql.contains('select')) {
-                sql = sql.replaceFirst('select', replace_str)
-            }
-        }
         this.sql = sql
     }
 

--- a/regression-test/suites/query_p0/session_variable/test_invalid_session.groovy
+++ b/regression-test/suites/query_p0/session_variable/test_invalid_session.groovy
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_invalid_session") {
+    try {
+        sql "set parallel_pipeline_task_num = -1;"
+    } catch (Exception ex) {
+        assert("${ex}".contains("parallel_pipeline_task_num value should greater than or equal 0, you set value is: -1"))
+    }
+
+    try {
+        sql "set parallel_fragment_exec_instance_num = 0;"
+    } catch (Exception ex) {
+        assert("${ex}".contains("parallel_fragment_exec_instance_num value should greater than or equal 1, you set value is: 0"))
+    }
+}


### PR DESCRIPTION
in some case, if set incorrectly, will be cause BE core dump
```
10:18:19   *** SIGFPE integer divide by zero (@0x564853c204c8) received by PID 2132555 
    int max_scanners =
            config::doris_scanner_thread_pool_thread_num / state->query_parallel_instance_num();
```

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

