### PR TITLE
[fix](hash join) fix stack overflow caused by evaluate case expr on huge build block

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -285,6 +285,8 @@ if (COMPILER_CLANG)
         endif()
         add_definitions(-DUSE_LIBCPP)
     endif()
+
+    add_compile_options(-Werror=vla)
 endif ()
 
 add_compile_options(-D__STDC_FORMAT_MACROS

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -286,7 +286,9 @@ if (COMPILER_CLANG)
         add_definitions(-DUSE_LIBCPP)
     endif()
 
-    add_compile_options(-Werror=vla)
+    if (NOT MAKE_TEST)
+        add_compile_options(-Werror=vla)
+    endif()
 endif ()
 
 add_compile_options(-D__STDC_FORMAT_MACROS

--- a/be/src/exec/schema_scanner/schema_charsets_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_charsets_scanner.cpp
@@ -59,8 +59,10 @@ Status SchemaCharsetsScanner::get_next_block(vectorized::Block* block, bool* eos
     return _fill_block_impl(block);
 }
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
 Status SchemaCharsetsScanner::_fill_block_impl(vectorized::Block* block) {
     SCOPED_TIMER(_fill_block_timer);
     auto row_num = 0;
@@ -108,6 +110,8 @@ Status SchemaCharsetsScanner::_fill_block_impl(vectorized::Block* block) {
     }
     return Status::OK();
 }
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 } // namespace doris

--- a/be/src/exec/schema_scanner/schema_charsets_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_charsets_scanner.cpp
@@ -59,6 +59,8 @@ Status SchemaCharsetsScanner::get_next_block(vectorized::Block* block, bool* eos
     return _fill_block_impl(block);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
 Status SchemaCharsetsScanner::_fill_block_impl(vectorized::Block* block) {
     SCOPED_TIMER(_fill_block_timer);
     auto row_num = 0;
@@ -106,5 +108,6 @@ Status SchemaCharsetsScanner::_fill_block_impl(vectorized::Block* block) {
     }
     return Status::OK();
 }
+#pragma clang diagnostic pop
 
 } // namespace doris

--- a/be/src/exec/schema_scanner/schema_collations_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_collations_scanner.cpp
@@ -62,6 +62,8 @@ Status SchemaCollationsScanner::get_next_block(vectorized::Block* block, bool* e
     return _fill_block_impl(block);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
 Status SchemaCollationsScanner::_fill_block_impl(vectorized::Block* block) {
     SCOPED_TIMER(_fill_block_timer);
     auto row_num = 0;
@@ -126,5 +128,6 @@ Status SchemaCollationsScanner::_fill_block_impl(vectorized::Block* block) {
     }
     return Status::OK();
 }
+#pragma clang diagnostic pop
 
 } // namespace doris

--- a/be/src/exec/schema_scanner/schema_collations_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_collations_scanner.cpp
@@ -62,8 +62,10 @@ Status SchemaCollationsScanner::get_next_block(vectorized::Block* block, bool* e
     return _fill_block_impl(block);
 }
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
 Status SchemaCollationsScanner::_fill_block_impl(vectorized::Block* block) {
     SCOPED_TIMER(_fill_block_timer);
     auto row_num = 0;
@@ -128,6 +130,8 @@ Status SchemaCollationsScanner::_fill_block_impl(vectorized::Block* block) {
     }
     return Status::OK();
 }
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 } // namespace doris

--- a/be/src/exec/schema_scanner/schema_columns_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_columns_scanner.cpp
@@ -369,6 +369,8 @@ Status SchemaColumnsScanner::get_next_block(vectorized::Block* block, bool* eos)
     return _fill_block_impl(block);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
 Status SchemaColumnsScanner::_fill_block_impl(vectorized::Block* block) {
     SCOPED_TIMER(_fill_block_timer);
     auto columns_num = _desc_result.columns.size();
@@ -620,5 +622,6 @@ Status SchemaColumnsScanner::_fill_block_impl(vectorized::Block* block) {
     { RETURN_IF_ERROR(fill_dest_column_for_range(block, 23, null_datas)); }
     return Status::OK();
 }
+#pragma clang diagnostic pop
 
 } // namespace doris

--- a/be/src/exec/schema_scanner/schema_columns_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_columns_scanner.cpp
@@ -369,8 +369,10 @@ Status SchemaColumnsScanner::get_next_block(vectorized::Block* block, bool* eos)
     return _fill_block_impl(block);
 }
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
 Status SchemaColumnsScanner::_fill_block_impl(vectorized::Block* block) {
     SCOPED_TIMER(_fill_block_timer);
     auto columns_num = _desc_result.columns.size();
@@ -622,6 +624,8 @@ Status SchemaColumnsScanner::_fill_block_impl(vectorized::Block* block) {
     { RETURN_IF_ERROR(fill_dest_column_for_range(block, 23, null_datas)); }
     return Status::OK();
 }
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 } // namespace doris

--- a/be/src/exec/schema_scanner/schema_metadata_name_ids_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_metadata_name_ids_scanner.cpp
@@ -126,8 +126,10 @@ Status SchemaMetadataNameIdsScanner::_get_new_table() {
     return Status::OK();
 }
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
 Status SchemaMetadataNameIdsScanner::_fill_block_impl(vectorized::Block* block) {
     SCOPED_TIMER(_fill_block_timer);
     auto table_num = _table_result.tables.size();
@@ -226,7 +228,9 @@ Status SchemaMetadataNameIdsScanner::_fill_block_impl(vectorized::Block* block) 
 
     return Status::OK();
 }
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 Status SchemaMetadataNameIdsScanner::get_next_block(vectorized::Block* block, bool* eos) {
     if (!_is_init) {

--- a/be/src/exec/schema_scanner/schema_metadata_name_ids_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_metadata_name_ids_scanner.cpp
@@ -126,6 +126,8 @@ Status SchemaMetadataNameIdsScanner::_get_new_table() {
     return Status::OK();
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
 Status SchemaMetadataNameIdsScanner::_fill_block_impl(vectorized::Block* block) {
     SCOPED_TIMER(_fill_block_timer);
     auto table_num = _table_result.tables.size();
@@ -224,6 +226,7 @@ Status SchemaMetadataNameIdsScanner::_fill_block_impl(vectorized::Block* block) 
 
     return Status::OK();
 }
+#pragma clang diagnostic pop
 
 Status SchemaMetadataNameIdsScanner::get_next_block(vectorized::Block* block, bool* eos) {
     if (!_is_init) {

--- a/be/src/exec/schema_scanner/schema_rowsets_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_rowsets_scanner.cpp
@@ -108,6 +108,8 @@ Status SchemaRowsetsScanner::get_next_block(vectorized::Block* block, bool* eos)
     return _fill_block_impl(block);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
 Status SchemaRowsetsScanner::_fill_block_impl(vectorized::Block* block) {
     SCOPED_TIMER(_fill_block_timer);
     size_t fill_rowsets_num = std::min(1000ul, rowsets_.size() - _rowsets_idx);
@@ -238,4 +240,5 @@ Status SchemaRowsetsScanner::_fill_block_impl(vectorized::Block* block) {
     _rowsets_idx += fill_rowsets_num;
     return Status::OK();
 }
+#pragma clang diagnostic pop
 } // namespace doris

--- a/be/src/exec/schema_scanner/schema_rowsets_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_rowsets_scanner.cpp
@@ -108,8 +108,10 @@ Status SchemaRowsetsScanner::get_next_block(vectorized::Block* block, bool* eos)
     return _fill_block_impl(block);
 }
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
 Status SchemaRowsetsScanner::_fill_block_impl(vectorized::Block* block) {
     SCOPED_TIMER(_fill_block_timer);
     size_t fill_rowsets_num = std::min(1000ul, rowsets_.size() - _rowsets_idx);
@@ -240,5 +242,7 @@ Status SchemaRowsetsScanner::_fill_block_impl(vectorized::Block* block) {
     _rowsets_idx += fill_rowsets_num;
     return Status::OK();
 }
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 } // namespace doris

--- a/be/src/exec/schema_scanner/schema_schema_privileges_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_schema_privileges_scanner.cpp
@@ -97,6 +97,8 @@ Status SchemaSchemaPrivilegesScanner::get_next_block(vectorized::Block* block, b
     return _fill_block_impl(block);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
 Status SchemaSchemaPrivilegesScanner::_fill_block_impl(vectorized::Block* block) {
     SCOPED_TIMER(_fill_block_timer);
     auto privileges_num = _priv_result.privileges.size();
@@ -155,5 +157,6 @@ Status SchemaSchemaPrivilegesScanner::_fill_block_impl(vectorized::Block* block)
     }
     return Status::OK();
 }
+#pragma clang diagnostic pop
 
 } // namespace doris

--- a/be/src/exec/schema_scanner/schema_schema_privileges_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_schema_privileges_scanner.cpp
@@ -97,8 +97,10 @@ Status SchemaSchemaPrivilegesScanner::get_next_block(vectorized::Block* block, b
     return _fill_block_impl(block);
 }
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
 Status SchemaSchemaPrivilegesScanner::_fill_block_impl(vectorized::Block* block) {
     SCOPED_TIMER(_fill_block_timer);
     auto privileges_num = _priv_result.privileges.size();
@@ -157,6 +159,8 @@ Status SchemaSchemaPrivilegesScanner::_fill_block_impl(vectorized::Block* block)
     }
     return Status::OK();
 }
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 } // namespace doris

--- a/be/src/exec/schema_scanner/schema_schemata_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_schemata_scanner.cpp
@@ -95,6 +95,8 @@ Status SchemaSchemataScanner::get_next_block(vectorized::Block* block, bool* eos
     return _fill_block_impl(block);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
 Status SchemaSchemataScanner::_fill_block_impl(vectorized::Block* block) {
     SCOPED_TIMER(_fill_block_timer);
     auto dbs_num = _db_result.dbs.size();
@@ -147,5 +149,6 @@ Status SchemaSchemataScanner::_fill_block_impl(vectorized::Block* block) {
     { RETURN_IF_ERROR(fill_dest_column_for_range(block, 4, null_datas)); }
     return Status::OK();
 }
+#pragma clang diagnostic pop
 
 } // namespace doris

--- a/be/src/exec/schema_scanner/schema_schemata_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_schemata_scanner.cpp
@@ -95,8 +95,10 @@ Status SchemaSchemataScanner::get_next_block(vectorized::Block* block, bool* eos
     return _fill_block_impl(block);
 }
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
 Status SchemaSchemataScanner::_fill_block_impl(vectorized::Block* block) {
     SCOPED_TIMER(_fill_block_timer);
     auto dbs_num = _db_result.dbs.size();
@@ -149,6 +151,8 @@ Status SchemaSchemataScanner::_fill_block_impl(vectorized::Block* block) {
     { RETURN_IF_ERROR(fill_dest_column_for_range(block, 4, null_datas)); }
     return Status::OK();
 }
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 } // namespace doris

--- a/be/src/exec/schema_scanner/schema_table_privileges_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_table_privileges_scanner.cpp
@@ -99,8 +99,10 @@ Status SchemaTablePrivilegesScanner::get_next_block(vectorized::Block* block, bo
     return _fill_block_impl(block);
 }
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
 Status SchemaTablePrivilegesScanner::_fill_block_impl(vectorized::Block* block) {
     SCOPED_TIMER(_fill_block_timer);
     auto privileges_num = _priv_result.privileges.size();
@@ -169,6 +171,8 @@ Status SchemaTablePrivilegesScanner::_fill_block_impl(vectorized::Block* block) 
     }
     return Status::OK();
 }
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 } // namespace doris

