### PR TITLE
[fix](load) fix nullptr when getting memtable flush running count

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -126,8 +126,7 @@ Status BaseDeltaWriter::write(const vectorized::Block* block, const std::vector<
     if (!_is_init && !_is_cancelled) {
         RETURN_IF_ERROR(init());
     }
-    while (_memtable_writer->get_flush_token_stats().flush_running_count >=
-           config::memtable_flush_running_count_limit) {
+    while (_memtable_writer->flush_running_count() >= config::memtable_flush_running_count_limit) {
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
     return _memtable_writer->write(block, row_idxs, is_append);

--- a/be/src/olap/delta_writer_v2.cpp
+++ b/be/src/olap/delta_writer_v2.cpp
@@ -37,7 +37,6 @@
 #include "gutil/strings/numbers.h"
 #include "io/fs/file_writer.h" // IWYU pragma: keep
 #include "olap/data_dir.h"
-#include "olap/memtable_flush_executor.h"
 #include "olap/olap_define.h"
 #include "olap/rowset/beta_rowset.h"
 #include "olap/rowset/beta_rowset_writer_v2.h"
@@ -153,8 +152,7 @@ Status DeltaWriterV2::write(const vectorized::Block* block, const std::vector<ui
     if (!_is_init && !_is_cancelled) {
         RETURN_IF_ERROR(init());
     }
-    while (_memtable_writer->get_flush_token_stats().flush_running_count >=
-           config::memtable_flush_running_count_limit) {
+    while (_memtable_writer->flush_running_count() >= config::memtable_flush_running_count_limit) {
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
     SCOPED_RAW_TIMER(&_write_memtable_time);

--- a/be/src/olap/memtable_writer.cpp
+++ b/be/src/olap/memtable_writer.cpp
@@ -345,6 +345,10 @@ const FlushStatistic& MemTableWriter::get_flush_token_stats() {
     return _flush_token->get_stats();
 }
 
+uint64_t MemTableWriter::flush_running_count() const {
+    return _flush_token == nullptr ? 0 : _flush_token->get_stats().flush_running_count.load();
+}
+
 int64_t MemTableWriter::mem_consumption(MemType mem) {
     if (!_is_init) {
         // This method may be called before this writer is initialized.

--- a/be/src/olap/memtable_writer.h
+++ b/be/src/olap/memtable_writer.h
@@ -108,7 +108,7 @@ public:
     int64_t total_received_rows() const { return _total_received_rows; }
 
     const FlushStatistic& get_flush_token_stats();
-    
+
     uint64_t flush_running_count() const;
 
 private:

--- a/be/src/olap/memtable_writer.h
+++ b/be/src/olap/memtable_writer.h
@@ -108,6 +108,8 @@ public:
     int64_t total_received_rows() const { return _total_received_rows; }
 
     const FlushStatistic& get_flush_token_stats();
+    
+    uint64_t flush_running_count() const;
 
 private:
     // push a full memtable to flush executor


### PR DESCRIPTION
## Proposed changes

Fix coredump when accessing flush running count due to flush token is nullptr.

```cpp
Program terminated with signal SIGSEGV, Segmentation fault.
#0  std::__atomic_base<unsigned long>::load (this=0x58, __m=std::memory_order::seq_cst) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/atomic_base.h:481
481             return __atomic_load_n(&_M_i, int(__m));
[Current thread is 1 (Thread 0x7f3165554700 (LWP 2752768))]
(gdb) bt
#0  std::__atomic_base<unsigned long>::load (this=0x58, __m=std::memory_order::seq_cst)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/atomic_base.h:481
#1  std::__atomic_base<unsigned long>::operator unsigned long (this=0x58)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/atomic_base.h:341
#2  doris::BaseDeltaWriter::write (this=0x7f319c0bdf80, block=0x7f31655460f0, row_idxs=..., is_append=false)
    at /home/zcp/repo_center/doris_master/doris/be/src/olap/delta_writer.cpp:129
#3  0x0000559362af9262 in doris::BaseTabletsChannel::add_batch(doris::PTabletWriterAddBlockRequest const&, doris::PTabletWriterAddBlockResult*)::$_3::operator()(doris::BaseDeltaWriter*) const (writer=0x7f3165545f78, this=<optimized out>)
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

