### PR TITLE
[fix](iterator) Fix mem leak when initial iterator failed

### DIFF
--- a/be/src/vec/olap/vertical_merge_iterator.h
+++ b/be/src/vec/olap/vertical_merge_iterator.h
@@ -121,7 +121,7 @@ public:
 
     size_t same_source_count(uint16_t source, size_t limit);
 
-    // return continous agg_flag=true count from index
+    // return continuous agg_flag=true count from index
     size_t continuous_agg_count(uint64_t index);
 
 private:
@@ -155,7 +155,7 @@ public:
               _order(order),
               _seq_col_idx(seq_col_idx),
               _num_key_columns(_iter->schema().num_key_columns()),
-              _key_group_cluster_key_idxes(key_group_cluster_key_idxes) {}
+              _key_group_cluster_key_idxes(std::move(key_group_cluster_key_idxes)) {}
 
     VerticalMergeIteratorContext(const VerticalMergeIteratorContext&) = delete;
     VerticalMergeIteratorContext(VerticalMergeIteratorContext&&) = delete;
@@ -209,7 +209,7 @@ private:
     size_t _ori_return_cols = 0;
 
     // segment order, used to compare key
-    uint32_t _order = 0;
+    const uint32_t _order = 0;
 
     int32_t _seq_col_idx = -1;
 
@@ -243,21 +243,17 @@ public:
                               RowSourcesBuffer* row_sources_buf,
                               std::vector<uint32_t> key_group_cluster_key_idxes)
             : _origin_iters(std::move(iters)),
-              _iterator_init_flags(iterator_init_flags),
-              _rowset_ids(rowset_ids),
+              _iterator_init_flags(std::move(iterator_init_flags)),
+              _rowset_ids(std::move(rowset_ids)),
               _ori_return_cols(ori_return_cols),
               _keys_type(keys_type),
               _seq_col_idx(seq_col_idx),
               _row_sources_buf(row_sources_buf),
-              _key_group_cluster_key_idxes(key_group_cluster_key_idxes) {}
+              _key_group_cluster_key_idxes(std::move(key_group_cluster_key_idxes)) {}
 
-    ~VerticalHeapMergeIterator() override {
-        while (!_merge_heap.empty()) {
-            auto ctx = _merge_heap.top();
-            _merge_heap.pop();
-            delete ctx;
-        }
-    }
+    ~VerticalHeapMergeIterator() override = default;
+    VerticalHeapMergeIterator(const VerticalHeapMergeIterator&) = delete;
+    VerticalHeapMergeIterator& operator=(const VerticalHeapMergeIterator&) = delete;
 
     Status init(const StorageReadOptions& opts) override;
     Status next_batch(Block* block) override;
@@ -292,7 +288,7 @@ private:
                                            VerticalMergeContextComparator>;
 
     VMergeHeap _merge_heap;
-    std::vector<VerticalMergeIteratorContext*> _ori_iter_ctx;
+    std::vector<std::unique_ptr<VerticalMergeIteratorContext>> _ori_iter_ctx;
     int _block_row_max = 0;
     KeysType _keys_type;
     int32_t _seq_col_idx = -1;
@@ -314,14 +310,16 @@ public:
                               KeysType keys_type, int32_t seq_col_idx,
                               RowSourcesBuffer* row_sources_buf)
             : _origin_iters(std::move(iters)),
-              _iterator_init_flags(iterator_init_flags),
-              _rowset_ids(rowset_ids),
+              _iterator_init_flags(std::move(iterator_init_flags)),
+              _rowset_ids(std::move(rowset_ids)),
               _ori_return_cols(ori_return_cols),
               _keys_type(keys_type),
               _seq_col_idx(seq_col_idx),
               _row_sources_buf(row_sources_buf) {}
 
     ~VerticalFifoMergeIterator() override = default;
+    VerticalFifoMergeIterator(const VerticalFifoMergeIterator&) = delete;
+    VerticalFifoMergeIterator& operator=(const VerticalFifoMergeIterator&) = delete;
 
     Status init(const StorageReadOptions& opts) override;
     Status next_batch(Block* block) override;
@@ -365,11 +363,9 @@ public:
               _ori_return_cols(ori_return_cols),
               _row_sources_buf(row_sources_buf) {}
 
-    ~VerticalMaskMergeIterator() override {
-        for (auto iter : _origin_iter_ctx) {
-            delete iter;
-        }
-    }
+    ~VerticalMaskMergeIterator() override = default;
+    VerticalMaskMergeIterator(const VerticalMaskMergeIterator&) = delete;
+    VerticalMaskMergeIterator& operator=(const VerticalMaskMergeIterator&) = delete;
 
     Status init(const StorageReadOptions& opts) override;
 
@@ -392,7 +388,7 @@ private:
     std::vector<RowwiseIteratorUPtr> _origin_iters;
     size_t _ori_return_cols = 0;
 
-    std::vector<VerticalMergeIteratorContext*> _origin_iter_ctx;
+    std::vector<std::unique_ptr<VerticalMergeIteratorContext>> _origin_iter_ctx;
 
     const Schema* _schema = nullptr;
 


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Memory leaks are prone to occur when using raw pointers, such as directly using the `RETURN_IF_ERROR` macro to skip error handling. This PR replaces the raw pointers managed in `VerticalMergeIterator` with smart pointers; it also fixes some unnecessary copy construction.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

