### PR TITLE
[fix](decimalv2) avoid crashing caused by decimalv2 arithmetic with check_overflow_for_decimal enabled

### DIFF
--- a/be/src/vec/functions/function_binary_arithmetic.h
+++ b/be/src/vec/functions/function_binary_arithmetic.h
@@ -961,6 +961,8 @@ public:
         }
 
         bool check_overflow_for_decimal = context->check_overflow_for_decimal();
+        auto status = Status::RuntimeError("{}'s arguments do not match the expected data types",
+                                           get_name());
         bool valid = cast_both_types(
                 left_generic, right_generic, result_generic,
                 [&](const auto& left, const auto& right, const auto& res) {
@@ -978,6 +980,13 @@ public:
                                                         (IsDataTypeDecimal<LeftDataType> ||
                                                          IsDataTypeDecimal<RightDataType>))) {
                         if (check_overflow_for_decimal) {
+                            if constexpr ((IsDecimalV2<typename LeftDataType::FieldType> ||
+                                           IsDecimalV2<typename RightDataType::
+                                                               FieldType>)&&!is_to_null_type) {
+                                status = Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>(
+                                        "cannot check overflow with decimalv2");
+                                return false;
+                            }
                             auto column_result = ConstOrVectorAdapter<
                                     LeftDataType, RightDataType,
                                     std::conditional_t<IsDataTypeDecimal<ExpectedResultDataType>,
@@ -1007,8 +1016,7 @@ public:
                     return false;
                 });
         if (!valid) {
-            return Status::RuntimeError("{}'s arguments do not match the expected data types",
-                                        get_name());
+            return status;
         }
 
         return Status::OK();


### PR DESCRIPTION
## Proposed changes
Decimalv2 will cause log fatal:
```cpp
        if constexpr (check_overflow && !is_to_null_type &&
                      ((!OpTraits::is_multiply && !OpTraits::is_plus_minus) || IsDecimalV2<A> ||
                       IsDecimalV2<B>)) {
            LOG(FATAL) << "Invalid function type!";
            return column_result;
        } else if constexpr (is_to_null_type) {
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

