### PR TITLE
[improve](move-memtable) report failed tablets with status

### DIFF
--- a/be/src/runtime/load_stream.cpp
+++ b/be/src/runtime/load_stream.cpp
@@ -291,8 +291,7 @@ Status IndexStream::_init_tablet_stream(TabletStreamSharedPtr& tablet_stream, in
 }
 
 Status IndexStream::close(const std::vector<PTabletID>& tablets_to_commit,
-                          std::vector<int64_t>* success_tablet_ids,
-                          std::vector<int64_t>* failed_tablet_ids) {
+                          std::vector<int64_t>* success_tablet_ids, FailedTablets* failed_tablets) {
     std::lock_guard lock_guard(_lock);
     SCOPED_TIMER(_close_wait_timer);
     // open all need commit tablets
@@ -311,7 +310,7 @@ Status IndexStream::close(const std::vector<PTabletID>& tablets_to_commit,
             success_tablet_ids->push_back(tablet_stream->id());
         } else {
             LOG(INFO) << "close tablet stream " << *tablet_stream << ", status=" << st;
-            failed_tablet_ids->push_back(tablet_stream->id());
+            failed_tablets->emplace_back(tablet_stream->id(), st);
         }
     }
     return Status::OK();
@@ -347,8 +346,7 @@ Status LoadStream::init(const POpenLoadStreamRequest* request) {
 }
 
 Status LoadStream::close(int64_t src_id, const std::vector<PTabletID>& tablets_to_commit,
-                         std::vector<int64_t>* success_tablet_ids,
-                         std::vector<int64_t>* failed_tablet_ids) {
+                         std::vector<int64_t>* success_tablet_ids, FailedTablets* failed_tablets) {
     std::lock_guard<bthread::Mutex> lock_guard(_lock);
     SCOPED_TIMER(_close_wait_timer);
 
@@ -371,26 +369,28 @@ Status LoadStream::close(int64_t src_id, const std::vector<PTabletID>& tablets_t
 
     for (auto& [_, index_stream] : _index_streams_map) {
         RETURN_IF_ERROR(
-                index_stream->close(_tablets_to_commit, success_tablet_ids, failed_tablet_ids));
+                index_stream->close(_tablets_to_commit, success_tablet_ids, failed_tablets));
     }
     LOG(INFO) << "close load " << *this << ", success_tablet_num=" << success_tablet_ids->size()
-              << ", failed_tablet_num=" << failed_tablet_ids->size();
+              << ", failed_tablet_num=" << failed_tablets->size();
     return Status::OK();
 }
 
