### PR TITLE
[chore](unused) Remove unused const variables NUMBER, ZERO in vnumbers_tvf.cpp

### DIFF
--- a/be/src/vec/exec/data_gen_functions/vnumbers_tvf.cpp
+++ b/be/src/vec/exec/data_gen_functions/vnumbers_tvf.cpp
@@ -37,9 +37,6 @@
 
 namespace doris::vectorized {
 
-const static std::string NUMBER = std::string {"number"};
-const static std::string ZERO = std::string {"zero"};
-
 VNumbersTVF::VNumbersTVF(TupleId tuple_id, const TupleDescriptor* tuple_desc)
         : VDataGenFunctionInf(tuple_id, tuple_desc) {}
 


### PR DESCRIPTION
## Proposed changes

Remove unused const variables NUMBER, ZERO in vnumbers_tvf.cpp

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

