### PR TITLE
[fix](topn opt) avoid using topn runtime predicate which segment does…

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -150,7 +150,8 @@ Status Segment::new_iterator(SchemaSPtr schema, const StorageReadOptions& read_o
             AndBlockColumnPredicate and_predicate;
             auto single_predicate = new SingleColumnBlockPredicate(runtime_predicate.get());
             and_predicate.add_column_predicate(single_predicate);
-            if (can_apply_predicate_safely(runtime_predicate->column_id(), runtime_predicate.get(),
+            if (_column_readers.count(uid) >= 1 &&
+                can_apply_predicate_safely(runtime_predicate->column_id(), runtime_predicate.get(),
                                            *schema, read_options.io_ctx.reader_type) &&
                 !_column_readers.at(uid)->match_condition(&and_predicate)) {
                 // any condition not satisfied, return.

--- a/regression-test/suites/datatype_p0/scalar_types/test_key_topn_merge_block_columns.groovy
+++ b/regression-test/suites/datatype_p0/scalar_types/test_key_topn_merge_block_columns.groovy
@@ -73,4 +73,9 @@ suite("test_key_topn_merge_block_columns", "p0") {
 
     // will cause be core if bug not fix by #20820
     sql "SELECT /*+ SET_VAR(topn_opt_limit_threshold=1024) */ * FROM ${testTable} WHERE c_int = 100 or k1 = 1000 ORDER BY k1 LIMIT 10"
+    sql "insert into ${testTable} select * from ${testTable}"
+    sql "insert into ${testTable} select * from ${testTable}"
+    sql "insert into ${testTable} select * from ${testTable}"
+    sql """ alter table ${testTable} ADD COLUMN (new_k1 INT DEFAULT '1', new_k2 INT DEFAULT '2');"""
+    sql "select * from ${testTable} order by new_k1 limit 1"
 }


### PR DESCRIPTION
… not contain such column(column unique id) when pruning segment

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

