### PR TITLE
[fix](memlimiter) refresh memtracker before flush active memtables

### DIFF
--- a/be/src/olap/memtable_memory_limiter.cpp
+++ b/be/src/olap/memtable_memory_limiter.cpp
@@ -141,7 +141,12 @@ void MemTableMemoryLimiter::handle_memtable_flush() {
 }
 
 void MemTableMemoryLimiter::_flush_active_memtables(int64_t need_flush) {
-    if (need_flush <= 0 || _active_writers.size() == 0) {
+    if (need_flush <= 0) {
+        return;
+    }
+
+    _refresh_mem_tracker();
+    if (_active_writers.size() == 0) {
         return;
     }
     int64_t mem_flushed = 0;


### PR DESCRIPTION
## Proposed changes

Currently, `_flush_active_memtables()` is using stale memtracker data, especially when some other thread has just called it.
Refresh memtrackers before flush to avoid this problem.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

