### PR TITLE
[Enhancement](build support) make run_clang_format compatible with python3

### DIFF
--- a/build-support/run_clang_format.py
+++ b/build-support/run_clang_format.py
@@ -23,7 +23,25 @@ import signal
 import subprocess
 import sys
 import traceback
-from distutils.util import strtobool
+try:
+    from distutils.util import strtobool
+except ImportError:
+    def strtobool(val):
+        """
+        Convert a string representation of truth to true (1) or false (0).
+
+        True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+        are 'n', 'no', 'f', 'false', 'off', and '0'. Raises ValueError if
+        'val' is anything else.
+        """
+        val = val.lower()
+        if val in ('y', 'yes', 't', 'true', 'on', '1'):
+            return 1
+        elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+            return 0
+        else:
+            raise ValueError(f"Invalid truth value '{val}'")
+
 
 from functools import partial
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

run_clang_format.py in python3 env will produce error like "ModuleNotFoundError: No module named 'distutils.util' ", try to fix this.
## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

