### PR TITLE
[fix](memory) Fix file meta lru cache grace exit

### DIFF
--- a/be/src/olap/lru_cache.cpp
+++ b/be/src/olap/lru_cache.cpp
@@ -670,7 +670,7 @@ void ShardedLRUCache::update_cache_metrics() const {
 Cache::Handle* DummyLRUCache::insert(const CacheKey& key, void* value, size_t charge,
                                      void (*deleter)(const CacheKey& key, void* value),
                                      CachePriority priority, size_t bytes) {
-    size_t handle_size = sizeof(LRUHandle) - 1 + key.size();
+    size_t handle_size = sizeof(LRUHandle);
     auto* e = reinterpret_cast<LRUHandle*>(malloc(handle_size));
     e->value = value;
     e->deleter = deleter;

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -626,7 +626,7 @@ void ExecEnv::destroy() {
     SAFE_DELETE(_external_scan_context_mgr);
     SAFE_DELETE(_user_function_cache);
 
-    // cache_manager must be destoried after _inverted_index_query_cache
+    // cache_manager must be destoried after all cache.
     // https://github.com/apache/doris/issues/24082#issuecomment-1712544039
     SAFE_DELETE(_cache_manager);
 


### PR DESCRIPTION
## Proposed changes

cache_manager must be destoried after all cache.
![img_v3_026k_44fbed81-b0ee-494a-b7e5-4b762982cfcg](https://github.com/apache/doris/assets/13197424/5abdc2a8-1acc-44a1-97b0-a2fa8b34cb0d)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

