### PR TITLE
[fix](cluster by) Fix cluster_by used-after-moved in compaction

### DIFF
--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -183,7 +183,9 @@ void Merger::vertical_split_columns(TabletSchemaSPtr tablet_schema,
     }
     for (auto i = num_key_cols; i < total_cols; ++i) {
         if (i == sequence_col_idx || i == delete_sign_idx ||
-            key_columns.end() != std::find(key_columns.begin(), key_columns.end(), i)) {
+            tablet_schema->cluster_key_idxes().end() !=
+                    std::find(tablet_schema->cluster_key_idxes().begin(),
+                              tablet_schema->cluster_key_idxes().end(), i)) {
             continue;
         }
         if ((i - num_key_cols) % config::vertical_compaction_num_columns_per_group == 0) {

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -181,11 +181,11 @@ void Merger::vertical_split_columns(TabletSchemaSPtr tablet_schema,
     if (!key_columns.empty()) {
         column_groups->emplace_back(std::move(key_columns));
     }
-    for (auto i = num_key_cols; i < total_cols; ++i) {
+    auto&& cluster_key_idxes = tablet_schema->cluster_key_idxes();
+    for (uint32_t i = num_key_cols; i < total_cols; ++i) {
         if (i == sequence_col_idx || i == delete_sign_idx ||
-            tablet_schema->cluster_key_idxes().end() !=
-                    std::find(tablet_schema->cluster_key_idxes().begin(),
-                              tablet_schema->cluster_key_idxes().end(), i)) {
+            cluster_key_idxes.end() !=
+                    std::find(cluster_key_idxes.begin(), cluster_key_idxes.end(), i)) {
             continue;
         }
         if ((i - num_key_cols) % config::vertical_compaction_num_columns_per_group == 0) {

--- a/be/src/olap/tablet_schema.h
+++ b/be/src/olap/tablet_schema.h
@@ -266,7 +266,7 @@ public:
     std::vector<TabletColumn>& mutable_columns();
     size_t num_columns() const { return _num_columns; }
     size_t num_key_columns() const { return _num_key_columns; }
-    std::vector<uint32_t> cluster_key_idxes() const { return _cluster_key_idxes; }
+    const std::vector<uint32_t>& cluster_key_idxes() const { return _cluster_key_idxes; }
     size_t num_null_columns() const { return _num_null_columns; }
     size_t num_short_key_columns() const { return _num_short_key_columns; }
     size_t num_rows_per_row_block() const { return _num_rows_per_row_block; }


### PR DESCRIPTION
## Proposed changes

The linter report a used-after-moved

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

