### PR TITLE
[fix](mtmv)fix thread local reference to checkpoint's Env, causing Env to be unable to be reclaimed, resulting in excessive memory usage by FE

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MTMV.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MTMV.java
@@ -157,12 +157,15 @@ public class MTMV extends OlapTable {
                 this.status.setSchemaChangeDetail(null);
                 this.status.setRefreshState(MTMVRefreshState.SUCCESS);
                 this.relation = relation;
-                try {
-                    this.cache = MTMVCache.from(this, MTMVPlanUtil.createMTMVContext(this));
-                } catch (Throwable e) {
-                    this.cache = null;
-                    LOG.warn("generate cache failed", e);
+                if (!Env.isCheckpointThread()) {
+                    try {
+                        this.cache = MTMVCache.from(this, MTMVPlanUtil.createMTMVContext(this));
+                    } catch (Throwable e) {
+                        this.cache = null;
+                        LOG.warn("generate cache failed", e);
+                    }
                 }
+
             } else {
                 this.status.setRefreshState(MTMVRefreshState.FAIL);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MTMV.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MTMV.java
@@ -165,7 +165,6 @@ public class MTMV extends OlapTable {
                         LOG.warn("generate cache failed", e);
                     }
                 }
-
             } else {
                 this.status.setRefreshState(MTMVRefreshState.FAIL);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPlanUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPlanUtil.java
@@ -45,7 +45,7 @@ public class MTMVPlanUtil {
 
     public static ConnectContext createMTMVContext(MTMV mtmv) throws AnalysisException {
         ConnectContext ctx = new ConnectContext();
-        ctx.setEnv(Env.getCurrentEnv());
+        ctx.setEnv(Env.getServingEnv());
         ctx.setQualifiedUser(Auth.ADMIN_USER);
         ctx.setCurrentUserIdentity(UserIdentity.ADMIN);
         ctx.getState().reset();

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPlanUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVPlanUtil.java
@@ -45,7 +45,7 @@ public class MTMVPlanUtil {
 
     public static ConnectContext createMTMVContext(MTMV mtmv) throws AnalysisException {
         ConnectContext ctx = new ConnectContext();
-        ctx.setEnv(Env.getServingEnv());
+        ctx.setEnv(Env.getCurrentEnv());
         ctx.setQualifiedUser(Auth.ADMIN_USER);
         ctx.setCurrentUserIdentity(UserIdentity.ADMIN);
         ctx.getState().reset();


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

when replay `addTaskResult` log,will create one `ConnectContext`,and set Env.getCurrentEnv,then store this ctx in `ConnectContext.threadLocalInfo`,`threadLocalInfo` is `static`,so this ctx can not be recycling，`Env` of replay thread also can not be recycling


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

