### PR TITLE
[refactor](profilev2) using dst_id in pipelinex profile to be same as non pipeline rename some function names

### DIFF
--- a/be/src/pipeline/exec/exchange_sink_operator.cpp
+++ b/be/src/pipeline/exec/exchange_sink_operator.cpp
@@ -69,7 +69,7 @@ Status ExchangeSinkOperator::prepare(RuntimeState* state) {
 
     _sink_buffer->set_query_statistics(_sink->query_statistics());
     RETURN_IF_ERROR(DataSinkOperator::prepare(state));
-    _sink->registe_channels(_sink_buffer.get());
+    _sink->register_pipeline_channels(_sink_buffer.get());
     return Status::OK();
 }
 
@@ -249,7 +249,7 @@ Status ExchangeSinkLocalState::open(RuntimeState* state) {
 std::string ExchangeSinkLocalState::name_suffix() {
     std::string name = " (id=" + std::to_string(_parent->node_id());
     auto& p = _parent->cast<ExchangeSinkOperatorX>();
-    name += ",dest_id=" + std::to_string(p._dest_node_id);
+    name += ",dst_id=" + std::to_string(p._dest_node_id);
     name += ")";
     return name;
 }
@@ -450,7 +450,8 @@ Status ExchangeSinkOperatorX::serialize_block(ExchangeSinkLocalState& state, vec
 void ExchangeSinkLocalState::register_channels(
         pipeline::ExchangeSinkBuffer<ExchangeSinkLocalState>* buffer) {
     for (auto channel : channels) {
-        ((vectorized::PipChannel<ExchangeSinkLocalState>*)channel)->registe(buffer);
+        ((vectorized::PipChannel<ExchangeSinkLocalState>*)channel)
+                ->register_exchange_buffer(buffer);
     }
 }
 

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -791,9 +791,10 @@ Status VDataStreamSender::_get_next_available_buffer(BroadcastPBlockHolder** hol
     return Status::OK();
 }
 
-void VDataStreamSender::registe_channels(pipeline::ExchangeSinkBuffer<VDataStreamSender>* buffer) {
+void VDataStreamSender::register_pipeline_channels(
+        pipeline::ExchangeSinkBuffer<VDataStreamSender>* buffer) {
     for (auto channel : _channels) {
-        ((PipChannel<VDataStreamSender>*)channel)->registe(buffer);
+        ((PipChannel<VDataStreamSender>*)channel)->register_exchange_buffer(buffer);
     }
 }
 

--- a/be/src/vec/sink/vdata_stream_sender.h
+++ b/be/src/vec/sink/vdata_stream_sender.h
@@ -129,7 +129,7 @@ public:
 
     RuntimeState* state() { return _state; }
 
-    void registe_channels(pipeline::ExchangeSinkBuffer<VDataStreamSender>* buffer);
+    void register_pipeline_channels(pipeline::ExchangeSinkBuffer<VDataStreamSender>* buffer);
 
     bool channel_all_can_write();
 
@@ -530,7 +530,7 @@ public:
         return Status::OK();
     }
 
-    void registe(pipeline::ExchangeSinkBuffer<Parent>* buffer) {
+    void register_exchange_buffer(pipeline::ExchangeSinkBuffer<Parent>* buffer) {
         _buffer = buffer;
         _buffer->register_sink(Channel<Parent>::_fragment_instance_id);
     }


### PR DESCRIPTION
## Proposed changes

![img_v3_0269_c3e5be6b-81a4-4950-8068-978288a1564g](https://github.com/apache/doris/assets/9208457/2f1255f1-5477-490f-9928-dc9ce783d6a9)

![img_v3_0269_ea510e3e-8163-4328-98c5-4d51c3e2226g](https://github.com/apache/doris/assets/9208457/54423935-177e-4993-9e1d-71555d9f2257)


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

