### PR TITLE
[Fix](Job)Fixed job scheduling missing certain time window schedules

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/base/JobExecutionConfiguration.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/base/JobExecutionConfiguration.java
@@ -178,8 +178,8 @@ public class JobExecutionConfiguration {
 
         // Calculate the trigger time list
         for (long triggerTime = firstTriggerTime; triggerTime <= windowEndTimeMs; triggerTime += intervalMs) {
-            if (triggerTime >= currentTimeMs && (null == timerDefinition.getEndTimeMs()
-                    || triggerTime < timerDefinition.getEndTimeMs())) {
+            if (null == timerDefinition.getEndTimeMs()
+                    || triggerTime < timerDefinition.getEndTimeMs()) {
                 timerDefinition.setLatestSchedulerTimeMs(triggerTime);
                 timestamps.add(queryDelayTimeSecond(currentTimeMs, triggerTime));
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/job/base/JobExecutionConfigurationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/job/base/JobExecutionConfigurationTest.java
@@ -64,7 +64,7 @@ public class JobExecutionConfigurationTest {
         Assertions.assertArrayEquals(new Long[]{ 500L}, delayTimes.toArray());
         delayTimes = configuration.getTriggerDelayTimes(
                 1001000L, 0L, 1000000L);
-        Assertions.assertEquals(0, delayTimes.size());
+        Assertions.assertEquals(1, delayTimes.size());
     }
 
 }


### PR DESCRIPTION
Since the tasks scheduled periodically will occupy a certain time window, this will cause some tasks within this time to be unable to be scheduled. To compensate, we set the time start window to the last scheduled end time instead of the current time.
eg: 
If the next scheduling time of a JOB is the next 1 second, but other task cycle window scheduling takes 1 second, at this time, because the time window start time and end time we use are the current time, the current time + 10min, the current time > job next times scheduling time, so the JOB is missed scheduling.
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

