### PR TITLE
[Fix](format) compatible run_clang_format format string with python2/3.6/higher

### DIFF
--- a/build-support/run_clang_format.py
+++ b/build-support/run_clang_format.py
@@ -40,7 +40,7 @@ except ImportError:
         elif val in ('n', 'no', 'f', 'false', 'off', '0'):
             return 0
         else:
-            raise ValueError(f"Invalid truth value '{val}'")
+            raise ValueError("Invalid truth value '{}'".format(val))
 
 
 from functools import partial


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

