### PR TITLE
[branch-1.2](bug) Fix coredump in aggregation node's destruction

### DIFF
--- a/be/src/vec/exec/vaggregation_node.cpp
+++ b/be/src/vec/exec/vaggregation_node.cpp
@@ -822,18 +822,25 @@ void AggregationNode::_emplace_into_hash_table(AggregateDataPtr* places, ColumnR
 
                 auto creator = [this](const auto& ctor, const auto& key) {
                     using KeyType = std::decay_t<decltype(key)>;
-                    if constexpr (HashTableTraits<HashTableType>::is_string_hash_table &&
-                                  !std::is_same_v<StringRef, KeyType>) {
-                        StringRef string_ref = to_string_ref(key);
-                        ArenaKeyHolder key_holder {string_ref, *_agg_arena_pool};
-                        key_holder_persist_key(key_holder);
-                        auto mapped = _aggregate_data_container->append_data(key_holder.key);
-                        _create_agg_status(mapped);
-                        ctor(key, mapped);
-                    } else {
-                        auto mapped = _aggregate_data_container->append_data(key);
-                        _create_agg_status(mapped);
-                        ctor(key, mapped);
+		    try {
+                        if constexpr (HashTableTraits<HashTableType>::is_string_hash_table &&
+                                      !std::is_same_v<StringRef, KeyType>) {
+                            StringRef string_ref = to_string_ref(key);
+                            ArenaKeyHolder key_holder {string_ref, *_agg_arena_pool};
+                            key_holder_persist_key(key_holder);
+                            auto mapped = _aggregate_data_container->append_data(key_holder.key);
+                            _create_agg_status(mapped);
+                            ctor(key, mapped);
+                        } else {
+                            auto mapped = _aggregate_data_container->append_data(key);
+                            _create_agg_status(mapped);
+                            ctor(key, mapped);
+                        }
+                    } catch (...) {
+		        // Exception-safety - if it can not allocate memory or create status,
+		        // the destructors will not be called.
+                        ctor(key, nullptr);
+                        throw;
                     }
                 };
 

--- a/be/src/vec/exec/vaggregation_node.cpp
+++ b/be/src/vec/exec/vaggregation_node.cpp
@@ -822,7 +822,7 @@ void AggregationNode::_emplace_into_hash_table(AggregateDataPtr* places, ColumnR
 
                 auto creator = [this](const auto& ctor, const auto& key) {
                     using KeyType = std::decay_t<decltype(key)>;
-		    try {
+                    try {
                         if constexpr (HashTableTraits<HashTableType>::is_string_hash_table &&
                                       !std::is_same_v<StringRef, KeyType>) {
                             StringRef string_ref = to_string_ref(key);
@@ -837,8 +837,8 @@ void AggregationNode::_emplace_into_hash_table(AggregateDataPtr* places, ColumnR
                             ctor(key, mapped);
                         }
                     } catch (...) {
-		        // Exception-safety - if it can not allocate memory or create status,
-		        // the destructors will not be called.
+                        // Exception-safety - if it can not allocate memory or create status,
+                        // the destructors will not be called.
                         ctor(key, nullptr);
                         throw;
                     }


### PR DESCRIPTION
## Proposed changes

```
(gdb) bt
#0  HashTable<StringRef, HashSetCellWithSavedHash<StringRef, DefaultHash<StringRef, void>, HashTableNoState>, DefaultHash<StringRef, void>, HashTableGrower<4ul>, AllocatorWithStackMemory<Allocator<true, true>, 384ul, 1ul> >::free (this=0x3c98da21) at /data/doris-1.x/be/src/vec/common/hash_table/hash_table.h:635
#1  HashTable<StringRef, HashSetCellWithSavedHash<StringRef, DefaultHash<StringRef, void>, HashTableNoState>, DefaultHash<StringRef, void>, HashTableGrower<4ul>, AllocatorWithStackMemory<Allocator<true, true>, 384ul, 1ul> >::~HashTable (this=0x3c98da21, __in_chrg=<optimized out>) at /data/doris-1.x/be/src/vec/common/hash_table/hash_table.h:637
#2  HashSetTable<StringRef, HashSetCellWithSavedHash<StringRef, DefaultHash<StringRef, void>, HashTableNoState>, DefaultHash<StringRef, void>, HashTableGrower<4ul>, AllocatorWithStackMemory<Allocator<true, true>, 384ul, 1ul> >::~HashSetTable (this=0x3c98da21, __in_chrg=<optimized out>) at /data/doris-1.x/be/src/vec/common/hash_table/hash_set.h:34
#3  doris::vectorized::AggregateFunctionCollectSetData<StringRef, std::integral_constant<bool, false> >::~AggregateFunctionCollectSetData (this=0x3c98da21, __in_chrg=<optimized out>)
    at /data/doris-1.x/be/src/vec/aggregate_functions/aggregate_function_collect.h:81
#4  doris::vectorized::IAggregateFunctionDataHelper<doris::vectorized::AggregateFunctionCollectSetData<StringRef, std::integral_constant<bool, false> >, doris::vectorized::AggregateFunctionCollect<doris::vectorized::AggregateFunctionCollectSetData<StringRef, std::integral_constant<bool, false> >, std::integral_constant<bool, false> > >::destroy (this=0x7fa89ea48ae0, 
    place=0x3c98da21 <error: Cannot access memory at address 0x3c98da21>) at /data/doris-1.x/be/src/vec/aggregate_functions/aggregate_function.h:389
#5  0x0000562c7639e483 in doris::vectorized::AggregationNode::_destroy_agg_status (data=<optimized out>, this=<optimized out>) at /var/local/ldb-toolchain/include/c++/11/bits/stl_vector.h:1043
#6  operator()<char*> (mapped=@0x7f954b07e2c0: 0x3c98da19 <error: Cannot access memory at address 0x3c98da19>, __closure=<optimized out>) at /data/doris-1.x/be/src/vec/exec/vaggregation_node.cpp:1342
#7  PHHashMap<StringRef, char*, DefaultHash<StringRef, void>, false>::for_each_mapped<doris::vectorized::AggregationNode::_close_with_serialized_key()::<lambda(auto:49&&)>::<lambda(auto:50&)> > (func=..., 
    this=<optimized out>) at /data/doris-1.x/be/src/vec/common/hash_table/ph_hash_map.h:203
#8  operator()<doris::vectorized::AggregationMethodSerialized<PHHashMap<StringRef, char*, DefaultHash<StringRef> > >&> (agg_method=..., __closure=<optimized out>)
    at /data/doris-1.x/be/src/vec/exec/vaggregation_node.cpp:1340
#9  std::__invoke_impl<void, doris::vectorized::AggregationNode::_close_with_serialized_key()::<lambda(auto:49&&)>, doris::vectorized::AggregationMethodSerialized<PHHashMap<StringRef, char*, DefaultHash<StringRef, void>, false> >&> (__f=...) at /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:61
#10 std::__invoke<doris::vectorized::AggregationNode::_close_with_serialized_key()::<lambda(auto:49&&)>, doris::vectorized::AggregationMethodSerialized<PHHashMap<StringRef, char*, DefaultHash<StringRef, void>, false> >&> (__fn=...) at /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:96
#11 std::__detail::__variant::__gen_vtable_impl<std::__detail::__variant::_Multi_array<std::__detail::__variant::__deduce_visit_result<void> (*)(doris::vectorized::AggregationNode::_close_with_serialized_key()::<lambda(auto:49&&)>&&, std::variant<doris::vectorized::AggregationMethodSerialized<PHHashMap<StringRef, char*, DefaultHash<StringRef, void>, false> >, doris::vectorized::AggregationMethodOneNumber<unsigned char, FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> >, false>, doris::vectorized::AggregationMethodOneNumber<short unsigned int, FixedHashMap<short unsigned int, char*, FixedHashMapImplicitZeroCell<short unsigned int, char*, HashTableNoState>, FixedHashTableStoredSize<FixedHashMapImplicitZeroCell<short unsigned int, char*, HashTableNoState> >, Allocator<true, true> >, false>, doris::vectorized::AggregationMethodOneNumber<unsigned int, PHHashMap<unsigned int, char*, HashCRC32<unsigned int>, false>, false>, doris::vectorized::AggregationMethodOneNumber<long unsigned int, PHHashMap<long unsigned int, char*, HashCRC32<long unsigned int>, false>, false>, doris::vectorized::AggregationMethodStringNoCache<StringHashMap<char*, Allocator<true, true> > >, doris::vectorized::AggregationMethodOneNumber<doris::vectorized::UInt128, PHHashMap<doris::vectorized::UInt128, char*, HashCRC32<doris::vectorized::UInt128>, false>, false>, doris::vectorized::AggregationMethodOneNumber<unsigned int, PHHashMap<unsigned int, char*, HashMixWrapper<unsigned int, HashCRC32<unsigned int> >, false>, false>, doris::vectorized::AggregationMethodOneNumber<long unsigned int, PHHashMap<long unsigned int, char*, HashMixWrapper<long unsigned int, HashCRC32<long unsigned int> >, false>, false>, doris::vectorized::AggregationMethodOneNumber<doris::vectorized::UInt128, PHHashMap<doris::vectorized::UInt128, char*, HashMixWrapper<doris::vectorized::UInt128, HashCRC32<doris::vectorized::UInt128> >, false>, false>, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned char, doris::vectorized::AggregationDataWithNullKey<FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> > >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<short unsigned int, doris::vectorized::AggregationDataWithNullKey<FixedHashMap<short unsigned int, char*, FixedHashMapImplicitZeroCell<short unsigned int, char*, HashTableNoState>, FixedHashTableStoredSize<FixedHashMapImplicitZeroCell<short unsigned int, char*, HashTableNoState> >, Allocator<true, true> > >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned int, doris::vectorized::AggregationDataWithNullKey<PHHashMap<unsigned int, char*, HashCRC32<unsigned int>, false> >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<long unsigned int, doris::vectorized::AggregationDataWithNullKey<PHHashMap<long unsigned int, char*, HashCRC32<long unsigned int>, false> >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned int, doris::vectorized::AggregationDataWithNullKey<PHHashMap<unsigned int, char*, HashMixWrapper<unsigned int, HashCRC32<unsigned int> >, false> >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<long unsigned int, doris::vectorized::AggregationDataWithNullKey<PHHashMap<long unsigned int, char*, HashMixWrapper<long unsigned int, HashCRC32<long unsigned int> >, false> >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<doris::vectorized::UInt128, doris::vectorized::AggregationDataWithNullKey<PHHashMap<doris::vectorized::UInt128, char*, HashCRC32<doris::vectorized::UInt128>, false> >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<doris::vectorized::UInt128, doris::vectorized::AggregationDataWithNullKey<PHHashMap<doris::vectorized::UInt128, char*, HashMixWrapper<doris::vectorized::UInt128, HashCRC32<doris::vectorized::UInt128> >, false> >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodStringNoCache<doris::vectorized::AggregationDataWithNullKey<StringHashMap<char*, Allocator<true, true> > > > >, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<long unsigned int, char*, HashCRC32<long unsigned int>, false>, false>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<long unsigned int, char*, HashCRC32<long unsigned int>, false>, true>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt128, char*, HashCRC32<doris::vectorized::UInt128>, false>, false>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt128, char*, HashCRC32<doris::vectorized::UInt128>, false>, true>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt256, char*, HashCRC32<doris::vectorized::UInt256>, false>, false>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt256, char*, HashCRC32<doris::vectorized::UInt256>, false>, true>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<long unsigned int, char*, HashMixWrapper<long unsigned int, HashCRC32<long unsigned int> >, false>, false>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<long unsigned int, char*, HashMixWrapper<long unsigned int, HashCRC32<long unsigned int> >, false>, true>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt128, char*, HashMixWrapper<doris::vectorized::UInt128, HashCRC32<doris::vectorized::UInt128> >, false>, false>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt128, char*, HashMixWrapper<doris::vectorized::UInt128, HashCRC32<doris::vectorized::UInt128> >, false>, true>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt256, char*, HashMixWrapper<doris::vectorized::UInt256, HashCRC32<doris::vectorized::UInt256> >, false>, false>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt256, char*, HashMixWrapper<doris::vectorized::UInt256, HashCRC32<doris::vectorized::UInt256> >, false>, true> >&)>, std::integer_sequence<long unsigned int, 0> >::__visit_invoke(struct {...} &&, std::variant<doris::vectorized::AggregationMethodSerialized<PHHashMap<StringRef, char*, DefaultHash<StringRef, void>, false> >, doris::vectorized::AggregationMethodOneNumber<unsigned char, FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> >, false>, doris::vectorized::AggregationMethodOneNumber<unsigned short, FixedHashMap<unsigned short, char*, FixedHashMapImplicitZeroCell<unsigned short, char*, HashTableNoState>, FixedHashTableStoredSize<FixedHashMapImplicitZeroCell<unsigned short, char*, HashTableNoState> >, Allocator<true, true> >, false>, doris::vectorized::AggregationMethodOneNumber<unsigned int, PHHashMap<unsigned int, char*, Hash--Type <RET> for more, q to quit, c to continue without paging--
CRC32<unsigned int>, false>, false>, doris::vectorized::AggregationMethodOneNumber<unsigned long, PHHashMap<unsigned long, char*, HashCRC32<unsigned long>, false>, false>, doris::vectorized::AggregationMethodStringNoCache<StringHashMap<char*, Allocator<true, true> > >, doris::vectorized::AggregationMethodOneNumber<doris::vectorized::UInt128, PHHashMap<doris::vectorized::UInt128, char*, HashCRC32<doris::vectorized::UInt128>, false>, false>, doris::vectorized::AggregationMethodOneNumber<unsigned int, PHHashMap<unsigned int, char*, HashMixWrapper<unsigned int, HashCRC32<unsigned int> >, false>, false>, doris::vectorized::AggregationMethodOneNumber<unsigned long, PHHashMap<unsigned long, char*, HashMixWrapper<unsigned long, HashCRC32<unsigned long> >, false>, false>, doris::vectorized::AggregationMethodOneNumber<doris::vectorized::UInt128, PHHashMap<doris::vectorized::UInt128, char*, HashMixWrapper<doris::vectorized::UInt128, HashCRC32<doris::vectorized::UInt128> >, false>, false>, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned char, doris::vectorized::AggregationDataWithNullKey<FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> > >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned short, doris::vectorized::AggregationDataWithNullKey<FixedHashMap<unsigned short, char*, FixedHashMapImplicitZeroCell<unsigned short, char*, HashTableNoState>, FixedHashTableStoredSize<FixedHashMapImplicitZeroCell<unsigned short, char*, HashTableNoState> >, Allocator<true, true> > >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned int, doris::vectorized::AggregationDataWithNullKey<PHHashMap<unsigned int, char*, HashCRC32<unsigned int>, false> >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned long, doris::vectorized::AggregationDataWithNullKey<PHHashMap<unsigned long, char*, HashCRC32<unsigned long>, false> >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned int, doris::vectorized::AggregationDataWithNullKey<PHHashMap<unsigned int, char*, HashMixWrapper<unsigned int, HashCRC32<unsigned int> >, false> >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned long, doris::vectorized::AggregationDataWithNullKey<PHHashMap<unsigned long, char*, HashMixWrapper<unsigned long, HashCRC32<unsigned long> >, false> >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<doris::vectorized::UInt128, doris::vectorized::AggregationDataWithNullKey<PHHashMap<doris::vectorized::UInt128, char*, HashCRC32<doris::vectorized::UInt128>, false> >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<doris::vectorized::UInt128, doris::vectorized::AggregationDataWithNullKey<PHHashMap<doris::vectorized::UInt128, char*, HashMixWrapper<doris::vectorized::UInt128, HashCRC32<doris::vectorized::UInt128> >, false> >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodStringNoCache<doris::vectorized::AggregationDataWithNullKey<StringHashMap<char*, Allocator<true, true> > > > >, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<unsigned long, char*, HashCRC32<unsigned long>, false>, false>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<unsigned long, char*, HashCRC32<unsigned long>, false>, true>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt128, char*, HashCRC32<doris::vectorized::UInt128>, false>, false>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt128, char*, HashCRC32<doris::vectorized::UInt128>, false>, true>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt256, char*, HashCRC32<doris::vectorized::UInt256>, false>, false>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt256, char*, HashCRC32<doris::vectorized::UInt256>, false>, true>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<unsigned long, char*, HashMixWrapper<unsigned long, HashCRC32<unsigned long> >, false>, false>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<unsigned long, char*, HashMixWrapper<unsigned long, HashCRC32<unsigned long> >, false>, true>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt128, char*, HashMixWrapper<doris::vectorized::UInt128, HashCRC32<doris::vectorized::UInt128> >, false>, false>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt128, char*, HashMixWrapper<doris::vectorized::UInt128, HashCRC32<doris::vectorized::UInt128> >, false>, true>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt256, char*, HashMixWrapper<doris::vectorized::UInt256, HashCRC32<doris::vectorized::UInt256> >, false>, false>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt256, char*, HashMixWrapper<doris::vectorized::UInt256, HashCRC32<doris::vectorized::UInt256> >, false>, true> > &) (__visitor=..., 
    __vars#0=...) at /var/local/ldb-toolchain/include/c++/11/variant:1013
#12 0x0000562c7639f946 in std::__do_visit<std::__detail::__variant::__deduce_visit_result<void>, doris::vectorized::AggregationNode::_close_with_serialized_key()::<lambda(auto:49&&)>, std::variant<doris::vectorized::AggregationMethodSerialized<PHHashMap<StringRef, char*, DefaultHash<StringRef, void>, false> >, doris::vectorized::AggregationMethodOneNumber<unsigned char, FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> >, false>, doris::vectorized::AggregationMethodOneNumber<short unsigned int, FixedHashMap<short unsigned int, char*, FixedHashMapImplicitZeroCell<short unsigned int, char*, HashTableNoState>, FixedHashTableStoredSize<FixedHashMapImplicitZeroCell<short unsigned int, char*, HashTableNoState> >, Allocator<true, true> >, false>, doris::vectorized::AggregationMethodOneNumber<unsigned int, PHHashMap<unsigned int, char*, HashCRC32<unsigned int>, false>, false>, doris::vectorized::AggregationMethodOneNumber<long unsigned int, PHHashMap<long unsigned int, char*, HashCRC32<long unsigned int>, false>, false>, doris::vectorized::AggregationMethodStringNoCache<StringHashMap<char*, Allocator<true, true> > >, doris::vectorized::AggregationMethodOneNumber<doris::vectorized::UInt128, PHHashMap<doris::vectorized::UInt128, char*, HashCRC32<doris::vectorized::UInt128>, false>, false>, doris::vectorized::AggregationMethodOneNumber<unsigned int, PHHashMap<unsigned int, char*, HashMixWrapper<unsigned int, HashCRC32<unsigned int> >, false>, false>, doris::vectorized::AggregationMethodOneNumber<long unsigned int, PHHashMap<long unsigned int, char*, HashMixWrapper<long unsigned int, HashCRC32<long unsigned int> >, false>, false>, doris::vectorized::AggregationMethodOneNumber<doris::vectorized::UInt128, PHHashMap<doris::vectorized::UInt128, char*, HashMixWrapper<doris::vectorized::UInt128, HashCRC32<doris::vectorized::UInt128> >, false>, false>, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned char, doris::vectorized::AggregationDataWithNullKey<FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> > >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<short unsigned int, doris::vectorized::AggregationDataWithNullKey<FixedHashMap<short unsigned int, char*, FixedHashMapImplicitZeroCell<short unsigned int, char*, HashTableNoState>, FixedHashTableStoredSize<FixedHashMapImplicitZeroCell<short unsigned int, char*, HashTableNoState> >, Allocator<true, true> > >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned int, doris::vectorized::AggregationDataWithNullKey<PHHashMap<unsigned int, char*, HashCRC32<unsigned int>, false> >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<long unsigned int, doris::vectorized::AggregationDataWithNullKey<PHHashMap<long unsigned int, char*, HashCRC32<long unsigned int>, false> >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned int, doris::vectorized::AggregationDataWithNullKey<PHHashMap<unsigned int, char*, HashMixWrapper<unsigned int, HashCRC32<unsigned int> >, false> >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<long unsigned int, doris::vectorized::AggregationDataWithNullKey<PHHashMap<long unsigned int, char*, HashMixWrapper<long unsigned int, HashCRC32<long unsigned int> >, false> >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<doris::vectorized::UInt128, doris::vectorized::AggregationDataWithNullKey<PHHashMap<doris::vectorized::UInt128, char*, HashCRC32<doris::vectorized::UInt128>, false> >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<doris::vectorized::UInt128, doris::vectorized::AggregationDataWithNullKey<PHHashMap<doris::vectorized::UInt128, char*, HashMixWrapper<doris::vectorized::UInt128, HashCRC32<doris::vectorized::UInt128> >, false> >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodStringNoCache<doris::vectorized::AggregationDataWithNullKey<StringHashMap<char*, Allocator<true, true> > > > >, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<long unsigned int, char*, HashCRC32<long unsigned int>, false>, false>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<long unsigned int, char*, HashCRC32<long unsigned int>, false>, true>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt128, char*, HashCRC32<doris::vectorized::UInt128>, false>, false>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt128, char*, HashCRC32<doris::vectorized::UInt128>, false>, true>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt256, char*, HashCRC32<doris::vectorized::UInt256>, false>, false>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt256, char*, HashCRC32<doris::vectorized::UInt256>, false>, true>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<long unsigned int, char*, HashMixWrapper<long unsigned int, HashCRC32<long unsigned int> >, false>, false>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<long unsigned int, char*, HashMixWrapper<long unsigned int, HashCRC32<long unsigned int> >, false>, true>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt128, char*, HashMixWrapper<doris::vectorized::UInt128, HashCRC32<doris::vectorized::UInt128> >, false>, false>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt128, ch--Type <RET> for more, q to quit, c to continue without paging--
ar*, HashMixWrapper<doris::vectorized::UInt128, HashCRC32<doris::vectorized::UInt128> >, false>, true>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt256, char*, HashMixWrapper<doris::vectorized::UInt256, HashCRC32<doris::vectorized::UInt256> >, false>, false>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt256, char*, HashMixWrapper<doris::vectorized::UInt256, HashCRC32<doris::vectorized::UInt256> >, false>, true> >&> (__visitor=...) at /var/local/ldb-toolchain/include/c++/11/variant:1708
#13 std::visit<doris::vectorized::AggregationNode::_close_with_serialized_key()::<lambda(auto:49&&)>, std::variant<doris::vectorized::AggregationMethodSerialized<PHHashMap<StringRef, char*, DefaultHash<StringRef, void>, false> >, doris::vectorized::AggregationMethodOneNumber<unsigned char, FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> >, false>, doris::vectorized::AggregationMethodOneNumber<short unsigned int, FixedHashMap<short unsigned int, char*, FixedHashMapImplicitZeroCell<short unsigned int, char*, HashTableNoState>, FixedHashTableStoredSize<FixedHashMapImplicitZeroCell<short unsigned int, char*, HashTableNoState> >, Allocator<true, true> >, false>, doris::vectorized::AggregationMethodOneNumber<unsigned int, PHHashMap<unsigned int, char*, HashCRC32<unsigned int>, false>, false>, doris::vectorized::AggregationMethodOneNumber<long unsigned int, PHHashMap<long unsigned int, char*, HashCRC32<long unsigned int>, false>, false>, doris::vectorized::AggregationMethodStringNoCache<StringHashMap<char*, Allocator<true, true> > >, doris::vectorized::AggregationMethodOneNumber<doris::vectorized::UInt128, PHHashMap<doris::vectorized::UInt128, char*, HashCRC32<doris::vectorized::UInt128>, false>, false>, doris::vectorized::AggregationMethodOneNumber<unsigned int, PHHashMap<unsigned int, char*, HashMixWrapper<unsigned int, HashCRC32<unsigned int> >, false>, false>, doris::vectorized::AggregationMethodOneNumber<long unsigned int, PHHashMap<long unsigned int, char*, HashMixWrapper<long unsigned int, HashCRC32<long unsigned int> >, false>, false>, doris::vectorized::AggregationMethodOneNumber<doris::vectorized::UInt128, PHHashMap<doris::vectorized::UInt128, char*, HashMixWrapper<doris::vectorized::UInt128, HashCRC32<doris::vectorized::UInt128> >, false>, false>, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned char, doris::vectorized::AggregationDataWithNullKey<FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> > >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<short unsigned int, doris::vectorized::AggregationDataWithNullKey<FixedHashMap<short unsigned int, char*, FixedHashMapImplicitZeroCell<short unsigned int, char*, HashTableNoState>, FixedHashTableStoredSize<FixedHashMapImplicitZeroCell<short unsigned int, char*, HashTableNoState> >, Allocator<true, true> > >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned int, doris::vectorized::AggregationDataWithNullKey<PHHashMap<unsigned int, char*, HashCRC32<unsigned int>, false> >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<long unsigned int, doris::vectorized::AggregationDataWithNullKey<PHHashMap<long unsigned int, char*, HashCRC32<long unsigned int>, false> >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned int, doris::vectorized::AggregationDataWithNullKey<PHHashMap<unsigned int, char*, HashMixWrapper<unsigned int, HashCRC32<unsigned int> >, false> >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<long unsigned int, doris::vectorized::AggregationDataWithNullKey<PHHashMap<long unsigned int, char*, HashMixWrapper<long unsigned int, HashCRC32<long unsigned int> >, false> >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<doris::vectorized::UInt128, doris::vectorized::AggregationDataWithNullKey<PHHashMap<doris::vectorized::UInt128, char*, HashCRC32<doris::vectorized::UInt128>, false> >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<doris::vectorized::UInt128, doris::vectorized::AggregationDataWithNullKey<PHHashMap<doris::vectorized::UInt128, char*, HashMixWrapper<doris::vectorized::UInt128, HashCRC32<doris::vectorized::UInt128> >, false> >, false> >, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodStringNoCache<doris::vectorized::AggregationDataWithNullKey<StringHashMap<char*, Allocator<true, true> > > > >, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<long unsigned int, char*, HashCRC32<long unsigned int>, false>, false>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<long unsigned int, char*, HashCRC32<long unsigned int>, false>, true>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt128, char*, HashCRC32<doris::vectorized::UInt128>, false>, false>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt128, char*, HashCRC32<doris::vectorized::UInt128>, false>, true>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt256, char*, HashCRC32<doris::vectorized::UInt256>, false>, false>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt256, char*, HashCRC32<doris::vectorized::UInt256>, false>, true>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<long unsigned int, char*, HashMixWrapper<long unsigned int, HashCRC32<long unsigned int> >, false>, false>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<long unsigned int, char*, HashMixWrapper<long unsigned int, HashCRC32<long unsigned int> >, false>, true>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt128, char*, HashMixWrapper<doris::vectorized::UInt128, HashCRC32<doris::vectorized::UInt128> >, false>, false>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt128, char*, HashMixWrapper<doris::vectorized::UInt128, HashCRC32<doris::vectorized::UInt128> >, false>, true>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt256, char*, HashMixWrapper<doris::vectorized::UInt256, HashCRC32<doris::vectorized::UInt256> >, false>, false>, doris::vectorized::AggregationMethodKeysFixed<PHHashMap<doris::vectorized::UInt256, char*, HashMixWrapper<doris::vectorized::UInt256, HashCRC32<doris::vectorized::UInt256> >, false>, true> >&> (
    __visitor=...) at /var/local/ldb-toolchain/include/c++/11/variant:1764
#14 doris::vectorized::AggregationNode::_close_with_serialized_key (this=0x7fac0b815a00) at /data/doris-1.x/be/src/vec/exec/vaggregation_node.cpp:1337
#15 0x0000562c763f592b in std::function<void ()>::operator()() const (this=0x7fac0b815f30) at /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:556

#16 doris::vectorized::AggregationNode::close (this=0x7fac0b815a00, state=0x7fab3a572a00) at /data/doris-1.x/be/src/vec/exec/vaggregation_node.cpp:532
#17 0x0000562c75192b89 in doris::PlanFragmentExecutor::close (this=this@entry=0x7faa044c7780) at /data/doris-1.x/be/src/runtime/plan_fragment_executor.cpp:687
#18 0x0000562c75171595 in doris::FragmentExecState::execute (this=0x7faa044c7700) at /data/doris-1.x/be/src/runtime/fragment_mgr.cpp:268
#19 0x0000562c75174ace in doris::FragmentMgr::_exec_actual(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>) (this=this@entry=0x7fae9a988800, exec_state=..., 
    cb=...) at /var/local/ldb-toolchain/include/c++/11/bits/shared_ptr_base.h:1290
#20 0x0000562c75175002 in operator() (__closure=<optimized out>) at /var/local/ldb-toolchain/include/c++/11/ext/atomicity.h:109
#21 std::__invoke_impl<void, doris::FragmentMgr::exec_plan_fragment(const doris::TExecPlanFragmentParams&, doris::FragmentMgr::FinishCallback)::<lambda()>&> (__f=...)
    at /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:61
#22 std::__invoke_r<void, doris::FragmentMgr::exec_plan_fragment(const doris::TExecPlanFragmentParams&, doris::FragmentMgr::FinishCallback)::<lambda()>&> (__fn=...)
    at /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:111
#23 std::_Function_handler<void(), doris::FragmentMgr::exec_plan_fragment(const doris::TExecPlanFragmentParams&, doris::FragmentMgr::FinishCallback)::<lambda()> >::_M_invoke(const std::_Any_data &) (
    __functor=...) at /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:291
#24 0x0000562c7542cef5 in std::function<void ()>::operator()() const (this=<optimized out>) at /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:556
#25 doris::FunctionRunnable::run (this=<optimized out>) at /data/doris-1.x/be/src/util/threadpool.cpp:46
#26 doris::ThreadPool::dispatch_thread (this=0x7fae9bf4d040) at /data/doris-1.x/be/src/util/threadpool.cpp:535
#27 0x0000562c7542234f in std::function<void ()>::operator()() const (this=0x7fab268e4398) at /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:556
#28 doris::Thread::supervise_thread (arg=0x7fab268e4380) at /data/doris-1.x/be/src/util/thread.cpp:454
#29 0x00007fae9f96cea5 in start_thread () from /lib64/libpthread.so.0
#30 0x00007fae9fc7f9fd in clone () from /lib64/libc.so.6
```

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

