### PR TITLE
[fix](statistics)Escape load stats sql.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
@@ -111,7 +111,7 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
             params.put("dbId", String.valueOf(db.getId()));
             params.put("tblId", String.valueOf(tbl.getId()));
             params.put("idxId", String.valueOf(info.indexId));
-            params.put("colId", String.valueOf(info.colName));
+            params.put("colId", StatisticsUtil.escapeSQL(String.valueOf(info.colName)));
             params.put("dataSizeFunction", getDataSizeFunction(col, false));
             params.put("dbName", db.getFullName());
             params.put("colName", info.colName);
@@ -183,7 +183,7 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
         params.put("dbId", String.valueOf(db.getId()));
         params.put("tblId", String.valueOf(tbl.getId()));
         params.put("idxId", String.valueOf(info.indexId));
-        params.put("colId", String.valueOf(info.colName));
+        params.put("colId", StatisticsUtil.escapeSQL(String.valueOf(info.colName)));
         params.put("dataSizeFunction", getDataSizeFunction(col, false));
         params.put("catalogName", catalog.getName());
         params.put("dbName", db.getFullName());

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsRepository.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsRepository.java
@@ -142,7 +142,7 @@ public class StatisticsRepository {
     private static ResultRow queryColumnStatisticById(long tblId, String colName, boolean isHistogram) {
         Map<String, String> map = new HashMap<>();
         String id = constructId(tblId, -1, colName);
-        map.put("id", id);
+        map.put("id", StatisticsUtil.escapeSQL(id));
         List<ResultRow> rows = isHistogram ? StatisticsUtil.executeQuery(FETCH_COLUMN_HISTOGRAM_TEMPLATE, map) :
                 StatisticsUtil.executeQuery(FETCH_COLUMN_STATISTIC_TEMPLATE, map);
         int size = rows.size();
@@ -336,7 +336,7 @@ public class StatisticsRepository {
         Map<String, String> params = new HashMap<>();
         params.put("tblId", String.valueOf(tableId));
         params.put("idxId", String.valueOf(idxId));
-        params.put("colId", colName);
+        params.put("colId", StatisticsUtil.escapeSQL(colName));
 
         return StatisticsUtil.execStatisticQuery(new StringSubstitutor(params)
                 .replace(QUERY_COLUMN_STATISTICS));

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatsId.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatsId.java
@@ -59,12 +59,12 @@ public class StatsId {
 
     public String toSQL() {
         StringJoiner sj = new StringJoiner(",");
-        sj.add(StatisticsUtil.quote(id));
+        sj.add(StatisticsUtil.quote(StatisticsUtil.escapeSQL(id)));
         sj.add(String.valueOf(catalogId));
         sj.add(String.valueOf(dbId));
         sj.add(String.valueOf(tblId));
         sj.add(String.valueOf(idxId));
-        sj.add(StatisticsUtil.quote(colId));
+        sj.add(StatisticsUtil.quote(StatisticsUtil.escapeSQL(colId)));
         sj.add(partId);
         return sj.toString();
     }


### PR DESCRIPTION
Escape load stats sql, because column name may contain special characters.
backport https://github.com/apache/doris/pull/28117

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

