### PR TITLE
[fix](load) reduce lock scope in MemTableWriter active consumption

### DIFF
--- a/be/src/olap/memtable_writer.cpp
+++ b/be/src/olap/memtable_writer.cpp
@@ -130,7 +130,12 @@ Status MemTableWriter::write(const vectorized::Block* block, const std::vector<u
 
 Status MemTableWriter::_flush_memtable_async() {
     DCHECK(_flush_token != nullptr);
-    return _flush_token->submit(std::move(_mem_table));
+    std::unique_ptr<MemTable> memtable;
+    {
+        std::lock_guard<SpinLock> l(_mem_table_ptr_lock);
+        memtable = std::move(_mem_table);
+    }
+    return _flush_token->submit(std::move(memtable));
 }
 
 Status MemTableWriter::flush_async() {
@@ -197,9 +202,12 @@ void MemTableWriter::_reset_mem_table() {
         _mem_table_insert_trackers.push_back(mem_table_insert_tracker);
         _mem_table_flush_trackers.push_back(mem_table_flush_tracker);
     }
-    _mem_table.reset(new MemTable(_req.tablet_id, _tablet_schema.get(), _req.slots, _req.tuple_desc,
-                                  _unique_key_mow, _partial_update_info.get(),
-                                  mem_table_insert_tracker, mem_table_flush_tracker));
+    {
+        std::lock_guard<SpinLock> l(_mem_table_ptr_lock);
+        _mem_table.reset(new MemTable(_req.tablet_id, _tablet_schema.get(), _req.slots,
+                                      _req.tuple_desc, _unique_key_mow, _partial_update_info.get(),
+                                      mem_table_insert_tracker, mem_table_flush_tracker));
+    }
 
     _segment_num++;
 }
@@ -221,7 +229,10 @@ Status MemTableWriter::close() {
     }
 
     auto s = _flush_memtable_async();
-    _mem_table.reset();
+    {
+        std::lock_guard<SpinLock> l(_mem_table_ptr_lock);
+        _mem_table.reset();
+    }
     _is_closed = true;
     if (UNLIKELY(!s.ok())) {
         return s;
@@ -250,8 +261,6 @@ Status MemTableWriter::_do_close_wait() {
         LOG(WARNING) << "previous flush failed tablet " << _req.tablet_id;
         return st;
     }
-
-    _mem_table.reset();
 
     if (_rowset_writer->num_rows() + _flush_token->memtable_stat().merged_rows !=
         _total_received_rows) {
@@ -319,7 +328,10 @@ Status MemTableWriter::cancel_with_status(const Status& st) {
     if (_is_cancelled) {
         return Status::OK();
     }
-    _mem_table.reset();
+    {
+        std::lock_guard<SpinLock> l(_mem_table_ptr_lock);
+        _mem_table.reset();
+    }
     if (_flush_token != nullptr) {
         // cancel and wait all memtables in flush queue to be finished
         _flush_token->cancel();
@@ -357,7 +369,7 @@ int64_t MemTableWriter::mem_consumption(MemType mem) {
 }
 
 int64_t MemTableWriter::active_memtable_mem_consumption() {
-    std::lock_guard<std::mutex> l(_lock);
+    std::lock_guard<SpinLock> l(_mem_table_ptr_lock);
     return _mem_table != nullptr ? _mem_table->memory_usage() : 0;
 }
 

--- a/be/src/olap/memtable_writer.h
+++ b/be/src/olap/memtable_writer.h
@@ -132,6 +132,7 @@ private:
     std::vector<std::shared_ptr<MemTracker>> _mem_table_insert_trackers;
     std::vector<std::shared_ptr<MemTracker>> _mem_table_flush_trackers;
     SpinLock _mem_table_tracker_lock;
+    SpinLock _mem_table_ptr_lock;
     std::atomic<uint32_t> _mem_table_num = 1;
 
     std::mutex _lock;


### PR DESCRIPTION
## Proposed changes

`MemTableMemoryLimiter::refresh_mem_tracker()` may be blocked by lock contention in `MemTableWriter::active_memtable_mem_consumption()`.
Then memtable writes will be blocked by `MemTableMemoryLimiter::handle_memtable_flush()` due to another lock contention with `MemTableMemoryLimiter::refresh_mem_tracker()`.

Reduce lock scope in `MemTableWriter::active_memtable_mem_consumption()` to avoid this problem.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

