### PR TITLE
[Chore](sort) fix block used after it was moved

### DIFF
--- a/be/src/vec/common/sort/heap_sorter.cpp
+++ b/be/src/vec/common/sort/heap_sorter.cpp
@@ -83,12 +83,11 @@ Status HeapSorter::append_block(Block* block) {
     }
     Block tmp_block = block->clone_empty();
     tmp_block.swap(*block);
+    size_t num_rows = tmp_block.rows();
     HeapSortCursorBlockView block_view_val(std::move(tmp_block), _sort_description);
-    SharedHeapSortCursorBlockView* block_view =
-            new SharedHeapSortCursorBlockView(std::move(block_view_val));
+    auto* block_view = new SharedHeapSortCursorBlockView(std::move(block_view_val));
     block_view->ref();
     Defer defer([&] { block_view->unref(); });
-    size_t num_rows = tmp_block.rows();
     if (_heap_size == _heap->size()) {
         {
             SCOPED_TIMER(_topn_filter_timer);


### PR DESCRIPTION
## Proposed changes
/mnt/disk2/pengyu/codebase/apache/doris/be/src/vec/common/sort/heap_sorter.cpp:91:23: error: 'tmp_block' used after it was moved [bugprone-use-after-move,-warnings-as-errors]

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

