### PR TITLE
[improve](group commit) Fix select tablet policy for random partition and remove some log

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
@@ -350,8 +350,13 @@ public class OlapTableSink extends DataSink {
                     }
                     tPartition.setIsMutable(table.getPartitionInfo().getIsMutable(partitionId));
                     if (partition.getDistributionInfo().getType() == DistributionInfoType.RANDOM) {
-                        int tabletIndex = Env.getCurrentEnv().getTabletLoadIndexRecorderMgr()
-                                .getCurrentTabletLoadIndex(dbId, table.getId(), partition);
+                        int tabletIndex;
+                        if (tDataSink != null && tDataSink.type == TDataSinkType.GROUP_COMMIT_BLOCK_SINK) {
+                            tabletIndex = 0;
+                        } else {
+                            tabletIndex = Env.getCurrentEnv().getTabletLoadIndexRecorderMgr()
+                                    .getCurrentTabletLoadIndex(dbId, table.getId(), partition);
+                        }
                         tPartition.setLoadTabletIdx(tabletIndex);
                     }
 
@@ -419,8 +424,13 @@ public class OlapTableSink extends DataSink {
                 }
 
                 if (partition.getDistributionInfo().getType() == DistributionInfoType.RANDOM) {
-                    int tabletIndex = Env.getCurrentEnv().getTabletLoadIndexRecorderMgr()
-                            .getCurrentTabletLoadIndex(dbId, table.getId(), partition);
+                    int tabletIndex;
+                    if (tDataSink != null && tDataSink.type == TDataSinkType.GROUP_COMMIT_BLOCK_SINK) {
+                        tabletIndex = 0;
+                    } else {
+                        tabletIndex = Env.getCurrentEnv().getTabletLoadIndexRecorderMgr()
+                                .getCurrentTabletLoadIndex(dbId, table.getId(), partition);
+                    }
                     tPartition.setLoadTabletIdx(tabletIndex);
                 }
                 partitionParam.addToPartitions(tPartition);


### PR DESCRIPTION
## Proposed changes

This pr contains 2 improvements:
1. For random partition table, select tablet in the original way for load balance;
2. Skip execute stmt audit log since it's expensive in CPU;

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

