### PR TITLE
[bug](json)Fix the problem of be down caused by json path ending with \

### DIFF
--- a/be/src/util/jsonb_document.h
+++ b/be/src/util/jsonb_document.h
@@ -1573,6 +1573,7 @@ inline bool JsonbPath::parse_member(Stream* stream, JsonbPath* path) {
             stream->skip(1);
             stream->add_leg_len();
             stream->set_has_escapes(true);
+            if (stream->exhausted()) return false;
             continue;
         } else if (stream->peek() == DOUBLE_QUOTE) {
             if (left_quotation_marks == nullptr) {

--- a/be/src/util/jsonb_document.h
+++ b/be/src/util/jsonb_document.h
@@ -1573,7 +1573,8 @@ inline bool JsonbPath::parse_member(Stream* stream, JsonbPath* path) {
             stream->skip(1);
             stream->add_leg_len();
             stream->set_has_escapes(true);
-            if (stream->exhausted()) return false;
+            if (stream->exhausted()) { return false;
+}
             continue;
         } else if (stream->peek() == DOUBLE_QUOTE) {
             if (left_quotation_marks == nullptr) {

--- a/be/src/util/jsonb_document.h
+++ b/be/src/util/jsonb_document.h
@@ -1573,8 +1573,9 @@ inline bool JsonbPath::parse_member(Stream* stream, JsonbPath* path) {
             stream->skip(1);
             stream->add_leg_len();
             stream->set_has_escapes(true);
-            if (stream->exhausted()) { return false;
-}
+            if (stream->exhausted()) {
+                return false;
+            }
             continue;
         } else if (stream->peek() == DOUBLE_QUOTE) {
             if (left_quotation_marks == nullptr) {

--- a/be/src/vec/functions/function_json.cpp
+++ b/be/src/vec/functions/function_json.cpp
@@ -229,12 +229,19 @@ rapidjson::Value* get_json_object(std::string_view json_string, std::string_view
     std::vector<JsonPath>* parsed_paths;
     std::vector<JsonPath> tmp_parsed_paths;
 
+    //Cannot use '/' as the last character, return NULL
+    if(path_string.back() == '\\') {
+        document->SetNull();
+        return document;
+    }
+
 #ifdef USE_LIBCPP
     std::string s(path_string);
     auto tok = get_json_token(s);
 #else
     auto tok = get_json_token(path_string);
 #endif
+
     std::vector<std::string> paths(tok.begin(), tok.end());
     get_parsed_paths(paths, &tmp_parsed_paths);
     if (tmp_parsed_paths.empty()) {

--- a/be/src/vec/functions/function_json.cpp
+++ b/be/src/vec/functions/function_json.cpp
@@ -229,7 +229,7 @@ rapidjson::Value* get_json_object(std::string_view json_string, std::string_view
     std::vector<JsonPath>* parsed_paths;
     std::vector<JsonPath> tmp_parsed_paths;
 
-    //Cannot use '/' as the last character, return NULL
+    //Cannot use '\' as the last character, return NULL
     if (path_string.back() == '\\') {
         document->SetNull();
         return document;

--- a/be/src/vec/functions/function_json.cpp
+++ b/be/src/vec/functions/function_json.cpp
@@ -230,7 +230,7 @@ rapidjson::Value* get_json_object(std::string_view json_string, std::string_view
     std::vector<JsonPath> tmp_parsed_paths;
 
     //Cannot use '/' as the last character, return NULL
-    if(path_string.back() == '\\') {
+    if (path_string.back() == '\\') {
         document->SetNull();
         return document;
     }

--- a/regression-test/data/json_p0/test_json_load_and_function.out
+++ b/regression-test/data/json_p0/test_json_load_and_function.out
@@ -46,6 +46,9 @@
 31	18446744073709551615
 
 -- !select --
+\N
+
+-- !select --
 1	\N	\N
 2	null	null
 3	true	true

--- a/regression-test/suites/json_p0/test_json_load_and_function.groovy
+++ b/regression-test/suites/json_p0/test_json_load_and_function.groovy
@@ -158,6 +158,7 @@ suite("test_json_load_and_function", "p0") {
     qt_select "SELECT * FROM ${testTable} ORDER BY id"
 
     // json_extract
+    qt_select "SELECT json_extract( '{\"k1\\\\\": \"v1\"}', \"\$.k1\\\\\")"
     qt_select "SELECT id, j, jsonb_extract(j, '\$') FROM ${testTable} ORDER BY id"
     qt_select "SELECT id, j, jsonb_extract(j, '\$.*') FROM ${testTable} ORDER BY id"
 


### PR DESCRIPTION
## Proposed changes

before:
```sql
mysql> select json_extract( '{"k1\": "v1"}', "$.k1\\");
ERROR 1105 (HY000): RpcException, msg: io.grpc.StatusRuntimeException: UNAVAILABLE: Network closed for unknown reason
```
now
```sql
mysql> select json_extract( '{"k1\\": "v1"}', "$.k1.");
+----------------------------------------+
| json_extract('{"k1\": "v1"}', '$.k1.') |
+----------------------------------------+
| NULL                                   |
+----------------------------------------+
1 row in set (0.02 sec)

mysql> select jsonb_extract( '{"k1\\": "v1"}', "$.k1\\");
ERROR 1105 (HY000): errCode = 2, detailMessage = (127.0.0.1)[CANCELLED]Json path error: Invalid Json Path for value: $.k1\
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

