### PR TITLE
(fix)[meta][export] fix replay export NPE issue

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ExportStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ExportStmt.java
@@ -124,9 +124,12 @@ public class ExportStmt extends StatementBase {
         this.lineDelimiter = DEFAULT_LINE_DELIMITER;
         this.timeout = DEFAULT_TIMEOUT;
 
-        Optional<SessionVariable> optionalSessionVariable = Optional.ofNullable(
-                ConnectContext.get().getSessionVariable());
-        this.sessionVariables = optionalSessionVariable.orElse(VariableMgr.getDefaultSessionVariable());
+        // ConnectionContext may not exist when in replay thread
+        if (ConnectContext.get() != null) {
+            this.sessionVariables = VariableMgr.cloneSessionVariable(ConnectContext.get().getSessionVariable());
+        } else {
+            this.sessionVariables = VariableMgr.cloneSessionVariable(VariableMgr.getDefaultSessionVariable());
+        }
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes

The ConnectionContext does not exist in replay thread

```
Caused by: java. lang. NullPointerException
      at org. apache.doris. analysis. ExportStmt. <init>(ExportStmt.java: 126) ~[doris-fe. jar:1.2-SNAPSHOT]
      at org.apache.dor15.analys1s.CUP$SqlParser$actions.case283 （SqlParser.java:45050）~［doris-fe.jar:1.2-SNAPSHOTI
      at org.apache.doris. analysis. CUP$SqlParser$actions. CUP$SqlParser$do_action (SqlParser.java:16813) ~[doris-fe.jar:1.2-SNAPSHOT]
      at org-apache.doris, analysis. SqlParser.do_action (SqlParser. java:2706) ~[doris-fe. jar:1.2-SNAPSHOT]
      at java_cup. runtime. 1r_parser.parse(1r_parser.java:584) ~[jflex-1.4.3. jar:71
      at org-apache, doris, common, util, SqlParserutils.getstmt （SqlParserutils.java:51）~［doris-fe.jar:1.2-SNAPSHOTI
      at org-apache.doris. load. Export Job. readFields (ExportJob. java: 772) ~[doris-fe. jar:1.2-SNAPSHOT] at org-apache. doris, load. Export.Job, read (ExportJob. java: 687) ~ [doris-fe. jar:1.2-SNAPSHOT]
      at org-apache. doris, catalog.Env. loadExportJob(Env. java: 1805) ~[doris-fe. jar:1.2-SNAPSHOT)
      at sun. reflect.NativeMethodAccessor Impl. invoke®(Native Method) ~[7:1.8.0_3911
      at sun. reflect. NativeMethodAccessorImpl, invoke (NativeMethodAccessor Impl. java: 62) ~[7:1.8.0_391]
      at sun, reflect, Delegat ingMethodAccessorImpl. invoke 
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

