### PR TITLE
[fix](memory) Fix LRU Cache of type `NUMBER` charge

### DIFF
--- a/be/src/olap/lru_cache.cpp
+++ b/be/src/olap/lru_cache.cpp
@@ -667,9 +667,4 @@ void ShardedLRUCache::update_cache_metrics() const {
             total_lookup_count == 0 ? 0 : ((double)total_hit_count / total_lookup_count));
 }
 
-Cache* new_lru_cache(const std::string& name, size_t capacity, LRUCacheType type,
-                     uint32_t num_shards) {
-    return new ShardedLRUCache(name, capacity, type, num_shards);
-}
-
 } // namespace doris

--- a/be/src/olap/lru_cache.cpp
+++ b/be/src/olap/lru_cache.cpp
@@ -523,7 +523,9 @@ ShardedLRUCache::ShardedLRUCache(const std::string& name, size_t total_capacity,
           _shards(nullptr),
           _last_id(1),
           _total_capacity(total_capacity) {
-    _mem_tracker = std::make_unique<MemTrackerLimiter>(MemTrackerLimiter::Type::GLOBAL, name);
+    _mem_tracker = std::make_unique<MemTrackerLimiter>(
+            MemTrackerLimiter::Type::GLOBAL,
+            fmt::format("{}[{}]", name, lru_cache_type_string(type)));
     CHECK(num_shards > 0) << "num_shards cannot be 0";
     CHECK_EQ((num_shards & (num_shards - 1)), 0)
             << "num_shards should be power of two, but got " << num_shards;

--- a/be/src/olap/lru_cache.h
+++ b/be/src/olap/lru_cache.h
@@ -58,17 +58,6 @@ enum LRUCacheType {
     NUMBER // The capacity of cache is based on the number of cache entry.
 };
 
-static std::string lru_cache_type_string(LRUCacheType type) {
-    switch (type) {
-    case LRUCacheType::SIZE:
-        return "size";
-    case LRUCacheType::NUMBER:
-        return "number";
-    default:
-        LOG(FATAL) << "not match type of lru cache:" << static_cast<int>(type);
-    }
-}
-
 // Create a new cache with a specified name and capacity.
 // This implementation of Cache uses a least-recently-used eviction policy.
 extern Cache* new_lru_cache(const std::string& name, size_t capacity,
@@ -431,6 +420,17 @@ public:
 
 private:
     void update_cache_metrics() const;
+
+    static std::string lru_cache_type_string(LRUCacheType type) {
+        switch (type) {
+        case LRUCacheType::SIZE:
+            return "size";
+        case LRUCacheType::NUMBER:
+            return "number";
+        default:
+            LOG(FATAL) << "not match type of lru cache:" << static_cast<int>(type);
+        }
+    }
 
 private:
     static uint32_t _hash_slice(const CacheKey& s);

--- a/be/src/olap/lru_cache.h
+++ b/be/src/olap/lru_cache.h
@@ -58,6 +58,17 @@ enum LRUCacheType {
     NUMBER // The capacity of cache is based on the number of cache entry.
 };
 
+static std::string lru_cache_type_string(LRUCacheType type) {
+    switch (type) {
+    case LRUCacheType::SIZE:
+        return "size";
+    case LRUCacheType::NUMBER:
+        return "number";
+    default:
+        LOG(FATAL) << "not match type of lru cache:" << static_cast<int>(type);
+    }
+}
+
 // Create a new cache with a specified name and capacity.
 // This implementation of Cache uses a least-recently-used eviction policy.
 extern Cache* new_lru_cache(const std::string& name, size_t capacity,

--- a/be/src/olap/lru_cache.h
+++ b/be/src/olap/lru_cache.h
@@ -58,11 +58,6 @@ enum LRUCacheType {
     NUMBER // The capacity of cache is based on the number of cache entry.
 };
 
-// Create a new cache with a specified name and capacity.
-// This implementation of Cache uses a least-recently-used eviction policy.
-extern Cache* new_lru_cache(const std::string& name, size_t capacity,
-                            LRUCacheType type = LRUCacheType::SIZE, uint32_t num_shards = 16);
-
 class CacheKey {
 public:
     CacheKey() : _data(nullptr), _size(0) {}
@@ -394,8 +389,9 @@ private:
 
 class ShardedLRUCache : public Cache {
 public:
-    explicit ShardedLRUCache(const std::string& name, size_t total_capacity, LRUCacheType type,
-                             uint32_t num_shards, uint32_t element_count_capacity = 0);
+    explicit ShardedLRUCache(const std::string& name, size_t total_capacity,
+                             LRUCacheType type = LRUCacheType::SIZE, uint32_t num_shards = 16,
+                             uint32_t element_count_capacity = 0);
     explicit ShardedLRUCache(const std::string& name, size_t total_capacity, LRUCacheType type,
                              uint32_t num_shards,
                              CacheValueTimeExtractor cache_value_time_extractor,

--- a/be/src/olap/schema_cache.h
+++ b/be/src/olap/schema_cache.h
@@ -100,8 +100,8 @@ public:
             CacheValue* cache_value = (CacheValue*)value;
             delete cache_value;
         };
-        auto lru_handle = _cache->insert(key, value, sizeof(CacheValue), deleter,
-                                         CachePriority::NORMAL, schema->mem_size());
+        auto lru_handle =
+                _cache->insert(key, value, 1, deleter, CachePriority::NORMAL, schema->mem_size());
         _cache->release(lru_handle);
     }
 

--- a/be/src/olap/segment_loader.cpp
+++ b/be/src/olap/segment_loader.cpp
@@ -45,9 +45,8 @@ void SegmentCache::insert(const SegmentCache::CacheKey& key, SegmentCache::Cache
         delete cache_value;
     };
 
-    auto lru_handle =
-            _cache->insert(key.encode(), &value, sizeof(SegmentCache::CacheValue), deleter,
-                           CachePriority::NORMAL, value.segment->meta_mem_usage());
+    auto lru_handle = _cache->insert(key.encode(), &value, 1, deleter, CachePriority::NORMAL,
+                                     value.segment->meta_mem_usage());
     handle->push_segment(_cache.get(), lru_handle);
 }
 

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -914,8 +914,8 @@ void TxnManager::update_tablet_version_txn(int64_t tablet_id, int64_t version, i
         delete cache_value;
     };
 
-    auto handle = _tablet_version_cache->insert(cache_key, value, sizeof(txn_id), deleter,
-                                                CachePriority::NORMAL, sizeof(txn_id));
+    auto handle = _tablet_version_cache->insert(cache_key, value, 1, deleter, CachePriority::NORMAL,
+                                                sizeof(txn_id));
     _tablet_version_cache->release(handle);
 }
 

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -116,8 +116,8 @@ TxnManager::TxnManager(int32_t txn_map_shard_size, int32_t txn_shard_size)
     _txn_tablet_delta_writer_map = new txn_tablet_delta_writer_map_t[_txn_map_shard_size];
     _txn_tablet_delta_writer_map_locks = new std::shared_mutex[_txn_map_shard_size];
     // For debugging
-    _tablet_version_cache =
-            new ShardedLRUCache("TabletVersionCache", 100000, LRUCacheType::NUMBER, 32);
+    _tablet_version_cache = std::unique_ptr<Cache>(
+            new ShardedLRUCache("TabletVersionCache", 100000, LRUCacheType::NUMBER, 32));
 }
 
 // prepare txn should always be allowed because ingest task will be retried

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -85,7 +85,6 @@ public:
         delete[] _txn_mutex;
         delete[] _txn_tablet_delta_writer_map;
         delete[] _txn_tablet_delta_writer_map_locks;
-        delete _tablet_version_cache;
     }
 
     // add a txn to manager
@@ -239,7 +238,7 @@ private:
     std::shared_mutex* _txn_mutex = nullptr;
 
     txn_tablet_delta_writer_map_t* _txn_tablet_delta_writer_map = nullptr;
-    ShardedLRUCache* _tablet_version_cache = nullptr;
+    std::unique_ptr<Cache> _tablet_version_cache;
     std::shared_mutex* _txn_tablet_delta_writer_map_locks = nullptr;
     DISALLOW_COPY_AND_ASSIGN(TxnManager);
 }; // TxnManager

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -72,10 +72,6 @@ LoadChannelMgr::LoadChannelMgr() : _stop_background_threads_latch(1) {
     });
 }
 
