### PR TITLE
[Enhancement](metadata) show full columns support for external tables

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -1035,26 +1035,34 @@ public class ShowExecutor {
                 final String isKey = col.isKey() ? "YES" : "NO";
                 final String defaultValue = col.getDefaultValue();
                 final String aggType = col.getAggregationType() == null ? "" : col.getAggregationType().toSql();
-                if (showStmt.isVerbose()) {
-                    // Field Type Collation Null Key Default Extra
-                    // Privileges Comment
-                    rows.add(Lists.newArrayList(columnName,
-                            columnType,
-                            "",
-                            isAllowNull,
-                            isKey,
-                            defaultValue,
-                            aggType,
-                            "",
-                            col.getComment()));
-                } else {
-                    // Field Type Null Key Default Extra
-                    rows.add(Lists.newArrayList(columnName,
-                            columnType,
-                            isAllowNull,
-                            isKey,
-                            defaultValue,
-                            aggType));
+                try {
+                    Env.getCurrentEnv().getAccessManager()
+                            .checkColumnsPriv(ConnectContext.get().getCurrentUserIdentity(), showStmt.getCtl(),
+                                ClusterNamespace.getFullName(SystemInfoService.DEFAULT_CLUSTER, showStmt.getDb()),
+                                showStmt.getTable(), Sets.newHashSet(columnName), PrivPredicate.SHOW);
+                    if (showStmt.isVerbose()) {
+                        // Field Type Collation Null Key Default Extra
+                        // Privileges Comment
+                        rows.add(Lists.newArrayList(columnName,
+                                columnType,
+                                "",
+                                isAllowNull,
+                                isKey,
+                                defaultValue,
+                                aggType,
+                                "",
+                                col.getComment()));
+                    } else {
+                        // Field Type Null Key Default Extra
+                        rows.add(Lists.newArrayList(columnName,
+                                columnType,
+                                isAllowNull,
+                                isKey,
+                                defaultValue,
+                                aggType));
+                    }
+                } catch (Exception e) {
+                    LOG.debug(e.getMessage());
                 }
             }
         } finally {


### PR DESCRIPTION
## Proposed changes

Support for the "SHOW FULL COLUMNS" query in the External Hive catalog in Doris.

Issue Number: close #25899

Add suport for SHOW FULL COLUMNS for external tables.

## Further comments
Additionally added check for column permissions in SHOW FULL COLUMNS path; this was present in Describe, but missing in SHOW FULL COLUMNS.