### PR TITLE
[fix](nereids)cast string to integer type use wrong datatype's valueOf method

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/Literal.java
@@ -218,11 +218,11 @@ public abstract class Literal extends Expression implements LeafExpression, Comp
             }
         }
         if (targetType.isTinyIntType()) {
-            return Literal.of(Double.valueOf(desc).byteValue());
+            return Literal.of(Byte.valueOf(desc).byteValue());
         } else if (targetType.isSmallIntType()) {
-            return Literal.of(Double.valueOf(desc).shortValue());
+            return Literal.of(Short.valueOf(desc).shortValue());
         } else if (targetType.isIntegerType()) {
-            return Literal.of(Double.valueOf(desc).intValue());
+            return Literal.of(Integer.valueOf(desc).intValue());
         } else if (targetType.isBigIntType()) {
             return Literal.of(Long.valueOf(desc));
         } else if (targetType.isLargeIntType()) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
@@ -263,7 +263,7 @@ class FoldConstantTest extends ExpressionRewriteTestHelper {
                 : new DateTimeLiteral(1995, 5, 1, 0, 0, 0);
         assertRewrite(e7, e8);
 
-        interval = "interval 3 + 3 / 2 hour + '1991-05-01 10:00:00'";
+        interval = "interval 3 + 3 / 3 hour + '1991-05-01 10:00:00'";
         e7 = process((TimestampArithmetic) PARSER.parseExpression(interval));
         e8 = Config.enable_date_conversion
                 ? new DateTimeV2Literal(1991, 5, 1, 14, 0, 0)
@@ -277,7 +277,7 @@ class FoldConstantTest extends ExpressionRewriteTestHelper {
                 : new DateTimeLiteral(1991, 5, 1, 10, 2, 0);
         assertRewrite(e7, e8);
 
-        interval = "interval 3 / 2 + 1 second + '1991-05-01 10:00:00'";
+        interval = "interval 3 / 3 + 1 second + '1991-05-01 10:00:00'";
         e7 = process((TimestampArithmetic) PARSER.parseExpression(interval));
         e8 = Config.enable_date_conversion
                 ? new DateTimeV2Literal(1991, 5, 1, 10, 0, 2)

--- a/regression-test/data/nereids_p0/sql_functions/cast_function/test_cast_function.out
+++ b/regression-test/data/nereids_p0/sql_functions/cast_function/test_cast_function.out
@@ -17,9 +17,18 @@
 -- !sql --
 20
 
--- !sql --
-1
-
 -- !sql_null_cast_bitmap --
 true
+
+-- !sql_to_tiny --
+\N
+
+-- !sql_to_small --
+\N
+
+-- !sql_to_int --
+\N
+
+-- !sql_to_big --
+\N
 

--- a/regression-test/suites/nereids_p0/sql_functions/cast_function/test_cast_function.groovy
+++ b/regression-test/suites/nereids_p0/sql_functions/cast_function/test_cast_function.groovy
@@ -24,7 +24,10 @@ suite("test_cast_function") {
     qt_sql """ select cast ("0.0000031417" as datetime) """
     qt_sql """ select cast (NULL AS CHAR(1)); """
     qt_sql """ select cast ('20190101' AS CHAR(2)); """
-    qt_sql """ select cast ('1.23' AS int); """
     qt_sql_null_cast_bitmap """ select cast (case when BITMAP_EMPTY() is NULL then null else null end as bitmap) is NULL; """
+    qt_sql_to_tiny """ select cast('1212.31' as tinyint);""" 
+    qt_sql_to_small """ select cast('1212.31' as smallint);""" 
+    qt_sql_to_int """ select cast('1212.31' as int);""" 
+    qt_sql_to_big """ select cast('1212.31' as bigint);""" 
 }
 


### PR DESCRIPTION
```
select cast('12.31' as tinyint);
select cast('12.31' as smallint);
select cast('12.31' as int);

should return NULL
```

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

