### PR TITLE
[fix](read) fix unexpected overflow of uninitialized column data in VStatisticsIterator::next_batch

### DIFF
--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -76,7 +76,7 @@ Status VStatisticsIterator::next_batch(Block* block) {
         if (_push_down_agg_type_opt == TPushAggOp::COUNT) {
             size = std::min(_target_rows - _output_rows, MAX_ROW_SIZE_IN_COUNT);
             for (int i = 0; i < columns.size(); ++i) {
-                columns[i]->resize(size);
+                columns[i]->insert_many_defaults(size);
             }
         } else {
             for (int i = 0; i < columns.size(); ++i) {

--- a/regression-test/data/datatype_p0/decimalv3/test_decimalv3.out
+++ b/regression-test/data/datatype_p0/decimalv3/test_decimalv3.out
@@ -5,6 +5,12 @@
 -- !decimalv3 --
 100.00000000000000000000
 
+-- !decimalv3_view1 --
+1
+
+-- !decimalv3_view2 --
+1
+
 -- !aEb_test1 --
 0
 

--- a/regression-test/suites/datatype_p0/decimalv3/test_decimalv3.groovy
+++ b/regression-test/suites/datatype_p0/decimalv3/test_decimalv3.groovy
@@ -27,6 +27,11 @@ suite("test_decimalv3") {
 
     qt_decimalv3 "select * from test5_v"
     qt_decimalv3 "select cast(a as decimalv3(12,10)) * cast(b as decimalv3(18,10)) from test5"
+    qt_decimalv3_view1 "select count(*) from test5_v;"
+
+    sql "drop view if exists test5_v2"
+    sql "create view test5_v2 (amout) as select cast(a as decimalv3(18,6)) from test5"
+    qt_decimalv3_view2 "select count(*) from test5_v2;"
 
     /*
     sql "drop table if exists test_decimal256;"


### PR DESCRIPTION

## Proposed changes

Issue Number: close #xxx

Reproduce: see added regression test case`qt_decimalv3_view2`.

```
[CANCELLED][E-124] Arithmetic overflow, convert failed from -86738642548474510294585684, expected data is [-999999999999999999, 999999999999999999]

        0#  doris::get_stack_trace[abi:cxx11](int) at /mnt/disk2/tengjianping/doris-master/be/src/util/stack_util.cpp:51
        1#  doris::Exception::Exception(int, std::basic_string_view<char, std::char_traits<char> > const&) at /mnt/disk2/tengjianping/doris-master/be/src/common/exception.cpp:28
        2#  doris::Exception::Exception<__int128&, long, long&>(int, std::basic_string_view<char, std::char_traits<char> > const&, __int128&, long&&, long&) at /mnt/disk2/tengjianping/doris-master/be/src/common/exception.h:49
        3#  void doris::vectorized::convert_decimal_cols<doris::vectorized::DataTypeDecimal<doris::vectorized::Decimal128I>, doris::vectorized::DataTypeDecimal<doris::vectorized::Decimal<long> >, true, true>(doris::vectorized::ColumnDecimal<doris::vectorized::DataTypeDecimal<doris::vectorized::Decimal128I>::FieldType>::Container::value_type const*, doris::vectorized::ColumnDecimal<doris::vectorized::DataTypeDecimal<doris::vectorized::Decimal<long> >::FieldType>::Container::value_type*, unsigned int, unsigned int, unsigned int, unsigned int, unsigned long) at /mnt/disk2/tengjianping/doris-master/be/src/vec/data_types/data_type_decimal.h:577
        4#  auto doris::vectorized::ConvertImpl<doris::vectorized::DataTypeDecimal<doris::vectorized::Decimal128I>, doris::vectorized::DataTypeDecimal<doris::vectorized::Decimal<long> >, doris::vectorized::NameCast>::execute<doris::vectorized::PrecisionScaleArg>(doris::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, doris::vectorized::PrecisionScaleArg)::{lambda(auto:1, auto:2)#1}::operator()<std::integral_constant<bool, true>, std::integral_constant<bool, true> >(std::integral_constant<bool, true>, std::integral_constant<bool, true>) const at /mnt/disk2/tengjianping/doris-master/be/src/vec/functions/function_cast.h:355
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