-LoadChannelMgr::~LoadChannelMgr() {
-    delete _last_success_channel;
-}
-
 void LoadChannelMgr::stop() {
     DEREGISTER_HOOK_METRIC(load_channel_count);
     DEREGISTER_HOOK_METRIC(load_channel_mem_consumption);
@@ -86,7 +82,8 @@ void LoadChannelMgr::stop() {
 }
 
 Status LoadChannelMgr::init(int64_t process_mem_limit) {
-    _last_success_channel = new_lru_cache("LastestSuccessChannelCache", 1024);
+    _last_success_channel =
+            std::unique_ptr<Cache>(new ShardedLRUCache("LastestSuccessChannelCache", 1024));
     RETURN_IF_ERROR(_start_bg_worker());
     return Status::OK();
 }

--- a/be/src/runtime/load_channel_mgr.h
+++ b/be/src/runtime/load_channel_mgr.h
@@ -49,7 +49,6 @@ class Thread;
 class LoadChannelMgr {
 public:
     LoadChannelMgr();
-    ~LoadChannelMgr();
 
     Status init(int64_t process_mem_limit);
 
@@ -77,7 +76,7 @@ protected:
     std::mutex _lock;
     // load id -> load channel
     std::unordered_map<UniqueId, std::shared_ptr<LoadChannel>> _load_channels;
-    Cache* _last_success_channel = nullptr;
+    std::unique_ptr<Cache> _last_success_channel;
 
     MemTableMemoryLimiter* _memtable_memory_limiter = nullptr;
 

--- a/be/src/runtime/memory/lru_cache_policy.h
+++ b/be/src/runtime/memory/lru_cache_policy.h
@@ -41,9 +41,9 @@ public:
             : CachePolicy(type, stale_sweep_time_s) {
         _cache = num_shards == -1
                          ? std::unique_ptr<Cache>(
-                                   new_lru_cache(type_string(type), capacity, lru_cache_type))
-                         : std::unique_ptr<Cache>(new_lru_cache(type_string(type), capacity,
-                                                                lru_cache_type, num_shards));
+                                   new ShardedLRUCache(type_string(type), capacity, lru_cache_type))
+                         : std::unique_ptr<Cache>(new ShardedLRUCache(type_string(type), capacity,
+                                                                      lru_cache_type, num_shards));
     }
 
     ~LRUCachePolicy() override = default;

--- a/be/src/service/point_query_executor.cpp
+++ b/be/src/service/point_query_executor.cpp
@@ -114,7 +114,7 @@ LookupConnectionCache* LookupConnectionCache::create_global_instance(size_t capa
 RowCache::RowCache(int64_t capacity, int num_shards) {
     // Create Row Cache
     _cache = std::unique_ptr<Cache>(
-            new_lru_cache("RowCache", capacity, LRUCacheType::SIZE, num_shards));
+            new ShardedLRUCache("RowCache", capacity, LRUCacheType::SIZE, num_shards));
 }
 
 // Create global instance of this class

--- a/be/src/util/obj_lru_cache.cpp
+++ b/be/src/util/obj_lru_cache.cpp
@@ -23,7 +23,7 @@ ObjLRUCache::ObjLRUCache(int64_t capacity, uint32_t num_shards) {
     _enabled = (capacity > 0);
     if (_enabled) {
         _cache = std::unique_ptr<Cache>(
-                new_lru_cache("ObjLRUCache", capacity, LRUCacheType::NUMBER, num_shards));
+                new ShardedLRUCache("ObjLRUCache", capacity, LRUCacheType::NUMBER, num_shards));
     }
 }
 

