### PR TITLE
[draft](feature) support fully fallback to plain encoding page if the dict page is full for string column

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1148,6 +1148,8 @@ DEFINE_mInt64(local_exchange_buffer_mem_limit, "134217728");
 
 DEFINE_Bool(enable_dict_page_automatically_fall_back, "false");
 
+DEFINE_Int32(dict_page_size_limit, "1048576");
+
 // clang-format off
 #ifdef BE_TEST
 // test s3

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1146,6 +1146,8 @@ DEFINE_mInt32(variant_max_merged_tablet_schema_size, "2048");
 // 128 MB
 DEFINE_mInt64(local_exchange_buffer_mem_limit, "134217728");
 
+DEFINE_Bool(enable_dict_page_automatically_fall_back, "false");
+
 // clang-format off
 #ifdef BE_TEST
 // test s3

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1225,6 +1225,8 @@ DECLARE_mInt64(local_exchange_buffer_mem_limit);
 // whether the entire dict pags fall back to plain page when the dict page size overflows
 DECLARE_Bool(enable_dict_page_automatically_fall_back);
 
+DECLARE_Int32(dict_page_size_limit);
+
 #ifdef BE_TEST
 // test s3
 DECLARE_String(test_s3_resource);

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1222,6 +1222,9 @@ DECLARE_mInt32(variant_max_merged_tablet_schema_size);
 
 DECLARE_mInt64(local_exchange_buffer_mem_limit);
 
+// whether the entire dict pags fall back to plain page when the dict page size overflows
+DECLARE_Bool(enable_dict_page_automatically_fall_back);
+
 #ifdef BE_TEST
 // test s3
 DECLARE_String(test_s3_resource);

--- a/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
@@ -71,10 +71,13 @@ bool BinaryDictPageBuilder::is_page_full() {
         return true;
     }
     if (_encoding_type == DICT_ENCODING && _dict_builder->is_page_full()) {
+        LOG_INFO("[BinaryDictPageBuilder::is_page_full] _has_first_page_been_written: {}",
+                 _has_first_page_been_written);
         if (config::enable_dict_page_automatically_fall_back && !_has_first_page_been_written) {
             _should_convert_previous_data = true;
             _encoding_type = PLAIN_ENCODING;
-            _dict_builder.reset();
+            _dict_builder->reset();
+            LOG_INFO("[BinaryDictPageBuilder::is_page_full] _should_convert_previous_data = true");
         }
         return true;
     }
