### PR TITLE
[branch-2.0] Pick "[fix](txn_manager) Fix wrong use of std::map::erase in TxnManager::delete_txn #28507"

### DIFF
--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -614,8 +614,8 @@ Status TxnManager::delete_txn(OlapMeta* meta, TPartitionId partition_id,
                                         : "0");
             }
         }
+        it->second.erase(load_itr);
     }
-    it->second.erase(tablet_info);
     if (it->second.empty()) {
         txn_tablet_map.erase(it);
         _clear_txn_partition_map_unlocked(transaction_id, partition_id);


### PR DESCRIPTION
## Proposed changes

picks https://github.com/apache/doris/pull/28507

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

