### PR TITLE
[Opt](parquet-reader)(date) Opt parquet date type reading.

### DIFF
--- a/be/src/vec/exec/format/parquet/fix_length_dict_decoder.hpp
+++ b/be/src/vec/exec/format/parquet/fix_length_dict_decoder.hpp
@@ -225,12 +225,8 @@ protected:
                         column_data.push_back_without_reserve(
                                 unaligned_load<Int64>(reinterpret_cast<char*>(&v)));
                     } else {
-                        //column_data.push_back_without_reserve(date_dict[date_value]);
                         column_data.push_back_without_reserve(
                                 date_dict[date_value].to_date_int_val());
-                        //column_data.push_back_without_reserve(date_dict.get_value_for_day(date_value).to_date_int_val());
-                        //column_data.push_back_without_reserve(date_dict.get_value_for_day(date_value).to_date_int_val());
-                        //column_data.push_back_without_reserve(date_dict.get_value_for_day(date_value));
                     }
                 }
                 break;

--- a/be/src/vec/exec/format/parquet/fix_length_dict_decoder.hpp
+++ b/be/src/vec/exec/format/parquet/fix_length_dict_decoder.hpp
@@ -55,17 +55,6 @@ public:
             assert_cast<ColumnDictI32&>(*doris_column)
                     .insert_many_dict_data(&dict_items[0], dict_items.size());
         }
-        if (doris_column->is_column_dictionary()) {
-            ColumnDictI32& dict_column = assert_cast<ColumnDictI32&>(*doris_column);
-            if (dict_column.dict_size() == 0) {
-                std::vector<StringRef> dict_items;
-                dict_items.reserve(_dict_items.size());
-                for (int i = 0; i < _dict_items.size(); ++i) {
-                    dict_items.emplace_back((char*)(&_dict_items[i]), _type_length);
-                }
-                dict_column.insert_many_dict_data(&dict_items[0], dict_items.size());
-            }
-        }
         _indexes.resize(non_null_size);
         _index_batch_decoder->GetBatch(&_indexes[0], non_null_size);
 
