### PR TITLE
[enhancement](tablet-channel) enhance performance for load under multi-core scenario with a coarse-grained read lock when checking broken tablets

### DIFF
--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -116,9 +116,14 @@ protected:
     Status _open_all_writers(const PTabletWriterOpenRequest& request);
 
     void _add_broken_tablet(int64_t tablet_id);
+    // thread-unsafe, add a shared lock for `_tablet_writers_lock` if needed
+    bool _is_broken_tablet(int64_t tablet_id) const;
     void _add_error_tablet(google::protobuf::RepeatedPtrField<PTabletError>* tablet_errors,
                            int64_t tablet_id, Status error) const;
-    bool _is_broken_tablet(int64_t tablet_id);
+    void _build_tablet_to_rowidxs(
+            const PTabletWriterAddBlockRequest& request,
+            std::unordered_map<int64_t /* tablet_id */, std::vector<uint32_t> /* row index */>*
+                    tablet_to_rowidxs);
     virtual void _init_profile(RuntimeProfile* profile);
 
     // id of this load channel


### PR DESCRIPTION
## Proposed changes

close: #28564

Tests show that insert into may be 13% ~ 18% faster under multi-core scenario.

Try to get the read lock `std::shared_lock<std::shared_mutex> rlock(_broken_tablets_lock)` once per batch rather than each time visiting the broken tablet list.

The original usage of `std::shared_lock<std::shared_mutex> rlock(_broken_tablets_lock)` make it too fine-grained, especially in normal case that there is no broken tablet (writer) at all. Even if it is a read lock, the overhead of memory barrier and CPU cache invalidation are assignable under scenario of `multi-core` + `high-concurrency`.

## Further comments

env: `1FE + 3BE` `84c` `130G for load` `3 * 500G high performance SSD`
scenario: insert 4800000000 lines data into TPCH lineitem table.

before
RW lock during `LoadChannel::add_batch` seems to be disaster.
<img width="1188" alt="image" src="https://github.com/apache/doris/assets/82279870/4ecf1af3-cfbb-41eb-9101-c1799f9fb395">
load duration: 7m41s avg

after
<img width="1183" alt="image" src="https://github.com/apache/doris/assets/82279870/a723c2e2-51b4-4b92-83bb-72b59b275cd3">
load duration: 6m27 avg

