### PR TITLE
[fix](partial update) update error code when failed to fill the missing fields

### DIFF
--- a/be/src/olap/memtable_flush_executor.cpp
+++ b/be/src/olap/memtable_flush_executor.cpp
@@ -161,7 +161,8 @@ void FlushToken::_flush_memtable(MemTable* mem_table, int32_t segment_id,
     }
     if (!s.ok()) {
         std::lock_guard wrlk(_flush_status_lock);
-        LOG(WARNING) << "Flush memtable failed with res = " << s;
+        LOG(WARNING) << "Flush memtable failed with res = " << s
+                     << ", load_id: " << print_id(_rowset_writer->load_id());
         _flush_status = s;
         return;
     }

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -471,7 +471,7 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
             }
 
             if (!_opts.rowset_ctx->partial_update_info->can_insert_new_rows_in_partial_update) {
-                return Status::InternalError(
+                return Status::Error<INVALID_SCHEMA, false>(
                         "the unmentioned columns should have default value or be nullable for "
                         "newly inserted rows in non-strict mode partial update");
             }

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -471,9 +471,17 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
             }
 
             if (!_opts.rowset_ctx->partial_update_info->can_insert_new_rows_in_partial_update) {
+                std::string error_column;
+                for (auto cid : _opts.rowset_ctx->partial_update_info->missing_cids) {
+                    const TabletColumn& col = _tablet_schema->column(cid);
+                    if (!col.has_default_value() && !col.is_nullable()) {
+                        error_column = col.name();
+                        break;
+                    }
+                }
                 return Status::Error<INVALID_SCHEMA, false>(
-                        "the unmentioned columns should have default value or be nullable for "
-                        "newly inserted rows in non-strict mode partial update");
+                        "the unmentioned column `{}` should have default value or be nullable for "
+                        "newly inserted rows in non-strict mode partial update", error_column);
             }
             has_default_or_nullable = true;
             use_default_or_null_flag.emplace_back(true);

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -481,7 +481,8 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
                 }
                 return Status::Error<INVALID_SCHEMA, false>(
                         "the unmentioned column `{}` should have default value or be nullable for "
-                        "newly inserted rows in non-strict mode partial update", error_column);
+                        "newly inserted rows in non-strict mode partial update",
+                        error_column);
             }
             has_default_or_nullable = true;
             use_default_or_null_flag.emplace_back(true);

--- a/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
@@ -414,7 +414,7 @@ Status VerticalSegmentWriter::_append_block_with_partial_content(RowsInBlock& da
                     }
                 }
                 return Status::Error<INVALID_SCHEMA, false>(
-                        "the unmentioned column {} should have default value or be nullable for "
+                        "the unmentioned column `{}` should have default value or be nullable for "
                         "newly inserted rows in non-strict mode partial update", error_column);
             }
             has_default_or_nullable = true;

--- a/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
@@ -415,7 +415,8 @@ Status VerticalSegmentWriter::_append_block_with_partial_content(RowsInBlock& da
                 }
                 return Status::Error<INVALID_SCHEMA, false>(
                         "the unmentioned column `{}` should have default value or be nullable for "
-                        "newly inserted rows in non-strict mode partial update", error_column);
+                        "newly inserted rows in non-strict mode partial update",
+                        error_column);
             }
             has_default_or_nullable = true;
             use_default_or_null_flag.emplace_back(true);

--- a/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
@@ -405,7 +405,7 @@ Status VerticalSegmentWriter::_append_block_with_partial_content(RowsInBlock& da
             }
 
             if (!_opts.rowset_ctx->partial_update_info->can_insert_new_rows_in_partial_update) {
-                return Status::InternalError(
+                return Status::Error<INVALID_SCHEMA, false>(
                         "the unmentioned columns should have default value or be nullable for "
                         "newly inserted rows in non-strict mode partial update");
             }

--- a/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
@@ -405,9 +405,17 @@ Status VerticalSegmentWriter::_append_block_with_partial_content(RowsInBlock& da
             }
 
             if (!_opts.rowset_ctx->partial_update_info->can_insert_new_rows_in_partial_update) {
+                std::string error_column;
+                for (auto cid : _opts.rowset_ctx->partial_update_info->missing_cids) {
+                    const TabletColumn& col = _tablet_schema->column(cid);
+                    if (!col.has_default_value() && !col.is_nullable()) {
+                        error_column = col.name();
+                        break;
+                    }
+                }
                 return Status::Error<INVALID_SCHEMA, false>(
-                        "the unmentioned columns should have default value or be nullable for "
-                        "newly inserted rows in non-strict mode partial update");
+                        "the unmentioned column {} should have default value or be nullable for "
+                        "newly inserted rows in non-strict mode partial update", error_column);
             }
             has_default_or_nullable = true;
             use_default_or_null_flag.emplace_back(true);

