### PR TITLE
[Enhancement](plan) Optimize preagg for aggregate function

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
@@ -2632,7 +2632,7 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         return this instanceof NullLiteral;
     }
 
-    public boolean isConstantZero() {
+    public boolean isZeroLiteral() {
         return this instanceof LiteralExpr && ((LiteralExpr) this).isZero();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
@@ -2627,5 +2627,13 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
             expr.replaceSlot(tuple);
         }
     }
+
+    public boolean isNullLiteral() {
+        return this instanceof NullLiteral;
+    }
+
+    public boolean isConstantZero() {
+        return this instanceof LiteralExpr && ((LiteralExpr) this).isZero();
+    }
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LiteralExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LiteralExpr.java
@@ -34,8 +34,10 @@ import org.apache.logging.log4j.Logger;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 public abstract class LiteralExpr extends Expr implements Comparable<LiteralExpr> {
@@ -448,5 +450,32 @@ public abstract class LiteralExpr extends Expr implements Comparable<LiteralExpr
     @Override
     public boolean matchExprs(List<Expr> exprs, SelectStmt stmt, boolean ignoreAlias, TupleDescriptor tuple) {
         return true;
+    }
+
+    /** whether is ZERO value **/
+    public boolean isZero() {
+        boolean isZero = false;
+        switch (type.getPrimitiveType()) {
+            case TINYINT:
+            case SMALLINT:
+            case INT:
+            case BIGINT:
+            case LARGEINT:
+                isZero = this.getLongValue() == 0;
+                break;
+            case FLOAT:
+            case DOUBLE:
+                isZero = this.getDoubleValue() == 0.0f;
+                break;
+            case DECIMALV2:
+            case DECIMAL32:
+            case DECIMAL64:
+            case DECIMAL128:
+            case DECIMAL256:
+                isZero = Objects.equals(((DecimalLiteral) this).getValue(), BigDecimal.ZERO);
+                break;
+            default:
+        }
+        return isZero;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
@@ -260,6 +260,10 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
         }
     }
 
+    public boolean isConstantZero() {
+        return this instanceof Literal && ((Literal) this).isZero();
+    }
+
     public final Expression castTo(DataType targetType) throws AnalysisException {
         return uncheckedCastTo(targetType);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
@@ -260,7 +260,7 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
         }
     }
 
-    public boolean isConstantZero() {
+    public boolean isZeroLiteral() {
         return this instanceof Literal && ((Literal) this).isZero();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/Literal.java
@@ -366,4 +366,27 @@ public abstract class Literal extends Expression implements LeafExpression, Comp
     public boolean isStringLikeLiteral() {
         return dataType.isStringLikeType();
     }
+
+    /** whether is ZERO value **/
+    public boolean isZero() {
+        if (isNullLiteral()) {
+            return false;
+        }
+        if (dataType.isSmallIntType() || dataType.isTinyIntType() || dataType.isIntegerType()) {
+            return getValue().equals(0);
+        } else if (dataType.isBigIntType()) {
+            return getValue().equals(0L);
+        } else if (dataType.isLargeIntType()) {
+            return getValue().equals(BigInteger.ZERO);
+        } else if (dataType.isFloatType()) {
+            return getValue().equals(0.0f);
+        } else if (dataType.isDoubleType()) {
+            return getValue().equals(0.0);
+        } else if (dataType.isDecimalV2Type()) {
+            return getValue().equals(BigDecimal.ZERO);
+        } else if (dataType.isDecimalV3Type()) {
+            return getValue().equals(BigDecimal.ZERO);
+        }
+        return false;
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/mv/SelectMvIndexTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/mv/SelectMvIndexTest.java
@@ -1251,4 +1251,88 @@ class SelectMvIndexTest extends BaseMaterializedIndexSelectTest implements MemoP
             Assertions.assertEquals(secondTableIndexName, scan1.getSelectedIndexName());
         });
     }
