### PR TITLE
[fix](partial update) Fix error message when doing strict mode partial update on a table with column that is non-nullable and has no default value

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -468,21 +468,23 @@ Status SegmentWriter::append_block_with_partial_content(const vectorized::Block*
                 _mow_context->delete_bitmap->add({_opts.rowset_ctx->rowset_id, _segment_id,
                                                   DeleteBitmap::TEMP_VERSION_COMMON},
                                                  segment_pos);
-            }
 
-            if (!_opts.rowset_ctx->partial_update_info->can_insert_new_rows_in_partial_update) {
-                std::string error_column;
-                for (auto cid : _opts.rowset_ctx->partial_update_info->missing_cids) {
-                    const TabletColumn& col = _tablet_schema->column(cid);
-                    if (!col.has_default_value() && !col.is_nullable()) {
-                        error_column = col.name();
-                        break;
+            } else {
+                if (!_opts.rowset_ctx->partial_update_info->can_insert_new_rows_in_partial_update) {
+                    std::string error_column;
+                    for (auto cid : _opts.rowset_ctx->partial_update_info->missing_cids) {
+                        const TabletColumn& col = _tablet_schema->column(cid);
+                        if (!col.has_default_value() && !col.is_nullable()) {
+                            error_column = col.name();
+                            break;
+                        }
                     }
+                    return Status::Error<INVALID_SCHEMA, false>(
+                            "the unmentioned column `{}` should have default value or be nullable "
+                            "for "
+                            "newly inserted rows in non-strict mode partial update",
+                            error_column);
                 }
-                return Status::Error<INVALID_SCHEMA, false>(
-                        "the unmentioned column `{}` should have default value or be nullable for "
-                        "newly inserted rows in non-strict mode partial update",
-                        error_column);
             }
             has_default_or_nullable = true;
             use_default_or_null_flag.emplace_back(true);

--- a/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/vertical_segment_writer.cpp
@@ -402,21 +402,22 @@ Status VerticalSegmentWriter::_append_block_with_partial_content(RowsInBlock& da
                 _mow_context->delete_bitmap->add({_opts.rowset_ctx->rowset_id, _segment_id,
                                                   DeleteBitmap::TEMP_VERSION_COMMON},
                                                  segment_pos);
-            }
-
-            if (!_opts.rowset_ctx->partial_update_info->can_insert_new_rows_in_partial_update) {
-                std::string error_column;
-                for (auto cid : _opts.rowset_ctx->partial_update_info->missing_cids) {
-                    const TabletColumn& col = _tablet_schema->column(cid);
-                    if (!col.has_default_value() && !col.is_nullable()) {
-                        error_column = col.name();
-                        break;
+            } else {
+                if (!_opts.rowset_ctx->partial_update_info->can_insert_new_rows_in_partial_update) {
+                    std::string error_column;
+                    for (auto cid : _opts.rowset_ctx->partial_update_info->missing_cids) {
+                        const TabletColumn& col = _tablet_schema->column(cid);
+                        if (!col.has_default_value() && !col.is_nullable()) {
+                            error_column = col.name();
+                            break;
+                        }
                     }
+                    return Status::Error<INVALID_SCHEMA, false>(
+                            "the unmentioned column `{}` should have default value or be nullable "
+                            "for "
+                            "newly inserted rows in non-strict mode partial update",
+                            error_column);
                 }
-                return Status::Error<INVALID_SCHEMA, false>(
-                        "the unmentioned column `{}` should have default value or be nullable for "
-                        "newly inserted rows in non-strict mode partial update",
-                        error_column);
             }
             has_default_or_nullable = true;
             use_default_or_null_flag.emplace_back(true);

--- a/regression-test/data/unique_with_mow_p0/partial_update/test_partial_update_strict_mode.out
+++ b/regression-test/data/unique_with_mow_p0/partial_update/test_partial_update_strict_mode.out
@@ -27,6 +27,14 @@
 
 -- !sql --
 1	kevin	18	shenzhen	400	2023-07-01T12:00
+3	steve	23	beijing	500	2023-07-03T12:00:02
+
+-- !sql --
+1	kevin	18	shenzhen	400	2023-07-01T12:00
+3	steve	23	beijing	500	2023-07-03T12:00:02
+
+-- !sql --
+1	kevin	18	shenzhen	400	2023-07-01T12:00
 
 -- !sql --
 1	kevin	18	shenzhen	500	2023-07-03T12:00:01
@@ -42,6 +50,14 @@
 
 -- !sql --
 1	kevin	18	shenzhen	400	2023-07-01T12:00
+
+-- !sql --
+1	kevin	18	shenzhen	400	2023-07-01T12:00
+3	steve	23	beijing	500	2023-07-03T12:00:02
+
+-- !sql --
+1	kevin	18	shenzhen	400	2023-07-01T12:00
+3	steve	23	beijing	500	2023-07-03T12:00:02
 
 -- !sql --
 1	kevin	18	shenzhen	400	2023-07-01T12:00

--- a/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_strict_mode.groovy
+++ b/regression-test/suites/unique_with_mow_p0/partial_update/test_partial_update_strict_mode.groovy
@@ -219,6 +219,45 @@ suite("test_partial_update_strict_mode", "p0") {
             sql "sync"
             qt_sql """select * from ${tableName4} order by id;"""
             sql """ DROP TABLE IF EXISTS ${tableName4}; """
+
+
+            // column `city` is non-nullable and has no default value
+            def tableName5 = "test_partial_update_strict_mode5"
+            sql """ DROP TABLE IF EXISTS ${tableName5} """
+            sql """
+                    CREATE TABLE ${tableName5} ( 
+                        `id` int(11) NULL, 
+                        `name` varchar(10) NULL,
+                        `age` int(11) NULL DEFAULT "20", 
+                        `city` varchar(10) NOT NULL, 
+                        `balance` decimalv3(9, 0) NULL, 
+                        `last_access_time` datetime NULL 
+                    ) ENGINE = OLAP UNIQUE KEY(`id`) 
+                    COMMENT 'OLAP' DISTRIBUTED BY HASH(`id`) 
+                    BUCKETS 4 PROPERTIES ( 
+                        "replication_allocation" = "tag.location.default: 1", 
+                        "storage_format" = "V2", 
+                        "enable_unique_key_merge_on_write" = "true", 
+                        "light_schema_change" = "true", 
+                        "disable_auto_compaction" = "false", 
+                        "enable_single_replica_compaction" = "false",
+                        "store_row_column" = "${use_row_store}"); """
+            sql """insert into ${tableName5} values(1,"kevin",18,"shenzhen",400,"2023-07-01 12:00:00");"""
+            sql """insert into ${tableName5} values(3,"steve",23,"beijing",500,"2023-07-03 12:00:02");"""
+            sql "sync;"
+            qt_sql """select * from ${tableName5} order by id;"""
+            sql "set enable_unique_key_partial_update=true;"
+            sql "set enable_insert_strict=true;"
+            sql "sync"
+            test {
+                sql """insert into ${tableName5}(id,balance,last_access_time) values
+                    (1,600,"2023-08-03 12:00:01"),
+                    (2,500,"2023-07-03 12:00:01"),
+                    (4,23,"2023-07-03 12:00:02");"""
+                exception "Insert has filtered data in strict mode"
+            }
+            sql "sync;"
+            qt_sql """select * from ${tableName5} order by id;"""
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

When inserting new rows in strict mode partial update on a table with column that is non-nullable and has no default value, Doris should not report "the unmentioned column xxx should have default value or be nullable for newly inserted rows in non-strict mode partial update"

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

