### PR TITLE
[fix](pipelineX)  fix cannot runtime obtain  profile on pipelineX

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -3178,9 +3178,7 @@ public class Coordinator implements CoordInterface {
                     loadChannelProfile.update(params.loadChannelProfile);
                 }
                 this.done = params.done;
-                if (this.done) {
-                    attachInstanceProfileToFragmentProfile();
-                }
+                attachInstanceProfileToFragmentProfile();
                 return this.done;
             } else {
                 RuntimeProfile profile = fragmentInstancesMap.get(params.fragment_instance_id);


### PR DESCRIPTION
## Proposed changes

```
SET enable_profile=true;
set profile_level = 1;
set parallel_pipeline_task_num = 8;
set ENABLE_SHARED_SCAN = true;
set enable_local_exchange = true;
set enable_local_shuffle = true;
set experimental_enable_pipeline_x_engine=true;
```

in web profile running 
before
```
  MergedProfile  
          Fragments:
              Fragment  0:
              Fragment  1:
              Fragment  2:

Execution  Profile  2de9ec928873480b-94c249517286bb4e:(Active:  42ms,  %  non-child:  0.00%)
    Fragments:
        Fragment  0:
        Fragment  1:
        Fragment  2:
    LoadChannels:
```


now

```
MergedProfile  
          Fragments:
              Fragment  0:
              Fragment  1:
              Fragment  2:
                  Pipeline  :  0(instance_num=8):
                      DATA_STREAM_SINK_OPERATOR  (id=249,dst_id=249):
                            -  PlanInfo
                                  -  offset:  0
                            -  BlocksProduced:  sum  0,  avg  0,  max  0,  min  0
                            -  CloseTime:  avg  0ns,  max  0ns,  min  0ns
                            -  ExecTime:  avg  274.497us,  max  288.723us,  min  263.824us
                            -  InputRows:  sum  0,  avg  0,  max  0,  min  0
                            -  OpenTime:  avg  274.308us,  max  288.446us,  min  263.616us
                            -  RowsProduced:  sum  0,  avg  0,  max  0,  min  0
                            -  WaitForDependencyTime:  avg  0ns,  max  0ns,  min  0ns
                                -  WaitForRpcBufferQueue:  avg  0ns,  max  0ns,  min  0ns
                          STREAMING_AGGREGATION_OPERATOR  (id=246):
                                -  PlanInfo
                                      -  STREAMING
                                      -  output:  partial_sum(l_quantity)[#24],  partial_sum(l_extendedprice)[#25],  partial_sum((l_extendedprice  *  (1.00  -  CAST(l_discount  AS  DECIMALV3(16,  2)))))[#26],  partial_sum(((l_extendedprice  *  (1.00  -  CAST(l_discount  AS  DECIMALV3(16,  2))))  *  (1.00  +  CAST(l_tax  AS  DECIMALV3(16,  2)))))[#27],  partial_avg(CAST(l_quantity  AS  DECIMALV3(17,  4)))[#28],  partial_avg(CAST(l_extendedprice  AS  DECIMALV3(17,  4)))[#29],  partial_avg(CAST(l_discount  AS  DECIMALV3(17,  4)))[#30],  partial_count(*)[#31]
                                      -  group  by:  l_returnflag,  l_linestatus
                                      -  cardinality=2
                                -  BlocksProduced:  sum  0,  avg  0,  max  0,  min  0
                                -  CloseTime:  avg  0ns,  max  0ns,  min  0ns
                                -  ExecTime:  avg  17.444us,  max  20.595us,  min  15.795us
                                -  OpenTime:  avg  17.324us,  max  20.455us,  min  15.693us
                                -  ProjectionTime:  avg  0ns,  max  0ns,  min  0ns
                                -  RowsProduced:  sum  0,  avg  0,  max  0,  min  0
                                -  WaitForDependency[AggSourceDependency]Time:  avg  0ns,  max  0ns,  min  0ns
                  Pipeline  :  1(instance_num=8):
                      STREAMING_AGGREGATION_SINK_OPERATOR  (id=246):
                            -  CloseTime:  avg  0ns,  max  0ns,  min  0ns
                            -  ExecTime:  avg  1s968ms,  max  1s970ms,  min  1s964ms
                            -  InputRows:  sum  18.241848M  (18241848),  avg  2.280231M  (2280231),  max  2.303224M  (2303224),  min  2.267712M  (2267712)
                            -  OpenTime:  avg  182.518us,  max  197.85us,  min  177.164us
                            -  WaitForDependency[AggSinkDependency]Time:  avg  0ns,  max  0ns,  min  0ns
                          LOCAL_EXCHANGE_OPERATOR  (PASSTHROUGH)  (id=2):
                                -  BlocksProduced:  sum  4.509K  (4509),  avg  563,  max  569,  min  558
                                -  CloseTime:  avg  0ns,  max  0ns,  min  0ns
                                -  ExecTime:  avg  5.325ms,  max  5.461ms,  min  5.92ms
                                -  GetBlockFailedTime:  sum  0,  avg  0,  max  0,  min  0
                                -  OpenTime:  avg  3.296us,  max  4.445us,  min  2.915us
                                -  ProjectionTime:  avg  0ns,  max  0ns,  min  0ns
                                -  RowsProduced:  sum  18.241848M  (18241848),  avg  2.280231M  (2280231),  max  2.303224M  (2303224),  min  2.267712M  (2267712)
                                -  WaitForDependency[LocalExchangeSourceDependency]Time:  avg  0ns,  max  0ns,  min  0ns
                  Pipeline  :  2(instance_num=8):
                      LOCAL_EXCHANGE_SINK_OPERATOR  (PASSTHROUGH)  (id=2):
                            -  CloseTime:  avg  0ns,  max  0ns,  min  0ns
                            -  ExecTime:  avg  5.528ms,  max  5.788ms,  min  5.128ms
                            -  InputRows:  sum  20.929088M  (20929088),  avg  2.616136M  (2616136),  max  2.7472M  (2747200),  min  2.52368M  (2523680)
                            -  OpenTime:  avg  6.77us,  max  8.869us,  min  5.108us
                            -  WaitForDependency[LocalExchangeSinkDependency]Time:  avg  0ns,  max  0ns,  min  0ns
                          OLAP_SCAN_OPERATOR  (id=237.  table  name  =  lineitem):
                                -  PlanInfo
                                      -  TABLE:  tpch.lineitem(lineitem),  PREAGGREGATION:  ON
                                      -  PREDICATES:  l_shipdate  <=  '1998-09-02'
                                      -  partitions=1/1  (lineitem),  tablets=32/32,  tabletList=10137,10139,10141  ...
                                      -  cardinality=600037902,  avgRowSize=0.0,  numNodes=1
                                      -  pushAggOp=NONE
                                      -  projections:  l_quantity,  l_extendedprice,  l_discount,  l_tax,  l_returnflag,  l_linestatus
                                      -  project  output  tuple  id:  1
                                -  BlocksProduced:  sum  5.175K  (5175),  avg  646,  max  679,  min  624
                                -  CloseTime:  avg  0ns,  max  0ns,  min  0ns
                                -  ExecTime:  avg  73.784ms,  max  76.162ms,  min  71.53ms
                                -  OpenTime:  avg  1.10ms,  max  1.176ms,  min  926.33us
                                -  ProjectionTime:  avg  65.641ms,  max  67.853ms,  min  63.134ms
                                -  RowsProduced:  sum  20.937216M  (20937216),  avg  2.617152M  (2617152),  max  2.751264M  (2751264),  min  2.52368M  (2523680)
                                -  RuntimeFilterInfo:  sum  ,  avg  ,  max  ,  min  
                                -  WaitForDependencyTime:  avg  0ns,  max  0ns,  min  0ns
                                    -  WaitForData:  avg  0ns,  max  0ns,  min  0ns
                                    -  WaitForEos:  avg  0ns,  max  0ns,  min  0ns
                                    -  WaitForScannerDone:  avg  0ns,  max  0ns,  min  0ns
```
<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