+
+    @Test
+    public void testSubExpressionsInAggregation() throws Exception {
+        createTable("CREATE TABLE db1.`test_pre_agg_tbl` (\n"
+                + "  `k1` int,\n"
+                + "  `k2` int,\n"
+                + "  `k3` char,\n"
+                + "  `k4` int,\n"
+                + "  `k5` bigint,\n"
+                + "  `k6` bigint,\n"
+                + "  `v1` bigint SUM,\n"
+                + "  `v2` bigint SUM,\n"
+                + "  `v3` bigint MAX, \n"
+                + "  `v4` bigint MIN\n"
+                + ") ENGINE=OLAP\n"
+                + "AGGREGATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`, `k6`)\n"
+                + "COMMENT \"OLAP\"\n"
+                + "DISTRIBUTED BY HASH(`k1`) BUCKETS 5\n"
+                + "PROPERTIES (\n"
+                + "\"replication_num\" = \"1\"\n"
+                + ");");
+        addRollup("alter table db1.test_pre_agg_tbl add rollup test_rollup(k1, k2, k3, v1, v2, v3, v4)");
+
+        String sql1 = "select sum(case when k1 > 0 then v1 when k1 = 0 then 0 when k1 < 0 then v2 else 0 end),"
+                + "sum(case when k1 = 1 then v2 else null end),"
+                + "sum(case when k2 = 0 then 0 else v1 end),"
+                + "sum(case when k2 = 1 then null else v2 end) "
+                + "from test_pre_agg_tbl";
+        // legacy planner
+        Assertions.assertTrue(getSQLPlanOrErrorMsg(sql1).contains(
+                "TABLE: db1.test_pre_agg_tbl(test_rollup), PREAGGREGATION: ON"));
+        // nereids planner
+        PlanChecker.from(connectContext)
+                .analyze(sql1)
+                .rewrite()
+                .matches(logicalOlapScan().when(scan -> {
+                    Assertions.assertEquals("test_rollup", scan.getSelectedMaterializedIndexName().get());
+                    Assertions.assertTrue(scan.getPreAggStatus().isOn());
+                    return true;
+                }));
+
+        String sql2 = "select sum(case when k1 > 0 then v1 else 1 end) from db1.test_pre_agg_tbl";
+        // legacy planner
+        Assertions.assertTrue(getSQLPlanOrErrorMsg(sql2).contains("PREAGGREGATION: OFF"));
+        // nereids planner
+        PlanChecker.from(connectContext)
+                .analyze(sql2)
+                .rewrite()
+                .matches(logicalOlapScan().when(scan -> {
+                    Assertions.assertEquals("test_pre_agg_tbl", scan.getSelectedMaterializedIndexName().get());
+                    Assertions.assertTrue(scan.getPreAggStatus().isOff());
+                    return true;
+                }));
+
+        String sql3 = "select max(case when k1 > 0 then v3 else null end),min(case when k1 > 0 then null else v4 end)"
+                + " from db1.test_pre_agg_tbl";
+        // legacy planner
+        Assertions.assertTrue(getSQLPlanOrErrorMsg(sql3).contains(
+                "TABLE: db1.test_pre_agg_tbl(test_rollup), PREAGGREGATION: ON"));
+        // nereids planner
+        PlanChecker.from(connectContext)
+                .analyze(sql3)
+                .rewrite()
+                .matches(logicalOlapScan().when(scan -> {
+                    Assertions.assertEquals("test_rollup", scan.getSelectedMaterializedIndexName().get());
+                    Assertions.assertTrue(scan.getPreAggStatus().isOn());
+                    return true;
+                }));
+
+        String sql4 = "select count(distinct case when k1 > 0 then k1 else null end), "
+                + "count(distinct if(k2 < 0, null, k2)) from db1.test_pre_agg_tbl";
+        // legacy planner
+        Assertions.assertTrue(getSQLPlanOrErrorMsg(sql4).contains(
+                "TABLE: db1.test_pre_agg_tbl(test_rollup), PREAGGREGATION: ON"));
+        // nereids planner
+        PlanChecker.from(connectContext)
+                .analyze(sql4)
+                .rewrite()
+                .matches(logicalOlapScan().when(scan -> {
+                    Assertions.assertEquals("test_rollup", scan.getSelectedMaterializedIndexName().get());
+                    Assertions.assertTrue(scan.getPreAggStatus().isOn());
+                    return true;
+                }));
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/mv/SelectMvIndexTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/mv/SelectMvIndexTest.java
@@ -1261,10 +1261,13 @@ class SelectMvIndexTest extends BaseMaterializedIndexSelectTest implements MemoP
                 + "  `k4` int,\n"
                 + "  `k5` bigint,\n"
                 + "  `k6` bigint,\n"
-                + "  `v1` bigint SUM,\n"
+                + "  `v1` int SUM,\n"
                 + "  `v2` bigint SUM,\n"
-                + "  `v3` bigint MAX, \n"
-                + "  `v4` bigint MIN\n"
+                + "  `v3` bigint MAX,\n"
+                + "  `v4` bigint MIN,\n"
+                + "  `v5` float SUM,\n"
+                + "  `v6` double SUM,\n"
+                + "  `v7` decimal SUM\n"
                 + ") ENGINE=OLAP\n"
                 + "AGGREGATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`, `k6`)\n"
                 + "COMMENT \"OLAP\"\n"
@@ -1272,13 +1275,15 @@ class SelectMvIndexTest extends BaseMaterializedIndexSelectTest implements MemoP
                 + "PROPERTIES (\n"
                 + "\"replication_num\" = \"1\"\n"
                 + ");");
