### PR TITLE
[Fix](executor)Fix scan queue query hang

### DIFF
--- a/be/src/vec/exec/scan/scan_task_queue.h
+++ b/be/src/vec/exec/scan/scan_task_queue.h
@@ -29,33 +29,22 @@ namespace taskgroup {
 
 using WorkFunction = std::function<void()>;
 
-// Like PriorityThreadPool::Task
 struct ScanTask {
     ScanTask();
-    ScanTask(WorkFunction scan_func, std::shared_ptr<vectorized::ScannerContext> scanner_context,
-             TGSTEntityPtr scan_entity, int priority);
-    bool operator<(const ScanTask& o) const { return priority < o.priority; }
-    ScanTask& operator++() {
-        priority += 2;
-        return *this;
-    }
+    ScanTask(WorkFunction scan_func, std::shared_ptr<vectorized::ScannerContext> scanner_context);
 
     WorkFunction scan_func;
     std::shared_ptr<vectorized::ScannerContext> scanner_context = nullptr;
-    TGSTEntityPtr scan_entity;
-    int priority;
 };
 
-// Like pipeline::PriorityTaskQueue use BlockingPriorityQueue directly?
 class ScanTaskQueue {
 public:
-    ScanTaskQueue();
     Status try_push_back(ScanTask);
-    bool try_get(ScanTask* scan_task, uint32_t timeout_ms);
-    int size() { return _queue.get_size(); }
+    bool try_get(ScanTask* scan_task);
+    size_t size() { return _queue.size(); }
 
 private:
-    BlockingPriorityQueue<ScanTask> _queue;
+    std::queue<ScanTask> _queue;
 };
 
 // Like TaskGroupTaskQueue

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -255,8 +255,7 @@ void ScannerScheduler::_schedule_scanners(std::shared_ptr<ScannerContext> ctx) {
                     auto work_func = [this, scanner = *iter, ctx] {
                         this->_scanner_scan(this, ctx, scanner);
                     };
-                    taskgroup::ScanTask scan_task = {
-                            work_func, ctx, ctx->get_task_group()->local_scan_task_entity(), nice};
+                    taskgroup::ScanTask scan_task = {work_func, ctx};
                     ret = _task_group_local_scan_queue->push_back(scan_task);
                 } else {
                     PriorityThreadPool::Task task;


### PR DESCRIPTION
## Proposed changes

Fix query may hang when set enable_workload_group_for_scan = true, this because there bug in BlockingPriorityQueue.blocking_get.
When set timeout_ms > 0  and calling method BlockingPriorityQueue.blocking_get, if queue is not empty,  then wait_successful could never be called, then caller can never get a task even queue is not empty.


