### PR TITLE
[improvement](jdbc catalog) Optimize connection pool caching logic

### DIFF
--- a/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/JdbcDataSource.java
+++ b/fe/be-java-extensions/jdbc-scanner/src/main/java/org/apache/doris/jdbc/JdbcDataSource.java
@@ -30,15 +30,20 @@ public class JdbcDataSource {
         return jdbcDataSource;
     }
 
-    public DruidDataSource getSource(String jdbcUrl) {
-        return sourcesMap.get(jdbcUrl);
+    public DruidDataSource getSource(String cacheKey) {
+        return sourcesMap.get(cacheKey);
     }
 
-    public void putSource(String jdbcUrl, DruidDataSource ds) {
-        sourcesMap.put(jdbcUrl, ds);
+    public void putSource(String cacheKey, DruidDataSource ds) {
+        sourcesMap.put(cacheKey, ds);
     }
 
     public Map<String, DruidDataSource> getSourcesMap() {
         return sourcesMap;
+    }
+
+    public String createCacheKey(String jdbcUrl, String jdbcUser, String jdbcPassword, String jdbcDriverUrl,
+            String jdbcDriverClass) {
+        return jdbcUrl + jdbcUser + jdbcPassword + jdbcDriverUrl + jdbcDriverClass;
     }
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

In the old caching logic, we only used jdbcurl, user, and password as cache keys. This may cause the old link to be still used when replacing the jar package, so we should concatenate all the parameters required for the connection pool as the key.

2.0 #28857 

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

