### PR TITLE
[enchancement](delete) fix delete stmt return error with fold on be

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DeleteStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DeleteStmt.java
@@ -245,10 +245,8 @@ public class DeleteStmt extends DdlStmt {
             binaryPredicate.setChild(1, binaryPredicate.getChild(1).castTo(binaryPredicate.getChild(0).getType()));
             binaryPredicate.analyze(analyzer);
 
-            ExprRewriter exprRewriter = new ExprRewriter(FoldConstantsRule.INSTANCE);
-            FoldConstantsRule foldConstantsRule = (FoldConstantsRule) exprRewriter.getRules().get(0);
             Expr rightChild = binaryPredicate.getChild(1);
-            Expr rewrittenExpr = foldConstantsRule.apply(rightChild, analyzer, null);
+            Expr rewrittenExpr = FoldConstantsRule.INSTANCE.apply(rightChild, analyzer, null);
             if (rightChild != rewrittenExpr) {
                 binaryPredicate.setChild(1, rewrittenExpr);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DeleteStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DeleteStmt.java
@@ -246,7 +246,13 @@ public class DeleteStmt extends DdlStmt {
             binaryPredicate.analyze(analyzer);
 
             ExprRewriter exprRewriter = new ExprRewriter(FoldConstantsRule.INSTANCE);
-            binaryPredicate.setChild(1, exprRewriter.rewrite(binaryPredicate.getChild(1), analyzer, null));
+            FoldConstantsRule foldConstantsRule = (FoldConstantsRule) exprRewriter.getRules().get(0);
+            Expr rightChild = binaryPredicate.getChild(1);
+            Expr rewrittenExpr = foldConstantsRule.apply(rightChild, analyzer, null);
+            if (rightChild != rewrittenExpr) {
+                binaryPredicate.setChild(1, rewrittenExpr);
+            }
+
             Expr leftExpr = binaryPredicate.getChild(0);
             if (!(leftExpr instanceof SlotRef)) {
                 throw new AnalysisException(

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/ExprRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/ExprRewriter.java
@@ -133,6 +133,10 @@ public class ExprRewriter {
         rules = Lists.newArrayList(rule);
     }
 
+    public List<ExprRewriteRule> getRules() {
+        return rules;
+    }
+
     public void setInfoMVRewriter(Set<TupleId> disableTuplesMVRewriter, ExprSubstitutionMap mvSMap,
             ExprSubstitutionMap aliasSMap) {
         for (ExprRewriteRule rule : rules) {

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/ExprRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/ExprRewriter.java
@@ -133,10 +133,6 @@ public class ExprRewriter {
         rules = Lists.newArrayList(rule);
     }
 
-    public List<ExprRewriteRule> getRules() {
-        return rules;
-    }
-
     public void setInfoMVRewriter(Set<TupleId> disableTuplesMVRewriter, ExprSubstitutionMap mvSMap,
             ExprSubstitutionMap aliasSMap) {
         for (ExprRewriteRule rule : rules) {

--- a/regression-test/suites/delete_p0/test_delete.groovy
+++ b/regression-test/suites/delete_p0/test_delete.groovy
@@ -407,4 +407,21 @@ suite("test_delete") {
     qt_check_data7 """ select * from  every_type_table order by col_1; """
     sql "drop table every_type_table"
 
+
+    sql "drop table if exists test2"
+    sql """
+    CREATE TABLE `test2`  
+    (
+            col_1 int,
+            col_2 decimalv2(10,3)
+    )ENGINE=OLAP
+    duplicate KEY(`col_1`)
+    COMMENT 'OLAP'
+    DISTRIBUTED BY HASH(`col_1`) BUCKETS 1
+    PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1"
+    );
+    """
+    sql "set enable_fold_constant_by_be = true;"
+    sql "DELETE FROM test2  WHERE col_2 = cast(123.45 as decimalv2(10,3));"
 }


### PR DESCRIPTION
## Proposed changes
```
set enable_fold_constant_by_be = true;
DELETE FROM test  WHERE col_2 = cast(123.45 as decimalv3(10,3));
ERROR 1105 (HY000): errCode = 2, detailMessage = errCode = 2, detailMessage = Right expr of binary predicate should be value, predicate: `col_2` = CAST(CAST(123.45 AS DECIMALV3(10, 3)) AS DECIMAL(10, 3)), right expr type:DECIMAL(10, 3)

exprRewriter.rewrite() function will not apply when:
      if (rule instanceof FoldConstantsRule && analyzer.safeIsEnableFoldConstantByBe()) {
          continue;
      }
```


Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

