### PR TITLE
[fix](compaction) compaction should catch exception when vertical block reader read next block

### DIFF
--- a/be/src/vec/olap/vertical_block_reader.cpp
+++ b/be/src/vec/olap/vertical_block_reader.cpp
@@ -537,10 +537,12 @@ Status VerticalBlockReader::_unique_key_next_block(Block* block, bool* eof) {
         }
         const auto& src_block = _next_row.block;
         assert(src_block->columns() == column_count);
-        for (size_t i = 0; i < column_count; ++i) {
-            target_columns[i]->insert_from(*(src_block->get_by_position(i).column),
-                                           _next_row.row_pos);
-        }
+        RETURN_IF_CATCH_EXCEPTION({
+            for (size_t i = 0; i < column_count; ++i) {
+                target_columns[i]->insert_from(*(src_block->get_by_position(i).column),
+                                               _next_row.row_pos);
+            }
+        });
         ++target_block_row;
     } while (target_block_row < _reader_context.batch_size);
     return Status::OK();


### PR DESCRIPTION
## Proposed changes
when string column insert length is too large which is over 4GB, it will throw excpetion, vertical block reader should catch these prolem to avoid be core.
these is a supplement for pr https://github.com/apache/doris/pull/24484
Issue Number: close #28584

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

