### PR TITLE
Revert "[Opt](scanner-scheduler) Optimize `BlockingQueue`, `BlockingP…

### DIFF
--- a/be/src/util/blocking_queue.hpp
+++ b/be/src/util/blocking_queue.hpp
@@ -41,9 +41,7 @@ public:
             : _shutdown(false),
               _max_elements(max_elements),
               _total_get_wait_time(0),
-              _total_put_wait_time(0),
-              _get_waiting(0),
-              _put_waiting(0) {}
+              _total_put_wait_time(0) {}
 
     // Get an element from the queue, waiting indefinitely for one to become available.
     // Returns false if we were shut down prior to getting the element, and there
@@ -52,20 +50,13 @@ public:
         MonotonicStopWatch timer;
         timer.start();
         std::unique_lock<std::mutex> unique_lock(_lock);
-        while (!(_shutdown || !_list.empty())) {
-            ++_get_waiting;
-            _get_cv.wait(unique_lock);
-        }
+        _get_cv.wait(unique_lock, [this] { return _shutdown || !_list.empty(); });
         _total_get_wait_time += timer.elapsed_time();
 
         if (!_list.empty()) {
             *out = _list.front();
             _list.pop_front();
-            if (_put_waiting > 0) {
-                --_put_waiting;
-                unique_lock.unlock();
-                _put_cv.notify_one();
-            }
+            _put_cv.notify_one();
             return true;
         } else {
             assert(_shutdown);
@@ -79,10 +70,7 @@ public:
         MonotonicStopWatch timer;
         timer.start();
         std::unique_lock<std::mutex> unique_lock(_lock);
-        while (!(_shutdown || _list.size() < _max_elements)) {
-            ++_put_waiting;
-            _put_cv.wait(unique_lock);
-        }
+        _put_cv.wait(unique_lock, [this] { return _shutdown || _list.size() < _max_elements; });
         _total_put_wait_time += timer.elapsed_time();
 
         if (_shutdown) {
@@ -90,11 +78,7 @@ public:
         }
 
         _list.push_back(val);
-        if (_get_waiting > 0) {
-            --_get_waiting;
-            unique_lock.unlock();
-            _get_cv.notify_one();
-        }
+        _get_cv.notify_one();
         return true;
     }
 
@@ -114,11 +98,7 @@ public:
         }
 
         _list.push_back(val);
-        if (_get_waiting > 0) {
-            --_get_waiting;
-            unique_lock.unlock();
-            _get_cv.notify_one();
-        }
+        _get_cv.notify_one();
         return true;
     }
 
@@ -156,8 +136,6 @@ private:
     std::list<T> _list;
     std::atomic<uint64_t> _total_get_wait_time;
     std::atomic<uint64_t> _total_put_wait_time;
-    size_t _get_waiting;
-    size_t _put_waiting;
 };
 
 } // namespace doris

--- a/be/src/vec/exec/scan/scanner_scheduler.h
+++ b/be/src/vec/exec/scan/scanner_scheduler.h
@@ -111,7 +111,7 @@ private:
     // _remote_scan_thread_pool is for remote scan task(cold data on s3, hdfs, etc.)
     // _limited_scan_thread_pool is a special pool for queries with resource limit
     std::unique_ptr<PriorityThreadPool> _local_scan_thread_pool;
-    std::unique_ptr<PriorityThreadPool> _remote_scan_thread_pool;
+    std::unique_ptr<ThreadPool> _remote_scan_thread_pool;
     std::unique_ptr<ThreadPool> _limited_scan_thread_pool;
 
     std::unique_ptr<taskgroup::ScanTaskTaskGroupQueue> _task_group_local_scan_queue;


### PR DESCRIPTION
…riorityQueue` and change remote scan thread pool. (#26784)"

This is only a test to see if the commit causing load performance drop This reverts commit 0491437a8692a30c9fe9888551c72ab22fe7101c.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

