### PR TITLE
[fix](session variables) Make default value of max_execution_time same to query_timeout

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/AcceptListener.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/AcceptListener.java
@@ -56,7 +56,9 @@ public class AcceptListener implements ChannelListener<AcceptingChannel<StreamCo
             // connection has been established, so need to call context.cleanup()
             // if exception happens.
             ConnectContext context = new ConnectContext(connection);
-            LOG.info("Connection query timeout: {}", context.getSessionVariable().getQueryTimeoutS());
+            if (context.getSessionVariable().getQueryTimeoutS() <= 0) {
+                LOG.warn("Connection query timeout is invalid: {}", context.getSessionVariable().getQueryTimeoutS());
+            }
             context.setEnv(Env.getCurrentEnv());
             connectScheduler.submit(context);
 
@@ -79,10 +81,12 @@ public class AcceptListener implements ChannelListener<AcceptingChannel<StreamCo
                         throw new AfterConnectedException("Reach limit of connections");
                     }
                     context.setStartTime();
-                    context.setUserQueryTimeout(
-                            context.getEnv().getAuth().getQueryTimeout(context.getQualifiedUser()));
-                    LOG.info("Connection set query timeout {}",
+                    int userQueryTimeout = context.getEnv().getAuth().getQueryTimeout(context.getQualifiedUser());
+                    if (userQueryTimeout <= 0) {
+                        LOG.warn("Connection set query timeout to {}",
                                     context.getSessionVariable().getQueryTimeoutS());
+                    }
+                    context.setUserQueryTimeout(userQueryTimeout);
                     context.setUserInsertTimeout(
                             context.getEnv().getAuth().getInsertTimeout(context.getQualifiedUser()));
                     ConnectProcessor processor = new MysqlConnectProcessor(context);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -470,7 +470,12 @@ public class VariableMgr {
                     LOG.error("failed to get global variable {} when replaying", (String) varName);
                     continue;
                 }
-                setValue(varContext.getObj(), varContext.getField(), root.get((String) varName).toString());
+                try {
+                    setValue(varContext.getObj(), varContext.getField(), root.get((String) varName).toString());
+                } catch (Exception exception) {
+                    LOG.warn("Exception during replay global variabl {} oplog, {}, THIS EXCEPTION WILL BE IGNORED.",
+                            (String) varName, exception.getMessage());
+                }
             }
         } finally {
             wlock.unlock();

--- a/regression-test/suites/correctness/test_set_session_var_exception.groovy
+++ b/regression-test/suites/correctness/test_set_session_var_exception.groovy
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_set_session_var_exception") {
+    test {
+        sql """
+        set query_timeout=0;
+        """
+        exception "query_timeout can not be set to 0, it must be greater than 0"
+    }
+    test {
+        sql """
+        set max_execution_time=999;
+        """
+        exception "max_execution_time can not be set to 999"
+    }
+
+    sql """
+    set max_execution_time=1000;
+    """
+
+    sql """
+    UNSET VARIABLE max_execution_time;
+    """
+}
+
+
+
+


### PR DESCRIPTION
Current problem, `UNSET global VARIABLE ALL` will write an oplog, which makes query_timeout = 0 when we replay it in a future time-stamp. So we change default value of max_execution_time to 90000 which is consistent to query_timeout default value.