--- a/be/src/exec/schema_scanner/schema_table_privileges_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_table_privileges_scanner.cpp
@@ -99,6 +99,8 @@ Status SchemaTablePrivilegesScanner::get_next_block(vectorized::Block* block, bo
     return _fill_block_impl(block);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
 Status SchemaTablePrivilegesScanner::_fill_block_impl(vectorized::Block* block) {
     SCOPED_TIMER(_fill_block_timer);
     auto privileges_num = _priv_result.privileges.size();
@@ -167,5 +169,6 @@ Status SchemaTablePrivilegesScanner::_fill_block_impl(vectorized::Block* block) 
     }
     return Status::OK();
 }
+#pragma clang diagnostic pop
 
 } // namespace doris

--- a/be/src/exec/schema_scanner/schema_tables_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_tables_scanner.cpp
@@ -133,8 +133,10 @@ Status SchemaTablesScanner::_get_new_table() {
     return Status::OK();
 }
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
 Status SchemaTablesScanner::_fill_block_impl(vectorized::Block* block) {
     SCOPED_TIMER(_fill_block_timer);
     auto table_num = _table_result.tables.size();
@@ -343,7 +345,9 @@ Status SchemaTablesScanner::_fill_block_impl(vectorized::Block* block) {
     }
     return Status::OK();
 }
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 Status SchemaTablesScanner::get_next_block(vectorized::Block* block, bool* eos) {
     if (!_is_init) {

--- a/be/src/exec/schema_scanner/schema_tables_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_tables_scanner.cpp
@@ -133,6 +133,8 @@ Status SchemaTablesScanner::_get_new_table() {
     return Status::OK();
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
 Status SchemaTablesScanner::_fill_block_impl(vectorized::Block* block) {
     SCOPED_TIMER(_fill_block_timer);
     auto table_num = _table_result.tables.size();
@@ -341,6 +343,7 @@ Status SchemaTablesScanner::_fill_block_impl(vectorized::Block* block) {
     }
     return Status::OK();
 }
+#pragma clang diagnostic pop
 
 Status SchemaTablesScanner::get_next_block(vectorized::Block* block, bool* eos) {
     if (!_is_init) {

--- a/be/src/exec/schema_scanner/schema_user_privileges_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_user_privileges_scanner.cpp
@@ -96,8 +96,10 @@ Status SchemaUserPrivilegesScanner::get_next_block(vectorized::Block* block, boo
     return _fill_block_impl(block);
 }
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
 Status SchemaUserPrivilegesScanner::_fill_block_impl(vectorized::Block* block) {
     SCOPED_TIMER(_fill_block_timer);
     auto privileges_num = _priv_result.privileges.size();
@@ -146,6 +148,8 @@ Status SchemaUserPrivilegesScanner::_fill_block_impl(vectorized::Block* block) {
     }
     return Status::OK();
 }
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 } // namespace doris

--- a/be/src/exec/schema_scanner/schema_user_privileges_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_user_privileges_scanner.cpp
@@ -96,6 +96,8 @@ Status SchemaUserPrivilegesScanner::get_next_block(vectorized::Block* block, boo
     return _fill_block_impl(block);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
 Status SchemaUserPrivilegesScanner::_fill_block_impl(vectorized::Block* block) {
     SCOPED_TIMER(_fill_block_timer);
     auto privileges_num = _priv_result.privileges.size();
@@ -144,5 +146,6 @@ Status SchemaUserPrivilegesScanner::_fill_block_impl(vectorized::Block* block) {
     }
     return Status::OK();
 }
+#pragma clang diagnostic pop
 
 } // namespace doris

--- a/be/src/exec/schema_scanner/schema_variables_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_variables_scanner.cpp
@@ -85,6 +85,8 @@ Status SchemaVariablesScanner::get_next_block(vectorized::Block* block, bool* eo
     return _fill_block_impl(block);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
 Status SchemaVariablesScanner::_fill_block_impl(vectorized::Block* block) {
     SCOPED_TIMER(_fill_block_timer);
     auto row_num = _var_result.variables.size();
@@ -113,5 +115,6 @@ Status SchemaVariablesScanner::_fill_block_impl(vectorized::Block* block) {
     }
     return Status::OK();
 }
+#pragma clang diagnostic pop
 
 } // namespace doris

--- a/be/src/exec/schema_scanner/schema_variables_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_variables_scanner.cpp
@@ -85,8 +85,10 @@ Status SchemaVariablesScanner::get_next_block(vectorized::Block* block, bool* eo
     return _fill_block_impl(block);
 }
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
 Status SchemaVariablesScanner::_fill_block_impl(vectorized::Block* block) {
     SCOPED_TIMER(_fill_block_timer);
     auto row_num = _var_result.variables.size();
@@ -115,6 +117,8 @@ Status SchemaVariablesScanner::_fill_block_impl(vectorized::Block* block) {
     }
     return Status::OK();
 }
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 } // namespace doris

--- a/be/src/exec/schema_scanner/schema_views_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_views_scanner.cpp
@@ -130,6 +130,8 @@ Status SchemaViewsScanner::get_next_block(vectorized::Block* block, bool* eos) {
     return _fill_block_impl(block);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
 Status SchemaViewsScanner::_fill_block_impl(vectorized::Block* block) {
     SCOPED_TIMER(_fill_block_timer);
     auto tables_num = _table_result.tables.size();
@@ -225,5 +227,6 @@ Status SchemaViewsScanner::_fill_block_impl(vectorized::Block* block) {
     { RETURN_IF_ERROR(fill_dest_column_for_range(block, 9, null_datas)); }
     return Status::OK();
 }
+#pragma clang diagnostic pop
 
 } // namespace doris

--- a/be/src/exec/schema_scanner/schema_views_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_views_scanner.cpp
@@ -130,8 +130,10 @@ Status SchemaViewsScanner::get_next_block(vectorized::Block* block, bool* eos) {
     return _fill_block_impl(block);
 }
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
 Status SchemaViewsScanner::_fill_block_impl(vectorized::Block* block) {
     SCOPED_TIMER(_fill_block_timer);
     auto tables_num = _table_result.tables.size();
@@ -227,6 +229,8 @@ Status SchemaViewsScanner::_fill_block_impl(vectorized::Block* block) {
     { RETURN_IF_ERROR(fill_dest_column_for_range(block, 9, null_datas)); }
     return Status::OK();
 }
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 } // namespace doris

--- a/be/src/glibc-compatibility/musl/glob.c
+++ b/be/src/glibc-compatibility/musl/glob.c
@@ -47,6 +47,8 @@ static int append(struct match **tail, const char *name, size_t len, int mark)
 	return 0;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
 static int match_in_dir(const char *d, const char *p, int flags, int (*errfunc)(const char *path, int err), struct match **tail)
 {
 	DIR *dir;
@@ -139,6 +141,7 @@ static int match_in_dir(const char *d, const char *p, int flags, int (*errfunc)(
 		return GLOB_ABORTED;
 	return 0;
 }
+#pragma clang diagnostic pop
 
 static int ignore_err(const char *path, int err)
 {

--- a/be/src/glibc-compatibility/musl/glob.c
+++ b/be/src/glibc-compatibility/musl/glob.c
@@ -47,8 +47,10 @@ static int append(struct match **tail, const char *name, size_t len, int mark)
 	return 0;
 }
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
 static int match_in_dir(const char *d, const char *p, int flags, int (*errfunc)(const char *path, int err), struct match **tail)
 {
 	DIR *dir;
@@ -141,7 +143,9 @@ static int match_in_dir(const char *d, const char *p, int flags, int (*errfunc)(
 		return GLOB_ABORTED;
 	return 0;
 }
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 static int ignore_err(const char *path, int err)
 {

--- a/be/src/io/cache/block/block_lru_file_cache.cpp
+++ b/be/src/io/cache/block/block_lru_file_cache.cpp
@@ -953,8 +953,6 @@ Status LRUFileCache::write_file_cache_version() const {
     return Status::OK();
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wvla"
 std::string LRUFileCache::read_file_cache_version() const {
     std::string version_path = get_version_path();
     const FileSystemSPtr& fs = global_local_filesystem();
@@ -966,7 +964,14 @@ std::string LRUFileCache::read_file_cache_version() const {
     FileReaderSPtr version_reader;
     int64_t file_size = -1;
     static_cast<void>(fs->file_size(version_path, &file_size));
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
+#endif
     char version[file_size];
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
     static_cast<void>(fs->open_file(version_path, &version_reader));
     size_t bytes_read = 0;
@@ -974,7 +979,6 @@ std::string LRUFileCache::read_file_cache_version() const {
     static_cast<void>(version_reader->close());
     return std::string(version, bytes_read);
 }
-#pragma clang diagnostic pop
 
 size_t LRUFileCache::get_used_cache_size(CacheType cache_type) const {
     std::lock_guard cache_lock(_mutex);

--- a/be/src/io/cache/block/block_lru_file_cache.cpp
+++ b/be/src/io/cache/block/block_lru_file_cache.cpp
@@ -953,6 +953,8 @@ Status LRUFileCache::write_file_cache_version() const {
     return Status::OK();
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
 std::string LRUFileCache::read_file_cache_version() const {
     std::string version_path = get_version_path();
     const FileSystemSPtr& fs = global_local_filesystem();
@@ -972,6 +974,7 @@ std::string LRUFileCache::read_file_cache_version() const {
     static_cast<void>(version_reader->close());
     return std::string(version, bytes_read);
 }
+#pragma clang diagnostic pop
 
 size_t LRUFileCache::get_used_cache_size(CacheType cache_type) const {
     std::lock_guard cache_lock(_mutex);

--- a/be/src/io/fs/local_file_writer.cpp
+++ b/be/src/io/fs/local_file_writer.cpp
@@ -92,16 +92,21 @@ Status LocalFileWriter::abort() {
     return io::global_local_filesystem()->delete_file(_path);
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wvla"
 Status LocalFileWriter::appendv(const Slice* data, size_t data_cnt) {
     DCHECK(!_closed);
     _dirty = true;
 
     // Convert the results into the iovec vector to request
     // and calculate the total bytes requested.
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
+#endif
     size_t bytes_req = 0;
     struct iovec iov[data_cnt];
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
     for (size_t i = 0; i < data_cnt; i++) {
         const Slice& result = data[i];
         bytes_req += result.size;
@@ -145,7 +150,6 @@ Status LocalFileWriter::appendv(const Slice* data, size_t data_cnt) {
     _bytes_appended += bytes_req;
     return Status::OK();
 }
-#pragma clang diagnostic pop
 
 Status LocalFileWriter::write_at(size_t offset, const Slice& data) {
     DCHECK(!_closed);

--- a/be/src/io/fs/local_file_writer.cpp
+++ b/be/src/io/fs/local_file_writer.cpp
@@ -92,6 +92,8 @@ Status LocalFileWriter::abort() {
     return io::global_local_filesystem()->delete_file(_path);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
 Status LocalFileWriter::appendv(const Slice* data, size_t data_cnt) {
     DCHECK(!_closed);
     _dirty = true;
@@ -143,6 +145,7 @@ Status LocalFileWriter::appendv(const Slice* data, size_t data_cnt) {
     _bytes_appended += bytes_req;
     return Status::OK();
 }
+#pragma clang diagnostic pop
 
 Status LocalFileWriter::write_at(size_t offset, const Slice& data) {
     DCHECK(!_closed);

--- a/be/src/olap/block_column_predicate.cpp
+++ b/be/src/olap/block_column_predicate.cpp
@@ -87,7 +87,10 @@ uint16_t OrBlockColumnPredicate::evaluate(vectorized::MutableColumns& block, uin
         if (!selected_size) {
             return 0;
         }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
         bool ret_flags[selected_size];
+#pragma clang diagnostic pop
         memset(ret_flags, false, selected_size);
         for (int i = 0; i < num_of_column_predicate(); ++i) {
             auto column_predicate = _block_column_predicate_vec[i];
@@ -116,7 +119,10 @@ void OrBlockColumnPredicate::evaluate_and(vectorized::MutableColumns& block, uin
     if (num_of_column_predicate() == 1) {
         _block_column_predicate_vec[0]->evaluate_and(block, sel, selected_size, flags);
     } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
         bool ret_flags[selected_size];
+#pragma clang diagnostic pop
         memset(ret_flags, false, selected_size);
         for (int i = 0; i < num_of_column_predicate(); ++i) {
             auto column_predicate = _block_column_predicate_vec[i];
@@ -178,7 +184,10 @@ void AndBlockColumnPredicate::evaluate_or(vectorized::MutableColumns& block, uin
     if (num_of_column_predicate() == 1) {
         _block_column_predicate_vec[0]->evaluate_or(block, sel, selected_size, flags);
     } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
         bool new_flags[selected_size];
+#pragma clang diagnostic pop
         memset(new_flags, true, selected_size);
 
         for (auto block_column_predicate : _block_column_predicate_vec) {
@@ -197,7 +206,10 @@ void AndBlockColumnPredicate::evaluate_vec(vectorized::MutableColumns& block, ui
     if (num_of_column_predicate() == 1) {
         _block_column_predicate_vec[0]->evaluate_vec(block, size, flags);
     } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
         bool new_flags[size];
+#pragma clang diagnostic pop
         bool initialized = false;
         for (auto block_column_predicate : _block_column_predicate_vec) {
             if (initialized) {

--- a/be/src/olap/block_column_predicate.cpp
+++ b/be/src/olap/block_column_predicate.cpp
@@ -87,10 +87,14 @@ uint16_t OrBlockColumnPredicate::evaluate(vectorized::MutableColumns& block, uin
         if (!selected_size) {
             return 0;
         }
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
         bool ret_flags[selected_size];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
         memset(ret_flags, false, selected_size);
         for (int i = 0; i < num_of_column_predicate(); ++i) {
             auto column_predicate = _block_column_predicate_vec[i];
@@ -119,10 +123,14 @@ void OrBlockColumnPredicate::evaluate_and(vectorized::MutableColumns& block, uin
     if (num_of_column_predicate() == 1) {
         _block_column_predicate_vec[0]->evaluate_and(block, sel, selected_size, flags);
     } else {
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
         bool ret_flags[selected_size];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
         memset(ret_flags, false, selected_size);
         for (int i = 0; i < num_of_column_predicate(); ++i) {
             auto column_predicate = _block_column_predicate_vec[i];
@@ -184,10 +192,14 @@ void AndBlockColumnPredicate::evaluate_or(vectorized::MutableColumns& block, uin
     if (num_of_column_predicate() == 1) {
         _block_column_predicate_vec[0]->evaluate_or(block, sel, selected_size, flags);
     } else {
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
         bool new_flags[selected_size];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
         memset(new_flags, true, selected_size);
 
         for (auto block_column_predicate : _block_column_predicate_vec) {
@@ -206,10 +218,14 @@ void AndBlockColumnPredicate::evaluate_vec(vectorized::MutableColumns& block, ui
     if (num_of_column_predicate() == 1) {
         _block_column_predicate_vec[0]->evaluate_vec(block, size, flags);
     } else {
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
         bool new_flags[size];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
         bool initialized = false;
         for (auto block_column_predicate : _block_column_predicate_vec) {
             if (initialized) {

--- a/be/src/olap/match_predicate.cpp
+++ b/be/src/olap/match_predicate.cpp
@@ -71,10 +71,14 @@ Status MatchPredicate::evaluate(const vectorized::NameAndTypePair& name_with_typ
     } else if (column_desc.type == TYPE_ARRAY &&
                is_numeric_type(
                        TabletColumn::get_field_type_by_type(column_desc.children[0].type))) {
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
         char buf[column_desc.children[0].len];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
         const TypeInfo* type_info = get_scalar_type_info(
                 TabletColumn::get_field_type_by_type(column_desc.children[0].type));
         RETURN_IF_ERROR(type_info->from_string(buf, _value));

--- a/be/src/olap/match_predicate.cpp
+++ b/be/src/olap/match_predicate.cpp
@@ -71,7 +71,10 @@ Status MatchPredicate::evaluate(const vectorized::NameAndTypePair& name_with_typ
     } else if (column_desc.type == TYPE_ARRAY &&
                is_numeric_type(
                        TabletColumn::get_field_type_by_type(column_desc.children[0].type))) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
         char buf[column_desc.children[0].len];
+#pragma clang diagnostic pop
         const TypeInfo* type_info = get_scalar_type_info(
                 TabletColumn::get_field_type_by_type(column_desc.children[0].type));
         RETURN_IF_ERROR(type_info->from_string(buf, _value));

--- a/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
@@ -296,10 +296,14 @@ Status BinaryDictPageDecoder::read_by_rowids(const rowid_t* rowids, ordinal_t pa
     const auto* data_array = reinterpret_cast<const int32_t*>(_bit_shuffle_ptr->get_data(0));
     auto total = *n;
     size_t read_count = 0;
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
     int32_t data[total];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
     for (size_t i = 0; i < total; ++i) {
         ordinal_t ord = rowids[i] - page_first_ordinal;
         if (PREDICT_FALSE(ord >= _bit_shuffle_ptr->_num_elements)) {

--- a/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
@@ -296,7 +296,10 @@ Status BinaryDictPageDecoder::read_by_rowids(const rowid_t* rowids, ordinal_t pa
     const auto* data_array = reinterpret_cast<const int32_t*>(_bit_shuffle_ptr->get_data(0));
     auto total = *n;
     size_t read_count = 0;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
     int32_t data[total];
+#pragma clang diagnostic pop
     for (size_t i = 0; i < total; ++i) {
         ordinal_t ord = rowids[i] - page_first_ordinal;
         if (PREDICT_FALSE(ord >= _bit_shuffle_ptr->_num_elements)) {

--- a/be/src/olap/rowset/segment_v2/binary_plain_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_plain_page.h
@@ -220,7 +220,10 @@ public:
         const size_t max_fetch = std::min(*n, static_cast<size_t>(_num_elems - _cur_idx));
 
         uint32_t last_offset = guarded_offset(_cur_idx);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
         uint32_t offsets[max_fetch + 1];
+#pragma clang diagnostic pop
         offsets[0] = last_offset;
         for (int i = 0; i < max_fetch - 1; i++, _cur_idx++) {
             const uint32_t start_offset = last_offset;
@@ -255,8 +258,12 @@ public:
 
         auto total = *n;
         size_t read_count = 0;
+        auto len_array_uptr = std::unique_ptr<uint32_t[]>(new uint32_t[total]);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
         uint32_t len_array[total];
         uint32_t start_offset_array[total];
+#pragma clang diagnostic pop
         for (size_t i = 0; i < total; ++i) {
             ordinal_t ord = rowids[i] - page_first_ordinal;
             if (UNLIKELY(ord >= _num_elems)) {

--- a/be/src/olap/rowset/segment_v2/binary_plain_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_plain_page.h
@@ -220,10 +220,14 @@ public:
         const size_t max_fetch = std::min(*n, static_cast<size_t>(_num_elems - _cur_idx));
 
         uint32_t last_offset = guarded_offset(_cur_idx);
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
         uint32_t offsets[max_fetch + 1];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
         offsets[0] = last_offset;
         for (int i = 0; i < max_fetch - 1; i++, _cur_idx++) {
             const uint32_t start_offset = last_offset;
@@ -259,11 +263,15 @@ public:
         auto total = *n;
         size_t read_count = 0;
         auto len_array_uptr = std::unique_ptr<uint32_t[]>(new uint32_t[total]);
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
         uint32_t len_array[total];
         uint32_t start_offset_array[total];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
         for (size_t i = 0; i < total; ++i) {
             ordinal_t ord = rowids[i] - page_first_ordinal;
             if (UNLIKELY(ord >= _num_elems)) {

--- a/be/src/olap/rowset/segment_v2/bitshuffle_page.h
+++ b/be/src/olap/rowset/segment_v2/bitshuffle_page.h
@@ -399,7 +399,10 @@ public:
 
         auto total = *n;
         auto read_count = 0;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
         CppType data[total];
+#pragma clang diagnostic pop
         for (size_t i = 0; i < total; ++i) {
             ordinal_t ord = rowids[i] - page_first_ordinal;
             if (UNLIKELY(ord >= _num_elements)) {

--- a/be/src/olap/rowset/segment_v2/bitshuffle_page.h
+++ b/be/src/olap/rowset/segment_v2/bitshuffle_page.h
@@ -399,10 +399,14 @@ public:
 
         auto total = *n;
         auto read_count = 0;
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
         CppType data[total];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
         for (size_t i = 0; i < total; ++i) {
             ordinal_t ord = rowids[i] - page_first_ordinal;
             if (UNLIKELY(ord >= _num_elements)) {

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
@@ -733,7 +733,10 @@ Status BkdIndexReader::bkd_query(OlapReaderStatistics* stats, const std::string&
                                  const void* query_value,
                                  std::shared_ptr<lucene::util::bkd::bkd_reader> r,
                                  InvertedIndexVisitor<QT>* visitor) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
     char tmp[r->bytes_per_dim_];
+#pragma clang diagnostic pop
     if constexpr (QT == InvertedIndexQueryType::EQUAL_QUERY) {
         _value_key_coder->full_encode_ascending(query_value, &visitor->query_max);
         _value_key_coder->full_encode_ascending(query_value, &visitor->query_min);

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
@@ -733,10 +733,14 @@ Status BkdIndexReader::bkd_query(OlapReaderStatistics* stats, const std::string&
                                  const void* query_value,
                                  std::shared_ptr<lucene::util::bkd::bkd_reader> r,
                                  InvertedIndexVisitor<QT>* visitor) {
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
     char tmp[r->bytes_per_dim_];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
     if constexpr (QT == InvertedIndexQueryType::EQUAL_QUERY) {
         _value_key_coder->full_encode_ascending(query_value, &visitor->query_max);
         _value_key_coder->full_encode_ascending(query_value, &visitor->query_min);

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -1926,7 +1926,10 @@ uint16_t SegmentIterator::_evaluate_vectorization_predicate(uint16_t* sel_rowid_
     }
 
     uint16_t original_size = selected_size;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
     bool ret_flags[original_size];
+#pragma clang diagnostic pop
     DCHECK(_pre_eval_block_predicate.size() > 0);
     auto column_id = _pre_eval_block_predicate[0]->column_id();
     auto& column = _current_return_columns[column_id];
@@ -2166,7 +2169,10 @@ Status SegmentIterator::_next_batch_internal(vectorized::Block* block) {
         _output_index_result_column(nullptr, 0, block);
     } else {
         uint16_t selected_size = _current_batch_rows_read;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
         uint16_t sel_rowid_idx[selected_size];
+#pragma clang diagnostic pop
 
         if (_is_need_vec_eval || _is_need_short_eval) {
             _convert_dict_code_for_predicate_if_necessary();

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -1926,10 +1926,14 @@ uint16_t SegmentIterator::_evaluate_vectorization_predicate(uint16_t* sel_rowid_
     }
 
     uint16_t original_size = selected_size;
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
     bool ret_flags[original_size];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
     DCHECK(_pre_eval_block_predicate.size() > 0);
     auto column_id = _pre_eval_block_predicate[0]->column_id();
     auto& column = _current_return_columns[column_id];
@@ -2169,10 +2173,14 @@ Status SegmentIterator::_next_batch_internal(vectorized::Block* block) {
         _output_index_result_column(nullptr, 0, block);
     } else {
         uint16_t selected_size = _current_batch_rows_read;
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
         uint16_t sel_rowid_idx[selected_size];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
         if (_is_need_vec_eval || _is_need_short_eval) {
             _convert_dict_code_for_predicate_if_necessary();

--- a/be/src/pipeline/exec/exchange_sink_operator.cpp
+++ b/be/src/pipeline/exec/exchange_sink_operator.cpp
@@ -466,7 +466,10 @@ Status ExchangeSinkOperatorX::channel_add_rows(RuntimeState* state, Channels& ch
                                                int num_channels,
                                                const HashValueType* __restrict channel_ids,
                                                int rows, vectorized::Block* block, bool eos) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
     std::vector<uint32_t> channel2rows[num_channels];
+#pragma clang diagnostic pop
 
     for (uint32_t i = 0; i < rows; i++) {
         channel2rows[channel_ids[i]].emplace_back(i);

--- a/be/src/pipeline/exec/exchange_sink_operator.cpp
+++ b/be/src/pipeline/exec/exchange_sink_operator.cpp
@@ -466,10 +466,14 @@ Status ExchangeSinkOperatorX::channel_add_rows(RuntimeState* state, Channels& ch
                                                int num_channels,
                                                const HashValueType* __restrict channel_ids,
                                                int rows, vectorized::Block* block, bool eos) {
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
     std::vector<uint32_t> channel2rows[num_channels];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
     for (uint32_t i = 0; i < rows; i++) {
         channel2rows[channel_ids[i]].emplace_back(i);

--- a/be/src/pipeline/exec/hashjoin_build_sink.cpp
+++ b/be/src/pipeline/exec/hashjoin_build_sink.cpp
@@ -230,8 +230,6 @@ Status HashJoinBuildSinkLocalState::process_build_block(RuntimeState* state,
     vectorized::ColumnRawPtrs raw_ptrs(_build_expr_ctxs.size());
 
     vectorized::ColumnUInt8::MutablePtr null_map_val;
-    std::vector<int> res_col_ids(_build_expr_ctxs.size());
-    RETURN_IF_ERROR(_do_evaluate(block, _build_expr_ctxs, *_build_expr_call_timer, res_col_ids));
     if (p._join_op == TJoinOp::LEFT_OUTER_JOIN || p._join_op == TJoinOp::FULL_OUTER_JOIN) {
         _convert_block_to_null(block);
         // first row is mocked
@@ -247,7 +245,7 @@ Status HashJoinBuildSinkLocalState::process_build_block(RuntimeState* state,
     //  so we have to initialize this flag by the first build block.
     if (!_has_set_need_null_map_for_build) {
         _has_set_need_null_map_for_build = true;
-        _set_build_ignore_flag(block, res_col_ids);
+        _set_build_ignore_flag(block, _build_col_ids);
     }
     if (p._short_circuit_for_null_in_build_side || _build_side_ignore_null) {
         null_map_val = vectorized::ColumnUInt8::create();
@@ -255,7 +253,7 @@ Status HashJoinBuildSinkLocalState::process_build_block(RuntimeState* state,
     }
 
     // Get the key column that needs to be built
-    Status st = _extract_join_column(block, null_map_val, raw_ptrs, res_col_ids);
+    Status st = _extract_join_column(block, null_map_val, raw_ptrs, _build_col_ids);
 
     st = std::visit(
             Overload {[&](std::monostate& arg, auto join_op, auto has_null_value,
@@ -458,13 +456,22 @@ Status HashJoinBuildSinkOperatorX::sink(RuntimeState* state, vectorized::Block* 
         if (local_state._build_side_mutable_block.empty()) {
             auto tmp_build_block = vectorized::VectorizedUtils::create_empty_columnswithtypename(
                     _child_x->row_desc());
+            tmp_build_block = *(tmp_build_block.create_same_struct_block(1, false));
+            local_state._build_col_ids.resize(_build_expr_ctxs.size());
+            RETURN_IF_ERROR(local_state._do_evaluate(tmp_build_block, local_state._build_expr_ctxs,
+                                                     *local_state._build_expr_call_timer,
+                                                     local_state._build_col_ids));
+
             local_state._build_side_mutable_block =
                     vectorized::MutableBlock::build_mutable_block(&tmp_build_block);
-            RETURN_IF_ERROR(local_state._build_side_mutable_block.merge(
-                    *(tmp_build_block.create_same_struct_block(1, false))));
         }
 
         if (in_block->rows() != 0) {
+            std::vector<int> res_col_ids(_build_expr_ctxs.size());
+            RETURN_IF_ERROR(local_state._do_evaluate(*in_block, local_state._build_expr_ctxs,
+                                                     *local_state._build_expr_call_timer,
+                                                     res_col_ids));
+
             SCOPED_TIMER(local_state._build_side_merge_block_timer);
             RETURN_IF_ERROR(local_state._build_side_mutable_block.merge(*in_block));
             if (local_state._build_side_mutable_block.rows() >

--- a/be/src/pipeline/exec/hashjoin_build_sink.h
+++ b/be/src/pipeline/exec/hashjoin_build_sink.h
@@ -116,6 +116,7 @@ protected:
     bool _build_side_ignore_null = false;
     std::unordered_set<const vectorized::Block*> _inserted_blocks;
     std::shared_ptr<SharedHashTableDependency> _shared_hash_table_dependency;
+    std::vector<int> _build_col_ids;
 
     RuntimeProfile::Counter* _build_table_timer = nullptr;
     RuntimeProfile::Counter* _build_expr_call_timer = nullptr;

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -967,7 +967,10 @@ Status FragmentMgr::exec_plan_fragment(const TPipelineFragmentParams& params,
 
         if (target_size > 1) {
             int prepare_done = {0};
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
             Status prepare_status[target_size];
+#pragma clang diagnostic pop
             std::mutex m;
             std::condition_variable cv;
 

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -967,10 +967,14 @@ Status FragmentMgr::exec_plan_fragment(const TPipelineFragmentParams& params,
 
         if (target_size > 1) {
             int prepare_done = {0};
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
             Status prepare_status[target_size];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
             std::mutex m;
             std::condition_variable cv;
 

--- a/be/src/vec/aggregate_functions/aggregate_function.h
+++ b/be/src/vec/aggregate_functions/aggregate_function.h
@@ -332,7 +332,10 @@ public:
 
     void streaming_agg_serialize(const IColumn** columns, BufferWritable& buf,
                                  const size_t num_rows, Arena* arena) const override {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
         char place[size_of_data()];
+#pragma clang diagnostic pop
         for (size_t i = 0; i != num_rows; ++i) {
             assert_cast<const Derived*>(this)->create(place);
             DEFER({ assert_cast<const Derived*>(this)->destroy(place); });
@@ -453,7 +456,10 @@ public:
         for (size_t i = begin; i <= end; ++i) {
             VectorBufferReader buffer_reader(
                     (assert_cast<const ColumnString&>(column)).get_data_at(i));
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
             char deserialized_data[size_of_data()];
+#pragma clang diagnostic pop
             AggregateDataPtr deserialized_place = (AggregateDataPtr)deserialized_data;
             assert_cast<const Derived*>(this)->create(deserialized_place);
             DEFER({ assert_cast<const Derived*>(this)->destroy(deserialized_place); });

--- a/be/src/vec/aggregate_functions/aggregate_function.h
+++ b/be/src/vec/aggregate_functions/aggregate_function.h
@@ -332,10 +332,14 @@ public:
 
     void streaming_agg_serialize(const IColumn** columns, BufferWritable& buf,
                                  const size_t num_rows, Arena* arena) const override {
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
         char place[size_of_data()];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
         for (size_t i = 0; i != num_rows; ++i) {
             assert_cast<const Derived*>(this)->create(place);
             DEFER({ assert_cast<const Derived*>(this)->destroy(place); });
@@ -456,10 +460,14 @@ public:
         for (size_t i = begin; i <= end; ++i) {
             VectorBufferReader buffer_reader(
                     (assert_cast<const ColumnString&>(column)).get_data_at(i));
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
             char deserialized_data[size_of_data()];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
             AggregateDataPtr deserialized_place = (AggregateDataPtr)deserialized_data;
             assert_cast<const Derived*>(this)->create(deserialized_place);
             DEFER({ assert_cast<const Derived*>(this)->destroy(deserialized_place); });

--- a/be/src/vec/aggregate_functions/aggregate_function_null.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_null.h
@@ -292,10 +292,14 @@ public:
     void add(AggregateDataPtr __restrict place, const IColumn** columns, size_t row_num,
              Arena* arena) const override {
         /// This container stores the columns we really pass to the nested function.
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
         const IColumn* nested_columns[number_of_arguments];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
         for (size_t i = 0; i < number_of_arguments; ++i) {
             if (is_nullable[i]) {

--- a/be/src/vec/aggregate_functions/aggregate_function_null.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_null.h
@@ -292,7 +292,10 @@ public:
     void add(AggregateDataPtr __restrict place, const IColumn** columns, size_t row_num,
              Arena* arena) const override {
         /// This container stores the columns we really pass to the nested function.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
         const IColumn* nested_columns[number_of_arguments];
+#pragma clang diagnostic pop
 
         for (size_t i = 0; i < number_of_arguments; ++i) {
             if (is_nullable[i]) {

--- a/be/src/vec/columns/column_dictionary.h
+++ b/be/src/vec/columns/column_dictionary.h
@@ -208,7 +208,10 @@ public:
 
     Status filter_by_selector(const uint16_t* sel, size_t sel_size, IColumn* col_ptr) override {
         auto* res_col = reinterpret_cast<vectorized::ColumnString*>(col_ptr);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
         StringRef strings[sel_size];
+#pragma clang diagnostic pop
         size_t length = 0;
         for (size_t i = 0; i != sel_size; ++i) {
             auto& value = _dict.get_value(_codes[sel[i]]);

--- a/be/src/vec/columns/column_dictionary.h
+++ b/be/src/vec/columns/column_dictionary.h
@@ -208,10 +208,14 @@ public:
 
     Status filter_by_selector(const uint16_t* sel, size_t sel_size, IColumn* col_ptr) override {
         auto* res_col = reinterpret_cast<vectorized::ColumnString*>(col_ptr);
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
         StringRef strings[sel_size];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
         size_t length = 0;
         for (size_t i = 0; i != sel_size; ++i) {
             auto& value = _dict.get_value(_codes[sel[i]]);

--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -524,7 +524,8 @@ ColumnPtr ColumnVector<T>::replicate(const IColumn::Offsets& offsets) const {
     res_data.reserve(offsets.back());
 
     // vectorized this code to speed up
-    IColumn::Offset counts[size];
+    auto counts_uptr = std::unique_ptr<IColumn::Offset[]>(new IColumn::Offset[size]);
+    IColumn::Offset* counts = counts_uptr.get();
     for (ssize_t i = 0; i < size; ++i) {
         counts[i] = offsets[i] - offsets[i - 1];
     }

--- a/be/src/vec/columns/predicate_column.h
+++ b/be/src/vec/columns/predicate_column.h
@@ -49,7 +49,10 @@ private:
     using ColumnType = typename PrimitiveTypeTraits<Type>::ColumnType;
 
     void insert_string_to_res_column(const uint16_t* sel, size_t sel_size, ColumnString* res_ptr) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
         StringRef refs[sel_size];
+#pragma clang diagnostic pop
         size_t length = 0;
         for (size_t i = 0; i < sel_size; i++) {
             uint16_t n = sel[i];

--- a/be/src/vec/columns/predicate_column.h
+++ b/be/src/vec/columns/predicate_column.h
@@ -49,10 +49,14 @@ private:
     using ColumnType = typename PrimitiveTypeTraits<Type>::ColumnType;
 
     void insert_string_to_res_column(const uint16_t* sel, size_t sel_size, ColumnString* res_ptr) {
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
         StringRef refs[sel_size];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
         size_t length = 0;
         for (size_t i = 0; i < sel_size; i++) {
             uint16_t n = sel[i];

--- a/be/src/vec/data_types/data_type_hll.cpp
+++ b/be/src/vec/data_types/data_type_hll.cpp
@@ -39,10 +39,14 @@ char* DataTypeHLL::serialize(const IColumn& column, char* buf, int be_exec_versi
     auto& data_column = assert_cast<const ColumnHLL&>(*ptr);
 
     size_t row_num = column.size();
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
     size_t hll_size_array[row_num + 1];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
     hll_size_array[0] = row_num;
 
     auto allocate_len_size = sizeof(size_t) * (row_num + 1);
@@ -69,10 +73,14 @@ const char* DataTypeHLL::deserialize(const char* buf, IColumn* column, int be_ex
 
     size_t row_num = *reinterpret_cast<const size_t*>(buf);
     buf += sizeof(size_t);
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
     size_t hll_size_array[row_num];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
     memcpy(hll_size_array, buf, sizeof(size_t) * row_num);
     buf += sizeof(size_t) * row_num;
 

--- a/be/src/vec/data_types/data_type_hll.cpp
+++ b/be/src/vec/data_types/data_type_hll.cpp
@@ -39,7 +39,10 @@ char* DataTypeHLL::serialize(const IColumn& column, char* buf, int be_exec_versi
     auto& data_column = assert_cast<const ColumnHLL&>(*ptr);
 
     size_t row_num = column.size();
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
     size_t hll_size_array[row_num + 1];
+#pragma clang diagnostic pop
     hll_size_array[0] = row_num;
 
     auto allocate_len_size = sizeof(size_t) * (row_num + 1);
@@ -66,7 +69,10 @@ const char* DataTypeHLL::deserialize(const char* buf, IColumn* column, int be_ex
 
     size_t row_num = *reinterpret_cast<const size_t*>(buf);
     buf += sizeof(size_t);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
     size_t hll_size_array[row_num];
+#pragma clang diagnostic pop
     memcpy(hll_size_array, buf, sizeof(size_t) * row_num);
     buf += sizeof(size_t) * row_num;
 

--- a/be/src/vec/exec/format/parquet/parquet_thrift_util.h
+++ b/be/src/vec/exec/format/parquet/parquet_thrift_util.h
@@ -40,7 +40,10 @@ static Status parse_thrift_footer(io::FileReaderSPtr file, FileMetaData** file_m
                                   size_t* meta_size, io::IOContext* io_ctx) {
     size_t file_size = file->size();
     size_t bytes_read = std::min(file_size, INIT_META_SIZE);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
     uint8_t footer[bytes_read];
+#pragma clang diagnostic pop
     RETURN_IF_ERROR(
             file->read_at(file_size - bytes_read, Slice(footer, bytes_read), &bytes_read, io_ctx));
 

--- a/be/src/vec/exec/format/parquet/parquet_thrift_util.h
+++ b/be/src/vec/exec/format/parquet/parquet_thrift_util.h
@@ -40,10 +40,14 @@ static Status parse_thrift_footer(io::FileReaderSPtr file, FileMetaData** file_m
                                   size_t* meta_size, io::IOContext* io_ctx) {
     size_t file_size = file->size();
     size_t bytes_read = std::min(file_size, INIT_META_SIZE);
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
     uint8_t footer[bytes_read];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
     RETURN_IF_ERROR(
             file->read_at(file_size - bytes_read, Slice(footer, bytes_read), &bytes_read, io_ctx));
 

--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -767,7 +767,10 @@ Status ParquetReader::_process_page_index(const tparquet::RowGroup& row_group,
         read_whole_row_group();
         return Status::OK();
     }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
     uint8_t col_index_buff[page_index._column_index_size];
+#pragma clang diagnostic pop
     size_t bytes_read = 0;
     Slice result(col_index_buff, page_index._column_index_size);
     RETURN_IF_ERROR(
@@ -775,7 +778,10 @@ Status ParquetReader::_process_page_index(const tparquet::RowGroup& row_group,
     _column_statistics.read_bytes += bytes_read;
     auto& schema_desc = _file_metadata->schema();
     std::vector<RowRange> skipped_row_ranges;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
     uint8_t off_index_buff[page_index._offset_index_size];
+#pragma clang diagnostic pop
     Slice res(off_index_buff, page_index._offset_index_size);
     RETURN_IF_ERROR(
             _file_reader->read_at(page_index._offset_index_start, res, &bytes_read, _io_ctx));

--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -767,10 +767,14 @@ Status ParquetReader::_process_page_index(const tparquet::RowGroup& row_group,
         read_whole_row_group();
         return Status::OK();
     }
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
     uint8_t col_index_buff[page_index._column_index_size];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
     size_t bytes_read = 0;
     Slice result(col_index_buff, page_index._column_index_size);
     RETURN_IF_ERROR(
@@ -778,10 +782,14 @@ Status ParquetReader::_process_page_index(const tparquet::RowGroup& row_group,
     _column_statistics.read_bytes += bytes_read;
     auto& schema_desc = _file_metadata->schema();
     std::vector<RowRange> skipped_row_ranges;
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
     uint8_t off_index_buff[page_index._offset_index_size];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
     Slice res(off_index_buff, page_index._offset_index_size);
     RETURN_IF_ERROR(
             _file_reader->read_at(page_index._offset_index_start, res, &bytes_read, _io_ctx));

--- a/be/src/vec/exec/join/vhash_join_node.cpp
+++ b/be/src/vec/exec/join/vhash_join_node.cpp
@@ -725,12 +725,18 @@ Status HashJoinNode::sink(doris::RuntimeState* state, vectorized::Block* in_bloc
         if (_build_side_mutable_block.empty()) {
             auto tmp_build_block =
                     VectorizedUtils::create_empty_columnswithtypename(child(1)->row_desc());
+            tmp_build_block = *(tmp_build_block.create_same_struct_block(1, false));
+            _build_col_ids.resize(_build_expr_ctxs.size());
+            RETURN_IF_ERROR(_do_evaluate(tmp_build_block, _build_expr_ctxs, *_build_expr_call_timer,
+                                         _build_col_ids));
             _build_side_mutable_block = MutableBlock::build_mutable_block(&tmp_build_block);
-            RETURN_IF_ERROR(_build_side_mutable_block.merge(
-                    *(tmp_build_block.create_same_struct_block(1, false))));
         }
 
         if (in_block->rows() != 0) {
+            std::vector<int> res_col_ids(_build_expr_ctxs.size());
+            RETURN_IF_ERROR(_do_evaluate(*in_block, _build_expr_ctxs, *_build_expr_call_timer,
+                                         res_col_ids));
+
             SCOPED_TIMER(_build_side_merge_block_timer);
             RETURN_IF_ERROR(_build_side_mutable_block.merge(*in_block));
             if (_build_side_mutable_block.rows() > JOIN_BUILD_SIZE_LIMIT) {
@@ -952,8 +958,6 @@ Status HashJoinNode::_process_build_block(RuntimeState* state, Block& block) {
     ColumnRawPtrs raw_ptrs(_build_expr_ctxs.size());
 
     ColumnUInt8::MutablePtr null_map_val;
-    std::vector<int> res_col_ids(_build_expr_ctxs.size());
-    RETURN_IF_ERROR(_do_evaluate(block, _build_expr_ctxs, *_build_expr_call_timer, res_col_ids));
     if (_join_op == TJoinOp::LEFT_OUTER_JOIN || _join_op == TJoinOp::FULL_OUTER_JOIN) {
         _convert_block_to_null(block);
         // first row is mocked
@@ -969,7 +973,7 @@ Status HashJoinNode::_process_build_block(RuntimeState* state, Block& block) {
     //  so we have to initialize this flag by the first build block.
     if (!_has_set_need_null_map_for_build) {
         _has_set_need_null_map_for_build = true;
-        _set_build_ignore_flag(block, res_col_ids);
+        _set_build_ignore_flag(block, _build_col_ids);
     }
     if (_short_circuit_for_null_in_build_side || _build_side_ignore_null) {
         null_map_val = ColumnUInt8::create();
@@ -977,7 +981,7 @@ Status HashJoinNode::_process_build_block(RuntimeState* state, Block& block) {
     }
 
     // Get the key column that needs to be built
-    Status st = _extract_join_column<true>(block, null_map_val, raw_ptrs, res_col_ids);
+    Status st = _extract_join_column<true>(block, null_map_val, raw_ptrs, _build_col_ids);
 
     st = std::visit(
             Overload {[&](std::monostate& arg, auto join_op, auto has_null_value,

--- a/be/src/vec/exec/join/vhash_join_node.h
+++ b/be/src/vec/exec/join/vhash_join_node.h
@@ -451,6 +451,8 @@ private:
 
     std::vector<IRuntimeFilter*> _runtime_filters;
     std::atomic_bool _probe_open_finish = false;
+
+    std::vector<int> _build_col_ids;
 };
 } // namespace vectorized
 } // namespace doris

--- a/be/src/vec/exec/scan/pip_scanner_context.h
+++ b/be/src/vec/exec/scan/pip_scanner_context.h
@@ -149,10 +149,14 @@ public:
                     hashes[i] = hashes[i] % element_size;
                 }
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
                 std::vector<uint32_t> channel2rows[element_size];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
                 for (uint32_t i = 0; i < rows; i++) {
                     channel2rows[hashes[i]].emplace_back(i);
                 }

--- a/be/src/vec/exec/scan/pip_scanner_context.h
+++ b/be/src/vec/exec/scan/pip_scanner_context.h
@@ -149,7 +149,10 @@ public:
                     hashes[i] = hashes[i] % element_size;
                 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
                 std::vector<uint32_t> channel2rows[element_size];
+#pragma clang diagnostic pop
                 for (uint32_t i = 0; i < rows; i++) {
                     channel2rows[hashes[i]].emplace_back(i);
                 }

--- a/be/src/vec/exprs/vectorized_agg_fn.cpp
+++ b/be/src/vec/exprs/vectorized_agg_fn.cpp
@@ -296,10 +296,14 @@ std::string AggFnEvaluator::debug_string() const {
 Status AggFnEvaluator::_calc_argument_columns(Block* block) {
     SCOPED_TIMER(_expr_timer);
     _agg_columns.resize(_input_exprs_ctxs.size());
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
     int column_ids[_input_exprs_ctxs.size()];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
     for (int i = 0; i < _input_exprs_ctxs.size(); ++i) {
         int column_id = -1;
         RETURN_IF_ERROR(_input_exprs_ctxs[i]->execute(block, &column_id));

--- a/be/src/vec/exprs/vectorized_agg_fn.cpp
+++ b/be/src/vec/exprs/vectorized_agg_fn.cpp
@@ -296,7 +296,10 @@ std::string AggFnEvaluator::debug_string() const {
 Status AggFnEvaluator::_calc_argument_columns(Block* block) {
     SCOPED_TIMER(_expr_timer);
     _agg_columns.resize(_input_exprs_ctxs.size());
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
     int column_ids[_input_exprs_ctxs.size()];
+#pragma clang diagnostic pop
     for (int i = 0; i < _input_exprs_ctxs.size(); ++i) {
         int column_id = -1;
         RETURN_IF_ERROR(_input_exprs_ctxs[i]->execute(block, &column_id));

--- a/be/src/vec/functions/array/function_array_constructor.cpp
+++ b/be/src/vec/functions/array/function_array_constructor.cpp
@@ -78,7 +78,10 @@ public:
         result_offset_col.resize(input_rows_count);
 
         // convert to nullable column
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
         ColumnPtr arg[num_element];
+#pragma clang diagnostic pop
         for (size_t i = 0; i < num_element; ++i) {
             auto& col = block.get_by_position(arguments[i]).column;
             col = col->convert_to_full_column_if_const();

--- a/be/src/vec/functions/array/function_array_constructor.cpp
+++ b/be/src/vec/functions/array/function_array_constructor.cpp
@@ -78,10 +78,14 @@ public:
         result_offset_col.resize(input_rows_count);
 
         // convert to nullable column
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
         ColumnPtr arg[num_element];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
         for (size_t i = 0; i < num_element; ++i) {
             auto& col = block.get_by_position(arguments[i]).column;
             col = col->convert_to_full_column_if_const();

--- a/be/src/vec/functions/function_binary_arithmetic.h
+++ b/be/src/vec/functions/function_binary_arithmetic.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <memory>
 #include <type_traits>
 
 #include "common/exception.h"
@@ -265,7 +266,8 @@ private:
                     make_bool_variant(need_adjust_scale && check_overflow));
 
             if (OpTraits::is_multiply && need_adjust_scale && !check_overflow) {
-                int8_t sig[size];
+                auto sig_uptr = std::unique_ptr<int8_t[]>(new int8_t[size]);
+                int8_t* sig = sig_uptr.get();
                 for (size_t i = 0; i < size; i++) {
                     sig[i] = sgn(c[i].value);
                 }

--- a/be/src/vec/functions/function_binary_arithmetic.h
+++ b/be/src/vec/functions/function_binary_arithmetic.h
@@ -919,7 +919,7 @@ public:
                     if constexpr (!std::is_same_v<ResultDataType, InvalidType>) {
                         need_replace_null_data_to_default_ =
                                 IsDataTypeDecimal<ResultDataType> ||
-                                (name == "pow" &&
+                                (get_name() == "pow" &&
                                  std::is_floating_point_v<typename ResultDataType::FieldType>);
                         if constexpr (IsDataTypeDecimal<LeftDataType> &&
                                       IsDataTypeDecimal<RightDataType>) {

--- a/be/src/vec/functions/function_bitmap_variadic.cpp
+++ b/be/src/vec/functions/function_bitmap_variadic.cpp
@@ -150,9 +150,13 @@ namespace doris::vectorized {
         }                                                                                         \
     }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
 BITMAP_FUNCTION_VARIADIC(BitmapOr, bitmap_or, |=);
 BITMAP_FUNCTION_VARIADIC(BitmapAnd, bitmap_and, &=);
 BITMAP_FUNCTION_VARIADIC(BitmapXor, bitmap_xor, ^=);
+#pragma clang diagnostic pop
+
 BITMAP_FUNCTION_COUNT_VARIADIC(BitmapOrCount, bitmap_or_count, |=);
 BITMAP_FUNCTION_COUNT_VARIADIC(BitmapAndCount, bitmap_and_count, &=);
 BITMAP_FUNCTION_COUNT_VARIADIC(BitmapXorCount, bitmap_xor_count, ^=);
@@ -224,7 +228,10 @@ public:
                                  const ColumnNumbers& arguments, size_t result,
                                  size_t input_rows_count) const {
         size_t argument_size = arguments.size();
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
         ColumnPtr argument_columns[argument_size];
+#pragma clang diagnostic pop
 
         for (size_t i = 0; i < argument_size; ++i) {
             argument_columns[i] =

--- a/be/src/vec/functions/function_bitmap_variadic.cpp
+++ b/be/src/vec/functions/function_bitmap_variadic.cpp
@@ -150,12 +150,16 @@ namespace doris::vectorized {
         }                                                                                         \
     }
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
 BITMAP_FUNCTION_VARIADIC(BitmapOr, bitmap_or, |=);
 BITMAP_FUNCTION_VARIADIC(BitmapAnd, bitmap_and, &=);
 BITMAP_FUNCTION_VARIADIC(BitmapXor, bitmap_xor, ^=);
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 BITMAP_FUNCTION_COUNT_VARIADIC(BitmapOrCount, bitmap_or_count, |=);
 BITMAP_FUNCTION_COUNT_VARIADIC(BitmapAndCount, bitmap_and_count, &=);
@@ -228,10 +232,14 @@ public:
                                  const ColumnNumbers& arguments, size_t result,
                                  size_t input_rows_count) const {
         size_t argument_size = arguments.size();
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
         ColumnPtr argument_columns[argument_size];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
         for (size_t i = 0; i < argument_size; ++i) {
             argument_columns[i] =

--- a/be/src/vec/functions/function_case.h
+++ b/be/src/vec/functions/function_case.h
@@ -159,9 +159,9 @@ public:
         int rows_count = column_holder.rows_count;
 
         // `then` data index corresponding to each row of results, 0 represents `else`.
-        int then_idx[rows_count];
-        int* __restrict then_idx_ptr = then_idx;
-        memset(then_idx_ptr, 0, sizeof(then_idx));
+        auto then_idx_uptr = std::unique_ptr<int[]>(new int[rows_count]);
+        int* __restrict then_idx_ptr = then_idx_uptr.get();
+        memset(then_idx_ptr, 0, rows_count * sizeof(int));
 
         for (int row_idx = 0; row_idx < column_holder.rows_count; row_idx++) {
             for (int i = 1; i < column_holder.pair_count; i++) {
@@ -189,7 +189,7 @@ public:
         }
 
         auto result_column_ptr = data_type->create_column();
-        update_result_normal<int, ColumnType, then_null>(result_column_ptr, then_idx,
+        update_result_normal<int, ColumnType, then_null>(result_column_ptr, then_idx_ptr,
                                                          column_holder);
         block.replace_by_position(result, std::move(result_column_ptr));
         return Status::OK();
@@ -206,9 +206,9 @@ public:
         int rows_count = column_holder.rows_count;
 
         // `then` data index corresponding to each row of results, 0 represents `else`.
-        uint8_t then_idx[rows_count];
-        uint8_t* __restrict then_idx_ptr = then_idx;
-        memset(then_idx_ptr, 0, sizeof(then_idx));
+        auto then_idx_uptr = std::unique_ptr<uint8_t[]>(new uint8_t[rows_count]);
+        uint8_t* __restrict then_idx_ptr = then_idx_uptr.get();
+        memset(then_idx_ptr, 0, rows_count);
 
         auto case_column_ptr = column_holder.when_ptrs[0].value_or(nullptr);
 
@@ -245,13 +245,13 @@ public:
             }
         }
 
-        return execute_update_result<ColumnType, then_null>(data_type, result, block, then_idx,
+        return execute_update_result<ColumnType, then_null>(data_type, result, block, then_idx_ptr,
                                                             column_holder);
     }
 
     template <typename ColumnType, bool then_null>
     Status execute_update_result(const DataTypePtr& data_type, size_t result, Block& block,
-                                 uint8* then_idx, CaseWhenColumnHolder& column_holder) const {
+                                 const uint8* then_idx, CaseWhenColumnHolder& column_holder) const {
         auto result_column_ptr = data_type->create_column();
 
         if constexpr (std::is_same_v<ColumnType, ColumnString> ||
@@ -282,7 +282,8 @@ public:
     }
 
     template <typename IndexType, typename ColumnType, bool then_null>
-    void update_result_normal(MutableColumnPtr& result_column_ptr, IndexType* then_idx,
+    void update_result_normal(MutableColumnPtr& result_column_ptr,
+                              const IndexType* __restrict then_idx,
                               CaseWhenColumnHolder& column_holder) const {
         std::vector<uint8_t> is_consts(column_holder.then_ptrs.size());
         std::vector<ColumnPtr> raw_columns(column_holder.then_ptrs.size());

--- a/be/src/vec/functions/function_coalesce.cpp
+++ b/be/src/vec/functions/function_coalesce.cpp
@@ -137,10 +137,14 @@ public:
         auto null_map = ColumnUInt8::create(
                 input_rows_count, 1); //if null_map_data==1, the current row should be null
         auto* __restrict null_map_data = null_map->get_data().data();
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
         ColumnPtr argument_columns[argument_size]; //use to save nested_column if is nullable column
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
         for (size_t i = 0; i < argument_size; ++i) {
             block.get_by_position(filtered_args[i]).column =

--- a/be/src/vec/functions/function_coalesce.cpp
+++ b/be/src/vec/functions/function_coalesce.cpp
@@ -137,7 +137,10 @@ public:
         auto null_map = ColumnUInt8::create(
                 input_rows_count, 1); //if null_map_data==1, the current row should be null
         auto* __restrict null_map_data = null_map->get_data().data();
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
         ColumnPtr argument_columns[argument_size]; //use to save nested_column if is nullable column
+#pragma clang diagnostic pop
 
         for (size_t i = 0; i < argument_size; ++i) {
             block.get_by_position(filtered_args[i]).column =

--- a/be/src/vec/functions/function_encryption.cpp
+++ b/be/src/vec/functions/function_encryption.cpp
@@ -111,7 +111,10 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         size_t result, size_t input_rows_count) const override {
         size_t argument_size = arguments.size();
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
         ColumnPtr argument_columns[argument_size];
+#pragma clang diagnostic pop
         std::vector<const ColumnString::Offsets*> offsets_list(argument_size);
         std::vector<const ColumnString::Chars*> chars_list(argument_size);
 

--- a/be/src/vec/functions/function_encryption.cpp
+++ b/be/src/vec/functions/function_encryption.cpp
@@ -111,10 +111,14 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         size_t result, size_t input_rows_count) const override {
         size_t argument_size = arguments.size();
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
         ColumnPtr argument_columns[argument_size];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
         std::vector<const ColumnString::Offsets*> offsets_list(argument_size);
         std::vector<const ColumnString::Chars*> chars_list(argument_size);
 

--- a/be/src/vec/functions/function_string.cpp
+++ b/be/src/vec/functions/function_string.cpp
@@ -654,8 +654,17 @@ struct UnHexImpl {
                 continue;
             }
 
+            constexpr int MAX_STACK_CIPHER_LEN = 1024 * 8;
+            char dst_array[MAX_STACK_CIPHER_LEN];
+            char* dst = dst_array;
+
             int cipher_len = srclen / 2;
-            char dst[cipher_len];
+            std::unique_ptr<char[]> dst_uptr;
+            if (cipher_len > MAX_STACK_CIPHER_LEN) {
+                dst_uptr.reset(new char[cipher_len]);
+                dst = dst_uptr.get();
+            }
+
             int outlen = hex_decode(source, srclen, dst);
 
             if (outlen < 0) {
@@ -725,8 +734,16 @@ struct ToBase64Impl {
                 continue;
             }
 
+            constexpr int MAX_STACK_CIPHER_LEN = 1024 * 8;
+            char dst_array[MAX_STACK_CIPHER_LEN];
+            char* dst = dst_array;
+
             int cipher_len = (int)(4.0 * ceil((double)srclen / 3.0));
-            char dst[cipher_len];
+            std::unique_ptr<char[]> dst_uptr;
+            if (cipher_len > MAX_STACK_CIPHER_LEN) {
+                dst_uptr.reset(new char[cipher_len]);
+                dst = dst_uptr.get();
+            }
             int outlen = base64_encode((const unsigned char*)source, srclen, (unsigned char*)dst);
 
             if (outlen < 0) {
@@ -766,7 +783,10 @@ struct FromBase64Impl {
             }
 
             int cipher_len = srclen;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
             char dst[cipher_len];
+#pragma clang diagnostic pop
             int outlen = base64_decode(source, srclen, dst);
 
             if (outlen < 0) {

--- a/be/src/vec/functions/function_string.cpp
+++ b/be/src/vec/functions/function_string.cpp
@@ -782,11 +782,16 @@ struct FromBase64Impl {
                 continue;
             }
 
+            constexpr int MAX_STACK_CIPHER_LEN = 1024 * 8;
+            char dst_array[MAX_STACK_CIPHER_LEN];
+            char* dst = dst_array;
+
             int cipher_len = srclen;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wvla"
-            char dst[cipher_len];
-#pragma clang diagnostic pop
+            std::unique_ptr<char[]> dst_uptr;
+            if (cipher_len > MAX_STACK_CIPHER_LEN) {
+                dst_uptr.reset(new char[cipher_len]);
+                dst = dst_uptr.get();
+            }
             int outlen = base64_decode(source, srclen, dst);
 
             if (outlen < 0) {

--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -743,10 +743,14 @@ public:
         }
 
         int argument_size = arguments.size();
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
         ColumnPtr argument_columns[argument_size];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
         std::vector<const ColumnString::Offsets*> offsets_list(argument_size);
         std::vector<const ColumnString::Chars*> chars_list(argument_size);
@@ -953,11 +957,15 @@ public:
         std::vector<const Chars*> chars_list(argument_size);
         std::vector<const ColumnUInt8::Container*> null_list(argument_size);
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
         ColumnPtr argument_columns[argument_size];
         ColumnPtr argument_null_columns[argument_size];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
         for (size_t i = 0; i < argument_size; ++i) {
             argument_columns[i] =
@@ -1262,10 +1270,14 @@ public:
         auto res = ColumnString::create();
 
         size_t argument_size = arguments.size();
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
         ColumnPtr argument_columns[argument_size];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
         for (size_t i = 0; i < argument_size; ++i) {
             argument_columns[i] =
                     block.get_by_position(arguments[i]).column->convert_to_full_column_if_const();
@@ -1414,10 +1426,14 @@ public:
         res_offsets.resize(input_rows_count);
 
         const size_t argument_size = arguments.size();
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
         ColumnPtr argument_columns[argument_size];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
         for (size_t i = 0; i < argument_size; ++i) {
             argument_columns[i] =
                     block.get_by_position(arguments[i]).column->convert_to_full_column_if_const();
@@ -2021,10 +2037,14 @@ public:
         DCHECK_GE(arguments.size(), 1);
 
         int argument_size = arguments.size();
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
         ColumnPtr argument_columns[argument_size];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
         std::vector<const ColumnString::Offsets*> offsets_list(argument_size);
         std::vector<const ColumnString::Chars*> chars_list(argument_size);
@@ -2241,10 +2261,14 @@ public:
         size_t argument_size = arguments.size();
         bool has_key = argument_size >= 3;
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
         ColumnPtr argument_columns[argument_size];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
         for (size_t i = 0; i < argument_size; ++i) {
             argument_columns[i] =
                     block.get_by_position(arguments[i]).column->convert_to_full_column_if_const();

--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -743,7 +743,10 @@ public:
         }
 
         int argument_size = arguments.size();
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
         ColumnPtr argument_columns[argument_size];
+#pragma clang diagnostic pop
 
         std::vector<const ColumnString::Offsets*> offsets_list(argument_size);
         std::vector<const ColumnString::Chars*> chars_list(argument_size);
@@ -950,8 +953,11 @@ public:
         std::vector<const Chars*> chars_list(argument_size);
         std::vector<const ColumnUInt8::Container*> null_list(argument_size);
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
         ColumnPtr argument_columns[argument_size];
         ColumnPtr argument_null_columns[argument_size];
+#pragma clang diagnostic pop
 
         for (size_t i = 0; i < argument_size; ++i) {
             argument_columns[i] =
@@ -1256,7 +1262,10 @@ public:
         auto res = ColumnString::create();
 
         size_t argument_size = arguments.size();
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
         ColumnPtr argument_columns[argument_size];
+#pragma clang diagnostic pop
         for (size_t i = 0; i < argument_size; ++i) {
             argument_columns[i] =
                     block.get_by_position(arguments[i]).column->convert_to_full_column_if_const();
@@ -1405,7 +1414,10 @@ public:
         res_offsets.resize(input_rows_count);
 
         const size_t argument_size = arguments.size();
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
         ColumnPtr argument_columns[argument_size];
+#pragma clang diagnostic pop
         for (size_t i = 0; i < argument_size; ++i) {
             argument_columns[i] =
                     block.get_by_position(arguments[i]).column->convert_to_full_column_if_const();
@@ -2009,7 +2021,10 @@ public:
         DCHECK_GE(arguments.size(), 1);
 
         int argument_size = arguments.size();
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
         ColumnPtr argument_columns[argument_size];
+#pragma clang diagnostic pop
 
         std::vector<const ColumnString::Offsets*> offsets_list(argument_size);
         std::vector<const ColumnString::Chars*> chars_list(argument_size);
@@ -2226,7 +2241,10 @@ public:
         size_t argument_size = arguments.size();
         bool has_key = argument_size >= 3;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
         ColumnPtr argument_columns[argument_size];
+#pragma clang diagnostic pop
         for (size_t i = 0; i < argument_size; ++i) {
             argument_columns[i] =
                     block.get_by_position(arguments[i]).column->convert_to_full_column_if_const();

--- a/be/src/vec/functions/least_greast.cpp
+++ b/be/src/vec/functions/least_greast.cpp
@@ -175,7 +175,10 @@ struct FunctionFieldImpl {
         auto& res_data = static_cast<ColumnInt32*>(result_column)->get_data();
 
         const auto& column_size = arguments.size();
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
         ColumnPtr argument_columns[column_size];
+#pragma clang diagnostic pop
         for (int i = 0; i < column_size; ++i) {
             argument_columns[i] = block.get_by_position(arguments[i]).column;
         }

--- a/be/src/vec/functions/least_greast.cpp
+++ b/be/src/vec/functions/least_greast.cpp
@@ -175,10 +175,14 @@ struct FunctionFieldImpl {
         auto& res_data = static_cast<ColumnInt32*>(result_column)->get_data();
 
         const auto& column_size = arguments.size();
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
         ColumnPtr argument_columns[column_size];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
         for (int i = 0; i < column_size; ++i) {
             argument_columns[i] = block.get_by_position(arguments[i]).column;
         }

--- a/be/src/vec/functions/multiply.cpp
+++ b/be/src/vec/functions/multiply.cpp
@@ -20,6 +20,7 @@
 
 #include <stddef.h>
 
+#include <memory>
 #include <utility>
 
 #include "gutil/integral_types.h"
@@ -56,7 +57,8 @@ struct MultiplyImpl {
     static void vector_vector(const ColumnDecimal128::Container::value_type* __restrict a,
                               const ColumnDecimal128::Container::value_type* __restrict b,
                               ColumnDecimal128::Container::value_type* c, size_t size) {
-        int8 sgn[size];
+        auto sng_uptr = std::unique_ptr<int8[]>(new int8[size]);
+        int8* sgn = sng_uptr.get();
         auto max = DecimalV2Value::get_max_decimal();
         auto min = DecimalV2Value::get_min_decimal();
 

--- a/be/src/vec/sink/vdata_stream_sender.h
+++ b/be/src/vec/sink/vdata_stream_sender.h
@@ -412,7 +412,10 @@ Status VDataStreamSender::channel_add_rows(RuntimeState* state, Channels& channe
                                            int num_channels,
                                            const HashValueType* __restrict channel_ids, int rows,
                                            Block* block, bool eos) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
     std::vector<uint32_t> channel2rows[num_channels];
+#pragma clang diagnostic pop
 
     for (uint32_t i = 0; i < rows; i++) {
         channel2rows[channel_ids[i]].emplace_back(i);

--- a/be/src/vec/sink/vdata_stream_sender.h
+++ b/be/src/vec/sink/vdata_stream_sender.h
@@ -412,10 +412,14 @@ Status VDataStreamSender::channel_add_rows(RuntimeState* state, Channels& channe
                                            int num_channels,
                                            const HashValueType* __restrict channel_ids, int rows,
                                            Block* block, bool eos) {
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
+#endif
     std::vector<uint32_t> channel2rows[num_channels];
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
     for (uint32_t i = 0; i < rows; i++) {
         channel2rows[channel_ids[i]].emplace_back(i);


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Hash join operator will merge build blocks to a big block with a lot rows, and using variable length array in expr execution may cause stack overflow.

Also add `-Werror=vla` compiler option to report compile error by default and 
```
#pragma clang diagnostic push
#pragma clang diagnostic ignored "-Wvla"
#pragma clang diagnostic pop
```
to ignore VLA usages where it's sure not to cause stack overflow.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

