### PR TITLE
[fix](pipelineX) fix use-after-free in filter timer queue

### DIFF
--- a/be/src/pipeline/pipeline_x/dependency.cpp
+++ b/be/src/pipeline/pipeline_x/dependency.cpp
@@ -116,7 +116,7 @@ std::string AndDependency::debug_string(int indentation_level) {
 
 bool RuntimeFilterTimer::has_ready() {
     std::unique_lock<std::mutex> lc(_lock);
-    return _runtime_filter->is_ready();
+    return _is_ready;
 }
 
 void RuntimeFilterTimer::call_timeout() {
@@ -139,6 +139,7 @@ void RuntimeFilterTimer::call_ready() {
     if (_parent) {
         _parent->sub_filters();
     }
+    _is_ready = true;
 }
 
 void RuntimeFilterTimer::call_has_ready() {
@@ -160,7 +161,7 @@ void RuntimeFilterDependency::add_filters(IRuntimeFilter* runtime_filter) {
     int32 wait_time_ms = runtime_filter->wait_time_ms();
     auto filter_timer = std::make_shared<RuntimeFilterTimer>(
             registration_time, wait_time_ms,
-            std::dynamic_pointer_cast<RuntimeFilterDependency>(shared_from_this()), runtime_filter);
+            std::dynamic_pointer_cast<RuntimeFilterDependency>(shared_from_this()));
     runtime_filter->set_filter_timer(filter_timer);
     ExecEnv::GetInstance()->runtime_filter_timer_queue()->push_filter_timer(filter_timer);
 }

--- a/be/src/pipeline/pipeline_x/dependency.h
+++ b/be/src/pipeline/pipeline_x/dependency.h
@@ -161,12 +161,10 @@ class RuntimeFilterDependency;
 class RuntimeFilterTimer {
 public:
     RuntimeFilterTimer(int64_t registration_time, int32_t wait_time_ms,
-                       std::shared_ptr<RuntimeFilterDependency> parent,
-                       IRuntimeFilter* runtime_filter)
+                       std::shared_ptr<RuntimeFilterDependency> parent)
             : _parent(std::move(parent)),
               _registration_time(registration_time),
-              _wait_time_ms(wait_time_ms),
-              _runtime_filter(runtime_filter) {}
+              _wait_time_ms(wait_time_ms) {}
 
     void call_ready();
 
@@ -188,7 +186,7 @@ private:
     std::mutex _lock;
     const int64_t _registration_time;
     const int32_t _wait_time_ms;
-    IRuntimeFilter* _runtime_filter = nullptr;
+    bool _is_ready = false;
 };
 
 struct RuntimeFilterTimerQueue {


### PR DESCRIPTION
## Proposed changes

```
  ==9803==ERROR: AddressSanitizer: heap-use-after-free on address 0x6130023d6ac0 at pc 0x562ae579d24f bp 0x7f8b191c5360 sp 0x7f8b191c5358
01:35:04   READ of size 1 at 0x6130023d6ac0 thread T343
01:35:04       #0 0x562ae579d24e in doris::IRuntimeFilter::is_ready() const /root/doris/be/src/exprs/runtime_filter.h:264:18
01:35:04       #1 0x562ae579d24e in doris::pipeline::RuntimeFilterTimer::has_ready() /root/doris/be/src/pipeline/pipeline_x/dependency.cpp:119:29
01:35:04       #2 0x562abd64e234 in doris::pipeline::RuntimeFilterTimerQueue::start() /root/doris/be/src/pipeline/pipeline_x/dependency.h:211:36
01:35:04       #3 0x562ae884aaef in execute_native_thread_routine /data/gcc-11.1.0/build/x86_64-pc-linux-gnu/libstdc++-v3/src/c++11/../../../../../libstdc++-v3/src/c++11/thread.cc:82:18
01:35:04       #4 0x7f8d474e6608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477:8
01:35:04       #5 0x7f8d47793132 in __clone /build/glibc-SzIz7B/glibc-2.31/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95
01:35:04   
01:35:04   0x6130023d6ac0 is located 256 bytes inside of 336-byte region [0x6130023d69c0,0x6130023d6b10)
01:35:04   freed by thread T312 (WithGroupTaskSc) here:
01:35:04       #0 0x562abb1f580d in operator delete(void*) (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be+0x138cf80d) (BuildId: f97fb76ef8a45a85)
01:35:04       #1 0x562abd8f5721 in doris::ObjectPool::clear() /root/doris/be/src/common/object_pool.h:57:13
01:35:04       #2 0x562abd8f5721 in doris::ObjectPool::~ObjectPool() /root/doris/be/src/common/object_pool.h:34:21
01:35:04       #3 0x562abd8f5721 in doris::RuntimeFilterMgr::~RuntimeFilterMgr() /root/doris/be/src/runtime/runtime_filter_mgr.h:72:33
01:35:04       #4 0x562abd9a5bf1 in std::default_delete<doris::RuntimeFilterMgr>::operator()(doris::RuntimeFilterMgr*) const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:85:2
01:35:04       #5 0x562abd9a5bf1 in std::__uniq_ptr_impl<doris::RuntimeFilterMgr, std::default_delete<doris::RuntimeFilterMgr> >::reset(doris::RuntimeFilterMgr*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:182:4
01:35:04       #6 0x562abd9a5bf1 in std::unique_ptr<doris::RuntimeFilterMgr, std::default_delete<doris::RuntimeFilterMgr> >::reset(doris::RuntimeFilterMgr*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:456:7
01:35:04       #7 0x562abd9a5bf1 in doris::RuntimeState::~RuntimeState() /root/doris/be/src/runtime/runtime_state.cpp:219:25
```
 
```c++
bool RuntimeFilterTimer::has_ready() {
    std::unique_lock<std::mutex> lc(_lock);
    return _runtime_filter->is_ready();
}
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