@@ -271,6 +274,7 @@ Status BinaryDictPageDecoder::init() {
     _encoding_type = static_cast<EncodingTypePB>(type);
     _data.remove_prefix(BINARY_DICT_PAGE_HEADER_SIZE);
     if (_encoding_type == DICT_ENCODING) {
+        LOG(INFO) << fmt::format("[BinaryDictPageDecoder::init] _encoding_type == DICT_ENCODING");
         _data_page_decoder.reset(
                 _bit_shuffle_ptr =
                         new BitShufflePageDecoder<FieldType::OLAP_FIELD_TYPE_INT>(_data, _options));

--- a/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
@@ -192,6 +192,10 @@ void BinaryDictPageBuilder::reset() {
     }
 }
 
+bool BinaryDictPageBuilder::is_dict_encoding() const {
+    return _encoding_type == DICT_ENCODING;
+}
+
 size_t BinaryDictPageBuilder::count() const {
     return _data_page_builder->count();
 }
@@ -201,11 +205,7 @@ uint64_t BinaryDictPageBuilder::size() const {
 }
 
 Status BinaryDictPageBuilder::get_dictionary_page(OwnedSlice* dictionary_page) {
-    if (_dict_builder) {
-        *dictionary_page = _dict_builder->finish();
-    } else {
-        *dictionary_page = OwnedSlice();
-    }
+    *dictionary_page = _dict_builder->finish();
     return Status::OK();
 }
 

--- a/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
@@ -26,11 +26,13 @@
 #include <utility>
 
 #include "common/compiler_util.h" // IWYU pragma: keep
+#include "common/config.h"
 #include "common/logging.h"
 #include "common/status.h"
 #include "gutil/port.h"
 #include "gutil/strings/substitute.h" // for Substitute
 #include "olap/rowset/segment_v2/bitshuffle_page.h"
+#include "olap/rowset/segment_v2/options.h"
 #include "util/coding.h"
 #include "util/slice.h" // for Slice
 #include "vec/columns/column.h"
@@ -55,6 +57,7 @@ BinaryDictPageBuilder::BinaryDictPageBuilder(const PageBuilderOptions& options)
     _data_page_builder =
             std::make_unique<BitshufflePageBuilder<FieldType::OLAP_FIELD_TYPE_INT>>(options);
     PageBuilderOptions dict_builder_options;
+    dict_builder_options.dict_page_size = _options.dict_page_size;
     dict_builder_options.data_page_size =
             std::min(_options.data_page_size, _options.dict_page_size);
     dict_builder_options.is_dict_page = true;
@@ -280,11 +283,6 @@ Status BinaryDictPageDecoder::seek_to_position_in_page(size_t pos) {
 bool BinaryDictPageDecoder::is_dict_encoding() const {
     return _encoding_type == DICT_ENCODING;
 }
-
-void BinaryDictPageDecoder::set_dict_decoder(uint32_t dict_num, StringRef* dict_word_info) {
-    _dict_num = dict_num;
-    _dict_word_info = dict_word_info;
-};
 
 void BinaryDictPageDecoder::set_dict_decoder(PageDecoder* dict_decoder, StringRef* dict_word_info) {
     _dict_num =

--- a/be/src/olap/rowset/segment_v2/binary_dict_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.h
@@ -104,8 +104,6 @@ private:
     };
     // query for dict item -> dict id
     phmap::flat_hash_map<Slice, uint32_t, HashOfSlice> _dictionary;
-    // used to remember the insertion order of dict keys
-    std::vector<Slice> _dict_items;
     // TODO(zc): rethink about this arena
     vectorized::Arena _arena;
     faststring _buffer;
@@ -115,7 +113,6 @@ private:
     uint32_t _empty_code = 0;
 
     bool _has_first_page_been_written = false;
-    std::vector<Slice> _pending_pages;
     bool _should_convert_previous_data = false;
 };
 

--- a/be/src/olap/rowset/segment_v2/binary_dict_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.h
@@ -79,19 +79,13 @@ public:
 
     Status get_last_value(void* value) const override;
 
-    bool should_convert_previous_data() const {
-        return _should_convert_previous_data && !_has_first_page_been_written;
-    }
+    bool should_convert_previous_data() const;
 
     bool is_dict_encoding() const;
 
     std::vector<Slice> get_previous_data();
 
-    void fallback_data_page_builder() {
-        _data_page_builder =
-                std::make_unique<BinaryPlainPageBuilder<FieldType::OLAP_FIELD_TYPE_VARCHAR>>(
-                        _options);
-    }
+    void fallback_data_page_builder();
 
 private:
     PageBuilderOptions _options;

--- a/be/src/olap/rowset/segment_v2/binary_dict_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.h
@@ -83,6 +83,8 @@ public:
         return _should_convert_previous_data && !_has_first_page_been_written;
     }
 
