### PR TITLE
[chore](error msg) print type info when colocate with ddl failed due to type mismatch

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ColocateGroupSchema.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ColocateGroupSchema.java
@@ -105,8 +105,11 @@ public class ColocateGroupSchema implements Writable {
                     continue;
                 }
                 if (!targetColType.equals(info.getDistributionColumns().get(i).getType())) {
+                    String typeName = info.getDistributionColumns().get(i).getType().toString();
+                    String colName = info.getDistributionColumns().get(i).getName();
+                    String formattedString = colName + "(" + typeName + ")";
                     ErrorReport.reportDdlException(ErrorCode.ERR_COLOCATE_TABLE_MUST_HAS_SAME_DISTRIBUTION_COLUMN_TYPE,
-                            info.getDistributionColumns().get(i).getName(), targetColType);
+                                                formattedString, targetColType);
                 }
             }
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/ColocateTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/ColocateTableTest.java
@@ -310,7 +310,7 @@ public class ColocateTableTest {
                 + ");");
 
         expectedEx.expect(DdlException.class);
-        expectedEx.expectMessage("Colocate tables distribution columns must have the same data type: k2 should be INT");
+        expectedEx.expectMessage("Colocate tables distribution columns must have the same data type: k2(VARCHAR(10)) should be INT");
         createTable("create table " + dbName + "." + tableName2 + " (\n"
                 + " `k1` int NULL COMMENT \"\",\n"
                 + " `k2` varchar(10) NULL COMMENT \"\"\n"


### PR DESCRIPTION
before:
```
ERROR 1105 (HY000): errCode = 2, detailMessage = Colocate tables distribution columns must have the same data type: k1 should be INT
```
after:
```
ERROR 1105 (HY000): errCode = 2, detailMessage = Colocate tables distribution columns must have the same data type: k1(DATEV2) should be INT
```