### PR TITLE
[fix](regression)Change analyze_timeout to global.

### DIFF
--- a/regression-test/suites/external_table_p2/hive/test_hive_statistic_timeout.groovy
+++ b/regression-test/suites/external_table_p2/hive/test_hive_statistic_timeout.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_hive_statistic_timeout", "p2,external,hive,external_remote,external_remote_hive") {
+suite("test_hive_statistic_timeout", "p2,external,hive,external_remote,external_remote_hive, nonConcurrent") {
     String enabled = context.config.otherConfigs.get("enableExternalHiveTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
         String extHiveHmsHost = context.config.otherConfigs.get("extHiveHmsHost")
@@ -32,11 +32,13 @@ suite("test_hive_statistic_timeout", "p2,external,hive,external_remote,external_
         logger.info("catalog " + catalog_name + " created")
 
         sql """use ${catalog_name}.tpch_1000_parquet"""
-        sql """set analyze_timeout=1"""
+        sql """set global analyze_timeout=1"""
         try {
             sql """analyze table part (p_partkey, p_container, p_type, p_retailprice) with sync with full;"""
         } catch (Exception e) {
             assertTrue(e.getMessage().contains("Cancelled"));
+        } finally {
+            sql """set global analyze_timeout=43200"""
         }
         sql """drop catalog ${catalog_name}""";
     }


### PR DESCRIPTION
Fix hive statistics regression case. analyze_timeout is a global session variable.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

