### PR TITLE
[bugfix](scannercore) scanner will core in deconstructor during collect profile

### DIFF
--- a/be/src/exec/exec_node.h
+++ b/be/src/exec/exec_node.h
@@ -239,6 +239,10 @@ public:
 
     size_t children_count() const { return _children.size(); }
 
+    // when the fragment is normal finished, call this method to do some finish work
+    // such as send the last buffer to remote.
+    virtual Status try_close(RuntimeState* state) { return Status::OK(); }
+
 protected:
     friend class DataSink;
 

--- a/be/src/io/fs/stream_load_pipe.cpp
+++ b/be/src/io/fs/stream_load_pipe.cpp
@@ -242,6 +242,7 @@ Status StreamLoadPipe::finish() {
 void StreamLoadPipe::cancel(const std::string& reason) {
     {
         std::lock_guard<std::mutex> l(_lock);
+        LOG(INFO) << Status::InternalError("you cancelled");
         _cancelled = true;
         _cancelled_reason = reason;
     }

--- a/be/src/io/fs/stream_load_pipe.cpp
+++ b/be/src/io/fs/stream_load_pipe.cpp
@@ -242,7 +242,6 @@ Status StreamLoadPipe::finish() {
 void StreamLoadPipe::cancel(const std::string& reason) {
     {
         std::lock_guard<std::mutex> l(_lock);
-        LOG(INFO) << Status::InternalError("you cancelled");
         _cancelled = true;
         _cancelled_reason = reason;
     }

--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -1419,17 +1419,6 @@ Status ScanOperatorX<LocalStateType>::open(RuntimeState* state) {
     return Status::OK();
 }
 
-template <typename LocalStateType>
-Status ScanOperatorX<LocalStateType>::try_close(RuntimeState* state) {
-    auto& local_state = get_local_state(state);
-    if (local_state._scanner_ctx) {
-        // mark this scanner ctx as should_stop to make sure scanners will not be scheduled anymore
-        // TODO: there is a lock in `set_should_stop` may cause some slight impact
-        local_state._scanner_ctx->stop_scanners(state);
-    }
-    return Status::OK();
-}
-
 template <typename Derived>
 Status ScanLocalState<Derived>::close(RuntimeState* state) {
     if (_closed) {

--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -64,10 +64,6 @@ bool ScanOperator::can_read() {
     }
 }
 
-bool ScanOperator::is_pending_finish() const {
-    return false;
-}
-
 Status ScanOperator::try_close(RuntimeState* state) {
     return _node->try_close(state);
 }

--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -1226,7 +1226,7 @@ Status ScanLocalState<Derived>::_prepare_scanners() {
     RETURN_IF_ERROR(_init_scanners(&scanners));
     // Init scanner wrapper
     for (auto it = scanners.begin(); it != scanners.end(); ++it) {
-        _scanners.emplace_back(std::make_shared<ScannerDelegate>(*it));
+        _scanners.emplace_back(std::make_shared<vectorized::ScannerDelegate>(*it));
     }
     if (scanners.empty()) {
         _eos = true;

--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -64,10 +64,6 @@ bool ScanOperator::can_read() {
     }
 }
 
-Status ScanOperator::try_close(RuntimeState* state) {
-    return _node->try_close(state);
-}
-
 bool ScanOperator::runtime_filters_are_ready_or_timeout() {
     return _node->runtime_filters_are_ready_or_timeout();
 }

--- a/be/src/pipeline/exec/scan_operator.h
+++ b/be/src/pipeline/exec/scan_operator.h
@@ -419,7 +419,7 @@ protected:
     std::shared_ptr<Dependency> _finish_dependency;
 
     // ScanLocalState owns the ownership of scanner, scanner context only has its weakptr
-    std::list<std::shared_ptr<ScannerDelegate>> _scanners;
+    std::list<std::shared_ptr<vectorized::ScannerDelegate>> _scanners;
 };
 
 template <typename LocalStateType>

--- a/be/src/pipeline/exec/scan_operator.h
+++ b/be/src/pipeline/exec/scan_operator.h
@@ -31,6 +31,9 @@
 namespace doris {
 class ExecNode;
 } // namespace doris
+namespace doris::vectorized {
+class ScannerDelegate;
+}
 
 namespace doris::pipeline {
 class PipScannerContext;

--- a/be/src/pipeline/exec/scan_operator.h
+++ b/be/src/pipeline/exec/scan_operator.h
@@ -417,8 +417,6 @@ protected:
 template <typename LocalStateType>
 class ScanOperatorX : public OperatorX<LocalStateType> {
 public:
-    Status try_close(RuntimeState* state) override;
-
     Status init(const TPlanNode& tnode, RuntimeState* state) override;
     Status prepare(RuntimeState* state) override { return OperatorXBase::prepare(state); }
     Status open(RuntimeState* state) override;

--- a/be/src/pipeline/exec/scan_operator.h
+++ b/be/src/pipeline/exec/scan_operator.h
@@ -174,6 +174,7 @@ protected:
     RuntimeProfile::Counter* _wait_for_scanner_done_timer = nullptr;
     // time of prefilter input block from scanner
     RuntimeProfile::Counter* _wait_for_eos_timer = nullptr;
+    RuntimeProfile::Counter* _wait_for_rf_timer = nullptr;
 };
 
 template <typename LocalStateType>

--- a/be/src/pipeline/exec/scan_operator.h
+++ b/be/src/pipeline/exec/scan_operator.h
@@ -215,7 +215,6 @@ class ScanLocalState : public ScanLocalStateBase {
     Dependency* dependency() override { return _scan_dependency.get(); }
 
     RuntimeFilterDependency* filterdependency() override { return _filter_dependency.get(); };
-    Dependency* finishdependency() override { return _finish_dependency.get(); }
 
 protected:
     template <typename LocalStateType>
@@ -413,8 +412,6 @@ protected:
     std::mutex _block_lock;
 
     std::shared_ptr<RuntimeFilterDependency> _filter_dependency;
-
-    std::shared_ptr<Dependency> _finish_dependency;
 
     // ScanLocalState owns the ownership of scanner, scanner context only has its weakptr
     std::list<std::shared_ptr<vectorized::ScannerDelegate>> _scanners;

--- a/be/src/pipeline/exec/scan_operator.h
+++ b/be/src/pipeline/exec/scan_operator.h
@@ -174,8 +174,6 @@ protected:
     RuntimeProfile::Counter* _wait_for_scanner_done_timer = nullptr;
     // time of prefilter input block from scanner
     RuntimeProfile::Counter* _wait_for_eos_timer = nullptr;
-    RuntimeProfile::Counter* _wait_for_finish_dependency_timer = nullptr;
-    RuntimeProfile::Counter* _wait_for_rf_timer = nullptr;
 };
 
 template <typename LocalStateType>

--- a/be/src/pipeline/exec/scan_operator.h
+++ b/be/src/pipeline/exec/scan_operator.h
@@ -54,8 +54,6 @@ public:
     bool runtime_filters_are_ready_or_timeout() override;
 
     std::string debug_string() const override;
-
-    Status try_close(RuntimeState* state) override;
 };
 
 class ScanDependency final : public Dependency {

--- a/be/src/pipeline/exec/scan_operator.h
+++ b/be/src/pipeline/exec/scan_operator.h
@@ -350,7 +350,7 @@ protected:
     Status _prepare_scanners();
 
     // Submit the scanner to the thread pool and start execution
-    Status _start_scanners(const std::list<vectorized::VScannerSPtr>& scanners);
+    Status _start_scanners(const std::list<std::shared_ptr<vectorized::ScannerDelegate>>& scanners);
 
     // For some conjunct there is chance to elimate cast operator
     // Eg. Variant's sub column could eliminate cast in storage layer if
@@ -414,6 +414,9 @@ protected:
     std::shared_ptr<RuntimeFilterDependency> _filter_dependency;
 
     std::shared_ptr<Dependency> _finish_dependency;
+
+    // ScanLocalState owns the ownership of scanner, scanner context only has its weakptr
+    std::list<std::shared_ptr<ScannerDelegate>> _scanners;
 };
 
 template <typename LocalStateType>

--- a/be/src/pipeline/exec/scan_operator.h
+++ b/be/src/pipeline/exec/scan_operator.h
@@ -51,8 +51,6 @@ public:
 
     bool can_read() override; // for source
 
-    bool is_pending_finish() const override;
-
     bool runtime_filters_are_ready_or_timeout() override;
 
     std::string debug_string() const override;

--- a/be/src/vec/exec/scan/pip_scanner_context.h
+++ b/be/src/vec/exec/scan/pip_scanner_context.h
@@ -44,11 +44,10 @@ public:
                       const std::list<std::shared_ptr<vectorized::ScannerDelegate>>& scanners,
                       int64_t limit_, int64_t max_bytes_in_blocks_queue,
                       const std::vector<int>& col_distribute_ids, const int num_parallel_instances,
-                      std::shared_ptr<pipeline::ScanDependency> dependency,
-                      std::shared_ptr<pipeline::Dependency> finish_dependency)
+                      std::shared_ptr<pipeline::ScanDependency> dependency)
             : vectorized::ScannerContext(state, output_tuple_desc, scanners, limit_,
                                          max_bytes_in_blocks_queue, num_parallel_instances,
-                                         local_state, dependency, finish_dependency),
+                                         local_state, dependency),
               _need_colocate_distribute(false) {}
 
     Status get_block_from_queue(RuntimeState* state, vectorized::BlockUPtr* block, bool* eos,

--- a/be/src/vec/exec/scan/pip_scanner_context.h
+++ b/be/src/vec/exec/scan/pip_scanner_context.h
@@ -110,9 +110,6 @@ public:
         return Status::OK();
     }
 
-    // We should make those method lock free.
-    bool done() override { return _is_finished || _should_stop; }
-
     void append_blocks_to_queue(std::vector<vectorized::BlockUPtr>& blocks) override {
         const int queue_size = _blocks_queues.size();
         const int block_size = blocks.size();

--- a/be/src/vec/exec/scan/pip_scanner_context.h
+++ b/be/src/vec/exec/scan/pip_scanner_context.h
@@ -31,9 +31,9 @@ class PipScannerContext : public vectorized::ScannerContext {
 public:
     PipScannerContext(RuntimeState* state, vectorized::VScanNode* parent,
                       const TupleDescriptor* output_tuple_desc,
-                      const std::list<vectorized::VScannerSPtr>& scanners, int64_t limit_,
-                      int64_t max_bytes_in_blocks_queue, const std::vector<int>& col_distribute_ids,
-                      const int num_parallel_instances)
+                      const std::list<std::shared_ptr<vectorized::ScannerDelegate>>& scanners,
+                      int64_t limit_, int64_t max_bytes_in_blocks_queue,
+                      const std::vector<int>& col_distribute_ids, const int num_parallel_instances)
             : vectorized::ScannerContext(state, parent, output_tuple_desc, scanners, limit_,
                                          max_bytes_in_blocks_queue, num_parallel_instances),
               _col_distribute_ids(col_distribute_ids),
@@ -41,9 +41,9 @@ public:
 
     PipScannerContext(RuntimeState* state, ScanLocalStateBase* local_state,
                       const TupleDescriptor* output_tuple_desc,
-                      const std::list<vectorized::VScannerSPtr>& scanners, int64_t limit_,
-                      int64_t max_bytes_in_blocks_queue, const std::vector<int>& col_distribute_ids,
-                      const int num_parallel_instances,
+                      const std::list<std::shared_ptr<vectorized::ScannerDelegate>>& scanners,
+                      int64_t limit_, int64_t max_bytes_in_blocks_queue,
+                      const std::vector<int>& col_distribute_ids, const int num_parallel_instances,
                       std::shared_ptr<pipeline::ScanDependency> dependency,
                       std::shared_ptr<pipeline::Dependency> finish_dependency)
             : vectorized::ScannerContext(state, output_tuple_desc, scanners, limit_,

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -392,7 +392,7 @@ bool ScannerContext::set_status_on_error(const Status& status, bool need_lock) {
     return false;
 }
 
-Status ScannerContext::stop_scanners(RuntimeState* state) {
+void ScannerContext::stop_scanners(RuntimeState* state) {
     std::unique_lock l(_transfer_lock);
     _should_stop = true;
     _set_scanner_done();
@@ -442,7 +442,6 @@ Status ScannerContext::stop_scanners(RuntimeState* state) {
     }
 
     _blocks_queue_added_cv.notify_one();
-    return Status::OK();
 }
 
 void ScannerContext::_set_scanner_done() {

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -46,8 +46,9 @@ namespace doris::vectorized {
 using namespace std::chrono_literals;
 
 ScannerContext::ScannerContext(RuntimeState* state, const TupleDescriptor* output_tuple_desc,
-                               const std::list<VScannerSPtr>& scanners, int64_t limit_,
-                               int64_t max_bytes_in_blocks_queue, const int num_parallel_instances,
+                               const std::list<std::shared_ptr<ScannerDelegate>>& scanners,
+                               int64_t limit_, int64_t max_bytes_in_blocks_queue,
+                               const int num_parallel_instances,
                                pipeline::ScanLocalStateBase* local_state,
                                std::shared_ptr<pipeline::ScanDependency> dependency,
                                std::shared_ptr<pipeline::Dependency> finish_dependency)
@@ -61,8 +62,8 @@ ScannerContext::ScannerContext(RuntimeState* state, const TupleDescriptor* outpu
           _max_bytes_in_queue(std::max(max_bytes_in_blocks_queue, (int64_t)1024) *
                               num_parallel_instances),
           _scanner_scheduler(state->exec_env()->scanner_scheduler()),
-          _scanners(scanners),
-          _scanners_ref(scanners.begin(), scanners.end()),
+          _scanners(scanners.begin(), scanners.end()),
+          _all_scanners(scanners.begin(), scanners.end()),
           _num_parallel_instances(num_parallel_instances),
           _dependency(dependency),
           _finish_dependency(finish_dependency) {
@@ -92,8 +93,9 @@ ScannerContext::ScannerContext(RuntimeState* state, const TupleDescriptor* outpu
 
 ScannerContext::ScannerContext(doris::RuntimeState* state, doris::vectorized::VScanNode* parent,
                                const doris::TupleDescriptor* output_tuple_desc,
-                               const std::list<VScannerSPtr>& scanners, int64_t limit_,
-                               int64_t max_bytes_in_blocks_queue, const int num_parallel_instances,
+                               const std::list<std::shared_ptr<ScannerDelegate>>& scanners,
+                               int64_t limit_, int64_t max_bytes_in_blocks_queue,
+                               const int num_parallel_instances,
                                pipeline::ScanLocalStateBase* local_state)
         : _state(state),
           _parent(parent),
@@ -105,8 +107,8 @@ ScannerContext::ScannerContext(doris::RuntimeState* state, doris::vectorized::VS
           _max_bytes_in_queue(std::max(max_bytes_in_blocks_queue, (int64_t)1024) *
                               num_parallel_instances),
           _scanner_scheduler(state->exec_env()->scanner_scheduler()),
-          _scanners(scanners),
-          _scanners_ref(scanners.begin(), scanners.end()),
+          _scanners(scanners.begin(), scanners.end()),
+          _all_scanners(scanners.begin(), scanners.end()),
           _num_parallel_instances(num_parallel_instances) {
     // Use the task exec context as a lock between scanner threads and fragment exection threads
     _task_exec_ctx = _state->get_task_execution_context();
@@ -181,10 +183,6 @@ Status ScannerContext::init() {
         }
     }
 #endif
-
-    // 4. This ctx will be submitted to the scanner scheduler right after init.
-    // So set _num_scheduling_ctx to 1 here.
-    _num_scheduling_ctx = 1;
 
     _num_unfinished_scanners = _scanners.size();
 
@@ -276,9 +274,7 @@ Status ScannerContext::get_block_from_queue(RuntimeState* state, vectorized::Blo
         if (!done() && to_be_schedule && _num_running_scanners == 0) {
             is_scheduled = true;
             auto state = _scanner_scheduler->submit(shared_from_this());
-            if (state.ok()) {
-                _num_scheduling_ctx++;
-            } else {
+            if (!state.ok()) {
                 set_status_on_error(state, false);
             }
         }
@@ -370,38 +366,14 @@ Status ScannerContext::validate_block_schema(Block* block) {
     return Status::OK();
 }
 
-void ScannerContext::set_should_stop() {
-    std::lock_guard l(_transfer_lock);
-    _should_stop = true;
-    _set_scanner_done();
-    for (const VScannerWPtr& scanner : _scanners_ref) {
-        if (VScannerSPtr sc = scanner.lock()) {
-            sc->try_stop();
-        }
-    }
-    _blocks_queue_added_cv.notify_one();
-    set_ready_to_finish();
-}
-
 void ScannerContext::inc_num_running_scanners(int32_t inc) {
     std::lock_guard l(_transfer_lock);
     _num_running_scanners += inc;
 }
 
-void ScannerContext::dec_num_scheduling_ctx() {
+void ScannerContext::dec_num_running_scanners(int32_t scanner_dec) {
     std::lock_guard l(_transfer_lock);
-    _num_scheduling_ctx--;
-    set_ready_to_finish();
-    if (_num_running_scanners == 0 && _num_scheduling_ctx == 0) {
-        _ctx_finish_cv.notify_one();
-    }
-}
-
-void ScannerContext::set_ready_to_finish() {
-    // `_should_stop == true` means this task has already ended and wait for pending finish now.
-    if (_finish_dependency && done() && _num_running_scanners == 0 && _num_scheduling_ctx == 0) {
-        _finish_dependency->set_ready();
-    }
+    _num_running_scanners -= scanner_dec;
 }
 
 bool ScannerContext::set_status_on_error(const Status& status, bool need_lock) {
@@ -420,9 +392,17 @@ bool ScannerContext::set_status_on_error(const Status& status, bool need_lock) {
     return false;
 }
 
-template <typename Parent>
-Status ScannerContext::_close_and_clear_scanners(Parent* parent, RuntimeState* state) {
-    std::unique_lock l(_scanners_lock);
+Status ScannerContext::stop_scanners(RuntimeState* state) {
+    std::unique_lock l(_transfer_lock);
+    _should_stop = true;
+    _set_scanner_done();
+    for (const std::weak_ptr<ScannerDelegate>& scanner : _all_scanners) {
+        if (std::shared_ptr<ScannerDelegate> sc = scanner.lock()) {
+            sc->_scanner->try_stop();
+        }
+    }
+    _blocks_queue.clear();
+    // TODO yiguolei, call mark close to scanners
     if (state->enable_profile()) {
         std::stringstream scanner_statistics;
         std::stringstream scanner_rows_read;
@@ -430,76 +410,39 @@ Status ScannerContext::_close_and_clear_scanners(Parent* parent, RuntimeState* s
         scanner_statistics << "[";
         scanner_rows_read << "[";
         scanner_wait_worker_time << "[";
-        for (auto finished_scanner_time : _finished_scanner_runtime) {
-            scanner_statistics << PrettyPrinter::print(finished_scanner_time, TUnit::TIME_NS)
-                               << ", ";
-        }
-        for (auto finished_scanner_rows : _finished_scanner_rows_read) {
-            scanner_rows_read << PrettyPrinter::print(finished_scanner_rows, TUnit::UNIT) << ", ";
-        }
-        for (auto finished_scanner_wait_time : _finished_scanner_wait_worker_time) {
-            scanner_wait_worker_time
-                    << PrettyPrinter::print(finished_scanner_wait_time, TUnit::TIME_NS) << ", ";
-        }
-        // Only unfinished scanners here
-        for (auto& scanner : _scanners) {
-            // Scanners are in ObjPool in ScanNode,
-            // so no need to delete them here.
+        // Scanners can in 3 state
+        //  state 1: in scanner context, not scheduled
+        //  state 2: in scanner worker pool's queue, scheduled but not running
+        //  state 3: scanner is running.
+        for (auto& scanner_ref : _all_scanners) {
+            auto scanner = scanner_ref.lock();
+            if (scanner == nullptr) {
+                continue;
+            }
             // Add per scanner running time before close them
-            scanner_statistics << PrettyPrinter::print(scanner->get_time_cost_ns(), TUnit::TIME_NS)
+            scanner_statistics << PrettyPrinter::print(scanner->_scanner->get_time_cost_ns(),
+                                                       TUnit::TIME_NS)
                                << ", ";
-            scanner_rows_read << PrettyPrinter::print(scanner->get_rows_read(), TUnit::UNIT)
+            scanner_rows_read << PrettyPrinter::print(scanner->_scanner->get_rows_read(),
+                                                      TUnit::UNIT)
                               << ", ";
             scanner_wait_worker_time
-                    << PrettyPrinter::print(scanner->get_scanner_wait_worker_timer(),
+                    << PrettyPrinter::print(scanner->_scanner->get_scanner_wait_worker_timer(),
                                             TUnit::TIME_NS)
                     << ", ";
+            // since there are all scanners, some scanners is running, so that could not call scanner
+            // close here.
         }
         scanner_statistics << "]";
         scanner_rows_read << "]";
         scanner_wait_worker_time << "]";
-        parent->scanner_profile()->add_info_string("PerScannerRunningTime",
-                                                   scanner_statistics.str());
-        parent->scanner_profile()->add_info_string("PerScannerRowsRead", scanner_rows_read.str());
-        parent->scanner_profile()->add_info_string("PerScannerWaitTime",
-                                                   scanner_wait_worker_time.str());
+        _scanner_profile->add_info_string("PerScannerRunningTime", scanner_statistics.str());
+        _scanner_profile->add_info_string("PerScannerRowsRead", scanner_rows_read.str());
+        _scanner_profile->add_info_string("PerScannerWaitTime", scanner_wait_worker_time.str());
     }
-    // Only unfinished scanners here
-    for (auto& scanner : _scanners) {
-        static_cast<void>(scanner->close(state));
-        // Scanners are in ObjPool in ScanNode,
-        // so no need to delete them here.
-    }
-    _scanners.clear();
+
+    _blocks_queue_added_cv.notify_one();
     return Status::OK();
-}
-
-template <typename Parent>
-void ScannerContext::clear_and_join(Parent* parent, RuntimeState* state) {
-    std::unique_lock l(_transfer_lock);
-    do {
-        if (_num_running_scanners == 0 && _num_scheduling_ctx == 0) {
-            break;
-        } else {
-            DCHECK(!state->enable_pipeline_exec())
-                    << " _num_running_scanners: " << _num_running_scanners
-                    << " _num_scheduling_ctx: " << _num_scheduling_ctx;
-            while (!(_num_running_scanners == 0 && _num_scheduling_ctx == 0)) {
-                _ctx_finish_cv.wait(l);
-            }
-            break;
-        }
-    } while (false);
-    // Must wait all running scanners stop running.
-    // So that we can make sure to close all scanners.
-    static_cast<void>(_close_and_clear_scanners(parent, state));
-
-    _blocks_queue.clear();
-}
-
-bool ScannerContext::no_schedule() {
-    std::unique_lock l(_transfer_lock);
-    return _num_running_scanners == 0 && _num_scheduling_ctx == 0;
 }
 
 void ScannerContext::_set_scanner_done() {
@@ -512,12 +455,11 @@ std::string ScannerContext::debug_string() {
     return fmt::format(
             "id: {}, sacnners: {}, blocks in queue: {},"
             " status: {}, _should_stop: {}, _is_finished: {}, free blocks: {},"
-            " limit: {}, _num_running_scanners: {}, _num_scheduling_ctx: {}, _max_thread_num: {},"
+            " limit: {}, _num_running_scanners: {}, _max_thread_num: {},"
             " _block_per_scanner: {}, _cur_bytes_in_queue: {}, MAX_BYTE_OF_QUEUE: {}",
             ctx_id, _scanners.size(), _blocks_queue.size(), status().ok(), _should_stop,
-            _is_finished, _free_blocks.size_approx(), limit, _num_running_scanners,
-            _num_scheduling_ctx, _max_thread_num, _block_per_scanner, _cur_bytes_in_queue,
-            _max_bytes_in_queue);
+            _is_finished, _free_blocks.size_approx(), limit, _num_running_scanners, _max_thread_num,
+            _block_per_scanner, _cur_bytes_in_queue, _max_bytes_in_queue);
 }
 
 void ScannerContext::reschedule_scanner_ctx() {
@@ -527,82 +469,63 @@ void ScannerContext::reschedule_scanner_ctx() {
     }
     auto state = _scanner_scheduler->submit(shared_from_this());
     //todo(wb) rethinking is it better to mark current scan_context failed when submit failed many times?
-    if (state.ok()) {
-        _num_scheduling_ctx++;
-    } else {
+    if (!state.ok()) {
         set_status_on_error(state, false);
     }
 }
 
-void ScannerContext::push_back_scanner_and_reschedule(VScannerSPtr scanner) {
-    {
-        std::unique_lock l(_scanners_lock);
-        _scanners.push_front(scanner);
-    }
+void ScannerContext::push_back_scanner_and_reschedule(std::shared_ptr<ScannerDelegate> scanner) {
     std::lock_guard l(_transfer_lock);
+    // Use a transfer lock to avoid the scanner be scheduled concurrently. For example, that after
+    // calling "_scanners.push_front(scanner)", there may be other ctx in scheduler
+    // to schedule that scanner right away, and in that schedule run, the scanner may be marked as closed
+    // before we call the following if() block.
+    if (scanner->need_to_close()) {
+        --_num_unfinished_scanners;
+        if (_num_unfinished_scanners == 0) {
+            _dispose_coloate_blocks_not_in_queue();
+            _is_finished = true;
+            _set_scanner_done();
+            _blocks_queue_added_cv.notify_one();
+            return;
+        }
+    }
 
-    // In pipeline engine, doris will close scanners when `no_schedule`.
-    // We have to decrease _num_running_scanners before schedule, otherwise
-    // schedule does not woring due to _num_running_scanners.
-    _num_running_scanners--;
-    set_ready_to_finish();
+    _scanners.push_front(scanner);
 
-    if (!done() && should_be_scheduled()) {
+    if (should_be_scheduled()) {
         auto state = _scanner_scheduler->submit(shared_from_this());
-        if (state.ok()) {
-            _num_scheduling_ctx++;
-        } else {
+        if (!state.ok()) {
             set_status_on_error(state, false);
         }
     }
-
-    // Notice that after calling "_scanners.push_front(scanner)", there may be other ctx in scheduler
-    // to schedule that scanner right away, and in that schedule run, the scanner may be marked as closed
-    // before we call the following if() block.
-    // So we need "scanner->set_counted_down()" to avoid "_num_unfinished_scanners" being decreased twice by
-    // same scanner.
-    if (scanner->need_to_close() && scanner->set_counted_down() &&
-        (--_num_unfinished_scanners) == 0) {
-        _dispose_coloate_blocks_not_in_queue();
-        _is_finished = true;
-        _set_scanner_done();
-        _blocks_queue_added_cv.notify_one();
-    }
-    _ctx_finish_cv.notify_one();
 }
 
-void ScannerContext::get_next_batch_of_scanners(std::list<VScannerSPtr>* current_run) {
+// This method is called in scanner scheduler, and task context is hold
+void ScannerContext::get_next_batch_of_scanners(
+        std::list<std::weak_ptr<ScannerDelegate>>* current_run) {
+    std::lock_guard l(_transfer_lock);
     // 1. Calculate how many scanners should be scheduled at this run.
-    int thread_slot_num = 0;
-    {
-        // If there are enough space in blocks queue,
-        // the scanner number depends on the _free_blocks numbers
-        thread_slot_num = get_available_thread_slot_num();
-    }
+    // If there are enough space in blocks queue,
+    // the scanner number depends on the _free_blocks numbers
+    int thread_slot_num = get_available_thread_slot_num();
 
     // 2. get #thread_slot_num scanners from ctx->scanners
     // and put them into "this_run".
-    {
-        std::unique_lock l(_scanners_lock);
-        for (int i = 0; i < thread_slot_num && !_scanners.empty();) {
-            VScannerSPtr scanner = _scanners.front();
-            _scanners.pop_front();
-            if (scanner->need_to_close()) {
-                _finished_scanner_runtime.push_back(scanner->get_time_cost_ns());
-                _finished_scanner_rows_read.push_back(scanner->get_rows_read());
-                _finished_scanner_wait_worker_time.push_back(
-                        scanner->get_scanner_wait_worker_timer());
-                static_cast<void>(scanner->close(_state));
-            } else {
-                current_run->push_back(scanner);
-                i++;
-            }
+    for (int i = 0; i < thread_slot_num && !_scanners.empty();) {
+        std::weak_ptr<ScannerDelegate> scanner_ref = _scanners.front();
+        std::shared_ptr<ScannerDelegate> scanner = scanner_ref.lock();
+        _scanners.pop_front();
+        if (scanner == nullptr) {
+            continue;
+        }
+        if (scanner->_scanner->need_to_close()) {
+            static_cast<void>(scanner->_scanner->close(_state));
+        } else {
+            current_run->push_back(scanner_ref);
+            i++;
         }
     }
 }
-
-template void ScannerContext::clear_and_join(pipeline::ScanLocalStateBase* parent,
-                                             RuntimeState* state);
-template void ScannerContext::clear_and_join(VScanNode* parent, RuntimeState* state);
 
 } // namespace doris::vectorized

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -50,8 +50,7 @@ ScannerContext::ScannerContext(RuntimeState* state, const TupleDescriptor* outpu
                                int64_t limit_, int64_t max_bytes_in_blocks_queue,
                                const int num_parallel_instances,
                                pipeline::ScanLocalStateBase* local_state,
-                               std::shared_ptr<pipeline::ScanDependency> dependency,
-                               std::shared_ptr<pipeline::Dependency> finish_dependency)
+                               std::shared_ptr<pipeline::ScanDependency> dependency)
         : _state(state),
           _parent(nullptr),
           _local_state(local_state),
@@ -65,8 +64,7 @@ ScannerContext::ScannerContext(RuntimeState* state, const TupleDescriptor* outpu
           _scanners(scanners.begin(), scanners.end()),
           _all_scanners(scanners.begin(), scanners.end()),
           _num_parallel_instances(num_parallel_instances),
-          _dependency(dependency),
-          _finish_dependency(finish_dependency) {
+          _dependency(dependency) {
     // Use the task exec context as a lock between scanner threads and fragment exection threads
     _task_exec_ctx = _state->get_task_execution_context();
     _query_id = _state->get_query_ctx()->query_id();

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -479,7 +479,7 @@ void ScannerContext::push_back_scanner_and_reschedule(std::shared_ptr<ScannerDel
     // calling "_scanners.push_front(scanner)", there may be other ctx in scheduler
     // to schedule that scanner right away, and in that schedule run, the scanner may be marked as closed
     // before we call the following if() block.
-    if (scanner->need_to_close()) {
+    if (scanner->_scanner->need_to_close()) {
         --_num_unfinished_scanners;
         if (_num_unfinished_scanners == 0) {
             _dispose_coloate_blocks_not_in_queue();

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -500,6 +500,8 @@ void ScannerContext::push_back_scanner_and_reschedule(std::shared_ptr<ScannerDel
 void ScannerContext::get_next_batch_of_scanners(
         std::list<std::weak_ptr<ScannerDelegate>>* current_run) {
     std::lock_guard l(_transfer_lock);
+    // Update the sched counter for profile
+    Defer defer {[&]() { _scanner_sched_counter->update(current_run->size()); }};
     // 1. Calculate how many scanners should be scheduled at this run.
     // If there are enough space in blocks queue,
     // the scanner number depends on the _free_blocks numbers

--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -281,7 +281,6 @@ protected:
     RuntimeProfile::Counter* _scanner_wait_batch_timer = nullptr;
 
     std::shared_ptr<pipeline::ScanDependency> _dependency = nullptr;
-    std::shared_ptr<pipeline::Dependency> _finish_dependency = nullptr;
 };
 } // namespace vectorized
 } // namespace doris

--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -105,7 +105,7 @@ public:
     }
 
     // Return true if this ScannerContext need no more process
-    virtual bool done() const { return _is_finished || _should_stop; }
+    bool done() const { return _is_finished || _should_stop; }
     bool is_finished() { return _is_finished.load(); }
     bool should_stop() { return _should_stop.load(); }
     bool status_error() { return _status_error.load(); }

--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -157,7 +157,7 @@ public:
 
     SimplifiedScanScheduler* get_simple_scan_scheduler() { return _simple_scan_scheduler; }
 
-    Status stop_scanners(RuntimeState* state);
+    void stop_scanners(RuntimeState* state);
 
     void reschedule_scanner_ctx();
 

--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -176,8 +176,7 @@ protected:
                    const std::list<std::shared_ptr<ScannerDelegate>>& scanners_, int64_t limit_,
                    int64_t max_bytes_in_blocks_queue_, const int num_parallel_instances,
                    pipeline::ScanLocalStateBase* local_state,
-                   std::shared_ptr<pipeline::ScanDependency> dependency,
-                   std::shared_ptr<pipeline::Dependency> finish_dependency);
+                   std::shared_ptr<pipeline::ScanDependency> dependency);
     virtual void _dispose_coloate_blocks_not_in_queue() {}
 
     void _set_scanner_done();

--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -105,7 +105,7 @@ public:
     }
 
     // Return true if this ScannerContext need no more process
-    virtual bool done() { return _is_finished || _should_stop; }
+    virtual bool done() const { return _is_finished || _should_stop; }
     bool is_finished() { return _is_finished.load(); }
     bool should_stop() { return _should_stop.load(); }
     bool status_error() { return _status_error.load(); }

--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -126,7 +126,6 @@ public:
 
     void incr_num_ctx_scheduling(int64_t num) { _scanner_ctx_sched_counter->update(num); }
     void incr_ctx_scheduling_time(int64_t num) { _scanner_ctx_sched_time->update(num); }
-    void incr_num_scanner_scheduling(int64_t num) { _scanner_sched_counter->update(num); }
 
     std::string parent_name();
 

--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -53,6 +53,7 @@ class TaskGroup;
 namespace vectorized {
 
 class VScanner;
+class ScannerDelegate;
 class VScanNode;
 class ScannerScheduler;
 class SimplifiedScanScheduler;

--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -95,7 +95,7 @@ public:
     // to return the scanner to the list for next scheduling.
     void push_back_scanner_and_reschedule(std::shared_ptr<ScannerDelegate> scanner);
 
-    bool set_status_on_error(const Status& status, bool need_lock = true);
+    void set_status_on_error(const Status& status, bool need_lock = true);
 
     Status status() {
         if (_process_status.is<ErrorCode::END_OF_FILE>()) {

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -229,14 +229,14 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
             bool ret = false;
             if (type == TabletStorageType::STORAGE_TYPE_LOCAL) {
                 if (auto* scan_sche = ctx->get_simple_scan_scheduler()) {
-                    auto work_func = [this, scanner = *iter, ctx]() {
+                    auto work_func = [this, scanner_ref = *iter, ctx]() {
                         this->_scanner_scan(this, ctx, scanner_ref);
                     };
                     SimplifiedScanTask simple_scan_task = {work_func, ctx};
                     ret = scan_sche->get_scan_queue()->try_put(simple_scan_task);
                 } else {
                     PriorityThreadPool::Task task;
-                    task.work_function = [this, scanner = *iter, ctx]() {
+                    task.work_function = [this, scanner_ref = *iter, ctx]() {
                         this->_scanner_scan(this, ctx, scanner_ref);
                     };
                     task.priority = nice;
@@ -244,7 +244,7 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
                 }
             } else {
                 PriorityThreadPool::Task task;
-                task.work_function = [this, scanner = *iter, ctx]() {
+                task.work_function = [this, scanner_ref = *iter, ctx]() {
                     this->_scanner_scan(this, ctx, scanner_ref);
                 };
                 task.priority = nice;

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -223,7 +223,7 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
                 this->_scanner_scan(this, ctx, scanner);
                 // will release scanner if it is the last one, task lock is hold here, to ensure
                 // that scanner could call scannode's method during deconstructor
-                Dependencyscanner.reset();
+                scanner.reset();
             });
             if (s.ok()) {
                 this_run.erase(iter++);
@@ -249,7 +249,7 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
                         this->_scanner_scan(this, ctx, scanner);
                         // will release scanner if it is the last one, task lock is hold here, to ensure
                         // that scanner could call scannode's method during deconstructor
-                        Dependencyscanner.reset();
+                        scanner.reset();
                     };
                     SimplifiedScanTask simple_scan_task = {work_func, ctx};
                     ret = scan_sche->get_scan_queue()->try_put(simple_scan_task);
@@ -265,7 +265,7 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
                         this->_scanner_scan(this, ctx, scanner);
                         // will release scanner if it is the last one, task lock is hold here, to ensure
                         // that scanner could call scannode's method during deconstructor
-                        Dependencyscanner.reset();
+                        scanner.reset();
                     };
                     task.priority = nice;
                     ret = _local_scan_thread_pool->offer(task);
@@ -282,7 +282,7 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
                     this->_scanner_scan(this, ctx, scanner);
                     // will release scanner if it is the last one, task lock is hold here, to ensure
                     // that scanner could call scannode's method during deconstructor
-                    Dependencyscanner.reset();
+                    scanner.reset();
                 };
                 task.priority = nice;
                 ret = _remote_scan_thread_pool->offer(task);

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -213,7 +213,7 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
         // TODO llj tg how to treat this?
         while (iter != this_run.end()) {
             (*iter)->start_wait_worker_timer();
-            auto s = ctx->thread_token->submit_func([this, scanner = *iter, ctx] mutable {
+            auto s = ctx->thread_token->submit_func([this, scanner = *iter, ctx]() mutable {
                 auto task_lock = ctx->get_task_execution_context().lock();
                 if (task_lock == nullptr) {
                     // LOG(WARNING) << "could not lock task execution context, query " << print_id(_query_id)
@@ -239,7 +239,7 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
             bool ret = false;
             if (type == TabletStorageType::STORAGE_TYPE_LOCAL) {
                 if (auto* scan_sche = ctx->get_simple_scan_scheduler()) {
-                    auto work_func = [this, scanner = *iter, ctx] mutable {
+                    auto work_func = [this, scanner = *iter, ctx]() mutable {
                         auto task_lock = ctx->get_task_execution_context().lock();
                         if (task_lock == nullptr) {
                             // LOG(WARNING) << "could not lock task execution context, query " << print_id(_query_id)
@@ -255,7 +255,7 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
                     ret = scan_sche->get_scan_queue()->try_put(simple_scan_task);
                 } else {
                     PriorityThreadPool::Task task;
-                    task.work_function = [this, scanner = *iter, ctx] mutable {
+                    task.work_function = [this, scanner = *iter, ctx]() mutable {
                         auto task_lock = ctx->get_task_execution_context().lock();
                         if (task_lock == nullptr) {
                             // LOG(WARNING) << "could not lock task execution context, query " << print_id(_query_id)
@@ -272,7 +272,7 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
                 }
             } else {
                 PriorityThreadPool::Task task;
-                task.work_function = [this, scanner = *iter, ctx] mutable {
+                task.work_function = [this, scanner = *iter, ctx]() mutable {
                     auto task_lock = ctx->get_task_execution_context().lock();
                     if (task_lock == nullptr) {
                         // LOG(WARNING) << "could not lock task execution context, query " << print_id(_query_id)

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -233,7 +233,7 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
                 continue;
             }
             scanner_delegate->_scanner->start_wait_worker_timer();
-            TabletStorageType type = (*iter)->get_storage_type();
+            TabletStorageType type = scanner_delegate->_scanner->get_storage_type();
             bool ret = false;
             if (type == TabletStorageType::STORAGE_TYPE_LOCAL) {
                 if (auto* scan_sche = ctx->get_simple_scan_scheduler()) {

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -417,7 +417,7 @@ void ScannerScheduler::_scanner_scan(ScannerScheduler* scheduler,
     if (eos || should_stop) {
         scanner->mark_to_need_to_close();
     }
-    ctx->push_back_scanner_and_reschedule(std::make_shared<ScannerDelegate>(scanner));
+    ctx->push_back_scanner_and_reschedule(scanner_delegate);
 }
 
 void ScannerScheduler::_register_metrics() {

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -223,7 +223,7 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
                 this->_scanner_scan(this, ctx, scanner);
                 // will release scanner if it is the last one, task lock is hold here, to ensure
                 // that scanner could call scannode's method during deconstructor
-                scanner.reset(nullptr);
+                Dependencyscanner.reset();
             });
             if (s.ok()) {
                 this_run.erase(iter++);
@@ -249,7 +249,7 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
                         this->_scanner_scan(this, ctx, scanner);
                         // will release scanner if it is the last one, task lock is hold here, to ensure
                         // that scanner could call scannode's method during deconstructor
-                        scanner.reset(nullptr);
+                        Dependencyscanner.reset();
                     };
                     SimplifiedScanTask simple_scan_task = {work_func, ctx};
                     ret = scan_sche->get_scan_queue()->try_put(simple_scan_task);
@@ -265,7 +265,7 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
                         this->_scanner_scan(this, ctx, scanner);
                         // will release scanner if it is the last one, task lock is hold here, to ensure
                         // that scanner could call scannode's method during deconstructor
-                        scanner.reset(nullptr);
+                        Dependencyscanner.reset();
                     };
                     task.priority = nice;
                     ret = _local_scan_thread_pool->offer(task);
@@ -282,7 +282,7 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
                     this->_scanner_scan(this, ctx, scanner);
                     // will release scanner if it is the last one, task lock is hold here, to ensure
                     // that scanner could call scannode's method during deconstructor
-                    scanner.reset(nullptr);
+                    Dependencyscanner.reset();
                 };
                 task.priority = nice;
                 ret = _remote_scan_thread_pool->offer(task);

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -213,7 +213,7 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
         // TODO llj tg how to treat this?
         while (iter != this_run.end()) {
             (*iter)->start_wait_worker_timer();
-            auto s = ctx->thread_token->submit_func([this, scanner = *iter, ctx] {
+            auto s = ctx->thread_token->submit_func([this, scanner = *iter, ctx] mutable {
                 auto task_lock = ctx->get_task_execution_context().lock();
                 if (task_lock == nullptr) {
                     // LOG(WARNING) << "could not lock task execution context, query " << print_id(_query_id)
@@ -239,7 +239,7 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
             bool ret = false;
             if (type == TabletStorageType::STORAGE_TYPE_LOCAL) {
                 if (auto* scan_sche = ctx->get_simple_scan_scheduler()) {
-                    auto work_func = [this, scanner = *iter, ctx] {
+                    auto work_func = [this, scanner = *iter, ctx] mutable {
                         auto task_lock = ctx->get_task_execution_context().lock();
                         if (task_lock == nullptr) {
                             // LOG(WARNING) << "could not lock task execution context, query " << print_id(_query_id)
@@ -255,7 +255,7 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
                     ret = scan_sche->get_scan_queue()->try_put(simple_scan_task);
                 } else {
                     PriorityThreadPool::Task task;
-                    task.work_function = [this, scanner = *iter, ctx] {
+                    task.work_function = [this, scanner = *iter, ctx] mutable {
                         auto task_lock = ctx->get_task_execution_context().lock();
                         if (task_lock == nullptr) {
                             // LOG(WARNING) << "could not lock task execution context, query " << print_id(_query_id)
@@ -272,7 +272,7 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
                 }
             } else {
                 PriorityThreadPool::Task task;
-                task.work_function = [this, scanner = *iter, ctx] {
+                task.work_function = [this, scanner = *iter, ctx] mutable {
                     auto task_lock = ctx->get_task_execution_context().lock();
                     if (task_lock == nullptr) {
                         // LOG(WARNING) << "could not lock task execution context, query " << print_id(_query_id)

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -211,7 +211,11 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
     if (ctx->thread_token != nullptr) {
         // TODO llj tg how to treat this?
         while (iter != this_run.end()) {
-            (*iter)->start_wait_worker_timer();
+            std::shared_ptr<ScannerDelegate> scanner_delegate = (*iter).lock();
+            if (scanner_delegate == nullptr) {
+                continue;
+            }
+            scanner_delegate->_scanner->start_wait_worker_timer();
             auto s = ctx->thread_token->submit_func([this, scanner_ref = *iter, ctx]() {
                 this->_scanner_scan(this, ctx, scanner_ref);
             });
@@ -224,7 +228,11 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
         }
     } else {
         while (iter != this_run.end()) {
-            (*iter)->start_wait_worker_timer();
+            std::shared_ptr<ScannerDelegate> scanner_delegate = (*iter).lock();
+            if (scanner_delegate == nullptr) {
+                continue;
+            }
+            scanner_delegate->_scanner->start_wait_worker_timer();
             TabletStorageType type = (*iter)->get_storage_type();
             bool ret = false;
             if (type == TabletStorageType::STORAGE_TYPE_LOCAL) {

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -180,10 +180,6 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
     watch.reset();
     watch.start();
     ctx->incr_num_ctx_scheduling(1);
-    size_t size = 0;
-    // Not move this code, it has to be here.!!!! because it need to modify schedule ctx and running
-    // scanners, two variables.
-    Defer defer {[&]() { ctx->incr_num_scanner_scheduling(size); }};
 
     if (ctx->done()) {
         return;
@@ -191,8 +187,7 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
 
     std::list<std::weak_ptr<ScannerDelegate>> this_run;
     ctx->get_next_batch_of_scanners(&this_run);
-    size = this_run.size();
-    if (!size) {
+    if (this_run.empty()) {
         // There will be 2 cases when this_run is empty:
         // 1. The blocks queue reaches limit.
         //      The consumer will continue scheduling the ctx.

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -417,7 +417,7 @@ void ScannerScheduler::_scanner_scan(ScannerScheduler* scheduler,
     if (eos || should_stop) {
         scanner->mark_to_need_to_close();
     }
-    ctx->push_back_scanner_and_reschedule(scanner);
+    ctx->push_back_scanner_and_reschedule(std::make_shared<ScannerDelegate>(scanner));
 }
 
 void ScannerScheduler::_register_metrics() {

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -223,7 +223,7 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
                 this->_scanner_scan(this, ctx, scanner);
                 // will release scanner if it is the last one, task lock is hold here, to ensure
                 // that scanner could call scannode's method during deconstructor
-                scanner.reset();
+                scanner.reset(nullptr);
             });
             if (s.ok()) {
                 this_run.erase(iter++);
@@ -249,7 +249,7 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
                         this->_scanner_scan(this, ctx, scanner);
                         // will release scanner if it is the last one, task lock is hold here, to ensure
                         // that scanner could call scannode's method during deconstructor
-                        scanner.reset();
+                        scanner.reset(nullptr);
                     };
                     SimplifiedScanTask simple_scan_task = {work_func, ctx};
                     ret = scan_sche->get_scan_queue()->try_put(simple_scan_task);
@@ -265,7 +265,7 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
                         this->_scanner_scan(this, ctx, scanner);
                         // will release scanner if it is the last one, task lock is hold here, to ensure
                         // that scanner could call scannode's method during deconstructor
-                        scanner.reset();
+                        scanner.reset(nullptr);
                     };
                     task.priority = nice;
                     ret = _local_scan_thread_pool->offer(task);
@@ -282,7 +282,7 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
                     this->_scanner_scan(this, ctx, scanner);
                     // will release scanner if it is the last one, task lock is hold here, to ensure
                     // that scanner could call scannode's method during deconstructor
-                    scanner.reset();
+                    scanner.reset(nullptr);
                 };
                 task.priority = nice;
                 ret = _remote_scan_thread_pool->offer(task);

--- a/be/src/vec/exec/scan/scanner_scheduler.h
+++ b/be/src/vec/exec/scan/scanner_scheduler.h
@@ -36,7 +36,7 @@ class BlockingQueue;
 } // namespace doris
 
 namespace doris::vectorized {
-
+class ScannerDelegate;
 class ScannerContext;
 
 // Responsible for the scheduling and execution of all Scanners of a BE node.

--- a/be/src/vec/exec/scan/scanner_scheduler.h
+++ b/be/src/vec/exec/scan/scanner_scheduler.h
@@ -79,7 +79,7 @@ private:
     void _schedule_scanners(std::shared_ptr<ScannerContext> ctx);
     // execution thread function
     void _scanner_scan(ScannerScheduler* scheduler, std::shared_ptr<ScannerContext> ctx,
-                       VScannerSPtr scanner);
+                       std::weak_ptr<ScannerDelegate> scanner);
 
     void _register_metrics();
 

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -335,7 +335,7 @@ Status VScanNode::close(RuntimeState* state) {
     if (is_closed()) {
         return Status::OK();
     }
-    _scanners.clear();
+
     RETURN_IF_ERROR(ExecNode::close(state));
     return Status::OK();
 }
@@ -348,7 +348,7 @@ void VScanNode::release_resource(RuntimeState* state) {
             _scanner_ctx->stop_scanners(state);
         }
     }
-
+    _scanners.clear();
     ExecNode::release_resource(state);
 }
 

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -1327,7 +1327,7 @@ Status VScanNode::_prepare_scanners(const int query_parallel_instance_num) {
     RETURN_IF_ERROR(_init_scanners(&scanners));
     // Init scanner wrapper
     for (auto it = scanners.begin(); it != scanners.end(); ++it) {
-        _scanners.emplace_back(*it);
+        _scanners.emplace_back(std::make_shared<ScannerDelegate>(*it));
     }
     if (scanners.empty()) {
         _eos = true;

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -335,6 +335,7 @@ Status VScanNode::close(RuntimeState* state) {
     if (is_closed()) {
         return Status::OK();
     }
+    _scanners.clear();
     RETURN_IF_ERROR(ExecNode::close(state));
     return Status::OK();
 }

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -273,7 +273,7 @@ Status VScanNode::get_next(RuntimeState* state, vectorized::Block* block, bool* 
     reached_limit(block, eos);
     if (*eos) {
         // reach limit, stop the scanners.
-        _scanner_ctx->set_should_stop();
+        _scanner_ctx->stop_scanners(state);
     }
 
     return Status::OK();
@@ -318,8 +318,8 @@ Status VScanNode::_init_profile() {
     return Status::OK();
 }
 
-Status VScanNode::_start_scanners(const std::list<VScannerSPtr>& scanners,
-                                  const int query_parallel_instance_num) {
+void VScanNode::_start_scanners(const std::list<std::shared_ptr<ScannerDelegate>>& scanners,
+                                const int query_parallel_instance_num) {
     if (_is_pipeline_scan) {
         int max_queue_size = _shared_scan_opt ? std::max(query_parallel_instance_num, 1) : 1;
         _scanner_ctx = pipeline::PipScannerContext::create_shared(
@@ -329,7 +329,6 @@ Status VScanNode::_start_scanners(const std::list<VScannerSPtr>& scanners,
         _scanner_ctx = ScannerContext::create_shared(_state, this, _output_tuple_desc, scanners,
                                                      limit(), _state->scan_queue_mem_limit());
     }
-    return Status::OK();
 }
 
 Status VScanNode::close(RuntimeState* state) {
@@ -342,13 +341,10 @@ Status VScanNode::close(RuntimeState* state) {
 
 void VScanNode::release_resource(RuntimeState* state) {
     if (_scanner_ctx) {
-        if (!state->enable_pipeline_exec()) {
+        if (!state->enable_pipeline_exec() || _should_create_scanner) {
             // stop and wait the scanner scheduler to be done
             // _scanner_ctx may not be created for some short circuit case.
-            _scanner_ctx->set_should_stop();
-            _scanner_ctx->clear_and_join(this, state);
-        } else if (_should_create_scanner) {
-            _scanner_ctx->clear_and_join(this, state);
+            _scanner_ctx->stop_scanners(state);
         }
     }
 
@@ -359,7 +355,7 @@ Status VScanNode::try_close(RuntimeState* state) {
     if (_scanner_ctx) {
         // mark this scanner ctx as should_stop to make sure scanners will not be scheduled anymore
         // TODO: there is a lock in `set_should_stop` may cause some slight impact
-        _scanner_ctx->set_should_stop();
+        _scanner_ctx->stop_scanners(state);
     }
     return Status::OK();
 }
@@ -1329,11 +1325,15 @@ VScanNode::PushDownType VScanNode::_should_push_down_in_predicate(VInPredicate* 
 Status VScanNode::_prepare_scanners(const int query_parallel_instance_num) {
     std::list<VScannerSPtr> scanners;
     RETURN_IF_ERROR(_init_scanners(&scanners));
+    // Init scanner wrapper
+    for (auto& it = scanners.begin(); it != scanners.end(); ++it) {
+        _scanners.emplace_back(*it);
+    }
     if (scanners.empty()) {
         _eos = true;
     } else {
         COUNTER_SET(_num_scanners, static_cast<int64_t>(scanners.size()));
-        RETURN_IF_ERROR(_start_scanners(scanners, query_parallel_instance_num));
+        _start_scanners(_scanners, query_parallel_instance_num);
     }
     return Status::OK();
 }

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -352,15 +352,6 @@ void VScanNode::release_resource(RuntimeState* state) {
     ExecNode::release_resource(state);
 }
 
-Status VScanNode::try_close(RuntimeState* state) {
-    if (_scanner_ctx) {
-        // mark this scanner ctx as should_stop to make sure scanners will not be scheduled anymore
-        // TODO: there is a lock in `set_should_stop` may cause some slight impact
-        _scanner_ctx->stop_scanners(state);
-    }
-    return Status::OK();
-}
-
 Status VScanNode::_normalize_conjuncts() {
     // The conjuncts is always on output tuple, so use _output_tuple_desc;
     std::vector<SlotDescriptor*> slots = _output_tuple_desc->slots();

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -1326,7 +1326,7 @@ Status VScanNode::_prepare_scanners(const int query_parallel_instance_num) {
     std::list<VScannerSPtr> scanners;
     RETURN_IF_ERROR(_init_scanners(&scanners));
     // Init scanner wrapper
-    for (auto& it = scanners.begin(); it != scanners.end(); ++it) {
+    for (auto it = scanners.begin(); it != scanners.end(); ++it) {
         _scanners.emplace_back(*it);
     }
     if (scanners.empty()) {

--- a/be/src/vec/exec/scan/vscan_node.h
+++ b/be/src/vec/exec/scan/vscan_node.h
@@ -166,8 +166,6 @@ public:
     Status alloc_resource(RuntimeState* state) override;
     void release_resource(RuntimeState* state) override;
 
-    Status try_close(RuntimeState* state) override;
-
     bool should_run_serial() const {
         return _should_run_serial || _state->enable_scan_node_run_serial();
     }

--- a/be/src/vec/exec/scan/vscan_node.h
+++ b/be/src/vec/exec/scan/vscan_node.h
@@ -110,7 +110,7 @@ public:
             }
         }
     }
-    ~VScanNode() = default;
+    ~VScanNode() override = default;
 
     friend class VScanner;
     friend class NewOlapScanner;

--- a/be/src/vec/exec/scan/vscan_node.h
+++ b/be/src/vec/exec/scan/vscan_node.h
@@ -94,6 +94,7 @@ public:
     VScannerSPtr _scanner;
     ScannerDelegate(VScannerSPtr& scanner_ptr) : _scanner(scanner_ptr) {}
     ~ScannerDelegate() { static_cast<void>(_scanner->close(_scanner->runtime_state())); }
+    ScannerDelegate(ScannerDelegate&&) = delete;
 };
 
 class VScanNode : public ExecNode, public RuntimeFilterConsumer {
@@ -109,7 +110,7 @@ public:
             }
         }
     }
-    ~VScanNode() { LOG(INFO) << Status::InternalError("closed"); }
+    ~VScanNode() = default;
 
     friend class VScanner;
     friend class NewOlapScanner;

--- a/be/src/vec/exec/scan/vscan_node.h
+++ b/be/src/vec/exec/scan/vscan_node.h
@@ -87,6 +87,15 @@ struct FilterPredicates {
     std::vector<std::pair<std::string, std::shared_ptr<HybridSetBase>>> in_filters;
 };
 
+// We want to close scanner automatically, so using a delegate class
+// and call close method in the delegate class's dctor.
+class ScannerDelegate {
+public:
+    VScannerSPtr _scanner;
+    ScannerDelegate(VScannerSPtr& scanner_ptr) : _scanner(scanner_ptr) {}
+    ~ScannerDelegate() { _scanner->close(_scanner->runtime_state()); }
+};
+
 class VScanNode : public ExecNode, public RuntimeFilterConsumer {
 public:
     VScanNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs)
@@ -262,8 +271,11 @@ protected:
     int _max_scan_key_num;
     int _max_pushdown_conditions_per_column;
 
-    // Each scan node will generates a ScannerContext to manage all Scanners.
-    // See comments of ScannerContext for more details
+    // ScanNode owns the ownership of scanner, scanner context only has its weakptr
+    std::list<std::shared_ptr<ScannerDelegate>> _scanners;
+
+    // Each scan node will generates a ScannerContext to do schedule work
+    // ScannerContext will be added to scanner scheduler
     std::shared_ptr<ScannerContext> _scanner_ctx = nullptr;
 
     // indicate this scan node has no more data to return
@@ -437,8 +449,8 @@ private:
                                       const std::string& fn_name, int slot_ref_child = -1);
 
     // Submit the scanner to the thread pool and start execution
-    Status _start_scanners(const std::list<VScannerSPtr>& scanners,
-                           const int query_parallel_instance_num);
+    void _start_scanners(const std::list<std::shared_ptr<ScannerDelegate>>& scanners,
+                         const int query_parallel_instance_num);
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/exec/scan/vscan_node.h
+++ b/be/src/vec/exec/scan/vscan_node.h
@@ -166,7 +166,7 @@ public:
     Status alloc_resource(RuntimeState* state) override;
     void release_resource(RuntimeState* state) override;
 
-    Status try_close(RuntimeState* state);
+    Status try_close(RuntimeState* state) override;
 
     bool should_run_serial() const {
         return _should_run_serial || _state->enable_scan_node_run_serial();

--- a/be/src/vec/exec/scan/vscan_node.h
+++ b/be/src/vec/exec/scan/vscan_node.h
@@ -93,7 +93,7 @@ class ScannerDelegate {
 public:
     VScannerSPtr _scanner;
     ScannerDelegate(VScannerSPtr& scanner_ptr) : _scanner(scanner_ptr) {}
-    ~ScannerDelegate() { _scanner->close(_scanner->runtime_state()); }
+    ~ScannerDelegate() { static_cast<void>(_scanner->close(_scanner->runtime_state())); }
 };
 
 class VScanNode : public ExecNode, public RuntimeFilterConsumer {

--- a/be/src/vec/exec/scan/vscan_node.h
+++ b/be/src/vec/exec/scan/vscan_node.h
@@ -109,7 +109,7 @@ public:
             }
         }
     }
-    ~VScanNode() override = default;
+    ~VScanNode() { LOG(INFO) << Status::InternalError("closed"); }
 
     friend class VScanner;
     friend class NewOlapScanner;

--- a/be/src/vec/exec/scan/vscanner.h
+++ b/be/src/vec/exec/scan/vscanner.h
@@ -145,16 +145,6 @@ public:
 
     void set_status_on_failure(const Status& st) { _status = st; }
 
-    // return false if _is_counted_down is already true,
-    // otherwise, set _is_counted_down to true and return true.
-    bool set_counted_down() {
-        if (_is_counted_down) {
-            return false;
-        }
-        _is_counted_down = true;
-        return true;
-    }
-
 protected:
     void _discard_conjuncts() {
         for (auto& conjunct : _conjuncts) {
@@ -215,8 +205,6 @@ protected:
     int64_t _scan_cpu_timer = 0;
 
     bool _is_load = false;
-    // set to true after decrease the "_num_unfinished_scanners" in scanner context
-    bool _is_counted_down = false;
 
     bool _is_init = true;
 
@@ -227,6 +215,5 @@ protected:
 };
 
 using VScannerSPtr = std::shared_ptr<VScanner>;
-using VScannerWPtr = std::weak_ptr<VScanner>;
 
 } // namespace doris::vectorized


### PR DESCRIPTION
1. use a scannerdelegate object to hold scanner shared ptr, it will auto close scanner if it is released.
2. in scannercontext and scanner scheduler using scannerdelegate's weak ptr
3. scanner running thread using scanner delegate lock to get the ptr.
4. the scanner will be released in two thread: scanner running thread and fragment execute thread. 
5. both pipeline and non pipeline and pipelinex engine not need to wait scanner run finished or closed. So that the query could finished quickly and pipeline engine's code will be simple.



## Proposed changes

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

