### PR TITLE
[fix][function]Fixed the round function missing precision

### DIFF
--- a/gensrc/script/doris_builtins_functions.py
+++ b/gensrc/script/doris_builtins_functions.py
@@ -1749,7 +1749,7 @@ visible_functions = [
             '_ZN5doris13MathFunctions4ceilEPN9doris_udf15FunctionContextERKNS1_9DoubleValE', '', '', 'vec', ''],
     [['floor', 'dfloor'], 'DOUBLE', ['DOUBLE'],
             '_ZN5doris13MathFunctions5floorEPN9doris_udf15FunctionContextERKNS1_9DoubleValE', '', '', 'vec', ''],
-    [['round', 'dround'], 'DOUBLE', ['DOUBLE'],
+    [['round', 'dround'], 'DECIMALV2', ['DECIMALV2'],
             '_ZN5doris13MathFunctions5roundEPN9doris_udf15FunctionContextERKNS1_9DoubleValE', '', '', 'vec', ''],
     [['truncate'], 'DOUBLE', ['DOUBLE'],
             '_ZN5doris13MathFunctions5roundEPN9doris_udf15FunctionContextERKNS1_9DoubleValE', '', '', 'vec', ''],
@@ -1758,7 +1758,7 @@ visible_functions = [
             '_ZN5doris13MathFunctions4ceilEPN9doris_udf15FunctionContextERKNS1_9DoubleValE', '', '', 'vec', ''],
     [['floor', 'dfloor'], 'DOUBLE', ['DOUBLE', 'INT'],
             '_ZN5doris13MathFunctions5floorEPN9doris_udf15FunctionContextERKNS1_9DoubleValE', '', '', 'vec', ''],
-    [['round', 'dround'], 'DOUBLE', ['DOUBLE', 'INT'],
+    [['round', 'dround'], 'DECIMALV2', ['DECIMALV2', 'INT'],
             '_ZN5doris13MathFunctions5roundEPN9doris_udf15FunctionContextERKNS1_9DoubleValE', '', '', 'vec', ''],
     [['truncate'], 'DOUBLE', ['DOUBLE', 'INT'],
              '_ZN5doris13MathFunctions11round_up_toEPN9doris_udf'
@@ -1782,7 +1782,7 @@ visible_functions = [
             '_ZN5doris13MathFunctions5floorEPN9doris_udf15FunctionContextERKNS1_9DoubleValE', '', '', 'vec', ''],
     [['round', 'dround'], 'DECIMAL128', ['DECIMAL128'],
             '_ZN5doris13MathFunctions5roundEPN9doris_udf15FunctionContextERKNS1_9DoubleValE', '', '', 'vec', ''],
-    [['round', 'dround'], 'DOUBLE', ['DOUBLE', 'INT'],
+    [['round', 'dround'], 'DECIMALV2', ['DECIMALV2', 'INT'],
             '_ZN5doris13MathFunctions11round_up_toEPN9doris_udf'
             '15FunctionContextERKNS1_9DoubleValERKNS1_6IntValE', '', '', 'vec', ''],
     [['round', 'dround'], 'DECIMAL32', ['DECIMAL32', 'INT'],


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->
select round(2.5);
before：
<img width="1349" alt="image" src="https://github.com/apache/doris/assets/131352377/8f627b85-265e-4a7b-8a65-05afab71dc7a">
later：
<img width="394" alt="image" src="https://github.com/apache/doris/assets/131352377/d30a7cdc-57e1-4f23-8a6d-09792d7726b3">
Bug Cause：
The problem is that in 1.2, the double is round, but the doule type does not guarantee accuracy .

Solution：
Change round's function label to double to decimalV2 .


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

