### PR TITLE
[fix](Export) Fix an export error when lower_case_table_names=1

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
@@ -458,6 +458,10 @@ public class ExportJob implements Writable {
                 int end = i + MAXIMUM_TABLETS_OF_OUTFILE_IN_EXPORT < tabletsList.size()
                         ? i + MAXIMUM_TABLETS_OF_OUTFILE_IN_EXPORT : tabletsList.size();
                 List<Long> tablets = new ArrayList<>(tabletsList.subList(i, end));
+                // Since export does not support the alias, here we pass the null value.
+                // we can not use this.tableRef.getAlias(),
+                // because the constructor of `Tableref` will convert this.tableRef.getAlias()
+                // into lower case when lower_case_table_names = 1
                 TableRef tblRef = new TableRef(this.tableRef.getName(), null,
                         this.tableRef.getPartitionNames(), (ArrayList) tablets,
                         this.tableRef.getTableSample(), this.tableRef.getCommonHints());

--- a/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
@@ -458,7 +458,7 @@ public class ExportJob implements Writable {
                 int end = i + MAXIMUM_TABLETS_OF_OUTFILE_IN_EXPORT < tabletsList.size()
                         ? i + MAXIMUM_TABLETS_OF_OUTFILE_IN_EXPORT : tabletsList.size();
                 List<Long> tablets = new ArrayList<>(tabletsList.subList(i, end));
-                TableRef tblRef = new TableRef(this.tableRef.getName(), this.tableRef.getAlias(),
+                TableRef tblRef = new TableRef(this.tableRef.getName(), null,
                         this.tableRef.getPartitionNames(), (ArrayList) tablets,
                         this.tableRef.getTableSample(), this.tableRef.getCommonHints());
                 tableRefList.add(tblRef);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

if `lower_case_table_names=1` and using old optimizer, when the table we want to export belongs to a database containing a capital letter, we will get an error.
For example, if the db named XXX, and the table we want to export is named yyy, then when we execute `export` job, we will get the error:
Unknown table 'yyy' in default_cluster:XXX

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