+    bool is_dict_encoding() const;
+
     std::vector<Slice> get_previous_data();
 
     void fallback_data_page_builder() {

--- a/be/src/olap/rowset/segment_v2/binary_dict_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.h
@@ -144,7 +144,6 @@ public:
 
     bool is_dict_encoding() const;
 
-    void set_dict_decoder(uint32_t dict_num, StringRef* dict_word_info);
     void set_dict_decoder(PageDecoder* dict_decoder, StringRef* dict_word_info);
 
     ~BinaryDictPageDecoder() override;

--- a/be/src/olap/rowset/segment_v2/binary_plain_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_plain_page.h
@@ -54,6 +54,10 @@ public:
     bool is_page_full() override {
         bool ret = false;
         if (_options.is_dict_page) {
+            LOG_INFO(
+                    "[BinaryPlainPageBuilder::is_page_full] _size_estimate: {}, "
+                    "_options.dict_page_size: {}",
+                    _size_estimate, _options.dict_page_size);
             // dict_page_size is 0, do not limit the page size
             ret = _options.dict_page_size != 0 && _size_estimate > _options.dict_page_size;
         } else {

--- a/be/src/olap/rowset/segment_v2/bitshuffle_page.h
+++ b/be/src/olap/rowset/segment_v2/bitshuffle_page.h
@@ -238,6 +238,8 @@ private:
     faststring _buffer;
     CppType _first_value;
     CppType _last_value;
+
+    friend class BinaryDictPageBuilder;
 };
 
 inline Status parse_bit_shuffle_header(const Slice& data, size_t& num_elements,

--- a/be/src/olap/rowset/segment_v2/column_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/column_writer.cpp
@@ -496,6 +496,8 @@ Status ScalarColumnWriter::init() {
     _opts.meta->set_encoding(_encoding_info->encoding());
     // create page builder
     PageBuilderOptions opts;
+    opts.dict_page_size =
+            (config::dict_page_size_limit > 0 ? config::dict_page_size_limit : DEFAULT_PAGE_SIZE);
     opts.data_page_size = _opts.data_page_size;
     RETURN_IF_ERROR(_encoding_info->create_page_builder(opts, &page_builder));
     if (page_builder == nullptr) {
@@ -755,6 +757,7 @@ Status ScalarColumnWriter::finish_current_page() {
 }
 
 Status ScalarColumnWriter::_rewrite_previous_data(const Slice* data, size_t num_rows) {
+    LOG_INFO("[ScalarColumnWriter::_rewrite_previous_data] num_rows: {}", num_rows);
     const auto* ptr = reinterpret_cast<const uint8_t*>(data);
 
     RETURN_IF_ERROR(_init_index_builder());
@@ -782,6 +785,7 @@ Status ScalarColumnWriter::_rewrite_previous_data(const Slice* data, size_t num_
     } else {
         RETURN_IF_ERROR(append_data(&ptr, num_rows));
     }
+    LOG_INFO("[ScalarColumnWriter::_rewrite_previous_data] _next_rowid: {}", _next_rowid);
     return Status::OK();
 }
 

--- a/be/src/olap/rowset/segment_v2/column_writer.h
+++ b/be/src/olap/rowset/segment_v2/column_writer.h
@@ -244,6 +244,9 @@ private:
 
     Status _write_data_page(Page* page);
 
+    Status _init_index_builder();
+    Status _rewrite_previous_data(const Slice* data, size_t num_rows);
+
 private:
     io::FileWriter* _file_writer = nullptr;
     // total size of data page list

--- a/be/src/olap/rowset/segment_v2/encoding_info.cpp
+++ b/be/src/olap/rowset/segment_v2/encoding_info.cpp
@@ -24,6 +24,7 @@
 #include <unordered_map>
 #include <utility>
 
+#include "common/config.h"
 #include "olap/olap_common.h"
 #include "olap/rowset/segment_v2/binary_dict_page.h"
 #include "olap/rowset/segment_v2/binary_plain_page.h"

--- a/be/test/olap/rowset/segment_v2/binary_dict_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/binary_dict_page_test.cpp
@@ -19,12 +19,9 @@
 
 #include <gtest/gtest.h>
 
-#include <algorithm>
 #include <fstream>
 #include <iostream>
-#include <numeric>
 
-#include "common/config.h"
 #include "common/logging.h"
 #include "olap/olap_common.h"
 #include "olap/rowset/segment_v2/binary_plain_page.h"
@@ -224,55 +221,7 @@ public:
                                       << ", line number:" << page_start_ids[slice_index] + pos + 1;
         }
     }
-
-    void test_automatically_fallback() {
-        int start = 1000;
-        int end = 9000;
-        std::vector<std::string> data;
-        std::vector<Slice> slices;
-        for (int i = start; i < end; i++) {
-            data.emplace_back(std::to_string(i));
-        }
-        for (const auto& s : data) {
-            slices.emplace_back(s);
-        }
-
-        auto test_convert_status = [&](size_t dict_page_size, size_t data_page_size,
-                                       bool expected_should_covert,
-                                       bool expected_is_dict_encoding) {
-            config::enable_dict_page_automatically_fall_back = true;
-            PageBuilderOptions options;
-            options.data_page_size = data_page_size;
-            options.dict_page_size = dict_page_size;
-            BinaryDictPageBuilder page_builder(options);
-            size_t count = slices.size();
-
-            for (int i = 0; i < count;) {
-                size_t add_num = 1;
-                const Slice* ptr = &slices[i];
-                Status ret = page_builder.add(reinterpret_cast<const uint8_t*>(ptr), &add_num);
-                EXPECT_TRUE(ret.ok());
-                if (page_builder.is_page_full()) {
-                    EXPECT_EQ(page_builder.should_convert_previous_data(), expected_should_covert);
-                    EXPECT_EQ(page_builder.is_dict_encoding(), expected_is_dict_encoding);
-                    return;
-                }
-                i += add_num;
-            }
-            config::enable_dict_page_automatically_fall_back = false;
-        };
-
-        {
-            // 1. dict page is full before data page is full
-            EXPECT_NO_FATAL_FAILURE(test_convert_status(1024, 1 * 1024 * 1024, true, false));
-        }
-
-        {
-            // 2. data page is full before dict page is full
-            EXPECT_NO_FATAL_FAILURE(test_convert_status(1 * 1024 * 1024, 1024, false, true));
-        }
-    };
-}
+};
 
 TEST_F(BinaryDictPageTest, TestBySmallDataSize) {
     std::vector<Slice> slices;
@@ -304,10 +253,6 @@ TEST_F(BinaryDictPageTest, TestEncodingRatio) {
 
     LOG(INFO) << "source line number:" << slices.size();
     test_with_large_data_size(slices);
-}
-
-TEST_F(BinaryDictPageTest, TestAutomaticallyFallback) {
-    test_automatically_fallback();
 }
 
 } // namespace segment_v2

--- a/be/test/olap/rowset/segment_v2/dict_page_automatical_fallback_test.cpp
+++ b/be/test/olap/rowset/segment_v2/dict_page_automatical_fallback_test.cpp
@@ -28,7 +28,11 @@
 #include "io/fs/file_system.h"
 #include "io/fs/file_writer.h"
 #include "io/fs/local_file_system.h"
+#include "olap/olap_common.h"
 #include "olap/rowset/segment_v2/binary_dict_page.h"
+#include "olap/rowset/segment_v2/bitshuffle_page_pre_decoder.h"
+#include "olap/rowset/segment_v2/column_reader.h"
+#include "olap/rowset/segment_v2/column_writer.h"
 #include "testutil/test_util.h"
 
 namespace doris {
@@ -87,6 +91,7 @@ public:
 
     void test_dict_page_fallback(size_t dict_page_size, size_t data_page_size,
                                  bool expected_should_covert) {
+        // encode
         PageBuilderOptions options;
         options.data_page_size = data_page_size;
         options.dict_page_size = dict_page_size;
@@ -104,7 +109,6 @@ public:
                 Slice slice = s.slice();
                 size_t type = decode_fixed32_le((const uint8_t*)&slice.data[0]);
                 auto encoding_type = static_cast<EncodingTypePB>(type);
-                LOG_INFO("encoding_type: {}", encoding_type);
                 EXPECT_EQ(encoding_type, PLAIN_ENCODING);
             }
         } else {
@@ -119,6 +123,180 @@ public:
                 }
             }
             EXPECT_GT(dict_encoding_count, 0);
