### PR TITLE
[Enhancement](FE) add ping request when validate broker thrift client

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/BrokerGenericPool.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/BrokerGenericPool.java
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common;
+
+import org.apache.doris.thrift.TBrokerOperationStatus;
+import org.apache.doris.thrift.TBrokerOperationStatusCode;
+import org.apache.doris.thrift.TBrokerPingBrokerRequest;
+import org.apache.doris.thrift.TBrokerVersion;
+import org.apache.doris.thrift.TNetworkAddress;
+import org.apache.doris.thrift.TPaloBrokerService;
+
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
+import org.apache.commons.pool2.impl.GenericKeyedObjectPoolConfig;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class BrokerGenericPool extends GenericPool {
+
+    private static final Logger LOG = LogManager.getLogger(BrokerGenericPool.class);
+
+    public BrokerGenericPool(String className, GenericKeyedObjectPoolConfig config, int timeoutMs) {
+        super(className, config, timeoutMs);
+        BrokerThriftClientFactory factory = new BrokerThriftClientFactory();
+        pool = new GenericKeyedObjectPool<>(factory, config);
+    }
+
+    private class BrokerThriftClientFactory extends ThriftClientFactory {
+        @Override
+        public boolean validateObject(TNetworkAddress key, PooledObject p) {
+            try {
+                TBrokerPingBrokerRequest request = new TBrokerPingBrokerRequest(TBrokerVersion.VERSION_ONE,
+                        key.getHostname());
+                TBrokerOperationStatus status = ((TPaloBrokerService.Client) p.getObject()).ping(request);
+                return status.getStatusCode() == TBrokerOperationStatusCode.OK;
+            } catch (Exception e) {
+                LOG.error("broker client validate error: ", e);
+                return false;
+            }
+        }
+
+    }
+
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/common/ClientPool.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/ClientPool.java
@@ -72,5 +72,5 @@ public class ClientPool {
     public static GenericPool<BackendService.Client> backendPool =
             new GenericPool("BackendService", backendConfig, Config.backend_rpc_timeout_ms);
     public static GenericPool<TPaloBrokerService.Client> brokerPool =
-            new GenericPool("TPaloBrokerService", brokerPoolConfig, brokerTimeoutMs);
+            new BrokerGenericPool("TPaloBrokerService", brokerPoolConfig, brokerTimeoutMs);
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/GenericPool.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/GenericPool.java
@@ -37,7 +37,7 @@ import java.lang.reflect.Constructor;
 
 public class GenericPool<VALUE extends org.apache.thrift.TServiceClient>  {
     private static final Logger LOG = LogManager.getLogger(GenericPool.class);
-    private GenericKeyedObjectPool<TNetworkAddress, VALUE> pool;
+    protected GenericKeyedObjectPool<TNetworkAddress, VALUE> pool;
     private String className;
     private int timeoutMs;
     private boolean isNonBlockingIO;
@@ -123,7 +123,7 @@ public class GenericPool<VALUE extends org.apache.thrift.TServiceClient>  {
         }
     }
 
-    private class ThriftClientFactory extends BaseKeyedPooledObjectFactory<TNetworkAddress, VALUE> {
+    protected class ThriftClientFactory extends BaseKeyedPooledObjectFactory<TNetworkAddress, VALUE> {
 
         private Object newInstance(String className, TProtocol protocol) throws Exception {
             Class newoneClass = Class.forName(className);


### PR DESCRIPTION
## Proposed changes

My organization try to run TPC-DS 100G HMS Lake query.  During the testing process, we encountered the following issues.

- when  BrokerFileSystem listLocatedFiles, many such errors have occurred. `Socket is closed by peer` .  After debugging, we found that the broker thrift client connection was closed.

![a456f2f975cf26d0592ac591a75ef073](https://github.com/apache/doris/assets/154484896/aed9175a-3f20-453d-812a-79bb2c8c886b)

This pr adds ping request during validate broker thrift client to avoid using abnormal clients.


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

