### PR TITLE
[enhancement](bulk-load) strict second level granularity for timeout between (0,1)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadLoadingTask.java
@@ -154,6 +154,7 @@ public class LoadLoadingTask extends LoadTask {
          * here we use exec_mem_limit to directly override the load_mem_limit property.
          */
         curCoordinator.setLoadMemLimit(execMemLimit);
+        curCoordinator.setMemTableOnSinkNode(enableMemTableOnSinkNode);
 
         long leftTimeMs = getLeftTimeMs();
         if (leftTimeMs <= 0) {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadLoadingTask.java
@@ -154,7 +154,6 @@ public class LoadLoadingTask extends LoadTask {
          * here we use exec_mem_limit to directly override the load_mem_limit property.
          */
         curCoordinator.setLoadMemLimit(execMemLimit);
-        curCoordinator.setMemTableOnSinkNode(enableMemTableOnSinkNode);
 
         long leftTimeMs = getLeftTimeMs();
         if (leftTimeMs <= 0) {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadLoadingTask.java
@@ -159,7 +159,8 @@ public class LoadLoadingTask extends LoadTask {
         if (leftTimeMs <= 0) {
             throw new LoadException("failed to execute loading task when timeout");
         }
-        int timeoutS = (int) (leftTimeMs / 1000);
+        // 1 second is the minimum granularity of actual execution
+        int timeoutS = Math.max((int) (leftTimeMs / 1000), 1);
         curCoordinator.setTimeout(timeoutS);
 
         try {


### PR DESCRIPTION
## Proposed changes

Treat timeout between (0,1)s as 1s, or coordinator may throw an exception.