-void LoadStream::_report_result(StreamId stream, const Status& st,
+void LoadStream::_report_result(StreamId stream, const Status& status,
                                 const std::vector<int64_t>& success_tablet_ids,
-                                const std::vector<int64_t>& failed_tablet_ids) {
+                                const FailedTablets& failed_tablets) {
     LOG(INFO) << "report result " << *this << ", success tablet num " << success_tablet_ids.size()
-              << ", failed tablet num " << failed_tablet_ids.size();
+              << ", failed tablet num " << failed_tablets.size();
     butil::IOBuf buf;
-    PWriteStreamSinkResponse response;
-    st.to_protobuf(response.mutable_status());
+    PLoadStreamResponse response;
+    status.to_protobuf(response.mutable_status());
     for (auto& id : success_tablet_ids) {
         response.add_success_tablet_ids(id);
     }
-    for (auto& id : failed_tablet_ids) {
-        response.add_failed_tablet_ids(id);
+    for (auto& [id, st] : failed_tablets) {
+        auto pb = response.add_failed_tablets();
+        pb->set_id(id);
+        st.to_protobuf(pb->mutable_status());
     }
 
     if (_enable_profile && _close_load_cnt == _total_streams) {
@@ -419,7 +419,7 @@ void LoadStream::_report_result(StreamId stream, const Status& st,
 
 void LoadStream::_report_schema(StreamId stream, const PStreamHeader& hdr) {
     butil::IOBuf buf;
-    PWriteStreamSinkResponse response;
+    PLoadStreamResponse response;
     Status st = Status::OK();
     for (const auto& req : hdr.tablets()) {
         TabletManager* tablet_mgr = StorageEngine::instance()->tablet_manager();
@@ -531,10 +531,10 @@ void LoadStream::_dispatch(StreamId id, const PStreamHeader& hdr, butil::IOBuf* 
     } break;
     case PStreamHeader::CLOSE_LOAD: {
         std::vector<int64_t> success_tablet_ids;
-        std::vector<int64_t> failed_tablet_ids;
+        FailedTablets failed_tablets;
         std::vector<PTabletID> tablets_to_commit(hdr.tablets().begin(), hdr.tablets().end());
-        auto st = close(hdr.src_id(), tablets_to_commit, &success_tablet_ids, &failed_tablet_ids);
-        _report_result(id, st, success_tablet_ids, failed_tablet_ids);
+        auto st = close(hdr.src_id(), tablets_to_commit, &success_tablet_ids, &failed_tablets);
+        _report_result(id, st, success_tablet_ids, failed_tablets);
         brpc::StreamClose(id);
     } break;
     case PStreamHeader::GET_SCHEMA: {

--- a/be/src/runtime/load_stream.h
+++ b/be/src/runtime/load_stream.h
@@ -41,6 +41,7 @@ class OlapTableSchemaParam;
 
 // origin_segid(index) -> new_segid(value in vector)
 using SegIdMapping = std::vector<uint32_t>;
+using FailedTablets = std::vector<std::pair<int64_t, Status>>;
 class TabletStream {
 public:
     TabletStream(PUniqueId load_id, int64_t id, int64_t txn_id, LoadStreamMgr* load_stream_mgr,
@@ -83,7 +84,7 @@ public:
     Status append_data(const PStreamHeader& header, butil::IOBuf* data);
 
     Status close(const std::vector<PTabletID>& tablets_to_commit,
-                 std::vector<int64_t>* success_tablet_ids, std::vector<int64_t>* failed_tablet_ids);
+                 std::vector<int64_t>* success_tablet_ids, FailedTablets* failed_tablet_ids);
 
 private:
     Status _init_tablet_stream(TabletStreamSharedPtr& tablet_stream, int64_t tablet_id,
@@ -118,7 +119,7 @@ public:
     }
 
     Status close(int64_t src_id, const std::vector<PTabletID>& tablets_to_commit,
-                 std::vector<int64_t>* success_tablet_ids, std::vector<int64_t>* failed_tablet_ids);
+                 std::vector<int64_t>* success_tablet_ids, FailedTablets* failed_tablet_ids);
 
     // callbacks called by brpc
     int on_received_messages(StreamId id, butil::IOBuf* const messages[], size_t size) override;
@@ -132,19 +133,18 @@ private:
     void _dispatch(StreamId id, const PStreamHeader& hdr, butil::IOBuf* data);
     Status _append_data(const PStreamHeader& header, butil::IOBuf* data);
 
-    void _report_result(StreamId stream, const Status& st,
+    void _report_result(StreamId stream, const Status& status,
                         const std::vector<int64_t>& success_tablet_ids,
-                        const std::vector<int64_t>& failed_tablet_ids);
+                        const FailedTablets& failed_tablets);
     void _report_schema(StreamId stream, const PStreamHeader& hdr);
 
     // report failure for one message
     void _report_failure(StreamId stream, const Status& status, const PStreamHeader& header) {
-        std::vector<int64_t> success; // empty
-        std::vector<int64_t> failure;
+        FailedTablets failed_tablets;
         if (header.has_tablet_id()) {
-            failure.push_back(header.tablet_id());
+            failed_tablets.emplace_back(header.tablet_id(), status);
         }
-        _report_result(stream, status, success, failure);
+        _report_result(stream, status, {}, failed_tablets);
     }
 
 private:

--- a/be/src/vec/sink/load_stream_stub.h
+++ b/be/src/vec/sink/load_stream_stub.h
@@ -132,7 +132,7 @@ private:
             return _success_tablets;
         }
 
-        std::vector<int64_t> failed_tablets() {
+        std::unordered_map<int64_t, Status> failed_tablets() {
             std::lock_guard<bthread::Mutex> lock(_failed_tablets_mutex);
             return _failed_tablets;
         }
@@ -150,7 +150,7 @@ private:
         bthread::Mutex _success_tablets_mutex;
         bthread::Mutex _failed_tablets_mutex;
         std::vector<int64_t> _success_tablets;
-        std::vector<int64_t> _failed_tablets;
+        std::unordered_map<int64_t, Status> _failed_tablets;
 
         LoadStreamStub* _stub = nullptr;
     };
@@ -254,7 +254,7 @@ public:
 
     std::vector<int64_t> success_tablets() { return _handler.success_tablets(); }
 
-    std::vector<int64_t> failed_tablets() { return _handler.failed_tablets(); }
+    std::unordered_map<int64_t, Status> failed_tablets() { return _handler.failed_tablets(); }
 
     brpc::StreamId stream_id() const { return _stream_id; }
 

--- a/be/src/vec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.cpp
@@ -597,7 +597,7 @@ Status VTabletWriterV2::close(Status exec_status) {
 }
 
 Status VTabletWriterV2::_failed_reason(int64_t tablet_id) {
-    Status st = Status::Error<INTERNAL_ERROR, false>("unknown");
+    Status st = Status::InternalError("tablet {} failed", tablet_id);
     auto backends = _location->find_tablet(tablet_id)->node_ids;
     for (auto& backend_id : backends) {
         auto failed_tablets = _streams_for_node[backend_id]->streams()[0]->failed_tablets();

--- a/be/src/vec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.cpp
@@ -542,6 +542,9 @@ Status VTabletWriterV2::close(Status exec_status) {
             }
         }
 
+        std::unordered_map<int64_t, int> success_tablets;
+        std::unordered_map<int64_t, int> failed_tablets;
+
         std::vector<TTabletCommitInfo> tablet_commit_infos;
         for (const auto& [node_id, streams] : _streams_for_node) {
             for (const auto& stream : streams->streams()) {
@@ -550,8 +553,24 @@ Status VTabletWriterV2::close(Status exec_status) {
                     commit_info.tabletId = tablet_id;
                     commit_info.backendId = node_id;
                     tablet_commit_infos.emplace_back(std::move(commit_info));
+                    success_tablets[tablet_id]++;
+                }
+                for (auto [tablet_id, _] : stream->failed_tablets()) {
+                    failed_tablets[tablet_id]++;
                 }
             }
+        }
+        for (auto [tablet_id, replicas] : success_tablets) {
+            if (replicas > _num_replicas / 2) {
+                continue;
+            }
+            return _failed_reason(tablet_id);
+        }
+        for (auto [tablet_id, replicas] : failed_tablets) {
+            if (replicas <= (_num_replicas - 1) / 2) {
+                continue;
+            }
+            return _failed_reason(tablet_id);
         }
         _state->tablet_commit_infos().insert(_state->tablet_commit_infos().end(),
                                              std::make_move_iterator(tablet_commit_infos.begin()),
@@ -575,6 +594,19 @@ Status VTabletWriterV2::close(Status exec_status) {
     _is_closed = true;
     _close_status = status;
     return status;
+}
+
+Status VTabletWriterV2::_failed_reason(int64_t tablet_id) {
+    Status st = Status::Error<INTERNAL_ERROR, false>("unknown");
+    auto backends = _location->find_tablet(tablet_id)->node_ids;
+    for (auto& backend_id : backends) {
+        auto failed_tablets = _streams_for_node[backend_id]->streams()[0]->failed_tablets();
+        if (failed_tablets.contains(tablet_id)) {
+            st = failed_tablets[tablet_id];
+            break;
+        }
+    }
+    return st;
 }
 
 Status VTabletWriterV2::_close_load(const Streams& streams) {

--- a/be/src/vec/sink/writer/vtablet_writer_v2.h
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.h
@@ -140,6 +140,8 @@ private:
     Status _select_streams(int64_t tablet_id, int64_t partition_id, int64_t index_id,
                            Streams& streams);
 
+    Status _failed_reason(int64_t tablet_id);
+
     Status _close_load(const Streams& streams);
 
     Status _cancel(Status status);

--- a/be/test/runtime/load_stream_test.cpp
+++ b/be/test/runtime/load_stream_test.cpp
@@ -324,7 +324,7 @@ public:
         int on_received_messages(StreamId id, butil::IOBuf* const messages[],
                                  size_t size) override {
             for (size_t i = 0; i < size; i++) {
-                PWriteStreamSinkResponse response;
+                PLoadStreamResponse response;
                 butil::IOBufAsZeroCopyInputStream wrapper(*messages[i]);
                 response.ParseFromZeroCopyStream(&wrapper);
                 LOG(INFO) << "response " << response.DebugString();
@@ -332,8 +332,8 @@ public:
                 for (auto& id : response.success_tablet_ids()) {
                     g_response_stat.success_tablet_ids.push_back(id);
                 }
-                for (auto& id : response.failed_tablet_ids()) {
-                    g_response_stat.failed_tablet_ids.push_back(id);
+                for (auto& tablet : response.failed_tablets()) {
+                    g_response_stat.failed_tablet_ids.push_back(tablet.id());
                 }
                 g_response_stat.num++;
             }

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -767,10 +767,15 @@ message POpenLoadStreamResponse {
     repeated PTabletSchemaWithIndex tablet_schemas = 2;
 }
 
-message PWriteStreamSinkResponse {
+message PFailedTablet {
+    optional int64 id = 1;
+    optional PStatus status = 2;
+}
+
+message PLoadStreamResponse {
     optional PStatus status = 1;
     repeated int64 success_tablet_ids = 2;
-    repeated int64 failed_tablet_ids = 3;
+    repeated PFailedTablet failed_tablets = 3;
     optional bytes load_stream_profile = 4;
     repeated PTabletSchemaWithIndex tablet_schemas = 5;
 }


### PR DESCRIPTION
## Proposed changes

Report failed tablets with status.

Tested when -238 error:
```
mysql> insert into mm select * from mm;
ERROR 1105 (HY000): errCode = 2, detailMessage = (10.16.10.7)[CANCELLED][E-238]PStatus: (10.16.10.7)[E-238]too many segments in rowset. tablet_id:54156, rowset_id:02000000000000c21a49eae90af77e7db08183a913b42f9d, max:1, _num_segment:1200, _segcompacted_point:0, _num_segcompacted:0
``` 

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

