### PR TITLE
(feature)(LOG) Support to change be vlog level dynamically using http

### DIFF
--- a/be/src/http/action/adjust_log_level.cpp
+++ b/be/src/http/action/adjust_log_level.cpp
@@ -37,7 +37,7 @@ int handle_request(HttpRequest* req) {
         return value;
     };
     const auto& module = parse_param("module");
-    const auto& level = req->param("level");
+    const auto& level = parse_param("level");
     int new_level = std::stoi(level);
     return google::SetVLOGLevel(module.c_str(), new_level);
 }

--- a/be/src/http/action/adjust_log_level.cpp
+++ b/be/src/http/action/adjust_log_level.cpp
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <glog/vlog_is_on.h>
 #include <http/action/adjust_log_level.h>
 
 #include "common/logging.h"

--- a/be/src/http/action/adjust_log_level.cpp
+++ b/be/src/http/action/adjust_log_level.cpp
@@ -1,0 +1,56 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <glog/vlog_is_on.h>
+#include <http/action/adjust_log_level.h>
+
+#include "common/logging.h"
+#include "common/status.h"
+#include "http/http_channel.h"
+#include "http/http_request.h"
+
+namespace doris {
+
+// **Note**: If the module_name does not exist in the vlog modules, vlog
+// would create corresponding module for it.
+int handle_request(HttpRequest* req) {
+    auto parse_param = [&req](std::string param) {
+        const auto& value = req->param(param);
+        if (value.empty()) {
+            auto error_msg = fmt::format("parameter {} not specified in url.", param);
+            throw std::runtime_error(error_msg);
+        }
+        return value;
+    };
+    const auto& module = parse_param("module");
+    const auto& level = req->param("level");
+    int new_level = std::stoi(level);
+    return google::SetVLOGLevel(module.c_str(), new_level);
+}
+
+void AdjustLogLevelAction::handle(HttpRequest* req) {
+    try {
+        auto old_level = handle_request(req);
+        auto msg = fmt::format("adjust log level success, origin level is {}", old_level);
+        HttpChannel::send_reply(req, msg);
+    } catch (const std::exception& e) {
+        HttpChannel::send_reply(req, HttpStatus::INTERNAL_SERVER_ERROR, e.what());
+        LOG(WARNING) << "adjust log level failed, error: " << e.what();
+        return;
+    }
+}
+} // namespace doris

--- a/be/src/http/action/adjust_log_level.h
+++ b/be/src/http/action/adjust_log_level.h
@@ -1,0 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <string>
+
+#include "common/status.h"
+#include "http/http_handler.h"
+
+namespace doris {
+
+class HttpRequest;
+
+class AdjustLogLevelAction : public HttpHandler {
+public:
+    AdjustLogLevelAction() = default;
+
+    ~AdjustLogLevelAction() override = default;
+
+    void handle(HttpRequest* req) override;
+};
+} // namespace doris

--- a/be/src/service/http_service.cpp
+++ b/be/src/service/http_service.cpp
@@ -26,6 +26,7 @@
 
 #include "common/config.h"
 #include "common/status.h"
+#include "http/action/adjust_log_level.h"
 #include "http/action/check_rpc_channel_action.h"
 #include "http/action/check_tablet_segment_action.h"
 #include "http/action/checksum_action.h"
@@ -157,6 +158,10 @@ Status HttpService::start() {
                                       download_binlog_action);
     _ev_http_server->register_handler(HttpMethod::HEAD, "/api/_binlog/_download",
                                       download_binlog_action);
+
+    AdjustLogLevelAction* adjust_log_level_action = _pool.add(new AdjustLogLevelAction());
+    _ev_http_server->register_handler(HttpMethod::POST, "api/_glog/_adjust",
+                                      adjust_log_level_action);
 
     // Register BE version action
     VersionAction* version_action =

--- a/be/src/service/http_service.cpp
+++ b/be/src/service/http_service.cpp
@@ -160,8 +160,7 @@ Status HttpService::start() {
                                       download_binlog_action);
 
     AdjustLogLevelAction* adjust_log_level_action = _pool.add(new AdjustLogLevelAction());
-    _ev_http_server->register_handler(HttpMethod::POST, "api/glog/adjust",
-                                      adjust_log_level_action);
+    _ev_http_server->register_handler(HttpMethod::POST, "api/glog/adjust", adjust_log_level_action);
 
     // Register BE version action
     VersionAction* version_action =

--- a/be/src/service/http_service.cpp
+++ b/be/src/service/http_service.cpp
@@ -160,7 +160,7 @@ Status HttpService::start() {
                                       download_binlog_action);
 
     AdjustLogLevelAction* adjust_log_level_action = _pool.add(new AdjustLogLevelAction());
-    _ev_http_server->register_handler(HttpMethod::POST, "api/_glog/_adjust",
+    _ev_http_server->register_handler(HttpMethod::POST, "api/glog/adjust",
                                       adjust_log_level_action);
 
     // Register BE version action


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx
Now we can adjust be's vlog level dynamically using http action. According to [649](https://github.com/google/glog/issues/649#issue-884664610) and [650](https://github.com/google/glog/pull/650). we just need to use `SetVLOGLevel` to update the log level of the corresponding module.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

