### PR TITLE
[feature-wip](nereids) Support some spark-sql built-in functions when set dialect=spark_sql

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/PlaceholderExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/PlaceholderExpression.java
@@ -35,7 +35,8 @@ import java.util.Objects;
 public class PlaceholderExpression extends Expression implements AlwaysNotNullable {
     private final Class<? extends Expression> delegateClazz;
     /**
-     * 1 based
+     * start from 1,
+     * a placeholderExpression will be replaced later by the position of sourceFnTransformedArguments
      */
     private final int position;
 
@@ -51,6 +52,7 @@ public class PlaceholderExpression extends Expression implements AlwaysNotNullab
 
     @Override
     public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
+        visitor.visitPlaceholderExpression(this, context);
         return visitor.visit(this, context);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/PlaceholderExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/PlaceholderExpression.java
@@ -23,9 +23,11 @@ import org.apache.doris.nereids.trees.expressions.functions.AlwaysNotNullable;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Expression placeHolder, the expression in PlaceHolderExpression will be collected by
@@ -33,7 +35,8 @@ import java.util.Objects;
  * @see PlaceholderCollector
  */
 public class PlaceholderExpression extends Expression implements AlwaysNotNullable {
-    private final Class<? extends Expression> delegateClazz;
+
+    private final ImmutableSet<Class<? extends Expression>> delegateClazzSet;
     /**
      * start from 1, set the index of this placeholderExpression in sourceFnTransformedArguments
      * this placeholderExpression will be replaced later
@@ -42,12 +45,24 @@ public class PlaceholderExpression extends Expression implements AlwaysNotNullab
 
     public PlaceholderExpression(List<Expression> children, Class<? extends Expression> delegateClazz, int position) {
         super(children);
-        this.delegateClazz = Objects.requireNonNull(delegateClazz, "delegateClazz should not be null");
+        this.delegateClazzSet = ImmutableSet.of(
+                Objects.requireNonNull(delegateClazz, "delegateClazz should not be null"));
+        this.position = position;
+    }
+
+    public PlaceholderExpression(List<Expression> children,
+                                 Set<Class<? extends Expression>> delegateClazzSet, int position) {
+        super(children);
+        this.delegateClazzSet = ImmutableSet.copyOf(delegateClazzSet);
         this.position = position;
     }
 
     public static PlaceholderExpression of(Class<? extends Expression> delegateClazz, int position) {
         return new PlaceholderExpression(ImmutableList.of(), delegateClazz, position);
+    }
+
+    public static PlaceholderExpression of(Set<Class<? extends Expression>> delegateClazzSet, int position) {
+        return new PlaceholderExpression(ImmutableList.of(), delegateClazzSet, position);
     }
 
     @Override
@@ -56,8 +71,8 @@ public class PlaceholderExpression extends Expression implements AlwaysNotNullab
         return visitor.visit(this, context);
     }
 
-    public Class<? extends Expression> getDelegateClazz() {
-        return delegateClazz;
+    public Set<Class<? extends Expression>> getDelegateClazzSet() {
+        return delegateClazzSet;
     }
 
     public int getPosition() {
@@ -76,11 +91,11 @@ public class PlaceholderExpression extends Expression implements AlwaysNotNullab
             return false;
         }
         PlaceholderExpression that = (PlaceholderExpression) o;
-        return position == that.position && Objects.equals(delegateClazz, that.delegateClazz);
+        return position == that.position && Objects.equals(delegateClazzSet, that.delegateClazzSet);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), delegateClazz, position);
+        return Objects.hash(super.hashCode(), delegateClazzSet, position);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/PlaceholderExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/PlaceholderExpression.java
@@ -35,8 +35,8 @@ import java.util.Objects;
 public class PlaceholderExpression extends Expression implements AlwaysNotNullable {
     private final Class<? extends Expression> delegateClazz;
     /**
-     * start from 1,
-     * a placeholderExpression will be replaced later by the position of sourceFnTransformedArguments
+     * start from 1, set the index of this placeholderExpression in sourceFnTransformedArguments
+     * this placeholderExpression will be replaced later
      */
     private final int position;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/AbstractFnCallTransformers.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/AbstractFnCallTransformers.java
@@ -77,17 +77,15 @@ public abstract class AbstractFnCallTransformers {
 
     protected void doRegister(
             String sourceFnNme,
-            int sourceFnArgumentsNum,
             String targetFnName,
-            List<? extends Expression> targetFnArguments,
-            boolean variableArgument) {
+            List<? extends Expression> targetFnArguments) {
 
         List<Expression> castedTargetFnArguments = targetFnArguments
                 .stream()
                 .map(each -> (Expression) each)
                 .collect(Collectors.toList());
         transformerBuilder.put(sourceFnNme, new CommonFnCallTransformer(new UnboundFunction(
-                targetFnName, castedTargetFnArguments), variableArgument, sourceFnArgumentsNum));
+                targetFnName, castedTargetFnArguments)));
     }
 
     protected void doRegister(

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/CommonFnCallTransformer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/CommonFnCallTransformer.java
@@ -59,7 +59,8 @@ public class CommonFnCallTransformer extends AbstractFnCallTransformer {
         }
         for (PlaceholderExpression targetArgument : targetArguments) {
             int position = targetArgument.getPosition();
-            if (!targetArgument.getDelegateClazz().isAssignableFrom(sourceFnTransformedArgClazz.get(position - 1))) {
+            Class<? extends Expression> sourceArgClazz = sourceFnTransformedArgClazz.get(position - 1);
+            if (!targetArgument.getDelegateClazz().isAssignableFrom(sourceArgClazz)) {
                 return false;
             }
         }
@@ -72,7 +73,7 @@ public class CommonFnCallTransformer extends AbstractFnCallTransformer {
             ParserContext context) {
         List<Expression> sourceFnTransformedArgumentsInorder = Lists.newArrayList();
         for (PlaceholderExpression placeholderExpression : targetArguments) {
-            Expression expression = sourceFnTransformedArguments.get(placeholderExpression.getPosition() -1);
+            Expression expression = sourceFnTransformedArguments.get(placeholderExpression.getPosition() - 1);
             sourceFnTransformedArgumentsInorder.add(expression);
         }
         return targetFunction.withChildren(sourceFnTransformedArgumentsInorder);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/CommonFnCallTransformer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/CommonFnCallTransformer.java
@@ -69,7 +69,8 @@ public class CommonFnCallTransformer extends AbstractFnCallTransformer {
         // if variableArguments=true, we can not recognize if the type of all arguments is valid or not,
         // because:
         //     1. the argument size is not sure
-        //     2. there are some functions which can accept different types of arguments, for example: struct(1, 'a', 'abc')
+        //     2. there are some functions which can accept different types of arguments,
+        //        for example: struct(1, 'a', 'abc')
         // so just return true here.
         if (variableArguments) {
             return true;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/ComplexFnCallTransformer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/ComplexFnCallTransformer.java
@@ -15,14 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.nereids.parser.trino;
-
-import org.apache.doris.nereids.parser.AbstractFnCallTransformer;
+package org.apache.doris.nereids.parser;
 
 /**
  * Trino complex function transformer
  */
-public abstract class ComplexTrinoFnCallTransformer extends AbstractFnCallTransformer {
+public abstract class ComplexFnCallTransformer extends AbstractFnCallTransformer {
 
     protected abstract String getSourceFnName();
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/spark/DateTruncFnCallTransformer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/spark/DateTruncFnCallTransformer.java
@@ -66,12 +66,12 @@ public class DateTruncFnCallTransformer extends ComplexFnCallTransformer {
         if (YEAR.contains(fmtLiteral.getValue().toUpperCase())) {
             return new UnboundFunction(
                     "date_trunc",
-                    ImmutableList.of(sourceFnTransformedArguments.get(0), VarcharLiteral.of("YEAR")));
+                    ImmutableList.of(sourceFnTransformedArguments.get(0), new VarcharLiteral("YEAR")));
         }
         if (MONTH.contains(fmtLiteral.getValue().toUpperCase())) {
             return new UnboundFunction(
                     "date_trunc",
-                    ImmutableList.of(sourceFnTransformedArguments.get(0), VarcharLiteral.of("MONTH")));
+                    ImmutableList.of(sourceFnTransformedArguments.get(0), new VarcharLiteral("MONTH")));
         }
 
         return new UnboundFunction(

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/spark/DateTruncFnCallTransformer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/spark/DateTruncFnCallTransformer.java
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.nereids.parser.trino;
+package org.apache.doris.nereids.parser.spark;
 
 import org.apache.doris.nereids.analyzer.UnboundFunction;
 import org.apache.doris.nereids.parser.ComplexFnCallTransformer;
@@ -25,40 +25,57 @@ import org.apache.doris.nereids.trees.expressions.functions.Function;
 import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
 
 /**
- * DateDiff complex function transformer
+ * DateTrunc complex function transformer
  */
-public class DateDiffFnCallTransformer extends ComplexFnCallTransformer {
+public class DateTruncFnCallTransformer extends ComplexFnCallTransformer {
 
-    private static final String SECOND = "second";
-    private static final String HOUR = "hour";
-    private static final String DAY = "day";
-    private static final String MILLI_SECOND = "millisecond";
+    // reference: https://spark.apache.org/docs/latest/api/sql/index.html#trunc
+    // spark-sql support YEAR/YYYY/YY for year, support MONTH/MON/MM for month
+    private static final ImmutableSet<String> YEAR = ImmutableSet.<String>builder()
+            .add("YEAR")
+            .add("YYYY")
+            .add("YY")
+            .build();
+
+    private static final ImmutableSet<String> MONTH = ImmutableSet.<String>builder()
+            .add("MONTH")
+            .add("MON")
+            .add("MM")
+            .build();
 
     @Override
     public String getSourceFnName() {
-        return "date_diff";
+        return "trunc";
     }
 
     @Override
     protected boolean check(String sourceFnName, List<Expression> sourceFnTransformedArguments,
             ParserContext context) {
-        return getSourceFnName().equalsIgnoreCase(sourceFnName) && (sourceFnTransformedArguments.size() == 3);
+        return getSourceFnName().equalsIgnoreCase(sourceFnName) && (sourceFnTransformedArguments.size() == 2);
     }
 
     @Override
     protected Function transform(String sourceFnName, List<Expression> sourceFnTransformedArguments,
             ParserContext context) {
-        VarcharLiteral diffGranularity = (VarcharLiteral) sourceFnTransformedArguments.get(0);
-        if (SECOND.equals(diffGranularity.getValue())) {
+        VarcharLiteral fmtLiteral = (VarcharLiteral) sourceFnTransformedArguments.get(1);
+        if (YEAR.contains(fmtLiteral.getValue().toUpperCase())) {
             return new UnboundFunction(
-                    "seconds_diff",
-                    ImmutableList.of(sourceFnTransformedArguments.get(1), sourceFnTransformedArguments.get(2)));
+                    "date_trunc",
+                    ImmutableList.of(sourceFnTransformedArguments.get(0), VarcharLiteral.of("YEAR")));
         }
-        // TODO: support other date diff granularity
-        return null;
+        if (MONTH.contains(fmtLiteral.getValue().toUpperCase())) {
+            return new UnboundFunction(
+                    "date_trunc",
+                    ImmutableList.of(sourceFnTransformedArguments.get(0), VarcharLiteral.of("MONTH")));
+        }
+
+        return new UnboundFunction(
+                "date_trunc",
+                ImmutableList.of(sourceFnTransformedArguments.get(0), sourceFnTransformedArguments.get(1)));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/spark/SparkSql3FnCallTransformers.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/spark/SparkSql3FnCallTransformers.java
@@ -18,15 +18,13 @@
 package org.apache.doris.nereids.parser.spark;
 
 import org.apache.doris.nereids.analyzer.PlaceholderExpression;
-import org.apache.doris.nereids.parser.AbstractFnCallTransformer;
 import org.apache.doris.nereids.parser.AbstractFnCallTransformers;
 import org.apache.doris.nereids.trees.expressions.Expression;
 
 import com.google.common.collect.Lists;
 
 /**
- * The builder and factory for spark-sql 3.x {@link AbstractFnCallTransformer},
- * and supply transform facade ability.
+ * The builder and factory for spark-sql 3.x FnCallTransformers, supply transform facade ability.
  */
 public class SparkSql3FnCallTransformers extends AbstractFnCallTransformers {
 
@@ -35,30 +33,54 @@ public class SparkSql3FnCallTransformers extends AbstractFnCallTransformers {
 
     @Override
     protected void registerTransformers() {
-        doRegister("get_json_object", 2, "json_extract",
-                Lists.newArrayList(
-                        PlaceholderExpression.of(Expression.class, 1),
-                        PlaceholderExpression.of(Expression.class, 2)), true);
-
-        doRegister("get_json_object", 2, "json_extract",
-                Lists.newArrayList(
-                        PlaceholderExpression.of(Expression.class, 1),
-                        PlaceholderExpression.of(Expression.class, 2)), false);
-
-        doRegister("split", 2, "split_by_string",
-                Lists.newArrayList(
-                        PlaceholderExpression.of(Expression.class, 1),
-                        PlaceholderExpression.of(Expression.class, 2)), true);
-        doRegister("split", 2, "split_by_string",
-                Lists.newArrayList(
-                        PlaceholderExpression.of(Expression.class, 1),
-                        PlaceholderExpression.of(Expression.class, 2)), false);
+        // register json functions
+        registerJsonFunctionTransformers();
+        // register string functions
+        registerStringFunctionTransformers();
+        // register date functions
+        registerDateFunctionTransformers();
+        // register numeric functions
+        registerNumericFunctionTransformers();
         // TODO: add other function transformer
     }
 
     @Override
     protected void registerComplexTransformers() {
+        DateTruncFnCallTransformer dateTruncFnCallTransformer = new DateTruncFnCallTransformer();
+        doRegister(dateTruncFnCallTransformer.getSourceFnName(), dateTruncFnCallTransformer);
         // TODO: add other complex function transformer
+    }
+
+    private void registerJsonFunctionTransformers() {
+        doRegister("get_json_object", "json_extract",
+                Lists.newArrayList(
+                        PlaceholderExpression.of(Expression.class, 1),
+                        PlaceholderExpression.of(Expression.class, 2)));
+    }
+
+    private void registerStringFunctionTransformers() {
+        doRegister("split", "split_by_string",
+                Lists.newArrayList(
+                        PlaceholderExpression.of(Expression.class, 1),
+                        PlaceholderExpression.of(Expression.class, 2)));
+    }
+
+    private void registerDateFunctionTransformers() {
+        // spark-sql support to_date(date_str, fmt) function but doris only support to_date(date_str)
+        // here try to compat with this situation by using str_to_date(str, fmt),
+        // this function support the following three formats which can handle the mainly situations:
+        //  1. yyyyMMdd
+        //  2. yyyy-MM-dd
+        //  3. yyyy-MM-dd HH:mm:ss
+        doRegister("to_date", "str_to_date",
+                Lists.newArrayList(
+                        PlaceholderExpression.of(Expression.class, 1),
+                        PlaceholderExpression.of(Expression.class, 2)));;
+    }
+
+    private void registerNumericFunctionTransformers() {
+        doRegister("mean", "avg",
+                Lists.newArrayList(PlaceholderExpression.of(Expression.class, 1)));
     }
 
     static class SingletonHolder {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/spark/SparkSql3FnCallTransformers.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/spark/SparkSql3FnCallTransformers.java
@@ -75,7 +75,7 @@ public class SparkSql3FnCallTransformers extends AbstractFnCallTransformers {
         doRegister("to_date", "str_to_date",
                 Lists.newArrayList(
                         PlaceholderExpression.of(Expression.class, 1),
-                        PlaceholderExpression.of(Expression.class, 2)));;
+                        PlaceholderExpression.of(Expression.class, 2)));
     }
 
     private void registerNumericFunctionTransformers() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/trino/TrinoFnCallTransformers.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/trino/TrinoFnCallTransformers.java
@@ -18,14 +18,13 @@
 package org.apache.doris.nereids.parser.trino;
 
 import org.apache.doris.nereids.analyzer.PlaceholderExpression;
-import org.apache.doris.nereids.parser.AbstractFnCallTransformer;
 import org.apache.doris.nereids.parser.AbstractFnCallTransformers;
 import org.apache.doris.nereids.trees.expressions.Expression;
 
 import com.google.common.collect.Lists;
 
 /**
- * The builder and factory for trino {@link AbstractFnCallTransformer},
+ * The builder and factory for trino function call transformers,
  * and supply transform facade ability.
  */
 public class TrinoFnCallTransformers extends AbstractFnCallTransformers {
@@ -47,8 +46,8 @@ public class TrinoFnCallTransformers extends AbstractFnCallTransformers {
     }
 
     protected void registerStringFunctionTransformer() {
-        doRegister("codepoint", 1, "ascii",
-                Lists.newArrayList(PlaceholderExpression.of(Expression.class, 1)), false);
+        doRegister("codepoint", "ascii",
+                Lists.newArrayList(PlaceholderExpression.of(Expression.class, 1)));
         // TODO: add other string function transformer
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/spark/FnTransformTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/spark/FnTransformTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.parser.spark;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.parser.ParserTestBase;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
@@ -30,26 +31,59 @@ import org.junit.jupiter.api.Test;
 public class FnTransformTest extends ParserTestBase {
 
     @Test
-    public void testCommonFnTransform() {
-        NereidsParser nereidsParser = new NereidsParser();
+    public void testCommonFnTransformers() {
+        // test json functions
+        testFunction("SELECT json_extract('{\"c1\": 1}', '$.c1') as b FROM t",
+                    "SELECT get_json_object('{\"c1\": 1}', '$.c1') as b FROM t",
+                    "json_extract('{\"c1\": 1}', '$.c1')");
 
-        String sql1 = "SELECT json_extract('{\"a\": 1}', '$.a') as b FROM t";
-        String dialectSql1 = "SELECT get_json_object('{\"a\": 1}', '$.a') as b FROM t";
-        LogicalPlan logicalPlan1 = nereidsParser.parseSingle(sql1);
-        LogicalPlan dialectLogicalPlan1 = nereidsParser.parseSingle(dialectSql1,
-                    new SparkSql3LogicalPlanBuilder());
-        Assertions.assertEquals(dialectLogicalPlan1, logicalPlan1);
-        Assertions.assertTrue(dialectLogicalPlan1.child(0).toString().toLowerCase()
-                    .contains("json_extract('{\"a\": 1}', '$.a')"));
+        testFunction("SELECT json_extract(c1, '$.c1') as b FROM t",
+                    "SELECT get_json_object(c1, '$.c1') as b FROM t",
+                    "json_extract('c1, '$.c1')");
 
-        String sql2 = "SELECT json_extract(a, '$.a') as b FROM t";
-        String dialectSql2 = "SELECT get_json_object(a, '$.a') as b FROM t";
-        LogicalPlan logicalPlan2 = nereidsParser.parseSingle(sql2);
-        LogicalPlan dialectLogicalPlan2 = nereidsParser.parseSingle(dialectSql2,
-                new SparkSql3LogicalPlanBuilder());
-        Assertions.assertEquals(dialectLogicalPlan2, logicalPlan2);
-        Assertions.assertTrue(dialectLogicalPlan2.child(0).toString().toLowerCase()
-                    .contains("json_extract('a, '$.a')"));
+        // test string functions
+        testFunction("SELECT str_to_date('2023-12-16', 'yyyy-MM-dd') as b FROM t",
+                    "SELECT to_date('2023-12-16', 'yyyy-MM-dd') as b FROM t",
+                    "str_to_date('2023-12-16', 'yyyy-MM-dd')");
+        testFunction("SELECT str_to_date(c1, 'yyyy-MM-dd') as b FROM t",
+                "SELECT to_date(c1, 'yyyy-MM-dd') as b FROM t",
+                "str_to_date('c1, 'yyyy-MM-dd')");
+
+        testFunction("SELECT date_trunc('2023-12-16', 'YEAR') as a FROM t",
+                    "SELECT trunc('2023-12-16', 'YEAR') as a FROM t",
+                    "date_trunc('2023-12-16', 'YEAR')");
+        testFunction("SELECT date_trunc(c1, 'YEAR') as a FROM t",
+                "SELECT trunc(c1, 'YEAR') as a FROM t",
+                "date_trunc('c1, 'YEAR')");
+
+        testFunction("SELECT date_trunc('2023-12-16', 'YEAR') as a FROM t",
+                    "SELECT trunc('2023-12-16', 'YY') as a FROM t",
+                    "date_trunc('2023-12-16', 'YEAR')");
+        testFunction("SELECT date_trunc(c1, 'YEAR') as a FROM t",
+                "SELECT trunc(c1, 'YY') as a FROM t",
+                "date_trunc('c1, 'YEAR')");
+
+        testFunction("SELECT date_trunc('2023-12-16', 'MONTH') as a FROM t",
+                    "SELECT trunc('2023-12-16', 'MON') as a FROM t",
+                    "date_trunc('2023-12-16', 'MONTH')");
+        testFunction("SELECT date_trunc(c1, 'MONTH') as a FROM t",
+                "SELECT trunc(c1, 'MON') as a FROM t",
+                "date_trunc('c1, 'MONTH')");
+
+        // test numeric functions
+        testFunction("SELECT avg(c1) as a from t",
+                    "SELECT mean(c1) as a from t",
+                    "avg('c1)");
     }
 
+    private void testFunction(String sql, String dialectSql, String expectLogicalPlanStr) {
+        NereidsParser nereidsParser = new NereidsParser();
+        LogicalPlan logicalPlan = nereidsParser.parseSingle(sql);
+        LogicalPlan dialectLogicalPlan = nereidsParser.parseSingle(dialectSql,
+                new SparkSql3LogicalPlanBuilder());
+        Assertions.assertEquals(dialectLogicalPlan, logicalPlan);
+        String dialectLogicalPlanStr = dialectLogicalPlan.child(0).toString().toLowerCase();
+        System.out.println("dialectLogicalPlanStr: " + dialectLogicalPlanStr);
+        Assertions.assertTrue(StringUtils.containsIgnoreCase(dialectLogicalPlanStr, expectLogicalPlanStr));
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/spark/FnTransformTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/spark/FnTransformTest.java
@@ -17,11 +17,11 @@
 
 package org.apache.doris.nereids.parser.spark;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.parser.ParserTestBase;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
## Proposed changes

relevent pr: #27231 

I analyzed the sql autit logs of users on our online doris cluster for the past month, and found some error records which the reason to failed is the difference between spark-sql built-in functions and doris built-in functions. 

```sql

+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------+
| error_message                                                                                                                                                                                           | count(0) |
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------+
| errCode = 2, detailMessage = No matching function with signature: to_date(VARCHAR(*), VARCHAR(*)).                                                                                                      |      522 |
| errCode = 2, detailMessage = No matching function with signature: md5x(TEXT).                                                                                                                           |      295 |
| errCode = 2, detailMessage = No matching function with signature: ods.dstname(TEXT).                                                                                                                    |      230 |
| errCode = 2, detailMessage = No matching function with signature: trunc(TEXT, VARCHAR(*)).                                                                                                              |      157 |
| errCode = 2, detailMessage = No matching function with signature: explode(VARCHAR(*)).                                                                                                                  |       73 |
| errCode = 2, detailMessage = No matching function with signature: mean(INT).                                                                                                                            |       72 |
| errCode = 2, detailMessage = No matching function with signature: trunc(DATE, VARCHAR(*)).                                                                                                              |       71 |
| errCode = 2, detailMessage = No matching function with signature: auc_udaf(DOUBLE, INT).                                                                                                                |       61 |
| errCode = 2, detailMessage = No matching function with signature: to_date(VARCHAR(10), VARCHAR(*)).                                                                                                     |       45 |
| errCode = 2, detailMessage = No matching function with signature: months_between(TEXT, TEXT).                                                                                                           |       42 |
| errCode = 2, detailMessage = No matching function with signature: to_date(TEXT, VARCHAR(*)).                                                                                                            |       40 |
| errCode = 2, detailMessage = Unexpected exception: org.apache.doris.common.AnalysisException: errCode = 2, detailMessage = No matching function with signature: if(BOOLEAN, NULL_TYPE, MAP<TEXT,TEXT>). |       33 |
| errCode = 2, detailMessage = No matching function with signature: auc_udaf(TEXT, INT).                                                                                                                  |       32 |
| errCode = 2, detailMessage = No matching function with signature: percentile_approx(DOUBLE, ARRAY<DECIMALV3(2, 2)>).                                                                                    |       30 |
| errCode = 2, detailMessage = No matching function with signature: json_tuple(TEXT, VARCHAR(*)).                                                                                                         |       29 |
| errCode = 2, detailMessage = No matching function with signature: format_number(DOUBLE, TINYINT).                                                                                                       |       28 |
| errCode = 2, detailMessage = No matching function with signature: translate(VARCHAR(*), VARCHAR(*), VARCHAR(*)).                                                                                        |       24 |
| errCode = 2, detailMessage = No matching function with signature: months_between(DATE, DATE).                                                                                                           |       21 |
| errCode = 2, detailMessage = No matching function with signature: trunc(DATETIME, VARCHAR(*)).                                                                                                          |       19 |
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------+
```

This pr mainly do some function transformers to adapt these differences.

```sql

+----------------------------------------------------------+
| date_trunc(cast('2023-12-12' as DATETIMEV2(0)), 'MONTH') |
+----------------------------------------------------------+
| 2023-12-01 00:00:00                                      |
+----------------------------------------------------------+
1 row in set (1.08 sec)

MySQL [(none)]> select trunc('2023-12-12', 'MM');
+----------------------------------------------------------+
| date_trunc(cast('2023-12-12' as DATETIMEV2(0)), 'MONTH') |
+----------------------------------------------------------+
| 2023-12-01 00:00:00                                      |
+----------------------------------------------------------+
1 row in set (0.02 sec)

MySQL [(none)]> select trunc('2023-12-12', 'YYYY');
+---------------------------------------------------------+
| date_trunc(cast('2023-12-12' as DATETIMEV2(0)), 'YEAR') |
+---------------------------------------------------------+
| 2023-01-01 00:00:00                                     |
+---------------------------------------------------------+
1 row in set (0.02 sec)

MySQL [(none)]> select trunc('2023-12-12', 'YY');
+---------------------------------------------------------+
| date_trunc(cast('2023-12-12' as DATETIMEV2(0)), 'YEAR') |
+---------------------------------------------------------+
| 2023-01-01 00:00:00                                     |
+---------------------------------------------------------+
1 row in set (0.03 sec)

MySQL [(none)]> select trunc('2023-12-12', 'YEAR');
+---------------------------------------------------------+
| date_trunc(cast('2023-12-12' as DATETIMEV2(0)), 'YEAR') |
+---------------------------------------------------------+
| 2023-01-01 00:00:00                                     |
+---------------------------------------------------------+
1 row in set (0.02 sec)

MySQL [(none)]> 
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

