### PR TITLE
[feature](mv) add mv rewrite info to explain

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -41,6 +41,7 @@ import org.apache.doris.nereids.minidump.NereidsTracer;
 import org.apache.doris.nereids.processor.post.PlanPostProcessors;
 import org.apache.doris.nereids.processor.pre.PlanPreprocessors;
 import org.apache.doris.nereids.properties.PhysicalProperties;
+import org.apache.doris.nereids.rules.exploration.mv.MaterializationContext;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
@@ -399,7 +400,9 @@ public class NereidsPlanner extends Planner {
             case MEMO_PLAN:
                 plan = cascadesContext.getMemo().toString()
                     + "\n\n========== OPTIMIZED PLAN ==========\n"
-                    + optimizedPlan.treeString();
+                    + optimizedPlan.treeString()
+                    + "\n\n========== MATERIALIZATIONS ==========\n"
+                    + MaterializationContext.toString(cascadesContext.getMaterializationContexts());
                 break;
             case ALL_PLAN:
                 plan = "========== PARSED PLAN ==========\n"

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -415,7 +415,9 @@ public class NereidsPlanner extends Planner {
                         + optimizedPlan.treeString();
                 break;
             default:
-                plan = super.getExplainString(explainOptions);
+                plan = super.getExplainString(explainOptions)
+                        + "\n\n========== MATERIALIZATIONS ==========\n"
+                        + MaterializationContext.toSummaryString(cascadesContext.getMaterializationContexts());
         }
         if (statementContext != null && !statementContext.getHints().isEmpty()) {
             String hint = getHintExplainString(statementContext.getHints());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -22,6 +22,7 @@ import org.apache.doris.analysis.ExplainOptions;
 import org.apache.doris.analysis.LiteralExpr;
 import org.apache.doris.analysis.StatementBase;
 import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.MTMV;
 import org.apache.doris.common.NereidsException;
 import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.CascadesContext.Lock;
@@ -48,6 +49,7 @@ import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.commands.ExplainCommand.ExplainLevel;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalCatalogRelation;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalOneRowRelation;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalResultSink;
@@ -415,9 +417,15 @@ public class NereidsPlanner extends Planner {
                         + optimizedPlan.treeString();
                 break;
             default:
+                List<MTMV> chosenMaterializationNames = this.getPhysicalPlan()
+                        .collectToList(node -> node instanceof PhysicalCatalogRelation
+                                && ((PhysicalCatalogRelation) node).getTable() instanceof MTMV).stream()
+                        .map(node -> (MTMV) ((PhysicalCatalogRelation) node).getTable())
+                        .collect(Collectors.toList());
                 plan = super.getExplainString(explainOptions)
-                        + "\n\n========== MATERIALIZATIONS ==========\n"
-                        + MaterializationContext.toSummaryString(cascadesContext.getMaterializationContexts());
+                        + "\n\n========== MATERIALIZATION'S ==========\n"
+                        + MaterializationContext.toSummaryString(cascadesContext.getMaterializationContexts(),
+                        chosenMaterializationNames);
         }
         if (statementContext != null && !statementContext.getHints().isEmpty()) {
             String hint = getHintExplainString(statementContext.getHints());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -417,15 +417,14 @@ public class NereidsPlanner extends Planner {
                         + optimizedPlan.treeString();
                 break;
             default:
-                List<MTMV> chosenMaterializationNames = this.getPhysicalPlan()
+                List<MTMV> materializationListChosenByCbo = this.getPhysicalPlan()
                         .collectToList(node -> node instanceof PhysicalCatalogRelation
                                 && ((PhysicalCatalogRelation) node).getTable() instanceof MTMV).stream()
                         .map(node -> (MTMV) ((PhysicalCatalogRelation) node).getTable())
                         .collect(Collectors.toList());
                 plan = super.getExplainString(explainOptions)
-                        + "\n\n========== MATERIALIZATION'S ==========\n"
                         + MaterializationContext.toSummaryString(cascadesContext.getMaterializationContexts(),
-                        chosenMaterializationNames);
+                        materializationListChosenByCbo);
         }
         if (statementContext != null && !statementContext.getHints().isEmpty()) {
             String hint = getHintExplainString(statementContext.getHints());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/edge/Edge.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/edge/Edge.java
@@ -211,10 +211,22 @@ public abstract class Edge {
         return getExpressions().get(i);
     }
 
+    public String getTypeName() {
+        if (this instanceof FilterEdge) {
+            return "FILTER";
+        } else {
+            return ((JoinEdge) this).getJoinType().toString();
+        }
+    }
+
     @Override
     public String toString() {
-        return String.format("<%s - %s>", LongBitmap.toString(leftExtendedNodes), LongBitmap.toString(
-                rightExtendedNodes));
+        if (!leftRejectEdges.isEmpty() || !rightRejectEdges.isEmpty()) {
+            return String.format("<%s --%s-- %s>[%s , %s]", LongBitmap.toString(leftExtendedNodes),
+                    this.getTypeName(), LongBitmap.toString(rightExtendedNodes), leftRejectEdges, rightRejectEdges);
+        }
+        return String.format("<%s --%s-- %s>", LongBitmap.toString(leftExtendedNodes),
+                this.getTypeName(), LongBitmap.toString(rightExtendedNodes));
     }
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/node/StructInfoNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/node/StructInfoNode.java
@@ -21,6 +21,7 @@ import org.apache.doris.nereids.jobs.joinorder.hypergraph.HyperGraph;
 import org.apache.doris.nereids.jobs.joinorder.hypergraph.edge.Edge;
 import org.apache.doris.nereids.trees.plans.GroupPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.util.Utils;
 
 import com.google.common.collect.ImmutableList;
 
@@ -67,4 +68,9 @@ public class StructInfoNode extends AbstractNode {
         return graphs;
     }
 
+    @Override
+    public String toString() {
+        return Utils.toSqlString("StructInfoNode[" + this.getName() + "]",
+                "plan", this.plan.treeString());
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewJoinRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewJoinRule.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.rules.exploration.mv;
 
+import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.jobs.joinorder.hypergraph.HyperGraph;
 import org.apache.doris.nereids.jobs.joinorder.hypergraph.edge.JoinEdge;
 import org.apache.doris.nereids.jobs.joinorder.hypergraph.node.AbstractNode;
@@ -61,10 +62,12 @@ public abstract class AbstractMaterializedViewJoinRule extends AbstractMateriali
         if (expressionsRewritten.isEmpty()
                 || expressionsRewritten.stream().anyMatch(expr -> !(expr instanceof NamedExpression))) {
             materializationContext.recordFailReason(queryStructInfo.getOriginalPlanId(),
-                    String.format("join rewrite query by view fail, expressionToRewritten is %s,\n"
-                                    + "mvExprToMvScanExprMapping is %s,\n queryToViewSlotMapping = %s",
-                            queryStructInfo.getExpressions(), materializationContext.getMvExprToMvScanExprMapping(),
-                            queryToViewSlotMapping));
+                    Pair.of("Rewrite expressions by view in join fail",
+                            String.format("expressionToRewritten is %s,\n mvExprToMvScanExprMapping is %s,\n"
+                                            + "queryToViewSlotMapping = %s",
+                                    queryStructInfo.getExpressions(),
+                                    materializationContext.getMvExprToMvScanExprMapping(),
+                                    queryToViewSlotMapping)));
             return null;
         }
         // record the group id in materializationContext, and when rewrite again in

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewJoinRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewJoinRule.java
@@ -60,7 +60,11 @@ public abstract class AbstractMaterializedViewJoinRule extends AbstractMateriali
         // Can not rewrite, bail out
         if (expressionsRewritten.isEmpty()
                 || expressionsRewritten.stream().anyMatch(expr -> !(expr instanceof NamedExpression))) {
-            logger.warn(currentClassName + " expression to rewrite is not named expr so return null");
+            materializationContext.recordFailReason(queryStructInfo.getOriginalPlanId(),
+                    String.format("join rewrite query by view fail, expressionToRewritten is %s,\n"
+                                    + "mvExprToMvScanExprMapping is %s,\n queryToViewSlotMapping = %s",
+                            queryStructInfo.getExpressions(), materializationContext.getMvExprToMvScanExprMapping(),
+                            queryToViewSlotMapping));
             return null;
         }
         // record the group id in materializationContext, and when rewrite again in

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewRule.java
@@ -30,6 +30,7 @@ import org.apache.doris.mtmv.MTMVPartitionInfo;
 import org.apache.doris.mtmv.MTMVUtil;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.jobs.executor.Rewriter;
+import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.rules.exploration.ExplorationRuleFactory;
 import org.apache.doris.nereids.rules.exploration.mv.Predicates.SplitPredicate;
 import org.apache.doris.nereids.rules.exploration.mv.mapping.EquivalenceClassSetMapping;
@@ -45,6 +46,7 @@ import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.plans.JoinType;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.algebra.CatalogRelation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
@@ -70,8 +72,8 @@ import java.util.stream.Collectors;
  * The abstract class for all materialized view rules
  */
 public abstract class AbstractMaterializedViewRule implements ExplorationRuleFactory {
-    public static final HashSet<JoinType> SUPPORTED_JOIN_TYPE_SET =
-            Sets.newHashSet(JoinType.INNER_JOIN, JoinType.LEFT_OUTER_JOIN);
+    public static final HashSet<JoinType> SUPPORTED_JOIN_TYPE_SET = Sets.newHashSet(JoinType.INNER_JOIN,
+            JoinType.LEFT_OUTER_JOIN);
     protected final String currentClassName = this.getClass().getSimpleName();
     private final Logger logger = LogManager.getLogger(this.getClass());
 
@@ -83,63 +85,65 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
         List<MaterializationContext> materializationContexts = cascadesContext.getMaterializationContexts();
         List<Plan> rewriteResults = new ArrayList<>();
         if (materializationContexts.isEmpty()) {
-            logger.debug(currentClassName + " materializationContexts is empty so return");
             return rewriteResults;
         }
-
         List<StructInfo> queryStructInfos = extractStructInfo(queryPlan, cascadesContext);
         // TODO Just Check query queryPlan firstly, support multi later.
         StructInfo queryStructInfo = queryStructInfos.get(0);
         if (!checkPattern(queryStructInfo)) {
-            logger.debug(currentClassName + " queryStructInfo is not valid so return");
+            materializationContexts.forEach(ctx -> ctx.recordFailReason(queryStructInfo.getOriginalPlanId(),
+                    String.format("queryStructInfo is invalid, queryPlan is %s", queryPlan.treeString())));
             return rewriteResults;
         }
-
         for (MaterializationContext materializationContext : materializationContexts) {
             // already rewrite, bail out
-            if (queryPlan.getGroupExpression().isPresent()
-                    && materializationContext.alreadyRewrite(
+            if (queryPlan.getGroupExpression().isPresent() && materializationContext.alreadyRewrite(
                     queryPlan.getGroupExpression().get().getOwnerGroup().getGroupId())) {
-                logger.debug(currentClassName + " this group is already rewritten so skip");
                 continue;
             }
-            List<StructInfo> viewStructInfos = extractStructInfo(materializationContext.getMvPlan(),
-                    cascadesContext);
+            List<StructInfo> viewStructInfos = extractStructInfo(materializationContext.getMvPlan(), cascadesContext);
             if (viewStructInfos.size() > 1) {
                 // view struct info should only have one
-                logger.warn(currentClassName + " the num of view struct info is more then one so return");
+                materializationContext.recordFailReason(queryStructInfo.getOriginalPlanId(),
+                        String.format("the num of view struct info is more then one, mv plan is %s",
+                                materializationContext.getMvPlan().treeString()));
                 return rewriteResults;
             }
             StructInfo viewStructInfo = viewStructInfos.get(0);
             if (!checkPattern(viewStructInfo)) {
-                logger.debug(currentClassName + " viewStructInfo is not valid so return");
+                materializationContext.recordFailReason(queryStructInfo.getOriginalPlanId(),
+                        String.format("viewStructInfo is not valid, view plan is %s",
+                                viewStructInfo.getOriginalPlan().treeString()));
                 continue;
             }
             MatchMode matchMode = decideMatchMode(queryStructInfo.getRelations(), viewStructInfo.getRelations());
             if (MatchMode.COMPLETE != matchMode) {
-                logger.debug(currentClassName + " match mode is not complete so return");
+                materializationContext.recordFailReason(queryStructInfo.getOriginalPlanId(),
+                        String.format("match mode is invalid, matchMode is %s", matchMode));
                 continue;
             }
-            List<RelationMapping> queryToViewTableMappings =
-                    RelationMapping.generate(queryStructInfo.getRelations(), viewStructInfo.getRelations());
+            List<RelationMapping> queryToViewTableMappings = RelationMapping.generate(queryStructInfo.getRelations(),
+                    viewStructInfo.getRelations());
             // if any relation in query and view can not map, bail out.
             if (queryToViewTableMappings == null) {
-                logger.warn(currentClassName + " query to view table mapping null so return");
+                materializationContext.recordFailReason(queryStructInfo.getOriginalPlanId(),
+                        "query to view table mapping null");
                 return rewriteResults;
             }
             for (RelationMapping queryToViewTableMapping : queryToViewTableMappings) {
                 SlotMapping queryToViewSlotMapping = SlotMapping.generate(queryToViewTableMapping);
                 if (queryToViewSlotMapping == null) {
-                    logger.warn(currentClassName + " query to view slot mapping null so continue");
+                    materializationContext.recordFailReason(queryStructInfo.getOriginalPlanId(),
+                            "query to view slot mapping null");
                     continue;
                 }
-                LogicalCompatibilityContext compatibilityContext =
-                        LogicalCompatibilityContext.from(queryToViewTableMapping, queryToViewSlotMapping,
-                                queryStructInfo, viewStructInfo);
+                LogicalCompatibilityContext compatibilityContext = LogicalCompatibilityContext.from(
+                        queryToViewTableMapping, queryToViewSlotMapping, queryStructInfo, viewStructInfo);
                 ComparisonResult comparisonResult = StructInfo.isGraphLogicalEquals(queryStructInfo, viewStructInfo,
                         compatibilityContext);
                 if (comparisonResult.isInvalid()) {
-                    logger.debug(currentClassName + " graph logical is not equals so continue");
+                    materializationContext.recordFailReason(queryStructInfo.getOriginalPlanId(),
+                            comparisonResult.getErrorMessage());
                     continue;
                 }
                 // TODO: Use set of list? And consider view expr
@@ -152,7 +156,13 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
                         queryToViewSlotMapping);
                 // Can not compensate, bail out
                 if (compensatePredicates.isEmpty()) {
-                    logger.debug(currentClassName + " predicate compensate fail so continue");
+                    materializationContext.recordFailReason(queryStructInfo.getOriginalPlanId(), String.format(
+                            "predicate compensate fail, query predicates = %s,\n query equivalenceClass = %s, \n"
+                                    + "view predicates = %s,\n query equivalenceClass = %s\n",
+                            queryStructInfo.getPredicates(),
+                            queryStructInfo.getEquivalenceClass(),
+                            viewStructInfo.getPredicates(),
+                            viewStructInfo.getEquivalenceClass()));
                     continue;
                 }
                 Plan rewrittenPlan;
@@ -161,54 +171,55 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
                     rewrittenPlan = mvScan;
                 } else {
                     // Try to rewrite compensate predicates by using mv scan
-                    List<Expression> rewriteCompensatePredicates = rewriteExpression(
-                            compensatePredicates.toList(),
-                            queryPlan,
-                            materializationContext.getMvExprToMvScanExprMapping(),
-                            queryToViewSlotMapping,
+                    List<Expression> rewriteCompensatePredicates = rewriteExpression(compensatePredicates.toList(),
+                            queryPlan, materializationContext.getMvExprToMvScanExprMapping(), queryToViewSlotMapping,
                             true);
                     if (rewriteCompensatePredicates.isEmpty()) {
-                        logger.debug(currentClassName + " compensate predicate rewrite by view fail so continue");
+                        materializationContext.recordFailReason(queryStructInfo.getOriginalPlanId(), String.format(
+                                "rewrite compensate predicate fail, compensatePredicates = %s,\n"
+                                        + "mvExprToMvScanExprMapping = %s\n, queryToViewSlotMapping = %s",
+                                compensatePredicates, materializationContext.getMvExprToMvScanExprMapping(),
+                                queryToViewSlotMapping));
                         continue;
                     }
                     rewrittenPlan = new LogicalFilter<>(Sets.newHashSet(rewriteCompensatePredicates), mvScan);
                 }
                 // Rewrite query by view
-                rewrittenPlan = rewriteQueryByView(matchMode,
-                        queryStructInfo,
-                        viewStructInfo,
-                        queryToViewSlotMapping,
-                        rewrittenPlan,
-                        materializationContext);
+                rewrittenPlan = rewriteQueryByView(matchMode, queryStructInfo, viewStructInfo, queryToViewSlotMapping,
+                        rewrittenPlan, materializationContext);
                 if (rewrittenPlan == null) {
-                    logger.debug(currentClassName + " rewrite query by view fail so continue");
                     continue;
                 }
                 if (!checkPartitionIsValid(queryStructInfo, materializationContext, cascadesContext)) {
-                    logger.debug(currentClassName + " check partition validation fail so continue");
+                    materializationContext.recordFailReason(queryStructInfo.getOriginalPlanId(),
+                            "check partition validation fail");
                     continue;
                 }
-                if (!checkOutput(queryPlan, rewrittenPlan)) {
-                    logger.debug(currentClassName + " check output validation fail so continue");
+                if (!checkOutput(queryPlan, rewrittenPlan, materializationContext)) {
                     continue;
                 }
                 // run rbo job on mv rewritten plan
-                CascadesContext rewrittenPlanContext =
-                        CascadesContext.initContext(cascadesContext.getStatementContext(), rewrittenPlan,
-                                cascadesContext.getCurrentJobContext().getRequiredProperties());
+                CascadesContext rewrittenPlanContext = CascadesContext.initContext(
+                        cascadesContext.getStatementContext(), rewrittenPlan,
+                        cascadesContext.getCurrentJobContext().getRequiredProperties());
                 Rewriter.getWholeTreeRewriter(rewrittenPlanContext).execute();
                 rewrittenPlan = rewrittenPlanContext.getRewritePlan();
-                logger.debug(currentClassName + "rewrite by materialized view success");
+                materializationContext.setSuccess(true);
                 rewriteResults.add(rewrittenPlan);
             }
         }
         return rewriteResults;
     }
 
-    protected boolean checkOutput(Plan sourcePlan, Plan rewrittenPlan) {
-        if (sourcePlan.getGroupExpression().isPresent() && !rewrittenPlan.getLogicalProperties().equals(
-                sourcePlan.getGroupExpression().get().getOwnerGroup().getLogicalProperties())) {
-            logger.error("rewrittenPlan output logical properties is not same with target group");
+    protected boolean checkOutput(Plan sourcePlan, Plan rewrittenPlan, MaterializationContext materializationContext) {
+        if (sourcePlan.getGroupExpression().isPresent() && !rewrittenPlan.getLogicalProperties()
+                .equals(sourcePlan.getGroupExpression().get().getOwnerGroup().getLogicalProperties())) {
+            ObjectId planObjId = sourcePlan.getGroupExpression().map(GroupExpression::getId)
+                    .orElseGet(() -> new ObjectId(-1));
+            materializationContext.recordFailReason(planObjId, String.format(
+                    "rewrittenPlan output logical properties is not same with target group,"
+                            + "planOutput = %s, groupOutput = %s", rewrittenPlan.getLogicalProperties(),
+                    sourcePlan.getGroupExpression().get().getOwnerGroup().getLogicalProperties()));
             return false;
         }
         return true;
@@ -220,9 +231,7 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
      * Maybe only just some partitions is valid in materialized view, so we should check if the mv can
      * offer the partitions which query used or not.
      */
-    protected boolean checkPartitionIsValid(
-            StructInfo queryInfo,
-            MaterializationContext materializationContext,
+    protected boolean checkPartitionIsValid(StructInfo queryInfo, MaterializationContext materializationContext,
             CascadesContext cascadesContext) {
         // check partition is valid or not
         MTMV mtmv = materializationContext.getMTMV();
@@ -240,8 +249,7 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
         Optional<LogicalOlapScan> relatedTableRelation = queryInfo.getRelations().stream()
                 .filter(LogicalOlapScan.class::isInstance)
                 .filter(relation -> relatedPartitionTable.equals(new BaseTableInfo(relation.getTable())))
-                .map(LogicalOlapScan.class::cast)
-                .findFirst();
+                .map(LogicalOlapScan.class::cast).findFirst();
         if (!relatedTableRelation.isPresent()) {
             logger.warn("mv is partition update, but related table relation is null");
             return false;
@@ -263,37 +271,29 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
             return false;
         }
         // get mv related table valid partitions
-        Set<Long> relatedTalbeValidSet = mvDataValidPartitions.stream()
-                .map(partition -> {
-                    Set<Long> relatedBaseTablePartitions = mvToBasePartitionMap.get(partition.getId());
-                    if (relatedBaseTablePartitions == null || relatedBaseTablePartitions.isEmpty()) {
-                        return ImmutableList.of();
-                    } else {
-                        return relatedBaseTablePartitions;
-                    }
-                })
-                .flatMap(Collection::stream)
-                .map(Long.class::cast)
-                .collect(Collectors.toSet());
+        Set<Long> relatedTalbeValidSet = mvDataValidPartitions.stream().map(partition -> {
+            Set<Long> relatedBaseTablePartitions = mvToBasePartitionMap.get(partition.getId());
+            if (relatedBaseTablePartitions == null || relatedBaseTablePartitions.isEmpty()) {
+                return ImmutableList.of();
+            } else {
+                return relatedBaseTablePartitions;
+            }
+        }).flatMap(Collection::stream).map(Long.class::cast).collect(Collectors.toSet());
         // get query selected partitions to make the partitions is valid or not
-        Set<Long> relatedTableSelectedPartitionToCheck =
-                new HashSet<>(relatedTableRelation.get().getSelectedPartitionIds());
+        Set<Long> relatedTableSelectedPartitionToCheck = new HashSet<>(
+                relatedTableRelation.get().getSelectedPartitionIds());
         if (relatedTableSelectedPartitionToCheck.isEmpty()) {
             relatedTableSelectedPartitionToCheck.addAll(relatedTable.getPartitionIds());
         }
-        return !relatedTalbeValidSet.isEmpty()
-                && relatedTalbeValidSet.containsAll(relatedTableSelectedPartitionToCheck);
+        return !relatedTalbeValidSet.isEmpty() && relatedTalbeValidSet.containsAll(
+                relatedTableSelectedPartitionToCheck);
     }
 
     /**
      * Rewrite query by view, for aggregate or join rewriting should be different inherit class implementation
      */
-    protected Plan rewriteQueryByView(MatchMode matchMode,
-            StructInfo queryStructInfo,
-            StructInfo viewStructInfo,
-            SlotMapping queryToViewSlotMapping,
-            Plan tempRewritedPlan,
-            MaterializationContext materializationContext) {
+    protected Plan rewriteQueryByView(MatchMode matchMode, StructInfo queryStructInfo, StructInfo viewStructInfo,
+            SlotMapping queryToViewSlotMapping, Plan tempRewritedPlan, MaterializationContext materializationContext) {
         return tempRewritedPlan;
     }
 
@@ -306,11 +306,8 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
      * the key expression in targetExpressionMapping should be shuttled. with the method
      * ExpressionUtils.shuttleExpressionWithLineage.
      */
-    protected List<Expression> rewriteExpression(
-            List<? extends Expression> sourceExpressionsToWrite,
-            Plan sourcePlan,
-            ExpressionMapping targetExpressionMapping,
-            SlotMapping sourceToTargetMapping,
+    protected List<Expression> rewriteExpression(List<? extends Expression> sourceExpressionsToWrite, Plan sourcePlan,
+            ExpressionMapping targetExpressionMapping, SlotMapping sourceToTargetMapping,
             boolean targetExpressionNeedSourceBased) {
         // Firstly, rewrite the target expression using source with inverse mapping
         // then try to use the target expression to represent the query. if any of source expressions
@@ -325,13 +322,12 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
         //        project(slot 2, 1)
         //            target
         // generate target to target replacement expression mapping, and change target expression to source based
-        List<? extends Expression> sourceShuttledExpressions =
-                ExpressionUtils.shuttleExpressionWithLineage(sourceExpressionsToWrite, sourcePlan);
+        List<? extends Expression> sourceShuttledExpressions = ExpressionUtils.shuttleExpressionWithLineage(
+                sourceExpressionsToWrite, sourcePlan);
         ExpressionMapping expressionMappingKeySourceBased = targetExpressionNeedSourceBased
                 ? targetExpressionMapping.keyPermute(sourceToTargetMapping.inverse()) : targetExpressionMapping;
         // target to target replacement expression mapping, because mv is 1:1 so get first element
-        List<Map<Expression, Expression>> flattenExpressionMap =
-                expressionMappingKeySourceBased.flattenMap();
+        List<Map<Expression, Expression>> flattenExpressionMap = expressionMappingKeySourceBased.flattenMap();
         Map<? extends Expression, ? extends Expression> targetToTargetReplacementMapping = flattenExpressionMap.get(0);
 
         List<Expression> rewrittenExpressions = new ArrayList<>();
@@ -341,8 +337,8 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
                 rewrittenExpressions.add(expressionToRewrite);
                 continue;
             }
-            final Set<Object> slotsToRewrite =
-                    expressionToRewrite.collectToSet(expression -> expression instanceof Slot);
+            final Set<Object> slotsToRewrite = expressionToRewrite.collectToSet(
+                    expression -> expression instanceof Slot);
             Expression replacedExpression = ExpressionUtils.replace(expressionToRewrite,
                     targetToTargetReplacementMapping);
             if (replacedExpression.anyMatch(slotsToRewrite::contains)) {
@@ -360,11 +356,8 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
         return rewrittenExpressions;
     }
 
-    protected Expression rewriteExpression(
-            Expression sourceExpressionsToWrite,
-            Plan sourcePlan,
-            ExpressionMapping targetExpressionMapping,
-            SlotMapping sourceToTargetMapping,
+    protected Expression rewriteExpression(Expression sourceExpressionsToWrite, Plan sourcePlan,
+            ExpressionMapping targetExpressionMapping, SlotMapping sourceToTargetMapping,
             boolean targetExpressionNeedSourceBased) {
         List<Expression> expressionToRewrite = new ArrayList<>();
         expressionToRewrite.add(sourceExpressionsToWrite);
@@ -382,11 +375,8 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
      * For another example as following:
      * predicate a = b in mv, and a = b and c = d in query, the compensatory predicate is c = d
      */
-    protected SplitPredicate predicatesCompensate(
-            StructInfo queryStructInfo,
-            StructInfo viewStructInfo,
-            SlotMapping queryToViewSlotMapping
-    ) {
+    protected SplitPredicate predicatesCompensate(StructInfo queryStructInfo, StructInfo viewStructInfo,
+            SlotMapping queryToViewSlotMapping) {
         EquivalenceClass queryEquivalenceClass = queryStructInfo.getEquivalenceClass();
         EquivalenceClass viewEquivalenceClass = viewStructInfo.getEquivalenceClass();
         // viewEquivalenceClass to query based
@@ -394,24 +384,20 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
                 .toSlotReferenceMap();
         EquivalenceClass viewEquivalenceClassQueryBased = viewEquivalenceClass.permute(viewToQuerySlotMapping);
         if (viewEquivalenceClassQueryBased == null) {
-            logger.info(currentClassName + " permute view equivalence class by query fail so return empty");
             return SplitPredicate.empty();
         }
         final List<Expression> equalCompensateConjunctions = new ArrayList<>();
         if (queryEquivalenceClass.isEmpty() && viewEquivalenceClass.isEmpty()) {
             equalCompensateConjunctions.add(BooleanLiteral.of(true));
         }
-        if (queryEquivalenceClass.isEmpty()
-                && !viewEquivalenceClass.isEmpty()) {
-            logger.info(currentClassName + " view has equivalence class but query not so return empty");
+        if (queryEquivalenceClass.isEmpty() && !viewEquivalenceClass.isEmpty()) {
             return SplitPredicate.empty();
         }
-        EquivalenceClassSetMapping queryToViewEquivalenceMapping =
-                EquivalenceClassSetMapping.generate(queryEquivalenceClass, viewEquivalenceClassQueryBased);
+        EquivalenceClassSetMapping queryToViewEquivalenceMapping = EquivalenceClassSetMapping.generate(
+                queryEquivalenceClass, viewEquivalenceClassQueryBased);
         // can not map all target equivalence class, can not compensate
         if (queryToViewEquivalenceMapping.getEquivalenceClassSetMap().size()
                 < viewEquivalenceClass.getEquivalenceSetList().size()) {
-            logger.info(currentClassName + " view has more equivalence than query so return empty");
             return SplitPredicate.empty();
         }
         // do equal compensate
@@ -449,17 +435,14 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
         List<Expression> rangeCompensate = new ArrayList<>();
         Expression queryRangePredicate = querySplitPredicate.getRangePredicate();
         Expression viewRangePredicate = viewSplitPredicate.getRangePredicate();
-        Expression viewRangePredicateQueryBased =
-                ExpressionUtils.replace(viewRangePredicate, viewToQuerySlotMapping);
+        Expression viewRangePredicateQueryBased = ExpressionUtils.replace(viewRangePredicate, viewToQuerySlotMapping);
 
-        Set<Expression> queryRangeSet =
-                Sets.newHashSet(ExpressionUtils.extractConjunction(queryRangePredicate));
-        Set<Expression> viewRangeQueryBasedSet =
-                Sets.newHashSet(ExpressionUtils.extractConjunction(viewRangePredicateQueryBased));
+        Set<Expression> queryRangeSet = Sets.newHashSet(ExpressionUtils.extractConjunction(queryRangePredicate));
+        Set<Expression> viewRangeQueryBasedSet = Sets.newHashSet(
+                ExpressionUtils.extractConjunction(viewRangePredicateQueryBased));
         // query range predicate can not contain all view range predicate when view have range predicate, bail out
-        if (!viewRangePredicateQueryBased.equals(BooleanLiteral.TRUE)
-                && !queryRangeSet.containsAll(viewRangeQueryBasedSet)) {
-            logger.info(currentClassName + " query range predicate set can not contains all view range predicate");
+        if (!viewRangePredicateQueryBased.equals(BooleanLiteral.TRUE) && !queryRangeSet.containsAll(
+                viewRangeQueryBasedSet)) {
             return SplitPredicate.empty();
         }
         queryRangeSet.removeAll(viewRangeQueryBasedSet);
@@ -477,10 +460,8 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
                 Sets.newHashSet(ExpressionUtils.extractConjunction(viewResidualPredicateQueryBased));
         // query residual predicate can not contain all view residual predicate when view have residual predicate,
         // bail out
-        if (!viewResidualPredicateQueryBased.equals(BooleanLiteral.TRUE)
-                && !queryResidualSet.containsAll(viewResidualQueryBasedSet)) {
-            logger.info(
-                    currentClassName + " query residual predicate set can not contains all view residual predicate");
+        if (!viewResidualPredicateQueryBased.equals(BooleanLiteral.TRUE) && !queryResidualSet.containsAll(
+                viewResidualQueryBasedSet)) {
             return SplitPredicate.empty();
         }
         queryResidualSet.removeAll(viewResidualQueryBasedSet);
@@ -497,13 +478,9 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
      * @see MatchMode
      */
     private MatchMode decideMatchMode(List<CatalogRelation> queryRelations, List<CatalogRelation> viewRelations) {
-        List<TableIf> queryTableRefs = queryRelations
-                .stream()
-                .map(CatalogRelation::getTable)
+        List<TableIf> queryTableRefs = queryRelations.stream().map(CatalogRelation::getTable)
                 .collect(Collectors.toList());
-        List<TableIf> viewTableRefs = viewRelations
-                .stream()
-                .map(CatalogRelation::getTable)
+        List<TableIf> viewTableRefs = viewRelations.stream().map(CatalogRelation::getTable)
                 .collect(Collectors.toList());
         boolean sizeSame = viewTableRefs.size() == queryTableRefs.size();
         boolean queryPartial = viewTableRefs.containsAll(queryTableRefs);
@@ -524,8 +501,8 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
      * Extract struct info from plan, support to get struct info from logical plan or plan in group.
      */
     public static List<StructInfo> extractStructInfo(Plan plan, CascadesContext cascadesContext) {
-        if (plan.getGroupExpression().isPresent()
-                && !plan.getGroupExpression().get().getOwnerGroup().getStructInfos().isEmpty()) {
+        if (plan.getGroupExpression().isPresent() && !plan.getGroupExpression().get().getOwnerGroup().getStructInfos()
+                .isEmpty()) {
             return plan.getGroupExpression().get().getOwnerGroup().getStructInfos();
         } else {
             // build struct info and add them to current group

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/EquivalenceClass.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/EquivalenceClass.java
@@ -141,4 +141,9 @@ public class EquivalenceClass {
         this.equivalenceSlotList = equivalenceSets;
         return this.equivalenceSlotList;
     }
+
+    @Override
+    public String toString() {
+        return "EquivalenceClass{" + "equivalenceSlotMap=" + equivalenceSlotMap + '}';
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/HyperGraphComparator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/HyperGraphComparator.java
@@ -123,7 +123,7 @@ public class HyperGraphComparator {
                     .filter(expr -> !ExpressionUtils.isInferred(expr))
                     .collect(Collectors.toList());
             if (!rawFilter.isEmpty() && !canPullUp(e.getKey())) {
-                return ComparisonResult.newInvalidResWithErrorMessage(getErrorMessage() + "\nwith error edge " + e);
+                return ComparisonResult.newInvalidResWithErrorMessage(getErrorMessage() + "with error edge\n" + e);
             }
             builder.addViewExpressions(rawFilter);
         }
@@ -138,11 +138,12 @@ public class HyperGraphComparator {
      */
     public String getErrorMessage() {
         return String.format(
-                "graph logical is not equal, query join edges is %s,\n" + "query filter edges is %s,\n"
-                        + "view join edges is %s,\n" + "view filter edges is %s\n" + "inferred edge with conds %s",
+                "graph logical is not equal\n query join edges is\n %s,\n view join edges is\n %s,\n"
+                        + "query filter edges\n is %s,\nview filter edges\n is %s\n"
+                        + "inferred edge with conditions\n %s",
                 getQueryJoinEdges(),
-                getQueryFilterEdges(),
                 getViewJoinEdges(),
+                getQueryFilterEdges(),
                 getViewFilterEdges(),
                 inferredViewEdgeMap);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/HyperGraphComparator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/HyperGraphComparator.java
@@ -69,7 +69,7 @@ public class HyperGraphComparator {
     private final Map<Edge, List<? extends Expression>> pullUpViewExprWithEdge = new HashMap<>();
     private final LogicalCompatibilityContext logicalCompatibilityContext;
 
-    HyperGraphComparator(HyperGraph queryHyperGraph, HyperGraph viewHyperGraph,
+    public HyperGraphComparator(HyperGraph queryHyperGraph, HyperGraph viewHyperGraph,
             LogicalCompatibilityContext logicalCompatibilityContext) {
         this.queryHyperGraph = queryHyperGraph;
         this.viewHyperGraph = viewHyperGraph;
@@ -114,7 +114,7 @@ public class HyperGraphComparator {
                     .filter(expr -> !ExpressionUtils.isInferred(expr))
                     .collect(Collectors.toList());
             if (!rawFilter.isEmpty() && !canPullUp(e.getKey())) {
-                return ComparisonResult.INVALID;
+                return ComparisonResult.newInvalidResWithErrorMessage(getErrorMessage() + "\nwith error edge " + e);
             }
             builder.addQueryExpressions(rawFilter);
         }
@@ -123,7 +123,7 @@ public class HyperGraphComparator {
                     .filter(expr -> !ExpressionUtils.isInferred(expr))
                     .collect(Collectors.toList());
             if (!rawFilter.isEmpty() && !canPullUp(e.getKey())) {
-                return ComparisonResult.INVALID;
+                return ComparisonResult.newInvalidResWithErrorMessage(getErrorMessage() + "\nwith error edge " + e);
             }
             builder.addViewExpressions(rawFilter);
         }
@@ -131,6 +131,20 @@ public class HyperGraphComparator {
             builder.addViewNoNullableSlot(inferredCond.second);
         }
         return builder.build();
+    }
+
+    /**
+     * get error message
+     */
+    public String getErrorMessage() {
+        return String.format(
+                "graph logical is not equal, query join edges is %s,\n" + "query filter edges is %s,\n"
+                        + "view join edges is %s,\n" + "view filter edges is %s\n" + "inferred edge with conds %s",
+                getQueryJoinEdges(),
+                getQueryFilterEdges(),
+                getViewJoinEdges(),
+                getViewFilterEdges(),
+                inferredViewEdgeMap);
     }
 
     private boolean canPullUp(Edge edge) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializationContext.java
@@ -143,7 +143,9 @@ public class MaterializationContext {
         this.failReason.clear();
     }
 
-    /**recordFailReason*/
+    /**
+     * recordFailReason
+     */
     public void recordFailReason(ObjectId objectId, Pair<String, String> summaryAndReason) {
         // once success, do not record the fail reason
         if (this.success) {
@@ -190,26 +192,25 @@ public class MaterializationContext {
     public static String toSummaryString(List<MaterializationContext> materializationContexts,
             List<MTMV> chosenMaterializationNames) {
         StringBuilder builder = new StringBuilder();
-        builder.append("materializationContexts:").append("\n");
-        builder.append("========== AVAILABLE MATERIALIZATION'S ==========\n");
-        builder.append("[\n");
+        builder.append("\n========== AVAILABLE MATERIALIZATION'S ==========\n");
+        builder.append("[");
         for (MaterializationContext ctx : materializationContexts) {
-            builder.append(ctx.getMTMV().getName());
+            builder.append("\n").append(ctx.getMTMV().getName());
         }
         builder.append("\n]\n");
         List<MaterializationContext> queryRewriteSuccessMaterializationList = materializationContexts.stream()
                 .filter(MaterializationContext::isSuccess)
                 .collect(Collectors.toList());
         builder.append("========== REWRITTEN SUCCESS MATERIALIZATION'S ==========\n");
-        builder.append("[\n");
+        builder.append("[");
         for (MaterializationContext ctx : queryRewriteSuccessMaterializationList) {
-            builder.append(ctx.getMTMV().getName());
+            builder.append("\n").append(ctx.getMTMV().getName());
         }
         builder.append("\n]\n");
         builder.append("========== CHOSEN MATERIALIZATION'S ==========\n");
-        builder.append("[\n");
+        builder.append("[");
         for (MTMV mtmv : chosenMaterializationNames) {
-            builder.append(mtmv.getName());
+            builder.append("\n").append(mtmv.getName());
         }
         builder.append("\n]\n");
         return builder.toString();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializationContext.java
@@ -24,15 +24,19 @@ import org.apache.doris.mtmv.MTMVCache;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.memo.GroupId;
 import org.apache.doris.nereids.rules.exploration.mv.mapping.ExpressionMapping;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.util.ExpressionUtils;
+import org.apache.doris.nereids.util.Utils;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -53,6 +57,11 @@ public class MaterializationContext {
     private boolean available = true;
     // the mv plan from cache at present, record it to make sure query rewrite by mv is right when cache change.
     private Plan mvPlan;
+    // mark rewrite success or not
+    private boolean success = false;
+    // if rewrite by mv fail, record the reason, if success the failReason should be empty.
+    // The key is the query belonged group expression objectId, the value is the fail reason
+    private final Map<ObjectId, String> failReason = new HashMap<>();
 
     /**
      * MaterializationContext, this contains necessary info for query rewriting by mv
@@ -125,6 +134,44 @@ public class MaterializationContext {
 
     public Plan getMvPlan() {
         return mvPlan;
+    }
+
+    public void setSuccess(boolean success) {
+        this.success = success;
+        this.failReason.clear();
+    }
+
+    /**recordFailReason*/
+    public void recordFailReason(ObjectId objectId, String reason) {
+        // once success, do not record the fail reason
+        if (this.success) {
+            return;
+        }
+        this.success = false;
+        this.failReason.put(objectId, reason);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder failReasonBuilder = new StringBuilder("[").append("\n");
+        for (Map.Entry<ObjectId, String> reason : this.failReason.entrySet()) {
+            failReasonBuilder.append(reason.getKey()).append(" : \n")
+                    .append(reason.getValue()).append("\n");
+        }
+        failReasonBuilder.append("\n").append("]");
+        return Utils.toSqlString("MaterializationContext[" + mtmv.getName() + "]",
+                "rewriteSuccess", this.success,
+                "failReason", failReasonBuilder.toString());
+    }
+
+    /**toString*/
+    public static String toString(List<MaterializationContext> materializationContexts) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("materializationContexts:").append("\n");
+        for (MaterializationContext ctx : materializationContexts) {
+            builder.append("\n\n").append(ctx).append("\n");
+        }
+        return builder.toString();
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializationContext.java
@@ -200,26 +200,26 @@ public class MaterializationContext {
                 .map(MTMV::getName)
                 .collect(Collectors.toSet());
         StringBuilder builder = new StringBuilder();
-        builder.append("\n\nMaterialized View\n");
-        builder.append("\nMATERIALIZED VIEW REWRITE FAIL:");
+        builder.append("\n\nMaterializedView\n");
+        builder.append("\nMaterializedViewRewriteFail:");
         for (MaterializationContext ctx : materializationContexts) {
             if (!ctx.isSuccess()) {
                 Set<String> failReasonSet =
                         ctx.getFailReason().values().stream().map(Pair::key).collect(Collectors.toSet());
                 builder.append("\n\n")
-                        .append("  NAME: ").append(ctx.getMTMV().getName())
+                        .append("  Name: ").append(ctx.getMTMV().getName())
                         .append("\n")
-                        .append("  FAIL_SUMMARY: ").append(String.join(", ", failReasonSet));
+                        .append("  FailSummary: ").append(String.join(", ", failReasonSet));
             }
         }
-        builder.append("\n\nMATERIALIZED VIEW REWRITE SUCCESS BUT NOT CHOSEN:\n");
-        builder.append("  NAMES: ").append(materializationContexts.stream()
+        builder.append("\n\nMaterializedViewRewriteSuccessButNotChose:\n");
+        builder.append("  Names: ").append(materializationContexts.stream()
                 .filter(materializationContext -> materializationContext.isSuccess()
                         && !materializationChosenNameSet.contains(materializationContext.getMTMV().getName()))
                 .map(materializationContext -> materializationContext.getMTMV().getName())
                 .collect(Collectors.joining(", ")));
-        builder.append("\n\nMATERIALIZED VIEW REWRITE SUCCESS AND CHOSEN:\n");
-        builder.append("  NAMES: ").append(String.join(", ", materializationChosenNameSet));
+        builder.append("\n\nMaterializedViewRewriteSuccessAndChose:\n");
+        builder.append("  Names: ").append(String.join(", ", materializationChosenNameSet));
         return builder.toString();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializationContext.java
@@ -168,6 +168,7 @@ public class MaterializationContext {
         StringBuilder failReasonBuilder = new StringBuilder("[").append("\n");
         for (Map.Entry<ObjectId, Pair<String, String>> reason : this.failReason.entrySet()) {
             failReasonBuilder
+                    .append("\n")
                     .append("ObjectId : ").append(reason.getKey()).append(".\n")
                     .append("Summary : ").append(reason.getValue().key()).append(".\n")
                     .append("Reason : ").append(reason.getValue().value()).append(".\n");

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializationContext.java
@@ -201,7 +201,7 @@ public class MaterializationContext {
                 .collect(Collectors.toSet());
         StringBuilder builder = new StringBuilder();
         builder.append("\n\nMaterialized View\n");
-        builder.append("\nMATERIALIZED VIEW REWRITTEN FAIL:");
+        builder.append("\nMATERIALIZED VIEW REWRITE FAIL:");
         for (MaterializationContext ctx : materializationContexts) {
             if (!ctx.isSuccess()) {
                 Set<String> failReasonSet =
@@ -212,13 +212,13 @@ public class MaterializationContext {
                         .append("  FAIL_SUMMARY: ").append(String.join(", ", failReasonSet));
             }
         }
-        builder.append("\n\nMATERIALIZED VIEW REWRITTEN SUCCESS BUT NOT CHOSEN:\n");
+        builder.append("\n\nMATERIALIZED VIEW REWRITE SUCCESS BUT NOT CHOSEN:\n");
         builder.append("  NAMES: ").append(materializationContexts.stream()
                 .filter(materializationContext -> materializationContext.isSuccess()
                         && !materializationChosenNameSet.contains(materializationContext.getMTMV().getName()))
                 .map(materializationContext -> materializationContext.getMTMV().getName())
                 .collect(Collectors.joining(", ")));
-        builder.append("\n\nMATERIALIZED VIEW SUCCESS AND CHOSEN:\n");
+        builder.append("\n\nMATERIALIZED VIEW REWRITE SUCCESS AND CHOSEN:\n");
         builder.append("  NAMES: ").append(String.join(", ", materializationChosenNameSet));
         return builder.toString();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializationContext.java
@@ -159,7 +159,7 @@ public class MaterializationContext {
             failReasonBuilder
                     .append("ObjectId : ").append(reason.getKey()).append(".\n")
                     .append("Summary : ").append(reason.getValue().key()).append(".\n")
-                    .append("Reason : ").append(reason.getValue().value()).append(".\n\n");
+                    .append("Reason : ").append(reason.getValue().value()).append(".\n");
         }
         failReasonBuilder.append("\n").append("]");
         return Utils.toSqlString("MaterializationContext[" + mtmv.getName() + "]",
@@ -174,7 +174,7 @@ public class MaterializationContext {
         StringBuilder builder = new StringBuilder();
         builder.append("materializationContexts:").append("\n");
         for (MaterializationContext ctx : materializationContexts) {
-            builder.append("\n\n").append(ctx).append("\n\n");
+            builder.append("\n").append(ctx).append("\n");
         }
         return builder.toString();
     }
@@ -187,7 +187,7 @@ public class MaterializationContext {
         for (Map.Entry<ObjectId, Pair<String, String>> reason : this.failReason.entrySet()) {
             failReasonBuilder
                     .append("ObjectId : ").append(reason.getKey()).append(".\n")
-                    .append("Summary : ").append(reason.getValue().key()).append(".\n\n");
+                    .append("Summary : ").append(reason.getValue().key()).append(".\n");
         }
         failReasonBuilder.append("\n").append("]");
         return Utils.toSqlString("MaterializationContext[" + mtmv.getName() + "]",
@@ -202,7 +202,7 @@ public class MaterializationContext {
         StringBuilder builder = new StringBuilder();
         builder.append("materializationContexts:").append("\n");
         for (MaterializationContext ctx : materializationContexts) {
-            builder.append("\n\n").append(ctx.toSummaryString()).append("\n");
+            builder.append("\n").append(ctx.toSummaryString()).append("\n");
         }
         return builder.toString();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/Predicates.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/Predicates.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.rules.exploration.mv;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
 import org.apache.doris.nereids.util.ExpressionUtils;
+import org.apache.doris.nereids.util.Utils;
 
 import com.google.common.collect.ImmutableList;
 
@@ -69,6 +70,11 @@ public class Predicates {
     public static SplitPredicate splitPredicates(Expression expression) {
         PredicatesSplitter predicatesSplit = new PredicatesSplitter(expression);
         return predicatesSplit.getSplitPredicate();
+    }
+
+    @Override
+    public String toString() {
+        return Utils.toSqlString("Predicates", "pulledUpPredicates", pulledUpPredicates);
     }
 
     /**
@@ -138,6 +144,14 @@ public class Predicates {
                     && ((BooleanLiteral) equalExpr).getValue()
                     && ((BooleanLiteral) rangeExpr).getValue()
                     && ((BooleanLiteral) residualExpr).getValue();
+        }
+
+        @Override
+        public String toString() {
+            return Utils.toSqlString("SplitPredicate",
+                    "equalPredicate", equalPredicate,
+                    "rangePredicate", rangePredicate,
+                    "residualPredicate", residualPredicate);
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/mapping/ExpressionMapping.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/mapping/ExpressionMapping.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.rules.exploration.mv.mapping;
 import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.util.ExpressionUtils;
+import org.apache.doris.nereids.util.Utils;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableMultimap;
@@ -122,5 +123,10 @@ public class ExpressionMapping extends Mapping {
             });
         }
         return new ExpressionMapping(foldedMappingBuilder.build());
+    }
+
+    @Override
+    public String toString() {
+        return Utils.toSqlString("ExpressionMapping", "expressionMapping", expressionMapping);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/mapping/Mapping.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/mapping/Mapping.java
@@ -135,6 +135,11 @@ public abstract class Mapping {
         public int hashCode() {
             return Objects.hash(exprId);
         }
+
+        @Override
+        public String toString() {
+            return "MappedSlot{" + "slot=" + slot + '}';
+        }
     }
 
     /** Chain fold tow mapping, such as this mapping is {[a -> b]}, the target mapping is

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/mapping/SlotMapping.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/mapping/SlotMapping.java
@@ -95,4 +95,9 @@ public class SlotMapping extends Mapping {
         this.slotReferenceMap = slotReferenceSlotReferenceMap;
         return this.slotReferenceMap;
     }
+
+    @Override
+    public String toString() {
+        return "SlotMapping{" + "relationSlotMap=" + relationSlotMap + '}';
+    }
 }

--- a/regression-test/suites/nereids_rules_p0/mv/agg_with_roll_up/aggregate_with_roll_up.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/agg_with_roll_up/aggregate_with_roll_up.groovy
@@ -147,9 +147,7 @@ suite("aggregate_with_roll_up") {
         waitingMTMVTaskFinished(job_name)
         explain {
             sql("${query_sql}")
-            check {
-                result -> return result.split("MaterializedViewRewriteSuccessAndChose")[1].contains("${mv_name}")
-            }
+            contains("${mv_name}(${mv_name})")
         }
     }
 
@@ -169,9 +167,7 @@ suite("aggregate_with_roll_up") {
         waitingMTMVTaskFinished(job_name)
         explain {
             sql("${query_sql}")
-            check {
-                result -> return result.split("MaterializedViewRewriteSuccessAndChose")[1].contains("${mv_name}")
-            }
+            contains("${mv_name}(${mv_name})")
         }
     }
 
@@ -195,9 +191,7 @@ suite("aggregate_with_roll_up") {
         waitingMTMVTaskFinished(job_name)
         explain {
             sql("${query_sql}")
-            check {
-                result -> return result.split("MaterializedViewRewriteSuccessAndChose")[1].contains("${mv_name}")
-            }
+            contains("${mv_name}(${mv_name})")
         }
     }
 
@@ -216,9 +210,7 @@ suite("aggregate_with_roll_up") {
         waitingMTMVTaskFinished(job_name)
         explain {
             sql("${query_sql}")
-            check {
-                result -> return !result.split("MaterializedViewRewriteSuccessAndChose")[1].contains("${mv_name}")
-            }
+            notContains("${mv_name}(${mv_name})")
         }
     }
 

--- a/regression-test/suites/nereids_rules_p0/mv/agg_with_roll_up/aggregate_with_roll_up.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/agg_with_roll_up/aggregate_with_roll_up.groovy
@@ -148,7 +148,7 @@ suite("aggregate_with_roll_up") {
         explain {
             sql("${query_sql}")
             check {
-                result -> return result.split("CHOSEN MATERIALIZATION'S")[1].contains("${mv_name}")
+                result -> return result.split("MATERIALIZED VIEW REWRITE SUCCESS AND CHOSEN")[1].contains("${mv_name}")
             }
         }
     }
@@ -170,7 +170,7 @@ suite("aggregate_with_roll_up") {
         explain {
             sql("${query_sql}")
             check {
-                result -> return result.split("CHOSEN MATERIALIZATION'S")[1].contains("${mv_name}")
+                result -> return result.split("MATERIALIZED VIEW REWRITE SUCCESS AND CHOSEN")[1].contains("${mv_name}")
             }
         }
     }
@@ -196,7 +196,7 @@ suite("aggregate_with_roll_up") {
         explain {
             sql("${query_sql}")
             check {
-                result -> return result.split("CHOSEN MATERIALIZATION'S")[1].contains("${mv_name}")
+                result -> return result.split("MATERIALIZED VIEW REWRITE SUCCESS AND CHOSEN")[1].contains("${mv_name}")
             }
         }
     }
@@ -217,7 +217,7 @@ suite("aggregate_with_roll_up") {
         explain {
             sql("${query_sql}")
             check {
-                result -> return !result.split("CHOSEN MATERIALIZATION'S")[1].contains("${mv_name}")
+                result -> return !result.split("MATERIALIZED VIEW REWRITE SUCCESS AND CHOSEN")[1].contains("${mv_name}")
             }
         }
     }

--- a/regression-test/suites/nereids_rules_p0/mv/agg_with_roll_up/aggregate_with_roll_up.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/agg_with_roll_up/aggregate_with_roll_up.groovy
@@ -147,7 +147,9 @@ suite("aggregate_with_roll_up") {
         waitingMTMVTaskFinished(job_name)
         explain {
             sql("${query_sql}")
-            contains "(${mv_name})"
+            check {
+                result -> return result.split("CHOSEN MATERIALIZATION'S")[1].contains("${mv_name}")
+            }
         }
     }
 
@@ -167,7 +169,9 @@ suite("aggregate_with_roll_up") {
         waitingMTMVTaskFinished(job_name)
         explain {
             sql("${query_sql}")
-            contains "(${mv_name})"
+            check {
+                result -> return result.split("CHOSEN MATERIALIZATION'S")[1].contains("${mv_name}")
+            }
         }
     }
 
@@ -191,7 +195,9 @@ suite("aggregate_with_roll_up") {
         waitingMTMVTaskFinished(job_name)
         explain {
             sql("${query_sql}")
-            contains "(${mv_name})"
+            check {
+                result -> return result.split("CHOSEN MATERIALIZATION'S")[1].contains("${mv_name}")
+            }
         }
     }
 
@@ -210,7 +216,9 @@ suite("aggregate_with_roll_up") {
         waitingMTMVTaskFinished(job_name)
         explain {
             sql("${query_sql}")
-            notContains "(${mv_name})"
+            check {
+                result -> return !result.split("CHOSEN MATERIALIZATION'S")[1].contains("${mv_name}")
+            }
         }
     }
 

--- a/regression-test/suites/nereids_rules_p0/mv/agg_with_roll_up/aggregate_with_roll_up.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/agg_with_roll_up/aggregate_with_roll_up.groovy
@@ -148,7 +148,7 @@ suite("aggregate_with_roll_up") {
         explain {
             sql("${query_sql}")
             check {
-                result -> return result.split("MATERIALIZED VIEW REWRITE SUCCESS AND CHOSEN")[1].contains("${mv_name}")
+                result -> return result.split("MaterializedViewRewriteSuccessAndChose")[1].contains("${mv_name}")
             }
         }
     }
@@ -170,7 +170,7 @@ suite("aggregate_with_roll_up") {
         explain {
             sql("${query_sql}")
             check {
-                result -> return result.split("MATERIALIZED VIEW REWRITE SUCCESS AND CHOSEN")[1].contains("${mv_name}")
+                result -> return result.split("MaterializedViewRewriteSuccessAndChose")[1].contains("${mv_name}")
             }
         }
     }
@@ -196,7 +196,7 @@ suite("aggregate_with_roll_up") {
         explain {
             sql("${query_sql}")
             check {
-                result -> return result.split("MATERIALIZED VIEW REWRITE SUCCESS AND CHOSEN")[1].contains("${mv_name}")
+                result -> return result.split("MaterializedViewRewriteSuccessAndChose")[1].contains("${mv_name}")
             }
         }
     }
@@ -217,7 +217,7 @@ suite("aggregate_with_roll_up") {
         explain {
             sql("${query_sql}")
             check {
-                result -> return !result.split("MATERIALIZED VIEW REWRITE SUCCESS AND CHOSEN")[1].contains("${mv_name}")
+                result -> return !result.split("MaterializedViewRewriteSuccessAndChose")[1].contains("${mv_name}")
             }
         }
     }

--- a/regression-test/suites/nereids_rules_p0/mv/agg_without_roll_up/aggregate_without_roll_up.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/agg_without_roll_up/aggregate_without_roll_up.groovy
@@ -151,7 +151,7 @@ suite("aggregate_without_roll_up") {
         explain {
             sql("${query_sql}")
             check {
-                result -> return result.split("CHOSEN MATERIALIZATION'S")[1].contains("${mv_name}")
+                result -> return result.split("MATERIALIZED VIEW REWRITE SUCCESS AND CHOSEN")[1].contains("${mv_name}")
             }
         }
     }
@@ -172,7 +172,7 @@ suite("aggregate_without_roll_up") {
         explain {
             sql("${query_sql}")
             check {
-                result -> return !result.split("CHOSEN MATERIALIZATION'S")[1].contains("${mv_name}")
+                result -> return !result.split("MATERIALIZED VIEW REWRITE SUCCESS AND CHOSEN")[1].contains("${mv_name}")
             }
         }
     }

--- a/regression-test/suites/nereids_rules_p0/mv/agg_without_roll_up/aggregate_without_roll_up.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/agg_without_roll_up/aggregate_without_roll_up.groovy
@@ -150,7 +150,9 @@ suite("aggregate_without_roll_up") {
         waitingMTMVTaskFinished(job_name)
         explain {
             sql("${query_sql}")
-            contains "(${mv_name})"
+            check {
+                result -> return result.split("CHOSEN MATERIALIZATION'S")[1].contains("${mv_name}")
+            }
         }
     }
 
@@ -169,7 +171,9 @@ suite("aggregate_without_roll_up") {
         waitingMTMVTaskFinished(job_name)
         explain {
             sql("${query_sql}")
-            notContains "(${mv_name})"
+            check {
+                result -> return !result.split("CHOSEN MATERIALIZATION'S")[1].contains("${mv_name}")
+            }
         }
     }
 

--- a/regression-test/suites/nereids_rules_p0/mv/agg_without_roll_up/aggregate_without_roll_up.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/agg_without_roll_up/aggregate_without_roll_up.groovy
@@ -150,9 +150,7 @@ suite("aggregate_without_roll_up") {
         waitingMTMVTaskFinished(job_name)
         explain {
             sql("${query_sql}")
-            check {
-                result -> return result.split("MaterializedViewRewriteSuccessAndChose")[1].contains("${mv_name}")
-            }
+            contains("${mv_name}(${mv_name})")
         }
     }
 
@@ -171,9 +169,7 @@ suite("aggregate_without_roll_up") {
         waitingMTMVTaskFinished(job_name)
         explain {
             sql("${query_sql}")
-            check {
-                result -> return !result.split("MaterializedViewRewriteSuccessAndChose")[1].contains("${mv_name}")
-            }
+            notContains("${mv_name}(${mv_name})")
         }
     }
 

--- a/regression-test/suites/nereids_rules_p0/mv/agg_without_roll_up/aggregate_without_roll_up.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/agg_without_roll_up/aggregate_without_roll_up.groovy
@@ -151,7 +151,7 @@ suite("aggregate_without_roll_up") {
         explain {
             sql("${query_sql}")
             check {
-                result -> return result.split("MATERIALIZED VIEW REWRITE SUCCESS AND CHOSEN")[1].contains("${mv_name}")
+                result -> return result.split("MaterializedViewRewriteSuccessAndChose")[1].contains("${mv_name}")
             }
         }
     }
@@ -172,7 +172,7 @@ suite("aggregate_without_roll_up") {
         explain {
             sql("${query_sql}")
             check {
-                result -> return !result.split("MATERIALIZED VIEW REWRITE SUCCESS AND CHOSEN")[1].contains("${mv_name}")
+                result -> return !result.split("MaterializedViewRewriteSuccessAndChose")[1].contains("${mv_name}")
             }
         }
     }

--- a/regression-test/suites/nereids_rules_p0/mv/join/inner/inner_join.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/join/inner/inner_join.groovy
@@ -141,7 +141,7 @@ suite("inner_join") {
         explain {
             sql("${query_sql}")
             check {
-                result -> return result.split("CHOSEN MATERIALIZATION'S")[1].contains("${mv_name}")
+                result -> return result.split("MATERIALIZED VIEW REWRITE SUCCESS AND CHOSEN")[1].contains("${mv_name}")
             }
         }
     }
@@ -162,7 +162,7 @@ suite("inner_join") {
         explain {
             sql("${query_sql}")
             check {
-                result -> return !result.split("CHOSEN MATERIALIZATION'S")[1].contains("${mv_name}")
+                result -> return !result.split("MATERIALIZED VIEW REWRITE SUCCESS AND CHOSEN")[1].contains("${mv_name}")
             }
         }
     }

--- a/regression-test/suites/nereids_rules_p0/mv/join/inner/inner_join.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/join/inner/inner_join.groovy
@@ -140,7 +140,9 @@ suite("inner_join") {
         waitingMTMVTaskFinished(job_name)
         explain {
             sql("${query_sql}")
-            contains "(${mv_name})"
+            check {
+                result -> return result.split("CHOSEN MATERIALIZATION'S")[1].contains("${mv_name}")
+            }
         }
     }
 
@@ -159,7 +161,9 @@ suite("inner_join") {
         waitingMTMVTaskFinished(job_name)
         explain {
             sql("${query_sql}")
-            notContains "(${mv_name})"
+            check {
+                result -> return !result.split("CHOSEN MATERIALIZATION'S")[1].contains("${mv_name}")
+            }
         }
     }
 

--- a/regression-test/suites/nereids_rules_p0/mv/join/inner/inner_join.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/join/inner/inner_join.groovy
@@ -140,9 +140,7 @@ suite("inner_join") {
         waitingMTMVTaskFinished(job_name)
         explain {
             sql("${query_sql}")
-            check {
-                result -> return result.split("MaterializedViewRewriteSuccessAndChose")[1].contains("${mv_name}")
-            }
+            contains("${mv_name}(${mv_name})")
         }
     }
 
@@ -161,9 +159,7 @@ suite("inner_join") {
         waitingMTMVTaskFinished(job_name)
         explain {
             sql("${query_sql}")
-            check {
-                result -> return !result.split("MaterializedViewRewriteSuccessAndChose")[1].contains("${mv_name}")
-            }
+            notContains("${mv_name}(${mv_name})")
         }
     }
 

--- a/regression-test/suites/nereids_rules_p0/mv/join/inner/inner_join.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/join/inner/inner_join.groovy
@@ -141,7 +141,7 @@ suite("inner_join") {
         explain {
             sql("${query_sql}")
             check {
-                result -> return result.split("MATERIALIZED VIEW REWRITE SUCCESS AND CHOSEN")[1].contains("${mv_name}")
+                result -> return result.split("MaterializedViewRewriteSuccessAndChose")[1].contains("${mv_name}")
             }
         }
     }
@@ -162,7 +162,7 @@ suite("inner_join") {
         explain {
             sql("${query_sql}")
             check {
-                result -> return !result.split("MATERIALIZED VIEW REWRITE SUCCESS AND CHOSEN")[1].contains("${mv_name}")
+                result -> return !result.split("MaterializedViewRewriteSuccessAndChose")[1].contains("${mv_name}")
             }
         }
     }

--- a/regression-test/suites/nereids_rules_p0/mv/join/left_outer/outer_join.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/join/left_outer/outer_join.groovy
@@ -140,7 +140,9 @@ suite("outer_join") {
         waitingMTMVTaskFinished(job_name)
         explain {
             sql("${query_sql}")
-            contains "(${mv_name})"
+            check {
+                result -> return result.split("CHOSEN MATERIALIZATION'S")[1].contains("${mv_name}")
+            }
         }
     }
 
@@ -159,7 +161,9 @@ suite("outer_join") {
         waitingMTMVTaskFinished(job_name)
         explain {
             sql("${query_sql}")
-            notContains "(${mv_name})"
+            check {
+                result -> return !result.split("CHOSEN MATERIALIZATION'S")[1].contains("${mv_name}")
+            }
         }
     }
 

--- a/regression-test/suites/nereids_rules_p0/mv/join/left_outer/outer_join.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/join/left_outer/outer_join.groovy
@@ -141,7 +141,7 @@ suite("outer_join") {
         explain {
             sql("${query_sql}")
             check {
-                result -> return result.split("CHOSEN MATERIALIZATION'S")[1].contains("${mv_name}")
+                result -> return result.split("MATERIALIZED VIEW REWRITE SUCCESS AND CHOSEN")[1].contains("${mv_name}")
             }
         }
     }
@@ -162,7 +162,7 @@ suite("outer_join") {
         explain {
             sql("${query_sql}")
             check {
-                result -> return !result.split("CHOSEN MATERIALIZATION'S")[1].contains("${mv_name}")
+                result -> return !result.split("MATERIALIZED VIEW REWRITE SUCCESS AND CHOSEN")[1].contains("${mv_name}")
             }
         }
     }

--- a/regression-test/suites/nereids_rules_p0/mv/join/left_outer/outer_join.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/join/left_outer/outer_join.groovy
@@ -140,9 +140,7 @@ suite("outer_join") {
         waitingMTMVTaskFinished(job_name)
         explain {
             sql("${query_sql}")
-            check {
-                result -> return result.split("MaterializedViewRewriteSuccessAndChose")[1].contains("${mv_name}")
-            }
+            contains("${mv_name}(${mv_name})")
         }
     }
 
@@ -161,9 +159,7 @@ suite("outer_join") {
         waitingMTMVTaskFinished(job_name)
         explain {
             sql("${query_sql}")
-            check {
-                result -> return !result.split("MaterializedViewRewriteSuccessAndChose")[1].contains("${mv_name}")
-            }
+            notContains("${mv_name}(${mv_name})")
         }
     }
 

--- a/regression-test/suites/nereids_rules_p0/mv/join/left_outer/outer_join.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/join/left_outer/outer_join.groovy
@@ -141,7 +141,7 @@ suite("outer_join") {
         explain {
             sql("${query_sql}")
             check {
-                result -> return result.split("MATERIALIZED VIEW REWRITE SUCCESS AND CHOSEN")[1].contains("${mv_name}")
+                result -> return result.split("MaterializedViewRewriteSuccessAndChose")[1].contains("${mv_name}")
             }
         }
     }
@@ -162,7 +162,7 @@ suite("outer_join") {
         explain {
             sql("${query_sql}")
             check {
-                result -> return !result.split("MATERIALIZED VIEW REWRITE SUCCESS AND CHOSEN")[1].contains("${mv_name}")
+                result -> return !result.split("MaterializedViewRewriteSuccessAndChose")[1].contains("${mv_name}")
             }
         }
     }

--- a/regression-test/suites/nereids_rules_p0/mv/partition_mv_rewrite.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/partition_mv_rewrite.groovy
@@ -167,10 +167,14 @@ suite("partition_mv_rewrite") {
     // only can use valid partition
     explain {
         sql("${all_partition_sql}")
-        notContains "mv_10086"
+        check { result ->
+            return !result.split("CHOSEN MATERIALIZATION'S")[1].contains("mv_10086")
+        }
     }
     explain {
         sql("${partition_sql}")
-        contains "mv_10086"
+        check { result ->
+            return result.split("CHOSEN MATERIALIZATION'S")[1].contains("mv_10086")
+        }
     }
 }

--- a/regression-test/suites/nereids_rules_p0/mv/partition_mv_rewrite.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/partition_mv_rewrite.groovy
@@ -146,16 +146,18 @@ suite("partition_mv_rewrite") {
         ${mv_def_sql}
         """
 
-    def job_name = getJobName(db, "mv_10086");
+    def mv_name = "mv_10086"
+
+    def job_name = getJobName(db, mv_name);
     waitingMTMVTaskFinished(job_name)
 
     explain {
         sql("${all_partition_sql}")
-        contains "mv_10086"
+        contains("${mv_name}(${mv_name})")
     }
     explain {
         sql("${partition_sql}")
-        contains "mv_10086"
+        contains("${mv_name}(${mv_name})")
     }
     // partition is invalid, so can not use partition 2023-10-17 to rewrite
     sql """
@@ -167,14 +169,10 @@ suite("partition_mv_rewrite") {
     // only can use valid partition
     explain {
         sql("${all_partition_sql}")
-        check { result ->
-            return !result.split("MaterializedViewRewriteSuccessAndChose")[1].contains("mv_10086")
-        }
+        notContains("${mv_name}(${mv_name})")
     }
     explain {
         sql("${partition_sql}")
-        check { result ->
-            return result.split("MaterializedViewRewriteSuccessAndChose")[1].contains("mv_10086")
-        }
+        contains("${mv_name}(${mv_name})")
     }
 }

--- a/regression-test/suites/nereids_rules_p0/mv/partition_mv_rewrite.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/partition_mv_rewrite.groovy
@@ -168,13 +168,13 @@ suite("partition_mv_rewrite") {
     explain {
         sql("${all_partition_sql}")
         check { result ->
-            return !result.split("CHOSEN MATERIALIZATION'S")[1].contains("mv_10086")
+            return !result.split("MATERIALIZED VIEW REWRITE SUCCESS AND CHOSEN")[1].contains("mv_10086")
         }
     }
     explain {
         sql("${partition_sql}")
         check { result ->
-            return result.split("CHOSEN MATERIALIZATION'S")[1].contains("mv_10086")
+            return result.split("MATERIALIZED VIEW REWRITE SUCCESS AND CHOSEN")[1].contains("mv_10086")
         }
     }
 }

--- a/regression-test/suites/nereids_rules_p0/mv/partition_mv_rewrite.groovy
+++ b/regression-test/suites/nereids_rules_p0/mv/partition_mv_rewrite.groovy
@@ -168,13 +168,13 @@ suite("partition_mv_rewrite") {
     explain {
         sql("${all_partition_sql}")
         check { result ->
-            return !result.split("MATERIALIZED VIEW REWRITE SUCCESS AND CHOSEN")[1].contains("mv_10086")
+            return !result.split("MaterializedViewRewriteSuccessAndChose")[1].contains("mv_10086")
         }
     }
     explain {
         sql("${partition_sql}")
         check { result ->
-            return result.split("MATERIALIZED VIEW REWRITE SUCCESS AND CHOSEN")[1].contains("mv_10086")
+            return result.split("MaterializedViewRewriteSuccessAndChose")[1].contains("mv_10086")
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

In query rewrite by mv process, we may want know the mv rewrite process info
such as which materializedView is used by rewrite, which materializedView is rewritten successfully, and 
chose which materializedView by cost finally.

We can run sql as following to see the mv rewrite process summary info
`explain <your_query_sql>`

MaterializedView rewrite info is under the **MATERIALIZATIONS** tag.
For example as following:
we can see that materializedView with name `mv2_3` is rewritten successfuly and chosen finally.
and materializedView with name `mv2_4` and `mv1_3` is avaliable but rewrite fail

>Materialized View
>
>MaterializedViewRewriteFail:
>
  >name: mv2_4
  >FailSummary: The graph logic between query and view is not consistent
>
  >name: mv1_3
  >FailSummary: Match mode is invalid
>
>MaterializedViewRewriteSuccessButNotChose:
  >Names: 
>
>MaterializedViewRewriteSuccessAndChose:
  >Names: mv2_3

`MaterializedViewRewriteFail`:
it means that it's failure when try to use this materilaized view to represnt the query,
`NAME` is the name of MTMV.
`FAIL_SUMMARY` is the summary for the fail reason.

`MaterializedViewRewriteSuccessButNotChose`
it means that try to use this  materilaized view to represnt the query successfully, but cbo optimizer doesn't chose it finally.

`MaterializedViewRewriteSuccessAndChose`
it means that try to use this  materilaized view to represnt the query successfully and cbo optimizer  chose it finally.


If want to see detail info, we can also run sql as following to see the mv rewrite process detail info

`explain memo plan <your_query_sql>`

MaterializedView rewrite info is under the **MATERIALIZATIONS** tag, 
For example as following:

we can see the materializedView with name `mv2_3` is rewritten successfuly and chosen finally.
and materializedViews with name of `mv2_4` and `mv1_3` is failed with falil reason.

> ========== MATERIALIZATIONS ==========
>materializationContexts:
>
> MaterializationContext[mv1_3] ( rewriteSuccess=false, failReason=[
ObjectId : ObjectId#257.
Summary : Match mode is invalid.
Reason : matchMode is VIEW_PARTIAL.
>
>ObjectId : ObjectId#260.
Summary : Match mode is invalid.
Reason : matchMode is VIEW_PARTIAL.
>
>ObjectId : ObjectId#251.
Summary : Match mode is invalid.
Reason : matchMode is VIEW_PARTIAL.
>
>ObjectId : ObjectId#254.
Summary : Match mode is invalid.
Reason : matchMode is VIEW_PARTIAL.
>
>] )
>
> MaterializationContext[mv2_4] ( rewriteSuccess=false, failReason=[
>ObjectId : ObjectId#771.
>Summary : The graph logic between query and view is not consistent.
>Reason : graph logical is not equal
 >query join edges is
 >[<{0} --LEFT_OUTER_JOIN-- {1}>],
 >view join edges is
 >[<{0} --LEFT_OUTER_JOIN-- {1}>],
>query filter edges
 >is [<{0} --FILTER-- {}>, <{1} --FILTER-- {}>[[] , [<{0} --LEFT_OUTER_JOIN-- {1}>]]],
>view filter edges
 >is [<{0} --FILTER-- {}>, <{1} --FILTER-- {}>[[] , [<{0} --LEFT_OUTER_JOIN-- {1}>]]]
>inferred edge with conditions
 {}
>with error edge <{1} --FILTER-- {}>[[] , [<{0} --LEFT_OUTER_JOIN-- {1}>]]=[(o_orderdate#20 = 2023-12-01)].

>ObjectId : ObjectId#762.
>Summary : The graph logic between query and view is not consistent.
>Reason : graph logical is not equal
 >query join edges is
 >[<{0} --LEFT_OUTER_JOIN-- {1}>],
 >view join edges is
 >[<{0} --LEFT_OUTER_JOIN-- {1}>],
>query filter edges
 >is [<{0} --FILTER-- {}>, <{1} --FILTER-- {}>[[] , [<{0} --LEFT_OUTER_JOIN-- {1}>]]],
>view filter edges
 >is [<{0} --FILTER-- {}>, <{1} --FILTER-- {}>[[] , [<{0} --LEFT_OUTER_JOIN-- {1}>]]]
>inferred edge with conditions
 >{}
>with error edge <{1} --FILTER-- {}>[[] , [<{0} --LEFT_OUTER_JOIN-- {1}>]]=[(o_orderdate#20 = 2023-12-01)].
>] )
>
> MaterializationContext[mv2_3] ( rewriteSuccess=true, failReason=[
>] )

`ObjectId` is the id of group expression.
`Summary`is is the summary for the fail reason.
`Reason` is the detail fail reason

such as the info as above

> MaterializationContext[mv2_4] ( rewriteSuccess=false, failReason=[
>ObjectId : ObjectId#762.
>Summary : The graph logic between query and view is not consistent.
>Reason : graph logical is not equal
 >query join edges is
 >[<{0} --LEFT_OUTER_JOIN-- {1}>],
 >view join edges is
 >[<{0} --LEFT_OUTER_JOIN-- {1}>],
>query filter edges
 >is [<{0} --FILTER-- {}>, <{1} --FILTER-- {}>[[] , [<{0} --LEFT_OUTER_JOIN-- {1}>]]],
>view filter edges
 >is [<{0} --FILTER-- {}>, <{1} --FILTER-- {}>[[] , [<{0} --LEFT_OUTER_JOIN-- {1}>]]]
>inferred edge with conditions
 >{}
>with error edge <{1} --FILTER-- {}>[[] , [<{0} --LEFT_OUTER_JOIN-- {1}>]]=[(o_orderdate#20 = 2023-12-01)].
>]

`0` represent table lineitem
`1` represent table orders
`[<{0} --LEFT_OUTER_JOIN-- {1}>]` means the edge which is lineitem left outer join orders
`[<{0} --FILTER-- {}>, <{1} --FILTER-- {}>[[] , [<{0} --LEFT_OUTER_JOIN-- {1}>]]]` means there is filter above orders which can not pull up because the edge `[<{0} --LEFT_OUTER_JOIN-- {1}>]`.
this can not rewrite because `[(o_orderdate#20 = 2023-12-01)]` in query is not found in **mv2_4**



**mv1_3**  def as following:
>CREATE MATERIALIZED VIEW mv1_3
>BUILD IMMEDIATE REFRESH auto ON SCHEDULE EVERY 1 hour
>DISTRIBUTED BY RANDOM BUCKETS 12
>PROPERTIES ('replication_num' = '1') as 
>select 
>  o_orderstatus, 
>  o_clerk 
>from 
>  orders 
>where 
>  O_ORDERDATE = '2023-12-01'
>group by 
>  o_orderstatus, 
> o_clerk;

**mv2_3**  def as following:
>CREATE MATERIALIZED VIEW mv2_3
>BUILD IMMEDIATE REFRESH auto ON SCHEDULE EVERY 1 hour
>DISTRIBUTED BY RANDOM BUCKETS 12
>PROPERTIES ('replication_num' = '1') as 
>select 
>  l_linestatus, 
 > o_clerk, 
>from 
 > (
  >  select 
  >    * 
  >  from 
  >    lineitem 
  >  where 
  >    l_shipdate = '2023-12-01'
 > ) t1 
 > left join (
  >  select 
  >    * 
  >  from 
  >    orders 
  >  where 
  >    o_orderdate = '2023-12-01'
 > ) t2 on l_orderkey = o_orderkey 
>group by 
 > l_linestatus, 
 > o_clerk;

**mv2_4**  def as following:
 > CREATE MATERIALIZED VIEW mv2_4
 > BUILD IMMEDIATE REFRESH auto ON SCHEDULE EVERY 1 hour
 > DISTRIBUTED BY RANDOM BUCKETS 12
 > PROPERTIES ('replication_num' = '1') as 
 > select 
   > l_linestatus, 
   > o_clerk, 
 > from 
   > (
    >  select 
     >   * 
    >  from 
     >   lineitem 
     > where 
     >   l_shipdate >= '2023-12-01' and l_shipdate <= '2023-12-05'
   > ) t1 
   > left join (
     > select 
       > * 
     > from 
     >   orders 
    >  where 
     >   o_orderdate >= '2023-12-01' and o_orderdate <= '2023-12-05'
   > ) t2 on l_orderkey = o_orderkey 
 > group by 
   > l_linestatus, 
   > o_clerk;


## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

