### PR TITLE
(enhance)(InternalQuery) Support to collect profile for intenal query

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2361,7 +2361,7 @@ public class Config extends ConfigBase {
     public static String sql_convertor_service = "";
 
     @ConfField(mutable = true)
-    public static boolean enable_profile_when_analyze = false;    
+    public static boolean enable_profile_when_analyze = false;
     @ConfField(mutable = true)
     public static boolean enable_collect_internal_query_profile = false;
 }

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2359,4 +2359,9 @@ public class Config extends ConfigBase {
     @ConfField(description = {"用于SQL方言转换的服务地址。",
             "The service address for SQL dialect conversion."})
     public static String sql_convertor_service = "";
+
+    @ConfField(mutable = true)
+    public static boolean enable_profile_when_analyze = false;    
+    @ConfField(mutable = true)
+    public static boolean enable_collect_internal_query_profile = false;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -2762,6 +2762,9 @@ public class StmtExecutor {
             }
             AuditLogHelper.logAuditLog(context, originStmt.toString(), parsedStmt, getQueryStatisticsForAuditLog(),
                     true);
+            if (Config.enable_collect_internal_query_profile) {
+                updateProfile(true);
+            }
             QeProcessorImpl.INSTANCE.unregisterQuery(context.queryId());
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/BaseAnalysisTask.java
@@ -22,6 +22,7 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.TableIf;
+import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.qe.AutoCloseConnectContext;
 import org.apache.doris.qe.StmtExecutor;
@@ -313,12 +314,15 @@ public abstract class BaseAnalysisTask {
 
     protected void runQuery(String sql) {
         long startTime = System.currentTimeMillis();
+        String queryId = "";
         try (AutoCloseConnectContext a  = StatisticsUtil.buildConnectContext()) {
             stmtExecutor = new StmtExecutor(a.connectContext, sql);
             ColStatsData colStatsData = new ColStatsData(stmtExecutor.executeInternalQuery().get(0));
+            queryId = DebugUtil.printId(stmtExecutor.getContext().queryId());
             job.appendBuf(this, Collections.singletonList(colStatsData));
         } finally {
-            LOG.debug("End cost time in secs: " + (System.currentTimeMillis() - startTime) / 1000);
+            LOG.debug("End cost time in millisec: " + (System.currentTimeMillis() - startTime)
+                    + " Analyze SQL: " + sql + " QueryId: " + queryId);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -181,6 +181,7 @@ public class StatisticsUtil {
         sessionVariable.cpuResourceLimit = Config.cpu_resource_limit_per_analyze_task;
         sessionVariable.setEnableInsertStrict(true);
         sessionVariable.enablePageCache = false;
+        sessionVariable.enableProfile = Config.enable_profile_when_analyze;
         sessionVariable.parallelExecInstanceNum = Config.statistics_sql_parallel_exec_instance_num;
         sessionVariable.parallelPipelineTaskNum = Config.statistics_sql_parallel_exec_instance_num;
         sessionVariable.setEnableNereidsPlanner(true);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
The profile information is ignored even though enable profile for internal query. This pr adds one config to control whether collecting the profile for internal query.

![image](https://github.com/apache/doris/assets/43750022/6b79e976-71c1-416b-aa66-5ca103fe5d51)

![image](https://github.com/apache/doris/assets/43750022/30a01e6c-2ad9-43a2-a60f-82874e0a910a)


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