+        }
+    }
+
+    template <FieldType type, EncodingTypePB encoding>
+    void test_nullable_data(uint8_t* src_data, uint8_t* src_is_null, int num_rows,
+                            std::string test_name) {
+        using Type = typename TypeTraits<type>::CppType;
+        Type* src = (Type*)src_data;
+
+        ColumnMetaPB meta;
+
+        // write data
+        std::string fname = TEST_DIR + "/" + test_name;
+        auto fs = io::global_local_filesystem();
+        {
+            io::FileWriterPtr file_writer;
+            Status st = fs->create_file(fname, &file_writer);
+            EXPECT_TRUE(st.ok()) << st;
+
+            ColumnWriterOptions writer_opts;
+            writer_opts.meta = &meta;
+            writer_opts.meta->set_column_id(0);
+            writer_opts.meta->set_unique_id(0);
+            writer_opts.meta->set_type(type);
+            if (type == FieldType::OLAP_FIELD_TYPE_CHAR ||
+                type == FieldType::OLAP_FIELD_TYPE_VARCHAR) {
+                writer_opts.meta->set_length(10);
+            } else {
+                writer_opts.meta->set_length(0);
+            }
+            writer_opts.meta->set_encoding(encoding);
+            writer_opts.meta->set_compression(segment_v2::CompressionTypePB::LZ4F);
+            writer_opts.meta->set_is_nullable(true);
+            writer_opts.need_zone_map = true;
+
+            TabletColumn column(OLAP_FIELD_AGGREGATION_NONE, type);
+            if (type == FieldType::OLAP_FIELD_TYPE_VARCHAR) {
+                column = create_varchar_key(1);
+            } else if (type == FieldType::OLAP_FIELD_TYPE_CHAR) {
+                column = create_char_key(1);
+            }
+            std::unique_ptr<ColumnWriter> writer;
+            ColumnWriter::create(writer_opts, &column, file_writer.get(), &writer);
+            st = writer->init();
+            EXPECT_TRUE(st.ok()) << st.to_string();
+
+            for (int i = 0; i < num_rows; ++i) {
+                st = writer->append(BitmapTest(src_is_null, i), src + i);
+                EXPECT_TRUE(st.ok());
+            }
+
+            EXPECT_TRUE(writer->finish().ok());
+            EXPECT_TRUE(writer->write_data().ok());
+            EXPECT_TRUE(writer->write_ordinal_index().ok());
+            EXPECT_TRUE(writer->write_zone_map().ok());
+
+            // close the file
+            EXPECT_TRUE(file_writer->close().ok());
+        }
+        auto type_info = get_scalar_type_info(type);
+        io::FileReaderSPtr file_reader;
+        ASSERT_EQ(fs->open_file(fname, &file_reader), Status::OK());
+        // read and check
+        {
+            // sequence read
+            {
+                ColumnReaderOptions reader_opts;
+                std::unique_ptr<ColumnReader> reader;
+                auto st = ColumnReader::create(reader_opts, meta, num_rows, file_reader, &reader);
+                EXPECT_TRUE(st.ok());
+
+                ColumnIterator* iter = nullptr;
+                st = reader->new_iterator(&iter);
+                EXPECT_TRUE(st.ok());
+
+                ColumnIteratorOptions iter_opts;
+                OlapReaderStatistics stats;
+                iter_opts.stats = &stats;
+                iter_opts.file_reader = file_reader.get();
+                st = iter->init(iter_opts);
+                EXPECT_TRUE(st.ok());
+
+                st = iter->seek_to_first();
+                EXPECT_TRUE(st.ok()) << st.to_string();
+
+                vectorized::Arena pool;
+                std::unique_ptr<ColumnVectorBatch> cvb;
+                ColumnVectorBatch::create(0, true, type_info, nullptr, &cvb);
+                cvb->resize(1024);
+                ColumnBlock col(cvb.get(), &pool);
+
+                int idx = 0;
+                while (true) {
+                    size_t rows_read = 1024;
+                    ColumnBlockView dst(&col);
+                    st = iter->next_batch(&rows_read, &dst);
+                    EXPECT_TRUE(st.ok());
+                    for (int j = 0; j < rows_read; ++j) {
+                        EXPECT_EQ(BitmapTest(src_is_null, idx), col.is_null(j));
+                        if (!col.is_null(j)) {
+                            if (type == FieldType::OLAP_FIELD_TYPE_VARCHAR ||
+                                type == FieldType::OLAP_FIELD_TYPE_CHAR) {
+                                Slice* src_slice = (Slice*)src_data;
+                                EXPECT_EQ(src_slice[idx].to_string(),
+                                          reinterpret_cast<const Slice*>(col.cell_ptr(j))
+                                                  ->to_string())
+                                        << "j:" << j;
+                            } else {
+                                EXPECT_EQ(src[idx],
+                                          *reinterpret_cast<const Type*>(col.cell_ptr(j)));
+                            }
+                        }
+                        idx++;
+                    }
+                    if (rows_read < 1024) {
+                        break;
+                    }
+                }
+                delete iter;
+            }
+
+            {
+                ColumnReaderOptions reader_opts;
+                std::unique_ptr<ColumnReader> reader;
+                auto st = ColumnReader::create(reader_opts, meta, num_rows, file_reader, &reader);
+                EXPECT_TRUE(st.ok());
+
+                ColumnIterator* iter = nullptr;
+                st = reader->new_iterator(&iter);
+                EXPECT_TRUE(st.ok());
+
+                EXPECT_TRUE(st.ok());
+                ColumnIteratorOptions iter_opts;
+                OlapReaderStatistics stats;
+                iter_opts.stats = &stats;
+                iter_opts.file_reader = file_reader.get();
+                st = iter->init(iter_opts);
+                EXPECT_TRUE(st.ok());
+
+                vectorized::Arena pool;
+                std::unique_ptr<ColumnVectorBatch> cvb;
+                ColumnVectorBatch::create(0, true, type_info, nullptr, &cvb);
+                cvb->resize(1024);
+                ColumnBlock col(cvb.get(), &pool);
+
+                for (int rowid = 0; rowid < num_rows; rowid += 4025) {
+                    st = iter->seek_to_ordinal(rowid);
+                    EXPECT_TRUE(st.ok());
+
+                    int idx = rowid;
+                    size_t rows_read = 1024;
+                    ColumnBlockView dst(&col);
+
+                    st = iter->next_batch(&rows_read, &dst);
+                    EXPECT_TRUE(st.ok());
+                    for (int j = 0; j < rows_read; ++j) {
+                        EXPECT_EQ(BitmapTest(src_is_null, idx), col.is_null(j));
+                        if (!col.is_null(j)) {
+                            if (type == FieldType::OLAP_FIELD_TYPE_VARCHAR ||
+                                type == FieldType::OLAP_FIELD_TYPE_CHAR) {
+                                Slice* src_slice = (Slice*)src_data;
+                                EXPECT_EQ(src_slice[idx].to_string(),
+                                          reinterpret_cast<const Slice*>(col.cell_ptr(j))
+                                                  ->to_string());
+                            } else {
+                                EXPECT_EQ(src[idx],
+                                          *reinterpret_cast<const Type*>(col.cell_ptr(j)));
+                            }
+                        }
+                        idx++;
+                    }
+                }
+                delete iter;
+            }
         }
     }
 };

