### PR TITLE
[Opt](expr) Opt decimal comparsion expr.

### DIFF
--- a/be/src/vec/core/decimal_comparison.h
+++ b/be/src/vec/core/decimal_comparison.h
@@ -189,8 +189,6 @@ private:
 
     template <bool scale_left, bool scale_right>
     static ColumnPtr apply(const ColumnPtr& c0, const ColumnPtr& c1, CompareInt scale) {
-        auto c_res = ColumnUInt8::create();
-
         if constexpr (_actual) {
             bool c0_is_const = is_column_const(*c0);
             bool c1_is_const = is_column_const(*c1);
@@ -205,8 +203,8 @@ private:
                 return DataTypeUInt8().create_column_const(c0->size(), to_field(res));
             }
 
+            auto c_res = ColumnUInt8::create(c0->size());
             ColumnUInt8::Container& vec_res = c_res->get_data();
-            vec_res.resize(c0->size());
 
             if (c0_is_const) {
                 const ColumnConst* c0_const = check_and_get_column_const<ColVecA>(c0.get());
@@ -236,13 +234,14 @@ private:
                     LOG(FATAL) << "Wrong column in Decimal comparison";
                 }
             }
+            return c_res;
+        } else {
+            return ColumnUInt8::create();
         }
-
-        return c_res;
     }
 
     template <bool scale_left, bool scale_right>
-    static NO_INLINE UInt8 apply(A a, B b, CompareInt scale [[maybe_unused]]) {
+    static UInt8 apply(A a, B b, CompareInt scale [[maybe_unused]]) {
         CompareInt x = a;
         CompareInt y = b;
 


### PR DESCRIPTION
## Proposed changes

[Opt] (expr) Opt decimal comparsion expr.
- Remove the resize() call.
- Remove 'NO_INLINE' for apply() function.

### Test Result:
TPCH 19: 7.6 s to 6.47 s.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

