### PR TITLE
[fix](doc) fix en doc content that list partition column must be NOT NULL

### DIFF
--- a/docs/en/docs/data-table/data-partition.md
+++ b/docs/en/docs/data-table/data-partition.md
@@ -96,7 +96,7 @@ CREATE TABLE IF NOT EXISTS example_db.example_list_tbl
     `user_id` LARGEINT NOT NULL COMMENT "User ID",
     `date` DATE NOT NULL COMMENT "Date when the data are imported",
     `timestamp` DATETIME NOT NULL COMMENT "Timestamp when the data are imported",
-    `city` VARCHAR(20) COMMENT "User location city",
+    `city` VARCHAR(20) NOT NULL COMMENT "User location city",
     `age` SMALLINT COMMENT "User Age",
     `sex` TINYINT COMMENT "User gender",
     `last_visit_date` DATETIME REPLACE DEFAULT "1970-01-01 00:00:00" COMMENT "User last visit time",


### PR DESCRIPTION
## Proposed changes
en doc Data Partition the list partition column must be NOT NULL

## Further comments
```
mysql> CREATE TABLE IF NOT EXISTS example_db.example_list_tbl
    -> (
    ->     `user_id` LARGEINT NOT NULL COMMENT "User ID",
    ->     `date` DATE NOT NULL COMMENT "Date when the data are imported",
    ->     `timestamp` DATETIME NOT NULL COMMENT "Timestamp when the data are imported",
    ->     `city` VARCHAR(20) COMMENT "User location city",
    ->     `age` SMALLINT COMMENT "User Age",
    ->     `sex` TINYINT COMMENT "User gender",
    ->     `last_visit_date` DATETIME REPLACE DEFAULT "1970-01-01 00:00:00" COMMENT "User last visit time",
    ->     `cost` BIGINT SUM DEFAULT "0" COMMENT "Total user consumption",
    ->     `max_dwell_time` INT MAX DEFAULT "0" COMMENT "Maximum user dwell time",
    ->     `min_dwell_time` INT MIN DEFAULT "99999" COMMENT "Minimum user dwell time"
    -> )
    -> ENGINE=olap
    -> AGGREGATE KEY(`user_id`, `date`, `timestamp`, `city`, `age`, `sex`)
    -> PARTITION BY LIST(`city`)
    -> (
    ->     PARTITION `p_cn` VALUES IN ("Beijing", "Shanghai", "Hong Kong"),
    ->     PARTITION `p_usa` VALUES IN ("New York", "San Francisco"),
    ->     PARTITION `p_jp` VALUES IN ("Tokyo")
    -> )
    -> DISTRIBUTED BY HASH(`user_id`) BUCKETS 16
    -> PROPERTIES
    -> (
    ->     "replication_num" = "3",
    ->     "storage_medium" = "SSD",
    ->     "storage_cooldown_time" = "2018-01-01 12:00:00"
    -> );
ERROR 1105 (HY000): errCode = 2, detailMessage = The list partition column must be NOT NULL
```