### PR TITLE
[fix](load) select more active memtables at once in memtable limiter

### DIFF
--- a/be/src/olap/memtable_memory_limiter.cpp
+++ b/be/src/olap/memtable_memory_limiter.cpp
@@ -167,13 +167,13 @@ int64_t MemTableMemoryLimiter::_flush_memtable(std::weak_ptr<MemTableWriter> wri
     auto mem_usage = writer->active_memtable_mem_consumption();
     // if the memtable writer just got flushed, don't flush it again
     if (mem_usage < threshold) {
-        LOG(INFO) << "flusing active memtables, active mem usage "
-                  << PrettyPrinter::print_bytes(mem_usage) << " is less than "
-                  << PrettyPrinter::print_bytes(threshold) << ", skipping";
+        VLOG_DEBUG << "flushing active memtables, active mem usage "
+                   << PrettyPrinter::print_bytes(mem_usage) << " is less than "
+                   << PrettyPrinter::print_bytes(threshold) << ", skipping";
         return 0;
     }
-    LOG(INFO) << "flusing active memtables, active mem usage "
-                << PrettyPrinter::print_bytes(mem_usage);
+    VLOG_DEBUG << "flushing active memtables, active mem usage "
+               << PrettyPrinter::print_bytes(mem_usage);
     Status st = writer->flush_async();
     if (!st.ok()) {
         auto err_msg = fmt::format(

--- a/be/src/olap/memtable_memory_limiter.cpp
+++ b/be/src/olap/memtable_memory_limiter.cpp
@@ -159,7 +159,8 @@ void MemTableMemoryLimiter::_flush_active_memtables(int64_t need_flush) {
               << " active writers, flushed size: " << PrettyPrinter::print_bytes(mem_flushed);
 }
 
-int64_t MemTableMemoryLimiter::_flush_memtable(std::weak_ptr<MemTableWriter> writer_to_flush, int64_t threshold) {
+int64_t MemTableMemoryLimiter::_flush_memtable(std::weak_ptr<MemTableWriter> writer_to_flush,
+                                               int64_t threshold) {
     auto writer = writer_to_flush.lock();
     if (!writer) {
         return 0;

--- a/be/src/olap/memtable_memory_limiter.cpp
+++ b/be/src/olap/memtable_memory_limiter.cpp
@@ -162,7 +162,7 @@ void MemTableMemoryLimiter::_flush_active_memtables(int64_t need_flush) {
 int64_t MemTableMemoryLimiter::_flush_memtable(std::weak_ptr<MemTableWriter> writer_to_flush, int64_t threshold) {
     auto writer = writer_to_flush.lock();
     if (!writer) {
-        return;
+        return 0;
     }
     auto mem_usage = writer->active_memtable_mem_consumption();
     // if the memtable writer just got flushed, don't flush it again

--- a/be/src/olap/memtable_memory_limiter.h
+++ b/be/src/olap/memtable_memory_limiter.h
@@ -54,7 +54,8 @@ private:
 
     bool _soft_limit_reached();
     bool _hard_limit_reached();
-    void _flush_active_memtables();
+    void _flush_active_memtables(int64_t need_flush);
+    int64_t _flush_memtable(std::weak_ptr<MemTableWriter> writer_to_flush, int64_t threshold);
     void _refresh_mem_tracker();
 
     std::mutex _lock;
@@ -69,7 +70,6 @@ private:
     int64_t _load_soft_mem_limit = -1;
 
     std::vector<std::weak_ptr<MemTableWriter>> _writers;
-    std::weak_ptr<MemTableWriter> _largest_active_writer;
-    int64_t _largest_active_mem = 0;
+    std::vector<std::weak_ptr<MemTableWriter>> _active_writers;
 };
 } // namespace doris

--- a/be/src/olap/memtable_memory_limiter.h
+++ b/be/src/olap/memtable_memory_limiter.h
@@ -55,6 +55,7 @@ private:
     bool _soft_limit_reached();
     bool _hard_limit_reached();
     void _flush_active_memtables();
+    void _refresh_mem_tracker();
 
     std::mutex _lock;
     std::condition_variable _hard_limit_end_cond;


### PR DESCRIPTION
## Proposed changes

When memtable size is small, flush one by one is not fast enough.
Also memtables may be skipped when the size info is stale (flushed after refresh).

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