--- a/be/src/vec/sink/writer/vtablet_writer.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer.cpp
@@ -176,7 +176,7 @@ void IndexChannel::mark_as_failed(const VNodeChannel* node_channel, const std::s
                 _failed_channels_msgs.emplace(the_tablet_id,
                                               err + ", host: " + node_channel->host());
                 if (_failed_channels[the_tablet_id].size() >= ((_parent->_num_replicas + 1) / 2)) {
-                    _intolerable_failure_status = Status::Error<INTERNAL_ERROR, false>(
+                    _intolerable_failure_status = Status::Error<ErrorCode::INTERNAL_ERROR, false>(
                             _failed_channels_msgs[the_tablet_id]);
                 }
             }
@@ -184,8 +184,8 @@ void IndexChannel::mark_as_failed(const VNodeChannel* node_channel, const std::s
             _failed_channels[tablet_id].insert(node_id);
             _failed_channels_msgs.emplace(tablet_id, err + ", host: " + node_channel->host());
             if (_failed_channels[tablet_id].size() >= ((_parent->_num_replicas + 1) / 2)) {
-                _intolerable_failure_status =
-                        Status::Error<INTERNAL_ERROR, false>(_failed_channels_msgs[tablet_id]);
+                _intolerable_failure_status = Status::Error<ErrorCode::INTERNAL_ERROR, false>(
+                        _failed_channels_msgs[tablet_id]);
             }
         }
     }
