### PR TITLE
[fix](memory_leak) fix memory leak on vrow_distribution

### DIFF
--- a/be/src/vec/sink/vrow_distribution.cpp
+++ b/be/src/vec/sink/vrow_distribution.cpp
@@ -21,6 +21,8 @@
 #include <gen_cpp/FrontendService_types.h>
 #include <glog/logging.h>
 
+#include <memory>
+
 #include "common/status.h"
 #include "runtime/client_cache.h"
 #include "runtime/exec_env.h"
@@ -308,7 +310,8 @@ Status VRowDistribution::generate_rows_distribution(
 
     // batching block rows which need new partitions. deal together at finish.
     if (!_batching_block) [[unlikely]] {
-        _batching_block = MutableBlock::create_unique(block->create_same_struct_block(0).release());
+        std::unique_ptr<Block> tmp_block = block->create_same_struct_block(0);
+        _batching_block = MutableBlock::create_unique(std::move(*tmp_block));
     }
 
     _row_distribution_watch.start();


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

which like
```
Direct leak of 136 byte(s) in 1 object(s) allocated from:
#0 0x55ee8ae54fad in operator new(unsigned long) (/root/doris/be/ut_build_ASAN/test/doris_be_test+0x1565cfad) (BuildId: ddd1c0d2a55f7934)
#1 0x55ee8ca46308 in doris::vectorized::Block::operator new(unsigned long) /root/doris/be/src/vec/core/block.h:71:5
#2 0x55ee8ca22236 in std::unique_ptr<doris::vectorized::Block, std::default_delete<doris::vectorized::Block>> doris::vectorized::Block::create_unique<>() /root/doris/be/src/vec/core/block.h:71:5
#3 0x55eea685f09a in doris::vectorized::Block::create_same_struct_block(unsigned long, bool) const /root/doris/be/src/vec/core/block.cpp:1087:23
#4 0x55eec5a70699 in doris::vectorized::VRowDistribution::generate_rows_distribution(doris::vectorized::Block&, std::shared_ptr<doris::vectorized::Block>&, long&, bool&, std::vector<doris::vectorized::RowPartTabletIds, std::allocator<doris::vectorized::RowPartTabletIds>>&, long&) /root/doris/be/src/vec/sink/vrow_distribution.cpp:311:62
#5 0x55eec59aca24 in doris::vectorized::VTabletWriter::append_block(doris::vectorized::Block&) /root/doris/be/src/vec/sink/writer/vtablet_writer.cpp:1628:5
#6 0x55ee8cb6e7c3 in doris::vectorized::AsyncWriterSink<doris::vectorized::VTabletWriter, &doris::vectorized::VOLAP_TABLE_SINK.<char const at offset 0>>::send(doris::RuntimeState*, doris::vectorized::Block*, bool) /root/doris/be/src/vec/sink/async_writer_sink.h:85:25
#7 0x55ee8cb6ba93 in doris::vectorized::VOlapTableSinkTest::test_normal(int) /root/doris/be/test/vec/exec/vtablet_sink_test.cpp:482:19
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

