### PR TITLE
[refactor](broadcastbuffer) using a queue to remove ref and unref codes

### DIFF
--- a/be/src/pipeline/exec/exchange_sink_buffer.h
+++ b/be/src/pipeline/exec/exchange_sink_buffer.h
@@ -29,6 +29,7 @@
 #include <memory>
 #include <mutex>
 #include <queue>
+#include <stack>
 #include <string>
 
 #include "common/global_types.h"
@@ -45,7 +46,6 @@ class TUniqueId;
 using InstanceLoId = int64_t;
 
 namespace pipeline {
-class BroadcastDependency;
 class ExchangeSinkQueueDependency;
 class Dependency;
 } // namespace pipeline
@@ -71,25 +71,52 @@ struct AtomicWrapper {
 // We use BroadcastPBlockHolder to hold a broadcasted PBlock. For broadcast shuffle, one PBlock
 // will be shared between different channel, so we have to use a ref count to mark if this
 // PBlock is available for next serialization.
+class BroadcastPBlockHolderQueue;
 class BroadcastPBlockHolder {
+    ENABLE_FACTORY_CREATOR(BroadcastPBlockHolder);
+
 public:
-    BroadcastPBlockHolder() : _ref_count(0), _dep(nullptr) {}
-    BroadcastPBlockHolder(pipeline::BroadcastDependency* dep) : _ref_count(0), _dep(dep) {}
-    ~BroadcastPBlockHolder() noexcept = default;
+    BroadcastPBlockHolder() { _pblock = std::make_unique<PBlock>(); }
+    BroadcastPBlockHolder(std::unique_ptr<PBlock>&& pblock) { _pblock = std::move(pblock); }
+    ~BroadcastPBlockHolder();
 
-    void ref(int delta) noexcept { _ref_count._value.fetch_add(delta); }
-    void unref() noexcept;
-    void ref() noexcept { ref(1); }
-
-    bool available() { return _ref_count._value == 0; }
-
-    PBlock* get_block() { return &pblock; }
+    PBlock* get_block() { return _pblock.get(); }
 
 private:
-    AtomicWrapper<int32_t> _ref_count;
-    PBlock pblock;
-    pipeline::BroadcastDependency* _dep = nullptr;
+    friend class BroadcastPBlockHolderQueue;
+    std::unique_ptr<PBlock> _pblock;
+    std::weak_ptr<BroadcastPBlockHolderQueue> _parent_creator;
+    void set_parent_creator(std::shared_ptr<BroadcastPBlockHolderQueue> parent_creator) {
+        _parent_creator = parent_creator;
+    }
 };
+
+// Use a stack inside to ensure that the PBlock is in cpu cache
+class BroadcastPBlockHolderQueue : public std::enable_shared_from_this<BroadcastPBlockHolderQueue> {
+    ENABLE_FACTORY_CREATOR(BroadcastPBlockHolderQueue);
+
+public:
+    BroadcastPBlockHolderQueue() = default;
+
+    BroadcastPBlockHolderQueue(std::shared_ptr<pipeline::Dependency>& broadcast_dependency) {
+        _broadcast_dependency = broadcast_dependency;
+    }
+
+    void push(std::shared_ptr<BroadcastPBlockHolder> holder);
+
+    bool empty() {
+        std::unique_lock l(_holders_lock);
+        return _holders.empty();
+    }
+
+    std::shared_ptr<BroadcastPBlockHolder> pop();
+
+private:
+    std::stack<std::shared_ptr<BroadcastPBlockHolder>> _holders;
+    std::shared_ptr<pipeline::Dependency> _broadcast_dependency;
+    std::mutex _holders_lock;
+};
+
 } // namespace vectorized
 
 namespace pipeline {
@@ -104,7 +131,7 @@ struct TransmitInfo {
 template <typename Parent>
 struct BroadcastTransmitInfo {
     vectorized::PipChannel<Parent>* channel = nullptr;
-    vectorized::BroadcastPBlockHolder* block_holder = nullptr;
+    std::shared_ptr<vectorized::BroadcastPBlockHolder> block_holder = nullptr;
     bool eos;
 };
 
@@ -115,10 +142,9 @@ class ExchangeSendCallback : public ::doris::DummyBrpcCallback<Response> {
 public:
     ExchangeSendCallback() = default;
 
-    void init(InstanceLoId id, bool eos, vectorized::BroadcastPBlockHolder* data) {
+    void init(InstanceLoId id, bool eos) {
         _id = id;
         _eos = eos;
-        _data = data;
     }
 
     ~ExchangeSendCallback() override = default;
@@ -135,9 +161,6 @@ public:
 
     void call() noexcept override {
         try {
-            if (_data) {
-                _data->unref();
-            }
             if (::doris::DummyBrpcCallback<Response>::cntl_->Failed()) {
                 std::string err = fmt::format(
                         "failed to send brpc when exchange, error={}, error_text={}, client: {}, "
@@ -164,7 +187,6 @@ private:
     std::function<void(const InstanceLoId&, const bool&, const Response&, const int64_t&)> _suc_fn;
     InstanceLoId _id;
     bool _eos;
-    vectorized::BroadcastPBlockHolder* _data = nullptr;
 };
 
 struct ExchangeRpcContext {

--- a/be/src/pipeline/exec/exchange_sink_operator.h
+++ b/be/src/pipeline/exec/exchange_sink_operator.h
@@ -72,51 +72,6 @@ public:
     ~ExchangeSinkQueueDependency() override = default;
 };
 
-class BroadcastDependency final : public Dependency {
-public:
-    ENABLE_FACTORY_CREATOR(BroadcastDependency);
-    BroadcastDependency(int id, int node_id, QueryContext* query_ctx)
-            : Dependency(id, node_id, "BroadcastDependency", true, query_ctx),
-              _available_block(0) {}
-    ~BroadcastDependency() override = default;
-
-    std::string debug_string(int indentation_level = 0) override {
-        fmt::memory_buffer debug_string_buffer;
-        fmt::format_to(debug_string_buffer,
-                       "{}{}: id={}, block task = {}, ready={}, _available_block = {}",
-                       std::string(indentation_level * 2, ' '), _name, _node_id,
-                       _blocked_task.size(), _ready, _available_block.load());
-        return fmt::to_string(debug_string_buffer);
-    }
-
-    void set_available_block(int available_block) { _available_block = available_block; }
-
-    void return_available_block() {
-        if (_available_block.fetch_add(1) == 0) {
-            std::lock_guard<std::mutex> lock(_lock);
-            if (_available_block == 0) {
-                return;
-            }
-            Dependency::set_ready();
-        }
-    }
-
-    void take_available_block() {
-        if (_available_block.fetch_sub(1) == 1) {
-            std::lock_guard<std::mutex> lock(_lock);
-            if (_available_block == 0) {
-                Dependency::block();
-            }
-        }
-    }
-
-    int available_blocks() const { return _available_block; }
-
-private:
-    std::atomic<int> _available_block;
-    std::mutex _lock;
-};
-
 /**
  * We use this to control the execution for local exchange.
  *              +---------------+                                    +---------------+                               +---------------+
@@ -165,7 +120,7 @@ public:
     Dependency* finishdependency() override { return _finish_dependency.get(); }
     Status serialize_block(vectorized::Block* src, PBlock* dest, int num_receivers = 1);
     void register_channels(pipeline::ExchangeSinkBuffer<ExchangeSinkLocalState>* buffer);
-    Status get_next_available_buffer(vectorized::BroadcastPBlockHolder** holder);
+    Status get_next_available_buffer(std::shared_ptr<vectorized::BroadcastPBlockHolder>* holder);
 
     RuntimeProfile::Counter* brpc_wait_timer() { return _brpc_wait_timer; }
     RuntimeProfile::Counter* blocks_sent_counter() { return _blocks_sent_counter; }
@@ -231,12 +186,12 @@ private:
 
     // Sender instance id, unique within a fragment.
     int _sender_id;
-    std::vector<vectorized::BroadcastPBlockHolder> _broadcast_pb_blocks;
+    std::shared_ptr<vectorized::BroadcastPBlockHolderQueue> _broadcast_pb_blocks;
 
     vectorized::BlockSerializer<ExchangeSinkLocalState> _serializer;
 
     std::shared_ptr<ExchangeSinkQueueDependency> _queue_dependency;
-    std::shared_ptr<BroadcastDependency> _broadcast_dependency;
+    std::shared_ptr<Dependency> _broadcast_dependency;
     std::vector<std::shared_ptr<LocalExchangeChannelDependency>> _local_channels_dependency;
     std::unique_ptr<vectorized::PartitionerBase> _partitioner;
     int _partition_count;

--- a/be/src/pipeline/exec/result_file_sink_operator.cpp
+++ b/be/src/pipeline/exec/result_file_sink_operator.cpp
@@ -240,8 +240,7 @@ Status ResultFileSinkLocalState::close(RuntimeState* state, Status exec_status) 
                                     status = channel->send_local_block(&cur_block);
                                 } else {
                                     SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
-                                    status = channel->send_broadcast_block(_block_holder.get(),
-                                                                           true);
+                                    status = channel->send_broadcast_block(_block_holder, true);
                                 }
                                 HANDLE_CHANNEL_STATUS(state, channel, status);
                             }

--- a/be/src/pipeline/exec/result_file_sink_operator.h
+++ b/be/src/pipeline/exec/result_file_sink_operator.h
@@ -77,7 +77,7 @@ private:
     std::vector<vectorized::Channel<ResultFileSinkLocalState>*> _channels;
     bool _only_local_exchange = false;
     vectorized::BlockSerializer<ResultFileSinkLocalState> _serializer;
-    std::unique_ptr<vectorized::BroadcastPBlockHolder> _block_holder;
+    std::shared_ptr<vectorized::BroadcastPBlockHolder> _block_holder;
     RuntimeProfile::Counter* _brpc_wait_timer = nullptr;
     RuntimeProfile::Counter* _local_send_timer = nullptr;
     RuntimeProfile::Counter* _brpc_send_timer = nullptr;

--- a/be/src/pipeline/pipeline_x/dependency.h
+++ b/be/src/pipeline/pipeline_x/dependency.h
@@ -67,6 +67,8 @@ struct BasicSharedState {
 };
 
 class Dependency : public std::enable_shared_from_this<Dependency> {
+    ENABLE_FACTORY_CREATOR(Dependency);
+
 public:
     Dependency(int id, int node_id, std::string name, QueryContext* query_ctx)
             : _id(id),

--- a/be/src/runtime/query_context.cpp
+++ b/be/src/runtime/query_context.cpp
@@ -40,7 +40,8 @@ QueryContext::QueryContext(TUniqueId query_id, int total_fragment_num, ExecEnv* 
     _start_time = VecDateTimeValue::local_time();
     _shared_hash_table_controller.reset(new vectorized::SharedHashTableController());
     _shared_scanner_controller.reset(new vectorized::SharedScannerController());
-    _execution_dependency.reset(new pipeline::Dependency(-1, -1, "ExecutionDependency", this));
+    _execution_dependency =
+            pipeline::Dependency::create_unique(-1, -1, "ExecutionDependency", this);
     _runtime_filter_mgr.reset(
             new RuntimeFilterMgr(TUniqueId(), RuntimeFilterParamsContext::create(this)));
 }

--- a/be/src/vec/sink/vdata_stream_sender.h
+++ b/be/src/vec/sink/vdata_stream_sender.h
@@ -158,7 +158,7 @@ protected:
     friend class pipeline::ExchangeSinkBuffer<VDataStreamSender>;
 
     void _roll_pb_block();
-    Status _get_next_available_buffer(BroadcastPBlockHolder** holder);
+    Status _get_next_available_buffer(std::shared_ptr<BroadcastPBlockHolder>* holder);
 
     template <typename Channels, typename HashValueType>
     Status channel_add_rows(RuntimeState* state, Channels& channels, int num_channels,
@@ -185,8 +185,7 @@ protected:
     PBlock* _cur_pb_block = nullptr;
 
     // used by pipeline engine
-    std::vector<BroadcastPBlockHolder> _broadcast_pb_blocks;
-    int _broadcast_pb_block_idx;
+    std::shared_ptr<BroadcastPBlockHolderQueue> _broadcast_pb_blocks;
 
     std::unique_ptr<PartitionerBase> _partitioner;
     size_t _partition_count;
@@ -273,7 +272,8 @@ public:
     virtual Status send_remote_block(PBlock* block, bool eos = false,
                                      Status exec_status = Status::OK());
 
-    virtual Status send_broadcast_block(BroadcastPBlockHolder* block, bool eos = false) {
+    virtual Status send_broadcast_block(std::shared_ptr<BroadcastPBlockHolder>& block,
+                                        bool eos = false) {
         return Status::InternalError("Send BroadcastPBlockHolder is not allowed!");
     }
 
@@ -488,11 +488,11 @@ public:
         return Status::OK();
     }
 
-    Status send_broadcast_block(BroadcastPBlockHolder* block, bool eos = false) override {
+    Status send_broadcast_block(std::shared_ptr<BroadcastPBlockHolder>& block,
+                                bool eos = false) override {
         COUNTER_UPDATE(Channel<Parent>::_parent->blocks_sent_counter(), 1);
         if (eos) {
             if (_eos_send) {
-                block->unref();
                 return Status::OK();
             }
             _eos_send = true;
@@ -536,13 +536,13 @@ public:
     }
 
     std::shared_ptr<pipeline::ExchangeSendCallback<PTransmitDataResult>> get_send_callback(
-            InstanceLoId id, bool eos, vectorized::BroadcastPBlockHolder* data) {
+            InstanceLoId id, bool eos) {
         if (!_send_callback) {
             _send_callback = pipeline::ExchangeSendCallback<PTransmitDataResult>::create_shared();
         } else {
             _send_callback->cntl_->Reset();
         }
-        _send_callback->init(id, eos, data);
+        _send_callback->init(id, eos);
         return _send_callback;
     }
 


### PR DESCRIPTION
## Proposed changes
1. Add a new class broadcastbufferholderqueue to manage holders
2. Using shared ptr to manage holders,  not use ref and unref, it is too difficult to maintain.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

