### PR TITLE
[Fix](Job)Concurrency may result in event loss

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/disruptor/TaskDisruptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/disruptor/TaskDisruptor.java
@@ -50,7 +50,7 @@ public class TaskDisruptor<T> {
                          WaitStrategy waitStrategy, WorkHandler<T>[] workHandlers,
                          EventTranslatorVararg<T> eventTranslator) {
         disruptor = new Disruptor<>(eventFactory, ringBufferSize, threadFactory,
-                ProducerType.SINGLE, waitStrategy);
+                ProducerType.MULTI, waitStrategy);
         disruptor.handleEventsWithWorkerPool(workHandlers);
         this.eventTranslator = eventTranslator;
         disruptor.start();

--- a/fe/fe-core/src/main/java/org/apache/doris/scheduler/disruptor/TaskDisruptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/scheduler/disruptor/TaskDisruptor.java
@@ -81,7 +81,7 @@ public class TaskDisruptor implements Closeable {
     public void start() {
         ThreadFactory producerThreadFactory = DaemonThreadFactory.INSTANCE;
         disruptor = new Disruptor<>(TaskEvent.FACTORY, DEFAULT_RING_BUFFER_SIZE, producerThreadFactory,
-                ProducerType.SINGLE, new BlockingWaitStrategy());
+                ProducerType.MULTI, new BlockingWaitStrategy());
         WorkHandler<TaskEvent>[] workers = new TaskHandler[consumerThreadCount];
         for (int i = 0; i < consumerThreadCount; i++) {
             workers[i] = new TaskHandler(transientTaskManager);


### PR DESCRIPTION
## Proposed changes

Our previous internal scheduling was single-threaded, without concurrency, so we adopted the single-producer mode, but later provided an external trigger method. At this time, concurrency would occasionally occur, resulting in message loss. Now we have switched to multi-producer, which is used by the bottom layer CAS controls concurrency

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

