### PR TITLE
[test](jdbc catalog) Use different table names to prevent case errors

### DIFF
--- a/regression-test/suites/external_table_p0/jdbc/test_mysql_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_mysql_jdbc_catalog.groovy
@@ -57,7 +57,7 @@ suite("test_mysql_jdbc_catalog", "p0,external,mysql,external_docker,external_doc
         String ex_tb21 = "test_key_word";
         String test_insert = "test_insert";
         String test_insert2 = "test_insert2";
-        String test_insert_all_types = "test_insert_all_types";
+        String test_insert_all_types = "test_mysql_insert_all_types";
         String test_ctas = "test_ctas";
         String auto_default_t = "auto_default_t";
         String dt = "dt";

--- a/regression-test/suites/external_table_p0/jdbc/test_oracle_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_oracle_jdbc_catalog.groovy
@@ -30,7 +30,7 @@ suite("test_oracle_jdbc_catalog", "p0,external,oracle,external_docker,external_d
         String SID = "XE";
         String test_insert = "TEST_INSERT";
         String test_all_types = "TEST_ALL_TYPES";
-        String test_insert_all_types = "test_insert_all_types";
+        String test_insert_all_types = "test_oracle_insert_all_types";
         String test_ctas = "test_ctas";
 
         String inDorisTable = "doris_in_tb";

--- a/regression-test/suites/external_table_p0/jdbc/test_pg_jdbc_catalog.groovy
+++ b/regression-test/suites/external_table_p0/jdbc/test_pg_jdbc_catalog.groovy
@@ -30,7 +30,7 @@ suite("test_pg_jdbc_catalog", "p0,external,pg,external_docker,external_docker_pg
         String inDorisTable = "test_pg_jdbc_doris_in_tb";
         String test_insert = "test_insert";
         String test_all_types = "test_all_types";
-        String test_insert_all_types = "test_insert_all_types";
+        String test_insert_all_types = "test_pg_insert_all_types";
         String test_ctas = "test_ctas";
 
         sql """create database if not exists ${internal_db_name}; """


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

In the old test, all three tests use the same table name: `test_insert_all_types`
This will cause table confusion when concurrent testing is similar to `insert into internal.regression_test_jdbc_catalog_p0.test_insert_all_types select * from TEST_ALL_TYPES;` , resulting in an error `Column count doesn't match value count`

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

