### PR TITLE
[fix](nereids)group by expr may be bound twice in bind agg slot

### DIFF
--- a/regression-test/suites/nereids_syntax_p0/analyze_agg.groovy
+++ b/regression-test/suites/nereids_syntax_p0/analyze_agg.groovy
@@ -77,4 +77,15 @@ suite("analyze_agg") {
 
     // should not bind g /g in group by again, otherwise will throw exception
     sql "select g / g as nu, sum(c) from t2 group by nu"
+    sql """
+            select
+                1,
+                id / (select max(id) from t2)  as 'x',
+                count(distinct c) as 'y'
+            from
+                t2
+            group by
+                1,
+                x
+        """
 }


### PR DESCRIPTION
## Proposed changes
```
select
      1,
      id / (select max(id) from t2)  as 'x',
      count(distinct c) as 'y'
  from
      t2
  group by
      1,
      x
```
in above sql, Alias(x) may be bound both in binding agg output and binding group by expr. This pr fix the problem and make sure the Alias(x) can be bound only once.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

