### PR TITLE
[fix](memory) Add thread asynchronous purge jemalloc dirty pages

### DIFF
--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -356,14 +356,11 @@ void Daemon::block_spill_gc_thread() {
 
 void Daemon::je_purge_dirty_pages_thread() const {
     do {
-        {
-            std::unique_lock<std::mutex> l(doris::MemInfo::je_purge_dirty_pages_lock);
-            doris::MemInfo::je_purge_dirty_pages_cv.wait(l);
-        }
+        std::unique_lock<std::mutex> l(doris::MemInfo::je_purge_dirty_pages_lock);
+        doris::MemInfo::je_purge_dirty_pages_cv.wait(l);
         if (_stop_background_threads_latch.count() == 0) {
             break;
         }
-        // cannot lock je_purge_all_arena_dirty_pages, otherwise it will block GC thread.
         doris::MemInfo::je_purge_all_arena_dirty_pages();
     } while (true);
 }

--- a/be/src/common/daemon.h
+++ b/be/src/common/daemon.h
@@ -36,10 +36,6 @@ public:
     // Stop background threads
     void stop();
 
-    static void count_down_je_purge_dirty_pages_thread_latch() {
-        _je_purge_dirty_pages_thread_latch.count_down();
-    }
-
 private:
     void tcmalloc_gc_thread();
     void memory_maintenance_thread();
@@ -50,8 +46,6 @@ private:
     void je_purge_dirty_pages_thread() const;
 
     CountDownLatch _stop_background_threads_latch;
-    static CountDownLatch _je_purge_dirty_pages_thread_latch;
-    bool _is_stopped {};
     std::vector<scoped_refptr<Thread>> _threads;
 };
 } // namespace doris

--- a/be/src/common/daemon.h
+++ b/be/src/common/daemon.h
@@ -36,6 +36,10 @@ public:
     // Stop background threads
     void stop();
 
+    static void count_down_je_purge_dirty_pages_thread_latch() {
+        _je_purge_dirty_pages_thread_latch.count_down();
+    }
+
 private:
     void tcmalloc_gc_thread();
     void memory_maintenance_thread();
@@ -43,8 +47,11 @@ private:
     void memtable_memory_limiter_tracker_refresh_thread();
     void calculate_metrics_thread();
     void block_spill_gc_thread();
+    void je_purge_dirty_pages_thread() const;
 
     CountDownLatch _stop_background_threads_latch;
