### PR TITLE
[Fix](dialect) Fix trino dialect converter when sql does not end with delimiter.

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/NereidsParserTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/NereidsParserTest.java
@@ -207,6 +207,20 @@ public class NereidsParserTest extends ParserTestBase {
     }
 
     @Test
+    public void testParseSingleStmtWithTrinoDialect() {
+        String sql = "select `AD``D` from t1 where a = 1";
+        NereidsParser nereidsParser = new NereidsParser();
+        SessionVariable sessionVariable = new SessionVariable();
+        sessionVariable.setSqlDialect("trino");
+        // test fall back to doris parser
+        List<StatementBase> statementBases = nereidsParser.parseSQL(sql, sessionVariable);
+        Assertions.assertEquals(1, statementBases.size());
+        Assertions.assertTrue(statementBases.get(0) instanceof LogicalPlanAdapter);
+        LogicalPlan logicalPlan0 = ((LogicalPlanAdapter) statementBases.get(0)).getLogicalPlan();
+        Assertions.assertTrue(logicalPlan0 instanceof UnboundResultSink);
+    }
+
+    @Test
     public void testParseSQLWithSparkSqlDialect() {
         // doris parser will throw a ParseException when derived table does not have alias
         String sql1 = "select * from (select * from t1);";


### PR DESCRIPTION

## Proposed changes

![image](https://github.com/apache/doris/assets/5926365/8a668062-32e0-4f70-8dc6-e92e350b9c41)
![image](https://github.com/apache/doris/assets/5926365/3bce508c-d091-473d-876e-28d4a44e54ff)


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

