### PR TITLE
[Improve][COLOCATE] improve colocate balance and colocate join

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2324,4 +2324,10 @@ public class Config extends ConfigBase {
     @ConfField(description = {"是否开启通过http接口获取log文件的功能",
             "Whether to enable the function of getting log files through http interface"})
     public static boolean enable_get_log_file_api = false;
+
+    @ConfField(mutable = true, masterOnly = true)
+    public static int max_scheduling_colocate_tablets = 2000;
+
+    @ConfField(mutable = true, masterOnly = true)
+    public static boolean enable_colocate_balance_improve = true;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ColocateTableIndex.java
@@ -429,7 +429,7 @@ public class ColocateTableIndex implements Writable {
     public Set<GroupId> getAllGroupIds() {
         readLock();
         try {
-            return group2Tables.keySet();
+            return group2Schema.keySet();
         } finally {
             readUnlock();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
@@ -691,6 +691,23 @@ public class Tablet extends MetaObject implements Writable {
         return TabletStatus.HEALTHY;
     }
 
+    public Set<Long> getUnavailableBeIdsForColocate(Set<Long> backendsSet, long visibleVersion) {
+        Set<Long> replicaBackendIds = getBackendIds();
+        Set<Long> unavailableBeIds = Sets.newHashSet(Sets.difference(backendsSet, replicaBackendIds));
+        for (Replica replica : replicas) {
+            long backendId = replica.getBackendId();
+            if (backendsSet.contains(backendId)) {
+                if (!replica.isAlive()) {
+                    unavailableBeIds.add(backendId);
+                }
+                if (replica.getLastFailedVersion() > 0 || replica.getVersion() < visibleVersion) {
+                    unavailableBeIds.add(backendId);
+                }
+            }
+        }
+        return unavailableBeIds;
+    }
+
     /**
      * check if this tablet is ready to be repaired, based on priority.
      * VERY_HIGH: repair immediately

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
@@ -213,6 +213,8 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
 
     private SubCode schedFailedCode;
 
+    private boolean isColocate = false;
+
     public TabletSchedCtx(Type type, long dbId, long tblId, long partId,
             long idxId, long tabletId, ReplicaAllocation replicaAlloc, long createTime) {
         this.type = type;
@@ -334,6 +336,14 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
 
     public void setDecommissionTime(long decommissionTime) {
         this.decommissionTime = decommissionTime;
+    }
+
+    public boolean isColocate() {
+        return isColocate;
+    }
+
+    public void setColocate(boolean colocate) {
+        isColocate = colocate;
     }
 
     public State getState() {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/DistributedPlanColocateRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/DistributedPlanColocateRule.java
@@ -29,4 +29,6 @@ public class DistributedPlanColocateRule {
             = "Inconsistent distribution of table and queries";
     public static final String NULL_AWARE_LEFT_ANTI_JOIN_MUST_BROADCAST
             = "Build side of null aware left anti join must be broadcast";
+    public static final String COLOCATE_GROUP_IS_STABLE_BUT_NO_CROSS_DATA
+            = "colocate group is stable, but no cross data for olpa scan nodes";
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
@@ -1207,4 +1207,16 @@ public abstract class PlanNode extends TreeNode<PlanNode> implements PlanStats {
     public boolean pushDownAggNoGroupingCheckCol(FunctionCallExpr aggExpr, Column col) {
         return false;
     }
+
+    public List<OlapScanNode> getChildrenOlapScanNodes() {
+        List<OlapScanNode> res = Lists.newArrayList();
+        if (this instanceof OlapScanNode) {
+            res.add((OlapScanNode) this);
+        } else if (!(this instanceof ExchangeNode)) {
+            for (PlanNode child : children) {
+                res.addAll(child.getChildrenOlapScanNodes());
+            }
+        }
+        return res;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
@@ -993,6 +993,18 @@ public class SystemInfoService {
         return bes.stream().filter(b -> b.getLocationTag().equals(tag)).collect(Collectors.toList());
     }
 
+    public Map<Tag, Set<Long>> groupBackendsByTag(Set<Long> backendIds) {
+        Map<Tag, Set<Long>> res = Maps.newHashMap();
+        for (Long beId : backendIds) {
+            Backend backend = getBackend(beId);
+            if (backend != null) {
+                Tag tag = backend.getLocationTag();
+                res.computeIfAbsent(tag, k -> Sets.newHashSet()).add(beId);
+            }
+        }
+        return res;
+    }
+
     public int getMinPipelineExecutorSize() {
         if (idToBackendRef.size() == 0) {
             return 1;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
The current colocate group has the following problems:

1. If there is an unrecoverable be or decommission some be, or a tablet is faulty and the tablet is slowly repaired, if the group is very large, the whole group is in a unstable state for a long time, and the colocate join is unavailable for a long time. One obvious problem here is that the control granularity of colocate balance is too coarse, and it is not reasonable to mark the group unstable once a tablet in the whole group is unavailable.

2. colocate balance generates a large number of replica repair tasks, which affect other normal repair tasks

Based on the above problems, the following optimization is done:
1. If any be is unavailable, immediately replace all the be nodes in the unavailable buckets. If we decommission some be nodes, then we replace them one by one. Then, when we query, we take the intersection of query locations, and try not to degrade the performance of join.
2. Perform traffic limiting for the colocate tablet repair

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

