### PR TITLE
[fix](journal) Fix infinite block due to initial BDB journal failed

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBJEJournal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBJEJournal.java
@@ -271,6 +271,15 @@ public class BDBJEJournal implements Journal { // CHECKSTYLE IGNORE THIS LINE: B
 
     @Override
     public long getMaxJournalId() {
+        return getMaxJournalIdInternal(true);
+    }
+
+    // get max journal id but do not check whether the txn is matched.
+    private long getMaxJournalIdWithoutCheck() {
+        return getMaxJournalIdInternal(false);
+    }
+
+    private long getMaxJournalIdInternal(boolean checkTxnMatched) {
         long ret = -1;
         if (bdbEnvironment == null) {
             return ret;
@@ -287,7 +296,7 @@ public class BDBJEJournal implements Journal { // CHECKSTYLE IGNORE THIS LINE: B
         String dbName = dbNames.get(index).toString();
         long dbNumberName = dbNames.get(index);
         Database database = bdbEnvironment.openDatabase(dbName);
-        if (!isReplicaTxnAreMatched(database, dbNumberName)) {
+        if (checkTxnMatched && !isReplicaTxnAreMatched(database, dbNumberName)) {
             LOG.warn("The current replica hasn't synced up with the master, current db name: {}", dbNumberName);
             if (index != 0) {
                 // Because roll journal occurs after write, the previous write must have
@@ -419,7 +428,7 @@ public class BDBJEJournal implements Journal { // CHECKSTYLE IGNORE THIS LINE: B
                 }
 
                 // set next journal id
-                nextJournalId.set(getMaxJournalId() + 1);
+                nextJournalId.set(getMaxJournalIdWithoutCheck() + 1);
 
                 break;
             } catch (InsufficientLogException insufficientLogEx) {


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Introduced by: #28192.

Opening a BDBJournal will acquire the max journal id, but it doesn't need to check whether the replica txn is matched with the master.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

