### PR TITLE
[improve](move-memtable) tweak load stream flush token num and max tasks

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -777,7 +777,7 @@ DEFINE_Int32(load_stream_messages_in_batch, "128");
 // brpc streaming StreamWait seconds on EAGAIN
 DEFINE_Int32(load_stream_eagain_wait_seconds, "60");
 // max tasks per flush token in load stream
-DEFINE_Int32(load_stream_flush_token_max_tasks, "2");
+DEFINE_Int32(load_stream_flush_token_max_tasks, "5");
 
 // max send batch parallelism for OlapTableSink
 // The value set by the user for send_batch_parallelism is not allowed to exceed max_send_batch_parallelism_per_job,

--- a/be/src/runtime/load_stream.cpp
+++ b/be/src/runtime/load_stream.cpp
@@ -46,10 +46,7 @@ namespace doris {
 TabletStream::TabletStream(PUniqueId load_id, int64_t id, int64_t txn_id,
                            LoadStreamMgr* load_stream_mgr, RuntimeProfile* profile)
         : _id(id), _next_segid(0), _load_id(load_id), _txn_id(txn_id) {
-    for (int i = 0; i < 10; i++) {
-        _flush_tokens.emplace_back(load_stream_mgr->new_token());
-    }
-
+    load_stream_mgr->create_tokens(_flush_tokens);
     _failed_st = std::make_shared<Status>();
     _profile = profile->create_child(fmt::format("TabletStream {}", id), true, true);
     _append_data_timer = ADD_TIMER(_profile, "AppendDataTime");

--- a/be/src/runtime/load_stream_mgr.cpp
+++ b/be/src/runtime/load_stream_mgr.cpp
@@ -34,7 +34,9 @@ namespace doris {
 
 LoadStreamMgr::LoadStreamMgr(uint32_t segment_file_writer_thread_num,
                              FifoThreadPool* heavy_work_pool, FifoThreadPool* light_work_pool)
-        : _heavy_work_pool(heavy_work_pool), _light_work_pool(light_work_pool) {
+        : _num_threads(segment_file_writer_thread_num),
+          _heavy_work_pool(heavy_work_pool),
+          _light_work_pool(light_work_pool) {
     static_cast<void>(ThreadPoolBuilder("SegmentFileWriterThreadPool")
                               .set_min_threads(segment_file_writer_thread_num)
                               .set_max_threads(segment_file_writer_thread_num)

--- a/be/src/runtime/load_stream_mgr.h
+++ b/be/src/runtime/load_stream_mgr.h
@@ -41,8 +41,11 @@ public:
     Status open_load_stream(const POpenLoadStreamRequest* request,
                             LoadStreamSharedPtr& load_stream);
     void clear_load(UniqueId loadid);
-    std::unique_ptr<ThreadPoolToken> new_token() {
-        return _file_writer_thread_pool->new_token(ThreadPool::ExecutionMode::SERIAL);
+    void create_tokens(std::vector<std::unique_ptr<ThreadPoolToken>>& tokens) {
+        for (int i = 0; i < _num_threads * 2; i++) {
+            tokens.push_back(
+                    _file_writer_thread_pool->new_token(ThreadPool::ExecutionMode::SERIAL));
+        }
     }
 
     // only used by ut
@@ -55,6 +58,8 @@ private:
     std::mutex _lock;
     std::unordered_map<UniqueId, LoadStreamSharedPtr> _load_streams_map;
     std::unique_ptr<ThreadPool> _file_writer_thread_pool;
+
+    uint32_t _num_threads = 0;
 
     FifoThreadPool* _heavy_work_pool = nullptr;
     FifoThreadPool* _light_work_pool = nullptr;


### PR DESCRIPTION
## Proposed changes

Set load stream flush token to 2x flush thread num. 
Increase max tasks per token to 5.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

