### PR TITLE
[fix](mtmv) Related partition exclude null generate column when increment build materialized view

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtils.java
@@ -272,6 +272,7 @@ public class MaterializedViewUtils {
         private boolean pctPossible = true;
         private TableIf relatedTable;
         private Column relatedTableColumn;
+        private boolean joinNullGenerateSide;
 
         public IncrementCheckerContext(SlotReference mvPartitionColumn) {
             this.mvPartitionColumn = mvPartitionColumn;
@@ -303,6 +304,14 @@ public class MaterializedViewUtils {
 
         public void setRelatedTableColumn(Column relatedTableColumn) {
             this.relatedTableColumn = relatedTableColumn;
+        }
+
+        public boolean isJoinNullGenerateSide() {
+            return joinNullGenerateSide;
+        }
+
+        public void setJoinNullGenerateSide(boolean joinNullGenerateSide) {
+            this.joinNullGenerateSide = joinNullGenerateSide;
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtils.java
@@ -28,6 +28,7 @@ import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.WindowExpression;
+import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
 import org.apache.doris.nereids.trees.plans.logical.LogicalCatalogRelation;
@@ -45,6 +46,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * The common util for materialized view
@@ -175,6 +177,28 @@ public class MaterializedViewUtils {
         @Override
         public Void visitLogicalJoin(LogicalJoin<? extends Plan, ? extends Plan> join,
                 IncrementCheckerContext context) {
+            Plan left = join.child(0);
+            Set<Column> leftColumnSet = left.getOutputSet().stream()
+                    .filter(slot -> slot instanceof SlotReference
+                            && slot.isColumnFromTable())
+                    .map(slot -> ((SlotReference) slot).getColumn().get())
+                    .collect(Collectors.toSet());
+            boolean useLeft = leftColumnSet.contains(context.getMvPartitionColumn().getColumn().get());
+            JoinType joinType = join.getJoinType();
+            if (joinType.isInnerJoin() || joinType.isCrossJoin()) {
+                context.setPctPossible(true);
+            } else if (joinType.isLeftJoin()
+                    || joinType.isLefSemiJoin()
+                    || joinType.isLeftAntiJoin()) {
+                context.setPctPossible(useLeft);
+            } else if (joinType.isRightJoin()
+                    || joinType.isRightAntiJoin()
+                    || joinType.isRightSemiJoin()) {
+                context.setPctPossible(!useLeft);
+            } else {
+                // un supported join type
+                context.setPctPossible(false);
+            }
             return visit(join, context);
         }
 

--- a/regression-test/suites/nereids_rules_p0/mv/join/inner/inner_join.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/join/inner/inner_join.groovy
@@ -393,7 +393,7 @@ suite("inner_join") {
     sql """ DROP MATERIALIZED VIEW IF EXISTS mv6_0"""
 
 
-    // filter inside + inner + right
+    // filter inside + left + right
     def mv7_0 = "select l_shipdate, o_orderdate, l_partkey, l_suppkey " +
             "from lineitem " +
             "inner join (select * from orders where o_orderdate = '2023-12-08') t2 " +


### PR DESCRIPTION
## Proposed changes

Infer partition column by materialized view partition column, exclude null generate column in join when increment build materialized view

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

