### PR TITLE
[improvement](disk) pick disk randomly when usage is less than 0.7

### DIFF
--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -870,8 +870,7 @@ size_t DataDir::tablet_size() const {
 }
 
 bool DataDir::reach_capacity_limit(int64_t incoming_data_size) {
-    double used_pct = (_disk_capacity_bytes - _available_bytes + incoming_data_size) /
-                      (double)_disk_capacity_bytes;
+    double used_pct = get_usage(incoming_data_size);
     int64_t left_bytes = _available_bytes - incoming_data_size;
     if (used_pct >= config::storage_flood_stage_usage_percent / 100.0 &&
         left_bytes <= config::storage_flood_stage_left_capacity_bytes) {

--- a/be/src/olap/data_dir.h
+++ b/be/src/olap/data_dir.h
@@ -133,6 +133,11 @@ public:
 
     void disks_compaction_num_increment(int64_t delta);
 
+    double get_usage(int64_t incoming_data_size) const {
+        return _disk_capacity_bytes == 0 ? 0 :
+                (_disk_capacity_bytes - _available_bytes + incoming_data_size) / (double)_disk_capacity_bytes;
+    }
+
     // Move tablet to trash.
     Status move_to_trash(const std::string& tablet_path);
 

--- a/be/src/olap/data_dir.h
+++ b/be/src/olap/data_dir.h
@@ -134,8 +134,10 @@ public:
     void disks_compaction_num_increment(int64_t delta);
 
     double get_usage(int64_t incoming_data_size) const {
-        return _disk_capacity_bytes == 0 ? 0 :
-                (_disk_capacity_bytes - _available_bytes + incoming_data_size) / (double)_disk_capacity_bytes;
+        return _disk_capacity_bytes == 0
+                       ? 0
+                       : (_disk_capacity_bytes - _available_bytes + incoming_data_size) /
+                                 (double)_disk_capacity_bytes;
     }
 
     // Move tablet to trash.

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -470,11 +470,12 @@ std::vector<DataDir*> StorageEngine::get_stores_for_create_tablet(
     size_t eighty_five_percent_index = stores.size() - 1;
     for (size_t index = 0; index < stores.size(); index++) {
         // If the usage of the store is less than 70%, we choose disk randomly.
-        if (stores[index]->get_usage(0) > 0.7) {
+        if (stores[index]->get_usage(0) > 0.7 && seventy_percent_index == stores.size() - 1) {
             seventy_percent_index = index;
         }
-        if (stores[index]->get_usage(0) > 0.85) {
+        if (stores[index]->get_usage(0) > 0.85 && eighty_five_percent_index == stores.size() - 1) {
             eighty_five_percent_index = index;
+            break;
         }
     }
 
@@ -483,6 +484,7 @@ std::vector<DataDir*> StorageEngine::get_stores_for_create_tablet(
     std::shuffle(stores.begin(), stores.begin() + seventy_percent_index, g);
     std::shuffle(stores.begin() + seventy_percent_index, stores.begin() + eighty_five_percent_index,
                  g);
+    std::shuffle(stores.begin() + eighty_five_percent_index, stores.end(), g);
 
     return stores;
 }

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -463,17 +463,18 @@ std::vector<DataDir*> StorageEngine::get_stores_for_create_tablet(
             }
         }
     }
+
     std::sort(stores.begin(), stores.end(),
               [](DataDir* a, DataDir* b) { return a->get_usage(0) < b->get_usage(0); });
 
-    size_t seventy_percent_index = stores.size() - 1;
-    size_t eighty_five_percent_index = stores.size() - 1;
+    size_t seventy_percent_index = stores.size();
+    size_t eighty_five_percent_index = stores.size();
     for (size_t index = 0; index < stores.size(); index++) {
         // If the usage of the store is less than 70%, we choose disk randomly.
-        if (stores[index]->get_usage(0) > 0.7 && seventy_percent_index == stores.size() - 1) {
+        if (stores[index]->get_usage(0) > 0.7 && seventy_percent_index == stores.size()) {
             seventy_percent_index = index;
         }
-        if (stores[index]->get_usage(0) > 0.85 && eighty_five_percent_index == stores.size() - 1) {
+        if (stores[index]->get_usage(0) > 0.85 && eighty_five_percent_index == stores.size()) {
             eighty_five_percent_index = index;
             break;
         }

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -456,16 +456,15 @@ std::vector<DataDir*> StorageEngine::get_stores_for_create_tablet(
         for (auto& it : _store_map) {
             if (it.second->is_used()) {
                 if ((_available_storage_medium_type_count == 1 ||
-                    it.second->storage_medium() == storage_medium) &&
+                     it.second->storage_medium() == storage_medium) &&
                     !it.second->reach_capacity_limit(0)) {
                     stores.push_back(it.second);
                 }
             }
         }
     }
-    std::sort(stores.begin(), stores.end(), [](DataDir* a, DataDir* b) {
-        return a->get_usage(0) < b->get_usage(0);
-    });
+    std::sort(stores.begin(), stores.end(),
+              [](DataDir* a, DataDir* b) { return a->get_usage(0) < b->get_usage(0); });
 
     size_t seventy_percent_index = stores.size() - 1;
     size_t eighty_five_percent_index = stores.size() - 1;
@@ -482,7 +481,8 @@ std::vector<DataDir*> StorageEngine::get_stores_for_create_tablet(
     std::random_device rd;
     std::mt19937 g(rd());
     std::shuffle(stores.begin(), stores.begin() + seventy_percent_index, g);
-    std::shuffle(stores.begin() + seventy_percent_index, stores.begin() + eighty_five_percent_index, g);
+    std::shuffle(stores.begin() + seventy_percent_index, stores.begin() + eighty_five_percent_index,
+                 g);
 
     return stores;
 }


### PR DESCRIPTION
## Proposed changes

When creating a tablet, firstly we try to pick a disk from disks whose usage is below 70% randomly. If all disks are beyonds 70%, then we try to pick a disk from disks whose usage is below 85% randomly. If all disks are beyond 85%, then we try to pick a disk from them randomly.
Issue Number: close #xxx

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

