### PR TITLE
[fix](move-memtable) don't abort in replica write layer unless all replica fails

### DIFF
--- a/be/src/io/fs/stream_sink_file_writer.cpp
+++ b/be/src/io/fs/stream_sink_file_writer.cpp
@@ -58,6 +58,14 @@ Status StreamSinkFileWriter::appendv(const Slice* data, size_t data_cnt) {
         ok = ok || st.ok();
     }
     if (!ok) {
+        std::stringstream ss;
+        for (auto& stream : _streams) {
+            ss << " " << stream->dst_id();
+        }
+        LOG(WARNING) << "failed to write any replicas, load_id: " << print_id(_load_id)
+                     << ", index_id: " << _index_id << ", tablet_id: " << _tablet_id
+                     << ", segment_id: " << _segment_id << ", data_length: " << bytes_req
+                     << ", backends:" << ss.str();
         return Status::InternalError("failed to write any replicas");
     }
     _bytes_appended += bytes_req;
@@ -75,6 +83,13 @@ Status StreamSinkFileWriter::finalize() {
         ok = ok || st.ok();
     }
     if (!ok) {
+        std::stringstream ss;
+        for (auto& stream : _streams) {
+            ss << " " << stream->dst_id();
+        }
+        LOG(WARNING) << "failed to finalize any replicas, load_id: " << print_id(_load_id)
+                     << ", index_id: " << _index_id << ", tablet_id: " << _tablet_id
+                     << ", segment_id: " << _segment_id << ", backends:" << ss.str();
         return Status::InternalError("failed to finalize any replicas");
     }
     return Status::OK();


### PR DESCRIPTION
## Proposed changes

Currently, if any replica fails in rpc layer, the load will be aborted.
This is bad when there are multiple replicas and only need quorum to success.

This PR makes the replica write layer to keep writing unless all replica fails.
The quorum logic will be handled in upper layer.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

