### PR TITLE
[fix](block) fix nullptr in MutableBlock::allocated_bytes

### DIFF
--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -1109,7 +1109,9 @@ void Block::shrink_char_type_column_suffix_zero(const std::vector<size_t>& char_
 size_t MutableBlock::allocated_bytes() const {
     size_t res = 0;
     for (const auto& col : _columns) {
-        res += col->allocated_bytes();
+        if (col) {
+            res += col->allocated_bytes();
+        }
     }
 
     return res;


### PR DESCRIPTION
## Proposed changes

Check nullptr when calculating allocated bytes in MutableBlock.

According to other methods in MutableBlock, column ptr could be nullptr.
For example:

```cpp
void MutableBlock::clear_column_data() noexcept {
    for (auto& col : _columns) {
        if (col) {
            col->clear();
        }
    }
}
```

```cpp
size_t MutableBlock::rows() const {
    for (const auto& column : _columns) {
        if (column) {
            return column->size();
        }
    }

    return 0;
}
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

