### PR TITLE
[chore](docs) straight_join is not supported

### DIFF
--- a/docs/en/docs/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/SELECT.md
+++ b/docs/en/docs/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/SELECT.md
@@ -118,8 +118,6 @@ table_factor:
         ON conditional_expr }
 join_table:
     table_reference [INNER | CROSS] JOIN table_factor [join_condition]
-  | table_reference STRAIGHT_JOIN table_factor
-  | table_reference STRAIGHT_JOIN table_factor ON condition
   | table_reference LEFT [OUTER] JOIN table_reference join_condition
   | table_reference NATURAL [LEFT [OUTER]] JOIN table_factor
   | table_reference RIGHT [OUTER] JOIN table_reference join_condition

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/SELECT.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/SELECT.md
@@ -118,8 +118,6 @@ table_factor:
         ON conditional_expr }
 join_table:
     table_reference [INNER | CROSS] JOIN table_factor [join_condition]
-  | table_reference STRAIGHT_JOIN table_factor
-  | table_reference STRAIGHT_JOIN table_factor ON condition
   | table_reference LEFT [OUTER] JOIN table_reference join_condition
   | table_reference NATURAL [LEFT [OUTER]] JOIN table_factor
   | table_reference RIGHT [OUTER] JOIN table_reference join_condition


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

we can see that straight_join is not supported
https://github.com/apache/doris/blob/3f202477ec4da962745b4ef4871143e0f08354c2/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4#L412-L422

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

