### PR TITLE
[fix](load) count MemTable::to_block() memory in flush tracker

### DIFF
--- a/be/src/olap/memtable_flush_executor.cpp
+++ b/be/src/olap/memtable_flush_executor.cpp
@@ -116,9 +116,9 @@ Status FlushToken::_do_flush_memtable(MemTable* memtable, int32_t segment_id, in
     int64_t duration_ns;
     SCOPED_RAW_TIMER(&duration_ns);
     signal::set_signal_task_id(_rowset_writer->load_id());
-    std::unique_ptr<vectorized::Block> block = memtable->to_block();
     {
         SCOPED_CONSUME_MEM_TRACKER(memtable->flush_mem_tracker());
+        std::unique_ptr<vectorized::Block> block = memtable->to_block();
         SKIP_MEMORY_CHECK(RETURN_IF_ERROR(
                 _rowset_writer->flush_memtable(block.get(), segment_id, flush_size)));
     }


### PR DESCRIPTION
## Proposed changes

Currently MemTable::to_block() memory is not counted in any mem tracker.
This may cause memtable memory limiter to underestimate load mem usage.

This PR proposes to count MemTable::to_block() memory in flush tracker, since it's in flush threads.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

