### PR TITLE
[feature](coverage): refresh the coverage file before exiting the program

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -739,7 +739,7 @@ set(BUILD_SHARED_LIBS OFF)
 
 option(ENABLE_CLANG_COVERAGE "coverage option" OFF)
 if (ENABLE_CLANG_COVERAGE AND ENABLE_CLANG_COVERAGE STREQUAL ON AND COMPILER_CLANG)
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-instr-generate -fcoverage-mapping -DLLVM_PROFILE")
 endif ()
 
 if (${MAKE_TEST} STREQUAL "ON")

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -77,6 +77,7 @@ static void help(const char*);
 
 extern "C" {
 void __lsan_do_leak_check();
+int __llvm_profile_write_file();
 }
 
 namespace doris {
@@ -549,7 +550,11 @@ int main(int argc, char** argv) {
 #endif
         sleep(10);
     }
-
+    LOG(INFO) << "Doris main exiting.";
+#if defined(LLVM_PROFILE)
+    __llvm_profile_write_file();
+    LOG(INFO) << "Flush profile file.";
+#endif
     doris::TabletSchemaCache::stop_and_join();
     http_service.stop();
     brpc_service.join();


### PR DESCRIPTION

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

refresh the coverage file before exiting the program
[using-the-profiling-runtime-without-static-initializers](https://clang.llvm.org/docs/SourceBasedCodeCoverage.html#using-the-profiling-runtime-without-static-initializers)

Link https://github.com/apache/doris/pull/28354

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

