### PR TITLE
[fix](proxy) Fix getProxy frequently parse hostname to ip

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -585,6 +585,8 @@ DEFINE_mInt32(memtable_flush_running_count_limit, "2");
 
 DEFINE_Int32(load_process_max_memory_limit_percent, "50"); // 50%
 
+DEFINE_mInt32(thrift_client_open_num_tries, "3");
+
 // If the memory consumption of load jobs exceed load_process_max_memory_limit,
 // all load jobs will hang there to wait for memtable flush. We should have a
 // soft limit which can trigger the memtable flush for the load channel who

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -585,7 +585,7 @@ DEFINE_mInt32(memtable_flush_running_count_limit, "2");
 
 DEFINE_Int32(load_process_max_memory_limit_percent, "50"); // 50%
 
-DEFINE_mInt32(thrift_client_open_num_tries, "3");
+DEFINE_mInt32(thrift_client_open_num_tries, "1");
 
 // If the memory consumption of load jobs exceed load_process_max_memory_limit,
 // all load jobs will hang there to wait for memtable flush. We should have a

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -635,6 +635,10 @@ DECLARE_mInt32(memtable_flush_running_count_limit);
 
 DECLARE_Int32(load_process_max_memory_limit_percent); // 50%
 
+// Number of open tries, default 1 means only try to open once.
+// Retry the Open num_retries time waiting 100 milliseconds between retries.
+DECLARE_mInt32(thrift_client_open_num_tries);
+
 // If the memory consumption of load jobs exceed load_process_max_memory_limit,
 // all load jobs will hang there to wait for memtable flush. We should have a
 // soft limit which can trigger the memtable flush for the load channel who

--- a/be/src/runtime/client_cache.cpp
+++ b/be/src/runtime/client_cache.cpp
@@ -114,7 +114,7 @@ Status ClientCacheHelper::_create_client(const TNetworkAddress& hostport,
 
     client_impl->set_conn_timeout(config::thrift_connect_timeout_seconds * 1000);
 
-    Status status = client_impl->open();
+    Status status = client_impl->open_with_retry(config::thrift_client_open_num_tries, 100);
 
     if (!status.ok()) {
         *client_key = nullptr;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/NetUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/NetUtils.java
@@ -95,9 +95,19 @@ public class NetUtils {
         return hostName;
     }
 
-    public static String getIpByHost(String host) throws UnknownHostException {
-        InetAddress inetAddress = InetAddress.getByName(host);
-        return inetAddress.getHostAddress();
+    public static String getIpByHost(String host, int retryTimes) throws UnknownHostException {
+        InetAddress inetAddress;
+        while (true) {
+            try {
+                inetAddress = InetAddress.getByName(host);
+                return inetAddress.getHostAddress();
+            } catch (UnknownHostException e) {
+                LOG.warn("NetUtils.getIpByHost failed, hostanme: {}, remaining retryTimes: {}", host, retryTimes);
+                if (retryTimes-- <= 0) {
+                    throw e;
+                }
+            }
+        }
     }
 
     // This is the implementation is inspired by Apache camel project:

--- a/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
@@ -64,6 +64,8 @@ public class Backend implements Writable {
     private long id;
     @SerializedName("host")
     private volatile String host;
+    @SerializedName("ip")
+    private volatile String ip;
     private String version;
 
     @SerializedName("heartbeatPort")
@@ -145,6 +147,7 @@ public class Backend implements Writable {
 
     public Backend() {
         this.host = "";
+        this.ip = "";
         this.version = "";
         this.lastUpdateMs = 0;
         this.lastStartTime = 0;
@@ -162,6 +165,7 @@ public class Backend implements Writable {
     public Backend(long id, String host, int heartbeatPort) {
         this.id = id;
         this.host = host;
+        this.ip = "";
         this.version = "";
         this.heartbeatPort = heartbeatPort;
         this.bePort = -1;
@@ -219,6 +223,10 @@ public class Backend implements Writable {
 
     public String getHost() {
         return host;
+    }
+
+    public String getIP() {
+        return ip;
     }
 
     public String getVersion() {
@@ -324,6 +332,10 @@ public class Backend implements Writable {
 
     public void setHost(String host) {
         this.host = host;
+    }
+
+    public void setIP(String ip) {
+        this.ip = ip;
     }
 
     public void setAlive(boolean isAlive) {
@@ -715,9 +727,9 @@ public class Backend implements Writable {
 
     @Override
     public String toString() {
-        return "Backend [id=" + id + ", host=" + host + ", heartbeatPort=" + heartbeatPort + ", alive=" + isAlive.get()
-                + ", lastStartTime=" + TimeUtils.longToTimeString(lastStartTime) + ", process epoch=" + lastStartTime
-                + ", tags: " + tagMap + "]";
+        return "Backend [id=" + id + ", host=" + host + ", ip=" + ip + ", heartbeatPort=" + heartbeatPort + ", alive="
+                + isAlive.get() + ", lastStartTime=" + TimeUtils.longToTimeString(lastStartTime) + ", process epoch="
+                + lastStartTime + ", tags: " + tagMap + "]";
     }
 
     public String getHealthyStatus() {


### PR DESCRIPTION
## Proposed changes

Each RPC between Doris FE and BE will call getProxy. Each getProxy will parse hostname and check whether the IP has changed.

When the hostname resolution server is unstable, frequent parse hostname will often fail and cause performance problems.

Therefore, only check whether the backend IP changes during heartbeat, and if so, recreate the rpc client.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

