### PR TITLE
[opt](config) create custom conf dir if not exists

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/ConfigBase.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/ConfigBase.java
@@ -391,6 +391,7 @@ public class ConfigBase {
             throws IOException {
         File file = new File(customConfFile);
         if (!file.exists()) {
+            file.getParentFile().mkdirs();
             file.createNewFile();
         } else if (resetPersist) {
             // clear the customConfFile content


### PR DESCRIPTION
## Proposed changes

When calling `/api/_set_config/` with `persist=true`, Doris will create the custom conf dir
if it does not exist

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

