### PR TITLE
[Fix](multi-catalog) skip hms events if hms table is not supported.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
@@ -382,6 +382,12 @@ public interface TableIf {
                 getName());
     }
 
+    default String getNameWithFullQualifiers() {
+        return String.format("%s.%s.%s", getDatabase().getCatalog().getName(),
+                ClusterNamespace.getNameFromFullName(getDatabase().getFullName()),
+                getName());
+    }
+
     default boolean isManagedTable() {
         return getType() == TableType.OLAP || getType() == TableType.MATERIALIZED_VIEW;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
@@ -28,6 +28,7 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.datasource.HMSExternalCatalog;
 import org.apache.doris.datasource.hive.HMSCachedClient;
 import org.apache.doris.datasource.hive.HiveMetaStoreCache;
+import org.apache.doris.nereids.exceptions.NotSupportedException;
 import org.apache.doris.statistics.AnalysisInfo;
 import org.apache.doris.statistics.BaseAnalysisTask;
 import org.apache.doris.statistics.ColumnStatistic;
@@ -136,8 +137,13 @@ public class HMSExternalTable extends ExternalTable {
     }
 
     public boolean isSupportedHmsTable() {
-        makeSureInitialized();
-        return dlaType != DLAType.UNKNOWN;
+        try {
+            makeSureInitialized();
+            return true;
+        } catch (NotSupportedException e) {
+            LOG.warn("Not supported hms table, message: {}", e.getMessage());
+            return false;
+        }
     }
 
     protected synchronized void makeSureInitialized() {
@@ -145,7 +151,7 @@ public class HMSExternalTable extends ExternalTable {
         if (!objectCreated) {
             remoteTable = ((HMSExternalCatalog) catalog).getClient().getTable(dbName, name);
             if (remoteTable == null) {
-                dlaType = DLAType.UNKNOWN;
+                throw new IllegalArgumentException("Hms table not exists, table: " + getNameWithFullQualifiers());
             } else {
                 if (supportedIcebergTable()) {
                     dlaType = DLAType.ICEBERG;
@@ -154,7 +160,7 @@ public class HMSExternalTable extends ExternalTable {
                 } else if (supportedHiveTable()) {
                     dlaType = DLAType.HIVE;
                 } else {
-                    dlaType = DLAType.UNKNOWN;
+                    throw new NotSupportedException("Unsupported dlaType for table: " + getNameWithFullQualifiers());
                 }
             }
             objectCreated = true;
@@ -201,12 +207,8 @@ public class HMSExternalTable extends ExternalTable {
         if (inputFileFormat == null) {
             return false;
         }
-        boolean supportedFileFormat = SUPPORTED_HIVE_FILE_FORMATS.contains(inputFileFormat);
-        if (!supportedFileFormat) {
-            throw new IllegalArgumentException("Unsupported hive input format: " + inputFileFormat);
-        }
         LOG.debug("hms table {} is {} with file format: {}", name, remoteTable.getTableType(), inputFileFormat);
-        return true;
+        return SUPPORTED_HIVE_FILE_FORMATS.contains(inputFileFormat);
     }
 
     /**


### PR DESCRIPTION
## Proposed changes

```java
2023-12-19 16:04:00,170 WARN (org.apache.doris.datasource.hive.event.MetastoreEventsProcessor|37) [MetastoreEventsProcessor.realRun():123] Failed to process hive metastore [hive_safe_lycc] events .
java.lang.IllegalArgumentException: Unsupported hive input format: org.apache.hadoop.mapred.SequenceFileInputFormat
        at org.apache.doris.catalog.external.HMSExternalTable.supportedHiveTable(HMSExternalTable.java:210) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.external.HMSExternalTable.makeSureInitialized(HMSExternalTable.java:158) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.catalog.external.HMSExternalTable.getPartitionColumnTypes(HMSExternalTable.java:225) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.datasource.ExternalMetaCacheMgr.addPartitionsCache(ExternalMetaCacheMgr.java:165) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.datasource.CatalogMgr.addExternalPartitions(CatalogMgr.java:913) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.datasource.hive.event.AddPartitionEvent.process(AddPartitionEvent.java:106) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.datasource.hive.event.MetastoreEventsProcessor.doExecute(MetastoreEventsProcessor.java:152) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.datasource.hive.event.MetastoreEventsProcessor.processEvents(MetastoreEventsProcessor.java:174) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.datasource.hive.event.MetastoreEventsProcessor.realRun(MetastoreEventsProcessor.java:118) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.datasource.hive.event.MetastoreEventsProcessor.runAfterCatalogReady(MetastoreEventsProcessor.java:100) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.common.util.MasterDaemon.runOneCycle(MasterDaemon.java:58) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.common.util.Daemon.run(Daemon.java:116) ~[doris-fe.jar:1.2-SNAPSHOT]
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

