### PR TITLE
[fix](meta) fix meta replay issue when upgrading from v2.0 to master

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -1261,7 +1261,6 @@ public class InternalCatalog implements CatalogIf<Database> {
     }
 
     public void replayCreateTable(String dbName, Table table) throws MetaNotFoundException {
-
         Database db = this.fullNameToDb.get(dbName);
         try {
             db.createTableWithLock(table, true, false);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -254,6 +254,8 @@ public class InternalCatalog implements CatalogIf<Database> {
         if (StringUtils.isEmpty(dbName)) {
             return null;
         }
+        // ATTN: this should be removed in v3.0
+        dbName = ClusterNamespace.getNameFromFullName(dbName);
         if (fullNameToDb.containsKey(dbName)) {
             return fullNameToDb.get(dbName);
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
@@ -217,8 +217,7 @@ public class JournalEntity implements Writable {
                 break;
             }
             case OperationType.OP_CREATE_TABLE: {
-                data = new CreateTableInfo();
-                ((CreateTableInfo) data).readFields(in);
+                data = CreateTableInfo.read(in);
                 isRead = true;
                 break;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/AlterDatabasePropertyInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/AlterDatabasePropertyInfo.java
@@ -17,8 +17,10 @@
 
 package org.apache.doris.persist;
 
+import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
+import org.apache.doris.persist.gson.GsonPostProcessable;
 import org.apache.doris.persist.gson.GsonUtils;
 
 import com.google.gson.annotations.SerializedName;
@@ -28,7 +30,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.Map;
 
-public class AlterDatabasePropertyInfo implements Writable {
+public class AlterDatabasePropertyInfo implements Writable, GsonPostProcessable {
     @SerializedName(value = "dbId")
     private long dbId;
 
@@ -37,12 +39,6 @@ public class AlterDatabasePropertyInfo implements Writable {
 
     @SerializedName(value = "properties")
     private Map<String, String> properties;
-
-    public AlterDatabasePropertyInfo() {
-        // for persist
-        this.dbName = "";
-        this.properties = null;
-    }
 
     public AlterDatabasePropertyInfo(long dbId, String dbName, Map<String, String> properties) {
         this.dbId = dbId;
@@ -73,5 +69,10 @@ public class AlterDatabasePropertyInfo implements Writable {
 
     public String toJson() {
         return GsonUtils.GSON.toJson(this);
+    }
+
+    @Override
+    public void gsonPostProcess() throws IOException {
+        dbName = ClusterNamespace.getNameFromFullName(dbName);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/meta/PersistMetaModules.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/meta/PersistMetaModules.java
@@ -43,7 +43,7 @@ public class PersistMetaModules {
 
     // Modules in this list is deprecated and will not be saved in meta file. (also should not be in MODULE_NAMES)
     public static final ImmutableList<String> DEPRECATED_MODULE_NAMES = ImmutableList.of(
-            "loadJob", "cooldownJob", "AnalysisMgr", "mtmvJobManager");
+            "loadJob", "cooldownJob", "AnalysisMgr", "mtmvJobManager", "JobTaskManager");
 
     static {
         MODULES_MAP = Maps.newHashMap();


### PR DESCRIPTION
## Proposed changes

Introduced from #27861

The `dbName` saved in `CreateTableInfo` has `default_cluster` prefix, it should be removed.

Also modify the entry of `getDb` in internal catalog. This is a cover-up plan in case there may still 
db name exist with `default_cluster` prefix.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

