### PR TITLE
Update get-starting.md

### DIFF
--- a/docs/zh-CN/docs/get-starting/get-starting.md
+++ b/docs/zh-CN/docs/get-starting/get-starting.md
@@ -40,7 +40,7 @@ java -version
 接下来，[下载 Doris 的最新二进制版本](https://doris.apache.org/zh-CN/download)，然后解压。
 
 ```
-tar zxf apache-doris-x.x.x.tar.gz
+tar xf apache-doris-x.x.x.tar.gz
 ```
 
 ## 配置 Doris


### PR DESCRIPTION
Remove incorrect tar command parameters

## Proposed changes

Version 1.2 packages are XZ compressed files, not gzip compressed files. This change modified an incorrect parameter

![image](https://github.com/apache/doris/assets/14886044/e61e602b-6fcc-4563-9c37-a477ac3ca8c8)


## Further comments


