### PR TITLE
[pipelineX](profile) make dep time merge

### DIFF
--- a/be/src/pipeline/exec/exchange_sink_operator.cpp
+++ b/be/src/pipeline/exec/exchange_sink_operator.cpp
@@ -127,8 +127,9 @@ Status ExchangeSinkLocalState::init(RuntimeState* state, LocalSinkStateInfo& inf
     _local_bytes_send_counter = ADD_COUNTER(_profile, "LocalBytesSent", TUnit::BYTES);
     _memory_usage_counter = ADD_LABEL_COUNTER(_profile, "MemoryUsage");
     static const std::string timer_name = "WaitForDependencyTime";
-    _wait_for_dependency_timer = ADD_TIMER(_profile, timer_name);
-    _wait_queue_timer = ADD_CHILD_TIMER(_profile, "WaitForRpcBufferQueue", timer_name);
+    _wait_for_dependency_timer = ADD_TIMER_WITH_LEVEL(_profile, timer_name, 1);
+    _wait_queue_timer =
+            ADD_CHILD_TIMER_WITH_LEVEL(_profile, "WaitForRpcBufferQueue", timer_name, 1);
 
     auto& p = _parent->cast<ExchangeSinkOperatorX>();
 

--- a/be/src/pipeline/exec/exchange_source_operator.cpp
+++ b/be/src/pipeline/exec/exchange_source_operator.cpp
@@ -88,9 +88,10 @@ Status ExchangeLocalState::init(RuntimeState* state, LocalStateInfo& info) {
     }
     static const std::string timer_name =
             "WaitForDependency[" + source_dependency->name() + "]Time";
-    _wait_for_dependency_timer = ADD_TIMER(_runtime_profile, timer_name);
+    _wait_for_dependency_timer = ADD_TIMER_WITH_LEVEL(_runtime_profile, timer_name, 1);
     for (size_t i = 0; i < queues.size(); i++) {
-        metrics[i] = ADD_CHILD_TIMER(_runtime_profile, fmt::format("WaitForData{}", i), timer_name);
+        metrics[i] = ADD_CHILD_TIMER_WITH_LEVEL(_runtime_profile, fmt::format("WaitForData{}", i),
+                                                timer_name, 1);
     }
     RETURN_IF_ERROR(_parent->cast<ExchangeSourceOperatorX>()._vsort_exec_exprs.clone(
             state, vsort_exec_exprs));

--- a/be/src/pipeline/exec/result_sink_operator.cpp
+++ b/be/src/pipeline/exec/result_sink_operator.cpp
@@ -55,7 +55,7 @@ Status ResultSinkLocalState::init(RuntimeState* state, LocalSinkStateInfo& info)
     SCOPED_TIMER(exec_time_counter());
     SCOPED_TIMER(_open_timer);
     static const std::string timer_name = "WaitForDependencyTime";
-    _wait_for_dependency_timer = ADD_TIMER(_profile, timer_name);
+    _wait_for_dependency_timer = ADD_TIMER_WITH_LEVEL(_profile, timer_name, 1);
     auto fragment_instance_id = state->fragment_instance_id();
     // create sender
     std::shared_ptr<BufferControlBlock> sender = nullptr;

--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -148,11 +148,12 @@ Status ScanLocalState<Derived>::init(RuntimeState* state, LocalStateInfo& info) 
     _prepare_rf_timer(_runtime_profile.get());
 
     static const std::string timer_name = "WaitForDependencyTime";
-    _wait_for_dependency_timer = ADD_TIMER(_runtime_profile, timer_name);
-    _wait_for_data_timer = ADD_CHILD_TIMER(_runtime_profile, "WaitForData", timer_name);
+    _wait_for_dependency_timer = ADD_TIMER_WITH_LEVEL(_runtime_profile, timer_name, 1);
+    _wait_for_data_timer =
+            ADD_CHILD_TIMER_WITH_LEVEL(_runtime_profile, "WaitForData", timer_name, 1);
     _wait_for_scanner_done_timer =
-            ADD_CHILD_TIMER(_runtime_profile, "WaitForScannerDone", timer_name);
-    _wait_for_eos_timer = ADD_CHILD_TIMER(_runtime_profile, "WaitForEos", timer_name);
+            ADD_CHILD_TIMER_WITH_LEVEL(_runtime_profile, "WaitForScannerDone", timer_name, 1);
+    _wait_for_eos_timer = ADD_CHILD_TIMER_WITH_LEVEL(_runtime_profile, "WaitForEos", timer_name, 1);
     return Status::OK();
 }
 

--- a/be/src/pipeline/pipeline_x/dependency.h
+++ b/be/src/pipeline/pipeline_x/dependency.h
@@ -276,16 +276,6 @@ public:
     AndDependency(int id, int node_id, QueryContext* query_ctx)
             : Dependency(id, node_id, "AndDependency", query_ctx) {}
 
