### PR TITLE
[pipelineX](fix) Fix heap-use-after-free for AggSource dependency

### DIFF
--- a/be/src/pipeline/pipeline_x/dependency.h
+++ b/be/src/pipeline/pipeline_x/dependency.h
@@ -56,8 +56,8 @@ static constexpr auto TIME_UNIT_DEPENDENCY_LOG = 30 * 1000L * 1000L * 1000L;
 static_assert(TIME_UNIT_DEPENDENCY_LOG < SLOW_DEPENDENCY_THRESHOLD);
 
 struct BasicSharedState {
-    Dependency* source_dep = nullptr;
-    Dependency* sink_dep = nullptr;
+    DependencySPtr source_dep = nullptr;
+    DependencySPtr sink_dep = nullptr;
 
     virtual Status close(RuntimeState* state) { return Status::OK(); }
     virtual ~BasicSharedState() = default;

--- a/be/src/pipeline/pipeline_x/operator.cpp
+++ b/be/src/pipeline/pipeline_x/operator.cpp
@@ -336,15 +336,15 @@ Status PipelineXLocalState<DependencyType>::init(RuntimeState* state, LocalState
             _shared_state =
                     (typename DependencyType::SharedState*)_dependency->shared_state().get();
 
-            _shared_state->source_dep = _dependency;
-            _shared_state->sink_dep = deps.front().get();
+            _shared_state->source_dep = info.dependency;
+            _shared_state->sink_dep = deps.front();
         } else if constexpr (!is_fake_shared) {
             _dependency->set_shared_state(deps.front()->shared_state());
             _shared_state =
                     (typename DependencyType::SharedState*)_dependency->shared_state().get();
 
-            _shared_state->source_dep = _dependency;
-            _shared_state->sink_dep = deps.front().get();
+            _shared_state->source_dep = info.dependency;
+            _shared_state->sink_dep = deps.front();
         }
     }
 


### PR DESCRIPTION
## Proposed changes

