### PR TITLE
[improvement](statistics)Use key column id to query column statistic table. (#28885)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsRepository.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsRepository.java
@@ -99,10 +99,6 @@ public class StatisticsRepository {
             + " WHERE tbl_id = ${tblId}"
             + " AND part_id IS NOT NULL";
 
-    private static final String QUERY_COLUMN_STATISTICS = "SELECT * FROM " + FeConstants.INTERNAL_DB_NAME
-            + "." + StatisticConstants.STATISTIC_TBL_NAME + " WHERE "
-            + "tbl_id=${tblId} AND idx_id=${idxId} AND col_id='${colId}'";
-
     private static final String QUERY_PARTITION_STATISTICS = "SELECT * FROM " + FeConstants.INTERNAL_DB_NAME
             + "." + StatisticConstants.STATISTIC_TBL_NAME + " WHERE "
             + " ${inPredicate}"
@@ -359,12 +355,11 @@ public class StatisticsRepository {
 
     public static List<ResultRow> loadColStats(long tableId, long idxId, String colName) {
         Map<String, String> params = new HashMap<>();
-        params.put("tblId", String.valueOf(tableId));
-        params.put("idxId", String.valueOf(idxId));
-        params.put("colId", StatisticsUtil.escapeSQL(colName));
+        String id = constructId(tableId, idxId, colName);
+        params.put("id", StatisticsUtil.escapeSQL(id));
 
         return StatisticsUtil.execStatisticQuery(new StringSubstitutor(params)
-                .replace(QUERY_COLUMN_STATISTICS));
+                .replace(FETCH_COLUMN_STATISTIC_TEMPLATE));
     }
 
     public static List<ResultRow> loadPartStats(Collection<StatisticsCacheKey> keys) {


### PR DESCRIPTION
Use id as where predicate to load column statistic cache. This could improve performance, because id is the first order key in column statistics table.

backport https://github.com/apache/doris/pull/28885

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

