### PR TITLE
[fix](Nereids) generating function should not folding to NullLiteral

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
@@ -47,6 +47,7 @@ import org.apache.doris.nereids.trees.expressions.WhenClause;
 import org.apache.doris.nereids.trees.expressions.functions.BoundFunction;
 import org.apache.doris.nereids.trees.expressions.functions.PropagateNullable;
 import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateFunction;
+import org.apache.doris.nereids.trees.expressions.functions.generator.TableGeneratingFunction;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Array;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.ConnectionId;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.CurrentCatalog;
@@ -549,7 +550,7 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule {
     }
 
     private Optional<Expression> preProcess(Expression expression) {
-        if (expression instanceof AggregateFunction) {
+        if (expression instanceof AggregateFunction || expression instanceof TableGeneratingFunction) {
             return Optional.of(expression);
         }
         if (expression instanceof PropagateNullable && argsHasNullLiteral(expression)) {

--- a/regression-test/suites/correctness/test_explode_numbers.groovy
+++ b/regression-test/suites/correctness/test_explode_numbers.groovy
@@ -17,6 +17,7 @@
 
 suite("test_explode_numbers") {
     sql 'set enable_nereids_planner=true'
+    sql 'set enable_fallback_to_original_planner=false'
     qt_select1 """
         select e1 from (select 1 k1) as t lateral view explode_numbers(5) tmp1 as e1 order by e1;
     """


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

should not fold table generating function to null when do constant folding.
we should remove Generate node and replaced it by project later.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

