### PR TITLE
[fix](expr) Re fix BE core dump while common expr filter delete condition column

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -2185,7 +2185,6 @@ Status SegmentIterator::_next_batch_internal(vectorized::Block* block) {
     // so no need to filter a column by expr.
     if (_opts.stats->blocks_load == 0) {
         for (auto it = _columns_to_filter.begin(); it != _columns_to_filter.end();) {
-            LOG(INFO) << "_is_common_expr_column 111 " << *it;
             if (*it >= block->columns()) {
                 it = _columns_to_filter.erase(it);
             } else {

--- a/regression-test/suites/variant_p0/delete_update.groovy
+++ b/regression-test/suites/variant_p0/delete_update.groovy
@@ -63,9 +63,7 @@ suite("regression_test_variant_delete_and_update", "variant_type"){
     sql """update ${table_name} set v = '{"updated_value" : 1111}' where k = 7"""
     qt_sql "select * from ${table_name} order by k"
 
-    sql """select * from ${table_name} where v = 'xxx' or vs = 'yyy'"""
     sql """delete from ${table_name} where v = 'xxx' or vs = 'yyy'"""
-    sql """select * from ${table_name} where vs = 'xxx' or vs = 'yyy'"""
     sql """delete from ${table_name} where vs = 'xxx' or vs = 'yyy'"""
     qt_sql "select * from ${table_name} order by k"
 

--- a/regression-test/suites/variant_p0/delete_update.groovy
+++ b/regression-test/suites/variant_p0/delete_update.groovy
@@ -63,6 +63,9 @@ suite("regression_test_variant_delete_and_update", "variant_type"){
     sql """update ${table_name} set v = '{"updated_value" : 1111}' where k = 7"""
     qt_sql "select * from ${table_name} order by k"
 
+    sql """select * from ${table_name} where v = 'xxx' or vs = 'yyy'"""
+    sql """delete from ${table_name} where v = 'xxx' or vs = 'yyy'"""
+    sql """select * from ${table_name} where vs = 'xxx' or vs = 'yyy'"""
     sql """delete from ${table_name} where vs = 'xxx' or vs = 'yyy'"""
     qt_sql "select * from ${table_name} order by k"
 


### PR DESCRIPTION
## Proposed changes

Additional deleted filter condition will be materialized column be at the end of the block,
after _output_column_by_sel_idx  will be erase, we not need to filter it,
so erase it from _columns_to_filter in the first next_batch.
Eg:
      `delete from table where a = 10;`
      `select b from table;`
 a column only effective in segment iterator, the block from query engine only contain the b column,
 so no need to filter a column by expr.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

