### PR TITLE
[fix](merge-on-write) fix migration may cause duplicate keys for mow table

### DIFF
--- a/be/src/olap/task/engine_storage_migration_task.cpp
+++ b/be/src/olap/task/engine_storage_migration_task.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <ctime>
 #include <memory>
+#include <mutex>
 #include <new>
 #include <ostream>
 #include <set>
@@ -194,6 +195,21 @@ Status EngineStorageMigrationTask::_migrate() {
     int32_t start_version = 0;
     int32_t end_version = 0;
     std::vector<RowsetSharedPtr> consistent_rowsets;
+
+    // During migration, if the rowsets being migrated undergoes a compaction operation,
+    // that will result in incorrect delete bitmaps after migration for mow table. Therefore,
+    // compaction will be prohibited for the mow table when migration. Moreover, it is useless
+    // to perform a compaction operation on the migration data, as the migration still migrates
+    // the data of rowsets before the compaction operation.
+    std::unique_lock full_compaction_lock(_tablet->get_full_compaction_lock(), std::defer_lock);
+    std::unique_lock base_compaction_lock(_tablet->get_base_compaction_lock(), std::defer_lock);
+    std::unique_lock cumu_compaction_lock(_tablet->get_cumulative_compaction_lock(),
+                                          std::defer_lock);
+    if (_tablet->enable_unique_key_merge_on_write()) {
+        full_compaction_lock.lock();
+        base_compaction_lock.lock();
+        cumu_compaction_lock.lock();
+    }
 
     // try hold migration lock first
     Status res;


### PR DESCRIPTION
## Proposed changes

During migration, if the rowsets being migrated undergoes a compaction operation, that will result in incorrect delete bitmaps after migration for mow table. Therefore, compaction will be prohibited for the mow table when migration. Moreover, it is useless to perform a compaction operation on the migration data, as the migration still migrates the data of rowsets before the compaction operation.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

