### PR TITLE
[chore](Nereids): remove SemiJoinCommute in rewriter

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Analyzer.java
@@ -43,7 +43,7 @@ import org.apache.doris.nereids.rules.analysis.ReplaceExpressionByChildOutput;
 import org.apache.doris.nereids.rules.analysis.ResolveOrdinalInOrderByAndGroupBy;
 import org.apache.doris.nereids.rules.analysis.SubqueryToApply;
 import org.apache.doris.nereids.rules.analysis.UserAuthentication;
-import org.apache.doris.nereids.rules.rewrite.JoinCommute;
+import org.apache.doris.nereids.rules.rewrite.SemiJoinCommute;
 
 import java.util.List;
 import java.util.Objects;
@@ -124,7 +124,7 @@ public class Analyzer extends AbstractBatchJobExecutor {
             bottomUp(new CheckAnalysis()),
             topDown(new EliminateGroupByConstant()),
             topDown(new NormalizeAggregate()),
-            bottomUp(new JoinCommute()),
+            bottomUp(new SemiJoinCommute()),
             bottomUp(
                     new CollectSubQueryAlias(),
                     new CollectJoinConstraint()

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Rewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Rewriter.java
@@ -73,7 +73,6 @@ import org.apache.doris.nereids.rules.rewrite.InferFilterNotNull;
 import org.apache.doris.nereids.rules.rewrite.InferJoinNotNull;
 import org.apache.doris.nereids.rules.rewrite.InferPredicates;
 import org.apache.doris.nereids.rules.rewrite.InferSetOperatorDistinct;
-import org.apache.doris.nereids.rules.rewrite.JoinCommute;
 import org.apache.doris.nereids.rules.rewrite.LimitSortToTopN;
 import org.apache.doris.nereids.rules.rewrite.MergeFilters;
 import org.apache.doris.nereids.rules.rewrite.MergeOneRowRelationIntoUnion;
@@ -228,7 +227,6 @@ public class Rewriter extends AbstractBatchJobExecutor {
                     ),
                     // push down SEMI Join
                     bottomUp(
-                            new JoinCommute(),
                             new TransposeSemiJoinLogicalJoin(),
                             new TransposeSemiJoinLogicalJoinProject(),
                             new TransposeSemiJoinAgg(),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/SemiJoinCommute.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/SemiJoinCommute.java
@@ -27,7 +27,7 @@ import org.apache.doris.qe.ConnectContext;
  * RightAntiJoin -> LeftAntiJoin
  * RightOuterJoin -> LeftOuterJoin
  */
-public class JoinCommute extends OneRewriteRuleFactory {
+public class SemiJoinCommute extends OneRewriteRuleFactory {
     @Override
     public Rule build() {
         return logicalJoin()

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/ReorderJoinTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/ReorderJoinTest.java
@@ -124,6 +124,7 @@ class ReorderJoinTest implements MemoPatternMatchSupported {
                 .filter(new EqualTo(scan3.getOutput().get(0), scan1.getOutput().get(0)))
                 .build();
         PlanChecker.from(MemoTestUtils.createConnectContext(), plan2)
+                .applyBottomUp(new SemiJoinCommute())
                 .rewrite()
                 .matchesFromRoot(
                     logicalProject(


### PR DESCRIPTION
## Proposed changes

analyzer already contained SemiJoinCommute

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