--- a/be/test/olap/rowset/segment_v2/dict_page_automatical_fallback_test.cpp
+++ b/be/test/olap/rowset/segment_v2/dict_page_automatical_fallback_test.cpp
@@ -1,0 +1,93 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <numeric>
+
+#include "common/config.h"
+#include "common/logging.h"
+#include "olap/rowset/segment_v2/binary_dict_page.h"
+#include "testutil/test_util.h"
+
+namespace doris {
+namespace segment_v2 {
+
+class DictPageAutomaticalFallbackTest : public testing::Test {
+public:
+    void test_binary_dict_page_state() {
+        int start = 1000;
+        int end = 9000;
+        std::vector<std::string> data;
+        std::vector<Slice> slices;
+        for (int i = start; i < end; i++) {
+            data.emplace_back(std::to_string(i));
+        }
+        for (const auto& s : data) {
+            slices.emplace_back(s);
+        }
+
+        auto test_convert_status = [&](size_t dict_page_size, size_t data_page_size,
+                                       bool expected_should_covert,
+                                       bool expected_is_dict_encoding) {
+            config::enable_dict_page_automatically_fall_back = true;
+            PageBuilderOptions options;
+            options.data_page_size = data_page_size;
+            options.dict_page_size = dict_page_size;
+            BinaryDictPageBuilder page_builder(options);
+            size_t count = slices.size();
+            LOG_INFO("count: {}", count);
+            bool is_page_full = false;
+
+            for (int i = 0; i < count;) {
+                size_t add_num = 1;
+                const Slice* ptr = &slices[i];
+                Status ret = page_builder.add(reinterpret_cast<const uint8_t*>(ptr), &add_num);
+                EXPECT_TRUE(ret.ok());
+                if (page_builder.is_page_full()) {
+                    is_page_full = true;
+                    EXPECT_EQ(page_builder.should_convert_previous_data(), expected_should_covert);
+                    EXPECT_EQ(page_builder.is_dict_encoding(), expected_is_dict_encoding);
+                    break;
+                }
+                i += add_num;
+            }
+            EXPECT_TRUE(is_page_full);
+            config::enable_dict_page_automatically_fall_back = false;
+        };
+
+        {
+            // 1. dict page is full before data page is full, should re-write previous data
+            EXPECT_NO_FATAL_FAILURE(test_convert_status(100, 1 * 1024 * 1024, true, false));
+        }
+
+        {
+            // 2. data page is full before dict page is full, don't fallback
+            EXPECT_NO_FATAL_FAILURE(test_convert_status(1 * 1024 * 1024, 100, false, true));
+        }
+    };
+};
+
+TEST_F(DictPageAutomaticalFallbackTest, TestBinaryDictPageState) {
+    test_binary_dict_page_state();
+}
+
+} // namespace segment_v2
+} // namespace doris

