### PR TITLE
[fix](group commit) Fix group commit memory calculation

### DIFF
--- a/be/src/runtime/group_commit_mgr.cpp
+++ b/be/src/runtime/group_commit_mgr.cpp
@@ -85,7 +85,7 @@ Status LoadBlockQueue::get_block(vectorized::Block* block, bool* find_block, boo
         block->swap(*fblock.get());
         *find_block = true;
         _block_queue.pop_front();
-        _all_block_queues_bytes->fetch_sub(fblock->bytes(), std::memory_order_relaxed);
+        _all_block_queues_bytes->fetch_sub(block->bytes(), std::memory_order_relaxed);
         _single_block_queue_bytes->fetch_sub(block->bytes(), std::memory_order_relaxed);
     }
     if (_block_queue.empty() && need_commit && _load_ids.empty()) {


### PR DESCRIPTION
## Proposed changes

The block queue memory is calculated uncorrectly.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

