### PR TITLE
[fix](user) Avoid throw unknown UserProperty after FE rollback version

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
@@ -960,6 +960,12 @@ public class Auth implements Writable {
                 Env.getCurrentEnv().getEditLog().logUpdateUserProperty(propertyInfo);
             }
             LOG.info("finished to set properties for user: {}", user);
+        } catch (DdlException e) {
+            if (isReplay && e.getMessage().contains("Unknown user property")) {
+                LOG.warn("ReplayUpdateUserProperty failed, maybe FE rolled back version, " + e.getMessage());
+            } else {
+                throw e;
+            }
         } finally {
             writeUnlock();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/Auth.java
@@ -954,18 +954,12 @@ public class Auth implements Writable {
             throws UserException {
         writeLock();
         try {
-            propertyMgr.updateUserProperty(user, properties);
+            propertyMgr.updateUserProperty(user, properties, isReplay);
             if (!isReplay) {
                 UserPropertyInfo propertyInfo = new UserPropertyInfo(user, properties);
                 Env.getCurrentEnv().getEditLog().logUpdateUserProperty(propertyInfo);
             }
             LOG.info("finished to set properties for user: {}", user);
-        } catch (DdlException e) {
-            if (isReplay && e.getMessage().contains("Unknown user property")) {
-                LOG.warn("ReplayUpdateUserProperty failed, maybe FE rolled back version, " + e.getMessage());
-            } else {
-                throw e;
-            }
         } finally {
             writeUnlock();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserProperty.java
@@ -179,6 +179,10 @@ public class UserProperty implements Writable {
         return commonProperties.getExecMemLimit();
     }
 
+    public void update(List<Pair<String, String>> properties) throws UserException {
+        update(properties, false);
+    }
+
     public void update(List<Pair<String, String>> properties, boolean isReplay) throws UserException {
         // copy
         long newMaxConn = this.commonProperties.getMaxConn();

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserProperty.java
@@ -37,6 +37,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -51,8 +53,13 @@ import java.util.regex.Pattern;
 /*
  * UserProperty contains properties set for a user
  * This user is just qualified by cluster name, not host which it connected from.
+ *
+ * If UserProperty and SessionVeriable have the same name, UserProperty has a higher priority than SessionVeriable.
+ * This usually means that the cluster administrator force user restrictions.
+ * Users cannot modify these SessionVeriables with the same name.
  */
 public class UserProperty implements Writable {
+    private static final Logger LOG = LogManager.getLogger(UserProperty.class);
     // advanced properties
     private static final String PROP_MAX_USER_CONNECTIONS = "max_user_connections";
     private static final String PROP_MAX_QUERY_INSTANCES = "max_query_instances";
@@ -172,7 +179,7 @@ public class UserProperty implements Writable {
         return commonProperties.getExecMemLimit();
     }
 
-    public void update(List<Pair<String, String>> properties) throws UserException {
+    public void update(List<Pair<String, String>> properties, boolean isReplay) throws UserException {
         // copy
         long newMaxConn = this.commonProperties.getMaxConn();
         long newMaxQueryInstances = this.commonProperties.getMaxQueryInstances();
@@ -312,7 +319,14 @@ public class UserProperty implements Writable {
                 }
                 workloadGroup = value;
             } else {
-                throw new DdlException("Unknown user property(" + key + ")");
+                if (isReplay) {
+                    // After using SET PROPERTY to modify the user property, if FE rolls back to a version without
+                    // this property, `Unknown user property` error will be reported when replay EditLog,
+                    // just ignore it.
+                    LOG.warn("Unknown user property(" + key + "), maybe FE rolled back version, Ignore it");
+                } else {
+                    throw new DdlException("Unknown user property(" + key + ")");
+                }
             }
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserPropertyMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserPropertyMgr.java
@@ -73,7 +73,8 @@ public class UserPropertyMgr implements Writable {
         }
     }
 
-    public void updateUserProperty(String user, List<Pair<String, String>> properties, boolean isReplay) throws UserException {
+    public void updateUserProperty(String user, List<Pair<String, String>> properties, boolean isReplay)
+            throws UserException {
         UserProperty property = propertyMap.get(user);
         if (property == null) {
             throw new DdlException("Unknown user(" + user + ")");

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserPropertyMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserPropertyMgr.java
@@ -73,13 +73,13 @@ public class UserPropertyMgr implements Writable {
         }
     }
 
-    public void updateUserProperty(String user, List<Pair<String, String>> properties) throws UserException {
+    public void updateUserProperty(String user, List<Pair<String, String>> properties, boolean isReplay) throws UserException {
         UserProperty property = propertyMap.get(user);
         if (property == null) {
             throw new DdlException("Unknown user(" + user + ")");
         }
 
-        property.update(properties);
+        property.update(properties, isReplay);
     }
 
     public int getQueryTimeout(String qualifiedUser) {


### PR DESCRIPTION
## Proposed changes

After using SET PROPERTY to modify the user property, if FE rolls back to a version without this property, `Unknown user property` error will be reported when replay EditLog, just ignore it.
![img_v3_0262_90aa299f-d6d7-481f-9f17-f0012e55d91g](https://github.com/apache/doris/assets/13197424/7946353d-7d27-4dd6-9c8a-1bd87f092808)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

