### PR TITLE
[fix](txn_manager) Fix wrong use of `std::map::erase` in `TxnManager::delete_txn`

### DIFF
--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -652,8 +652,8 @@ Status TxnManager::delete_txn(OlapMeta* meta, TPartitionId partition_id,
                             << (rowset != nullptr ? rowset->rowset_id().to_string() : "0");
             }
         }
+        it->second.erase(load_itr);
     }
-    it->second.erase(load_itr);
     if (it->second.empty()) {
         txn_tablet_map.erase(it);
         _clear_txn_partition_map_unlocked(transaction_id, partition_id);


### PR DESCRIPTION
## Proposed changes

The iterator passed to `std::map::erase` must be valid and dereferenceable, but `end()` is not dereferenceable.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

