### PR TITLE
[fix](regression) fix test_set_replica_status due to force_olap_table_replication_num=3

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -876,6 +876,29 @@ class Suite implements GroovyInterceptable {
         return result.last().get(0);
     }
 
+    String getFeConfig(String key) {
+        return sql_return_maparray("ADMIN SHOW FRONTEND CONFIG LIKE '${key}'")[0].Value
+    }
+
+    void setFeConfig(String key, Object value) {
+        sql "ADMIN SET FRONTEND CONFIG ('${key}' = '${value}')"
+    }
+
+    void setFeConfigTemporary(Map<String, Object> tempConfig, Closure actionSupplier) {
+        def oldConfig = tempConfig.keySet().collectEntries { [it, getFeConfig(it)] }
+
+        def updateConfig = { conf ->
+            conf.each { key, value -> setFeConfig(key, value) }
+        }
+
+        try {
+            updateConfig tempConfig
+            actionSupplier()
+        } finally {
+            updateConfig oldConfig
+        }
+    }
+
     void waiteCreateTableFinished(String tableName) {
         Thread.sleep(2000);
         String showCreateTable = "SHOW CREATE TABLE ${tableName}"

--- a/regression-test/suites/control_p0/set_replica_status.groovy
+++ b/regression-test/suites/control_p0/set_replica_status.groovy
@@ -15,59 +15,61 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_set_replica_status", "p0") {
-    def tableName = "test_set_replica_status_table"
-    sql "DROP TABLE IF EXISTS ${tableName}"
-    sql """
-        CREATE TABLE ${tableName} (
-            `id` LARGEINT NOT NULL,
-            `count` LARGEINT SUM DEFAULT "0")
-        AGGREGATE KEY(`id`)
-        DISTRIBUTED BY HASH(`id`) BUCKETS 2
-        PROPERTIES
-        (
-            "replication_num" = "1"
-        )
-        """
+suite('test_set_replica_status', 'nonConcurrent') {
+    setFeConfigTemporary([disable_tablet_scheduler:true]) {
+        def tableName = 'test_set_replica_status_table'
+        sql "DROP TABLE IF EXISTS ${tableName}"
+        sql """
+            CREATE TABLE ${tableName} (
+                `id` LARGEINT NOT NULL,
+                `count` LARGEINT SUM DEFAULT "0")
+            AGGREGATE KEY(`id`)
+            DISTRIBUTED BY HASH(`id`) BUCKETS 2
+            PROPERTIES
+            (
+                "replication_num" = "1"
+            )
+            """
 
-    List<String> values = []
-    for (int i = 1; i <= 10; ++i) {
-        values.add("(${i}, ${i})")
-    }
-    sql """INSERT INTO ${tableName} VALUES ${values.join(",")}"""
+        List<String> values = []
+        for (int i = 1; i <= 10; ++i) {
+            values.add("(${i}, ${i})")
+        }
+        sql """INSERT INTO ${tableName} VALUES ${values.join(',')}"""
 
-    def result = sql_return_maparray """show tablets from ${tableName}"""
-    assertNotNull(result)
-    def tabletId = null
-    def backendId = null
-    for (def res : result) {
-        tabletId = res.TabletId
-        backendId = res.BackendId
-        break
-    }
-    sql """ADMIN SET REPLICA STATUS PROPERTIES("tablet_id" = "${tabletId}", "backend_id" = "${backendId}", "status" = "bad");"""
-    result = sql_return_maparray """ADMIN SHOW REPLICA STATUS FROM ${tableName}"""
-    for (def res : result) {
-        if (res.TabletId == tabletId) {
-            logger.info("admin show replica status ${res}")
-            assertTrue(res.IsBad.toBoolean())
+        def result = sql_return_maparray """show tablets from ${tableName}"""
+        assertNotNull(result)
+        def tabletId = null
+        def backendId = null
+        for (def res : result) {
+            tabletId = res.TabletId
+            backendId = res.BackendId
+            break
         }
-    }
-    sql """ADMIN SET REPLICA STATUS PROPERTIES("tablet_id" = "${tabletId}", "backend_id" = "${backendId}", "status" = "ok");"""
-    result = sql_return_maparray """ADMIN SHOW REPLICA STATUS FROM ${tableName}"""
-    for (def res : result) {
-        if (res.TabletId == tabletId) {
-            logger.info("admin show replica status ${res}")
-            assertFalse(res.IsBad.toBoolean())
+        sql """ADMIN SET REPLICA STATUS PROPERTIES("tablet_id" = "${tabletId}", "backend_id" = "${backendId}", "status" = "bad");"""
+        result = sql_return_maparray """ADMIN SHOW REPLICA STATUS FROM ${tableName}"""
+        for (def res : result) {
+            if (res.TabletId == tabletId && res.BackendId == backendId) {
+                logger.info("admin show replica status ${res}")
+                assertTrue(res.IsBad.toBoolean())
+            }
         }
-    }
-    sql """ADMIN SET REPLICA VERSION PROPERTIES("tablet_id" = "${tabletId}", "backend_id" = "${backendId}", "last_failed_version" = "10");"""
-    result = sql_return_maparray """ADMIN SHOW REPLICA STATUS FROM ${tableName}"""
-    for (def res : result) {
-        if (res.TabletId == tabletId) {
-            logger.info("admin show replica version ${res}")
-            assertEquals(10L, res.LastFailedVersion.toLong())
+        sql """ADMIN SET REPLICA STATUS PROPERTIES("tablet_id" = "${tabletId}", "backend_id" = "${backendId}", "status" = "ok");"""
+        result = sql_return_maparray """ADMIN SHOW REPLICA STATUS FROM ${tableName}"""
+        for (def res : result) {
+            if (res.TabletId == tabletId && res.BackendId == backendId) {
+                logger.info("admin show replica status ${res}")
+                assertFalse(res.IsBad.toBoolean())
+            }
         }
+        sql """ADMIN SET REPLICA VERSION PROPERTIES("tablet_id" = "${tabletId}", "backend_id" = "${backendId}", "last_failed_version" = "10");"""
+        result = sql_return_maparray """ADMIN SHOW REPLICA STATUS FROM ${tableName}"""
+        for (def res : result) {
+            if (res.TabletId == tabletId && res.BackendId == backendId) {
+                logger.info("admin show replica version ${res}")
+                assertEquals(10L, res.LastFailedVersion.toLong())
+            }
+        }
+        sql '''ADMIN CLEAN TRASH'''
     }
-    sql """ADMIN CLEAN TRASH"""
 }

--- a/regression-test/suites/demo_p0/set_config_temporary_action.groovy
+++ b/regression-test/suites/demo_p0/set_config_temporary_action.groovy
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite('set_config_temporary_action', 'nonConcurrent') {
+    def key = 'schedule_slot_num_per_ssd_path'
+    setFeConfig(key, 8)
+    assertEquals(8, getFeConfig(key) as int)
+    setFeConfigTemporary(["${key}": 4]) {
+        assertEquals(4, getFeConfig(key) as int)
+    }
+    assertEquals(8, getFeConfig(key) as int)
+}


### PR DESCRIPTION
The master branch fe.conf set force_olap_table_replication_num=3,  than all tablet are 3 replicas.

But  test is suppose replica num = 1. Fix it.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

