### PR TITLE
[fix](scan) [fix](scan) _insert_data_normal should catch exception when BlockReader::_unique_key_next_block

### DIFF
--- a/be/src/vec/olap/block_reader.cpp
+++ b/be/src/vec/olap/block_reader.cpp
@@ -301,8 +301,7 @@ Status BlockReader::_agg_key_next_block(Block* block, bool* eof) {
     auto target_block_row = 0;
     auto merged_row = 0;
     auto target_columns = block->mutate_columns();
-
-    _insert_data_normal(target_columns);
+    RETURN_IF_ERROR(_insert_data_normal(target_columns));
     target_block_row++;
     _append_agg_data(target_columns);
 
@@ -325,7 +324,8 @@ Status BlockReader::_agg_key_next_block(Block* block, bool* eof) {
             _agg_data_counters.push_back(_last_agg_data_counter);
             _last_agg_data_counter = 0;
 
-            _insert_data_normal(target_columns);
+            RETURN_IF_ERROR(_insert_data_normal(target_columns));
+
             target_block_row++;
         } else {
             merged_row++;
@@ -356,7 +356,8 @@ Status BlockReader::_unique_key_next_block(Block* block, bool* eof) {
     }
 
     do {
-        _insert_data_normal(target_columns);
+        RETURN_IF_ERROR(_insert_data_normal(target_columns));
+
         if (UNLIKELY(_reader_context.record_rowids)) {
             _block_row_locations[target_block_row] = _vcollect_iter.current_row_location();
         }
@@ -429,12 +430,16 @@ Status BlockReader::_unique_key_next_block(Block* block, bool* eof) {
     return Status::OK();
 }
 
-void BlockReader::_insert_data_normal(MutableColumns& columns) {
+Status BlockReader::_insert_data_normal(MutableColumns& columns) {
     auto block = _next_row.block.get();
-    for (auto idx : _normal_columns_idx) {
-        columns[_return_columns_loc[idx]]->insert_from(*block->get_by_position(idx).column,
-                                                       _next_row.row_pos);
-    }
+
+    RETURN_IF_CATCH_EXCEPTION({
+        for (auto idx : _normal_columns_idx) {
+            columns[_return_columns_loc[idx]]->insert_from(*block->get_by_position(idx).column,
+                                                           _next_row.row_pos);
+        }
+    });
+    return Status::OK();
 }
 
 void BlockReader::_append_agg_data(MutableColumns& columns) {

--- a/be/src/vec/olap/block_reader.h
+++ b/be/src/vec/olap/block_reader.h
@@ -74,7 +74,7 @@ private:
 
     void _init_agg_state(const ReaderParams& read_params);
 
-    void _insert_data_normal(MutableColumns& columns);
+    Status _insert_data_normal(MutableColumns& columns);
 
     void _append_agg_data(MutableColumns& columns);
 


### PR DESCRIPTION
[fix](scan) _insert_data_normal should catch exception when BlockReader::_unique_key_next_block

## Proposed changes

Issue Number: close #29387 

<!--Describe your changes.-->

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

