### PR TITLE
[fix](nereids) partition prunner evaluates "not x=const" on single node range 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/OneRangePartitionEvaluator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/OneRangePartitionEvaluator.java
@@ -458,7 +458,7 @@ public class OneRangePartitionEvaluator
     @Override
     public EvaluateRangeResult visitNot(Not not, EvaluateRangeInput context) {
         EvaluateRangeResult result = evaluateChildrenThenThis(not, context);
-        if (result.isRejectNot()) {
+        if (result.isRejectNot() && !result.result.equals(BooleanLiteral.TRUE)) {
             Map<Slot, ColumnRange> newRanges = Maps.newHashMap();
             for (Map.Entry<Slot, ColumnRange> entry : result.childrenResult.get(0).columnRanges.entrySet()) {
                 Slot slot = entry.getKey();

--- a/regression-test/suites/nereids_rules_p0/partition_prune/test_multi_range_partition.groovy
+++ b/regression-test/suites/nereids_rules_p0/partition_prune/test_multi_range_partition.groovy
@@ -272,4 +272,40 @@ suite("test_multi_range_partition") {
         sql "select * from pt where not k3 < 5;"
         contains "partitions=3/3 (p1,p2,p3)"
     }
+
+    sql "drop table if exists tt"
+    sql """
+    CREATE TABLE `tt` (
+     a bigint(20) NULL,
+     b bigint(20) null
+    ) ENGINE=OLAP
+    duplicate KEY(`a`)
+    COMMENT 'OLAP'
+    PARTITION BY RANGE(`a`, `b`)
+    (PARTITION p0 VALUES [("-2147483648", "-9223372036854775808"), ("5", "5")),
+    PARTITION p1 VALUES [("5", "5"), ("7", "7")),
+    PARTITION p2 VALUES [("7", "7"), ("2147483647", "2147483647000")))
+    DISTRIBUTED BY HASH(`b`) BUCKETS 10
+    PROPERTIES (
+    "replication_allocation" = "tag.location.default: 1",
+    "is_being_synced" = "false",
+    "storage_format" = "V2",
+    "light_schema_change" = "true",
+    "disable_auto_compaction" = "false",
+    "enable_single_replica_compaction" = "false"
+    ); 
+    """
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+    sql "insert into tt values (0, 0), (6, 6), (8, 8)"
+    explain {
+        sql """SELECT
+            *
+            FROM
+            tt
+            WHERE
+            ( NOT ( a  IN ( 5 ) )
+            AND b  BETWEEN 2 AND 13 )"""
+        contains "partitions=3/3 (p0,p1,p2)"    
+    }
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

