### PR TITLE
[improve](load) remove extra layer of heavy work pool in tablet_writer_add_block

### DIFF
--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -240,11 +240,6 @@ private:
                          ::doris::PTransmitDataResult* response, ::google::protobuf::Closure* done,
                          const Status& extract_st);
 
-    void _tablet_writer_add_block(google::protobuf::RpcController* controller,
-                                  const PTabletWriterAddBlockRequest* request,
-                                  PTabletWriterAddBlockResult* response,
-                                  google::protobuf::Closure* done);
-
     void _response_pull_slave_rowset(const std::string& remote_host, int64_t brpc_port,
                                      int64_t txn_id, int64_t tablet_id, int64_t node_id,
                                      bool is_succeed);


### PR DESCRIPTION
## Proposed changes

Heavy work pool is causing too many overheads in cpu sys usage (due to context switches).
Remove one extra layer of heavy work pool in tablet_writer_add_block to mitigate this problem.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

