### PR TITLE
[performance](Planner): avoid toStringValue() in DateLiteral compare

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/PlaceHolderExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/PlaceHolderExpr.java
@@ -93,16 +93,15 @@ public class PlaceHolderExpr extends LiteralExpr {
         return lExpr.compareLiteral(expr);
     }
 
-    @Override
-    public int compareTo(LiteralExpr literalExpr) {
-        return compareLiteral(literalExpr);
-    }
-
     public String getStringValue() {
         if (lExpr == null) {
             return "";
         }
         return lExpr.getStringValue();
+    }
+
+    public LiteralExpr getlExpr() {
+        return lExpr;
     }
 
     public long getLongValue() {

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/FEFunctions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/FEFunctions.java
@@ -81,9 +81,10 @@ public class FEFunctions {
     @FEFunction(name = "dayofweek", argTypes = {"DATETIME"}, returnType = "TINYINT")
     public static IntLiteral dayOfWeek(LiteralExpr date) throws AnalysisException {
         // use zellar algorithm.
-        long year = ((DateLiteral) date).getYear();
-        long month = ((DateLiteral) date).getMonth();
-        long day = ((DateLiteral) date).getDay();
+        DateLiteral dateLiteral = (DateLiteral) date;
+        long year = dateLiteral.getYear();
+        long month = dateLiteral.getMonth();
+        long day = dateLiteral.getDay();
         if (month < 3) {
             month += 12;
             year -= 1;
@@ -91,7 +92,9 @@ public class FEFunctions {
         long c = year / 100;
         long y = year % 100;
         long t;
-        if (date.compareTo(new DateLiteral(1582, 10, 4)) > 0) {
+        if (dateLiteral.getYear() > 1582
+                || (dateLiteral.getYear() == 1582 && dateLiteral.getMonth() > 10)
+                || (dateLiteral.getYear() == 1582 && dateLiteral.getMonth() == 10 && dateLiteral.getDay() > 4)) {
             t = (y + y / 4 + c / 4 - 2 * c + 26 * (month + 1) / 10 + day - 1) % 7;
         } else {
             t = (y + y / 4 - c + 26 * (month + 1) / 10 + day + 4) % 7;
@@ -533,8 +536,7 @@ public class FEFunctions {
                             (int) dateLiteral.getHour(), (int) dateLiteral.getMinute(), (int) dateLiteral.getSecond()),
                     truncate.getStringValue());
 
-            return new DateLiteral(localDate.getYear(), localDate.getMonthValue(), localDate.getDayOfMonth(),
-                    localDate.getHour(), localDate.getMinute(), localDate.getSecond(), date.getType());
+            return new DateLiteral(localDate, date.getType());
         }
         return null;
     }
@@ -548,8 +550,7 @@ public class FEFunctions {
                             (int) dateLiteral.getHour(), (int) dateLiteral.getMinute(), (int) dateLiteral.getSecond()),
                     truncate.getStringValue());
 
-            return new DateLiteral(localDate.getYear(), localDate.getMonthValue(), localDate.getDayOfMonth(),
-                    localDate.getHour(), localDate.getMinute(), localDate.getSecond(), date.getType());
+            return new DateLiteral(localDate, date.getType());
         }
         return null;
     }
@@ -562,8 +563,7 @@ public class FEFunctions {
                     (int) dateLiteral.getYear(), (int) dateLiteral.getMonth(), (int) dateLiteral.getDay(), 0, 0, 0),
                     truncate.getStringValue());
 
-            return new DateLiteral(localDate.getYear(), localDate.getMonthValue(), localDate.getDayOfMonth(),
-                    localDate.getHour(), localDate.getMinute(), localDate.getSecond(), date.getType());
+            return new DateLiteral(localDate, date.getType());
         }
         return null;
     }
@@ -576,8 +576,7 @@ public class FEFunctions {
                     (int) dateLiteral.getYear(), (int) dateLiteral.getMonth(), (int) dateLiteral.getDay(), 0, 0, 0),
                     truncate.getStringValue());
 
-            return new DateLiteral(localDate.getYear(), localDate.getMonthValue(), localDate.getDayOfMonth(),
-                    localDate.getHour(), localDate.getMinute(), localDate.getSecond(), date.getType());
+            return new DateLiteral(localDate, date.getType());
         }
         return null;
     }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