@@ -216,30 +205,38 @@ protected:
     Status _decode_date(MutableColumnPtr& doris_column, ColumnSelectVector& select_vector) {
         auto& column_data = static_cast<ColumnVector<ColumnType>&>(*doris_column).get_data();
         size_t data_index = column_data.size();
-        column_data.resize(data_index + select_vector.num_values() - select_vector.num_filtered());
+        column_data.reserve(data_index + select_vector.num_values() - select_vector.num_filtered());
         size_t dict_index = 0;
         date_day_offset_dict& date_dict = date_day_offset_dict::get();
         ColumnSelectVector::DataReadType read_type;
+
         while (size_t run_length = select_vector.get_next_run<has_filter>(&read_type)) {
             switch (read_type) {
             case ColumnSelectVector::CONTENT: {
                 for (size_t i = 0; i < run_length; ++i) {
                     int64_t date_value =
                             _dict_items[_indexes[dict_index++]] + _decode_params->offset_days;
+                    static_cast<void>(dict_index);
                     if constexpr (std::is_same_v<CppType, VecDateTimeValue>) {
-                        auto& v = reinterpret_cast<CppType&>(column_data[data_index++]);
+                        VecDateTimeValue v;
                         v.create_from_date_v2(date_dict[date_value], TIME_DATE);
                         // we should cast to date if using date v1.
                         v.cast_to_date();
+                        column_data.push_back_without_reserve(
+                                unaligned_load<Int64>(reinterpret_cast<char*>(&v)));
                     } else {
-                        reinterpret_cast<CppType&>(column_data[data_index++]) =
-                                date_dict[date_value];
+                        //column_data.push_back_without_reserve(date_dict[date_value]);
+                        column_data.push_back_without_reserve(
+                                date_dict[date_value].to_date_int_val());
+                        //column_data.push_back_without_reserve(date_dict.get_value_for_day(date_value).to_date_int_val());
+                        //column_data.push_back_without_reserve(date_dict.get_value_for_day(date_value).to_date_int_val());
+                        //column_data.push_back_without_reserve(date_dict.get_value_for_day(date_value));
                     }
                 }
                 break;
             }
             case ColumnSelectVector::NULL_DATA: {
-                data_index += run_length;
+                column_data.resize_assume_reserved(run_length);
                 break;
             }
             case ColumnSelectVector::FILTERED_CONTENT: {

--- a/be/src/vec/runtime/vdatetime_value.cpp
+++ b/be/src/vec/runtime/vdatetime_value.cpp
@@ -2663,17 +2663,14 @@ char* DateV2Value<T>::to_string(char* to, int scale) const {
     return to + len + 1;
 }
 
-template <typename T>
-typename DateV2Value<T>::underlying_value DateV2Value<T>::to_date_int_val() const {
-    return int_val_;
-}
 // [1900-01-01, 2039-12-31]
-static std::array<DateV2Value<DateV2ValueType>, date_day_offset_dict::DICT_DAYS>
-        DATE_DAY_OFFSET_ITEMS;
-// [1900-01-01, 2039-12-31]
-static std::array<std::array<std::array<int, 31>, 12>, 140> DATE_DAY_OFFSET_DICT;
+std::array<DateV2Value<DateV2ValueType>, date_day_offset_dict::DICT_DAYS>
+        date_day_offset_dict::DATE_DAY_OFFSET_ITEMS;
 
-static bool DATE_DAY_OFFSET_ITEMS_INIT = false;
+// [1900-01-01, 2039-12-31]
+std::array<std::array<std::array<int, 31>, 12>, 140> date_day_offset_dict::DATE_DAY_OFFSET_DICT;
+
+bool date_day_offset_dict::DATE_DAY_OFFSET_ITEMS_INIT = false;
 
 date_day_offset_dict date_day_offset_dict::instance = date_day_offset_dict();
 
@@ -2711,16 +2708,6 @@ date_day_offset_dict::date_day_offset_dict() {
     }
 
     DATE_DAY_OFFSET_ITEMS_INIT = true;
-}
-
-DateV2Value<DateV2ValueType> date_day_offset_dict::operator[](int day) const {
-    int index = day + DAY_BEFORE_EPOCH;
-    if (LIKELY(index >= 0 && index < DICT_DAYS)) {
-        return DATE_DAY_OFFSET_ITEMS[index];
-    } else {
-        DateV2Value<DateV2ValueType> d = DATE_DAY_OFFSET_ITEMS[0];
-        return d += index;
-    }
 }
 
 int date_day_offset_dict::daynr(int year, int month, int day) const {

--- a/be/src/vec/runtime/vdatetime_value.h
+++ b/be/src/vec/runtime/vdatetime_value.h
@@ -1574,44 +1574,6 @@ public:
         }
     }
 
-    inline DateV2Value<DateV2ValueType> get_value_for_day(int day) const {
-        int index = day + DAY_BEFORE_EPOCH;
-        if (LIKELY(index >= 0 && index < DICT_DAYS)) {
-            return DATE_DAY_OFFSET_ITEMS[index];
-        } else {
-            DateV2Value<DateV2ValueType> d = DATE_DAY_OFFSET_ITEMS[0];
-            return d += index;
-        }
-    }
-
-    inline DateV2Value<DateV2ValueType> get_value_for_day7(int day) const {
-        int index = day + DAY_BEFORE_EPOCH;
-        if (index >= 0 && index < DICT_DAYS) {
-            return DATE_DAY_OFFSET_ITEMS[index];
-        } else {
-            DateV2Value<DateV2ValueType> d = DATE_DAY_OFFSET_ITEMS[0];
-            return d += index;
-        }
-    }
-
-    inline DateV2Value<DateV2ValueType> get_value_for_day8(int day) const {
-        int index = day + DAY_BEFORE_EPOCH;
-        if (index >= 0 && index < DICT_DAYS) [[likely]] {
-            return DATE_DAY_OFFSET_ITEMS[index];
-        } else {
-            DateV2Value<DateV2ValueType> d = DATE_DAY_OFFSET_ITEMS[0];
-            return d += index;
-        }
-    }
-
-    inline DateV2Value<DateV2ValueType> get_value_for_day2(int day) const {
-        return DATE_DAY_OFFSET_ITEMS[day + DAY_BEFORE_EPOCH];
-    }
-
-    inline DateV2Value<DateV2ValueType>& get_value_for_day3(int day) const {
-        return DATE_DAY_OFFSET_ITEMS[day + DAY_BEFORE_EPOCH];
-    }
-
     int daynr(int year, int month, int day) const;
 };
 

--- a/be/src/vec/runtime/vdatetime_value.h
+++ b/be/src/vec/runtime/vdatetime_value.h
@@ -752,9 +752,11 @@ public:
     // Constructor
     DateV2Value() : date_v2_value_(0, 0, 0, 0, 0, 0, 0) {}
 
-    DateV2Value(DateV2Value<T>& other) { int_val_ = other.to_date_int_val(); }
+    DateV2Value(underlying_value int_val) : int_val_(int_val) {}
 
-    DateV2Value(const DateV2Value<T>& other) { int_val_ = other.to_date_int_val(); }
+    DateV2Value(DateV2Value<T>& other) : int_val_(other.int_val_) {}
+
+    DateV2Value(const DateV2Value<T>& other) : int_val_(other.int_val_) {}
 
     static DateV2Value create_from_olap_date(uint64_t value) {
         DateV2Value<T> date;
@@ -1131,7 +1133,7 @@ public:
                this->microsecond() == 0;
     }
 
-    underlying_value to_date_int_val() const;
+    underlying_value to_date_int_val() const { return int_val_; }
 
     bool from_date(uint32_t value);
     bool from_datetime(uint64_t value);
@@ -1527,14 +1529,6 @@ int64_t datetime_diff(const VecDateTimeValue& ts_value1, const DateV2Value<T>& t
  */
 class date_day_offset_dict {
 private:
-    static date_day_offset_dict instance;
-
-    date_day_offset_dict();
-    ~date_day_offset_dict() = default;
-    date_day_offset_dict(const date_day_offset_dict&) = default;
-    date_day_offset_dict& operator=(const date_day_offset_dict&) = default;
-
-public:
     static constexpr int DAY_BEFORE_EPOCH = 25567;                           // 1900-01-01
     static constexpr int DAY_AFTER_EPOCH = 25566;                            // 2039-12-31
     static constexpr int DICT_DAYS = DAY_BEFORE_EPOCH + 1 + DAY_AFTER_EPOCH; // 1 means 1970-01-01
@@ -1544,6 +1538,19 @@ public:
     static constexpr int DAY_OFFSET_CAL_START_POINT_DAYNR =
             719528; // 1970-01-01 (start from 0000-01-01, 0000-01-01 is day 1, returns 1)
 
+    static std::array<DateV2Value<DateV2ValueType>, DICT_DAYS> DATE_DAY_OFFSET_ITEMS;
+    static std::array<std::array<std::array<int, 31>, 12>, 140> DATE_DAY_OFFSET_DICT;
+
+    static bool DATE_DAY_OFFSET_ITEMS_INIT;
+
+    static date_day_offset_dict instance;
+
+    date_day_offset_dict();
+    ~date_day_offset_dict() = default;
+    date_day_offset_dict(const date_day_offset_dict&) = default;
+    date_day_offset_dict& operator=(const date_day_offset_dict&) = default;
+
+public:
     static bool can_speed_up_calc_daynr(int year) { return year >= START_YEAR && year <= END_YEAR; }
 
     static int get_offset_by_daynr(int daynr) { return daynr - DAY_OFFSET_CAL_START_POINT_DAYNR; }
@@ -1557,7 +1564,53 @@ public:
 
     static bool get_dict_init();
 
-    DateV2Value<DateV2ValueType> operator[](int day) const;
+    inline DateV2Value<DateV2ValueType> operator[](int day) const {
+        int index = day + DAY_BEFORE_EPOCH;
+        if (LIKELY(index >= 0 && index < DICT_DAYS)) {
+            return DATE_DAY_OFFSET_ITEMS[index];
+        } else {
+            DateV2Value<DateV2ValueType> d = DATE_DAY_OFFSET_ITEMS[0];
+            return d += index;
+        }
+    }
+
+    inline DateV2Value<DateV2ValueType> get_value_for_day(int day) const {
+        int index = day + DAY_BEFORE_EPOCH;
+        if (LIKELY(index >= 0 && index < DICT_DAYS)) {
+            return DATE_DAY_OFFSET_ITEMS[index];
+        } else {
+            DateV2Value<DateV2ValueType> d = DATE_DAY_OFFSET_ITEMS[0];
+            return d += index;
+        }
+    }
+
+    inline DateV2Value<DateV2ValueType> get_value_for_day7(int day) const {
+        int index = day + DAY_BEFORE_EPOCH;
+        if (index >= 0 && index < DICT_DAYS) {
+            return DATE_DAY_OFFSET_ITEMS[index];
+        } else {
+            DateV2Value<DateV2ValueType> d = DATE_DAY_OFFSET_ITEMS[0];
+            return d += index;
+        }
+    }
+
+    inline DateV2Value<DateV2ValueType> get_value_for_day8(int day) const {
+        int index = day + DAY_BEFORE_EPOCH;
+        if (index >= 0 && index < DICT_DAYS) [[likely]] {
+            return DATE_DAY_OFFSET_ITEMS[index];
+        } else {
+            DateV2Value<DateV2ValueType> d = DATE_DAY_OFFSET_ITEMS[0];
+            return d += index;
+        }
+    }
+
+    inline DateV2Value<DateV2ValueType> get_value_for_day2(int day) const {
+        return DATE_DAY_OFFSET_ITEMS[day + DAY_BEFORE_EPOCH];
+    }
+
+    inline DateV2Value<DateV2ValueType>& get_value_for_day3(int day) const {
+        return DATE_DAY_OFFSET_ITEMS[day + DAY_BEFORE_EPOCH];
+    }
 
     int daynr(int year, int month, int day) const;
 };


### PR DESCRIPTION
## Proposed changes

```
select count(l_orderkey), count(l_extendedprice), count(l_discount), count(l_shipdate) from lineitem where l_shipdate > '1995-03-15';
```

### Test Result
two nodes
7.9 s to 7.4 s

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