--- a/be/src/util/obj_lru_cache.h
+++ b/be/src/util/obj_lru_cache.h
@@ -85,8 +85,8 @@ public:
                 void (*deleter)(const CacheKey& key, void* value)) {
         if (_enabled) {
             const std::string& encoded_key = key.key;
-            auto handle = _cache->insert(encoded_key, (void*)value, sizeof(T), deleter,
-                                         CachePriority::NORMAL, 1);
+            auto handle = _cache->insert(encoded_key, (void*)value, 1, deleter,
+                                         CachePriority::NORMAL, sizeof(T));
             *cache_handle = CacheHandle {_cache.get(), handle};
         } else {
             cache_handle = nullptr;

--- a/be/test/olap/lru_cache_test.cpp
+++ b/be/test/olap/lru_cache_test.cpp
@@ -80,7 +80,7 @@ public:
     std::vector<int> _deleted_values;
     Cache* _cache;
 
-    CacheTest() : _cache(new_lru_cache("test", kCacheSize)) { _s_current = this; }
+    CacheTest() : _cache(new ShardedLRUCache("test", kCacheSize)) { _s_current = this; }
 
     ~CacheTest() { delete _cache; }
 


### PR DESCRIPTION
## Proposed changes

 LRU Cache of type `LRUCacheType::NUMBER` cache capacity means the number of entries, so the `charge` of insert is always `1` instead of `sizeof(CacheValue)`, which is easier to understand.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

