### PR TITLE
[fix](Nereids): TransposeSemiJoinAgg can't apply in Scalar Agg

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/TransposeSemiJoinAgg.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/TransposeSemiJoinAgg.java
@@ -51,6 +51,10 @@ public class TransposeSemiJoinAgg extends OneRewriteRuleFactory {
     public static boolean canTranspose(LogicalAggregate<? extends Plan> aggregate,
             LogicalJoin<? extends Plan, ? extends Plan> join) {
         Set<Slot> canPushDownSlots = PushDownFilterThroughAggregation.getCanPushDownSlots(aggregate);
+        // avoid push down scalar agg.
+        if (canPushDownSlots.isEmpty()) {
+            return false;
+        }
         Set<Slot> leftConditionSlot = join.getLeftConditionSlot();
         return canPushDownSlots.containsAll(leftConditionSlot);
     }


### PR DESCRIPTION
## Proposed changes

Scalar Agg shouldn't be pushdown, it will cause wrong result

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

