### PR TITLE
[bugfix](topn) fix coredump in copy_column_data_to_block when nullable mismatch

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -2070,8 +2070,7 @@ Status SegmentIterator::copy_column_data_by_selector(vectorized::IColumn* input_
         col_ptr_nullable->get_null_map_column().insert_many_defaults(select_size);
         output_col = col_ptr_nullable->get_nested_column_ptr();
     } else if (!output_col->is_nullable() && input_col_ptr->is_nullable()) {
-        LOG(WARNING) << "nullable mismatch for output_column: "
-                     << output_col->dump_structure()
+        LOG(WARNING) << "nullable mismatch for output_column: " << output_col->dump_structure()
                      << " input_column: " << input_col_ptr->dump_structure()
                      << " select_size: " << select_size;
         return Status::RuntimeError("copy_column_data_by_selector nullable mismatch");

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -2069,6 +2069,12 @@ Status SegmentIterator::copy_column_data_by_selector(vectorized::IColumn* input_
         auto col_ptr_nullable = reinterpret_cast<vectorized::ColumnNullable*>(output_col.get());
         col_ptr_nullable->get_null_map_column().insert_many_defaults(select_size);
         output_col = col_ptr_nullable->get_nested_column_ptr();
+    } else if (!output_col->is_nullable() && input_col_ptr->is_nullable()) {
+        LOG(WARNING) << "nullable mismatch for output_column: "
+                     << output_col->dump_structure()
+                     << " input_column: " << input_col_ptr->dump_structure()
+                     << " select_size: " << select_size;
+        return Status::RuntimeError("copy_column_data_by_selector nullable mismatch");
     }
 
     return input_col_ptr->filter_by_selector(sel_rowid_idx, select_size, output_col);


### PR DESCRIPTION
## Proposed changes

pick from branch-2.0: #27765

return RuntimeError if copy_column_data_to_block nullable mismatch to avoid coredump in input_col_ptr->filter_by_selector(sel_rowid_idx, select_size, raw_res_ptr) .

The problem is reported by a doris user but I can not reproduce it, so there is no testcase added currently.


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

