### PR TITLE
[fix](group-commit) check if wal need recovery is abnormal

### DIFF
--- a/be/src/olap/wal_manager.h
+++ b/be/src/olap/wal_manager.h
@@ -54,15 +54,12 @@ public:
     Status create_wal_reader(const std::string& wal_path, std::shared_ptr<WalReader>& wal_reader);
     Status create_wal_writer(int64_t wal_id, std::shared_ptr<WalWriter>& wal_writer);
     Status scan();
-    size_t get_wal_table_size(const std::string& table_id);
-    Status add_recover_wal(const std::string& db_id, const std::string& table_id,
-                           std::vector<std::string> wals);
+    size_t get_wal_table_size(int64_t table_id);
+    Status add_recover_wal(int64_t db_id, int64_t table_id, std::vector<std::string> wals);
     Status add_wal_path(int64_t db_id, int64_t table_id, int64_t wal_id, const std::string& label);
     Status get_wal_path(int64_t wal_id, std::string& wal_path);
     Status get_wal_status_queue_size(const PGetWalQueueSizeRequest* request,
                                      PGetWalQueueSizeResponse* response);
-    Status get_all_wal_status_queue_size(const PGetWalQueueSizeRequest* request,
-                                         PGetWalQueueSizeResponse* response);
     void add_wal_status_queue(int64_t table_id, int64_t wal_id, WAL_STATUS wal_status);
     Status erase_wal_status_queue(int64_t table_id, int64_t wal_id);
     void print_wal_status_queue();
@@ -78,7 +75,7 @@ private:
     std::shared_mutex _lock;
     scoped_refptr<Thread> _replay_thread;
     CountDownLatch _stop_background_threads_latch;
-    std::map<std::string, std::shared_ptr<WalTable>> _table_map;
+    std::map<int64_t, std::shared_ptr<WalTable>> _table_map;
     std::vector<std::string> _wal_dirs;
     std::shared_mutex _wal_lock;
     std::shared_mutex _wal_status_lock;

--- a/be/src/runtime/group_commit_mgr.h
+++ b/be/src/runtime/group_commit_mgr.h
@@ -116,7 +116,7 @@ private:
                                const TPipelineFragmentParams& pipeline_params);
     Status _finish_group_commit_load(int64_t db_id, int64_t table_id, const std::string& label,
                                      int64_t txn_id, const TUniqueId& instance_id, Status& status,
-                                     bool prepare_failed, RuntimeState* state);
+                                     RuntimeState* state);
 
     ExecEnv* _exec_env = nullptr;
     ThreadPool* _thread_pool = nullptr;

--- a/be/src/vec/sink/group_commit_block_sink.cpp
+++ b/be/src/vec/sink/group_commit_block_sink.cpp
@@ -36,7 +36,11 @@ GroupCommitBlockSink::GroupCommitBlockSink(ObjectPool* pool, const RowDescriptor
     _name = "GroupCommitBlockSink";
 }
 
