### PR TITLE
[fix](regression) fix test_alter_colocate_table due to force_olap_table_replication_num=3

### DIFF
--- a/regression-test/suites/schema_change_p0/test_alter_colocate_table.groovy
+++ b/regression-test/suites/schema_change_p0/test_alter_colocate_table.groovy
@@ -23,6 +23,20 @@ suite ("test_alter_colocate_table") {
         """
     }
 
+    // wait group clean
+    def existsGroup = false;
+    for (def i = 0; i < 60; i++) {
+        def dbName = sql("SELECT DATABASE()")[0][0]
+        def result = sql_return_maparray "show proc '/colocation_group'"
+        existsGroup = result.any { it.GroupName.indexOf(dbName + ".x_group_") >= 0 }
+        if (existsGroup) {
+            sleep(1000)
+        } else {
+            break
+        }
+    }
+    assertFalse(existsGroup)
+
     sql """
         CREATE TABLE IF NOT EXISTS col_tbl1
         (


### PR DESCRIPTION
sometimes fe.conf set force_olap_table_replication_num=3, then replica num = 3.

wait group detroy before run test. 

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

