### PR TITLE
[fix](planner) ctas update datev1 to datev2 should use equals

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableAsSelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableAsSelectStmt.java
@@ -89,11 +89,11 @@ public class CreateTableAsSelectStmt extends DdlStmt {
                 queryStmt.getResultExprs().get(i).getSrcSlotRef().getDesc().setColumn(columnCopy);
             }
             if (Config.enable_date_conversion) {
-                if (queryStmt.getResultExprs().get(i).getType() == Type.DATE) {
+                if (queryStmt.getResultExprs().get(i).getType().isDate()) {
                     Expr castExpr = queryStmt.getResultExprs().get(i).castTo(Type.DATEV2);
                     queryStmt.getResultExprs().set(i, castExpr);
                 }
-                if (queryStmt.getResultExprs().get(i).getType() == Type.DATETIME) {
+                if (queryStmt.getResultExprs().get(i).getType().isDatetime()) {
                     Expr castExpr = queryStmt.getResultExprs().get(i).castTo(Type.DATETIMEV2);
                     queryStmt.getResultExprs().set(i, castExpr);
                 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

