### PR TITLE
[improvement](publish version) publish txn fail retry do not wait 1s

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1493,7 +1493,6 @@ void PublishVersionWorkerPool::publish_version_callback(const TAgentTaskRequest&
                 .tag("retry_time", retry_time)
                 .error(status);
         ++retry_time;
-        std::this_thread::sleep_for(std::chrono::seconds(1));
     }
 
     for (auto& item : discontinuous_version_tablets) {


### PR DESCRIPTION
If  many txns publish failed,   then txns start to pile up.

No need wait here,   even if BE publish failed,  FE will send retry tasks later (in no more than 15s).

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

