### PR TITLE
[fix](pipeline) Fix query is not cancelled when be report error status

### DIFF
--- a/be/src/pipeline/exec/exchange_sink_buffer.cpp
+++ b/be/src/pipeline/exec/exchange_sink_buffer.cpp
@@ -197,6 +197,9 @@ Status ExchangeSinkBuffer::_send_rpc(InstanceLoId id) {
         if (request.block) {
             brpc_request->set_allocated_block(request.block.get());
         }
+        if (!request.exec_status.ok()) {
+            request.exec_status.to_protobuf(brpc_request->mutable_exec_status());
+        }
         auto* closure = request.channel->get_closure(id, request.eos, nullptr);
 
         _instance_to_rpc_ctx[id]._closure = closure;

--- a/be/src/pipeline/exec/exchange_sink_buffer.h
+++ b/be/src/pipeline/exec/exchange_sink_buffer.h
@@ -88,6 +88,7 @@ struct TransmitInfo {
     vectorized::PipChannel* channel;
     std::unique_ptr<PBlock> block;
     bool eos;
+    Status exec_status;
 };
 
 struct BroadcastTransmitInfo {

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -158,8 +158,7 @@ void PipelineFragmentContext::cancel(const PPlanFragmentCancelReason& reason,
             _exec_status = Status::Cancelled(msg);
         }
         _runtime_state->set_is_cancelled(true, msg);
-
-        LOG(WARNING) << "PipelineFragmentContext Canceled. reason=" << msg;
+        LOG_WARNING("Instance {} cancelled, reason {}", print_id(_fragment_instance_id), msg.substr(0, 50));
 
         // Print detail informations below when you debugging here.
         //

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -158,7 +158,8 @@ void PipelineFragmentContext::cancel(const PPlanFragmentCancelReason& reason,
             _exec_status = Status::Cancelled(msg);
         }
         _runtime_state->set_is_cancelled(true, msg);
-        LOG_WARNING("Instance {} cancelled, reason {}", print_id(_fragment_instance_id), msg.substr(0, 50));
+        LOG_WARNING("Instance {} cancelled, reason {}", print_id(_fragment_instance_id),
+                    msg.substr(0, 50));
 
         // Print detail informations below when you debugging here.
         //

--- a/be/src/pipeline/task_scheduler.cpp
+++ b/be/src/pipeline/task_scheduler.cpp
@@ -272,7 +272,9 @@ void TaskScheduler::_do_work(size_t index) {
         task->set_previous_core_id(index);
         if (!status.ok()) {
             task->set_eos_time();
-            LOG(WARNING) << fmt::format("Pipeline task failed. reason: {}", status.to_string());
+            LOG_WARNING("Instance {} pipeline task {} failed, reason: {}",
+                        print_id(task->fragment_context()->get_fragment_instance_id()),
+                        task->get_core_id(), status.msg());
             // Print detail informations below when you debugging here.
             //
             // LOG(WARNING)<< "task:\n"<<task->debug_string();

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -479,10 +479,9 @@ void FragmentMgr::coordinator_callback(const ReportStatusRequest& req) {
     VLOG_DEBUG << "reportExecStatus params is "
                << apache::thrift::ThriftDebugString(params).c_str();
     if (!exec_status.ok()) {
-        LOG(WARNING) << "report error status: " << exec_status.to_string()
-                     << " to coordinator: " << req.coord_addr
-                     << ", query id: " << print_id(req.query_id)
-                     << ", instance id: " << print_id(req.fragment_instance_id);
+        LOG_WARNING("Query {} instance {} report error status to coor {}:{}, error status: {}",
+                    print_id(req.query_id), print_id(req.fragment_instance_id),
+                    req.coord_addr.hostname, req.coord_addr.port, exec_status.code());
     }
     try {
         try {
@@ -548,6 +547,7 @@ void FragmentMgr::_exec_actual(std::shared_ptr<FragmentExecState> exec_state,
         std::lock_guard<std::mutex> lock(_lock);
         _fragment_map.erase(exec_state->fragment_instance_id());
         if (all_done && query_ctx) {
+            LOG_INFO("Query {} finished", print_id(query_ctx->query_id));
             _query_ctx_map.erase(query_ctx->query_id);
         }
     }
@@ -654,6 +654,7 @@ void FragmentMgr::remove_pipeline_context(
     bool all_done = q_context->countdown();
     _pipeline_map.erase(f_context->get_fragment_instance_id());
     if (all_done) {
+        LOG_INFO("Query {} finished", print_id(query_id));
         _query_ctx_map.erase(query_id);
     }
 }
@@ -1012,7 +1013,8 @@ void FragmentMgr::cancel(const TUniqueId& fragment_id, const PPlanFragmentCancel
     }
 
     if (!find_the_fragment) {
-        LOG(WARNING) << "Do not find the fragment instance id:" << fragment_id << " to cancel";
+        LOG(WARNING) << "Do not find the fragment instance id:" << print_id(fragment_id)
+                     << " to cancel";
     }
 }
 

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -169,7 +169,8 @@ public:
         _is_cancelled.store(v);
         // Create a error status, so that we could print error stack, and
         // we could know which path call cancel.
-        LOG_WARNING("Task {} is cancelled, msg: {}", print_id(_fragment_instance_id), Status::Error<ErrorCode::CANCELLED>(msg));
+        LOG_WARNING("Task {} is cancelled, msg: {}", print_id(_fragment_instance_id),
+                    Status::Error<ErrorCode::CANCELLED>(msg));
     }
 
     void set_backend_id(int64_t backend_id) { _backend_id = backend_id; }

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -169,7 +169,7 @@ public:
         _is_cancelled.store(v);
         // Create a error status, so that we could print error stack, and
         // we could know which path call cancel.
-        LOG(INFO) << "task is cancelled, st = " << Status::Error<ErrorCode::CANCELLED>(msg);
+        LOG_WARNING("Task {} is cancelled, msg: {}", print_id(_fragment_instance_id), Status::Error<ErrorCode::CANCELLED>(msg));
     }
 
     void set_backend_id(int64_t backend_id) { _backend_id = backend_id; }

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -518,7 +518,7 @@ void PInternalServiceImpl::cancel_plan_fragment(google::protobuf::RpcController*
 
         Status st = Status::OK();
         if (request->has_cancel_reason()) {
-            LOG(INFO) << "cancel fragment, fragment_instance_id=" << print_id(tid)
+            LOG(INFO) << "Cancel fragment, fragment_instance_id=" << print_id(tid)
                       << ", reason: " << PPlanFragmentCancelReason_Name(request->cancel_reason());
             _exec_env->fragment_mgr()->cancel(tid, request->cancel_reason());
         } else {

--- a/be/src/vec/core/sort_cursor.h
+++ b/be/src/vec/core/sort_cursor.h
@@ -20,6 +20,10 @@
 
 #pragma once
 
+#include <fmt/core.h>
+
+#include <stdexcept>
+
 #include "vec/columns/column.h"
 #include "vec/core/block.h"
 #include "vec/core/sort_description.h"
@@ -244,6 +248,10 @@ struct BlockSupplierSortCursorImpl : public MergeSortCursorImpl {
             }
             MergeSortCursorImpl::reset(_block);
             return status.ok();
+        } else if (!status.ok()) {
+            // Currently, a known error status is emitted when sender
+            // close recei
+            throw std::runtime_error(status.msg());
         }
         return false;
     }

--- a/be/src/vec/runtime/vdata_stream_recvr.cpp
+++ b/be/src/vec/runtime/vdata_stream_recvr.cpp
@@ -79,7 +79,7 @@ Status VDataStreamRecvr::SenderQueue::get_batch(Block* block, bool* eos) {
 
 Status VDataStreamRecvr::SenderQueue::_inner_get_batch_without_lock(Block* block, bool* eos) {
     if (_is_cancelled) {
-        return Status::Cancelled("Cancelled");
+        return Status::Cancelled(_cancel_msg);
     }
 
     if (_block_queue.empty()) {
@@ -246,14 +246,15 @@ void VDataStreamRecvr::SenderQueue::decrement_senders(int be_number) {
     }
 }
 
-void VDataStreamRecvr::SenderQueue::cancel() {
+void VDataStreamRecvr::SenderQueue::cancel(const std::string& msg) {
     {
         std::lock_guard<std::mutex> l(_lock);
         if (_is_cancelled) {
             return;
         }
         _is_cancelled = true;
-        VLOG_QUERY << "cancelled stream: _fragment_instance_id=" << _recvr->fragment_instance_id()
+        _cancel_msg = msg; // TODO: std::string copy, maybe we can do this better.
+        VLOG_QUERY << "cancelled stream: _fragment_instance_id=" << print_id(_recvr->fragment_instance_id())
                    << " node_id=" << _recvr->dest_node_id();
     }
     // Wake up all threads waiting to produce/consume batches.  They will all
@@ -407,20 +408,17 @@ Status VDataStreamRecvr::get_next(Block* block, bool* eos) {
     }
 }
 
-void VDataStreamRecvr::remove_sender(int sender_id, int be_number) {
-    int use_sender_id = _is_merging ? sender_id : 0;
-    _sender_queues[use_sender_id]->decrement_senders(be_number);
-}
-
 void VDataStreamRecvr::remove_sender(int sender_id, int be_number, QueryStatisticsPtr statistics) {
     int use_sender_id = _is_merging ? sender_id : 0;
     _sender_queues[use_sender_id]->decrement_senders(be_number);
-    _sub_plan_query_statistics_recvr->insert(statistics, sender_id);
+    if (statistics != nullptr) {
+        _sub_plan_query_statistics_recvr->insert(statistics, sender_id);
+    }
 }
 
-void VDataStreamRecvr::cancel_stream() {
+void VDataStreamRecvr::cancel_stream(const std::string& msg) {
     for (int i = 0; i < _sender_queues.size(); ++i) {
-        _sender_queues[i]->cancel();
+        _sender_queues[i]->cancel(msg);
     }
 }
 

--- a/be/src/vec/runtime/vdata_stream_recvr.cpp
+++ b/be/src/vec/runtime/vdata_stream_recvr.cpp
@@ -254,7 +254,8 @@ void VDataStreamRecvr::SenderQueue::cancel(const std::string& msg) {
         }
         _is_cancelled = true;
         _cancel_msg = msg; // TODO: std::string copy, maybe we can do this better.
-        VLOG_QUERY << "cancelled stream: _fragment_instance_id=" << print_id(_recvr->fragment_instance_id())
+        VLOG_QUERY << "cancelled stream: _fragment_instance_id="
+                   << print_id(_recvr->fragment_instance_id())
                    << " node_id=" << _recvr->dest_node_id();
     }
     // Wake up all threads waiting to produce/consume batches.  They will all

--- a/be/src/vec/runtime/vdata_stream_recvr.h
+++ b/be/src/vec/runtime/vdata_stream_recvr.h
@@ -96,12 +96,10 @@ public:
 
     // Indicate that a particular sender is done. Delegated to the appropriate
     // sender queue. Called from DataStreamMgr.
+    void remove_sender(int sender_id, int be_number, QueryStatisticsPtr statistics = nullptr);
 
-    void remove_sender(int sender_id, int be_number);
-
-    void remove_sender(int sender_id, int be_number, QueryStatisticsPtr statistics);
-
-    void cancel_stream();
+    // We need msg to make sure we can pass existing regression test.
+    void cancel_stream(const std::string& msg = "");
 
     void close();
 
@@ -203,7 +201,7 @@ public:
 
     void decrement_senders(int sender_id);
 
-    void cancel();
+    void cancel(const std::string& msg = "");
 
     void close();
 
@@ -219,6 +217,7 @@ protected:
     VDataStreamRecvr* _recvr;
     std::mutex _lock;
     bool _is_cancelled;
+    std::string _cancel_msg = "";
     int _num_remaining_senders;
     std::condition_variable _data_arrival_cv;
     std::condition_variable _data_removal_cv;

--- a/be/src/vec/runtime/vsorted_run_merger.cpp
+++ b/be/src/vec/runtime/vsorted_run_merger.cpp
@@ -69,12 +69,16 @@ void VSortedRunMerger::init_timers(RuntimeProfile* profile) {
 }
 
 Status VSortedRunMerger::prepare(const vector<BlockSupplier>& input_runs) {
-    for (const auto& supplier : input_runs) {
-        if (_use_sort_desc) {
-            _cursors.emplace_back(supplier, _desc);
-        } else {
-            _cursors.emplace_back(supplier, _ordering_expr, _is_asc_order, _nulls_first);
+    try {
+        for (const auto& supplier : input_runs) {
+            if (_use_sort_desc) {
+                _cursors.emplace_back(supplier, _desc);
+            } else {
+                _cursors.emplace_back(supplier, _ordering_expr, _is_asc_order, _nulls_first);
+            }
         }
+    } catch (const std::exception& e) {
+        return Status::Cancelled(e.what());
     }
 
     for (auto& _cursor : _cursors) {

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -274,9 +274,9 @@ Status Channel::close_internal(const Status& exec_status) {
     }
 
     VLOG_RPC << "Channel::close() instance_id=" << print_id(_fragment_instance_id)
-              << " dest_node=" << _dest_node_id
-              << " #rows= " << ((_mutable_block == nullptr) ? 0 : _mutable_block->rows())
-              << " receiver status: " << _receiver_status << " close status: " << exec_status.msg();
+             << " dest_node=" << _dest_node_id
+             << " #rows= " << ((_mutable_block == nullptr) ? 0 : _mutable_block->rows())
+             << " receiver status: " << _receiver_status << " close status: " << exec_status.msg();
 
     if (is_receiver_eof()) {
         _mutable_block.reset();

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -103,27 +103,32 @@ Status Channel::init(RuntimeState* state) {
     return Status::OK();
 }
 
-Status Channel::send_current_block(bool eos) {
+Status Channel::send_current_block(bool eos, const Status& exec_status) {
     // FIXME: Now, local exchange will cause the performance problem is in a multi-threaded scenario
     // so this feature is turned off here by default. We need to re-examine this logic
     if (is_local()) {
-        return send_local_block(eos);
+        return send_local_block(eos, exec_status);
     }
     SCOPED_CONSUME_MEM_TRACKER(_parent->_mem_tracker.get());
     auto block = _mutable_block->to_block();
     RETURN_IF_ERROR(_parent->serialize_block(&block, _ch_cur_pb_block));
     block.clear_column_data();
     _mutable_block->set_muatable_columns(block.mutate_columns());
-    RETURN_IF_ERROR(send_block(_ch_cur_pb_block, eos));
+    RETURN_IF_ERROR(send_remote_block(_ch_cur_pb_block, eos, exec_status));
     ch_roll_pb_block();
     return Status::OK();
 }
 
-Status Channel::send_local_block(bool eos) {
+Status Channel::send_local_block(bool eos, const Status& exec_status) {
     SCOPED_TIMER(_parent->_local_send_timer);
     Block block = _mutable_block->to_block();
     _mutable_block->set_muatable_columns(block.clone_empty_columns());
     if (_recvr_is_valid()) {
+        if (!exec_status.ok()) {
+            _local_recvr->cancel_stream(exec_status.msg());
+            return Status::OK();
+        }
+
         COUNTER_UPDATE(_parent->_local_bytes_send_counter, block.bytes());
         COUNTER_UPDATE(_parent->_local_sent_rows, block.rows());
         COUNTER_UPDATE(_parent->_blocks_sent_counter, 1);
@@ -139,9 +144,14 @@ Status Channel::send_local_block(bool eos) {
     }
 }
 
-Status Channel::send_local_block(Block* block) {
+Status Channel::send_local_block(Block* block, const Status& exec_status) {
     SCOPED_TIMER(_parent->_local_send_timer);
     if (_recvr_is_valid()) {
+        if (!exec_status.ok()) {
+            _local_recvr->cancel_stream(exec_status.msg());
+            return Status::OK();
+        }
+
         COUNTER_UPDATE(_parent->_local_bytes_send_counter, block->bytes());
         COUNTER_UPDATE(_parent->_local_sent_rows, block->rows());
         COUNTER_UPDATE(_parent->_blocks_sent_counter, 1);
@@ -152,7 +162,7 @@ Status Channel::send_local_block(Block* block) {
     }
 }
 
-Status Channel::send_block(PBlock* block, bool eos) {
+Status Channel::send_remote_block(PBlock* block, bool eos, const Status& exec_status) {
     SCOPED_TIMER(_parent->_brpc_send_timer);
     COUNTER_UPDATE(_parent->_blocks_sent_counter, 1);
     if (_closure == nullptr) {
@@ -172,6 +182,11 @@ Status Channel::send_block(PBlock* block, bool eos) {
     }
 
     _brpc_request.set_eos(eos);
+
+    if (!exec_status.ok()) {
+        exec_status.to_protobuf(_brpc_request.mutable_exec_status());
+    }
+
     if (block != nullptr) {
         _brpc_request.set_allocated_block(block);
     }
@@ -253,30 +268,35 @@ Status Channel::close_wait(RuntimeState* state) {
     return Status::OK();
 }
 
-Status Channel::close_internal() {
+Status Channel::close_internal(const Status& exec_status) {
     if (!_need_close) {
         return Status::OK();
     }
-    VLOG_RPC << "Channel::close() instance_id=" << _fragment_instance_id
-             << " dest_node=" << _dest_node_id
-             << " #rows= " << ((_mutable_block == nullptr) ? 0 : _mutable_block->rows())
-             << " receiver status: " << _receiver_status;
+
+    VLOG_RPC << "Channel::close() instance_id=" << print_id(_fragment_instance_id)
+              << " dest_node=" << _dest_node_id
+              << " #rows= " << ((_mutable_block == nullptr) ? 0 : _mutable_block->rows())
+              << " receiver status: " << _receiver_status << " close status: " << exec_status.msg();
+
     if (is_receiver_eof()) {
         _mutable_block.reset();
         return Status::OK();
     }
     Status status;
     if (_mutable_block != nullptr && _mutable_block->rows() > 0) {
-        status = send_current_block(true);
+        status = send_current_block(true, exec_status);
     } else {
         SCOPED_CONSUME_MEM_TRACKER(_parent->_mem_tracker.get());
         if (is_local()) {
             if (_recvr_is_valid()) {
+                if (!exec_status.ok()) {
+                    _local_recvr->cancel_stream(exec_status.msg());
+                }
                 _local_recvr->remove_sender(_parent->_sender_id, _be_number,
                                             _parent->query_statisticsPtr());
             }
         } else {
-            status = send_block((PBlock*)nullptr, true);
+            status = send_remote_block((PBlock*)nullptr, true, exec_status);
         }
     }
     // Don't wait for the last packet to finish, left it to close_wait.
@@ -287,13 +307,13 @@ Status Channel::close_internal() {
     }
 }
 
-Status Channel::close(RuntimeState* state) {
+Status Channel::close(RuntimeState* state, const Status& exec_status) {
     if (_closed) {
         return Status::OK();
     }
     _closed = true;
 
-    Status st = close_internal();
+    Status st = close_internal(exec_status);
     if (!st.ok()) {
         state->log_error(st.to_string());
     }
@@ -555,7 +575,7 @@ Status VDataStreamSender::send(RuntimeState* state, Block* block, bool eos) {
                         status = channel->send_local_block(block);
                     } else {
                         SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
-                        status = channel->send_block(block_holder, eos);
+                        status = channel->send_broadcast_block(block_holder, eos);
                     }
                     HANDLE_CHANNEL_STATUS(state, channel, status);
                 }
@@ -573,7 +593,7 @@ Status VDataStreamSender::send(RuntimeState* state, Block* block, bool eos) {
                         status = channel->send_local_block(block);
                     } else {
                         SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
-                        status = channel->send_block(_cur_pb_block, eos);
+                        status = channel->send_remote_block(_cur_pb_block, eos);
                     }
                     HANDLE_CHANNEL_STATUS(state, channel, status);
                 }
@@ -592,7 +612,8 @@ Status VDataStreamSender::send(RuntimeState* state, Block* block, bool eos) {
             } else {
                 SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
                 RETURN_IF_ERROR(serialize_block(block, current_channel->ch_cur_pb_block()));
-                auto status = current_channel->send_block(current_channel->ch_cur_pb_block(), eos);
+                auto status =
+                        current_channel->send_remote_block(current_channel->ch_cur_pb_block(), eos);
                 HANDLE_CHANNEL_STATUS(state, current_channel, status);
                 current_channel->ch_roll_pb_block();
             }
@@ -682,7 +703,7 @@ Status VDataStreamSender::send(RuntimeState* state, Block* block, bool eos) {
 Status VDataStreamSender::try_close(RuntimeState* state, Status exec_status) {
     Status final_st = Status::OK();
     for (int i = 0; i < _channels.size(); ++i) {
-        Status st = _channels[i]->close(state);
+        Status st = _channels[i]->close(state, exec_status);
         if (!st.ok() && final_st.ok()) {
             final_st = st;
         }
@@ -698,7 +719,7 @@ Status VDataStreamSender::close(RuntimeState* state, Status exec_status) {
     Status final_st = Status::OK();
     if (!state->enable_pipeline_exec()) {
         for (int i = 0; i < _channels.size(); ++i) {
-            Status st = _channels[i]->close(state);
+            Status st = _channels[i]->close(state, exec_status);
             if (!st.ok() && final_st.ok()) {
                 final_st = st;
             }

--- a/be/src/vec/sink/vdata_stream_sender.h
+++ b/be/src/vec/sink/vdata_stream_sender.h
@@ -254,24 +254,25 @@ public:
     // Returns the status of the most recently finished transmit_data
     // rpc (or OK if there wasn't one that hasn't been reported yet).
     // if batch is nullptr, send the eof packet
-    virtual Status send_block(PBlock* block, bool eos = false);
+    virtual Status send_remote_block(PBlock* block, bool eos = false,
+                                     const Status& st = Status::OK());
 
-    virtual Status send_block(BroadcastPBlockHolder* block, bool eos = false) {
+    virtual Status send_broadcast_block(BroadcastPBlockHolder* block, bool eos = false) {
         return Status::InternalError("Send BroadcastPBlockHolder is not allowed!");
     }
 
     Status add_rows(Block* block, const std::vector<int>& row);
 
-    virtual Status send_current_block(bool eos);
+    virtual Status send_current_block(bool eos, const Status& exec_status = Status::OK());
 
-    Status send_local_block(bool eos = false);
+    Status send_local_block(bool eos = false, const Status& exec_status = Status::OK());
 
-    Status send_local_block(Block* block);
+    Status send_local_block(Block* block, const Status& exec_status = Status::OK());
     // Flush buffered rows and close channel. This function don't wait the response
     // of close operation, client should call close_wait() to finish channel's close.
     // We split one close operation into two phases in order to make multiple channels
     // can run parallel.
-    Status close(RuntimeState* state);
+    Status close(RuntimeState* state, const Status& exec_status = Status::OK());
 
     // Get close wait's response, to finish channel close operation.
     Status close_wait(RuntimeState* state);
@@ -337,7 +338,7 @@ protected:
     // Serialize _batch into _thrift_batch and send via send_batch().
     // Returns send_batch() status.
     Status send_current_batch(bool eos = false);
-    Status close_internal();
+    Status close_internal(const Status& exec_status = Status::OK());
 
     VDataStreamSender* _parent;
 
@@ -443,7 +444,8 @@ public:
     // Returns the status of the most recently finished transmit_data
     // rpc (or OK if there wasn't one that hasn't been reported yet).
     // if batch is nullptr, send the eof packet
-    Status send_block(PBlock* block, bool eos = false) override {
+    Status send_remote_block(PBlock* block, bool eos = false,
+                             const Status& st = Status::OK()) override {
         COUNTER_UPDATE(_parent->_blocks_sent_counter, 1);
         std::unique_ptr<PBlock> pblock_ptr;
         pblock_ptr.reset(block);
@@ -456,12 +458,12 @@ public:
             }
         }
         if (eos || block->column_metas_size()) {
-            RETURN_IF_ERROR(_buffer->add_block({this, std::move(pblock_ptr), eos}));
+            RETURN_IF_ERROR(_buffer->add_block({this, std::move(pblock_ptr), eos, st}));
         }
         return Status::OK();
     }
 
-    Status send_block(BroadcastPBlockHolder* block, bool eos = false) override {
+    Status send_broadcast_block(BroadcastPBlockHolder* block, bool eos = false) override {
         COUNTER_UPDATE(_parent->_blocks_sent_counter, 1);
         if (eos) {
             if (_eos_send) {
@@ -477,9 +479,9 @@ public:
     }
 
     // send _mutable_block
-    Status send_current_block(bool eos) override {
+    Status send_current_block(bool eos, const Status& st) override {
         if (is_local()) {
-            return send_local_block(eos);
+            return send_local_block(eos, st);
         }
         SCOPED_CONSUME_MEM_TRACKER(_parent->_mem_tracker.get());
         auto block_ptr = std::make_unique<PBlock>();
@@ -489,7 +491,7 @@ public:
             block.clear_column_data();
             _mutable_block->set_muatable_columns(block.mutate_columns());
         }
-        RETURN_IF_ERROR(send_block(block_ptr.release(), eos));
+        RETURN_IF_ERROR(send_remote_block(block_ptr.release(), eos, st));
         return Status::OK();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/QeProcessorImpl.java
@@ -128,9 +128,7 @@ public final class QeProcessorImpl implements QeProcessor {
     public void unregisterQuery(TUniqueId queryId) {
         QueryInfo queryInfo = coordinatorMap.remove(queryId);
         if (queryInfo != null) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("deregister query id {}", DebugUtil.printId(queryId));
-            }
+            LOG.info("deregister query id {}", DebugUtil.printId(queryId));
             if (queryInfo.getConnectContext() != null
                     && !Strings.isNullOrEmpty(queryInfo.getConnectContext().getQualifiedUser())
             ) {
@@ -139,7 +137,7 @@ public final class QeProcessorImpl implements QeProcessor {
                     String user = queryInfo.getConnectContext().getQualifiedUser();
                     AtomicInteger instancesNum = userToInstancesCount.get(user);
                     if (instancesNum == null) {
-                        LOG.warn("WTF?? query {} in queryToInstancesNum but not in userToInstancesCount",
+                        LOG.warn("Query {} in queryToInstancesNum but not in userToInstancesCount",
                                 DebugUtil.printId(queryId)
                         );
                     } else {
@@ -148,9 +146,7 @@ public final class QeProcessorImpl implements QeProcessor {
                 }
             }
         } else {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("not found query {} when unregisterQuery", DebugUtil.printId(queryId));
-            }
+            LOG.info("not found query {} when unregisterQuery", DebugUtil.printId(queryId));
         }
 
         // commit hive tranaction if needed

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -49,6 +49,9 @@ message PTransmitDataParams {
     // transfer the RowBatch to the Controller Attachment
     optional bool transfer_by_attachment = 10 [default = false];
     optional PUniqueId query_id = 11;
+    // Send will spread its exec_status to receiver
+    // and receiver could cancel itself if any thing goes wrong.
+    optional PStatus exec_status = 12;
 };
 
 message PTransmitDataResult {


### PR DESCRIPTION
FE will return empty set instead of error, if:

1. BE report error status
2. An instance has multiple pipelines
3. FE process report slowly

This pr fix above problem on branch-2.0 by:
1. Exchange sender will spread Error status to receiver so that
2. Receiver of last result sink fragment will make itself cancelled instead of send an EOS to FE.

PS: Maybe the fix is not perfect ... but it works with almost least modification. A complete fix needs almost a refactor on DataExchangeNode.