### PR TITLE
[refine](pipelineX)Make the 'set ready' logic of SenderQueue in pipelineX the same as that in the pipeline.

### DIFF
--- a/be/src/vec/runtime/vdata_stream_recvr.cpp
+++ b/be/src/vec/runtime/vdata_stream_recvr.cpp
@@ -100,7 +100,8 @@ Status VDataStreamRecvr::SenderQueue::_inner_get_batch_without_lock(Block* block
     auto [next_block, block_byte_size] = std::move(_block_queue.front());
     _recvr->update_blocks_memory_usage(-block_byte_size);
     _block_queue.pop_front();
-    if (_block_queue.size() == 0 && _dependency) {
+    _record_debug_info();
+    if (_block_queue.empty() && _dependency) {
         if (!_is_cancelled && _num_remaining_senders > 0) {
             _dependency->block();
         }
@@ -120,6 +121,16 @@ Status VDataStreamRecvr::SenderQueue::_inner_get_batch_without_lock(Block* block
     block->swap(*next_block);
     *eos = false;
     return Status::OK();
+}
+
+void VDataStreamRecvr::SenderQueue::try_set_dep_ready_without_lock() {
+    if (!_dependency) {
+        return;
+    }
+    const bool should_wait = !_is_cancelled && _block_queue.empty() && _num_remaining_senders > 0;
+    if (!should_wait) {
+        _dependency->set_ready();
+    }
 }
 
 Status VDataStreamRecvr::SenderQueue::add_block(const PBlock& pblock, int be_number,
@@ -178,9 +189,8 @@ Status VDataStreamRecvr::SenderQueue::add_block(const PBlock& pblock, int be_num
 
     if (!empty) {
         _block_queue.emplace_back(std::move(block), block_byte_size);
-        if (_dependency) {
-            _dependency->set_ready();
-        }
+        _record_debug_info();
+        try_set_dep_ready_without_lock();
     }
     // if done is nullptr, this function can't delay this response
     if (done != nullptr && _recvr->exceeds_limit(block_byte_size)) {
@@ -234,9 +244,8 @@ void VDataStreamRecvr::SenderQueue::add_block(Block* block, bool use_move) {
 
     if (!empty) {
         _block_queue.emplace_back(std::move(nblock), block_mem_size);
-        if (_dependency) {
-            _dependency->set_ready();
-        }
+        _record_debug_info();
+        try_set_dep_ready_without_lock();
         _data_arrival_cv.notify_one();
     }
 
@@ -269,13 +278,12 @@ void VDataStreamRecvr::SenderQueue::decrement_senders(int be_number) {
     _sender_eos_set.insert(be_number);
     DCHECK_GT(_num_remaining_senders, 0);
     _num_remaining_senders--;
+    _record_debug_info();
     VLOG_FILE << "decremented senders: fragment_instance_id="
               << print_id(_recvr->fragment_instance_id()) << " node_id=" << _recvr->dest_node_id()
               << " #senders=" << _num_remaining_senders;
     if (_num_remaining_senders == 0) {
-        if (_dependency) {
-            _dependency->set_ready();
-        }
+        try_set_dep_ready_without_lock();
         _data_arrival_cv.notify_one();
     }
 }
@@ -288,9 +296,7 @@ void VDataStreamRecvr::SenderQueue::cancel(Status cancel_status) {
         }
         _is_cancelled = true;
         _cancel_status = cancel_status;
-        if (_dependency) {
-            _dependency->set_ready();
-        }
+        try_set_dep_ready_without_lock();
         VLOG_QUERY << "cancelled stream: _fragment_instance_id="
                    << print_id(_recvr->fragment_instance_id())
                    << " node_id=" << _recvr->dest_node_id();
@@ -318,9 +324,7 @@ void VDataStreamRecvr::SenderQueue::close() {
         // is clear will be memory leak
         std::lock_guard<std::mutex> l(_lock);
         _is_cancelled = true;
-        if (_dependency) {
-            _dependency->set_ready();
-        }
+        try_set_dep_ready_without_lock();
 
         for (auto closure_pair : _pending_closures) {
             closure_pair.first->Run();
@@ -561,9 +565,8 @@ void VDataStreamRecvr::PipSenderQueue::add_block(Block* block, bool use_move) {
             return;
         }
         _block_queue.emplace_back(std::move(nblock), block_mem_size);
-        if (_dependency) {
-            _dependency->set_ready();
-        }
+        _record_debug_info();
+        try_set_dep_ready_without_lock();
         COUNTER_UPDATE(_recvr->_local_bytes_received_counter, block_mem_size);
         _recvr->update_blocks_memory_usage(block_mem_size);
         _data_arrival_cv.notify_one();


### PR DESCRIPTION
## Proposed changes

core in pipelineX
```
vdata_stream_recvr.h:272] Check failed: _is_cancelled || !_block_queue.empty() || _num_remaining_senders == 0  _is_cancelled: 0, _block_queue_empty: 1, _num_remaining_senders: 2
```

```C++
bool VDataStreamRecvr::ready_to_read() {
    for (const auto& queue : _sender_queues) {
        if (queue->should_wait()) {
            return false;
        }
    }
    return true;
}
bool VDataStreamRecvr::SenderQueue::should_wait() {
    std::unique_lock<std::mutex> l(_lock);
    return !_is_cancelled && _block_queue.empty() && _num_remaining_senders > 0;
}
```
However, pipelineX is different, so here it is changed to be consistent.

add debug info ,like this

```
( _block_queue size : 1 , _num_remaining_senders : 8 ) 
( _block_queue size : 1 , _num_remaining_senders : 7 ) 
( _block_queue size : 2 , _num_remaining_senders : 7 ) 
( _block_queue size : 1 , _num_remaining_senders : 7 ) 
( _block_queue size : 1 , _num_remaining_senders : 6 ) 
( _block_queue size : 0 , _num_remaining_senders : 6 ) 
( _block_queue size : 1 , _num_remaining_senders : 6 ) 
( _block_queue size : 1 , _num_remaining_senders : 5 ) 
( _block_queue size : 0 , _num_remaining_senders : 5 ) 
( _block_queue size : 1 , _num_remaining_senders : 5 ) 
( _block_queue size : 1 , _num_remaining_senders : 4 ) 
( _block_queue size : 0 , _num_remaining_senders : 4 ) 
( _block_queue size : 1 , _num_remaining_senders : 4 ) 
( _block_queue size : 1 , _num_remaining_senders : 3 ) 
( _block_queue size : 0 , _num_remaining_senders : 3 ) 
( _block_queue size : 1 , _num_remaining_senders : 3 ) 
( _block_queue size : 1 , _num_remaining_senders : 2 ) 
( _block_queue size : 0 , _num_remaining_senders : 2 ) 
( _block_queue size : 1 , _num_remaining_senders : 2 ) 
( _block_queue size : 1 , _num_remaining_senders : 1 ) 
( _block_queue size : 0 , _num_remaining_senders : 1 ) 
( _block_queue size : 1 , _num_remaining_senders : 1 ) 
( _block_queue size : 1 , _num_remaining_senders : 0 ) 
( _block_queue size : 0 , _num_remaining_senders : 0 ) 
```



<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

