### PR TITLE
[Fix](executor)Fix workload scheduler start too early may cause npe

### DIFF
--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -196,9 +196,6 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths,
                               .set_max_queue_size(1000000)
                               .build(&_lazy_release_obj_pool));
 
-    _workload_sched_mgr = new WorkloadSchedPolicyMgr();
-    _workload_sched_mgr->start(this);
-
     init_file_cache_factory();
     RETURN_IF_ERROR(init_pipeline_task_scheduler());
     _task_group_manager = new taskgroup::TaskGroupManager();
@@ -274,6 +271,9 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths,
         LOG(ERROR) << "Failed to starge bg threads of storage engine, res=" << st;
         return st;
     }
+
+    _workload_sched_mgr = new WorkloadSchedPolicyMgr();
+    _workload_sched_mgr->start(this);
 
     _s_ready = true;
 


### PR DESCRIPTION
## Proposed changes
```
*** Query id: 0-0 ***
*** tablet id: 0 ***
*** Aborted at 1703764858 (unix time) try "date -d @1703764858" if you are using GNU date ***
*** Current BE git commitID: 102335f ***
*** SIGSEGV address not mapped to object (@0x20) received by PID 91773 (TID 92595 OR 0x7f8ac94b6700) from PID 32; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:417
 1# os::Linux::chained_handler(int, siginfo*, void*) in /usr/local/software/jdk1.8.0_131/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/local/software/jdk1.8.0_131/jre/lib/amd64/server/libjvm.so
 3# signalHandler(int, siginfo*, void*) in /usr/local/software/jdk1.8.0_131/jre/lib/amd64/server/libjvm.so
 4# 0x00007F8C86805090 in /lib/x86_64-linux-gnu/libc.so.6
 5# __pthread_mutex_lock at ../nptl/pthread_mutex_lock.c:67
 6# pthread_mutex_lock in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P1/Cluster0/be/lib/doris_be
 7# doris::FragmentMgr::get_runtime_query_info(std::vector<doris::WorkloadQueryInfo, std::allocator<doris::WorkloadQueryInfo> >*) at /root/doris/be/src/runtime/fragment_mgr.cpp:1573
 8# doris::WorkloadSchedPolicyMgr::_schedule_workload() at /root/doris/be/src/runtime/workload_management/workload_sched_policy_mgr.cpp:81
 9# doris::Thread::supervise_thread(void*) at /root/doris/be/src/util/thread.cpp:499
10# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
11# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97

```