### PR TITLE
[feature](scan) Implement parallel scanning by dividing the tablets based on the row range

### DIFF
--- a/be/src/olap/iterators.h
+++ b/be/src/olap/iterators.h
@@ -24,6 +24,7 @@
 #include "olap/block_column_predicate.h"
 #include "olap/column_predicate.h"
 #include "olap/olap_common.h"
+#include "olap/rowset/segment_v2/row_ranges.h"
 #include "olap/tablet_schema.h"
 #include "runtime/runtime_state.h"
 #include "vec/core/block.h"
@@ -115,6 +116,7 @@ public:
     int32_t tablet_id = 0;
     // slots that cast may be eliminated in storage layer
     std::map<std::string, PrimitiveType> target_cast_type_for_variants;
+    RowRanges row_ranges;
 };
 
 class RowwiseIterator;

--- a/be/src/olap/parallel_scanner_builder.cpp
+++ b/be/src/olap/parallel_scanner_builder.cpp
@@ -1,0 +1,251 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "parallel_scanner_builder.h"
+
+#include "olap/rowset/beta_rowset.h"
+#include "vec/exec/scan/new_olap_scanner.h"
+
+namespace doris {
+
+using namespace vectorized;
+
+template <typename ParentType>
+Status ParallelScannerBuilder<ParentType>::build_scanners(std::list<VScannerSPtr>& scanners) {
+    return _build_scanners_by_rowid(scanners);
+}
+
+template <typename ParentType>
+Status ParallelScannerBuilder<ParentType>::_build_scanners_by_rowid(
+        std::list<VScannerSPtr>& scanners) {
+    size_t total_rows = 0;
+    for (auto&& [tablet, _] : _tablets) {
+        total_rows += tablet->num_rows();
+    }
+
+    size_t rows_per_scanner = total_rows / _max_scanners_count;
+    rows_per_scanner = std::max<size_t>(rows_per_scanner, _min_rows_per_scanner);
+
+    for (auto&& [tablet, version] : _tablets) {
+        std::vector<RowsetSharedPtr> rowsets;
+        RETURN_IF_ERROR(tablet->capture_consistent_rowsets({0, version}, &rowsets));
+
+        TabletReader::ReadSource read_source;
+
+        int64_t rows_collected = 0;
+        for (auto& rowset : rowsets) {
+            auto beta_rowset = std::dynamic_pointer_cast<BetaRowset>(rowset);
+            RowsetReaderSharedPtr reader;
+            RETURN_IF_ERROR(beta_rowset->create_reader(&reader));
+            const auto rowset_id = beta_rowset->rowset_id();
+            auto& segment_cache_handle = _segment_cache_handles[rowset_id];
+
+            RETURN_IF_ERROR(beta_rowset->load());
+            RETURN_IF_ERROR(SegmentLoader::instance()->load_segments(beta_rowset,
+                                                                     &segment_cache_handle, true));
+
+            if (beta_rowset->num_rows() == 0) {
+                continue;
+            }
+
+            const auto& segments = segment_cache_handle.get_segments();
+            int segment_start = 0;
+            auto split = RowSetSplits(reader->clone());
+            size_t total_collected = 0;
+
+            for (size_t i = 0; i != segments.size(); ++i) {
+                const auto& segment = segments[i];
+                RowRanges row_ranges;
+                const size_t rows_of_segment = segment->num_rows();
+                int64_t offset_in_segment = 0;
+
+                while (offset_in_segment < rows_of_segment) {
+                    const int64_t remaining_rows = rows_of_segment - offset_in_segment;
+                    auto rows_need = rows_per_scanner - rows_collected;
+                    if (rows_need >= remaining_rows * 0.9) {
+                        rows_need = remaining_rows;
+                    }
+                    DCHECK_LE(rows_need, remaining_rows);
+
+                    auto old_count = row_ranges.count();
+                    row_ranges.add({offset_in_segment,
+                                    offset_in_segment + static_cast<int64_t>(rows_need)});
+                    DCHECK_EQ(rows_need + old_count, row_ranges.count());
+                    rows_collected += rows_need;
+                    offset_in_segment += rows_need;
+                    total_collected += rows_need;
+
+                    if (rows_collected >= rows_per_scanner) { // build a new scanner
+                        split.segment_offsets.first = segment_start,
+                        split.segment_offsets.second = i + 1;
+                        split.segment_row_ranges.emplace_back(std::move(row_ranges));
+
+                        DCHECK_EQ(split.segment_offsets.second - split.segment_offsets.first,
+                                  split.segment_row_ranges.size());
+
+                        read_source.rs_splits.emplace_back(std::move(split));
+
+                        scanners.emplace_back(_build_scanner(tablet, version, _key_ranges,
+                                                             std::move(read_source)));
+
+                        read_source = TabletReader::ReadSource();
+                        split = RowSetSplits(reader->clone());
+                        row_ranges = RowRanges();
+                        DCHECK(row_ranges.is_empty());
+                        DCHECK_EQ(row_ranges.range_size(), 0);
+
+                        segment_start = offset_in_segment < rows_of_segment ? i : i + 1;
+                        rows_collected = 0;
+                    }
+                }
+
+                if (!row_ranges.is_empty()) {
+                    DCHECK_GT(rows_collected, 0);
+                    DCHECK_EQ(row_ranges.to(), segment->num_rows());
+                    split.segment_row_ranges.emplace_back(std::move(row_ranges));
+                }
+            }
+            DCHECK_EQ(total_collected, beta_rowset->num_rows());
+
+            DCHECK_LE(rows_collected, rows_per_scanner);
+            if (rows_collected > 0) {
+                split.segment_offsets.first = segment_start;
+                split.segment_offsets.second = segments.size();
+                DCHECK_GT(split.segment_offsets.second, split.segment_offsets.first);
+                DCHECK_EQ(split.segment_row_ranges.size(),
+                          split.segment_offsets.second - split.segment_offsets.first);
+                read_source.rs_splits.emplace_back(std::move(split));
+            }
+        } // end `for (auto& rowset : rowsets)`
+
+        DCHECK_LE(rows_collected, rows_per_scanner);
+        if (rows_collected > 0) {
+            DCHECK_GT(read_source.rs_splits.size(), 0);
+            for (auto& split : read_source.rs_splits) {
+                DCHECK(split.rs_reader != nullptr);
+                DCHECK_LT(split.segment_offsets.first, split.segment_offsets.second);
+                DCHECK_EQ(split.segment_row_ranges.size(),
+                          split.segment_offsets.second - split.segment_offsets.first);
+            }
+            scanners.emplace_back(
+                    _build_scanner(tablet, version, _key_ranges, std::move(read_source)));
+        }
+    }
+
+    return Status::OK();
+}
+template <typename ParentType>
+Status ParallelScannerBuilder<ParentType>::_load() {
+    for (auto&& [tablet, version] : _tablets) {
+        const auto tablet_id = tablet->table_id();
+        auto& rowsets = _all_rowsets[tablet_id];
+        RETURN_IF_ERROR(tablet->capture_consistent_rowsets({0, version}, &rowsets));
+
+        for (auto& rowset : rowsets) {
+            RETURN_IF_ERROR(rowset->load());
+            const auto rowset_id = rowset->rowset_id();
+            auto& segment_cache_handle = _segment_cache_handles[rowset_id];
+
+            RETURN_IF_ERROR(SegmentLoader::instance()->load_segments(
+                    std::dynamic_pointer_cast<BetaRowset>(rowset), &segment_cache_handle, true));
+        }
+    }
+}
+
+template <typename ParentType>
+std::unique_ptr<SegmentGroup>
+ParallelScannerBuilder<ParentType>::_create_segment_group_from_rowsets(
+        const std::vector<RowsetSharedPtr>& rowsets) {
+    if (rowsets.empty()) {
+        return {};
+    }
+
+    size_t max_rows = 0;
+    for (const auto& rowset : rowsets) {
+        const auto rowset_id = rowset->rowset_id();
+        DCHECK(_segment_cache_handles.contains(rowset_id));
+        auto& cache_handle = _segment_cache_handles[rowset_id];
+        auto& segments = cache_handle.get_segments();
+
+        if (segments.empty()) {
+            continue;
+        }
+
+        if (rowset->is_segments_overlapping()) {
+            auto* largest_segment = segments[0].get();
+            for (size_t i = 1; i != segments.size(); ++i) {
+                if (segments[i]->num_rows() > largest_segment->num_rows()) {
+                    largest_segment = segments[i].get();
+                }
+            }
+
+            if (largest_segment->num_rows() > max_rows) {
+
+            }
+        }
+    }
+
+    auto get_max_rows = [this](Rowset* rowset) -> uint32_t {
+        const auto rowset_id = rowset->rowset_id();
+        DCHECK(_segment_cache_handles.contains(rowset_id));
+        auto& cache_handle = _segment_cache_handles[rowset_id];
+
+        auto& segments = cache_handle.get_segments();
+        if (segments.empty()) {
+            return 0;
+        }
+
+        if (rowset->is_segments_overlapping()) {
+            auto* largest_segment = segments[0].get();
+            for (size_t i = 1; i != segments.size(); ++i) {
+                if (segments[i]->num_rows() > largest_segment->num_rows()) {
+                    largest_segment = segments[i].get();
+                }
+            }
+            return largest_segment->num_rows();
+        }
+
+        return rowset->num_rows();
+    };
+
+    auto* biggest_rowset = rowsets[0].get();
+    for (size_t i = 1; i != rowsets.size(); ++i) {
+        if (rowsets[i]->num_rows() > biggest_rowset->num_rows()) {
+            biggest_rowset = rowsets[i].get();
+        }
+    }
+}
+
+        template <typename ParentType>
+std::shared_ptr<NewOlapScanner> ParallelScannerBuilder<ParentType>::_build_scanner(
+        BaseTabletSPtr tablet, int64_t version, const std::vector<OlapScanRange*>& key_ranges,
+        TabletReader::ReadSource&& read_source) {
+    NewOlapScanner::Params params {
+            _state,  _scanner_profile.get(), key_ranges,         std::move(tablet),
+            version, std::move(read_source), _limit_per_scanner, _is_preaggregation};
+    return NewOlapScanner::create_shared(_parent, std::move(params));
+}
+
+template <typename ParentType>
+Status ParallelScannerBuilder<ParentType>::_build_scanners_by_key_range(
+        std::list<VScannerSPtr>& scanners) {
+    return Status::OK();
+}
+
+template class ParallelScannerBuilder<NewOlapScanNode>;
+
+} // namespace doris

