### PR TITLE
[fix](regression) mow cases should use assertEquals not assertTrue

### DIFF
--- a/regression-test/suites/inverted_index_p0/unique_with_mow/test_pk_uk_case.groovy
+++ b/regression-test/suites/inverted_index_p0/unique_with_mow/test_pk_uk_case.groovy
@@ -197,10 +197,7 @@ suite("test_pk_uk_case", "inverted_index") {
         def result0 = sql """ SELECT count(*) FROM ${tableNamePk}; """
         def result1 = sql """ SELECT count(*) FROM ${tableNameUk}; """
         logger.info("result:" + result0[0][0] + "|" + result1[0][0])
-        assertTrue(result0[0]==result1[0])
-        if (result0[0][0]!=result1[0][0]) {
-            logger.info("result:" + result0[0][0] + "|" + result1[0][0])
-        }
+        assertEquals(result0[0], result1[0])
 
         result0 = sql """ SELECT
                             l_returnflag,
@@ -242,11 +239,11 @@ suite("test_pk_uk_case", "inverted_index") {
                             l_returnflag,
                             l_linestatus
                         """  
-        assertTrue(result0.size()==result1.size())
+        assertEquals(result0.size(), result1.size())
         for (int i = 0; i < result0.size(); ++i) {
-            for (j = 0; j < result0[0].size(); j++) {
+            for (int j = 0; j < result0[0].size(); j++) {
                 logger.info("result: " + result0[i][j] + "|" + result1[i][j])
-                assertTrue(result0[i][j]==result1[i][j])
+                assertEquals(result0[i][j], result1[i][j])
             }
         }       
 

--- a/regression-test/suites/unique_with_mow_p0/cluster_key/test_pk_uk_case.groovy
+++ b/regression-test/suites/unique_with_mow_p0/cluster_key/test_pk_uk_case.groovy
@@ -193,10 +193,7 @@ suite("test_pk_uk_case") {
         def result0 = sql """ SELECT count(*) FROM ${tableNamePk}; """
         def result1 = sql """ SELECT count(*) FROM ${tableNameUk}; """
         logger.info("result:" + result0[0][0] + "|" + result1[0][0])
-        assertTrue(result0[0]==result1[0])
-        if (result0[0][0]!=result1[0][0]) {
-            logger.info("result:" + result0[0][0] + "|" + result1[0][0])
-        }
+        assertEquals(result0[0], result1[0])
 
         result0 = sql """ SELECT
                             l_returnflag,
@@ -238,11 +235,11 @@ suite("test_pk_uk_case") {
                             l_returnflag,
                             l_linestatus
                         """  
-        assertTrue(result0.size()==result1.size())
+        assertEquals(result0.size(), result1.size())
         for (int i = 0; i < result0.size(); ++i) {
-            for (j = 0; j < result0[0].size(); j++) {
+            for (int j = 0; j < result0[0].size(); j++) {
                 logger.info("result: " + result0[i][j] + "|" + result1[i][j])
-                assertTrue(result0[i][j]==result1[i][j])
+                assertEquals(result0[i][j], result1[i][j])
             }
         }       
 

--- a/regression-test/suites/unique_with_mow_p0/test_pk_uk_case.groovy
+++ b/regression-test/suites/unique_with_mow_p0/test_pk_uk_case.groovy
@@ -190,10 +190,7 @@ suite("test_pk_uk_case") {
         def result0 = sql """ SELECT count(*) FROM ${tableNamePk}; """
         def result1 = sql """ SELECT count(*) FROM ${tableNameUk}; """
         logger.info("result:" + result0[0][0] + "|" + result1[0][0])
-        assertTrue(result0[0]==result1[0])
-        if (result0[0][0]!=result1[0][0]) {
-            logger.info("result:" + result0[0][0] + "|" + result1[0][0])
-        }
+        assertEquals(result0[0], result1[0])
 
         result0 = sql """ SELECT
                             l_returnflag,
@@ -234,12 +231,12 @@ suite("test_pk_uk_case") {
                             ORDER BY
                             l_returnflag,
                             l_linestatus
-                        """  
-        assertTrue(result0.size()==result1.size())
+                        """
+        assertEquals(result0.size(), result1.size())
         for (int i = 0; i < result0.size(); ++i) {
-            for (j = 0; j < result0[0].size(); j++) {
+            for (int j = 0; j < result0[0].size(); j++) {
                 logger.info("result: " + result0[i][j] + "|" + result1[i][j])
-                assertTrue(result0[i][j]==result1[i][j])
+                assertEquals(result0[i][j], result1[i][j])
             }
         }       
 

--- a/regression-test/suites/unique_with_mow_p2/test_pk_uk_case.groovy
+++ b/regression-test/suites/unique_with_mow_p2/test_pk_uk_case.groovy
@@ -190,10 +190,7 @@ suite("test_pk_uk_case") {
         def result0 = sql """ SELECT count(*) FROM ${tableNamePk}; """
         def result1 = sql """ SELECT count(*) FROM ${tableNameUk}; """
         logger.info("result:" + result0[0][0] + "|" + result1[0][0])
-        assertTrue(result0[0]==result1[0])
-        if (result0[0][0]!=result1[0][0]) {
-            logger.info("result:" + result0[0][0] + "|" + result1[0][0])
-        }
+        assertEquals(result0[0], result1[0])
 
         result0 = sql """ SELECT
                             l_returnflag,
@@ -234,12 +231,12 @@ suite("test_pk_uk_case") {
                             ORDER BY
                             l_returnflag,
                             l_linestatus
-                        """  
-        assertTrue(result0.size()==result1.size())
+                        """
+        assertEquals(result0.size(), result1.size())
         for (int i = 0; i < result0.size(); ++i) {
-            for (j = 0; j < result0[0].size(); j++) {
+            for (int j = 0; j < result0[0].size(); j++) {
                 logger.info("result: " + result0[i][j] + "|" + result1[i][j])
-                assertTrue(result0[i][j]==result1[i][j])
+                assertEquals(result0[i][j], result1[i][j])
             }
         }       
 

--- a/regression-test/suites/unique_with_mow_p2/test_pk_uk_case_cluster.groovy
+++ b/regression-test/suites/unique_with_mow_p2/test_pk_uk_case_cluster.groovy
@@ -191,10 +191,7 @@ suite("test_pk_uk_case_cluster") {
         def result0 = sql """ SELECT count(*) FROM ${tableNamePk}; """
         def result1 = sql """ SELECT count(*) FROM ${tableNameUk}; """
         logger.info("result:" + result0[0][0] + "|" + result1[0][0])
-        assertTrue(result0[0]==result1[0])
-        if (result0[0][0]!=result1[0][0]) {
-            logger.info("result:" + result0[0][0] + "|" + result1[0][0])
-        }
+        assertEquals(result0[0], result1[0])
 
         result0 = sql """ SELECT
                             l_returnflag,
@@ -235,12 +232,12 @@ suite("test_pk_uk_case_cluster") {
                             ORDER BY
                             l_returnflag,
                             l_linestatus
-                        """  
-        assertTrue(result0.size()==result1.size())
+                        """
+        assertEquals(result0.size(), result1.size())
         for (int i = 0; i < result0.size(); ++i) {
-            for (j = 0; j < result0[0].size(); j++) {
+            for (int j = 0; j < result0[0].size(); j++) {
                 logger.info("result: " + result0[i][j] + "|" + result1[i][j])
-                assertTrue(result0[i][j]==result1[i][j])
+                assertEquals(result0[i][j], result1[i][j])
             }
         }       
 


### PR DESCRIPTION
## Proposed changes

The regression is failed because mow cases use `assertTrue(a == b)` to compare double values:

```
2023-12-13 13:22:22.091 INFO [suite-thread-6] (test_pk_uk_case.groovy:244) - result: 111.1100|111.1100
2023-12-13 13:22:22.096 ERROR [suite-thread-6] (ScriptContext.groovy:122) - Run test_pk_uk_case in /home/work/pipline/OpenSourceDoris/clusterRegressionCenter/P0/Cluster0/regression-test/suites/unique_with_mow_p0/cluster_key/test_pk_uk_case.groovy failed
org.opentest4j.AssertionFailedError: expected: <true> but was: <false>
  at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:55)
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

