### PR TITLE
[opt](memory) All LRU Cache inherit from LRUCachePolicy

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -275,7 +275,8 @@ DEFINE_mInt64(memory_limitation_per_thread_for_storage_migration_bytes, "1000000
 
 DEFINE_mInt32(cache_prune_stale_interval, "10");
 // the clean interval of tablet lookup cache
-DEFINE_mInt32(tablet_lookup_cache_clean_interval, "30");
+DEFINE_mInt32(tablet_lookup_cache_stale_sweep_time_sec, "30");
+DEFINE_mInt32(point_query_row_cache_stale_sweep_time_sec, "300");
 DEFINE_mInt32(disk_stat_monitor_interval, "5");
 DEFINE_mInt32(unused_rowset_monitor_interval, "30");
 DEFINE_String(storage_root_path, "${DORIS_HOME}/storage");
@@ -809,6 +810,9 @@ DEFINE_mInt32(external_table_connect_timeout_sec, "30");
 
 // Global bitmap cache capacity for aggregation cache, size in bytes
 DEFINE_Int64(delete_bitmap_agg_cache_capacity, "104857600");
+DEFINE_mInt32(delete_bitmap_agg_cache_stale_sweep_time_sec, "1800");
+
+DEFINE_mInt32(common_obj_lru_cache_stale_sweep_time_sec, "900");
 
 // s3 config
 DEFINE_mInt32(max_remote_storage_count, "10");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -318,7 +318,8 @@ DECLARE_mInt64(memory_limitation_per_thread_for_storage_migration_bytes);
 // the prune stale interval of all cache
 DECLARE_mInt32(cache_prune_stale_interval);
 // the clean interval of tablet lookup cache
-DECLARE_mInt32(tablet_lookup_cache_clean_interval);
+DECLARE_mInt32(tablet_lookup_cache_stale_sweep_time_sec);
+DECLARE_mInt32(point_query_row_cache_stale_sweep_time_sec);
 DECLARE_mInt32(disk_stat_monitor_interval);
 DECLARE_mInt32(unused_rowset_monitor_interval);
 DECLARE_String(storage_root_path);
@@ -863,6 +864,10 @@ DECLARE_mInt32(external_table_connect_timeout_sec);
 
 // Global bitmap cache capacity for aggregation cache, size in bytes
 DECLARE_Int64(delete_bitmap_agg_cache_capacity);
+DECLARE_mInt32(delete_bitmap_agg_cache_stale_sweep_time_sec);
+
+// A common object cache depends on an Sharded LRU Cache.
+DECLARE_mInt32(common_obj_lru_cache_stale_sweep_time_sec);
 
 // s3 config
 DECLARE_mInt32(max_remote_storage_count);

--- a/be/src/olap/lru_cache.cpp
+++ b/be/src/olap/lru_cache.cpp
@@ -529,9 +529,11 @@ ShardedLRUCache::ShardedLRUCache(const std::string& name, size_t total_capacity,
     CHECK(num_shards > 0) << "num_shards cannot be 0";
     CHECK_EQ((num_shards & (num_shards - 1)), 0)
             << "num_shards should be power of two, but got " << num_shards;
-    CHECK(total_capacity >= _num_shards)
-            << "lru cache capacity cannot be 0. total_capacity: " << total_capacity
-            << ", _num_shards: " << _num_shards;
+    if (total_capacity < _num_shards) {
+        LOG(INFO) << name
+                  << " lru cache capacity less than _num_shards. capacity: " << total_capacity
+                  << ", num_shards: " << _num_shards;
+    }
 
     const size_t per_shard = (total_capacity + (_num_shards - 1)) / _num_shards;
     const size_t per_shard_element_count_capacity =

--- a/be/src/olap/lru_cache.cpp
+++ b/be/src/olap/lru_cache.cpp
@@ -529,6 +529,9 @@ ShardedLRUCache::ShardedLRUCache(const std::string& name, size_t total_capacity,
     CHECK(num_shards > 0) << "num_shards cannot be 0";
     CHECK_EQ((num_shards & (num_shards - 1)), 0)
             << "num_shards should be power of two, but got " << num_shards;
+    CHECK(total_capacity >= _num_shards)
+            << "lru cache capacity cannot be 0. total_capacity: " << total_capacity
+            << ", _num_shards: " << _num_shards;
 
     const size_t per_shard = (total_capacity + (_num_shards - 1)) / _num_shards;
     const size_t per_shard_element_count_capacity =

--- a/be/src/olap/lru_cache.cpp
+++ b/be/src/olap/lru_cache.cpp
@@ -531,11 +531,6 @@ ShardedLRUCache::ShardedLRUCache(const std::string& name, size_t total_capacity,
     CHECK(num_shards > 0) << "num_shards cannot be 0";
     CHECK_EQ((num_shards & (num_shards - 1)), 0)
             << "num_shards should be power of two, but got " << num_shards;
-    if (total_capacity < _num_shards) {
-        LOG(INFO) << name
-                  << " lru cache capacity less than _num_shards. capacity: " << total_capacity
-                  << ", num_shards: " << _num_shards;
-    }
 
     const size_t per_shard = (total_capacity + (_num_shards - 1)) / _num_shards;
     const size_t per_shard_element_count_capacity =

--- a/be/src/olap/page_cache.cpp
+++ b/be/src/olap/page_cache.cpp
@@ -36,24 +36,20 @@ StoragePageCache* StoragePageCache::create_global_cache(size_t capacity,
 StoragePageCache::StoragePageCache(size_t capacity, int32_t index_cache_percentage,
                                    int64_t pk_index_cache_capacity, uint32_t num_shards)
         : _index_cache_percentage(index_cache_percentage) {
-    if (capacity >= num_shards * 2) { // data page cache + index page cache
-        if (index_cache_percentage == 0) {
-            _data_page_cache = std::make_unique<DataPageCache>(capacity, num_shards);
-        } else if (index_cache_percentage == 100) {
-            _index_page_cache = std::make_unique<IndexPageCache>(capacity, num_shards);
-        } else if (index_cache_percentage > 0 && index_cache_percentage < 100) {
-            _data_page_cache = std::make_unique<DataPageCache>(
-                    capacity * (100 - index_cache_percentage) / 100, num_shards);
-            _index_page_cache = std::make_unique<IndexPageCache>(
-                    capacity * index_cache_percentage / 100, num_shards);
-        } else {
-            CHECK(false) << "invalid index page cache percentage";
-        }
+    if (index_cache_percentage == 0) {
+        _data_page_cache = std::make_unique<DataPageCache>(capacity, num_shards);
+    } else if (index_cache_percentage == 100) {
+        _index_page_cache = std::make_unique<IndexPageCache>(capacity, num_shards);
+    } else if (index_cache_percentage > 0 && index_cache_percentage < 100) {
+        _data_page_cache = std::make_unique<DataPageCache>(
+                capacity * (100 - index_cache_percentage) / 100, num_shards);
+        _index_page_cache = std::make_unique<IndexPageCache>(
+                capacity * index_cache_percentage / 100, num_shards);
+    } else {
+        CHECK(false) << "invalid index page cache percentage";
     }
-    if (pk_index_cache_capacity >= num_shards) {
-        _pk_index_page_cache =
-                std::make_unique<PKIndexPageCache>(pk_index_cache_capacity, num_shards);
-    }
+
+    _pk_index_page_cache = std::make_unique<PKIndexPageCache>(pk_index_cache_capacity, num_shards);
 }
 
 bool StoragePageCache::lookup(const CacheKey& key, PageCacheHandle* handle,

--- a/be/src/olap/page_cache.cpp
+++ b/be/src/olap/page_cache.cpp
@@ -36,19 +36,21 @@ StoragePageCache* StoragePageCache::create_global_cache(size_t capacity,
 StoragePageCache::StoragePageCache(size_t capacity, int32_t index_cache_percentage,
                                    int64_t pk_index_cache_capacity, uint32_t num_shards)
         : _index_cache_percentage(index_cache_percentage) {
-    if (index_cache_percentage == 0) {
-        _data_page_cache = std::make_unique<DataPageCache>(capacity, num_shards);
-    } else if (index_cache_percentage == 100) {
-        _index_page_cache = std::make_unique<IndexPageCache>(capacity, num_shards);
-    } else if (index_cache_percentage > 0 && index_cache_percentage < 100) {
-        _data_page_cache = std::make_unique<DataPageCache>(
-                capacity * (100 - index_cache_percentage) / 100, num_shards);
-        _index_page_cache = std::make_unique<IndexPageCache>(
-                capacity * index_cache_percentage / 100, num_shards);
-    } else {
-        CHECK(false) << "invalid index page cache percentage";
+    if (capacity >= num_shards * 2) { // data page cache + index page cache
+        if (index_cache_percentage == 0) {
+            _data_page_cache = std::make_unique<DataPageCache>(capacity, num_shards);
+        } else if (index_cache_percentage == 100) {
+            _index_page_cache = std::make_unique<IndexPageCache>(capacity, num_shards);
+        } else if (index_cache_percentage > 0 && index_cache_percentage < 100) {
+            _data_page_cache = std::make_unique<DataPageCache>(
+                    capacity * (100 - index_cache_percentage) / 100, num_shards);
+            _index_page_cache = std::make_unique<IndexPageCache>(
+                    capacity * index_cache_percentage / 100, num_shards);
+        } else {
+            CHECK(false) << "invalid index page cache percentage";
+        }
     }
-    if (pk_index_cache_capacity > 0) {
+    if (pk_index_cache_capacity >= num_shards) {
         _pk_index_page_cache =
                 std::make_unique<PKIndexPageCache>(pk_index_cache_capacity, num_shards);
     }

--- a/be/src/olap/page_cache.h
+++ b/be/src/olap/page_cache.h
@@ -177,20 +177,20 @@ private:
     Cache* _get_page_cache(segment_v2::PageTypePB page_type) {
         switch (page_type) {
         case segment_v2::DATA_PAGE: {
-            if (_data_page_cache) {
-                return _data_page_cache->get();
+            if (_data_page_cache->is_init()) {
+                return _data_page_cache->cache();
             }
             return nullptr;
         }
         case segment_v2::INDEX_PAGE: {
-            if (_index_page_cache) {
-                return _index_page_cache->get();
+            if (_index_page_cache->is_init()) {
+                return _index_page_cache->cache();
             }
             return nullptr;
         }
         case segment_v2::PRIMARY_KEY_INDEX_PAGE: {
-            if (_pk_index_page_cache) {
-                return _pk_index_page_cache->get();
+            if (_pk_index_page_cache->is_init()) {
+                return _pk_index_page_cache->cache();
             }
             return nullptr;
         }

--- a/be/src/olap/page_cache.h
+++ b/be/src/olap/page_cache.h
@@ -157,12 +157,6 @@ public:
     void insert(const CacheKey& key, DataPage* data, PageCacheHandle* handle,
                 segment_v2::PageTypePB page_type, bool in_memory = false);
 
-    // Page cache available check.
-    // When percentage is set to 0 or 100, the index or data cache will not be allocated.
-    bool is_cache_available(segment_v2::PageTypePB page_type) {
-        return _get_page_cache(page_type) != nullptr;
-    }
-
 private:
     StoragePageCache();
 
@@ -177,26 +171,19 @@ private:
     Cache* _get_page_cache(segment_v2::PageTypePB page_type) {
         switch (page_type) {
         case segment_v2::DATA_PAGE: {
-            if (_data_page_cache->is_init()) {
-                return _data_page_cache->cache();
-            }
-            return nullptr;
+            return _data_page_cache->cache();
         }
         case segment_v2::INDEX_PAGE: {
-            if (_index_page_cache->is_init()) {
-                return _index_page_cache->cache();
-            }
-            return nullptr;
+            return _index_page_cache->cache();
         }
         case segment_v2::PRIMARY_KEY_INDEX_PAGE: {
-            if (_pk_index_page_cache->is_init()) {
-                return _pk_index_page_cache->cache();
-            }
-            return nullptr;
+            return _pk_index_page_cache->cache();
         }
         default:
-            return nullptr;
+            LOG(FATAL) << "get error type page cache";
         }
+        LOG(FATAL) << "__builtin_unreachable";
+        __builtin_unreachable();
     }
 };
 

--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
@@ -287,7 +287,6 @@ Status InvertedIndexSearcherCache::erase(const std::string& index_file_path) {
 
 int64_t InvertedIndexSearcherCache::mem_consumption() {
     return cache()->mem_consumption();
-    ;
 }
 
 bool InvertedIndexSearcherCache::_lookup(const InvertedIndexSearcherCache::CacheKey& key,

--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
@@ -113,13 +113,10 @@ InvertedIndexSearcherCache::InvertedIndexSearcherCache(size_t capacity, uint32_t
             auto* cache_value = (InvertedIndexSearcherCache::CacheValue*)value;
             return cache_value->last_visit_time;
         };
-        _cache = std::unique_ptr<Cache>(
-                new ShardedLRUCache("InvertedIndexSearcherCache", capacity, LRUCacheType::SIZE,
-                                    num_shards, get_last_visit_time, true, open_searcher_limit));
+        init(capacity, LRUCacheType::SIZE, num_shards, get_last_visit_time, true,
+             open_searcher_limit);
     } else {
-        _cache = std::unique_ptr<Cache>(new ShardedLRUCache("InvertedIndexSearcherCache", capacity,
-                                                            LRUCacheType::SIZE, num_shards,
-                                                            open_searcher_limit));
+        init(capacity, LRUCacheType::SIZE, num_shards, open_searcher_limit);
     }
 }
 

--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.h
@@ -113,12 +113,6 @@ public:
     static InvertedIndexSearcherCache* create_global_instance(size_t capacity,
                                                               uint32_t num_shards = 16);
 
-    void reset() {
-        _cache.reset();
-        _mem_tracker.reset();
-        // Reset or clear the state of the object.
-    }
-
     // Return global instance.
     // Client should call create_global_cache before.
     static InvertedIndexSearcherCache* instance() {
@@ -153,9 +147,6 @@ private:
     // And the cache entry will be returned in handle.
     // This function is thread-safe.
     Cache::Handle* _insert(const InvertedIndexSearcherCache::CacheKey& key, CacheValue* value);
-
-private:
-    std::unique_ptr<MemTracker> _mem_tracker;
 };
 
 using IndexCacheValuePtr = std::unique_ptr<InvertedIndexSearcherCache::CacheValue>;

--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.h
@@ -133,6 +133,8 @@ public:
     // function `erase` called after compaction remove segment
     Status erase(const std::string& index_file_path);
 
+    void release(Cache::Handle* handle) { _policy->cache()->release(handle); }
+
     int64_t mem_consumption();
 
 private:

--- a/be/src/olap/rowset/segment_v2/page_io.cpp
+++ b/be/src/olap/rowset/segment_v2/page_io.cpp
@@ -120,7 +120,7 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
     PageCacheHandle cache_handle;
     StoragePageCache::CacheKey cache_key(opts.file_reader->path().native(),
                                          opts.file_reader->size(), opts.page_pointer.offset);
-    if (opts.use_page_cache && cache->lookup(cache_key, &cache_handle, opts.type)) {
+    if (opts.use_page_cache && cache && cache->lookup(cache_key, &cache_handle, opts.type)) {
         // we find page in cache, use it
         *handle = PageHandle(std::move(cache_handle));
         opts.stats->cached_pages_num++;
@@ -217,7 +217,7 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
 
     *body = Slice(page_slice.data, page_slice.size - 4 - footer_size);
     page->reset_size(page_slice.size);
-    if (opts.use_page_cache) {
+    if (opts.use_page_cache && cache) {
         // insert this page into cache and return the cache handle
         cache->insert(cache_key, page.get(), &cache_handle, opts.type, opts.kept_in_memory);
         *handle = PageHandle(std::move(cache_handle));

--- a/be/src/olap/rowset/segment_v2/page_io.cpp
+++ b/be/src/olap/rowset/segment_v2/page_io.cpp
@@ -120,8 +120,7 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
     PageCacheHandle cache_handle;
     StoragePageCache::CacheKey cache_key(opts.file_reader->path().native(),
                                          opts.file_reader->size(), opts.page_pointer.offset);
-    if (opts.use_page_cache && cache->is_cache_available(opts.type) &&
-        cache->lookup(cache_key, &cache_handle, opts.type)) {
+    if (opts.use_page_cache && cache->lookup(cache_key, &cache_handle, opts.type)) {
         // we find page in cache, use it
         *handle = PageHandle(std::move(cache_handle));
         opts.stats->cached_pages_num++;
@@ -218,7 +217,7 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
 
     *body = Slice(page_slice.data, page_slice.size - 4 - footer_size);
     page->reset_size(page_slice.size);
-    if (opts.use_page_cache && cache->is_cache_available(opts.type)) {
+    if (opts.use_page_cache) {
         // insert this page into cache and return the cache handle
         cache->insert(cache_key, page.get(), &cache_handle, opts.type, opts.kept_in_memory);
         *handle = PageHandle(std::move(cache_handle));

--- a/be/src/olap/schema_cache.h
+++ b/be/src/olap/schema_cache.h
@@ -65,10 +65,10 @@ public:
         if (!instance() || schema_key.empty()) {
             return {};
         }
-        auto lru_handle = _cache->lookup(schema_key);
+        auto lru_handle = cache()->lookup(schema_key);
         if (lru_handle) {
-            Defer release([cache = _cache.get(), lru_handle] { cache->release(lru_handle); });
-            auto value = (CacheValue*)_cache->value(lru_handle);
+            Defer release([cache = cache(), lru_handle] { cache->release(lru_handle); });
+            auto value = (CacheValue*)cache()->value(lru_handle);
             value->last_visit_time = UnixMillis();
             VLOG_DEBUG << "use cache schema";
             if constexpr (std::is_same_v<SchemaType, TabletSchemaSPtr>) {
@@ -101,8 +101,8 @@ public:
             delete cache_value;
         };
         auto lru_handle =
-                _cache->insert(key, value, 1, deleter, CachePriority::NORMAL, schema->mem_size());
-        _cache->release(lru_handle);
+                cache()->insert(key, value, 1, deleter, CachePriority::NORMAL, schema->mem_size());
+        cache()->release(lru_handle);
     }
 
     // Try to prune the cache if expired.

--- a/be/src/olap/segment_loader.cpp
+++ b/be/src/olap/segment_loader.cpp
@@ -29,11 +29,11 @@ SegmentLoader* SegmentLoader::instance() {
 }
 
 bool SegmentCache::lookup(const SegmentCache::CacheKey& key, SegmentCacheHandle* handle) {
-    auto lru_handle = _cache->lookup(key.encode());
+    auto lru_handle = cache()->lookup(key.encode());
     if (lru_handle == nullptr) {
         return false;
     }
-    handle->push_segment(_cache.get(), lru_handle);
+    handle->push_segment(cache(), lru_handle);
     return true;
 }
 
@@ -45,13 +45,13 @@ void SegmentCache::insert(const SegmentCache::CacheKey& key, SegmentCache::Cache
         delete cache_value;
     };
 
-    auto lru_handle = _cache->insert(key.encode(), &value, 1, deleter, CachePriority::NORMAL,
-                                     value.segment->meta_mem_usage());
-    handle->push_segment(_cache.get(), lru_handle);
+    auto lru_handle = cache()->insert(key.encode(), &value, 1, deleter, CachePriority::NORMAL,
+                                      value.segment->meta_mem_usage());
+    handle->push_segment(cache(), lru_handle);
 }
 
 void SegmentCache::erase(const SegmentCache::CacheKey& key) {
-    _cache->erase(key.encode());
+    cache()->erase(key.encode());
 }
 
 Status SegmentLoader::load_segments(const BetaRowsetSharedPtr& rowset,

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -1074,7 +1074,7 @@ std::shared_ptr<roaring::Roaring> DeleteBitmap::get_agg(const BitmapKey& bmk) co
             &val->bitmap, [this, handle](...) { _agg_cache->repr()->release(handle); });
 }
 
-std::atomic<ShardedLRUCache*> DeleteBitmap::AggCache::s_repr {nullptr};
+std::atomic<DeleteBitmap::AggCachePolicy*> DeleteBitmap::AggCache::s_repr {nullptr};
 
 std::string tablet_state_name(TabletState state) {
     switch (state) {

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -495,7 +495,7 @@ public:
             }
         }
 
-        static Cache* repr() { return s_repr.load(std::memory_order_acquire)->get(); }
+        static Cache* repr() { return s_repr.load(std::memory_order_acquire)->cache(); }
         static std::atomic<AggCachePolicy*> s_repr;
     };
 

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -46,6 +46,7 @@
 #include "olap/olap_common.h"
 #include "olap/rowset/rowset_meta.h"
 #include "olap/tablet_schema.h"
+#include "runtime/memory/lru_cache_policy.h"
 #include "util/uid_util.h"
 
 namespace json2pb {
@@ -469,6 +470,14 @@ public:
      */
     std::shared_ptr<roaring::Roaring> get_agg(const BitmapKey& bmk) const;
 
+    class AggCachePolicy : public LRUCachePolicy {
+    public:
+        AggCachePolicy(size_t capacity)
+                : LRUCachePolicy(CachePolicy::CacheType::DELETE_BITMAP_AGG_CACHE, capacity,
+                                 LRUCacheType::SIZE,
+                                 config::delete_bitmap_agg_cache_stale_sweep_time_sec, 256) {}
+    };
+
     class AggCache {
     public:
         struct Value {
@@ -478,8 +487,7 @@ public:
         AggCache(size_t size_in_bytes) {
             static std::once_flag once;
             std::call_once(once, [size_in_bytes] {
-                auto tmp = new ShardedLRUCache("DeleteBitmap AggCache", size_in_bytes,
-                                               LRUCacheType::SIZE, 256);
+                auto* tmp = new AggCachePolicy(size_in_bytes);
                 AggCache::s_repr.store(tmp, std::memory_order_release);
             });
 
@@ -487,8 +495,8 @@ public:
             }
         }
 
-        static ShardedLRUCache* repr() { return s_repr.load(std::memory_order_acquire); }
-        static std::atomic<ShardedLRUCache*> s_repr;
+        static Cache* repr() { return s_repr.load(std::memory_order_acquire)->get(); }
+        static std::atomic<AggCachePolicy*> s_repr;
     };
 
 private:

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -888,12 +888,12 @@ int64_t TxnManager::get_txn_by_tablet_version(int64_t tablet_id, int64_t version
     memcpy(key + sizeof(int64_t), &version, sizeof(int64_t));
     CacheKey cache_key((const char*)&key, sizeof(key));
 
-    auto handle = _tablet_version_cache->get()->lookup(cache_key);
+    auto* handle = _tablet_version_cache->cache()->lookup(cache_key);
     if (handle == nullptr) {
         return -1;
     }
-    int64_t res = *(int64_t*)_tablet_version_cache->get()->value(handle);
-    _tablet_version_cache->get()->release(handle);
+    int64_t res = *(int64_t*)_tablet_version_cache->cache()->value(handle);
+    _tablet_version_cache->cache()->release(handle);
     return res;
 }
 
@@ -910,9 +910,9 @@ void TxnManager::update_tablet_version_txn(int64_t tablet_id, int64_t version, i
         delete cache_value;
     };
 
-    auto handle = _tablet_version_cache->get()->insert(cache_key, value, 1, deleter,
-                                                       CachePriority::NORMAL, sizeof(txn_id));
-    _tablet_version_cache->get()->release(handle);
+    auto* handle = _tablet_version_cache->cache()->insert(cache_key, value, 1, deleter,
+                                                          CachePriority::NORMAL, sizeof(txn_id));
+    _tablet_version_cache->cache()->release(handle);
 }
 
 TxnState TxnManager::get_txn_state(TPartitionId partition_id, TTransactionId transaction_id,

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -225,7 +225,8 @@ private:
     public:
         TabletVersionCache(size_t capacity)
                 : LRUCachePolicy(CachePolicy::CacheType::TABLET_VERSION_CACHE, capacity,
-                                 LRUCacheType::NUMBER, -1, DEFAULT_LRU_CACHE_NUM_SHARDS, false) {}
+                                 LRUCacheType::NUMBER, -1, DEFAULT_LRU_CACHE_NUM_SHARDS,
+                                 DEFAULT_LRU_CACHE_ELEMENT_COUNT_CAPACITY, false) {}
     };
 
 private:

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -44,6 +44,7 @@
 #include "olap/rowset/segment_v2/segment_writer.h"
 #include "olap/tablet.h"
 #include "olap/tablet_meta.h"
+#include "runtime/memory/lru_cache_policy.h"
 #include "util/time.h"
 #include "vec/core/block.h"
 
@@ -220,6 +221,13 @@ private:
     void _insert_txn_partition_map_unlocked(int64_t transaction_id, int64_t partition_id);
     void _clear_txn_partition_map_unlocked(int64_t transaction_id, int64_t partition_id);
 
+    class TabletVersionCache : public LRUCachePolicy {
+    public:
+        TabletVersionCache(size_t capacity)
+                : LRUCachePolicy(CachePolicy::CacheType::TABLET_VERSION_CACHE, capacity,
+                                 LRUCacheType::NUMBER, -1, DEFAULT_LRU_CACHE_NUM_SHARDS, false) {}
+    };
+
 private:
     const int32_t _txn_map_shard_size;
 
@@ -238,7 +246,7 @@ private:
     std::shared_mutex* _txn_mutex = nullptr;
 
     txn_tablet_delta_writer_map_t* _txn_tablet_delta_writer_map = nullptr;
-    std::unique_ptr<Cache> _tablet_version_cache;
+    std::unique_ptr<TabletVersionCache> _tablet_version_cache;
     std::shared_mutex* _txn_tablet_delta_writer_map_locks = nullptr;
     DISALLOW_COPY_AND_ASSIGN(TxnManager);
 }; // TxnManager

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -262,7 +262,7 @@ public:
     segment_v2::InvertedIndexQueryCache* get_inverted_index_query_cache() {
         return _inverted_index_query_cache;
     }
-    DummyLRUCache* get_dummy_lru_cache() { return _dummy_lru_cache; }
+    std::shared_ptr<DummyLRUCache> get_dummy_lru_cache() { return _dummy_lru_cache; }
 
     std::shared_ptr<doris::pipeline::BlockedTaskScheduler> get_global_block_scheduler() {
         return _global_block_scheduler;
@@ -373,7 +373,7 @@ private:
     CacheManager* _cache_manager = nullptr;
     segment_v2::InvertedIndexSearcherCache* _inverted_index_searcher_cache = nullptr;
     segment_v2::InvertedIndexQueryCache* _inverted_index_query_cache = nullptr;
-    DummyLRUCache* _dummy_lru_cache = nullptr;
+    std::shared_ptr<DummyLRUCache> _dummy_lru_cache = nullptr;
 
     // used for query with group cpu hard limit
     std::shared_ptr<doris::pipeline::BlockedTaskScheduler> _global_block_scheduler;

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -102,6 +102,7 @@ class StoragePageCache;
 class SegmentLoader;
 class LookupConnectionCache;
 class RowCache;
+class DummyLRUCache;
 class CacheManager;
 class WalManager;
 
@@ -261,6 +262,7 @@ public:
     segment_v2::InvertedIndexQueryCache* get_inverted_index_query_cache() {
         return _inverted_index_query_cache;
     }
+    DummyLRUCache* get_dummy_lru_cache() { return _dummy_lru_cache; }
 
     std::shared_ptr<doris::pipeline::BlockedTaskScheduler> get_global_block_scheduler() {
         return _global_block_scheduler;
@@ -371,6 +373,7 @@ private:
     CacheManager* _cache_manager = nullptr;
     segment_v2::InvertedIndexSearcherCache* _inverted_index_searcher_cache = nullptr;
     segment_v2::InvertedIndexQueryCache* _inverted_index_query_cache = nullptr;
+    DummyLRUCache* _dummy_lru_cache = nullptr;
 
     // used for query with group cpu hard limit
     std::shared_ptr<doris::pipeline::BlockedTaskScheduler> _global_block_scheduler;

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -233,6 +233,9 @@ public:
         this->_routine_load_task_executor = r;
     }
     void set_wal_mgr(std::shared_ptr<WalManager> wm) { this->_wal_manager = wm; }
+    void set_dummy_lru_cache(std::shared_ptr<DummyLRUCache> dummy_lru_cache) {
+        this->_dummy_lru_cache = dummy_lru_cache;
+    }
 
 #endif
     stream_load::LoadStreamStubPool* load_stream_stub_pool() {

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -216,7 +216,6 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths,
     _small_file_mgr = new SmallFileMgr(this, config::small_file_dir);
     _block_spill_mgr = new BlockSpillManager(store_paths);
     _group_commit_mgr = new GroupCommitMgr(this);
-    _file_meta_cache = new FileMetaCache(config::max_external_file_meta_cache_num);
     _memtable_memory_limiter = std::make_unique<MemTableMemoryLimiter>();
     _load_stream_stub_pool = std::make_unique<stream_load::LoadStreamStubPool>();
     _delta_writer_v2_pool = std::make_unique<vectorized::DeltaWriterV2Pool>();
@@ -371,13 +370,11 @@ Status ExecEnv::_init_mem_env() {
     init_hook();
 #endif
 
-    // 2. init buffer pool
     if (!BitUtil::IsPowerOf2(config::min_buffer_size)) {
         ss << "Config min_buffer_size must be a power-of-two: " << config::min_buffer_size;
         return Status::InternalError(ss.str());
     }
 
-    // 3. init storage page cache
     _cache_manager = CacheManager::create_global_instance();
 
     int64_t storage_cache_limit =
@@ -395,6 +392,12 @@ Status ExecEnv::_init_mem_env() {
                      << ". Rounded up to " << num_shards
                      << ". Please modify the 'storage_page_cache_shard_size' parameter in your "
                         "conf file to be a power of two for better performance.";
+    }
+    if (storage_cache_limit < num_shards * 2) {
+        LOG(WARNING) << "storage_cache_limit(" << storage_cache_limit << ") less than num_shards("
+                     << num_shards
+                     << ") * 2, cache capacity will be 0, continuing to use "
+                        "cache will only have negative effects, will be disabled.";
     }
     int64_t pk_storage_page_cache_limit =
             ParseUtil::parse_mem_spec(config::pk_storage_page_cache_limit, MemInfo::mem_limit(),
@@ -442,6 +445,8 @@ Status ExecEnv::_init_mem_env() {
 
     _schema_cache = new SchemaCache(config::schema_cache_capacity);
 
+    _file_meta_cache = new FileMetaCache(config::max_external_file_meta_cache_num);
+
     _lookup_connection_cache = LookupConnectionCache::create_global_instance(
             config::lookup_connection_cache_bytes_limit);
 
@@ -473,7 +478,6 @@ Status ExecEnv::_init_mem_env() {
               << PrettyPrinter::print(inverted_index_cache_limit, TUnit::BYTES)
               << ", origin config value: " << config::inverted_index_query_cache_limit;
 
-    // 4. init other managers
     RETURN_IF_ERROR(_block_spill_mgr->init());
     return Status::OK();
 }

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -375,6 +375,8 @@ Status ExecEnv::_init_mem_env() {
         return Status::InternalError(ss.str());
     }
 
+    _dummy_lru_cache = new DummyLRUCache();
+
     _cache_manager = CacheManager::create_global_instance();
 
     int64_t storage_cache_limit =

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -375,7 +375,7 @@ Status ExecEnv::_init_mem_env() {
         return Status::InternalError(ss.str());
     }
 
-    _dummy_lru_cache = new DummyLRUCache();
+    _dummy_lru_cache = std::make_shared<DummyLRUCache>();
 
     _cache_manager = CacheManager::create_global_instance();
 

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -123,10 +123,10 @@ Status LoadChannelMgr::_get_load_channel(std::shared_ptr<LoadChannel>& channel, 
     std::lock_guard<std::mutex> l(_lock);
     auto it = _load_channels.find(load_id);
     if (it == _load_channels.end()) {
-        auto handle = _last_success_channels->get()->lookup(load_id.to_string());
+        auto handle = _last_success_channels->cache()->lookup(load_id.to_string());
         // success only when eos be true
         if (handle != nullptr) {
-            _last_success_channels->get()->release(handle);
+            _last_success_channels->cache()->release(handle);
             if (request.has_eos() && request.eos()) {
                 is_eof = true;
                 return Status::OK();
@@ -182,9 +182,9 @@ void LoadChannelMgr::_finish_load_channel(const UniqueId load_id) {
         if (_load_channels.find(load_id) != _load_channels.end()) {
             _load_channels.erase(load_id);
         }
-        auto handle = _last_success_channels->get()->insert(load_id.to_string(), nullptr, 1,
-                                                            dummy_deleter);
-        _last_success_channels->get()->release(handle);
+        auto handle = _last_success_channels->cache()->insert(load_id.to_string(), nullptr, 1,
+                                                              dummy_deleter);
+        _last_success_channels->cache()->release(handle);
     }
     VLOG_CRITICAL << "removed load channel " << load_id;
 }

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -82,8 +82,7 @@ void LoadChannelMgr::stop() {
 }
 
 Status LoadChannelMgr::init(int64_t process_mem_limit) {
-    _last_success_channel =
-            std::unique_ptr<Cache>(new ShardedLRUCache("LastSuccessChannelCache", 1024));
+    _last_success_channels = std::make_unique<LastSuccessChannelCache>(1024);
     RETURN_IF_ERROR(_start_bg_worker());
     return Status::OK();
 }
@@ -124,10 +123,10 @@ Status LoadChannelMgr::_get_load_channel(std::shared_ptr<LoadChannel>& channel, 
     std::lock_guard<std::mutex> l(_lock);
     auto it = _load_channels.find(load_id);
     if (it == _load_channels.end()) {
-        auto handle = _last_success_channel->lookup(load_id.to_string());
+        auto handle = _last_success_channels->get()->lookup(load_id.to_string());
         // success only when eos be true
         if (handle != nullptr) {
-            _last_success_channel->release(handle);
+            _last_success_channels->get()->release(handle);
             if (request.has_eos() && request.eos()) {
                 is_eof = true;
                 return Status::OK();
@@ -183,8 +182,9 @@ void LoadChannelMgr::_finish_load_channel(const UniqueId load_id) {
         if (_load_channels.find(load_id) != _load_channels.end()) {
             _load_channels.erase(load_id);
         }
-        auto handle = _last_success_channel->insert(load_id.to_string(), nullptr, 1, dummy_deleter);
-        _last_success_channel->release(handle);
+        auto handle = _last_success_channels->get()->insert(load_id.to_string(), nullptr, 1,
+                                                            dummy_deleter);
+        _last_success_channels->get()->release(handle);
     }
     VLOG_CRITICAL << "removed load channel " << load_id;
 }

--- a/be/src/runtime/load_channel_mgr.h
+++ b/be/src/runtime/load_channel_mgr.h
@@ -33,6 +33,7 @@
 #include "olap/lru_cache.h"
 #include "olap/memtable_memory_limiter.h"
 #include "runtime/load_channel.h"
+#include "runtime/memory/lru_cache_policy.h"
 #include "runtime/memory/mem_tracker_limiter.h"
 #include "runtime/thread_context.h"
 #include "util/countdown_latch.h"
@@ -71,12 +72,19 @@ private:
 
     Status _start_bg_worker();
 
+    class LastSuccessChannelCache : public LRUCachePolicy {
+    public:
+        LastSuccessChannelCache(size_t capacity)
+                : LRUCachePolicy(CachePolicy::CacheType::LAST_SUCCESS_CHANNEL_CACHE, capacity,
+                                 LRUCacheType::SIZE, -1, DEFAULT_LRU_CACHE_NUM_SHARDS, false) {}
+    };
+
 protected:
     // lock protect the load channel map
     std::mutex _lock;
     // load id -> load channel
     std::unordered_map<UniqueId, std::shared_ptr<LoadChannel>> _load_channels;
-    std::unique_ptr<Cache> _last_success_channel;
+    std::unique_ptr<LastSuccessChannelCache> _last_success_channels;
 
     MemTableMemoryLimiter* _memtable_memory_limiter = nullptr;
 

--- a/be/src/runtime/load_channel_mgr.h
+++ b/be/src/runtime/load_channel_mgr.h
@@ -76,7 +76,8 @@ private:
     public:
         LastSuccessChannelCache(size_t capacity)
                 : LRUCachePolicy(CachePolicy::CacheType::LAST_SUCCESS_CHANNEL_CACHE, capacity,
-                                 LRUCacheType::SIZE, -1, DEFAULT_LRU_CACHE_NUM_SHARDS, false) {}
+                                 LRUCacheType::SIZE, -1, DEFAULT_LRU_CACHE_NUM_SHARDS,
+                                 DEFAULT_LRU_CACHE_ELEMENT_COUNT_CAPACITY, false) {}
     };
 
 protected:

--- a/be/src/runtime/memory/cache_manager.cpp
+++ b/be/src/runtime/memory/cache_manager.cpp
@@ -27,6 +27,9 @@ int64_t CacheManager::for_each_cache_prune_stale_wrap(
     int64_t freed_size = 0;
     std::lock_guard<std::mutex> l(_caches_lock);
     for (auto cache_policy : _caches) {
+        if (!cache_policy->enable_prune()) {
+            continue;
+        }
         func(cache_policy);
         freed_size += cache_policy->profile()->get_counter("FreedMemory")->value();
         if (cache_policy->profile()->get_counter("FreedMemory")->value() != 0 && profile) {

--- a/be/src/runtime/memory/cache_policy.cpp
+++ b/be/src/runtime/memory/cache_policy.cpp
@@ -21,8 +21,8 @@
 
 namespace doris {
 
-CachePolicy::CachePolicy(CacheType type, uint32_t stale_sweep_time_s)
-        : _type(type), _stale_sweep_time_s(stale_sweep_time_s) {
+CachePolicy::CachePolicy(CacheType type, uint32_t stale_sweep_time_s, bool enable_prune)
+        : _type(type), _stale_sweep_time_s(stale_sweep_time_s), _enable_prune(enable_prune) {
     _it = CacheManager::instance()->register_cache(this);
     init_profile();
 }

--- a/be/src/runtime/memory/cache_policy.h
+++ b/be/src/runtime/memory/cache_policy.h
@@ -34,7 +34,12 @@ public:
         SEGMENT_CACHE = 4,
         INVERTEDINDEX_SEARCHER_CACHE = 5,
         INVERTEDINDEX_QUERY_CACHE = 6,
-        LOOKUP_CONNECTION_CACHE = 7
+        LOOKUP_CONNECTION_CACHE = 7,
+        POINT_QUERY_ROW_CACHE = 8,
+        DELETE_BITMAP_AGG_CACHE = 9,
+        TABLET_VERSION_CACHE = 10,
+        LAST_SUCCESS_CHANNEL_CACHE = 11,
+        COMMON_OBJ_LRU_CACHE = 12
     };
 
     static std::string type_string(CacheType type) {
@@ -54,7 +59,17 @@ public:
         case CacheType::INVERTEDINDEX_QUERY_CACHE:
             return "InvertedIndexQueryCache";
         case CacheType::LOOKUP_CONNECTION_CACHE:
-            return "LookupConnectionCache";
+            return "PointQueryLookupConnectionCache";
+        case CacheType::POINT_QUERY_ROW_CACHE:
+            return "PointQueryRowCache";
+        case CacheType::DELETE_BITMAP_AGG_CACHE:
+            return "MowDeleteBitmapAggCache";
+        case CacheType::TABLET_VERSION_CACHE:
+            return "MowTabletVersionCache";
+        case CacheType::LAST_SUCCESS_CHANNEL_CACHE:
+            return "LastSuccessChannelCache";
+        case CacheType::COMMON_OBJ_LRU_CACHE:
+            return "CommonObjLRUCache";
         default:
             LOG(FATAL) << "not match type of cache policy :" << static_cast<int>(type);
         }
@@ -62,13 +77,14 @@ public:
         __builtin_unreachable();
     }
 
-    CachePolicy(CacheType type, uint32_t stale_sweep_time_s);
+    CachePolicy(CacheType type, uint32_t stale_sweep_time_s, bool enable_prune);
     virtual ~CachePolicy();
 
     virtual void prune_stale() = 0;
     virtual void prune_all(bool clear) = 0;
 
     CacheType type() { return _type; }
+    bool enable_prune() const { return _enable_prune; }
     RuntimeProfile* profile() { return _profile.get(); }
 
 protected:
@@ -94,6 +110,7 @@ protected:
     RuntimeProfile::Counter* _cost_timer = nullptr;
 
     uint32_t _stale_sweep_time_s;
+    bool _enable_prune = true;
 };
 
 } // namespace doris

--- a/be/src/runtime/memory/cache_policy.h
+++ b/be/src/runtime/memory/cache_policy.h
@@ -39,7 +39,8 @@ public:
         DELETE_BITMAP_AGG_CACHE = 9,
         TABLET_VERSION_CACHE = 10,
         LAST_SUCCESS_CHANNEL_CACHE = 11,
-        COMMON_OBJ_LRU_CACHE = 12
+        COMMON_OBJ_LRU_CACHE = 12,
+        FOR_UT = 13
     };
 
     static std::string type_string(CacheType type) {
@@ -70,6 +71,8 @@ public:
             return "LastSuccessChannelCache";
         case CacheType::COMMON_OBJ_LRU_CACHE:
             return "CommonObjLRUCache";
+        case CacheType::FOR_UT:
+            return "ForUT";
         default:
             LOG(FATAL) << "not match type of cache policy :" << static_cast<int>(type);
         }

--- a/be/src/runtime/memory/lru_cache_policy.h
+++ b/be/src/runtime/memory/lru_cache_policy.h
@@ -46,6 +46,7 @@ public:
                     new ShardedLRUCache(type_string(type), capacity, lru_cache_type, num_shards,
                                         element_count_capacity));
         } else {
+            CHECK(ExecEnv::GetInstance()->get_dummy_lru_cache());
             _cache = ExecEnv::GetInstance()->get_dummy_lru_cache();
         }
     }
@@ -62,6 +63,7 @@ public:
                                         cache_value_time_extractor, cache_value_check_timestamp,
                                         element_count_capacity));
         } else {
+            CHECK(ExecEnv::GetInstance()->get_dummy_lru_cache());
             _cache = ExecEnv::GetInstance()->get_dummy_lru_cache();
         }
     }

--- a/be/src/service/point_query_executor.cpp
+++ b/be/src/service/point_query_executor.cpp
@@ -111,11 +111,10 @@ LookupConnectionCache* LookupConnectionCache::create_global_instance(size_t capa
     return res;
 }
 
-RowCache::RowCache(int64_t capacity, int num_shards) {
-    // Create Row Cache
-    _cache = std::unique_ptr<Cache>(
-            new ShardedLRUCache("RowCache", capacity, LRUCacheType::SIZE, num_shards));
-}
+RowCache::RowCache(int64_t capacity, int num_shards)
+        : LRUCachePolicy(CachePolicy::CacheType::POINT_QUERY_ROW_CACHE, capacity,
+                         LRUCacheType::SIZE, config::point_query_row_cache_stale_sweep_time_sec,
+                         num_shards) {}
 
 // Create global instance of this class
 RowCache* RowCache::create_global_cache(int64_t capacity, uint32_t num_shards) {

--- a/be/src/service/point_query_executor.cpp
+++ b/be/src/service/point_query_executor.cpp
@@ -129,12 +129,12 @@ RowCache* RowCache::instance() {
 
 bool RowCache::lookup(const RowCacheKey& key, CacheHandle* handle) {
     const std::string& encoded_key = key.encode();
-    auto lru_handle = _cache->lookup(encoded_key);
+    auto lru_handle = cache()->lookup(encoded_key);
     if (!lru_handle) {
         // cache miss
         return false;
     }
-    *handle = CacheHandle(_cache.get(), lru_handle);
+    *handle = CacheHandle(cache(), lru_handle);
     return true;
 }
 
@@ -144,14 +144,14 @@ void RowCache::insert(const RowCacheKey& key, const Slice& value) {
     memcpy(cache_value, value.data, value.size);
     const std::string& encoded_key = key.encode();
     auto handle =
-            _cache->insert(encoded_key, cache_value, value.size, deleter, CachePriority::NORMAL);
+            cache()->insert(encoded_key, cache_value, value.size, deleter, CachePriority::NORMAL);
     // handle will released
-    auto tmp = CacheHandle {_cache.get(), handle};
+    auto tmp = CacheHandle {cache(), handle};
 }
 
 void RowCache::erase(const RowCacheKey& key) {
     const std::string& encoded_key = key.encode();
-    _cache->erase(encoded_key);
+    cache()->erase(encoded_key);
 }
 
 Status PointQueryExecutor::init(const PTabletKeyLookupRequest* request,

--- a/be/src/service/point_query_executor.h
+++ b/be/src/service/point_query_executor.h
@@ -222,20 +222,20 @@ private:
             delete cache_value;
         };
         LOG(INFO) << "Add item mem size " << item->mem_size()
-                  << ", cache_capacity: " << _cache->get_total_capacity()
-                  << ", cache_usage: " << _cache->get_usage()
-                  << ", mem_consum: " << _cache->mem_consumption();
+                  << ", cache_capacity: " << cache()->get_total_capacity()
+                  << ", cache_usage: " << cache()->get_usage()
+                  << ", mem_consum: " << cache()->mem_consumption();
         auto lru_handle =
-                _cache->insert(key, value, item->mem_size(), deleter, CachePriority::NORMAL);
-        _cache->release(lru_handle);
+                cache()->insert(key, value, item->mem_size(), deleter, CachePriority::NORMAL);
+        cache()->release(lru_handle);
     }
 
     std::shared_ptr<Reusable> get(__int128_t cache_id) {
         std::string key = encode_key(cache_id);
-        auto lru_handle = _cache->lookup(key);
+        auto lru_handle = cache()->lookup(key);
         if (lru_handle) {
-            Defer release([cache = _cache.get(), lru_handle] { cache->release(lru_handle); });
-            auto value = (CacheValue*)_cache->value(lru_handle);
+            Defer release([cache = cache(), lru_handle] { cache->release(lru_handle); });
+            auto value = (CacheValue*)cache()->value(lru_handle);
             value->last_visit_time = UnixMillis();
             return value->item;
         }

--- a/be/src/service/point_query_executor.h
+++ b/be/src/service/point_query_executor.h
@@ -109,7 +109,7 @@ private:
 };
 
 // RowCache is a LRU cache for row store
-class RowCache {
+class RowCache : public LRUCachePolicy {
 public:
     // The cache key for row lru cache
     struct RowCacheKey {
@@ -187,7 +187,6 @@ public:
 private:
     static constexpr uint32_t kDefaultNumShards = 128;
     RowCache(int64_t capacity, int num_shards = kDefaultNumShards);
-    std::unique_ptr<Cache> _cache;
 };
 
 // A cache used for prepare stmt.
@@ -204,7 +203,8 @@ private:
     friend class PointQueryExecutor;
     LookupConnectionCache(size_t capacity)
             : LRUCachePolicy(CachePolicy::CacheType::LOOKUP_CONNECTION_CACHE, capacity,
-                             LRUCacheType::SIZE, config::tablet_lookup_cache_clean_interval) {}
+                             LRUCacheType::SIZE, config::tablet_lookup_cache_stale_sweep_time_sec) {
+    }
 
     std::string encode_key(__int128_t cache_id) {
         fmt::memory_buffer buffer;

--- a/be/src/util/obj_lru_cache.cpp
+++ b/be/src/util/obj_lru_cache.cpp
@@ -19,11 +19,12 @@
 
 namespace doris {
 
-ObjLRUCache::ObjLRUCache(int64_t capacity, uint32_t num_shards) {
+ObjLRUCache::ObjLRUCache(int64_t capacity, uint32_t num_shards)
+        : LRUCachePolicy(CachePolicy::CacheType::COMMON_OBJ_LRU_CACHE,
+                         config::common_obj_lru_cache_stale_sweep_time_sec) {
     _enabled = (capacity > 0);
     if (_enabled) {
-        _cache = std::unique_ptr<Cache>(
-                new ShardedLRUCache("ObjLRUCache", capacity, LRUCacheType::NUMBER, num_shards));
+        init(capacity, LRUCacheType::NUMBER, num_shards);
     }
 }
 

--- a/be/src/util/obj_lru_cache.cpp
+++ b/be/src/util/obj_lru_cache.cpp
@@ -32,18 +32,18 @@ bool ObjLRUCache::lookup(const ObjKey& key, CacheHandle* handle) {
     if (!_enabled) {
         return false;
     }
-    auto lru_handle = _cache->lookup(key.key);
+    auto lru_handle = cache()->lookup(key.key);
     if (!lru_handle) {
         // cache miss
         return false;
     }
-    *handle = CacheHandle(_cache.get(), lru_handle);
+    *handle = CacheHandle(cache(), lru_handle);
     return true;
 }
 
 void ObjLRUCache::erase(const ObjKey& key) {
     if (_enabled) {
-        _cache->erase(key.key);
+        cache()->erase(key.key);
     }
 }
 

--- a/be/src/util/obj_lru_cache.cpp
+++ b/be/src/util/obj_lru_cache.cpp
@@ -20,12 +20,10 @@
 namespace doris {
 
 ObjLRUCache::ObjLRUCache(int64_t capacity, uint32_t num_shards)
-        : LRUCachePolicy(CachePolicy::CacheType::COMMON_OBJ_LRU_CACHE,
-                         config::common_obj_lru_cache_stale_sweep_time_sec) {
+        : LRUCachePolicy(CachePolicy::CacheType::COMMON_OBJ_LRU_CACHE, capacity,
+                         LRUCacheType::NUMBER, config::common_obj_lru_cache_stale_sweep_time_sec,
+                         num_shards) {
     _enabled = (capacity > 0);
-    if (_enabled) {
-        init(capacity, LRUCacheType::NUMBER, num_shards);
-    }
 }
 
 bool ObjLRUCache::lookup(const ObjKey& key, CacheHandle* handle) {

--- a/be/src/util/obj_lru_cache.h
+++ b/be/src/util/obj_lru_cache.h
@@ -18,14 +18,14 @@
 #pragma once
 
 #include "olap/lru_cache.h"
+#include "runtime/memory/lru_cache_policy.h"
 
 namespace doris {
 
 // A common object cache depends on an Sharded LRU Cache.
 // It has a certain capacity, which determin how many objects it can cache.
 // Caller must hold a CacheHandle instance when visiting the cached object.
-// TODO shouble add gc prune
-class ObjLRUCache {
+class ObjLRUCache : public LRUCachePolicy {
 public:
     struct ObjKey {
         ObjKey(const std::string& key_) : key(key_) {}
@@ -67,7 +67,7 @@ public:
         DISALLOW_COPY_AND_ASSIGN(CacheHandle);
     };
 
-    ObjLRUCache(int64_t capacity, uint32_t num_shards = kDefaultNumShards);
+    ObjLRUCache(int64_t capacity, uint32_t num_shards = DEFAULT_LRU_CACHE_NUM_SHARDS);
 
     bool lookup(const ObjKey& key, CacheHandle* handle);
 
@@ -96,8 +96,6 @@ public:
     void erase(const ObjKey& key);
 
 private:
-    static constexpr uint32_t kDefaultNumShards = 16;
-    std::unique_ptr<Cache> _cache;
     bool _enabled;
 };
 

--- a/be/src/util/obj_lru_cache.h
+++ b/be/src/util/obj_lru_cache.h
@@ -85,9 +85,9 @@ public:
                 void (*deleter)(const CacheKey& key, void* value)) {
         if (_enabled) {
             const std::string& encoded_key = key.key;
-            auto handle = _cache->insert(encoded_key, (void*)value, 1, deleter,
-                                         CachePriority::NORMAL, sizeof(T));
-            *cache_handle = CacheHandle {_cache.get(), handle};
+            auto handle = cache()->insert(encoded_key, (void*)value, 1, deleter,
+                                          CachePriority::NORMAL, sizeof(T));
+            *cache_handle = CacheHandle {cache(), handle};
         } else {
             cache_handle = nullptr;
         }

--- a/be/test/olap/lru_cache_test.cpp
+++ b/be/test/olap/lru_cache_test.cpp
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "gtest/gtest_pred_impl.h"
+#include "runtime/memory/lru_cache_policy.h"
 #include "runtime/memory/mem_tracker_limiter.h"
 #include "testutil/test_util.h"
 
@@ -72,25 +73,34 @@ public:
         _s_current->_deleted_values.push_back(DecodeValue(v));
     }
 
+    class CacheTestPolicy : public LRUCachePolicy {
+    public:
+        CacheTestPolicy(size_t capacity)
+                : LRUCachePolicy(CachePolicy::CacheType::FOR_UT, capacity, LRUCacheType::SIZE, -1) {
+        }
+    };
+
     // there is 16 shards in ShardedLRUCache
     // And the LRUHandle size is about 100B. So the cache size should big enough
     // to run the UT.
     static const int kCacheSize = 1000 * 16;
     std::vector<int> _deleted_keys;
     std::vector<int> _deleted_values;
-    Cache* _cache;
+    CacheTestPolicy* _cache;
 
-    CacheTest() : _cache(new ShardedLRUCache("test", kCacheSize)) { _s_current = this; }
+    CacheTest() : _cache(new CacheTestPolicy(kCacheSize)) { _s_current = this; }
 
     ~CacheTest() { delete _cache; }
 
+    Cache* cache() { return _cache->get(); }
+
     int Lookup(int key) {
         std::string result;
-        Cache::Handle* handle = _cache->lookup(EncodeKey(&result, key));
-        const int r = (handle == nullptr) ? -1 : DecodeValue(_cache->value(handle));
+        Cache::Handle* handle = cache()->lookup(EncodeKey(&result, key));
+        const int r = (handle == nullptr) ? -1 : DecodeValue(cache()->value(handle));
 
         if (handle != nullptr) {
-            _cache->release(handle);
+            cache()->release(handle);
         }
 
         return r;
@@ -98,19 +108,19 @@ public:
 
     void Insert(int key, int value, int charge) {
         std::string result;
-        _cache->release(_cache->insert(EncodeKey(&result, key), EncodeValue(value), charge,
-                                       &CacheTest::Deleter));
+        cache()->release(cache()->insert(EncodeKey(&result, key), EncodeValue(value), charge,
+                                         &CacheTest::Deleter));
     }
 
     void InsertDurable(int key, int value, int charge) {
         std::string result;
-        _cache->release(_cache->insert(EncodeKey(&result, key), EncodeValue(value), charge,
-                                       &CacheTest::Deleter, CachePriority::DURABLE));
+        cache()->release(cache()->insert(EncodeKey(&result, key), EncodeValue(value), charge,
+                                         &CacheTest::Deleter, CachePriority::DURABLE));
     }
 
     void Erase(int key) {
         std::string result;
-        _cache->erase(EncodeKey(&result, key));
+        cache()->erase(EncodeKey(&result, key));
     }
 
     void SetUp() {}
@@ -164,16 +174,16 @@ TEST_F(CacheTest, Erase) {
 TEST_F(CacheTest, EntriesArePinned) {
     Insert(100, 101, 1);
     std::string result1;
-    Cache::Handle* h1 = _cache->lookup(EncodeKey(&result1, 100));
-    EXPECT_EQ(101, DecodeValue(_cache->value(h1)));
+    Cache::Handle* h1 = cache()->lookup(EncodeKey(&result1, 100));
+    EXPECT_EQ(101, DecodeValue(cache()->value(h1)));
 
     Insert(100, 102, 1);
     std::string result2;
-    Cache::Handle* h2 = _cache->lookup(EncodeKey(&result2, 100));
-    EXPECT_EQ(102, DecodeValue(_cache->value(h2)));
+    Cache::Handle* h2 = cache()->lookup(EncodeKey(&result2, 100));
+    EXPECT_EQ(102, DecodeValue(cache()->value(h2)));
     EXPECT_EQ(0, _deleted_keys.size());
 
-    _cache->release(h1);
+    cache()->release(h1);
     EXPECT_EQ(1, _deleted_keys.size());
     EXPECT_EQ(100, _deleted_keys[0]);
     EXPECT_EQ(101, _deleted_values[0]);
@@ -182,7 +192,7 @@ TEST_F(CacheTest, EntriesArePinned) {
     EXPECT_EQ(-1, Lookup(100));
     EXPECT_EQ(1, _deleted_keys.size());
 
-    _cache->release(h2);
+    cache()->release(h2);
     EXPECT_EQ(2, _deleted_keys.size());
     EXPECT_EQ(100, _deleted_keys[1]);
     EXPECT_EQ(102, _deleted_values[1]);
@@ -400,8 +410,8 @@ TEST_F(CacheTest, HeavyEntries) {
 }
 
 TEST_F(CacheTest, NewId) {
-    uint64_t a = _cache->new_id();
-    uint64_t b = _cache->new_id();
+    uint64_t a = cache()->new_id();
+    uint64_t b = cache()->new_id();
     EXPECT_NE(a, b);
 }
 

--- a/be/test/olap/lru_cache_test.cpp
+++ b/be/test/olap/lru_cache_test.cpp
@@ -92,7 +92,7 @@ public:
 
     ~CacheTest() { delete _cache; }
 
-    Cache* cache() { return _cache->get(); }
+    Cache* cache() { return _cache->cache(); }
 
     int Lookup(int key) {
         std::string result;

--- a/be/test/olap/rowset/segment_v2/inverted_index_searcher_cache_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index_searcher_cache_test.cpp
@@ -161,8 +161,7 @@ TEST_F(InvertedIndexSearcherCacheTest, evict_by_usage) {
     cache_value_1->size = 200;
     //cache_value_1->index_searcher;
     cache_value_1->last_visit_time = 10;
-    index_searcher_cache->cache()->release(
-            index_searcher_cache->_insert(key_1, cache_value_1.release()));
+    index_searcher_cache->release(index_searcher_cache->_insert(key_1, cache_value_1.release()));
 
     // should evict {key_1, cache_value_1}
     std::string file_name_2 = "test_2.idx";
@@ -171,8 +170,7 @@ TEST_F(InvertedIndexSearcherCacheTest, evict_by_usage) {
     cache_value_2->size = 800;
     //cache_value_2->index_searcher;
     cache_value_2->last_visit_time = 20;
-    index_searcher_cache->cache()->release(
-            index_searcher_cache->_insert(key_2, cache_value_2.release()));
+    index_searcher_cache->release(index_searcher_cache->_insert(key_2, cache_value_2.release()));
     {
         InvertedIndexCacheHandle cache_handle;
         // lookup key_1
@@ -188,8 +186,7 @@ TEST_F(InvertedIndexSearcherCacheTest, evict_by_usage) {
     cache_value_3->size = 400;
     //cache_value_3->index_searcher;
     cache_value_3->last_visit_time = 30;
-    index_searcher_cache->cache()->release(
-            index_searcher_cache->_insert(key_3, cache_value_3.release()));
+    index_searcher_cache->release(index_searcher_cache->_insert(key_3, cache_value_3.release()));
     {
         InvertedIndexCacheHandle cache_handle;
         // lookup key_2
@@ -205,8 +202,7 @@ TEST_F(InvertedIndexSearcherCacheTest, evict_by_usage) {
     cache_value_4->size = 100;
     //cache_value_4->index_searcher;
     cache_value_4->last_visit_time = 40;
-    index_searcher_cache->cache()->release(
-            index_searcher_cache->_insert(key_4, cache_value_4.release()));
+    index_searcher_cache->release(index_searcher_cache->_insert(key_4, cache_value_4.release()));
     {
         InvertedIndexCacheHandle cache_handle;
         // lookup key_3
@@ -228,8 +224,7 @@ TEST_F(InvertedIndexSearcherCacheTest, evict_by_element_count_limit) {
     cache_value_1->size = 20;
     //cache_value_1->index_searcher;
     cache_value_1->last_visit_time = 10;
-    index_searcher_cache->cache()->release(
-            index_searcher_cache->_insert(key_1, cache_value_1.release()));
+    index_searcher_cache->release(index_searcher_cache->_insert(key_1, cache_value_1.release()));
 
     // no need evict
     std::string file_name_2 = "test_2.idx";
@@ -238,8 +233,7 @@ TEST_F(InvertedIndexSearcherCacheTest, evict_by_element_count_limit) {
     cache_value_2->size = 50;
     //cache_value_2->index_searcher;
     cache_value_2->last_visit_time = 20;
-    index_searcher_cache->cache()->release(
-            index_searcher_cache->_insert(key_2, cache_value_2.release()));
+    index_searcher_cache->release(index_searcher_cache->_insert(key_2, cache_value_2.release()));
     {
         InvertedIndexCacheHandle cache_handle;
         // lookup key_1
@@ -259,8 +253,7 @@ TEST_F(InvertedIndexSearcherCacheTest, evict_by_element_count_limit) {
     cache_value_3->size = 80;
     //cache_value_3->index_searcher;
     cache_value_3->last_visit_time = 30;
-    index_searcher_cache->cache()->release(
-            index_searcher_cache->_insert(key_3, cache_value_3.release()));
+    index_searcher_cache->release(index_searcher_cache->_insert(key_3, cache_value_3.release()));
     {
         InvertedIndexCacheHandle cache_handle;
         // lookup key_1
@@ -286,8 +279,7 @@ TEST_F(InvertedIndexSearcherCacheTest, evict_by_element_count_limit) {
     cache_value_4->size = 100;
     //cache_value_4->index_searcher;
     cache_value_4->last_visit_time = 40;
-    index_searcher_cache->cache()->release(
-            index_searcher_cache->_insert(key_4, cache_value_4.release()));
+    index_searcher_cache->release(index_searcher_cache->_insert(key_4, cache_value_4.release()));
     {
         InvertedIndexCacheHandle cache_handle;
         // lookup key_1
@@ -321,8 +313,7 @@ TEST_F(InvertedIndexSearcherCacheTest, remove_element_only_in_table) {
     cache_value_1->size = 200;
     //cache_value_1->index_searcher;
     cache_value_1->last_visit_time = 10;
-    index_searcher_cache->cache()->release(
-            index_searcher_cache->_insert(key_1, cache_value_1.release()));
+    index_searcher_cache->release(index_searcher_cache->_insert(key_1, cache_value_1.release()));
 
     std::string file_name_2 = "test_2.idx";
     InvertedIndexSearcherCache::CacheKey key_2(file_name_2);
@@ -338,7 +329,7 @@ TEST_F(InvertedIndexSearcherCacheTest, remove_element_only_in_table) {
         cache_value_2->size = 800;
         //cache_value_2->index_searcher;
         cache_value_2->last_visit_time = 20;
-        index_searcher_cache->cache()->release(
+        index_searcher_cache->release(
                 index_searcher_cache->_insert(key_2, cache_value_2.release()));
 
         // lookup key_2, key_2 has removed from table due to cache is full

--- a/be/test/olap/rowset/segment_v2/inverted_index_searcher_cache_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index_searcher_cache_test.cpp
@@ -161,7 +161,7 @@ TEST_F(InvertedIndexSearcherCacheTest, evict_by_usage) {
     cache_value_1->size = 200;
     //cache_value_1->index_searcher;
     cache_value_1->last_visit_time = 10;
-    index_searcher_cache->_cache->release(
+    index_searcher_cache->cache()->release(
             index_searcher_cache->_insert(key_1, cache_value_1.release()));
 
     // should evict {key_1, cache_value_1}
@@ -171,7 +171,7 @@ TEST_F(InvertedIndexSearcherCacheTest, evict_by_usage) {
     cache_value_2->size = 800;
     //cache_value_2->index_searcher;
     cache_value_2->last_visit_time = 20;
-    index_searcher_cache->_cache->release(
+    index_searcher_cache->cache()->release(
             index_searcher_cache->_insert(key_2, cache_value_2.release()));
     {
         InvertedIndexCacheHandle cache_handle;
@@ -188,7 +188,7 @@ TEST_F(InvertedIndexSearcherCacheTest, evict_by_usage) {
     cache_value_3->size = 400;
     //cache_value_3->index_searcher;
     cache_value_3->last_visit_time = 30;
-    index_searcher_cache->_cache->release(
+    index_searcher_cache->cache()->release(
             index_searcher_cache->_insert(key_3, cache_value_3.release()));
     {
         InvertedIndexCacheHandle cache_handle;
@@ -205,7 +205,7 @@ TEST_F(InvertedIndexSearcherCacheTest, evict_by_usage) {
     cache_value_4->size = 100;
     //cache_value_4->index_searcher;
     cache_value_4->last_visit_time = 40;
-    index_searcher_cache->_cache->release(
+    index_searcher_cache->cache()->release(
             index_searcher_cache->_insert(key_4, cache_value_4.release()));
     {
         InvertedIndexCacheHandle cache_handle;
@@ -228,7 +228,7 @@ TEST_F(InvertedIndexSearcherCacheTest, evict_by_element_count_limit) {
     cache_value_1->size = 20;
     //cache_value_1->index_searcher;
     cache_value_1->last_visit_time = 10;
-    index_searcher_cache->_cache->release(
+    index_searcher_cache->cache()->release(
             index_searcher_cache->_insert(key_1, cache_value_1.release()));
 
     // no need evict
@@ -238,7 +238,7 @@ TEST_F(InvertedIndexSearcherCacheTest, evict_by_element_count_limit) {
     cache_value_2->size = 50;
     //cache_value_2->index_searcher;
     cache_value_2->last_visit_time = 20;
-    index_searcher_cache->_cache->release(
+    index_searcher_cache->cache()->release(
             index_searcher_cache->_insert(key_2, cache_value_2.release()));
     {
         InvertedIndexCacheHandle cache_handle;
@@ -259,7 +259,7 @@ TEST_F(InvertedIndexSearcherCacheTest, evict_by_element_count_limit) {
     cache_value_3->size = 80;
     //cache_value_3->index_searcher;
     cache_value_3->last_visit_time = 30;
-    index_searcher_cache->_cache->release(
+    index_searcher_cache->cache()->release(
             index_searcher_cache->_insert(key_3, cache_value_3.release()));
     {
         InvertedIndexCacheHandle cache_handle;
@@ -286,7 +286,7 @@ TEST_F(InvertedIndexSearcherCacheTest, evict_by_element_count_limit) {
     cache_value_4->size = 100;
     //cache_value_4->index_searcher;
     cache_value_4->last_visit_time = 40;
-    index_searcher_cache->_cache->release(
+    index_searcher_cache->cache()->release(
             index_searcher_cache->_insert(key_4, cache_value_4.release()));
     {
         InvertedIndexCacheHandle cache_handle;
@@ -321,7 +321,7 @@ TEST_F(InvertedIndexSearcherCacheTest, remove_element_only_in_table) {
     cache_value_1->size = 200;
     //cache_value_1->index_searcher;
     cache_value_1->last_visit_time = 10;
-    index_searcher_cache->_cache->release(
+    index_searcher_cache->cache()->release(
             index_searcher_cache->_insert(key_1, cache_value_1.release()));
 
     std::string file_name_2 = "test_2.idx";
@@ -338,7 +338,7 @@ TEST_F(InvertedIndexSearcherCacheTest, remove_element_only_in_table) {
         cache_value_2->size = 800;
         //cache_value_2->index_searcher;
         cache_value_2->last_visit_time = 20;
-        index_searcher_cache->_cache->release(
+        index_searcher_cache->cache()->release(
                 index_searcher_cache->_insert(key_2, cache_value_2.release()));
 
         // lookup key_2, key_2 has removed from table due to cache is full

--- a/be/test/testutil/run_all_tests.cpp
+++ b/be/test/testutil/run_all_tests.cpp
@@ -46,10 +46,10 @@ int main(int argc, char** argv) {
     doris::ExecEnv::GetInstance()->set_tablet_schema_cache(
             doris::TabletSchemaCache::create_global_schema_cache());
     doris::ExecEnv::GetInstance()->get_tablet_schema_cache()->start();
+    doris::ExecEnv::GetInstance()->set_dummy_lru_cache(std::make_shared<doris::DummyLRUCache>());
     doris::ExecEnv::GetInstance()->set_storage_page_cache(
             doris::StoragePageCache::create_global_cache(1 << 30, 10, 0));
     doris::ExecEnv::GetInstance()->set_segment_loader(new doris::SegmentLoader(1000));
-    doris::ExecEnv::GetInstance()->set_dummy_lru_cache(std::make_shared<doris::DummyLRUCache>());
     std::string conf = std::string(getenv("DORIS_HOME")) + "/conf/be.conf";
     auto st = doris::config::init(conf.c_str(), false);
     LOG(INFO) << "init config " << st;

--- a/be/test/testutil/run_all_tests.cpp
+++ b/be/test/testutil/run_all_tests.cpp
@@ -49,6 +49,7 @@ int main(int argc, char** argv) {
     doris::ExecEnv::GetInstance()->set_storage_page_cache(
             doris::StoragePageCache::create_global_cache(1 << 30, 10, 0));
     doris::ExecEnv::GetInstance()->set_segment_loader(new doris::SegmentLoader(1000));
+    doris::ExecEnv::GetInstance()->set_dummy_lru_cache(std::make_shared<doris::DummyLRUCache>());
     std::string conf = std::string(getenv("DORIS_HOME")) + "/conf/be.conf";
     auto st = doris::config::init(conf.c_str(), false);
     LOG(INFO) << "init config " << st;


### PR DESCRIPTION
## Proposed changes

1. After all LRU Cache inherits from `LRUCachePolicy`, this will allow prune stale entry, eviction when memory exceeds limit, and define common properties. `LRUCache` constructor change to private, only allow `LRUCachePolicy` to construct it.

2. Impl DummyLRUCache, when LRU Cache capacity is 0, will no longer be meaningless insert and evict.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

