### PR TITLE
[improvement](be report) add be report http

### DIFF
--- a/be/src/http/action/report_action.cpp
+++ b/be/src/http/action/report_action.cpp
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "http/action/report_action.h"
+
+#include "common/status.h"
+
+namespace doris {
+
+ReportAction::ReportAction(ExecEnv* exec_env, TPrivilegeHier::type hier, TPrivilegeType::type type,
+                           const std::string& report_name)
+        : HttpHandlerWithAuth(exec_env, hier, type), _report_name(report_name) {}
+
+void ReportAction::handle(HttpRequest* req) {
+    if (StorageEngine::instance()->notify_listener(_report_name)) {
+        HttpChannel::send_reply(req, HttpStatus::OK, Status::OK().to_string());
+    } else {
+        HttpChannel::send_reply(req, HttpStatus::INTERNAL_SERVER_ERROR, Status::InternalError("unknown reporter with name: " + _report_name);
+    }
+}
+
+} // namespace doris

--- a/be/src/http/action/report_action.cpp
+++ b/be/src/http/action/report_action.cpp
@@ -18,6 +18,8 @@
 #include "http/action/report_action.h"
 
 #include "common/status.h"
+#include "http/http_channel.h"
+#include "olap/storage_engine.h"
 
 namespace doris {
 
@@ -27,9 +29,11 @@ ReportAction::ReportAction(ExecEnv* exec_env, TPrivilegeHier::type hier, TPrivil
 
 void ReportAction::handle(HttpRequest* req) {
     if (StorageEngine::instance()->notify_listener(_report_name)) {
-        HttpChannel::send_reply(req, HttpStatus::OK, Status::OK().to_string());
+        HttpChannel::send_reply(req, HttpStatus::OK, Status::OK().to_json());
     } else {
-        HttpChannel::send_reply(req, HttpStatus::INTERNAL_SERVER_ERROR, Status::InternalError("unknown reporter with name: " + _report_name);
+        HttpChannel::send_reply(
+                req, HttpStatus::INTERNAL_SERVER_ERROR,
+                Status::InternalError("unknown reporter with name: " + _report_name).to_json());
     }
 }
 

--- a/be/src/http/action/report_action.h
+++ b/be/src/http/action/report_action.h
@@ -1,0 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "http/http_handler_with_auth.h"
+#include "http/http_request.h"
+
+namespace doris {
+
+// use in regression test, just for test.
+
+class ReportAction : public HttpHandlerWithAuth {
+public:
+    ReportAction(ExecEnv* exec_env, TPrivilegeHier::type hier, TPrivilegeType::type type,
+                 const std::string& report_name);
+    void handle(HttpRequest* req) override;
+
+private:
+    const std::string _report_name;
+};
+
+} // namespace doris

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -1229,13 +1229,15 @@ void StorageEngine::notify_listeners() {
     }
 }
 
-void StorageEngine::notify_listener(std::string_view name) {
+bool StorageEngine::notify_listener(std::string_view name) {
     std::lock_guard<std::mutex> l(_report_mtx);
     for (auto& listener : _report_listeners) {
         if (listener->name() == name) {
             listener->notify();
+            return true;
         }
     }
+    return false;
 }
 
 // check whether any unused rowsets's id equal to rowset_id

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -139,7 +139,7 @@ public:
     void register_report_listener(ReportWorker* listener);
     void deregister_report_listener(ReportWorker* listener);
     void notify_listeners();
-    void notify_listener(std::string_view name);
+    bool notify_listener(std::string_view name);
 
     TabletManager* tablet_manager() { return _tablet_manager.get(); }
     TxnManager* txn_manager() { return _txn_manager.get(); }

--- a/be/src/service/http_service.cpp
+++ b/be/src/service/http_service.cpp
@@ -290,6 +290,18 @@ Status HttpService::start() {
     _ev_http_server->register_handler(HttpMethod::POST, "/api/debug_point/clear",
                                       clear_debug_points_action);
 
+    ReportAction* report_tablet_action = _pool.add(new ReportAction(
+            _env, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN, "REPORT_OLAP_TABLE"));
+    _ev_http_server->register_handler(HttpMethod::GET, "/api/report/tablet", report_tablet_action);
+
+    ReportAction* report_disk_action = _pool.add(new ReportAction(
+            _env, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN, "REPORT_DISK_STATE"));
+    _ev_http_server->register_handler(HttpMethod::GET, "/api/report/disk", report_disk_action);
+
+    ReportAction* report_task_action = _pool.add(
+            new ReportAction(_env, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN, "REPORT_TASK"));
+    _ev_http_server->register_handler(HttpMethod::GET, "/api/report/task", report_task_action);
+
     _ev_http_server->start();
     return Status::OK();
 }

--- a/be/src/service/http_service.cpp
+++ b/be/src/service/http_service.cpp
@@ -44,6 +44,7 @@
 #include "http/action/pipeline_task_action.h"
 #include "http/action/pprof_actions.h"
 #include "http/action/reload_tablet_action.h"
+#include "http/action/report_action.h"
 #include "http/action/reset_rpc_channel_action.h"
 #include "http/action/restore_tablet_action.h"
 #include "http/action/snapshot_action.h"

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/util/DebugPoint.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/util/DebugPoint.groovy
@@ -49,7 +49,7 @@ class DebugPoint {
         if (params != null && params.size() > 0) {
             url += '?' + params.collect((k, v) -> k + '=' + v).join('&')
         }
-        def result = Http.http_post(url, null, true)
+        def result = Http.POST(url, null, true)
         Http.checkHttpResult(result, type)
     }
 
@@ -62,7 +62,7 @@ class DebugPoint {
      */
     static def disableDebugPoint(String host, int httpPort, NodeType type, String name) {
         def url = 'http://' + host + ':' + httpPort + '/api/debug_point/remove/' + name
-        def result = Http.http_post(url, null, true)
+        def result = Http.POST(url, null, true)
         Http.checkHttpResult(result, type)
     }
 
@@ -74,7 +74,7 @@ class DebugPoint {
      */
     static def clearDebugPoints(String host, int httpPort, NodeType type) {
         def url = 'http://' + host + ':' + httpPort + '/api/debug_point/clear'
-        def result = Http.http_post(url, null, true)
+        def result = Http.POST(url, null, true)
         Http.checkHttpResult(result, type)
     }
 

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/util/Http.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/util/Http.groovy
@@ -47,7 +47,24 @@ class Http {
         }
     }
 
-    static Object http_post(url, data = null, isJson = false) {
+    static Object GET(url, isJson = false) {
+        def conn = new URL(url).openConnection()
+        conn.setRequestMethod('GET')
+        conn.setRequestProperty('Authorization', 'Basic cm9vdDo=') //token for root
+        def code = conn.responseCode
+        def text = conn.content.text
+        logger.info("http post url=${url}, isJson=${isJson}, response code=${code}, text=${text}")
+        Assert.assertEquals(200, code)
+        if (isJson) {
+            def json = new JsonSlurper()
+            def result = json.parseText(text)
+            return result
+        } else {
+            return text
+        }
+    }
+
+    static Object POST(url, data = null, isJson = false) {
         def conn = new URL(url).openConnection()
         conn.setRequestMethod('POST')
         conn.setRequestProperty('Authorization', 'Basic cm9vdDo=') //token for root

--- a/regression-test/plugins/plugin_curl_requester.groovy
+++ b/regression-test/plugins/plugin_curl_requester.groovy
@@ -17,6 +17,7 @@
 
 import org.apache.doris.regression.suite.Suite
 import org.apache.doris.regression.util.Http
+import org.apache.doris.regression.util.NodeType
 import org.codehaus.groovy.runtime.IOGroovyMethods
 
 Suite.metaClass.curl = { String method, String url /* param */-> 
@@ -97,10 +98,35 @@ Suite.metaClass.update_all_be_config = { String key, Object value ->
     backendId_to_backendIP.each { beId, beIp ->
         def port = backendId_to_backendHttpPort.get(beId)
         def url = "http://${beIp}:${port}/api/update_config?${key}=${value}"
-        def result = Http.http_post(url, null, true)
+        def result = Http.POST(url, null, true)
         assert result.size() == 1, result.toString()
         assert result[0].status == "OK", result.toString()
     }
 }
 
 logger.info("Added 'update_all_be_config' function to Suite")
+
+
+Suite.metaClass._be_report = { String ip, int port, String reportName ->
+    def url = "http://${beIp}:${port}/api/report/${reportName}"
+    def result = Http.GET(url, true)
+    Http.checkHttpResult(result, NodeType.BE)
+}
+
+Suite.metaClass.be_report_disk = { String ip, int port ->
+    _be_report(ip, port, "disk")
+}
+
+logger.info("Added 'be_report_disk' function to Suite")
+
+Suite.metaClass.be_report_tablet = { String ip, int port ->
+    _be_report(ip, port, "tablet")
+}
+
+logger.info("Added 'be_report_tablet' function to Suite")
+
+Suite.metaClass.be_report_task = { String ip, int port ->
+    _be_report(ip, port, "task")
+}
+
+logger.info("Added 'be_report_task' function to Suite")

--- a/regression-test/plugins/plugin_curl_requester.groovy
+++ b/regression-test/plugins/plugin_curl_requester.groovy
@@ -108,23 +108,26 @@ logger.info("Added 'update_all_be_config' function to Suite")
 
 
 Suite.metaClass._be_report = { String ip, int port, String reportName ->
-    def url = "http://${beIp}:${port}/api/report/${reportName}"
+    def url = "http://${ip}:${port}/api/report/${reportName}"
     def result = Http.GET(url, true)
     Http.checkHttpResult(result, NodeType.BE)
 }
 
+// before report, be need random sleep 5s
 Suite.metaClass.be_report_disk = { String ip, int port ->
     _be_report(ip, port, "disk")
 }
 
 logger.info("Added 'be_report_disk' function to Suite")
 
+// before report, be need random sleep 5s
 Suite.metaClass.be_report_tablet = { String ip, int port ->
     _be_report(ip, port, "tablet")
 }
 
 logger.info("Added 'be_report_tablet' function to Suite")
 
+// before report, be need random sleep 5s
 Suite.metaClass.be_report_task = { String ip, int port ->
     _be_report(ip, port, "task")
 }

--- a/regression-test/suites/plugin_p0/test_plugin_curl_requester.groovy
+++ b/regression-test/suites/plugin_p0/test_plugin_curl_requester.groovy
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite('test_plugin_curl_requester') {
+    def backendId_to_backendIP = [:]
+    def backendId_to_backendHttpPort = [:]
+    getBackendIpHttpPort(backendId_to_backendIP, backendId_to_backendHttpPort)
+
+    backendId_to_backendIP.each { beId, beIp ->
+        def port = backendId_to_backendHttpPort.get(beId) as int
+        be_report_disk(beIp, port)
+        be_report_task(beIp, port)
+        be_report_tablet(beIp, port)
+    }
+}
+


### PR DESCRIPTION
used for regression test.  we can send be report http and no need to wait.

usage:

|type|http| regression test suites|
|---  |---  |---|
|report disk |  http://beIp:beHttpPort/api/report/disk |  be_report_disk(beIp, beHttpPort)
|report task |  http://beIp:beHttpPort/api/report/task |  be_report_task(beIp, beHttpPort)
|report tablet |  http://beIp:beHttpPort/api/report/tablet |  be_report_tablet(beIp, beHttpPort)


## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

