### PR TITLE
the jump count of NLJ is 2 for runtime filter prune on external db

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterPrunerForExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterPrunerForExternalTable.java
@@ -113,7 +113,7 @@ public class RuntimeFilterPrunerForExternalTable extends PlanPostProcessor {
         join.right().setMutableState(MutableState.KEY_PARENT, join);
         // nested loop join is slow, so jump add 2
         join.setMutableState(MutableState.KEY_RF_JUMP,
-            (Integer) join.right().getMutableState(MutableState.KEY_RF_JUMP).get() + 1);
+            (Integer) join.right().getMutableState(MutableState.KEY_RF_JUMP).get() + 2);
         join.left().accept(this, context);
         join.left().setMutableState(MutableState.KEY_PARENT, join);
         return join;


### PR DESCRIPTION
## Proposed changes

Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

