### PR TITLE
[fix](pipeline) sort_merge should throw exception in has_next_block if got failed status

### DIFF
--- a/be/src/vec/core/sort_cursor.h
+++ b/be/src/vec/core/sort_cursor.h
@@ -244,6 +244,13 @@ struct BlockSupplierSortCursorImpl : public MergeSortCursorImpl {
             }
             MergeSortCursorImpl::reset(_block);
             return status.ok();
+<<<<<<< HEAD
+=======
+        } else if (!status.ok()) {
+            // Currently, a known error status is emitted when sender
+            // close recei
+            throw std::runtime_error(status.msg());
+>>>>>>> 39fe5a4412 (Fix need)
         }
         return false;
     }

--- a/be/src/vec/core/sort_cursor.h
+++ b/be/src/vec/core/sort_cursor.h
@@ -244,13 +244,8 @@ struct BlockSupplierSortCursorImpl : public MergeSortCursorImpl {
             }
             MergeSortCursorImpl::reset(_block);
             return status.ok();
-<<<<<<< HEAD
-=======
         } else if (!status.ok()) {
-            // Currently, a known error status is emitted when sender
-            // close recei
             throw std::runtime_error(status.msg());
->>>>>>> 39fe5a4412 (Fix need)
         }
         return false;
     }

--- a/be/src/vec/runtime/vsorted_run_merger.cpp
+++ b/be/src/vec/runtime/vsorted_run_merger.cpp
@@ -69,12 +69,16 @@ void VSortedRunMerger::init_timers(RuntimeProfile* profile) {
 }
 
 Status VSortedRunMerger::prepare(const vector<BlockSupplier>& input_runs) {
-    for (const auto& supplier : input_runs) {
-        if (_use_sort_desc) {
-            _cursors.emplace_back(supplier, _desc);
-        } else {
-            _cursors.emplace_back(supplier, _ordering_expr, _is_asc_order, _nulls_first);
+    try {
+        for (const auto& supplier : input_runs) {
+            if (_use_sort_desc) {
+                _cursors.emplace_back(supplier, _desc);
+            } else {
+                _cursors.emplace_back(supplier, _ordering_expr, _is_asc_order, _nulls_first);
+            }
         }
+    } catch (const std::exception& e) {
+        return Status::Cancelled(e.what());
     }
 
     for (auto& _cursor : _cursors) {


### PR DESCRIPTION
Test in regression-test/suites/datatype_p0/decimalv3/test_decimalv3_overflow.groovy::249 sometimes failed when there are multiple BEs and FE process report status slowly for some reason.

```
explain select k1, k2, k1 * k2 from test_decimal128_overflow2 order by 1,2,3
--------------

+----------------------------------------------------------------------------------------------------------------------------+
| Explain String(Nereids Planner)                                                                                            |
+----------------------------------------------------------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                                                                            |
|   OUTPUT EXPRS:                                                                                                            |
|     k1[#5]                                                                                                                 |
|     k2[#6]                                                                                                                 |
|     (k1 * k2)[#7]                                                                                                          |
|   PARTITION: UNPARTITIONED                                                                                                 |
|                                                                                                                            |
|   HAS_COLO_PLAN_NODE: false                                                                                                |
|                                                                                                                            |
|   VRESULT SINK                                                                                                             |
|      MYSQL_PROTOCAL                                                                                                        |
|                                                                                                                            |
|   111:VMERGING-EXCHANGE                                                                                                    |
|      offset: 0                                                                                                             |
|                                                                                                                            |
| PLAN FRAGMENT 1                                                                                                            |
|                                                                                                                            |
|   PARTITION: HASH_PARTITIONED: k1[#0], k2[#1]                                                                              |
|                                                                                                                            |
|   HAS_COLO_PLAN_NODE: false                                                                                                |
|                                                                                                                            |
|   STREAM DATA SINK                                                                                                         |
|     EXCHANGE ID: 111                                                                                                       |
|     UNPARTITIONED                                                                                                          |
|                                                                                                                            |
|   108:VSORT                                                                                                                |
|   |  order by: k1[#5] ASC, k2[#6] ASC, (k1 * k2)[#7] ASC                                                                   |
|   |  offset: 0                                                                                                             |
|   |                                                                                                                        |
|   102:VOlapScanNode                                                                                                        |
|      TABLE: regression_test_datatype_p0_decimalv3.test_decimal128_overflow2(test_decimal128_overflow2), PREAGGREGATION: ON |
|      partitions=1/1 (test_decimal128_overflow2), tablets=8/8, tabletList=22841,22843,22845 ...                             |
|      cardinality=6, avgRowSize=0.0, numNodes=1                                                                             |
|      pushAggOp=NONE                                                                                                        |
|      projections: k1[#0], k2[#1], (k1[#0] * k2[#1])                                                                        |
|      project output tuple id: 1                                                                                            |
+----------------------------------------------------------------------------------------------------------------------------+
36 rows in set (0.03 sec)
```
Why failed:
1. Multiple BEs
2. Fragments 0 and 1 are MUST on different BEs
3. Pipeline task of VOlapScanNode which executes k1*k2 failed sets query status to cancelled
4. Pipeline task of VSort call try close, send Cancelled status to VMergeExchange
5. sort_curso did not throw exception when it meets error