### PR TITLE
[Fix](exectutor)Fix topicPublisher thread may NPE when no topic exists

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/publish/TopicPublisherThread.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/publish/TopicPublisherThread.java
@@ -66,9 +66,8 @@ public class TopicPublisherThread extends MasterDaemon {
             topicPublisher.getTopicInfo(request);
         }
 
-        if (request.getTopicMap().size() == 0) {
-            return;
-        }
+        // even request contains no group and schedule policy, we still need to send an empty rpc.
+        // because it may means workload group/policy is dropped
 
         // step 2: publish topic info to all be
         Collection<Backend> nodesToPublish = clusterInfoService.getIdToBackend().values();

--- a/fe/fe-core/src/main/java/org/apache/doris/common/publish/WorkloadGroupPublisher.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/publish/WorkloadGroupPublisher.java
@@ -35,8 +35,6 @@ public class WorkloadGroupPublisher implements TopicPublisher {
     @Override
     public void getTopicInfo(TPublishTopicRequest req) {
         List<TopicInfo> list = env.getWorkloadGroupMgr().getPublishTopicInfo();
-        if (list.size() > 0) {
-            req.putToTopicMap(TTopicInfoType.WORKLOAD_GROUP, list);
-        }
+        req.putToTopicMap(TTopicInfoType.WORKLOAD_GROUP, list);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/workloadschedpolicy/WorkloadSchedPolicyPublisher.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/workloadschedpolicy/WorkloadSchedPolicyPublisher.java
@@ -36,9 +36,7 @@ public class WorkloadSchedPolicyPublisher implements TopicPublisher {
     @Override
     public void getTopicInfo(TPublishTopicRequest req) {
         List<TopicInfo> list = env.getWorkloadSchedPolicyMgr().getPublishTopicInfoList();
-        if (list.size() > 0) {
-            req.putToTopicMap(TTopicInfoType.WORKLOAD_SCHED_POLICY, list);
-        }
+        req.putToTopicMap(TTopicInfoType.WORKLOAD_SCHED_POLICY, list);
     }
 
 }


### PR DESCRIPTION
1 How NPE happens?
```
 public int getTopicMapSize() {
    return (this.topic_map == null) ? 0 : this.topic_map.size();
  }

  public void putToTopicMap(TTopicInfoType key, java.util.List<TopicInfo> val) {
    if (this.topic_map == null) {
      this.topic_map = new java.util.EnumMap<TTopicInfoType,java.util.List<TopicInfo>>(TTopicInfoType.class);
    }
    this.topic_map.put(key, val);
  }

  @org.apache.thrift.annotation.Nullable
  public java.util.Map<TTopicInfoType,java.util.List<TopicInfo>> getTopicMap() {
    return this.topic_map;
  }
```

When visiting A thrift Class's collection size, should use getXXXsize(), should not first getXXX then get size, because it may be a null.


2 how to fix?
Currently even request has no topicinfo list,  it still needs send an empty rpc to be, because empty may means delete.