-        addRollup("alter table db1.test_pre_agg_tbl add rollup test_rollup(k1, k2, k3, v1, v2, v3, v4)");
+        addRollup("alter table db1.test_pre_agg_tbl add rollup test_rollup(k1, k2, k3, v1, v2, v3, v4, v5, v6, v7)");
 
         String sql1 = "select sum(case when k1 > 0 then v1 when k1 = 0 then 0 when k1 < 0 then v2 else 0 end),"
-                + "sum(case when k1 = 1 then v2 else null end),"
-                + "sum(case when k2 = 0 then 0 else v1 end),"
-                + "sum(case when k2 = 1 then null else v2 end) "
-                + "from test_pre_agg_tbl";
+                + "sum(case when k2 = 1 then 0 else v1 end),"
+                + "sum(case when k2 = 1 then null else v2 end),"
+                + "sum(case when k2 = 1 then null else v5 end),"
+                + "sum(case when k2 = 1 then null else v6 end),"
+                + "sum(case when k2 = 1 then null else v7 end)"
+                + "from db1.test_pre_agg_tbl";
         // legacy planner
         Assertions.assertTrue(getSQLPlanOrErrorMsg(sql1).contains(
                 "TABLE: db1.test_pre_agg_tbl(test_rollup), PREAGGREGATION: ON"));

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/mv/SelectRollupIndexTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/mv/SelectRollupIndexTest.java
@@ -242,7 +242,7 @@ class SelectRollupIndexTest extends BaseMaterializedIndexSelectTest implements M
                 .matches(logicalOlapScan().when(scan -> {
                     PreAggStatus preAgg = scan.getPreAggStatus();
                     Assertions.assertTrue(preAgg.isOff());
-                    Assertions.assertEquals("Slot((v1 + 1)) in sum((v1 + 1)) is neither key column nor value column.",
+                    Assertions.assertEquals("do not support compound expression [(v1 + 1)] in SUM.",
                             preAgg.getOffReason());
                     return true;
                 }));


### PR DESCRIPTION
If the `case when` contains a constant zero/null in SUM agg function, we can use preaggregation to speed up queries and it will not effect the correctness of result.

Issue Number: close #8562

If we use `case when` or `if` in `SUM`, Planner will get the follows steps:
1、rewrite expression `if` to `case when`.
2、check the Index contains all key columns in `when` expr.
3、check the expr in `then` is constant zero、null or value column in index.
4、check the expr in `else` is constant zero、null or value column in Index.

If conditions 2, 3, and 4 are all met, we open preagg.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

