### PR TITLE
[fix](routine_load) change librdkafka version from 2.0.2 to 1.9.2 to avoid memory leak

### DIFF
--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -327,10 +327,10 @@ fi
 echo "Finished patching ${ARROW_SOURCE}"
 
 # patch librdkafka to avoid crash
-if [[ "${LIBRDKAFKA_SOURCE}" == "librdkafka-2.0.2" ]]; then
+if [[ "${LIBRDKAFKA_SOURCE}" == "librdkafka-1.9.2" ]]; then
     cd "${TP_SOURCE_DIR}/${LIBRDKAFKA_SOURCE}"
     if [[ ! -f "${PATCHED_MARK}" ]]; then
-        patch -p0 <"${TP_PATCH_DIR}/librdkafka-2.0.2.patch"
+        patch -p0 <"${TP_PATCH_DIR}/librdkafka-1.9.2.patch"
         touch "${PATCHED_MARK}"
     fi
     cd -

--- a/thirdparty/patches/librdkafka-1.9.2.patch
+++ b/thirdparty/patches/librdkafka-1.9.2.patch
@@ -36,7 +36,7 @@
          return 1
 --- src/rdkafka_broker.c
 +++ src/rdkafka_broker.c
-@@ -4613,7 +4613,9 @@ static int rd_kafka_broker_thread_main(void *arg) {
+@@ -5461,7 +5461,9 @@ static int rd_kafka_broker_thread_main(void *arg) {
   */
  void rd_kafka_broker_destroy_final(rd_kafka_broker_t *rkb) {
  
@@ -47,4 +47,3 @@
          rd_assert(TAILQ_EMPTY(&rkb->rkb_monitors));
          rd_assert(TAILQ_EMPTY(&rkb->rkb_outbufs.rkbq_bufs));
          rd_assert(TAILQ_EMPTY(&rkb->rkb_waitresps.rkbq_bufs));
-

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -215,11 +215,11 @@ CYRUS_SASL_NAME=cyrus-sasl-2.1.27.tar.gz
 CYRUS_SASL_SOURCE=cyrus-sasl-2.1.27
 CYRUS_SASL_MD5SUM="a33820c66e0622222c5aefafa1581083"
 
-# librdkafka-2.0.2
-LIBRDKAFKA_DOWNLOAD="https://github.com/confluentinc/librdkafka/archive/refs/tags/v2.0.2.tar.gz"
-LIBRDKAFKA_NAME=librdkafka-2.0.2.tar.gz
-LIBRDKAFKA_SOURCE=librdkafka-2.0.2
-LIBRDKAFKA_MD5SUM="c0120dc32acc129bfb4656fe17568da1"
+# librdkafka-1.9.2
+LIBRDKAFKA_DOWNLOAD="https://github.com/edenhill/librdkafka/archive/v1.9.2.tar.gz"
+LIBRDKAFKA_NAME=librdkafka-1.9.2.tar.gz
+LIBRDKAFKA_SOURCE=librdkafka-1.9.2
+LIBRDKAFKA_MD5SUM="fe9624e905abbf8324b0f6be520d9c24"
 
 # zstd
 ZSTD_DOWNLOAD="https://github.com/facebook/zstd/releases/download/v1.5.5/zstd-1.5.5.tar.gz"


### PR DESCRIPTION
## Proposed changes

```
=================================================================
03:11:44   ==4386==ERROR: LeakSanitizer: detected memory leaks
03:11:44   
03:11:44   Indirect leak of 1048 byte(s) in 1 object(s) allocated from:
03:11:44       #0 0x56147d7b57d8 in calloc (/root/doris/be/ut_build_ASAN/test/doris_be_test+0x156297d8) (BuildId: f0d4dff9c34d29dd)
03:11:44       #1 0x5614bc89d4b4 in rd_kafka_toppar_new0 (/root/doris/be/ut_build_ASAN/test/doris_be_test+0x547114b4) (BuildId: f0d4dff9c34d29dd)
03:11:44   
03:11:44   Indirect leak of 1000 byte(s) in 1 object(s) allocated from:
03:11:44       #0 0x56147d7b57d8 in calloc (/root/doris/be/ut_build_ASAN/test/doris_be_test+0x156297d8) (BuildId: f0d4dff9c34d29dd)
03:11:44       #1 0x5614bc85e29e in rd_kafka_topic_new0 (/root/doris/be/ut_build_ASAN/test/doris_be_test+0x546d229e) (BuildId: f0d4dff9c34d29dd)
03:11:44   
03:11:44   Indirect leak of 528 byte(s) in 3 object(s) allocated from:
03:11:44       #0 0x56147d7b55ee in malloc (/root/doris/be/ut_build_ASAN/test/doris_be_test+0x156295ee) (BuildId: f0d4dff9c34d29dd)
03:11:44       #1 0x5614bc86e374 in rd_kafka_q_new0 (/root/doris/be/ut_build_ASAN/test/doris_be_test+0x546e2374) (BuildId: f0d4dff9c34d29dd)
03:11:44   
03:11:44   Indirect leak of 128 byte(s) in 1 object(s) allocated from:
03:11:44       #0 0x56147d7b55ee in malloc (/root/doris/be/ut_build_ASAN/test/doris_be_test+0x156295ee) (BuildId: f0d4dff9c34d29dd)
03:11:44       #1 0x5614bc8b93fd in rd_list_init (/root/doris/be/ut_build_ASAN/test/doris_be_test+0x5472d3fd) (BuildId: f0d4dff9c34d29dd)
03:11:44   
03:11:44   Indirect leak of 112 byte(s) in 1 object(s) allocated from:
03:11:44       #0 0x56147d7b57d8 in calloc (/root/doris/be/ut_build_ASAN/test/doris_be_test+0x156297d8) (BuildId: f0d4dff9c34d29dd)
03:11:44       #1 0x5614bc870abd in rd_kafka_op_new0 (/root/doris/be/ut_build_ASAN/test/doris_be_test+0x546e4abd) (BuildId: f0d4dff9c34d29dd)
03:11:44   
03:11:44   Indirect leak of 23 byte(s) in 1 object(s) allocated from:
03:11:44       #0 0x56147d7b55ee in malloc (/root/doris/be/ut_build_ASAN/test/doris_be_test+0x156295ee) (BuildId: f0d4dff9c34d29dd)
03:11:44       #1 0x5614bc85e2dc in rd_kafka_topic_new0 (/root/doris/be/ut_build_ASAN/test/doris_be_test+0x546d22dc) (BuildId: f0d4dff9c34d29dd)
03:11:44   
03:11:44   Indirect leak of 20 byte(s) in 2 object(s) allocated from:
03:11:44       #0 0x56147d79f6ad in strdup (/root/doris/be/ut_build_ASAN/test/doris_be_test+0x156136ad) (BuildId: f0d4dff9c34d29dd)
03:11:44       #1 0x5614bc867935  (/root/doris/be/ut_build_ASAN/test/doris_be_test+0x546db935) (BuildId: f0d4dff9c34d29dd)
03:11:44   
03:11:44   SUMMARY: AddressSanitizer: 2859 byte(s) leaked in 10 allocation(s).
```

Memory leak happened when upgrade librdkafka version from 1.8.2 to 2.0.2(https://github.com/apache/doris/pull/28210), refer to https://github.com/confluentinc/librdkafka/issues/4486, bug still exist in lastest version, so we change version to 1.9.2.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

