### PR TITLE
[fix](test) disable join reorder in bucket shuffle join test (#27930)

### DIFF
--- a/regression-test/suites/nereids_p0/join/bucket_shuffle_join.groovy
+++ b/regression-test/suites/nereids_p0/join/bucket_shuffle_join.groovy
@@ -59,6 +59,9 @@ suite("bucket-shuffle-join") {
     sql """analyze table shuffle_join_t1 with sync;"""
     sql """analyze table shuffle_join_t2 with sync;"""
 
+    // we must disable join reorder since right xx join cannot be bucket shuffle join now
+    sql """set disable_join_reorder=true"""
+
     explain {
         sql("select * from shuffle_join_t1 t1 left join shuffle_join_t2 t2 on t1.a = t2.a;")
         contains "BUCKET_SHUFFLE"


### PR DESCRIPTION
pick from master
PR #27930
commit c80807a5c7f9454bd4ec8d5a2c829ed986efa653

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