--- a/be/src/olap/parallel_scanner_builder.h
+++ b/be/src/olap/parallel_scanner_builder.h
@@ -1,0 +1,105 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "olap/reader.h"
+#include "olap/rowset/segment_v2/row_ranges.h"
+#include "olap/segment_loader.h"
+#include "olap/tablet.h"
+#include "vec/exec/scan/new_olap_scanner.h"
+
+namespace doris {
+
+namespace vectorized {
+class VScanner;
+}
+
+using TabletSPtr = std::shared_ptr<Tablet>;
+using VScannerSPtr = std::shared_ptr<vectorized::VScanner>;
+
+struct TabletWithVersion {
+    TabletSPtr tablet;
+    int64_t version;
+};
+
+struct SegmentGroup {
+private:
+    std::vector<Segment*> _segments;
+};
+
+template <typename ParentType>
+class ParallelScannerBuilder {
+public:
+    ParallelScannerBuilder(ParentType* parent, const std::vector<TabletWithVersion>& tablets,
+                           const std::shared_ptr<RuntimeProfile>& profile,
+                           const std::vector<OlapScanRange*>& key_ranges, RuntimeState* state,
+                           int64_t limit_per_scanner, bool is_preaggregation)
+            : _parent(parent),
+              _scanner_profile(profile),
+              _state(state),
+              _limit_per_scanner(limit_per_scanner),
+              _is_preaggregation(is_preaggregation),
+              _tablets(tablets.cbegin(), tablets.cend()),
+              _key_ranges(key_ranges.cbegin(), key_ranges.cend()) {}
+
+    Status build_scanners(std::list<VScannerSPtr>& scanners);
+
+    void set_max_scanners_count(size_t count) { _max_scanners_count = count; }
+
+private:
+    Status _load();
+
+    Status _build_scanners_by_rowid(std::list<VScannerSPtr>& scanners);
+
+    Status _build_scanners_by_key_range(std::list<VScannerSPtr>& scanners);
+
+    std::unique_ptr<SegmentGroup> _create_segment_group_from_rowsets(const std::vector<RowsetSharedPtr>& rowsets);
+
+    std::vector<SegmentSharedPtr> _load_segments_of_rowset(const RowsetSharedPtr& rowset);
+
+    Status _parse_segment_group(const SegmentGroup& group, size_t& index_count,
+                                std::string& min_value, std::string& max_value);
+
+    std::shared_ptr<vectorized::NewOlapScanner> _build_scanner(
+            BaseTabletSPtr tablet, int64_t version, const std::vector<OlapScanRange*>& key_ranges,
+            TabletReader::ReadSource&& read_source);
+
+    ParentType* _parent;
+
+    /// Max scanners count limit to build
+    size_t _max_scanners_count {16};
+
+    /// Min rows per scanner
+    size_t _min_rows_per_scanner {16384};
+
+    std::map<RowsetId, SegmentCacheHandle> _segment_cache_handles;
+
+    std::shared_ptr<RuntimeProfile> _scanner_profile;
+    RuntimeState* _state;
+    int64_t _limit_per_scanner;
+    bool _is_preaggregation;
+    std::vector<TabletWithVersion> _tablets;
+    std::vector<OlapScanRange*> _key_ranges;
+    std::unordered_map<int64_t, std::vector<RowsetSharedPtr>> _all_rowsets;
+};
+
+} // namespace doris

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -237,10 +237,21 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
     for (int i = seg_start; i < seg_end; i++) {
         auto& seg_ptr = segments[i];
         std::unique_ptr<RowwiseIterator> iter;
-        auto s = seg_ptr->new_iterator(_input_schema, _read_options, &iter);
-        if (!s.ok()) {
-            LOG(WARNING) << "failed to create iterator[" << seg_ptr->id() << "]: " << s.to_string();
-            return Status::Error<ROWSET_READER_INIT>(s.to_string());
+        Status status;
+        if (_segment_row_ranges.empty()) {
+            _read_options.row_ranges = RowRanges::create_single(seg_ptr->num_rows());
+            status = seg_ptr->new_iterator(_input_schema, _read_options, &iter);
+        } else {
+            DCHECK_EQ(seg_end - seg_start, _segment_row_ranges.size());
+            auto local_options = _read_options;
+            local_options.row_ranges = _segment_row_ranges[i - seg_start];
+            status = seg_ptr->new_iterator(_input_schema, std::move(local_options), &iter);
+        }
+
+        if (!status.ok()) {
+            LOG(WARNING) << "failed to create iterator[" << seg_ptr->id()
+                         << "]: " << status.to_string();
+            return Status::Error<ROWSET_READER_INIT>(status.to_string());
         }
         if (iter->empty()) {
             continue;
@@ -255,6 +266,7 @@ Status BetaRowsetReader::init(RowsetReaderContext* read_context, const RowSetSpl
     _read_context = read_context;
     _read_context->rowset_id = _rowset->rowset_id();
     _segment_offsets = rs_splits.segment_offsets;
+    _segment_row_ranges = rs_splits.segment_row_ranges;
     return Status::OK();
 }
 

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -238,14 +238,16 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
         auto& seg_ptr = segments[i];
         std::unique_ptr<RowwiseIterator> iter;
         Status status;
+
+        /// If `_segment_row_ranges` is empty, the segment is not split.
         if (_segment_row_ranges.empty()) {
-            _read_options.row_ranges = RowRanges::create_single(seg_ptr->num_rows());
+            _read_options.row_ranges.clear();
             status = seg_ptr->new_iterator(_input_schema, _read_options, &iter);
         } else {
             DCHECK_EQ(seg_end - seg_start, _segment_row_ranges.size());
             auto local_options = _read_options;
             local_options.row_ranges = _segment_row_ranges[i - seg_start];
-            status = seg_ptr->new_iterator(_input_schema, std::move(local_options), &iter);
+            status = seg_ptr->new_iterator(_input_schema, local_options, &iter);
         }
 
         if (!status.ok()) {

--- a/be/src/olap/rowset/beta_rowset_reader.h
+++ b/be/src/olap/rowset/beta_rowset_reader.h
@@ -96,6 +96,7 @@ private:
     DorisCallOnce<Status> _init_iter_once;
 
     std::pair<int, int> _segment_offsets;
+    std::vector<RowRanges> _segment_row_ranges;
 
     SchemaSPtr _input_schema;
     RowsetReaderContext* _read_context = nullptr;

--- a/be/src/olap/rowset/rowset_reader.h
+++ b/be/src/olap/rowset/rowset_reader.h
@@ -25,6 +25,7 @@
 #include "olap/iterators.h"
 #include "olap/rowset/rowset_fwd.h"
 #include "olap/rowset/rowset_reader_context.h"
+#include "olap/rowset/segment_v2/row_ranges.h"
 #include "vec/core/block.h"
 
 namespace doris {
@@ -40,6 +41,9 @@ struct RowSetSplits {
     // [pair.first, pair.second) segment in rs_reader, only effective in dup key
     // and pipeline
     std::pair<int, int> segment_offsets;
+
+    // RowRanges of each segment.
+    std::vector<RowRanges> segment_row_ranges;
 
     RowSetSplits(RowsetReaderSharedPtr rs_reader_)
             : rs_reader(rs_reader_), segment_offsets({0, 0}) {}

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -381,6 +381,10 @@ Status SegmentIterator::_lazy_init() {
                    << _opts.delete_bitmap.at(segment_id())->cardinality() << ", "
                    << _opts.stats->rows_del_by_bitmap << " rows deleted by bitmap";
     }
+
+    if (!_opts.row_ranges.is_empty()) {
+        _row_bitmap &= RowRanges::ranges_to_roaring(_opts.row_ranges);
+    }
     if (_opts.read_orderby_key_reverse) {
         _range_iter.reset(new BackwardBitmapRangeIterator(_row_bitmap));
     } else {

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -488,6 +488,22 @@ public:
                _query_options.enable_hash_join_early_start_probe;
     }
 
+    bool enable_parallel_scan() const {
+        return _query_options.__isset.enable_parallel_scan && _query_options.enable_parallel_scan;
+    }
+
+    int parallel_scan_max_scanners_count() const {
+        return _query_options.__isset.parallel_scan_max_scanners_count
+                       ? _query_options.parallel_scan_max_scanners_count
+                       : 0;
+    }
+
+    int64_t parallel_scan_min_rows_per_scanner() const {
+        return _query_options.__isset.parallel_scan_min_rows_per_scanner
+                       ? _query_options.parallel_scan_min_rows_per_scanner
+                       : 0;
+    }
+
     int repeat_max_num() const {
 #ifndef BE_TEST
         if (!_query_options.__isset.repeat_max_num) {

--- a/be/src/vec/columns/column_dictionary.h
+++ b/be/src/vec/columns/column_dictionary.h
@@ -207,7 +207,7 @@ public:
     }
 
     Status filter_by_selector(const uint16_t* sel, size_t sel_size, IColumn* col_ptr) override {
-        auto* res_col = reinterpret_cast<vectorized::ColumnString*>(col_ptr);
+        auto* res_col = assert_cast<vectorized::ColumnString*>(col_ptr);
         StringRef strings[sel_size];
         size_t length = 0;
         for (size_t i = 0; i != sel_size; ++i) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -224,6 +224,14 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String IGNORE_STORAGE_DATA_DISTRIBUTION = "ignore_storage_data_distribution";
 
+    public static final String ENABLE_PARALLEL_SCAN = "enable_parallel_scan";
+
+    // Limit the max count of scanners to prevent generate too many scanners.
+    public static final String PARALLEL_SCAN_MAX_SCANNERS_COUNT = "parallel_scan_max_scanners_count";
+
+    // Avoid splitting small segments, each scanner should scan `parallel_scan_min_rows_per_scanner` rows.
+    public static final String PARALLEL_SCAN_MIN_ROWS_PER_SCANNER = "parallel_scan_min_rows_per_scanner";
+
     public static final String ENABLE_LOCAL_SHUFFLE = "enable_local_shuffle";
 
     public static final String ENABLE_AGG_STATE = "enable_agg_state";
@@ -784,7 +792,19 @@ public class SessionVariable implements Serializable, Writable {
 
     @VariableMgr.VarAttr(name = ENABLE_SHARED_SCAN, fuzzy = false, varType = VariableAnnotation.EXPERIMENTAL,
             needForward = true)
-    private boolean enableSharedScan = false;
+    private boolean enableSharedScan = true;
+
+    @VariableMgr.VarAttr(name = ENABLE_PARALLEL_SCAN, fuzzy = false, varType = VariableAnnotation.EXPERIMENTAL,
+            needForward = true)
+    private boolean enableParallelScan = true;
+
+    @VariableMgr.VarAttr(name = PARALLEL_SCAN_MAX_SCANNERS_COUNT, fuzzy = false,
+            varType = VariableAnnotation.EXPERIMENTAL, needForward = true)
+    private int parallelScanMaxScannersCount = 48;
+
+    @VariableMgr.VarAttr(name = PARALLEL_SCAN_MIN_ROWS_PER_SCANNER, fuzzy = false,
+            varType = VariableAnnotation.EXPERIMENTAL, needForward = true)
+    private long parallelScanMinRowsPerScanner = 65536; // 2MB
 
     @VariableMgr.VarAttr(name = IGNORE_STORAGE_DATA_DISTRIBUTION, fuzzy = false,
             varType = VariableAnnotation.EXPERIMENTAL, needForward = true)
@@ -2746,6 +2766,10 @@ public class SessionVariable implements Serializable, Writable {
 
         tResult.setInvertedIndexSkipThreshold(invertedIndexSkipThreshold);
 
+        tResult.setEnableParallelScan(enableParallelScan);
+        tResult.setParallelScanMaxScannersCount(parallelScanMaxScannersCount);
+        tResult.setParallelScanMinRowsPerScanner(parallelScanMinRowsPerScanner);
+
         return tResult;
     }
 
@@ -3057,6 +3081,14 @@ public class SessionVariable implements Serializable, Writable {
 
     public boolean getEnableSharedScan() {
         return enableSharedScan;
+    }
+
+    public void setEnableSharedScan(boolean value) {
+        enableSharedScan = value;
+    }
+
+    public boolean getEnableParallelScan() {
+        return enableParallelScan;
     }
 
     public boolean getEnablePipelineXEngine() {

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/ColocatePlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/ColocatePlanTest.java
@@ -169,6 +169,7 @@ public class ColocatePlanTest extends TestWithFeService {
 
     @Test
     public void checkColocatePlanFragment() throws Exception {
+        connectContext.getSessionVariable().setEnableSharedScan(false);
         String sql
                 = "select /*+ SET_VAR(enable_nereids_planner=false) */ a.k1 from db1.test_colocate a, db1.test_colocate b where a.k1=b.k1 and a.k2=b.k2 group by a.k1;";
         StmtExecutor executor = getSqlStmtExecutor(sql);

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -263,6 +263,12 @@ struct TQueryOptions {
   93: optional i32 inverted_index_max_expansions = 50;
 
   94: optional i32 inverted_index_skip_threshold = 50;
+
+  95: optional bool enable_parallel_scan = false;
+
+  96: optional i32 parallel_scan_max_scanners_count = 0;
+
+  97: optional i64 parallel_scan_min_rows_per_scanner = 0;
 }
 
 

--- a/regression-test/suites/performance_p0/redundant_conjuncts.groovy
+++ b/regression-test/suites/performance_p0/redundant_conjuncts.groovy
@@ -32,10 +32,10 @@ suite("redundant_conjuncts") {
     """
     
     qt_redundant_conjuncts """
-    EXPLAIN SELECT /*+SET_VAR(enable_nereids_planner=false, REWRITE_OR_TO_IN_PREDICATE_THRESHOLD=2, parallel_fragment_exec_instance_num = 1) */ v1 FROM redundant_conjuncts WHERE k1 = 1 AND k1 = 1;
+    EXPLAIN SELECT /*+SET_VAR(enable_nereids_planner=false, REWRITE_OR_TO_IN_PREDICATE_THRESHOLD=2, parallel_fragment_exec_instance_num = 1, enable_shared_scan = false) */ v1 FROM redundant_conjuncts WHERE k1 = 1 AND k1 = 1;
     """
 
     qt_redundant_conjuncts_gnerated_by_extract_common_filter """
-    EXPLAIN SELECT /*+SET_VAR(enable_nereids_planner=false, REWRITE_OR_TO_IN_PREDICATE_THRESHOLD=100, parallel_fragment_exec_instance_num = 1) */ v1 FROM redundant_conjuncts WHERE k1 = 1 OR k1 = 2;
+    EXPLAIN SELECT /*+SET_VAR(enable_nereids_planner=false, REWRITE_OR_TO_IN_PREDICATE_THRESHOLD=100, parallel_fragment_exec_instance_num = 1, enable_shared_scan = false) */ v1 FROM redundant_conjuncts WHERE k1 = 1 OR k1 = 2;
     """
 }


### PR DESCRIPTION
## Proposed changes

This PR supports splitting tablets into multiple scanners by row ranges.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

