### PR TITLE
[Fix](core) Fix file system scan deleted file

### DIFF
--- a/be/src/io/fs/local_file_system.cpp
+++ b/be/src/io/fs/local_file_system.cpp
@@ -32,6 +32,7 @@
 #include <system_error>
 #include <utility>
 
+#include "common/exception.h"
 #include "gutil/macros.h"
 #include "io/fs/err_utils.h"
 #include "io/fs/file_system.h"
@@ -182,7 +183,11 @@ Status LocalFileSystem::directory_size(const Path& dir_path, size_t* dir_size) {
     if (std::filesystem::exists(dir_path) && std::filesystem::is_directory(dir_path)) {
         for (const auto& entry : std::filesystem::recursive_directory_iterator(dir_path)) {
             if (std::filesystem::is_regular_file(entry)) {
-                *dir_size += std::filesystem::file_size(entry);
+                try {
+                    *dir_size += std::filesystem::file_size(entry);
+                } catch (const std::exception& e) {
+                    LOG(INFO) << "{}", e.what();
+                }
             }
         }
         return Status::OK();


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

Fix core:

terminate called after throwing an instance of 'std::filesystem::__cxx11::filesystem_error'
[19:53:53 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/319209?buildTab=log&focusLine=121220&linesState=121220&logView=linear)    what():  filesystem error: cannot get file size: No such file or directory [/mnt/ssd01/cluster_storage/doris.SSD/P0/cluster0/wal/192735/194510/9158_group_commit_414e0ba38971bc59_16f57becc4aeca90]
[19:53:53 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/319209?buildTab=log&focusLine=121221&linesState=121221&logView=linear)  *** Query id: 0-0 ***
[19:53:53 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/319209?buildTab=log&focusLine=121222&linesState=121222&logView=linear)  *** tablet id: 0 ***
[19:53:53 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/319209?buildTab=log&focusLine=121223&linesState=121223&logView=linear)  *** Aborted at 1703763396 (unix time) try "date -d @1703763396" if you are using GNU date ***
[19:53:53 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/319209?buildTab=log&focusLine=121224&linesState=121224&logView=linear)  *** Current BE git commitID: b4cc7c5 ***
[19:53:53 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/319209?buildTab=log&focusLine=121225&linesState=121225&logView=linear)  *** SIGABRT unknown detail explain (@0x15274) received by PID 86644 (TID 87963 OR 0x7f9cb0044700) from PID 86644; stack trace: ***
[19:53:53 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/319209?buildTab=log&focusLine=121226&linesState=121226&logView=linear)   0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:417
[19:53:53 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/319209?buildTab=log&focusLine=121227&linesState=121227&logView=linear)   1# 0x00007FA32E3BD090 in /lib/x86_64-linux-gnu/libc.so.6
[19:53:53 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/319209?buildTab=log&focusLine=121228&linesState=121228&logView=linear)   2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
[19:53:53 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/319209?buildTab=log&focusLine=121229&linesState=121229&logView=linear)   3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
[19:53:53 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/319209?buildTab=log&focusLine=121230&linesState=121230&logView=linear)   4# __gnu_cxx::__verbose_terminate_handler() [clone .cold] at ../../../../libstdc++-v3/libsupc++/vterminate.cc:75
[19:53:53 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/319209?buildTab=log&focusLine=121231&linesState=121231&logView=linear)   5# __cxxabiv1::__terminate(void (*)()) at ../../../../libstdc++-v3/libsupc++/eh_terminate.cc:48
[19:53:53 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/319209?buildTab=log&focusLine=121232&linesState=121232&logView=linear)   6# 0x0000562DE4732E61 in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
[19:53:53 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/319209?buildTab=log&focusLine=121233&linesState=121233&logView=linear)   7# 0x0000562DE4732FB4 in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
[19:53:53 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/319209?buildTab=log&focusLine=121234&linesState=121234&logView=linear)   8# std::filesystem::file_size(std::filesystem::__cxx11::path const&) [clone .cold] at ../../../../../libstdc++-v3/src/c++17/fs_ops.cc:919
[19:53:53 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/319209?buildTab=log&focusLine=121235&linesState=121235&logView=linear)   9# doris::io::LocalFileSystem::directory_size(std::filesystem::__cxx11::path const&, unsigned long*) in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
[19:53:53 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/319209?buildTab=log&focusLine=121236&linesState=121236&logView=linear)  10# doris::WalDirInfo::update_wal_dir_limit(unsigned long) at /root/doris/be/src/olap/wal_dirs_info.cpp:93
[19:53:53 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/319209?buildTab=log&focusLine=121237&linesState=121237&logView=linear)  11# doris::WalDirsInfo::update_all_wal_dir_limit() at /root/doris/be/src/olap/wal_dirs_info.cpp:181
[19:53:53 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/319209?buildTab=log&focusLine=121238&linesState=121238&logView=linear)  12# doris::WalManager::_update_wal_dir_info_thread() in /mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be
[19:53:53 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/319209?buildTab=log&focusLine=121239&linesState=121239&logView=linear)  13# std::_Function_handler<void (), doris::WalManager::_init_wal_dirs_info()::$_0>::_M_invoke(std::_Any_data const&) at /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
[19:53:53 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/319209?buildTab=log&focusLine=121240&linesState=121240&logView=linear)  14# doris::Thread::supervise_thread(void*) at /root/doris/be/src/util/thread.cpp:499
[19:53:53 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/319209?buildTab=log&focusLine=121241&linesState=121241&logView=linear)  15# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
[19:53:53 ](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_P0Regression/319209?buildTab=log&focusLine=121242&linesState=121242&logView=linear)  16# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

