### PR TITLE
[Fix](memtable) fix `shrink_memtable_by_agg` without duplicated keys

### DIFF
--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -468,10 +468,7 @@ void MemTable::shrink_memtable_by_agg() {
         return;
     }
     size_t same_keys_num = _sort();
-    if (same_keys_num == 0) {
-        vectorized::Block in_block = _input_mutable_block.to_block();
-        _put_into_output(in_block);
-    } else {
+    if (same_keys_num != 0) {
         _aggregate<false>();
     }
 }

--- a/regression-test/suites/load_p0/insert/test_insert_with_aggregation_memtable.groovy
+++ b/regression-test/suites/load_p0/insert/test_insert_with_aggregation_memtable.groovy
@@ -132,6 +132,8 @@ suite("test_insert_with_aggregation_memtable", "nonConcurrent") {
     sql """INSERT INTO ${table_name} SELECT k, v from ${table_name}"""
     createMV("""create materialized view var_cnt as select k, count(k) from ${table_name} group by k""")    
     sql """INSERT INTO ${table_name} SELECT k, v from ${table_name} limit 8101"""
+    // insert with no duplicate
+    sql """INSERT INTO ${table_name} SELECT *, '{"k1":1, "k2": "hello world", "k3" : [1234], "k4" : 1.10000, "k5" : [[123]]}' FROM numbers("number" = "4096"); """
 
     reset_be_param("enable_shrink_memory")
     reset_be_param("write_buffer_size_for_agg")


### PR DESCRIPTION
remove duplicated logic:
```
vectorized::Block in_block = _input_mutable_block.to_block();
_put_into_output(in_block);
```
`_input_mutable_block.to_block()` will move `_input_mutable_block`, and lead to `flush` with empty block

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

