### PR TITLE
[fix](statistics)Fix set partition loaded replayer try to write edit log bug.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisManager.java
@@ -936,7 +936,7 @@ public class AnalysisManager implements Writable {
     // Set to true means new partition loaded data
     public void setNewPartitionLoaded(long tblId) {
         TableStatsMeta statsStatus = idToTblStats.get(tblId);
-        if (statsStatus != null) {
+        if (statsStatus != null && Env.getCurrentEnv().isMaster() && !Env.isCheckpointThread()) {
             statsStatus.newPartitionLoaded.set(true);
             logCreateTableStats(statsStatus);
         }


### PR DESCRIPTION
While observer or checkpointer replay SetPartitionLoaded log, it shouldn't try to write the log. This pr is to fix the bug.

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

