### PR TITLE
[improve](move-memtable) increase load stream flush token max tasks

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -782,7 +782,7 @@ DEFINE_Int32(load_stream_messages_in_batch, "128");
 // brpc streaming StreamWait seconds on EAGAIN
 DEFINE_Int32(load_stream_eagain_wait_seconds, "60");
 // max tasks per flush token in load stream
-DEFINE_Int32(load_stream_flush_token_max_tasks, "5");
+DEFINE_Int32(load_stream_flush_token_max_tasks, "15");
 
 // max send batch parallelism for OlapTableSink
 // The value set by the user for send_batch_parallelism is not allowed to exceed max_send_batch_parallelism_per_job,


### PR DESCRIPTION
## Proposed changes

Increase `load_stream_flush_token_max_tasks` to 15 and reduce wait time to 2ms.

Add bvar `load_stream_flush_wait_ms` and `load_stream_flush_wait_threads`.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