==66678==ERROR: AddressSanitizer: heap-use-after-free on address 0x61100533b490 at pc 0x55a9804a3dcf bp 0x7f823f7f2830 sp 0x7f823f7f2828
READ of size 8 at 0x61100533b490 thread T335 (PipeGSchePool [)
    #0 0x55a9804a3dce in doris::pipeline::Dependency::set_ready_to_read() /root/doris/be/src/pipeline/pipeline_x/dependency.h:111:36
    #1 0x55a9813031d9 in doris::pipeline::AggSinkOperatorX<doris::pipeline::BlockingAggSinkLocalState>::sink(doris::RuntimeState*, doris::vectorized::Block*, doris::pipeline::SourceState) /root/doris/be/s
rc/pipeline/exec/aggregation_sink_operator.cpp:864:34
    #2 0x55a981cb13b6 in doris::pipeline::PipelineXTask::execute(bool*) /root/doris/be/src/pipeline/pipeline_x/pipeline_x_task.cpp:283:34
    #3 0x55a981cd09ec in doris::pipeline::TaskScheduler::_do_work(unsigned long) /root/doris/be/src/pipeline/task_scheduler.cpp:284:28
    #4 0x55a959e06c7c in doris::ThreadPool::dispatch_thread() /root/doris/be/src/util/threadpool.cpp:543:24
    #5 0x55a959de5ac8 in std::function<void ()>::operator()() const /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #6 0x55a959de5ac8 in doris::Thread::supervise_thread(void*) /root/doris/be/src/util/thread.cpp:498:5
    #7 0x7f8461987608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477:8
    #8 0x7f8461c34132 in __clone /build/glibc-SzIz7B/glibc-2.31/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:950x61100533b490 is located 16 bytes inside of 232-byte region [0x61100533b480,0x61100533b568)
freed by thread T325 (PipeGSchePool [) here:
    #0 0x55a95715280d in operator delete(void*) (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster0/be/lib/doris_be+0x13bc380d) (BuildId: b363418359d5a938)
    #1 0x55a981cbdd9b in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:184:1
0
    #2 0x55a981cbdd9b in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:70
2:11
    #3 0x55a981cbdd9b in std::__shared_ptr<doris::pipeline::Dependency, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/
bits/shared_ptr_base.h:1149:31
    #4 0x55a981cbdd9b in std::pair<int const, std::shared_ptr<doris::pipeline::Dependency> >::~pair() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_iterat
or.h:2379:12
    #5 0x55a981cbdd9b in void std::destroy_at<std::pair<int const, std::shared_ptr<doris::pipeline::Dependency> > >(std::pair<int const, std::shared_ptr<doris::pipeline::Dependency> >*) /var/local/ldb-too
lchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:88:15
    #6 0x55a981cbdd9b in void std::allocator_traits<std::allocator<std::_Rb_tree_node<std::pair<int const, std::shared_ptr<doris::pipeline::Dependency> > > > >::destroy<std::pair<int const, std::shared_pt
r<doris::pipeline::Dependency> > >(std::allocator<std::_Rb_tree_node<std::pair<int const, std::shared_ptr<doris::pipeline::Dependency> > > >&, std::pair<int const, std::shared_ptr<doris::pipeline::Depende
ncy> >*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:533:4
    #7 0x55a981cbdd9b in std::_Rb_tree<int, std::pair<int const, std::shared_ptr<doris::pipeline::Dependency> >, std::_Select1st<std::pair<int const, std::shared_ptr<doris::pipeline::Dependency> > >, std:
:less<int>, std::allocator<std::pair<int const, std::shared_ptr<doris::pipeline::Dependency> > > >::_M_destroy_node(std::_Rb_tree_node<std::pair<int const, std::shared_ptr<doris::pipeline::Dependency> > >
*) /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:623:2
    #8 0x55a981cbdd9b in std::_Rb_tree<int, std::pair<int const, std::shared_ptr<doris::pipeline::Dependency> >, std::_Select1st<std::pair<int const, std::shared_ptr<doris::pipeline::Dependency> > >, std:
:less<int>, std::allocator<std::pair<int const, std::shared_ptr<doris::pipeline::Dependency> > > >::_M_drop_node(std::_Rb_tree_node<std::pair<int const, std::shared_ptr<doris::pipeline::Dependency> > >*)
/var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:631:2
    #9 0x55a981cbdd9b in std::_Rb_tree<int, std::pair<int const, std::shared_ptr<doris::pipeline::Dependency> >, std::_Select1st<std::pair<int const, std::shared_ptr<doris::pipeline::Dependency> > >, std:
:less<int>, std::allocator<std::pair<int const, std::shared_ptr<doris::pipeline::Dependency> > > >::_M_erase(std::_Rb_tree_node<std::pair<int const, std::shared_ptr<doris::pipeline::Dependency> > >*) /var
/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:1889:4
    #10 0x55a981cb2d10 in std::_Rb_tree<int, std::pair<int const, std::shared_ptr<doris::pipeline::Dependency> >, std::_Select1st<std::pair<int const, std::shared_ptr<doris::pipeline::Dependency> > >, std
::less<int>, std::allocator<std::pair<int const, std::shared_ptr<doris::pipeline::Dependency> > > >::~_Rb_tree() /var/local/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits
/stl_tree.h:984:9
    #11 0x55a981cb2d10 in std::map<int, std::shared_ptr<doris::pipeline::Dependency>, std::less<int>, std::allocator<std::pair<int const, std::shared_ptr<doris::pipeline::Dependency> > > >::~map() /var/lo
cal/ldb-toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_map.h:302:22
    #12 0x55a981cb2d10 in doris::pipeline::PipelineXTask::finalize() /root/doris/be/src/pipeline/pipeline_x/pipeline_x_task.cpp:303:5 

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

