### PR TITLE
[Enhancement](Broker) Add high concurrency broker thrift server.

### DIFF
--- a/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/BrokerBootstrap.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/BrokerBootstrap.java
@@ -50,7 +50,9 @@ public class BrokerBootstrap {
 
             TProcessor tprocessor = new TPaloBrokerService.Processor<TPaloBrokerService.Iface>(
                     new HDFSBrokerServiceImpl());
-            ThriftServer server = new ThriftServer(BrokerConfig.broker_ipc_port, tprocessor);
+            ThriftServer server = new ThriftServer(BrokerConfig.broker_ipc_port,
+                    tprocessor,
+                    ThriftServer.ThriftServerType.valueOf(BrokerConfig.brokerThriftServerType));
             server.start();
             logger.info("starting apache hdfs broker....succeed");
             while (true) {

--- a/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/BrokerConfig.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/BrokerConfig.java
@@ -39,4 +39,7 @@ public class BrokerConfig extends ConfigBase {
 
     @ConfField
     public static int broker_ipc_port = 8000;
+
+    @ConfField(value = "broker_thrift_server_type")
+    public static String brokerThriftServerType = "THREADED_SELECTOR";
 }

--- a/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/common/ThriftServer.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/common/ThriftServer.java
@@ -35,7 +35,7 @@ import java.io.IOException;
  */
 public class ThriftServer {
     private static final Logger           LOG  = Logger.getLogger(ThriftServer.class);
-    private              ThriftServerType type = ThriftServerType.THREAD_POOL;
+    private              ThriftServerType type = ThriftServerType.THREADED_SELECTOR;
     private int        port;
     private TProcessor processor;
     private TServer    server;
@@ -66,6 +66,13 @@ public class ThriftServer {
         server = new TThreadPoolServer(args);
     }
 
+    private void createThreadedSelectorServer() throws TTransportException {
+        TThreadedSelectorServer.Args args =
+            new TThreadedSelectorServer.Args(new TNonblockingServerSocket(port)).protocolFactory(
+                new TBinaryProtocol.Factory()).processor(processor);
+        server = new TThreadedSelectorServer(args);
+    }
+
     public void start() throws IOException {
         try {
             switch (type) {
@@ -77,6 +84,9 @@ public class ThriftServer {
                     break;
                 case THREAD_POOL:
                     createThreadPoolServer();
+                    break;
+                case THREADED_SELECTOR:
+                    createThreadedSelectorServer();
                     break;
                 default:
                     break;
@@ -111,6 +121,7 @@ public class ThriftServer {
     public static enum ThriftServerType {
         SIMPLE,
         THREADED,
-        THREAD_POOL
+        THREAD_POOL,
+        THREADED_SELECTOR
     }
 }

--- a/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/common/ThriftServer.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/common/ThriftServer.java
@@ -35,15 +35,16 @@ import java.io.IOException;
  */
 public class ThriftServer {
     private static final Logger           LOG  = Logger.getLogger(ThriftServer.class);
-    private              ThriftServerType type = ThriftServerType.THREADED_SELECTOR;
+    private final ThriftServerType type;
     private int        port;
     private TProcessor processor;
     private TServer    server;
     private Thread     serverThread;
     
-    public ThriftServer(int port, TProcessor processor) {
+    public ThriftServer(int port, TProcessor processor, ThriftServerType type) {
         this.port = port;
         this.processor = processor;
+        this.type = type;
     }
 
     private void createSimpleServer() throws TTransportException {


### PR DESCRIPTION
## Proposed changes

This PR has added TThreadedSelectorServer as the default broker thrift server. TThreadedSelectorServer uses non blocking I/O and a multi-threaded model, which is suitable for handling a large number of concurrent connections and improves performance in high concurrency scenarios.


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

