### PR TITLE
Revert "[fix](move-memtable) only check missing tablets when commit i…

### DIFF
--- a/be/src/vec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.cpp
@@ -549,31 +549,9 @@ Status VTabletWriterV2::close(Status exec_status) {
                     TTabletCommitInfo commit_info;
                     commit_info.tabletId = tablet_id;
                     commit_info.backendId = node_id;
-                    _missing_tablets.erase(tablet_id);
                     tablet_commit_infos.emplace_back(std::move(commit_info));
                 }
             }
-        }
-        if (!_missing_tablets.empty()) {
-            std::stringstream ss("pre-commit check failed, ");
-            ss << "missing " << _missing_tablets.size() << " tablets:";
-            int print_limit = 3;
-            for (auto tablet_id : _missing_tablets | std::ranges::views::take(print_limit)) {
-                ss << " (tablet_id=" << tablet_id;
-                auto backends = _location->find_tablet(tablet_id)->node_ids;
-                ss << ", backend_id=[";
-                bool first = true;
-                for (auto& backend_id : backends) {
-                    (first ? ss : ss << ',') << backend_id;
-                    first = false;
-                }
-                ss << "])";
-            }
-            if (_missing_tablets.size() > print_limit) {
-                ss << ", ...";
-            }
-            LOG(INFO) << ss.str() << ", load_id=" << print_id(_load_id);
-            return Status::InternalError(ss.str());
         }
         _state->tablet_commit_infos().insert(_state->tablet_commit_infos().end(),
                                              std::make_move_iterator(tablet_commit_infos.begin()),
@@ -605,7 +583,6 @@ Status VTabletWriterV2::_close_load(const Streams& streams) {
     for (auto [tablet_id, tablet] : _tablets_for_node[node_id]) {
         if (_tablet_finder->partition_ids().contains(tablet.partition_id())) {
             tablets_to_commit.push_back(tablet);
-            _missing_tablets.insert(tablet_id);
         }
     }
     for (const auto& stream : streams) {

--- a/be/src/vec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.cpp
@@ -554,9 +554,9 @@ Status VTabletWriterV2::close(Status exec_status) {
                 }
             }
         }
-        if (!tablet_commit_infos.empty() && !_missing_tablets.empty()) {
-            std::stringstream ss;
-            ss << "pre-commit check failed, missing " << _missing_tablets.size() << " tablets:";
+        if (!_missing_tablets.empty()) {
+            std::stringstream ss("pre-commit check failed, ");
+            ss << "missing " << _missing_tablets.size() << " tablets:";
             int print_limit = 3;
             for (auto tablet_id : _missing_tablets | std::ranges::views::take(print_limit)) {
                 ss << " (tablet_id=" << tablet_id;

--- a/be/src/vec/sink/writer/vtablet_writer_v2.h
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.h
@@ -211,7 +211,7 @@ private:
     RuntimeState* _state = nullptr;     // not owned, set when open
     RuntimeProfile* _profile = nullptr; // not owned, set when open
 
-    std::unordered_set<int64_t> _missing_tablets;
+    std::unordered_set<int64_t> _opened_partitions;
 
     std::unordered_map<int64_t, std::unordered_map<int64_t, PTabletID>> _tablets_for_node;
     std::unordered_map<int64_t, std::vector<PTabletID>> _indexes_from_node;


### PR DESCRIPTION
…nfo is not empty (#29326)"

This reverts commit 4634c723d7fb86f434060c0e6fa6168d92630cb9.

## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

