### PR TITLE
[fix](case) update load_colddata_to_hdfs.groovy

### DIFF
--- a/regression-test/suites/cold_heat_separation_p2/load_colddata_to_hdfs.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/load_colddata_to_hdfs.groovy
@@ -135,11 +135,12 @@ suite("load_colddata_to_hdfs") {
         """
     }
 
+    String hdfsFs = getHdfsFs()
     sql """
         CREATE RESOURCE IF NOT EXISTS ${resource_name}
         PROPERTIES (
             "type"="hdfs",
-            "fs.defaultFS"="127.0.0.1:8120",
+            "fs.defaultFS"="${hdfsFs}",
             "hadoop.username"="hive",
             "hadoop.password"="hive",
             "dfs.nameservices" = "my_ha",


### PR DESCRIPTION
this case will cause pretty large logs in be.out, maybe more than 100G
```
hdfsCreateDirectory(data/406912): FileSystem#mkdirs error:
ConnectException: Connection refusedjava.net.ConnectException: Call From VM-0-42-ubuntu/127.0.1.1 to localhost:8120 failed on connection exception: java.net.ConnectException: Connection refused; For more details see:  http://wiki.apache.org/hadoop/Co
nnectionRefused
        at sun.reflect.GeneratedConstructorAccessor42.newInstance(Unknown Source)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
        at org.apache.hadoop.net.NetUtils.wrapWithMessage(NetUtils.java:930)
        at org.apache.hadoop.net.NetUtils.wrapException(NetUtils.java:845)
        at org.apache.hadoop.ipc.Client.getRpcResponse(Client.java:1571)
        at org.apache.hadoop.ipc.Client.call(Client.java:1513)
        at org.apache.hadoop.ipc.Client.call(Client.java:1410)
        at org.apache.hadoop.ipc.ProtobufRpcEngine2$Invoker.invoke(ProtobufRpcEngine2.java:258)
        at org.apache.hadoop.ipc.ProtobufRpcEngine2$Invoker.invoke(ProtobufRpcEngine2.java:139)
        at com.sun.proxy.$Proxy9.mkdirs(Unknown Source)
        at org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolTranslatorPB.mkdirs(ClientNamenodeProtocolTranslatorPB.java:675)
        at sun.reflect.GeneratedMethodAccessor23.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.apache.hadoop.io.retry.RetryInvocationHandler.invokeMethod(RetryInvocationHandler.java:433)
        at org.apache.hadoop.io.retry.RetryInvocationHandler$Call.invokeMethod(RetryInvocationHandler.java:166)
        at org.apache.hadoop.io.retry.RetryInvocationHandler$Call.invoke(RetryInvocationHandler.java:158)
        at org.apache.hadoop.io.retry.RetryInvocationHandler$Call.invokeOnce(RetryInvocationHandler.java:96)
        at org.apache.hadoop.io.retry.RetryInvocationHandler.invoke(RetryInvocationHandler.java:362)
        at com.sun.proxy.$Proxy10.mkdirs(Unknown Source)
        at org.apache.hadoop.hdfs.DFSClient.primitiveMkdir(DFSClient.java:2507)
        at org.apache.hadoop.hdfs.DFSClient.mkdirs(DFSClient.java:2483)
        at org.apache.hadoop.hdfs.DistributedFileSystem$27.doCall(DistributedFileSystem.java:1498)
        at org.apache.hadoop.hdfs.DistributedFileSystem$27.doCall(DistributedFileSystem.java:1495)
        at org.apache.hadoop.fs.FileSystemLinkResolver.resolve(FileSystemLinkResolver.java:81)
        at org.apache.hadoop.hdfs.DistributedFileSystem.mkdirsInternal(DistributedFileSystem.java:1512)
        at org.apache.hadoop.hdfs.DistributedFileSystem.mkdirs(DistributedFileSystem.java:1487)
        at org.apache.hadoop.fs.FileSystem.mkdirs(FileSystem.java:2496)
Caused by: java.net.ConnectException: Connection refused
        at sun.nio.ch.SocketChannelImpl.checkConnect(Native Method)
        at sun.nio.ch.SocketChannelImpl.finishConnect(SocketChannelImpl.java:716)
        at org.apache.hadoop.net.SocketIOWithTimeout.connect(SocketIOWithTimeout.java:205)
        at org.apache.hadoop.net.NetUtils.connect(NetUtils.java:600)
        at org.apache.hadoop.ipc.Client$Connection.setupConnection(Client.java:652)
        at org.apache.hadoop.ipc.Client$Connection.setupIOstreams(Client.java:773)
        at org.apache.hadoop.ipc.Client$Connection.access$3800(Client.java:347)
        at org.apache.hadoop.ipc.Client.getConnection(Client.java:1632)
        at org.apache.hadoop.ipc.Client.call(Client.java:1457)
        ... 22 more
```

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