--- a/be/test/olap/rowset/segment_v2/dict_page_automatical_fallback_test.cpp
+++ b/be/test/olap/rowset/segment_v2/dict_page_automatical_fallback_test.cpp
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <gen_cpp/segment_v2.pb.h>
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -24,69 +25,132 @@
 
 #include "common/config.h"
 #include "common/logging.h"
+#include "io/fs/file_system.h"
+#include "io/fs/file_writer.h"
+#include "io/fs/local_file_system.h"
 #include "olap/rowset/segment_v2/binary_dict_page.h"
 #include "testutil/test_util.h"
 
 namespace doris {
 namespace segment_v2 {
 
+static const std::string TEST_DIR = "./ut_dir/dict_page_automatical_fallback_test";
+
 class DictPageAutomaticalFallbackTest : public testing::Test {
 public:
-    void test_binary_dict_page_state() {
-        int start = 1000;
-        int end = 9000;
-        std::vector<std::string> data;
-        std::vector<Slice> slices;
-        for (int i = start; i < end; i++) {
-            data.emplace_back(std::to_string(i));
-        }
-        for (const auto& s : data) {
-            slices.emplace_back(s);
-        }
+    DictPageAutomaticalFallbackTest() = default;
+    ~DictPageAutomaticalFallbackTest() override = default;
 
-        auto test_convert_status = [&](size_t dict_page_size, size_t data_page_size,
-                                       bool expected_should_covert,
-                                       bool expected_is_dict_encoding) {
-            config::enable_dict_page_automatically_fall_back = true;
-            PageBuilderOptions options;
-            options.data_page_size = data_page_size;
-            options.dict_page_size = dict_page_size;
-            BinaryDictPageBuilder page_builder(options);
-            size_t count = slices.size();
-            LOG_INFO("count: {}", count);
-            bool is_page_full = false;
+protected:
+    void SetUp() override {
+        config::disable_storage_page_cache = true;
+        EXPECT_TRUE(io::global_local_filesystem()->delete_and_create_directory(TEST_DIR).ok());
+        config::enable_dict_page_automatically_fall_back = true;
+    }
 
-            for (int i = 0; i < count;) {
-                size_t add_num = 1;
-                const Slice* ptr = &slices[i];
-                Status ret = page_builder.add(reinterpret_cast<const uint8_t*>(ptr), &add_num);
-                EXPECT_TRUE(ret.ok());
-                if (page_builder.is_page_full()) {
-                    is_page_full = true;
-                    EXPECT_EQ(page_builder.should_convert_previous_data(), expected_should_covert);
-                    EXPECT_EQ(page_builder.is_dict_encoding(), expected_is_dict_encoding);
-                    break;
+    void TearDown() override {
+        EXPECT_TRUE(io::global_local_filesystem()->delete_directory(TEST_DIR).ok());
+        config::enable_dict_page_automatically_fall_back = false;
+    }
+
+public:
+    std::vector<std::string> data;
+    std::vector<Slice> slices;
+    std::vector<OwnedSlice> results;
+    bool converted = false;
+
+public:
+    void finish_current_page(BinaryDictPageBuilder& page_builder) {
+        OwnedSlice s = page_builder.finish();
+        page_builder.reset();
+        results.emplace_back(std::move(s));
+    }
+
+    void append_data(BinaryDictPageBuilder& page_builder, const Slice* data, size_t count) {
+        for (int i = 0; i < count;) {
+            size_t add_num = 1;
+            const Slice* ptr = &data[i];
+            EXPECT_TRUE(page_builder.add(reinterpret_cast<const uint8_t*>(ptr), &add_num).ok());
+            if (page_builder.is_page_full()) {
+                if (page_builder.should_convert_previous_data()) {
+                    converted = true;
+                    std::vector<Slice> previous_data = page_builder.get_previous_data();
+                    page_builder.fallback_data_page_builder();
+                    append_data(page_builder, previous_data.data(), previous_data.size());
+                    continue;
                 }
-                i += add_num;
+                finish_current_page(page_builder);
             }
-            EXPECT_TRUE(is_page_full);
-            config::enable_dict_page_automatically_fall_back = false;
-        };
-
-        {
-            // 1. dict page is full before data page is full, should re-write previous data
-            EXPECT_NO_FATAL_FAILURE(test_convert_status(100, 1 * 1024 * 1024, true, false));
+            i += add_num;
         }
+    }
 
-        {
-            // 2. data page is full before dict page is full, don't fallback
-            EXPECT_NO_FATAL_FAILURE(test_convert_status(1 * 1024 * 1024, 100, false, true));
+    void test_dict_page_fallback(size_t dict_page_size, size_t data_page_size,
+                                 bool expected_should_covert) {
+        PageBuilderOptions options;
+        options.data_page_size = data_page_size;
+        options.dict_page_size = dict_page_size;
+        BinaryDictPageBuilder page_builder(options);
+        size_t count = slices.size();
+        results.clear();
+        converted = false;
+
+        append_data(page_builder, slices.data(), count);
+        finish_current_page(page_builder);
+
+        if (expected_should_covert) {
+            EXPECT_TRUE(converted);
+            for (auto& s : results) {
+                Slice slice = s.slice();
+                size_t type = decode_fixed32_le((const uint8_t*)&slice.data[0]);
+                auto encoding_type = static_cast<EncodingTypePB>(type);
+                LOG_INFO("encoding_type: {}", encoding_type);
+                EXPECT_EQ(encoding_type, PLAIN_ENCODING);
+            }
+        } else {
+            EXPECT_FALSE(converted);
+            int dict_encoding_count = 0;
+            for (auto& s : results) {
+                Slice slice = s.slice();
+                size_t type = decode_fixed32_le((const uint8_t*)&slice.data[0]);
+                auto encoding_type = static_cast<EncodingTypePB>(type);
+                if (encoding_type == PLAIN_ENCODING) {
+                    ++dict_encoding_count;
+                }
+            }
+            EXPECT_GT(dict_encoding_count, 0);
         }
-    };
+    }
 };
 
-TEST_F(DictPageAutomaticalFallbackTest, TestBinaryDictPageState) {
-    test_binary_dict_page_state();
+TEST_F(DictPageAutomaticalFallbackTest, TestBinaryDictPageShouldConvert) {
+    int start = 1000;
+    int end = 5000;
+    data.clear();
+    slices.clear();
+    for (int i = start; i < end; i++) {
+        data.emplace_back(std::to_string(i));
+    }
+    for (const auto& s : data) {
+        slices.emplace_back(s);
+    }
+    // dict page is full before data page is full, should re-write previous data
+    EXPECT_NO_FATAL_FAILURE(test_dict_page_fallback(100, 1 * 1024 * 1024, true));
+}
+
+TEST_F(DictPageAutomaticalFallbackTest, TestBinaryDictPageShouldNotConvert) {
+    int start = 1000;
+    int end = 5000;
+    data.clear();
+    slices.clear();
+    for (int i = start; i < end; i++) {
+        data.emplace_back(std::to_string(i));
+    }
+    for (const auto& s : data) {
+        slices.emplace_back(s);
+    }
+    // data page is full before dict page is full, don't fallback
+    EXPECT_NO_FATAL_FAILURE(test_dict_page_fallback(100, 1 * 1024 * 1024, true));
 }
 
 } // namespace segment_v2


### PR DESCRIPTION
## Proposed changes


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

