### PR TITLE
[fix](memory) `TabletSchema` and `Schema` no longer track memory, only track columns count.

### DIFF
--- a/be/src/olap/schema.h
+++ b/be/src/olap/schema.h
@@ -50,7 +50,6 @@ using SchemaSPtr = std::shared_ptr<const Schema>;
 class Schema {
 public:
     Schema(TabletSchemaSPtr tablet_schema) {
-        SCOPED_MEM_COUNT_BY_HOOK(&_mem_size);
         size_t num_columns = tablet_schema->num_columns();
         // ignore this column
         if (tablet_schema->columns().back().name() == BeConsts::ROW_STORE_COL) {
@@ -86,7 +85,6 @@ public:
 
     // All the columns of one table may exist in the columns param, but col_ids is only a subset.
     Schema(const std::vector<TabletColumn>& columns, const std::vector<ColumnId>& col_ids) {
-        SCOPED_MEM_COUNT_BY_HOOK(&_mem_size);
         size_t num_key_columns = 0;
         _unique_ids.resize(columns.size());
         for (size_t i = 0; i < columns.size(); ++i) {
@@ -109,7 +107,6 @@ public:
 
     // Only for UT
     Schema(const std::vector<TabletColumn>& columns, size_t num_key_columns) {
-        SCOPED_MEM_COUNT_BY_HOOK(&_mem_size);
         std::vector<ColumnId> col_ids(columns.size());
         _unique_ids.resize(columns.size());
         for (uint32_t cid = 0; cid < columns.size(); ++cid) {
@@ -121,7 +118,6 @@ public:
     }
 
     Schema(const std::vector<const Field*>& cols, size_t num_key_columns) {
-        SCOPED_MEM_COUNT_BY_HOOK(&_mem_size);
         std::vector<ColumnId> col_ids(cols.size());
         _unique_ids.resize(cols.size());
         for (uint32_t cid = 0; cid < cols.size(); ++cid) {
@@ -181,6 +177,9 @@ public:
     bool has_sequence_col() const { return _has_sequence_col; }
     int32_t rowid_col_idx() const { return _rowid_col_idx; }
     int32_t version_col_idx() const { return _version_col_idx; }
+    // Don't use.
+    // TODO: memory size of Schema cannot be accurately tracked.
+    // In some places, temporarily use num_columns() as Schema size.
     int64_t mem_size() const { return _mem_size; }
 
 private:

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -118,7 +118,8 @@ StorageEngine::StorageEngine(const EngineOptions& options)
           _is_all_cluster_id_exist(true),
           _stopped(false),
           _segcompaction_mem_tracker(std::make_shared<MemTracker>("SegCompaction")),
-          _segment_meta_mem_tracker(std::make_shared<MemTracker>("SegmentMeta")),
+          _segment_meta_mem_tracker(std::make_shared<MemTracker>(
+                  "SegmentMeta", ExecEnv::GetInstance()->experimental_mem_tracker())),
           _stop_background_threads_latch(1),
           _tablet_manager(new TabletManager(config::tablet_map_shard_size)),
           _txn_manager(new TxnManager(config::txn_map_shard_size, config::txn_shard_size)),

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -392,6 +392,9 @@ private:
     std::shared_ptr<MemTracker> _segcompaction_mem_tracker;
     // This mem tracker is only for tracking memory use by segment meta data such as footer or index page.
     // The memory consumed by querying is tracked in segment iterator.
+    // TODO: Segment::_meta_mem_usage Unknown value overflow, causes the value of SegmentMeta mem tracker
+    // is similar to `-2912341218700198079`. So, temporarily put it in experimental type tracker.
+    // maybe have to use ColumnReader count as segment meta size.
     std::shared_ptr<MemTracker> _segment_meta_mem_tracker;
 
     CountDownLatch _stop_background_threads_latch;

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -79,25 +79,23 @@ using std::vector;
 namespace doris {
 using namespace ErrorCode;
 
-DEFINE_GAUGE_METRIC_PROTOTYPE_5ARG(tablet_meta_mem_consumption, MetricUnit::BYTES, "",
+DEFINE_GAUGE_METRIC_PROTOTYPE_5ARG(tablet_meta_schema_columns_count, MetricUnit::NOUNIT, "",
                                    mem_consumption, Labels({{"type", "tablet_meta"}}));
 
 TabletManager::TabletManager(int32_t tablet_map_lock_shard_size)
-        : _mem_tracker(std::make_shared<MemTracker>(
-                  "TabletManager", ExecEnv::GetInstance()->experimental_mem_tracker())),
-          _tablet_meta_mem_tracker(std::make_shared<MemTracker>(
-                  "TabletMeta", ExecEnv::GetInstance()->experimental_mem_tracker())),
+        : _tablet_meta_schema_columns_tracker(
+                  std::make_shared<MemTracker>("TabletMetaSchemaColumnsCount")),
           _tablets_shards_size(tablet_map_lock_shard_size),
           _tablets_shards_mask(tablet_map_lock_shard_size - 1) {
     CHECK_GT(_tablets_shards_size, 0);
     CHECK_EQ(_tablets_shards_size & _tablets_shards_mask, 0);
     _tablets_shards.resize(_tablets_shards_size);
-    REGISTER_HOOK_METRIC(tablet_meta_mem_consumption,
-                         [this]() { return _mem_tracker->consumption(); });
+    REGISTER_HOOK_METRIC(tablet_meta_schema_columns_count,
+                         [this]() { return _tablet_meta_schema_columns_tracker->consumption(); });
 }
 
 TabletManager::~TabletManager() {
-    DEREGISTER_HOOK_METRIC(tablet_meta_mem_consumption);
+    DEREGISTER_HOOK_METRIC(tablet_meta_schema_columns_count);
 }
 
 Status TabletManager::_add_tablet_unlocked(TTabletId tablet_id, const TabletSharedPtr& tablet,
@@ -236,10 +234,12 @@ Status TabletManager::_add_tablet_to_map_unlocked(TTabletId tablet_id,
     tablet_map_t& tablet_map = _get_tablet_map(tablet_id);
     tablet_map[tablet_id] = tablet;
     _add_tablet_to_partition(tablet);
+    // TODO: memory size of TabletSchema cannot be accurately tracked.
     // TODO: remove multiply 2 of tablet meta mem size
     // Because table schema will copy in tablet, there will be double mem cost
     // so here multiply 2
-    _tablet_meta_mem_tracker->consume(tablet->tablet_meta()->mem_size() * 2);
+    // _tablet_meta_schema_columns_tracker->consume(tablet->tablet_meta()->mem_size() * 2);
+    _tablet_meta_schema_columns_tracker->consume(tablet->tablet_meta()->tablet_columns_num());
     COUNTER_UPDATE(ADD_CHILD_TIMER(profile, "RegisterTabletInfo", "AddTablet"),
                    static_cast<int64_t>(watch.reset()));
 
@@ -261,7 +261,6 @@ bool TabletManager::_check_tablet_id_exist_unlocked(TTabletId tablet_id) {
 
 Status TabletManager::create_tablet(const TCreateTabletReq& request, std::vector<DataDir*> stores,
                                     RuntimeProfile* profile) {
-    SCOPED_CONSUME_MEM_TRACKER(_mem_tracker);
     DorisMetrics::instance()->create_tablet_requests_total->increment(1);
 
     int64_t tablet_id = request.tablet_id;
@@ -515,7 +514,6 @@ Status TabletManager::drop_tablet(TTabletId tablet_id, TReplicaId replica_id,
     if (shard.tablets_under_clone.count(tablet_id) > 0) {
         return Status::Aborted("tablet {} is under clone, skip drop task", tablet_id);
     }
-    SCOPED_CONSUME_MEM_TRACKER(_mem_tracker);
     return _drop_tablet_unlocked(tablet_id, replica_id, false, is_drop_table_or_partition);
 }
 
@@ -579,7 +577,9 @@ Status TabletManager::_drop_tablet_unlocked(TTabletId tablet_id, TReplicaId repl
     }
 
     to_drop_tablet->deregister_tablet_from_dir();
-    _tablet_meta_mem_tracker->release(to_drop_tablet->tablet_meta()->mem_size() * 2);
+    // _tablet_meta_schema_columns_tracker->release(to_drop_tablet->tablet_meta()->mem_size() * 2);
+    _tablet_meta_schema_columns_tracker->release(
+            to_drop_tablet->tablet_meta()->tablet_columns_num());
     return Status::OK();
 }
 
@@ -797,7 +797,6 @@ Status TabletManager::load_tablet_from_meta(DataDir* data_dir, TTabletId tablet_
                                             TSchemaHash schema_hash, const string& meta_binary,
                                             bool update_meta, bool force, bool restore,
                                             bool check_path) {
-    SCOPED_CONSUME_MEM_TRACKER(_mem_tracker);
     TabletMetaSharedPtr tablet_meta(new TabletMeta());
     Status status = tablet_meta->deserialize(meta_binary);
     if (!status.ok()) {
@@ -880,7 +879,6 @@ Status TabletManager::load_tablet_from_meta(DataDir* data_dir, TTabletId tablet_
 Status TabletManager::load_tablet_from_dir(DataDir* store, TTabletId tablet_id,
                                            SchemaHash schema_hash, const string& schema_hash_path,
                                            bool force, bool restore) {
-    SCOPED_CONSUME_MEM_TRACKER(_mem_tracker);
     LOG(INFO) << "begin to load tablet from dir. "
               << " tablet_id=" << tablet_id << " schema_hash=" << schema_hash
               << " path = " << schema_hash_path << " force = " << force << " restore = " << restore;
@@ -1031,7 +1029,6 @@ Status TabletManager::start_trash_sweep() {
         return Status::OK();
     }
 
-    SCOPED_CONSUME_MEM_TRACKER(_mem_tracker);
     for_each_tablet([](const TabletSharedPtr& tablet) { tablet->delete_expired_stale_rowset(); },
                     filter_all_tablets);
 
@@ -1191,7 +1188,6 @@ void TabletManager::unregister_clone_tablet(int64_t tablet_id) {
 void TabletManager::try_delete_unused_tablet_path(DataDir* data_dir, TTabletId tablet_id,
                                                   SchemaHash schema_hash,
                                                   const string& schema_hash_path) {
-    SCOPED_CONSUME_MEM_TRACKER(_mem_tracker);
     // acquire the read lock, so that there is no creating tablet or load tablet from meta tasks
     // create tablet and load tablet task should check whether the dir exists
     tablets_shard& shard = _get_tablets_shard(tablet_id);
@@ -1252,7 +1248,6 @@ void TabletManager::get_partition_related_tablets(int64_t partition_id,
 }
 
 void TabletManager::do_tablet_meta_checkpoint(DataDir* data_dir) {
-    SCOPED_CONSUME_MEM_TRACKER(_mem_tracker);
     auto filter = [data_dir](Tablet* tablet) -> bool {
         return tablet->tablet_state() == TABLET_RUNNING &&
                tablet->data_dir()->path_hash() == data_dir->path_hash() && tablet->is_used() &&

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -225,8 +225,9 @@ private:
         std::set<int64_t> tablets_under_clone;
     };
 
-    // trace the columns number use by meta of tablet
-    std::shared_ptr<MemTracker> _tablet_meta_schema_columns_tracker;
+    // TODO: memory size of TabletSchema cannot be accurately tracked.
+    // trace the memory use by meta of tablet
+    std::shared_ptr<MemTracker> _tablet_meta_mem_tracker;
 
     const int32_t _tablets_shards_size;
     const int32_t _tablets_shards_mask;

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -225,9 +225,8 @@ private:
         std::set<int64_t> tablets_under_clone;
     };
 
-    // trace the memory use by meta of tablet
-    std::shared_ptr<MemTracker> _mem_tracker;
-    std::shared_ptr<MemTracker> _tablet_meta_mem_tracker;
+    // trace the columns number use by meta of tablet
+    std::shared_ptr<MemTracker> _tablet_meta_schema_columns_tracker;
 
     const int32_t _tablets_shards_size;
     const int32_t _tablets_shards_mask;

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -679,7 +679,7 @@ void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb) {
             time_series_compaction_time_threshold_seconds());
 }
 
-uint32_t TabletMeta::mem_size() const {
+int64_t TabletMeta::mem_size() const {
     auto size = sizeof(TabletMeta);
     size += _schema->mem_size();
     return size;

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -131,7 +131,11 @@ public:
 
     void to_meta_pb(TabletMetaPB* tablet_meta_pb);
     void to_json(std::string* json_string, json2pb::Pb2JsonOptions& options);
-    uint32_t mem_size() const;
+    // Don't use.
+    // TODO: memory size of TabletSchema cannot be accurately tracked.
+    // In some places, temporarily use num_columns() as TabletSchema size.
+    int64_t mem_size() const;
+    size_t tablet_columns_num() const { return _schema->num_columns(); }
 
     TabletTypePB tablet_type() const { return _tablet_type; }
     TabletUid tablet_uid() const;

--- a/be/src/olap/tablet_schema.cpp
+++ b/be/src/olap/tablet_schema.cpp
@@ -842,7 +842,6 @@ void TabletSchema::clear_columns() {
 }
 
 void TabletSchema::init_from_pb(const TabletSchemaPB& schema, bool ignore_extracted_columns) {
-    SCOPED_MEM_COUNT_BY_HOOK(&_mem_size);
     _keys_type = schema.keys_type();
     _num_columns = 0;
     _num_variant_columns = 0;

--- a/be/src/olap/tablet_schema.h
+++ b/be/src/olap/tablet_schema.h
@@ -244,6 +244,9 @@ public:
     void add_row_column();
     void copy_from(const TabletSchema& tablet_schema);
     std::string to_key() const;
+    // Don't use.
+    // TODO: memory size of TabletSchema cannot be accurately tracked.
+    // In some places, temporarily use num_columns() as TabletSchema size.
     int64_t mem_size() const { return _mem_size; }
     size_t row_size() const;
     int32_t field_index(const std::string& field_name) const;

--- a/be/src/olap/tablet_schema_cache.cpp
+++ b/be/src/olap/tablet_schema_cache.cpp
@@ -29,8 +29,8 @@ TabletSchemaSPtr TabletSchemaCache::insert(const std::string& key) {
         tablet_schema_ptr->init_from_pb(pb);
         _cache[key] = tablet_schema_ptr;
         DorisMetrics::instance()->tablet_schema_cache_count->increment(1);
-        DorisMetrics::instance()->tablet_schema_cache_memory_bytes->increment(
-                tablet_schema_ptr->mem_size());
+        DorisMetrics::instance()->tablet_schema_cache_columns_count->increment(
+                tablet_schema_ptr->num_columns());
         return tablet_schema_ptr;
     }
     return iter->second;
@@ -69,8 +69,8 @@ void TabletSchemaCache::_recycle() {
         LOG(INFO) << "Tablet Schema Cache Capacity " << _cache.size();
         for (auto iter = _cache.begin(), last = _cache.end(); iter != last;) {
             if (iter->second.unique()) {
-                DorisMetrics::instance()->tablet_schema_cache_memory_bytes->increment(
-                        -iter->second->mem_size());
+                DorisMetrics::instance()->tablet_schema_cache_columns_count->increment(
+                        -iter->second->num_columns());
                 DorisMetrics::instance()->tablet_schema_cache_count->increment(-1);
                 iter = _cache.erase(iter);
             } else {

--- a/be/src/olap/tablet_schema_cache.cpp
+++ b/be/src/olap/tablet_schema_cache.cpp
@@ -17,7 +17,12 @@
 
 #include "olap/tablet_schema_cache.h"
 
+#include "bvar/bvar.h"
+
 namespace doris {
+
+bvar::Adder<int64_t> g_tablet_schema_cache_count("tablet_schema_cache_count");
+bvar::Adder<int64_t> g_tablet_schema_cache_columns_count("tablet_schema_cache_columns_count");
 
 TabletSchemaSPtr TabletSchemaCache::insert(const std::string& key) {
     std::lock_guard guard(_mtx);
@@ -28,9 +33,8 @@ TabletSchemaSPtr TabletSchemaCache::insert(const std::string& key) {
         pb.ParseFromString(key);
         tablet_schema_ptr->init_from_pb(pb);
         _cache[key] = tablet_schema_ptr;
-        DorisMetrics::instance()->tablet_schema_cache_count->increment(1);
-        DorisMetrics::instance()->tablet_schema_cache_columns_count->increment(
-                tablet_schema_ptr->num_columns());
+        g_tablet_schema_cache_count << 1;
+        g_tablet_schema_cache_columns_count << tablet_schema_ptr->num_columns();
         return tablet_schema_ptr;
     }
     return iter->second;
@@ -69,9 +73,8 @@ void TabletSchemaCache::_recycle() {
         LOG(INFO) << "Tablet Schema Cache Capacity " << _cache.size();
         for (auto iter = _cache.begin(), last = _cache.end(); iter != last;) {
             if (iter->second.unique()) {
-                DorisMetrics::instance()->tablet_schema_cache_columns_count->increment(
-                        -iter->second->num_columns());
-                DorisMetrics::instance()->tablet_schema_cache_count->increment(-1);
+                g_tablet_schema_cache_count << -1;
+                g_tablet_schema_cache_columns_count << -iter->second->num_columns();
                 iter = _cache.erase(iter);
             } else {
                 ++iter;

--- a/be/src/util/doris_metrics.cpp
+++ b/be/src/util/doris_metrics.cpp
@@ -163,7 +163,7 @@ DEFINE_GAUGE_CORE_METRIC_PROTOTYPE_2ARG(query_cache_sql_total_count, MetricUnit:
 DEFINE_GAUGE_CORE_METRIC_PROTOTYPE_2ARG(query_cache_partition_total_count, MetricUnit::NOUNIT);
 
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(tablet_schema_cache_count, MetricUnit::NOUNIT);
-DEFINE_GAUGE_CORE_METRIC_PROTOTYPE_2ARG(tablet_schema_cache_memory_bytes, MetricUnit::BYTES);
+DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(tablet_schema_cache_columns_count, MetricUnit::NOUNIT);
 DEFINE_GAUGE_CORE_METRIC_PROTOTYPE_2ARG(lru_cache_memory_bytes, MetricUnit::BYTES);
 
 DEFINE_GAUGE_CORE_METRIC_PROTOTYPE_2ARG(upload_total_byte, MetricUnit::BYTES);
@@ -289,7 +289,7 @@ DorisMetrics::DorisMetrics() : _metric_registry(_s_registry_name) {
     INT_UGAUGE_METRIC_REGISTER(_server_metric_entity, query_cache_partition_total_count);
 
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, tablet_schema_cache_count);
-    INT_UGAUGE_METRIC_REGISTER(_server_metric_entity, tablet_schema_cache_memory_bytes);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, tablet_schema_cache_columns_count);
     INT_GAUGE_METRIC_REGISTER(_server_metric_entity, lru_cache_memory_bytes);
 
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, local_file_reader_total);

--- a/be/src/util/doris_metrics.cpp
+++ b/be/src/util/doris_metrics.cpp
@@ -162,8 +162,6 @@ DEFINE_GAUGE_CORE_METRIC_PROTOTYPE_2ARG(query_cache_memory_total_byte, MetricUni
 DEFINE_GAUGE_CORE_METRIC_PROTOTYPE_2ARG(query_cache_sql_total_count, MetricUnit::NOUNIT);
 DEFINE_GAUGE_CORE_METRIC_PROTOTYPE_2ARG(query_cache_partition_total_count, MetricUnit::NOUNIT);
 
-DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(tablet_schema_cache_count, MetricUnit::NOUNIT);
-DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(tablet_schema_cache_columns_count, MetricUnit::NOUNIT);
 DEFINE_GAUGE_CORE_METRIC_PROTOTYPE_2ARG(lru_cache_memory_bytes, MetricUnit::BYTES);
 
 DEFINE_GAUGE_CORE_METRIC_PROTOTYPE_2ARG(upload_total_byte, MetricUnit::BYTES);
@@ -288,8 +286,6 @@ DorisMetrics::DorisMetrics() : _metric_registry(_s_registry_name) {
     INT_UGAUGE_METRIC_REGISTER(_server_metric_entity, query_cache_sql_total_count);
     INT_UGAUGE_METRIC_REGISTER(_server_metric_entity, query_cache_partition_total_count);
 
-    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, tablet_schema_cache_count);
-    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, tablet_schema_cache_columns_count);
     INT_GAUGE_METRIC_REGISTER(_server_metric_entity, lru_cache_memory_bytes);
 
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, local_file_reader_total);

--- a/be/src/util/doris_metrics.h
+++ b/be/src/util/doris_metrics.h
@@ -186,7 +186,7 @@ public:
     UIntGauge* query_mem_consumption = nullptr;
     UIntGauge* schema_change_mem_consumption = nullptr;
     UIntGauge* storage_migration_mem_consumption = nullptr;
-    UIntGauge* tablet_meta_mem_consumption = nullptr;
+    UIntGauge* tablet_meta_schema_columns_count = nullptr;
 
     // Cache metrics
     UIntGauge* query_cache_memory_total_byte = nullptr;
@@ -194,7 +194,7 @@ public:
     UIntGauge* query_cache_partition_total_count = nullptr;
 
     IntCounter* tablet_schema_cache_count = nullptr;
-    UIntGauge* tablet_schema_cache_memory_bytes = nullptr;
+    IntCounter* tablet_schema_cache_columns_count = nullptr;
     IntGauge* lru_cache_memory_bytes = nullptr;
 
     UIntGauge* scanner_thread_pool_queue_size = nullptr;

--- a/be/src/util/doris_metrics.h
+++ b/be/src/util/doris_metrics.h
@@ -186,7 +186,7 @@ public:
     UIntGauge* query_mem_consumption = nullptr;
     UIntGauge* schema_change_mem_consumption = nullptr;
     UIntGauge* storage_migration_mem_consumption = nullptr;
-    UIntGauge* tablet_meta_schema_columns_count = nullptr;
+    UIntGauge* tablet_meta_mem_consumption = nullptr;
 
     // Cache metrics
     UIntGauge* query_cache_memory_total_byte = nullptr;

--- a/be/src/util/doris_metrics.h
+++ b/be/src/util/doris_metrics.h
@@ -193,8 +193,6 @@ public:
     UIntGauge* query_cache_sql_total_count = nullptr;
     UIntGauge* query_cache_partition_total_count = nullptr;
 
-    IntCounter* tablet_schema_cache_count = nullptr;
-    IntCounter* tablet_schema_cache_columns_count = nullptr;
     IntGauge* lru_cache_memory_bytes = nullptr;
 
     UIntGauge* scanner_thread_pool_queue_size = nullptr;


### PR DESCRIPTION
## Proposed changes

1. `TabletSchema` and `Schema` no longer track memory, only track columns count. because cannot accurately track memory size.

2. TabletMeta MemTracker changed to track TabletSchema columns count.

3. Segment::_meta_mem_usage Unknown value overflow, causes the value of SegmentMeta MemTracker is similar to `-2912341218700198079`. So, temporarily put it in experimental type tracker. 
 
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

