### PR TITLE
[Fix](Export) Fix BE core when the `columns` attribute of `export` parquet is specified as an asterisk

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ExportStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ExportStmt.java
@@ -66,7 +66,6 @@ public class ExportStmt extends StatementBase {
 
     private static final String DEFAULT_COLUMN_SEPARATOR = "\t";
     private static final String DEFAULT_LINE_DELIMITER = "\n";
-    private static final String DEFAULT_COLUMNS = "";
     private static final String DEFAULT_PARALLELISM = "1";
     private static final Integer DEFAULT_TIMEOUT = 7200;
 
@@ -123,7 +122,6 @@ public class ExportStmt extends StatementBase {
         this.columnSeparator = DEFAULT_COLUMN_SEPARATOR;
         this.lineDelimiter = DEFAULT_LINE_DELIMITER;
         this.timeout = DEFAULT_TIMEOUT;
-        this.columns = DEFAULT_COLUMNS;
 
         // The ExportStmt may be created in replay thread, there is no ConnectionContext
         // in replay thread, so we need to clone session variable from default session variable.
@@ -354,8 +352,14 @@ public class ExportStmt extends StatementBase {
                 properties, ExportStmt.DEFAULT_COLUMN_SEPARATOR));
         this.lineDelimiter = Separator.convertSeparator(PropertyAnalyzer.analyzeLineDelimiter(
                 properties, ExportStmt.DEFAULT_LINE_DELIMITER));
-        this.columns = properties.getOrDefault(LoadStmt.KEY_IN_PARAM_COLUMNS, DEFAULT_COLUMNS);
-        checkColumns();
+
+        // null means not specified
+        // "" means user specified zero columns
+        this.columns = properties.getOrDefault(LoadStmt.KEY_IN_PARAM_COLUMNS, null);
+        // check columns are exits
+        if (this.columns != null) {
+            checkColumns();
+        }
 
         // format
         this.format = properties.getOrDefault(LoadStmt.KEY_IN_PARAM_FORMAT_TYPE, "csv").toLowerCase();


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

**problem:**
If we export data to parquet file format, and specify the `columns` attribute as `*`, it will occur BE core dump.
Such as:
```sql
EXPORT TABLE student TO "file:///xxx/exp_"
PROPERTIES(
    "format" = "parquet",
    "max_file_size" = "1024MB",
    "columns" = "*"
);
```

BE stack:

```
0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/datadisk1/fangtiewei/projects/doris-2.0/doris/be/src/common/signal_handler.h:417
 1# os::Linux::chained_handler(int, siginfo*, void*) in /mnt/datadisk1/fangtiewei/tools/jdk1.8.0_131/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /mnt/datadisk1/fangtiewei/tools/jdk1.8.0_131/jre/lib/amd64/server/libjvm.so
 3# signalHandler(int, siginfo*, void*) in /mnt/datadisk1/fangtiewei/tools/jdk1.8.0_131/jre/lib/amd64/server/libjvm.so
 4# 0x00007F2539D09400 in /lib64/libc.so.6
 5# parquet::SchemaDescriptor::Init(std::shared_ptr<parquet::schema::Node>) in /mnt/datadisk1/fangtiewei/projects/doris-2.0/doris/output/be/lib/doris_be
 6# parquet::FileSerializer::FileSerializer(std::shared_ptr<arrow::io::OutputStream>, std::shared_ptr<parquet::schema::GroupNode>, std::shared_ptr<parquet::WriterProperties>, std::shared_ptr<arrow::KeyValueMetadata const>) in /mnt/datadisk1/fangtiewei/projects/doris-2.0/doris/output/be/lib/doris_be
 7# parquet::ParquetFileWriter::Open(std::shared_ptr<arrow::io::OutputStream>, std::shared_ptr<parquet::schema::GroupNode>, std::shared_ptr<parquet::WriterProperties>, std::shared_ptr<arrow::KeyValueMetadata const>) in /mnt/datadisk1/fangtiewei/projects/doris-2.0/doris/output/be/lib/doris_be
 8# doris::vectorized::VParquetWriterWrapper::prepare() at /mnt/datadisk1/fangtiewei/projects/doris-2.0/doris/be/src/vec/runtime/vparquet_writer.cpp:915
 9# doris::vectorized::VFileResultWriter::_create_file_writer(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at /mnt/datadisk1/fangtiewei/projects/doris-2.0/doris/be/src/vec/runtime/vfile_result_writer.cpp:166
10# doris::vectorized::VFileResultWriter::_create_next_file_writer() at /mnt/datadisk1/fangtiewei/projects/doris-2.0/doris/be/src/vec/runtime/vfile_result_writer.cpp:150
11# doris::vectorized::VFileResultWriter::init(doris::RuntimeState*) at /mnt/datadisk1/fangtiewei/projects/doris-2.0/doris/be/src/vec/runtime/vfile_result_writer.cpp:102
12# doris::vectorized::VResultFileSink::prepare(doris::RuntimeState*) at /mnt/datadisk1/fangtiewei/projects/doris-2.0/doris/be/src/vec/sink/vresult_file_sink.cpp:138
13# doris::PlanFragmentExecutor::prepare(doris::TExecPlanFragmentParams const&, doris::QueryContext*) at /mnt/datadisk1/fangtiewei/projects/doris-2.0/doris/be/src/runtime/plan_fragment_executor.cpp:216
```


<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