+    static CountDownLatch _je_purge_dirty_pages_thread_latch;
+    bool _is_stopped {};
     std::vector<scoped_refptr<Thread>> _threads;
 };
 } // namespace doris

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -130,7 +130,7 @@ bool MemInfo::process_minor_gc() {
     std::string pre_sys_mem_available = MemInfo::sys_mem_available_str();
 
     Defer defer {[&]() {
-        notify_all_je_purge_dirty_pages_cv();
+        je_purge_dirty_pages_cv.notify_all();
         std::stringstream ss;
         profile->pretty_print(&ss);
         LOG(INFO) << fmt::format(
@@ -140,7 +140,7 @@ bool MemInfo::process_minor_gc() {
     }};
 
     freed_mem += CacheManager::instance()->for_each_cache_prune_stale(profile.get());
-    notify_all_je_purge_dirty_pages_cv();
+    je_purge_dirty_pages_cv.notify_all();
     if (freed_mem > _s_process_minor_gc_size) {
         return true;
     }
@@ -181,7 +181,7 @@ bool MemInfo::process_full_gc() {
     std::string pre_sys_mem_available = MemInfo::sys_mem_available_str();
 
     Defer defer {[&]() {
-        notify_all_je_purge_dirty_pages_cv();
+        je_purge_dirty_pages_cv.notify_all();
         std::stringstream ss;
         profile->pretty_print(&ss);
         LOG(INFO) << fmt::format(
@@ -191,7 +191,7 @@ bool MemInfo::process_full_gc() {
     }};
 
     freed_mem += CacheManager::instance()->for_each_cache_prune_all(profile.get());
-    notify_all_je_purge_dirty_pages_cv();
+    je_purge_dirty_pages_cv.notify_all();
     if (freed_mem > _s_process_full_gc_size) {
         return true;
     }

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -37,7 +37,6 @@
 #include <vector>
 
 #include "common/config.h"
-#include "common/daemon.h"
 #include "common/status.h"
 #include "gutil/strings/split.h"
 #include "runtime/exec_env.h"
@@ -81,6 +80,9 @@ int64_t MemInfo::_s_sys_mem_available_low_water_mark = -1;
 int64_t MemInfo::_s_sys_mem_available_warning_water_mark = -1;
 int64_t MemInfo::_s_process_minor_gc_size = -1;
 int64_t MemInfo::_s_process_full_gc_size = -1;
+std::mutex MemInfo::je_purge_dirty_pages_lock;
+std::condition_variable MemInfo::je_purge_dirty_pages_cv;
+std::atomic<bool> MemInfo::je_purge_dirty_pages_notify {false};
 
 void MemInfo::refresh_allocator_mem() {
 #if defined(ADDRESS_SANITIZER) || defined(LEAK_SANITIZER) || defined(THREAD_SANITIZER)
@@ -130,7 +132,7 @@ bool MemInfo::process_minor_gc() {
     std::string pre_sys_mem_available = MemInfo::sys_mem_available_str();
 
     Defer defer {[&]() {
-        je_purge_dirty_pages_cv.notify_all();
+        notify_je_purge_dirty_pages();
         std::stringstream ss;
         profile->pretty_print(&ss);
         LOG(INFO) << fmt::format(
@@ -140,7 +142,7 @@ bool MemInfo::process_minor_gc() {
     }};
 
     freed_mem += CacheManager::instance()->for_each_cache_prune_stale(profile.get());
-    je_purge_dirty_pages_cv.notify_all();
+    notify_je_purge_dirty_pages();
     if (freed_mem > _s_process_minor_gc_size) {
         return true;
     }
@@ -181,7 +183,7 @@ bool MemInfo::process_full_gc() {
     std::string pre_sys_mem_available = MemInfo::sys_mem_available_str();
 
     Defer defer {[&]() {
-        je_purge_dirty_pages_cv.notify_all();
+        notify_je_purge_dirty_pages();
         std::stringstream ss;
         profile->pretty_print(&ss);
         LOG(INFO) << fmt::format(
@@ -191,7 +193,7 @@ bool MemInfo::process_full_gc() {
     }};
 
     freed_mem += CacheManager::instance()->for_each_cache_prune_all(profile.get());
-    je_purge_dirty_pages_cv.notify_all();
+    notify_je_purge_dirty_pages();
     if (freed_mem > _s_process_full_gc_size) {
         return true;
     }

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -130,7 +130,7 @@ bool MemInfo::process_minor_gc() {
     std::string pre_sys_mem_available = MemInfo::sys_mem_available_str();
 
     Defer defer {[&]() {
-        Daemon::count_down_je_purge_dirty_pages_thread_latch();
+        notify_all_je_purge_dirty_pages_cv();
         std::stringstream ss;
         profile->pretty_print(&ss);
         LOG(INFO) << fmt::format(
@@ -140,7 +140,7 @@ bool MemInfo::process_minor_gc() {
     }};
 
     freed_mem += CacheManager::instance()->for_each_cache_prune_stale(profile.get());
-    Daemon::count_down_je_purge_dirty_pages_thread_latch();
+    notify_all_je_purge_dirty_pages_cv();
     if (freed_mem > _s_process_minor_gc_size) {
         return true;
     }
@@ -181,7 +181,7 @@ bool MemInfo::process_full_gc() {
     std::string pre_sys_mem_available = MemInfo::sys_mem_available_str();
 
     Defer defer {[&]() {
-        Daemon::count_down_je_purge_dirty_pages_thread_latch();
+        notify_all_je_purge_dirty_pages_cv();
         std::stringstream ss;
         profile->pretty_print(&ss);
         LOG(INFO) << fmt::format(
@@ -191,7 +191,7 @@ bool MemInfo::process_full_gc() {
     }};
 
     freed_mem += CacheManager::instance()->for_each_cache_prune_all(profile.get());
-    Daemon::count_down_je_purge_dirty_pages_thread_latch();
+    notify_all_je_purge_dirty_pages_cv();
     if (freed_mem > _s_process_full_gc_size) {
         return true;
     }

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -129,10 +129,6 @@ public:
 
     static std::mutex je_purge_dirty_pages_lock;
     static std::condition_variable je_purge_dirty_pages_cv;
-    static void notify_all_je_purge_dirty_pages_cv() {
-        std::lock_guard l(je_purge_dirty_pages_lock);
-        je_purge_dirty_pages_cv.notify_all();
-    }
 
     static inline size_t allocator_virtual_mem() {
         return _s_virtual_memory_used.load(std::memory_order_relaxed);

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -129,6 +129,11 @@ public:
 
     static std::mutex je_purge_dirty_pages_lock;
     static std::condition_variable je_purge_dirty_pages_cv;
+    static std::atomic<bool> je_purge_dirty_pages_notify;
+    static void notify_je_purge_dirty_pages() {
+        je_purge_dirty_pages_notify.store(true, std::memory_order_relaxed);
+        je_purge_dirty_pages_cv.notify_all();
+    }
 
     static inline size_t allocator_virtual_mem() {
         return _s_virtual_memory_used.load(std::memory_order_relaxed);

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -127,6 +127,13 @@ public:
 #endif
     }
 
+    static std::mutex je_purge_dirty_pages_lock;
+    static std::condition_variable je_purge_dirty_pages_cv;
+    static void notify_all_je_purge_dirty_pages_cv() {
+        std::lock_guard l(je_purge_dirty_pages_lock);
+        je_purge_dirty_pages_cv.notify_all();
+    }
+
     static inline size_t allocator_virtual_mem() {
         return _s_virtual_memory_used.load(std::memory_order_relaxed);
     }

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -24,6 +24,7 @@
 #include <stdint.h>
 
 #include <atomic>
+#include <condition_variable>
 #include <string>
 
 #if !defined(__APPLE__) || !defined(_POSIX_C_SOURCE)


### PR DESCRIPTION
## Proposed changes

jemallctl purge all arena dirty pages may take several seconds, which will block memory GC and cause OOM.
So purge asynchronously in a thread.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