-    [[nodiscard]] std::string name() const override {
-        fmt::memory_buffer debug_string_buffer;
-        fmt::format_to(debug_string_buffer, "{}[", Dependency::_name);
-        for (auto& child : Dependency::_children) {
-            fmt::format_to(debug_string_buffer, "{}, ", child->name());
-        }
-        fmt::format_to(debug_string_buffer, "]");
-        return fmt::to_string(debug_string_buffer);
-    }
-
     std::string debug_string(int indentation_level = 0) override;
 
     [[nodiscard]] Dependency* is_blocked_by(PipelineXTask* task) override {

--- a/be/src/pipeline/pipeline_x/operator.cpp
+++ b/be/src/pipeline/pipeline_x/operator.cpp
@@ -346,8 +346,8 @@ Status PipelineXLocalState<DependencyType>::init(RuntimeState* state, LocalState
         }
         _shared_state = (typename DependencyType::SharedState*)_dependency->shared_state().get();
         _shared_state->ref();
-        _wait_for_dependency_timer =
-                ADD_TIMER(_runtime_profile, "WaitForDependency[" + _dependency->name() + "]Time");
+        _wait_for_dependency_timer = ADD_TIMER_WITH_LEVEL(
+                _runtime_profile, "WaitForDependency[" + _dependency->name() + "]Time", 1);
         _shared_state->source_dep = _dependency;
         _shared_state->sink_dep = deps.front().get();
     }
@@ -414,8 +414,8 @@ Status PipelineXSinkLocalState<DependencyType>::init(RuntimeState* state,
         if (_dependency) {
             _shared_state =
                     (typename DependencyType::SharedState*)_dependency->shared_state().get();
-            _wait_for_dependency_timer =
-                    ADD_TIMER(_profile, "WaitForDependency[" + _dependency->name() + "]Time");
+            _wait_for_dependency_timer = ADD_TIMER_WITH_LEVEL(
+                    _profile, "WaitForDependency[" + _dependency->name() + "]Time", 1);
         }
         _shared_state->ref();
     } else {
@@ -511,8 +511,8 @@ Status AsyncWriterSink<Writer, Parent>::init(RuntimeState* state, LocalSinkState
             _parent->operator_id(), _parent->node_id(), state->get_query_ctx());
     _writer->set_dependency(_async_writer_dependency.get(), _finish_dependency.get());
 
-    _wait_for_dependency_timer =
-            ADD_TIMER(_profile, "WaitForDependency[" + _async_writer_dependency->name() + "]Time");
+    _wait_for_dependency_timer = ADD_TIMER_WITH_LEVEL(
+            _profile, "WaitForDependency[" + _async_writer_dependency->name() + "]Time", 1);
     _finish_dependency->block();
     return Status::OK();
 }


### PR DESCRIPTION
## Proposed changes

```
                          HASH_JOIN_OPERATOR  (id=2194):
                                -  PlanInfo
                                      -  join  op:  INNER  JOIN(PARTITIONED)[]
                                      -  equal  join  conjunct:  c_customer_sk  =  ctr_customer_sk
                                      -  runtime  filters:  RF002[bloom]  <-  ctr_customer_sk(143414/131072/1048576)
                                      -  cardinality=144,624
                                      -  vec  output  tuple  id:  22
                                      -  vIntermediate  tuple  ids:  21  
                                      -  hash  output  slot  ids:  132  
                                -  BlocksProduced:  sum  1.89K  (1890),  avg  236,  max  239,  min  235
                                -  CloseTime:  avg  13.499us,  max  17.966us,  min  10.834us
                                -  ExecTime:  avg  110.215ms,  max  126.396ms,  min  99.841ms
                                -  OpenTime:  avg  126.161us,  max  206.154us,  min  50.523us
                                -  ProbeRows:  sum  4.0M  (4000000),  avg  500.0K  (500000),  max  500.0K  (500000),  min  500.0K  (500000)
                                -  ProjectionTime:  avg  4.722ms,  max  5.329ms,  min  4.209ms
                                -  RowsProduced:  sum  4.732096M  (4732096),  avg  591.512K  (591512),  max  598.464K  (598464),  min  585.216K  (585216)
                                -  WaitForDependency[HashJoinProbeDependency]Time:  avg  1s370ms,  max  1s373ms,  min  1s368ms
                              EXCHANGE_OPERATOR  (id=2146):
                                    -  PlanInfo
                                          -  offset:  0
                                    -  BlocksProduced:  sum  969,  avg  121,  max  123,  min  120
                                    -  CloseTime:  avg  9.399us,  max  14.61us,  min  6.874us
                                    -  ExecTime:  avg  881.577us,  max  1.16ms,  min  801.197us
                                    -  OpenTime:  avg  58.196us,  max  61.881us,  min  54.785us
                                    -  ProjectionTime:  avg  0ns,  max  0ns,  min  0ns
                                    -  RowsProduced:  sum  4.0M  (4000000),  avg  500.0K  (500000),  max  500.0K  (500000),  min  500.0K  (500000)
                                    -  WaitForDependency[AndDependency]Time:  avg  0ns,  max  0ns,  min  0ns
                                        -  WaitForData0:  avg  935.118ms,  max  935.567ms,  min  934.531ms
```
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