-GroupCommitBlockSink::~GroupCommitBlockSink() = default;
+GroupCommitBlockSink::~GroupCommitBlockSink() {
+    if (_load_block_queue) {
+        _load_block_queue->remove_load_id(_load_id);
+    }
+}
 
 Status GroupCommitBlockSink::init(const TDataSink& t_sink) {
     DCHECK(t_sink.__isset.olap_table_sink);

--- a/be/test/olap/wal_manager_test.cpp
+++ b/be/test/olap/wal_manager_test.cpp
@@ -91,24 +91,24 @@ TEST_F(WalManagerTest, recovery_normal) {
     k_request_line = "{\"Status\": \"Success\",    \"Message\": \"Test\"}";
 
     std::string db_id = "1";
-    std::string tb_1_id = "1";
+    int64_t tb_1_id = 1;
     std::string wal_100_id = "100";
     std::string wal_101_id = "101";
-    std::string tb_2_id = "2";
+    int64_t tb_2_id = 2;
     std::string wal_200_id = "200";
     std::string wal_201_id = "201";
 
     std::filesystem::create_directory(wal_dir + "/" + db_id);
-    std::filesystem::create_directory(wal_dir + "/" + db_id + "/" + tb_1_id);
-    std::string wal_100 = wal_dir + "/" + db_id + "/" + tb_1_id + "/" + wal_100_id;
-    std::string wal_101 = wal_dir + "/" + db_id + "/" + tb_1_id + "/" + wal_101_id;
+    std::filesystem::create_directory(wal_dir + "/" + db_id + "/" + std::to_string(tb_1_id));
+    std::string wal_100 = wal_dir + "/" + db_id + "/" + std::to_string(tb_1_id) + "/" + wal_100_id;
+    std::string wal_101 = wal_dir + "/" + db_id + "/" + std::to_string(tb_1_id) + "/" + wal_101_id;
     createWal(wal_100);
     createWal(wal_101);
 
     std::filesystem::create_directory(wal_dir + "/" + db_id);
-    std::filesystem::create_directory(wal_dir + "/" + db_id + "/" + tb_2_id);
-    std::string wal_200 = wal_dir + "/" + db_id + "/" + tb_2_id + "/" + wal_200_id;
-    std::string wal_201 = wal_dir + "/" + db_id + "/" + tb_2_id + "/" + wal_201_id;
+    std::filesystem::create_directory(wal_dir + "/" + db_id + "/" + std::to_string(tb_2_id));
+    std::string wal_200 = wal_dir + "/" + db_id + "/" + std::to_string(tb_2_id) + "/" + wal_200_id;
+    std::string wal_201 = wal_dir + "/" + db_id + "/" + std::to_string(tb_2_id) + "/" + wal_201_id;
     createWal(wal_200);
     createWal(wal_201);
     static_cast<void>(_env->wal_mgr()->init());

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/NativeInsertStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/NativeInsertStmt.java
@@ -1157,7 +1157,8 @@ public class NativeInsertStmt extends InsertStmt {
 
     public GroupCommitPlanner planForGroupCommit(TUniqueId queryId) throws UserException, TException {
         OlapTable olapTable = (OlapTable) getTargetTable();
-        if (execPlanFragmentParamsBytes != null && olapTable.getBaseSchemaVersion() == baseSchemaVersion) {
+        if (groupCommitPlanner != null && olapTable.getBaseSchemaVersion() == baseSchemaVersion) {
+            LOG.debug("reuse group commit plan, table={}", olapTable);
             return groupCommitPlanner;
         }
         if (!targetColumns.isEmpty()) {

--- a/regression-test/data/insert_p0/insert_group_commit_with_prepare_stmt.out
+++ b/regression-test/data/insert_p0/insert_group_commit_with_prepare_stmt.out
@@ -19,8 +19,12 @@
 -- !sql --
 1	a	10
 2	NULL	20
+2	NULL	20
+3	c	\N
 3	c	\N
 4	d	40
+4	d	40
+5	e	\N
 5	e	\N
 6	f	40
 
@@ -28,8 +32,12 @@
 1	a	-1
 1	a	10
 2	NULL	20
+2	NULL	20
+3	c	\N
 3	c	\N
 4	d	40
+4	d	40
+5	e	\N
 5	e	\N
 6	f	40
 7	e	-1

--- a/regression-test/data/insert_p0/prepare_insert.out
+++ b/regression-test/data/insert_p0/prepare_insert.out
@@ -6,7 +6,11 @@
 4	abcd	93
 5	a5	94
 10	a	90
+10	a	90
+20	ab	91
 20	ab	91
 30	abc	92
+30	abc	92
+40	abcd	93
 40	abcd	93
 

--- a/regression-test/suites/insert_p0/insert_group_commit_with_prepare_stmt.groovy
+++ b/regression-test/suites/insert_p0/insert_group_commit_with_prepare_stmt.groovy
@@ -15,7 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import com.mysql.cj.ServerPreparedQuery
+import com.mysql.cj.jdbc.ConnectionImpl
+import com.mysql.cj.jdbc.JdbcStatement
+import com.mysql.cj.jdbc.ServerPreparedStatement
 import com.mysql.cj.jdbc.StatementImpl
+
+import java.lang.reflect.Field
+import java.util.concurrent.CopyOnWriteArrayList
 
 suite("insert_group_commit_with_prepare_stmt") {
     def user = context.config.jdbcUser
@@ -68,7 +75,12 @@ suite("insert_group_commit_with_prepare_stmt") {
     def group_commit_insert = { stmt, expected_row_count ->
         def result = stmt.executeBatch()
         logger.info("insert result: " + result)
-        def serverInfo = (((StatementImpl) stmt).results).getServerInfo()
+        def results = ((StatementImpl) stmt).results
+        if (results == null) {
+            logger.warn("result is null")
+            return
+        }
+        def serverInfo = results.getServerInfo()
         logger.info("result server info: " + serverInfo)
         if (result != expected_row_count) {
             logger.warn("insert result: " + result + ", expected_row_count: " + expected_row_count)
@@ -76,6 +88,22 @@ suite("insert_group_commit_with_prepare_stmt") {
         // assertEquals(result, expected_row_count)
         assertTrue(serverInfo.contains("'status':'PREPARE'"))
         assertTrue(serverInfo.contains("'label':'group_commit_"))
+    }
+
+    def getStmtId = { stmt ->
+        ConnectionImpl connection = (ConnectionImpl) stmt.getConnection()
+        Field field = ConnectionImpl.class.getDeclaredField("openStatements")
+        field.setAccessible(true)
+        CopyOnWriteArrayList<JdbcStatement> openStatements = (CopyOnWriteArrayList<JdbcStatement>) field.get(connection)
+        List<Long> serverStatementIds = new ArrayList<Long>()
+        for (JdbcStatement openStatement : openStatements) {
+            ServerPreparedStatement serverPreparedStatement = (ServerPreparedStatement) openStatement
+            ServerPreparedQuery serverPreparedQuery = (ServerPreparedQuery) serverPreparedStatement.getQuery()
+            long serverStatementId = serverPreparedQuery.getServerStatementId()
+            serverStatementIds.add(serverStatementId)
+        }
+        logger.info("server statement ids: " + serverStatementIds)
+        return serverStatementIds
     }
 
     def url = getServerPrepareJdbcUrl(context.config.jdbcUrl, realDb)
@@ -107,15 +135,18 @@ suite("insert_group_commit_with_prepare_stmt") {
 
             insert_prepared insert_stmt, 1, "a", 10
             group_commit_insert insert_stmt, 1
+            def stmtId = getStmtId(insert_stmt)
 
             insert_prepared insert_stmt, 2, null, 20
             insert_prepared insert_stmt, 3, "c", null
             insert_prepared insert_stmt, 4, "d", 40
             group_commit_insert insert_stmt, 3
+            assertEquals(stmtId, getStmtId(insert_stmt))
 
             insert_prepared insert_stmt, 5, "e", null
             insert_prepared insert_stmt, 6, "f", 40
             group_commit_insert insert_stmt, 2
+            assertEquals(stmtId, getStmtId(insert_stmt))
 
             getRowCount(6)
             qt_sql """ select * from ${table} order by id asc; """
@@ -126,10 +157,12 @@ suite("insert_group_commit_with_prepare_stmt") {
 
             insert_prepared_partial insert_stmt, 'a', 1, 1
             group_commit_insert insert_stmt, 1
+            def stmtId2 = getStmtId(insert_stmt)
 
             insert_prepared_partial insert_stmt, 'e', 7, 0
             insert_prepared_partial insert_stmt, null, 8, 0
             group_commit_insert insert_stmt, 2
+            assertEquals(stmtId2, getStmtId(insert_stmt))
 
             getRowCount(7)
             qt_sql """ select * from ${table} order by id, name, score asc; """
@@ -140,7 +173,7 @@ suite("insert_group_commit_with_prepare_stmt") {
     }
 
     table = "test_prepared_stmt_duplicate"
-    result1 = connect(user=user, password=password, url=url) {
+    result1 = connect(user, password, url + "&rewriteBatchedStatements=true&cachePrepStmts=true&sessionVariables=group_commit=async_mode") {
         try {
             // create table
             sql """ drop table if exists ${table}; """
@@ -158,7 +191,6 @@ suite("insert_group_commit_with_prepare_stmt") {
             );
             """
 
-            sql """ set group_commit = async_mode; """
             sql """ set enable_insert_strict = false; """
 
             // 1. insert into
@@ -167,17 +199,30 @@ suite("insert_group_commit_with_prepare_stmt") {
 
             insert_prepared insert_stmt, 1, "a", 10
             group_commit_insert insert_stmt, 1
+            def stmtId = getStmtId(insert_stmt)
 
             insert_prepared insert_stmt, 2, null, 20
             insert_prepared insert_stmt, 3, "c", null
             insert_prepared insert_stmt, 4, "d", 40
             group_commit_insert insert_stmt, 3
+            def stmtId2 = getStmtId(insert_stmt)
+
+            insert_prepared insert_stmt, 2, null, 20
+            insert_prepared insert_stmt, 3, "c", null
+            insert_prepared insert_stmt, 4, "d", 40
+            group_commit_insert insert_stmt, 3
+            assertEquals(stmtId2, getStmtId(insert_stmt))
 
             insert_prepared insert_stmt, 5, "e", null
             insert_prepared insert_stmt, 6, "f", 40
             group_commit_insert insert_stmt, 2
+            def stmtId3 = getStmtId(insert_stmt)
 
-            getRowCount(6)
+            insert_prepared insert_stmt, 5, "e", null
+            group_commit_insert insert_stmt, 1
+            assertEquals(stmtId3, getStmtId(insert_stmt))
+
+            getRowCount(10)
             qt_sql """ select * from ${table} order by id asc; """
 
             // 2. insert into partial columns
@@ -186,12 +231,14 @@ suite("insert_group_commit_with_prepare_stmt") {
 
             insert_prepared_partial_dup insert_stmt, 'a', 1
             group_commit_insert insert_stmt, 1
+            getStmtId(insert_stmt)
 
             insert_prepared_partial_dup insert_stmt, 'e', 7
             insert_prepared_partial_dup insert_stmt, null, 8
             group_commit_insert insert_stmt, 2
+            getStmtId(insert_stmt)
 
-            getRowCount(9)
+            getRowCount(13)
             qt_sql """ select * from ${table} order by id, name, score asc; """
 
         } finally {

--- a/regression-test/suites/insert_p0/insert_group_commit_with_prepare_stmt.groovy
+++ b/regression-test/suites/insert_p0/insert_group_commit_with_prepare_stmt.groovy
@@ -81,7 +81,7 @@ suite("insert_group_commit_with_prepare_stmt") {
     def url = getServerPrepareJdbcUrl(context.config.jdbcUrl, realDb)
     logger.info("url: " + url)
 
-    def result1 = connect(user=user, password=password, url=url) {
+    def result1 = connect(user, password, url + "&sessionVariables=group_commit=async_mode") {
         try {
             // create table
             sql """ drop table if exists ${table}; """
@@ -99,7 +99,6 @@ suite("insert_group_commit_with_prepare_stmt") {
             );
             """
 
-            sql """ set group_commit = async_mode; """
             sql """ set enable_insert_strict = false; """
 
             // 1. insert into

--- a/regression-test/suites/insert_p0/prepare_insert.groovy
+++ b/regression-test/suites/insert_p0/prepare_insert.groovy
@@ -1,4 +1,3 @@
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
@@ -16,9 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// The cases is copied from https://github.com/trinodb/trino/tree/master
-// /testing/trino-product-tests/src/main/resources/sql-tests/testcases
-// and modified by Doris.
+import com.mysql.cj.ServerPreparedQuery
+import com.mysql.cj.jdbc.ConnectionImpl
+import com.mysql.cj.jdbc.JdbcStatement
+import com.mysql.cj.jdbc.ServerPreparedStatement
+import com.mysql.cj.jdbc.StatementImpl
+
+import java.lang.reflect.Field
+import java.util.concurrent.CopyOnWriteArrayList
+
 suite("prepare_insert") {
     def user = context.config.jdbcUser
     def password = context.config.jdbcPassword
@@ -41,6 +46,29 @@ suite("prepare_insert") {
         );
     """
 
+    def getServerInfo = { stmt ->
+        def serverInfo = (((StatementImpl) stmt).results).getServerInfo()
+        logger.info("server info: " + serverInfo)
+        return serverInfo
+    }
+
+    def getStmtId = { stmt ->
+        ConnectionImpl connection = (ConnectionImpl) stmt.getConnection()
+        Field field = ConnectionImpl.class.getDeclaredField("openStatements")
+        field.setAccessible(true)
+        CopyOnWriteArrayList<JdbcStatement> openStatements = (CopyOnWriteArrayList<JdbcStatement>) field.get(
+                connection)
+        List<Long> serverStatementIds = new ArrayList<Long>()
+        for (JdbcStatement openStatement : openStatements) {
+            ServerPreparedStatement serverPreparedStatement = (ServerPreparedStatement) openStatement
+            ServerPreparedQuery serverPreparedQuery = (ServerPreparedQuery) serverPreparedStatement.getQuery()
+            long serverStatementId = serverPreparedQuery.getServerStatementId()
+            serverStatementIds.add(serverStatementId)
+        }
+        logger.info("server statement ids: " + serverStatementIds)
+        return serverStatementIds
+    }
+
     // Parse url
     String url = getServerPrepareJdbcUrl(context.config.jdbcUrl, realDb)
 
@@ -52,11 +80,16 @@ suite("prepare_insert") {
         stmt.setInt(3, 90)
         def result = stmt.execute()
         logger.info("result: ${result}")
+        getServerInfo(stmt)
+        def stmtId = getStmtId(stmt)
+
         stmt.setInt(1, 2)
         stmt.setString(2, "ab")
         stmt.setInt(3, 91)
         result = stmt.execute()
         logger.info("result: ${result}")
+        getServerInfo(stmt)
+        assertEquals(stmtId, getStmtId(stmt))
 
         stmt.setInt(1, 3)
         stmt.setString(2, "abc")
@@ -71,6 +104,10 @@ suite("prepare_insert") {
         assertEquals(result.size(), 2)
         assertEquals(result[0], 1)
         assertEquals(result[1], 1)
+        getServerInfo(stmt)
+        // Even if we write 2 rows as a batch, but the client does not add rewriteBatchedStatements=true in the url,
+        // so the insert is executed in fe one by one.
+        assertEquals(stmtId, getStmtId(stmt))
 
         stmt.close()
     }
@@ -85,6 +122,7 @@ suite("prepare_insert") {
         stmt.setInt(3, 94)
         def result = stmt.execute()
         logger.info("result: ${result}")
+        getServerInfo(stmt)
 
         stmt.close()
     }
@@ -98,11 +136,16 @@ suite("prepare_insert") {
         stmt.setInt(3, 90)
         def result = stmt.execute()
         logger.info("result: ${result}")
+        getServerInfo(stmt)
+        def stmtId = getStmtId(stmt)
+
         stmt.setInt(1, 20)
         stmt.setString(2, "ab")
         stmt.setInt(3, 91)
         result = stmt.execute()
         logger.info("result: ${result}")
+        getServerInfo(stmt)
+        assertEquals(stmtId, getStmtId(stmt))
 
         stmt.setInt(1, 30)
         stmt.setString(2, "abc")
@@ -118,6 +161,49 @@ suite("prepare_insert") {
         // TODO why return -2
         assertEquals(result[0], -2)
         assertEquals(result[1], -2)
+        getServerInfo(stmt)
+        assertEquals(stmtId, getStmtId(stmt))
+
+        stmt.close()
+    }
+
+    url += "&cachePrepStmts=true"
+    result1 = connect(user = user, password = password, url = url) {
+        def stmt = prepareStatement "insert into ${tableName} values(?, ?, ?)"
+        assertEquals(com.mysql.cj.jdbc.ServerPreparedStatement, stmt.class)
+        stmt.setInt(1, 10)
+        stmt.setString(2, "a")
+        stmt.setInt(3, 90)
+        def result = stmt.execute()
+        logger.info("result: ${result}")
+        getServerInfo(stmt)
+        def stmtId = getStmtId(stmt)
+
+        stmt.setInt(1, 20)
+        stmt.setString(2, "ab")
+        stmt.setInt(3, 91)
+        result = stmt.execute()
+        logger.info("result: ${result}")
+        getServerInfo(stmt)
+        assertEquals(stmtId, getStmtId(stmt))
+
+        stmt.setInt(1, 30)
+        stmt.setString(2, "abc")
+        stmt.setInt(3, 92)
+        stmt.addBatch()
+        stmt.setInt(1, 40)
+        stmt.setString(2, "abcd")
+        stmt.setInt(3, 93)
+        stmt.addBatch()
+        result = stmt.executeBatch()
+        logger.info("result: ${result}")
+        assertEquals(result.size(), 2)
+        // TODO why return -2
+        assertEquals(result[0], -2)
+        assertEquals(result[1], -2)
+        getServerInfo(stmt)
+        def stmtId2 = getStmtId(stmt)
+        assertEquals(2, stmtId2.size())
 
         stmt.close()
     }


### PR DESCRIPTION
## Proposed changes

1. The original logic does not consider plan fragment execute status, so some wal may be deleted directly, but in fact, it need replay.
2. If a stream load is cancelled in client side, should remove it from load ids, otherwise, the internal group commit can not commit because it is waiting for the load is finished.
3. regression test check server parepare statement id; add session varaibels in  jdbc url  to check if it works
4. reuse fe plan fragment does not work

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

