### PR TITLE
[fix](memtable-limiter) do not block write if load mem usage is low

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -600,6 +600,10 @@ DEFINE_Int32(load_process_max_memory_limit_percent, "50"); // 50%
 // might avoid all load jobs hang at the same time.
 DEFINE_Int32(load_process_soft_mem_limit_percent, "80");
 
+// If load memory consumption is within load_process_safe_mem_permit_percent,
+// memtable memory limiter will do nothing.
+DEFINE_Int32(load_process_safe_mem_permit_percent, "2");
+
 // result buffer cancelled time (unit: second)
 DEFINE_mInt32(result_buffer_cancelled_interval_time, "300");
 

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -602,7 +602,7 @@ DEFINE_Int32(load_process_soft_mem_limit_percent, "80");
 
 // If load memory consumption is within load_process_safe_mem_permit_percent,
 // memtable memory limiter will do nothing.
-DEFINE_Int32(load_process_safe_mem_permit_percent, "2");
+DEFINE_Int32(load_process_safe_mem_permit_percent, "5");
 
 // result buffer cancelled time (unit: second)
 DEFINE_mInt32(result_buffer_cancelled_interval_time, "300");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -659,6 +659,10 @@ DECLARE_Int32(load_process_max_memory_limit_percent); // 50%
 // might avoid all load jobs hang at the same time.
 DECLARE_Int32(load_process_soft_mem_limit_percent);
 
+// If load memory consumption is within load_process_safe_mem_permit_percent,
+// memtable memory limiter will do nothing.
+DECLARE_Int32(load_process_safe_mem_permit_percent);
+
 // result buffer cancelled time (unit: second)
 DECLARE_mInt32(result_buffer_cancelled_interval_time);
 

--- a/be/src/olap/memtable_memory_limiter.cpp
+++ b/be/src/olap/memtable_memory_limiter.cpp
@@ -59,8 +59,7 @@ Status MemTableMemoryLimiter::init(int64_t process_mem_limit) {
     _load_hard_mem_limit = calc_process_max_load_memory(process_mem_limit);
     _load_soft_mem_limit = _load_hard_mem_limit * config::load_process_soft_mem_limit_percent / 100;
     _load_safe_mem_permit =
-            _load_hard_mem_limit * config::load_process_safe_mem_permit_percent / 100;  
-    _load_safe_mem_permit = _load_hard_mem_limit * config::load_process_safe_mem_permit_percent / 100;
+            _load_hard_mem_limit * config::load_process_safe_mem_permit_percent / 100;
     g_load_hard_mem_limit.set_value(_load_hard_mem_limit);
     g_load_soft_mem_limit.set_value(_load_soft_mem_limit);
     _mem_tracker = std::make_unique<MemTrackerLimiter>(MemTrackerLimiter::Type::LOAD,

--- a/be/src/olap/memtable_memory_limiter.cpp
+++ b/be/src/olap/memtable_memory_limiter.cpp
@@ -58,6 +58,8 @@ MemTableMemoryLimiter::~MemTableMemoryLimiter() {
 Status MemTableMemoryLimiter::init(int64_t process_mem_limit) {
     _load_hard_mem_limit = calc_process_max_load_memory(process_mem_limit);
     _load_soft_mem_limit = _load_hard_mem_limit * config::load_process_soft_mem_limit_percent / 100;
+    _load_safe_mem_permit =
+            _load_hard_mem_limit * config::load_process_safe_mem_permit_percent / 100;  
     _load_safe_mem_permit = _load_hard_mem_limit * config::load_process_safe_mem_permit_percent / 100;
     g_load_hard_mem_limit.set_value(_load_hard_mem_limit);
     g_load_soft_mem_limit.set_value(_load_soft_mem_limit);

--- a/be/src/olap/memtable_memory_limiter.cpp
+++ b/be/src/olap/memtable_memory_limiter.cpp
@@ -58,6 +58,7 @@ MemTableMemoryLimiter::~MemTableMemoryLimiter() {
 Status MemTableMemoryLimiter::init(int64_t process_mem_limit) {
     _load_hard_mem_limit = calc_process_max_load_memory(process_mem_limit);
     _load_soft_mem_limit = _load_hard_mem_limit * config::load_process_soft_mem_limit_percent / 100;
+    _load_safe_mem_permit = _load_hard_mem_limit * config::load_process_safe_mem_permit_percent / 100;
     g_load_hard_mem_limit.set_value(_load_hard_mem_limit);
     g_load_soft_mem_limit.set_value(_load_soft_mem_limit);
     _mem_tracker = std::make_unique<MemTrackerLimiter>(MemTrackerLimiter::Type::LOAD,
@@ -96,10 +97,14 @@ bool MemTableMemoryLimiter::_hard_limit_reached() {
            _proc_mem_extra() >= 0;
 }
 
+bool MemTableMemoryLimiter::_load_usage_low() {
+    return _mem_tracker->consumption() <= _load_safe_mem_permit;
+}
+
 void MemTableMemoryLimiter::handle_memtable_flush() {
     // Check the soft limit.
     DCHECK(_load_soft_mem_limit > 0);
-    if (!_soft_limit_reached()) {
+    if (!_soft_limit_reached() || _load_usage_low()) {
         return;
     }
     MonotonicStopWatch timer;

--- a/be/src/olap/memtable_memory_limiter.h
+++ b/be/src/olap/memtable_memory_limiter.h
@@ -54,6 +54,7 @@ private:
 
     bool _soft_limit_reached();
     bool _hard_limit_reached();
+    bool _load_usage_low();
     void _flush_active_memtables(int64_t need_flush);
     int64_t _flush_memtable(std::weak_ptr<MemTableWriter> writer_to_flush, int64_t threshold);
     void _refresh_mem_tracker();
@@ -68,6 +69,7 @@ private:
     std::unique_ptr<MemTrackerLimiter> _mem_tracker;
     int64_t _load_hard_mem_limit = -1;
     int64_t _load_soft_mem_limit = -1;
+    int64_t _load_safe_mem_permit = -1;
 
     std::vector<std::weak_ptr<MemTableWriter>> _writers;
     std::vector<std::weak_ptr<MemTableWriter>> _active_writers;


### PR DESCRIPTION
## Proposed changes

Sometimes load can be blocked by memtable limiter because process memory usage is high, but load memory usage is low (near zero). In this case, if the memory is piled up before write memtables, memtable limiter can do nothing to help (i.e. flush active memtables).

This PR gives a unlimited margin to let memtable to be written without intervened by memtable limiter.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