@@ -432,7 +432,7 @@ Status VNodeChannel::open_wait() {
             _cancelled = true;
             auto error_code = open_callback->cntl_->ErrorCode();
             auto error_text = open_callback->cntl_->ErrorText();
-            return Status::Error<INTERNAL_ERROR, false>(
+            return Status::Error<ErrorCode::INTERNAL_ERROR, false>(
                     "failed to open tablet writer, error={}, error_text={}, info={}",
                     berror(error_code), error_text, channel_info());
         }
@@ -466,7 +466,8 @@ Status VNodeChannel::add_block(vectorized::Block* block, const Payload* payload,
     if (!st.ok()) {
         if (_cancelled) {
             std::lock_guard<doris::SpinLock> l(_cancel_msg_lock);
-            return Status::Error<INTERNAL_ERROR, false>("add row failed. {}", _cancel_msg);
+            return Status::Error<ErrorCode::INTERNAL_ERROR, false>("add row failed. {}",
+                                                                   _cancel_msg);
         } else {
             return std::move(st.prepend("already stopped, can't add row. cancelled/eos: "));
         }
@@ -872,7 +873,8 @@ Status VNodeChannel::close_wait(RuntimeState* state) {
     if (!st.ok()) {
         if (_cancelled) {
             std::lock_guard<doris::SpinLock> l(_cancel_msg_lock);
-            return Status::Error<INTERNAL_ERROR, false>("wait close failed. {}", _cancel_msg);
+            return Status::Error<ErrorCode::INTERNAL_ERROR, false>("wait close failed. {}",
+                                                                   _cancel_msg);
         } else {
             return std::move(
                     st.prepend("already stopped, skip waiting for close. cancelled/!eos: "));
@@ -902,7 +904,7 @@ Status VNodeChannel::close_wait(RuntimeState* state) {
         return Status::OK();
     }
 
-    return Status::Error<INTERNAL_ERROR, false>(get_cancel_msg());
+    return Status::Error<ErrorCode::INTERNAL_ERROR, false>(get_cancel_msg());
 }
 
 void VNodeChannel::_close_check() {
@@ -1049,7 +1051,7 @@ Status VTabletWriter::open(doris::RuntimeState* state, doris::RuntimeProfile* pr
 
     // start to send batch continually. this must be called after _init
     if (bthread_start_background(&_sender_thread, nullptr, periodic_send_batch, (void*)this) != 0) {
-        return Status::Error<INTERNAL_ERROR>("bthread_start_backgroud failed");
+        return Status::Error<ErrorCode::INTERNAL_ERROR>("bthread_start_backgroud failed");
     }
     return Status::OK();
 }

--- a/be/src/vec/sink/writer/vtablet_writer.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer.cpp
@@ -176,8 +176,8 @@ void IndexChannel::mark_as_failed(const VNodeChannel* node_channel, const std::s
                 _failed_channels_msgs.emplace(the_tablet_id,
                                               err + ", host: " + node_channel->host());
                 if (_failed_channels[the_tablet_id].size() >= ((_parent->_num_replicas + 1) / 2)) {
-                    _intolerable_failure_status =
-                            Status::InternalError(_failed_channels_msgs[the_tablet_id]);
+                    _intolerable_failure_status = Status::Error<INTERNAL_ERROR, false>(
+                            _failed_channels_msgs[the_tablet_id]);
                 }
             }
         } else {
@@ -185,7 +185,7 @@ void IndexChannel::mark_as_failed(const VNodeChannel* node_channel, const std::s
             _failed_channels_msgs.emplace(tablet_id, err + ", host: " + node_channel->host());
             if (_failed_channels[tablet_id].size() >= ((_parent->_num_replicas + 1) / 2)) {
                 _intolerable_failure_status =
-                        Status::InternalError(_failed_channels_msgs[tablet_id]);
+                        Status::Error<INTERNAL_ERROR, false>(_failed_channels_msgs[tablet_id]);
             }
         }
     }
@@ -432,7 +432,7 @@ Status VNodeChannel::open_wait() {
             _cancelled = true;
             auto error_code = open_callback->cntl_->ErrorCode();
             auto error_text = open_callback->cntl_->ErrorText();
-            return Status::InternalError(
+            return Status::Error<INTERNAL_ERROR, false>(
                     "failed to open tablet writer, error={}, error_text={}, info={}",
                     berror(error_code), error_text, channel_info());
         }
@@ -466,7 +466,7 @@ Status VNodeChannel::add_block(vectorized::Block* block, const Payload* payload,
     if (!st.ok()) {
         if (_cancelled) {
             std::lock_guard<doris::SpinLock> l(_cancel_msg_lock);
-            return Status::InternalError("add row failed. {}", _cancel_msg);
+            return Status::Error<INTERNAL_ERROR, false>("add row failed. {}", _cancel_msg);
         } else {
             return std::move(st.prepend("already stopped, can't add row. cancelled/eos: "));
         }
@@ -872,7 +872,7 @@ Status VNodeChannel::close_wait(RuntimeState* state) {
     if (!st.ok()) {
         if (_cancelled) {
             std::lock_guard<doris::SpinLock> l(_cancel_msg_lock);
-            return Status::InternalError("wait close failed. {}", _cancel_msg);
+            return Status::Error<INTERNAL_ERROR, false>("wait close failed. {}", _cancel_msg);
         } else {
             return std::move(
                     st.prepend("already stopped, skip waiting for close. cancelled/!eos: "));
@@ -902,7 +902,7 @@ Status VNodeChannel::close_wait(RuntimeState* state) {
         return Status::OK();
     }
 
-    return Status::InternalError(get_cancel_msg());
+    return Status::Error<INTERNAL_ERROR, false>(get_cancel_msg());
 }
 
 void VNodeChannel::_close_check() {

--- a/regression-test/suites/nereids_p0/insert_into_table/partial_update.groovy
+++ b/regression-test/suites/nereids_p0/insert_into_table/partial_update.groovy
@@ -122,7 +122,7 @@ suite("nereids_partial_update_native_insert_stmt", "p0") {
             // but field `name` is not nullable and doesn't have default value
             test {
                 sql """insert into ${tableName3}(id,score) values(2,400),(1,200),(4,400)"""
-                exception "INTERNAL_ERROR"
+                exception "the unmentioned column name should have default value or be nullable"
             }
             sql "set enable_unique_key_partial_update=false;"
             sql "sync;"

--- a/regression-test/suites/nereids_p0/insert_into_table/partial_update.groovy
+++ b/regression-test/suites/nereids_p0/insert_into_table/partial_update.groovy
@@ -122,7 +122,7 @@ suite("nereids_partial_update_native_insert_stmt", "p0") {
             // but field `name` is not nullable and doesn't have default value
             test {
                 sql """insert into ${tableName3}(id,score) values(2,400),(1,200),(4,400)"""
-                exception "the unmentioned column name should have default value or be nullable"
+                exception "the unmentioned column `name` should have default value or be nullable"
             }
             sql "set enable_unique_key_partial_update=false;"
             sql "sync;"

--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_native_insert_stmt.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_native_insert_stmt.groovy
@@ -122,7 +122,7 @@ suite("test_partial_update_native_insert_stmt", "p0") {
             // but field `name` is not nullable and doesn't have default value
             test {
                 sql """insert into ${tableName3}(id,score) values(2,400),(1,200),(4,400)"""
-                exception "INTERNAL_ERROR"
+                exception "the unmentioned column `name` should have default value or be nullable"
             }
             sql "set enable_unique_key_partial_update=false;"
             sql "sync;"


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

1. InternalError is not clear for such error, use InvalidSchema Error instead
2. avoid some useless stacktrace on InternalError when load failed

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

