### PR TITLE
[Fix](Transactional-Hive) Fix transactional hive core dump when `TransactionalHiveReader::init_row_filters()`.

### DIFF
--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -734,11 +734,14 @@ Status OrcReader::set_fill_columns(
         }
     }
 
-    for (auto& each : _tuple_descriptor->slots()) {
-        PrimitiveType column_type = each->col_type();
-        if (column_type == TYPE_ARRAY || column_type == TYPE_MAP || column_type == TYPE_STRUCT) {
-            _has_complex_type = true;
-            break;
+    if (_tuple_descriptor != nullptr) {
+        for (auto& each : _tuple_descriptor->slots()) {
+            PrimitiveType column_type = each->col_type();
+            if (column_type == TYPE_ARRAY || column_type == TYPE_MAP ||
+                column_type == TYPE_STRUCT) {
+                _has_complex_type = true;
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
## Proposed changes

Fix transactional hive core dump when `TransactionalHiveReader::init_row_filters()`.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

